### PR TITLE
Fixing bug in parsing test from script_tests.json

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -15,11 +15,11 @@
 
 
 
-    <root level="DEBUG">
+    <root level="WARN">
         <appender-ref ref="FILE" />
         <appender-ref ref="STDOUT" />
     </root>
 
-    <logger name="org.bitcoins" level="DEBUG"/>
+    <logger name="org.bitcoins" level="WARN"/>
 
 </configuration>

--- a/src/main/scala/org/bitcoins/script/ScriptProgram.scala
+++ b/src/main/scala/org/bitcoins/script/ScriptProgram.scala
@@ -163,6 +163,7 @@ object ScriptProgram {
   case object Stack extends UpdateIndicator
   case object Script extends UpdateIndicator
   case object AltStack extends UpdateIndicator
+  case object OriginalScript extends UpdateIndicator
 
 
   /**
@@ -247,6 +248,18 @@ object ScriptProgram {
         case program : ExecutedScriptProgram =>
           throw new RuntimeException("Cannot update the alt stack for a program that has been fully executed")
       }
+
+      case OriginalScript => oldProgram match {
+        case program : PreExecutionScriptProgram =>
+          PreExecutionScriptProgramImpl(program.txSignatureComponent, program.stack,program.script,tokens.toList,
+            program.altStack,program.flags)
+        case program : ExecutionInProgressScriptProgram =>
+          ExecutionInProgressScriptProgramImpl(program.txSignatureComponent, program.stack, program.script, tokens.toList,
+            program.altStack, program.flags)
+        case program : ExecutedScriptProgram =>
+          throw new RuntimeException("Cannot update the alt stack for a program that has been fully executed")
+      }
+
     }
   }
 

--- a/src/main/scala/org/bitcoins/script/arithmetic/ArithmeticInterpreter.scala
+++ b/src/main/scala/org/bitcoins/script/arithmetic/ArithmeticInterpreter.scala
@@ -281,7 +281,7 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
         !BitcoinScriptUtil.isShortestEncoding(b) || !BitcoinScriptUtil.isShortestEncoding(a))) {
 
         logger.error("The constant you gave us is not encoded in the shortest way possible")
-        ScriptProgram(program, ScriptErrorMinimalData)
+        ScriptProgram(program, ScriptErrorUnknownError)
       } else if (isLargerThan4Bytes(c) || isLargerThan4Bytes(b) || isLargerThan4Bytes(a)) {
         //pretty sure that an error is thrown inside of CScriptNum which in turn is caught by interpreter.cpp here
         //https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L999-L1002
@@ -369,7 +369,7 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
         case (x : ScriptNumber, y : ScriptNumber) =>
           if (ScriptFlagUtil.requireMinimalData(program.flags) && (!BitcoinScriptUtil.isShortestEncoding(x) || !BitcoinScriptUtil.isShortestEncoding(y))) {
             logger.error("The constant you gave us is not encoded in the shortest way possible")
-            ScriptProgram(program, ScriptErrorMinimalData)
+            ScriptProgram(program, ScriptErrorUnknownError)
           } else if (isLargerThan4Bytes(x) || isLargerThan4Bytes(y)) {
             //pretty sure that an error is thrown inside of CScriptNum which in turn is caught by interpreter.cpp here
             //https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L999-L1002
@@ -420,7 +420,7 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
       if (ScriptFlagUtil.requireMinimalData(program.flags) &&
         (!BitcoinScriptUtil.isShortestEncoding(x) || !BitcoinScriptUtil.isShortestEncoding(y))) {
         logger.error("The constant you gave us is not encoded in the shortest way possible")
-        ScriptProgram(program, ScriptErrorMinimalData)
+        ScriptProgram(program, ScriptErrorUnknownError)
       } else if (isLargerThan4Bytes(x) || isLargerThan4Bytes(y)) {
         //pretty sure that an error is thrown inside of CScriptNum which in turn is caught by interpreter.cpp here
         //https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L999-L1002

--- a/src/main/scala/org/bitcoins/script/arithmetic/ArithmeticInterpreter.scala
+++ b/src/main/scala/org/bitcoins/script/arithmetic/ArithmeticInterpreter.scala
@@ -17,7 +17,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * a is added to b
- *
    * @param program
    * @return
    */
@@ -28,7 +27,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Increments the stack top by 1
- *
    * @param program
    * @return
    */
@@ -39,7 +37,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Decrements the stack top by 1
- *
    * @param program
    * @return
    */
@@ -51,7 +48,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * b is subtracted from a.
- *
    * @param program
    * @return
    */
@@ -62,7 +58,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Takes the absolute value of the stack top
- *
    * @param program
    * @return
    */
@@ -76,7 +71,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Negates the stack top
- *
    * @param program
    * @return
    */
@@ -87,7 +81,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * If the input is 0 or 1, it is flipped. Otherwise the output will be 0.
- *
    * @param program
    * @return
    */
@@ -99,7 +92,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Returns 0 if the input is 0. 1 otherwise.
- *
    * @param program
    * @return
    */
@@ -111,7 +103,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * 	If both a and b are not 0, the output is 1. Otherwise 0.
- *
    * @param program
    * @return
    */
@@ -127,7 +118,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * If a or b is not 0, the output is 1. Otherwise 0.
- *
    * @param program
    * @return
    */
@@ -140,7 +130,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Returns 1 if the numbers are equal, 0 otherwise.
- *
    * @param program
    * @return
    */
@@ -152,7 +141,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Same as OP_NUMEQUAL, but runs OP_VERIFY afterward.
- *
    * @param program
    * @return
    */
@@ -178,8 +166,7 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
 
   /**
-   * 	Returns 1 if the numbers are not equal, 0 otherwise.
- *
+   * Returns 1 if the numbers are not equal, 0 otherwise.
    * @param program
    * @return
    */
@@ -193,8 +180,7 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
 
   /**
-   * 	Returns 1 if a is less than b, 0 otherwise.
- *
+   * Returns 1 if a is less than b, 0 otherwise.
    * @param program
    * @return
    */
@@ -206,8 +192,7 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
 
   /**
-   * 	Returns 1 if a is greater than b, 0 otherwise.
- *
+   * Returns 1 if a is greater than b, 0 otherwise.
    * @param program
    * @return
    */
@@ -219,7 +204,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Returns 1 if a is less than or equal to b, 0 otherwise.
- *
    * @param program
    * @return
    */
@@ -231,7 +215,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    *	Returns 1 if a is greater than or equal to b, 0 otherwise.
- *
    * @param program
    * @return
    */
@@ -244,7 +227,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Returns the smaller of a and b.
- *
    * @param program
    * @return
    */
@@ -264,7 +246,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Returns the larger of a and b.
- *
    * @param program
    * @return
    */
@@ -282,7 +263,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Returns 1 if x is within the specified range (left-inclusive), 0 otherwise.
- *
    * @param program
    * @return
    */
@@ -324,7 +304,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
    * This function checks if a number is <= 4 bytes in size
    * We cannot perform arithmetic operations on bitcoin numbers that are larger than 4 bytes.
    * https://github.com/bitcoin/bitcoin/blob/a6a860796a44a2805a58391a009ba22752f64e32/src/script/script.h#L214-L239
- *
    * @param scriptNumber the script number to be checked
    * @return false if the number is larger than 4 bytes
    */
@@ -333,7 +312,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Performs the given arithmetic operation on the stack head
- *
    * @param program the program whose stack top is used as an argument for the arithmetic operation
    * @param op the arithmetic ooperation that needs to be executed on the number, for instance incrementing by 1
    * @return the program with the result from performing the arithmetic operation pushed onto the top of the stack
@@ -366,7 +344,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
           val newProgram = ScriptProgram(program, interpretedNumber ::  program.stack.tail, ScriptProgram.Stack)
           performUnaryArithmeticOperation(newProgram, op)
         }
-
       case Some(s : ScriptToken) =>
         //pretty sure that an error is thrown inside of CScriptNum which in turn is caught by interpreter.cpp here
         //https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L999-L1002
@@ -403,38 +380,20 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
             ScriptProgram(program,newStackTop :: program.stack.tail.tail,program.script.tail)
           }
         case (x : ScriptConstant, y : ScriptNumber) =>
-          if (ScriptFlagUtil.requireMinimalData(program.flags) && !BitcoinScriptUtil.isShortestEncoding(x)) {
-            logger.error("The number you gave us is not encoded in the shortest way possible")
-            ScriptProgram(program, ScriptErrorMinimalData)
-          } else {
-            //interpret x as a number
-            val interpretedNumber = ScriptNumber(BitcoinSUtil.hexToLong(x.hex))
-            val newProgram = ScriptProgram(program, interpretedNumber :: program.stack.tail, ScriptProgram.Stack)
-            performBinaryArithmeticOperation(newProgram, op)
-          }
+          //interpret x as a number
+          val interpretedNumber = ScriptNumber(x.hex)
+          val newProgram = ScriptProgram(program, interpretedNumber :: program.stack.tail, ScriptProgram.Stack)
+          performBinaryArithmeticOperation(newProgram, op)
         case (x : ScriptNumber, y : ScriptConstant) =>
-          if (ScriptFlagUtil.requireMinimalData(program.flags) && !BitcoinScriptUtil.isShortestEncoding(y)) {
-            logger.error("The number you gave us is not encoded in the shortest way possible")
-            ScriptProgram(program, ScriptErrorMinimalData)
-          } else {
-          //interpret y as a number
-            val interpretedNumber = ScriptNumber(BitcoinSUtil.hexToLong(y.hex))
-            val newProgram = ScriptProgram(program, x :: interpretedNumber ::  program.stack.tail, ScriptProgram.Stack)
-            performBinaryArithmeticOperation(newProgram, op)
-          }
+          val interpretedNumber = ScriptNumber(y.hex)
+          val newProgram = ScriptProgram(program, x :: interpretedNumber ::  program.stack.tail, ScriptProgram.Stack)
+          performBinaryArithmeticOperation(newProgram, op)
         case (x : ScriptConstant, y : ScriptConstant) =>
-
-          if (ScriptFlagUtil.requireMinimalData(program.flags) && (!BitcoinScriptUtil.isShortestEncoding(x) || !BitcoinScriptUtil.isShortestEncoding(y))) {
-            logger.error("The constant you gave us is not encoded in the shortest way possible")
-            ScriptProgram(program, ScriptErrorMinimalData)
-          } else {
-            //interpret x and y as a number
-            val interpretedNumberX = ScriptNumber(BitcoinSUtil.hexToLong(x.hex))
-            val interpretedNumberY = ScriptNumber(BitcoinSUtil.hexToLong(y.hex))
-            val newProgram = ScriptProgram(program, interpretedNumberX :: interpretedNumberY ::  program.stack.tail.tail, ScriptProgram.Stack)
-            performBinaryArithmeticOperation(newProgram, op)
-          }
-
+          //interpret x and y as a number
+          val interpretedNumberX = ScriptNumber(x.hex)
+          val interpretedNumberY = ScriptNumber(y.hex)
+          val newProgram = ScriptProgram(program, interpretedNumberX :: interpretedNumberY ::  program.stack.tail.tail, ScriptProgram.Stack)
+          performBinaryArithmeticOperation(newProgram, op)
         case (x : ScriptToken, y : ScriptToken) =>
           //pretty sure that an error is thrown inside of CScriptNum which in turn is caught by interpreter.cpp here
           //https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L999-L1002
@@ -442,8 +401,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
           ScriptProgram(program,ScriptErrorUnknownError)
       }
     }
-
-
   }
 
   /**
@@ -480,7 +437,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
   /**
    * Takes the top two stack items, parses them to numbers then executes the op function on them and places the result
    * onto the stack top
- *
    * @param program the script program whose two top stack items are used as arguments for op
    * @param op the operation that needs to be executed on the two stack top items
    * @return the program with the result of op pushed onto the top of the stack
@@ -493,7 +449,6 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
 
   /**
    * Takes the top two stack elements and parses them as script numbers
- *
    * @param program the program whose top two stack elements are being parsed as script numbers
    * @return the tuple with the first element being the first stack element, the second element in the tuple being the second stack element
    */

--- a/src/main/scala/org/bitcoins/script/control/ControlOperationsInterpreter.scala
+++ b/src/main/scala/org/bitcoins/script/control/ControlOperationsInterpreter.scala
@@ -142,7 +142,6 @@ trait ControlOperationsInterpreter extends BitcoinSLogger {
 
   /**
    * Marks transaction as invalid if top stack value is not true.
- *
    * @param program
    * @return
    */

--- a/src/main/scala/org/bitcoins/script/crypto/CryptoInterpreter.scala
+++ b/src/main/scala/org/bitcoins/script/crypto/CryptoInterpreter.scala
@@ -170,7 +170,7 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
         ScriptProgram(program,ScriptErrorPubKeyCount)
       } else if (ScriptFlagUtil.requireMinimalData(program.flags) && !nPossibleSignatures.isShortestEncoding) {
         logger.error("The required signatures and the possible signatures must be encoded as the shortest number possible")
-        ScriptProgram(program, ScriptErrorMinimalData)
+        ScriptProgram(program, ScriptErrorUnknownError)
       } else if (program.stack.size < 2) {
         logger.error("We need at least 2 operations on the stack")
         ScriptProgram(program,ScriptErrorInvalidStackOperation)
@@ -179,7 +179,7 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
 
         if (ScriptFlagUtil.requireMinimalData(program.flags) && !mRequiredSignatures.isShortestEncoding) {
           logger.error("The required signatures val must be the shortest encoding as possible")
-          return ScriptProgram(program,ScriptErrorMinimalData)
+          return ScriptProgram(program,ScriptErrorUnknownError)
         }
 
         if (mRequiredSignatures < ScriptNumber.zero) {

--- a/src/main/scala/org/bitcoins/script/crypto/CryptoInterpreter.scala
+++ b/src/main/scala/org/bitcoins/script/crypto/CryptoInterpreter.scala
@@ -31,7 +31,6 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
 
   /**
    * The input is hashed using RIPEMD-160.
- *
    * @param program
    * @return
    */
@@ -42,7 +41,6 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
 
   /**
    * The input is hashed using SHA-256.
- *
    * @param program
    * @return
    */
@@ -53,7 +51,6 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
 
   /**
    * The input is hashed two times with SHA-256.
- *
    * @param program
    * @return
    */
@@ -64,7 +61,6 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
 
   /**
    * The input is hashed using SHA-1.
- *
    * @param program
    * @return
    */
@@ -79,7 +75,6 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
    * The signature used by OP_CHECKSIG must be a valid signature for this hash and public key.
    * If it is, 1 is returned, 0 otherwise.
    * https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L818
- *
    * @param program
    * @return
    */
@@ -128,18 +123,13 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
   /**
    * All of the signature checking words will only match signatures to the data
    * after the most recently-executed OP_CODESEPARATOR.
- *
    * @param program
    * @return
    */
   def opCodeSeparator(program : ScriptProgram) : ScriptProgram = {
     require(program.script.headOption.isDefined && program.script.head == OP_CODESEPARATOR, "Script top must be OP_CODESEPARATOR")
-    val fullScript = program.txSignatureComponent.scriptSignature.asm.containsSlice(program.script) match {
-      case true => program.txSignatureComponent.scriptSignature.asm
-      case false => program.txSignatureComponent.scriptPubKey.asm
-    }
-    val indexOfOpCodeSeparator = fullScript.indexOf(OP_CODESEPARATOR)
-    require(indexOfOpCodeSeparator != -1,"The script we searched MUST contain an OP_CODESEPARTOR. Script: " + fullScript)
+    val indexOfOpCodeSeparator = program.originalScript.indexOf(OP_CODESEPARATOR)
+    require(indexOfOpCodeSeparator != -1,"The script we searched MUST contain an OP_CODESEPARTOR. Script: " + program.originalScript)
     val e = program match {
       case e : PreExecutionScriptProgram => ScriptProgram.toExecutionInProgress(e)
       case e : ExecutionInProgressScriptProgram => ScriptProgram(e,program.script.tail,ScriptProgram.Script,indexOfOpCodeSeparator)
@@ -160,7 +150,6 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
    * signatures must be placed in the scriptSig using the same order as their corresponding public keys
    * were placed in the scriptPubKey or redeemScript. If all signatures are valid, 1 is returned, 0 otherwise.
    * Due to a bug, one extra unused value is removed from the stack.
- *
    * @param program
    * @return
    */
@@ -263,7 +252,6 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
 
   /**
    * Runs OP_CHECKMULTISIG with an OP_VERIFY afterwards
- *
    * @param program
    * @return
    */
@@ -290,7 +278,6 @@ trait CryptoInterpreter extends ControlOperationsInterpreter with BitcoinSLogger
    * This is a higher order function designed to execute a hash function on the stack top of the program
    * For instance, we could pass in CryptoUtil.sha256 function as the 'hashFunction' argument, which would then
    * apply sha256 to the stack top
- *
    * @param program the script program whose stack top needs to be hashed
    * @param hashFunction the hash function which needs to be used on the stack top (sha256,ripemd160,etc..)
    * @return

--- a/src/main/scala/org/bitcoins/script/splice/SpliceInterpreter.scala
+++ b/src/main/scala/org/bitcoins/script/splice/SpliceInterpreter.scala
@@ -14,7 +14,6 @@ trait SpliceInterpreter extends BitcoinSLogger {
 
   /**
    * Pushes the string length of the top element of the stack (without popping it).
- *
    * @param program
    * @return
    */

--- a/src/main/scala/org/bitcoins/script/stack/StackInterpreter.scala
+++ b/src/main/scala/org/bitcoins/script/stack/StackInterpreter.scala
@@ -381,7 +381,7 @@ trait StackInterpreter extends BitcoinSLogger {
       case Success(n) => op(n)
       case Failure(_) =>
         logger.error("Script number was not minimally encoded")
-        ScriptProgram(program,ScriptErrorMinimalData)
+        ScriptProgram(program,ScriptErrorUnknownError)
     }
   }
 

--- a/src/main/scala/org/bitcoins/script/stack/StackInterpreter.scala
+++ b/src/main/scala/org/bitcoins/script/stack/StackInterpreter.scala
@@ -56,7 +56,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Puts the number of stack items onto the stack.
- *
    * @param program
    * @return
    */
@@ -71,7 +70,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Puts the input onto the top of the alt stack. Removes it from the main stack.
- *
    * @param program
    * @return
    */
@@ -88,7 +86,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Puts the input onto the top of the main stack. Removes it from the alt stack.
- *
    * @param program
    * @return
    */
@@ -105,7 +102,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Removes the top stack item.
- *
    * @param program
    * @return
    */
@@ -123,7 +119,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Removes the second-to-top stack item
- *
    * @param program
    * @return
    */
@@ -143,7 +138,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Copies the second-to-top stack item to the top.
- *
    * @param program
    * @return
    */
@@ -161,7 +155,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * The item n back in the stack is copied to the top.
- *
    * @param program
    * @return
    */
@@ -183,7 +176,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * The item n back in the stack is moved to the top
- *
    * @param program
    * @return
    */
@@ -207,7 +199,6 @@ trait StackInterpreter extends BitcoinSLogger {
   /**
    * The top three items on the stack are rotated to the left.
    * x1 x2 x3 -> x2 x3 x1
- *
    * @param program
    * @return
    */
@@ -228,7 +219,6 @@ trait StackInterpreter extends BitcoinSLogger {
   /**
    * The fifth and sixth items back are moved to the top of the stack.
    * x1 x2 x3 x4 x5 x6 -> x3 x4 x5 x6 x1 x2
- *
    * @param program
    * @return
    */
@@ -247,7 +237,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Removes the top two stack items.
- *
    * @param program
    * @return
    */
@@ -266,7 +255,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * The top two items on the stack are swapped.
- *
    * @param program
    * @return
    */
@@ -287,7 +275,6 @@ trait StackInterpreter extends BitcoinSLogger {
   /**
    * The item at the top of the stack is copied and inserted before the second-to-top item.
    * x1 x2 -> x1 x2 x1
- *
    * @param program
    * @return
    */
@@ -308,7 +295,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Duplicates the top two stack items.
- *
    * @param program
    * @return
    */
@@ -328,7 +314,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Duplicates the top three stack items.
- *
    * @param program
    * @return
    */
@@ -349,7 +334,6 @@ trait StackInterpreter extends BitcoinSLogger {
   /**
    * Copies the pair of items two spaces back in the stack to the front.
    * x1 x2 x3 x4 -> x1 x2 x3 x4 x1 x2
- *
    * @param program
    * @return
    */
@@ -369,7 +353,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Swaps the top two pairs of items.
- *
    * @param program
    * @return
    */
@@ -388,7 +371,6 @@ trait StackInterpreter extends BitcoinSLogger {
 
   /**
    * Executes an operation with the stack top inside of the program as the argument
- *
    * @param program the program whose stack top is used as an argument for the operation
    * @param op the operation that is executed with the script number on the top of the stack
    * @return the program with the result of the op pushed onto to the top of the stack

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,11 +16,11 @@
 
 
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT" />
     </root>
 
-    <logger name="org.bitcoins" level="INFO"/>
+    <logger name="org.bitcoins" level="DEBUG"/>
 
 
 </configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,11 +16,11 @@
 
 
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 
-    <logger name="org.bitcoins" level="DEBUG"/>
+    <logger name="org.bitcoins" level="INFO"/>
 
 
 </configuration>

--- a/src/test/scala/org/bitcoins/policy/PolicyTest.scala
+++ b/src/test/scala/org/bitcoins/policy/PolicyTest.scala
@@ -1,0 +1,18 @@
+package org.bitcoins.policy
+
+import org.bitcoins.script.flag._
+import org.scalatest.{FlatSpec, MustMatchers}
+
+/**
+  * Created by chris on 5/2/16.
+  */
+class PolicyTest extends FlatSpec with MustMatchers {
+
+  "Policy" must "determine what the mandatory script verify flags are" in {
+    Policy.mandatoryScriptVerifyFlags must be (Seq(ScriptVerifyP2SH))
+  }
+
+  it must "determine what the non mandatory script verify flags are" in {
+    Policy.standardNotMandatoryScriptVerifyFlags must be (Seq(ScriptVerifyDerSig, ScriptVerifyStrictEnc, ScriptVerifyMinimalData, ScriptVerifyNullDummy, ScriptVerifyDiscourageUpgradableNOPs, ScriptVerifyCleanStack, ScriptVerifyCheckLocktimeVerify, ScriptVerifyCheckSequenceVerify, ScriptVerifyLowS))
+  }
+}

--- a/src/test/scala/org/bitcoins/script/arithmetic/ArithmeticInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/script/arithmetic/ArithmeticInterpreterTest.scala
@@ -3,7 +3,7 @@ package org.bitcoins.script.arithmetic
 
 import org.bitcoins.script.result._
 import org.bitcoins.script.flag.ScriptFlag
-import org.bitcoins.script.{ScriptProgram}
+import org.bitcoins.script.{ExecutedScriptProgram, ExecutionInProgressScriptProgram, ScriptProgram}
 import org.bitcoins.script.constant._
 import org.bitcoins.util.{ScriptProgramTestUtil, TestUtil}
 import org.scalatest.{FlatSpec, MustMatchers}
@@ -260,6 +260,34 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers with Arithmet
     newProgram.script.isEmpty must be (true)
   }
 
+  it must "evaluate an OP_NUMEQUALVERIFY for two zeros" in {
+    val stack = List(ScriptNumber.zero, ScriptNumber.zero)
+    val script = List(OP_NUMEQUALVERIFY)
+    val program = ScriptProgram(TestUtil.testProgramExecutionInProgress, stack,script)
+    val newProgram = opNumEqualVerify(program)
+    newProgram.isInstanceOf[ExecutionInProgressScriptProgram] must be (true)
+    newProgram.stack.isEmpty must be (true)
+  }
+
+  it must "evaluate an OP_NUMEQUALVERIFY for two different numbers" in {
+    val stack = List(ScriptNumber.zero, ScriptNumber.one)
+    val script = List(OP_NUMEQUALVERIFY)
+    val program = ScriptProgram(TestUtil.testProgramExecutionInProgress, stack,script)
+    val newProgram = opNumEqualVerify(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorVerify))
+  }
+
+  it must "mark the script as invalid for OP_NUMEQAULVERIFY without two stack elements" in {
+    val stack = List(ScriptNumber.zero)
+    val script = List(OP_NUMEQUALVERIFY)
+    val program = ScriptProgram(TestUtil.testProgramExecutionInProgress, stack,script)
+    val newProgram = opNumEqualVerify(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorInvalidStackOperation))
+  }
+
+
   it must "evaluate an OP_NUMNOTEQUAL for two numbers that are the same" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.zero)
     val script = List(OP_NUMNOTEQUAL)
@@ -309,6 +337,33 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers with Arithmet
     newProgram2.script.isEmpty must be (true)
   }
 
+  it must "evaluate an OP_LESSTHANOREQUAL correctly" in {
+    val stack = List(ScriptNumber.zero, ScriptNumber.one)
+    val script = List(OP_LESSTHANOREQUAL)
+    val program = ScriptProgram(TestUtil.testProgram, stack,script)
+    val newProgram = opLessThanOrEqual(program)
+
+    newProgram.stack.head must be (OP_FALSE)
+    newProgram.script.isEmpty must be (true)
+
+    val stack1 = List(ScriptNumber.zero, ScriptNumber.zero)
+    val script1 = List(OP_LESSTHANOREQUAL)
+    ScriptProgram(TestUtil.testProgram, stack,script)
+    val program1 = ScriptProgram(TestUtil.testProgram,stack1,script1)
+    val newProgram1 = opLessThanOrEqual(program1)
+
+    newProgram1.stack.head must be (OP_TRUE)
+    newProgram1.script.isEmpty must be (true)
+
+    val stack2 = List(ScriptNumber.one, ScriptNumber.zero)
+    val script2 = List(OP_LESSTHANOREQUAL)
+    val program2 = ScriptProgram(TestUtil.testProgram, stack2,script2)
+    val newProgram2 = opLessThanOrEqual(program2)
+
+    newProgram2.stack.head must be (OP_TRUE)
+    newProgram2.script.isEmpty must be (true)
+  }
+
   it must "evaluate an OP_GREATERTHAN correctly" in  {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_GREATERTHAN)
@@ -335,6 +390,32 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers with Arithmet
     newProgram2.script.isEmpty must be (true)
   }
 
+  it must "evaluate an OP_GREATERTHANOREQUAL correctly" in  {
+    val stack = List(ScriptNumber.zero, ScriptNumber.one)
+    val script = List(OP_GREATERTHANOREQUAL)
+    val program = ScriptProgram(TestUtil.testProgram, stack,script)
+    val newProgram = opGreaterThanOrEqual(program)
+
+    newProgram.stack.head must be (OP_TRUE)
+    newProgram.script.isEmpty must be (true)
+
+    val stack1 = List(ScriptNumber.zero, ScriptNumber.zero)
+    val script1 = List(OP_GREATERTHANOREQUAL)
+    val program1 = ScriptProgram(TestUtil.testProgram,stack1,script1)
+    val newProgram1 = opGreaterThanOrEqual(program1)
+
+    newProgram1.stack.head must be (OP_TRUE)
+    newProgram1.script.isEmpty must be (true)
+
+    val stack2 = List(ScriptNumber.one, ScriptNumber.zero)
+    val script2 = List(OP_GREATERTHANOREQUAL)
+    val program2 = ScriptProgram(TestUtil.testProgram, stack2,script2)
+    val newProgram2 = opGreaterThanOrEqual(program2)
+
+    newProgram2.stack.head must be (OP_FALSE)
+    newProgram2.script.isEmpty must be (true)
+  }
+
 
   it must "evaluate an OP_MIN correctly" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
@@ -345,6 +426,16 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers with Arithmet
     newProgram.stack must be (List(ScriptNumber.zero))
   }
 
+  it must "mark a script invalid for OP_MIN if there isn't two elements on the stack" in {
+    val stack = List(ScriptNumber.zero)
+    val script = List(OP_MIN)
+    val program = ScriptProgram(TestUtil.testProgramExecutionInProgress, stack,script)
+    val newProgram = opMin(program)
+
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorInvalidStackOperation))
+  }
+
   it must "evaluate an OP_MAX correctly" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_MAX)
@@ -352,6 +443,16 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers with Arithmet
     val newProgram = opMax(program)
 
     newProgram.stack must be (List(ScriptNumber.one))
+  }
+
+  it must "mark a script invalid for OP_MAX if there isn't two elements on the stack" in {
+    val stack = List(ScriptNumber.zero)
+    val script = List(OP_MAX)
+    val program = ScriptProgram(TestUtil.testProgramExecutionInProgress, stack,script)
+    val newProgram = opMax(program)
+
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorInvalidStackOperation))
   }
 
   it must "evaluate an OP_WITHIN correctly" in {
@@ -369,6 +470,33 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers with Arithmet
     val newProgram1 = opWithin(program1)
     newProgram1.stack must be (List(OP_TRUE))
     newProgram1.script.isEmpty must be (true)
+  }
+
+  it must "mark the script as invalid if one of the numbers within OP_WITHIN is not encoded the smallest way possible" in {
+    val stack = List(ScriptNumber("00"), ScriptNumber.one, ScriptNumber.one)
+    val script = List(OP_WITHIN)
+    val program = ScriptProgram(TestUtil.testProgramExecutionInProgress, stack,script)
+    val newProgram = opWithin(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorMinimalData))
+  }
+
+  it must "mark the script as invalid for OP_WITHIN if one of the numbers is larger than 4 bytes" in {
+    val stack = List(ScriptNumber("0000000000000000"), ScriptNumber.one, ScriptNumber.one)
+    val script = List(OP_WITHIN)
+    val program = ScriptProgram(ScriptProgram(TestUtil.testProgramExecutionInProgress, stack,script), Seq[ScriptFlag]())
+    val newProgram = opWithin(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorUnknownError))
+  }
+
+  it must "mark the script as invalid for OP_WITHIN if we do not have 3 stack elements" in {
+    val stack = List(ScriptNumber("0000000000000000"), ScriptNumber.one)
+    val script = List(OP_WITHIN)
+    val program = ScriptProgram(ScriptProgram(TestUtil.testProgramExecutionInProgress, stack,script), Seq[ScriptFlag]())
+    val newProgram = opWithin(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorInvalidStackOperation))
   }
 
 

--- a/src/test/scala/org/bitcoins/script/arithmetic/ArithmeticInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/script/arithmetic/ArithmeticInterpreterTest.scala
@@ -478,7 +478,7 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers with Arithmet
     val program = ScriptProgram(TestUtil.testProgramExecutionInProgress, stack,script)
     val newProgram = opWithin(program)
     newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
-    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorMinimalData))
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorUnknownError))
   }
 
   it must "mark the script as invalid for OP_WITHIN if one of the numbers is larger than 4 bytes" in {

--- a/src/test/scala/org/bitcoins/script/bitwise/BitwiseInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/script/bitwise/BitwiseInterpreterTest.scala
@@ -3,8 +3,9 @@ package org.bitcoins.script.bitwise
 import org.bitcoins.script.{ExecutedScriptProgram, ScriptProgram}
 import org.bitcoins.script.arithmetic.OP_NUMEQUAL
 import org.bitcoins.script.constant._
+import org.bitcoins.script.result.ScriptErrorInvalidStackOperation
 import org.bitcoins.util.TestUtil
-import org.scalatest.{MustMatchers, FlatSpec}
+import org.scalatest.{FlatSpec, MustMatchers}
 
 /**
  * Created by chris on 1/6/16.
@@ -78,5 +79,15 @@ class BitwiseInterpreterTest extends FlatSpec with MustMatchers with BitwiseInte
     val script = List(OP_EQUAL)
     val program = ScriptProgram(TestUtil.testProgram, stack,script)
     opEqual(program).stack.head must be (OP_TRUE)
+  }
+
+
+  it must "mark the script as invalid of OP_EQUALVERIFY is run without two stack elements" in {
+    val stack = List(OP_0)
+    val script = List(OP_EQUALVERIFY)
+    val program = ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
+    val newProgram = opEqualVerify(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorInvalidStackOperation))
   }
 }

--- a/src/test/scala/org/bitcoins/script/control/ControlOperationsInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/script/control/ControlOperationsInterpreterTest.scala
@@ -106,7 +106,7 @@ class ControlOperationsInterpreterTest extends FlatSpec with MustMatchers with C
   it must "remove the first OP_ELSE in a binary tree" in {
     val script1 = List(OP_IF,OP_ELSE,OP_ENDIF)
     val bTree1 = parseBinaryTree(script1)
-    removeFirstOpElse(bTree1).toSeq must be (List(OP_IF))
+    removeFirstOpElse(bTree1).toSeq must be (List(OP_IF,OP_ENDIF))
 
     val script2 = List(OP_IF,OP_ENDIF)
     val bTree2 = parseBinaryTree(script2)
@@ -334,6 +334,15 @@ class ControlOperationsInterpreterTest extends FlatSpec with MustMatchers with C
 
     newProgram.stack must be (List())
     newProgram.script must be (List(OP_1))
+  }
+
+  it must "evalute an OP_IF block with and leave the remaining operations outside of the OP_IF" in {
+    val stack = List(OP_TRUE)
+    val script = List(OP_IF, OP_ELSE, OP_ENDIF, OP_ELSE)
+    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val newProgram = opIf(program)
+    newProgram.stack.isEmpty must be (true)
+    newProgram.script must be (List(OP_ENDIF,OP_ELSE))
   }
 
   it must "evaluate a weird case using multiple OP_ELSEs" in {

--- a/src/test/scala/org/bitcoins/script/crypto/CryptoInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/script/crypto/CryptoInterpreterTest.scala
@@ -1,14 +1,14 @@
 package org.bitcoins.script.crypto
 
-import org.bitcoins.protocol.script.{ScriptSignature, ScriptPubKey}
+import org.bitcoins.protocol.script.{ScriptPubKey, ScriptSignature}
 import org.bitcoins.protocol.transaction._
 import org.bitcoins.script.result._
-import org.bitcoins.script.{ExecutionInProgressScriptProgram, PreExecutionScriptProgram, ExecutedScriptProgram, ScriptProgram}
+import org.bitcoins.script._
 import org.bitcoins.script.arithmetic.OP_NOT
 import org.bitcoins.script.flag.{ScriptFlagFactory, ScriptVerifyDerSig, ScriptVerifyNullDummy}
 import org.bitcoins.script.constant._
-import org.bitcoins.util.{ScriptProgramTestUtil, TransactionTestUtil, BitcoinSLogger, TestUtil}
-import org.scalatest.{MustMatchers, FlatSpec}
+import org.bitcoins.util.{BitcoinSLogger, ScriptProgramTestUtil, TestUtil, TransactionTestUtil}
+import org.scalatest.{FlatSpec, MustMatchers}
 
 /**
  * Created by chris on 1/6/16.
@@ -209,4 +209,17 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers with CryptoInterp
 
   }
 
+  it must "evaluate an OP_CODESEPARATOR" in {
+    val stack = List()
+    val script = Seq(OP_CODESEPARATOR)
+    val program = ScriptProgram(ScriptProgram(TestUtil.testProgramExecutionInProgress,stack,script),script,ScriptProgram.OriginalScript)
+    println(program)
+    println(program.script)
+    println(program.originalScript)
+    val newProgram = ScriptProgramTestUtil.toExecutionInProgressScriptProgram(opCodeSeparator(program))
+    newProgram.lastCodeSeparator must be (0)
+
+
+
+  }
 }

--- a/src/test/scala/org/bitcoins/script/interpreter/ScriptInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/script/interpreter/ScriptInterpreterTest.scala
@@ -36,7 +36,7 @@ class ScriptInterpreterTest extends FlatSpec with MustMatchers with ScriptInterp
 /*    val lines =
         """
           |
-          |[["'a'", "SHA256 0x20 0xca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb EQUAL", "P2SH,STRICTENC", "OK"]]
+          |[["1", "IF ELSE ENDIF ELSE", "P2SH,STRICTENC", "UNBALANCED_CONDITIONAL"]]
    """.stripMargin*/
     val lines = try source.getLines.filterNot(_.isEmpty).map(_.trim) mkString "\n" finally source.close()
     val json = lines.parseJson

--- a/src/test/scala/org/bitcoins/script/interpreter/ScriptInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/script/interpreter/ScriptInterpreterTest.scala
@@ -36,17 +36,14 @@ class ScriptInterpreterTest extends FlatSpec with MustMatchers with ScriptInterp
 /*    val lines =
         """
           |
-          |[["1",
-"0x616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161",
-"P2SH,STRICTENC",
-"201 opcodes executed. 0x61 is NOP"]]
+          |[["'a'", "SHA256 0x20 0xca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb EQUAL", "P2SH,STRICTENC", "OK"]]
    """.stripMargin*/
     val lines = try source.getLines.filterNot(_.isEmpty).map(_.trim) mkString "\n" finally source.close()
     val json = lines.parseJson
     val testCasesOpt : Seq[Option[CoreTestCase]] = json.convertTo[Seq[Option[CoreTestCase]]]
     val testCases : Seq[CoreTestCase] = testCasesOpt.flatten
 
-
+    println(testCases)
     for {
       testCase <- testCases
       (creditingTx,outputIndex) = TransactionTestUtil.buildCreditingTransaction(testCase.scriptPubKey.scriptPubKey)

--- a/src/test/scala/org/bitcoins/script/interpreter/testprotocol/CoreTestCaseProtocol.scala
+++ b/src/test/scala/org/bitcoins/script/interpreter/testprotocol/CoreTestCaseProtocol.scala
@@ -29,6 +29,18 @@ object CoreTestCaseProtocol extends DefaultJsonProtocol with BitcoinSLogger {
         //means that the line is probably a separator between different types of test cases i.e.
         //["Equivalency of different numeric encodings"]
         None
+      } else if (elements.size == 4) {
+        val scriptPubKeyAsm : Seq[ScriptToken] = parseScriptPubKeyAsm(elements(1))
+        val scriptPubKey = ScriptPubKey.fromAsm(scriptPubKeyAsm)
+        val scriptPubKeyCoreTestCase = ScriptPubKeyCoreTestCaseImpl(scriptPubKeyAsm, scriptPubKey)
+        val scriptSignatureAsm : Seq[ScriptToken] = parseScriptSignatureAsm(elements.head)
+        val scriptSignature : ScriptSignature = ScriptSignature(scriptSignatureAsm,scriptPubKey)
+        val scriptSignatureCoreTestCase = ScriptSignatureCoreTestCaseImpl(scriptSignatureAsm,scriptSignature)
+        val flags = elements(2).convertTo[String]
+        logger.info("Result: " + elements(3).convertTo[String])
+        val expectedResult = ScriptResult(elements(3).convertTo[String])
+        Some(CoreTestCaseImpl(scriptSignatureCoreTestCase,scriptPubKeyCoreTestCase,flags,
+          expectedResult,"", elements.toString))
       } else if (elements.size == 5) {
         val scriptPubKeyAsm : Seq[ScriptToken] = parseScriptPubKeyAsm(elements(1))
         val scriptPubKey = ScriptPubKey.fromAsm(scriptPubKeyAsm)

--- a/src/test/scala/org/bitcoins/script/splice/SpliceInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/script/splice/SpliceInterpreterTest.scala
@@ -1,10 +1,11 @@
 package org.bitcoins.script.splice
 
-import org.bitcoins.script.{ScriptProgram}
+import org.bitcoins.script.{ExecutedScriptProgram, ScriptProgram}
 import org.bitcoins.script.bitwise.OP_EQUAL
 import org.bitcoins.script.constant._
+import org.bitcoins.script.result.ScriptErrorInvalidStackOperation
 import org.bitcoins.util.TestUtil
-import org.scalatest.{MustMatchers, FlatSpec}
+import org.scalatest.{FlatSpec, MustMatchers}
 
 /**
  * Created by chris on 2/4/16.
@@ -57,5 +58,14 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers with SpliceInterp
     val newProgram = opSize(program)
     newProgram.stack must be (List(ScriptNumber.one,ScriptNumber(-1)))
     newProgram.script.isEmpty must be (true)
+  }
+
+  it must "mark the script as invalid if OP_SIZE has nothing on the stack" in {
+    val stack = List()
+    val script = List(OP_SIZE)
+    val program = ScriptProgram(TestUtil.testProgramExecutionInProgress, stack,script)
+    val newProgram = opSize(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorInvalidStackOperation))
   }
 }

--- a/src/test/scala/org/bitcoins/script/stack/StackInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/script/stack/StackInterpreterTest.scala
@@ -214,7 +214,7 @@ class StackInterpreterTest extends FlatSpec with MustMatchers with StackInterpre
     val newProgram = opRoll(program)
 
     newProgram.isInstanceOf[ExecutedScriptProgram] must be (true)
-    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorMinimalData))
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be (Some(ScriptErrorUnknownError))
   }
 
   it must "evaluate an OP_ROT correctly" in {


### PR DESCRIPTION
There was a bug in how we parsed script_tests.json. The test cases without comments were not being run by our test program. This is now fixed and lead me to another error in removing empty OP_ELSE branches in our tree structure used to represent control structures in Script. This is fixed as well. 
