### PR TITLE
Renaming TransactionElement to NetworkElement

### DIFF
--- a/src/main/scala/org/bitcoins/core/protocol/NetworkElement.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/NetworkElement.scala
@@ -1,13 +1,14 @@
-package org.bitcoins.core.protocol.transaction
+package org.bitcoins.core.protocol
 
 import org.bitcoins.core.util.BitcoinSUtil
 
+
 /**
- * Created by chris on 1/14/16.
- * Represents an element of a transction.
- * Examples would be inputs, outputs, scriptSigs, scriptPubKeys etc.
- */
-trait TransactionElement {
+  * Created by chris on 1/14/16.
+  * This represents a element that can be serialized to
+  * be sent over the network
+  */
+trait NetworkElement {
 
   /**
    * The size of the TransactionElement in bytes.

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -3,7 +3,6 @@ package org.bitcoins.core.protocol.script
 import org.bitcoins.core.crypto.{ECFactory, ECPublicKey}
 import org.bitcoins.core.serializers.script.{RawScriptPubKeyParser, ScriptParser}
 import org.bitcoins.core.protocol._
-import org.bitcoins.core.protocol.transaction.TransactionElement
 import org.bitcoins.core.script.bitwise.{OP_EQUAL, OP_EQUALVERIFY}
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.crypto.{OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY, OP_CHECKSIG, OP_HASH160}
@@ -13,7 +12,7 @@ import org.bitcoins.core.util.{BitcoinSLogger, BitcoinScriptUtil, Factory}
 /**
  * Created by chris on 12/26/15.
  */
-sealed trait ScriptPubKey extends TransactionElement with BitcoinSLogger {
+sealed trait ScriptPubKey extends NetworkElement with BitcoinSLogger {
 
   /**
    * Representation of a scriptSignature in a parsed assembly format

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.{ECDigitalSignature, ECFactory, ECPublicKey, EmptyDigitalSignature}
-import org.bitcoins.core.protocol.transaction.TransactionElement
+import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.serializers.script.{RawScriptPubKeyParser, RawScriptSignatureParser, ScriptParser}
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.crypto.{HashType, HashTypeFactory, OP_CHECKMULTISIG, SIGHASH_ALL}
@@ -14,7 +14,7 @@ import scala.util.{Failure, Success, Try}
   * Created by chris on 12/26/15.
   *
   */
-sealed trait ScriptSignature extends TransactionElement with BitcoinSLogger {
+sealed trait ScriptSignature extends NetworkElement with BitcoinSLogger {
 
   /**
    * Representation of a scriptSignature in a parsed assembly format

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -1,14 +1,15 @@
 package org.bitcoins.core.protocol.transaction
 
+import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.serializers.transaction.RawTransactionParser
-import org.bitcoins.core.util.{Factory, BitcoinSUtil, CryptoUtil}
+import org.bitcoins.core.util.{BitcoinSUtil, CryptoUtil, Factory}
 
 /**
  * Created by chris on 7/14/15.
  */
 
 
-sealed trait Transaction extends TransactionElement {
+sealed trait Transaction extends NetworkElement {
   /**
     * The sha256(sha256(tx)) of this transaction
  *

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionInput.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionInput.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol.transaction
 
 import org.bitcoins.core.serializers.transaction.RawTransactionInputParser
-import org.bitcoins.core.protocol.CompactSizeUInt
+import org.bitcoins.core.protocol.{CompactSizeUInt, NetworkElement}
 import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptSignature}
 import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.util.{BitcoinSUtil, Factory}
@@ -10,7 +10,7 @@ import org.bitcoins.core.util.{BitcoinSUtil, Factory}
  * Created by chris on 12/26/15.
   * Algebraic data type that represents a transaction input
  */
-sealed trait TransactionInput extends TransactionElement {
+sealed trait TransactionInput extends NetworkElement {
 
   def previousOutput : TransactionOutPoint
   def scriptSignature : ScriptSignature

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutPoint.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutPoint.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.transaction
 
+import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.serializers.transaction.RawTransactionOutPointParser
 import org.bitcoins.core.util.Factory
 
@@ -7,7 +8,7 @@ import org.bitcoins.core.util.Factory
  * Created by chris on 12/26/15.
  *
  */
-sealed trait TransactionOutPoint extends TransactionElement {
+sealed trait TransactionOutPoint extends NetworkElement {
   /**
     * The transaction id for the crediting transaction for this input
  *

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutput.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutput.scala
@@ -1,17 +1,16 @@
 package org.bitcoins.core.protocol.transaction
 
-import org.bitcoins.core.currency.{CurrencyUnits, CurrencyUnit, Satoshis}
+import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits, Satoshis}
 import org.bitcoins.core.serializers.transaction.RawTransactionOutputParser
-import org.bitcoins.core.protocol.CompactSizeUInt
-
-import org.bitcoins.core.protocol.script.{ScriptPubKey}
-import org.bitcoins.core.util.{Factory, BitcoinSUtil}
+import org.bitcoins.core.protocol.{CompactSizeUInt, NetworkElement}
+import org.bitcoins.core.protocol.script.ScriptPubKey
+import org.bitcoins.core.util.{BitcoinSUtil, Factory}
 
 
 /**
  * Created by chris on 12/26/15.
  */
-sealed trait TransactionOutput extends TransactionElement {
+sealed trait TransactionOutput extends NetworkElement {
 
   def value : CurrencyUnit
   def scriptPubKey : ScriptPubKey


### PR DESCRIPTION
This renames our previous trait 'TransactionElement' to 'NetworkElement'. A 'NetworkElement' is any object that be serialized to hex/binary
