### PR TITLE
Moving apply(bytes) & apply(hex) into the Factory trait

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,1 +1,1 @@
-import AssemblyKeys._
+import AssemblyKeys._test in assembly := {} 

--- a/src/main/scala/org/bitcoins/core/crypto/BaseECKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/BaseECKey.scala
@@ -62,8 +62,4 @@ object BaseECKey extends Factory[BaseECKey] {
     * @return
     */
   override def fromBytes(bytes : Seq[Byte]) : BaseECKey = ECPrivateKey(bytes)
-  
-  def apply(hex : String) : BaseECKey = fromHex(hex)
-
-  def apply(bytes : Seq[Byte]) : BaseECKey = fromBytes(bytes)
 }

--- a/src/main/scala/org/bitcoins/core/crypto/ECDigitalSignature.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECDigitalSignature.scala
@@ -64,12 +64,6 @@ object ECDigitalSignature extends Factory[ECDigitalSignature] {
     else ECDigitalSignatureImpl(bytes)
   }
 
-  override def fromHex(hex : String) : ECDigitalSignature = fromBytes(BitcoinSUtil.decodeHex(hex))
-
-  def apply(bytes : Seq[Byte]) : ECDigitalSignature = fromBytes(bytes)
-
-  def apply(hex : String) : ECDigitalSignature = fromHex(hex)
-
   def apply(r : BigInt, s : BigInt) = fromRS(r,s)
   /**
     * Takes in the r and s component of a digital signature and gives back a ECDigitalSignature object

--- a/src/main/scala/org/bitcoins/core/crypto/ECPrivateKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECPrivateKey.scala
@@ -55,12 +55,6 @@ object ECPrivateKey extends Factory[ECPrivateKey] {
 
   override def fromBytes(bytes : Seq[Byte]) : ECPrivateKey = ECPrivateKeyImpl(bytes)
 
-  override def fromHex(hex : String) : ECPrivateKey = fromBytes(BitcoinSUtil.decodeHex(hex))
-
-  def apply(bytes : Seq[Byte]) : ECPrivateKey = fromBytes(bytes)
-
-  def apply(hex : String) : ECPrivateKey = fromHex(hex)
-
   /**
     * This function creates a fresh private key to use
     * @return

--- a/src/main/scala/org/bitcoins/core/crypto/ECPublicKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECPublicKey.scala
@@ -85,12 +85,6 @@ object ECPublicKey extends Factory[ECPublicKey] {
 
   override def fromBytes(bytes : Seq[Byte]) : ECPublicKey = ECPublicKeyImpl(bytes)
 
-  override def fromHex(hex : String) : ECPublicKey = fromBytes(BitcoinSUtil.decodeHex(hex))
-
-  def apply(bytes : Seq[Byte]) : ECPublicKey = fromBytes(bytes)
-
-  def apply(hex : String) : ECPublicKey = fromHex(hex)
-
   /**
     * Generates a fresh public key that has not been used before
     * @return

--- a/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -149,6 +149,5 @@ object Address extends Factory[Address] {
 
   override def fromHex(hex : String) : Address = throw new RuntimeException("We cannot create a bitcoin address from hex - bitcoin addresses are base 58 encoded")
 
-  def apply(bytes : Seq[Byte]) : Address = fromBytes(bytes)
-  def apply(str : String) : Address = factory(str)
+  override def apply(str : String) : Address = factory(str)
 }

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -170,8 +170,4 @@ object ScriptPubKey extends Factory[ScriptPubKey] {
 
   def fromBytes(bytes : Seq[Byte]) : ScriptPubKey = RawScriptPubKeyParser.read(bytes)
 
-  def apply(bytes: Seq[Byte]) : ScriptPubKey = fromBytes(bytes)
-
-  def apply(hex : String) : ScriptPubKey = fromHex(hex)
-
 }

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -347,9 +347,8 @@ object ScriptSignature extends Factory[ScriptSignature] with BitcoinSLogger {
     }
   }
 
-  def apply(bytes: Seq[Byte]) : ScriptSignature = fromBytes(bytes)
-  def apply(hex : String) : ScriptSignature = fromHex(hex)
   def apply(signature : ECDigitalSignature, pubKey : ECPublicKey) : ScriptSignature = factory(signature,pubKey)
+
   def apply(tokens : Seq[ScriptToken], scriptPubKey : ScriptPubKey) : ScriptSignature = fromScriptPubKey(tokens, scriptPubKey)
 }
 

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -126,8 +126,6 @@ object Transaction extends Factory[Transaction] {
 
   def fromBytes(bytes : Seq[Byte]) : Transaction = RawTransactionParser.read(bytes)
 
-  def apply(bytes : Seq[Byte]) : Transaction = fromBytes(bytes)
-  def apply(hex: String) : Transaction = fromHex(hex)
   def apply(bytes : Array[Byte]) : Transaction = factory(bytes)
   def apply(oldTx : Transaction, lockTime : Long)  : Transaction = factory(oldTx,lockTime)
   def apply(oldTx : Transaction, updatedInputs : UpdateTransactionInputs) : Transaction = factory(oldTx, updatedInputs)

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionInput.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionInput.scala
@@ -112,5 +112,4 @@ object TransactionInput extends Factory[TransactionInput] {
 
   def apply(outPoint : TransactionOutPoint, scriptSignature : ScriptSignature, sequenceNumber : Long) : TransactionInput = factory(outPoint,scriptSignature,sequenceNumber)
 
-  def apply(bytes : Seq[Byte]) : TransactionInput = fromBytes(bytes)
 }

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutPoint.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutPoint.scala
@@ -58,9 +58,8 @@ object TransactionOutPoint extends Factory[TransactionOutPoint] {
 
   def fromBytes(bytes : Seq[Byte]) : TransactionOutPoint = RawTransactionOutPointParser.read(bytes)
 
-  def apply(bytes : Seq[Byte]) : TransactionOutPoint = fromBytes(bytes)
-  def apply(hex : String) : TransactionOutPoint = fromHex(hex)
   def apply(output : TransactionOutput,parentTransaction : Transaction) : TransactionOutPoint = factory(output,parentTransaction)
+
   def apply(txId : DoubleSha256Digest, index: Int) : TransactionOutPoint = factory(txId,index)
 }
 

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutput.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutput.scala
@@ -43,7 +43,9 @@ object TransactionOutput extends Factory[TransactionOutput] {
   def fromBytes(bytes : Seq[Byte]) : TransactionOutput = RawTransactionOutputParser.read(bytes).head
 
   def apply(oldOutput : TransactionOutput, newCurrencyUnit: CurrencyUnit) : TransactionOutput = factory(oldOutput,newCurrencyUnit)
+
   def apply(oldOutput : TransactionOutput, newScriptPubKey : ScriptPubKey) : TransactionOutput = factory(oldOutput, newScriptPubKey)
+
   def apply(currencyUnit: CurrencyUnit, scriptPubKey: ScriptPubKey) : TransactionOutput = factory(currencyUnit, scriptPubKey)
-  def apply(bytes : Seq[Byte]) : TransactionOutput = fromBytes(bytes)
+
 }

--- a/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
+++ b/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
@@ -133,10 +133,6 @@ object ScriptNumber extends Factory[ScriptNumber] {
     if (num == 0) zero else apply(BitcoinSUtil.longToHex(num))
   }
 
-  def apply(hex : String) : ScriptNumber = fromHex(hex)
-
-  def apply(bytes : Seq[Byte]) : ScriptNumber = fromBytes(bytes)
-
   def apply(hex : String, requireMinimal : Boolean) : Try[ScriptNumber] = {
     if (requireMinimal && !BitcoinScriptUtil.isShortestEncoding(hex)) {
       Failure(new IllegalArgumentException("The given hex was not the shortest encoding for the script number: " + hex))
@@ -404,7 +400,4 @@ object ScriptConstant extends Factory[ScriptConstant] {
     */
   def fromBytes(bytes : Seq[Byte]) : ScriptConstant = ScriptConstantImpl(BitcoinSUtil.encodeHex(bytes))
 
-  def apply(hex : String) : ScriptConstant = fromHex(hex)
-
-  def apply(bytes : Seq[Byte]) : ScriptConstant = fromBytes(bytes)
 }

--- a/src/main/scala/org/bitcoins/core/util/Factory.scala
+++ b/src/main/scala/org/bitcoins/core/util/Factory.scala
@@ -20,4 +20,17 @@ trait Factory[T] {
    */
   def fromBytes(bytes : Seq[Byte]) : T
 
+  /**
+    * Creates a T out of a sequence of bytes
+    * @param bytes
+    * @return
+    */
+  def apply(bytes : Seq[Byte]) : T = fromBytes(bytes)
+
+  /**
+    * Creates a T from a hex string
+    * @param hex
+    * @return
+    */
+  def apply(hex : String) : T = fromHex(hex)
 }


### PR DESCRIPTION
This removes the redundant implementations of the two 'apply' functions found in all of our companion object factories to their common parent trait called 'Factory'. This was becoming boilerplate code added to every companion object factory - best to refactor it to its parent trait.
