### PR TITLE
Add functions to create address

### DIFF
--- a/src/main/scala/org/bitcoins/core/gen/NumberGenerator.scala
+++ b/src/main/scala/org/bitcoins/core/gen/NumberGenerator.scala
@@ -5,6 +5,7 @@ import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.util.NumberUtil
 import org.scalacheck.Gen
+import org.scalacheck.Arbitrary.arbitrary
 
 /**
   * Created by chris on 6/16/16.
@@ -73,6 +74,27 @@ trait NumberGenerator {
 
   def compactSizeUInts : Gen[CompactSizeUInt] = uInt64s.map(CompactSizeUInt(_))
 
+  /**
+    * Generates an arbitrary [[Byte]] in Scala
+    * @return
+    */
+  def byte: Gen[Byte] = arbitrary[Byte]
+
+  /**
+    * Generates a 100 byte sequence
+    * @return
+    */
+  def bytes: Gen[Seq[Byte]] = for {
+    num <- Gen.choose(0,100)
+    b <- bytes(num)
+  } yield b
+
+  /**
+    * Generates the number of bytes specified by num
+    * @param num
+    * @return
+    */
+  def bytes(num : Int): Gen[Seq[Byte]] = Gen.listOfN(num,byte)
 }
 
 object NumberGenerator extends NumberGenerator

--- a/src/main/scala/org/bitcoins/core/gen/ScriptGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/ScriptGenerators.scala
@@ -77,7 +77,7 @@ trait ScriptGenerators extends BitcoinSLogger {
 
   def emptyScriptPubKey = p2pkScriptPubKey.map(_ => EmptyScriptPubKey)
 
-  private def pickRandomNonP2SHScriptPubKey : Gen[ScriptPubKey] = {
+  def pickRandomNonP2SHScriptPubKey : Gen[ScriptPubKey] = {
     val randomNum = (scala.util.Random.nextInt() % 3).abs
     if (randomNum == 0) p2pkScriptPubKey
     else if (randomNum == 1) p2pkhScriptPubKey

--- a/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -1,8 +1,9 @@
 package org.bitcoins.core.protocol
-import org.bitcoins.core.config.{RegTest, TestNet3, MainNet}
-import org.bitcoins.core.util.{Factory, BitcoinSUtil}
-import org.bitcoins.core.config.{RegTest, TestNet3, MainNet}
-import org.bitcoins.core.util.{CryptoUtil, Base58, Factory}
+import org.bitcoins.core.config._
+import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
+import org.bitcoins.core.crypto.Sha256Hash160Digest
+import org.bitcoins.core.util.{Base58, CryptoUtil, Factory}
+
 import scala.util.{Failure, Success, Try}
 
 sealed abstract class Address(val value : String)
@@ -94,6 +95,19 @@ object BitcoinAddress {
    * @return
    */
   def p2pkh(address : BitcoinAddress) : Boolean = p2pkh(address.value)
+
+  /**
+    * Encodes a pubkey hash to a base 58 address on the corresponding network
+    * @param hash the result of Sha256(RipeMD160(pubkey))
+    * @param network the network on which this address is being generated for
+    * @return
+    */
+  def encodePubKeyHashToAddress(hash: Sha256Hash160Digest, network: NetworkParameters): Address = {
+    val versionByte: Byte = network.p2pkhNetworkByte
+    val bytes = Seq(versionByte) ++ hash.bytes
+    val checksum = CryptoUtil.doubleSHA256(bytes).bytes.take(4)
+    Address(Base58.encode(bytes ++ checksum))
+  }
 }
 
 object AssetAddress {

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -182,12 +182,13 @@ object P2SHScriptPubKey extends Factory[P2SHScriptPubKey] with BitcoinSLogger {
 
   def apply(scriptPubKey: ScriptPubKey) : P2SHScriptPubKey = {
     val hash = CryptoUtil.sha256Hash160(scriptPubKey.bytes)
-    logger.error("calculated hash: " + hash.hex)
     val pushOps = BitcoinScriptUtil.calculatePushOp(hash.bytes)
     val asm = Seq(OP_HASH160) ++ pushOps ++ Seq(ScriptConstant(hash.bytes), OP_EQUAL)
     val p2shScriptPubKey = ScriptPubKey.fromAsm(asm)
     matchP2SHScriptPubKey(p2shScriptPubKey)
   }
+
+
 
   private def matchP2SHScriptPubKey(scriptPubKey : ScriptPubKey): P2SHScriptPubKey = scriptPubKey match {
     case p2shScriptPubKey : P2SHScriptPubKey => p2shScriptPubKey

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.protocol.script
 
-import org.bitcoins.core.crypto.ECPublicKey
+import org.bitcoins.core.crypto.{ECPublicKey, Sha256Hash160Digest}
 import org.bitcoins.core.serializers.script.{RawScriptPubKeyParser, ScriptParser}
 import org.bitcoins.core.protocol._
 import org.bitcoins.core.script.ScriptSettings
@@ -166,7 +166,13 @@ object MultiSignatureScriptPubKey extends Factory[MultiSignatureScriptPubKey] wi
  * https://bitcoin.org/en/developer-guide#pay-to-script-hash-p2sh
  * Format: OP_HASH160 <Hash160(redeemScript)> OP_EQUAL
  */
-trait P2SHScriptPubKey extends ScriptPubKey
+trait P2SHScriptPubKey extends ScriptPubKey {
+  /**
+    * The hash of the script for which this scriptPubKey is being created from
+    * @return
+    */
+  def scriptHash : Sha256Hash160Digest = Sha256Hash160Digest(asm(asm.length - 2).bytes)
+}
 
 object P2SHScriptPubKey extends Factory[P2SHScriptPubKey] {
   override def fromBytes(bytes : Seq[Byte]): P2SHScriptPubKey = {

--- a/src/main/scala/org/bitcoins/core/serializers/BitcoinAddressProtocol.scala
+++ b/src/main/scala/org/bitcoins/core/serializers/BitcoinAddressProtocol.scala
@@ -5,12 +5,6 @@ import spray.json._
 /**
  * Created by chris on 12/19/15.
  */
-object BitcoinAddressProtocol extends DefaultJsonProtocol {
-
-  implicit val bitcoinAddressFormat = jsonFormat(BitcoinAddress.apply _, "value")
-
-}
-
 object AddressProtocol extends DefaultJsonProtocol {
 
   implicit object AddressFormat extends RootJsonFormat[Address] {
@@ -18,7 +12,7 @@ object AddressProtocol extends DefaultJsonProtocol {
       jsValue match {
         case JsString(string) => string match {
           case s if s(0) == 'a' => AssetAddress(s)
-          case s if s(0) == '1' || s(0) == '3' => BitcoinAddress(s)
+          case s if Seq('1','3','2','m','n').contains(s(0)) => BitcoinAddress(s)
           case _ => throw new RuntimeException("Addresses should always start with 'a' '1' or '3'")
         }
         case _ => throw new RuntimeException("Addresses should always be represented by a JsString")

--- a/src/main/scala/org/bitcoins/core/util/Base58.scala
+++ b/src/main/scala/org/bitcoins/core/util/Base58.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.util
 
-import org.bitcoins.core.config.{MainNet, TestNet3}
+import org.bitcoins.core.config.{MainNet, NetworkParameters, TestNet3}
 import org.bitcoins.core.crypto.{ECPrivateKey, Sha256Hash160Digest}
 import org.bitcoins.core.protocol.Address
 import org.bitcoins.core.protocol.blockchain._
@@ -69,34 +69,6 @@ trait Base58 extends BitcoinSLogger {
   }
 
   def encode(byte : Byte) : String = encode(Seq(byte))
-
-  /**
-    * Encodes a Base58 address from a hash
-    *
-    * @param hash The result of Sha256(RipeMD-160(public key))
-    * @param addressType "pubkey" or "script"
-    * @param isTestNet Boolean
-    * @return
-    */
-    //TODO: add logic to determine pubkey/script from first byte
-  def encodePubKeyHashToBase58Address(hash: Sha256Hash160Digest, addressType : String, isTestNet : Boolean) : Address = {
-    val versionByte : Byte = findVersionByte(addressType, isTestNet)
-    val bytes : Seq[Byte] = Seq(versionByte) ++ hash.bytes
-    val checksum = CryptoUtil.doubleSHA256(bytes).bytes.take(4)
-    Address(encode(bytes ++ checksum))
-  }
-
-  /**
-    * Determines the version byte of an address given the address type and network
- *
-    * @param addressType "pubkey" or "script"
-    * @param isTestnet Boolean
-    * @return
-    */
-  private def findVersionByte(addressType : String, isTestnet : Boolean) : Byte = isTestnet match {
-    case true => if (addressType == "pubkey") TestNet3.p2pkhNetworkByte else TestNet3.p2shNetworkByte
-    case false => if (addressType == "pubkey") MainNet.p2pkhNetworkByte else MainNet.p2shNetworkByte
-  }
 
   /**
     * Encodes a private key into Wallet Import Format (WIF)

--- a/src/test/scala/org/bitcoins/core/protocol/BitcoinAddressSpec.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/BitcoinAddressSpec.scala
@@ -1,0 +1,39 @@
+package org.bitcoins.core.protocol
+
+import org.bitcoins.core.config.TestNet3
+import org.bitcoins.core.gen.{CryptoGenerators, ScriptGenerators}
+import org.bitcoins.core.protocol.script.P2SHScriptPubKey
+import org.bitcoins.core.util.CryptoUtil
+import org.scalacheck.{Prop, Properties}
+
+/**
+  * Created by chris on 7/21/16.
+  */
+class BitcoinAddressSpec extends Properties("BitcoinAddressSpec") {
+
+  property("get the same p2sh address no matter what factory function we use") =
+    Prop.forAll(ScriptGenerators.pickRandomNonP2SHScriptPubKey) { scriptPubKey =>
+      //we should get the same address no matter which factory function we use
+      val p2shScriptPubKey = P2SHScriptPubKey(scriptPubKey)
+      P2SHAddress(scriptPubKey, TestNet3) == P2SHAddress(p2shScriptPubKey,TestNet3)
+
+    }
+
+  property("All p2sh addresses created from factory functions must be valid") =
+    Prop.forAll(ScriptGenerators.pickRandomNonP2SHScriptPubKey) { scriptPubKey =>
+      //we should get the same address no matter which factory function we use
+      val addr = P2SHAddress(scriptPubKey, TestNet3)
+      P2SHAddress.isP2SHAddress(addr)
+    }
+
+  property("get the same p2pkh address no matter what factory function we use") =
+    Prop.forAll(CryptoGenerators.publicKey) { pubKey =>
+      val hash = CryptoUtil.sha256Hash160(pubKey.bytes)
+      P2PKHAddress(pubKey,TestNet3) == P2PKHAddress(hash,TestNet3)
+    }
+  property("All p2pkh addresses created from factory functions must be valid") =
+    Prop.forAll(CryptoGenerators.publicKey) { pubKey =>
+      val addr = P2PKHAddress(pubKey,TestNet3)
+      P2PKHAddress.isP2PKHAddress(addr)
+    }
+}

--- a/src/test/scala/org/bitcoins/core/protocol/BitcoinAddressTest.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/BitcoinAddressTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.core.protocol
 
 import org.bitcoins.core.config.MainNet
 import org.bitcoins.core.crypto.Sha256Hash160Digest
+import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.util.Base58
 import org.scalatest.{FlatSpec, MustMatchers}
 
@@ -15,14 +16,14 @@ class BitcoinAddressTest extends FlatSpec with MustMatchers {
 
   "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy" must "be a valid p2sh address and not a valid p2pkh" in {
     val address = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"
-    BitcoinAddress.p2shAddress(address) must be (true)
-    BitcoinAddress.p2pkh(address) must be (false)
+    P2SHAddress.isP2SHAddress(address) must be (true)
+    P2PKHAddress.isP2PKHAddress(address) must be (false)
   }
 
   "17WN1kFw8D6w1eHzqvkh49xwjE3iPN925b" must "be a valid p2pkh" in {
     val address = "17WN1kFw8D6w1eHzqvkh49xwjE3iPN925b"
-    BitcoinAddress.p2pkh(address) must be (true)
-    BitcoinAddress.p2shAddress(address) must be (false)
+    P2PKHAddress.isP2PKHAddress(address) must be (true)
+    P2SHAddress.isP2SHAddress(address) must be (false)
   }
 
   "The empty string" must "not be a valid bitcoin address" in {
@@ -60,6 +61,14 @@ class BitcoinAddressTest extends FlatSpec with MustMatchers {
     //from https://stackoverflow.com/questions/19233053/hashing-from-a-public-key-to-a-bitcoin-address-in-php
     val hash = Sha256Hash160Digest("010966776006953d5567439e5e39f86a0d273bee")
     val address = Address("16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM")
-    BitcoinAddress.encodePubKeyHashToAddress(hash, MainNet) must be (address)
+    P2PKHAddress.encodePubKeyHashToAddress(hash, MainNet) must be (address)
+  }
+
+  it must "encode a scriptPubKey to an address" in {
+    //redeemScript from https://en.bitcoin.it/wiki/Pay_to_script_hash
+    val hex = "5141042f90074d7a5bf30c72cf3a8dfd1381bdbd30407010e878f3a11269d5f74a58788505cdca22ea6eab7cfb40dc0e07aba200424ab0d79122a653ad0c7ec9896bdf51ae"
+    val scriptPubKey = ScriptPubKey(hex)
+    val addr = P2SHAddress.encodeScriptPubKeyToAddress(scriptPubKey,MainNet)
+    addr must be (P2SHAddress("3P14159f73E4gFr7JterCCQh9QjiTjiZrG"))
   }
 }

--- a/src/test/scala/org/bitcoins/core/protocol/BitcoinAddressTest.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/BitcoinAddressTest.scala
@@ -1,5 +1,8 @@
 package org.bitcoins.core.protocol
 
+import org.bitcoins.core.config.MainNet
+import org.bitcoins.core.crypto.Sha256Hash160Digest
+import org.bitcoins.core.util.Base58
 import org.scalatest.{FlatSpec, MustMatchers}
 
 class BitcoinAddressTest extends FlatSpec with MustMatchers {
@@ -51,5 +54,12 @@ class BitcoinAddressTest extends FlatSpec with MustMatchers {
     intercept[IllegalArgumentException] {
       val assetAddress = AssetAddress("aJ98t1WpEZ73CNmQviecrnyiWrnqRhWNLyy")
     }
+  }
+
+  it must "encode a pubKeyHash to an address" in {
+    //from https://stackoverflow.com/questions/19233053/hashing-from-a-public-key-to-a-bitcoin-address-in-php
+    val hash = Sha256Hash160Digest("010966776006953d5567439e5e39f86a0d273bee")
+    val address = Address("16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM")
+    BitcoinAddress.encodePubKeyHashToAddress(hash, MainNet) must be (address)
   }
 }

--- a/src/test/scala/org/bitcoins/core/serializers/AddressProtocolTest.scala
+++ b/src/test/scala/org/bitcoins/core/serializers/AddressProtocolTest.scala
@@ -9,13 +9,6 @@ import spray.json.{JsObject, JsValue, JsString}
  */
 class AddressProtocolTest extends FlatSpec with MustMatchers with BitcoinSLogger {
 
-  "BitcoinAddressProtocol" must "read a bitcoin address from a json string" in {
-    val m : Map[String,JsValue] = Map("value" -> JsString(TestUtil.bitcoinAddress.value))
-    val obj = JsObject(m)
-    BitcoinAddressProtocol.bitcoinAddressFormat.read(obj) must be (TestUtil.bitcoinAddress)
-
-  }
-
   it must "read an asset address from a json string" in {
     logger.debug("asset address as jsstring: akJsoCcyh34FGPotxfEoSXGwFPCNAkyCgTA")
     logger.debug("testutil address: " + TestUtil.assetAddress)

--- a/src/test/scala/org/bitcoins/core/util/Base58Test.scala
+++ b/src/test/scala/org/bitcoins/core/util/Base58Test.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.util
 
+import org.bitcoins.core.config.MainNet
 import org.bitcoins.core.crypto.{ECPrivateKey, Sha256Hash160Digest}
 import org.bitcoins.core.protocol.Address
 import org.bitcoins.core.util.testprotocol._
@@ -145,16 +146,10 @@ class Base58Test extends FlatSpec with MustMatchers with BitcoinSLogger {
   }
 
   it must "decodeCheck a string with a length less than 4 and fail" in {
-      Base58.decodeCheck("asf").isFailure must be (true)
+    Base58.decodeCheck("asf").isFailure must be (true)
   }
   it must "decodeCheck a valid string and succeed" in {
     Base58.decodeCheck("3CMNFxN1oHBc4R1EpboAL5yzHGgE611Xou").isSuccess must be (true)
-  }
-
-  it must "encode a pubKeyHash to an address" in {
-    val hash = Sha256Hash160Digest("74f209f6ea907e2ea48f74fae05782ae8a665257")
-    val address = Address("3CMNFxN1oHBc4R1EpboAL5yzHGgE611Xou")
-    Base58.encodePubKeyHashToBase58Address(hash, "script", false) must be (address)
   }
 
   it must "encode a private key to WIF, then decode it from WIF to hex private key" in {


### PR DESCRIPTION
Refactoring address types to Algebraic Data Types. Making companion objects for `P2PKHAddress` and `P2SHAddress` and adding helper functions inside of each to make it easier to create their corresponding type. 
