### PR TITLE
Ec priv key compressed

### DIFF
--- a/src/main/scala/org/bitcoins/core/crypto/BaseECKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/BaseECKey.scala
@@ -19,13 +19,6 @@ trait BaseECKey extends BitcoinSLogger {
   def bytes : Seq[Byte]
 
   /**
-    * Use compressed keys by default
-    * @return
-    */
-  //TODO: implement isCompressed function similar to that in ECPrivateKey
-  def compressed : Boolean = true
-
-  /**
    * Signs a given sequence of bytes with the signingKey
    * @param dataToSign the bytes to be signed
    * @param signingKey the key to sign the bytes with

--- a/src/main/scala/org/bitcoins/core/crypto/ECPrivateKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECPrivateKey.scala
@@ -11,29 +11,19 @@ import org.spongycastle.crypto.generators.ECKeyPairGenerator
 import org.spongycastle.crypto.params.{ECKeyGenerationParameters, ECPrivateKeyParameters}
 import org.spongycastle.math.ec.{ECPoint, FixedPointCombMultiplier}
 
+import scala.annotation.tailrec
 import scala.util.{Failure, Success}
 
 /**
  * Created by chris on 2/16/16.
  */
 sealed trait ECPrivateKey extends BaseECKey {
+  /** Signifies if the this private key corresponds to a compressed public key */
+  def isCompressed : Boolean
 
-  private def ecPoint = CryptoParams.curve.getCurve.decodePoint(bytes.toArray)
-  /**
-    * This represents the private key inside of the bouncy castle library
-    *
-    * @return
-    */
-  private def privateKeyParams =
-    new ECPrivateKeyParameters(new BigInteger(1,bytes.toArray), CryptoParams.curve)
-
-  /**
-   * Derives the public for a the private key
-    *
-    * @return
-   */
+  /** Derives the public for a the private key */
   def publicKey : ECPublicKey = {
-    val pubKeyBytes : Seq[Byte] = publicKeyPoint.getEncoded(compressed)
+    val pubKeyBytes : Seq[Byte] = publicKeyPoint.getEncoded(isCompressed)
     ECPublicKey(pubKeyBytes)
   }
 
@@ -59,41 +49,57 @@ sealed trait ECPrivateKey extends BaseECKey {
     */
   def toWIF(network: NetworkParameters): String = {
     val networkByte = network.privateKey
-    val fullBytes = networkByte +: bytes
+    //append 1 byte to the end of the priv key byte representation if we need a compressed pub key
+    val fullBytes = if (isCompressed) networkByte +: (bytes ++ Seq(1.toByte)) else networkByte +: bytes
     val hash = CryptoUtil.doubleSHA256(fullBytes)
     val checksum = hash.bytes.take(4)
     val encodedPrivKey = fullBytes ++ checksum
     Base58.encode(encodedPrivKey)
   }
 
-  override def toString = "ECPrivateKey(" + hex + ")"
+  override def toString = "ECPrivateKey(" + hex + "," + isCompressed +")"
 }
 
 object ECPrivateKey extends Factory[ECPrivateKey] with BitcoinSLogger {
 
-  private case class ECPrivateKeyImpl(bytes : Seq[Byte]) extends ECPrivateKey
+  private case class ECPrivateKeyImpl(bytes : Seq[Byte], isCompressed: Boolean) extends ECPrivateKey {
+    require(bytes.size == 32, "Keys are required to be 32 bytes in size as per bitcoin core, got: " + bytes.size + " hex: " + BitcoinSUtil.encodeHex(bytes))
+  }
 
-  override def fromBytes(bytes : Seq[Byte]) : ECPrivateKey = {
-    if (bytes.size <= 32) ECPrivateKeyImpl(bytes)
+  override def fromBytes(bytes : Seq[Byte]) : ECPrivateKey = fromBytes(bytes,true)
+
+  @tailrec
+  def fromBytes(bytes: Seq[Byte], isCompressed: Boolean): ECPrivateKey = {
+    if (bytes.size == 32) ECPrivateKeyImpl(bytes,isCompressed)
+    else if (bytes.size < 32) {
+      //means we need to pad the private key with 0 bytes so we have 32 bytes    val paddingNeeded = 32 - bytes.size
+      val paddingNeeded = 32 - bytes.size
+      val padding = for { _ <- 0 until paddingNeeded} yield 0.toByte
+      ECPrivateKey.fromBytes(padding ++ bytes,isCompressed)
+    }
     //this is for the case when java serialies a BigInteger to 33 bytes to hold the signed num representation
-    else if (bytes.size == 33) ECPrivateKeyImpl(bytes.slice(1,33))
+    else if (bytes.size == 33) ECPrivateKey.fromBytes(bytes.slice(1,33),isCompressed)
     else throw new IllegalArgumentException("Private keys cannot be greater than 33 bytes in size, got: " +
       BitcoinSUtil.encodeHex(bytes) + " which is of size: " + bytes.size)
   }
 
+  def fromHex(hex: String, isCompressed: Boolean): ECPrivateKey = fromBytes(BitcoinSUtil.decodeHex(hex),isCompressed)
   /**
     * This function creates a fresh private key to use
     *
     * @return
     */
-  def apply() : ECPrivateKey = freshPrivateKey
+  def apply() : ECPrivateKey = ECPrivateKey(true)
 
+  def apply(isCompressed: Boolean) = freshPrivateKey(isCompressed)
   /**
     * This function creates a fresh private key to use
     *
     * @return
     */
-  def freshPrivateKey : ECPrivateKey = {
+  def freshPrivateKey : ECPrivateKey = freshPrivateKey(true)
+
+  def freshPrivateKey(isCompressed: Boolean): ECPrivateKey = {
     val secureRandom = new SecureRandom
     val generator : ECKeyPairGenerator = new ECKeyPairGenerator
     val keyGenParams : ECKeyGenerationParameters = new ECKeyGenerationParameters(CryptoParams.curve, secureRandom)
@@ -102,9 +108,8 @@ object ECPrivateKey extends Factory[ECPrivateKey] with BitcoinSLogger {
     val privParams: ECPrivateKeyParameters = keypair.getPrivate.asInstanceOf[ECPrivateKeyParameters]
     val priv : BigInteger = privParams.getD
     val bytes = priv.toByteArray
-    ECPrivateKey(bytes)
+    ECPrivateKey.fromBytes(bytes,isCompressed)
   }
-
   /**
     * Takes in a base58 string and converts it into a private key.
     * Private keys starting with 'K', 'L', or 'c' correspond to compressed public keys.
@@ -114,9 +119,10 @@ object ECPrivateKey extends Factory[ECPrivateKey] with BitcoinSLogger {
     * @return
     */
   def fromWIFToPrivateKey(WIF : String) : ECPrivateKey = {
+    val isCompressed = ECPrivateKey.isCompressed(WIF)
     val trimmedBytes = trimFunction(WIF)
-    val privateKeyBytesToHex = BitcoinSUtil.encodeHex(trimmedBytes)
-    ECPrivateKey(privateKeyBytesToHex)
+    val privateKeyBytes = trimmedBytes
+    ECPrivateKey.fromBytes(privateKeyBytes,isCompressed)
   }
 
   /**
@@ -150,7 +156,7 @@ object ECPrivateKey extends Factory[ECPrivateKey] with BitcoinSLogger {
     */
   private def trimFunction(WIF : String) : Seq[Byte] = {
     val bytesChecked = Base58.decodeCheck(WIF)
-    val uncompressedKeyPrefixes = Seq(Some('5'),Some('9'))
+
     //see https://en.bitcoin.it/wiki/List_of_address_prefixes
     //for where '5' and '9' come from
     bytesChecked match {
@@ -161,6 +167,11 @@ object ECPrivateKey extends Factory[ECPrivateKey] with BitcoinSLogger {
     }
   }
 
+  /** The Base58 prefixes that represent compressed private keys */
+  def compressedKeyPrefixes = Seq(Some('K'), Some('L'), Some('c'))
+
+  /** The Base58 prefixes that represent uncompressed private keys */
+  def uncompressedKeyPrefixes = Seq(Some('5'),Some('9'))
 }
 
 

--- a/src/main/scala/org/bitcoins/core/crypto/ECPrivateKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECPrivateKey.scala
@@ -72,7 +72,7 @@ object ECPrivateKey extends Factory[ECPrivateKey] with BitcoinSLogger {
   def fromBytes(bytes: Seq[Byte], isCompressed: Boolean): ECPrivateKey = {
     if (bytes.size == 32) ECPrivateKeyImpl(bytes,isCompressed)
     else if (bytes.size < 32) {
-      //means we need to pad the private key with 0 bytes so we have 32 bytes    val paddingNeeded = 32 - bytes.size
+      //means we need to pad the private key with 0 bytes so we have 32 bytes
       val paddingNeeded = 32 - bytes.size
       val padding = for { _ <- 0 until paddingNeeded} yield 0.toByte
       ECPrivateKey.fromBytes(padding ++ bytes,isCompressed)

--- a/src/test/scala/org/bitcoins/core/crypto/ECPrivateKeyTest.scala
+++ b/src/test/scala/org/bitcoins/core/crypto/ECPrivateKeyTest.scala
@@ -82,10 +82,7 @@ class ECPrivateKeyTest extends FlatSpec with MustMatchers with BitcoinSLogger {
   it must "serialize a private key to WIF when the private key is prefixed with 0 bytes" in {
     val hex = "00fc391adf4d6063a16a2e38b14d2be10133c4dacd4348b49d23ee0ce5ff4f1701"
     val privKey = ECPrivateKey(hex)
-    require(privKey.isCompressed == true)
     val wif = privKey.toWIF(TestNet3)
-    require(ECPrivateKey.isCompressed(wif) == true)
-    logger.debug("WIF:" + wif)
     val privKeyFromWIF = ECPrivateKey.fromWIFToPrivateKey(wif)
     privKeyFromWIF must be (privKey)
   }

--- a/src/test/scala/org/bitcoins/core/crypto/ECPrivateKeyTest.scala
+++ b/src/test/scala/org/bitcoins/core/crypto/ECPrivateKeyTest.scala
@@ -71,11 +71,8 @@ class ECPrivateKeyTest extends FlatSpec with MustMatchers with BitcoinSLogger {
   it must "serialize a private key to WIF and then be able to deserialize it" in {
     val hex = "2cecbfb72f8d5146d7fe7e5a3f80402c6dd688652c332dff2e44618d2d3372"
     val privKey = ECPrivateKey(hex)
-    require(privKey.isCompressed == true)
     val wif = privKey.toWIF(TestNet3)
     val privKeyFromWIF = ECPrivateKey.fromWIFToPrivateKey(wif)
-    require(privKeyFromWIF.isCompressed == true)
-
     privKeyFromWIF must be (privKey)
   }
 

--- a/src/test/scala/org/bitcoins/core/crypto/ECPrivateKeyTest.scala
+++ b/src/test/scala/org/bitcoins/core/crypto/ECPrivateKeyTest.scala
@@ -50,11 +50,6 @@ class ECPrivateKeyTest extends FlatSpec with MustMatchers with BitcoinSLogger {
     privateKey.hex must be (bitcoinJKey.getPrivateKeyAsHex)
   }
 
-  it must "create a private key from bytes" in {
-    val privKeyBytes = Seq(0.toByte)
-    ECPrivateKey(privKeyBytes).bytes must be (privKeyBytes)
-  }
-
   it must "create a private key from its hex representation" in {
     val privateKeyHex = "180cb41c7c600be951b5d3d0a7334acc7506173875834f7a6c4c786a28fcbb19"
     val key: ECPrivateKey = ECPrivateKey(privateKeyHex)
@@ -76,8 +71,10 @@ class ECPrivateKeyTest extends FlatSpec with MustMatchers with BitcoinSLogger {
   it must "serialize a private key to WIF and then be able to deserialize it" in {
     val hex = "2cecbfb72f8d5146d7fe7e5a3f80402c6dd688652c332dff2e44618d2d3372"
     val privKey = ECPrivateKey(hex)
+    require(privKey.isCompressed == true)
     val wif = privKey.toWIF(TestNet3)
     val privKeyFromWIF = ECPrivateKey.fromWIFToPrivateKey(wif)
+    require(privKeyFromWIF.isCompressed == true)
 
     privKeyFromWIF must be (privKey)
   }
@@ -85,10 +82,14 @@ class ECPrivateKeyTest extends FlatSpec with MustMatchers with BitcoinSLogger {
   it must "serialize a private key to WIF when the private key is prefixed with 0 bytes" in {
     val hex = "00fc391adf4d6063a16a2e38b14d2be10133c4dacd4348b49d23ee0ce5ff4f1701"
     val privKey = ECPrivateKey(hex)
+    require(privKey.isCompressed == true)
     val wif = privKey.toWIF(TestNet3)
+    require(ECPrivateKey.isCompressed(wif) == true)
+    logger.debug("WIF:" + wif)
     val privKeyFromWIF = ECPrivateKey.fromWIFToPrivateKey(wif)
     privKeyFromWIF must be (privKey)
   }
+
 
   it must "correctly decode a private key from WIF" in {
     val privateKey = ECPrivateKey.fromWIFToPrivateKey("cTPg4Zc5Jis2EZXy3NXShgbn487GWBTapbU63BerLDZM3w2hQSjC")
@@ -96,5 +97,10 @@ class ECPrivateKeyTest extends FlatSpec with MustMatchers with BitcoinSLogger {
     privateKey.hex must be ("ad59fb6aadf617fb0f93469741fcd9a9f48700f1d1f465ddc0f26fa7f7bfa1ac")
   }
 
+  it must "decode a WIF private key corresponding to uncompressed public key" in {
+    val wif = "5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C"
+    val privKey = ECPrivateKey.fromWIFToPrivateKey(wif)
+    privKey.publicKey.hex must be ("045b81f0017e2091e2edcd5eecf10d5bdd120a5514cb3ee65b8447ec18bfc4575c6d5bf415e54e03b1067934a0f0ba76b01c6b9ab227142ee1d543764b69d901e0")
+  }
 
 }


### PR DESCRIPTION
This adds support to actually specify if you want a `ECPrivateKey` to correspond to a compressed or uncompressed public key. This is important because a compressed private key will generate a different bitcoin address. 
