### PR TITLE
Segwit sighash tests

### DIFF
--- a/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -45,9 +45,9 @@ trait TransactionSignatureChecker extends BitcoinSLogger {
       logger.error("Signature did not have a low s value")
       ScriptValidationFailureHighSValue
     } else if (ScriptFlagUtil.requireStrictEncoding(flags) && signature.bytes.nonEmpty &&
-      !HashType.hashTypes.contains(HashType(signature.bytes.last))) {
-      logger.error("signature: " + signature.bytes)
-      logger.error("Hash type was not defined on the signature")
+      !HashType.isDefinedHashtypeSignature(signature)) {
+      logger.error("signature: " + signature.hex)
+      logger.error("Hash type was not defined on the signature, got: " + signature.bytes.last)
       ScriptValidationFailureHashType
     } else if (pubKeyEncodedCorrectly.isDefined) {
       val err = pubKeyEncodedCorrectly.get

--- a/src/main/scala/org/bitcoins/core/gen/ScriptGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/ScriptGenerators.scala
@@ -385,7 +385,7 @@ trait ScriptGenerators extends BitcoinSLogger {
       signedMultiSignatureScriptSignature)
   }
 
-  /** Generates a random [[ScriptSignature]], the [[ScriptPubKey]]/[[CurrencyUnit]] it is spending, and the [[ECPrivateKey]] needed to spend it. */
+  /** Generates a random [[ScriptSignature]], the [[ScriptPubKey]] it is spending, and the [[ECPrivateKey]] needed to spend it. */
   def randomScriptSig : Gen[(ScriptSignature, ScriptPubKey, Seq[ECPrivateKey])] = {
     val wit = signedP2SHP2WPKHScriptSignature.map(x => (x._1,x._2,x._3))
     Gen.oneOf(packageToSequenceOfPrivateKeys(signedP2PKHScriptSignature),

--- a/src/main/scala/org/bitcoins/core/gen/WitnessGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/WitnessGenerators.scala
@@ -48,12 +48,11 @@ trait WitnessGenerators extends BitcoinSLogger {
   def signedP2WPKHTransactionWitness: Gen[(TransactionWitness, WitnessV0TransactionSignatureComponent, Seq[ECPrivateKey])] = for {
     privKey <- CryptoGenerators.privateKey
     amount <- CurrencyUnitGenerator.satoshis
-    //TODO: Uncomment this so we can have random hash types inside of p2wpkh txs
-    //hashType <- CryptoGenerators.hashType
+    hashType <- CryptoGenerators.hashType
     witScriptPubKey = WitnessScriptPubKeyV0(privKey.publicKey)
     unsignedScriptWitness = ScriptWitness(Seq(privKey.publicKey.bytes, Nil))
     unsignedWTxSigComponent = createUnsignedWtxSigComponent(witScriptPubKey,amount,unsignedScriptWitness)
-    createdSig = TransactionSignatureCreator.createSig(unsignedWTxSigComponent,privKey,HashType.sigHashAll)
+    createdSig = TransactionSignatureCreator.createSig(unsignedWTxSigComponent,privKey, hashType)
     scriptWitness = ScriptWitness(Seq(privKey.publicKey.bytes, createdSig.bytes))
     (witness,signedWtxSigComponent) = createSignedWTxComponent(scriptWitness,unsignedWTxSigComponent)
   } yield (witness,signedWtxSigComponent,Seq(privKey))
@@ -62,10 +61,11 @@ trait WitnessGenerators extends BitcoinSLogger {
   def signedP2WSHP2PKTransactionWitness: Gen[(TransactionWitness, WitnessV0TransactionSignatureComponent, Seq[ECPrivateKey])] = for {
     (scriptPubKey, privKeys) <- ScriptGenerators.p2pkScriptPubKey
     amount <- CurrencyUnitGenerator.satoshis
+    hashType <- CryptoGenerators.hashType
     witScriptPubKey = WitnessScriptPubKeyV0(scriptPubKey)
     unsignedScriptWitness = ScriptWitness(Seq(scriptPubKey.asmBytes))
     unsignedWTxSigComponent = createUnsignedWtxSigComponent(witScriptPubKey,amount,unsignedScriptWitness)
-    createdSig = TransactionSignatureCreator.createSig(unsignedWTxSigComponent,privKeys,HashType.sigHashAll)
+    createdSig = TransactionSignatureCreator.createSig(unsignedWTxSigComponent,privKeys,hashType)
     signedScriptWitness = ScriptWitness(scriptPubKey.asmBytes +: Seq(createdSig.bytes))
     (witness,signedWtxSigComponent) = createSignedWTxComponent(signedScriptWitness,unsignedWTxSigComponent)
   } yield (witness,signedWtxSigComponent,Seq(privKeys))
@@ -74,10 +74,11 @@ trait WitnessGenerators extends BitcoinSLogger {
   def signedP2WSHP2PKHTransactionWitness: Gen[(TransactionWitness, WitnessV0TransactionSignatureComponent, Seq[ECPrivateKey])]  = for {
     (scriptPubKey, privKeys) <- ScriptGenerators.p2pkhScriptPubKey
     amount <- CurrencyUnitGenerator.satoshis
+    hashType <- CryptoGenerators.hashType
     witScriptPubKey = WitnessScriptPubKeyV0(scriptPubKey)
     unsignedScriptWitness = ScriptWitness(Seq(scriptPubKey.asmBytes))
     unsignedWTxSigComponent = createUnsignedWtxSigComponent(witScriptPubKey,amount,unsignedScriptWitness)
-    createdSig = TransactionSignatureCreator.createSig(unsignedWTxSigComponent,privKeys,HashType.sigHashAll)
+    createdSig = TransactionSignatureCreator.createSig(unsignedWTxSigComponent,privKeys,hashType)
     signedScriptWitness = ScriptWitness(scriptPubKey.asmBytes +: Seq(privKeys.publicKey.bytes, createdSig.bytes))
     (witness,signedWtxSigComponent) = createSignedWTxComponent(signedScriptWitness,unsignedWTxSigComponent)
   } yield (witness,signedWtxSigComponent,Seq(privKeys))
@@ -86,10 +87,11 @@ trait WitnessGenerators extends BitcoinSLogger {
   def signedP2WSHMultiSigTransactionWitness: Gen[(TransactionWitness, WitnessV0TransactionSignatureComponent, Seq[ECPrivateKey])] = for {
     (scriptPubKey, privKeys) <- ScriptGenerators.multiSigScriptPubKey
     amount <- CurrencyUnitGenerator.satoshis
+    hashType <- CryptoGenerators.hashType
     witScriptPubKey = WitnessScriptPubKeyV0(scriptPubKey)
     unsignedScriptWitness = ScriptWitness(Seq(scriptPubKey.asmBytes))
     unsignedWTxSigComponent = createUnsignedWtxSigComponent(witScriptPubKey,amount,unsignedScriptWitness)
-    signedScriptSig = multiSigScriptSigGenHelper(privKeys,scriptPubKey.requiredSigs.toInt,scriptPubKey,unsignedWTxSigComponent)
+    signedScriptSig = multiSigScriptSigGenHelper(privKeys, scriptPubKey.requiredSigs, scriptPubKey, unsignedWTxSigComponent, hashType)
     signedScriptSigPushOpsRemoved = BitcoinScriptUtil.filterPushOps(signedScriptSig.asm).tail.reverse
     signedScriptWitness = ScriptWitness(scriptPubKey.asm.flatMap(_.bytes) +: (signedScriptSigPushOpsRemoved.map(_.bytes) ++ Seq(Nil)))
     (witness,signedWtxSigComponent) = createSignedWTxComponent(signedScriptWitness,unsignedWTxSigComponent)
@@ -120,7 +122,8 @@ trait WitnessGenerators extends BitcoinSLogger {
     val flags = Policy.standardScriptVerifyFlags
     val (creditingTx,outputIndex) = TransactionGenerators.buildCreditingTransaction(witScriptPubKey,amount)
     val (unsignedSpendingTx,inputIndex) = TransactionGenerators.buildSpendingTransaction(creditingTx,EmptyScriptSignature,outputIndex,witness)
-    val unsignedWtxSigComponent = WitnessV0TransactionSignatureComponent(unsignedSpendingTx,inputIndex,witScriptPubKey,flags,amount, SigVersionWitnessV0)
+    val unsignedWtxSigComponent = WitnessV0TransactionSignatureComponent(unsignedSpendingTx,inputIndex,witScriptPubKey,
+      flags,amount,SigVersionWitnessV0)
     unsignedWtxSigComponent
   }
 
@@ -128,10 +131,11 @@ trait WitnessGenerators extends BitcoinSLogger {
   /** Helps generate a signed [[MultiSignatureScriptSignature]] */
   private def multiSigScriptSigGenHelper(privateKeys : Seq[ECPrivateKey], requiredSigs : Int,
                                          scriptPubKey : MultiSignatureScriptPubKey,
-                                         unsignedWtxSigComponent: WitnessV0TransactionSignatureComponent) : MultiSignatureScriptSignature = {
+                                         unsignedWtxSigComponent: WitnessV0TransactionSignatureComponent,
+                                         hashType: HashType) : MultiSignatureScriptSignature = {
     val txSignatures = for {
       i <- 0 until requiredSigs
-    } yield TransactionSignatureCreator.createSig(unsignedWtxSigComponent,privateKeys(i), HashType.sigHashAll)
+    } yield TransactionSignatureCreator.createSig(unsignedWtxSigComponent,privateKeys(i), hashType)
 
     //add the signature to the scriptSig instead of having an empty scriptSig
     val signedScriptSig = MultiSignatureScriptSignature(txSignatures)

--- a/src/main/scala/org/bitcoins/core/script/crypto/HashType.scala
+++ b/src/main/scala/org/bitcoins/core/script/crypto/HashType.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.script.crypto
 
+import org.bitcoins.core.crypto.ECDigitalSignature
 import org.bitcoins.core.number.Int32
 import org.bitcoins.core.util.Factory
 
@@ -68,6 +69,8 @@ object HashType extends Factory[HashType] {
   lazy val hashTypes = Seq(sigHashAll, sigHashNone, sigHashSingle, sigHashAnyoneCanPay,
     sigHashNoneAnyoneCanPay, sigHashAllAnyoneCanPay, sigHashSingleAnyoneCanPay)
 
+  lazy val hashTypeBytes: Seq[Byte] = Seq(sigHashAllByte, sigHashSingleByte, sigHashNoneByte, sigHashAnyoneCanPayByte,
+    sigHashNoneAnyoneCanPayByte, sigHashSingleAnyoneCanPayByte, sigHashAllAnyoneCanPayByte)
   def apply(num : Int32) : HashType = fromNumber(num)
 
   def apply(int : Int) : HashType = HashType(Int32(int))
@@ -105,7 +108,6 @@ object HashType extends Factory[HashType] {
 
   val sigHashSingle: SIGHASH_SINGLE = SIGHASH_SINGLE(Int32(sigHashSingleByte))
 
-
   val sigHashAllAnyoneCanPayByte = (HashType.sigHashAllByte | HashType.sigHashAnyoneCanPayByte).toByte
 
   val sigHashAllAnyoneCanPayNum = (Int32(sigHashAllByte) | sigHashAnyoneCanPayNum)
@@ -123,6 +125,15 @@ object HashType extends Factory[HashType] {
   val sigHashSingleAnyoneCanPayNum = (Int32(sigHashSingleByte) | sigHashAnyoneCanPayNum)
 
   val sigHashSingleAnyoneCanPay = SIGHASH_SINGLE_ANYONECANPAY(sigHashSingleAnyoneCanPayNum)
+
+  /**
+    * Checks if the given digital signature has a valid hash type
+    * Mimics this functionality inside of Bitcoin Core
+    * https://github.com/bitcoin/bitcoin/blob/b83264d9c7a8ddb79f64bd9540caddc8632ef31f/src/script/interpreter.cpp#L186
+    */
+  def isDefinedHashtypeSignature(sig: ECDigitalSignature): Boolean = {
+    sig.bytes.nonEmpty && hashTypeBytes.contains(sig.bytes.last)
+  }
 }
 
 /**

--- a/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorSpec.scala
+++ b/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorSpec.scala
@@ -13,6 +13,7 @@ import org.scalacheck.{Prop, Properties}
   * Created by chris on 7/25/16.
   */
 class TransactionSignatureCreatorSpec extends Properties("TransactionSignatureCreatorSpec") with BitcoinSLogger {
+
   property("Must generate a valid signature for a p2pk transaction") =
     Prop.forAll(TransactionGenerators.signedP2PKTransaction) {
       case (txSignatureComponent: TransactionSignatureComponent, _) =>

--- a/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionSpec.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionSpec.scala
@@ -10,6 +10,7 @@ import org.scalacheck.{Prop, Properties}
 class TransactionSpec extends Properties("TransactionSpec") with BitcoinSLogger {
 
   property("Serialization symmetry") =
+    
     Prop.forAll(TransactionGenerators.transactions) { tx =>
       val result = Transaction(tx.hex) == tx
       if (!result) logger.error("Incorrect tx hex: " + tx.hex)

--- a/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionSpec.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionSpec.scala
@@ -12,14 +12,14 @@ class TransactionSpec extends Properties("TransactionSpec") with BitcoinSLogger 
   property("Serialization symmetry") =
     Prop.forAll(TransactionGenerators.transactions) { tx =>
       val result = Transaction(tx.hex) == tx
-      if (!result) logger.error("Incorrect hex: " + tx.hex)
+      if (!result) logger.error("Incorrect tx hex: " + tx.hex)
       result
     }
 
   property("Serialization symmetry for witness transactions") =
     Prop.forAll(TransactionGenerators.witnessTransaction) { wtx: WitnessTransaction =>
       val result = WitnessTransaction(wtx.hex) == wtx
-      if (!result) logger.error("Incorrect hex: " + wtx.hex)
+      if (!result) logger.error("Incorrect wtx hex: " + wtx.hex)
       result
     }
 }


### PR DESCRIPTION
Bitcoin Core did not add any test vectors to [`sighash.json`](https://github.com/bitcoin/bitcoin/blob/master/src/test/data/sighash.json), therefore this pull request simply changes our generators from using a constant hash type (`SIGHASH_ALL`) to using a generated hash type ([`CryptoGenerators.hashType`](https://github.com/Christewart/bitcoin-s-core/blob/segwit_sighash_tests/src/main/scala/org/bitcoins/core/gen/CryptoGenerators.scala#L91))

