### PR TITLE
Refactor flag checks to sig checker

### DIFF
--- a/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerResult.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerResult.scala
@@ -64,3 +64,10 @@ case object ScriptValidationFailureHashType extends SignatureValidationError
 /** Fails the script if the given public key was not compressed and the [[org.bitcoins.core.script.flag.ScriptVerifyWitnessPubKeyType]]
   * flag was set  */
 case object ScriptValidationFailureWitnessPubKeyType extends SignatureValidationError
+
+/**
+  * Fails the script if a an invalid signature is not an empty byte vector
+  * See BIP146
+  * [[https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#nullfail]]
+  */
+case object SignatureValidationErrorNullFail extends SignatureValidationError

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -2,7 +2,6 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.{ECDigitalSignature, ECPublicKey}
 import org.bitcoins.core.protocol.NetworkElement
-import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.serializers.script.RawScriptWitnessParser
 import org.bitcoins.core.util.{BitcoinSUtil, Factory}
 
@@ -16,7 +15,7 @@ sealed trait ScriptWitness extends NetworkElement {
   /** The byte vectors that are placed on to the stack when evaluating a witness program */
   def stack : Seq[Seq[Byte]]
 
-  override def toString = stack.map(BitcoinSUtil.encodeHex(_)).toString
+  override def toString = "ScriptWitness(" + stack.map(BitcoinSUtil.encodeHex(_)).toString + ")"
 
   override def hex = RawScriptWitnessParser.write(this)
 }

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionInput.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionInput.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.core.protocol.transaction
 
 import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptSignature}
-import org.bitcoins.core.protocol.{CompactSizeUInt, NetworkElement}
 import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.serializers.transaction.RawTransactionInputParser
 import org.bitcoins.core.util.Factory

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionWitness.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionWitness.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.protocol.transaction
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.protocol.script.ScriptWitness
 import org.bitcoins.core.serializers.transaction.RawTransactionWitnessParser
-import org.bitcoins.core.util.{BitcoinSUtil, Factory}
+import org.bitcoins.core.util.BitcoinSUtil
 
 /**
   * Created by chris on 11/21/16.

--- a/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.core.script.interpreter
 
-import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.crypto.{BaseTransactionSignatureComponent, WitnessV0TransactionSignatureComponent}
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
@@ -10,7 +9,7 @@ import org.bitcoins.core.protocol.transaction.{BaseTransaction, EmptyTransaction
 import org.bitcoins.core.script._
 import org.bitcoins.core.script.arithmetic._
 import org.bitcoins.core.script.bitwise._
-import org.bitcoins.core.script.constant._
+import org.bitcoins.core.script.constant.{ScriptToken, _}
 import org.bitcoins.core.script.control._
 import org.bitcoins.core.script.crypto._
 import org.bitcoins.core.script.flag._

--- a/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -75,8 +75,8 @@ trait ScriptInterpreter extends CryptoInterpreter with StackInterpreter with Con
           case p2sh : P2SHScriptPubKey =>
             if (p2shEnabled) executeP2shScript(scriptSigExecutedProgram, program, p2sh)
             else scriptPubKeyExecutedProgram
-          case _ @ (_ : P2PKHScriptPubKey | _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey | _: CSVScriptPubKey |
-              _ : CLTVScriptPubKey | _ : NonStandardScriptPubKey | EmptyScriptPubKey) =>
+          case _ : P2PKHScriptPubKey | _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey | _: CSVScriptPubKey |
+              _ : CLTVScriptPubKey | _ : NonStandardScriptPubKey | _ : WitnessCommitment | EmptyScriptPubKey =>
             scriptPubKeyExecutedProgram
         }
       }
@@ -160,7 +160,7 @@ trait ScriptInterpreter extends CryptoInterpreter with StackInterpreter with Con
                 run(scriptPubKeyExecutedProgram,stack,w)
               }
             case s @ (_ : P2SHScriptPubKey | _ : P2PKHScriptPubKey | _ : P2PKScriptPubKey | _ : MultiSignatureScriptPubKey |
-              _ : CLTVScriptPubKey | _ : CSVScriptPubKey | _: NonStandardScriptPubKey | EmptyScriptPubKey) =>
+              _ : CLTVScriptPubKey | _ : CSVScriptPubKey | _: NonStandardScriptPubKey | _ : WitnessCommitment | EmptyScriptPubKey) =>
               logger.debug("redeemScript: " + s.asm)
               run(scriptPubKeyExecutedProgram,stack,s)
           }
@@ -516,7 +516,7 @@ trait ScriptInterpreter extends CryptoInterpreter with StackInterpreter with Con
               w.witness.stack.isEmpty
           }
           case _ : CLTVScriptPubKey | _ : CSVScriptPubKey | _ : MultiSignatureScriptPubKey | _ : NonStandardScriptPubKey |
-            _ : P2PKScriptPubKey | _ : P2PKHScriptPubKey | EmptyScriptPubKey =>
+            _ : P2PKScriptPubKey | _ : P2PKHScriptPubKey | _ : WitnessCommitment | EmptyScriptPubKey =>
             w.witness.stack.isEmpty
         }
         !witnessedUsed

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
 
 
-    <root level="ERROR">
+    <root level="WARN">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
 
 
-    <root level="WARN">
+    <root level="ERROR">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorSpec.scala
+++ b/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorSpec.scala
@@ -38,6 +38,7 @@ class TransactionSignatureCreatorSpec extends Properties("TransactionSignatureCr
         //run it through the interpreter
         val program = ScriptProgram(txSignatureComponent)
         val result = ScriptInterpreter.run(program)
+        logger.info("result: " + result)
         result == ScriptOk
   }
 

--- a/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -31,17 +31,7 @@ class ScriptInterpreterTest extends FlatSpec with MustMatchers with ScriptInterp
     //use this to represent a single test case from script_valid.json
 /*    val lines =
         """
-          | [ [
-          |  [
-          |   "",
-          |   0.00000000
-          |  ],
-          |  "0x47 0x304402200a5c6163f07b8d3b013c4d1d6dba25e780b39658d79ba37af7057a3b7f15ffa102201fd9b4eaa9943f734928b99a83592c2e7bf342ea2680f6a2bb705167966b742001",
-          |  "0x41 0x0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 CHECKSIG",
-          |  "P2SH,WITNESS",
-          |  "WITNESS_UNEXPECTED",
-          |  "P2PK with witness"
-          | ]]
+          | [ ["0 0x09 0x300602010102010101 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0", "0x01 0x14 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0x01 0x14 CHECKMULTISIG NOT", "DERSIG,NULLFAIL", "NULLFAIL", "BIP66-compliant but not NULLFAIL-compliant"]]
    """.stripMargin*/
     val lines = try source.getLines.filterNot(_.isEmpty).map(_.trim) mkString "\n" finally source.close()
     val json = lines.parseJson


### PR DESCRIPTION
The way we check digital signatures in Bitcoin depends on what [ScriptFlags](https://github.com/bitcoin-s/bitcoin-s-core/blob/464964d4a1838ff946c9a8417ee3dfd7afa5980b/src/main/scala/org/bitcoins/core/script/flag/ScriptFlags.scala#L11-L137) are set when executing a [ScriptProgram](https://github.com/bitcoin-s/bitcoin-s-core/blob/464964d4a1838ff946c9a8417ee3dfd7afa5980b/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala#L15-L83). This pull request aims to refactor some of the flag checking logic from [CryptoInterpreter](https://github.com/bitcoin-s/bitcoin-s-core/blob/464964d4a1838ff946c9a8417ee3dfd7afa5980b/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala#L80-L308) to [TransactionSignatureChecker](https://github.com/Christewart/bitcoin-s-core/blob/655e10a9d86769761f8799d8e74da045424530ef/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala#L37-L144) and remove redundant checks that were happening in both places