### PR TITLE
Refactoring dependencies to only include scalacheck & spongycastle in…

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,14 +8,21 @@ object BitcoinSCoreBuild extends Build {
   val organization = "org.bitcoins.core"
   val slf4jV = "1.7.5"
   val logbackV = "1.0.13"
+  val scalaTestV = "2.2.0"
+  val scalacheckV = "1.13.0"
+  val sprayV = "1.3.2"
+  val spongyCastleV = "1.51.0.0"
   val appDependencies = Seq(
-    "org.scalatest" % "scalatest_2.11" % "2.2.0",
-    ("org.bitcoinj" % "bitcoinj-core" % "0.13.3" % "test").exclude("org.slf4j", "slf4j-api"),
-    "com.madgag.spongycastle" % "core" % "1.51.0.0",
-    "org.slf4j" % "slf4j-api" % slf4jV /*% "provided"*/,
-    "io.spray" %% "spray-json" % "1.3.2" % "test",  
-    "ch.qos.logback" % "logback-classic" % logbackV,
-    "org.scalacheck" %% "scalacheck" % "1.13.0" withSources() withJavadoc()
+    "org.scalatest" % "scalatest_2.11" % scalaTestV % "test",
+    "org.scalacheck" %% "scalacheck" % scalacheckV withSources() withJavadoc(),
+
+    ("org.bitcoinj" % "bitcoinj-core" % "0.13.3" % "test"),
+    "com.madgag.spongycastle" % "core" % spongyCastleV,
+
+    "org.slf4j" % "slf4j-api" % slf4jV % "provided",
+    "ch.qos.logback" % "logback-classic" % logbackV % "test",
+
+    "io.spray" %% "spray-json" % sprayV  % "test"
   )
   
   val main = Project(appName, file(".")).enablePlugins().settings(

--- a/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -1,17 +1,10 @@
 package org.bitcoins.core.crypto
 
-import org.bitcoins.core.config.TestNet3
-import org.bitcoins.core.number.Int32
-import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction.{Transaction, TransactionInput}
-import org.bitcoins.core.script.ScriptProgram
-import org.bitcoins.core.script.constant.{ScriptConstant, ScriptToken}
+import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.script.crypto._
-import org.bitcoins.core.script.flag.{ScriptFlag, ScriptFlagUtil, ScriptVerifyDerSig}
+import org.bitcoins.core.script.flag.{ScriptFlag, ScriptFlagUtil}
 import org.bitcoins.core.script.result.ScriptErrorWitnessPubKeyType
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, BitcoinScriptUtil}
-import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
+++ b/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
@@ -9,8 +9,7 @@ import org.bitcoins.core.script.locktime.LocktimeOperation
 import org.bitcoins.core.script.reserved.ReservedOperation
 import org.bitcoins.core.script.splice.SpliceOperation
 import org.bitcoins.core.script.stack.StackOperation
-import org.bitcoins.core.util.{BitcoinSUtil, BitcoinSLogger}
-import org.slf4j.LoggerFactory
+import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
 
 /**
  * Created by chris on 1/8/16.

--- a/src/main/scala/org/bitcoins/core/script/control/ControlOperationsInterpreter.scala
+++ b/src/main/scala/org/bitcoins/core/script/control/ControlOperationsInterpreter.scala
@@ -1,12 +1,11 @@
 package org.bitcoins.core.script.control
 
 import org.bitcoins.core.protocol.script.SigVersionWitnessV0
-import org.bitcoins.core.script.result._
 import org.bitcoins.core.script.ScriptProgram
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.flag.ScriptFlagUtil
+import org.bitcoins.core.script.result._
 import org.bitcoins.core.util._
-import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParser.scala
+++ b/src/main/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParser.scala
@@ -1,11 +1,9 @@
 package org.bitcoins.core.serializers.script
 
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.serializers.RawBitcoinSerializer
 import org.bitcoins.core.protocol.script.{EmptyScriptPubKey, ScriptPubKey}
 import org.bitcoins.core.script.constant.ScriptToken
-import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
-import org.slf4j.LoggerFactory
+import org.bitcoins.core.serializers.RawBitcoinSerializer
 
 import scala.util.Try
 

--- a/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
+++ b/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
@@ -1,12 +1,10 @@
 package org.bitcoins.core.serializers.script
 
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.serializers.RawBitcoinSerializer
 import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.script.constant.{ScriptConstant, ScriptToken}
-import org.bitcoins.core.script.crypto.{OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY}
-import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
-import org.slf4j.LoggerFactory
+import org.bitcoins.core.script.constant.ScriptToken
+import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.util.BitcoinSLogger
 
 import scala.util.Try
 

--- a/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -3,12 +3,10 @@ package org.bitcoins.core.serializers.script
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.script._
 import org.bitcoins.core.script.constant._
-import org.bitcoins.core.script.crypto.{OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY}
-import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, Factory, NumberUtil}
-import org.slf4j.LoggerFactory
+import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, Factory}
 
 import scala.annotation.tailrec
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 /**
  * Created by chris on 1/7/16.

--- a/src/main/scala/org/bitcoins/core/serializers/transaction/RawBaseTransactionParser.scala
+++ b/src/main/scala/org/bitcoins/core/serializers/transaction/RawBaseTransactionParser.scala
@@ -1,10 +1,9 @@
 package org.bitcoins.core.serializers.transaction
 
 import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.transaction.BaseTransaction
 import org.bitcoins.core.serializers.RawBitcoinSerializer
-import org.bitcoins.core.protocol.transaction.{BaseTransaction, Transaction}
-import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, CryptoUtil}
-import org.slf4j.LoggerFactory
+import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
 
 /**
  * Created by chris on 1/14/16.

--- a/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParser.scala
+++ b/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParser.scala
@@ -2,12 +2,11 @@ package org.bitcoins.core.serializers.transaction
 
 import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
 import org.bitcoins.core.number.UInt64
-import org.bitcoins.core.serializers.{RawBitcoinSerializer, RawSatoshisSerializer}
-import org.bitcoins.core.serializers.script.{RawScriptPubKeyParser, ScriptParser}
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.protocol.transaction.{TransactionOutput, TransactionOutputImpl}
+import org.bitcoins.core.protocol.transaction.TransactionOutput
+import org.bitcoins.core.serializers.script.{RawScriptPubKeyParser, ScriptParser}
+import org.bitcoins.core.serializers.{RawBitcoinSerializer, RawSatoshisSerializer}
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
-import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 


### PR DESCRIPTION
…side a fat jar

Moving dependencies around

This pull request adjusts the scope of various dependencies. For instance, previously we had a scalatest dependency included in the fat jar, we now added the `"test"` scope so it is only used as a dependency when we run test cases. 