### PR TITLE
Specify sbt version to 0.13.13

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13


### PR DESCRIPTION
It's better to specify sbt version to avoid unnecessary troubles with each developers environment.