### PR TITLE
Changed - of ScriptNumber to unary_-

### DIFF
--- a/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
+++ b/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
@@ -50,7 +50,7 @@ trait ArithmeticInterpreter extends ControlOperationsInterpreter {
   /** Negates the stack top. */
   def opNegate(program : ScriptProgram) : ScriptProgram = {
     require(program.script.headOption.contains(OP_NEGATE), "Script top must be OP_NEGATE")
-    performUnaryArithmeticOperation(program, x => x -)
+    performUnaryArithmeticOperation(program, x => -x)
   }
 
   /** If the input is 0 or 1, it is flipped. Otherwise the output will be 0. */

--- a/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
+++ b/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
@@ -44,7 +44,7 @@ sealed trait ScriptNumber extends ScriptConstant {
   def underlying : Long
 
   def + (that : ScriptNumber) : ScriptNumber = ScriptNumber(underlying + that.underlying)
-  def - = ScriptNumber(-underlying)
+  def unary_- = ScriptNumber(-underlying)
   def - (that : ScriptNumber) : ScriptNumber = ScriptNumber(underlying - that.underlying)
   def * (that : ScriptNumber) : ScriptNumber = ScriptNumber(underlying * that.underlying)
 


### PR DESCRIPTION
Removed warning about `x -`

```
[warn] bitcoin-s-core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala:53: postfix operator - should be enabled
[warn] by making the implicit value scala.language.postfixOps visible.
[warn] This can be achieved by adding the import clause 'import scala.language.postfixOps'
[warn] or by setting the compiler option -language:postfixOps.
[warn] See the Scala docs for value scala.language.postfixOps for a discussion
[warn] why the feature should be explicitly enabled.
[warn]     performUnaryArithmeticOperation(program, x => x -)
[warn]                                                     ^
[warn] one warning found
```
