### PR TITLE
Fixing bug in calculating pushops for ScriptNumberOperations

### DIFF
--- a/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -157,7 +157,8 @@ trait BitcoinScriptUtil extends BitcoinSLogger {
     //push ops following an OP_PUSHDATA operation are interpreted as unsigned numbers
     val scriptTokenSize = UInt32(scriptToken.bytes.size)
     val bytes = scriptTokenSize.bytes
-    if (scriptTokenSize <= UInt32(75)) Seq(BytesToPushOntoStack(scriptToken.bytes.size))
+    if (scriptToken.isInstanceOf[ScriptNumberOperation]) Nil
+    else if (scriptTokenSize <= UInt32(75)) Seq(BytesToPushOntoStack(scriptToken.bytes.size))
     else if (scriptTokenSize <= UInt32(OP_PUSHDATA1.max)) {
       //we need the push op to be only 1 byte in size
       val pushConstant = ScriptConstant(BitcoinSUtil.flipEndianness(bytes.slice(bytes.length-1,bytes.length)))

--- a/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
@@ -127,12 +127,22 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers with ConstantIn
     }
   }
 
-  it must "return ScriptErrorMinimalData if program contains ScriptVerifyMinimalData flag and 2nd item in script is" +
-    " zero" in {
+  it must "return ScriptErrorMinimalData if program contains ScriptVerifyMinimalData flag and 2nd item in script is zero" in {
     val stack = List()
     val script = List(OP_PUSHDATA4,ScriptNumber.zero)
     val program = ScriptProgram(ScriptProgram(TestUtil.testProgram, stack,script),Seq[ScriptFlag](ScriptVerifyMinimalData))
     val newProgram = ScriptProgramTestUtil.toExecutedScriptProgram(opPushData4(program))
     newProgram.error must be (Some(ScriptErrorMinimalData))
+  }
+
+  it must "push a constant onto the stack that is using OP_PUSHDATA1 where the pushop can be interpreted as a script number operation" in {
+    val constant = ScriptConstant("01000000010000000000000000000000000000000000000000000000000000000000000000" +
+      "ffffffff00ffffffff014a7afa8f7d52fd9e17a914b167f19394cd656c34f843ac2387e602007fd15b8700000000")
+    val stack = Nil
+    val script = List(OP_PUSHDATA1, OP_3, constant)
+    val program = ScriptProgram(TestUtil.testProgram, stack,script)
+    val newProgram = opPushData1(program)
+    newProgram.stack must be (Seq(constant))
+
   }
 }


### PR DESCRIPTION
ScriptNumberOperations do not need a push operation for them to be pushed onto the stack, it simply pushes the number itself onto the stack.

For instance, if the interpreter sees an OP_1 it simply pushes the number 1 onto the stack. 

This also fixes a bug where if we have a script of the format: 
`
OP_PUSHDATA1 OP_3 <83 byte constant> `

It will now interpret OP_3 as an 83 byte push operation, instead of pushing the number 3 onto the stack