### PR TITLE
P2pkh script sig bug rd2

### DIFF
--- a/src/main/scala/org/bitcoins/core/crypto/ECPublicKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECPublicKey.scala
@@ -62,7 +62,10 @@ sealed trait ECPublicKey extends BaseECKey with BitcoinSLogger {
   }
 
   /** Checks if the [[ECPublicKey]] is compressed */
-  def isCompressed = bytes.size == 33
+  def isCompressed: Boolean = bytes.size == 33
+
+  /** Checks if the [[ECPublicKey]] is valid according to secp256k1 */
+  def isFullyValid = ECPublicKey.isFullyValid(bytes)
 }
 
 object ECPublicKey extends Factory[ECPublicKey] {

--- a/src/main/scala/org/bitcoins/core/crypto/ECPublicKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECPublicKey.scala
@@ -84,6 +84,13 @@ object ECPublicKey extends Factory[ECPublicKey] {
   /** Generates a fresh [[ECPublicKey]] that has not been used before. */
   def freshPublicKey = ECPrivateKey.freshPrivateKey.publicKey
 
+
+  /** Checks if the public key is valid according to secp256k1
+    * Mimics this function in bitcoin core
+    * [[https://github.com/bitcoin/bitcoin/blob/27765b6403cece54320374b37afb01a0cfe571c3/src/pubkey.cpp#L207-L212]]
+    */
+  def isFullyValid(bytes: Seq[Byte]): Boolean = Try(NativeSecp256k1.isValidPubKey(bytes.toArray)).isSuccess
+
 }
 
 

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -107,7 +107,8 @@ object P2PKHScriptSignature extends ScriptFactory[P2PKHScriptSignature] {
   def isP2PKHScriptSig(asm: Seq[ScriptToken]): Boolean = asm match {
     case List(w : BytesToPushOntoStack, x : ScriptConstant, y : BytesToPushOntoStack,
       z : ScriptConstant) =>
-      !P2SHScriptSignature.isRedeemScript(z)
+      if (ECPublicKey.isFullyValid(z.bytes)) true
+      else !P2SHScriptSignature.isRedeemScript(z)
     case _ => false
   }
 }

--- a/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -31,19 +31,7 @@ class ScriptInterpreterTest extends FlatSpec with MustMatchers with ScriptInterp
     //use this to represent a single test case from script_valid.json
 /*    val lines =
         """
-          | [
-          | [
-          |  [
-          |   "",
-          |   0.00000000
-          |  ],
-          |  "0x47 0x304402200a5c6163f07b8d3b013c4d1d6dba25e780b39658d79ba37af7057a3b7f15ffa102201fd9b4eaa9943f734928b99a83592c2e7bf342ea2680f6a2bb705167966b742001",
-          |  "0x41 0x0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8 CHECKSIG",
-          |  "P2SH,WITNESS",
-          |  "WITNESS_UNEXPECTED",
-          |  "P2PK with witness"
-          | ]
-          | ]
+          | [ ["", "0 0 0 1 CHECKMULTISIG VERIFY DEPTH 0 EQUAL", "P2SH,STRICTENC", "OK", "Zero sigs means no sigs are checked"]]
    """.stripMargin*/
     val lines = try source.getLines.filterNot(_.isEmpty).map(_.trim) mkString "\n" finally source.close()
     val json = lines.parseJson


### PR DESCRIPTION
This is the second attempt to fix #57 

This depends on #69 -- 69 implements functionality to verify that we have a valid public key according to libsecp256k1. We can use this check inside of `P2PKHScriptSIgnature` as the last constant in the `asm` should be a public key. 

From my testing on my machine, this seems to have fixed the problem.  