### PR TITLE
Using 'Try' return type when using ScriptSignature.fromScriptPubKey

### DIFF
--- a/src/test/scala/org/bitcoins/core/protocol/script/P2SHScriptSignatureSpec.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/script/P2SHScriptSignatureSpec.scala
@@ -12,7 +12,6 @@ class P2SHScriptSignatureSpec extends Properties("P2SHScriptSignatureSpec") with
 
   property("Symmetrical serialization") =
     Prop.forAll(ScriptGenerators.p2shScriptSignature) { p2shScriptSig =>
-      logger.info("P2shScriptSig: " + p2shScriptSig)
       P2SHScriptSignature(p2shScriptSig.hex) == p2shScriptSig
 
     }
@@ -21,7 +20,7 @@ class P2SHScriptSignatureSpec extends Properties("P2SHScriptSignatureSpec") with
     Prop.forAll(ScriptGenerators.witnessScriptPubKeyV0) { case (witScriptPubKey,privKeys) =>
       val p2shScriptSig = P2SHScriptSignature(witScriptPubKey)
       p2shScriptSig.redeemScript == witScriptPubKey
-      p2shScriptSig.scriptSignatureNoRedeemScript == EmptyScriptSignature
+      p2shScriptSig.scriptSignatureNoRedeemScript.get == EmptyScriptSignature
 
   }
 }

--- a/src/test/scala/org/bitcoins/core/protocol/script/P2SHScriptSignatureTest.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/script/P2SHScriptSignatureTest.scala
@@ -31,7 +31,7 @@ class P2SHScriptSignatureTest extends FlatSpec with MustMatchers with BitcoinSLo
       case _ => throw new RuntimeException("Should be p2sh scriptSig")
     }
 
-    p2shScriptSig.scriptSignatureNoRedeemScript.asm must be (Seq(
+    p2shScriptSig.scriptSignatureNoRedeemScript.get.asm must be (Seq(
       OP_0, BytesToPushOntoStack(71), ScriptConstant("304402207d764cb90c9fd84b74d33a47cf3a0ffead9ded98333776becd6acd32c4426dac02203905a0d064e7f53d07793e86136571b6e4f700c1cfb888174e84d78638335b8101"),
       BytesToPushOntoStack(72),
       ScriptConstant("3045022100906aaca39f022acd8b7a38fd2f92aca9e9f35cfeaee69a6f13e1d083ae18222602204c9ed96fc6c4de56fd85c679fc59c16ee1ccc80c42563b86174e1a506fc007c801")


### PR DESCRIPTION
Starting to address #70 , this is a really small start this. Start wrapping returned values for `ScriptSignature` with a `Try`. 