### PR TITLE
Channel close with timeout

### DIFF
--- a/src/main/scala/org/bitcoins/core/channels/Channel.scala
+++ b/src/main/scala/org/bitcoins/core/channels/Channel.scala
@@ -64,7 +64,7 @@ sealed trait ChannelAwaitingAnchorTx extends Channel {
     val outPoint = TransactionOutPoint(anchorTx.txId, UInt32(outputIndex))
     val i1 = TransactionInput(outPoint,EmptyScriptSignature,TransactionConstants.sequence)
     val inputs = Seq(i1)
-    val inputIndex = UInt32.zero
+    val inputIndex = UInt32(inputs.indexOf(i1))
     val partiallySigned = EscrowTimeoutHelper.clientSign(inputs,outputs,inputIndex,privKey,
       lock,scriptPubKey, HashType.sigHashSingleAnyoneCanPay)
     val inProgress = ChannelInProgressClientSigned(anchorTx,lock,clientSPK,partiallySigned,Nil)
@@ -85,11 +85,11 @@ sealed trait ChannelAwaitingAnchorTx extends Channel {
   /** Attempts to close the [[Channel]] because the [[org.bitcoins.core.protocol.script.EscrowTimeoutScriptPubKey]]
     * has timed out
     */
-  def closeWithTimeout(refundSPK: ScriptPubKey, clientKey: ECPrivateKey, fee: CurrencyUnit): TxSigComponent = {
+  def closeWithTimeout(refundSPK: ScriptPubKey, clientKey: ECPrivateKey, fee: CurrencyUnit): ChannelClosedWithTimeout = {
     val outputs = Seq(TransactionOutput(lockedAmount - fee, refundSPK))
     val outPoint = TransactionOutPoint(anchorTx.txId,UInt32(outputIndex))
     val signedTxSigComponent = P2PKHHelper.sign(clientKey,lock,outPoint,outputs,HashType.sigHashAll)
-    signedTxSigComponent
+    ChannelClosedWithTimeout(anchorTx,lock,signedTxSigComponent,Nil,refundSPK)
   }
 
 }
@@ -162,11 +162,11 @@ sealed trait ChannelInProgress extends Channel {
     ChannelInProgressClientSigned(anchorTx,lock, clientSPK,txSigComponent, current +: old)
   }
 
-  /** Attempts to close the [[Channel]] because the [[org.bitcoins.core.protocol.script.EscrowTimeoutScriptPubKey]]
+  /** Attempts to close the [[Channel]] because the [[EscrowTimeoutScriptPubKey]]
     * has timed out
     */
   def closeWithTimeout(refundSPK: ScriptPubKey, clientKey: ECPrivateKey,
-                       fee: CurrencyUnit): TxSigComponent = {
+                       fee: CurrencyUnit): ChannelClosedWithTimeout = {
     val timeout = lock.timeout
     val scriptNum = timeout.locktime
     val sequence = UInt32(scriptNum.toLong + 1)
@@ -174,7 +174,7 @@ sealed trait ChannelInProgress extends Channel {
     val outPoint = TransactionOutPoint(anchorTx.txId,UInt32(outputIndex))
     val signedTxSigComponent = EscrowTimeoutHelper.closeWithTimeout(clientKey,lock,outPoint,outputs,HashType.sigHashAll,
       TransactionConstants.validLockVersion, sequence,TransactionConstants.lockTime)
-    signedTxSigComponent
+    ChannelClosedWithTimeout(this,signedTxSigComponent)
   }
 }
 
@@ -216,7 +216,7 @@ sealed trait ChannelInProgressClientSigned extends Channel {
   }
 
   /** Closes this payment channel, paying the server's amount to the given [[ScriptPubKey]] */
-  def close(serverSPK: ScriptPubKey, serverKey: ECPrivateKey, fee: CurrencyUnit): Try[ChannelClosed] = {
+  def close(serverSPK: ScriptPubKey, serverKey: ECPrivateKey, fee: CurrencyUnit): Try[ChannelClosedWithEscrow] = {
     val c = clientOutput
     val clientAmount = c.map(_.value).getOrElse(CurrencyUnits.zero)
     val serverAmount = lockedAmount - clientAmount - fee
@@ -235,7 +235,7 @@ sealed trait ChannelInProgressClientSigned extends Channel {
       partiallySigned.scriptPubKey,partiallySigned.flags)
     val updatedInProgressClientSigned = ChannelInProgressClientSigned(anchorTx,lock,clientSPK,txSigComponent,old)
     val serverSigned = invariant.flatMap(_ => updatedInProgressClientSigned.serverSign(serverKey))
-    serverSigned.map(s => ChannelClosed(s,serverSPK))
+    serverSigned.map(s => ChannelClosedWithEscrow(s,serverSPK))
   }
 
   /** Sanity checks for the amounts when closing a payment channel */
@@ -268,23 +268,30 @@ sealed trait ChannelClosed extends Channel {
 
   def old: Seq[TxSigComponent]
 
-  def serverSPK: ScriptPubKey
-
+  /** The [[ScriptPubKey]] that pays the client it's refund */
   def clientSPK: ScriptPubKey
-
-  /** The output that pays the server */
-  def serverOutput: TransactionOutput = {
-    //Invariant in ChannelClosedImpl states this has to exist
-    finalTx.transaction.outputs.find(_.scriptPubKey == serverSPK).get
-  }
-  /** The amount the server is being paid */
-  def serverAmount: CurrencyUnit = serverOutput.value
 
   /** The client's refund output */
   def clientOutput: Option[TransactionOutput] = finalTx.transaction.outputs.find(_.scriptPubKey == clientSPK)
 
   /** The amount the client is being refunded */
   def clientValue: Option[CurrencyUnit] = clientOutput.map(_.value)
+}
+
+sealed trait ChannelClosedWithTimeout extends ChannelClosed
+
+sealed trait ChannelClosedWithEscrow extends ChannelClosed {
+  /** The [[ScriptPubKey]] that pays the server */
+  def serverSPK: ScriptPubKey
+
+  /** The output that pays the server */
+  def serverOutput: TransactionOutput = {
+    //Invariant in ChannelClosedImpl states this has to exist
+    finalTx.transaction.outputs.find(_.scriptPubKey == serverSPK).get
+  }
+
+  /** The amount the server is being paid */
+  def serverAmount: CurrencyUnit = serverOutput.value
 }
 
 object ChannelAwaitingAnchorTx {
@@ -343,19 +350,35 @@ object ChannelInProgressClientSigned {
 
 }
 
-object ChannelClosed {
-  private case class ChannelClosedImpl(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey,
+object ChannelClosedWithEscrow {
+  private case class ChannelClosedWithEscrowImpl(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey,
                                        finalTx: TxSigComponent, old: Seq[TxSigComponent],
-                                       clientSPK: ScriptPubKey, serverSPK: ScriptPubKey) extends ChannelClosed {
+                                       clientSPK: ScriptPubKey, serverSPK: ScriptPubKey) extends ChannelClosedWithEscrow {
     require(finalTx.transaction.outputs.exists(_.scriptPubKey == serverSPK), "The final transaction must have a SPK that pays the server")
   }
 
   def apply(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey, finalTx: TxSigComponent,
-            old: Seq[TxSigComponent], clientSPK: ScriptPubKey, serverSPK: ScriptPubKey): ChannelClosed = {
-    ChannelClosedImpl(anchorTx,lock,finalTx,old,clientSPK, serverSPK)
+            old: Seq[TxSigComponent], clientSPK: ScriptPubKey, serverSPK: ScriptPubKey): ChannelClosedWithEscrow = {
+    ChannelClosedWithEscrowImpl(anchorTx,lock,finalTx,old,clientSPK, serverSPK)
   }
 
-  def apply(i: ChannelInProgress, serverSPK: ScriptPubKey): ChannelClosed = {
-    ChannelClosed(i.anchorTx,i.lock,i.current,i.old,i.clientSPK,serverSPK)
+  def apply(i: ChannelInProgress, serverSPK: ScriptPubKey): ChannelClosedWithEscrow = {
+    ChannelClosedWithEscrowImpl(i.anchorTx,i.lock,i.current,i.old,i.clientSPK,serverSPK)
+  }
+}
+
+object ChannelClosedWithTimeout {
+  private case class ChannelClosedWithTimeoutImpl(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey,
+                                                  finalTx: TxSigComponent, old: Seq[TxSigComponent],
+                                                  clientSPK: ScriptPubKey) extends ChannelClosedWithTimeout
+
+  def apply(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey,
+            finalTx: TxSigComponent, old: Seq[TxSigComponent],
+            clientSPK: ScriptPubKey): ChannelClosedWithTimeout = {
+    ChannelClosedWithTimeoutImpl(anchorTx,lock,finalTx,old,clientSPK)
+  }
+
+  def apply(i: ChannelInProgress, finalTx: TxSigComponent): ChannelClosedWithTimeout = {
+    ChannelClosedWithTimeout(i.anchorTx,i.lock,finalTx,i.current +: i.old,i.clientSPK)
   }
 }

--- a/src/main/scala/org/bitcoins/core/gen/ChannelGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/ChannelGenerators.scala
@@ -28,6 +28,10 @@ sealed trait ChannelGenerators extends BitcoinSLogger {
     (aTx,_) = TransactionGenerators.buildCreditingTransaction(TransactionConstants.validLockVersion,p2sh,amount)
   } yield (aTx,redeemScript,privKeys)
 
+  def channelAwaitingAnchorTxNotConfirmed: Gen[(ChannelAwaitingAnchorTx, Seq[ECPrivateKey])] = for {
+    (aTx,redeemScript,privKeys) <- anchorTx
+  } yield (ChannelAwaitingAnchorTx(aTx,redeemScript,0).get,privKeys)
+
   /** Creates a [[ChannelAwaitingAnchorTx]] and
     * the private keys needed to spend from the locked output.
     * This generator assumes that the anchor tx has sufficient confirmations */

--- a/src/main/scala/org/bitcoins/core/gen/NumberGenerator.scala
+++ b/src/main/scala/org/bitcoins/core/gen/NumberGenerator.scala
@@ -12,42 +12,23 @@ import org.scalacheck.Arbitrary.arbitrary
   */
 trait NumberGenerator {
 
-  /**
-    * Creates a generator that generates positive long numbers
-    *
-    * @return
-    */
+  /** Creates a generator that generates positive long numbers */
   def positiveLongs: Gen[Long] = Gen.choose(0, Long.MaxValue)
 
-  /**
-    * Creates a generator for positive longs without the number zero
-    *
-    * @return
-    */
+  /** Creates a generator for positive longs without the number zero */
   def positiveLongsNoZero : Gen[Long] = Gen.choose(1,Long.MaxValue)
 
-  /**
-    * Creates a number generator that generates negative long numbers
-    *
-    * @return
-    */
+  /** Creates a number generator that generates negative long numbers */
   def negativeLongs: Gen[Long] = Gen.choose(Long.MinValue,-1)
 
 
   /**
     * Generates a number in the range 0 <= x <= 2 ^^32 - 1
-    * then wraps it in a UInt32
-    *
-    * @return
-    */
+    * then wraps it in a UInt32 */
   def uInt32s: Gen[UInt32] = Gen.choose(0L,(NumberUtil.pow2(32)-1).toLong).map(UInt32(_))
 
 
-  /**
-    * Chooses a BigInt in the ranges of 0 <= bigInt < 2^^64
-    *
-    * @return
-    */
+  /** Chooses a BigInt in the ranges of 0 <= bigInt < 2^^64 */
   def bigInts : Gen[BigInt] = Gen.chooseNum(Long.MinValue,Long.MaxValue)
     .map(x => BigInt(x) + BigInt(2).pow(63))
 
@@ -58,8 +39,6 @@ trait NumberGenerator {
   /**
     * Generates a number in the range 0 <= x < 2^^64
     * then wraps it in a UInt64
-    *
-    * @return
     */
   def uInt64s : Gen[UInt64] = for {
     bigInt <- bigIntsUInt64Range
@@ -72,18 +51,21 @@ trait NumberGenerator {
 
   def scriptNumbers: Gen[ScriptNumber] = Gen.choose(Int64.min.underlying, Int64.max.underlying).map(ScriptNumber(_))
 
+  def positiveScriptNumbers: Gen[ScriptNumber] = Gen.choose(0L,Int64.max.underlying).map(ScriptNumber(_))
+
+  /** Generates a positive [[ScriptNumber]] that takes a maximum of 5 bytes of space.
+    * This is useful for generating a valid script number for OP_CHECKSEQUENCEVERIFY
+    * [[https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki#specification]]
+    * @return
+    */
+  def postiveScriptNumbers5Bytes: Gen[ScriptNumber] = Gen.choose(0, Int32.max.underlying).map(ScriptNumber(_))
+
   def compactSizeUInts : Gen[CompactSizeUInt] = uInt64s.map(CompactSizeUInt(_))
 
-  /**
-    * Generates an arbitrary [[Byte]] in Scala
-    * @return
-    */
+  /** Generates an arbitrary [[Byte]] in Scala */
   def byte: Gen[Byte] = arbitrary[Byte]
 
-  /**
-    * Generates a 100 byte sequence
-    * @return
-    */
+  /** Generates a 100 byte sequence */
   def bytes: Gen[Seq[Byte]] = for {
     num <- Gen.choose(0,100)
     b <- bytes(num)

--- a/src/main/scala/org/bitcoins/core/gen/NumberGenerator.scala
+++ b/src/main/scala/org/bitcoins/core/gen/NumberGenerator.scala
@@ -53,13 +53,6 @@ trait NumberGenerator {
 
   def positiveScriptNumbers: Gen[ScriptNumber] = Gen.choose(0L,Int64.max.underlying).map(ScriptNumber(_))
 
-  /** Generates a positive [[ScriptNumber]] that takes a maximum of 5 bytes of space.
-    * This is useful for generating a valid script number for OP_CHECKSEQUENCEVERIFY
-    * [[https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki#specification]]
-    * @return
-    */
-  def postiveScriptNumbers5Bytes: Gen[ScriptNumber] = Gen.choose(0, Int32.max.underlying).map(ScriptNumber(_))
-
   def compactSizeUInts : Gen[CompactSizeUInt] = uInt64s.map(CompactSizeUInt(_))
 
   /** Generates an arbitrary [[Byte]] in Scala */

--- a/src/main/scala/org/bitcoins/core/gen/TransactionGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/TransactionGenerators.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction.{TransactionInput, TransactionOutPoint, TransactionOutput, _}
 import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
+import org.bitcoins.core.script.locktime.LockTimeInterpreter
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinScriptUtil}
 import org.scalacheck.Gen
 
@@ -330,9 +331,11 @@ trait TransactionGenerators extends BitcoinSLogger {
   def buildSpendingTransaction(version: UInt32, creditingTx: Transaction, scriptSignature: ScriptSignature, outputIndex: UInt32,
                                locktime: UInt32, sequence: UInt32, witness: TransactionWitness): (WitnessTransaction, UInt32) = {
 
-    val outputs = Seq(TransactionOutput(CurrencyUnits.zero,EmptyScriptPubKey))
+    val outputs = dummyOutputs
     buildSpendingTransaction(version,creditingTx,scriptSignature,outputIndex,locktime,sequence,witness,outputs)
   }
+
+  def dummyOutputs: Seq[TransactionOutput] = Seq(TransactionOutput(CurrencyUnits.zero,EmptyScriptPubKey))
 
   def buildSpendingTransaction(version: UInt32, creditingTx: Transaction, scriptSignature: ScriptSignature, outputIndex: UInt32,
                                locktime: UInt32, sequence: UInt32, witness: TransactionWitness, outputs: Seq[TransactionOutput]): (WitnessTransaction, UInt32) = {
@@ -421,23 +424,8 @@ trait TransactionGenerators extends BitcoinSLogger {
     * (i.e. determines whether both are a timestamp or block-height)
     */
   private def csvLockTimesOfSameType(sequenceNumbers : (ScriptNumber, UInt32)) : Boolean = {
-    val (scriptNum, txSequence) = sequenceNumbers
-    val nLockTimeMask : UInt32 = TransactionConstants.sequenceLockTimeTypeFlag | TransactionConstants.sequenceLockTimeMask
-    val txToSequenceMasked : Int64 = Int64(txSequence.underlying & nLockTimeMask.underlying)
-    val nSequenceMasked : ScriptNumber = scriptNum & Int64(nLockTimeMask.underlying)
-
-    if (!ScriptInterpreter.isLockTimeBitOff(Int64(txSequence.underlying))) return false
-
-    if (!(
-      (txToSequenceMasked < Int64(TransactionConstants.sequenceLockTimeTypeFlag.underlying) &&
-        nSequenceMasked < Int64(TransactionConstants.sequenceLockTimeTypeFlag.underlying)) ||
-        (txToSequenceMasked >= Int64(TransactionConstants.sequenceLockTimeTypeFlag.underlying) &&
-          nSequenceMasked >= Int64(TransactionConstants.sequenceLockTimeTypeFlag.underlying))
-      )) return false
-
-    if (nSequenceMasked > Int64(txToSequenceMasked.underlying)) return false
-
-    true
+    LockTimeInterpreter.isCSVLockByRelativeLockTime(sequenceNumbers._1, sequenceNumbers._2) ||
+      LockTimeInterpreter.isCSVLockByBlockHeight(sequenceNumbers._1, sequenceNumbers._2)
   }
 
   /**
@@ -445,15 +433,59 @@ trait TransactionGenerators extends BitcoinSLogger {
     * sequence mask is always greater than the script sequence mask (i.e. generates values for a validly constructed and spendable CSV transaction)
     */
   def spendableCSVValues : Gen[(ScriptNumber, UInt32)] = for {
-    sequence <- NumberGenerator.uInt32s
-    csvScriptNum <- csvLockTimeBitOff.suchThat(x => ScriptInterpreter.isLockTimeBitOff(ScriptNumber(x.underlying)) &&
-      csvLockTimesOfSameType((ScriptNumber(x.underlying),sequence))).map(n => ScriptNumber(n.underlying))
-  } yield (csvScriptNum, sequence)
+    (scriptNumber,sequence) <- Gen.oneOf(validScriptNumberAndSequenceForBlockHeight,
+      validScriptNumberAndSequenceForRelativeLockTime)
+  } yield (scriptNumber, sequence)
 
+  /** Generates a [[UInt32]] s.t. the block height bit is set according to BIP68 */
+  private def sequenceForBlockHeight: Gen[UInt32] = validCSVSequence.map { n =>
+    val result: UInt32 = n & UInt32("ffbfffff")
+    require(LockTimeInterpreter.isCSVLockByBlockHeight(result), "Block height locktime bit was not set: " + result)
+    result
+  }
+
+  /** Genereates a [[ScriptNumber]] and [[UInt32]] s.t. the pair can be spent by an OP_CSV operation */
+  private def validScriptNumberAndSequenceForBlockHeight: Gen[(ScriptNumber,UInt32)] = {
+    sequenceForBlockHeight.flatMap { s =>
+      val seqMasked = TransactionConstants.sequenceLockTimeMask
+      val validScriptNums = s & seqMasked
+      Gen.choose(0L, validScriptNums.underlying - 1).map { sn =>
+        val scriptNum = ScriptNumber(sn & UInt32("ffbfffff").underlying)
+        require(LockTimeInterpreter.isCSVLockByBlockHeight(scriptNum))
+        require(LockTimeInterpreter.isCSVLockByBlockHeight(s))
+        (scriptNum,s)
+      }
+    }
+  }
+
+  /** Generates a [[UInt32]] with the locktime bit set according to BIP68 */
+  private def sequenceForRelativeLockTime: Gen[UInt32] = validCSVSequence.map { n =>
+    val result = n | TransactionConstants.sequenceLockTimeTypeFlag
+    require(LockTimeInterpreter.isCSVLockByRelativeLockTime(result), "Relative locktime bit was not set: " + result)
+    result
+  }
+
+  /** Generates a valid [[ScriptNumber]] and [[UInt32]] s.t. the pair can be spent by a OP_CSV operation */
+  private def validScriptNumberAndSequenceForRelativeLockTime: Gen[(ScriptNumber,UInt32)] = {
+    sequenceForRelativeLockTime.flatMap { s =>
+      val seqMasked = TransactionConstants.sequenceLockTimeMask
+      val validScriptNums = s & seqMasked
+      Gen.choose(0L, validScriptNums.underlying - 1).map { sn =>
+        val scriptNum = ScriptNumber(sn | TransactionConstants.sequenceLockTimeTypeFlag.underlying)
+        require(LockTimeInterpreter.isCSVLockByRelativeLockTime(scriptNum))
+        require(LockTimeInterpreter.isCSVLockByRelativeLockTime(s))
+        (scriptNum,s)
+      }
+    }
+  }
   /** Generates a [[UInt32]] s.t. the locktime enabled flag is set */
-  private def csvLockTimeBitOff: Gen[UInt32] = NumberGenerator.uInt32s.map { n =>
+  private def validCSVSequence: Gen[UInt32] = NumberGenerator.uInt32s.map { n =>
     //makes sure the 1 << 31 is TURNED OFF, need this to generate spendable CSV values without discarding a bunch of test cases
-    n & UInt32(0x3FFFFFFF)
+    //only the last 2 bytes have consensus meaning according to BIP68
+    //https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki#specification
+    val result = n & UInt32(0x7FFFFFFF)
+    require(LockTimeInterpreter.isLockTimeBitOff(ScriptNumber(result.underlying)))
+    result
   }
 
   /**

--- a/src/main/scala/org/bitcoins/core/gen/TransactionGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/TransactionGenerators.scala
@@ -444,7 +444,7 @@ trait TransactionGenerators extends BitcoinSLogger {
     result
   }
 
-  /** Genereates a [[ScriptNumber]] and [[UInt32]] s.t. the pair can be spent by an OP_CSV operation */
+  /** Generates a [[ScriptNumber]] and [[UInt32]] s.t. the pair can be spent by an OP_CSV operation */
   private def validScriptNumberAndSequenceForBlockHeight: Gen[(ScriptNumber,UInt32)] = {
     sequenceForBlockHeight.flatMap { s =>
       val seqMasked = TransactionConstants.sequenceLockTimeMask
@@ -465,7 +465,7 @@ trait TransactionGenerators extends BitcoinSLogger {
     result
   }
 
-  /** Generates a valid [[ScriptNumber]] and [[UInt32]] s.t. the pair can be spent by a OP_CSV operation */
+  /** Generates a valid [[ScriptNumber]] and [[UInt32]] s.t. the pair will evaluate to true by a OP_CSV operation */
   private def validScriptNumberAndSequenceForRelativeLockTime: Gen[(ScriptNumber,UInt32)] = {
     sequenceForRelativeLockTime.flatMap { s =>
       val seqMasked = TransactionConstants.sequenceLockTimeMask
@@ -478,11 +478,10 @@ trait TransactionGenerators extends BitcoinSLogger {
       }
     }
   }
-  /** Generates a [[UInt32]] s.t. the locktime enabled flag is set */
+  /** Generates a [[UInt32]] s.t. the locktime enabled flag is set. See BIP68 for more info */
   private def validCSVSequence: Gen[UInt32] = NumberGenerator.uInt32s.map { n =>
-    //makes sure the 1 << 31 is TURNED OFF, need this to generate spendable CSV values without discarding a bunch of test cases
-    //only the last 2 bytes have consensus meaning according to BIP68
-    //https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki#specification
+    //makes sure the 1 << 31 is TURNED OFF,
+    //need this to generate spendable CSV values without discarding a bunch of test cases
     val result = n & UInt32(0x7FFFFFFF)
     require(LockTimeInterpreter.isLockTimeBitOff(ScriptNumber(result.underlying)))
     result

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionConstants.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionConstants.scala
@@ -16,7 +16,6 @@ trait TransactionConstants {
     * If bit (1 << 31) of the sequence number is set,
     * then no consensus meaning is applied to the sequence number and can be included
     * in any block under all currently possible circumstances.
- *
     * @return the mask that ben used with a bitwise and to indicate if the sequence number has any meaning
     */
   def locktimeDisabledFlag = UInt32(1L << 31)
@@ -26,6 +25,8 @@ trait TransactionConstants {
     * applied to extract that lock-time from the sequence field.
     */
   def sequenceLockTimeMask = UInt32(0x0000ffff)
+
+  def fullSequenceLockTimeMask = sequenceLockTimeTypeFlag | sequenceLockTimeMask
 
   /**
     * If the transaction input sequence number encodes a relative lock-time and this flag
@@ -37,10 +38,7 @@ trait TransactionConstants {
 
   /**
     * Threshold for nLockTime: below this value it is interpreted as block number,
-    * otherwise as UNIX timestamp.
- *
-    * @return
-    */
+    * otherwise as UNIX timestamp. */
   def locktimeThreshold = UInt32(500000000)
 }
 

--- a/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
+++ b/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
@@ -177,7 +177,8 @@ trait LockTimeInterpreter extends BitcoinSLogger {
     true
   }
 
-  /** Checks if the given [[ScriptNumber]] and [[UInt32]] are valid values for locking a OP_CSV by block height */
+  /** Checks if the given [[ScriptNumber]] and [[UInt32]] are valid values for spending
+    * a OP_CSV value by block height */
   def isCSVLockByBlockHeight(scriptNumber: ScriptNumber, sequence: UInt32): Boolean = {
     isCSVLockByBlockHeight(scriptNumber) && isCSVLockByBlockHeight(sequence)
   }
@@ -187,6 +188,8 @@ trait LockTimeInterpreter extends BitcoinSLogger {
 
   def isCSVLockByBlockHeight(scriptNumber: ScriptNumber): Boolean = !isCSVLockByRelativeLockTime(scriptNumber)
 
+  /** Checks if the given [[ScriptNumber]] and [[UInt32]] are valid values
+    * for spending an OP_CSV value by time based relative lock time */
   def isCSVLockByRelativeLockTime(number: ScriptNumber, sequence: UInt32): Boolean = {
     isCSVLockByRelativeLockTime(number) && isCSVLockByRelativeLockTime(sequence)
   }

--- a/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
@@ -72,6 +72,12 @@ sealed trait EscrowTimeoutHelper extends BitcoinSLogger {
     signedTx.map(tx => TxSigComponent(tx,clientSigned.inputIndex, p2shScriptPubKey, clientSigned.flags))
   }
 
+  /** Closes the given [[EscrowTimeoutScriptPubKey]] with it's timeout branch.
+    * Assumes we are spending the given [[TransactionOutPoint]]
+    *
+    * It is important to note that we assume the nestedScriptPubKey inside of the EscrowTimeoutScriptPubKey
+    * is a [[P2PKHScriptPubKey]] that can be spent by the given [[ECPrivateKey]]
+    * */
   def closeWithTimeout(privKey: ECPrivateKey, escrowTimeoutSPK: EscrowTimeoutScriptPubKey, outPoint: TransactionOutPoint,
     outputs: Seq[TransactionOutput], hashType: HashType,
     version: UInt32, sequence: UInt32, lockTime: UInt32): TxSigComponent = {

--- a/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
@@ -80,7 +80,8 @@ sealed trait EscrowTimeoutHelper extends BitcoinSLogger {
     * */
   def closeWithTimeout(privKey: ECPrivateKey, escrowTimeoutSPK: EscrowTimeoutScriptPubKey, outPoint: TransactionOutPoint,
     outputs: Seq[TransactionOutput], hashType: HashType,
-    version: UInt32, sequence: UInt32, lockTime: UInt32): TxSigComponent = {
+    version: UInt32, sequence: UInt32, lockTime: UInt32): Try[TxSigComponent] = Try {
+    require(escrowTimeoutSPK.timeout.nestedScriptPubKey.isInstanceOf[P2PKHScriptPubKey], "We currently require the nested SPK in the timeout branch to be a P2PKHScriptPubKey, got: " + escrowTimeoutSPK.timeout.nestedScriptPubKey)
     val signedP2PKHTxSigComponent = P2PKHHelper.sign(privKey,escrowTimeoutSPK,outPoint,outputs,hashType,version,sequence,lockTime)
     val signedP2PKHTx = signedP2PKHTxSigComponent.transaction
     val signedScriptSig = signedP2PKHTxSigComponent.scriptSignature

--- a/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
@@ -71,6 +71,24 @@ sealed trait EscrowTimeoutHelper extends BitcoinSLogger {
     val signedTx = newInputs.map(inputs => Transaction(old.version,inputs,old.outputs,old.lockTime))
     signedTx.map(tx => TxSigComponent(tx,clientSigned.inputIndex, p2shScriptPubKey, clientSigned.flags))
   }
+
+  def closeWithTimeout(privKey: ECPrivateKey, escrowTimeoutSPK: EscrowTimeoutScriptPubKey, outPoint: TransactionOutPoint,
+    outputs: Seq[TransactionOutput], hashType: HashType,
+    version: UInt32, sequence: UInt32, lockTime: UInt32): TxSigComponent = {
+    val signedP2PKHTxSigComponent = P2PKHHelper.sign(privKey,escrowTimeoutSPK,outPoint,outputs,hashType,version,sequence,lockTime)
+    val signedP2PKHTx = signedP2PKHTxSigComponent.transaction
+    val signedScriptSig = signedP2PKHTxSigComponent.scriptSignature
+    val lockTimeScriptSig = escrowTimeoutSPK.timeout match {
+      case _: CSVScriptPubKey => CSVScriptSignature(signedScriptSig)
+      case _: CLTVScriptPubKey => CLTVScriptSignature(signedScriptSig)
+    }
+    val escrowTimeoutScriptSig = EscrowTimeoutScriptSignature.fromLockTime(lockTimeScriptSig)
+    val fullInput = TransactionInput(signedP2PKHTxSigComponent.input.previousOutput,escrowTimeoutScriptSig,
+      signedP2PKHTxSigComponent.input.sequence)
+    val inputs = signedP2PKHTx.inputs.updated(signedP2PKHTxSigComponent.inputIndex.toInt,fullInput)
+    val tx = Transaction(signedP2PKHTx.version,inputs,signedP2PKHTx.outputs, signedP2PKHTx.lockTime)
+    TxSigComponent(tx,signedP2PKHTxSigComponent.inputIndex, signedP2PKHTxSigComponent.scriptPubKey, signedP2PKHTxSigComponent.flags)
+  }
 }
 
 object EscrowTimeoutHelper extends EscrowTimeoutHelper

--- a/src/main/scala/org/bitcoins/core/wallet/P2PKHHelper.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/P2PKHHelper.scala
@@ -1,0 +1,50 @@
+package org.bitcoins.core.wallet
+
+import org.bitcoins.core.crypto._
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.policy.Policy
+import org.bitcoins.core.protocol.script.{EmptyScriptSignature, P2PKHScriptSignature, ScriptPubKey}
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.script.crypto.HashType
+
+/**
+  * Created by chris on 6/12/17.
+  */
+sealed trait P2PKHHelper {
+
+  /** This sign function generates a [[P2PKHScriptSignature]] for the given [[ScriptPubKey]]
+    * This function guesses the defaults for version/locktime/sequence
+    */
+  def sign(privKey: ECPrivateKey, spk: ScriptPubKey, outPoint: TransactionOutPoint,
+           outputs: Seq[TransactionOutput], hashType: HashType): TxSigComponent = {
+    sign(privKey,spk,outPoint,outputs,hashType,TransactionConstants.version,TransactionConstants.sequence,
+      TransactionConstants.lockTime)
+  }
+
+  /** This sign function gives you full customizability of what version/locktime/sequence number are used on the tx */
+  def sign(privKey: ECPrivateKey, spk: ScriptPubKey, outPoint: TransactionOutPoint,
+           outputs: Seq[TransactionOutput], hashType: HashType,
+           version: UInt32, sequence: UInt32, lockTime: UInt32): TxSigComponent = {
+    val publicKey = privKey.publicKey
+    val unsignedInput = buildP2PKHInput(EmptyDigitalSignature,publicKey,outPoint,sequence)
+    val unsignedInputs = Seq(unsignedInput)
+    val unsignedTx = Transaction(version,unsignedInputs,outputs,lockTime)
+    val inputIndex = UInt32.zero
+    val txSigComponent = TxSigComponent(unsignedTx,inputIndex,spk,
+      Policy.standardScriptVerifyFlags)
+    val signature = TransactionSignatureCreator.createSig(txSigComponent,privKey,hashType)
+
+    val signedInput = buildP2PKHInput(signature,publicKey,outPoint,sequence)
+    val signedInputs = Seq(signedInput)
+    val signedTx = Transaction(unsignedTx.version,signedInputs, unsignedTx.outputs, unsignedTx.lockTime)
+    TxSigComponent(signedTx,inputIndex,spk,txSigComponent.flags)
+  }
+
+  private def buildP2PKHInput(signature: ECDigitalSignature, publicKey: ECPublicKey,
+                              outPoint: TransactionOutPoint, sequence: UInt32): TransactionInput = {
+    val scriptSig = P2PKHScriptSignature(signature,publicKey)
+    TransactionInput(outPoint,scriptSig,sequence)
+  }
+}
+
+object P2PKHHelper extends P2PKHHelper

--- a/src/main/scala/org/bitcoins/core/wallet/P2PKHHelper.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/P2PKHHelper.scala
@@ -29,7 +29,7 @@ sealed trait P2PKHHelper {
     val unsignedInput = buildP2PKHInput(EmptyDigitalSignature,publicKey,outPoint,sequence)
     val unsignedInputs = Seq(unsignedInput)
     val unsignedTx = Transaction(version,unsignedInputs,outputs,lockTime)
-    val inputIndex = UInt32.zero
+    val inputIndex = UInt32(unsignedInputs.indexOf(unsignedInput))
     val txSigComponent = TxSigComponent(unsignedTx,inputIndex,spk,
       Policy.standardScriptVerifyFlags)
     val signature = TransactionSignatureCreator.createSig(txSigComponent,privKey,hashType)

--- a/src/test/scala/org/bitcoins/core/channels/ChannelsSpec.scala
+++ b/src/test/scala/org/bitcoins/core/channels/ChannelsSpec.scala
@@ -53,6 +53,15 @@ class ChannelsSpec extends Properties("ChannelProperties") with BitcoinSLogger {
     }
   }
 
+  property("close a payment channel with the timeout branch") = {
+    Prop.forAllNoShrink(ChannelGenerators.freshChannelInProgress, ScriptGenerators.p2pkhScriptPubKey) { case ((inProgress, privKeys),(refundSPK,_)) =>
+      val txSigComponent = inProgress.closeWithTimeout(refundSPK,privKeys(2),Satoshis.one)
+      val program = ScriptProgram(txSigComponent)
+      val result = ScriptInterpreter.run(program)
+      result == ScriptOk
+    }
+  }
+
   def verifyChannel(p: ChannelClosed, amount: CurrencyUnit, fee: CurrencyUnit): Boolean = {
     @tailrec
     def loop(last: TxSigComponent, remaining: Seq[TxSigComponent]): Boolean = {

--- a/src/test/scala/org/bitcoins/core/channels/ChannelsSpec.scala
+++ b/src/test/scala/org/bitcoins/core/channels/ChannelsSpec.scala
@@ -57,18 +57,18 @@ class ChannelsSpec extends Properties("ChannelProperties") with BitcoinSLogger {
   property("close a payment channel awaiting anchor tx with the timeout branch") = {
     Prop.forAllNoShrink(ChannelGenerators.channelAwaitingAnchorTxNotConfirmed) { case (awaiting, privKeys) =>
       val channelClosedWithTimeout = awaiting.closeWithTimeout(EmptyScriptPubKey,privKeys(2), Satoshis.one)
-      val program = ScriptProgram(channelClosedWithTimeout.finalTx)
-      val result = ScriptInterpreter.run(program)
-      result == ScriptOk
+      val program = channelClosedWithTimeout.map(c => ScriptProgram(c.finalTx))
+      val result = program.map(p => ScriptInterpreter.run(p))
+      result.get == ScriptOk
     }
   }
 
   property("close a payment channel in progress with the timeout branch") = {
     Prop.forAllNoShrink(ChannelGenerators.freshChannelInProgress) { case (inProgress, privKeys) =>
       val channelClosedWithTimeout = inProgress.closeWithTimeout(privKeys(2),Satoshis.one)
-      val program = ScriptProgram(channelClosedWithTimeout.finalTx)
-      val result = ScriptInterpreter.run(program)
-      result == ScriptOk
+      val program = channelClosedWithTimeout.map(c => ScriptProgram(c.finalTx))
+      val result = program.map(p => ScriptInterpreter.run(p))
+      result.get == ScriptOk
     }
   }
 

--- a/src/test/scala/org/bitcoins/core/channels/ChannelsSpec.scala
+++ b/src/test/scala/org/bitcoins/core/channels/ChannelsSpec.scala
@@ -55,8 +55,8 @@ class ChannelsSpec extends Properties("ChannelProperties") with BitcoinSLogger {
 
   property("close a payment channel with the timeout branch") = {
     Prop.forAllNoShrink(ChannelGenerators.freshChannelInProgress, ScriptGenerators.p2pkhScriptPubKey) { case ((inProgress, privKeys),(refundSPK,_)) =>
-      val txSigComponent = inProgress.closeWithTimeout(refundSPK,privKeys(2),Satoshis.one)
-      val program = ScriptProgram(txSigComponent)
+      val channelClosedWithTimeout = inProgress.closeWithTimeout(refundSPK,privKeys(2),Satoshis.one)
+      val program = ScriptProgram(channelClosedWithTimeout.finalTx)
       val result = ScriptInterpreter.run(program)
       result == ScriptOk
     }

--- a/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorSpec.scala
+++ b/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorSpec.scala
@@ -72,6 +72,7 @@ class TransactionSignatureCreatorSpec extends Properties("TransactionSignatureCr
         val result = ScriptInterpreter.run(program)
         Seq(ScriptOk, ScriptErrorPushSize).contains(result)
     }
+  
   property("fail to verify a transaction with a relative locktime that has not been satisfied yet") =
     Prop.forAllNoShrink(TransactionGenerators.unspendableCSVTransaction :| "unspendable csv") {
       case (txSignatureComponent: TxSigComponent, _) =>

--- a/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorSpec.scala
+++ b/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorSpec.scala
@@ -72,7 +72,6 @@ class TransactionSignatureCreatorSpec extends Properties("TransactionSignatureCr
         val result = ScriptInterpreter.run(program)
         Seq(ScriptOk, ScriptErrorPushSize).contains(result)
     }
-  
   property("fail to verify a transaction with a relative locktime that has not been satisfied yet") =
     Prop.forAllNoShrink(TransactionGenerators.unspendableCSVTransaction :| "unspendable csv") {
       case (txSignatureComponent: TxSigComponent, _) =>


### PR DESCRIPTION
Adds functionality to close a payment channel with the timeout branch of the EscrowTimeoutScriptPubKey. This pull request creates two Alegbraic Data Types for `ChannelClosed`. There are two ways we can close a Channel now, thus we have types to represent that. They are called `ChanneClosedWithEscrow` and `ChannelClosedWithTimeout`