### PR TITLE
Fixing bug in Channel.clientSigned where client output was not being …

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
 
 
-    <root level="OFF">
+    <root level="WARN">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/src/test/scala/org/bitcoins/core/channels/ChannelTest.scala
+++ b/src/test/scala/org/bitcoins/core/channels/ChannelTest.scala
@@ -56,7 +56,7 @@ class ChannelTest extends FlatSpec with MustMatchers with BitcoinSLogger {
 
   it must "fail to client sign a payment channel in progress if the value is more than the locked amount" in {
     val (inProgress,keys) = validInProgress
-    val i = inProgress.clientSign(inProgress.lockedAmount + Satoshis.one, keys.head)
+    val i = inProgress.clientSign(inProgress.lockedAmount, keys.head)
     i.isFailure must be (true)
   }
 
@@ -106,9 +106,6 @@ class ChannelTest extends FlatSpec with MustMatchers with BitcoinSLogger {
     val closed = inProgress.flatMap(_.close(serverSPK,keys(1), CurrencyUnits.oneBTC + Satoshis.one))
     closed.isFailure must be (true)
   }
-
-
-
 
   private def validInProgress: (ChannelInProgress, Seq[ECPrivateKey]) = {
     val clientSPK = ScriptGenerators.p2pkhScriptPubKey.sample.get._1


### PR DESCRIPTION
…removed if the client had spent all of it's funds

Previously we were not able to spend all funds in a payment channel, we would receive an error during the last incrementation of the payment channel where the client would have zero satoshis in his output, and the server would have `lockedAmount` - `fee`. This allows for the channel to be incremented until the full `lockedAmount` is spent to the server.