### PR TITLE
Update channel code with segwit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,1 +1,21 @@
-import AssemblyKeys._//test in assembly := {} testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "3")coverageExcludedPackages := ".*gen"coverageMinimum := 90coverageFailOnMinimum := truemergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>  {      case "logback.xml" => MergeStrategy.discard      case x => old(x)  }}assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+import AssemblyKeys._
+
+//test in assembly := {}
+
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "3")
+
+coverageExcludedPackages := ".*gen"
+
+coverageMinimum := 90
+
+coverageFailOnMinimum := true
+
+mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) => {
+    case "logback.xml" => MergeStrategy.discard
+    case x => old(x)
+  }
+}
+
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+
+testOptions in Test += Tests.Argument("-oF")

--- a/src/main/scala/org/bitcoins/core/channels/Channel.scala
+++ b/src/main/scala/org/bitcoins/core/channels/Channel.scala
@@ -10,6 +10,7 @@ import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.wallet.EscrowTimeoutHelper
 
+import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -21,7 +22,7 @@ sealed trait Channel extends BitcoinSLogger {
 
   /** The index of the output that is the [[EscrowTimeoutScriptPubKey]] in the [[anchorTx]] */
   def outputIndex: Int = {
-    val expectedLock = P2SHScriptPubKey(lock)
+    val expectedLock = P2SHScriptPubKey(WitnessScriptPubKeyV0(lock))
     val outputOpt = anchorTx.outputs.zipWithIndex.find { case (o, _) =>
       o.scriptPubKey == expectedLock
     }
@@ -52,20 +53,24 @@ sealed trait ChannelAwaitingAnchorTx extends Channel {
     * output. When the payment is actually redeemed the server will add one output that pays the server
     * and possibly add another input & output that pays a network fee.
     * */
-  def clientSign(clientSPK: ScriptPubKey, amount: CurrencyUnit,
+  def clientSign(clientChangeSPK: ScriptPubKey, amount: CurrencyUnit,
                        privKey: ECPrivateKey): Try[ChannelInProgressClientSigned] = Try {
     require(confirmations >= Policy.confirmations, "Need " + Policy.confirmations + " confirmations on the anchor tx before " +
       "we can create a payment channel in progress, got " + confirmations + " confirmations")
     require(amount >= Policy.minChannelAmount, "First payment channel payment amount must be: " + Policy.minChannelAmount + " got: " + amount)
-    val o1 = TransactionOutput(lockedAmount - amount, clientSPK)
+    val o1 = TransactionOutput(lockedAmount - amount, clientChangeSPK)
     val outputs = Seq(o1)
     val outPoint = TransactionOutPoint(anchorTx.txId, UInt32(outputIndex))
-    val i1 = TransactionInput(outPoint,EmptyScriptSignature,TransactionConstants.sequence)
+    val witSPK = WitnessScriptPubKeyV0(lock)
+    //TODO: Look at this, if we don't hit this we hit an except requiring the scriptSig to be a P2SHScriptSignature
+    val p2shScriptSig = P2SHScriptSignature(EmptyScriptSignature,witSPK)
+    val i1 = TransactionInput(outPoint,p2shScriptSig,TransactionConstants.sequence)
     val inputs = Seq(i1)
     val inputIndex = UInt32(inputs.indexOf(i1))
     val partiallySigned = EscrowTimeoutHelper.clientSign(inputs,outputs,inputIndex,privKey,
-      lock,scriptPubKey, HashType.sigHashSingleAnyoneCanPay)
-    val inProgress = ChannelInProgressClientSigned(anchorTx,lock,clientSPK,partiallySigned,Nil)
+      lock,TransactionOutput(lockedAmount,scriptPubKey), HashType.sigHashSingleAnyoneCanPay)
+    require(partiallySigned.transaction.outputs.exists(_.scriptPubKey == clientChangeSPK))
+    val inProgress = ChannelInProgressClientSigned(anchorTx,lock,clientChangeSPK,partiallySigned,Nil)
     inProgress
   }
 
@@ -73,10 +78,12 @@ sealed trait ChannelAwaitingAnchorTx extends Channel {
     * after we receive a partially signed transaction from the client.
     * If None is returned, that means we did not find an output that has the clientSPK
     */
-  def createClientSigned(partiallySigned: Transaction, changeClientSPK: ScriptPubKey): Option[ChannelInProgressClientSigned] = {
+  def createClientSigned(partiallySigned: WitnessTransaction, changeClientSPK: ScriptPubKey): Option[ChannelInProgressClientSigned] = {
     val inputOpt = partiallySigned.inputs.zipWithIndex.find(_._1.previousOutput.txId == anchorTx.txId)
     val inputIndex = inputOpt.map(i => UInt32(i._2))
-    val txSigComponent = inputIndex.map(i => TxSigComponent(partiallySigned, i, scriptPubKey,Policy.standardScriptVerifyFlags))
+    val txSigComponent = inputIndex.map { i =>
+      WitnessTxSigComponent(partiallySigned, i, scriptPubKey, Policy.standardScriptVerifyFlags, lockedAmount)
+    }
     txSigComponent.map(t => ChannelInProgressClientSigned(anchorTx,lock,changeClientSPK,t,Nil))
   }
 
@@ -85,15 +92,22 @@ sealed trait ChannelAwaitingAnchorTx extends Channel {
     * Note that this does not require any confirmations on the anchor tx,
     * this is because the Client is essentially refunding himself the money
     */
-  def closeWithTimeout(refundSPK: ScriptPubKey, clientKey: ECPrivateKey, fee: CurrencyUnit): Try[ChannelClosedWithTimeout] = {
+  def closeWithTimeout(clientChangeSPK: ScriptPubKey, clientKey: ECPrivateKey, fee: CurrencyUnit): Try[ChannelClosedWithTimeout] = {
     val timeout = lock.timeout
     val scriptNum = timeout.locktime
     val sequence = UInt32(scriptNum.toLong)
-    val outputs = Seq(TransactionOutput(lockedAmount - fee, refundSPK))
+    val outputs = Seq(TransactionOutput(lockedAmount - fee, clientChangeSPK))
     val outPoint = TransactionOutPoint(anchorTx.txId,UInt32(outputIndex))
-    val signedTxSigComponent = EscrowTimeoutHelper.closeWithTimeout(clientKey,lock,outPoint,outputs,HashType.sigHashAll,
-      TransactionConstants.validLockVersion, sequence,TransactionConstants.lockTime)
-    signedTxSigComponent.map(t => ChannelClosedWithTimeout(anchorTx,lock,t,Nil,refundSPK))
+    val tc = TransactionConstants
+    val witSPK = WitnessScriptPubKeyV0(lock)
+    val scriptSig = P2SHScriptSignature(witSPK)
+    val input = TransactionInput(outPoint,scriptSig,sequence)
+    val inputs = Seq(input)
+    val inputIndex = UInt32(inputs.indexOf(input))
+    val creditingOutput = lockingOutput
+    val signed: Try[WitnessTxSigComponent] = EscrowTimeoutHelper.closeWithTimeout(inputs,outputs, inputIndex, clientKey,
+      lock,creditingOutput,HashType.sigHashAll,tc.validLockVersion,sequence,tc.lockTime)
+    signed.map(t => ChannelClosedWithTimeout(anchorTx,lock,t,Nil,clientChangeSPK))
   }
 
 }
@@ -102,20 +116,20 @@ sealed trait ChannelAwaitingAnchorTx extends Channel {
 sealed trait BaseInProgress { this: Channel =>
 
   /** The most recent [[TxSigComponent]] in the payment channel */
-  def current: TxSigComponent
+  def current: WitnessTxSigComponent
 
   /** The previous states of the payment channel.
     * The first item in the Seq is the most recent [[TxSigComponent]] in the [[Channel]]
     */
-  def old: Seq[TxSigComponent]
+  def old: Seq[WitnessTxSigComponent]
 
-  /** The [[ScriptPubKey]] that pays the client it's refund */
-  def clientSPK: ScriptPubKey
+  /** The [[ScriptPubKey]] that pays the client it's change */
+  def clientChangeSPK: ScriptPubKey
 
   /** The output index that pays change to the client on the spending transaction */
   def clientOutputIndex: Option[Int] = {
     val outputOpt = current.transaction.outputs.zipWithIndex.find {
-      case (o, _) => o.scriptPubKey == clientSPK
+      case (o, _) => o.scriptPubKey == clientChangeSPK
     }
     outputOpt.map(_._2)
   }
@@ -138,11 +152,18 @@ sealed trait BaseInProgress { this: Channel =>
     val timeout = lock.timeout
     val scriptNum = timeout.locktime
     val sequence = UInt32(scriptNum.toLong)
-    val outputs = Seq(TransactionOutput(lockedAmount - fee, clientSPK))
+    val outputs = Seq(TransactionOutput(lockedAmount - fee, clientChangeSPK))
     val outPoint = TransactionOutPoint(anchorTx.txId,UInt32(outputIndex))
-    val signedTxSigComponent = EscrowTimeoutHelper.closeWithTimeout(clientKey,lock,outPoint,outputs,HashType.sigHashAll,
-      TransactionConstants.validLockVersion, sequence,TransactionConstants.lockTime)
-    signedTxSigComponent.map(t => ChannelClosedWithTimeout(anchorTx,lock,t,current +: old,clientSPK))
+    val tc = TransactionConstants
+    val witSPK = WitnessScriptPubKeyV0(lock)
+    val scriptSig = P2SHScriptSignature(witSPK)
+    val input = TransactionInput(outPoint,scriptSig,sequence)
+    val inputs = Seq(input)
+    val inputIndex = UInt32.zero
+    val creditingOutput = lockingOutput
+    val signed: Try[WitnessTxSigComponent] = EscrowTimeoutHelper.closeWithTimeout(inputs,outputs, inputIndex, clientKey,
+      lock,creditingOutput,HashType.sigHashAll,tc.validLockVersion,sequence,tc.lockTime)
+    signed.map(t => ChannelClosedWithTimeout(anchorTx,lock,t,Nil,clientChangeSPK))
   }
 
 
@@ -156,39 +177,52 @@ sealed trait ChannelInProgress extends Channel with BaseInProgress {
     val inputs = current.transaction.inputs
     val inputIndex = current.inputIndex
     val client = clientOutput
-    val newClient: Option[TransactionOutput] = client.flatMap { c =>
-      val newClientAmount = c.value - amount
-      if (newClientAmount <= Policy.dustThreshold && newClientAmount >= CurrencyUnits.zero) None
-      else Some(TransactionOutput(c, newClientAmount))
+    val newClient: Try[Option[TransactionOutput]] = client match {
+      case Some(c) =>
+        val newClientAmount = c.value - amount
+        if (newClientAmount < CurrencyUnits.zero) Failure(new IllegalArgumentException("Client is spending more money than was locked in the output"))
+        else if (newClientAmount <= Policy.dustThreshold) Success(None)
+        else Success(Some(TransactionOutput(newClientAmount,c.scriptPubKey)))
+      case None =>
+        Failure(new IllegalArgumentException("Client has already spent all of it's money to the server"))
     }
-    val newOutputs: Seq[TransactionOutput] = clientOutputIndex match {
-      case Some(idx) => newClient match {
+    val newOutputs: Try[Seq[TransactionOutput]] = clientOutputIndex match {
+      case Some(idx) => newClient.map {
         case Some(c) => outputs.updated(idx, c)
         case None =>
           //remove old client output
-          outputs.patch(idx,Nil,1)
+          outputs.patch(idx, Nil, 1)
       }
-      case None => outputs
+      case None => Success(outputs)
     }
-    val result: Try[ChannelInProgressClientSigned] = newClient match {
-      case Some(o) => checkAmount(o).map(_ => updateChannel(inputs, newOutputs, clientKey, inputIndex))
-      case None => Success(updateChannel(inputs,newOutputs,clientKey,inputIndex))
-    }
-    result
+    val invariant = newOutputs.flatMap(checkAmounts(_))
+    invariant.flatMap(_ => newOutputs.map(os => updateChannel(inputs,os,clientKey,inputIndex)))
   }
 
   /** Check that the amounts for the client output are valid */
-  private def checkAmount(output: TransactionOutput): Try[Unit] = Try {
-    require(output.value >= Policy.dustThreshold, "Client doesn't have enough money to pay server, money left: " + output.value)
-    require(output.value <= lockedAmount, "Client output cannot have more money than the total locked amount")
+  private def checkAmounts(outputs: Seq[TransactionOutput]): Try[Unit] = {
+    @tailrec
+    def loop(remaining: Seq[TransactionOutput]): Try[Unit] = {
+      if (remaining.isEmpty) Success(Unit)
+      else {
+        val output = remaining.head
+        val invariant1 = Try(require(output.value >= Policy.dustThreshold,
+          "Output is below the dust threshold, money left: " + output.value))
+        val invariant2 = invariant1.flatMap(_ => Try(require(output.value <= lockedAmount,
+          "Output cannot have more money than the total locked amount")))
+        if (invariant2.isFailure) invariant2
+        else loop(remaining.tail)
+      }
+    }
+    loop(outputs)
   }
 
   /** Updates the payment channel with the given parameters */
   private def updateChannel(inputs: Seq[TransactionInput], outputs: Seq[TransactionOutput], clientKey: ECPrivateKey,
                             inputIndex: UInt32): ChannelInProgressClientSigned = {
     val partiallySigned = EscrowTimeoutHelper.clientSign(inputs,outputs,inputIndex,clientKey,lock,
-      scriptPubKey, HashType.sigHashSingleAnyoneCanPay)
-    val inProgress = ChannelInProgressClientSigned(anchorTx,lock,clientSPK,
+      lockingOutput, HashType.sigHashSingleAnyoneCanPay)
+    val inProgress = ChannelInProgressClientSigned(anchorTx,lock,clientChangeSPK,
       partiallySigned, current +: old)
     inProgress
   }
@@ -196,10 +230,10 @@ sealed trait ChannelInProgress extends Channel with BaseInProgress {
   /** Useful for the server to create a [[org.bitcoins.core.channels.ChannelInProgressClientSigned]]
     * after we receive a partially signed transaction from the client
     */
-  def createClientSigned(partiallySigned: BaseTransaction): ChannelInProgressClientSigned = {
-    val txSigComponent = TxSigComponent(partiallySigned,current.inputIndex, scriptPubKey,
-      current.flags)
-    ChannelInProgressClientSigned(anchorTx,lock, clientSPK,txSigComponent, current +: old)
+  def createClientSigned(partiallySigned: WitnessTransaction): ChannelInProgressClientSigned = {
+    val txSigComponent = WitnessTxSigComponent(partiallySigned,current.inputIndex, scriptPubKey,
+      current.flags,lockedAmount)
+    ChannelInProgressClientSigned(anchorTx,lock, clientChangeSPK,txSigComponent, current +: old)
   }
 
 }
@@ -207,18 +241,18 @@ sealed trait ChannelInProgress extends Channel with BaseInProgress {
 /** A payment channel that has been signed by the client, but not signed by the server yet */
 sealed trait ChannelInProgressClientSigned extends Channel with BaseInProgress {
   /** The new payment channel transaction that has the clients digital signature but does not have the servers digital signature yet */
-  private def partiallySignedTx: Transaction = current.transaction
+  private def partiallySignedTx: WitnessTransaction = current.transaction
 
   /** Signs the payment channel transaction with the server's [[ECPrivateKey]] */
   def serverSign(serverKey: ECPrivateKey): Try[ChannelInProgress] = {
-    val unsignedTxSigComponent = TxSigComponent(partiallySignedTx,
-      current.inputIndex, lock, Policy.standardScriptVerifyFlags)
+    val unsignedTxSigComponent = WitnessTxSigComponentP2SH(partiallySignedTx,
+      current.inputIndex, scriptPubKey, Policy.standardScriptVerifyFlags,lockedAmount)
 
-    val signedTxSigComponent: Try[TxSigComponent] = EscrowTimeoutHelper.serverSign(serverKey,
+    val signedTxSigComponent: Try[WitnessTxSigComponent] = EscrowTimeoutHelper.serverSign(serverKey,
       unsignedTxSigComponent, HashType.sigHashAll)
 
     signedTxSigComponent.map { s =>
-      ChannelInProgress(anchorTx,lock, clientSPK, s, old)
+      ChannelInProgress(anchorTx,lock, clientChangeSPK, s, old)
     }
   }
 
@@ -237,10 +271,10 @@ sealed trait ChannelInProgressClientSigned extends Channel with BaseInProgress {
     }
     val invariant = checkCloseOutputs(outputs,fee, serverSPK)
     val oldTx = partiallySignedTx
-    val updatedTx = Transaction(oldTx.version,oldTx.inputs,outputs,oldTx.lockTime)
-    val txSigComponent = TxSigComponent(updatedTx,current.inputIndex,
-      current.scriptPubKey,current.flags)
-    val updatedInProgressClientSigned = ChannelInProgressClientSigned(anchorTx,lock,clientSPK,txSigComponent,old)
+    val updatedTx = WitnessTransaction(oldTx.version,oldTx.inputs,outputs,oldTx.lockTime,oldTx.witness)
+    val txSigComponent = WitnessTxSigComponent(updatedTx,current.inputIndex,
+      scriptPubKey,current.flags, current.amount)
+    val updatedInProgressClientSigned = ChannelInProgressClientSigned(anchorTx,lock,clientChangeSPK,txSigComponent,old)
     val serverSigned = invariant.flatMap(_ => updatedInProgressClientSigned.serverSign(serverKey))
     serverSigned.map(s => ChannelClosedWithEscrow(s,serverSPK))
   }
@@ -249,7 +283,7 @@ sealed trait ChannelInProgressClientSigned extends Channel with BaseInProgress {
   private def checkCloseOutputs(outputs: Seq[TransactionOutput], fee: CurrencyUnit,
                                 serverSPK: ScriptPubKey):Try[Unit] = Try {
     val serverOutput = outputs.find(_.scriptPubKey == serverSPK).get
-    val clientOutput = outputs.find(_.scriptPubKey == clientSPK)
+    val clientOutput = outputs.find(_.scriptPubKey == clientChangeSPK)
     val currencyUnits = outputs.map(_.value)
     val fullOutputValue = currencyUnits.fold(CurrencyUnits.zero)(_ + _)
 
@@ -293,9 +327,9 @@ sealed trait ChannelClosedWithEscrow extends ChannelClosed {
 object ChannelAwaitingAnchorTx {
   private case class ChannelAwaitAnchorTxImpl(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey,
                                                      confirmations: Long) extends ChannelAwaitingAnchorTx {
-    private val expectedScriptPubKey = P2SHScriptPubKey(lock)
+    private val expectedScriptPubKey = P2SHScriptPubKey(WitnessScriptPubKeyV0(lock))
     require(anchorTx.outputs.exists(_.scriptPubKey == expectedScriptPubKey),
-      "One output on the Anchor Transaction has to have a P2SH(EscrowTimeoutScriptPubKey)")
+      "One output on the Anchor Transaction has to have a P2SH(P2WSH(EscrowTimeoutScriptPubKey))")
     require(lockedAmount >= Policy.minChannelAmount, "We need to lock at least " + Policy.minChannelAmount +
       " in the payment channel, got: " + lockedAmount)
   }
@@ -314,67 +348,67 @@ object ChannelAwaitingAnchorTx {
 
 object ChannelInProgress {
   private case class ChannelInProgressImpl(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey,
-                                                  clientSPK: ScriptPubKey, current: TxSigComponent,
-                                                  old: Seq[TxSigComponent]) extends ChannelInProgress
+                                           clientChangeSPK: ScriptPubKey, current: WitnessTxSigComponent,
+                                           old: Seq[WitnessTxSigComponent]) extends ChannelInProgress
 
 
   def apply(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey, clientSPK: ScriptPubKey,
-            current: BaseTxSigComponent): ChannelInProgress = {
+            current: WitnessTxSigComponent): ChannelInProgress = {
     ChannelInProgress(anchorTx,lock,clientSPK, current,Nil)
   }
 
   def apply(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey, clientSPK: ScriptPubKey,
-    current: TxSigComponent, old: Seq[TxSigComponent]): ChannelInProgress = {
+    current: WitnessTxSigComponent, old: Seq[WitnessTxSigComponent]): ChannelInProgress = {
     ChannelInProgressImpl(anchorTx,lock,clientSPK,current,old)
   }
 }
 
 object ChannelInProgressClientSigned {
   private case class ChannelInProgressClientSignedImpl(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey,
-                                                              clientSPK: ScriptPubKey, current: TxSigComponent,
-                                                              old: Seq[TxSigComponent]) extends ChannelInProgressClientSigned
+                                                       clientChangeSPK: ScriptPubKey, current: WitnessTxSigComponent,
+                                                       old: Seq[WitnessTxSigComponent]) extends ChannelInProgressClientSigned
 
   def apply(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey, clientSPK: ScriptPubKey,
-            current: TxSigComponent): ChannelInProgressClientSigned = {
+            current: WitnessTxSigComponent): ChannelInProgressClientSigned = {
     ChannelInProgressClientSigned(anchorTx,lock, clientSPK, current,Nil)
   }
 
-  def apply(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey, clientSPK: ScriptPubKey,
-            current: TxSigComponent, old: Seq[TxSigComponent]): ChannelInProgressClientSigned = {
-    ChannelInProgressClientSignedImpl(anchorTx,lock, clientSPK, current,old)
+  def apply(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey, clientChangeSPK: ScriptPubKey,
+            current: WitnessTxSigComponent, old: Seq[WitnessTxSigComponent]): ChannelInProgressClientSigned = {
+    ChannelInProgressClientSignedImpl(anchorTx,lock, clientChangeSPK, current,old)
   }
 
 }
 
 object ChannelClosedWithEscrow {
   private case class ChannelClosedWithEscrowImpl(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey,
-                                                 current: TxSigComponent, old: Seq[TxSigComponent],
-                                       clientSPK: ScriptPubKey, serverSPK: ScriptPubKey) extends ChannelClosedWithEscrow {
+                                                 current: WitnessTxSigComponent, old: Seq[WitnessTxSigComponent],
+                                                 clientChangeSPK: ScriptPubKey, serverSPK: ScriptPubKey) extends ChannelClosedWithEscrow {
     require(current.transaction.outputs.exists(_.scriptPubKey == serverSPK), "The final transaction must have a SPK that pays the server")
   }
 
-  def apply(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey, finalTx: TxSigComponent,
-            old: Seq[TxSigComponent], clientSPK: ScriptPubKey, serverSPK: ScriptPubKey): ChannelClosedWithEscrow = {
-    ChannelClosedWithEscrowImpl(anchorTx,lock,finalTx,old,clientSPK, serverSPK)
+  def apply(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey, current: WitnessTxSigComponent,
+            old: Seq[WitnessTxSigComponent], clientSPK: ScriptPubKey, serverSPK: ScriptPubKey): ChannelClosedWithEscrow = {
+    ChannelClosedWithEscrowImpl(anchorTx,lock,current,old,clientSPK, serverSPK)
   }
 
   def apply(i: ChannelInProgress, serverSPK: ScriptPubKey): ChannelClosedWithEscrow = {
-    ChannelClosedWithEscrowImpl(i.anchorTx,i.lock,i.current,i.old,i.clientSPK,serverSPK)
+    ChannelClosedWithEscrowImpl(i.anchorTx,i.lock,i.current,i.old,i.clientChangeSPK,serverSPK)
   }
 }
 
 object ChannelClosedWithTimeout {
   private case class ChannelClosedWithTimeoutImpl(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey,
-                                                  current: TxSigComponent, old: Seq[TxSigComponent],
-                                                  clientSPK: ScriptPubKey) extends ChannelClosedWithTimeout {
-    require(current.transaction.outputs.exists(_.scriptPubKey == clientSPK),
+                                                  current: WitnessTxSigComponent, old: Seq[WitnessTxSigComponent],
+                                                  clientChangeSPK: ScriptPubKey) extends ChannelClosedWithTimeout {
+    require(current.transaction.outputs.exists(_.scriptPubKey == clientChangeSPK),
       "Client SPK was not defined on a output. This is SPK that is suppose to refund the client it's money")
   }
 
   def apply(anchorTx: Transaction, lock: EscrowTimeoutScriptPubKey,
-            finalTx: TxSigComponent, old: Seq[TxSigComponent],
+            current: WitnessTxSigComponent, old: Seq[WitnessTxSigComponent],
             clientSPK: ScriptPubKey): ChannelClosedWithTimeout = {
-    ChannelClosedWithTimeoutImpl(anchorTx,lock,finalTx,old,clientSPK)
+    ChannelClosedWithTimeoutImpl(anchorTx,lock,current,old,clientSPK)
   }
 
 }

--- a/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -175,26 +175,20 @@ trait TransactionSignatureSerializer extends RawBitcoinSerializerHelper with Bit
         CryptoUtil.doubleSHA256(bytes).bytes
       } else emptyHash.bytes
 
-      logger.debug("outPointHash: " + outPointHash.map(BitcoinSUtil.encodeHex(_)))
       val sequenceHash: Seq[Byte] = if (isNotAnyoneCanPay && isNotSigHashNone && isNotSigHashSingle) {
         val bytes = spendingTx.inputs.flatMap(_.sequence.bytes)
         CryptoUtil.doubleSHA256(bytes).bytes
       } else emptyHash.bytes
 
-      logger.debug("sequenceHash: " + sequenceHash.map(BitcoinSUtil.encodeHex(_)))
       val outputHash: Seq[Byte] = if (isNotSigHashSingle && isNotSigHashNone) {
-        logger.debug("Not SIGHASH_SINGLE & Not SIGHASH_NONE")
         val bytes = spendingTx.outputs.flatMap(o => BitcoinSUtil.decodeHex(RawTransactionOutputParser.write(o)))
         CryptoUtil.doubleSHA256(bytes).bytes
       } else if (HashType.isSIGHASH_SINGLE(hashType.num) && inputIndex < UInt32(spendingTx.outputs.size)) {
-        logger.debug("SIGHASH_SINGLE and input index < outputs size")
         val output = spendingTx.outputs(inputIndexInt)
         val bytes = CryptoUtil.doubleSHA256(RawTransactionOutputParser.write(output)).bytes
         bytes
       } else emptyHash.bytes
 
-      logger.debug("outputHash: " + outputHash.map(BitcoinSUtil.encodeHex(_)))
-      logger.debug("Script: " + script)
       val scriptBytes = script.flatMap(_.bytes)
       //helper function to flip endianness
       val fe: Seq[Byte] => Seq[Byte] = {bytes: Seq[Byte] => BitcoinSUtil.decodeHex(BitcoinSUtil.flipEndianness(bytes)) }
@@ -203,7 +197,7 @@ trait TransactionSignatureSerializer extends RawBitcoinSerializerHelper with Bit
         spendingTx.inputs(inputIndexInt).previousOutput.bytes ++ CompactSizeUInt.calculateCompactSizeUInt(scriptBytes).bytes ++
         scriptBytes ++ fe(amount.bytes) ++ fe(spendingTx.inputs(inputIndexInt).sequence.bytes) ++
         outputHash ++ fe(spendingTx.lockTime.bytes) ++ hashType.num.bytes.reverse
-      logger.info("Serialization for signature for WitnessV0Sig: " + BitcoinSUtil.encodeHex(serializationForSig))
+      logger.debug("Serialization for signature for WitnessV0Sig: " + BitcoinSUtil.encodeHex(serializationForSig))
       serializationForSig
   }
 

--- a/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
@@ -58,7 +58,7 @@ sealed trait WitnessTxSigComponent extends TxSigComponent {
   override def sigVersion = SigVersionWitnessV0
 }
 
-/** This represents checking the [[WitnessTransaction] against a P2WPKH or P2WSH ScriptPubKey */
+/** This represents checking the [[WitnessTransaction]] against a P2WPKH or P2WSH ScriptPubKey */
 sealed trait WitnessTxSigComponentRaw extends WitnessTxSigComponent {
   override def scriptPubKey: WitnessScriptPubKey
 
@@ -71,7 +71,7 @@ sealed trait WitnessTxSigComponentP2SH extends WitnessTxSigComponent {
 
   override def scriptSignature: P2SHScriptSignature = {
     val s = transaction.inputs(inputIndex.toInt).scriptSignature
-    require(s.isInstanceOf[P2SHScriptSignature], "Must have P2SHScriptSignature for P2SH(P2WSH())")
+    require(s.isInstanceOf[P2SHScriptSignature], "Must have P2SHScriptSignature for P2SH(P2WSH()), got: " + s)
     s.asInstanceOf[P2SHScriptSignature]
   }
 
@@ -137,7 +137,7 @@ object WitnessTxSigComponent {
 
 object WitnessTxSigComponentRaw {
   private case class WitnessTxSigComponentRawImpl(transaction: WitnessTransaction,inputIndex: UInt32,
-                                              scriptPubKey: WitnessScriptPubKey, flags: Seq[ScriptFlag],
+                                                  scriptPubKey: WitnessScriptPubKey, flags: Seq[ScriptFlag],
                                                   amount: CurrencyUnit) extends WitnessTxSigComponentRaw
 
   def apply(transaction: WitnessTransaction,inputIndex: UInt32,

--- a/src/main/scala/org/bitcoins/core/gen/ChannelGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/ChannelGenerators.scala
@@ -24,7 +24,7 @@ sealed trait ChannelGenerators extends BitcoinSLogger {
   def anchorTx: Gen[(Transaction, EscrowTimeoutScriptPubKey, Seq[ECPrivateKey])] = for {
     (redeemScript,privKeys) <- ScriptGenerators.escrowTimeoutScriptPubKey2Of2
     amount <- CurrencyUnitGenerator.satoshis.suchThat(_ >= Policy.minChannelAmount)
-    p2sh = P2SHScriptPubKey(redeemScript)
+    p2sh = P2SHScriptPubKey(WitnessScriptPubKeyV0(redeemScript))
     (aTx,_) = TransactionGenerators.buildCreditingTransaction(TransactionConstants.validLockVersion,p2sh,amount)
   } yield (aTx,redeemScript,privKeys)
 

--- a/src/main/scala/org/bitcoins/core/gen/TransactionGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/TransactionGenerators.scala
@@ -1,15 +1,15 @@
 package org.bitcoins.core.gen
 
-import org.bitcoins.core.crypto.{ECPrivateKey, TxSigComponent, WitnessTxSigComponent}
+import org.bitcoins.core.crypto.{ECPrivateKey, TxSigComponent, WitnessTxSigComponent, WitnessTxSigComponentRaw}
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
-import org.bitcoins.core.number.{Int64, UInt32}
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction.{TransactionInput, TransactionOutPoint, TransactionOutput, _}
 import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.locktime.LockTimeInterpreter
-import org.bitcoins.core.util.{BitcoinSLogger, BitcoinScriptUtil}
+import org.bitcoins.core.util.BitcoinSLogger
 import org.scalacheck.Gen
 
 /**
@@ -237,28 +237,28 @@ trait TransactionGenerators extends BitcoinSLogger {
   } yield (wtxSigComponent,privKeys)
 
   /** Generates a [[WitnessTransaction]] that has an input spends a raw P2WSH [[WitnessScriptPubKey]] */
-  def signedP2WSHP2PKTransaction: Gen[(WitnessTxSigComponent, Seq[ECPrivateKey])] = for {
+  def signedP2WSHP2PKTransaction: Gen[(WitnessTxSigComponentRaw, Seq[ECPrivateKey])] = for {
     (_,wtxSigComponent, privKeys) <- WitnessGenerators.signedP2WSHP2PKTransactionWitness
   } yield (wtxSigComponent,privKeys)
 
   /** Generates a [[WitnessTransaction]] that has an input spends a raw P2WSH [[WitnessScriptPubKey]] */
-  def signedP2WSHP2PKHTransaction: Gen[(WitnessTxSigComponent, Seq[ECPrivateKey])] = for {
+  def signedP2WSHP2PKHTransaction: Gen[(WitnessTxSigComponentRaw, Seq[ECPrivateKey])] = for {
     (_,wtxSigComponent, privKeys) <- WitnessGenerators.signedP2WSHP2PKHTransactionWitness
   } yield (wtxSigComponent,privKeys)
 
-  def signedP2WSHMultiSigTransaction: Gen[(WitnessTxSigComponent, Seq[ECPrivateKey])] = for {
+  def signedP2WSHMultiSigTransaction: Gen[(WitnessTxSigComponentRaw, Seq[ECPrivateKey])] = for {
     (_,wtxSigComponent, privKeys) <- WitnessGenerators.signedP2WSHMultiSigTransactionWitness
   } yield (wtxSigComponent,privKeys)
 
-  def signedP2WSHMultiSigEscrowTimeoutTransaction: Gen[(WitnessTxSigComponent, Seq[ECPrivateKey])] = for {
+  def signedP2WSHMultiSigEscrowTimeoutTransaction: Gen[(WitnessTxSigComponentRaw, Seq[ECPrivateKey])] = for {
     (_,wtxSigComponent,privKeys) <- WitnessGenerators.signedP2WSHMultiSigEscrowTimeoutWitness
   } yield (wtxSigComponent,privKeys)
 
-  def spendableP2WSHTimeoutEscrowTimeoutTransaction: Gen[(WitnessTxSigComponent, Seq[ECPrivateKey])] = for {
+  def spendableP2WSHTimeoutEscrowTimeoutTransaction: Gen[(WitnessTxSigComponentRaw, Seq[ECPrivateKey])] = for {
     (_,wtxSigComponent,privKeys) <- WitnessGenerators.spendableP2WSHTimeoutEscrowTimeoutWitness
   } yield (wtxSigComponent,privKeys)
 
-  def signedP2WSHEscrowTimeoutTransaction: Gen[(WitnessTxSigComponent, Seq[ECPrivateKey])] = {
+  def signedP2WSHEscrowTimeoutTransaction: Gen[(WitnessTxSigComponentRaw, Seq[ECPrivateKey])] = {
     Gen.oneOf(signedP2WSHMultiSigEscrowTimeoutTransaction,spendableP2WSHTimeoutEscrowTimeoutTransaction)
   }
 
@@ -272,7 +272,7 @@ trait TransactionGenerators extends BitcoinSLogger {
       scriptPubKey, Policy.standardScriptVerifyFlags,amount)
   } yield (signedTxSignatureComponent, privKeys)
 
-  def signedP2WSHTransaction: Gen[(WitnessTxSigComponent,Seq[ECPrivateKey])] = {
+  def signedP2WSHTransaction: Gen[(WitnessTxSigComponentRaw,Seq[ECPrivateKey])] = {
     Gen.oneOf(signedP2WSHP2PKTransaction, signedP2WSHP2PKHTransaction, signedP2WSHMultiSigTransaction,
       signedP2WSHEscrowTimeoutTransaction)
   }
@@ -284,7 +284,7 @@ trait TransactionGenerators extends BitcoinSLogger {
     (creditingTx,outputIndex) = buildCreditingTransaction(p2shScriptSig.redeemScript, wtxSigComponent.amount)
     sequence = wtxSigComponent.transaction.inputs(wtxSigComponent.inputIndex.toInt).sequence
     locktime = wtxSigComponent.transaction.lockTime
-    (signedTx,inputIndex) = buildSpendingTransaction(UInt32(2),creditingTx,p2shScriptSig,outputIndex,locktime,sequence,witness)
+    (signedTx,inputIndex) = buildSpendingTransaction(TransactionConstants.validLockVersion,creditingTx,p2shScriptSig,outputIndex,locktime,sequence,witness)
     signedTxSignatureComponent = WitnessTxSigComponent(signedTx,inputIndex,
       p2shScriptPubKey, Policy.standardScriptVerifyFlags, wtxSigComponent.amount)
   } yield (signedTxSignatureComponent,privKeys)

--- a/src/main/scala/org/bitcoins/core/policy/Policy.scala
+++ b/src/main/scala/org/bitcoins/core/policy/Policy.scala
@@ -30,6 +30,8 @@ trait Policy {
     ScriptVerifyLowS, ScriptVerifyWitness, ScriptVerifyMinimalIf, ScriptVerifyNullFail,
     ScriptVerifyNullDummy, ScriptVerifyWitnessPubKeyType, ScriptVerifyDiscourageUpgradableWitnessProgram)
 
+  def standardFlags = standardScriptVerifyFlags
+
   /** The number of confirmations for a payment to be considered as accepted */
   def confirmations: Long = 6
 

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -134,11 +134,14 @@ sealed trait P2SHScriptSignature extends ScriptSignature {
     //witness scriptPubKeys always have EmptyScriptSigs
     if (WitnessScriptPubKey.isWitnessScriptPubKey(asm)) Success(EmptyScriptSignature)
     else {
-      val asmWithoutRedeemScriptAndPushOp = asm(asm.size - 2) match {
-        case b : BytesToPushOntoStack => asm.dropRight(2)
-        case _ => asm.dropRight(3)
+      val asmWithoutRedeemScriptAndPushOp: Try[Seq[ScriptToken]] = Try {
+        asm(asm.size - 2) match {
+          case b: BytesToPushOntoStack => asm.dropRight(2)
+          case _ => asm.dropRight(3)
+        }
       }
-      ScriptSignature.fromScriptPubKey(asmWithoutRedeemScriptAndPushOp,redeemScript)
+      val script = asmWithoutRedeemScriptAndPushOp.getOrElse(EmptyScriptSignature.asm)
+      ScriptSignature.fromScriptPubKey(script,redeemScript)
     }
   }
 

--- a/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -511,18 +511,10 @@ trait ScriptInterpreter extends CryptoInterpreter with StackInterpreter with Con
             wtx.witness.witnesses(txSigComponent.inputIndex.toInt).stack.nonEmpty
           case _ : BaseTransaction => false
         }
-      case w : WitnessTxSigComponent =>
-        val witnessedUsed = w.scriptPubKey match {
-          case _ : WitnessScriptPubKey => true
-          case _ : P2SHScriptPubKey =>
-            val p2shScriptSig = P2SHScriptSignature(txSigComponent.scriptSignature.bytes)
-            p2shScriptSig.redeemScript.isInstanceOf[WitnessScriptPubKey]
-          case _: CLTVScriptPubKey | _: CSVScriptPubKey | _: MultiSignatureScriptPubKey | _: NonStandardScriptPubKey
-               | _: P2PKScriptPubKey | _: P2PKHScriptPubKey | _: WitnessCommitment
-               | _: EscrowTimeoutScriptPubKey | EmptyScriptPubKey =>
-            w.witness.stack.isEmpty
-        }
-        !witnessedUsed
+      case _: WitnessTxSigComponentRaw => false
+      case w: WitnessTxSigComponentP2SH =>
+        val p2shScriptSig = P2SHScriptSignature(w.scriptSignature.bytes)
+        !p2shScriptSig.redeemScript.isInstanceOf[WitnessScriptPubKey]
       case r: WitnessTxSigComponentRebuilt =>
         r.transaction match {
           case wtx: WitnessTransaction =>

--- a/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -513,8 +513,7 @@ trait ScriptInterpreter extends CryptoInterpreter with StackInterpreter with Con
         }
       case _: WitnessTxSigComponentRaw => false
       case w: WitnessTxSigComponentP2SH =>
-        val p2shScriptSig = P2SHScriptSignature(w.scriptSignature.bytes)
-        !p2shScriptSig.redeemScript.isInstanceOf[WitnessScriptPubKey]
+        !w.scriptSignature.redeemScript.isInstanceOf[WitnessScriptPubKey]
       case r: WitnessTxSigComponentRebuilt =>
         r.transaction match {
           case wtx: WitnessTransaction =>

--- a/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParser.scala
+++ b/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParser.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.serializers.script.{RawScriptPubKeyParser, ScriptParser}
 import org.bitcoins.core.serializers.{RawBitcoinSerializer, RawSatoshisSerializer}
-import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
+import org.bitcoins.core.util.BitcoinSUtil
 
 import scala.annotation.tailrec
 
@@ -49,9 +49,7 @@ trait RawTransactionOutputParser extends RawBitcoinSerializer[Seq[TransactionOut
     val satoshis = CurrencyUnits.toSatoshis(output.value)
     val satoshisHexWithoutPadding : String = BitcoinSUtil.flipEndianness(satoshis.hex)
     val satoshisHex = addPadding(16,satoshisHexWithoutPadding)
-    logger.debug("satoshis: " + satoshisHex)
-/*    if (compactSizeUIntHex == "00") satoshisHex + compactSizeUIntHex
-    else */ satoshisHex + output.scriptPubKey.hex
+    satoshisHex + output.scriptPubKey.hex
   }
 
   /** Reads a single output from the given bytes, note this is different than [[org.bitcoins.core.serializers.transaction.RawTransactionOutputParser.read]]
@@ -59,13 +57,11 @@ trait RawTransactionOutputParser extends RawBitcoinSerializer[Seq[TransactionOut
     */
   def readSingleOutput(bytes: Seq[Byte]): TransactionOutput = {
     val satoshisHex = BitcoinSUtil.encodeHex(bytes.take(8).reverse)
-    logger.debug("Satoshi hex: " + satoshisHex)
     val satoshis = parseSatoshis(satoshisHex)
     //it doesn't include itself towards the size, thats why it is incremented by one
     val scriptPubKeyBytes = bytes.slice(8, bytes.size)
     val scriptPubKey = RawScriptPubKeyParser.read(scriptPubKeyBytes)
     val parsedOutput = TransactionOutput(satoshis,scriptPubKey)
-    logger.debug("Parsed output: " + parsedOutput)
     parsedOutput
   }
 

--- a/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -290,7 +290,7 @@ trait BitcoinScriptUtil extends BitcoinSLogger {
   }
 
   def calculateScriptForSigning(txSignatureComponent: TxSigComponent, script: Seq[ScriptToken]): Seq[ScriptToken] = txSignatureComponent.scriptPubKey match {
-    case p2shScriptPubKey: P2SHScriptPubKey =>
+    case _: P2SHScriptPubKey =>
       val p2shScriptSig = P2SHScriptSignature(txSignatureComponent.scriptSignature.bytes)
       val sigsRemoved = removeSignaturesFromScript(p2shScriptSig.signatures,p2shScriptSig.redeemScript.asm)
       sigsRemoved
@@ -301,7 +301,7 @@ trait BitcoinScriptUtil extends BitcoinSLogger {
           parseScriptEither(scriptEither)
         case rWTxSigComponent: WitnessTxSigComponentRebuilt =>
           rWTxSigComponent.scriptPubKey.asm
-        case base : BaseTxSigComponent =>
+        case _: BaseTxSigComponent =>
           //shouldn't have BaseTxSigComponent
           //with a witness scriptPubKey
           script

--- a/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
@@ -17,7 +17,7 @@ import scala.util.Try
   */
 sealed abstract class EscrowTimeoutHelper extends BitcoinSLogger {
 
-  /** Signs a [[org.bitcoins.core.protocol.transaction.Transaction]] with the given private key
+  /** Signs a [[org.bitcoins.core.protocol.transaction.WitnessTransaction]] with the given private key
     * This will result in a Transaction that is partially signed, we need to send the transaction to
     * the server to be fully signed
     * */

--- a/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.wallet
 
 import org.bitcoins.core.crypto._
-import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
-import org.bitcoins.core.gen.WitnessGenerators
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
+import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinScriptUtil}
 
@@ -15,61 +15,74 @@ import scala.util.Try
 /**
   * Created by chris on 5/9/17.
   */
-sealed trait EscrowTimeoutHelper extends BitcoinSLogger {
+sealed abstract class EscrowTimeoutHelper extends BitcoinSLogger {
 
   /** Signs a [[org.bitcoins.core.protocol.transaction.Transaction]] with the given private key
     * This will result in a Transaction that is partially signed, we need to send the transaction to
     * the server to be fully signed
     * */
   def clientSign(inputs: Seq[TransactionInput], outputs: Seq[TransactionOutput], inputIndex: UInt32, privKey: ECPrivateKey,
-                 lock: EscrowTimeoutScriptPubKey, p2shScriptPubKey: P2SHScriptPubKey,
-                 hashType: HashType): TxSigComponent = {
-    val btx = BaseTransaction(TransactionConstants.validLockVersion, inputs, outputs, TransactionConstants.lockTime)
-    val unsignedBTxSigComponent = TxSigComponent(btx, inputIndex, lock, Policy.standardScriptVerifyFlags)
-    val signature = TransactionSignatureCreator.createSig(unsignedBTxSigComponent, privKey, hashType)
+                 lock: EscrowTimeoutScriptPubKey, creditingOutput: TransactionOutput,
+                 hashType: HashType): WitnessTxSigComponentP2SH = {
+    val (p2sh,amount) = (creditingOutput.scriptPubKey.asInstanceOf[P2SHScriptPubKey],creditingOutput.value)
+    val tc = TransactionConstants
+    val uScriptWitness = ScriptWitness(Seq(lock.asmBytes))
+    val wtx = WitnessTransaction(tc.validLockVersion, inputs, outputs, tc.lockTime, TransactionWitness(Seq(uScriptWitness)))
+    val witSPK = WitnessScriptPubKeyV0(lock)
+    val u = WitnessTxSigComponentRaw(wtx,inputIndex,witSPK,Policy.standardFlags,amount)
+    val signature = TransactionSignatureCreator.createSig(u, privKey, hashType)
     val sigs = Seq(signature)
     val multiSigScriptSig = MultiSignatureScriptSignature(sigs)
     val escrow = EscrowTimeoutScriptSignature.fromMultiSig(multiSigScriptSig)
-    val p2shScriptSig = P2SHScriptSignature(escrow, lock)
-    val oldInput = inputs(inputIndex.toInt)
-    val signedInput = TransactionInput(oldInput.previousOutput, p2shScriptSig, oldInput.sequence)
-    val newInputs = inputs.updated(inputIndex.toInt, signedInput)
-    val signedTx = Transaction(TransactionConstants.validLockVersion, newInputs, outputs, TransactionConstants.lockTime)
-
-    val signedBTxComponent = TxSigComponent(signedTx, unsignedBTxSigComponent.inputIndex,
-      p2shScriptPubKey, unsignedBTxSigComponent.flags)
-    signedBTxComponent
+    val witness = buildEscrowTimeoutScriptWitness(escrow,lock,u)
+    val signedWTx = WitnessTransaction(wtx.version, wtx.inputs, wtx.outputs,wtx.lockTime, witness)
+    WitnessTxSigComponentP2SH(signedWTx,u.inputIndex,p2sh,u.flags,u.amount)
   }
 
   /** Helper function to build a [[org.bitcoins.core.protocol.transaction.TransactionWitness]]
     * for an [[EscrowTimeoutScriptPubKey]] */
   def buildEscrowTimeoutScriptWitness(signedScriptSig: EscrowTimeoutScriptSignature,
-                                      scriptPubKey: EscrowTimeoutScriptPubKey,
-                                      unsignedWTxSigComponent: WitnessTxSigComponent): (TransactionWitness, WitnessTxSigComponent) = {
+                                      lock: EscrowTimeoutScriptPubKey,
+                                      unsigned: WitnessTxSigComponentRaw): TransactionWitness = {
     //need to remove the OP_0 or OP_1 and replace it with ScriptNumber.zero / ScriptNumber.one since witnesses are *not* run through the interpreter
     val s = BitcoinScriptUtil.minimalDummy(BitcoinScriptUtil.minimalIfOp(signedScriptSig.asm))
     val signedScriptSigPushOpsRemoved = BitcoinScriptUtil.filterPushOps(s).reverse
-    val signedScriptWitness = ScriptWitness(scriptPubKey.asm.flatMap(_.bytes) +: (signedScriptSigPushOpsRemoved.map(_.bytes)))
-    val (witness, signedWtxSigComponent) = WTxSigComponentHelper.createSignedWTxComponent(signedScriptWitness, unsignedWTxSigComponent)
-    (witness, signedWtxSigComponent)
+    val signedScriptWitness = ScriptWitness(lock.asmBytes +: (signedScriptSigPushOpsRemoved.map(_.bytes)))
+    val updatedWitnesses = unsigned.transaction.witness.witnesses.updated(unsigned.inputIndex.toInt,signedScriptWitness)
+    val txWitness: TransactionWitness = TransactionWitness(updatedWitnesses)
+    txWitness
   }
 
-  /** Signs the partially signed [[org.bitcoins.core.crypto.BaseTxSigComponent]] with the server's private key */
-  def serverSign(serverKey: ECPrivateKey,clientSigned: BaseTxSigComponent, hashType: HashType): Try[TxSigComponent] = {
-    val p2shScriptPubKey = P2SHScriptPubKey(clientSigned.scriptPubKey)
-    val signature = TransactionSignatureCreator.createSig(clientSigned, serverKey, hashType)
-    val p2sh = clientSigned.scriptSignature.asInstanceOf[P2SHScriptSignature]
-    val escrowTimeoutScriptSig = p2sh.scriptSignatureNoRedeemScript.map(_.asInstanceOf[EscrowTimeoutScriptSignature])
-    val oldSig = escrowTimeoutScriptSig.map(_.signatures.head)
-    val allSigs = oldSig.map(o => Seq(o, signature))
-    val multiSig = allSigs.map(all => MultiSignatureScriptSignature(all))
-    val escrow = multiSig.map(m => EscrowTimeoutScriptSignature.fromMultiSig(m))
-    val signedP2SH = escrow.map(e => P2SHScriptSignature(e,p2sh.redeemScript))
-    val input = signedP2SH.map(p => TransactionInput(clientSigned.input, p))
-    val old = clientSigned.transaction
-    val newInputs = input.map(i => clientSigned.transaction.inputs.updated(clientSigned.inputIndex.toInt,i))
-    val signedTx = newInputs.map(inputs => Transaction(old.version,inputs,old.outputs,old.lockTime))
-    signedTx.map(tx => TxSigComponent(tx,clientSigned.inputIndex, p2shScriptPubKey, clientSigned.flags))
+  /** Signs the partially signed [[org.bitcoins.core.crypto.WitnessTxSigComponent]] with the server's private key */
+  def serverSign(privKey: ECPrivateKey, clientSigned: WitnessTxSigComponentP2SH, hashType: HashType): Try[WitnessTxSigComponentP2SH] = {
+    val lockScript = clientSigned.witness.stack.head
+    val lock = Try(EscrowTimeoutScriptPubKey(CompactSizeUInt.calculateCompactSizeUInt(lockScript).bytes ++ lockScript))
+    val witSPK = lock.map(WitnessScriptPubKeyV0(_))
+    val stack = clientSigned.witness.stack
+    val clientSignature = ECDigitalSignature(stack(stack.size-2))
+    val raw = witSPK.map(w => WitnessTxSigComponentRaw(clientSigned.transaction,clientSigned.inputIndex,
+      w, clientSigned.flags,clientSigned.amount))
+    val signature = raw.map(r => TransactionSignatureCreator.createSig(r, privKey, hashType))
+    val escrow: Try[EscrowTimeoutScriptSignature] = signature.map { s =>
+      val sigs = Seq(clientSignature,s)
+      val multiSigScriptSig = MultiSignatureScriptSignature(sigs)
+      EscrowTimeoutScriptSignature.fromMultiSig(multiSigScriptSig)
+    }
+
+    val witness: Try[TransactionWitness] = lock.flatMap { l =>
+      raw.flatMap { r =>
+        escrow.map { e =>
+          buildEscrowTimeoutScriptWitness(e, l, r)
+        }
+      }
+    }
+    witness.flatMap { w =>
+      raw.map { r =>
+        val oldTx = r.transaction
+        val wtx = WitnessTransaction(oldTx.version, oldTx.inputs, oldTx.outputs, oldTx.lockTime, w)
+        WitnessTxSigComponentP2SH(wtx,r.inputIndex, clientSigned.scriptPubKey, r.flags, r.amount)
+      }
+    }
   }
 
   /** Closes the given [[EscrowTimeoutScriptPubKey]] with it's timeout branch.
@@ -78,25 +91,25 @@ sealed trait EscrowTimeoutHelper extends BitcoinSLogger {
     * It is important to note that we assume the nestedScriptPubKey inside of the EscrowTimeoutScriptPubKey
     * is a [[P2PKHScriptPubKey]] that can be spent by the given [[ECPrivateKey]]
     * */
-  def closeWithTimeout(privKey: ECPrivateKey, escrowTimeoutSPK: EscrowTimeoutScriptPubKey, outPoint: TransactionOutPoint,
-    outputs: Seq[TransactionOutput], hashType: HashType,
-    version: UInt32, sequence: UInt32, lockTime: UInt32): Try[TxSigComponent] = Try {
-    require(escrowTimeoutSPK.timeout.nestedScriptPubKey.isInstanceOf[P2PKHScriptPubKey], "We currently require the nested SPK in the timeout branch to be a P2PKHScriptPubKey, got: " + escrowTimeoutSPK.timeout.nestedScriptPubKey)
-    val p2sh = P2SHScriptPubKey(escrowTimeoutSPK)
-    val signedP2PKHTxSigComponent = P2PKHHelper.sign(privKey,escrowTimeoutSPK,outPoint,outputs,hashType,version,sequence,lockTime)
-    val signedP2PKHTx = signedP2PKHTxSigComponent.transaction
-    val signedScriptSig = signedP2PKHTxSigComponent.scriptSignature
-    val lockTimeScriptSig = escrowTimeoutSPK.timeout match {
-      case _: CSVScriptPubKey => CSVScriptSignature(signedScriptSig)
-      case _: CLTVScriptPubKey => CLTVScriptSignature(signedScriptSig)
-    }
-    val escrowTimeoutScriptSig = EscrowTimeoutScriptSignature.fromLockTime(lockTimeScriptSig)
-    val p2shScriptSig = P2SHScriptSignature(escrowTimeoutScriptSig,escrowTimeoutSPK)
-    val fullInput = TransactionInput(signedP2PKHTxSigComponent.input.previousOutput,p2shScriptSig,
-      signedP2PKHTxSigComponent.input.sequence)
-    val inputs = signedP2PKHTx.inputs.updated(signedP2PKHTxSigComponent.inputIndex.toInt,fullInput)
-    val tx = Transaction(signedP2PKHTx.version,inputs,signedP2PKHTx.outputs, signedP2PKHTx.lockTime)
-    TxSigComponent(tx,signedP2PKHTxSigComponent.inputIndex, p2sh, signedP2PKHTxSigComponent.flags)
+  def closeWithTimeout(inputs: Seq[TransactionInput], outputs: Seq[TransactionOutput], inputIndex: UInt32, privKey: ECPrivateKey,
+                       lock: EscrowTimeoutScriptPubKey, creditingOutput: TransactionOutput,
+                       hashType: HashType,
+                       version: UInt32, sequence: UInt32, lockTime: UInt32): Try[WitnessTxSigComponentP2SH] = Try {
+    require(lock.timeout.nestedScriptPubKey.isInstanceOf[P2PKHScriptPubKey],
+      "We currently require the nested SPK in the timeout branch to be a P2PKHScriptPubKey, got: " + lock.timeout.nestedScriptPubKey)
+    val witSPK = WitnessScriptPubKeyV0(lock)
+    val p2sh = P2SHScriptPubKey(witSPK)
+    val amount = creditingOutput.value
+    val tc = TransactionConstants
+    val uScriptWitness = ScriptWitness(Seq(lock.asmBytes))
+    val uTxWitness = TransactionWitness(Seq(uScriptWitness))
+    val uwtx = WitnessTransaction(tc.validLockVersion,inputs,outputs,tc.validLockVersion,uTxWitness)
+    val u = WitnessTxSigComponentRaw(uwtx,inputIndex,witSPK,Policy.standardFlags, amount)
+    val signature = TransactionSignatureCreator.createSig(u,privKey,hashType)
+    val scriptWitness = ScriptWitness(lock.asmBytes +: Seq(ScriptNumber.zero.bytes,privKey.publicKey.bytes, signature.bytes))
+    val witness = TransactionWitness(u.transaction.witness.witnesses.updated(u.inputIndex.toInt,scriptWitness))
+    val wtx = WitnessTransaction(uwtx.version, uwtx.inputs, uwtx.outputs, uwtx.lockTime, witness)
+    WitnessTxSigComponentP2SH(wtx,u.inputIndex,p2sh,u.flags,u.amount)
   }
 }
 

--- a/src/test/scala/org/bitcoins/core/channels/ChannelTest.scala
+++ b/src/test/scala/org/bitcoins/core/channels/ChannelTest.scala
@@ -72,7 +72,7 @@ class ChannelTest extends FlatSpec with MustMatchers with BitcoinSLogger {
     val inProgress = chan.flatMap(_.clientSign(clientSPK,amount,keys.head))
     val closed = inProgress.flatMap(_.close(serverSPK,keys(1),CurrencyUnits.zero))
     closed.isSuccess must be (true)
-    closed.get.serverAmount must be (amount)
+    closed.get.serverAmount.get must be (amount)
   }
 
   it must "be valid for the server to receive all of the money when a payment channel closes in two updates" in {
@@ -88,7 +88,7 @@ class ChannelTest extends FlatSpec with MustMatchers with BitcoinSLogger {
     val serverSign = inProgress.flatMap(_.serverSign(keys(1)))
     val inProgress2 = serverSign.flatMap(_.clientSign(CurrencyUnits.oneBTC,keys.head))
     val closed = inProgress2.flatMap(_.close(serverSPK,keys(1),CurrencyUnits.zero))
-    closed.get.serverAmount must be (amount)
+    closed.get.serverAmount.get must be (amount)
   }
 
 

--- a/src/test/scala/org/bitcoins/core/channels/ChannelsSpec.scala
+++ b/src/test/scala/org/bitcoins/core/channels/ChannelsSpec.scala
@@ -57,6 +57,7 @@ class ChannelsSpec extends Properties("ChannelProperties") with BitcoinSLogger {
   property("close a payment channel awaiting anchor tx with the timeout branch") = {
     Prop.forAllNoShrink(ChannelGenerators.channelAwaitingAnchorTxNotConfirmed) { case (awaiting, privKeys) =>
       val channelClosedWithTimeout = awaiting.closeWithTimeout(EmptyScriptPubKey,privKeys(2), Satoshis.one)
+      logger.info("closed.inputs: " + channelClosedWithTimeout.map(_.current.transaction.inputs))
       val program = channelClosedWithTimeout.map(c => ScriptProgram(c.current))
       val result = program.map(p => ScriptInterpreter.run(p))
       result.get == ScriptOk

--- a/src/test/scala/org/bitcoins/core/channels/ChannelsSpec.scala
+++ b/src/test/scala/org/bitcoins/core/channels/ChannelsSpec.scala
@@ -57,7 +57,7 @@ class ChannelsSpec extends Properties("ChannelProperties") with BitcoinSLogger {
   property("close a payment channel awaiting anchor tx with the timeout branch") = {
     Prop.forAllNoShrink(ChannelGenerators.channelAwaitingAnchorTxNotConfirmed) { case (awaiting, privKeys) =>
       val channelClosedWithTimeout = awaiting.closeWithTimeout(EmptyScriptPubKey,privKeys(2), Satoshis.one)
-      val program = channelClosedWithTimeout.map(c => ScriptProgram(c.finalTx))
+      val program = channelClosedWithTimeout.map(c => ScriptProgram(c.current))
       val result = program.map(p => ScriptInterpreter.run(p))
       result.get == ScriptOk
     }
@@ -66,7 +66,7 @@ class ChannelsSpec extends Properties("ChannelProperties") with BitcoinSLogger {
   property("close a payment channel in progress with the timeout branch") = {
     Prop.forAllNoShrink(ChannelGenerators.baseInProgress) { case (inProgress, privKeys) =>
       val channelClosedWithTimeout = inProgress.closeWithTimeout(privKeys(2),Satoshis.one)
-      val program = channelClosedWithTimeout.map(c => ScriptProgram(c.finalTx))
+      val program = channelClosedWithTimeout.map(c => ScriptProgram(c.current))
       val result = program.map(p => ScriptInterpreter.run(p))
       result.get == ScriptOk
     }
@@ -100,6 +100,6 @@ class ChannelsSpec extends Properties("ChannelProperties") with BitcoinSLogger {
       }
     }
     val inOrder = p.old.reverse
-    loop(inOrder.head, inOrder.tail ++ Seq(p.finalTx))
+    loop(inOrder.head, inOrder.tail ++ Seq(p.current))
   }
 }


### PR DESCRIPTION
Segregated witness is now locked into the bitcoin protocol. This pull request updates our Payment Channel code to integrate segwit transactions (`WitnessTransaction`) instead of using `BaseTransaction`