### PR TITLE
Bech32 implementation (BIP173)

### DIFF
--- a/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
+++ b/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
@@ -4,7 +4,7 @@ package org.bitcoins.core.config
 /**
  * Created by chris on 7/27/15.
   */
-trait NetworkParameters {
+sealed abstract class NetworkParameters {
   def p2pkhNetworkByte : Byte
   def p2shNetworkByte : Byte
   def privateKey : Byte

--- a/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -29,7 +29,7 @@ trait TransactionSignatureChecker extends BitcoinSLogger {
     */
   def checkSignature(txSignatureComponent : TxSigComponent, script : Seq[ScriptToken],
                      pubKey: ECPublicKey, signature : ECDigitalSignature, flags : Seq[ScriptFlag]) : TransactionSignatureCheckerResult = {
-    logger.info("Signature: " + signature)
+    logger.debug("Signature: " + signature)
     val pubKeyEncodedCorrectly = BitcoinScriptUtil.isValidPubKeyEncoding(pubKey,flags)
     if (ScriptFlagUtil.requiresStrictDerEncoding(flags) && !DERSignatureUtil.isValidSignatureEncoding(signature)) {
       logger.error("Signature was not stricly encoded der: " + signature.hex)

--- a/src/main/scala/org/bitcoins/core/gen/AddressGenerator.scala
+++ b/src/main/scala/org/bitcoins/core/gen/AddressGenerator.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.gen
 
-import org.bitcoins.core.protocol.{BitcoinAddress, P2PKHAddress, P2SHAddress}
+import org.bitcoins.core.protocol.{Bech32Address, BitcoinAddress, P2PKHAddress, P2SHAddress}
 import org.scalacheck.Gen
 
 /**
@@ -20,7 +20,13 @@ sealed trait AddressGenerator {
     addr = P2SHAddress(hash,network)
   } yield addr
 
-  def address: Gen[BitcoinAddress] = Gen.oneOf(p2pkhAddress,p2shAddress)
+  def bech32Address: Gen[Bech32Address] = for {
+    (witSPK,_) <- ScriptGenerators.witnessScriptPubKey
+    network <- ChainParamsGenerator.networkParams
+    addr = Bech32Address(witSPK,network)
+  } yield addr.get
+
+  def address: Gen[BitcoinAddress] = Gen.oneOf(p2pkhAddress,p2shAddress,bech32Address)
 }
 
 object AddressGenerator extends AddressGenerator

--- a/src/main/scala/org/bitcoins/core/gen/AddressGenerator.scala
+++ b/src/main/scala/org/bitcoins/core/gen/AddressGenerator.scala
@@ -21,7 +21,6 @@ sealed trait AddressGenerator {
   } yield addr
 
   def bech32Address: Gen[Bech32Address] = for {
-    //TODO: Change this generator from witSPKV0 -> witSPK after I ask about generating addresses for unassigned witSPKs
     (witSPK,_) <- ScriptGenerators.witnessScriptPubKey
     network <- ChainParamsGenerator.networkParams
     addr = Bech32Address(witSPK,network)

--- a/src/main/scala/org/bitcoins/core/gen/AddressGenerator.scala
+++ b/src/main/scala/org/bitcoins/core/gen/AddressGenerator.scala
@@ -21,7 +21,8 @@ sealed trait AddressGenerator {
   } yield addr
 
   def bech32Address: Gen[Bech32Address] = for {
-    (witSPK,_) <- ScriptGenerators.witnessScriptPubKey
+    //TODO: Change this generator from witSPKV0 -> witSPK after I ask about generating addresses for unassigned witSPKs
+    (witSPK,_) <- ScriptGenerators.witnessScriptPubKeyV0
     network <- ChainParamsGenerator.networkParams
     addr = Bech32Address(witSPK,network)
   } yield addr.get

--- a/src/main/scala/org/bitcoins/core/gen/AddressGenerator.scala
+++ b/src/main/scala/org/bitcoins/core/gen/AddressGenerator.scala
@@ -22,7 +22,7 @@ sealed trait AddressGenerator {
 
   def bech32Address: Gen[Bech32Address] = for {
     //TODO: Change this generator from witSPKV0 -> witSPK after I ask about generating addresses for unassigned witSPKs
-    (witSPK,_) <- ScriptGenerators.witnessScriptPubKeyV0
+    (witSPK,_) <- ScriptGenerators.witnessScriptPubKey
     network <- ChainParamsGenerator.networkParams
     addr = Bech32Address(witSPK,network)
   } yield addr.get

--- a/src/main/scala/org/bitcoins/core/gen/NumberGenerator.scala
+++ b/src/main/scala/org/bitcoins/core/gen/NumberGenerator.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.gen
 
-import org.bitcoins.core.number.{Int32, Int64, UInt32, UInt64}
+import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.util.NumberUtil
@@ -21,7 +21,9 @@ trait NumberGenerator {
   /** Creates a number generator that generates negative long numbers */
   def negativeLongs: Gen[Long] = Gen.choose(Long.MinValue,-1)
 
+  def uInt8: Gen[UInt8] = Gen.choose(0,255).map(n => UInt8(n.toShort))
 
+  def uInt8s: Gen[Seq[UInt8]] = Gen.listOf(uInt8)
   /**
     * Generates a number in the range 0 <= x <= 2 ^^32 - 1
     * then wraps it in a UInt32 */

--- a/src/main/scala/org/bitcoins/core/gen/ScriptGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/ScriptGenerators.scala
@@ -132,7 +132,8 @@ trait ScriptGenerators extends BitcoinSLogger {
     */
   def unassignedWitnessScriptPubKey: Gen[(UnassignedWitnessScriptPubKey, Seq[ECPrivateKey])] = for {
     (witV0,privKeys) <- witnessScriptPubKeyV0
-    unassignedAsm = OP_16 +: witV0.asm.tail
+    version <- Gen.oneOf(WitnessScriptPubKey.unassignedWitVersions)
+    unassignedAsm = version +: witV0.asm.tail
   } yield (UnassignedWitnessScriptPubKey(unassignedAsm),privKeys)
 
   /** Generates an arbitrary [[org.bitcoins.core.protocol.script.WitnessScriptPubKey]] */

--- a/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -430,6 +430,8 @@ object UInt8 extends Factory[UInt8] with BaseNumbers[UInt8] {
 
   def apply(short: Short): UInt8 = UInt8Impl(short)
 
+  def apply(byte: Byte): UInt8 = toUInt8(byte)
+
   def isValid(short: Short): Boolean = short >= 0  && short < 256
 
   override def fromBytes(bytes: Seq[Byte]): UInt8 = {
@@ -443,8 +445,12 @@ object UInt8 extends Factory[UInt8] with BaseNumbers[UInt8] {
     if ((byte & 0x80) == 0x80) {
       val r = (byte & 0x7f) + NumberUtil.pow2(7)
       UInt8(r.toShort)
-    } else UInt8(byte)
+    } else UInt8Impl(byte)
   }
+
+  def toByte(uInt8: UInt8): Byte = uInt8.underlying.toByte
+
+  def toBytes(us: Seq[UInt8]): Seq[Byte] = us.map(toByte(_))
 
   def toUInt8s(bytes: Seq[Byte]): Seq[UInt8] = bytes.map(toUInt8(_))
 }

--- a/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.core.number
 
-import org.bitcoins.core.number.UInt64.UInt64Impl
 import org.bitcoins.core.protocol.NetworkElement
-import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, Factory, NumberUtil}
+import org.bitcoins.core.util.{BitcoinSUtil, Factory, NumberUtil}
 
 import scala.util.{Failure, Success, Try}
 
@@ -436,7 +435,7 @@ object UInt8 extends Factory[UInt8] with BaseNumbers[UInt8] {
     if ((byte & 0x80) == 0x80) {
       val r = (byte & 0x7f) + NumberUtil.pow2(7)
       UInt8(r.toShort)
-    } else UInt8Impl(byte)
+    } else UInt8(byte.toShort)
   }
 
   def toByte(uInt8: UInt8): Byte = uInt8.underlying.toByte

--- a/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.number
 
+import org.bitcoins.core.number.UInt64.UInt64Impl
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, Factory, NumberUtil}
 
@@ -45,6 +46,78 @@ sealed trait NumberOperations[T <: Number] {
   def <= (num : T): Boolean
 }
 
+sealed abstract class UInt8 extends UnsignedNumber with NumberOperations[UInt8] {
+  override type A = Short
+
+  override def + (num : UInt8): UInt8 = {
+    val sum = underlying + num.underlying
+    checkResult(sum)
+  }
+
+  override def - (num : UInt8): UInt8 =  {
+    val difference = underlying - num.underlying
+    checkResult(difference)
+  }
+
+  override def * (num : UInt8): UInt8 =  {
+    val product = underlying * num.underlying
+    checkResult(product)
+  }
+
+  override def > (num : UInt8): Boolean = underlying > num.underlying
+
+  override def >= (num : UInt8): Boolean = underlying >= num.underlying
+
+  override def < (num : UInt8): Boolean = underlying < num.underlying
+
+  override def <= (num : UInt8): Boolean = underlying <= num.underlying
+
+  def | (num : UInt8) : UInt8 = {
+    val bitwiseOr = underlying | num.underlying
+    checkResult(bitwiseOr)
+  }
+
+  def & (num : UInt8) : UInt8 = {
+    val bitwiseAnd = underlying & num.underlying
+    checkResult(bitwiseAnd)
+  }
+
+  def >> (u: UInt8): UInt8 = this.>>(u.underlying)
+  def >> (i : Int): UInt8 = {
+    val r = underlying >> i
+    checkResult(r)
+  }
+
+  def <<(u: UInt8): UInt8 = this.<<(u.underlying)
+  def << (i: Int): UInt8 = {
+    val r = underlying << i
+    checkResult(r)
+  }
+  override def hex = BitcoinSUtil.encodeHex(underlying).slice(12,16)
+
+  override def toInt: Int = {
+    require(underlying <= Int.MaxValue, "Overflow error when casting " + this + " to an integer.")
+    require(underlying >= 0, "Unsigned integer should not be cast to a number less than 0" + this)
+    underlying.toInt
+  }
+
+  def toLong: Long = {
+    require(underlying <= Long.MaxValue, "Overflow error when casting " + this + " to an integer.")
+    require(underlying >= 0, "Unsigned integer should not be cast to a number less than 0" + this)
+    underlying.toLong
+  }
+
+  /**
+    * Checks the result of the arithmetic operation to see if an error occurred
+    * if an error does occur throw it, else return the [[UInt32]]
+    * @param result the try type wrapping the result of the arithmetic operation
+    * @return the result of the unsigned number operation
+    */
+  private def checkResult(result : Int): UInt8 = {
+    if (result > Short.MaxValue || result < 0) throw new IllegalArgumentException("Result of operation was out of bounds for a UInt8: " + result)
+    else UInt8(result.toShort)
+  }
+}
 
 /**
   * Represents a uint32_t in C
@@ -82,14 +155,40 @@ sealed trait UInt32 extends UnsignedNumber with NumberOperations[UInt32] {
 
   def & (num : UInt32) : UInt32 = UInt32(underlying & num.underlying)
 
+  def >> (u: UInt32): UInt32 = this.>>(u.underlying)
+  def >> (l: Long): UInt32 = {
+    val r = Try(UInt32(underlying >> l))
+    checkResult(r)
+  }
 
+  def <<(u: UInt32): UInt32 = this.<<(u.underlying)
+  def << (l: Long): UInt32 = {
+    if (l == 0) this
+    else {
+      //since we are going to shift left we can lose precision by converting .toInt
+      //TODO: There is a bug here wrt comparing shiftNoSignBit & (1 << 31) will always evaluate to false
+      val int = underlying.toInt
+      val shiftNoSignBit = (int << l) & (Int.MaxValue >> 1)
+      val shift = if ((shiftNoSignBit & (1 << 31)) == (1 << 31)) {
+        shiftNoSignBit + (1 << 31)
+      } else shiftNoSignBit
+      val r = Try(UInt32(shift))
+      checkResult(r)
+    }
+  }
 
   override def hex = BitcoinSUtil.encodeHex(underlying).slice(8,16)
 
-  override def toInt = {
+  override def toInt: Int = {
     require(underlying <= Int.MaxValue, "Overflow error when casting " + this + " to an integer.")
     require(underlying >= 0, "Unsigned integer should not be cast to a number less than 0" + this)
     underlying.toInt
+  }
+
+  def toLong: Long = {
+    require(underlying <= Long.MaxValue, "Overflow error when casting " + this + " to an integer.")
+    require(underlying >= 0, "Unsigned integer should not be cast to a number less than 0" + this)
+    underlying.toLong
   }
 
   /**
@@ -319,6 +418,37 @@ trait BaseNumbers[T] {
   def max : T
 }
 
+object UInt8 extends Factory[UInt8] with BaseNumbers[UInt8] {
+  private case class UInt8Impl(underlying: Short) extends UInt8 {
+    require(isValid(underlying), "Invalid range for a UInt8, got: " + underlying)
+  }
+  lazy val zero = UInt8(0.toShort)
+  lazy val one = UInt8(1.toShort)
+
+  lazy val min = zero
+  lazy val max = UInt8(255.toShort)
+
+  def apply(short: Short): UInt8 = UInt8Impl(short)
+
+  def isValid(short: Short): Boolean = short >= 0  && short < 256
+
+  override def fromBytes(bytes: Seq[Byte]): UInt8 = {
+    val individualByteValues = for {
+      (byte,index) <- bytes.reverse.zipWithIndex
+    } yield NumberUtil.calculateUnsignedNumberFromByte(index, byte)
+    UInt8(individualByteValues.sum.toShort)
+  }
+
+  def toUInt8(byte: Byte): UInt8 = {
+    if ((byte & 0x80) == 0x80) {
+      val r = (byte & 0x7f) + NumberUtil.pow2(7)
+      UInt8(r.toShort)
+    } else UInt8(byte)
+  }
+
+  def toUInt8s(bytes: Seq[Byte]): Seq[UInt8] = bytes.map(toUInt8(_))
+}
+
 object UInt32 extends Factory[UInt32] with BaseNumbers[UInt32] {
   private case class UInt32Impl(underlying : Long) extends UInt32 {
     require(underlying >= 0, "We cannot have a negative number in an unsigned number, got: " + underlying)
@@ -339,7 +469,7 @@ object UInt32 extends Factory[UInt32] with BaseNumbers[UInt32] {
     UInt32Impl(individualByteValues.sum.toLong)
   }
 
-  def apply(long : Long) : UInt32 = UInt32Impl(long)
+  def apply(long : Long): UInt32 = UInt32Impl(long)
 
 }
 

--- a/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -93,7 +93,7 @@ sealed abstract class UInt8 extends UnsignedNumber with NumberOperations[UInt8] 
     val r = underlying << i
     checkResult(r)
   }
-  override def hex = BitcoinSUtil.encodeHex(underlying).slice(12,16)
+  override def hex = BitcoinSUtil.encodeHex(underlying).slice(2,4)
 
   override def toInt: Int = {
     require(underlying <= Int.MaxValue, "Overflow error when casting " + this + " to an integer.")
@@ -168,8 +168,8 @@ sealed trait UInt32 extends UnsignedNumber with NumberOperations[UInt32] {
       //since we are going to shift left we can lose precision by converting .toInt
       //TODO: There is a bug here wrt comparing shiftNoSignBit & (1 << 31) will always evaluate to false
       val int = underlying.toInt
-      val shiftNoSignBit = (int << l) & (Int.MaxValue >> 1)
-      val shift = if ((shiftNoSignBit & (1 << 31)) == (1 << 31)) {
+      val shiftNoSignBit = (int << l) & 0xffffffffL
+      val shift = if (((shiftNoSignBit & (1 << 31)) == (1 << 31))) {
         shiftNoSignBit + (1 << 31)
       } else shiftNoSignBit
       val r = Try(UInt32(shift))

--- a/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -444,7 +444,7 @@ object Address extends Factory[Address] {
   def fromScriptPubKey(spk: ScriptPubKey, network: NetworkParameters): Try[BitcoinAddress] = spk match {
     case p2pkh: P2PKHScriptPubKey => Success(P2PKHAddress(p2pkh,network))
     case p2sh: P2SHScriptPubKey => Success(P2SHAddress(p2sh,network))
-    case witSPK: WitnessScriptPubKeyV0 => Bech32Address(witSPK,network)
+    case witSPK: WitnessScriptPubKey => Bech32Address(witSPK,network)
     case x @ (_: P2PKScriptPubKey | _: MultiSignatureScriptPubKey | _: LockTimeScriptPubKey
               | _: EscrowTimeoutScriptPubKey | _: NonStandardScriptPubKey
               | _: WitnessCommitment |  _: UnassignedWitnessScriptPubKey | EmptyScriptPubKey) =>

--- a/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala
@@ -68,6 +68,8 @@ object CompactSizeUInt extends Factory[CompactSizeUInt] {
     else CompactSizeUInt(UInt64(bytes.size),9)
   }
 
+  def calc(bytes: Seq[Byte]): CompactSizeUInt = calculateCompactSizeUInt(bytes)
+
   /** Responsible for calculating what the [[CompactSizeUInt]] is for this hex string. */
   def calculateCompactSizeUInt(hex : String) : CompactSizeUInt = calculateCompactSizeUInt(BitcoinSUtil.decodeHex(hex))
 
@@ -89,6 +91,8 @@ object CompactSizeUInt extends Factory[CompactSizeUInt] {
     //64 bit number
     else CompactSizeUInt(UInt64(bytes.slice(1,9).reverse),9)
   }
+
+  def parse(bytes: Seq[Byte]): CompactSizeUInt = parseCompactSizeUInt(bytes)
 
   /** Returns the size of a VarInt in the number of bytes
     * https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer. */

--- a/src/main/scala/org/bitcoins/core/protocol/HumanReadablePart.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/HumanReadablePart.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.protocol
 
-import org.bitcoins.core.config.{MainNet, NetworkParameters, TestNet3}
+import org.bitcoins.core.config.{MainNet, NetworkParameters, RegTest, TestNet3}
 
 /** Represents the HumanReadablePart of a Bech32 address
   * [[https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki]]
@@ -20,4 +20,18 @@ case object bc extends HumanReadablePart {
 case object tb extends HumanReadablePart {
   def network = TestNet3
   def bytes = Seq('t'.toByte, 'b'.toByte)
+}
+
+object HumanReadablePart {
+  //TODO: try and force a pattern match here so we can check case exhaustiveness
+  //i.e if we add a new HumanReadablepart, we get a compiler warning if we didn't add the new case
+  def apply(str: String) = str match {
+    case "bc" => bc
+    case "tb" => tb
+  }
+
+  def apply(network: NetworkParameters): HumanReadablePart = network match {
+    case _: MainNet => bc
+    case _: TestNet3 | _: RegTest => tb
+  }
 }

--- a/src/main/scala/org/bitcoins/core/protocol/HumanReadablePart.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/HumanReadablePart.scala
@@ -6,20 +6,25 @@ import org.bitcoins.core.config.{MainNet, NetworkParameters, RegTest, TestNet3}
   * [[https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki]]
   * */
 sealed abstract class HumanReadablePart {
-  def network: NetworkParameters
+  def network: Option[NetworkParameters]
   def bytes: Seq[Byte]
 }
 
 /** Represents the HumanReadablePart for a bitcoin mainnet bech32 address */
 case object bc extends HumanReadablePart {
-  def network = MainNet
+  def network = Some(MainNet)
   def bytes = Seq('b'.toByte, 'c'.toByte)
 }
 
 /** Represents the HumanReadablePart for a bitcoin testnet bech32 address */
 case object tb extends HumanReadablePart {
-  def network = TestNet3
+  def network = Some(TestNet3)
   def bytes = Seq('t'.toByte, 'b'.toByte)
+}
+
+/** An undefined HRP. This has not been assigned to a network yet */
+case class UndefinedHRP(bytes: Seq[Byte]) extends HumanReadablePart {
+  def network = None
 }
 
 object HumanReadablePart {
@@ -28,6 +33,7 @@ object HumanReadablePart {
   def apply(str: String) = str match {
     case "bc" => bc
     case "tb" => tb
+    case _ => UndefinedHRP(str.map(_.toByte))
   }
 
   def apply(network: NetworkParameters): HumanReadablePart = network match {

--- a/src/main/scala/org/bitcoins/core/protocol/HumanReadablePart.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/HumanReadablePart.scala
@@ -28,8 +28,7 @@ case class UndefinedHRP(bytes: Seq[Byte]) extends HumanReadablePart {
 }
 
 object HumanReadablePart {
-  //TODO: try and force a pattern match here so we can check case exhaustiveness
-  //i.e if we add a new HumanReadablepart, we get a compiler warning if we didn't add the new case
+
   def apply(str: String) = str match {
     case "bc" => bc
     case "tb" => tb

--- a/src/main/scala/org/bitcoins/core/protocol/HumanReadablePart.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/HumanReadablePart.scala
@@ -1,0 +1,23 @@
+package org.bitcoins.core.protocol
+
+import org.bitcoins.core.config.{MainNet, NetworkParameters, TestNet3}
+
+/** Represents the HumanReadablePart of a Bech32 address
+  * [[https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki]]
+  * */
+sealed abstract class HumanReadablePart {
+  def network: NetworkParameters
+  def bytes: Seq[Byte]
+}
+
+/** Represents the HumanReadablePart for a bitcoin mainnet bech32 address */
+case object bc extends HumanReadablePart {
+  def network = MainNet
+  def bytes = Seq('b'.toByte, 'c'.toByte)
+}
+
+/** Represents the HumanReadablePart for a bitcoin testnet bech32 address */
+case object tb extends HumanReadablePart {
+  def network = TestNet3
+  def bytes = Seq('t'.toByte, 'b'.toByte)
+}

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -491,8 +491,10 @@ sealed trait WitnessScriptPubKey extends ScriptPubKey {
 object WitnessScriptPubKey {
 
   /** Witness scripts must begin with one of these operations, see BIP141 */
-  private val validFirstOps: Seq[ScriptNumberOperation] = Seq(OP_0,OP_1,OP_2,OP_3,OP_4,OP_5,OP_6, OP_7, OP_8,
+  val validWitVersions: Seq[ScriptNumberOperation] = Seq(OP_0,OP_1,OP_2,OP_3,OP_4,OP_5,OP_6, OP_7, OP_8,
     OP_9, OP_10, OP_11, OP_12, OP_13, OP_14, OP_15, OP_16)
+
+  val unassignedWitVersions = validWitVersions.tail
 
   def apply(asm: Seq[ScriptToken]): Option[WitnessScriptPubKey] = fromAsm(asm)
 
@@ -510,7 +512,7 @@ object WitnessScriptPubKey {
     val bytes = asm.flatMap(_.bytes)
     val firstOp = asm.headOption
     if (bytes.size < 4 || bytes.size > 42) false
-    else if (!validFirstOps.contains(firstOp.getOrElse(OP_1NEGATE))) false
+    else if (!validWitVersions.contains(firstOp.getOrElse(OP_1NEGATE))) false
     else if (asm(1).toLong + 2 == bytes.size) true
     else false
   }

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -491,7 +491,7 @@ sealed trait WitnessScriptPubKey extends ScriptPubKey {
 object WitnessScriptPubKey {
 
   /** Witness scripts must begin with one of these operations, see BIP141 */
-  private val validFirstOps = Seq(OP_0,OP_1,OP_2,OP_3,OP_4,OP_5,OP_6, OP_7, OP_8,
+  private val validFirstOps: Seq[ScriptNumberOperation] = Seq(OP_0,OP_1,OP_2,OP_3,OP_4,OP_5,OP_6, OP_7, OP_8,
     OP_9, OP_10, OP_11, OP_12, OP_13, OP_14, OP_15, OP_16)
 
   def apply(asm: Seq[ScriptToken]): Option[WitnessScriptPubKey] = fromAsm(asm)

--- a/src/main/scala/org/bitcoins/core/protocol/script/WitnessVersion.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/WitnessVersion.scala
@@ -6,6 +6,8 @@ import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.result._
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, CryptoUtil}
 
+import scala.util.Try
+
 /**
   * Created by chris on 11/10/16.
   * The version of the [[WitnessScriptPubKey]], this indicates how a [[ScriptWitness]] is rebuilt
@@ -34,22 +36,20 @@ case object WitnessVersion0 extends WitnessVersion {
           Left((scriptWitness.stack.map(ScriptConstant(_)), P2PKHScriptPubKey(hash)))
         }
       case 32 =>
-        logger.info("Script witness stack: " + scriptWitness)
         //p2wsh
         if (scriptWitness.stack.isEmpty) Right(ScriptErrorWitnessProgramWitnessEmpty)
         else {
           //need to check if the hashes match
           val stackTop = scriptWitness.stack.head
           val stackHash = CryptoUtil.sha256(stackTop)
-          logger.debug("Stack top: " + BitcoinSUtil.encodeHex(stackTop))
-          logger.debug("Stack hash: " + stackHash)
-          logger.debug("Witness program: " + witnessProgram)
-          if (stackHash != Sha256Digest(witnessProgram.head.bytes)) Right(ScriptErrorWitnessProgramMisMatch)
+          if (stackHash != Sha256Digest(witnessProgram.head.bytes)) {
+            logger.debug("Witness hashes did not match Stack hash: " + stackHash)
+            logger.debug("Witness program: " + witnessProgram)
+            Right(ScriptErrorWitnessProgramMisMatch)
+          }
           else {
             val compactSizeUInt = CompactSizeUInt.calculateCompactSizeUInt(stackTop)
             val scriptPubKey = ScriptPubKey(compactSizeUInt.bytes ++ stackTop)
-            logger.debug("scriptPubKey: " + scriptPubKey)
-            logger.debug("Script pub key for p2wsh: " + scriptPubKey.asm)
             val stack = scriptWitness.stack.tail.map(ScriptConstant(_))
             Left(stack, scriptPubKey)
           }
@@ -67,11 +67,9 @@ case object WitnessVersion0 extends WitnessVersion {
 }
 
 /** The witness version that represents all witnesses that have not been allocated yet */
-case object UnassignedWitness extends WitnessVersion {
+case class UnassignedWitness(version: ScriptNumberOperation) extends WitnessVersion {
   override def rebuild(scriptWitness: ScriptWitness, witnessProgram: Seq[ScriptToken]): Either[(Seq[ScriptToken], ScriptPubKey),ScriptError] =
     Right(ScriptErrorDiscourageUpgradeableWitnessProgram)
-
-  override def version = OP_16
 }
 
 object WitnessVersion {
@@ -80,8 +78,8 @@ object WitnessVersion {
 
   def apply(scriptNumberOp: ScriptNumberOperation): WitnessVersion = scriptNumberOp match {
     case OP_0 | OP_FALSE => WitnessVersion0
-    case OP_1 | OP_TRUE | OP_2 | OP_3 | OP_4 | OP_5 | OP_6 | OP_7 | OP_8
-      | OP_9 | OP_10 | OP_11 | OP_12 | OP_13 | OP_14 | OP_15 | OP_16  => UnassignedWitness
+    case x @ (OP_1 | OP_TRUE | OP_2 | OP_3 | OP_4 | OP_5 | OP_6 | OP_7 | OP_8
+      | OP_9 | OP_10 | OP_11 | OP_12 | OP_13 | OP_14 | OP_15 | OP_16)  => UnassignedWitness(x)
     case OP_1NEGATE => throw new IllegalArgumentException("OP_1NEGATE is not a valid witness version")
   }
 
@@ -91,9 +89,6 @@ object WitnessVersion {
       throw new IllegalArgumentException("We can only have witness version that is a script number operation, i.e OP_0 through OP_16")
   }
 
-  def apply(int: Int): WitnessVersion = int match {
-    case 0 => WitnessVersion0
-    case _ => UnassignedWitness
-  }
+  def apply(int: Int): Option[WitnessVersion] = ScriptNumberOperation.fromNumber(int).map(WitnessVersion(_))
 
 }

--- a/src/main/scala/org/bitcoins/core/protocol/script/WitnessVersion.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/WitnessVersion.scala
@@ -68,6 +68,7 @@ case object WitnessVersion0 extends WitnessVersion {
 
 /** The witness version that represents all witnesses that have not been allocated yet */
 case class UnassignedWitness(version: ScriptNumberOperation) extends WitnessVersion {
+  require(WitnessScriptPubKey.unassignedWitVersions.contains(version), "Cannot created an unassigend witness version from one that is assigned already, got: " + version)
   override def rebuild(scriptWitness: ScriptWitness, witnessProgram: Seq[ScriptToken]): Either[(Seq[ScriptToken], ScriptPubKey),ScriptError] =
     Right(ScriptErrorDiscourageUpgradeableWitnessProgram)
 }

--- a/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -148,7 +148,7 @@ sealed abstract class ScriptInterpreter {
               if (segwitEnabled && (scriptSig.asmBytes == expectedScriptBytes)) {
                 // The scriptSig must be _exactly_ a single push of the redeemScript. Otherwise we
                 // reintroduce malleability.
-                logger.info("redeem script was witness script pubkey, segwit was enabled, scriptSig was single push of redeemScript")
+                logger.debug("redeem script was witness script pubkey, segwit was enabled, scriptSig was single push of redeemScript")
                 //TODO: remove .get here
                 executeSegWitScript(scriptPubKeyExecutedProgram,w).get
               } else if (segwitEnabled && (scriptSig.asmBytes != expectedScriptBytes)) {
@@ -273,7 +273,7 @@ sealed abstract class ScriptInterpreter {
         case p : PreExecutionScriptProgram => loop(ScriptProgram.toExecutionInProgress(p,Some(p.stack)),opCount)
         case p : ExecutedScriptProgram =>
           val countedOps = program.originalScript.map(BitcoinScriptUtil.countsTowardsScriptOpLimit(_)).count(_ == true)
-          logger.info("Counted ops: " + countedOps)
+          logger.debug("Counted ops: " + countedOps)
           if (countedOps > maxScriptOps && p.error.isEmpty) {
             loop(ScriptProgram(p,ScriptErrorOpCount),opCount)
           } else p

--- a/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -191,7 +191,7 @@ sealed abstract class ScriptInterpreter {
             case WitnessVersion0 =>
               logger.error("Cannot verify witness program with a BaseTxSigComponent")
               Success(ScriptProgram(scriptPubKeyExecutedProgram,ScriptErrorWitnessProgramWitnessEmpty))
-            case UnassignedWitness =>
+            case UnassignedWitness(_) =>
               evaluateUnassignedWitness(b)
           }
         }
@@ -241,7 +241,7 @@ sealed abstract class ScriptInterpreter {
             val program = ScriptProgram(wTxSigComponent,Nil,Nil,Nil)
             Success(ScriptProgram(program,err))
         }
-      case UnassignedWitness =>
+      case UnassignedWitness(_) =>
         evaluateUnassignedWitness(wTxSigComponent)
     }
   }

--- a/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
+++ b/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
@@ -33,6 +33,14 @@ trait BitcoinSUtil {
     addPadding(8,hex)
   }
 
+  def encodeHex(short: Short): String = {
+    val hex = short.toHexString.length % 2 match {
+      case 1 => "0" + short.toHexString
+      case _ : Int => short.toHexString
+    }
+    addPadding(4,hex)
+  }
+
   def encodeHex(bigInt : BigInt) : String = BitcoinSUtil.encodeHex(bigInt.toByteArray)
 
   /** Tests if a given string is a hexadecimal string. */

--- a/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -79,8 +79,8 @@ trait NumberUtil extends BitcoinSLogger {
   /** Converts a hex string to a [[Long]]. */
   def toLong(hex : String): Long = toLong(BitcoinSUtil.decodeHex(hex))
 
-  /** Converts a sequence bytes 'from' base to 'to' base */
-  def convertBits(data: Seq[UInt8], from: UInt32, to: UInt32, pad: Boolean): Try[Seq[UInt8]] = {
+  /** Converts a sequence uint8 'from' base to 'to' base */
+  def convertUInt8s(data: Seq[UInt8], from: UInt32, to: UInt32, pad: Boolean): Try[Seq[UInt8]] = {
     var acc: UInt32 = UInt32.zero
     var bits: UInt32 = UInt32.zero
     var ret: Seq[UInt8] = Nil
@@ -113,6 +113,10 @@ trait NumberUtil extends BitcoinSLogger {
       }
       Success(ret)
     }
+  }
+
+  def convertBytes(data: Seq[Byte], from: UInt32, to: UInt32, pad: Boolean): Try[Seq[UInt8]] = {
+    convertUInt8s(UInt8.toUInt8s(data),from,to,pad)
   }
 }
 

--- a/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -1,6 +1,9 @@
 package org.bitcoins.core.util
 
+import org.bitcoins.core.number.{UInt32, UInt8}
+
 import scala.math.BigInt
+import scala.util.{Failure, Success, Try}
 
 /**
  * Created by chris on 2/8/16.
@@ -76,6 +79,41 @@ trait NumberUtil extends BitcoinSLogger {
   /** Converts a hex string to a [[Long]]. */
   def toLong(hex : String): Long = toLong(BitcoinSUtil.decodeHex(hex))
 
+  /** Converts a sequence bytes 'from' base to 'to' base */
+  def convertBits(data: Seq[UInt8], from: UInt32, to: UInt32, pad: Boolean): Try[Seq[UInt8]] = {
+    var acc: UInt32 = UInt32.zero
+    var bits: UInt32 = UInt32.zero
+    var ret: Seq[UInt8] = Nil
+    val maxv: UInt32 = (UInt32.one << to) - UInt32.one
+    val eight = UInt32(8)
+    if (from > eight || to > eight) {
+      Failure(new IllegalArgumentException("Can't have convert bits 'from' or 'to' parameter greater than 8"))
+    } else {
+      data.map { h =>
+        if ((h >> UInt8(from.underlying.toShort)) != UInt8.zero) {
+          Failure(new IllegalArgumentException("Invalid input for bech32: " + h))
+        } else {
+          acc = (acc << from) | UInt32(h.underlying)
+          bits = bits + from
+          while (bits >= to) {
+            bits = bits - to
+            val r: Seq[UInt8] = Seq(UInt8((((acc >> bits) & maxv).underlying.toShort)))
+            ret = ret ++ r
+          }
+        }
+      }
+
+      if (pad) {
+        if (bits > UInt32.zero) {
+          val r: Long = (acc.underlying << (to.underlying - bits.underlying)) & maxv.underlying
+          ret = ret ++ Seq(UInt8(r.toShort))
+        }
+      } else if (bits >= from || ((acc << (to - bits)) & maxv) != UInt8.zero) {
+        Failure(new IllegalArgumentException("Invalid padding in encoding"))
+      }
+      Success(ret)
+    }
+  }
 }
 
 object NumberUtil extends NumberUtil

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
 
 
-    <root level="WARN">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
 
 
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/src/test/scala/org/bitcoins/core/number/UInt32Spec.scala
+++ b/src/test/scala/org/bitcoins/core/number/UInt32Spec.scala
@@ -107,4 +107,11 @@ class UInt32Spec extends Properties("UInt32") {
         r.isFailure
       }
     }
+
+  property(">>") =
+    Prop.forAll(NumberGenerator.uInt32s, Gen.choose(0,100)) { case (u32,shift) =>
+      val r = u32 >> shift
+      val expected = u32.underlying >> shift
+      r == UInt32(expected)
+    }
 }

--- a/src/test/scala/org/bitcoins/core/number/UInt32Spec.scala
+++ b/src/test/scala/org/bitcoins/core/number/UInt32Spec.scala
@@ -10,7 +10,7 @@ import scala.util.Try
   * Created by chris on 6/16/16.
   */
 class UInt32Spec extends Properties("UInt32") {
-
+  private val logger = BitcoinSLogger.logger
 
   property("serialization symmetry") = {
     Prop.forAll(NumberGenerator.uInt32s) { uInt32 : UInt32 =>
@@ -95,5 +95,16 @@ class UInt32Spec extends Properties("UInt32") {
   property("&") =
     Prop.forAll(NumberGenerator.uInt32s, NumberGenerator.uInt32s) { (num1: UInt32, num2: UInt32) =>
       UInt32(num1.underlying & num2.underlying) == (num1 & num2)
+    }
+
+  property("<<") =
+    Prop.forAllNoShrink(NumberGenerator.uInt32s, Gen.choose(0,32)) { case (u32, shift) =>
+      val r = Try(u32 << shift)
+      val expected = (u32.underlying << shift) & 0xffffffffL
+      if (expected <= UInt32.max.underlying) {
+        r.get == UInt32(expected)
+      } else {
+        r.isFailure
+      }
     }
 }

--- a/src/test/scala/org/bitcoins/core/number/UInt8Spec.scala
+++ b/src/test/scala/org/bitcoins/core/number/UInt8Spec.scala
@@ -1,10 +1,13 @@
 package org.bitcoins.core.number
 
 import org.bitcoins.core.gen.NumberGenerator
-import org.scalacheck.{Prop, Properties}
+import org.bitcoins.core.util.BitcoinSLogger
+import org.scalacheck.{Gen, Prop, Properties}
+
+import scala.util.Try
 
 class UInt8Spec extends Properties("UInt8Spec") {
-
+  private val logger = BitcoinSLogger.logger
   property("convert uint8 -> byte -> uint8") = {
     Prop.forAll(NumberGenerator.uInt8) { case u8: UInt8 =>
         UInt8(UInt8.toByte(u8)) == u8
@@ -14,6 +17,27 @@ class UInt8Spec extends Properties("UInt8Spec") {
   property("serialization symmetry") = {
     Prop.forAll(NumberGenerator.uInt8) { u8 =>
       UInt8(u8.hex) == u8
+    }
+  }
+
+  property("<<") = {
+    Prop.forAllNoShrink(NumberGenerator.uInt8, Gen.choose(0,8)) { case (u8: UInt8, shift: Int) =>
+      val r = Try(u8 << shift)
+      val expected = (u8.underlying << shift) & 0xffL
+      if (expected <= UInt8.max.underlying) {
+        r.get == UInt8(expected.toShort)
+      } else {
+        r.isFailure
+      }
+    }
+  }
+
+  property(">>") = {
+    Prop.forAllNoShrink(NumberGenerator.uInt8,Gen.choose(0,100)) { case (u8: UInt8, shift: Int) =>
+      val r = (u8 >> shift)
+      val expected = u8.underlying >> shift
+      r == UInt8(expected.toShort)
+
     }
   }
 }

--- a/src/test/scala/org/bitcoins/core/number/UInt8Spec.scala
+++ b/src/test/scala/org/bitcoins/core/number/UInt8Spec.scala
@@ -1,0 +1,13 @@
+package org.bitcoins.core.number
+
+import org.bitcoins.core.gen.NumberGenerator
+import org.scalacheck.{Prop, Properties}
+
+class UInt8Spec extends Properties("UInt8Spec") {
+
+  property("convert uint8 -> byte -> uint8") = {
+    Prop.forAll(NumberGenerator.uInt8) { case u8: UInt8 =>
+        UInt8(UInt8.toByte(u8)) == u8
+    }
+  }
+}

--- a/src/test/scala/org/bitcoins/core/number/UInt8Spec.scala
+++ b/src/test/scala/org/bitcoins/core/number/UInt8Spec.scala
@@ -10,4 +10,10 @@ class UInt8Spec extends Properties("UInt8Spec") {
         UInt8(UInt8.toByte(u8)) == u8
     }
   }
+
+  property("serialization symmetry") = {
+    Prop.forAll(NumberGenerator.uInt8) { u8 =>
+      UInt8(u8.hex) == u8
+    }
+  }
 }

--- a/src/test/scala/org/bitcoins/core/number/UInt8Test.scala
+++ b/src/test/scala/org/bitcoins/core/number/UInt8Test.scala
@@ -1,0 +1,13 @@
+package org.bitcoins.core.number
+
+import org.scalatest.{FlatSpec, MustMatchers}
+
+class UInt8Test extends FlatSpec with MustMatchers {
+
+  "UInt8" must "convert a byte to a UInt8 correctly" in {
+    UInt8.toUInt8(0.toByte) must be (UInt8.zero)
+    UInt8.toUInt8(1.toByte) must be (UInt8.one)
+    UInt8.toUInt8(255.toByte) must be (UInt8(255.toShort))
+  }
+
+}

--- a/src/test/scala/org/bitcoins/core/protocol/AddressFactoryTest.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/AddressFactoryTest.scala
@@ -3,28 +3,25 @@ package org.bitcoins.core.protocol
 import org.bitcoins.core.util.{Base58, BitcoinSUtil, TestUtil}
 import org.scalatest.{FlatSpec, MustMatchers}
 
+import scala.util.Success
+
 /**
  * Created by chris on 3/30/16.
  */
 class AddressFactoryTest extends FlatSpec with MustMatchers {
 
   "AddressFactory" must "create an address from a base58 encoded string" in {
-    Address(TestUtil.bitcoinAddress.value) must be (TestUtil.bitcoinAddress)
+    Address(TestUtil.bitcoinAddress.value) must be (Success(TestUtil.bitcoinAddress))
   }
 
   it must "create an address from a sequence of bytes"  in {
-    Address(Base58.decode(TestUtil.bitcoinAddress.value)) must be (TestUtil.bitcoinAddress)
-  }
-
-  it must "throw an exception if the given string" in {
-    intercept[RuntimeException] {
-      Address("01234567890abcdef")
-    }
+    val decoded = Base58.decode(TestUtil.bitcoinAddress.value)
+    Address(decoded) must be (Success(TestUtil.bitcoinAddress))
   }
 
   it must "throw an exception if we give a hex string to create a bitcoin address from" in {
-    intercept[RuntimeException] {
-      Address.fromHex("01234567890abcdef")
+    intercept[IllegalArgumentException] {
+      throw Address.fromHex("01234567890abcdef").failed.get
     }
   }
 }

--- a/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
@@ -36,7 +36,8 @@ class Bech32Spec extends Properties("Bech32Spec") {
       val old = addr.value
       val replaced = switchCaseRandChar(old)
       //should fail because we we switched the case of a random char
-      Bech32Address.fromString(replaced).isFailure
+      val actual = Bech32Address.fromString(replaced)
+      actual.isFailure
     }
   }
 

--- a/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
@@ -11,7 +11,8 @@ class Bech32Spec extends Properties("Bech32Spec") {
   private val logger = BitcoinSLogger.logger
 
   property("serialization symmetry") = {
-    Prop.forAll(ScriptGenerators.witnessScriptPubKeyV0,ChainParamsGenerator.networkParams) { case ((witSPK,_),network) =>
+    Prop.forAll(ScriptGenerators.witnessScriptPubKey,ChainParamsGenerator.networkParams) {
+      case ((witSPK,_),network) =>
         val addr = Bech32Address(witSPK,network)
         val spk = addr.flatMap(a => Bech32Address.fromStringToWitSPK(a.value))
         spk == Success(witSPK)

--- a/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
@@ -13,7 +13,7 @@ class Bech32Spec extends Properties("Bech32Spec") {
   property("serialization symmetry") = {
     Prop.forAll(ScriptGenerators.witnessScriptPubKeyV0,ChainParamsGenerator.networkParams) { case ((witSPK,_),network) =>
         val addr = Bech32Address(witSPK,network)
-        val spk = addr.flatMap(a => Bech32Address.fromString(a.value))
+        val spk = addr.flatMap(a => Bech32Address.fromStringToWitSPK(a.value))
         spk == Success(witSPK)
     }
   }

--- a/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
@@ -1,0 +1,30 @@
+package org.bitcoins.core.protocol
+
+import org.bitcoins.core.gen.{AddressGenerator, ChainParamsGenerator, ScriptGenerators}
+import org.scalacheck.{Gen, Prop, Properties}
+
+import scala.util.{Random, Success}
+
+class Bech32Spec extends Properties("Bech32Spec") {
+
+  property("serialization symmetry") = {
+    Prop.forAll(ScriptGenerators.witnessScriptPubKeyV0,ChainParamsGenerator.networkParams) { case ((witSPK,_),network) =>
+        val addr = Bech32Address(witSPK,network)
+        val spk = addr.flatMap(a => Bech32Address.fromString(a.value))
+        spk == Success(witSPK)
+    }
+  }
+
+  property("checksum must not work if we modify a char") = {
+    Prop.forAll(AddressGenerator.bech32Address) { case addr : Bech32Address =>
+      val old = addr. value
+      val rand = Math.abs(Random.nextInt)
+      val idx = rand % old.size
+      val replacementChar = Bech32Address.charset(rand % Bech32Address.charset.size)
+      val (f,l) = old.splitAt(idx)
+      val replaced = f ++ Seq(replacementChar) ++ l.tail
+      //should fail because we replaced a char in the addr, so checksum invalid
+      Bech32Address.fromString(replaced).isFailure
+    }
+  }
+}

--- a/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/Bech32Spec.scala
@@ -1,11 +1,14 @@
 package org.bitcoins.core.protocol
 
 import org.bitcoins.core.gen.{AddressGenerator, ChainParamsGenerator, ScriptGenerators}
+import org.bitcoins.core.util.BitcoinSLogger
 import org.scalacheck.{Gen, Prop, Properties}
 
+import scala.annotation.tailrec
 import scala.util.{Random, Success}
 
 class Bech32Spec extends Properties("Bech32Spec") {
+  private val logger = BitcoinSLogger.logger
 
   property("serialization symmetry") = {
     Prop.forAll(ScriptGenerators.witnessScriptPubKeyV0,ChainParamsGenerator.networkParams) { case ((witSPK,_),network) =>
@@ -16,15 +19,47 @@ class Bech32Spec extends Properties("Bech32Spec") {
   }
 
   property("checksum must not work if we modify a char") = {
-    Prop.forAll(AddressGenerator.bech32Address) { case addr : Bech32Address =>
-      val old = addr. value
+    Prop.forAll(AddressGenerator.bech32Address) { case addr: Bech32Address =>
+      val old = addr.value
       val rand = Math.abs(Random.nextInt)
       val idx = rand % old.size
-      val replacementChar = Bech32Address.charset(rand % Bech32Address.charset.size)
       val (f,l) = old.splitAt(idx)
+      val replacementChar = pickReplacementChar(l.head)
       val replaced = f ++ Seq(replacementChar) ++ l.tail
       //should fail because we replaced a char in the addr, so checksum invalid
       Bech32Address.fromString(replaced).isFailure
+    }
+  }
+
+  property("must fail if we have a mixed case") = {
+    Prop.forAllNoShrink(AddressGenerator.bech32Address) { case addr: Bech32Address =>
+      val old = addr.value
+      val replaced = switchCaseRandChar(old)
+      //should fail because we we switched the case of a random char
+      Bech32Address.fromString(replaced).isFailure
+    }
+  }
+
+  @tailrec
+  private def pickReplacementChar(oldChar: Char): Char = {
+    val rand = Math.abs(Random.nextInt)
+    val newChar = Bech32Address.charset(rand % Bech32Address.charset.size)
+    //make sure we don't pick the same char we are replacing in the bech32 address
+    if (oldChar == newChar) pickReplacementChar(oldChar)
+    else newChar
+  }
+
+  @tailrec
+  private def switchCaseRandChar(addr: String): String = {
+    val rand = Math.abs(Random.nextInt)
+    val idx = rand % addr.size
+    val (f,l) = addr.splitAt(idx)
+    if (l.head.isDigit) {
+      switchCaseRandChar(addr)
+    } else if (l.head.isUpper) {
+      f ++ Seq(l.head.toLower) ++ l.tail
+    } else {
+      f ++ Seq(l.head.toUpper) ++ l.tail
     }
   }
 }

--- a/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
@@ -1,0 +1,95 @@
+package org.bitcoins.core.protocol
+
+import org.bitcoins.core.config.TestNet3
+import org.bitcoins.core.crypto.ECPublicKey
+import org.bitcoins.core.number.UInt8
+import org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0
+import org.scalatest.{FlatSpec, MustMatchers}
+
+import scala.util.Success
+
+class Bech32Test extends FlatSpec with MustMatchers  {
+
+/*  "Bech32" must "validly encode the test vectors from bitcoin core correctly" in {
+    val valid = Seq("A12UEL5L",
+      "a12uel5l",
+      "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
+      "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
+      "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+      "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
+      "?1ezyfcl"
+    )
+  }
+
+  it must "mark invalid test vectors as invalid from bitcoin core" in {
+    val invalid = Seq(" 1nwldj5",
+    "\\x7f\"\"1axkwrx",
+    "\\x80\"\"1eym55h",
+    "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+    "pzry9x0s0muk",
+    "1pzry9x0s0muk",
+    "x1b4n0q5v",
+    "li1dgmt3",
+    "de1lg7wt\\xff",
+    "A1G7SGD8",
+    "10a06t8",
+    "1qzzfhee")
+
+  }*/
+
+  it must "follow the example in BIP173" in {
+    //https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#examples
+    val key = ECPublicKey("0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798".toLowerCase)
+    val p2wpkh = WitnessScriptPubKeyV0(key)
+    val expected = Seq(117, 30, 118, 232, 25, 145, 150, 212, 84, 148, 28, 69, 209, 179, 163, 35, 241, 67, 59, 214).map(_.toByte)
+    val bytes = p2wpkh.asmBytes.tail.tail
+    bytes.size must be (expected.size)
+    bytes must be (expected)
+    val addr = Bech32Address(p2wpkh,TestNet3)
+    addr.map(_.value) must be (Success("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"))
+  }
+
+  it must "encode 0 byte correctly" in {
+    val addr = Bech32Address(bc, Seq(UInt8.zero))
+    addr.value must be ("bc1q9zpgru")
+  }
+
+
+  it must "create the correct checksum for a 0 byte address" in {
+    val checksum = Bech32Address.createChecksum(bc,Seq(UInt8.zero))
+    checksum must be (Seq(5, 2, 1, 8, 3, 28).map(i => UInt8(i.toShort)))
+    checksum.map(ch => Bech32Address.charset(ch.underlying)).mkString must be ("9zpgru")
+  }
+
+  it must "encode base 8 to base 5" in {
+    val z = UInt8.zero
+    val encoded = Bech32Address.encode(Seq(z))
+    encoded.map(Bech32Address.encodeToString(_)) must be (Success("qq"))
+
+    val encoded1 = Bech32Address.encode(Seq(z, UInt8.one))
+    encoded1 must be (Success(Seq(z,z,z,UInt8(16.toShort))))
+    //130.toByte == -126
+    val encoded2 = Bech32Address.encode(Seq(130).map(i => UInt8(i.toShort)))
+    encoded2 must be (Success(Seq(16,8).map(i => UInt8(i.toShort))))
+
+    //130.toByte == -126
+    val encoded3 = Bech32Address.encode(Seq(255,255).map(i => UInt8(i.toShort)))
+    encoded3 must be (Success(Seq(31, 31, 31, 16).map(i => UInt8(i.toShort))))
+
+    val encoded4 = Bech32Address.encode(Seq(255,255,255,255).map(i => UInt8(i.toShort)))
+    encoded4 must be (Success(Seq(31, 31, 31, 31, 31, 31, 24).map(i => UInt8(i.toShort))))
+
+    val encoded5 = Bech32Address.encode(Seq(255,255,255,255,255).map(i => UInt8(i.toShort)))
+    encoded5 must be (Success(Seq(31, 31, 31, 31, 31, 31, 31, 31).map(i => UInt8(i.toShort))))
+
+    val encoded6 = Bech32Address.encode(Seq(255,255,255,255,255,255).map(i => UInt8(i.toShort)))
+    encoded6 must be (Success(Seq(31, 31, 31, 31, 31, 31, 31, 31, 31, 28).map(i => UInt8(i.toShort))))
+  }
+
+
+  it must "encode base 5 to base 8" in {
+    val z = UInt8.zero
+    val encoded = "qq"
+    Bech32Address.decode(Seq(z,z)) must be (Success(Seq(z)))
+  }
+}

--- a/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
@@ -3,14 +3,14 @@ package org.bitcoins.core.protocol
 import org.bitcoins.core.config.{MainNet, TestNet3}
 import org.bitcoins.core.crypto.ECPublicKey
 import org.bitcoins.core.number.UInt8
-import org.bitcoins.core.protocol.script.{P2PKHScriptPubKey, P2PKScriptPubKey, WitnessScriptPubKeyV0}
+import org.bitcoins.core.protocol.script.{P2PKHScriptPubKey, P2PKScriptPubKey, WitnessScriptPubKey, WitnessScriptPubKeyV0}
 import org.scalatest.{FlatSpec, MustMatchers}
 
-import scala.util.Success
+import scala.util.{Success, Try}
 
 class Bech32Test extends FlatSpec with MustMatchers  {
 
-/*  "Bech32" must "validly encode the test vectors from bitcoin core correctly" in {
+  "Bech32" must "validly encode the test vectors from bitcoin core correctly" in {
     val valid = Seq("A12UEL5L",
       "a12uel5l",
       "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
@@ -19,6 +19,8 @@ class Bech32Test extends FlatSpec with MustMatchers  {
       "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
       "?1ezyfcl"
     )
+    val results: Seq[Try[(HumanReadablePart,Seq[Byte])]] = valid.map(Bech32Address.fromString(_))
+    results.exists(_.isFailure) must be (false)
   }
 
   it must "mark invalid test vectors as invalid from bitcoin core" in {
@@ -34,8 +36,9 @@ class Bech32Test extends FlatSpec with MustMatchers  {
     "A1G7SGD8",
     "10a06t8",
     "1qzzfhee")
-
-  }*/
+    val results: Seq[Try[(HumanReadablePart,Seq[Byte])]] = invalid.map(Bech32Address.fromString(_))
+    results.exists(_.isSuccess) must be (false)
+  }
 
   it must "follow the example in BIP173" in {
     //https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#examples
@@ -45,13 +48,13 @@ class Bech32Test extends FlatSpec with MustMatchers  {
     addr.map(_.value) must be (Success("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"))
 
     //decode
-    val decoded = addr.flatMap(a => Bech32Address.fromString(a.value))
+    val decoded = addr.flatMap(a => Bech32Address.fromStringToWitSPK(a.value))
     decoded must be (Success(p2wpkh))
 
     val p2wpkhMain = Bech32Address(p2wpkh,MainNet)
     p2wpkhMain.map(_.value) must be (Success("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"))
 
-    val mp2wpkhDecoded = p2wpkhMain.flatMap(a => Bech32Address.fromString(a.value))
+    val mp2wpkhDecoded = p2wpkhMain.flatMap(a => Bech32Address.fromStringToWitSPK(a.value))
     mp2wpkhDecoded must be (Success(p2wpkh))
 
     val p2pk = P2PKScriptPubKey(key)
@@ -60,12 +63,12 @@ class Bech32Test extends FlatSpec with MustMatchers  {
     addr1.map(_.value) must be (Success("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"))
 
     //decode
-    val decoded1 = addr1.flatMap(a => Bech32Address.fromString(a.value))
+    val decoded1 = addr1.flatMap(a => Bech32Address.fromStringToWitSPK(a.value))
     decoded1 must be (Success(p2wsh))
 
     val p2wshMain = Bech32Address(p2wsh,MainNet)
     p2wshMain.map(_.value) must be (Success("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"))
-    val mp2wshDecoded = p2wshMain.flatMap(a => Bech32Address.fromString(a.value))
+    val mp2wshDecoded = p2wshMain.flatMap(a => Bech32Address.fromStringToWitSPK(a.value))
     mp2wshDecoded must be (Success(p2wsh))
   }
 
@@ -104,12 +107,5 @@ class Bech32Test extends FlatSpec with MustMatchers  {
 
     val encoded6 = Bech32Address.encode(Seq(255,255,255,255,255,255).map(i => UInt8(i.toShort)))
     encoded6 must be (Success(Seq(31, 31, 31, 31, 31, 31, 31, 31, 31, 28).map(i => UInt8(i.toShort))))
-  }
-
-
-  it must "encode base 5 to base 8" in {
-    val z = UInt8.zero
-    val encoded = "qq"
-    Bech32Address.decode(Seq(z,z)) must be (Success(Seq(z)))
   }
 }

--- a/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.core.protocol
 
-import org.bitcoins.core.config.TestNet3
+import org.bitcoins.core.config.{MainNet, TestNet3}
 import org.bitcoins.core.crypto.ECPublicKey
 import org.bitcoins.core.number.UInt8
-import org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0
+import org.bitcoins.core.protocol.script.{P2PKHScriptPubKey, P2PKScriptPubKey, WitnessScriptPubKeyV0}
 import org.scalatest.{FlatSpec, MustMatchers}
 
 import scala.util.Success
@@ -41,12 +41,19 @@ class Bech32Test extends FlatSpec with MustMatchers  {
     //https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#examples
     val key = ECPublicKey("0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798".toLowerCase)
     val p2wpkh = WitnessScriptPubKeyV0(key)
-    val expected = Seq(117, 30, 118, 232, 25, 145, 150, 212, 84, 148, 28, 69, 209, 179, 163, 35, 241, 67, 59, 214).map(_.toByte)
-    val bytes = p2wpkh.asmBytes.tail.tail
-    bytes.size must be (expected.size)
-    bytes must be (expected)
     val addr = Bech32Address(p2wpkh,TestNet3)
     addr.map(_.value) must be (Success("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"))
+
+    val p2wpkhMain = Bech32Address(p2wpkh,MainNet)
+    p2wpkhMain.map(_.value) must be (Success("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"))
+
+    val p2pk = P2PKScriptPubKey(key)
+    val p2wsh = WitnessScriptPubKeyV0(p2pk)
+    val addr1 = Bech32Address(p2wsh,TestNet3)
+    addr1.map(_.value) must be (Success("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"))
+
+    val p2wshMain = Bech32Address(p2wsh,MainNet)
+    p2wshMain.map(_.value) must be (Success("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"))
   }
 
   it must "encode 0 byte correctly" in {

--- a/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
@@ -44,16 +44,29 @@ class Bech32Test extends FlatSpec with MustMatchers  {
     val addr = Bech32Address(p2wpkh,TestNet3)
     addr.map(_.value) must be (Success("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"))
 
+    //decode
+    val decoded = addr.flatMap(a => Bech32Address.fromString(a.value))
+    decoded must be (Success(p2wpkh))
+
     val p2wpkhMain = Bech32Address(p2wpkh,MainNet)
     p2wpkhMain.map(_.value) must be (Success("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"))
+
+    val mp2wpkhDecoded = p2wpkhMain.flatMap(a => Bech32Address.fromString(a.value))
+    mp2wpkhDecoded must be (Success(p2wpkh))
 
     val p2pk = P2PKScriptPubKey(key)
     val p2wsh = WitnessScriptPubKeyV0(p2pk)
     val addr1 = Bech32Address(p2wsh,TestNet3)
     addr1.map(_.value) must be (Success("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"))
 
+    //decode
+    val decoded1 = addr1.flatMap(a => Bech32Address.fromString(a.value))
+    decoded1 must be (Success(p2wsh))
+
     val p2wshMain = Bech32Address(p2wsh,MainNet)
     p2wshMain.map(_.value) must be (Success("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"))
+    val mp2wshDecoded = p2wshMain.flatMap(a => Bech32Address.fromString(a.value))
+    mp2wshDecoded must be (Success(p2wsh))
   }
 
   it must "encode 0 byte correctly" in {

--- a/src/test/scala/org/bitcoins/core/protocol/BitcoinAddressTest.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/BitcoinAddressTest.scala
@@ -49,15 +49,15 @@ class BitcoinAddressTest extends FlatSpec with MustMatchers {
   it must "encode a pubKeyHash to an address" in {
     //from https://stackoverflow.com/questions/19233053/hashing-from-a-public-key-to-a-bitcoin-address-in-php
     val hash = Sha256Hash160Digest("010966776006953d5567439e5e39f86a0d273bee")
-    val address = Address("16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM")
-    P2PKHAddress.encodePubKeyHashToAddress(hash, MainNet) must be (address)
+    val address = Address("16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM").get
+    P2PKHAddress(hash, MainNet) must be (address)
   }
 
   it must "encode a scriptPubKey to an address" in {
     //redeemScript from https://en.bitcoin.it/wiki/Pay_to_script_hash
     val hex = "455141042f90074d7a5bf30c72cf3a8dfd1381bdbd30407010e878f3a11269d5f74a58788505cdca22ea6eab7cfb40dc0e07aba200424ab0d79122a653ad0c7ec9896bdf51ae"
     val scriptPubKey = ScriptPubKey(hex)
-    val addr = P2SHAddress.encodeScriptPubKeyToAddress(scriptPubKey,MainNet)
+    val addr = P2SHAddress(scriptPubKey,MainNet)
     addr must be (BitcoinAddress("3P14159f73E4gFr7JterCCQh9QjiTjiZrG"))
   }
 }

--- a/src/test/scala/org/bitcoins/core/protocol/HumanReadablePartTest.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/HumanReadablePartTest.scala
@@ -1,0 +1,17 @@
+package org.bitcoins.core.protocol
+
+import org.bitcoins.core.config.{MainNet, TestNet3}
+import org.scalatest.{FlatSpec, MustMatchers}
+
+class HumanReadablePartTest extends FlatSpec with MustMatchers {
+
+  "HumanReadablePart" must "match the correct hrp with the correct string" in {
+    HumanReadablePart("tb") must be (tb)
+    HumanReadablePart("bc") must be (bc)
+  }
+
+  it must "match the correct hrp with the correct network" in {
+    HumanReadablePart(TestNet3) must be (tb)
+    HumanReadablePart(MainNet) must be (bc)
+  }
+}

--- a/src/test/scala/org/bitcoins/core/util/NumberUtilSpec.scala
+++ b/src/test/scala/org/bitcoins/core/util/NumberUtilSpec.scala
@@ -1,12 +1,14 @@
 package org.bitcoins.core.util
 
 import org.bitcoins.core.gen.NumberGenerator
-import org.scalacheck.{Prop, Properties}
+import org.bitcoins.core.number.{UInt32, UInt8}
+import org.scalacheck.{Gen, Prop, Properties}
 
 /**
   * Created by chris on 6/20/16.
   */
 class NumberUtilSpec extends Properties("NumberUtilSpec") {
+  private val logger = BitcoinSLogger.logger
 
   property("Serialization symmetry for BigInt") =
     Prop.forAll(NumberGenerator.bigInts) { bigInt : BigInt =>
@@ -22,4 +24,21 @@ class NumberUtilSpec extends Properties("NumberUtilSpec") {
     Prop.forAll { long : Long =>
       NumberUtil.toLong(BitcoinSUtil.encodeHex(long)) == long
     }
+
+  property("converBits symmetry") = {
+    Prop.forAllNoShrink(Gen.choose(1,8),NumberGenerator.uInt8s) {
+      case (to,u8s: Seq[UInt8]) =>
+        //TODO: in the future make this a generated value instead of fixed to 8
+        //but the trick is we need to make sure that the u8s generated are valid numbers in the 'from' base
+        val u32From = UInt32(8.toShort)
+        val u32To = UInt32(to.toShort)
+        val converted = NumberUtil.convertUInt8s(u8s,u32From,u32To,true)
+        val original = converted.flatMap(c => NumberUtil.convertUInt8s(c,u32To,u32From,false))
+        if (original.isFailure) {
+          throw original.failed.get
+        } else {
+          original.get == u8s
+        }
+    }
+  }
 }

--- a/src/test/scala/org/bitcoins/core/util/testprotocol/Base58ValidTestCaseProtocol.scala
+++ b/src/test/scala/org/bitcoins/core/util/testprotocol/Base58ValidTestCaseProtocol.scala
@@ -20,7 +20,7 @@ object Base58ValidTestCaseProtocol extends DefaultJsonProtocol {
       val configParams : ConfigParams = elements(2).convertTo[ConfigParams]
 
       def addressOrPrivateKey(elements : Vector[JsValue]) : Either[Address, String] = configParams.isPrivKey match {
-        case false => Left(Address(elements(0).convertTo[String]))
+        case false => Left(Address(elements(0).convertTo[String]).get)
         case true => Right(elements(0).convertTo[String])
       }
 


### PR DESCRIPTION
This pull request provides an implementation of [BIP173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) for bitcoin-s-core.

Here is the motivation for Bech32 from the BIP: 

> For most of its history, Bitcoin has relied on base58 addresses with a truncated double-SHA256 checksum. They were part of the original software and their scope was extended in BIP13 for Pay-to-script-hash (P2SH). However, both the character set and the checksum algorithm have limitations:
> 
>     Base58 needs a lot of space in QR codes, as it cannot use the alphanumeric mode.
>     
>     The mixed case in base58 makes it inconvenient to reliably write down, type on mobile keyboards, or read out loud.
>
>     The double SHA256 checksum is slow and has no error-detection guarantees.
>     Most of the research on error-detecting codes only applies to character-set sizes that are a prime power, which 58 is not.
>
>     Base58 decoding is complicated and relatively slow.

Here are the main parts of the implementation:

1. The [abstract class](https://github.com/Christewart/bitcoin-s-core/blob/84cebb44a6844d120e63691d921f7d95e1e57f17/src/main/scala/org/bitcoins/core/protocol/Address.scala#L117-L140) used to represent/create a Bech32Address
2. The [companion object](https://github.com/Christewart/bitcoin-s-core/blob/84cebb44a6844d120e63691d921f7d95e1e57f17/src/main/scala/org/bitcoins/core/protocol/Address.scala#L142-L325) used to create a Bech32 address 
3. A new [UInt8](https://github.com/Christewart/bitcoin-s-core/blob/84cebb44a6844d120e63691d921f7d95e1e57f17/src/main/scala/org/bitcoins/core/number/NumberType.scala#L49-L120) number type to help with abstractions used with unsigned integers and signed integers in Bech32 address calculations
