### PR TITLE
Segwit other consensus changes

### DIFF
--- a/src/main/scala/org/bitcoins/core/consensus/Consensus.scala
+++ b/src/main/scala/org/bitcoins/core/consensus/Consensus.scala
@@ -2,13 +2,26 @@ package org.bitcoins.core.consensus
 
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.number.Int64
+import org.bitcoins.core.protocol.blockchain.Block
+import org.bitcoins.core.protocol.transaction.{BaseTransaction, WitnessTransaction}
+import org.bitcoins.core.serializers.transaction.RawBaseTransactionParser
 
 /**
   * Created by chris on 5/13/16.
   */
-trait Consensus {
+sealed abstract class Consensus {
 
-  def maxBlockSize = 1000000
+  def maxBlockSize: Long = 1000000
+
+  def weightScalar: Long = 4
+
+  def maxBlockWeight: Long = maxBlockSize * weightScalar
+
+  /**
+    * BIP141 changes this from 20,000 -> 80,000, to see how sigops are counted please see BIP 141
+    * [[https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#sigops]]
+    */
+  def maxSigOps = 80000
 
   def maxMoney : CurrencyUnit = Satoshis(Int64(2100000000000000L))
 }

--- a/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol.blockchain
 
 import org.bitcoins.core.number.UInt64
-import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.core.protocol.transaction.{BaseTransaction, Transaction, WitnessTransaction}
 import org.bitcoins.core.protocol.{CompactSizeUInt, NetworkElement}
 import org.bitcoins.core.serializers.blockchain.RawBlockSerializer
 import org.bitcoins.core.util.{BitcoinSLogger, Factory}
@@ -28,6 +28,18 @@ sealed abstract class Block extends NetworkElement {
 
   override def bytes = RawBlockSerializer.write(this)
 
+  /** This is the new computation to determine the maximum size of a block as per BIP141
+    * [[https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#block-size]]
+    * The weight of a block is determined as follows:
+    *
+    * Base size is the block size in bytes with the original transaction serialization without any witness-related data
+    *
+    * Total size is the block size in bytes with transactions serialized as described in BIP144, including base data and witness data.
+    *
+    * Block weight is defined as Base size * 3 + Total size
+    * [[https://github.com/bitcoin/bitcoin/blob/7490ae8b699d2955b665cf849d86ff5bb5245c28/src/primitives/block.cpp#L35]]
+    */
+  def blockWeight: Long = transactions.map(_.weight).sum
 }
 
 

--- a/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -30,6 +30,32 @@ sealed abstract class Transaction extends NetworkElement {
   /** The locktime for this transaction */
   def lockTime : UInt32
 
+  /** This is used to indicate how 'expensive' the transction is on the blockchain.
+    * This use to be a simple calculation before segwit (BIP141). Each byte in the transaction
+    * counted as 4 'weight' units. Now with segwit, the [[TransactionWitness]] is counted as 1 weight unit per byte,
+    * while other parts of the transaction (outputs, inputs, locktime etc) count as 4 weight units.
+    * As we add more witness versions, this may be subject to change
+    * [[https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#Transaction_size_calculations]]
+    * [[https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/validation.h#L96]]
+    * */
+  def weight: Long
+
+  /**
+    * The transaction's virtual size
+    * [[https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#Transaction_size_calculations]]
+    */
+  def vsize: Long = Math.ceil(weight / 4).toLong
+
+  /**
+    * Base transaction size is the size of the transaction serialised with the witness data stripped
+    * [[https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#Transaction_size_calculations]]
+    */
+  def baseSize: Long = this match {
+    case btx: BaseTransaction => btx.size
+    case wtx: WitnessTransaction => BaseTransaction(wtx.version,wtx.inputs,wtx.outputs,wtx.lockTime).baseSize
+  }
+
+  def totalSize: Long = bytes.size
 
   /** Determines if this transaction is a coinbase transaction. */
   def isCoinbase : Boolean = inputs.size match {
@@ -41,9 +67,9 @@ sealed abstract class Transaction extends NetworkElement {
   }
 }
 
-
 sealed abstract class BaseTransaction extends Transaction {
   override def bytes = RawBaseTransactionParser.write(this)
+  override def weight = bytes.size * 4
 }
 
 
@@ -72,6 +98,14 @@ sealed abstract class WitnessTransaction extends Transaction {
     * */
   def wTxId: DoubleSha256Digest = CryptoUtil.doubleSHA256(bytes)
 
+  /** Weight calculation in bitcoin for witness txs
+    * [[https://github.com/bitcoin/bitcoin/blob/5961b23898ee7c0af2626c46d5d70e80136578d3/src/consensus/validation.h#L96]]
+    * @return
+    */
+  override def weight: Long = {
+    val base = BaseTransaction(version,inputs,outputs,lockTime)
+    base.totalSize * 3 + totalSize
+  }
   override def bytes = RawWitnessTransactionParser.write(this)
 
 }


### PR DESCRIPTION
This pull request implements the remaining [consensus critical elements](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#other-consensus-critical-limits) of BIP141. This includes calculating the new block weight which is used to determine how large a block can be, and also implements the signature operation limit. 

Inside of Bitcoin Core both these rules are enforced inside of validation.cpp. [Here](https://github.com/bitcoin/bitcoin/blob/e8cfe1ee2d01c493b758a67ad14707dca15792ea/src/validation.cpp#L1826-L1829) is where the signature operation limit is enforced, and [here](https://github.com/bitcoin/bitcoin/blob/e8cfe1ee2d01c493b758a67ad14707dca15792ea/src/validation.cpp#L2975) is where the block weight limit is enforced. We do not have block validation functionality inside of bitcoin-s-core currently, only transaction verification functionality. Therefore we do not have the ability to thoroughly test this inside of bitcoin-s-core.

This pull request may be tabled until we have block validation functionality inside of bitcoin-s-core, or merged now and thoroughly tested inside of the block validation logic when that gets added. I think this can go either way.  