### PR TITLE
Adding invariant that says our signature scheme should NOT reuse r values

### DIFF
--- a/src/main/scala/org/bitcoins/core/crypto/CryptoParams.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/CryptoParams.scala
@@ -7,7 +7,7 @@ import org.spongycastle.crypto.params.ECDomainParameters
  * Created by chris on 3/29/16.
  * This trait represents all of the default parameters for our elliptic curve
  */
-trait CryptoParams {
+sealed abstract class CryptoParams {
 
   /** This is the parameters for the elliptic curve bitcoin uses. */
   def params = SECNamedCurves.getByName("secp256k1")

--- a/src/main/scala/org/bitcoins/core/crypto/DERSignatureUtil.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/DERSignatureUtil.scala
@@ -8,8 +8,9 @@ import scala.util.{Failure, Success, Try}
 /**
  * Created by chris on 3/23/16.
  */
-trait DERSignatureUtil extends BitcoinSLogger {
+sealed abstract class DERSignatureUtil {
 
+  private val logger = BitcoinSLogger.logger
   /**
    * Checks if this signature is encoded to DER correctly
    * https://crypto.stackexchange.com/questions/1795/how-can-i-convert-a-der-ecdsa-signature-to-asn-1

--- a/src/main/scala/org/bitcoins/core/crypto/ECDigitalSignature.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECDigitalSignature.scala
@@ -4,7 +4,8 @@ import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, Factory}
 /**
  * Created by chris on 2/26/16.
  */
-sealed trait ECDigitalSignature extends BitcoinSLogger {
+sealed abstract class ECDigitalSignature {
+  private val logger = BitcoinSLogger.logger
 
   def hex : String = BitcoinSUtil.encodeHex(bytes)
 

--- a/src/main/scala/org/bitcoins/core/gen/CryptoGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/CryptoGenerators.scala
@@ -9,7 +9,7 @@ import org.scalacheck.Gen
 /**
   * Created by chris on 6/22/16.
   */
-trait CryptoGenerators {
+sealed abstract class CryptoGenerators {
 
 
   def privateKey : Gen[ECPrivateKey] = Gen.const(ECPrivateKey())
@@ -38,7 +38,6 @@ trait CryptoGenerators {
   /**
     * Generates a random number of private keys less than the max public keys setting in [[ScriptSettings]]
     * also generates a random 'requiredSigs' number that a transaction needs to be signed with
-    * @return
     */
   def privateKeySeqWithRequiredSigs: Gen[(Seq[ECPrivateKey], Int)] = for {
     num <- Gen.choose(0,ScriptSettings.maxPublicKeysPerMultiSig)
@@ -52,27 +51,18 @@ trait CryptoGenerators {
   } yield keysAndRequiredSigs
 
 
-  /**
-    * Generates a random public key
-    * @return
-    */
+  /** Generates a random public key */
   def publicKey : Gen[ECPublicKey] = for {
     privKey <- privateKey
   } yield privKey.publicKey
 
-  /**
-    * Generates a random digital signature
-    * @return
-    */
+  /** Generates a random digital signature */
   def digitalSignature : Gen[ECDigitalSignature] = for {
     privKey <- privateKey
     hash <- CryptoGenerators.doubleSha256Digest
   } yield privKey.sign(hash)
 
-  /**
-    * Generates a random [[DoubleSha256Digest]]
-    * @return
-    */
+  /** Generates a random [[DoubleSha256Digest]] */
   def doubleSha256Digest : Gen[DoubleSha256Digest] = for {
     hex <- StringGenerators.hexString
     digest = CryptoUtil.doubleSHA256(hex)

--- a/src/main/scala/org/bitcoins/core/util/BitcoinSLogger.scala
+++ b/src/main/scala/org/bitcoins/core/util/BitcoinSLogger.scala
@@ -8,7 +8,7 @@ import org.slf4j.Logger
  */
 abstract class BitcoinSLogger {
 
-  def logger: Logger = LoggerFactory.getLogger(this.getClass().toString)
+  val logger: Logger = LoggerFactory.getLogger(this.getClass().toString)
 
 }
 

--- a/src/test/scala/org/bitcoins/core/crypto/ECDigitalSignatureSpec.scala
+++ b/src/test/scala/org/bitcoins/core/crypto/ECDigitalSignatureSpec.scala
@@ -24,4 +24,13 @@ class ECDigitalSignatureSpec extends Properties("ECDigitalSignatureSpec") {
         val sig = key.sign(hash)
         key.publicKey.verify(hash,sig)
     }
+
+  property("must not reuse r values") = {
+    Prop.forAll(CryptoGenerators.privateKey, CryptoGenerators.doubleSha256Digest, CryptoGenerators.doubleSha256Digest) {
+      case (key,hash1,hash2) =>
+        val sig1 = key.sign(hash1)
+        val sig2 = key.sign(hash2)
+        sig1.r != sig2.r
+    }
+  }
 }


### PR DESCRIPTION
Adding invariant to make sure we don't re-use r values when signing, this is not a issue in bitcoin-s-core before this as we use secp256k1 for signing. 

Also cleaning up some comments / classes in `org.bitcoins.core.crypto`. 