### PR TITLE
Network spk byte refactor

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,6 @@ object BitcoinSCoreBuild extends Build {
     "org.scalatest" % "scalatest_2.11" % scalaTestV % "test",
     "com.novocode" % "junit-interface" % "0.10" % "test",
     "org.scalacheck" %% "scalacheck" % scalacheckV withSources() withJavadoc(),
-    "com.google.guava" % "guava" % "18.0",
     
     ("org.bitcoinj" % "bitcoinj-core" % "0.14.4" % "test").exclude("org.slf4j", "slf4j-api"),
     "com.madgag.spongycastle" % "core" % spongyCastleV,

--- a/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
+++ b/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
@@ -10,9 +10,9 @@ sealed abstract class NetworkParameters {
   /** The parameters of the blockchain we are connecting to */
   def chainParams: ChainParams
 
-  def p2pkhNetworkByte: Byte = chainParams.base58Prefix(Base58Type.PubKeyAddress).head
-  def p2shNetworkByte: Byte = chainParams.base58Prefix(Base58Type.ScriptAddress).head
-  def privateKey: Byte = chainParams.base58Prefix(Base58Type.SecretKey).head
+  def p2pkhNetworkByte: Seq[Byte] = chainParams.base58Prefix(Base58Type.PubKeyAddress)
+  def p2shNetworkByte: Seq[Byte] = chainParams.base58Prefix(Base58Type.ScriptAddress)
+  def privateKey: Seq[Byte] = chainParams.base58Prefix(Base58Type.SecretKey)
 
   def port : Int
   def rpcPort: Int
@@ -85,7 +85,7 @@ object Networks {
   val p2pkhNetworkBytes = knownNetworks.map(_.p2pkhNetworkByte)
   val p2shNetworkBytes = knownNetworks.map(_.p2shNetworkByte)
 
-  def byteToNetwork: Map[Byte, NetworkParameters] = Map(
+  def byteToNetwork: Map[Seq[Byte], NetworkParameters] = Map(
     MainNet.p2shNetworkByte -> MainNet,
     MainNet.p2pkhNetworkByte -> MainNet,
     MainNet.privateKey -> MainNet,

--- a/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -79,7 +79,7 @@ sealed abstract class ECPrivateKey extends BaseECKey {
   def toWIF(network: NetworkParameters): String = {
     val networkByte = network.privateKey
     //append 1 byte to the end of the priv key byte representation if we need a compressed pub key
-    val fullBytes = if (isCompressed) networkByte +: (bytes ++ Seq(1.toByte)) else networkByte +: bytes
+    val fullBytes = if (isCompressed) networkByte ++ (bytes ++ Seq(1.toByte)) else networkByte ++ bytes
     val hash = CryptoUtil.doubleSHA256(fullBytes)
     val checksum = hash.bytes.take(4)
     val encodedPrivKey = fullBytes ++ checksum
@@ -156,8 +156,8 @@ object ECPrivateKey extends Factory[ECPrivateKey] {
     * @return
     */
   def isCompressed(bytes : Seq[Byte]): Boolean = {
-    val validCompressedBytes: Seq[Byte] = Networks.secretKeyBytes
-    val validCompressedBytesInHex: Seq[String] = validCompressedBytes.map(byte => BitcoinSUtil.encodeHex(byte))
+    val validCompressedBytes: Seq[Seq[Byte]] = Networks.secretKeyBytes
+    val validCompressedBytesInHex: Seq[String] = validCompressedBytes.map(b => BitcoinSUtil.encodeHex(b))
     val firstByteHex = BitcoinSUtil.encodeHex(bytes.head)
     if (validCompressedBytesInHex.contains(firstByteHex)) bytes(bytes.length - 5) == 0x01.toByte
     else false
@@ -199,7 +199,7 @@ object ECPrivateKey extends Factory[ECPrivateKey] {
     val decoded = Base58.decodeCheck(wif)
     decoded.map { bytes =>
       val b = bytes.head
-      Networks.byteToNetwork(b)
+      Networks.byteToNetwork(Seq(b))
     }
   }
 }

--- a/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -320,8 +320,7 @@ object P2PKHAddress {
     val decodeCheckP2PKH : Try[Seq[Byte]] = Base58.decodeCheck(address)
     decodeCheckP2PKH match {
       case Success(bytes) =>
-        val firstByte = bytes.head
-        Networks.p2pkhNetworkBytes.contains(firstByte) && bytes.size == 21
+        Networks.p2pkhNetworkBytes.find(bs => bytes.startsWith(bs)).isDefined && bytes.size == 21
       case Failure(exception) => false
     }
   }
@@ -355,8 +354,7 @@ object P2SHAddress {
     val decodeCheckP2SH : Try[Seq[Byte]] = Base58.decodeCheck(address)
     decodeCheckP2SH match {
       case Success(bytes) =>
-        val firstByte = bytes.head
-        Networks.p2shNetworkBytes.contains(firstByte) && bytes.size == 21
+        Networks.p2shNetworkBytes.find(bs => bytes.startsWith(bs)).isDefined && bytes.size == 21
       case Failure(_) => false
     }
   }
@@ -367,6 +365,7 @@ object P2SHAddress {
 }
 
 object BitcoinAddress {
+  private val logger = BitcoinSLogger.logger
   /** Checks if the given base58 bitcoin address is a valid address */
   def validate(bitcoinAddress: String): Boolean = {
     val decodeChecked = Base58.decodeCheck(bitcoinAddress)
@@ -379,12 +378,12 @@ object BitcoinAddress {
     val decodeChecked = Base58.decodeCheck(value)
     decodeChecked match {
       case Success(bytes) =>
-        val network = matchNetwork(bytes.head)
-        if (P2PKHAddress.isP2PKHAddress(value)) {
-          P2PKHAddress(Sha256Hash160Digest(bytes.tail),network)
+        val network: Option[(NetworkParameters, Seq[Byte])] = matchNetwork(bytes)
+        if (network.isDefined && P2PKHAddress.isP2PKHAddress(value)) {
+          P2PKHAddress(Sha256Hash160Digest(network.get._2),network.get._1)
         }
-        else if (P2SHAddress.isP2SHAddress(value)) {
-          P2SHAddress(Sha256Hash160Digest(bytes.tail), network)
+        else if (network.isDefined && P2SHAddress.isP2SHAddress(value)) {
+          P2SHAddress(Sha256Hash160Digest(network.get._2),network.get._1)
         } else throw new IllegalArgumentException("The address was not a p2pkh or p2sh address, got: " + value)
       case Failure(exception) =>
         throw exception
@@ -392,10 +391,19 @@ object BitcoinAddress {
   }
 
   /** Helper function for helping matching an address to a network byte */
-  private def matchNetwork(byte: Byte): NetworkParameters = byte match {
-    case _ if Seq(MainNet.p2pkhNetworkByte,MainNet.p2shNetworkByte).contains(byte) => MainNet
-    case _ if Seq(TestNet3.p2pkhNetworkByte, TestNet3.p2shNetworkByte).contains(byte) => TestNet3
-    case _ if Seq(RegTest.p2pkhNetworkByte,RegTest.p2shNetworkByte).contains(byte) => RegTest
+  private def matchNetwork(bytes: Seq[Byte]): Option[(NetworkParameters, Seq[Byte])] = {
+    val all: Seq[Seq[Byte]] = Networks.p2pkhNetworkBytes ++ Networks.p2shNetworkBytes
+    val hex = all.map(BitcoinSUtil.encodeHex(_))
+    val networkByte = all.find { b =>
+      bytes.startsWith(b)
+    }
+    val payload = networkByte.map(b => bytes.splitAt(b.size)._2)
+    val result: Option[(NetworkParameters, Seq[Byte])] = networkByte.flatMap { nb =>
+      payload.map { p =>
+        (Networks.byteToNetwork(nb), p)
+      }
+    }
+    result
   }
 }
 

--- a/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -33,7 +33,7 @@ sealed abstract class P2PKHAddress extends BitcoinAddress {
   /** The base58 string representation of this address */
   override def value : String = {
     val versionByte = networkParameters.p2pkhNetworkByte
-    val bytes = Seq(versionByte) ++ hash.bytes
+    val bytes = versionByte ++ hash.bytes
     val checksum = CryptoUtil.doubleSHA256(bytes).bytes.take(4)
     Base58.encode(bytes ++ checksum)
   }
@@ -48,7 +48,7 @@ sealed abstract class P2SHAddress extends BitcoinAddress {
   /** The base58 string representation of this address */
   override def value : String = {
     val versionByte = networkParameters.p2shNetworkByte
-    val bytes = Seq(versionByte) ++ hash.bytes
+    val bytes = versionByte ++ hash.bytes
     val checksum = CryptoUtil.doubleSHA256(bytes).bytes.take(4)
     Base58.encode(bytes ++ checksum)
   }


### PR DESCRIPTION
Not all networks have a single  byte for address prefixes, this changes the networks bytes to from `Byte` to `Seq[Byte]`