### PR TITLE
remove size requirements for address

### DIFF
--- a/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
+++ b/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
@@ -85,7 +85,7 @@ object Networks {
   val p2pkhNetworkBytes = knownNetworks.map(_.p2pkhNetworkByte)
   val p2shNetworkBytes = knownNetworks.map(_.p2shNetworkByte)
 
-  def byteToNetwork: Map[Seq[Byte], NetworkParameters] = Map(
+  def bytesToNetwork: Map[Seq[Byte], NetworkParameters] = Map(
     MainNet.p2shNetworkByte -> MainNet,
     MainNet.p2pkhNetworkByte -> MainNet,
     MainNet.privateKey -> MainNet,

--- a/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -197,11 +197,18 @@ object ECPrivateKey extends Factory[ECPrivateKey] {
   /** Returns the [[NetworkParameters]] from a serialized WIF key */
   def parseNetworkFromWIF(wif: String): Try[NetworkParameters] = {
     val decoded = Base58.decodeCheck(wif)
-    decoded.map { bytes =>
-      val b = bytes.head
-      Networks.byteToNetwork(Seq(b))
+    decoded match {
+      case Success(bytes) =>
+        val networkMatch = Networks.secretKeyBytes.find(b => bytes.startsWith(b))
+        if (networkMatch.isDefined) {
+          Success(Networks.bytesToNetwork(networkMatch.get))
+        } else {
+          Failure(new IllegalArgumentException("Failed to match network bytes for WIF"))
+        }
+      case Failure(exn) => Failure(exn)
     }
   }
+
 }
 
 

--- a/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -320,7 +320,7 @@ object P2PKHAddress {
     val decodeCheckP2PKH : Try[Seq[Byte]] = Base58.decodeCheck(address)
     decodeCheckP2PKH match {
       case Success(bytes) =>
-        Networks.p2pkhNetworkBytes.find(bs => bytes.startsWith(bs)).isDefined && bytes.size == 21
+        Networks.p2pkhNetworkBytes.find(bs => bytes.startsWith(bs)).isDefined
       case Failure(exception) => false
     }
   }
@@ -354,7 +354,7 @@ object P2SHAddress {
     val decodeCheckP2SH : Try[Seq[Byte]] = Base58.decodeCheck(address)
     decodeCheckP2SH match {
       case Success(bytes) =>
-        Networks.p2shNetworkBytes.find(bs => bytes.startsWith(bs)).isDefined && bytes.size == 21
+        Networks.p2shNetworkBytes.find(bs => bytes.startsWith(bs)).isDefined
       case Failure(_) => false
     }
   }

--- a/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -400,7 +400,7 @@ object BitcoinAddress {
     val payload = networkByte.map(b => bytes.splitAt(b.size)._2)
     val result: Option[(NetworkParameters, Seq[Byte])] = networkByte.flatMap { nb =>
       payload.map { p =>
-        (Networks.byteToNetwork(nb), p)
+        (Networks.bytesToNetwork(nb), p)
       }
     }
     result

--- a/src/test/scala/org/bitcoins/core/crypto/ECPrivateKeySpec.scala
+++ b/src/test/scala/org/bitcoins/core/crypto/ECPrivateKeySpec.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.crypto
 
-import org.bitcoins.core.config.{MainNet, TestNet3}
+import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
 import org.bitcoins.core.gen.{ChainParamsGenerator, CryptoGenerators}
 import org.scalacheck.{Prop, Properties}
 
@@ -12,14 +12,11 @@ class ECPrivateKeySpec extends Properties("ECPrivateKeySpec") {
   property("Serialization symmetry for WIF format") =
     Prop.forAll(CryptoGenerators.privateKey, ChainParamsGenerator.networkParams) { (privKey,network) =>
       val wif = privKey.toWIF(network)
-      val isCorrectNetwork = if (network == MainNet) {
-        ECPrivateKey.parseNetworkFromWIF(wif).get == network
-      } else {
-        // we need this hack because RegTest & TestNet3 have the same base58 prefixes
-        ECPrivateKey.parseNetworkFromWIF(wif).get == TestNet3
+      val isCorrectNetwork = network match {
+        case MainNet => ECPrivateKey.parseNetworkFromWIF(wif).get == network
+        case TestNet3 | RegTest => ECPrivateKey.parseNetworkFromWIF(wif).get == TestNet3
       }
       ECPrivateKey.fromWIFToPrivateKey(wif) == privKey && isCorrectNetwork
-
     }
 
   property("Serialization symmetry") =


### PR DESCRIPTION
Some address types do not have only one network byte, so we remove the requirement that says all `P2PKHAddress` and `P2SHAddress` need to be 21 bytes in length. 