### PR TITLE
Spongcastle to bouncycastle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val commonSettings = Seq(
   organization := "org.bitcoins",
   name := "bitcoin-s-core",
-  version := "0.0.1",
+  version := "0.0.1-SNAPSHOT",
   scalaVersion := "2.11.7"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,14 +12,14 @@ lazy val logbackV = "1.0.13"
 lazy val scalaTestV = "2.2.0"
 lazy val scalacheckV = "1.13.0"
 lazy val sprayV = "1.3.2"
-lazy val spongyCastleV = "1.51.0.0"
+lazy val bouncyCastleV = "1.55"
 lazy val appDependencies = Seq(
   "org.scalatest" % "scalatest_2.11" % scalaTestV % "test",
   "com.novocode" % "junit-interface" % "0.10" % "test",
   "org.scalacheck" %% "scalacheck" % scalacheckV withSources() withJavadoc(),
 
   ("org.bitcoinj" % "bitcoinj-core" % "0.14.4" % "test").exclude("org.slf4j", "slf4j-api"),
-  "com.madgag.spongycastle" % "core" % spongyCastleV,
+  "org.bouncycastle" % "bcprov-jdk15on" % bouncyCastleV,
 
   "org.slf4j" % "slf4j-api" % slf4jV % "provided",
   "ch.qos.logback" % "logback-classic" % logbackV % "test",

--- a/src/main/scala/org/bitcoins/core/crypto/CryptoParams.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/CryptoParams.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.crypto
 
-import org.spongycastle.asn1.sec.SECNamedCurves
-import org.spongycastle.crypto.params.ECDomainParameters
+import org.bouncycastle.asn1.sec.SECNamedCurves
+import org.bouncycastle.crypto.params.ECDomainParameters
 
 /**
  * Created by chris on 3/29/16.

--- a/src/main/scala/org/bitcoins/core/crypto/DERSignatureUtil.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/DERSignatureUtil.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.crypto
 
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
-import org.spongycastle.asn1.{ASN1InputStream, ASN1Integer, DLSequence}
+import org.bouncycastle.asn1.{ASN1InputStream, ASN1Integer, DLSequence}
 
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -7,11 +7,11 @@ import org.bitcoin.NativeSecp256k1
 import org.bitcoins.core.config.{NetworkParameters, Networks}
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.util.{BitcoinSUtil, _}
-import org.spongycastle.crypto.AsymmetricCipherKeyPair
-import org.spongycastle.crypto.digests.SHA256Digest
-import org.spongycastle.crypto.generators.ECKeyPairGenerator
-import org.spongycastle.crypto.params.{ECKeyGenerationParameters, ECPrivateKeyParameters, ECPublicKeyParameters}
-import org.spongycastle.crypto.signers.{ECDSASigner, HMacDSAKCalculator}
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+import org.bouncycastle.crypto.digests.SHA256Digest
+import org.bouncycastle.crypto.generators.ECKeyPairGenerator
+import org.bouncycastle.crypto.params.{ECKeyGenerationParameters, ECPrivateKeyParameters, ECPublicKeyParameters}
+import org.bouncycastle.crypto.signers.{ECDSASigner, HMacDSAKCalculator}
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}

--- a/src/main/scala/org/bitcoins/core/util/CryptoUtil.scala
+++ b/src/main/scala/org/bitcoins/core/util/CryptoUtil.scala
@@ -3,9 +3,9 @@ package org.bitcoins.core.util
 import java.security.MessageDigest
 
 import org.bitcoins.core.crypto._
-import org.spongycastle.crypto.digests.{RIPEMD160Digest, SHA512Digest}
-import org.spongycastle.crypto.macs.HMac
-import org.spongycastle.crypto.params.KeyParameter
+import org.bouncycastle.crypto.digests.{RIPEMD160Digest, SHA512Digest}
+import org.bouncycastle.crypto.macs.HMac
+import org.bouncycastle.crypto.params.KeyParameter
 
 /**
   * Created by chris on 1/14/16.


### PR DESCRIPTION
See this issue wrt to spongy castle: 

https://github.com/rtyley/spongycastle/issues/34

Another note, we can only bump the bouncy castle version to `1.55` for now. This is because there are some weird old ECDSA signatures in the early blockchain history that do not validate past bouncy castle 1.55. Eventually I would like to implement [this](https://github.com/bitcoin/bitcoin/blob/master/src/pubkey.cpp#L16-L165) functionality in bitcoin core to take care of those old cases in the blockchain. 