### PR TITLE
Adding scalariform formatting preferences

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,20 @@ lazy val appDependencies = Seq(
   "io.spray" %% "spray-json" % sprayV  % "test"
 )
 
+com.typesafe.sbt.SbtScalariform.ScalariformKeys.preferences := {
+  import scalariform.formatter.preferences._
+  FormattingPreferences()
+    .setPreference(FirstParameterOnNewline, Preserve)
+    .setPreference(FirstArgumentOnNewline, Preserve)
+    .setPreference(AlignParameters, true)
+    .setPreference(AlignArguments, true)
+    .setPreference(AlignSingleLineCaseStatements, true)
+    .setPreference(AlignSingleLineCaseStatements.MaxArrowIndent, 20)
+    .setPreference(DanglingCloseParenthesis, Force)
+    .setPreference(CompactControlReadability, true)
+    .setPreference(SpacesAroundMultiImports, false)
+}
+
 lazy val root = Project(appName, file(".")).enablePlugins().settings(
     commonSettings,
     libraryDependencies ++= appDependencies


### PR DESCRIPTION
Inspired by the `sbt-scalariform` plugin
[itself](https://github.com/sbt/sbt-scalariform/blob/master/build.sbt#L39-L48).

@Christewart I think this is a better approach than having things reformatted surprisingly, like 
what happened with https://github.com/bitcoin-s/bitcoin-s-core/pull/134.