### PR TITLE
Adding UTXOSpendingInfo to replace TxBuilder.UTXOTuple

### DIFF
--- a/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
@@ -9,6 +9,7 @@ import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.wallet.builder.{ TxBuilder, TxBuilderError }
 import org.bitcoins.core.wallet.signer.Signer
+import org.bitcoins.core.wallet.utxo.UTXOSpendingInfo
 
 import scala.util.{ Failure, Success, Try }
 
@@ -32,9 +33,6 @@ sealed abstract class EscrowTimeoutHelper {
     if (creditingOutput.scriptPubKey != P2WSHWitnessSPKV0(lock)) {
       Right(TxBuilderError.WrongSigner)
     } else {
-      val scriptWit = P2WSHWitnessV0(lock)
-      val utxoMap: TxBuilder.UTXOMap = Map(
-        outPoint -> (creditingOutput, Seq(signer), None, Some(scriptWit), hashType))
       val (p2wsh, amount) = (creditingOutput.scriptPubKey.asInstanceOf[P2WSHWitnessSPKV0], creditingOutput.value)
       val tc = TransactionConstants
       val uScriptWitness = P2WSHWitnessV0(lock)

--- a/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
@@ -1,0 +1,32 @@
+package org.bitcoins.core.wallet.utxo
+
+import org.bitcoins.core.protocol.script.{ ScriptPubKey, ScriptWitness }
+import org.bitcoins.core.protocol.transaction.{ TransactionOutPoint, TransactionOutput }
+import org.bitcoins.core.script.crypto.HashType
+import org.bitcoins.core.wallet.signer.Signer
+
+/**
+ * Contains the information required to spend a unspent transaction output (UTXO)
+ * on a blockchain.
+ */
+sealed abstract class UTXOSpendingInfo {
+  /** The funding transaction's txid and the index of the output in the transaction we are spending */
+  def outPoint: TransactionOutPoint
+  /** the actual output itself we are spending */
+  def output: TransactionOutput
+  /** the signers needed to spend from the output above */
+  def signers: Seq[Signer.Sign]
+  /** a redeemScript, if required, to spend the output above */
+  def redeemScriptOpt: Option[ScriptPubKey]
+  /** the scriptWitness, if required, to spend the output above */
+  def scriptWitnessOpt: Option[ScriptWitness]
+
+  def hashType: HashType
+}
+
+case class BitcoinUTXOSpendingInfo(outPoint: TransactionOutPoint, output: TransactionOutput,
+  signers: Seq[Signer.Sign],
+  redeemScriptOpt: Option[ScriptPubKey],
+  scriptWitnessOpt: Option[ScriptWitness],
+  hashType: HashType) extends UTXOSpendingInfo
+

--- a/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderSpec.scala
+++ b/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderSpec.scala
@@ -14,6 +14,7 @@ import org.bitcoins.core.script.result.{ ScriptOk, ScriptResult }
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.signer.Signer
+import org.bitcoins.core.wallet.utxo.{ BitcoinUTXOSpendingInfo, UTXOSpendingInfo }
 import org.scalacheck.{ Prop, Properties }
 
 import scala.annotation.tailrec
@@ -94,16 +95,16 @@ class BitcoinTxBuilderSpec extends Properties("TxBuilderSpec") {
     }
   }
 
-  private def buildCreditingTxInfo(info: Seq[TxBuilderSpec.CreditingTxInfo]): TxBuilderSpec.OutPointMap = {
+  private def buildCreditingTxInfo(info: Seq[TxBuilderSpec.CreditingTxInfo]): BitcoinTxBuilder.UTXOMap = {
     @tailrec
     def loop(
       rem: Seq[TxBuilderSpec.CreditingTxInfo],
-      accum: TxBuilderSpec.OutPointMap): TxBuilderSpec.OutPointMap = rem match {
+      accum: BitcoinTxBuilder.UTXOMap): BitcoinTxBuilder.UTXOMap = rem match {
       case Nil => accum
       case (tx, idx, signers, redeemScriptOpt, scriptWitOpt, hashType) :: t =>
         val o = TransactionOutPoint(tx.txId, UInt32(idx))
         val output = tx.outputs(idx)
-        val outPointsSpendingInfo = (output, signers, redeemScriptOpt, scriptWitOpt, hashType)
+        val outPointsSpendingInfo = BitcoinUTXOSpendingInfo(o, output, signers, redeemScriptOpt, scriptWitOpt, hashType)
         loop(t, accum.updated(o, outPointsSpendingInfo))
     }
     loop(info, Map.empty)

--- a/src/test/scala/org/bitcoins/core/wallet/builder/TxBuilderTest.scala
+++ b/src/test/scala/org/bitcoins/core/wallet/builder/TxBuilderTest.scala
@@ -1,0 +1,18 @@
+package org.bitcoins.core.wallet.builder
+
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.number.Int64
+import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.scalatest.{ FlatSpec, MustMatchers }
+
+class TxBuilderTest extends FlatSpec with MustMatchers {
+
+  "TxBuilder" must "detect a bad fee on the tx" in {
+    val estimatedFee = Satoshis(Int64(1000))
+    val actualFee = Satoshis.one
+    val feeRate = SatoshisPerVirtualByte(Satoshis.one)
+    TxBuilder.isValidFeeRange(estimatedFee, actualFee, feeRate) must be(Some(TxBuilderError.LowFee))
+
+    TxBuilder.isValidFeeRange(actualFee, estimatedFee, feeRate) must be(Some(TxBuilderError.HighFee))
+  }
+}


### PR DESCRIPTION
removing superflous utxoMap in EscrowTimeoutHelper

Instead of using type aliases for things inside of `TxBuilder`, use case classes. 