### PR TITLE
Creating 'fromAsmBytes' and 'fromAsmHex' in ScriptFactory

### DIFF
--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptFactory.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptFactory.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.protocol.script
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.serializers.script.ScriptParser
-import org.bitcoins.core.util.Factory
+import org.bitcoins.core.util.{ BitcoinSUtil, Factory }
 
 /**
  * Created by chris on 12/9/16.
@@ -30,4 +30,27 @@ trait ScriptFactory[T] extends Factory[T] {
     fromAsm(asm)
   }
 
+  /**
+   * Scripts are serialized with a [[org.bitcoins.core.protocol.CompactSizeUInt]] at the beginning
+   * to indicate how long the Script is. This construct assumes the [[CompactSizeUInt]]
+   * is NOT passed into the constructor. Only the actual Script program bytes.
+   * @param bytes
+   * @return
+   */
+  def fromAsmBytes(bytes: Seq[Byte]): T = {
+    val cmpct = CompactSizeUInt.calc(bytes)
+    val fullBytes = cmpct.bytes ++ bytes
+    fromBytes(fullBytes)
+  }
+
+  /**
+   * Scripts are serialized with a [[org.bitcoins.core.protocol.CompactSizeUInt]] at the beginning
+   * to indicate how long the [[ScriptSignature]] is. This construct assumes the [[CompactSizeUInt]]
+   * is NOT passed into the constructor. Only the actual Script program hex is.
+   * @param hex
+   * @return
+   */
+  def fromAsmHex(hex: String): T = {
+    fromAsmBytes(BitcoinSUtil.decodeHex(hex))
+  }
 }

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -474,7 +474,7 @@ case object EmptyScriptPubKey extends ScriptPubKey {
 }
 
 /** Factory companion object used to create ScriptPubKey objects */
-object ScriptPubKey extends Factory[ScriptPubKey] {
+object ScriptPubKey extends ScriptFactory[ScriptPubKey] {
   def empty: ScriptPubKey = fromAsm(Nil)
 
   /** Creates a scriptPubKey from its asm representation */
@@ -491,8 +491,6 @@ object ScriptPubKey extends Factory[ScriptPubKey] {
     case _ if EscrowTimeoutScriptPubKey.isValidEscrowTimeout(asm) => EscrowTimeoutScriptPubKey.fromAsm(asm)
     case _ => NonStandardScriptPubKey(asm)
   }
-
-  def fromBytes(bytes: Seq[Byte]): ScriptPubKey = RawScriptPubKeyParser.read(bytes)
 
   def apply(asm: Seq[ScriptToken]): ScriptPubKey = fromAsm(asm)
 }

--- a/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -372,12 +372,10 @@ case object EmptyScriptSignature extends ScriptSignature {
   def bytes = Seq(0.toByte)
 }
 
-object ScriptSignature extends Factory[ScriptSignature] {
+object ScriptSignature extends ScriptFactory[ScriptSignature] {
 
   /** Returns an empty script signature */
   def empty: ScriptSignature = EmptyScriptSignature
-
-  def fromBytes(bytes: Seq[Byte]): ScriptSignature = RawScriptSignatureParser.read(bytes)
 
   /** Creates a scriptSignature from the list of script tokens */
   def fromAsm(tokens: Seq[ScriptToken]): ScriptSignature = tokens match {

--- a/src/test/scala/org/bitcoins/core/protocol/script/ScriptSpec.scala
+++ b/src/test/scala/org/bitcoins/core/protocol/script/ScriptSpec.scala
@@ -1,0 +1,21 @@
+package org.bitcoins.core.protocol.script
+
+import org.bitcoins.core.gen.ScriptGenerators
+import org.scalacheck.{ Prop, Properties }
+
+class ScriptSpec extends Properties("ScriptSpec") {
+
+  property("serialization symmetry for ScriptFactory.fromAsmBytes") = {
+    Prop.forAllNoShrink(ScriptGenerators.scriptPubKey) {
+      case (spk, _) =>
+        ScriptPubKey.fromAsmBytes(spk.asmBytes) == spk
+    }
+  }
+
+  property("serialization symmetry for ScriptFactory.fromAsmBytes") = {
+    Prop.forAllNoShrink(ScriptGenerators.scriptSignature) {
+      case ss =>
+        ScriptSignature.fromAsmBytes(ss.asmBytes) == ss
+    }
+  }
+}


### PR DESCRIPTION
This pull request creates `ScriptFactor.fromAsmBytes` and `ScriptFactory.fromAsmHex`. This is useful for creating `ScriptSignature`s or `ScriptPubKey`s when you only have the `asm` byte vector. Bitcoinj only allows you to return the program byte vector with `getProgramBytes`