### PR TITLE
Refactor tx builder future

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,12 +9,12 @@ lazy val appName = "bitcoin-s-core"
 lazy val scalaV = "2.11.7"
 lazy val slf4jV = "1.7.5"
 lazy val logbackV = "1.0.13"
-lazy val scalaTestV = "2.2.0"
+lazy val scalaTestV = "3.0.5"
 lazy val scalacheckV = "1.13.0"
 lazy val sprayV = "1.3.2"
 lazy val bouncyCastleV = "1.55"
 lazy val appDependencies = Seq(
-  "org.scalatest" % "scalatest_2.11" % scalaTestV % "test",
+  "org.scalatest" %% "scalatest" % scalaTestV % "test",
   "com.novocode" % "junit-interface" % "0.10" % "test",
   "org.scalacheck" %% "scalacheck" % scalacheckV withSources() withJavadoc(),
 
@@ -38,6 +38,8 @@ lazy val root = Project(appName, file(".")).enablePlugins().settings(
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "2")
 
 //testOptions in Test += Tests.Argument("-oF")
+
+//parallelExecution in Test := false
 
 coverageExcludedPackages := ".*gen"
 

--- a/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -14,6 +14,7 @@ import org.bouncycastle.crypto.params.{ ECKeyGenerationParameters, ECPrivateKeyP
 import org.bouncycastle.crypto.signers.{ ECDSASigner, HMacDSAKCalculator }
 
 import scala.annotation.tailrec
+import scala.concurrent.ExecutionContext.Implicits
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
 
@@ -45,8 +46,6 @@ sealed abstract class BaseECKey extends NetworkElement with Sign {
 
   def signFuture(hash: HashDigest)(implicit ec: ExecutionContext): Future[ECDigitalSignature] = Future(sign(hash))
 
-  //def signFuture(dataToSign: Seq[Byte])(implicit ec: ExecutionContext): Future[ECDigitalSignature] = Future(sign(dataToSign))
-
   @deprecated("Deprecated in favor of signing algorithm inside of secp256k1", "2/20/2017")
   private def oldSign(dataToSign: Seq[Byte], signingKey: BaseECKey): ECDigitalSignature = {
     val signer: ECDSASigner = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()))
@@ -65,7 +64,6 @@ sealed abstract class BaseECKey extends NetworkElement with Sign {
     signatureLowS
   }
 
-  override implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
 }
 
 /**
@@ -104,15 +102,20 @@ sealed abstract class ECPrivateKey extends BaseECKey {
 
 object ECPrivateKey extends Factory[ECPrivateKey] {
 
-  private case class ECPrivateKeyImpl(override val bytes: Seq[Byte], isCompressed: Boolean) extends ECPrivateKey {
+  private case class ECPrivateKeyImpl(override val bytes: Seq[Byte], isCompressed: Boolean, ec: ExecutionContext) extends ECPrivateKey {
     require(NativeSecp256k1.secKeyVerify(bytes.toArray), "Invalid key according to secp256k1, hex: " + BitcoinSUtil.encodeHex(bytes))
+  }
+
+  def apply(bytes: Seq[Byte], isCompressed: Boolean)(implicit ec: ExecutionContext): ECPrivateKey = {
+    ECPrivateKeyImpl(bytes, isCompressed, ec)
   }
 
   override def fromBytes(bytes: Seq[Byte]): ECPrivateKey = fromBytes(bytes, true)
 
   @tailrec
   def fromBytes(bytes: Seq[Byte], isCompressed: Boolean): ECPrivateKey = {
-    if (bytes.size == 32) ECPrivateKeyImpl(bytes, isCompressed)
+
+    if (bytes.size == 32) ECPrivateKeyImpl(bytes, isCompressed, Implicits.global)
     else if (bytes.size < 32) {
       //means we need to pad the private key with 0 bytes so we have 32 bytes
       val paddingNeeded = 32 - bytes.size
@@ -285,7 +288,7 @@ sealed abstract class ECPublicKey extends BaseECKey {
 
 object ECPublicKey extends Factory[ECPublicKey] {
 
-  private case class ECPublicKeyImpl(override val bytes: Seq[Byte]) extends ECPublicKey {
+  private case class ECPublicKeyImpl(override val bytes: Seq[Byte], ec: ExecutionContext) extends ECPublicKey {
     //unfortunately we cannot place ANY invariants here
     //because of old transactions on the blockchain that have weirdly formatted public keys. Look at example in script_tests.json
     //https://github.com/bitcoin/bitcoin/blob/master/src/test/data/script_tests.json#L457
@@ -294,8 +297,9 @@ object ECPublicKey extends Factory[ECPublicKey] {
     //Eventually we would like this to be CPubKey::IsFullyValid() but since we are remaining backwards compatible
     //we cannot do this. If there ever is a hard fork this would be a good thing to add.
   }
-
-  override def fromBytes(bytes: Seq[Byte]): ECPublicKey = ECPublicKeyImpl(bytes)
+  override def fromBytes(bytes: Seq[Byte]): ECPublicKey = {
+    ECPublicKeyImpl(bytes, Implicits.global)
+  }
 
   def apply() = freshPublicKey
 

--- a/src/main/scala/org/bitcoins/core/crypto/Signer.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/Signer.scala
@@ -3,22 +3,6 @@ package org.bitcoins.core.crypto
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.DurationInt
 
-trait Sign {
-  def signFunction: Seq[Byte] => Future[ECDigitalSignature]
-
-  def signFuture(bytes: Seq[Byte])(implicit ec: ExecutionContext): Future[ECDigitalSignature] = signFunction(bytes)
-
-  def sign(bytes: Seq[Byte]): ECDigitalSignature = {
-    //TODO: review this later, is this ok?
-    import scala.concurrent.ExecutionContext.Implicits.global
-    Await.result(signFuture(bytes)(global), 30.seconds)
-  }
-
-  def pubKeyOpt: Option[ECPublicKey]
-
-  implicit val ec: ExecutionContext
-}
-
 /**
  * This is meant to be an abstraction for a [[org.bitcoins.core.crypto.ECPrivateKey]], sometimes we will not
  * have direct access to a private key in memory -- for instance if that key is on a hardware device -- so we need to create an
@@ -27,12 +11,26 @@ trait Sign {
  * [[Sign]] type by doing this:
  *
  * val key = ECPrivateKey()
- * val sign: (Seq[Byte] => ECDigitalSignature, Option[ECPublicKey]) = (key.sign(_: Seq[Byte]), key.publicKey)
+ * val sign: Seq[Byte] => Future[ECDigitalSignature] = key.signFunction
  *
  * If you have a hardware wallet, you will need to implement the protocol to send a message to the hardware device. The
- * type signature of the function you implement must be Seq[Byte] => ECDigitalSignature
+ * type signature of the function you implement must be Seq[Byte] => Future[ECDigitalSignature]
  *
  */
+trait Sign {
+  def signFunction: Seq[Byte] => Future[ECDigitalSignature]
+
+  def signFuture(bytes: Seq[Byte]): Future[ECDigitalSignature] = signFunction(bytes)
+
+  def sign(bytes: Seq[Byte]): ECDigitalSignature = {
+    Await.result(signFuture(bytes), 30.seconds)
+  }
+
+  def pubKeyOpt: Option[ECPublicKey]
+
+  implicit val ec: ExecutionContext
+}
+
 object Sign {
   private case class SignImpl(signFunction: Seq[Byte] => Future[ECDigitalSignature], pubKeyOpt: Option[ECPublicKey], implicit val ec: ExecutionContext) extends Sign
 

--- a/src/main/scala/org/bitcoins/core/crypto/Signer.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/Signer.scala
@@ -1,0 +1,51 @@
+package org.bitcoins.core.crypto
+
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.duration.DurationInt
+
+trait Sign {
+  def signFunction: Seq[Byte] => Future[ECDigitalSignature]
+
+  def signFuture(bytes: Seq[Byte])(implicit ec: ExecutionContext): Future[ECDigitalSignature] = signFunction(bytes)
+
+  def sign(bytes: Seq[Byte]): ECDigitalSignature = {
+    //TODO: review this later, is this ok?
+    import scala.concurrent.ExecutionContext.Implicits.global
+    Await.result(signFuture(bytes)(global), 30.seconds)
+  }
+
+  def pubKeyOpt: Option[ECPublicKey]
+
+  implicit val ec: ExecutionContext
+}
+
+/**
+ * This is meant to be an abstraction for a [[org.bitcoins.core.crypto.ECPrivateKey]], sometimes we will not
+ * have direct access to a private key in memory -- for instance if that key is on a hardware device -- so we need to create an
+ * abstraction of the signing process. Fundamentally a private key takes in a Seq[Byte] and returns a [[ECDigitalSignature]]
+ * That is what this abstraction is meant to represent. If you have a [[ECPrivateKey]] in your application, you can get it's
+ * [[Sign]] type by doing this:
+ *
+ * val key = ECPrivateKey()
+ * val sign: (Seq[Byte] => ECDigitalSignature, Option[ECPublicKey]) = (key.sign(_: Seq[Byte]), key.publicKey)
+ *
+ * If you have a hardware wallet, you will need to implement the protocol to send a message to the hardware device. The
+ * type signature of the function you implement must be Seq[Byte] => ECDigitalSignature
+ *
+ */
+object Sign {
+  private case class SignImpl(signFunction: Seq[Byte] => Future[ECDigitalSignature], pubKeyOpt: Option[ECPublicKey], implicit val ec: ExecutionContext) extends Sign
+
+  def apply(signFunction: Seq[Byte] => Future[ECDigitalSignature], pubKeyOpt: Option[ECPublicKey]): Sign = {
+    val ec = scala.concurrent.ExecutionContext.Implicits.global
+    Sign(signFunction, pubKeyOpt, ec)
+  }
+
+  def apply(signFunction: Seq[Byte] => Future[ECDigitalSignature]): Sign = {
+    Sign(signFunction, None)
+  }
+
+  def apply(signFunction: Seq[Byte] => Future[ECDigitalSignature], pubKeyOpt: Option[ECPublicKey], ec: ExecutionContext): Sign = {
+    SignImpl(signFunction, pubKeyOpt, ec)
+  }
+}

--- a/src/main/scala/org/bitcoins/core/gen/ChannelGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/ChannelGenerators.scala
@@ -11,12 +11,15 @@ import org.bitcoins.core.wallet.builder.TxBuilderError
 import org.scalacheck.Gen
 
 import scala.annotation.tailrec
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
  * Created by chris on 4/18/17.
  */
 sealed trait ChannelGenerators extends BitcoinSLogger {
-
+  val timeout = 5.seconds
   /** Creates an [[Transaction]], [[EscrowTimeoutScriptPubKey]] and the [[ECPrivateKey]] need to spend from the SPK */
   def anchorTx: Gen[(Transaction, EscrowTimeoutScriptPubKey, Seq[ECPrivateKey])] = for {
     (redeemScript, privKeys) <- ScriptGenerators.escrowTimeoutScriptPubKey2Of2
@@ -27,7 +30,7 @@ sealed trait ChannelGenerators extends BitcoinSLogger {
 
   def channelAwaitingAnchorTxNotConfirmed: Gen[(ChannelAwaitingAnchorTx, Seq[ECPrivateKey])] = for {
     (aTx, redeemScript, privKeys) <- anchorTx
-  } yield (ChannelAwaitingAnchorTx(aTx, redeemScript, 0).left.get, privKeys)
+  } yield (ChannelAwaitingAnchorTx(aTx, redeemScript, 0).get, privKeys)
 
   /**
    * Creates a [[ChannelAwaitingAnchorTx]] and
@@ -36,29 +39,29 @@ sealed trait ChannelGenerators extends BitcoinSLogger {
    */
   def channelAwaitingAnchorTx: Gen[(ChannelAwaitingAnchorTx, Seq[ECPrivateKey])] = for {
     (aTx, redeemScript, privKeys) <- anchorTx
-  } yield (ChannelAwaitingAnchorTx(aTx, redeemScript, Policy.confirmations).left.get, privKeys)
+  } yield (ChannelAwaitingAnchorTx(aTx, redeemScript, Policy.confirmations).get, privKeys)
 
   /** A [[ChannelInProgress]] that has paid the server exactly one time */
   def freshChannelInProgress: Gen[(ChannelInProgress, Seq[ECPrivateKey])] = for {
     (awaiting, privKeys) <- channelAwaitingAnchorTx
     (s1, _) <- ScriptGenerators.scriptPubKey
     amount = Policy.minChannelAmount
-    clientSigned = awaiting.clientSign(s1, amount, privKeys.head).left.get
-    fullySigned = clientSigned.serverSign(privKeys(1))
-  } yield (fullySigned.left.get, privKeys)
+    clientSigned = Await.result(awaiting.clientSign(s1, amount, privKeys.head), timeout)
+    fullySigned = Await.result(clientSigned.serverSign(privKeys(1)), timeout)
+  } yield (fullySigned, privKeys)
 
   /** A [[ChannelInProgress]] that has paid the server between 1 and 10 times */
   def channelInProgress: Gen[(ChannelInProgress, Seq[ECPrivateKey])] = for {
     (old, privKeys) <- freshChannelInProgress
     runs <- Gen.choose(1, 10)
     amount = Policy.dustThreshold
-    inProgress = simulate(runs, old, amount, privKeys.head, privKeys(1))
-  } yield (inProgress.left.get, privKeys)
+    inProgress = Await.result(simulate(runs, old, amount, privKeys.head, privKeys(1)), timeout)
+  } yield (inProgress, privKeys)
 
   /** Creates a Channel that has been signed by the client */
   def channelInProgressClientSigned: Gen[(ChannelInProgressClientSigned, Seq[ECPrivateKey])] = for {
     (old, privKeys) <- freshChannelInProgress
-    clientSigned = old.clientSign(Policy.dustThreshold, privKeys.head).left.get
+    clientSigned = Await.result(old.clientSign(Policy.dustThreshold, privKeys.head), timeout)
   } yield (clientSigned, privKeys)
 
   def baseInProgress: Gen[(BaseInProgress, Seq[ECPrivateKey])] = Gen.oneOf(channelInProgress, channelInProgressClientSigned)
@@ -71,8 +74,8 @@ sealed trait ChannelGenerators extends BitcoinSLogger {
     amount = Policy.dustThreshold
     fee = amount
     clientSigned = inProgress.clientSign(amount, clientKey)
-    closed = clientSigned.left.flatMap(_.close(serverScriptPubKey, serverKey, fee))
-  } yield (closed.left.get, privKeys)
+    closed = Await.result(clientSigned.flatMap(_.close(serverScriptPubKey, serverKey, fee)), 5.seconds)
+  } yield (closed, privKeys)
 
   /**
    * Simulates the execution of a [[Channel]]
@@ -84,17 +87,16 @@ sealed trait ChannelGenerators extends BitcoinSLogger {
    * @return
    */
   def simulate(runs: Int, inProgress: ChannelInProgress, amount: CurrencyUnit,
-    clientKey: ECPrivateKey, serverKey: ECPrivateKey): Either[ChannelInProgress, TxBuilderError] = {
-    @tailrec
-    def loop(old: Either[ChannelInProgress, TxBuilderError], remaining: Int): Either[ChannelInProgress, TxBuilderError] = {
-      if (old.isRight || remaining == 0) old
+    clientKey: ECPrivateKey, serverKey: ECPrivateKey): Future[ChannelInProgress] = {
+    def loop(oldFuture: Future[ChannelInProgress], remaining: Int): Future[ChannelInProgress] = oldFuture.flatMap { old =>
+      if (remaining == 0) Future.successful(old)
       else {
-        val clientSigned = old.left.flatMap(_.clientSign(amount, clientKey))
-        val serverSigned = clientSigned.left.flatMap(c => c.serverSign(serverKey))
+        val clientSigned = old.clientSign(amount, clientKey)
+        val serverSigned = clientSigned.flatMap(c => c.serverSign(serverKey))
         loop(serverSigned, remaining - 1)
       }
     }
-    loop(Left(inProgress), runs)
+    loop(Future.successful(inProgress), runs)
   }
 
 }

--- a/src/main/scala/org/bitcoins/core/gen/ScriptGenerators.scala
+++ b/src/main/scala/org/bitcoins/core/gen/ScriptGenerators.scala
@@ -259,8 +259,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     (creditingTx, outputIndex) = TransactionGenerators.buildCreditingTransaction(scriptPubKey)
     scriptSig = P2PKScriptSignature(EmptyDigitalSignature)
     (spendingTx, inputIndex) = TransactionGenerators.buildSpendingTransaction(creditingTx, scriptSig, outputIndex)
-    signer = Sign(privateKey.signFuture(_: Seq[Byte]), None)
-    txSigComponentFuture = P2PKSigner.sign(Seq(signer), creditingTx.outputs(outputIndex.toInt), spendingTx, inputIndex, hashType)
+    txSigComponentFuture = P2PKSigner.sign(Seq(privateKey), creditingTx.outputs(outputIndex.toInt), spendingTx, inputIndex, hashType)
     txSigComponent = Await.result(txSigComponentFuture, timeout)
     //add the signature to the scriptSig instead of having an empty scriptSig
     signedScriptSig = txSigComponent.scriptSignature.asInstanceOf[P2PKScriptSignature]

--- a/src/main/scala/org/bitcoins/core/util/BitcoinSLogger.scala
+++ b/src/main/scala/org/bitcoins/core/util/BitcoinSLogger.scala
@@ -8,7 +8,7 @@ import org.slf4j.Logger
  */
 abstract class BitcoinSLogger {
 
-  val logger: Logger = LoggerFactory.getLogger(this.getClass().toString)
+  def logger: Logger = LoggerFactory.getLogger(this.getClass().toString)
 
 }
 

--- a/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
@@ -7,10 +7,9 @@ import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.core.wallet.builder.{ TxBuilder, TxBuilderError }
-import org.bitcoins.core.wallet.signer.Signer
-import org.bitcoins.core.wallet.utxo.UTXOSpendingInfo
+import org.bitcoins.core.wallet.builder.TxBuilderError
 
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
 
 /**
@@ -26,12 +25,12 @@ sealed abstract class EscrowTimeoutHelper {
    * the server to be fully signed
    */
   def clientSign(outPoint: TransactionOutPoint, creditingTx: Transaction, destinations: Seq[TransactionOutput],
-    signer: Signer.Sign,
+    signer: Sign,
     lock: EscrowTimeoutScriptPubKey,
-    hashType: HashType): Either[WitnessTxSigComponentRaw, TxBuilderError] = {
+    hashType: HashType)(implicit ec: ExecutionContext): Future[WitnessTxSigComponentRaw] = {
     val creditingOutput = creditingTx.outputs(outPoint.vout.toInt)
     if (creditingOutput.scriptPubKey != P2WSHWitnessSPKV0(lock)) {
-      Right(TxBuilderError.WrongSigner)
+      Future.fromTry(TxBuilderError.WrongSigner)
     } else {
       val (p2wsh, amount) = (creditingOutput.scriptPubKey.asInstanceOf[P2WSHWitnessSPKV0], creditingOutput.value)
       val tc = TransactionConstants
@@ -40,14 +39,16 @@ sealed abstract class EscrowTimeoutHelper {
       val wtx = WitnessTransaction(tc.validLockVersion, inputs, destinations, tc.lockTime, TransactionWitness(Seq(uScriptWitness)))
       val witSPK = P2WSHWitnessSPKV0(lock)
       val u = WitnessTxSigComponentRaw(wtx, UInt32.zero, witSPK, Policy.standardFlags, amount)
-      val sign = signer._1
+      val sign = signer.signFunction
       val signature = TransactionSignatureCreator.createSig(u, sign, hashType)
-      val sigs = Seq(signature)
-      val multiSigScriptSig = MultiSignatureScriptSignature(sigs)
-      val escrow = EscrowTimeoutScriptSignature.fromMultiSig(multiSigScriptSig)
-      val witness = buildEscrowTimeoutScriptWitness(escrow, lock, u)
-      val signedWTx = WitnessTransaction(wtx.version, wtx.inputs, wtx.outputs, wtx.lockTime, witness)
-      Left(WitnessTxSigComponentRaw(signedWTx, u.inputIndex, p2wsh, u.flags, u.amount))
+      signature.map { sig =>
+        val multiSigScriptSig = MultiSignatureScriptSignature(Seq(sig))
+        val escrow = EscrowTimeoutScriptSignature.fromMultiSig(multiSigScriptSig)
+        val witness = buildEscrowTimeoutScriptWitness(escrow, lock, u)
+        val signedWTx = WitnessTransaction(wtx.version, wtx.inputs, wtx.outputs, wtx.lockTime, witness)
+        WitnessTxSigComponentRaw(signedWTx, u.inputIndex, p2wsh, u.flags, u.amount)
+      }
+
     }
   }
 
@@ -67,38 +68,38 @@ sealed abstract class EscrowTimeoutHelper {
   }
 
   /** Signs the partially signed [[org.bitcoins.core.crypto.WitnessTxSigComponent]] with the server's private key */
-  def serverSign(privKey: ECPrivateKey, clientSigned: WitnessTxSigComponentRaw, hashType: HashType): Either[WitnessTxSigComponentRaw, TxBuilderError] = {
+  def serverSign(privKey: ECPrivateKey, clientSigned: WitnessTxSigComponentRaw, hashType: HashType)(implicit ec: ExecutionContext): Future[WitnessTxSigComponentRaw] = {
     val oldTx = clientSigned.transaction
-    val lock: Either[EscrowTimeoutScriptPubKey, TxBuilderError] = clientSigned.witness match {
-      case _: P2WPKHWitnessV0 | EmptyScriptWitness => Right(TxBuilderError.NoRedeemScript)
+    val lock: Future[EscrowTimeoutScriptPubKey] = clientSigned.witness match {
+      case _: P2WPKHWitnessV0 | EmptyScriptWitness => Future.fromTry(TxBuilderError.NoRedeemScript)
       case p2wsh: P2WSHWitnessV0 => p2wsh.redeemScript match {
-        case lock: EscrowTimeoutScriptPubKey => Left(lock)
+        case lock: EscrowTimeoutScriptPubKey => Future.successful(lock)
         case _: P2PKScriptPubKey | _: P2PKHScriptPubKey | _: MultiSignatureScriptPubKey | _: NonStandardScriptPubKey
           | _: P2SHScriptPubKey | _: P2WSHWitnessSPKV0 | _: P2WPKHWitnessSPKV0 | _: CLTVScriptPubKey | _: CSVScriptPubKey
-          | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey | _: WitnessCommitment => Right(TxBuilderError.WrongRedeemScript)
+          | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey | _: WitnessCommitment => Future.fromTry(TxBuilderError.WrongRedeemScript)
       }
     }
-    val witSPK = lock.left.map(P2WSHWitnessSPKV0(_))
+    val witSPK = lock.map(P2WSHWitnessSPKV0(_))
     val stack = clientSigned.witness.stack
     val clientSignature = ECDigitalSignature(stack(stack.size - 2))
-    val raw = witSPK.left.map(w => WitnessTxSigComponentRaw(clientSigned.transaction, clientSigned.inputIndex,
+    val raw = witSPK.map(w => WitnessTxSigComponentRaw(clientSigned.transaction, clientSigned.inputIndex,
       w, clientSigned.flags, clientSigned.amount))
-    val signature = raw.left.map(r => TransactionSignatureCreator.createSig(r, privKey, hashType))
-    val escrow = signature.left.map { s =>
+    val signature = raw.map(r => TransactionSignatureCreator.createSig(r, privKey, hashType))
+    val escrow = signature.map { s =>
       val sigs = Seq(clientSignature, s)
       val multiSigScriptSig = MultiSignatureScriptSignature(sigs)
       EscrowTimeoutScriptSignature.fromMultiSig(multiSigScriptSig)
     }
 
-    val witness: Either[TransactionWitness, TxBuilderError] = lock.left.flatMap { l =>
-      raw.left.flatMap { r =>
-        escrow.left.map { e =>
+    val witness = lock.flatMap { l =>
+      raw.flatMap { r =>
+        escrow.map { e =>
           buildEscrowTimeoutScriptWitness(e, l, r)
         }
       }
     }
-    witness.left.flatMap { w =>
-      witSPK.left.map { spk =>
+    witness.flatMap { w =>
+      witSPK.map { spk =>
         val wtx = WitnessTransaction(oldTx.version, oldTx.inputs, oldTx.outputs, oldTx.lockTime, w)
         WitnessTxSigComponentRaw(wtx, clientSigned.inputIndex, spk, clientSigned.flags, clientSigned.amount)
       }
@@ -114,7 +115,7 @@ sealed abstract class EscrowTimeoutHelper {
    */
   def closeWithTimeout(inputs: Seq[TransactionInput], outputs: Seq[TransactionOutput], inputIndex: UInt32, privKey: ECPrivateKey,
     lock: EscrowTimeoutScriptPubKey, creditingOutput: TransactionOutput,
-    hashType: HashType): Either[WitnessTxSigComponentRaw, TxBuilderError] = lock.timeout.nestedScriptPubKey match {
+    hashType: HashType): Future[WitnessTxSigComponentRaw] = lock.timeout.nestedScriptPubKey match {
     case _: P2PKHScriptPubKey =>
       //for now we require the nested spk is p2pkh, this is an arbitrary limitation for now to make this simple
       val witSPK = P2WSHWitnessSPKV0(lock)
@@ -132,13 +133,13 @@ sealed abstract class EscrowTimeoutHelper {
           val scriptWitness = P2WSHWitnessV0(lock, e)
           val witness = TransactionWitness(u.transaction.witness.witnesses.updated(u.inputIndex.toInt, scriptWitness))
           val wtx = WitnessTransaction(uwtx.version, uwtx.inputs, uwtx.outputs, uwtx.lockTime, witness)
-          Left(WitnessTxSigComponentRaw(wtx, u.inputIndex, witSPK, u.flags, u.amount))
-        case Failure(_) => Right(TxBuilderError.UnknownError)
+          Future.successful(WitnessTxSigComponentRaw(wtx, u.inputIndex, witSPK, u.flags, u.amount))
+        case Failure(_) => Future.fromTry(TxBuilderError.UnknownError)
       }
     case _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey
       | _: P2WPKHWitnessSPKV0 | _: P2WSHWitnessSPKV0 | _: NonStandardScriptPubKey | _: EscrowTimeoutScriptPubKey
       | _: CSVScriptPubKey | _: CLTVScriptPubKey | _: WitnessCommitment | _: UnassignedWitnessScriptPubKey
-      | EmptyScriptPubKey => Right(TxBuilderError.WrongRedeemScript)
+      | EmptyScriptPubKey => Future.fromTry(TxBuilderError.WrongRedeemScript)
   }
 }
 

--- a/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -545,7 +545,8 @@ object BitcoinTxBuilder {
    *         from which you can call [[TxBuilder.sign]] to generate a signed tx,
    *         or a [[TxBuilderError]]
    */
-  def apply(destinations: Seq[TransactionOutput],
+  def apply(
+    destinations: Seq[TransactionOutput],
     utxos: BitcoinTxBuilder.UTXOMap, feeRate: FeeUnit, changeSPK: ScriptPubKey, network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
     if (feeRate.toLong <= 0) {
       Future.fromTry(TxBuilderError.LowFee)

--- a/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -128,7 +128,7 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
   def sign(
     invariants: (Seq[BitcoinUTXOSpendingInfo], Transaction) => Boolean,
     isRBFEnabled: Boolean = false)(implicit ec: ExecutionContext): Future[Transaction] = {
-    //@tailrec
+
     def loop(
       remaining: List[BitcoinUTXOSpendingInfo],
       txInProgress: Transaction): Future[Transaction] = remaining match {

--- a/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilderError.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilderError.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.core.wallet.builder
 
+import scala.util.Failure
+
 /**
  * Represents an error that can be returned by the [[org.bitcoins.core.wallet.builder.TxBuilder]]
  * if it failed to sign a set of utxos
@@ -12,127 +14,135 @@ object TxBuilderError {
    * true after the signing process was complete. An example of this is the transaction is too big,
    * or the fee level was too high or low.
    */
-  case object FailedUserInvariants extends TxBuilderError
-
+  //case object FailedUserInvariants extends TxBuilderError
+  val FailedUserInvariants = Failure(new IllegalArgumentException("This tx fails the invariants function you passed in"))
   /**
    * Means that we gave too many [[org.bitcoins.core.wallet.signer.Signer.Sign]] for the TxBuilder
    * to use during the signing process for a utxo.
    * An example of this occurring is if we gave 2 private keys to sign a p2pkh spk.
    * A p2pkh only requires one private key to sign the utxo.
    */
-  case object TooManySigners extends TxBuilderError
-
+  //case object TooManySigners extends TxBuilderError
+  val TooManySigners = Failure(new IllegalArgumentException("You passed in too many signers for this scriptPubKey type"))
   /**
    * Means that you are using the wrong [[org.bitcoins.core.wallet.signer.Signer]] to
    * sign the given [[org.bitcoins.core.protocol.script.ScriptPubKey]]
    */
-  case object WrongSigner extends TxBuilderError
-
+  //case object WrongSigner extends TxBuilderError
+  val WrongSigner = Failure(new IllegalArgumentException("You did not pass in the write Signer to sign the given transaction, you probably gave the wrong identifier"))
   /**
    * Means that the [[org.bitcoins.core.protocol.script.ScriptWitnessV0]] you passed as an argument does
    * not hash to the commitment inside of [[org.bitcoins.core.protocol.script.P2WSHWitnessSPKV0]]
    */
-  case object WrongWitness extends TxBuilderError
-
+  //case object WrongWitness extends TxBuilderError
+  val WrongWitness = Failure(new IllegalArgumentException("You passed in the wrong ScriptWitness type to sign the given WitnessScriptPubKey"))
   /**
    * Means that the redeem script you passed as an argument does not hash to the commitment
    * inside of the [[org.bitcoins.core.protocol.script.P2SHScriptPubKey]]
    */
-  case object WrongRedeemScript extends TxBuilderError
-
+  //case object WrongRedeemScript extends TxBuilderError
+  val WrongRedeemScript = Failure(new IllegalArgumentException("Means that the redeem script you passed as an argument does not hash to the commitment"))
   /**
    * Means that you passed the wrong public key for a [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey]] or a
    * [[org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0]] that you are trying to spend
    */
-  case object WrongPublicKey extends TxBuilderError
-
+  //case object WrongPublicKey extends TxBuilderError
+  val WrongPublicKey = Failure(new IllegalArgumentException("You passed in the wrong public key to sign a P2PKHScriptPubKey"))
   /**
    * Can occurr when we are trying to sign a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey]] but
    * we do not have a redeem script for that p2sh spk.
    */
-  case object NoRedeemScript extends TxBuilderError
-
+  //case object NoRedeemScript extends TxBuilderError
+  val NoRedeemScript = Failure(new IllegalArgumentException("We are missing a redeem script to sign a transaction"))
   /**
    * Can occurr when we are trying to sign a [[org.bitcoins.core.protocol.script.WitnessScriptPubKey]]
    * but we do not have a [[org.bitcoins.core.protocol.script.ScriptWitness]] for that witness spk
    */
-  case object NoWitness extends TxBuilderError
-
+  //case object NoWitness extends TxBuilderError
+  val NoWitness = Failure(new IllegalArgumentException("We are missing a witness redeem script"))
   /** We expected a [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0]], but got a non witness spk type */
-  case object NonWitnessSPK extends TxBuilderError
+  //case object NonWitnessSPK extends TxBuilderError
+  val NonWitnessSPK = Failure(new IllegalArgumentException("We expected a witness spk, but got a non witness spk"))
 
   /** We cannot have a [[org.bitcoins.core.protocol.script.WitnessScriptPubKey]] nested inside of another [[org.bitcoins.core.protocol.script.ScriptPubKey]] */
-  case object NestedWitnessSPK extends TxBuilderError
-
+  //case object NestedWitnessSPK extends TxBuilderError
+  val NestedWitnessSPK = Failure(new IllegalArgumentException("We cannot nested witness SPKs"))
   /** We cannot have a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey]] nested inside of another spk   */
-  case object NestedP2SHSPK extends TxBuilderError
-
+  //case object NestedP2SHSPK extends TxBuilderError
+  val NestedP2SHSPK = Failure(new IllegalArgumentException("We cannot sign nested P2SHScriptPubKeys"))
   /**
    * Means that there is no signer defined for the given [[org.bitcoins.core.protocol.script.ScriptPubKey]] type.
    * An example of a spk with no signer that is defined is [[org.bitcoins.core.protocol.script.WitnessCommitment]]
    */
-  case object NoSigner extends TxBuilderError
-
+  //case object NoSigner extends TxBuilderError
+  val NoSigner = Failure(new IllegalArgumentException("We have no means to sign the given scriptpubkey"))
   /**
    * Means that you specified a fee that was too large for the change output you provided.
    * This may happen if you have a transaction with a lot of inputs, or the change output you provided
    * is a output that contains a very small amount of bitcoin.
    */
-  case object FeeToLarge extends TxBuilderError
-
+  //case object FeeToLarge extends TxBuilderError
+  val FeeToLarge = Failure(new IllegalArgumentException("Fee too large"))
   /**
    * Means that the [[TxBuilder.destinations]] outputs you specified when creating the [[TxBuilder]] are NOT
    * all included in the final signed tx
    */
-  case object MissingDestinationOutput extends TxBuilderError
-
+  //case object MissingDestinationOutput extends TxBuilderError
+  val MissingDestinationOutput = Failure(new IllegalArgumentException("Lost a transaction output in the signing process"))
   /**
    * Means that you provided a outpoint in the [[TxBuilder.utxoMap]] that does not
    * exist inside of [[TxBuilder.creditingTxs]]. You cannot spend an outpoint that was not
    * passed into the txbuilder originally
    */
-  case object MissingCreditingTx extends TxBuilderError
+  //case object MissingCreditingTx extends TxBuilderError
 
+  val MissingCreditingTx = Failure(new IllegalArgumentException("You did not pass ina crediting tx for this transaction"))
   /**
    * Means that the script we are signing for requires a public key, but we did not pass one in
    * as a parameter inside of [[org.bitcoins.core.wallet.signer.Signer.Sign]]
    */
-  case object MissingPublicKey extends TxBuilderError
+  //case object MissingPublicKey extends TxBuilderError
+  val MissingPublicKey = Failure(new IllegalArgumentException("You did not pass in a public key to sign a P2PKHScriptPubKey with"))
 
-  case object MissingOutPoint extends TxBuilderError
+  //case object MissingOutPoint extends TxBuilderError
+  val MissingOutPoint = Failure(new IllegalArgumentException("We cannot this outpoint in the utxo map"))
   /**
    * Means that the signed version of this transaction has MORE outputs than what was specified
    * when building the [[TxBuilder]]. [[TxBuilder.destinations]] && [[TxBuilder.changeOutput]] should
    * be the only outputs in the signedTx
    */
-  case object ExtraOutputsAdded extends TxBuilderError
-
+  //case object ExtraOutputsAdded extends TxBuilderError
+  val ExtraOutputsAdded = Failure(new IllegalArgumentException("More outputs were added to the transaction than were initally passed in"))
   /**
    * Means that the transaction spends outpoints that were not given when creating
    * the [[TxBuilder]], aka, we should only spend outpoints in [[TxBuilder.outPoints]]
    */
-  case object ExtraOutPoints extends TxBuilderError
+  //case object ExtraOutPoints extends TxBuilderError
+  val ExtraOutPoints = Failure(new IllegalArgumentException("Means that the transaction spends outpoints that were not given when creating the TxBuilder"))
 
   /** Means that this transaction attempts to print satoshis out of thin air */
-  case object MintsMoney extends TxBuilderError
+  //case object MintsMoney extends TxBuilderError
+  val MintsMoney = Failure(new IllegalArgumentException("This transaction creates spends more money than it was funded by the given utxos"))
 
   /** Means that the fee was too low for [[TxBuilder.feeRate]] */
-  case object LowFee extends TxBuilderError
-
+  //case object LowFee extends TxBuilderError
+  val LowFee = Failure(new IllegalArgumentException("Means that the fee was too low"))
   /** Means tha this transaction pays too high of a fee for [[TxBuilder.feeRate]] */
-  case object HighFee extends TxBuilderError
-
+  //case object HighFee extends TxBuilderError
+  val HighFee = Failure(new IllegalArgumentException("Means that the fee was too high"))
   /**
    * Indicates we are spending multiple [[org.bitcoins.core.protocol.script.CLTVScriptPubKey]],
    * and that one of those spk's outputs are locked by block height, while the other is locked by
    * a time stamp. Since there is only one locktime field on a transaction, we cannot satisfy both of these
    * locktimes simultaneously.
    */
-  case object IncompatibleLockTimes extends TxBuilderError
+  //case object IncompatibleLockTimes extends TxBuilderError
+  val IncompatibleLockTimes = Failure(new IllegalArgumentException("Means you tried to spend an output that requires a lock by blockheight, and another output that requires a lock by timestamp"))
 
   /** Means we have a output on this transaction below [[org.bitcoins.core.policy.Policy.dustThreshold]] */
-  case object OutputBelowDustThreshold extends TxBuilderError
+  //case object OutputBelowDustThreshold extends TxBuilderError
+  val OutputBelowDustThreshold = Failure(new IllegalArgumentException("The p2p network discourages outputs below the dustThreshold, this tx won't be relayed"))
 
-  case object UnknownError extends TxBuilderError
-
+  //case object UnknownError extends TxBuilderError
+  val UnknownError = Failure(new IllegalArgumentException)
 }

--- a/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilderError.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilderError.scala
@@ -14,7 +14,6 @@ object TxBuilderError {
    * true after the signing process was complete. An example of this is the transaction is too big,
    * or the fee level was too high or low.
    */
-  //case object FailedUserInvariants extends TxBuilderError
   val FailedUserInvariants = Failure(new IllegalArgumentException("This tx fails the invariants function you passed in"))
   /**
    * Means that we gave too many [[org.bitcoins.core.wallet.signer.Signer.Sign]] for the TxBuilder
@@ -22,25 +21,21 @@ object TxBuilderError {
    * An example of this occurring is if we gave 2 private keys to sign a p2pkh spk.
    * A p2pkh only requires one private key to sign the utxo.
    */
-  //case object TooManySigners extends TxBuilderError
   val TooManySigners = Failure(new IllegalArgumentException("You passed in too many signers for this scriptPubKey type"))
   /**
    * Means that you are using the wrong [[org.bitcoins.core.wallet.signer.Signer]] to
    * sign the given [[org.bitcoins.core.protocol.script.ScriptPubKey]]
    */
-  //case object WrongSigner extends TxBuilderError
   val WrongSigner = Failure(new IllegalArgumentException("You did not pass in the write Signer to sign the given transaction, you probably gave the wrong identifier"))
   /**
    * Means that the [[org.bitcoins.core.protocol.script.ScriptWitnessV0]] you passed as an argument does
    * not hash to the commitment inside of [[org.bitcoins.core.protocol.script.P2WSHWitnessSPKV0]]
    */
-  //case object WrongWitness extends TxBuilderError
   val WrongWitness = Failure(new IllegalArgumentException("You passed in the wrong ScriptWitness type to sign the given WitnessScriptPubKey"))
   /**
    * Means that the redeem script you passed as an argument does not hash to the commitment
    * inside of the [[org.bitcoins.core.protocol.script.P2SHScriptPubKey]]
    */
-  //case object WrongRedeemScript extends TxBuilderError
   val WrongRedeemScript = Failure(new IllegalArgumentException("Means that the redeem script you passed as an argument does not hash to the commitment"))
   /**
    * Means that you passed the wrong public key for a [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey]] or a
@@ -61,47 +56,34 @@ object TxBuilderError {
   //case object NoWitness extends TxBuilderError
   val NoWitness = Failure(new IllegalArgumentException("We are missing a witness redeem script"))
   /** We expected a [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0]], but got a non witness spk type */
-  //case object NonWitnessSPK extends TxBuilderError
   val NonWitnessSPK = Failure(new IllegalArgumentException("We expected a witness spk, but got a non witness spk"))
 
   /** We cannot have a [[org.bitcoins.core.protocol.script.WitnessScriptPubKey]] nested inside of another [[org.bitcoins.core.protocol.script.ScriptPubKey]] */
   //case object NestedWitnessSPK extends TxBuilderError
   val NestedWitnessSPK = Failure(new IllegalArgumentException("We cannot nested witness SPKs"))
   /** We cannot have a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey]] nested inside of another spk   */
-  //case object NestedP2SHSPK extends TxBuilderError
   val NestedP2SHSPK = Failure(new IllegalArgumentException("We cannot sign nested P2SHScriptPubKeys"))
   /**
    * Means that there is no signer defined for the given [[org.bitcoins.core.protocol.script.ScriptPubKey]] type.
    * An example of a spk with no signer that is defined is [[org.bitcoins.core.protocol.script.WitnessCommitment]]
    */
-  //case object NoSigner extends TxBuilderError
   val NoSigner = Failure(new IllegalArgumentException("We have no means to sign the given scriptpubkey"))
   /**
    * Means that you specified a fee that was too large for the change output you provided.
    * This may happen if you have a transaction with a lot of inputs, or the change output you provided
    * is a output that contains a very small amount of bitcoin.
    */
-  //case object FeeToLarge extends TxBuilderError
   val FeeToLarge = Failure(new IllegalArgumentException("Fee too large"))
   /**
    * Means that the [[TxBuilder.destinations]] outputs you specified when creating the [[TxBuilder]] are NOT
    * all included in the final signed tx
    */
-  //case object MissingDestinationOutput extends TxBuilderError
   val MissingDestinationOutput = Failure(new IllegalArgumentException("Lost a transaction output in the signing process"))
-  /**
-   * Means that you provided a outpoint in the [[TxBuilder.utxoMap]] that does not
-   * exist inside of [[TxBuilder.creditingTxs]]. You cannot spend an outpoint that was not
-   * passed into the txbuilder originally
-   */
-  //case object MissingCreditingTx extends TxBuilderError
 
-  val MissingCreditingTx = Failure(new IllegalArgumentException("You did not pass ina crediting tx for this transaction"))
   /**
    * Means that the script we are signing for requires a public key, but we did not pass one in
-   * as a parameter inside of [[org.bitcoins.core.wallet.signer.Signer.Sign]]
+   * as a parameter inside of [[org.bitcoins.core.crypto.Sign]]
    */
-  //case object MissingPublicKey extends TxBuilderError
   val MissingPublicKey = Failure(new IllegalArgumentException("You did not pass in a public key to sign a P2PKHScriptPubKey with"))
 
   //case object MissingOutPoint extends TxBuilderError
@@ -111,24 +93,20 @@ object TxBuilderError {
    * when building the [[TxBuilder]]. [[TxBuilder.destinations]] && [[TxBuilder.changeOutput]] should
    * be the only outputs in the signedTx
    */
-  //case object ExtraOutputsAdded extends TxBuilderError
   val ExtraOutputsAdded = Failure(new IllegalArgumentException("More outputs were added to the transaction than were initally passed in"))
   /**
    * Means that the transaction spends outpoints that were not given when creating
    * the [[TxBuilder]], aka, we should only spend outpoints in [[TxBuilder.outPoints]]
    */
-  //case object ExtraOutPoints extends TxBuilderError
   val ExtraOutPoints = Failure(new IllegalArgumentException("Means that the transaction spends outpoints that were not given when creating the TxBuilder"))
 
   /** Means that this transaction attempts to print satoshis out of thin air */
-  //case object MintsMoney extends TxBuilderError
   val MintsMoney = Failure(new IllegalArgumentException("This transaction creates spends more money than it was funded by the given utxos"))
 
   /** Means that the fee was too low for [[TxBuilder.feeRate]] */
-  //case object LowFee extends TxBuilderError
   val LowFee = Failure(new IllegalArgumentException("Means that the fee was too low"))
   /** Means tha this transaction pays too high of a fee for [[TxBuilder.feeRate]] */
-  //case object HighFee extends TxBuilderError
+
   val HighFee = Failure(new IllegalArgumentException("Means that the fee was too high"))
   /**
    * Indicates we are spending multiple [[org.bitcoins.core.protocol.script.CLTVScriptPubKey]],
@@ -136,13 +114,10 @@ object TxBuilderError {
    * a time stamp. Since there is only one locktime field on a transaction, we cannot satisfy both of these
    * locktimes simultaneously.
    */
-  //case object IncompatibleLockTimes extends TxBuilderError
   val IncompatibleLockTimes = Failure(new IllegalArgumentException("Means you tried to spend an output that requires a lock by blockheight, and another output that requires a lock by timestamp"))
 
   /** Means we have a output on this transaction below [[org.bitcoins.core.policy.Policy.dustThreshold]] */
-  //case object OutputBelowDustThreshold extends TxBuilderError
   val OutputBelowDustThreshold = Failure(new IllegalArgumentException("The p2p network discourages outputs below the dustThreshold, this tx won't be relayed"))
 
-  //case object UnknownError extends TxBuilderError
   val UnknownError = Failure(new IllegalArgumentException)
 }

--- a/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -9,39 +9,22 @@ import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.wallet.builder.TxBuilderError
 
+import scala.concurrent.{ ExecutionContext, Future }
+
 /** The class used to represent a signing process for a specific [[org.bitcoins.core.protocol.script.ScriptPubKey]] type */
 sealed abstract class Signer {
 
   /**
    * The method used to sign a bitcoin unspent transaction output
-   * @param signers the [[Signer.Sign]] needed to sign the utxo
+   * @param signers the [[Signer]] needed to sign the utxo
    * @param output the utxo we are spending
    * @param unsignedTx the unsigned transaction which is spending the utxo
    * @param inputIndex the input index inside of the unsigned transaction which spends the utxo
    * @param hashType the signature hashing algorithm we should use to sign the utxo
    * @return
    */
-  def sign(signers: Seq[Signer.Sign], output: TransactionOutput, unsignedTx: Transaction,
-    inputIndex: UInt32, hashType: HashType): Either[TxSigComponent, TxBuilderError]
-}
-
-object Signer {
-  /**
-   * This is meant to be an abstraction for a [[org.bitcoins.core.crypto.ECPrivateKey]], sometimes we will not
-   * have direct access to a private key in memory -- for instance if that key is on a hardware device -- so we need to create an
-   * abstraction of the signing process. Fundamentally a private key takes in a Seq[Byte] and returns a [[ECDigitalSignature]]
-   * That is what this abstraction is meant to represent. If you have a [[ECPrivateKey]] in your application, you can get it's
-   * [[Sign]] type by doing this:
-   *
-   * val key = ECPrivateKey()
-   * val sign: Seq[Byte] => ECDigitalSignature = (key.sign(_: Seq[Byte]), key.publicKey)
-   *
-   * If you have a hardware wallet, you will need to implement the protocol to send a message to the hardware device. The
-   * type signature of the function you implement must be Seq[Byte] => ECDigitalSignature
-   *
-   * TODO: Investigate turning this into Seq[Byte] => Future[ECDigitalSignature]
-   */
-  type Sign = (Seq[Byte] => ECDigitalSignature, Option[ECPublicKey])
+  def sign(signers: Seq[Sign], output: TransactionOutput, unsignedTx: Transaction,
+    inputIndex: UInt32, hashType: HashType)(implicit ec: ExecutionContext): Future[TxSigComponent]
 }
 
 /** Represents all signers for the bitcoin protocol, we could add another network later like litecoin */
@@ -50,75 +33,82 @@ sealed abstract class BitcoinSigner extends Signer
 /** Used to sign a [[org.bitcoins.core.protocol.script.P2PKScriptPubKey]] */
 sealed abstract class P2PKSigner extends BitcoinSigner {
 
-  override def sign(signers: Seq[Signer.Sign], output: TransactionOutput, unsignedTx: Transaction,
-    inputIndex: UInt32, hashType: HashType): Either[TxSigComponent, TxBuilderError] = {
+  override def sign(signers: Seq[Sign], output: TransactionOutput, unsignedTx: Transaction,
+    inputIndex: UInt32, hashType: HashType)(implicit ec: ExecutionContext): Future[TxSigComponent] = {
     val spk = output.scriptPubKey
     if (signers.size != 1) {
-      Right(TxBuilderError.TooManySigners)
+      Future.fromTry(TxBuilderError.TooManySigners)
     } else {
-      val signer = signers.head._1
+      val sign: Seq[Byte] => Future[ECDigitalSignature] = signers.head.signFunction
       val unsignedInput = unsignedTx.inputs(inputIndex.toInt)
       val flags = Policy.standardFlags
       val amount = output.value
-      val signed: Either[TxSigComponent, TxBuilderError] = spk match {
+      val signed: Future[TxSigComponent] = spk match {
         case p2wshSPK: P2WSHWitnessSPKV0 =>
           val wtx = unsignedTx match {
             case btx: BaseTransaction => WitnessTransaction(btx.version, btx.inputs,
               btx.outputs, btx.lockTime, EmptyWitness)
             case wtx: WitnessTransaction => wtx
           }
-          val redeemScript = wtx.witness.witnesses(inputIndex.toInt) match {
-            case x: P2WSHWitnessV0 => Left(x.redeemScript)
-            case _: P2WPKHWitnessV0 => Right(TxBuilderError.NoRedeemScript)
-            case EmptyScriptWitness => Right(TxBuilderError.NoWitness)
+          val redeemScript: Future[ScriptPubKey] = wtx.witness.witnesses(inputIndex.toInt) match {
+            case x: P2WSHWitnessV0 => Future.successful(x.redeemScript)
+            case _: P2WPKHWitnessV0 => Future.fromTry(TxBuilderError.NoRedeemScript)
+            case EmptyScriptWitness => Future.fromTry(TxBuilderError.NoWitness)
           }
           val sigComponent = WitnessTxSigComponentRaw(wtx, inputIndex, p2wshSPK, flags, amount)
-          val signature = TransactionSignatureCreator.createSig(sigComponent, signer, hashType)
-          val p2pkScriptSig = P2PKScriptSignature(signature)
-          val scriptWit = redeemScript.left.map(s => P2WSHWitnessV0(s, p2pkScriptSig))
-          val signedWitness = scriptWit.left.map(s => TransactionWitness(wtx.witness.witnesses.updated(inputIndex.toInt, s)))
-          val signedWTx = signedWitness.left.map { wit =>
-            WitnessTransaction(wtx.version, wtx.inputs, wtx.outputs, wtx.lockTime, wit)
+          val signature = TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
+          signature.flatMap { s =>
+            redeemScript.map { rs =>
+              val p2pkScriptSig = P2PKScriptSignature(s)
+              val scriptWit = P2WSHWitnessV0(rs, p2pkScriptSig)
+              val signedWitness = TransactionWitness(wtx.witness.witnesses.updated(inputIndex.toInt, scriptWit))
+              val signedWTx = WitnessTransaction(wtx.version, wtx.inputs, wtx.outputs, wtx.lockTime, signedWitness)
+              WitnessTxSigComponentRaw(signedWTx, inputIndex, p2wshSPK, flags, amount)
+            }
           }
-          signedWTx.left.map(wtx => WitnessTxSigComponentRaw(wtx, inputIndex, p2wshSPK, flags, amount))
         case _: P2PKScriptPubKey =>
           val sigComponent = BaseTxSigComponent(unsignedTx, inputIndex, spk, flags)
-          val signature = TransactionSignatureCreator.createSig(sigComponent, signer, hashType)
-          val p2pkScriptSig = P2PKScriptSignature(signature)
-          val signedInput = TransactionInput(unsignedInput.previousOutput, p2pkScriptSig, unsignedInput.sequence)
-          val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
-          val signedTx = unsignedTx match {
-            case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
-              btx.outputs, btx.lockTime)
-            case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
-              wtx.outputs, wtx.lockTime, wtx.witness)
+          val signature = TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
+          signature.map { sig =>
+            val p2pkScriptSig = P2PKScriptSignature(sig)
+            val signedInput = TransactionInput(unsignedInput.previousOutput, p2pkScriptSig, unsignedInput.sequence)
+            val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
+            val signedTx = unsignedTx match {
+              case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
+                btx.outputs, btx.lockTime)
+              case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
+                wtx.outputs, wtx.lockTime, wtx.witness)
+            }
+            BaseTxSigComponent(signedTx, inputIndex, spk, flags)
           }
-          Left(BaseTxSigComponent(signedTx, inputIndex, spk, flags))
         case lock: LockTimeScriptPubKey =>
           lock.nestedScriptPubKey match {
             case _: P2PKScriptPubKey =>
               val sigComponent = BaseTxSigComponent(unsignedTx, inputIndex, lock, flags)
-              val signature = TransactionSignatureCreator.createSig(sigComponent, signer, hashType)
-              val p2pkScriptSig = P2PKScriptSignature(signature)
-              val signedInput = TransactionInput(unsignedInput.previousOutput, p2pkScriptSig, unsignedInput.sequence)
-              val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
-              val signedTx = unsignedTx match {
-                case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
-                  btx.outputs, btx.lockTime)
-                case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
-                  wtx.outputs, wtx.lockTime, wtx.witness)
+              val signature = TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
+              signature.map { sig =>
+                val p2pkScriptSig = P2PKScriptSignature(sig)
+                val signedInput = TransactionInput(unsignedInput.previousOutput, p2pkScriptSig, unsignedInput.sequence)
+                val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
+                val signedTx = unsignedTx match {
+                  case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
+                    btx.outputs, btx.lockTime)
+                  case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
+                    wtx.outputs, wtx.lockTime, wtx.witness)
+                }
+                BaseTxSigComponent(signedTx, inputIndex, lock, flags)
               }
-              Left(BaseTxSigComponent(signedTx, inputIndex, lock, flags))
+
             case _: P2PKHScriptPubKey | _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey
               | _: P2WPKHWitnessSPKV0 | _: P2WSHWitnessSPKV0 | _: NonStandardScriptPubKey
               | _: CLTVScriptPubKey | _: CSVScriptPubKey
               | _: WitnessCommitment | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey
-              | _: EscrowTimeoutScriptPubKey => Right(TxBuilderError.WrongSigner)
+              | _: EscrowTimeoutScriptPubKey => Future.fromTry(TxBuilderError.WrongSigner)
           }
         case _: P2PKHScriptPubKey | _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey
           | _: P2WPKHWitnessSPKV0 | _: NonStandardScriptPubKey
           | _: WitnessCommitment | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey
-          | _: EscrowTimeoutScriptPubKey => Right(TxBuilderError.WrongSigner)
+          | _: EscrowTimeoutScriptPubKey => Future.fromTry(TxBuilderError.WrongSigner)
       }
       signed
     }
@@ -130,20 +120,20 @@ object P2PKSigner extends P2PKSigner
 /** Used to sign a [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey]] */
 sealed abstract class P2PKHSigner extends BitcoinSigner {
 
-  override def sign(signers: Seq[Signer.Sign], output: TransactionOutput, unsignedTx: Transaction,
-    inputIndex: UInt32, hashType: HashType): Either[TxSigComponent, TxBuilderError] = {
+  override def sign(signers: Seq[Sign], output: TransactionOutput, unsignedTx: Transaction,
+    inputIndex: UInt32, hashType: HashType)(implicit ec: ExecutionContext): Future[TxSigComponent] = {
     val spk = output.scriptPubKey
     if (signers.size != 1) {
-      Right(TxBuilderError.TooManySigners)
-    } else if (signers.head._2.isEmpty) {
-      Right(TxBuilderError.MissingPublicKey)
+      Future.fromTry(TxBuilderError.TooManySigners)
+    } else if (signers.head.pubKeyOpt.isEmpty) {
+      Future.fromTry(TxBuilderError.MissingPublicKey)
     } else {
-      val signer = signers.head._1
-      val pubKey = signers.head._2.get
+      val sign = signers.head.signFunction
+      val pubKey = signers.head.pubKeyOpt.get
       val unsignedInput = unsignedTx.inputs(inputIndex.toInt)
       val flags = Policy.standardFlags
       val amount = output.value
-      val signed: Either[TxSigComponent, TxBuilderError] = spk match {
+      val signed: Future[TxSigComponent] = spk match {
         case p2wshSPK: P2WSHWitnessSPKV0 =>
           val wtx = unsignedTx match {
             case btx: BaseTransaction => WitnessTransaction(btx.version, btx.inputs,
@@ -151,86 +141,98 @@ sealed abstract class P2PKHSigner extends BitcoinSigner {
             case wtx: WitnessTransaction => wtx
           }
           val redeemScript = wtx.witness.witnesses(inputIndex.toInt) match {
-            case EmptyScriptWitness | _: P2WPKHWitnessV0 => Right(TxBuilderError.WrongWitness)
-            case p2wsh: P2WSHWitnessV0 => Left(p2wsh.redeemScript)
+            case EmptyScriptWitness | _: P2WPKHWitnessV0 => Future.fromTry(TxBuilderError.WrongWitness)
+            case p2wsh: P2WSHWitnessV0 => Future.successful(p2wsh.redeemScript)
           }
           val sigComponent = WitnessTxSigComponentRaw(wtx, inputIndex, p2wshSPK, flags, amount)
-          val signature = TransactionSignatureCreator.createSig(sigComponent, signer, hashType)
-          val p2pkhScriptSig = P2PKHScriptSignature(signature, pubKey)
-          val scriptWit = redeemScript.left.flatMap {
-            case p2pkh: P2PKHScriptPubKey =>
-              if (p2pkh != P2PKHScriptPubKey(pubKey)) {
-                Right(TxBuilderError.WrongPublicKey)
-              } else Left(P2WSHWitnessV0(p2pkh, p2pkhScriptSig))
-            case lock: LockTimeScriptPubKey =>
-              lock.nestedScriptPubKey match {
+          val signature = TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
+          val scriptWit: Future[ScriptWitness] = signature.flatMap { sig =>
+            redeemScript.flatMap { rs =>
+              val p2pkhScriptSig = P2PKHScriptSignature(sig, pubKey)
+              rs match {
                 case p2pkh: P2PKHScriptPubKey =>
                   if (p2pkh != P2PKHScriptPubKey(pubKey)) {
-                    Right(TxBuilderError.WrongPublicKey)
-                  } else {
-                    Left(P2WSHWitnessV0(lock, p2pkhScriptSig))
+                    Future.fromTry(TxBuilderError.WrongPublicKey)
+                  } else Future.successful(P2WSHWitnessV0(p2pkh, p2pkhScriptSig))
+                case lock: LockTimeScriptPubKey =>
+                  lock.nestedScriptPubKey match {
+                    case p2pkh: P2PKHScriptPubKey =>
+                      if (p2pkh != P2PKHScriptPubKey(pubKey)) {
+                        Future.fromTry(TxBuilderError.WrongPublicKey)
+                      } else {
+                        Future.successful(P2WSHWitnessV0(lock, p2pkhScriptSig))
+                      }
+                    case _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey
+                      | _: P2WPKHWitnessSPKV0 | _: P2WSHWitnessSPKV0 | _: NonStandardScriptPubKey
+                      | _: CLTVScriptPubKey | _: CSVScriptPubKey
+                      | _: WitnessCommitment | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey
+                      | _: EscrowTimeoutScriptPubKey => Future.fromTry(TxBuilderError.WrongSigner)
                   }
                 case _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey
                   | _: P2WPKHWitnessSPKV0 | _: P2WSHWitnessSPKV0 | _: NonStandardScriptPubKey
-                  | _: CLTVScriptPubKey | _: CSVScriptPubKey
                   | _: WitnessCommitment | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey
-                  | _: EscrowTimeoutScriptPubKey => Right(TxBuilderError.WrongSigner)
+                  | _: EscrowTimeoutScriptPubKey => Future.fromTry(TxBuilderError.WrongSigner)
               }
-            case _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey
-              | _: P2WPKHWitnessSPKV0 | _: P2WSHWitnessSPKV0 | _: NonStandardScriptPubKey
-              | _: WitnessCommitment | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey
-              | _: EscrowTimeoutScriptPubKey => Right(TxBuilderError.WrongSigner)
+            }
           }
-          val signedWitness = scriptWit.left.map(wit => TransactionWitness(wtx.witness.witnesses.updated(inputIndex.toInt, wit)))
-          val signedWTx = signedWitness.left.map(txWit => WitnessTransaction(wtx.version, wtx.inputs,
-            wtx.outputs, wtx.lockTime, txWit))
-          signedWTx.left.map(wtx => WitnessTxSigComponentRaw(wtx, inputIndex, p2wshSPK, flags, amount))
+
+          scriptWit.map { wit =>
+            val txWit = TransactionWitness(wtx.witness.witnesses.updated(inputIndex.toInt, wit))
+            val signedWTx = WitnessTransaction(wtx.version, wtx.inputs,
+              wtx.outputs, wtx.lockTime, txWit)
+            WitnessTxSigComponentRaw(signedWTx, inputIndex, p2wshSPK, flags, amount)
+          }
+
         case p2pkh: P2PKHScriptPubKey =>
           if (p2pkh != P2PKHScriptPubKey(pubKey)) {
-            Right(TxBuilderError.WrongPublicKey)
+            Future.fromTry(TxBuilderError.WrongPublicKey)
           } else {
             val sigComponent = BaseTxSigComponent(unsignedTx, inputIndex, p2pkh, flags)
-            val signature = TransactionSignatureCreator.createSig(sigComponent, signer, hashType)
-            val p2pkhScriptSig = P2PKHScriptSignature(signature, pubKey)
-            val signedInput = TransactionInput(unsignedInput.previousOutput, p2pkhScriptSig, unsignedInput.sequence)
-            val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
-            val signedTx = unsignedTx match {
-              case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
-                btx.outputs, btx.lockTime)
-              case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
-                wtx.outputs, wtx.lockTime, wtx.witness)
+            val signature = TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
+            signature.map { sig =>
+              val p2pkhScriptSig = P2PKHScriptSignature(sig, pubKey)
+              val signedInput = TransactionInput(unsignedInput.previousOutput, p2pkhScriptSig, unsignedInput.sequence)
+              val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
+              val signedTx = unsignedTx match {
+                case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
+                  btx.outputs, btx.lockTime)
+                case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
+                  wtx.outputs, wtx.lockTime, wtx.witness)
+              }
+              BaseTxSigComponent(signedTx, inputIndex, p2pkh, flags)
             }
-            Left(BaseTxSigComponent(signedTx, inputIndex, p2pkh, flags))
           }
         case lock: LockTimeScriptPubKey =>
           lock.nestedScriptPubKey match {
             case p2pkh: P2PKHScriptPubKey =>
               if (p2pkh != P2PKHScriptPubKey(pubKey)) {
-                Right(TxBuilderError.WrongPublicKey)
+                Future.fromTry(TxBuilderError.WrongPublicKey)
               } else {
                 val sigComponent = BaseTxSigComponent(unsignedTx, inputIndex, lock, flags)
-                val signature = TransactionSignatureCreator.createSig(sigComponent, signer, hashType)
-                val p2pkhScriptSig = P2PKHScriptSignature(signature, pubKey)
-                val signedInput = TransactionInput(unsignedInput.previousOutput, p2pkhScriptSig, unsignedInput.sequence)
-                val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
-                val signedTx = unsignedTx match {
-                  case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
-                    btx.outputs, btx.lockTime)
-                  case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
-                    wtx.outputs, wtx.lockTime, wtx.witness)
+                val signature = TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
+                signature.map { sig =>
+                  val p2pkhScriptSig = P2PKHScriptSignature(sig, pubKey)
+                  val signedInput = TransactionInput(unsignedInput.previousOutput, p2pkhScriptSig, unsignedInput.sequence)
+                  val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
+                  val signedTx = unsignedTx match {
+                    case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
+                      btx.outputs, btx.lockTime)
+                    case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
+                      wtx.outputs, wtx.lockTime, wtx.witness)
+                  }
+                  BaseTxSigComponent(signedTx, inputIndex, lock, flags)
                 }
-                Left(BaseTxSigComponent(signedTx, inputIndex, lock, flags))
               }
             case _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey
               | _: P2WPKHWitnessSPKV0 | _: P2WSHWitnessSPKV0 | _: NonStandardScriptPubKey
               | _: CLTVScriptPubKey | _: CSVScriptPubKey
               | _: WitnessCommitment | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey
-              | _: EscrowTimeoutScriptPubKey => Right(TxBuilderError.WrongSigner)
+              | _: EscrowTimeoutScriptPubKey => Future.fromTry(TxBuilderError.WrongSigner)
           }
         case _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey
           | _: P2WPKHWitnessSPKV0 | _: NonStandardScriptPubKey
           | _: WitnessCommitment | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey
-          | _: EscrowTimeoutScriptPubKey => Right(TxBuilderError.WrongSigner)
+          | _: EscrowTimeoutScriptPubKey => Future.fromTry(TxBuilderError.WrongSigner)
       }
       signed
     }
@@ -242,14 +244,14 @@ object P2PKHSigner extends P2PKHSigner
 sealed abstract class MultiSigSigner extends BitcoinSigner {
   private val logger = BitcoinSLogger.logger
 
-  override def sign(signersWithPubKeys: Seq[Signer.Sign], output: TransactionOutput, unsignedTx: Transaction,
-    inputIndex: UInt32, hashType: HashType): Either[TxSigComponent, TxBuilderError] = {
+  override def sign(signersWithPubKeys: Seq[Sign], output: TransactionOutput, unsignedTx: Transaction,
+    inputIndex: UInt32, hashType: HashType)(implicit ec: ExecutionContext): Future[TxSigComponent] = {
     val spk = output.scriptPubKey
-    val signers = signersWithPubKeys.map(_._1)
+    val signers = signersWithPubKeys.map(_.signFunction)
     val unsignedInput = unsignedTx.inputs(inputIndex.toInt)
     val flags = Policy.standardFlags
     val amount = output.value
-    val signed: Either[TxSigComponent, TxBuilderError] = spk match {
+    val signed: Future[TxSigComponent] = spk match {
       case p2wshSPK: P2WSHWitnessSPKV0 =>
         val wtx = unsignedTx match {
           case btx: BaseTransaction => WitnessTransaction(btx.version, btx.inputs,
@@ -257,109 +259,114 @@ sealed abstract class MultiSigSigner extends BitcoinSigner {
           case wtx: WitnessTransaction => wtx
         }
         val witness = wtx.witness.witnesses(inputIndex.toInt)
-        val multiSigSPK: Either[(MultiSignatureScriptPubKey, ScriptPubKey), TxBuilderError] = witness match {
-          case _: P2WPKHWitnessV0 => Right(TxBuilderError.WrongSigner)
-          case EmptyScriptWitness => Right(TxBuilderError.NoWitness)
+
+        //the reason we use (MultiSigSPK,ScriptPubKey) here is
+        //because we need to sign ScriptPubKey which could be
+        //multisig in the case of P2WSH(multisig), but
+        //ScriptPubkey could also be a LockTimeSPK we need to
+        //sign into the digital signature
+        val multiSigSPK: Future[(MultiSignatureScriptPubKey, ScriptPubKey)] = witness match {
+          case _: P2WPKHWitnessV0 => Future.fromTry(TxBuilderError.WrongSigner)
+          case EmptyScriptWitness => Future.fromTry(TxBuilderError.NoWitness)
           case p2wsh: P2WSHWitnessV0 =>
             p2wsh.redeemScript match {
               case lock: LockTimeScriptPubKey =>
                 lock.nestedScriptPubKey match {
-                  case m: MultiSignatureScriptPubKey => Left((m, lock))
+                  case m: MultiSignatureScriptPubKey => Future.successful((m, lock))
                   case _: P2PKScriptPubKey | _: P2PKHScriptPubKey | _: P2SHScriptPubKey | _: P2WPKHWitnessV0
                     | _: P2WSHWitnessSPKV0 | _: WitnessCommitment | _: EscrowTimeoutScriptPubKey | _: CSVScriptPubKey
                     | _: CLTVScriptPubKey | _: NonStandardScriptPubKey | _: UnassignedWitnessScriptPubKey
                     | _: P2WPKHWitnessSPKV0 | EmptyScriptPubKey =>
-                    Right(TxBuilderError.WrongSigner)
+                    Future.fromTry(TxBuilderError.WrongSigner)
                 }
-              case m: MultiSignatureScriptPubKey => Left((m, m))
+              case m: MultiSignatureScriptPubKey => Future.successful((m, m))
               case _: P2PKScriptPubKey | _: P2PKHScriptPubKey | _: P2SHScriptPubKey | _: P2WPKHWitnessV0
                 | _: P2WSHWitnessSPKV0 | _: WitnessCommitment | _: EscrowTimeoutScriptPubKey
                 | _: NonStandardScriptPubKey | _: P2WPKHWitnessSPKV0 | _: UnassignedWitnessScriptPubKey
                 | EmptyScriptPubKey =>
-                Right(TxBuilderError.WrongSigner)
+                Future.fromTry(TxBuilderError.WrongSigner)
             }
         }
-        val requiredSigs = multiSigSPK.left.map(_._1.requiredSigs)
-        val sigComponent = WitnessTxSigComponentRaw(wtx, inputIndex, p2wshSPK, flags, amount)
-        val signatures = requiredSigs.left.map { r =>
-          0.until(r).map(i => TransactionSignatureCreator.createSig(sigComponent, signers(i), hashType))
-        }
-        val multiSigScriptSig = signatures.left.map(s => MultiSignatureScriptSignature(s))
-        val scriptWit = multiSigSPK.left.flatMap {
-          case (_, redeem) =>
-            multiSigScriptSig.left.map { scriptSig =>
-              P2WSHWitnessV0(redeem, scriptSig)
+
+        multiSigSPK.flatMap {
+          case (multiSig, spk) =>
+            val requiredSigs = multiSig.requiredSigs
+            val sigComponent = WitnessTxSigComponentRaw(wtx, inputIndex, p2wshSPK, flags, amount)
+            val signaturesNested: Seq[Future[ECDigitalSignature]] = 0.until(requiredSigs).map { i =>
+              TransactionSignatureCreator.createSig(
+                sigComponent,
+                signers(i), hashType)
+            }
+            val signatures = Future.sequence(signaturesNested)
+            signatures.map { sigs =>
+              val multiSigScriptSig = MultiSignatureScriptSignature(sigs)
+              val scriptWit = P2WSHWitnessV0(spk, multiSigScriptSig)
+              val txWit = TransactionWitness(wtx.witness.witnesses.updated(inputIndex.toInt, scriptWit))
+              val signedWTx = WitnessTransaction(wtx.version, wtx.inputs, wtx.outputs, wtx.lockTime, txWit)
+              WitnessTxSigComponentRaw(signedWTx, inputIndex, p2wshSPK, flags, amount)
             }
         }
-        val signedWitness = scriptWit.left.map(wit => TransactionWitness(wtx.witness.witnesses.updated(inputIndex.toInt, wit)))
-        val signedWTx: Either[WitnessTransaction, TxBuilderError] = signedWitness.left.map { txWit =>
-          WitnessTransaction(wtx.version, wtx.inputs, wtx.outputs, wtx.lockTime, txWit)
-        }
-        signedWTx.left.map { wtx =>
-          WitnessTxSigComponentRaw(wtx, inputIndex, p2wshSPK, flags, amount)
-        }
+
       case multiSigSPK: MultiSignatureScriptPubKey =>
         val requiredSigs = multiSigSPK.requiredSigs
         if (signers.size < requiredSigs) {
-          Right(TxBuilderError.WrongSigner)
+          Future.fromTry(TxBuilderError.WrongSigner)
         } else {
           val sigComponent = BaseTxSigComponent(unsignedTx, inputIndex, multiSigSPK, flags)
-          val signatures = 0.until(requiredSigs).map(i => TransactionSignatureCreator.createSig(sigComponent, signers(i), hashType))
-          val multiSigScriptSig = MultiSignatureScriptSignature(signatures)
-          val signedInput = TransactionInput(unsignedInput.previousOutput, multiSigScriptSig, unsignedInput.sequence)
-          val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
-          val signedTx = unsignedTx match {
-            case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
-              btx.outputs, btx.lockTime)
-            case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
-              wtx.outputs, wtx.lockTime, wtx.witness)
+          val signaturesNested = 0.until(requiredSigs).map(i => TransactionSignatureCreator.createSig(sigComponent, signers(i), hashType))
+          val signatures = Future.sequence(signaturesNested)
+          signatures.map { sigs =>
+            val multiSigScriptSig = MultiSignatureScriptSignature(sigs)
+            val signedInput = TransactionInput(unsignedInput.previousOutput, multiSigScriptSig, unsignedInput.sequence)
+            val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
+            val signedTx = unsignedTx match {
+              case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
+                btx.outputs, btx.lockTime)
+              case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
+                wtx.outputs, wtx.lockTime, wtx.witness)
+            }
+            BaseTxSigComponent(signedTx, inputIndex, multiSigSPK, Policy.standardFlags)
           }
-          Left(BaseTxSigComponent(signedTx, inputIndex, multiSigSPK, Policy.standardFlags))
         }
       case lock: LockTimeScriptPubKey =>
         val nested = lock.nestedScriptPubKey
         val multiSigSPK = nested match {
-          case m: MultiSignatureScriptPubKey => Left(m)
+          case m: MultiSignatureScriptPubKey => Future.successful(m)
           case _: P2PKScriptPubKey | _: P2PKHScriptPubKey | _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey
             | _: P2WPKHWitnessSPKV0 | _: P2WSHWitnessSPKV0 | _: CLTVScriptPubKey | _: CSVScriptPubKey
             | _: UnassignedWitnessScriptPubKey | _: NonStandardScriptPubKey | _: WitnessCommitment
-            | _: EscrowTimeoutScriptPubKey | EmptyScriptPubKey => Right(TxBuilderError.WrongSigner)
+            | _: EscrowTimeoutScriptPubKey | EmptyScriptPubKey => Future.fromTry(TxBuilderError.WrongSigner)
         }
-        val requiredSigs = multiSigSPK.left.map(_.requiredSigs)
-        val sigComponent = BaseTxSigComponent(unsignedTx, inputIndex, lock, flags)
-        val signatures = requiredSigs.left.flatMap { n =>
-          if (signers.size < n) {
-            Right(TxBuilderError.WrongSigner)
+        multiSigSPK.flatMap { mSPK =>
+          val requiredSigs = mSPK.requiredSigs
+          val sigComponent = BaseTxSigComponent(unsignedTx, inputIndex, lock, flags)
+          val signatures: Future[Seq[ECDigitalSignature]] = if (signers.size < requiredSigs) {
+            Future.fromTry(TxBuilderError.WrongSigner)
           } else {
-            val sigs = 0.until(n).map { i =>
+            val sigs = 0.until(requiredSigs).map { i =>
               TransactionSignatureCreator.createSig(sigComponent, signers(i), hashType)
             }
-            Left(sigs)
+            Future.sequence(sigs)
           }
-        }
-        val tx = signatures.left.map { sigs =>
-          val multiSigScriptSig = MultiSignatureScriptSignature(sigs)
-          val signedInput = TransactionInput(unsignedInput.previousOutput, multiSigScriptSig, unsignedInput.sequence)
-          val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
-          val signedTx = unsignedTx match {
-            case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
-              btx.outputs, btx.lockTime)
-            case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
-              wtx.outputs, wtx.lockTime, wtx.witness)
+          val signedTxSigComp = signatures.map { sigs =>
+            val multiSigScriptSig = MultiSignatureScriptSignature(sigs)
+            val signedInput = TransactionInput(unsignedInput.previousOutput, multiSigScriptSig, unsignedInput.sequence)
+            val signedInputs = unsignedTx.inputs.updated(inputIndex.toInt, signedInput)
+            val signedTx = unsignedTx match {
+              case btx: BaseTransaction => BaseTransaction(btx.version, signedInputs,
+                btx.outputs, btx.lockTime)
+              case wtx: WitnessTransaction => WitnessTransaction(wtx.version, signedInputs,
+                wtx.outputs, wtx.lockTime, wtx.witness)
+            }
+            BaseTxSigComponent(signedTx, inputIndex, mSPK, flags)
           }
-          signedTx
-        }
-
-        tx.left.flatMap { t =>
-          multiSigSPK.left.map { m =>
-            BaseTxSigComponent(t, inputIndex, m, flags)
-          }
+          signedTxSigComp
         }
       case _: P2PKScriptPubKey | _: P2PKHScriptPubKey | _: P2SHScriptPubKey
         | _: P2WPKHWitnessSPKV0 | _: NonStandardScriptPubKey
         | _: WitnessCommitment | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey
         | _: EscrowTimeoutScriptPubKey =>
-        Right(TxBuilderError.WrongSigner)
+        Future.fromTry(TxBuilderError.WrongSigner)
     }
     signed
   }
@@ -368,45 +375,46 @@ sealed abstract class MultiSigSigner extends BitcoinSigner {
 object MultiSigSigner extends MultiSigSigner
 
 sealed abstract class P2WPKHSigner extends BitcoinSigner {
-  override def sign(signers: Seq[Signer.Sign], output: TransactionOutput, unsignedTx: Transaction,
-    inputIndex: UInt32, hashType: HashType): Either[TxSigComponent, TxBuilderError] = unsignedTx match {
+  override def sign(signers: Seq[Sign], output: TransactionOutput, unsignedTx: Transaction,
+    inputIndex: UInt32, hashType: HashType)(implicit ec: ExecutionContext): Future[TxSigComponent] = unsignedTx match {
     case wtx: WitnessTransaction =>
       if (signers.size != 1) {
-        Right(TxBuilderError.TooManySigners)
-      } else if (signers.head._2.isEmpty) {
-        Right(TxBuilderError.MissingPublicKey)
+        Future.fromTry(TxBuilderError.TooManySigners)
+      } else if (signers.head.pubKeyOpt.isEmpty) {
+        Future.fromTry(TxBuilderError.MissingPublicKey)
       } else {
-        val signer = signers.head._1
-        val pubKey = signers.head._2.get
+        val sign = signers.head.signFunction
+        val pubKey = signers.head.pubKeyOpt.get
         val unsignedScriptWit = P2WPKHWitnessV0(pubKey)
         val unsignedTxWitness = TransactionWitness(wtx.witness.witnesses.updated(inputIndex.toInt, unsignedScriptWit))
         val unsignedWtx = WitnessTransaction(wtx.version, wtx.inputs, wtx.outputs, wtx.lockTime, unsignedTxWitness)
         val witSPK = output.scriptPubKey match {
           case p2wpkh: P2WPKHWitnessSPKV0 =>
             if (p2wpkh != P2WPKHWitnessSPKV0(pubKey)) {
-              Right(TxBuilderError.WrongPublicKey)
-            } else Left(p2wpkh)
+              Future.fromTry(TxBuilderError.WrongPublicKey)
+            } else Future.successful(p2wpkh)
           case _: P2PKScriptPubKey | _: P2PKHScriptPubKey | _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey
             | _: P2WSHWitnessSPKV0 | _: NonStandardScriptPubKey | _: CLTVScriptPubKey | _: CSVScriptPubKey
             | _: WitnessCommitment | EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey
             | _: EscrowTimeoutScriptPubKey =>
-            Right(TxBuilderError.NonWitnessSPK)
+            Future.fromTry(TxBuilderError.NonWitnessSPK)
         }
-        val result = witSPK.left.map { w =>
+
+        witSPK.flatMap { w =>
           val wtxComp = WitnessTxSigComponentRaw(unsignedWtx, inputIndex, w, Policy.standardFlags, output.value)
-          val signature = TransactionSignatureCreator.createSig(wtxComp, signer, hashType)
-          val scriptWitness = P2WPKHWitnessV0(pubKey, signature)
-          val signedTxWitness = TransactionWitness(unsignedWtx.witness.witnesses.updated(inputIndex.toInt, scriptWitness))
-          val signedTx = WitnessTransaction(unsignedWtx.version, unsignedWtx.inputs, unsignedWtx.outputs,
-            unsignedWtx.lockTime, signedTxWitness)
-          WitnessTxSigComponentRaw(signedTx, inputIndex, w, Policy.standardFlags, output.value)
+          val signature = TransactionSignatureCreator.createSig(wtxComp, sign, hashType)
+          signature.map { sig =>
+            val scriptWitness = P2WPKHWitnessV0(pubKey, sig)
+            val signedTxWitness = TransactionWitness(unsignedWtx.witness.witnesses.updated(inputIndex.toInt, scriptWitness))
+            val signedTx = WitnessTransaction(unsignedWtx.version, unsignedWtx.inputs, unsignedWtx.outputs,
+              unsignedWtx.lockTime, signedTxWitness)
+            WitnessTxSigComponentRaw(signedTx, inputIndex, w, Policy.standardFlags, output.value)
+          }
         }
-        result
       }
     case btx: BaseTransaction =>
       val wtx = WitnessTransaction(btx.version, btx.inputs, btx.outputs, btx.lockTime, EmptyWitness)
       sign(signers, output, wtx, inputIndex, hashType)
   }
 }
-
 object P2WPKHSigner extends P2WPKHSigner

--- a/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.core.wallet.utxo
 
+import org.bitcoins.core.crypto.Sign
 import org.bitcoins.core.protocol.script.{ ScriptPubKey, ScriptWitness }
 import org.bitcoins.core.protocol.transaction.{ TransactionOutPoint, TransactionOutput }
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.wallet.signer.Signer
 
 /**
  * Contains the information required to spend a unspent transaction output (UTXO)
@@ -15,7 +15,7 @@ sealed abstract class UTXOSpendingInfo {
   /** the actual output itself we are spending */
   def output: TransactionOutput
   /** the signers needed to spend from the output above */
-  def signers: Seq[Signer.Sign]
+  def signers: Seq[Sign]
   /** a redeemScript, if required, to spend the output above */
   def redeemScriptOpt: Option[ScriptPubKey]
   /** the scriptWitness, if required, to spend the output above */
@@ -25,7 +25,7 @@ sealed abstract class UTXOSpendingInfo {
 }
 
 case class BitcoinUTXOSpendingInfo(outPoint: TransactionOutPoint, output: TransactionOutput,
-  signers: Seq[Signer.Sign],
+  signers: Seq[Sign],
   redeemScriptOpt: Option[ScriptPubKey],
   scriptWitnessOpt: Option[ScriptWitness],
   hashType: HashType) extends UTXOSpendingInfo

--- a/src/test/scala/org/bitcoins/core/channels/ChannelTest.scala
+++ b/src/test/scala/org/bitcoins/core/channels/ChannelTest.scala
@@ -8,16 +8,17 @@ import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script.{ P2SHScriptPubKey, P2WSHWitnessSPKV0, WitnessScriptPubKeyV0 }
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.util.BitcoinSLogger
-import org.scalatest.{ FlatSpec, MustMatchers }
+import org.scalatest.{ Assertion, AsyncFlatSpec, FlatSpec, MustMatchers }
 
+import scala.concurrent.{ Await, Future }
 import scala.util.Try
-
+import scala.concurrent.duration.DurationInt
 /**
  * Created by chris on 5/31/17.
  */
-class ChannelTest extends FlatSpec with MustMatchers {
+class ChannelTest extends AsyncFlatSpec with MustMatchers {
   private val logger = BitcoinSLogger.logger
-
+  val timeout = 5.seconds
   "ChannelTest" must "fail to create payment channel if we do not have the minimum amoutn required for initial deposit" in {
     val lock = ScriptGenerators.escrowTimeoutScriptPubKey2Of2.sample.get._1
     val p2sh = P2SHScriptPubKey(lock)
@@ -25,7 +26,7 @@ class ChannelTest extends FlatSpec with MustMatchers {
     val output = TransactionOutput(amount, p2sh)
     val tx = BaseTransaction(TransactionConstants.version, Nil, Seq(output), TransactionConstants.lockTime)
     val chan = ChannelAwaitingAnchorTx(tx, lock)
-    chan.isRight must be(true)
+    chan.isFailure must be(true)
   }
 
   it must "fail to create a payment channel if one of the outputs scriptPubKey's is not P2SH(lock)" in {
@@ -36,32 +37,36 @@ class ChannelTest extends FlatSpec with MustMatchers {
     val output = TransactionOutput(amount, p2sh)
     val tx = BaseTransaction(TransactionConstants.version, Nil, Seq(output), TransactionConstants.lockTime)
     val chan = ChannelAwaitingAnchorTx(tx, lock)
-    chan.isRight must be(true)
+    chan.isFailure must be(true)
 
     //it must also fail if we do not have a p2sh output at all
     val output2 = TransactionOutput(amount, randomScript)
     val tx2 = BaseTransaction(TransactionConstants.version, Nil, Seq(output2), TransactionConstants.lockTime)
     val chan2 = ChannelAwaitingAnchorTx(tx2, lock)
-    chan2.isRight must be(true)
+    chan2.isFailure must be(true)
   }
 
   it must "fail to client sign ChannelAwaitingAnchorTx if we do not have enough confs" in {
     val clientSPK = ScriptGenerators.p2pkhScriptPubKey.sample.get._1
     val (lock, keys) = ScriptGenerators.escrowTimeoutScriptPubKey2Of2.sample.get
-    val p2sh = P2SHScriptPubKey(P2WSHWitnessSPKV0(lock))
+    val p2sh = P2WSHWitnessSPKV0(lock)
     val amount = Policy.minChannelAmount
     val output = TransactionOutput(amount, p2sh)
     val tc = TransactionConstants
     val tx = BaseTransaction(tc.version, Nil, Seq(output), tc.lockTime)
-    val chan = ChannelAwaitingAnchorTx(tx, lock)
-    val clientSigned = chan.left.flatMap(_.clientSign(clientSPK, amount, keys.head))
-    clientSigned.isRight must be(true)
+    val chan = ChannelAwaitingAnchorTx(tx, lock).get
+    val clientSigned = chan.clientSign(clientSPK, amount, keys.head)
+    recoverToSucceededIf[IllegalArgumentException] {
+      clientSigned
+    }
   }
 
   it must "fail to client sign a payment channel in progress if the value is more than the locked amount" in {
-    val (inProgress, keys) = validInProgress
-    val i = inProgress.clientSign(inProgress.lockedAmount, keys.head)
-    i.isRight must be(true)
+    val inProgress = validInProgress.flatMap {
+      case (i, keys) =>
+        i.clientSign(i.lockedAmount, keys.head)
+    }
+    recoverToSucceededIf[IllegalArgumentException](inProgress)
   }
 
   it must "be valid for the server to receive all of the money when a payment channel closes" in {
@@ -73,12 +78,16 @@ class ChannelTest extends FlatSpec with MustMatchers {
     val output = TransactionOutput(amount, p2wsh)
     val tx = BaseTransaction(TransactionConstants.version, Nil, Seq(output), TransactionConstants.lockTime)
     val chan = ChannelAwaitingAnchorTx(tx, lock, Policy.confirmations)
-    chan.isLeft must be(true)
-    val inProgress = chan.left.flatMap(_.clientSign(clientSPK, amount, keys.head))
-    inProgress.isLeft must be(true)
-    val closed = inProgress.left.flatMap(_.close(serverSPK, keys(1), CurrencyUnits.zero))
-    closed.isLeft must be(true)
-    closed.left.get.serverAmount.get must be(amount)
+    chan.isSuccess must be(true)
+    val inProgress = chan.get.clientSign(clientSPK, amount, keys.head)
+    val f: Future[Assertion] = inProgress.flatMap { _ =>
+      val closed = inProgress.flatMap(_.close(serverSPK, keys(1), CurrencyUnits.zero))
+      closed.map { c =>
+        assert(c.serverAmount.get == amount)
+      }
+    }
+    f
+
   }
 
   it must "be valid for the server to receive all of the money when a payment channel closes in two updates" in {
@@ -90,11 +99,13 @@ class ChannelTest extends FlatSpec with MustMatchers {
     val output = TransactionOutput(amount, p2wsh)
     val tx = BaseTransaction(TransactionConstants.version, Nil, Seq(output), TransactionConstants.lockTime)
     val chan = ChannelAwaitingAnchorTx(tx, lock, Policy.confirmations)
-    val inProgress = chan.left.flatMap(_.clientSign(clientSPK, CurrencyUnits.oneBTC, keys.head))
-    val serverSign = inProgress.left.flatMap(_.serverSign(keys(1)))
-    val inProgress2 = serverSign.left.flatMap(_.clientSign(CurrencyUnits.oneBTC, keys.head))
-    val closed = inProgress2.left.flatMap(_.close(serverSPK, keys(1), CurrencyUnits.zero))
-    closed.left.get.serverAmount.get must be(amount)
+    val inProgress = chan.get.clientSign(clientSPK, CurrencyUnits.oneBTC, keys.head)
+    val serverSign = inProgress.flatMap(_.serverSign(keys(1)))
+    val inProgress2 = serverSign.flatMap(_.clientSign(CurrencyUnits.oneBTC, keys.head))
+    val closed = inProgress2.flatMap(_.close(serverSPK, keys(1), CurrencyUnits.zero))
+    closed.map { c =>
+      assert(c.serverAmount.get == amount)
+    }
   }
 
   it must "fail to close the payment channel if the payment channel's fee is larger than the locked amount" in {
@@ -106,13 +117,13 @@ class ChannelTest extends FlatSpec with MustMatchers {
     val output = TransactionOutput(amount, p2wsh)
     val tx = BaseTransaction(TransactionConstants.version, Nil, Seq(output), TransactionConstants.lockTime)
     val chan = ChannelAwaitingAnchorTx(tx, lock, Policy.confirmations)
-    val inProgress = chan.left.flatMap(_.clientSign(clientSPK, amount, keys.head))
+    val inProgress = chan.get.clientSign(clientSPK, amount, keys.head)
     //Note the fee here, we try and spend too much money
-    val closed = inProgress.left.flatMap(_.close(serverSPK, keys(1), CurrencyUnits.oneBTC + Satoshis.one))
-    closed.isRight must be(true)
+    val closed = inProgress.flatMap(_.close(serverSPK, keys(1), CurrencyUnits.oneBTC + Satoshis.one))
+    recoverToSucceededIf[IllegalArgumentException](closed)
   }
 
-  private def validInProgress: (ChannelInProgress, Seq[ECPrivateKey]) = {
+  private def validInProgress: Future[(ChannelInProgress, Seq[ECPrivateKey])] = {
     val clientSPK = ScriptGenerators.p2pkhScriptPubKey.sample.get._1
     val (lock, keys) = ScriptGenerators.escrowTimeoutScriptPubKey2Of2.sample.get
     val p2wsh = P2WSHWitnessSPKV0(lock)
@@ -122,8 +133,8 @@ class ChannelTest extends FlatSpec with MustMatchers {
     val tx = BaseTransaction(tc.version, Nil, Seq(output), tc.lockTime)
     val chan = ChannelAwaitingAnchorTx(tx, lock, Policy.confirmations)
     val paymentAmount = Policy.minChannelAmount
-    val clientSign = chan.left.flatMap(_.clientSign(clientSPK, paymentAmount, keys.head))
-    val i = clientSign.left.flatMap(_.serverSign(keys(1)))
-    (i.left.get, keys)
+    val clientSign = chan.get.clientSign(clientSPK, paymentAmount, keys.head)
+    val i = clientSign.flatMap(_.serverSign(keys(1)))
+    i.map((_, keys))
   }
 }

--- a/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -113,7 +113,7 @@ class BitcoinTxBuilderTest extends AsyncFlatSpec with MustMatchers {
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
 
     val feeUnit = SatoshisPerVirtualByte(Satoshis(Int64(1)))
-    val txBuilderWitness = BitcoinTxBuilder(destinations,  utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
+    val txBuilderWitness = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
     val resultFuture = txBuilderWitness.flatMap(_.sign)
     recoverToSucceededIf[IllegalArgumentException] {
       resultFuture

--- a/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -13,9 +13,9 @@ import org.bitcoins.core.wallet
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder.UTXOMap
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.BitcoinUTXOSpendingInfo
-import org.scalatest.{ FlatSpec, MustMatchers }
+import org.scalatest.{ AsyncFlatSpec, MustMatchers }
 
-class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
+class BitcoinTxBuilderTest extends AsyncFlatSpec with MustMatchers {
   private val logger = BitcoinSLogger.logger
   val tc = TransactionConstants
   val (spk, privKey) = ScriptGenerators.p2pkhScriptPubKey.sample.get
@@ -25,13 +25,14 @@ class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
     val destinations = Seq(TransactionOutput(Satoshis(Int64(1)), EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion, Nil, Seq(creditingOutput), tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val signer = (privKey.sign(_: Seq[Byte]), Some(privKey.publicKey))
-    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), None, None, HashType.sigHashAll)
+    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), None, None, HashType.sigHashAll)
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
     val feeUnit = SatoshisPerVirtualByte(Satoshis.one)
     val txBuilder = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
-    val result = txBuilder.left.flatMap(_.sign)
-    result must be(Right(TxBuilderError.MintsMoney))
+    val resultFuture = txBuilder.flatMap(_.sign)
+    recoverToSucceededIf[IllegalArgumentException] {
+      resultFuture
+    }
   }
 
   it must "fail to build a transaction when we pass in a negative fee rate" in {
@@ -39,12 +40,13 @@ class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
     val destinations = Seq(TransactionOutput(Satoshis(Int64(1)), EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion, Nil, Seq(creditingOutput), tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val signer = (privKey.sign(_: Seq[Byte]), Some(privKey.publicKey))
-    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), None, None, HashType.sigHashAll)
+    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), None, None, HashType.sigHashAll)
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
     val feeUnit = SatoshisPerVirtualByte(Satoshis(Int64(-1)))
     val txBuilder = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
-    txBuilder must be(Right(TxBuilderError.LowFee))
+    recoverToSucceededIf[IllegalArgumentException] {
+      txBuilder
+    }
   }
 
   it must "fail a transaction when the user invariants fail" in {
@@ -52,15 +54,16 @@ class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
     val destinations = Seq(TransactionOutput(Satoshis(Int64(1)), EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion, Nil, Seq(creditingOutput), tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val signer = (privKey.sign(_: Seq[Byte]), Some(privKey.publicKey))
-    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), None, None, HashType.sigHashAll)
+    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), None, None, HashType.sigHashAll)
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
     val feeUnit = SatoshisPerVirtualByte(Satoshis(Int64(1)))
     val txBuilder = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
     //trivially false
     val f = (_: Seq[BitcoinUTXOSpendingInfo], _: Transaction) => false
-    val result = txBuilder.left.flatMap(_.sign(f))
-    result must be(Right(TxBuilderError.FailedUserInvariants))
+    val resultFuture = txBuilder.flatMap(_.sign(f))
+    recoverToSucceededIf[IllegalArgumentException] {
+      resultFuture
+    }
   }
 
   it must "be able to create a BitcoinTxBuilder from UTXOTuple and UTXOMap" in {
@@ -68,16 +71,19 @@ class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
     val destinations = Seq(TransactionOutput(Satoshis(Int64(1)), EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion, Nil, Seq(creditingOutput), tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val signer = (privKey.sign(_: Seq[Byte]), Some(privKey.publicKey))
-    val utxo = wallet.utxo.BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), None, None, HashType.sigHashAll)
+    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), None, None, HashType.sigHashAll)
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
-    val uTXOSpendingInfo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), None, None, HashType.sigHashAll)
+    val utxoSpendingInfo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), None, None, HashType.sigHashAll)
 
     val feeUnit = SatoshisPerVirtualByte(Satoshis(Int64(1)))
     val txBuilderMap = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
-    val txBuilderTuple = BitcoinTxBuilder(destinations, Seq(uTXOSpendingInfo), feeUnit, EmptyScriptPubKey, TestNet3)
+    val txBuilderTuple = BitcoinTxBuilder(destinations, Seq(utxoSpendingInfo), feeUnit, EmptyScriptPubKey, TestNet3)
 
-    txBuilderTuple must be(txBuilderMap)
+    txBuilderTuple.flatMap { tup =>
+      txBuilderMap.map { map =>
+        assert(map == tup)
+      }
+    }
   }
 
   it must "fail to build a tx if you have the wrong redeemscript" in {
@@ -86,13 +92,14 @@ class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
     val destinations = Seq(TransactionOutput(Satoshis(Int64(1)), EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion, Nil, Seq(creditingOutput), tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val signer = (privKey.sign(_: Seq[Byte]), Some(privKey.publicKey))
-    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), Some(EmptyScriptPubKey), None, HashType.sigHashAll)
+    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), Some(EmptyScriptPubKey), None, HashType.sigHashAll)
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
     val feeUnit = SatoshisPerVirtualByte(Satoshis(Int64(1)))
     val txBuilderNoRedeem = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
-    val result = txBuilderNoRedeem.left.flatMap(_.sign)
-    result must be(Right(TxBuilderError.WrongRedeemScript))
+    val resultFuture = txBuilderNoRedeem.flatMap(_.sign)
+    recoverToSucceededIf[IllegalArgumentException] {
+      resultFuture
+    }
   }
 
   it must "fail to build a tx if you have the wrong script witness" in {
@@ -101,15 +108,16 @@ class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
     val destinations = Seq(TransactionOutput(Satoshis(Int64(1)), EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion, Nil, Seq(creditingOutput), tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val signer = (privKey.sign(_: Seq[Byte]), Some(privKey.publicKey))
-    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), None,
+    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), None,
       Some(P2WSHWitnessV0(EmptyScriptPubKey)), HashType.sigHashAll)
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
 
     val feeUnit = SatoshisPerVirtualByte(Satoshis(Int64(1)))
-    val txBuilderWitness = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
-    val result = txBuilderWitness.left.flatMap(_.sign)
-    result must be(Right(TxBuilderError.WrongWitness))
+    val txBuilderWitness = BitcoinTxBuilder(destinations,  utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
+    val resultFuture = txBuilderWitness.flatMap(_.sign)
+    recoverToSucceededIf[IllegalArgumentException] {
+      resultFuture
+    }
   }
 
   it must "fail to sign a p2pkh if we don't pass in the public key" in {
@@ -118,15 +126,16 @@ class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
     val destinations = Seq(TransactionOutput(Satoshis(Int64(1)), EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion, Nil, Seq(creditingOutput), tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val signer = (privKey.sign(_: Seq[Byte]), None)
-    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), None,
+    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), None,
       Some(P2WSHWitnessV0(EmptyScriptPubKey)), HashType.sigHashAll)
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
 
     val feeUnit = SatoshisPerVirtualByte(Satoshis(Int64(1)))
     val txBuilderWitness = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
-    val result = txBuilderWitness.left.flatMap(_.sign)
-    result must be(Right(TxBuilderError.MissingPublicKey))
+    val resultFuture = txBuilderWitness.flatMap(_.sign)
+    recoverToSucceededIf[IllegalArgumentException] {
+      resultFuture
+    }
   }
 
   it must "fail to sign a p2pkh if we pass in the wrong public key" in {
@@ -136,15 +145,16 @@ class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
     val destinations = Seq(TransactionOutput(Satoshis(Int64(1)), EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion, Nil, Seq(creditingOutput), tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val signer = (privKey.sign(_: Seq[Byte]), Some(pubKey2))
-    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), None,
+    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), None,
       Some(P2WSHWitnessV0(EmptyScriptPubKey)), HashType.sigHashAll)
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
 
     val feeUnit = SatoshisPerVirtualByte(Satoshis(Int64(1)))
     val txBuilderWitness = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
-    val result = txBuilderWitness.left.flatMap(_.sign)
-    result must be(Right(TxBuilderError.WrongPublicKey))
+    val resultFuture = txBuilderWitness.flatMap(_.sign)
+    recoverToSucceededIf[IllegalArgumentException] {
+      resultFuture
+    }
   }
 
   it must "fail to sign a p2wpkh if we don't pass in the public key" in {
@@ -153,15 +163,16 @@ class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
     val destinations = Seq(TransactionOutput(Satoshis(Int64(1)), EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion, Nil, Seq(creditingOutput), tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val signer = (privKey.sign(_: Seq[Byte]), None)
-    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), None,
+    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), None,
       Some(P2WSHWitnessV0(EmptyScriptPubKey)), HashType.sigHashAll)
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
 
     val feeUnit = SatoshisPerVirtualByte(Satoshis(Int64(1)))
     val txBuilderWitness = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
-    val result = txBuilderWitness.left.flatMap(_.sign)
-    result must be(Right(TxBuilderError.MissingPublicKey))
+    val resultFuture = txBuilderWitness.flatMap(_.sign)
+    recoverToSucceededIf[IllegalArgumentException] {
+      resultFuture
+    }
   }
 
   it must "fail to sign a p2wpkh if we pass in the wrong public key" in {
@@ -171,14 +182,15 @@ class BitcoinTxBuilderTest extends FlatSpec with MustMatchers {
     val destinations = Seq(TransactionOutput(Satoshis(Int64(1)), EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion, Nil, Seq(creditingOutput), tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val signer = (privKey.sign(_: Seq[Byte]), Some(pubKey2))
-    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(signer), None,
+    val utxo = BitcoinUTXOSpendingInfo(outPoint, creditingOutput, Seq(privKey), None,
       Some(P2WSHWitnessV0(EmptyScriptPubKey)), HashType.sigHashAll)
     val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
 
     val feeUnit = SatoshisPerVirtualByte(Satoshis(Int64(1)))
     val txBuilderWitness = BitcoinTxBuilder(destinations, utxoMap, feeUnit, EmptyScriptPubKey, TestNet3)
-    val result = txBuilderWitness.left.flatMap(_.sign)
-    result must be(Right(TxBuilderError.WrongPublicKey))
+    val resultFuture = txBuilderWitness.flatMap(_.sign)
+    recoverToSucceededIf[IllegalArgumentException] {
+      resultFuture
+    }
   }
 }

--- a/src/test/scala/org/bitcoins/core/wallet/builder/TxBuilderTest.scala
+++ b/src/test/scala/org/bitcoins/core/wallet/builder/TxBuilderTest.scala
@@ -11,8 +11,8 @@ class TxBuilderTest extends FlatSpec with MustMatchers {
     val estimatedFee = Satoshis(Int64(1000))
     val actualFee = Satoshis.one
     val feeRate = SatoshisPerVirtualByte(Satoshis.one)
-    TxBuilder.isValidFeeRange(estimatedFee, actualFee, feeRate) must be(Some(TxBuilderError.LowFee))
+    TxBuilder.isValidFeeRange(estimatedFee, actualFee, feeRate).isFailure must be(true)
 
-    TxBuilder.isValidFeeRange(actualFee, estimatedFee, feeRate) must be(Some(TxBuilderError.HighFee))
+    TxBuilder.isValidFeeRange(actualFee, estimatedFee, feeRate).isFailure must be(true)
   }
 }


### PR DESCRIPTION
This changes the `TxBuilder` api from returning an `Either` to returning a `Future`. This makes more sense in the fact that signing process can be slow and cumbersome at times. Some signing procedures may rely on user input (hardware wallets). We do not want to wait halt the world for operations like this. 