### PR TITLE
Refactoring Sign api to force the publicKey to be included

### DIFF
--- a/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -24,6 +24,7 @@ import scala.util.{ Failure, Success, Try }
 sealed abstract class BaseECKey extends NetworkElement with Sign {
 
   override def signFunction: Seq[Byte] => Future[ECDigitalSignature] = { bytes =>
+    import scala.concurrent.ExecutionContext.Implicits.global
     Future(sign(bytes))
   }
   /**
@@ -94,8 +95,6 @@ sealed abstract class ECPrivateKey extends BaseECKey {
     val encodedPrivKey = fullBytes ++ checksum
     Base58.encode(encodedPrivKey)
   }
-
-  override def pubKeyOpt: Option[ECPublicKey] = Some(publicKey)
 
   override def toString = "ECPrivateKey(" + hex + "," + isCompressed + ")"
 }
@@ -271,8 +270,7 @@ sealed abstract class ECPublicKey extends BaseECKey {
     }
     resultTry.getOrElse(false)
   }
-
-  override def pubKeyOpt: Option[ECPublicKey] = Some(this)
+  override def publicKey: ECPublicKey = this
 
   /** Checks if the [[ECPublicKey]] is compressed */
   def isCompressed: Boolean = bytes.size == 33

--- a/src/main/scala/org/bitcoins/core/crypto/Sign.scala
+++ b/src/main/scala/org/bitcoins/core/crypto/Sign.scala
@@ -4,7 +4,7 @@ import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.DurationInt
 
 /**
- * This is meant to be an abstraction for a [[org.bitcoins.core.crypto.ECPrivateKey]], sometimes we will not
+ * This is meant to be an abstraction for a [[org.bitcoins.core.crypto.ECPrivateKey]],f sometimes we will not
  * have direct access to a private key in memory -- for instance if that key is on a hardware device -- so we need to create an
  * abstraction of the signing process. Fundamentally a private key takes in a Seq[Byte] and returns a [[ECDigitalSignature]]
  * That is what this abstraction is meant to represent. If you have a [[ECPrivateKey]] in your application, you can get it's
@@ -26,24 +26,13 @@ trait Sign {
     Await.result(signFuture(bytes), 30.seconds)
   }
 
-  def pubKeyOpt: Option[ECPublicKey]
-
-  implicit val ec: ExecutionContext
+  def publicKey: ECPublicKey
 }
 
 object Sign {
-  private case class SignImpl(signFunction: Seq[Byte] => Future[ECDigitalSignature], pubKeyOpt: Option[ECPublicKey], implicit val ec: ExecutionContext) extends Sign
+  private case class SignImpl(signFunction: Seq[Byte] => Future[ECDigitalSignature], publicKey: ECPublicKey) extends Sign
 
-  def apply(signFunction: Seq[Byte] => Future[ECDigitalSignature], pubKeyOpt: Option[ECPublicKey]): Sign = {
-    val ec = scala.concurrent.ExecutionContext.Implicits.global
-    Sign(signFunction, pubKeyOpt, ec)
-  }
-
-  def apply(signFunction: Seq[Byte] => Future[ECDigitalSignature]): Sign = {
-    Sign(signFunction, None)
-  }
-
-  def apply(signFunction: Seq[Byte] => Future[ECDigitalSignature], pubKeyOpt: Option[ECPublicKey], ec: ExecutionContext): Sign = {
-    SignImpl(signFunction, pubKeyOpt, ec)
+  def apply(signFunction: Seq[Byte] => Future[ECDigitalSignature], pubKey: ECPublicKey): Sign = {
+    SignImpl(signFunction, pubKey)
   }
 }

--- a/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -125,11 +125,9 @@ sealed abstract class P2PKHSigner extends BitcoinSigner {
     val spk = output.scriptPubKey
     if (signers.size != 1) {
       Future.fromTry(TxBuilderError.TooManySigners)
-    } else if (signers.head.pubKeyOpt.isEmpty) {
-      Future.fromTry(TxBuilderError.MissingPublicKey)
     } else {
       val sign = signers.head.signFunction
-      val pubKey = signers.head.pubKeyOpt.get
+      val pubKey = signers.head.publicKey
       val unsignedInput = unsignedTx.inputs(inputIndex.toInt)
       val flags = Policy.standardFlags
       val amount = output.value
@@ -380,11 +378,9 @@ sealed abstract class P2WPKHSigner extends BitcoinSigner {
     case wtx: WitnessTransaction =>
       if (signers.size != 1) {
         Future.fromTry(TxBuilderError.TooManySigners)
-      } else if (signers.head.pubKeyOpt.isEmpty) {
-        Future.fromTry(TxBuilderError.MissingPublicKey)
       } else {
         val sign = signers.head.signFunction
-        val pubKey = signers.head.pubKeyOpt.get
+        val pubKey = signers.head.publicKey
         val unsignedScriptWit = P2WPKHWitnessV0(pubKey)
         val unsignedTxWitness = TransactionWitness(wtx.witness.witnesses.updated(inputIndex.toInt, unsignedScriptWit))
         val unsignedWtx = WitnessTransaction(wtx.version, wtx.inputs, wtx.outputs, wtx.lockTime, unsignedTxWitness)


### PR DESCRIPTION
This is removing the `ExecutionContext` from the `Sign` trait, and making the `publicKey` mandatory instead of optional.