### PR TITLE
Exposing the TxBuilder.unsignedTx field -- this gives developers acce…

### DIFF
--- a/core-gen/src/test/scala/org/bitcoins/core/gen/ScriptGenerators.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/ScriptGenerators.scala
@@ -259,7 +259,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     (creditingTx, outputIndex) = TransactionGenerators.buildCreditingTransaction(scriptPubKey)
     scriptSig = P2PKScriptSignature(EmptyDigitalSignature)
     (spendingTx, inputIndex) = TransactionGenerators.buildSpendingTransaction(creditingTx, scriptSig, outputIndex)
-    txSigComponentFuture = P2PKSigner.sign(Seq(privateKey), creditingTx.outputs(outputIndex.toInt), spendingTx, inputIndex, hashType)
+    txSigComponentFuture = P2PKSigner.sign(Seq(privateKey), creditingTx.outputs(outputIndex.toInt), spendingTx, inputIndex, hashType, false)
     txSigComponent = Await.result(txSigComponentFuture, timeout)
     //add the signature to the scriptSig instead of having an empty scriptSig
     signedScriptSig = txSigComponent.scriptSignature.asInstanceOf[P2PKScriptSignature]
@@ -278,7 +278,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     scriptPubKey = P2PKHScriptPubKey(publicKey)
     (creditingTx, outputIndex) = TransactionGenerators.buildCreditingTransaction(scriptPubKey)
     (unsignedTx, inputIndex) = TransactionGenerators.buildSpendingTransaction(creditingTx, EmptyScriptSignature, outputIndex)
-    txSigComponentFuture = P2PKHSigner.sign(Seq(privateKey), creditingTx.outputs(outputIndex.toInt), unsignedTx, inputIndex, hashType)
+    txSigComponentFuture = P2PKHSigner.sign(Seq(privateKey), creditingTx.outputs(outputIndex.toInt), unsignedTx, inputIndex, hashType, false)
     txSigComponent = Await.result(txSigComponentFuture, timeout)
     signedScriptSig = txSigComponent.scriptSignature.asInstanceOf[P2PKHScriptSignature]
   } yield (signedScriptSig, scriptPubKey, privateKey)
@@ -298,7 +298,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     scriptSig = MultiSignatureScriptSignature(emptyDigitalSignatures)
     (creditingTx, outputIndex) = TransactionGenerators.buildCreditingTransaction(multiSigScriptPubKey)
     (spendingTx, inputIndex) = TransactionGenerators.buildSpendingTransaction(creditingTx, scriptSig, outputIndex)
-    txSigComponentFuture = MultiSigSigner.sign(privateKeys, creditingTx.outputs(outputIndex.toInt), spendingTx, inputIndex, hashType)
+    txSigComponentFuture = MultiSigSigner.sign(privateKeys, creditingTx.outputs(outputIndex.toInt), spendingTx, inputIndex, hashType, false)
     txSigComponent = Await.result(txSigComponentFuture, timeout)
     signedScriptSig = txSigComponent.scriptSignature.asInstanceOf[MultiSignatureScriptSignature]
   } yield (signedScriptSig, multiSigScriptPubKey, privateKeys)

--- a/core/src/main/scala/org/bitcoins/core/crypto/ECDigitalSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ECDigitalSignature.scala
@@ -44,9 +44,20 @@ sealed abstract class ECDigitalSignature {
 }
 
 case object EmptyDigitalSignature extends ECDigitalSignature {
-  def bytes = Nil
+  override val bytes = Nil
   override def r = java.math.BigInteger.valueOf(0)
   override def s = r
+}
+
+/**
+ * The point of this case object is to help with fee estimation
+ * an average [[ECDigitalSignature]] is 72 bytes in size
+ * Technically this number can vary, 72 bytes is the most
+ * likely though according to
+ * https://en.bitcoin.it/wiki/Elliptic_Curve_Digital_Signature_Algorithm
+ */
+case object DummyECDigitalSignature extends ECDigitalSignature {
+  override val bytes = 0.until(72).map(_ => 0.toByte)
 }
 
 object ECDigitalSignature extends Factory[ECDigitalSignature] {


### PR DESCRIPTION
…ss to building a tx with a TxBuilder, but allows them to sign the tx out of band

This gives developers access to the built `unsignedTx` WITH fee estimation and a change output calculate. The fee estimation and change output is calculated with `DummyECDigitalSignatures` as place holders for the real `ECDigitalSignature`.