### PR TITLE
Changing Transaction, BlockHeader version type from UInt32 -> Int32 t…

### DIFF
--- a/core-gen/src/test/scala/org/bitcoins/core/gen/BlockchainElementsGenerator.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/BlockchainElementsGenerator.scala
@@ -2,7 +2,7 @@ package org.bitcoins.core.gen
 
 import org.bitcoins.core.consensus.Merkle
 import org.bitcoins.core.crypto.DoubleSha256Digest
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.blockchain.{ Block, BlockHeader }
 import org.bitcoins.core.protocol.transaction.{ EmptyTransaction, Transaction }
 import org.scalacheck.Gen
@@ -51,7 +51,7 @@ sealed abstract class BlockchainElementsGenerator {
 
   /** Generates a [[BlockHeader]]] that has the fields set to the given values */
   def blockHeader(previousBlockHash: DoubleSha256Digest, nBits: UInt32, txs: Seq[Transaction]): Gen[BlockHeader] = for {
-    version <- NumberGenerator.uInt32s
+    version <- NumberGenerator.int32s
     merkleRootHash = Merkle.computeMerkleRoot(txs)
     time <- NumberGenerator.uInt32s
     nonce <- NumberGenerator.uInt32s
@@ -90,7 +90,7 @@ sealed abstract class BlockchainElementsGenerator {
   private def buildBlockHeader(prevBlockHash: DoubleSha256Digest, nBits: UInt32): BlockHeader = {
     //nonce for the unique hash
     val nonce = NumberGenerator.uInt32s.sample.get
-    BlockHeader(UInt32.one, prevBlockHash, EmptyTransaction.txId, UInt32.one, nBits, nonce)
+    BlockHeader(Int32.one, prevBlockHash, EmptyTransaction.txId, UInt32.one, nBits, nonce)
   }
 }
 

--- a/core-gen/src/test/scala/org/bitcoins/core/gen/ScriptGenerators.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/ScriptGenerators.scala
@@ -414,10 +414,11 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   /** Helper function to generate [[LockTimeScriptSignature]]s */
   private def lockTimeHelper(lockTime: Option[UInt32], sequence: UInt32, lock: LockTimeScriptPubKey, privateKeys: Seq[ECPrivateKey], requiredSigs: Option[Int],
     hashType: HashType): LockTimeScriptSignature = {
+    val tc = TransactionConstants
     val pubKeys = privateKeys.map(_.publicKey)
-    val (creditingTx, outputIndex) = TransactionGenerators.buildCreditingTransaction(UInt32(2), lock)
-    val (unsignedSpendingTx, inputIndex) = TransactionGenerators.buildSpendingTransaction(UInt32(2), creditingTx,
-      EmptyScriptSignature, outputIndex, lockTime.getOrElse(TransactionConstants.lockTime), sequence)
+    val (creditingTx, outputIndex) = TransactionGenerators.buildCreditingTransaction(tc.validLockVersion, lock)
+    val (unsignedSpendingTx, inputIndex) = TransactionGenerators.buildSpendingTransaction(tc.validLockVersion, creditingTx,
+      EmptyScriptSignature, outputIndex, lockTime.getOrElse(tc.lockTime), sequence)
 
     val txSignatureComponent = BaseTxSigComponent(unsignedSpendingTx, inputIndex,
       lock, Policy.standardScriptVerifyFlags)

--- a/core-gen/src/test/scala/org/bitcoins/core/gen/TransactionGenerators.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/TransactionGenerators.scala
@@ -2,7 +2,7 @@ package org.bitcoins.core.gen
 
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency.{ CurrencyUnit, CurrencyUnits, Satoshis }
-import org.bitcoins.core.number.{ Int64, UInt32 }
+import org.bitcoins.core.number.{ Int32, Int64, UInt32 }
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction.{ TransactionInput, TransactionOutPoint, TransactionOutput, _ }
@@ -100,7 +100,7 @@ trait TransactionGenerators extends BitcoinSLogger {
   def transaction: Gen[Transaction] = Gen.oneOf(baseTransaction, witnessTransaction)
 
   def baseTransaction: Gen[BaseTransaction] = for {
-    version <- NumberGenerator.uInt32s
+    version <- NumberGenerator.int32s
     is <- smallInputs
     os <- smallOutputs
     lockTime <- NumberGenerator.uInt32s
@@ -108,7 +108,7 @@ trait TransactionGenerators extends BitcoinSLogger {
 
   /** Generates a random [[WitnessTransaction]] */
   def witnessTransaction: Gen[WitnessTransaction] = for {
-    version <- NumberGenerator.uInt32s
+    version <- NumberGenerator.int32s
     //we cannot have zero witnesses on a WitnessTx
     //https://github.com/bitcoin/bitcoin/blob/e8cfe1ee2d01c493b758a67ad14707dca15792ea/src/primitives/transaction.h#L276-L281
     is <- smallInputsNonEmpty
@@ -346,13 +346,13 @@ trait TransactionGenerators extends BitcoinSLogger {
    * Builds a spending transaction according to bitcoin core
    * @return the built spending transaction and the input index for the script signature
    */
-  def buildSpendingTransaction(version: UInt32, creditingTx: Transaction, scriptSignature: ScriptSignature,
+  def buildSpendingTransaction(version: Int32, creditingTx: Transaction, scriptSignature: ScriptSignature,
     outputIndex: UInt32, locktime: UInt32, sequence: UInt32): (Transaction, UInt32) = {
     val output = TransactionOutput(CurrencyUnits.zero, EmptyScriptPubKey)
     buildSpendingTransaction(version, creditingTx, scriptSignature, outputIndex, locktime, sequence, Seq(output))
   }
 
-  def buildSpendingTransaction(version: UInt32, creditingTx: Transaction, scriptSignature: ScriptSignature,
+  def buildSpendingTransaction(version: Int32, creditingTx: Transaction, scriptSignature: ScriptSignature,
     outputIndex: UInt32, locktime: UInt32, sequence: UInt32, outputs: Seq[TransactionOutput]): (Transaction, UInt32) = {
     val os = if (outputs.isEmpty) {
       Seq(TransactionOutput(CurrencyUnits.zero, EmptyScriptPubKey))
@@ -380,7 +380,7 @@ trait TransactionGenerators extends BitcoinSLogger {
     buildSpendingTransaction(TransactionConstants.version, creditingTx, scriptSignature, outputIndex, locktime, sequence, witness)
   }
 
-  def buildSpendingTransaction(version: UInt32, creditingTx: Transaction, scriptSignature: ScriptSignature, outputIndex: UInt32,
+  def buildSpendingTransaction(version: Int32, creditingTx: Transaction, scriptSignature: ScriptSignature, outputIndex: UInt32,
     locktime: UInt32, sequence: UInt32, witness: TransactionWitness): (WitnessTransaction, UInt32) = {
 
     val outputs = dummyOutputs
@@ -389,7 +389,7 @@ trait TransactionGenerators extends BitcoinSLogger {
 
   def dummyOutputs: Seq[TransactionOutput] = Seq(TransactionOutput(CurrencyUnits.zero, EmptyScriptPubKey))
 
-  def buildSpendingTransaction(version: UInt32, creditingTx: Transaction, scriptSignature: ScriptSignature, outputIndex: UInt32,
+  def buildSpendingTransaction(version: Int32, creditingTx: Transaction, scriptSignature: ScriptSignature, outputIndex: UInt32,
     locktime: UInt32, sequence: UInt32, witness: TransactionWitness, outputs: Seq[TransactionOutput]): (WitnessTransaction, UInt32) = {
     val outpoint = TransactionOutPoint(creditingTx.txId, outputIndex)
     val input = TransactionInput(outpoint, scriptSignature, sequence)
@@ -401,7 +401,7 @@ trait TransactionGenerators extends BitcoinSLogger {
     buildSpendingTransaction(TransactionConstants.version, creditingTx, scriptSignature, outputIndex, witness)
   }
 
-  def buildSpendingTransaction(version: UInt32, creditingTx: Transaction, scriptSignature: ScriptSignature, outputIndex: UInt32,
+  def buildSpendingTransaction(version: Int32, creditingTx: Transaction, scriptSignature: ScriptSignature, outputIndex: UInt32,
     witness: TransactionWitness): (WitnessTransaction, UInt32) = {
     val locktime = TransactionConstants.lockTime
     val sequence = TransactionConstants.sequence
@@ -430,11 +430,11 @@ trait TransactionGenerators extends BitcoinSLogger {
    * Example: useful for creating transactions with scripts containing OP_CHECKSEQUENCEVERIFY.
    * @return
    */
-  def buildCreditingTransaction(version: UInt32, scriptPubKey: ScriptPubKey): (Transaction, UInt32) = {
+  def buildCreditingTransaction(version: Int32, scriptPubKey: ScriptPubKey): (Transaction, UInt32) = {
     buildCreditingTransaction(version, scriptPubKey, CurrencyUnits.zero)
   }
 
-  def buildCreditingTransaction(version: UInt32, output: TransactionOutput): (Transaction, UInt32) = {
+  def buildCreditingTransaction(version: Int32, output: TransactionOutput): (Transaction, UInt32) = {
     val outpoint = EmptyTransactionOutPoint
     val scriptSignature = ScriptSignature("0000")
     val input = TransactionInput(outpoint, scriptSignature, TransactionConstants.sequence)
@@ -442,7 +442,7 @@ trait TransactionGenerators extends BitcoinSLogger {
     (tx, UInt32.zero)
   }
 
-  def buildCreditingTransaction(version: UInt32, scriptPubKey: ScriptPubKey, amount: CurrencyUnit): (Transaction, UInt32) = {
+  def buildCreditingTransaction(version: Int32, scriptPubKey: ScriptPubKey, amount: CurrencyUnit): (Transaction, UInt32) = {
     buildCreditingTransaction(version, TransactionOutput(amount, scriptPubKey))
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawBlockHeaderSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawBlockHeaderSerializerTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.serializers.blockchain
 
 import org.bitcoins.core.crypto.DoubleSha256Digest
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.util.BitcoinSUtil
 import org.scalatest.{ FlatSpec, MustMatchers }
 
@@ -24,7 +24,7 @@ class RawBlockHeaderSerializerTest extends FlatSpec with MustMatchers {
   val hex = version + prevBlockHash + merkleRoot + timeStamp + nBits + nonce
   "BlockHeader" must "parse genesis block header" in {
     val blockHeader = RawBlockHeaderSerializer.read(hex)
-    blockHeader.version must be(UInt32(BitcoinSUtil.flipEndianness(version)))
+    blockHeader.version must be(Int32(BitcoinSUtil.flipEndianness(version)))
     blockHeader.previousBlockHash must be(DoubleSha256Digest(prevBlockHash))
     blockHeader.merkleRootHash must be(DoubleSha256Digest(merkleRoot))
     blockHeader.time must be(UInt32(BitcoinSUtil.flipEndianness(timeStamp)))
@@ -55,7 +55,7 @@ class RawBlockHeaderSerializerTest extends FlatSpec with MustMatchers {
     val hex2 = version2 + prevBlockHash2 + merkleRoot2 + timeStamp2 + nBits2 + nonce2
     val hash = "2837af674e81436b09e0c937e94d96fe32e5c872391ba1090000000000000000"
     val blockHeader = RawBlockHeaderSerializer.read(hex2)
-    blockHeader.version must be(UInt32(2))
+    blockHeader.version must be(Int32(2))
     blockHeader.previousBlockHash must be(DoubleSha256Digest(prevBlockHash2))
     blockHeader.merkleRootHash must be(DoubleSha256Digest(merkleRoot2))
     blockHeader.time must be(UInt32(1415239972))
@@ -74,7 +74,7 @@ class RawBlockHeaderSerializerTest extends FlatSpec with MustMatchers {
     val hex = version + prevBlockHash + merkleRoot + timeStamp + nBits + nonce
     val hash = "c5a764eb61db336edb17be9c49dc07dcae0219bc51a2efe681df9f0000000000"
     val blockHeader = RawBlockHeaderSerializer.read(hex)
-    blockHeader.version must be(UInt32(536870912))
+    blockHeader.version must be(Int32(536870912))
     blockHeader.previousBlockHash must be(DoubleSha256Digest(prevBlockHash))
     blockHeader.merkleRootHash must be(DoubleSha256Digest(merkleRoot))
     blockHeader.time must be(UInt32(1465247498))

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializerTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.serializers.blockchain
 
 import org.bitcoins.core.crypto.DoubleSha256Digest
-import org.bitcoins.core.number.{ UInt32, UInt64 }
+import org.bitcoins.core.number.{ Int32, UInt32, UInt64 }
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.BitcoinSUtil
@@ -106,7 +106,7 @@ class RawBlockSerializerTest extends FlatSpec with MustMatchers {
 
     val block = RawBlockSerializer.read(hex)
     block.blockHeader.hash.hex must be("5f3d49113e7bf838a061a1661c672053deb90891edf3ecfa9e18000000000000")
-    block.blockHeader.version must be(UInt32(536870912))
+    block.blockHeader.version must be(Int32(536870912))
     block.blockHeader.previousBlockHash must be(DoubleSha256Digest(prevBlockHash))
     block.blockHeader.merkleRootHash must be(DoubleSha256Digest(merkleRoot))
     block.blockHeader.time must be(UInt32(1465354640))

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawMerkleBlockSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawMerkleBlockSerializerTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.serializers.blockchain
 
 import org.bitcoins.core.crypto.DoubleSha256Digest
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.blockchain.{ BlockHeader, MerkleBlock, PartialMerkleTree }
 import org.bitcoins.core.util.{ BitcoinSUtil, Leaf, Node }
 import org.scalatest.{ FlatSpec, MustMatchers }
@@ -14,7 +14,7 @@ class RawMerkleBlockSerializerTest extends FlatSpec with MustMatchers {
   "RawMerkleBlockSerializer" must "serialize a merkle block generated inside of scalacheck" in {
 
     val (merkleBlock, txIds) = (MerkleBlock(BlockHeader(
-      UInt32(49150652),
+      Int32(49150652),
       DoubleSha256Digest("6cf34aac6e3de2bf4b429d114ed4572a7ce4b1c44f2091ae6825ee9774dbae2f"),
       DoubleSha256Digest("4487def8ba376b38c1e4e5910d3c9efd27e740cb9be8d452598cbf2e243fad8a"),
       UInt32(2941790316L), UInt32(1626267458), UInt32(1688549344)), UInt32(1),
@@ -33,7 +33,7 @@ class RawMerkleBlockSerializerTest extends FlatSpec with MustMatchers {
   it must "not have any extra hashes left over when deserializing a previously valid partial merkle tree" in {
     val (merkleBlock, txIds) = (
       MerkleBlock(BlockHeader(
-        UInt32(1626792925),
+        Int32(1626792925),
         DoubleSha256Digest("de2fc5fac498126f27c8adaa17aa86a1ef15d2b0adf5f2d2c056495bec17153f"),
         DoubleSha256Digest("f27404d701b9047cfcaa8d8454d2ecc12f4aa3e900ba8e5945bbb9289d67dd63"),
         UInt32(3098237133L), UInt32(359220269), UInt32(590323230)), UInt32(6),

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawBaseTransactionParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawBaseTransactionParserTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.serializers.transaction
 
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.transaction.{ Transaction, TransactionConstants }
 import org.bitcoins.core.util.{ BitcoinSUtil, TestUtil }
 import org.scalatest.{ FlatSpec, MustMatchers }
@@ -12,7 +12,7 @@ class RawBaseTransactionParserTest extends FlatSpec with MustMatchers {
   val encode = BitcoinSUtil.encodeHex(_: Seq[Byte])
   "RawBaseTransactionParser" must "parse a raw transaction" in {
     val tx: Transaction = RawBaseTransactionParser.read(TestUtil.rawTransaction)
-    tx.version must be(UInt32.one)
+    tx.version must be(Int32.one)
     tx.inputs.size must be(2)
     tx.outputs.size must be(2)
     tx.lockTime must be(UInt32.zero)

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.core.protocol.blockchain
 
 import org.bitcoins.core.crypto.DoubleSha256Digest
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.serializers.blockchain.RawBlockHeaderSerializer
-import org.bitcoins.core.util.{ BitcoinSUtil, CryptoUtil, BitcoinSLogger, Factory }
+import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinSUtil, CryptoUtil, Factory }
 
 /**
  * Created by chris on 5/19/16.
@@ -29,7 +29,7 @@ sealed trait BlockHeader extends NetworkElement {
    *
    * @return the version number for this block
    */
-  def version: UInt32
+  def version: Int32
 
   /**
    * A SHA256(SHA256()) hash in internal byte order of the previous block’s header.
@@ -117,10 +117,10 @@ sealed trait BlockHeader extends NetworkElement {
  */
 object BlockHeader extends Factory[BlockHeader] {
 
-  private sealed case class BlockHeaderImpl(version: UInt32, previousBlockHash: DoubleSha256Digest,
+  private sealed case class BlockHeaderImpl(version: Int32, previousBlockHash: DoubleSha256Digest,
     merkleRootHash: DoubleSha256Digest, time: UInt32, nBits: UInt32, nonce: UInt32) extends BlockHeader
 
-  def apply(version: UInt32, previousBlockHash: DoubleSha256Digest, merkleRootHash: DoubleSha256Digest,
+  def apply(version: Int32, previousBlockHash: DoubleSha256Digest, merkleRootHash: DoubleSha256Digest,
     time: UInt32, nBits: UInt32, nonce: UInt32): BlockHeader = {
     BlockHeaderImpl(version, previousBlockHash, merkleRootHash, time, nBits, nonce)
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets
 import org.bitcoins.core.consensus.Merkle
 import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.currency.{ CurrencyUnit, Satoshis }
-import org.bitcoins.core.number.{ Int64, UInt32 }
+import org.bitcoins.core.number.{ Int32, Int64, UInt32 }
 import org.bitcoins.core.protocol.script.{ ScriptPubKey, ScriptSignature }
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.{ BytesToPushOntoStack, ScriptConstant, ScriptNumber }
@@ -57,7 +57,7 @@ sealed abstract class ChainParams {
    * @param amount the block reward for the genesis block (50 BTC in Bitcoin)
    * @return the newly minted genesis block
    */
-  def createGenesisBlock(time: UInt32, nonce: UInt32, nBits: UInt32, version: UInt32, amount: CurrencyUnit): Block = {
+  def createGenesisBlock(time: UInt32, nonce: UInt32, nBits: UInt32, version: Int32, amount: CurrencyUnit): Block = {
     val timestamp = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks"
     val asm = Seq(BytesToPushOntoStack(65), ScriptConstant("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f"), OP_CHECKSIG)
     val genesisOutputScript = ScriptPubKey.fromAsm(asm)
@@ -75,7 +75,7 @@ sealed abstract class ChainParams {
    * @return the newly minted genesis block
    */
   def createGenesisBlock(timestamp: String, scriptPubKey: ScriptPubKey, time: UInt32, nonce: UInt32, nBits: UInt32,
-    version: UInt32, amount: CurrencyUnit): Block = {
+    version: Int32, amount: CurrencyUnit): Block = {
     val timestampBytes = timestamp.getBytes(StandardCharsets.UTF_8)
     //see https://bitcoin.stackexchange.com/questions/13122/scriptsig-coinbase-structure-of-the-genesis-block
     //for a full breakdown of the genesis block & its script signature
@@ -99,7 +99,7 @@ object MainNetChainParams extends BitcoinChainParams {
 
   override def networkId = "main"
 
-  override def genesisBlock: Block = createGenesisBlock(UInt32(1231006505), UInt32(2083236893), UInt32(0x1d00ffff), UInt32.one, Satoshis(Int64(5000000000L)))
+  override def genesisBlock: Block = createGenesisBlock(UInt32(1231006505), UInt32(2083236893), UInt32(0x1d00ffff), Int32.one, Satoshis(Int64(5000000000L)))
 
   override def base58Prefixes: Map[Base58Type, Seq[Byte]] = Map(
     Base58Type.PubKeyAddress -> BitcoinSUtil.decodeHex("00"),
@@ -115,7 +115,7 @@ object TestNetChainParams extends BitcoinChainParams {
 
   override def networkId = "test"
 
-  override def genesisBlock: Block = createGenesisBlock(UInt32(1296688602), UInt32(414098458), UInt32(0x1d00ffff), UInt32.one, Satoshis(Int64(5000000000L)))
+  override def genesisBlock: Block = createGenesisBlock(UInt32(1296688602), UInt32(414098458), UInt32(0x1d00ffff), Int32.one, Satoshis(Int64(5000000000L)))
 
   override def base58Prefixes: Map[Base58Type, Seq[Byte]] = Map(
     Base58Type.PubKeyAddress -> BitcoinSUtil.decodeHex("6f"),
@@ -129,7 +129,7 @@ object TestNetChainParams extends BitcoinChainParams {
 
 object RegTestNetChainParams extends BitcoinChainParams {
   override def networkId = "regtest"
-  override def genesisBlock: Block = createGenesisBlock(UInt32(1296688602), UInt32(2), UInt32(0x207fffff), UInt32.one, Satoshis(Int64(5000000000L)))
+  override def genesisBlock: Block = createGenesisBlock(UInt32(1296688602), UInt32(2), UInt32(0x207fffff), Int32.one, Satoshis(Int64(5000000000L)))
   override def base58Prefixes: Map[Base58Type, Seq[Byte]] = TestNetChainParams.base58Prefixes
 }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol.transaction
 
 import org.bitcoins.core.crypto.DoubleSha256Digest
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.serializers.transaction.{ RawBaseTransactionParser, RawWitnessTransactionParser }
 import org.bitcoins.core.util.{ BitcoinSUtil, CryptoUtil, Factory }
@@ -30,7 +30,7 @@ sealed abstract class Transaction extends NetworkElement {
   def txIdBE: DoubleSha256Digest = txId.flip
 
   /** The version number for this transaction */
-  def version: UInt32
+  def version: Int32
 
   /** The inputs for this transaction */
   def inputs: Seq[TransactionInput]
@@ -141,21 +141,21 @@ object Transaction extends Factory[Transaction] {
 }
 
 object BaseTransaction extends Factory[BaseTransaction] {
-  private case class BaseTransactionImpl(version: UInt32, inputs: Seq[TransactionInput],
+  private case class BaseTransactionImpl(version: Int32, inputs: Seq[TransactionInput],
     outputs: Seq[TransactionOutput], lockTime: UInt32) extends BaseTransaction
 
   override def fromBytes(bytes: Seq[Byte]): BaseTransaction = RawBaseTransactionParser.read(bytes)
 
-  def apply(version: UInt32, inputs: Seq[TransactionInput],
+  def apply(version: Int32, inputs: Seq[TransactionInput],
     outputs: Seq[TransactionOutput], lockTime: UInt32): BaseTransaction = BaseTransactionImpl(version, inputs, outputs, lockTime)
 }
 
 object WitnessTransaction extends Factory[WitnessTransaction] {
-  private case class WitnessTransactionImpl(version: UInt32, inputs: Seq[TransactionInput],
+  private case class WitnessTransactionImpl(version: Int32, inputs: Seq[TransactionInput],
     outputs: Seq[TransactionOutput], lockTime: UInt32,
     witness: TransactionWitness) extends WitnessTransaction
 
-  def apply(version: UInt32, inputs: Seq[TransactionInput], outputs: Seq[TransactionOutput],
+  def apply(version: Int32, inputs: Seq[TransactionInput], outputs: Seq[TransactionOutput],
     lockTime: UInt32, witness: TransactionWitness): WitnessTransaction =
     WitnessTransactionImpl(version, inputs, outputs, lockTime, witness)
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionConstants.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionConstants.scala
@@ -1,14 +1,14 @@
 package org.bitcoins.core.protocol.transaction
 
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{ Int32, UInt32 }
 
 /**
  * Created by chris on 2/12/16.
  */
 trait TransactionConstants {
 
-  lazy val version = UInt32.one
-  lazy val validLockVersion = UInt32(2)
+  lazy val version = Int32.one
+  lazy val validLockVersion = Int32(2)
   lazy val lockTime = UInt32.zero
   lazy val sequence = UInt32(4294967295L)
 

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
@@ -94,7 +94,7 @@ sealed abstract class LockTimeInterpreter {
           //see BIP68 for semantic of locktimeDisableFlag
           logger.info("Locktime disable flag was set so OP_CHECKSEQUENCEVERIFY is treated as a NOP")
           ScriptProgram(program, program.script.tail, ScriptProgram.Script)
-        case s: ScriptNumber if (isLockTimeBitOff(s) && program.txSignatureComponent.transaction.version < UInt32(2)) =>
+        case s: ScriptNumber if (isLockTimeBitOff(s) && program.txSignatureComponent.transaction.version < TransactionConstants.validLockVersion) =>
           logger.error("OP_CSV fails if locktime bit is not set and the tx version < 2")
           ScriptProgram(program, ScriptErrorUnsatisfiedLocktime)
         case s: ScriptNumber =>
@@ -135,7 +135,7 @@ sealed abstract class LockTimeInterpreter {
 
     // Fail if the transaction's version number is not set high
     // enough to trigger BIP 68 rules.
-    if (program.txSignatureComponent.transaction.version < UInt32(2)) {
+    if (program.txSignatureComponent.transaction.version < TransactionConstants.validLockVersion) {
       logger.error("OP_CSV fails the script if the transaction's version is less than 2.")
       return false
     }

--- a/core/src/main/scala/org/bitcoins/core/serializers/blockchain/RawBlockHeaderSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/blockchain/RawBlockHeaderSerializer.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.serializers.blockchain
 
 import org.bitcoins.core.crypto.DoubleSha256Digest
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.serializers.RawBitcoinSerializer
 
@@ -15,7 +15,7 @@ sealed abstract class RawBlockHeaderSerializer extends RawBitcoinSerializer[Bloc
   /** Converts a list of bytes into a block header */
   def read(bytes: List[Byte]): BlockHeader = {
     //version first 4 bytes
-    val version = UInt32(bytes.take(4).reverse)
+    val version = Int32(bytes.take(4).reverse)
     //previous header hash next 32 bytes
     val prevBlockHashBytes = bytes.slice(4, 36)
     val prevBlockHash: DoubleSha256Digest = DoubleSha256Digest(prevBlockHashBytes)

--- a/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawBaseTransactionParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawBaseTransactionParser.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.serializers.transaction
 
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.transaction.{ BaseTransaction, TransactionInput, TransactionOutput }
 import org.bitcoins.core.serializers.{ RawBitcoinSerializer, RawSerializerHelper }
 
@@ -14,7 +14,7 @@ sealed abstract class RawBaseTransactionParser extends RawBitcoinSerializer[Base
   val helper = RawSerializerHelper
   def read(bytes: List[Byte]): BaseTransaction = {
     val versionBytes = bytes.take(4)
-    val version = UInt32(versionBytes.reverse)
+    val version = Int32(versionBytes.reverse)
     val txInputBytes = bytes.slice(4, bytes.size)
     val (inputs, outputBytes) = helper.parseCmpctSizeUIntSeq(txInputBytes, RawTransactionInputParser.read(_))
     val (outputs, lockTimeBytes) = helper.parseCmpctSizeUIntSeq(

--- a/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawWitnessTransactionParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawWitnessTransactionParser.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.serializers.transaction
 
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.script.EmptyScriptWitness
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.serializers.{ RawBitcoinSerializer, RawSerializerHelper }
@@ -21,7 +21,7 @@ sealed abstract class RawWitnessTransactionParser extends RawBitcoinSerializer[W
    */
   def read(bytes: List[Byte]): WitnessTransaction = {
     val versionBytes = bytes.take(4)
-    val version = UInt32(versionBytes.reverse)
+    val version = Int32(versionBytes.reverse)
     val marker = bytes(4)
     require(marker.toInt == 0, "Incorrect marker for witness transaction, the marker MUST be 0 for the marker according to BIP141, got: " + marker)
     val flag = bytes(5)

--- a/core/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
@@ -123,7 +123,7 @@ sealed abstract class EscrowTimeoutHelper {
       val tc = TransactionConstants
       val uScriptWitness = P2WSHWitnessV0(lock)
       val uTxWitness = TransactionWitness(Seq(uScriptWitness))
-      val uwtx = WitnessTransaction(tc.validLockVersion, inputs, outputs, tc.validLockVersion, uTxWitness)
+      val uwtx = WitnessTransaction(tc.validLockVersion, inputs, outputs, tc.lockTime, uTxWitness)
       val u = WitnessTxSigComponentRaw(uwtx, inputIndex, witSPK, Policy.standardFlags, amount)
       val signature = TransactionSignatureCreator.createSig(u, privKey, hashType)
       val scriptSig = CSVScriptSignature(P2PKHScriptSignature(signature, privKey.publicKey))


### PR DESCRIPTION
…o reflect what the bitcoin protocol actually is

The version types on [`Transaction`](https://github.com/bitcoin/bitcoin/blob/master/src/primitives/transaction.h#L366) and [`BlockHeader`](https://github.com/bitcoin/bitcoin/blob/master/src/primitives/block.h#L24) are actually `Int32`s, not `UInt32`s. 