### PR TITLE
Fix overflow bug with parsing script with OP_PUSHDATA4

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -93,6 +93,11 @@ class TransactionTest extends FlatSpec with MustMatchers {
 
   }
 
+  it must "parse a transaction with an OP_PUSHDATA4 op code but not enough data to push" in {
+    val hex = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff2a03f35c0507062f503253482ffe4ecb3b55fefbde06000963676d696e6572343208040000000000000000ffffffff0100f90295000000001976a91496621bc1c9d1e5a1293e401519365de820792bbc88ac00000000"
+    val btx = BaseTransaction.fromHex(hex)
+    btx.hex must be(hex)
+  }
   it must "read all of the tx_valid.json's contents and return ScriptOk" in {
     val source = Source.fromURL(getClass.getResource("/tx_valid.json"))
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -29,7 +29,7 @@ sealed abstract class TransactionSignatureSerializer {
 
   /**
    * Implements the signature serialization algorithim that Satoshi Nakamoto originally created
-    * and the new signature serialization algorithm as specified by BIP143
+   * and the new signature serialization algorithm as specified by BIP143
    * [[https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki]]
    * [[https://github.com/bitcoin/bitcoin/blob/f8528134fc188abc5c7175a19680206964a8fade/src/script/interpreter.cpp#L1113]]
    */

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -221,9 +221,14 @@ sealed abstract class ScriptParser extends Factory[List[ScriptToken]] {
       //TODO: Review this more, see this transaction's scriptSig as an example: b30d3148927f620f5b1228ba941c211fdabdae75d0ba0b688a58accbf018f3cc
       val bytesForPushOp = Try(uInt32Push.toInt).getOrElse(Int.MaxValue)
       val bytesToPushOntoStack = ScriptConstant(scriptConstantHex)
-      val scriptConstantBytes = tail.slice(numBytes, bytesForPushOp + numBytes)
+      val endIndex = {
+        val idx = bytesForPushOp + numBytes
+        //for the case of an overflow. Just assume Int.MaxValue for slice operation which only takes a Int
+        if (idx >= 0) idx else Int.MaxValue
+      }
+      val scriptConstantBytes = tail.slice(numBytes, endIndex)
       val scriptConstant = ScriptConstant(scriptConstantBytes)
-      val restOfBytes = tail.slice(bytesForPushOp + numBytes, tail.size)
+      val restOfBytes = tail.slice(endIndex, tail.size)
       buildParsingHelper(op, bytesToPushOntoStack, scriptConstant, restOfBytes, accum)
     }
 


### PR DESCRIPTION
This fixes a bug with parsing scripts and large values for `OP_PUSHDATA4`. We did not have an overflow check previously which would allow a number to go negative which would not cause a value to be pushed onto the stack. It would be interpreted as a `ScriptOperation` instead. 