### PR TITLE
fix generator bug for TranasctionInput

### DIFF
--- a/core-gen/src/test/scala/org/bitcoins/core/gen/TransactionGenerators.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/TransactionGenerators.scala
@@ -80,10 +80,10 @@ trait TransactionGenerators extends BitcoinSLogger {
     } else TransactionInput(outPoint, scriptSig, sequenceNumber)
   }
 
-  def inputs = Gen.listOf(input)
+  def inputs: Gen[List[TransactionInput]] = Gen.nonEmptyListOf(input)
 
   /** Generates a small list of [[TransactionInput]] */
-  def smallInputs: Gen[Seq[TransactionInput]] = Gen.choose(0, 5).flatMap(i => Gen.listOfN(i, input))
+  def smallInputs: Gen[Seq[TransactionInput]] = Gen.choose(1, 5).flatMap(i => Gen.listOfN(i, input))
 
   /** Generates a small non empty list of [[TransactionInput]] */
   def smallInputsNonEmpty: Gen[Seq[TransactionInput]] = Gen.choose(1, 5).flatMap(i => Gen.listOfN(i, input))


### PR DESCRIPTION
This PR modifies the `TransactionInput` generator to always generate at least 1 `TransactionInput`. [It is consensus invalid to have a transaction with zero inputs.](https://github.com/bitcoin/bitcoin/blob/master/src/consensus/tx_verify.cpp#L162).

This will resolve travis failures like this one, where parsing was failing due to a `BaseTransaction` with zero inputs looking like a `WitnessTransaction`. 

https://travis-ci.org/bitcoin-s/bitcoin-s-core/jobs/385314627#L3142

Here is a branch that explores that: 

https://github.com/Christewart/bitcoin-s-core/commits/block_serialization_bug