### PR TITLE
refactor hash type to derive the byte from the underlying int32, refa…

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/HashTypeSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/HashTypeSpec.scala
@@ -1,0 +1,24 @@
+package org.bitcoins.core.script.crypto
+
+import org.bitcoins.core.gen.NumberGenerator
+import org.bitcoins.core.util.BitcoinSLogger
+import org.scalacheck.{ Prop, Properties }
+
+class HashTypeSpec extends Properties("HashTypeSpec") {
+  private val logger = BitcoinSLogger.logger
+  property("serialization symmetry") = {
+    Prop.forAll(NumberGenerator.int32s) { i32 =>
+      val hashType = HashType.fromBytes(i32.bytes)
+
+      hashType.num == i32 &&
+        i32.bytes.last == hashType.byte &&
+        //this check cannot check the other 3 bytes in
+        //hash type as they are discarded from inclusion
+        //on a bitcoin digital signature. Not sure why satoshi
+        //would have just used a uint8_t to represent a hash type
+        //instead of a uint32_t.
+        HashType.fromByte(hashType.byte).byte == hashType.byte
+
+    }
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/HashTypeTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/HashTypeTest.scala
@@ -42,12 +42,12 @@ class HashTypeTest extends FlatSpec with MustMatchers {
   }
 
   it must "determine if a given number is of hashType SIGHASH_ALL" in {
-    HashType.isSIGHASH_ALL(Int32.zero) must be(true)
-    HashType.isSIGHASH_ALL(Int32.one) must be(true)
-    HashType.isSIGHASH_ALL(Int32(5)) must be(true)
+    HashType.isSigHashAll(Int32.zero) must be(true)
+    HashType.isSigHashAll(Int32.one) must be(true)
+    HashType.isSigHashAll(Int32(5)) must be(true)
 
-    HashType.isSIGHASH_ALL(HashType.sigHashNone.num) must be(false)
-    HashType.isSIGHASH_ALL(HashType.sigHashSingle.num) must be(false)
+    HashType.isSigHashAll(HashType.sigHashNone.num) must be(false)
+    HashType.isSigHashAll(HashType.sigHashSingle.num) must be(false)
   }
 
   it must "return the correct byte for a given hashtype" in {

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -136,8 +136,8 @@ sealed abstract class TransactionSignatureSerializer {
         }
       case SigVersionWitnessV0 =>
         val isNotAnyoneCanPay = !HashType.isAnyoneCanPay(hashType)
-        val isNotSigHashSingle = !(HashType.isSIGHASH_SINGLE(hashType.num))
-        val isNotSigHashNone = !(HashType.isSIGHASH_NONE(hashType.num))
+        val isNotSigHashSingle = !(HashType.isSigHashSingle(hashType.num))
+        val isNotSigHashNone = !(HashType.isSigHashNone(hashType.num))
         val inputIndexInt = inputIndex.toInt
         val emptyHash = CryptoUtil.emptyDoubleSha256Hash
 
@@ -154,7 +154,8 @@ sealed abstract class TransactionSignatureSerializer {
         val outputHash: Seq[Byte] = if (isNotSigHashSingle && isNotSigHashNone) {
           val bytes = spendingTransaction.outputs.flatMap(o => o.bytes)
           CryptoUtil.doubleSHA256(bytes).bytes
-        } else if (HashType.isSIGHASH_SINGLE(hashType.num) && inputIndex < UInt32(spendingTransaction.outputs.size)) {
+        } else if (HashType.isSigHashSingle(hashType.num) &&
+          inputIndex < UInt32(spendingTransaction.outputs.size)) {
           val output = spendingTransaction.outputs(inputIndexInt)
           val bytes = CryptoUtil.doubleSHA256(RawTransactionOutputParser.write(output)).bytes
           bytes


### PR DESCRIPTION
…ctor some other things to make hash type nicer

Fixes a bug where the underlying `Int32` inside of a HashType and the `byte` representation we cached could diverge. 