### PR TITLE
Configure Travis-CI for multiproject build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,9 @@ install:
   - ./configure --enable-jni --enable-experimental --enable-module-ecdh
   - sudo make install
   - cd ../
-script: sbt -Djava.library.path=secp256k1/.libs clean coverage test
-after_success: "sbt coverageReport coverageAggregate coveralls"
+script:
+  - sbt -Djava.library.path=secp256k1/.libs clean coverage test &&
+    sbt coverageReport &&
+    sbt coverageAggregate
+after_success:
+  - sbt coveralls


### PR DESCRIPTION
This pull request is intended to resolve issue #174. The issue was that Travis-CI requires an exit code of 1 to fail a build. With the previous build configuration, when the coverageReport failed, it was not correctly exiting, which caused the build to pass, even when coverage had fallen below 90%. I have modified the configuration to comply with the Travis-CI multiproject guidelines (see https://github.com/scoverage/sbt-coveralls#travis-ci-integration).

The build is now (correctly) failing when coverage is below 90%: https://travis-ci.org/TannerR1776/bitcoin-s-core/builds/395423421