### PR TITLE
WIP: Add support for Lightning Network Currency Units

### DIFF
--- a/core-gen/src/test/scala/org/bitcoins/core/gen/CurrencyUnitGenerator.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/CurrencyUnitGenerator.scala
@@ -1,7 +1,8 @@
 package org.bitcoins.core.gen
 
 import org.bitcoins.core.currency.{ Bitcoins, CurrencyUnit, CurrencyUnits, Satoshis }
-import org.bitcoins.core.number.Int64
+import org.bitcoins.core.number.{ Int32, Int64 }
+import org.bitcoins.core.protocol.ln._
 import org.scalacheck.Gen
 
 /**
@@ -31,3 +32,28 @@ trait CurrencyUnitGenerator {
 }
 
 object CurrencyUnitGenerator extends CurrencyUnitGenerator
+
+trait LnCurrencyUnitGenerator {
+
+  def milliBitcoin: Gen[MilliBitcoins] = for {
+    amount <- Gen.choose(MilliBitcoins.min.toLong, MilliBitcoins.max.toLong)
+  } yield MilliBitcoins(amount)
+
+  def microBitcoin: Gen[MicroBitcoins] = for {
+    amount <- Gen.choose(MicroBitcoins.min.toLong, MicroBitcoins.max.toLong)
+  } yield MicroBitcoins(amount)
+
+  def nanoBitcoin: Gen[NanoBitcoins] = for {
+    amount <- Gen.choose(NanoBitcoins.min.toLong, NanoBitcoins.max.toLong)
+  } yield NanoBitcoins(amount)
+
+  def picoBitcoin: Gen[PicoBitcoins] = for {
+    amount <- Gen.choose(PicoBitcoins.min.toLong, PicoBitcoins.max.toLong)
+  } yield PicoBitcoins(amount)
+
+  def lnCurrencyUnit: Gen[LnCurrencyUnit] = Gen.oneOf(milliBitcoin, microBitcoin, nanoBitcoin, picoBitcoin)
+
+  def negativeLnCurrencyUnit: Gen[LnCurrencyUnit] = lnCurrencyUnit.suchThat(_ < LnCurrencyUnits.zero)
+}
+
+object LnCurrencyUnitGenerator extends LnCurrencyUnitGenerator

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnCurrencyUnitSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnCurrencyUnitSpec.scala
@@ -1,0 +1,75 @@
+package org.bitcoins.core.protocol.ln
+
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.gen.LnCurrencyUnitGenerator
+import org.scalacheck.{ Prop, Properties }
+
+import scala.util.Try
+
+class LnCurrencyUnitSpec extends Properties("LnCurrencyUnitSpec") {
+
+  property("Additive identity for LnCurrencyUnits") =
+    Prop.forAll(LnCurrencyUnitGenerator.lnCurrencyUnit) { lnUnit =>
+      lnUnit + LnCurrencyUnits.zero == lnUnit
+    }
+
+  property("Add two LnCurrencyUnits") =
+    Prop.forAll(LnCurrencyUnitGenerator.lnCurrencyUnit, LnCurrencyUnitGenerator.lnCurrencyUnit) { (num1: LnCurrencyUnit, num2: LnCurrencyUnit) =>
+      val result: Try[LnCurrencyUnit] = Try(num1 + num2)
+      if (result.isSuccess && result.get >= PicoBitcoins.min &&
+        result.get <= PicoBitcoins.max) num1 + num2 == result.get
+      else Try(num1 + num2).isFailure
+    }
+
+  property("Subtractive identity for LnCurrencyUnits") =
+    Prop.forAll(LnCurrencyUnitGenerator.lnCurrencyUnit) { lnUnit =>
+      lnUnit - LnCurrencyUnits.zero == lnUnit
+    }
+
+  property("Subtract two LnCurrencyUnit values") =
+    Prop.forAll(LnCurrencyUnitGenerator.lnCurrencyUnit, LnCurrencyUnitGenerator.lnCurrencyUnit) { (num1: LnCurrencyUnit, num2: LnCurrencyUnit) =>
+      val result: Try[LnCurrencyUnit] = Try(num1 - num2)
+      if (result.isSuccess && result.get >= PicoBitcoins.min &&
+        result.get <= PicoBitcoins.max) num1 - num2 == result.get
+      else Try(num1 - num2).isFailure
+    }
+
+  property("Multiply LnCurrencyUnit by zero") =
+    Prop.forAll(LnCurrencyUnitGenerator.lnCurrencyUnit) { lnUnit =>
+      lnUnit * LnCurrencyUnits.zero == LnCurrencyUnits.zero
+    }
+
+  property("Multiplicative identity for LnCurrencyUnits") =
+    Prop.forAll(LnCurrencyUnitGenerator.lnCurrencyUnit) { lnUnit =>
+      lnUnit * LnCurrencyUnits.onePicoBTC == lnUnit
+    }
+
+  property("Multiply two LnCurrencyUnit values") =
+    Prop.forAll(LnCurrencyUnitGenerator.lnCurrencyUnit, LnCurrencyUnitGenerator.lnCurrencyUnit) { (num1: LnCurrencyUnit, num2: LnCurrencyUnit) =>
+      val result: Try[LnCurrencyUnit] = Try(num1 * num2)
+      if (result.isSuccess && result.get >= PicoBitcoins.min &&
+        result.get <= PicoBitcoins.max) num1 * num2 == result.get
+      else Try(num1 * num2).isFailure
+    }
+
+  property("Convert negative LnCurrencyUnit value to Satoshis") =
+    Prop.forAll(LnCurrencyUnitGenerator.negativeLnCurrencyUnit) { lnUnit =>
+      lnUnit.toSatoshis == Satoshis.zero
+    }
+
+  property("< & >=") =
+    Prop.forAll(LnCurrencyUnitGenerator.lnCurrencyUnit, LnCurrencyUnitGenerator.lnCurrencyUnit) { (num1: LnCurrencyUnit, num2: LnCurrencyUnit) =>
+      (num1 < num2) || (num1 >= num2)
+    }
+
+  property("<= & >") =
+    Prop.forAll(LnCurrencyUnitGenerator.lnCurrencyUnit, LnCurrencyUnitGenerator.lnCurrencyUnit) { (num1: LnCurrencyUnit, num2: LnCurrencyUnit) =>
+      (num1 <= num2) || (num1 > num2)
+    }
+
+  property("== & !=") =
+    Prop.forAll(LnCurrencyUnitGenerator.lnCurrencyUnit, LnCurrencyUnitGenerator.lnCurrencyUnit) { (num1: LnCurrencyUnit, num2: LnCurrencyUnit) =>
+      (num1 == num2) || (num1 != num2)
+    }
+}
+

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnCurrencyUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnCurrencyUnitTest.scala
@@ -1,0 +1,10 @@
+package org.bitcoins.core.protocol.ln
+
+import org.scalatest.{ FlatSpec, MustMatchers }
+
+class LnCurrencyUnitTest extends FlatSpec with MustMatchers {
+  it must "serialize MicroBitcoins to string" in {
+    val microBitcoins = MicroBitcoins(1000)
+    microBitcoins.toEncodedString must be("1000u")
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnCurrencyUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnCurrencyUnit.scala
@@ -1,0 +1,231 @@
+package org.bitcoins.core.protocol.ln
+
+import org.bitcoins.core.currency.{ Bitcoins, Satoshis }
+import org.bitcoins.core.number.{ BaseNumbers, Int64 }
+import org.bitcoins.core.protocol.NetworkElement
+import scodec.bits.ByteVector
+
+import scala.math.BigDecimal.RoundingMode
+
+sealed abstract class LnCurrencyUnit extends NetworkElement {
+  type A
+
+  def character: Char
+
+  def multiplier: BigDecimal
+
+  def >=(ln: LnCurrencyUnit): Boolean = {
+    toPicoBitcoinValue >= ln.toPicoBitcoinValue
+  }
+
+  def >(ln: LnCurrencyUnit): Boolean = {
+    toPicoBitcoinValue > ln.toPicoBitcoinValue
+  }
+
+  def <(ln: LnCurrencyUnit): Boolean = {
+    toPicoBitcoinValue < ln.toPicoBitcoinValue
+  }
+
+  def <=(ln: LnCurrencyUnit): Boolean = {
+    toPicoBitcoinValue <= ln.toPicoBitcoinValue
+  }
+
+  def !=(ln: LnCurrencyUnit): Boolean = !(this == ln)
+
+  def ==(ln: LnCurrencyUnit): Boolean = toPicoBitcoinValue == ln.toPicoBitcoinValue
+
+  def +(ln: LnCurrencyUnit): LnCurrencyUnit = {
+    PicoBitcoins(toPicoBitcoinValue + ln.toPicoBitcoinValue)
+  }
+
+  def -(ln: LnCurrencyUnit): LnCurrencyUnit = {
+    PicoBitcoins(toPicoBitcoinValue - ln.toPicoBitcoinValue)
+  }
+
+  def *(ln: LnCurrencyUnit): LnCurrencyUnit = {
+    PicoBitcoins(toPicoBitcoinValue * ln.toPicoBitcoinValue)
+  }
+
+  def unary_- : LnCurrencyUnit = {
+    PicoBitcoins(-toPicoBitcoinValue)
+  }
+
+  override def bytes: ByteVector = Int64(toPicoBitcoinValue).bytes.reverse
+
+  def toBigInt: BigInt
+
+  def toLong: Long = toBigInt.toLong
+
+  def toInt: Int = {
+    require(this.toBigInt >= Int.MinValue, "Number was too small for Int, got: " + underlying)
+    require(this.toBigInt <= Int.MaxValue, "Number was too big for Int, got: " + underlying)
+    toBigInt.toInt
+  }
+
+  protected def underlying: A
+
+  def toSatoshis: Satoshis
+
+  def toPicoBitcoinValue: BigInt
+
+  def toPicoBitcoinMultiplier: Int
+
+  def toEncodedString: String = this.toBigInt + this.character.toString()
+}
+
+sealed abstract class MilliBitcoins extends LnCurrencyUnit {
+  override type A = BigInt
+
+  override def character: Char = 'm'
+
+  override def multiplier: BigDecimal = LnPolicy.milliMultiplier
+
+  override def toPicoBitcoinMultiplier: Int = 1000000000
+
+  override def toBigInt: A = underlying
+
+  override def toSatoshis: Satoshis = LnCurrencyUnits.toSatoshi(this)
+
+  override def toPicoBitcoinValue: BigInt = LnCurrencyUnits.toPicoBitcoinValue(this)
+}
+
+object MilliBitcoins extends BaseNumbers[MilliBitcoins] {
+  val min = MilliBitcoins(LnPolicy.minMilliBitcoins)
+  val max = MilliBitcoins(LnPolicy.maxMilliBitcoins)
+  val zero = MilliBitcoins(0)
+  val one = MilliBitcoins(1)
+
+  def apply(milliBitcoins: Int64): MilliBitcoins = MilliBitcoins(milliBitcoins.toBigInt)
+
+  def apply(underlying: BigInt): MilliBitcoins = MilliBitcoinsImpl(underlying)
+
+  private case class MilliBitcoinsImpl(underlying: BigInt) extends MilliBitcoins {
+    require(underlying >= LnPolicy.minMilliBitcoins, "Number was too small for MilliBitcoins, got: " + underlying)
+    require(underlying <= LnPolicy.maxMilliBitcoins, "Number was too big for MilliBitcoins, got: " + underlying)
+  }
+}
+
+sealed abstract class MicroBitcoins extends LnCurrencyUnit {
+  override type A = BigInt
+
+  override def character: Char = 'u'
+
+  override def multiplier: BigDecimal = LnPolicy.microMultiplier
+
+  override def toPicoBitcoinMultiplier: Int = 1000000
+
+  override def toBigInt: A = underlying
+
+  override def toSatoshis: Satoshis = LnCurrencyUnits.toSatoshi(this)
+
+  override def toPicoBitcoinValue: BigInt = LnCurrencyUnits.toPicoBitcoinValue(this)
+}
+
+object MicroBitcoins extends BaseNumbers[MicroBitcoins] {
+  val min = MicroBitcoins(LnPolicy.minMicroBitcoins)
+  val max = MicroBitcoins(LnPolicy.maxMicroBitcoins)
+  val zero = MicroBitcoins(0)
+  val one = MicroBitcoins(1)
+
+  def apply(microBitcoins: Int64): MicroBitcoins = MicroBitcoins(microBitcoins.toBigInt)
+
+  def apply(underlying: BigInt): MicroBitcoins = MicroBitcoinsImpl(underlying)
+
+  private case class MicroBitcoinsImpl(underlying: BigInt) extends MicroBitcoins {
+    require(underlying >= LnPolicy.minMicroBitcoins, "Number was too small for MicroBitcoins, got: " + underlying)
+    require(underlying <= LnPolicy.maxMicroBitcoins, "Number was too big for MicroBitcoins, got: " + underlying)
+  }
+}
+
+sealed abstract class NanoBitcoins extends LnCurrencyUnit {
+  override type A = BigInt
+
+  override def character: Char = 'n'
+
+  override def multiplier: BigDecimal = LnPolicy.nanoMultiplier
+
+  override def toPicoBitcoinMultiplier: Int = 1000
+
+  override def toBigInt: A = underlying
+
+  override def toSatoshis: Satoshis = LnCurrencyUnits.toSatoshi(this)
+
+  override def toPicoBitcoinValue: BigInt = LnCurrencyUnits.toPicoBitcoinValue(this)
+}
+
+object NanoBitcoins extends BaseNumbers[NanoBitcoins] {
+  val min = NanoBitcoins(LnPolicy.minNanoBitcoins)
+  val max = NanoBitcoins(LnPolicy.maxNanoBitcoins)
+  val zero = NanoBitcoins(0)
+  val one = NanoBitcoins(1)
+
+  def apply(nanoBitcoins: Int64): NanoBitcoins = NanoBitcoins(nanoBitcoins.toBigInt)
+
+  def apply(underlying: BigInt): NanoBitcoins = NanoBitcoinsImpl(underlying)
+
+  private case class NanoBitcoinsImpl(underlying: BigInt) extends NanoBitcoins {
+    require(underlying >= LnPolicy.minNanoBitcoins, "Number was too small for NanoBitcoins, got: " + underlying)
+    require(underlying <= LnPolicy.maxNanoBitcoins, "Number was too big for NanoBitcoins, got: " + underlying)
+  }
+}
+
+sealed abstract class PicoBitcoins extends LnCurrencyUnit {
+  override type A = BigInt
+
+  override def character: Char = 'p'
+
+  override def multiplier: BigDecimal = LnPolicy.picoMultiplier
+
+  override def toPicoBitcoinMultiplier: Int = 1
+
+  override def toBigInt: A = underlying
+
+  override def toSatoshis: Satoshis = LnCurrencyUnits.toSatoshi(this)
+
+  override def toPicoBitcoinValue: BigInt = this.toBigInt
+}
+
+object PicoBitcoins extends BaseNumbers[PicoBitcoins] {
+  val min = PicoBitcoins(LnPolicy.minPicoBitcoins)
+  val max = PicoBitcoins(LnPolicy.maxPicoBitcoins)
+  val zero = PicoBitcoins(0)
+  val one = PicoBitcoins(1)
+
+  def apply(picoBitcoins: Int64): PicoBitcoins = PicoBitcoins(picoBitcoins.toBigInt)
+
+  def apply(underlying: BigInt): PicoBitcoins = PicoBitcoinsImpl(underlying)
+
+  private case class PicoBitcoinsImpl(underlying: BigInt) extends PicoBitcoins {
+    require(underlying >= LnPolicy.minPicoBitcoins, "Number was too small for PicoBitcoins, got: " + underlying)
+    require(underlying <= LnPolicy.maxPicoBitcoins, "Number was too big for PicoBitcoins, got: " + underlying)
+  }
+}
+
+object LnCurrencyUnits {
+  val oneMilliBTC: LnCurrencyUnit = MilliBitcoins.one
+  val oneMicroBTC: LnCurrencyUnit = MicroBitcoins.one
+  val oneNanoBTC: LnCurrencyUnit = NanoBitcoins.one
+  val onePicoBTC: LnCurrencyUnit = PicoBitcoins.one
+  val zero = PicoBitcoins(0)
+
+  val milliMultiplier: BigDecimal = LnPolicy.milliMultiplier
+  val microMultiplier: BigDecimal = LnPolicy.microMultiplier
+  val nanoMultiplier: BigDecimal = LnPolicy.nanoMultiplier
+  val picoMultiplier: BigDecimal = LnPolicy.picoMultiplier
+
+  def toPicoBitcoinValue(lnCurrencyUnits: LnCurrencyUnit): BigInt = {
+    lnCurrencyUnits.toBigInt * lnCurrencyUnits.toPicoBitcoinMultiplier
+  }
+
+  /**
+   * For information regarding the rounding of sub-Satoshi values, please visit:
+   * https://github.com/lightningnetwork/lightning-rfc/blob/master/03-transactions.md#commitment-transaction-outputs
+   */
+  def toSatoshi(lnCurrencyUnits: LnCurrencyUnit): Satoshis = {
+    val sat = BigDecimal(lnCurrencyUnits.toBigInt) * Bitcoins.one.satoshis.toBigDecimal * lnCurrencyUnits.multiplier
+    val rounded = sat.setScale(0, RoundingMode.DOWN)
+    if (rounded >= 1) {
+      Satoshis(Int64(rounded.toBigIntExact().get))
+    } else Satoshis.zero
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnPolicy.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnPolicy.scala
@@ -1,0 +1,22 @@
+package org.bitcoins.core.protocol.ln
+
+import org.bitcoins.core.number.Int64
+
+sealed abstract class LnPolicy {
+
+  val milliMultiplier: BigDecimal = BigDecimal(0.001)
+  val microMultiplier: BigDecimal = BigDecimal(0.000001)
+  val nanoMultiplier: BigDecimal = BigDecimal(0.000000001)
+  val picoMultiplier: BigDecimal = BigDecimal(0.000000000001)
+
+  val maxPicoBitcoins: BigInt = Int64.max.toBigInt
+  val minPicoBitcoins: BigInt = Int64.min.toBigInt
+  val maxMilliBitcoins: BigInt = maxPicoBitcoins / (milliMultiplier / picoMultiplier).toBigIntExact().get
+  val minMilliBitcoins: BigInt = -(maxPicoBitcoins / (milliMultiplier / picoMultiplier).toBigIntExact().get)
+  val maxMicroBitcoins: BigInt = maxPicoBitcoins / (microMultiplier / picoMultiplier).toBigIntExact().get
+  val minMicroBitcoins: BigInt = -(maxPicoBitcoins / (microMultiplier / picoMultiplier).toBigIntExact().get)
+  val maxNanoBitcoins: BigInt = maxPicoBitcoins / (nanoMultiplier / picoMultiplier).toBigIntExact().get
+  val minNanoBitcoins: BigInt = -(maxPicoBitcoins / (nanoMultiplier / picoMultiplier).toBigIntExact().get)
+}
+
+object LnPolicy extends LnPolicy


### PR DESCRIPTION
This PR is to add support for Lightning Network currency units, such as MilliBitcoin and MicroBitcoin.

These new currency units are in support of Issue #177, and will be used in the creation of Lightning network invoices in the future.

This PR is still a WIP.