### PR TITLE
Add 'Bitcoind' prefix to all bitcoind specific rpc stuff

### DIFF
--- a/rpc/src/main/scala/org/bitcoins/rpc/client/BitcoindRpcClient.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/client/BitcoindRpcClient.scala
@@ -11,27 +11,23 @@ import akka.util.ByteString
 import org.bitcoins.core.crypto.{ DoubleSha256Digest, ECPrivateKey, ECPublicKey }
 import org.bitcoins.core.currency.{ Bitcoins, Satoshis }
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.{ BitcoinAddress, P2PKHAddress }
 import org.bitcoins.core.protocol.blockchain.{ Block, BlockHeader, MerkleBlock }
 import org.bitcoins.core.protocol.script.ScriptPubKey
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionInput,
-  TransactionOutPoint
-}
+import org.bitcoins.core.protocol.transaction.{ Transaction, TransactionInput, TransactionOutPoint }
+import org.bitcoins.core.protocol.{ BitcoinAddress, P2PKHAddress }
 import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinSUtil }
 import org.bitcoins.rpc.client.RpcOpts.AddressType
-import org.bitcoins.rpc.config.DaemonInstance
-import play.api.libs.json._
+import org.bitcoins.rpc.config.BitcoindInstance
 import org.bitcoins.rpc.jsonmodels._
 import org.bitcoins.rpc.serializers.JsonSerializers._
+import play.api.libs.json._
 
-import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.sys.process._
 import scala.util.Try
 
-class RpcClient(instance: DaemonInstance)(
+class BitcoindRpcClient(instance: BitcoindInstance)(
   implicit
   m: ActorMaterializer) {
   private val resultKey = "result"
@@ -40,7 +36,7 @@ class RpcClient(instance: DaemonInstance)(
   private implicit val network = instance.network
   private implicit val ec: ExecutionContext = m.executionContext
 
-  def getDaemon: DaemonInstance = instance
+  def getDaemon: BitcoindInstance = instance
 
   def isStarted: Boolean = {
     val request = buildRequest(instance, "ping", JsArray.empty)
@@ -1157,7 +1153,7 @@ class RpcClient(instance: DaemonInstance)(
   }
 
   def buildRequest(
-    instance: DaemonInstance,
+    instance: BitcoindInstance,
     methodName: String,
     params: JsArray): HttpRequest = {
     val uuid = UUID.randomUUID().toString

--- a/rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindAuthCredentials.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindAuthCredentials.scala
@@ -5,7 +5,7 @@ import java.io.File
 /**
  * Created by chris on 5/2/17.
  */
-sealed trait AuthCredentials {
+sealed trait BitcoindAuthCredentials {
 
   /** The directory where our bitcoin.conf file is located */
   def datadir: File
@@ -17,22 +17,22 @@ sealed trait AuthCredentials {
   def password: String
 }
 
-object AuthCredentials {
-  private case class AuthCredentialsImpl(
+object BitcoindAuthCredentials {
+  private case class BitcoindAuthCredentialsImpl(
     username: String,
     password: String,
     datadir: File)
-    extends AuthCredentials
+    extends BitcoindAuthCredentials
 
-  def apply(username: String, password: String): AuthCredentials = {
+  def apply(username: String, password: String): BitcoindAuthCredentials = {
     val defaultDataDir = new File(System.getProperty("user.home") + "/.bitcoin")
-    AuthCredentials(username, password, defaultDataDir)
+    BitcoindAuthCredentials(username, password, defaultDataDir)
   }
 
   def apply(
     username: String,
     password: String,
-    datadir: File): AuthCredentials = {
-    AuthCredentialsImpl(username, password, datadir)
+    datadir: File): BitcoindAuthCredentials = {
+    BitcoindAuthCredentialsImpl(username, password, datadir)
   }
 }

--- a/rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -7,27 +7,27 @@ import org.bitcoins.core.config.NetworkParameters
 /**
  * Created by chris on 4/29/17.
  */
-sealed trait DaemonInstance {
+sealed trait BitcoindInstance {
 
   def network: NetworkParameters
   def uri: URI
   def rpcUri: URI
-  def authCredentials: AuthCredentials
+  def authCredentials: BitcoindAuthCredentials
 }
 
-object DaemonInstance {
-  private case class DaemonInstanceImpl(
+object BitcoindInstance {
+  private case class BitcoindInstanceImpl(
     network: NetworkParameters,
     uri: URI,
     rpcUri: URI,
-    authCredentials: AuthCredentials)
-    extends DaemonInstance
+    authCredentials: BitcoindAuthCredentials)
+    extends BitcoindInstance
 
   def apply(
     network: NetworkParameters,
     uri: URI,
     rpcUri: URI,
-    authCredentials: AuthCredentials): DaemonInstance = {
-    DaemonInstanceImpl(network, uri, rpcUri, authCredentials)
+    authCredentials: BitcoindAuthCredentials): BitcoindInstance = {
+    BitcoindInstanceImpl(network, uri, rpcUri, authCredentials)
   }
 }

--- a/rpc/src/test/scala/org/bitcoins/rpc/BitcoindRpcClientTest.scala
+++ b/rpc/src/test/scala/org/bitcoins/rpc/BitcoindRpcClientTest.scala
@@ -14,7 +14,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint
 }
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.rpc.client.{ RpcClient, RpcOpts }
+import org.bitcoins.rpc.client.{ BitcoindRpcClient, RpcOpts }
 import org.scalatest.{ AsyncFlatSpec, BeforeAndAfter, BeforeAndAfterAll }
 import org.bitcoins.core.number.{ Int64, UInt32 }
 import org.bitcoins.core.protocol.{ BitcoinAddress, P2PKHAddress }
@@ -34,7 +34,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.DurationInt
 import scala.util.Try
 
-class RpcClientTest
+class BitcoindRpcClientTest
   extends AsyncFlatSpec
   with BeforeAndAfterAll
   with BeforeAndAfter {
@@ -43,22 +43,22 @@ class RpcClientTest
   implicit val ec = m.executionContext
   implicit val networkParam = TestUtil.network
 
-  val client = new RpcClient(TestUtil.instance())
+  val client = new BitcoindRpcClient(TestUtil.instance())
 
-  val otherClient = new RpcClient(TestUtil.instance())
+  val otherClient = new BitcoindRpcClient(TestUtil.instance())
 
   // This client's wallet is encrypted
-  val walletClient = new RpcClient(TestUtil.instance())
+  val walletClient = new BitcoindRpcClient(TestUtil.instance())
 
-  val pruneClient = new RpcClient(TestUtil.instance(pruneMode = true))
+  val pruneClient = new BitcoindRpcClient(TestUtil.instance(pruneMode = true))
 
   val logger = BitcoinSLogger.logger
 
   var password = "password"
 
   private def createRawCoinbaseTransaction(
-    sender: RpcClient = client,
-    receiver: RpcClient = otherClient,
+    sender: BitcoindRpcClient = client,
+    receiver: BitcoindRpcClient = otherClient,
     amount: Bitcoins = Bitcoins(1)): Future[Transaction] = {
     sender.generate(2).flatMap { blocks =>
       sender.getBlock(blocks(0)).flatMap { block0 =>
@@ -89,8 +89,8 @@ class RpcClientTest
   }
 
   private def sendCoinbaseTransaction(
-    sender: RpcClient = client,
-    receiver: RpcClient = otherClient,
+    sender: BitcoindRpcClient = client,
+    receiver: BitcoindRpcClient = otherClient,
     amount: Bitcoins = Bitcoins(1)): Future[GetTransactionResult] = {
     createRawCoinbaseTransaction(sender, receiver, amount).flatMap {
       transaction =>
@@ -108,7 +108,7 @@ class RpcClientTest
   }
 
   private def fundMemPoolTransaction(
-    sender: RpcClient,
+    sender: BitcoindRpcClient,
     address: BitcoinAddress,
     amount: Bitcoins): Future[DoubleSha256Digest] = {
     sender.createRawTransaction(Vector.empty, Map(address -> amount)).flatMap {
@@ -122,7 +122,7 @@ class RpcClientTest
   }
 
   private def fundBlockChainTransaction(
-    sender: RpcClient,
+    sender: BitcoindRpcClient,
     address: BitcoinAddress,
     amount: Bitcoins): Future[DoubleSha256Digest] = {
     fundMemPoolTransaction(sender, address, amount).flatMap { txid =>
@@ -133,7 +133,7 @@ class RpcClientTest
   }
 
   private def getFirstBlock(
-    node: RpcClient = client): Future[GetBlockWithTransactionsResult] = {
+    node: BitcoindRpcClient = client): Future[GetBlockWithTransactionsResult] = {
     node.getBlockHash(1).flatMap { hash =>
       node.getBlockWithTransactions(hash)
     }
@@ -169,7 +169,7 @@ class RpcClientTest
     TestUtil.awaitConnection(client, otherClient)
   }
 
-  behavior of "RpcClient"
+  behavior of "BitcoindRpcClient"
 
   it should "be able to prune the blockchain" in {
     pruneClient.getBlockCount.flatMap { count =>


### PR DESCRIPTION
Adds the `Bitcoind` prefix to all bitcoind specific Rpc stuff. In general, we should prefix what network/rpc server rpc stuff is specific for. I.e. `EclairRpcClient` for an eclair rpc client. 