### PR TITLE
Eclair rpc v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: scala
 jdk: oraclejdk8
 
 scala:
-  - 2.11.7
+  - 2.11.12
 
 # These directories are cached to S3 at the end of the build
 cache:
@@ -36,6 +36,9 @@ install:
   - ./configure --enable-jni --enable-experimental --enable-module-ecdh
   - sudo make install
   - cd ../
+  - wget https://github.com/ACINQ/eclair/releases/download/v0.2-beta5/eclair-node-0.2-beta5-8aa51f4.jar
+  - export ECLAIR_PATH=$(pwd)
+
 script:
   - sbt -Djava.library.path=secp256k1/.libs clean coverage test &&
     sbt coverageReport &&

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,8 @@ lazy val compilerOpts =
 
 lazy val commonSettings = List(
   scalacOptions := compilerOpts,
-  assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+  assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false),
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF")
 )
 lazy val root = project
     .in(file("."))
@@ -15,7 +16,8 @@ lazy val root = project
       coreGen,
       coreTest,
       zmq,
-      rpc
+      rpc,
+      eclairRpc
     )
     .settings(commonSettings: _*)
 
@@ -67,5 +69,14 @@ lazy val rpc = project
   ).settings(
     testOptions in Test += Tests.Argument("-oF")
   )
+
+lazy val eclairRpc = project
+    .in(file("eclair-rpc"))
+    .enablePlugins()
+    .settings(commonSettings: _*)
+    .dependsOn(
+      core,
+      rpc
+    )
 
 publishArtifact in root := false

--- a/eclair-rpc/README.md
+++ b/eclair-rpc/README.md
@@ -1,0 +1,30 @@
+# Bitcoin-s Eclair RPC client
+
+This is a RPC client for [eclair](https://github.com/acinq/eclair)
+
+Currently this RPC client is written for the latest official version of eclair which is [v0.2-beta5](https://github.com/ACINQ/eclair/releases/tag/v0.2-beta5)
+
+## Configuration eclair 
+
+Please see this section of the eclair README
+
+https://github.com/acinq/eclair#configuring-eclair
+
+
+## Starting the jar 
+
+You need to download the jar from this link. 
+
+https://github.com/ACINQ/eclair/releases/tag/v0.2-beta5
+
+to run eclair you can use this command 
+
+```
+
+$ java -jar eclair-node-0.2-beta5-8aa51f4.jar &
+
+```
+
+alternatively you can set the `ECLAIR_PATH` env variable and then you can start Eclair with the `start` method on `EclairRpcClient`. 
+
+**YOU NEED TO SET `ECLAIR_PATH` CORRECTLY TO BE ABLE TO RUN THE UNIT TESTS**

--- a/eclair-rpc/build.sbt
+++ b/eclair-rpc/build.sbt
@@ -1,0 +1,3 @@
+name := "eclair-rpc"
+
+libraryDependencies ++= Deps.eclairRpc

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -1,0 +1,389 @@
+package org.bitcoins.eclair.rpc.client
+
+import java.util.UUID
+
+import akka.http.javadsl.model.headers.HttpCredentials
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.stream.ActorMaterializer
+import akka.util.ByteString
+import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.eclair.rpc.config.EclairInstance
+import org.bitcoins.eclair.rpc.json._
+import org.bitcoins.rpc.RpcUtil
+import play.api.libs.json._
+
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.duration.DurationInt
+import scala.sys.process._
+import scala.util.Try
+
+class EclairRpcClient(instance: EclairInstance)(implicit m: ActorMaterializer) {
+  import JsonReaders._
+
+  private val resultKey = "result"
+  private val errorKey = "error"
+  implicit val ec: ExecutionContext = m.executionContext
+  private val logger = BitcoinSLogger.logger
+
+  def getDaemon: EclairInstance = instance
+
+  def allChannels: Future[Vector[ChannelDesc]] = {
+    eclairCall[Vector[ChannelDesc]]("allchannels")
+  }
+
+  def allNodes: Future[Vector[NodeInfo]] = {
+    eclairCall[Vector[NodeInfo]]("allnodes")
+  }
+
+  private def allUpdates(
+    nodeId: Option[String]): Future[Vector[ChannelUpdate]] = {
+    val params = if (nodeId.isEmpty) List.empty else List(JsString(nodeId.get))
+    eclairCall[Vector[ChannelUpdate]]("allupdates", params)
+  }
+
+  def allUpdates: Future[Vector[ChannelUpdate]] = allUpdates(None)
+
+  def allUpdates(nodeId: String): Future[Vector[ChannelUpdate]] =
+    allUpdates(Some(nodeId))
+
+  def channel(channelId: String): Future[ChannelResult] = {
+    eclairCall[ChannelResult]("channel", List(JsString(channelId)))
+  }
+
+  private def channels(nodeId: Option[String]): Future[Vector[ChannelInfo]] = {
+    val params = if (nodeId.isEmpty) List.empty else List(JsString(nodeId.get))
+
+    eclairCall[Vector[ChannelInfo]]("channels", params)
+  }
+
+  def channels: Future[Vector[ChannelInfo]] = channels(None)
+
+  def channels(nodeId: String): Future[Vector[ChannelInfo]] =
+    channels(Some(nodeId))
+
+  def checkInvoice(invoice: String): Future[PaymentRequest] = {
+    eclairCall[PaymentRequest]("checkinvoice", List(JsString(invoice)))
+  }
+
+  // When types are introduced this can be two different functions
+  def checkPayment(invoiceOrHash: String): Future[Boolean] = {
+    eclairCall[Boolean]("checkpayment", List(JsString(invoiceOrHash)))
+  }
+
+  private def close(
+    channelId: String,
+    scriptPubKey: Option[String]): Future[String] = {
+    val params =
+      if (scriptPubKey.isEmpty) {
+        List(JsString(channelId))
+      } else {
+        List(JsString(channelId), JsString(scriptPubKey.get))
+      }
+
+    eclairCall[String]("close", params)
+  }
+
+  def close(channelId: String): Future[String] = close(channelId, None)
+
+  def close(channelId: String, scriptPubKey: String): Future[String] =
+    close(channelId, Some(scriptPubKey))
+
+  def connect(nodeId: String, host: String, port: Int): Future[String] = {
+    logger.info(s"Connecting to ${nodeId}@${host}:${port}")
+    eclairCall[String](
+      "connect",
+      List(JsString(nodeId), JsString(host), JsNumber(port)))
+  }
+
+  def connect(uri: String): Future[String] = {
+    eclairCall[String]("connect", List(JsString(uri)))
+  }
+
+  // When types are introduced this can be two different functions
+  def findRoute(nodeIdOrInvoice: String): Future[Vector[String]] = {
+    eclairCall[Vector[String]]("findroute", List(JsString(nodeIdOrInvoice)))
+  }
+
+  def forceClose(channelId: String): Future[String] = {
+    eclairCall[String]("forceclose", List(JsString(channelId)))
+  }
+
+  def getInfo: Future[GetInfoResult] = {
+    eclairCall[GetInfoResult]("getinfo")
+  }
+
+  def help: Future[Vector[String]] = {
+    eclairCall[Vector[String]]("help")
+  }
+
+  def isConnected(nodeId: String): Future[Boolean] = {
+    peers.map(_.exists(_.nodeId == nodeId))
+  }
+
+  private def open(
+    nodeId: String,
+    fundingSatoshis: Long,
+    pushMsat: Option[Long],
+    feerateSatPerByte: Option[Long],
+    channelFlags: Option[Byte]): Future[String] = {
+    val num: Long = pushMsat.getOrElse(0)
+    val pushMsatJson = JsNumber(num)
+
+    val params = {
+      if (feerateSatPerByte.isEmpty) {
+        List(JsString(nodeId), JsNumber(fundingSatoshis), pushMsatJson)
+      } else if (channelFlags.isEmpty) {
+        List(
+          JsString(nodeId),
+          JsNumber(fundingSatoshis),
+          pushMsatJson,
+          JsNumber(feerateSatPerByte.get))
+      } else {
+        List(
+          JsString(nodeId),
+          JsNumber(fundingSatoshis),
+          pushMsatJson,
+          JsNumber(feerateSatPerByte.get),
+          JsString(channelFlags.toString))
+      }
+    }
+
+    //this is unfortunately returned in this format
+    //created channel 30bdf849eb9f72c9b41a09e38a6d83138c2edf332cb116dd7cf0f0dfb66be395
+    val call = eclairCall[String]("open", params)
+
+    //let's just return the chanId
+    val chanId = call.map(_.split(" ").last)
+
+    chanId
+  }
+
+  def open(nodeId: String, fundingSatoshis: Long): Future[String] =
+    open(nodeId, fundingSatoshis, None, None, None)
+
+  def open(
+    nodeId: String,
+    fundingSatoshis: Long,
+    pushMsat: Long): Future[String] =
+    open(nodeId, fundingSatoshis, Some(pushMsat), None, None)
+
+  def open(
+    nodeId: String,
+    fundingSatoshis: Long,
+    pushMsat: Long,
+    feerateSatPerByte: Long): Future[String] =
+    open(nodeId, fundingSatoshis, Some(pushMsat), Some(feerateSatPerByte), None)
+
+  def open(
+    nodeId: String,
+    fundingSatoshis: Long,
+    pushMsat: Long = 0,
+    feerateSatPerByte: Long,
+    channelFlags: Byte): Future[String] =
+    open(
+      nodeId,
+      fundingSatoshis,
+      Some(pushMsat),
+      Some(feerateSatPerByte),
+      Some(channelFlags))
+
+  def open(
+    nodeId: String,
+    fundingSatoshis: Long,
+    feerateSatPerByte: Long,
+    channelFlags: Byte): Future[String] =
+    open(
+      nodeId,
+      fundingSatoshis,
+      None,
+      Some(feerateSatPerByte),
+      Some(channelFlags))
+
+  def peers: Future[Vector[PeerInfo]] = {
+    eclairCall[Vector[PeerInfo]]("peers")
+  }
+
+  private def receive(
+    description: Option[String],
+    amountMsat: Option[Long],
+    expirySeconds: Option[Long]): Future[String] = {
+    val params =
+      if (amountMsat.isEmpty) {
+        List(JsString(description.getOrElse("")))
+      } else if (expirySeconds.isEmpty) {
+        List(JsNumber(amountMsat.get), JsString(description.getOrElse("")))
+      } else {
+        List(
+          JsNumber(amountMsat.get),
+          JsString(description.getOrElse("")),
+          JsNumber(expirySeconds.get))
+      }
+
+    eclairCall[String]("receive", params)
+  }
+
+  def receive(): Future[String] =
+    receive(None, None, None)
+
+  def receive(description: String): Future[String] =
+    receive(Some(description), None, None)
+
+  def receive(description: String, amountMsat: Long): Future[String] =
+    receive(Some(description), Some(amountMsat), None)
+
+  def receive(
+    description: String,
+    amountMsat: Long,
+    expirySeconds: Long): Future[String] =
+    receive(Some(description), Some(amountMsat), Some(expirySeconds))
+
+  def receive(amountMsat: Long): Future[String] =
+    receive(None, Some(amountMsat), None)
+
+  def receive(amountMsat: Long, expirySeconds: Long): Future[String] =
+    receive(None, Some(amountMsat), Some(expirySeconds))
+
+  def send(
+    amountMsat: Long,
+    paymentHash: String,
+    nodeId: String): Future[SendResult] = {
+    eclairCall[SendResult](
+      "send",
+      List(JsNumber(amountMsat), JsString(paymentHash), JsString(nodeId)))
+  }
+
+  private def send(
+    invoice: String,
+    amountMsat: Option[Long]): Future[SendResult] = {
+    val params =
+      if (amountMsat.isEmpty) {
+        List(JsString(invoice))
+      } else {
+        List(JsString(invoice), JsNumber(amountMsat.get))
+      }
+
+    eclairCall[SendResult]("send", params)
+  }
+
+  def send(invoice: String): Future[SendResult] = send(invoice, None)
+
+  def send(invoice: String, amountMsat: Long): Future[SendResult] =
+    send(invoice, Some(amountMsat))
+
+  def updateRelayFee(
+    channelId: String,
+    feeBaseMsat: Long,
+    feeProportionalMillionths: Long): Future[String] = {
+    eclairCall[String](
+      "updaterelayfee",
+      List(
+        JsString(channelId),
+        JsNumber(feeBaseMsat),
+        JsNumber(feeProportionalMillionths)))
+  }
+
+  // TODO: channelstats, audit, networkfees?
+  // TODO: Add types
+
+  private def eclairCall[T](
+    command: String,
+    parameters: List[JsValue] = List.empty)(
+    implicit
+    reader: Reads[T]): Future[T] = {
+    val request = buildRequest(getDaemon, command, JsArray(parameters))
+    val responseF = sendRequest(request)
+
+    val payloadF: Future[JsValue] = responseF.flatMap(getPayload)
+
+    payloadF.map { payload =>
+      parseResult((payload \ resultKey).validate[T], payload)
+    }
+  }
+
+  case class RpcError(code: Int, message: String)
+  implicit val rpcErrorReads: Reads[RpcError] = Json.reads[RpcError]
+
+  private def parseResult[T](result: JsResult[T], json: JsValue): T = {
+    result match {
+      case res: JsSuccess[T] => res.value
+      case res: JsError =>
+        (json \ errorKey).validate[RpcError] match {
+          case err: JsSuccess[RpcError] =>
+            logger.error(s"Error ${err.value.code}: ${err.value.message}")
+            throw new RuntimeException(
+              s"Error ${err.value.code}: ${err.value.message}")
+          case _: JsError =>
+            logger.error(JsError.toJson(res).toString())
+            throw new IllegalArgumentException(
+              s"Could not parse JsResult: ${(json \ resultKey).get}")
+        }
+    }
+  }
+
+  private def getPayload(response: HttpResponse): Future[JsValue] = {
+    val payloadF = response.entity.dataBytes.runFold(ByteString.empty)(_ ++ _)
+
+    payloadF.map { payload =>
+      Json.parse(payload.decodeString(ByteString.UTF_8))
+    }
+  }
+
+  def sendRequest(req: HttpRequest): Future[HttpResponse] = {
+    Http(m.system).singleRequest(req)
+  }
+
+  def buildRequest(instance: EclairInstance, methodName: String, params: JsArray): HttpRequest = {
+    val uuid = UUID.randomUUID().toString
+
+    val obj: JsObject = JsObject(
+      Map(
+        "method" -> JsString(methodName),
+        "params" -> params,
+        "id" -> JsString(uuid)))
+
+    val uri = "http://" + instance.rpcUri.getHost + ":" + instance.rpcUri.getPort
+    val username = instance.authCredentials.username
+    val password = instance.authCredentials.password
+    HttpRequest(
+      method = HttpMethods.POST,
+      uri,
+      entity =
+        HttpEntity(ContentTypes.`application/json`, obj.toString))
+      .addCredentials(
+        HttpCredentials.createBasicHttpCredentials(username, password))
+  }
+
+  // TODO: THIS IS ALL HACKY
+
+  private def pathToEclairJar: String = {
+    System.getenv("ECLAIR_PATH") + "/eclair-node-0.2-beta5-8aa51f4.jar"
+  }
+
+  private var process: Option[Process] = None
+
+  def start(): Unit = {
+
+    if (process.isEmpty) {
+      val p = Process("java -jar -Declair.datadir=" + instance.authCredentials.datadir + s" ${pathToEclairJar} &")
+      val result = p.run()
+      logger.info(s"Starting eclair with datadir ${instance.authCredentials.datadir}")
+
+      process = Some(result)
+      ()
+    } else {
+      logger.info(s"Eclair was already started!")
+      ()
+    }
+
+  }
+
+  def isStarted(): Boolean = {
+    val t = Try(Await.result(getInfo, 1.second))
+    t.isSuccess
+  }
+
+  def stop(): Option[Unit] = {
+    process.map(_.destroy())
+  }
+}

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/AuthCredentials.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/AuthCredentials.scala
@@ -1,0 +1,48 @@
+package org.bitcoins.eclair.rpc.config
+
+import java.io.File
+
+sealed trait EclairAuthCredentials {
+
+  /** The directory where our eclair.conf file is located */
+  def datadir: File
+
+  /** rpcusername field in our bitcoin.conf file */
+  def bitcoinUsername: String
+
+  /** rpcpassword field in our bitcoin.conf file */
+  def bitcoinPassword: String
+
+  /** alias field in our eclair.conf file */
+  def username: String
+
+  /** api password field in our eclair.conf file */
+  def password: String
+}
+
+object EclairAuthCredentials {
+  private case class AuthCredentialsImpl(
+    username: String,
+    password: String,
+    bitcoinUsername: String,
+    bitcoinPassword: String,
+    datadir: File) extends EclairAuthCredentials
+
+  def apply(
+    username: String,
+    password: String,
+    bitcoinUsername: String,
+    bitcoinPassword: String): EclairAuthCredentials = {
+    val defaultDataDir = new File(System.getProperty("user.home") + "/.eclair")
+    EclairAuthCredentials(username, password, bitcoinUsername, bitcoinPassword, defaultDataDir)
+  }
+
+  def apply(
+    username: String,
+    password: String,
+    bitcoinUsername: String,
+    bitcoinPassword: String,
+    datadir: File): EclairAuthCredentials = {
+    AuthCredentialsImpl(username, password, bitcoinUsername, bitcoinPassword, datadir)
+  }
+}

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/EclairInstance.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/EclairInstance.scala
@@ -1,0 +1,28 @@
+package org.bitcoins.eclair.rpc.config
+
+import java.net.URI
+
+import org.bitcoins.core.config.NetworkParameters
+
+sealed trait EclairInstance {
+  def network: NetworkParameters
+  def uri: URI
+  def rpcUri: URI
+  def authCredentials: EclairAuthCredentials
+}
+
+object EclairInstance {
+  private case class EclairInstanceImpl(
+    network: NetworkParameters,
+    uri: URI,
+    rpcUri: URI,
+    authCredentials: EclairAuthCredentials) extends EclairInstance
+
+  def apply(
+    network: NetworkParameters,
+    uri: URI,
+    rpcUri: URI,
+    authCredentials: EclairAuthCredentials): EclairInstance = {
+    EclairInstanceImpl(network, uri, rpcUri, authCredentials)
+  }
+}

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
@@ -1,0 +1,188 @@
+package org.bitcoins.eclair.rpc.json
+
+import play.api.libs.json.{ JsArray, JsObject }
+
+sealed abstract class EclairModels
+
+case class GetInfoResult(
+  nodeId: String,
+  alias: String,
+  port: Int,
+  chainHash: String,
+  blockHeight: Long)
+
+case class PeerInfo(
+  nodeId: String,
+  state: String,
+  //address: String,
+  channels: Int)
+
+case class ChannelInfo(nodeId: String, channelId: String, state: String)
+
+case class NodeInfo(
+  signature: String,
+  features: String,
+  timestamp: Long,
+  nodeId: String,
+  rgbColor: String,
+  alias: String,
+  addresses: Vector[String])
+
+case class ChannelDesc(shortChannelId: String, a: String, b: String)
+
+case class ChannelUpdate(
+  signature: String,
+  chainHash: String,
+  shortChannelId: String,
+  timestamp: Long,
+  flags: String,
+  cltvExpiryDelta: Int,
+  htlcMinimumMsat: Long,
+  feeBaseMsat: Long,
+  feeProportionalMillionths: Long)
+
+/* ChannelResult starts here, some of this may be useful but it seems that data is different at different times
+
+case class CommitInput(
+  outPoint: String,
+  amountSatoshis: Long)
+implicit val commitInputReads: Reads[CommitInput] =
+  Json.reads[CommitInput]
+
+case class CommitChanges(
+  proposed: Vector[String], // IDK WHAT TYPE THIS SHOULD BE
+  signed: Vector[String], // IDK WHAT TYPE THIS SHOULD BE
+  acked: Vector[String] // IDK WHAT TYPE THIS SHOULD BE
+)
+implicit val commitChangesReads: Reads[CommitChanges] =
+  Json.reads[CommitChanges]
+
+case class CommitSpec(
+  htlcs: Vector[String],
+  feeratePerKw: Long,
+  toLocalMsat: Long,
+  toRemoteMsat: Long)
+implicit val commitSpecReads: Reads[CommitSpec] =
+  Json.reads[CommitSpec]
+
+case class RemoteCommit(
+  index: Int,
+  spec: CommitSpec,
+  txid: String,
+  remotePerCommitmentPoint: String)
+implicit val remoteCommitReads: Reads[RemoteCommit] =
+  Json.reads[RemoteCommit]
+
+case class PublishableTxs(
+  commitTx: String,
+  htlcTxsAndSigs: Vector[String])
+implicit val publishableTxsReads: Reads[PublishableTxs] =
+  Json.reads[PublishableTxs]
+
+case class LocalCommit(
+  index: Int,
+  spec: CommitSpec,
+  publishableTxs: PublishableTxs)
+implicit val localCommitReads: Reads[LocalCommit] =
+  Json.reads[LocalCommit]
+
+case class RemoteParams(
+  nodeId: String,
+  dustLimitSatoshis: Long,
+  maxHtlcValueInFlightMsat: Long,
+  channelReserveSatoshis: Long,
+  htlcMinimumMsat: Long,
+  toSelfDelay: Long,
+  maxAcceptedHtlcs: Long,
+  fundingPubKey: String,
+  revocationBasepoint: String,
+  paymentBasepoint: String,
+  delayedPaymentBasepoint: String,
+  htlcBasepoint: String,
+  globalFeatures: String,
+  localFeatures: String)
+implicit val remoteParamsReads: Reads[RemoteParams] =
+  Json.reads[RemoteParams]
+
+case class ChannelKeyPath(
+  path: Vector[Long])
+implicit val channelKeyPathReads: Reads[ChannelKeyPath] =
+  Json.reads[ChannelKeyPath]
+
+case class LocalParams(
+  nodeId: String,
+  channelKeyPath: ChannelKeyPath,
+  dustLimitSatoshis: Long,
+  maxHtlcValueInFlightMsat: Long,
+  channelReserveSatoshis: Long,
+  htlcMinimumMsat: Long,
+  toSelfDelay: Long,
+  maxAcceptedHtlcs: Long,
+  isFunder: Boolean,
+  defaultFinalScriptPubKey: String,
+  globalFeatures: String,
+  localFeatures: String)
+implicit val localParamsReads: Reads[LocalParams] =
+  Json.reads[LocalParams]
+
+case class ChannelCommitments(
+  localParams: LocalParams,
+  remoteParams: RemoteParams,
+  channelFlags: Int,
+  localCommit: LocalCommit,
+  remoteCommit: RemoteCommit,
+  localChanges: CommitChanges,
+  remoteChanges: CommitChanges,
+  localNextHtlcId: Long,
+  remoteNextHtlcId: Long,
+  originChannels: String, // IDK WHAT TYPE THIS SHOULD BE
+  remoteNextCommitInfo: String,
+  commitInput: CommitInput,
+  remotePerCommitmentSecrets: Option[String], // IDK WHAT TYPE THIS SHOULD BE
+  channelId: String)
+implicit val channelCommitmentsReads: Reads[ChannelCommitments] =
+  Json.reads[ChannelCommitments]
+
+case class ChannelData(
+  commitments: ChannelCommitments,
+  shortChannelId: String,
+  buried: Boolean,
+  channelUpdate: ChannelUpdate)
+implicit val channelDataReads: Reads[ChannelData] =
+  Json.reads[ChannelData]
+*/
+case class ChannelResult(
+  nodeId: String,
+  channelId: String,
+  state: String,
+  data: JsObject)
+
+// ChannelResult ends here
+
+case class PaymentRequest(
+  prefix: String,
+  amount: Option[Long],
+  timestamp: Long,
+  nodeId: String,
+  tags: Vector[JsObject],
+  signature: String)
+
+sealed trait SendResult
+case class PaymentSucceeded(
+  amountMsat: Long,
+  paymentHash: String,
+  paymentPreimage: String,
+  route: JsArray) extends SendResult
+
+/*
+case class PaymentFailure(???) extends SendResult
+implicit val paymentFailureReads: Reads[PaymentFailure] = Json.reads[PaymentFailure]
+implicit val sendResultReads: Reads[SendResult] = Reads[SendResult] { json =>
+  json.validate[PaymentSucceeded] match {
+    case success: JsSuccess[PaymentSucceeded] => success
+    case err1: JsError => json.validate[PaymentFailure] match {
+      case failure: JsSuccess[PaymentFailure] => failure
+      case err2: JsError => JsError.merge(err1, err2)
+    }
+  }
+}*/

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/JsonReaders.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/JsonReaders.scala
@@ -1,0 +1,46 @@
+package org.bitcoins.eclair.rpc.json
+
+import play.api.libs.json.{ Json, Reads }
+
+object JsonReaders {
+
+  implicit val getInfoResultReads: Reads[GetInfoResult] = {
+    Json.reads[GetInfoResult]
+  }
+
+  implicit val peerInfoReads: Reads[PeerInfo] = {
+    Json.reads[PeerInfo]
+  }
+
+  implicit val nodeInfoReads: Reads[NodeInfo] = {
+    Json.reads[NodeInfo]
+  }
+
+  implicit val channelDescReads: Reads[ChannelDesc] = {
+    Json.reads[ChannelDesc]
+  }
+
+  implicit val channelInfoReads: Reads[ChannelInfo] = {
+    Json.reads[ChannelInfo]
+  }
+
+  implicit val channelUpdateReads: Reads[ChannelUpdate] = {
+    Json.reads[ChannelUpdate]
+  }
+
+  implicit val paymentRequestReads: Reads[PaymentRequest] = {
+    Json.reads[PaymentRequest]
+  }
+
+  implicit val paymentSucceededReads: Reads[PaymentSucceeded] = {
+    Json.reads[PaymentSucceeded]
+  }
+
+  implicit val sendResultReads: Reads[SendResult] = {
+    Reads[SendResult](_.validate[PaymentSucceeded])
+  }
+
+  implicit val channelResultReads: Reads[ChannelResult] =
+    Json.reads[ChannelResult]
+
+}

--- a/eclair-rpc/src/test/resources/logback-test.xml
+++ b/eclair-rpc/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <configuration>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/test-application.log</file>
+        <file>logs/eclair-rpc-test.log</file>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{5}.%M\(%line\) - %msg%n</pattern>
         </encoder>
@@ -14,10 +14,15 @@
     </appender>
 
 
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE"/>
     </root>
 
+
+
+    <logger name="com.zaxxer" level="INFO"/>
+
+    <logger name="fr.acinq" level="INFO"/>
 
 </configuration>

--- a/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -1,0 +1,100 @@
+package org.bitcoins.eclair.rpc
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.eclair.rpc.client.EclairRpcClient
+import org.bitcoins.eclair.rpc.json.ChannelResult
+import org.bitcoins.rpc.RpcUtil
+import org.bitcoins.rpc.client.BitcoindRpcClient
+import org.scalatest.{ Assertion, AsyncFlatSpec, BeforeAndAfterAll }
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.DurationInt
+
+class EclairRpcClientTest extends AsyncFlatSpec with BeforeAndAfterAll {
+
+  implicit val system = ActorSystem("EclairRpcClient")
+  implicit val m = ActorMaterializer.create(system)
+  implicit val ec = m.executionContext
+  implicit val bitcoinNp = EclairTestUtil.bitcoinNetwork
+
+  val logger = BitcoinSLogger.logger
+
+  val bitcoindInstance = EclairTestUtil.startedBitcoindInstance()
+  val bitcoindRpc = new BitcoindRpcClient(bitcoindInstance)
+
+  val e1Instance = EclairTestUtil.eclairInstance(bitcoindInstance)
+  val e2Instance = EclairTestUtil.eclairInstance(bitcoindInstance)
+
+  val client = new EclairRpcClient(e1Instance)
+  val otherClient = new EclairRpcClient(e2Instance)
+
+  override def beforeAll(): Unit = {
+    logger.info("Temp eclair directory created")
+    logger.info("Temp eclair directory created")
+
+    logger.debug(client.getDaemon.authCredentials.datadir.toString)
+
+    client.start()
+    otherClient.start()
+
+    RpcUtil.awaitCondition(
+      condition = client.isStarted,
+      duration = 1.second)
+
+    RpcUtil.awaitCondition(
+      condition = otherClient.isStarted,
+      duration = 1.second)
+
+    val infoF = otherClient.getInfo
+
+    val connection: Future[String] = infoF.flatMap { info =>
+      client.connect(info.nodeId, "localhost", info.port)
+    }
+
+    def isConnected(): Future[Boolean] = {
+      val nodeIdF = infoF.map(_.nodeId)
+      nodeIdF.flatMap { nodeId =>
+        connection.flatMap { _ =>
+          val connected: Future[Boolean] = client.isConnected(nodeId)
+          connected
+        }
+      }
+    }
+
+    RpcUtil.awaitConditionF(
+      conditionF = isConnected,
+      duration = 1.second)
+  }
+
+  behavior of "RpcClient"
+
+  it should "be able to open a channel" in {
+    val result: Future[Assertion] = {
+      otherClient.getInfo.flatMap { info =>
+        val openedChanF = client.open(info.nodeId, 100000)
+        openedChanF.flatMap(channelId => hasChannel(client, channelId))
+      }
+    }
+
+    result
+  }
+
+  /** Checks that the given [[org.bitcoins.eclair.rpc.client.EclairRpcClient]] has the given chanId */
+  private def hasChannel(client: EclairRpcClient, chanId: String): Future[Assertion] = {
+    val recognizedOpenChannel: Future[Assertion] = {
+      val chanResultF: Future[ChannelResult] = client.channel(chanId)
+      chanResultF.map(c => assert(c.channelId == chanId))
+    }
+
+    recognizedOpenChannel
+  }
+
+  override def afterAll(): Unit = {
+    val s1 = client.stop()
+    val s2 = otherClient.stop()
+    val s3 = bitcoindRpc.stop()
+    system.terminate()
+  }
+}

--- a/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairTestUtil.scala
+++ b/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairTestUtil.scala
@@ -1,0 +1,150 @@
+package org.bitcoins.eclair.rpc
+
+import java.io.{ File, PrintWriter }
+import java.net.URI
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import org.bitcoins.core.config.RegTest
+import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.eclair.rpc.config.{ EclairAuthCredentials, EclairInstance }
+import org.bitcoins.rpc.RpcUtil
+import org.bitcoins.rpc.client.BitcoindRpcClient
+import org.bitcoins.rpc.config.{ BitcoindAuthCredentials, BitcoindInstance }
+
+trait EclairTestUtil extends BitcoinSLogger {
+
+  def randomDirName: String =
+    0.until(5).map(_ => scala.util.Random.alphanumeric.head).mkString
+
+  /**
+   * Creates a datadir and places the username/password combo
+   * in the bitcoin.conf in the datadir
+   */
+  def bitcoindAuthCredentials(
+    uri: URI,
+    rpcUri: URI,
+    pruneMode: Boolean): BitcoindAuthCredentials = {
+    val d = "/tmp/" + randomDirName
+    val f = new java.io.File(d)
+    f.mkdir()
+    val conf = new java.io.File(f.getAbsolutePath + "/bitcoin.conf")
+    conf.createNewFile()
+    val username = "random_user_name"
+    val pass = randomDirName
+    val pw = new PrintWriter(conf)
+    pw.write("rpcuser=" + username + "\n")
+    pw.write("rpcpassword=" + pass + "\n")
+    pw.write("rpcport=" + rpcUri.getPort + "\n")
+    pw.write("port=" + uri.getPort + "\n")
+    pw.write("daemon=1\n")
+    pw.write("server=1\n")
+    pw.write("debug=1\n")
+    pw.write("regtest=1\n")
+    pw.write("walletbroadcast=0\n")
+
+    pw.write("zmqpubhashtx=tcp://127.0.0.1:29000\n")
+    pw.write("zmqpubhashblock=tcp://127.0.0.1:29000\n")
+    pw.write("zmqpubrawtx=tcp://127.0.0.1:29000\n")
+    pw.write("zmqpubrawblock=tcp://127.0.0.1:29000\n")
+
+    if (pruneMode) {
+      pw.write("prune=1\n")
+    }
+    pw.close()
+    BitcoindAuthCredentials(username, pass, f)
+  }
+
+  lazy val network = RegTest
+
+  def bitcoindInstance(
+    port: Int = randomPort,
+    rpcPort: Int = randomPort,
+    pruneMode: Boolean = false): BitcoindInstance = {
+    val uri = new URI("http://localhost:" + port)
+    val rpcUri = new URI("http://localhost:" + rpcPort)
+    val auth = bitcoindAuthCredentials(uri, rpcUri, pruneMode)
+
+    BitcoindInstance(network, uri, rpcUri, auth)
+  }
+
+  def startedBitcoindInstance()(implicit system: ActorSystem): BitcoindInstance = {
+    implicit val m = ActorMaterializer.create(system)
+
+    val i = bitcoindInstance()
+
+    //start the bitcoind instance so eclair can properly use it
+    val rpc = new BitcoindRpcClient(i)(m)
+    rpc.start()
+    RpcUtil.awaitServer(rpc)
+
+    //fund the wallet by generating 102 blocks, need this to get over coinbase maturity
+    val blockGen = rpc.generate(102)
+    i
+  }
+
+  /**
+   * Creates a datadir and places the username/password combo
+   * in the eclair.conf in the datadir
+   */
+  def eclairAuthCredentials(uri: URI, rpcUri: URI, bitcoind: BitcoindInstance): EclairAuthCredentials = {
+    val bitcoindAuth = bitcoind.authCredentials
+    val bitcoindRpcUri = bitcoind.rpcUri
+
+    val d = "/tmp/" + randomDirName
+    val f = new java.io.File(d)
+    f.mkdir()
+    val conf = new java.io.File(f.getAbsolutePath + "/eclair.conf")
+    conf.createNewFile()
+    val username = "random_user_name"
+    val pass = randomDirName
+
+    val bitcoindUser = bitcoindAuth.username
+    val bitcoindPass = bitcoindAuth.password
+
+    val pw = new PrintWriter(conf)
+    pw.println("eclair.chain=regtest")
+
+    pw.println(s"eclair.bitcoind.rpcuser=${bitcoindUser}")
+    pw.println("eclair.bitcoind.rpcpassword=\"" + bitcoindPass + "\"")
+    pw.println(s"eclair.bitcoind.rpcport=${bitcoindRpcUri.getPort}")
+    pw.println(s"eclair.bitcoind.host=${bitcoindRpcUri.getHost}")
+
+    pw.println("eclair.api.enabled=true")
+    pw.println("eclair.node.alias = \"" + username + "\"")
+    pw.println("eclair.server.port = " + uri.getPort)
+    pw.println("eclair.api.password = \"" + pass + "\"")
+    pw.println("eclair.api.port = " + rpcUri.getPort)
+    pw.println("eclair.api.binding-ip = \"127.0.0.1\"")
+    pw.close()
+
+    EclairAuthCredentials(username, pass, bitcoindUser, bitcoindPass, f)
+  }
+
+  lazy val bitcoinNetwork = RegTest
+
+  def eclairInstance(bitcoind: BitcoindInstance, port: Int = randomPort, rpcPort: Int = randomPort)(implicit system: ActorSystem): EclairInstance = {
+    val uri = new URI("http://127.0.0.1:" + port)
+    val rpcUri = new URI("http://127.0.0.1:" + rpcPort)
+    val auth = eclairAuthCredentials(uri, rpcUri, bitcoind)
+    EclairInstance(bitcoinNetwork, uri, rpcUri, auth)
+  }
+
+  def randomPort: Int = {
+    val firstAttempt = Math.abs(scala.util.Random.nextInt % 15000)
+    if (firstAttempt < bitcoinNetwork.port) {
+      firstAttempt + bitcoinNetwork.port
+    } else firstAttempt
+  }
+
+  def deleteTmpDir(dir: File): Boolean = {
+    if (!dir.isDirectory) {
+      dir.delete()
+    } else {
+      dir.listFiles().foreach(deleteTmpDir)
+      dir.delete()
+    }
+  }
+}
+
+object EclairTestUtil extends EclairTestUtil

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -73,4 +73,15 @@ object Deps {
     Test.scalaTest,
     Test.scalacheck
   )
+
+  val eclairRpc = List(
+    Compile.akkaHttp,
+    Compile.akkaStream,
+    Compile.playJson,
+    Compile.slf4j,
+    Test.akkaHttp,
+    Test.logback,
+    Test.scalaTest,
+    Test.scalacheck
+  )
 }

--- a/rpc/src/main/scala/org/bitcoins/rpc/RpcUtil.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/RpcUtil.scala
@@ -15,44 +15,60 @@ trait RpcUtil extends BitcoinSLogger {
     }
   }
 
+  def retryUntilSatisfied(
+    condition: => Boolean,
+    duration: FiniteDuration = 100.milliseconds,
+    maxTries: Int = 50)(implicit system: ActorSystem): Future[Unit] = {
+    val f = () => Future.successful(condition)
+    retryUntilSatisfiedF(f, duration, maxTries)
+  }
+
   /**
    * The returned Future completes when condition becomes true
-   * @param condition The condition being waited on
+   * @param conditionF The condition being waited on
    * @param duration The interval between calls to check condition
    * @param maxTries If condition is tried this many times, the Future fails
    * @param system An ActorSystem to schedule calls to condition
    * @return A Future[Unit] that succeeds if condition becomes true and fails otherwise
    */
-  def retryUntilSatisfied(
-    condition: => Boolean,
+  def retryUntilSatisfiedF(
+    conditionF: () => Future[Boolean],
     duration: FiniteDuration = 100.milliseconds,
     maxTries: Int = 50)(implicit system: ActorSystem): Future[Unit] = {
-    retryUntilSatisfiedWithCounter(condition, duration, maxTries = maxTries)
+
+    retryUntilSatisfiedWithCounter(
+      conditionF = conditionF,
+      duration = duration,
+      maxTries = maxTries)
   }
 
   // Has a different name so that default values are permitted
   private def retryUntilSatisfiedWithCounter(
-    condition: => Boolean,
+    conditionF: () => Future[Boolean],
     duration: FiniteDuration = 100.milliseconds,
     counter: Int = 0,
     maxTries: Int = 50)(implicit system: ActorSystem): Future[Unit] = {
+
     implicit val ec = system.dispatcher
-    if (counter == maxTries) {
-      Future.failed(new RuntimeException("Condition timed out"))
-    } else if (condition) {
-      Future.successful(Unit)
-    } else {
 
-      val p = Promise[Boolean]()
-      val runnable = retryRunnable(condition, p)
+    conditionF().flatMap { condition =>
 
-      system.scheduler.scheduleOnce(duration, runnable)
+      if (condition) {
+        Future.successful(Unit)
+      } else if (counter == maxTries) {
+        Future.failed(new RuntimeException("Condition timed out"))
+      } else {
 
-      p.future.flatMap {
-        case true => Future.successful(Unit)
-        case false => retryUntilSatisfiedWithCounter(condition, duration, counter + 1, maxTries)
+        val p = Promise[Boolean]()
+        val runnable = retryRunnable(condition, p)
+
+        system.scheduler.scheduleOnce(duration, runnable)
+
+        p.future.flatMap {
+          case true => Future.successful(Unit)
+          case false => retryUntilSatisfiedWithCounter(conditionF, duration, counter + 1, maxTries)
+        }
       }
-
     }
   }
 
@@ -68,25 +84,49 @@ trait RpcUtil extends BitcoinSLogger {
    * @param system An ActorSystem to schedule calls to condition
    */
   def awaitCondition(
-    condition: => Boolean,
+    condition: () => Boolean,
     duration: FiniteDuration = 100.milliseconds,
     maxTries: Int = 50,
     overallTimeout: FiniteDuration = 1.hour)(implicit system: ActorSystem): Unit = {
-    Await.result(retryUntilSatisfied(condition, duration, maxTries), overallTimeout)
+    implicit val ec = system.dispatcher
+
+    //type hackery here to go from () => Boolean to () => Future[Boolean]
+    //to make sure we re-evaluate every time retryUntilSatisfied is called
+    def conditionDef: Boolean = condition()
+    val conditionF: () => Future[Boolean] = () => Future.successful(conditionDef)
+
+    awaitConditionF(conditionF, duration, maxTries, overallTimeout)
+  }
+
+  def awaitConditionF(
+    conditionF: () => Future[Boolean],
+    duration: FiniteDuration = 100.milliseconds,
+    maxTries: Int = 50,
+    overallTimeout: FiniteDuration = 1.hour)(implicit system: ActorSystem): Unit = {
+    implicit val d = system.dispatcher
+
+    val f: Future[Unit] = retryUntilSatisfiedF(
+      conditionF = conditionF,
+      duration = duration,
+      maxTries = maxTries)
+
+    Await.result(f, overallTimeout)
   }
 
   def awaitServer(
     server: BitcoindRpcClient,
     duration: FiniteDuration = 100.milliseconds,
     maxTries: Int = 50)(implicit system: ActorSystem): Unit = {
-    awaitCondition(server.isStarted, duration, maxTries)
+    val f = () => server.isStarted
+    awaitCondition(f, duration, maxTries)
   }
 
   def awaitServerShutdown(
     server: BitcoindRpcClient,
     duration: FiniteDuration = 300.milliseconds,
     maxTries: Int = 50)(implicit system: ActorSystem): Unit = {
-    awaitCondition(!server.isStarted, duration, maxTries)
+    val f = () => !server.isStarted
+    awaitCondition(f, duration, maxTries)
   }
 }
 

--- a/rpc/src/test/resources/logback-test.xml
+++ b/rpc/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <configuration>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/test-application.log</file>
+        <file>logs/rpc-test-application.log</file>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{5}.%M\(%line\) - %msg%n</pattern>
         </encoder>
@@ -14,7 +14,7 @@
     </appender>
 
 
-    <root level="ERROR">
+    <root level="WARN">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE"/>
     </root>

--- a/rpc/src/test/scala/org/bitcoins/rpc/BitcoindRpcClientTest.scala
+++ b/rpc/src/test/scala/org/bitcoins/rpc/BitcoindRpcClientTest.scala
@@ -160,7 +160,7 @@ class BitcoindRpcClientTest
         logger.info("Bitcoin server restarting")
         RpcUtil.awaitServer(walletClient)
       },
-      5.seconds)
+      10.seconds)
 
     logger.info("Mining some blocks")
     Await.result(client.generate(200), 3.seconds)
@@ -334,25 +334,41 @@ class BitcoindRpcClientTest
   it should "be able to mark a block as precious" in {
     TestUtil.createNodePair().flatMap {
       case (client1, client2) =>
+
         client1.disconnectNode(client2.getDaemon.uri).flatMap { _ =>
+
           TestUtil.awaitDisconnected(client1, client2)
+
           client1.generate(1).flatMap { blocks1 =>
+
             client2.generate(1).flatMap { blocks2 =>
+
               client1.getBestBlockHash.flatMap { bestHash1 =>
                 assert(bestHash1 == blocks1.head)
-                client2.getBestBlockHash.flatMap { bestHash2 =>
-                  assert(bestHash2 == blocks2.head)
-                  client1.addNode(client2.getDaemon.uri, "onetry").flatMap {
-                    _ =>
-                      RpcUtil.awaitCondition(
-                        Try(Await.result(
-                          client2.preciousBlock(bestHash1),
-                          2.seconds)).isSuccess)
 
-                      client2.getBestBlockHash.map { newBestHash =>
-                        TestUtil.deleteNodePair(client1, client2)
-                        assert(newBestHash == blocks1.head)
-                      }
+                client2.getBestBlockHash.flatMap { bestHash2 =>
+
+                  assert(bestHash2 == blocks2.head)
+
+                  val conn = client1.addNode(client2.getDaemon.uri, "onetry")
+
+                  conn.flatMap { _ =>
+
+                    //make sure the block was propogated to client2
+                    RpcUtil.awaitConditionF(
+                      conditionF = () => TestUtil.hasSeenBlock(client2, bestHash1))
+
+                    val precious = client2.preciousBlock(bestHash1)
+
+                    val client2BestBlock = precious.flatMap { _ =>
+                      val b = client2.getBestBlockHash
+                      b
+                    }
+
+                    client2BestBlock.map { newBestHash =>
+                      TestUtil.deleteNodePair(client1, client2)
+                      assert(newBestHash == bestHash1)
+                    }
                   }
                 }
               }
@@ -361,7 +377,6 @@ class BitcoindRpcClientTest
         }
     }
   }
-
   it should "be able to list address groupings" in {
     client.getNewAddress().flatMap { address =>
       fundBlockChainTransaction(client, address, Bitcoins(1.25)).flatMap {

--- a/rpc/src/test/scala/org/bitcoins/rpc/RpcUtilTest.scala
+++ b/rpc/src/test/scala/org/bitcoins/rpc/RpcUtilTest.scala
@@ -19,29 +19,35 @@ class RpcUtilTest extends AsyncFlatSpec with BeforeAndAfterAll {
     true
   }
 
-  private def boolLaterDoneAnd(bool: Boolean, boolFuture: Future[Boolean]): Boolean =
-    boolFuture.value.contains(Success(bool))
+  private def boolLaterDoneAnd(bool: Boolean, boolFuture: Future[Boolean]): Future[Boolean] = {
+    Future.successful(boolFuture.value.contains(Success(bool)))
+  }
 
-  private def boolLaterDoneAndTrue(trueLater: Future[Boolean]): Boolean =
-    boolLaterDoneAnd(true, trueLater)
+  private def boolLaterDoneAndTrue(trueLater: Future[Boolean]): () => Future[Boolean] = {
+    () => boolLaterDoneAnd(true, trueLater)
+  }
 
   behavior of "RpcUtil"
 
   it should "complete immediately if condition is true" in {
-    RpcUtil.retryUntilSatisfied(condition = true, duration = 0.millis).map { _ =>
+    RpcUtil.retryUntilSatisfiedF(
+      conditionF = () => Future.successful(true),
+      duration = 0.millis).map { _ =>
       succeed
     }
   }
 
   it should "fail if condition is false" in {
     recoverToSucceededIf[RuntimeException] {
-      RpcUtil.retryUntilSatisfied(condition = false, duration = 0.millis)
+      RpcUtil.retryUntilSatisfiedF(
+        conditionF = () => Future.successful(false),
+        duration = 0.millis)
     }
   }
 
   it should "succeed after a delay" in {
     val boolLater = trueLater(delay = 250)
-    RpcUtil.retryUntilSatisfied(boolLaterDoneAndTrue(boolLater)).map { _ =>
+    RpcUtil.retryUntilSatisfiedF(boolLaterDoneAndTrue(boolLater)).map { _ =>
       succeed
     }
   }
@@ -49,25 +55,25 @@ class RpcUtilTest extends AsyncFlatSpec with BeforeAndAfterAll {
   it should "fail if there is a delay and duration is zero" in {
     val boolLater = trueLater(delay = 250)
     recoverToSucceededIf[RuntimeException] {
-      RpcUtil.retryUntilSatisfied(boolLaterDoneAndTrue(boolLater), duration = 0.millis)
+      RpcUtil.retryUntilSatisfiedF(boolLaterDoneAndTrue(boolLater), duration = 0.millis)
     }
   }
 
   it should "succeed immediately if condition is true" in {
-    RpcUtil.awaitCondition(condition = true, 0.millis)
+    RpcUtil.awaitCondition(condition = () => true, 0.millis)
     succeed
   }
 
   it should "timeout if condition is false" in {
     assertThrows[RuntimeException] {
-      RpcUtil.awaitCondition(condition = false, duration = 0.millis)
+      RpcUtil.awaitCondition(condition = () => false, duration = 0.millis)
     }
   }
 
   it should "block for a delay and then succeed" in {
     val boolLater = trueLater(delay = 250)
     val before: Long = System.currentTimeMillis
-    RpcUtil.awaitCondition(boolLaterDoneAndTrue(boolLater))
+    RpcUtil.awaitConditionF(boolLaterDoneAndTrue(boolLater))
     val after: Long = System.currentTimeMillis
     assert(after - before >= 250)
   }
@@ -75,7 +81,7 @@ class RpcUtilTest extends AsyncFlatSpec with BeforeAndAfterAll {
   it should "timeout if there is a delay and duration is zero" in {
     val boolLater = trueLater(delay = 250)
     assertThrows[RuntimeException] {
-      RpcUtil.awaitCondition(boolLaterDoneAndTrue(boolLater), duration = 0.millis)
+      RpcUtil.awaitConditionF(boolLaterDoneAndTrue(boolLater), duration = 0.millis)
     }
   }
 

--- a/rpc/src/test/scala/org/bitcoins/rpc/TestUtil.scala
+++ b/rpc/src/test/scala/org/bitcoins/rpc/TestUtil.scala
@@ -6,13 +6,14 @@ import java.net.URI
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import org.bitcoins.core.config.RegTest
+import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.rpc.client.BitcoindRpcClient
 import org.bitcoins.rpc.config.{ BitcoindAuthCredentials, BitcoindInstance }
 
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.concurrent.duration.{ DurationInt, FiniteDuration }
-import scala.util.Try
+import scala.util.{ Failure, Success, Try }
 
 trait TestUtil extends BitcoinSLogger {
 
@@ -93,27 +94,60 @@ trait TestUtil extends BitcoinSLogger {
     duration: FiniteDuration = 100.milliseconds,
     maxTries: Int = 50)(implicit system: ActorSystem): Unit = {
     implicit val ec = system.dispatcher
-    RpcUtil.awaitCondition(
-      Await.result(
-        from
-          .getAddedNodeInfo(to.getDaemon.uri)
-          .map(info => info.nonEmpty && info.head.connected.contains(true)),
-        5.seconds),
-      duration,
-      maxTries)
+
+    def isConnected(): Future[Boolean] = {
+      from.getAddedNodeInfo(to.getDaemon.uri)
+        .map { info =>
+          info.nonEmpty && info.head.connected.contains(true)
+        }
+    }
+
+    RpcUtil.awaitConditionF(
+      conditionF = isConnected,
+      duration = duration,
+      maxTries = maxTries)
   }
 
   def awaitSynced(
     client1: BitcoindRpcClient,
     client2: BitcoindRpcClient,
-    duration: FiniteDuration = 100.milliseconds,
+    duration: FiniteDuration = 1.second,
     maxTries: Int = 50)(implicit system: ActorSystem): Unit = {
     implicit val ec = system.dispatcher
-    RpcUtil.awaitCondition(Await.result(client1.getBlockCount.flatMap { count1 =>
-      client2.getBlockCount.map { count2 =>
-        count1 == count2
+
+    def isSynced(): Future[Boolean] = {
+      client1.getBestBlockHash.flatMap { hash1 =>
+        client2.getBestBlockHash.map { hash2 =>
+          hash1 == hash2
+        }
       }
-    }, 2.seconds), duration, maxTries)
+    }
+
+    RpcUtil.awaitConditionF(
+      conditionF = isSynced,
+      duration = duration,
+      maxTries = maxTries)
+  }
+
+  def awaitSameBlockHeight(
+    client1: BitcoindRpcClient,
+    client2: BitcoindRpcClient,
+    duration: FiniteDuration = 1.second,
+    maxTries: Int = 50)(implicit system: ActorSystem): Unit = {
+    implicit val ec = system.dispatcher
+
+    def isSameBlockHeight(): Future[Boolean] = {
+      client1.getBlockCount.flatMap { count1 =>
+        client2.getBlockCount.map { count2 =>
+          count1 == count2
+        }
+      }
+    }
+
+    RpcUtil.awaitConditionF(
+      conditionF = isSameBlockHeight,
+      duration = duration,
+      maxTries = maxTries)
   }
 
   def awaitDisconnected(
@@ -122,14 +156,19 @@ trait TestUtil extends BitcoinSLogger {
     duration: FiniteDuration = 100.milliseconds,
     maxTries: Int = 50)(implicit system: ActorSystem): Unit = {
     implicit val ec = system.dispatcher
-    RpcUtil.awaitCondition(
-      Await.result(
-        from
-          .getAddedNodeInfo(to.getDaemon.uri)
-          .map(info => info.isEmpty || !info.head.connected.contains(true)),
-        2.seconds),
-      duration,
-      maxTries)
+
+    def isDisconnected(): Future[Boolean] = {
+      val f = from.getAddedNodeInfo(to.getDaemon.uri)
+        .map(info => info.isEmpty || info.head.connected.contains(false))
+
+      f
+
+    }
+
+    RpcUtil.awaitConditionF(
+      conditionF = isDisconnected,
+      duration = duration,
+      maxTries = maxTries)
   }
 
   /** Returns a pair of RpcClients that are connected with 100 blocks in the chain */
@@ -142,26 +181,37 @@ trait TestUtil extends BitcoinSLogger {
     implicit val ec = m.executionContext
     val client1: BitcoindRpcClient = new BitcoindRpcClient(instance(port1, rpcPort1))
     val client2: BitcoindRpcClient = new BitcoindRpcClient(instance(port2, rpcPort2))
+
     client1.start()
     client2.start()
+
     val try1 = Try(RpcUtil.awaitServer(client1))
     if (try1.isFailure) {
       deleteNodePair(client1, client2)
       throw try1.failed.get
     }
+
     val try2 = Try(RpcUtil.awaitServer(client2))
     if (try2.isFailure) {
       deleteNodePair(client1, client2)
       throw try2.failed.get
     }
+
     client1.addNode(client2.getDaemon.uri, "add").flatMap { _ =>
-      val try3 = Try(awaitConnection(client1, client2))
+      val try3 = Try(awaitConnection(
+        from = client1,
+        to = client2,
+        duration = 1.seconds))
+
       if (try3.isFailure) {
+        logger.error(s"Failed to connect client1 and client 2 ${try3.failed.get.getMessage}")
         deleteNodePair(client1, client2)
         throw try3.failed.get
       }
       client1.generate(100).map { _ =>
+
         val try4 = Try(awaitSynced(client1, client2))
+
         if (try4.isFailure) {
           deleteNodePair(client1, client2)
           throw try4.failed.get
@@ -176,6 +226,17 @@ trait TestUtil extends BitcoinSLogger {
     client2.stop()
     deleteTmpDir(client1.getDaemon.authCredentials.datadir)
     deleteTmpDir(client2.getDaemon.authCredentials.datadir)
+  }
+
+  def hasSeenBlock(client1: BitcoindRpcClient, hash: DoubleSha256Digest)(implicit ec: ExecutionContext): Future[Boolean] = {
+    val p = Promise[Boolean]()
+
+    client1.getBlock(hash).onComplete {
+      case Success(_) => p.success(true)
+      case Failure(_) => p.success(false)
+    }
+
+    p.future
   }
 }
 


### PR DESCRIPTION
This builds off of #188 

This PR aims to implement a RPC for [eclair](https://github.com/acinq/eclair) -- a lightning network implementation. 

We are aiming to have a full RPC client with a comprehensive set of unit tests that open create their own eclair instances, run unit tests against those eclair instances, and then destroy them.

Currently we have a unit test implemented for `open`

Here is a full list of Eclair's RPCs

https://github.com/acinq/eclair#json-rpc-api