### PR TITLE
Add NodeId, NodeUri, ChannelId

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/channel/ChannelId.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/channel/ChannelId.scala
@@ -1,0 +1,41 @@
+package org.bitcoins.core.protocol.ln.channel
+
+import org.bitcoins.core.protocol.NetworkElement
+import org.bitcoins.core.util.Factory
+import scodec.bits.ByteVector
+
+/**
+ * There are two types of ChannelIds in the lightning protocol
+ * There is a 'temporary' channel id used for the hand shake when initially establishing
+ * a channel and then a FundedChannelId indicating a channel that has a validly signed tx
+ * For more information on the distinction between these two types please read
+ * about establishing a channel
+ * [[https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#channel-establishment]]
+ */
+sealed abstract class ChannelId extends NetworkElement
+
+/**
+ * Represents the the temporary channelId created in the
+ * open_channel msg of the LN p2p protocol
+ * [[https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#the-open_channel-message]]
+ */
+case class TempChannelId(bytes: ByteVector) extends ChannelId {
+  require(bytes.length == 32, s"ChannelId must be 32 bytes in size, got ${bytes.length}")
+}
+
+/**
+ * Represents the stable ChannelId that represents a channel that has been signed by both parties
+ * This is created in the funding_signed msg on the lightning p2p protocol
+ * [[https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#the-funding_signed-message]]
+ *
+ * This channelId is derived It's derived from the funding transaction by combining the funding_txid and
+ * the funding_output_index using big-endian exclusive-OR (i.e. funding_output_index alters the last 2 bytes).
+ * @param bytes
+ */
+case class FundedChannelId(bytes: ByteVector) extends ChannelId {
+  require(bytes.length == 32, s"ChannelId must be 32 bytes in size, got ${bytes.length}")
+}
+
+object FundedChannelId extends Factory[FundedChannelId] {
+  override def fromBytes(bytes: ByteVector): FundedChannelId = FundedChannelId(bytes)
+}

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
@@ -1,29 +1,33 @@
 package org.bitcoins.eclair.rpc.json
 
+import org.bitcoins.core.crypto.{ DoubleSha256Digest, ECDigitalSignature }
+import org.bitcoins.core.protocol.ln.PicoBitcoins
+import org.bitcoins.core.protocol.ln.channel.FundedChannelId
+import org.bitcoins.eclair.rpc.network.{ NodeId, PeerState }
 import play.api.libs.json.{ JsArray, JsObject }
 
 sealed abstract class EclairModels
 
 case class GetInfoResult(
-  nodeId: String,
+  nodeId: NodeId,
   alias: String,
   port: Int,
-  chainHash: String,
+  chainHash: DoubleSha256Digest,
   blockHeight: Long)
 
 case class PeerInfo(
-  nodeId: String,
-  state: String,
+  nodeId: NodeId,
+  state: PeerState,
   //address: String,
   channels: Int)
 
-case class ChannelInfo(nodeId: String, channelId: String, state: String)
+case class ChannelInfo(nodeId: NodeId, channelId: FundedChannelId, state: String)
 
 case class NodeInfo(
-  signature: String,
+  signature: ECDigitalSignature,
   features: String,
   timestamp: Long,
-  nodeId: String,
+  nodeId: NodeId,
   rgbColor: String,
   alias: String,
   addresses: Vector[String])
@@ -31,14 +35,14 @@ case class NodeInfo(
 case class ChannelDesc(shortChannelId: String, a: String, b: String)
 
 case class ChannelUpdate(
-  signature: String,
-  chainHash: String,
+  signature: ECDigitalSignature,
+  chainHash: DoubleSha256Digest,
   shortChannelId: String,
   timestamp: Long,
   flags: String,
   cltvExpiryDelta: Int,
   htlcMinimumMsat: Long,
-  feeBaseMsat: Long,
+  feeBaseMsat: PicoBitcoins,
   feeProportionalMillionths: Long)
 
 /* ChannelResult starts here, some of this may be useful but it seems that data is different at different times
@@ -152,8 +156,8 @@ implicit val channelDataReads: Reads[ChannelData] =
   Json.reads[ChannelData]
 */
 case class ChannelResult(
-  nodeId: String,
-  channelId: String,
+  nodeId: NodeId,
+  channelId: FundedChannelId,
   state: String,
   data: JsObject)
 
@@ -163,13 +167,13 @@ case class PaymentRequest(
   prefix: String,
   amount: Option[Long],
   timestamp: Long,
-  nodeId: String,
+  nodeId: NodeId,
   tags: Vector[JsObject],
   signature: String)
 
 sealed trait SendResult
 case class PaymentSucceeded(
-  amountMsat: Long,
+  amountMsat: PicoBitcoins,
   paymentHash: String,
   paymentPreimage: String,
   route: JsArray) extends SendResult

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/JsonReaders.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/JsonReaders.scala
@@ -1,8 +1,39 @@
 package org.bitcoins.eclair.rpc.json
 
-import play.api.libs.json.{ Json, Reads }
+import org.bitcoins.core.crypto.{ DoubleSha256Digest, ECDigitalSignature }
+import org.bitcoins.core.protocol.ln.PicoBitcoins
+import org.bitcoins.core.protocol.ln.channel.FundedChannelId
+import org.bitcoins.eclair.rpc.network.{ NodeId, PeerState }
+import org.bitcoins.rpc.serializers.SerializerUtil
+import org.slf4j.LoggerFactory
+import play.api.libs.json._
+
+import scala.util.Try
 
 object JsonReaders {
+
+  import org.bitcoins.rpc.serializers.JsonReaders._
+
+  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
+
+  implicit val picoBitcoins: Reads[PicoBitcoins] = {
+    Reads { jsValue: JsValue =>
+      SerializerUtil.processJsNumberBigInt(PicoBitcoins.apply)(jsValue)
+    }
+  }
+
+  implicit val peerState: Reads[PeerState] = {
+    Reads { jsValue: JsValue =>
+      SerializerUtil.processJsStringOpt(PeerState.fromString)(jsValue)
+    }
+  }
+
+  implicit val nodeId: Reads[NodeId] = {
+    Reads { jsValue: JsValue =>
+      SerializerUtil.processJsString(NodeId.fromHex)(jsValue)
+    }
+
+  }
 
   implicit val getInfoResultReads: Reads[GetInfoResult] = {
     Json.reads[GetInfoResult]
@@ -14,6 +45,12 @@ object JsonReaders {
 
   implicit val nodeInfoReads: Reads[NodeInfo] = {
     Json.reads[NodeInfo]
+  }
+
+  implicit val fundedChannelIdReads: Reads[FundedChannelId] = {
+    Reads { jsValue: JsValue =>
+      SerializerUtil.processJsString(FundedChannelId.fromHex)(jsValue)
+    }
   }
 
   implicit val channelDescReads: Reads[ChannelDesc] = {
@@ -42,5 +79,4 @@ object JsonReaders {
 
   implicit val channelResultReads: Reads[ChannelResult] =
     Json.reads[ChannelResult]
-
 }

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/network/NodeId.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/network/NodeId.scala
@@ -1,0 +1,31 @@
+package org.bitcoins.eclair.rpc.network
+
+import org.bitcoins.core.crypto.ECPublicKey
+import org.bitcoins.core.protocol.NetworkElement
+import org.bitcoins.core.util.Factory
+import scodec.bits.ByteVector
+
+/**
+ * NodeId is simply a wrraper for [[ECPublicKey]]. This public key needs to be a
+ * 33 byte compressed secp256k1 public key.
+ * @param pubKey
+ */
+case class NodeId(pubKey: ECPublicKey) extends NetworkElement {
+  require(pubKey.isCompressed, s"Cannot create a nodeId from a public key that was not compressed ${pubKey.hex}")
+
+  override def toString: String = pubKey.hex
+
+  override def bytes = pubKey.bytes
+}
+
+object NodeId extends Factory[NodeId] {
+
+  def fromPubKey(pubKey: ECPublicKey): NodeId = {
+    NodeId(pubKey)
+  }
+
+  override def fromBytes(bytes: ByteVector): NodeId = {
+    val pubKey = ECPublicKey.fromBytes(bytes)
+    fromPubKey(pubKey)
+  }
+}

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/network/NodeUri.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/network/NodeUri.scala
@@ -1,0 +1,47 @@
+package org.bitcoins.eclair.rpc.network
+
+import org.slf4j.LoggerFactory
+
+import scala.util.{ Failure, Success, Try }
+
+case class NodeUri(nodeId: NodeId, host: String, port: Int) {
+  override def toString = s"$nodeId@$host:$port"
+}
+
+object NodeUri {
+  private val logger = LoggerFactory.getLogger(this.getClass().getSimpleName)
+
+  private val defaultPort = ":9735"
+
+  def fromString(uri: String): Try[NodeUri] = {
+    val patternWithPort = ("""(\w+)@([\w\.]+(\w+)):(\d{2,5})""").r
+
+    val isUriWithPort = patternWithPort.findFirstIn(uri)
+
+    val nodeUriT = isUriWithPort match {
+      case Some(uri) =>
+        Success(parse(uri))
+      case None =>
+        Failure(new IllegalArgumentException(s"Failed to parse $uri to a NodeUri"))
+    }
+    nodeUriT
+  }
+
+  def fromStringNoPort(uri: String): Try[NodeUri] = {
+    fromString(uri + defaultPort)
+  }
+
+  /**
+   * Assumes format is [nodeId]@[host]:[port]
+   */
+  private def parse(validUri: String): NodeUri = {
+    //key is 33 bytes in size
+    val (key: String, rest: String) = validUri.splitAt(66)
+
+    val (host, port) = rest.splitAt(rest.size - 5)
+
+    val nodeId = NodeId.fromHex(key)
+
+    NodeUri(nodeId, host.tail, port.tail.toInt)
+  }
+}

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/network/PeerState.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/network/PeerState.scala
@@ -1,0 +1,15 @@
+package org.bitcoins.eclair.rpc.network
+
+sealed abstract class PeerState
+
+object PeerState {
+  case object CONNECTED extends PeerState
+
+  case object DISCONNECTED extends PeerState
+
+  private val all = List(CONNECTED, DISCONNECTED)
+
+  def fromString(str: String): Option[PeerState] = {
+    all.find(_.toString == str)
+  }
+}

--- a/eclair-rpc/src/test/resources/logback-test.xml
+++ b/eclair-rpc/src/test/resources/logback-test.xml
@@ -14,7 +14,7 @@
     </appender>
 
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE"/>
     </root>

--- a/eclair-rpc/src/test/scala/org/bitcoins/eclair/network/NodeUriTest.scala
+++ b/eclair-rpc/src/test/scala/org/bitcoins/eclair/network/NodeUriTest.scala
@@ -1,0 +1,47 @@
+package org.bitcoins.eclair.network
+
+import org.bitcoins.eclair.rpc.network.NodeUri
+import org.scalatest.FlatSpec
+
+class NodeUriTest extends FlatSpec {
+
+  behavior of "NodeUri"
+
+  it must "read the suredbits node uri" in {
+    val sb = "0338f57e4e20abf4d5c86b71b59e995ce4378e373b021a7b6f41dabb42d3aad069@ln.test.suredbits.com:9735"
+    val uriT = NodeUri.fromString(sb)
+    assert(uriT.isSuccess == true)
+
+    assert(uriT.get.toString == sb)
+  }
+
+  it must "read the suredbits node uri without the port" in {
+    val sb = "0338f57e4e20abf4d5c86b71b59e995ce4378e373b021a7b6f41dabb42d3aad069@ln.test.suredbits.com"
+    val uriT = NodeUri.fromStringNoPort(sb)
+    assert(uriT.isSuccess == true)
+
+    assert(uriT.get.toString == (sb + ":9735"))
+  }
+
+  it must "read a node uri with a ip address" in {
+    val sb = "0338f57e4e20abf4d5c86b71b59e995ce4378e373b021a7b6f41dabb42d3aad069@127.0.0.1:9735"
+
+    val uriT = NodeUri.fromString(sb)
+
+    assert(uriT.isSuccess)
+
+    assert(uriT.get.toString == sb)
+  }
+
+  it must "fail to read a node uri without a nodeId" in {
+    val sb = "@ln.test.suredbits.com"
+    val uriT = NodeUri.fromString(sb)
+    assert(uriT.isFailure == true)
+  }
+
+  it must "fail to read a node uri with a invalid port" in {
+    val sb = "0338f57e4e20abf4d5c86b71b59e995ce4378e373b021a7b6f41dabb42d3aad069@ln.test.suredbits.com:abc2"
+    val uriT = NodeUri.fromString(sb)
+    assert(uriT.isFailure == true)
+  }
+}

--- a/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairTestUtil.scala
+++ b/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairTestUtil.scala
@@ -69,13 +69,14 @@ trait EclairTestUtil extends BitcoinSLogger {
   }
 
   def startedBitcoindInstance()(implicit system: ActorSystem): BitcoindInstance = {
-    implicit val m = ActorMaterializer.create(system)
 
     val i = bitcoindInstance()
 
     //start the bitcoind instance so eclair can properly use it
-    val rpc = new BitcoindRpcClient(i)(m)
+    val rpc = new BitcoindRpcClient(i)(system)
     rpc.start()
+
+    logger.debug(s"Starting bitcoind at ${i.authCredentials.datadir}")
     RpcUtil.awaitServer(rpc)
 
     //fund the wallet by generating 102 blocks, need this to get over coinbase maturity

--- a/rpc/src/main/scala/org/bitcoins/rpc/RpcUtil.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/RpcUtil.scala
@@ -115,7 +115,7 @@ trait RpcUtil extends BitcoinSLogger {
 
   def awaitServer(
     server: BitcoindRpcClient,
-    duration: FiniteDuration = 100.milliseconds,
+    duration: FiniteDuration = 1.seconds,
     maxTries: Int = 50)(implicit system: ActorSystem): Unit = {
     val f = () => server.isStarted
     awaitCondition(f, duration, maxTries)

--- a/rpc/src/main/scala/org/bitcoins/rpc/client/BitcoindRpcClient.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/client/BitcoindRpcClient.scala
@@ -3,6 +3,7 @@ package org.bitcoins.rpc.client
 import java.net.URI
 import java.util.UUID
 
+import akka.actor.ActorSystem
 import akka.http.javadsl.model.headers.HttpCredentials
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
@@ -16,6 +17,7 @@ import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.{ Transaction, TransactionInput, TransactionOutPoint }
 import org.bitcoins.core.protocol.{ BitcoinAddress, P2PKHAddress }
 import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinSUtil }
+import org.bitcoins.rpc.RpcUtil
 import org.bitcoins.rpc.client.RpcOpts.AddressType
 import org.bitcoins.rpc.config.BitcoindInstance
 import org.bitcoins.rpc.jsonmodels._
@@ -29,30 +31,41 @@ import scala.util.Try
 
 class BitcoindRpcClient(instance: BitcoindInstance)(
   implicit
-  m: ActorMaterializer) {
+  system: ActorSystem) {
   private val resultKey = "result"
   private val errorKey = "error"
   private val logger = BitcoinSLogger.logger
   private implicit val network = instance.network
+  private implicit val m = ActorMaterializer.create(system)
   private implicit val ec: ExecutionContext = m.executionContext
 
   def getDaemon: BitcoindInstance = instance
 
-  def isStarted: Boolean = {
-    val request = buildRequest(instance, "ping", JsArray.empty)
-    val responseF = sendRequest(request)
+  def isStarted(): Boolean = {
 
-    val payloadF: Future[JsValue] = responseF.flatMap(getPayload)
+    def isConnected(): Future[Boolean] = {
+      val request = buildRequest(instance, "ping", JsArray.empty)
+      val responseF = sendRequest(request)
+      responseF.map(r => logger.info(s"response isConnected $r"))
+      val payloadF: Future[JsValue] = responseF.flatMap(getPayload)
 
-    // Ping successful if no error can be parsed from the payload
-    val result = Try(Await.result(payloadF.map { payload =>
-      (payload \ errorKey).validate[RpcError] match {
-        case res: JsSuccess[RpcError] => false
-        case res: JsError => true
+      // Ping successful if no error can be parsed from the payload
+      val result: Future[Boolean] = payloadF.map { payload =>
+        (payload \ errorKey).validate[RpcError] match {
+          case res: JsSuccess[RpcError] => false
+          case res: JsError => true
+        }
       }
-    }, 2.seconds))
 
-    result.getOrElse(false)
+      result
+    }
+
+    val await = Try(
+      RpcUtil.awaitConditionF(
+        conditionF = isConnected,
+        duration = 1.seconds))
+
+    if (await.isSuccess) true else false
   }
 
   def abandonTransaction(txid: DoubleSha256Digest): Future[Unit] = {

--- a/rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
@@ -3,19 +3,10 @@ package org.bitcoins.rpc.serializers
 import java.io.File
 import java.net.{ InetAddress, URI }
 
-import org.bitcoins.core.crypto.{
-  DoubleSha256Digest,
-  ECPublicKey,
-  Sha256Hash160Digest
-}
+import org.bitcoins.core.crypto.{ DoubleSha256Digest, ECDigitalSignature, ECPublicKey, Sha256Hash160Digest }
 import org.bitcoins.core.currency.{ Bitcoins, Satoshis }
 import org.bitcoins.core.number.{ Int32, Int64, UInt32, UInt64 }
-import org.bitcoins.core.protocol.{
-  Address,
-  BitcoinAddress,
-  P2PKHAddress,
-  P2SHAddress
-}
+import org.bitcoins.core.protocol.{ Address, BitcoinAddress, P2PKHAddress, P2SHAddress }
 import org.bitcoins.core.protocol.blockchain.{ Block, BlockHeader, MerkleBlock }
 import org.bitcoins.core.protocol.script.{ ScriptPubKey, ScriptSignature }
 import org.bitcoins.core.protocol.transaction._
@@ -26,55 +17,30 @@ import play.api.libs.json._
 import scala.util.{ Failure, Success }
 
 object JsonReaders {
-  // For use in implementing reads method of Reads[T] where T is constructed from a JsNumber via numFunc
-  private def processJsNumber[T](numFunc: BigDecimal => T)(
-    json: JsValue): JsResult[T] = json match {
-    case JsNumber(n) => JsSuccess(numFunc(n))
-    case err @ (JsNull | _: JsBoolean | _: JsString | _: JsArray |
-      _: JsObject) =>
-      buildJsErrorMsg("jsnumber", err)
-  }
-
-  // For use in implementing reads method of Reads[T] where T is constructed from a JsString via strFunc
-  private def processJsString[T](strFunc: String => T)(
-    json: JsValue): JsResult[T] = json match {
-    case JsString(s) => JsSuccess(strFunc(s))
-    case err @ (JsNull | _: JsBoolean | _: JsNumber | _: JsArray |
-      _: JsObject) =>
-      buildJsErrorMsg("jsstring", err)
-  }
-
-  private def buildJsErrorMsg(expected: String, err: JsValue): JsError = {
-    JsError(s"error.expected.$expected, got ${Json.toJson(err).toString()}")
-  }
-
-  private def buildErrorMsg(expected: String, err: Any): JsError = {
-    JsError(s"error.expected.$expected, got ${err.toString}")
-  }
 
   implicit object BigIntReads extends Reads[BigInt] {
     override def reads(json: JsValue): JsResult[BigInt] =
-      processJsNumber[BigInt](_.toBigInt())(json)
+      SerializerUtil.processJsNumber[BigInt](_.toBigInt())(json)
   }
 
   implicit object DoubleSha256DigestReads extends Reads[DoubleSha256Digest] {
     override def reads(json: JsValue): JsResult[DoubleSha256Digest] =
-      processJsString[DoubleSha256Digest](DoubleSha256Digest.fromHex)(json)
+      SerializerUtil.processJsString[DoubleSha256Digest](DoubleSha256Digest.fromHex)(json)
   }
 
   implicit object BitcoinsReads extends Reads[Bitcoins] {
     override def reads(json: JsValue): JsResult[Bitcoins] =
-      processJsNumber[Bitcoins](Bitcoins(_))(json)
+      SerializerUtil.processJsNumber[Bitcoins](Bitcoins(_))(json)
   }
 
   implicit object SatoshisReads extends Reads[Satoshis] {
     override def reads(json: JsValue): JsResult[Satoshis] =
-      processJsNumber[Satoshis](num => Satoshis(Int64(num.toBigInt)))(json)
+      SerializerUtil.processJsNumber[Satoshis](num => Satoshis(Int64(num.toBigInt)))(json)
   }
 
   implicit object BlockHeaderReads extends Reads[BlockHeader] {
     override def reads(json: JsValue): JsResult[BlockHeader] =
-      processJsString[BlockHeader](BlockHeader.fromHex)(json)
+      SerializerUtil.processJsString[BlockHeader](BlockHeader.fromHex)(json)
   }
 
   implicit object Int32Reads extends Reads[Int32] {
@@ -82,11 +48,11 @@ object JsonReaders {
       case JsNumber(n) =>
         n.toBigIntExact() match {
           case Some(num) => JsSuccess(Int32(num))
-          case None => buildErrorMsg("Int32", n)
+          case None => SerializerUtil.buildErrorMsg("Int32", n)
         }
       case JsString(s) => JsSuccess(Int32.fromHex(s))
       case err @ (JsNull | _: JsBoolean | _: JsArray | _: JsObject) =>
-        buildJsErrorMsg("jsnumber", err)
+        SerializerUtil.buildJsErrorMsg("jsnumber", err)
     }
   }
 
@@ -98,13 +64,13 @@ object JsonReaders {
             if (num >= 0) {
               JsSuccess(UInt32(num))
             } else {
-              buildErrorMsg("positive_value", num)
+              SerializerUtil.buildErrorMsg("positive_value", num)
             }
-          case None => buildErrorMsg("UInt32", n)
+          case None => SerializerUtil.buildErrorMsg("UInt32", n)
         }
       case JsString(s) => JsSuccess(UInt32.fromHex(s))
       case err @ (JsNull | _: JsBoolean | _: JsArray | _: JsObject) =>
-        buildJsErrorMsg("jsnumber", err)
+        SerializerUtil.buildJsErrorMsg("jsnumber", err)
     }
   }
 
@@ -116,13 +82,13 @@ object JsonReaders {
             if (num >= 0) {
               JsSuccess(UInt64(num))
             } else {
-              buildErrorMsg("positive_value", num)
+              SerializerUtil.buildErrorMsg("positive_value", num)
             }
-          case None => buildErrorMsg("UInt32", n)
+          case None => SerializerUtil.buildErrorMsg("UInt32", n)
         }
       case JsString(s) => JsSuccess(UInt64.fromHex(s))
       case err @ (JsNull | _: JsBoolean | _: JsArray | _: JsObject) =>
-        buildJsErrorMsg("jsnumber", err)
+        SerializerUtil.buildJsErrorMsg("jsnumber", err)
     }
   }
 
@@ -132,11 +98,11 @@ object JsonReaders {
         Address.fromString(s) match {
           case Success(address) => JsSuccess(address)
           case Failure(err) =>
-            buildErrorMsg("address", err)
+            SerializerUtil.buildErrorMsg("address", err)
         }
       case err @ (JsNull | _: JsBoolean | _: JsNumber | _: JsArray |
         _: JsObject) =>
-        buildJsErrorMsg("jsstring", err)
+        SerializerUtil.buildJsErrorMsg("jsstring", err)
     }
   }
 
@@ -147,27 +113,33 @@ object JsonReaders {
 
   implicit object InetAddressReads extends Reads[InetAddress] {
     override def reads(json: JsValue): JsResult[InetAddress] =
-      processJsString[InetAddress](InetAddress.getByName)(json)
+      SerializerUtil.processJsString[InetAddress](InetAddress.getByName)(json)
+  }
+
+  implicit object ECDigitalSignatureReads extends Reads[ECDigitalSignature] {
+    override def reads(json: JsValue): JsResult[ECDigitalSignature] = {
+      SerializerUtil.processJsString(ECDigitalSignature.fromHex)(json)
+    }
   }
 
   implicit object ScriptPubKeyReads extends Reads[ScriptPubKey] {
     override def reads(json: JsValue): JsResult[ScriptPubKey] =
-      processJsString[ScriptPubKey](ScriptPubKey.fromAsmHex)(json)
+      SerializerUtil.processJsString[ScriptPubKey](ScriptPubKey.fromAsmHex)(json)
   }
 
   implicit object BlockReads extends Reads[Block] {
     override def reads(json: JsValue): JsResult[Block] =
-      processJsString[Block](Block.fromHex)(json)
+      SerializerUtil.processJsString[Block](Block.fromHex)(json)
   }
 
   implicit object Sha256Hash160DigestReads extends Reads[Sha256Hash160Digest] {
     override def reads(json: JsValue): JsResult[Sha256Hash160Digest] =
-      processJsString[Sha256Hash160Digest](Sha256Hash160Digest.fromHex)(json)
+      SerializerUtil.processJsString[Sha256Hash160Digest](Sha256Hash160Digest.fromHex)(json)
   }
 
   implicit object ECPublicKeyReads extends Reads[ECPublicKey] {
     override def reads(json: JsValue): JsResult[ECPublicKey] =
-      processJsString[ECPublicKey](ECPublicKey.fromHex)(json)
+      SerializerUtil.processJsString[ECPublicKey](ECPublicKey.fromHex)(json)
   }
 
   implicit object P2PKHAddressReads extends Reads[P2PKHAddress] {
@@ -176,11 +148,11 @@ object JsonReaders {
         P2PKHAddress.fromString(s) match {
           case Success(address) => JsSuccess(address)
           case Failure(err) =>
-            buildErrorMsg("p2pkhaddress", err)
+            SerializerUtil.buildErrorMsg("p2pkhaddress", err)
         }
       case err @ (JsNull | _: JsBoolean | _: JsNumber | _: JsArray |
         _: JsObject) =>
-        buildJsErrorMsg("jsstring", err)
+        SerializerUtil.buildJsErrorMsg("jsstring", err)
     }
   }
 
@@ -190,17 +162,17 @@ object JsonReaders {
         P2SHAddress.fromString(s) match {
           case Success(address) => JsSuccess(address)
           case Failure(err) =>
-            buildErrorMsg("p2shaddress", err)
+            SerializerUtil.buildErrorMsg("p2shaddress", err)
         }
       case err @ (JsNull | _: JsBoolean | _: JsNumber | _: JsArray |
         _: JsObject) =>
-        buildJsErrorMsg("jsstring", err)
+        SerializerUtil.buildJsErrorMsg("jsstring", err)
     }
   }
 
   implicit object ScriptSignatureReads extends Reads[ScriptSignature] {
     override def reads(json: JsValue): JsResult[ScriptSignature] =
-      processJsString[ScriptSignature](ScriptSignature.fromAsmHex)(json)
+      SerializerUtil.processJsString[ScriptSignature](ScriptSignature.fromAsmHex)(json)
   }
 
   implicit object TransactionInputReads extends Reads[TransactionInput] {
@@ -234,22 +206,22 @@ object JsonReaders {
         BitcoinAddress.fromString(s) match {
           case Success(address) => JsSuccess(address)
           case Failure(err) =>
-            buildErrorMsg("address", err)
+            SerializerUtil.buildErrorMsg("address", err)
         }
       case err @ (JsNull | _: JsBoolean | _: JsNumber | _: JsArray |
         _: JsObject) =>
-        buildJsErrorMsg("jsstring", err)
+        SerializerUtil.buildJsErrorMsg("jsstring", err)
     }
   }
 
   implicit object MerkleBlockReads extends Reads[MerkleBlock] {
     override def reads(json: JsValue): JsResult[MerkleBlock] =
-      processJsString[MerkleBlock](MerkleBlock.fromHex)(json)
+      SerializerUtil.processJsString[MerkleBlock](MerkleBlock.fromHex)(json)
   }
 
   implicit object TransactionReads extends Reads[Transaction] {
     override def reads(json: JsValue): JsResult[Transaction] =
-      processJsString[Transaction](Transaction.fromHex)(json)
+      SerializerUtil.processJsString[Transaction](Transaction.fromHex)(json)
   }
 
   implicit object TransactionOutPointReads extends Reads[TransactionOutPoint] {
@@ -274,7 +246,7 @@ object JsonReaders {
           case Some(
             err @ (JsNull | _: JsBoolean | _: JsString | _: JsArray |
               _: JsObject)) =>
-            buildJsErrorMsg("jsnumber", err)
+            SerializerUtil.buildJsErrorMsg("jsnumber", err)
           case None => JsError("error.expected.balance")
         }
         bitcoinResult.flatMap { bitcoins =>
@@ -285,7 +257,7 @@ object JsonReaders {
             case Some(s) =>
               BitcoinAddress.fromString(s) match {
                 case Success(a) => JsSuccess(a)
-                case Failure(err) => buildErrorMsg("address", err)
+                case Failure(err) => SerializerUtil.buildErrorMsg("address", err)
               }
             case None => JsError("error.expected.address")
           }
@@ -296,24 +268,24 @@ object JsonReaders {
         }
       case err @ (JsNull | _: JsBoolean | _: JsNumber | _: JsString |
         _: JsObject) =>
-        buildJsErrorMsg("jsarray", err)
+        SerializerUtil.buildJsErrorMsg("jsarray", err)
     }
   }
 
   // Currently takes in BTC/kB
   implicit object BitcoinFeeUnitReads extends Reads[BitcoinFeeUnit] {
     override def reads(json: JsValue): JsResult[BitcoinFeeUnit] =
-      processJsNumber[BitcoinFeeUnit](num =>
+      SerializerUtil.processJsNumber[BitcoinFeeUnit](num =>
         SatoshisPerByte(Satoshis(Int64((num * 100000).toBigInt()))))(json)
   }
 
   implicit object FileReads extends Reads[File] {
     override def reads(json: JsValue): JsResult[File] =
-      processJsString[File](new File(_))(json)
+      SerializerUtil.processJsString[File](new File(_))(json)
   }
 
   implicit object URIReads extends Reads[URI] {
     override def reads(json: JsValue): JsResult[URI] =
-      processJsString[URI](str => new URI("http://" + str))(json)
+      SerializerUtil.processJsString[URI](str => new URI("http://" + str))(json)
   }
 }

--- a/rpc/src/main/scala/org/bitcoins/rpc/serializers/SerializerUtil.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/serializers/SerializerUtil.scala
@@ -1,0 +1,64 @@
+package org.bitcoins.rpc.serializers
+
+import java.math.BigInteger
+
+import org.slf4j.LoggerFactory
+import play.api.libs.json._
+
+sealed abstract class SerializerUtil {
+  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
+
+  def processJsNumberBigInt[T](numFunc: BigInt => T)(
+    json: JsValue): JsResult[T] = json match {
+    case JsNumber(nDecimal) =>
+      val nOpt = nDecimal.toBigIntExact()
+      nOpt match {
+        case Some(t) => JsSuccess(numFunc(t))
+        case None => JsError(s"Could not parsed expected t from given string $nDecimal")
+      }
+    case err @ (JsNull | _: JsBoolean | _: JsString | _: JsArray |
+      _: JsObject) =>
+      buildJsErrorMsg("jsnumber", err)
+  }
+
+  def buildJsErrorMsg(expected: String, err: JsValue): JsError = {
+    JsError(s"error.expected.$expected, got ${Json.toJson(err).toString()}")
+  }
+
+  def buildErrorMsg(expected: String, err: Any): JsError = {
+    JsError(s"error.expected.$expected, got ${err.toString}")
+  }
+
+  // For use in implementing reads method of Reads[T] where T is constructed from a JsNumber via numFunc
+  def processJsNumber[T](numFunc: BigDecimal => T)(
+    json: JsValue): JsResult[T] = json match {
+    case JsNumber(n) => JsSuccess(numFunc(n))
+    case err @ (JsNull | _: JsBoolean | _: JsString | _: JsArray |
+      _: JsObject) =>
+      SerializerUtil.buildJsErrorMsg("jsnumber", err)
+  }
+
+  // For use in implementing reads method of Reads[T] where T is constructed from a JsString via strFunc
+  def processJsString[T](strFunc: String => T)(
+    json: JsValue): JsResult[T] = json match {
+    case JsString(s) => JsSuccess(strFunc(s))
+    case err @ (JsNull | _: JsBoolean | _: JsNumber | _: JsArray |
+      _: JsObject) =>
+      SerializerUtil.buildJsErrorMsg("jsstring", err)
+  }
+
+  def processJsStringOpt[T](f: String => Option[T])(jsValue: JsValue): JsResult[T] = {
+    jsValue match {
+      case JsString(key) =>
+        val tOpt = f(key)
+        tOpt match {
+          case Some(t) => JsSuccess(t)
+          case None => SerializerUtil.buildErrorMsg("invalid jsstring", jsValue)
+        }
+      case err @ (_: JsNumber | _: JsObject | _: JsArray | JsNull | _: JsBoolean) =>
+        SerializerUtil.buildErrorMsg("jsstring", err)
+    }
+  }
+}
+
+object SerializerUtil extends SerializerUtil


### PR DESCRIPTION
This adds three new types that are used in the LN network

1. NodeId - represents a unique identifier for a node
2. NodeUri - a uri you can use to connect to on the LN
3. ChannelId - a unique identifer for a lightning network channel -- has two sub types -- `TempChannelId` and `FundedChannelId`