### PR TITLE
Use Gen.delay instead of Gen.const for generating privateKey

### DIFF
--- a/core-gen/src/test/scala/org/bitcoins/core/gen/CryptoGenerators.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/CryptoGenerators.scala
@@ -10,7 +10,7 @@ import org.scalacheck.Gen
  */
 sealed abstract class CryptoGenerators {
 
-  def privateKey: Gen[ECPrivateKey] = Gen.const(ECPrivateKey())
+  def privateKey: Gen[ECPrivateKey] = Gen.delay(ECPrivateKey())
 
   /**
    * Generate a sequence of private keys


### PR DESCRIPTION
When using `Gen.listOf` for generating list of private keys or other cryptos that derived from private keys, it generates all the same objects in list.