### PR TITLE
Adding bitcoin-s types to the eclair-rpc, fixing bug with decoding nu…

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceTagsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceTagsTest.scala
@@ -1,29 +1,30 @@
 package org.bitcoins.core.protocol.ln
 
 import org.bitcoins.core.crypto.{ ECPublicKey, Sha256Digest }
-import org.bitcoins.core.number.{ UInt32, UInt64, UInt8 }
+import org.bitcoins.core.number.{ UInt32, UInt5, UInt64, UInt8 }
 import org.bitcoins.core.protocol.P2PKHAddress
-import org.bitcoins.core.protocol.ln.LnInvoiceTag.DescriptionHashTag
 import org.bitcoins.core.protocol.ln.fee.{ FeeBaseMSat, FeeProportionalMillionths }
 import org.bitcoins.core.protocol.ln.routing.LnRoute
+import org.bitcoins.core.protocol.ln.util.LnUtil
 import org.bitcoins.core.util.{ Bech32, CryptoUtil }
 import org.scalatest.{ FlatSpec, MustMatchers }
+import org.slf4j.LoggerFactory
 import scodec.bits.ByteVector
 
-class LnInvoiceTagsTest extends FlatSpec with MustMatchers {
-
+class LnTagsTest extends FlatSpec with MustMatchers {
+  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
   private val paymentHash = Sha256Digest.fromHex("0001020304050607080900010203040506070809000102030405060708090102")
-  private val paymentTag = LnInvoiceTag.PaymentHashTag(paymentHash)
+  private val paymentTag = LnTag.PaymentHashTag(paymentHash)
 
-  behavior of "LnInvoiceTags"
+  behavior of "LnTags"
 
   //https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#examples
   it must "serialize and deserialize BOLT11's example tags" in {
     //BOLT11 Example #1
     val expected = "pp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq"
 
-    val descriptionE = Left(LnInvoiceTag.DescriptionTag("Please consider supporting this project"))
-    val lnTags = LnInvoiceTaggedFields(
+    val descriptionE = Left(LnTag.DescriptionTag("Please consider supporting this project"))
+    val lnTags = LnTaggedFields(
       paymentHash = paymentTag,
       descriptionOrHash = descriptionE)
 
@@ -36,9 +37,9 @@ class LnInvoiceTagsTest extends FlatSpec with MustMatchers {
 
     val expected = "pp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpu"
 
-    val descriptionTagE = Left(LnInvoiceTag.DescriptionTag("1 cup coffee"))
-    val expiryTimeTag = LnInvoiceTag.ExpiryTimeTag(UInt32(60))
-    val lnTags = LnInvoiceTaggedFields(
+    val descriptionTagE = Left(LnTag.DescriptionTag("1 cup coffee"))
+    val expiryTimeTag = LnTag.ExpiryTimeTag(UInt32(60))
+    val lnTags = LnTaggedFields(
       paymentTag, descriptionTagE,
       expiryTime = Some(expiryTimeTag))
 
@@ -47,10 +48,10 @@ class LnInvoiceTagsTest extends FlatSpec with MustMatchers {
 
   it must "serialize and deserialize the example 3 tags" in {
     val expected = "pp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu"
-    val descriptionTagE = Left(LnInvoiceTag.DescriptionTag("ナンセンス 1杯"))
+    val descriptionTagE = Left(LnTag.DescriptionTag("ナンセンス 1杯"))
 
-    val expiryTag = LnInvoiceTag.ExpiryTimeTag(UInt32(60))
-    val lnTags = LnInvoiceTaggedFields(
+    val expiryTag = LnTag.ExpiryTimeTag(UInt32(60))
+    val lnTags = LnTaggedFields(
       paymentTag, descriptionTagE, None,
       Some(expiryTag), None, None,
       None)
@@ -63,8 +64,8 @@ class LnInvoiceTagsTest extends FlatSpec with MustMatchers {
     val expected = "pp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqs"
 
     val descriptionHash = Sha256Digest.fromHex("3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1")
-    val descriptionHashTagE = Right(LnInvoiceTag.DescriptionHashTag(descriptionHash))
-    val lnTags = LnInvoiceTaggedFields(
+    val descriptionHashTagE = Right(LnTag.DescriptionHashTag(descriptionHash))
+    val lnTags = LnTaggedFields(
       paymentHash = paymentTag,
       descriptionOrHash = descriptionHashTagE)
 
@@ -78,10 +79,10 @@ class LnInvoiceTagsTest extends FlatSpec with MustMatchers {
     /*    val expected = "hp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un98"
 
     val descriptionHash = Sha256Digest.fromHex("3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1")
-    val descriptionHashTagE = Right(LnInvoiceTag.DescriptionHashTag(descriptionHash))
-    val fallbackAddr = LnInvoiceTag.FallbackAddressTag(UInt8(17), P2PKHAddress.fromString("mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP").get)
+    val descriptionHashTagE = Right(LnTag.DescriptionHashTag(descriptionHash))
+    val fallbackAddr = LnTag.FallbackAddressTag(UInt8(17), P2PKHAddress.fromString("mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP").get)
 
-    val lnTags = LnInvoiceTags(
+    val lnTags = LnTags(
       paymentTag, descriptionHashTagE,
       fallbackAddress = Some(fallbackAddr))
 
@@ -102,9 +103,9 @@ class LnInvoiceTagsTest extends FlatSpec with MustMatchers {
 
     val descriptionHash = CryptoUtil.sha256(ByteVector(description))
 
-    val descpriptionHashTag = Right(LnInvoiceTag.DescriptionHashTag(descriptionHash))
+    val descpriptionHashTag = Right(LnTag.DescriptionHashTag(descriptionHash))
 
-    val fallbackAddr = LnInvoiceTag.FallbackAddressTag(P2PKHAddress.fromString("1RustyRX2oai4EYYDpQGWvEL62BBGqN9T").get)
+    val fallbackAddr = LnTag.FallbackAddressTag(P2PKHAddress.fromString("1RustyRX2oai4EYYDpQGWvEL62BBGqN9T").get)
 
     val route1 = LnRoute(
       pubkey = ECPublicKey.fromHex("029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"),
@@ -120,15 +121,38 @@ class LnInvoiceTagsTest extends FlatSpec with MustMatchers {
       feePropMilli = FeeProportionalMillionths(UInt32(30)),
       cltvExpiryDelta = 4)
 
-    val route = LnInvoiceTag.RoutingInfo(Vector(route1, route2))
+    val route = LnTag.RoutingInfo(Vector(route1, route2))
 
-    val lnTags = LnInvoiceTaggedFields(
+    val lnTags = LnTaggedFields(
       paymentHash = paymentTag,
       descriptionOrHash = descpriptionHashTag,
       fallbackAddress = Some(fallbackAddr),
       routingInfo = Some(route))
 
     lnTags.toString must be(expected)
+  }
+
+  it must "deserialize/serialize a timestamp that is larger than a single uint5" in {
+    //x = expiry time tag
+    //qr = 03 // data length
+    //rss = (3 * 32^2) + (16 * 32^1) + (16 * 32^0) = 3072 + 512 + 16 //answer should be 3600
+
+    val serialized = "xqrrss"
+
+    val u5s = Bech32.decodeStringToU5s(serialized)
+
+    //first u5 is the prefix
+    val prefix = LnTagPrefix.fromUInt5(u5s.head)
+
+    //next two 5 bit increments are data_length
+    val dataLengthU5s = Vector(u5s(1), u5s(2))
+
+    val dataLength = LnUtil.decodeNumber(dataLengthU5s)
+    //t is the actual possible payload
+    val payload: Vector[UInt5] = u5s.tail.tail.tail.take(dataLength.toInt)
+
+    val expiry: LnTag.ExpiryTimeTag = LnTag.fromLnTagPrefix(prefix.get, payload).asInstanceOf[LnTag.ExpiryTimeTag]
+    expiry.toString must be(serialized)
   }
 
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
@@ -20,7 +20,7 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
   val time = UInt64(1496314658)
 
   val paymentHash = Sha256Digest.fromHex("0001020304050607080900010203040506070809000102030405060708090102")
-  val paymentTag = LnInvoiceTag.PaymentHashTag(paymentHash)
+  val paymentTag = LnTag.PaymentHashTag(paymentHash)
 
   val description = {
     ("One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, " +
@@ -29,13 +29,13 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
   }
   val descriptionHash = CryptoUtil.sha256(ByteVector(description))
 
-  val descpriptionHashTag = Right(LnInvoiceTag.DescriptionHashTag(descriptionHash))
+  val descpriptionHashTag = Right(LnTag.DescriptionHashTag(descriptionHash))
 
   it must "parse BOLT11 example 1" in {
     //BOLT11 Example #1
 
-    val descriptionTagE = Left(LnInvoiceTag.DescriptionTag("Please consider supporting this project"))
-    val lnTags = LnInvoiceTaggedFields(
+    val descriptionTagE = Left(LnTag.DescriptionTag("Please consider supporting this project"))
+    val lnTags = LnTaggedFields(
       paymentHash = paymentTag,
       descriptionOrHash = descriptionTagE)
 
@@ -56,9 +56,9 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
   it must "parse BOLT11 example 2" in {
     //BOLT11 Example #2
 
-    val descriptionTagE = Left(LnInvoiceTag.DescriptionTag("1 cup coffee"))
-    val expiryTimeTag = LnInvoiceTag.ExpiryTimeTag(UInt32(60))
-    val lnTags = LnInvoiceTaggedFields(
+    val descriptionTagE = Left(LnTag.DescriptionTag("1 cup coffee"))
+    val expiryTimeTag = LnTag.ExpiryTimeTag(UInt32(60))
+    val lnTags = LnTaggedFields(
       paymentTag,
       descriptionOrHash = descriptionTagE,
       expiryTime = Some(expiryTimeTag))
@@ -81,9 +81,9 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
   it must "parse BOLT11 example 3" in {
     //BOLT11 Example #3 - Description field does not encode correctly due to Japanese letters
 
-    val descriptionTagE = Left(LnInvoiceTag.DescriptionTag("ナンセンス 1杯"))
-    val expiryTag = LnInvoiceTag.ExpiryTimeTag(UInt32(60))
-    val lnTags = LnInvoiceTaggedFields(
+    val descriptionTagE = Left(LnTag.DescriptionTag("ナンセンス 1杯"))
+    val expiryTag = LnTag.ExpiryTimeTag(UInt32(60))
+    val lnTags = LnTaggedFields(
       paymentTag, descriptionTagE, None,
       Some(expiryTag), None, None,
       None)
@@ -107,8 +107,8 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
     //BOLT11 Example #4
 
     val descriptionHash = Sha256Digest.fromHex("3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1")
-    val descriptionHashTagE = Right(LnInvoiceTag.DescriptionHashTag(descriptionHash))
-    val lnTags = LnInvoiceTaggedFields(
+    val descriptionHashTagE = Right(LnTag.DescriptionHashTag(descriptionHash))
+    val lnTags = LnTaggedFields(
       paymentHash = paymentTag,
       descriptionOrHash = descriptionHashTagE,
       None, None, None,
@@ -133,10 +133,10 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
     //BOLT11 Example #5
 
     val descriptionHash = Sha256Digest.fromHex("3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1")
-    val descriptionHashTagE = Right(LnInvoiceTag.DescriptionHashTag(descriptionHash))
-    val fallbackAddr = LnInvoiceTag.FallbackAddressTag(P2PKHAddress.fromString("mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP").get)
+    val descriptionHashTagE = Right(LnTag.DescriptionHashTag(descriptionHash))
+    val fallbackAddr = LnTag.FallbackAddressTag(P2PKHAddress.fromString("mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP").get)
 
-    val lnTags = LnInvoiceTaggedFields(
+    val lnTags = LnTaggedFields(
       paymentHash = paymentTag,
       descriptionOrHash = descriptionHashTagE,
       fallbackAddress = Some(fallbackAddr))
@@ -161,7 +161,7 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
   it must "parse BOLT11 example 6" in {
     val expected = "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85fr9yq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqpqqqqq9qqqvpeuqafqxu92d8lr6fvg0r5gv0heeeqgcrqlnm6jhphu9y00rrhy4grqszsvpcgpy9qqqqqqgqqqqq7qqzqj9n4evl6mr5aj9f58zp6fyjzup6ywn3x6sk8akg5v4tgn2q8g4fhx05wf6juaxu9760yp46454gpg5mtzgerlzezqcqvjnhjh8z3g2qqdhhwkj"
 
-    val fallbackAddr = LnInvoiceTag.FallbackAddressTag(P2PKHAddress.fromString("1RustyRX2oai4EYYDpQGWvEL62BBGqN9T").get)
+    val fallbackAddr = LnTag.FallbackAddressTag(P2PKHAddress.fromString("1RustyRX2oai4EYYDpQGWvEL62BBGqN9T").get)
 
     val signature = ECDigitalSignature.fromRS(
       "91675cb3fad8e9d915343883a49242e074474e26d42c7ed914655689a8074553733e8e4ea5ce9b85f69e40d755a55014536b12323f8b220600c94ef2b9c51428")
@@ -183,9 +183,9 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
       feePropMilli = FeeProportionalMillionths(UInt32(30)),
       cltvExpiryDelta = 4)
 
-    val route = LnInvoiceTag.RoutingInfo(Vector(route1, route2))
+    val route = LnTag.RoutingInfo(Vector(route1, route2))
 
-    val lnTags = LnInvoiceTaggedFields(
+    val lnTags = LnTaggedFields(
       paymentHash = paymentTag,
       descriptionOrHash = descpriptionHashTag,
       fallbackAddress = Some(fallbackAddr),
@@ -211,9 +211,9 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
       "dph2q7z9kmrgvr7xlaqm47apw3d48zm203kzcq357a4ls9al2ea73r8jcceyjtya6fu5wzzpe50zrge6ulk" +
       "4nvjcpxlekvmxl6qcs9j3tz0469gqsjurz5"
 
-    val fallbackAddr = LnInvoiceTag.FallbackAddressTag(P2SHAddress.fromString("3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX").get)
+    val fallbackAddr = LnTag.FallbackAddressTag(P2SHAddress.fromString("3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX").get)
 
-    val lnTags = LnInvoiceTaggedFields(
+    val lnTags = LnTaggedFields(
       paymentHash = paymentTag,
       descriptionOrHash = descpriptionHashTag,
       fallbackAddress = Some(fallbackAddr))
@@ -247,9 +247,9 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
       "2ur5j5cr03890fa7k2pypgttmh4897d3raaq85a293e9jpuqwl0rnfu" +
       "wzam7yr8e690nd2ypcq9hlkdwdvycqe4x4ch"
 
-    val fallbackAddr = LnInvoiceTag.FallbackAddressTag(Bech32Address.fromString("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4").get)
+    val fallbackAddr = LnTag.FallbackAddressTag(Bech32Address.fromString("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4").get)
 
-    val lnTags = LnInvoiceTaggedFields(
+    val lnTags = LnTaggedFields(
       paymentHash = paymentTag,
       descriptionOrHash = descpriptionHashTag,
       fallbackAddress = Some(fallbackAddr))
@@ -283,9 +283,9 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
       "q28j0v3rwgy9pvjnd48ee2pl8xrpxysd5g44td63g6xcjcu003j3qe8" +
       "878hluqlvl3km8rm92f5stamd3jw763n3hck0ct7p8wwj463cqm8cxgy"
 
-    val fallbackAddr = LnInvoiceTag.FallbackAddressTag(Bech32Address.fromString("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3").get)
+    val fallbackAddr = LnTag.FallbackAddressTag(Bech32Address.fromString("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3").get)
 
-    val lnTags = LnInvoiceTaggedFields(
+    val lnTags = LnTaggedFields(
       paymentHash = paymentTag,
       descriptionOrHash = descpriptionHashTag,
       fallbackAddress = Some(fallbackAddr))
@@ -309,5 +309,16 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers {
     val deserialized = LnInvoice.fromString(serialized)
 
     deserialized.get must be(lnInvoice)
+  }
+
+  it must "deserialize and reserialize a invoice with a explicity expiry time" in {
+    //from eclair
+    val bech32 = "lnbcrt1m1pd6ssf3pp5mqcepx6yzx7uu0uagw5x3c7kqhnpwr3mfn844hjux8tlza6ztr7sdqqxqrrss0rl3gzer9gfc54fs84rd4xk6g8nf0syharnnyljc9za933memdzxrjz0v2v94ntuhdxduk3z0nlmpmznryvvvl4gzgu28kjkm4ey98gpmyhjfa"
+
+    val invoiceT = LnInvoice.fromString(bech32)
+
+    val deserialized = invoiceT.get.toString
+
+    deserialized must be(bech32)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/DERSignatureUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/DERSignatureUtil.scala
@@ -67,7 +67,6 @@ sealed abstract class DERSignatureUtil {
    * @return
    */
   def decodeSignature(bytes: ByteVector): (BigInt, BigInt) = {
-    logger.debug("Signature to decode: " + BitcoinSUtil.encodeHex(bytes))
     val asn1InputStream = new ASN1InputStream(bytes.toArray)
     //TODO: this is nasty, is there any way to get rid of all this casting???
     //TODO: Not 100% this is completely right for signatures that are incorrectly DER encoded
@@ -88,7 +87,6 @@ sealed abstract class DERSignatureUtil {
         }
       case Failure(_) => default
     }
-    logger.debug("r: " + r)
     val s: ASN1Integer = Try(seq.getObjectAt(1).asInstanceOf[ASN1Integer]) match {
       case Success(s) =>
         //this is needed for a bug inside of bouncy castle where zero length values throw an exception

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
@@ -1,12 +1,9 @@
 package org.bitcoins.core.protocol.ln
 
-import org.bitcoins.core.crypto.ECDigitalSignature
-import org.bitcoins.core.number.{ UInt32, UInt5, UInt64, UInt8 }
-import org.bitcoins.core.protocol.{ Bech32Address, HumanReadablePart }
-import org.bitcoins.core.protocol.Bech32Address.{ checkHrpValidity, hrpExpand, verifyChecksum }
+import org.bitcoins.core.number.{ UInt5, UInt64 }
+import org.bitcoins.core.protocol.ln.util.LnUtil
 import org.bitcoins.core.util._
 import org.slf4j.LoggerFactory
-import scodec.bits.ByteVector
 
 import scala.util.{ Failure, Success, Try }
 
@@ -31,7 +28,7 @@ sealed abstract class LnInvoice {
 
   def timestamp: UInt64
 
-  def lnTags: LnInvoiceTaggedFields
+  def lnTags: LnTaggedFields
 
   def signature: LnInvoiceSignature
 
@@ -43,18 +40,7 @@ sealed abstract class LnInvoice {
 
   //TODO: Refactor Into Bech32Address?
   def uInt64ToBase32(input: UInt64): Vector[UInt5] = {
-    //To fit a UInt64 value, we need at most ceil(64 / 5) = 13 groups of 5 bits.
-    /*    val arr: Array[Int] = new Array[Int](13)
-    for (x <- 0 to 12) {
-      arr(x) = (input >> x * 5 & UInt64(0x1F)).toInt.toByte
-    }
-    arr.reverse.dropWhile(_ == 0).map(b => UInt5(b)).toVector*/
-    LnInvoiceTag.encodeNumber(input.toLong)
-  }
-
-  private def bech32Signature: String = {
-    val signatureBase32 = signature.data
-    Bech32.encode5bitToString(signatureBase32)
+    LnUtil.encodeNumber(input.toLong)
   }
 
   private def bech32TimeStamp: Vector[UInt5] = {
@@ -117,7 +103,7 @@ object LnInvoice {
 
     val tags = data.slice(7, data.length - 104)
 
-    val taggedFields = LnInvoiceTaggedFields.fromUInt5s(tags)
+    val taggedFields = LnTaggedFields.fromUInt5s(tags)
 
     Invoice(
       hrp = hrp,
@@ -160,5 +146,5 @@ object LnInvoice {
   }
 }
 
-case class Invoice(hrp: LnHumanReadablePart, timestamp: UInt64, lnTags: LnInvoiceTaggedFields,
+case class Invoice(hrp: LnHumanReadablePart, timestamp: UInt64, lnTags: LnTaggedFields,
   signature: LnInvoiceSignature) extends LnInvoice

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTagPrefix.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTagPrefix.scala
@@ -18,35 +18,35 @@ object LnTagPrefix {
   private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
 
   case object PaymentHash extends LnTagPrefix {
-    override def value: Char = 'p'
+    override val value: Char = 'p'
   }
   case object Description extends LnTagPrefix {
-    override def value: Char = 'd'
+    override val value: Char = 'd'
   }
 
   /** The nodeId of the node paying the invoice */
   case object NodeId extends LnTagPrefix {
-    override def value: Char = 'n'
+    override val value: Char = 'n'
   }
 
   case object DescriptionHash extends LnTagPrefix {
-    override def value: Char = 'h'
+    override val value: Char = 'h'
   }
 
   case object ExpiryTime extends LnTagPrefix {
-    override def value: Char = 'x'
+    override val value: Char = 'x'
   }
 
   case object CltvExpiry extends LnTagPrefix {
-    override def value: Char = 'c'
+    override val value: Char = 'c'
   }
 
   case object FallbackAddress extends LnTagPrefix {
-    override def value: Char = 'f'
+    override val value: Char = 'f'
   }
 
   case object RoutingInfo extends LnTagPrefix {
-    override def value: Char = 'r'
+    override val value: Char = 'r'
   }
 
   private val all: List[LnTagPrefix] = List(
@@ -66,6 +66,7 @@ object LnTagPrefix {
   }
 
   def fromUInt5(u5: UInt5): Option[LnTagPrefix] = {
-    prefixUInt5.get(u5)
+    val p = prefixUInt5.get(u5)
+    p
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTags.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTags.scala
@@ -6,21 +6,20 @@ import org.bitcoins.core.config.{ MainNet, NetworkParameters }
 import org.bitcoins.core.crypto.{ ECPublicKey, Sha256Digest, Sha256Hash160Digest }
 import org.bitcoins.core.number.{ UInt32, UInt5, UInt8 }
 import org.bitcoins.core.protocol._
-import org.bitcoins.core.protocol.ln.LnInvoiceTag.{ PaymentHashTag, encodeNumber }
 import org.bitcoins.core.protocol.ln.routing.LnRoute
+import org.bitcoins.core.protocol.ln.util.LnUtil
 import org.bitcoins.core.protocol.script.{ P2WPKHWitnessSPKV0, P2WSHWitnessSPKV0, WitnessScriptPubKeyV0 }
-import org.bitcoins.core.util.Bech32
+import org.bitcoins.core.util.{ Bech32, BitcoinSUtil }
 import org.slf4j.LoggerFactory
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 /**
  * One of the tagged fields on a Lightning Network invoice
  * [[https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#tagged-fields]]
  */
-sealed abstract class LnInvoiceTag {
+sealed abstract class LnTag {
 
   def prefix: LnTagPrefix
 
@@ -29,23 +28,20 @@ sealed abstract class LnInvoiceTag {
     UInt5(char.toByte)
   }
 
-  /** The payload for the tag without any meta infromation encoded with it */
+  /** The payload for the tag without any meta information encoded with it */
   def encoded: Vector[UInt5]
 
   def data: Vector[UInt5] = {
-    val len = encodeNumber(encoded.length)
+    val len = LnUtil.createDataLength(encoded)
     prefixUInt5 +: (len ++ encoded)
   }
 
   override def toString: String = {
-    val b = new mutable.StringBuilder
 
     val dataBech32 = Bech32.encode5bitToString(data)
 
-    b.append(prefix.toString)
-    b.append(dataBech32)
+    dataBech32
 
-    b.toString()
   }
 }
 
@@ -54,7 +50,7 @@ sealed abstract class LnInvoiceTag {
  * Refer to BOLT11 for a full list
  * [[https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#tagged-fields]]
  */
-object LnInvoiceTag {
+object LnTag {
   private val logger = LoggerFactory.getLogger(this.getClass.getName)
 
   /** Fallback address versions */
@@ -91,71 +87,26 @@ object LnInvoiceTag {
         }
       }
 
-      LnInvoiceTag.FallbackAddressTag(address)
+      LnTag.FallbackAddressTag(address)
 
     }
-  }
-
-  /**
-   * The formula for this calculation is as follows:
-   * Take the length of the Bech32 encoded input and divide it by 32.
-   * Take the quotient, and encode this value as Bech32. Take the remainder and encode this value as Bech32.
-   * Append these values to produce a valid Lighting Network data_length field.
-   * Please see Bolt-11 for examples:
-   * https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#examples
-   */
-  def dataLength(bech32String: String): Vector[UInt5] = {
-    val e = encodeNumber(bech32String.length)
-    e
   }
 
   private def u32ToU5(u32: UInt32): Vector[UInt5] = {
-    val encoded = encodeNumber(u32.toLong)
-    require(encoded.size == 2, s"u32ToU5 ${encoded} ${encoded.size}")
+    val encoded = LnUtil.encodeNumber(u32.toLong)
     encoded
   }
 
-  /** Returns a 5bit bytevector with the encoded number for a ln invoice */
-  @tailrec
-  def encodeNumber(len: Long, accum: Vector[UInt5] = Vector.empty): Vector[UInt5] = {
-    val quotient = len / 32
-    val remainder = UInt5(len % 32)
-    if (quotient >= 32) {
-      encodeNumber(quotient, remainder +: accum)
-    } else {
-      val quo = UInt5.fromByte(quotient.toByte)
-      val v = Vector(quo, remainder)
-      v ++ accum
-    }
-
-  }
-
-  @tailrec
-  def decodeNumber(vector: Vector[UInt5], accum: Long = 0): Long = {
-
-    if (vector.isEmpty) accum
-    else if (vector.size == 1) {
-      decodeNumber(vector.tail, vector.head.toInt + accum)
-    } else {
-      val newAccum = vector.head.toInt * 32 + accum
-      decodeNumber(vector.tail, newAccum)
-    }
-  }
-
-  case class PaymentHashTag(hash: Sha256Digest) extends LnInvoiceTag {
+  case class PaymentHashTag(hash: Sha256Digest) extends LnTag {
 
     override val prefix: LnTagPrefix = LnTagPrefix.PaymentHash
 
     override val encoded: Vector[UInt5] = {
       Bech32.from8bitTo5bit(hash.bytes)
     }
-
-    def fromBytes(vector: ByteVector): PaymentHashTag = {
-      ???
-    }
   }
 
-  case class DescriptionTag(string: String) extends LnInvoiceTag {
+  case class DescriptionTag(string: String) extends LnTag {
     override val prefix: LnTagPrefix = LnTagPrefix.Description
 
     override val encoded: Vector[UInt5] = {
@@ -165,7 +116,7 @@ object LnInvoiceTag {
 
   }
 
-  case class NodeIdTag(pubKey: ECPublicKey) extends LnInvoiceTag {
+  case class NodeIdTag(pubKey: ECPublicKey) extends LnTag {
 
     override val prefix: LnTagPrefix = LnTagPrefix.NodeId
 
@@ -174,7 +125,7 @@ object LnInvoiceTag {
     }
   }
 
-  case class DescriptionHashTag(hash: Sha256Digest) extends LnInvoiceTag {
+  case class DescriptionHashTag(hash: Sha256Digest) extends LnTag {
     override val prefix: LnTagPrefix = LnTagPrefix.DescriptionHash
 
     override val encoded: Vector[UInt5] = {
@@ -183,11 +134,11 @@ object LnInvoiceTag {
   }
 
   /** The amount in seconds until this payment request expires */
-  case class ExpiryTimeTag(u32: UInt32) extends LnInvoiceTag {
+  case class ExpiryTimeTag(u32: UInt32) extends LnTag {
     override val prefix: LnTagPrefix = LnTagPrefix.ExpiryTime
 
     override val encoded: Vector[UInt5] = {
-      u32ToU5(u32)
+      LnUtil.encodeNumber(u32.toLong)
     }
   }
 
@@ -197,7 +148,7 @@ object LnInvoiceTag {
    * This is denominated in blocks
    * [[https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#cltv_expiry_delta-selection]]
    */
-  case class MinFinalCltvExpiry(u32: UInt32) extends LnInvoiceTag {
+  case class MinFinalCltvExpiry(u32: UInt32) extends LnTag {
     override val prefix: LnTagPrefix = LnTagPrefix.CltvExpiry
 
     override val encoded: Vector[UInt5] = {
@@ -206,7 +157,7 @@ object LnInvoiceTag {
 
   }
 
-  case class FallbackAddressTag(address: Address) extends LnInvoiceTag {
+  case class FallbackAddressTag(address: Address) extends LnTag {
 
     /** The version of the fallback address is indicated here in BOLT11 */
     def version: UInt8 = {
@@ -227,7 +178,7 @@ object LnInvoiceTag {
     }
   }
 
-  case class RoutingInfo(routes: Vector[LnRoute]) extends LnInvoiceTag {
+  case class RoutingInfo(routes: Vector[LnRoute]) extends LnTag {
 
     override val prefix: LnTagPrefix = LnTagPrefix.RoutingInfo
 
@@ -258,46 +209,47 @@ object LnInvoiceTag {
       val bytes = UInt8.toBytes(Bech32.from5bitTo8bit(u5s))
       val vecRoutes: Vector[LnRoute] = loop(bytes, Vector.empty)
 
-      LnInvoiceTag.RoutingInfo(vecRoutes)
+      LnTag.RoutingInfo(vecRoutes)
 
     }
   }
 
-  def fromLnTagPrefix(prefix: LnTagPrefix, payload: Vector[UInt5]): LnInvoiceTag = {
+  def fromLnTagPrefix(prefix: LnTagPrefix, payload: Vector[UInt5]): LnTag = {
 
     val u8s = Bech32.from5bitTo8bit(payload)
     val bytes = UInt8.toBytes(u8s)
 
-    val tag: LnInvoiceTag = prefix match {
+    val tag: LnTag = prefix match {
       case LnTagPrefix.PaymentHash =>
 
         val hash = Sha256Digest.fromBytes(bytes)
-        LnInvoiceTag.PaymentHashTag(hash)
+        LnTag.PaymentHashTag(hash)
 
       case LnTagPrefix.Description =>
 
         val description = new String(bytes.toArray, Charset.forName("UTF-8"))
-        LnInvoiceTag.DescriptionTag(description)
+        LnTag.DescriptionTag(description)
 
       case LnTagPrefix.DescriptionHash =>
 
         val hash = Sha256Digest.fromBytes(bytes)
-        LnInvoiceTag.DescriptionHashTag(hash)
+        LnTag.DescriptionHashTag(hash)
 
       case LnTagPrefix.NodeId =>
 
         val pubKey = ECPublicKey.fromBytes(bytes)
-        LnInvoiceTag.NodeIdTag(pubKey)
+        LnTag.NodeIdTag(pubKey)
 
       case LnTagPrefix.ExpiryTime =>
 
-        val u32 = UInt32(decodeNumber(payload))
-        LnInvoiceTag.ExpiryTimeTag(u32)
+        val decoded = LnUtil.decodeNumber(payload)
+        val u32 = UInt32(decoded)
+        LnTag.ExpiryTimeTag(u32)
 
       case LnTagPrefix.CltvExpiry =>
 
         val u32 = UInt32.fromBytes(bytes)
-        LnInvoiceTag.MinFinalCltvExpiry(u32)
+        LnTag.MinFinalCltvExpiry(u32)
 
       case LnTagPrefix.FallbackAddress =>
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/util/LnUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/util/LnUtil.scala
@@ -1,0 +1,79 @@
+package org.bitcoins.core.protocol.ln.util
+
+import java.math.BigInteger
+
+import org.bitcoins.core.number.UInt5
+import org.bitcoins.core.util.Bech32
+
+import scala.annotation.tailrec
+
+trait LnUtil {
+
+  /**
+   * The formula for this calculation is as follows:
+   * Take the length of the Bech32 encoded input and divide it by 32.
+   * Take the quotient, and encode this value as Bech32. Take the remainder and encode this value as Bech32.
+   * Append these values to produce a valid Lighting Network data_length field.
+   * Please see Bolt-11 for examples:
+   * https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#examples
+   */
+  def createDataLength(bech32String: String): Vector[UInt5] = {
+    val u5s = Bech32.decodeStringToU5s(bech32String)
+    createDataLength(u5s)
+  }
+
+  /** Creates the appropriate 10 bit vector for the data length of an element */
+  def createDataLength(u5s: Vector[UInt5]): Vector[UInt5] = {
+    val len = u5s.size
+    val encodedNoPadding = encodeNumber(len)
+
+    val encoded = {
+      if (encodedNoPadding.size == 1) {
+        UInt5.zero +: encodedNoPadding
+      } else {
+        encodedNoPadding
+      }
+    }
+
+    require(encoded.size == 2, s"data_length must be 2 uint5s")
+
+    encoded
+  }
+
+  def decodeDataLength(u5s: Vector[UInt5]): Long = {
+    require(u5s.length == 2, s"Data Length is required to be 10 bits, got ${u5s.length}")
+    decodeNumber(u5s)
+  }
+
+  /** Returns a 5bit bytevector with the encoded number for a ln invoice */
+  @tailrec
+  final def encodeNumber(len: Long, accum: Vector[UInt5] = Vector.empty): Vector[UInt5] = {
+    val quotient = len / 32
+    val remainder = UInt5(len % 32)
+    if (quotient >= 32) {
+      encodeNumber(quotient, remainder +: accum)
+    } else if (quotient == 0) {
+      remainder +: accum
+    } else {
+      val quo = UInt5.fromByte(quotient.toByte)
+      val v = Vector(quo, remainder)
+      v ++ accum
+    }
+
+  }
+
+  @tailrec
+  final def decodeNumber(vector: Vector[UInt5], accum: Long = 0): Long = {
+
+    if (vector.isEmpty) accum
+    else if (vector.size == 1) {
+      decodeNumber(vector.tail, vector.head.toInt + accum)
+    } else {
+      val n = BigInt(32).pow(vector.size - 1)
+      val newAccum = vector.head.toBigInt * n + accum
+      decodeNumber(vector.tail, newAccum.toLong)
+    }
+  }
+}
+
+object LnUtil extends LnUtil

--- a/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
@@ -205,14 +205,11 @@ sealed abstract class Bech32 {
     NumberUtil.convertUInt5sToUInt8(b)
   }
 
-  private def handleEncodeTry[T](vecT: Try[Vector[T]]): Vector[T] = {
-    //should always be able to encode a hex string to bech32
-    vecT match {
-      case Success(vec) => vec
-      case Failure(err) =>
-        logger.error(s"Failed to encode a vec to bech32. Vec: ${vecT} err: ${err.getMessage}")
-        throw err
-    }
+  /** Assumes we are given a valid bech32 string */
+  def decodeStringToU5s(str: String): Vector[UInt5] = {
+    str.map { char =>
+      UInt5(Bech32.charset.indexOf(char))
+    }.toVector
   }
 
 }

--- a/eclair-rpc/src/test/resources/logback-test.xml
+++ b/eclair-rpc/src/test/resources/logback-test.xml
@@ -14,7 +14,7 @@
     </appender>
 
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE"/>
     </root>
@@ -23,6 +23,6 @@
 
     <logger name="com.zaxxer" level="INFO"/>
 
-    <logger name="fr.acinq" level="INFO"/>
+    <logger name="fr.acinq" level="DEBUG"/>
 
 </configuration>

--- a/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -117,7 +117,7 @@ class EclairRpcClientTest extends AsyncFlatSpec with BeforeAndAfterAll {
     val paymentAmount = NanoBitcoins(100000)
     val invoiceF = openChannelIdF.flatMap(_ => otherClient.receive(paymentAmount))
 
-    val isPaid1F = invoiceF.flatMap(i => otherClient.checkPayment(i))
+    val isPaid1F = invoiceF.flatMap(i => otherClient.checkPayment(Left(i)))
 
     val isNotPaidAssertF = isPaid1F.map(isPaid => assert(!isPaid))
 
@@ -127,7 +127,7 @@ class EclairRpcClientTest extends AsyncFlatSpec with BeforeAndAfterAll {
     val isPaid2F: Future[Boolean] = paidF.flatMap { p =>
       val succeed = p.asInstanceOf[PaymentSucceeded]
 
-      otherClient.checkPayment(succeed.paymentHash.hex)
+      otherClient.checkPayment(Right(succeed.paymentHash))
     }
 
     val isPaidAssertF = isPaid2F.map(isPaid => assert(isPaid))
@@ -150,7 +150,7 @@ class EclairRpcClientTest extends AsyncFlatSpec with BeforeAndAfterAll {
 
     val isPaidF: Future[Boolean] = paidF.flatMap { p =>
       val succeed = p.asInstanceOf[PaymentSucceeded]
-      otherClient.checkPayment(succeed.paymentHash.hex)
+      otherClient.checkPayment(Right(succeed.paymentHash))
     }
 
     val isPaidAssertF = isPaidF.map(isPaid => assert(isPaid))
@@ -163,7 +163,7 @@ class EclairRpcClientTest extends AsyncFlatSpec with BeforeAndAfterAll {
       val isPaid2F: Future[Boolean] = paid2F.flatMap { p =>
         assert(p.isInstanceOf[PaymentSucceeded])
         val succeed = p.asInstanceOf[PaymentSucceeded]
-        client.checkPayment(succeed.paymentHash.hex)
+        client.checkPayment(Right(succeed.paymentHash))
       }
 
       isPaid2F.map(isPaid => assert(isPaid))

--- a/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairTestUtil.scala
+++ b/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairTestUtil.scala
@@ -166,9 +166,12 @@ trait EclairTestUtil extends BitcoinSLogger {
   }
 
   private def awaitUntilChannelState(client: EclairRpcClient, chanId: ChannelId, state: ChannelState)(implicit system: ActorSystem): Unit = {
+
     def isState(): Future[Boolean] = {
       val chanF = client.channel(chanId)
-      chanF.map(_.state == state)(system.dispatcher)
+      chanF.map { chan =>
+        chan.state == state
+      }(system.dispatcher)
     }
 
     RpcUtil.awaitConditionF(


### PR DESCRIPTION
…mbers, refactoring more things

This adds the `LnInvoice` type to the eclair rpc

This PR fixes a bug in `decodeNumber` where we were not applying the correct exponent to fully expand the `Vector[UInt5]`.

Finally this PR renames a few things from `LnInvoice...` to just `Ln...`. An example of this is `LnInvoiceTaggedFields` -> `LnTaggedFields`. We should avoid using the `Invoice` word redundantly in class names. Makes it alot easier to type :-)