### PR TITLE
Switch bech32 p2wpkh hash from RipdeMd160 -> Sha256Hash160Digest

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -92,7 +92,7 @@ sealed abstract class Bech32Address extends BitcoinAddress {
     val byteVector = BitcoinSUtil.toByteVector(scriptPubKey.witnessProgram)
     scriptPubKey match {
       case _: P2WPKHWitnessSPKV0 =>
-        RipeMd160Digest(byteVector)
+        Sha256Hash160Digest(byteVector)
       case _: P2WSHWitnessSPKV0 =>
         Sha256Digest(byteVector)
       case _: UnassignedWitnessScriptPubKey =>


### PR DESCRIPTION
p2wpkh addresses are a `Sha256Hash160Digest`, not a `RipeMd160Digest`. 