### PR TITLE
implement p2sh(p2wpkh) inside of the interpreter and TxBuilder

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2SHScriptSignatureSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2SHScriptSignatureSpec.scala
@@ -20,7 +20,7 @@ class P2SHScriptSignatureSpec extends Properties("P2SHScriptSignatureSpec") {
       case (witScriptPubKey, privKeys) =>
         val p2shScriptSig = P2SHScriptSignature(witScriptPubKey)
         p2shScriptSig.redeemScript == witScriptPubKey
-        p2shScriptSig.scriptSignatureNoRedeemScript.get == EmptyScriptSignature
+        p2shScriptSig.scriptSignatureNoRedeemScript == EmptyScriptSignature
 
     }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2SHScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2SHScriptSignatureTest.scala
@@ -30,7 +30,7 @@ class P2SHScriptSignatureTest extends FlatSpec with MustMatchers {
       case _ => throw new RuntimeException("Should be p2sh scriptSig")
     }
 
-    p2shScriptSig.scriptSignatureNoRedeemScript.get.asm must be(Seq(
+    p2shScriptSig.scriptSignatureNoRedeemScript.asm must be(Seq(
       OP_0, BytesToPushOntoStack(71), ScriptConstant("304402207d764cb90c9fd84b74d33a47cf3a0ffead9ded98333776becd6acd32c4426dac02203905a0d064e7f53d07793e86136571b6e4f700c1cfb888174e84d78638335b8101"),
       BytesToPushOntoStack(72),
       ScriptConstant("3045022100906aaca39f022acd8b7a38fd2f92aca9e9f35cfeaee69a6f13e1d083ae18222602204c9ed96fc6c4de56fd85c679fc59c16ee1ccc80c42563b86174e1a506fc007c801")))
@@ -40,7 +40,7 @@ class P2SHScriptSignatureTest extends FlatSpec with MustMatchers {
     val hex = "ba00473044022051737de0cf47b6c367011ea0a9f164e878c228bbea1f4ea1b9a98183c24c34ce022050455ca8729d2275d3d9d4dfb712703c8e2ecd0adfe34fa333cf3b020c8e15d683514c6e63522103ebbcabd4878fe28998d518324587b3950eb868ef0bd25ff45e0a3649ee630c3b21038333b9faf7629d8b2e514ea8ec0d0645774a3c0ea66d797d45607069b0ec08c952ae67089ceb36b39e806a65b27576a91429dd76a8b34f5d6eafe1f24e3b255768ea28310b88ac68"
     val p2sh = P2SHScriptSignature(hex)
     p2sh.redeemScript.isInstanceOf[EscrowTimeoutScriptPubKey] must be(true)
-    p2sh.scriptSignatureNoRedeemScript.get.isInstanceOf[EscrowTimeoutScriptSignature] must be(true)
+    p2sh.scriptSignatureNoRedeemScript.isInstanceOf[EscrowTimeoutScriptSignature] must be(true)
   }
 
 }

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -13,6 +13,7 @@ import org.scalatest.{ FlatSpec, MustMatchers }
 import spray.json._
 
 import scala.io.Source
+import scala.util.Try
 /**
  * Created by chris on 1/6/16.
  */
@@ -25,7 +26,18 @@ class ScriptInterpreterTest extends FlatSpec with MustMatchers {
     //use this to represent a single test case from script_valid.json
     /*    val lines =
       """
-          | [["", "DEPTH 0 EQUAL", "P2SH,STRICTENC", "OK", "Test the test: we should have an empty stack after scriptSig evaluation"]]
+          | [[
+          |    [
+          |        "304402200929d11561cd958460371200f82e9cae64c727a495715a31828e27a7ad57b36d0220361732ced04a6f97351ecca21a56d0b8cd4932c1da1f8f569a2b68e5e48aed7801",
+          |        "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+          |        0.00000001
+          |    ],
+          |    "0x16 0x001491b24bf9f5288532960ac687abb035127b1d28a5",
+          |    "HASH160 0x14 0x17743beb429c55c942d2ec703b98c4d57c2df5c6 EQUAL",
+          |    "P2SH,WITNESS",
+          |    "OK",
+          |    "Basic P2SH(P2WPKH)"
+          |]]
    """.stripMargin*/
     val lines = try source.getLines.filterNot(_.isEmpty).map(_.trim) mkString "\n" finally source.close()
     val json = lines.parseJson
@@ -73,7 +85,15 @@ class ScriptInterpreterTest extends FlatSpec with MustMatchers {
       }
       val program = PreExecutionScriptProgram(txSigComponent)
       withClue(testCase.raw) {
-        ScriptInterpreter.run(program) must equal(testCase.expectedResult)
+
+        val runAttemptT = Try(ScriptInterpreter.run(program))
+
+        if (runAttemptT.isFailure) {
+          throw runAttemptT.failed.get
+        } else {
+          runAttemptT.get must equal(testCase.expectedResult)
+        }
+
       }
     }
   }

--- a/core-test/src/test/scala/org/bitcoins/core/util/TransactionTestUtil.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/TransactionTestUtil.scala
@@ -79,7 +79,7 @@ trait TransactionTestUtil extends BitcoinSLogger {
 
     val tx = witness match {
       case Some((scriptWitness, amount)) =>
-        val txWitness = TransactionWitness(Seq(scriptWitness))
+        val txWitness = TransactionWitness(Vector(scriptWitness))
         val output = TransactionOutput(amount, EmptyScriptPubKey)
         WitnessTransaction(TransactionConstants.version, Seq(input), Seq(output),
           TransactionConstants.lockTime, txWitness)

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -150,8 +150,8 @@ sealed abstract class TransactionSignatureSerializer {
 
         val sequenceHash: ByteVector = if (isNotAnyoneCanPay && isNotSigHashNone && isNotSigHashSingle) {
           val sequences = spendingTransaction.inputs.map(_.sequence)
-          val bytes = BitcoinSUtil.toByteVector(sequences)
-          CryptoUtil.doubleSHA256(bytes).bytes
+          val littleEndianSeq = sequences.foldLeft(ByteVector.empty)(_ ++ _.bytes.reverse)
+          CryptoUtil.doubleSHA256(littleEndianSeq).bytes
         } else emptyHash.bytes
 
         val outputHash: ByteVector = if (isNotSigHashSingle && isNotSigHashNone) {

--- a/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
@@ -82,8 +82,10 @@ sealed abstract class WitnessTxSigComponentP2SH extends WitnessTxSigComponent {
 
   override def scriptSignature: P2SHScriptSignature = {
     val s = transaction.inputs(inputIndex.toInt).scriptSignature
-    require(s.isInstanceOf[P2SHScriptSignature], "Must have P2SHScriptSignature for P2SH(P2WSH()), got: " + s)
-    s.asInstanceOf[P2SHScriptSignature]
+    require(s.isInstanceOf[P2SHScriptSignature], "Must have P2SHScriptSignature for P2SH(WitSPK()), got: " + s)
+    val p2sh = s.asInstanceOf[P2SHScriptSignature]
+    p2sh
+
   }
 
   def witnessScriptPubKey: Try[WitnessScriptPubKey] = scriptSignature.redeemScript match {

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -56,6 +56,16 @@ object P2WPKHWitnessV0 {
   def apply(publicKey: ECPublicKey, signature: ECDigitalSignature): P2WPKHWitnessV0 = {
     P2WPKHWitnessV0(Seq(publicKey.bytes, signature.bytes))
   }
+
+  def fromP2PKHScriptSig(scriptSig: ScriptSignature): P2WPKHWitnessV0 = scriptSig match {
+    case p2pkh: P2PKHScriptSignature =>
+      P2WPKHWitnessV0(p2pkh.publicKey, p2pkh.signature)
+    case x @ (_: LockTimeScriptSignature | _: EscrowTimeoutScriptSignature
+      | _: MultiSignatureScriptSignature | _: NonStandardScriptSignature
+      | _: P2PKScriptSignature | _: P2SHScriptSignature
+      | EmptyScriptSignature) =>
+      throw new IllegalArgumentException(s"Expected P2PKHScriptSignature, got $x")
+  }
 }
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionWitness.scala
@@ -12,21 +12,61 @@ import scodec.bits.ByteVector
  * [[https://github.com/bitcoin/bitcoin/blob/b4e4ba475a5679e09f279aaf2a83dcf93c632bdb/src/primitives/transaction.h#L232-L268]]
  */
 sealed abstract class TransactionWitness extends NetworkElement {
-  def witnesses: Seq[ScriptWitness]
+  def witnesses: Vector[ScriptWitness]
 
   override def bytes = RawTransactionWitnessParser.write(this)
+
+  /**
+   * Update the [[witnesses]] index to the given witness
+   * Pads the witnesses vector if needed to accomodate the new witness
+   */
+  def updated(index: Int, witness: ScriptWitness): TransactionWitness = {
+    val scriptWits = {
+      if (index < 0) {
+        throw new IndexOutOfBoundsException(index.toString)
+      } else if (index >= witnesses.size) {
+
+        val padded = padScriptWitness(index)
+
+        padded.updated(index, witness)
+
+      } else {
+        witnesses.updated(index, witness)
+      }
+    }
+
+    TransactionWitness(scriptWits)
+  }
+
+  /**
+   * Pads the existing [[witnesses]] so that we can insert a witness
+   * into the given index. If [[witnesses]] is not properly padded
+   * we can have an index out of bounds exception thrown
+   * when trying to update the vector.
+   */
+  private def padScriptWitness(index: Int): Vector[ScriptWitness] = {
+    val neededPadding = index - witnesses.size + 1
+    if (neededPadding > 0) {
+      val emptyWits = Vector.fill(neededPadding)(EmptyScriptWitness)
+      witnesses ++ emptyWits
+    } else {
+      witnesses
+    }
+
+  }
 }
 
 /** Used to represent a transaction witness pre segwit, see BIP141 for details */
 case object EmptyWitness extends TransactionWitness {
   override def bytes = ByteVector.low(1)
-  override def witnesses = Nil
+  override def witnesses: Vector[ScriptWitness] = Vector.empty
+
 }
 
 object TransactionWitness {
-  private case class TransactionWitnessImpl(witnesses: Seq[ScriptWitness]) extends TransactionWitness
+  private case class TransactionWitnessImpl(witnesses: Vector[ScriptWitness]) extends TransactionWitness
 
-  def apply(witnesses: Seq[ScriptWitness]): TransactionWitness = {
+  def apply(witnesses: Vector[ScriptWitness]): TransactionWitness = {
     if (witnesses.exists(_ != EmptyScriptWitness)) {
       TransactionWitnessImpl(witnesses)
     } else {
@@ -40,8 +80,8 @@ object TransactionWitness {
    * @param witnesses
    * @return
    */
-  def fromWitOpt(witnesses: Seq[Option[ScriptWitness]]): TransactionWitness = {
-    val replaced: Seq[ScriptWitness] = witnesses.map {
+  def fromWitOpt(witnesses: Vector[Option[ScriptWitness]]): TransactionWitness = {
+    val replaced: Vector[ScriptWitness] = witnesses.map {
       case Some(wit) => wit
       case None => EmptyScriptWitness
     }

--- a/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionWitnessParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionWitnessParser.scala
@@ -22,14 +22,14 @@ sealed abstract class RawTransactionWitnessParser {
    */
   def read(bytes: ByteVector, numInputs: Int): TransactionWitness = {
     @tailrec
-    def loop(remainingBytes: ByteVector, remainingInputs: Int, accum: Seq[ScriptWitness]): Seq[ScriptWitness] = {
+    def loop(remainingBytes: ByteVector, remainingInputs: Int, accum: Vector[ScriptWitness]): Vector[ScriptWitness] = {
       if (remainingInputs != 0) {
         val w = RawScriptWitnessParser.read(remainingBytes)
         val (_, newRemainingBytes) = remainingBytes.splitAt(w.bytes.size)
         loop(newRemainingBytes, remainingInputs - 1, w +: accum)
       } else accum.reverse
     }
-    val witnesses = loop(bytes, numInputs, Nil)
+    val witnesses = loop(bytes, numInputs, Vector.empty)
     require(witnesses.size == numInputs)
     TransactionWitness(witnesses)
   }

--- a/core/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
@@ -36,7 +36,7 @@ sealed abstract class EscrowTimeoutHelper {
       val tc = TransactionConstants
       val uScriptWitness = P2WSHWitnessV0(lock)
       val inputs = Seq(TransactionInput(outPoint, EmptyScriptSignature, tc.sequence))
-      val wtx = WitnessTransaction(tc.validLockVersion, inputs, destinations, tc.lockTime, TransactionWitness(Seq(uScriptWitness)))
+      val wtx = WitnessTransaction(tc.validLockVersion, inputs, destinations, tc.lockTime, TransactionWitness(Vector(uScriptWitness)))
       val witSPK = P2WSHWitnessSPKV0(lock)
       val witOutput = TransactionOutput(amount, witSPK)
       val u = WitnessTxSigComponentRaw(wtx, UInt32.zero, witOutput, Policy.standardFlags)
@@ -63,8 +63,7 @@ sealed abstract class EscrowTimeoutHelper {
     unsigned: WitnessTxSigComponentRaw): TransactionWitness = {
     //need to remove the OP_0 or OP_1 and replace it with ScriptNumber.zero / ScriptNumber.one since witnesses are *not* run through the interpreter
     val signedScriptWitness = P2WSHWitnessV0(lock, signedScriptSig)
-    val updatedWitnesses = unsigned.transaction.witness.witnesses.updated(unsigned.inputIndex.toInt, signedScriptWitness)
-    val txWitness: TransactionWitness = TransactionWitness(updatedWitnesses)
+    val txWitness: TransactionWitness = unsigned.transaction.witness.updated(unsigned.inputIndex.toInt, signedScriptWitness)
     txWitness
   }
 
@@ -129,7 +128,7 @@ sealed abstract class EscrowTimeoutHelper {
       val amount = creditingOutput.value
       val tc = TransactionConstants
       val uScriptWitness = P2WSHWitnessV0(lock)
-      val uTxWitness = TransactionWitness(Seq(uScriptWitness))
+      val uTxWitness = TransactionWitness(Vector(uScriptWitness))
       val uwtx = WitnessTransaction(tc.validLockVersion, inputs, outputs, tc.lockTime, uTxWitness)
       val witOutput = TransactionOutput(amount, witSPK)
       val u = WitnessTxSigComponentRaw(uwtx, inputIndex, witOutput, Policy.standardFlags)

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -11,7 +11,7 @@ import org.bitcoins.core.protocol.transaction.Transaction
 sealed abstract class FeeUnit {
   def currencyUnit: CurrencyUnit
   def *(tx: Transaction): CurrencyUnit = calc(tx)
-  def calc(tx: Transaction): CurrencyUnit = Satoshis(Int64(tx.size * toLong))
+  def calc(tx: Transaction): CurrencyUnit = Satoshis(Int64(tx.vsize * toLong))
   def toLong: Long = currencyUnit.satoshis.toLong
 }
 


### PR DESCRIPTION
fix bug in P2SHScriptSignature.redeemScript

This pull request implements the P2SH(P2WPKH) script type in bitcoin-s. 

This script type has unique semantics inside of the interpreter and in BIP143. You are required to reconstruct a full `P2PKHScriptPubKey` from the `P2WPKHWitnessSPKV0`

This adds the test vector for [BIP143](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#P2SHP2WPKH) to TransactionSignatureSerializerTest to make sure we are following the BIP correctly. 

This PR also adds the generator for a P2SH(P2WPKH) tx to make sure we are adding this transaction type too our property based testing suite. 