### PR TITLE
Reworking AuthCredentials and Instances so that we can read from conf…

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnCurrencyUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnCurrencyUnit.scala
@@ -81,9 +81,12 @@ sealed abstract class LnCurrencyUnit extends NetworkElement {
 
   def toPicoBitcoinMultiplier: Int
 
+  def toPicoBitcoins: PicoBitcoins = PicoBitcoins(toPicoBitcoinValue)
+
   def encodedBytes: ByteVector = {
     ByteVector(toEncodedString.map(_.toByte))
   }
+
   def toEncodedString: String = {
     toBigInt + character.toString()
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
@@ -26,6 +26,10 @@ sealed abstract class LnInvoice {
 
   def amount: Option[LnCurrencyUnit] = hrp.amount
 
+  def amountPicoBitcoins: Option[PicoBitcoins] = {
+    amount.map(_.toPicoBitcoins)
+  }
+
   def timestamp: UInt64
 
   def lnTags: LnTaggedFields

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoiceSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoiceSignature.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.util.Bech32
 import scodec.bits.ByteVector
 
-sealed abstract class LnInvoiceSignature {
+sealed abstract class LnInvoiceSignature extends NetworkElement {
   require(version.toInt >= 0 && version.toInt <= 3, s"signature recovery byte must be 0,1,2,3, got ${version.toInt}")
 
   def signature: ECDigitalSignature
@@ -16,6 +16,10 @@ sealed abstract class LnInvoiceSignature {
   def data: Vector[UInt5] = {
     val bytes = signature.toRawRS ++ version.bytes
     Bech32.from8bitTo5bit(bytes)
+  }
+
+  override def bytes: ByteVector = {
+    signature.toRawRS ++ version.bytes
   }
 }
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/AuthCredentials.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/AuthCredentials.scala
@@ -2,47 +2,91 @@ package org.bitcoins.eclair.rpc.config
 
 import java.io.File
 
+import com.typesafe.config.Config
+import org.bitcoins.rpc.config.BitcoindAuthCredentials
+
 sealed trait EclairAuthCredentials {
 
   /** The directory where our eclair.conf file is located */
-  def datadir: File
+  def datadir: Option[File]
+
+  def bitcoinAuthOpt: Option[BitcoindAuthCredentials]
 
   /** rpcusername field in our bitcoin.conf file */
-  def bitcoinUsername: String
+  def bitcoinUsername: Option[String] = {
+    bitcoinAuthOpt.map(_.username)
+  }
 
   /** rpcpassword field in our bitcoin.conf file */
-  def bitcoinPassword: String
+  def bitcoinPassword: Option[String] = {
+    bitcoinAuthOpt.map(_.password)
+  }
+
+  def bitcoinRpcPort: Option[Int] = {
+    bitcoinAuthOpt.map(_.rpcPort)
+  }
 
   /** alias field in our eclair.conf file */
   def username: String
 
   /** api password field in our eclair.conf file */
   def password: String
+
+  /** The port for eclair's rpc client */
+  def port: Int
 }
 
 object EclairAuthCredentials {
   private case class AuthCredentialsImpl(
     username: String,
     password: String,
-    bitcoinUsername: String,
-    bitcoinPassword: String,
-    datadir: File) extends EclairAuthCredentials
+    bitcoinAuthOpt: Option[BitcoindAuthCredentials],
+    port: Int,
+    datadir: Option[File]) extends EclairAuthCredentials
 
   def apply(
     username: String,
     password: String,
-    bitcoinUsername: String,
-    bitcoinPassword: String): EclairAuthCredentials = {
-    val defaultDataDir = new File(System.getProperty("user.home") + "/.eclair")
-    EclairAuthCredentials(username, password, bitcoinUsername, bitcoinPassword, defaultDataDir)
+    bitcoinAuthOpt: Option[BitcoindAuthCredentials],
+    port: Int): EclairAuthCredentials = {
+    EclairAuthCredentials(username, password, bitcoinAuthOpt, port, None)
   }
 
   def apply(
     username: String,
     password: String,
-    bitcoinUsername: String,
-    bitcoinPassword: String,
-    datadir: File): EclairAuthCredentials = {
-    AuthCredentialsImpl(username, password, bitcoinUsername, bitcoinPassword, datadir)
+    bitcoinAuthOpt: Option[BitcoindAuthCredentials],
+    port: Int,
+    datadir: Option[File]): EclairAuthCredentials = {
+    AuthCredentialsImpl(username, password, bitcoinAuthOpt, port, datadir)
+  }
+
+  /**
+   * Parses a config in the format of this to a [[EclairAuthCredentials]]
+   * [[https://github.com/ACINQ/eclair/blob/master/eclair-core/src/main/resources/reference.conf]]
+   * @param config
+   * @return
+   */
+  def fromConfig(config: Config): EclairAuthCredentials = {
+    //does eclair not have a username field??
+    val username = config.getString("eclair.alias")
+    val password = config.getString("eclair.api.password")
+    val bitcoindUsername = config.getString("eclair.bitcoind.rpcuser")
+    val bitcoindPassword = config.getString("eclair.bitcoind.rpcpassword")
+    val bitcoindRpcPort = config.getInt("eclair.bitcoind.rpcport")
+    val eclairRpcPort = config.getInt("eclair.api.port")
+
+    val bitcoindAuth = {
+      BitcoindAuthCredentials(
+        username = bitcoindUsername,
+        password = bitcoindPassword,
+        rpcPort = bitcoindRpcPort)
+    }
+
+    EclairAuthCredentials(
+      username = username,
+      password = password,
+      bitcoinAuthOpt = Some(bitcoindAuth),
+      port = eclairRpcPort)
   }
 }

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/EclairInstance.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/EclairInstance.scala
@@ -2,7 +2,8 @@ package org.bitcoins.eclair.rpc.config
 
 import java.net.URI
 
-import org.bitcoins.core.config.NetworkParameters
+import com.typesafe.config.Config
+import org.bitcoins.core.config.{ MainNet, NetworkParameters, RegTest, TestNet3 }
 
 sealed trait EclairInstance {
   def network: NetworkParameters
@@ -24,5 +25,42 @@ object EclairInstance {
     rpcUri: URI,
     authCredentials: EclairAuthCredentials): EclairInstance = {
     EclairInstanceImpl(network, uri, rpcUri, authCredentials)
+  }
+
+  /**
+   * Parses a [[Config]] to a [[EclairInstance]] in the format of this
+   * [[https://github.com/ACINQ/eclair/blob/master/eclair-core/src/main/resources/reference.conf]]
+   * @param config
+   * @return
+   */
+  def fromConfig(config: Config): EclairInstance = {
+    val chain = config.getString("eclair.chain")
+
+    val serverBindingIp = config.getString("eclair.server.binding-ip")
+    val serverPort = config.getInt("eclair.server.port")
+
+    val rpcHost = config.getString("eclair.api.binding-ip")
+    val rpcPort = config.getInt("eclair.api.port")
+
+    val np: NetworkParameters = chain match {
+      case "regtest" => RegTest
+      case "testnet" => TestNet3
+      case "mainnet" => MainNet
+      case network: String => throw new IllegalArgumentException(s"Unknown network $network in eclair.conf")
+    }
+
+    val uri: URI = new URI(s"http://${serverBindingIp}:${serverPort}")
+
+    val rpcUri: URI = new URI(s"http://${rpcHost}s:${rpcPort}")
+
+    val eclairAuth = EclairAuthCredentials.fromConfig(config)
+
+    val instance = EclairInstance(
+      network = np,
+      uri = uri,
+      rpcUri = rpcUri,
+      authCredentials = eclairAuth)
+
+    instance
   }
 }

--- a/rpc/src/main/scala/org/bitcoins/rpc/RpcUtil.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/RpcUtil.scala
@@ -119,6 +119,7 @@ trait RpcUtil extends BitcoinSLogger {
     maxTries: Int = 50)(implicit system: ActorSystem): Unit = {
     val f = () => server.isStarted
     awaitCondition(f, duration, maxTries)
+    logger.info(s"Server started ${server.getDaemon.authCredentials.datadir}")
   }
 
   def awaitServerShutdown(

--- a/rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindAuthCredentials.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindAuthCredentials.scala
@@ -15,24 +15,28 @@ sealed trait BitcoindAuthCredentials {
 
   /** rpcpassword field in our bitcoin.conf file */
   def password: String
+
+  def rpcPort: Int
 }
 
 object BitcoindAuthCredentials {
   private case class BitcoindAuthCredentialsImpl(
     username: String,
     password: String,
+    rpcPort: Int,
     datadir: File)
     extends BitcoindAuthCredentials
 
-  def apply(username: String, password: String): BitcoindAuthCredentials = {
+  def apply(username: String, password: String, rpcPort: Int): BitcoindAuthCredentials = {
     val defaultDataDir = new File(System.getProperty("user.home") + "/.bitcoin")
-    BitcoindAuthCredentials(username, password, defaultDataDir)
+    BitcoindAuthCredentials(username, password, rpcPort, defaultDataDir)
   }
 
   def apply(
     username: String,
     password: String,
+    rpcPort: Int,
     datadir: File): BitcoindAuthCredentials = {
-    BitcoindAuthCredentialsImpl(username, password, datadir)
+    BitcoindAuthCredentialsImpl(username, password, rpcPort, datadir)
   }
 }

--- a/rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -8,12 +8,15 @@ import org.bitcoins.core.config.NetworkParameters
  * Created by chris on 4/29/17.
  */
 sealed trait BitcoindInstance {
-
+  require(
+    rpcUri.getPort == rpcPort,
+    s"RpcUri and the rpcPort in authCredentials are different ${rpcUri} authcred: ${rpcPort}")
   def network: NetworkParameters
   def uri: URI
   def rpcUri: URI
   def authCredentials: BitcoindAuthCredentials
 
+  def rpcPort: Int = authCredentials.rpcPort
   def zmqPortOpt: Option[Int]
 }
 

--- a/rpc/src/test/scala/org/bitcoins/rpc/TestUtil.scala
+++ b/rpc/src/test/scala/org/bitcoins/rpc/TestUtil.scala
@@ -49,7 +49,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
       pw.write("prune=1\n")
     }
     pw.close()
-    BitcoindAuthCredentials(username, pass, f)
+    BitcoindAuthCredentials(username, pass, rpcUri.getPort, f)
   }
 
   lazy val network = RegTest

--- a/testkit/build.sbt
+++ b/testkit/build.sbt
@@ -1,3 +1,3 @@
-name := "testkit"
+name := "bitcoin-s-testkit"
 
 libraryDependencies ++= Deps.testkit

--- a/testkit/src/main/scala/org/bitcoins/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/rpc/BitcoindRpcTestUtil.scala
@@ -49,7 +49,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
       pw.write("prune=1\n")
     }
     pw.close()
-    BitcoindAuthCredentials(username, pass, f)
+    BitcoindAuthCredentials(username, pass, rpcUri.getPort, f)
   }
 
   lazy val network = RegTest
@@ -240,4 +240,4 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
   }
 }
 
-object BitcoindRpcTestUtil extends BitcoindRpcTestUtil
+object TestUtil extends BitcoindRpcTestUtil

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1-SNAPSHOT"
+version in ThisBuild := "0.0.5-LN-SNAPSHOT"


### PR DESCRIPTION
This PR makes it easier to read config files for `EclairInstance`, also makes it easier to get `BitcoinRpcClient` from `EclairInstance` in test functionality. This makes it easier to do things to the underlying blockchain when testing. 