### PR TITLE
Bitcoind spawn tweaks

### DIFF
--- a/rpc/src/main/scala/org/bitcoins/rpc/client/BitcoindRpcClient.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/client/BitcoindRpcClient.scala
@@ -1179,6 +1179,12 @@ class BitcoindRpcClient(instance: BitcoindInstance)(
         HttpCredentials.createBasicHttpCredentials(username, password))
   }
 
-  def start(): String =
-    ("bitcoind -datadir=" + instance.authCredentials.datadir).!!
+  def start(): String = {
+    val cmd = Seq(
+      "bitcoind",
+      "-datadir=" + instance.authCredentials.datadir,
+      "-rpcport=" + instance.rpcUri.getPort,
+      "-port=" + instance.uri.getPort)
+    cmd.!!
+  }
 }


### PR DESCRIPTION
For some reason, the only way I'm able to spawn two `bitcoind` instances is if I pass the parameters it needs directly to the process. 

Without these two commits, the tests in `RpcUtilTest` fail, at the last one. The test added in my first commit passes, and the second commit makes the last test also pass.