### PR TITLE
Make rpc client support eclair beta8 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - ./configure --enable-jni --enable-experimental --enable-module-ecdh
   - sudo make install
   - cd ../
-  - wget https://github.com/ACINQ/eclair/releases/download/v0.2-beta5/eclair-node-0.2-beta5-8aa51f4.jar
+  - wget https://github.com/ACINQ/eclair/releases/download/v0.2-beta8/eclair-node-0.2-beta8-52821b8.jar
   - export ECLAIR_PATH=$(pwd)
 
 script:

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -479,7 +479,8 @@ class EclairRpcClient(val instance: EclairInstance)(implicit system: ActorSystem
 
   private def pathToEclairJar: String = {
     val path = System.getenv("ECLAIR_PATH")
-    val eclairV = "/eclair-node-0.2-beta5-8aa51f4.jar"
+    val eclairV = "/eclair-node-0.2-beta8-52821b8.jar"
+
     path + eclairV
   }
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/JsonReaders.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/JsonReaders.scala
@@ -75,8 +75,8 @@ object JsonReaders {
   private def parsePaymentReq(obj: JsObject): JsResult[PaymentRequest] = {
     val prefix = obj("prefix").validate[String].get
     val amountOpt = obj("amount") match {
-      case o: JsObject => o("amount").validate[Long].asOpt
-      case x @ (_: JsArray | _: JsNumber | _: JsString | _: JsBoolean | JsNull) => None
+      case n: JsNumber => Some(n.value.toLongExact)
+      case x @ (_: JsArray | _: JsNumber | _: JsString | _: JsBoolean | _: JsObject | JsNull) => None
     }
     val timestamp = obj("timestamp").validate[Long].get
     val nodeId = obj("nodeId").validate[NodeId].get

--- a/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -45,7 +45,6 @@ class EclairRpcClientTest extends AsyncFlatSpec with BeforeAndAfterAll {
   it should "be able to list an existing peer and isConnected must be true" in {
     //test assumes that a connection to a peer was made in `beforeAll`
     val otherClientNodeIdF = otherClient.getInfo.map(_.nodeId)
-
     otherClientNodeIdF.flatMap(nid => hasConnection(client, nid))
   }
 


### PR DESCRIPTION
Eclair recently released a new version with a critical security update: 

https://github.com/ACINQ/eclair/releases/tag/v0.2-beta8

This PR adjusts our rpc client to support the basic functionality for eclair beta8 