### PR TITLE
Simplify LnCurrencyUnit, add MilliSatoshis, refactor EclairRpc to use…

### DIFF
--- a/core-gen/src/test/scala/org/bitcoins/core/gen/CurrencyUnitGenerator.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/CurrencyUnitGenerator.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.core.gen
 
 import org.bitcoins.core.currency.{ Bitcoins, CurrencyUnit, CurrencyUnits, Satoshis }
-import org.bitcoins.core.number.{ Int32, Int64 }
-import org.bitcoins.core.protocol.ln._
+import org.bitcoins.core.number.Int64
 import org.scalacheck.Gen
 
 /**

--- a/core-gen/src/test/scala/org/bitcoins/core/gen/NumberGenerator.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/NumberGenerator.scala
@@ -47,7 +47,9 @@ trait NumberGenerator {
    * Generates a number in the range 0 <= x < 2^^64
    * then wraps it in a UInt64
    */
-  def uInt64s: Gen[UInt64] = for {
+  def uInt64s: Gen[UInt64] = uInt64
+
+  def uInt64: Gen[UInt64] = for {
     bigInt <- bigIntsUInt64Range
   } yield UInt64(bigInt)
 

--- a/core-gen/src/test/scala/org/bitcoins/core/gen/ln/LnCurrencyUnitGen.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/ln/LnCurrencyUnitGen.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.gen.ln
 
+import org.bitcoins.core.gen.NumberGenerator
 import org.bitcoins.core.protocol.ln._
 import org.bitcoins.core.protocol.ln.currency._
 import org.scalacheck.Gen
@@ -39,6 +40,10 @@ trait LnCurrencyUnitGen {
   def negativeLnCurrencyUnit: Gen[LnCurrencyUnit] = {
     lnCurrencyUnit.suchThat(_ < LnCurrencyUnits.zero)
   }
+
+  def milliSatoshis: Gen[MilliSatoshis] = for {
+    i64 <- NumberGenerator.uInt64
+  } yield MilliSatoshis(i64.toBigInt)
 }
 
 object LnCurrencyUnitGen extends LnCurrencyUnitGen

--- a/core-gen/src/test/scala/org/bitcoins/core/gen/ln/LnCurrencyUnitGen.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/ln/LnCurrencyUnitGen.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.core.gen.ln
 
 import org.bitcoins.core.protocol.ln._
+import org.bitcoins.core.protocol.ln.currency._
 import org.scalacheck.Gen
 
 trait LnCurrencyUnitGen {

--- a/core-gen/src/test/scala/org/bitcoins/core/gen/ln/LnRouteGen.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/ln/LnRouteGen.scala
@@ -2,7 +2,8 @@ package org.bitcoins.core.gen.ln
 
 import org.bitcoins.core.gen.{ CryptoGenerators, NumberGenerator }
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.ln.{ PicoBitcoins, ShortChannelId }
+import org.bitcoins.core.protocol.ln.ShortChannelId
+import org.bitcoins.core.protocol.ln.currency.{ MilliSatoshis, PicoBitcoins }
 import org.bitcoins.core.protocol.ln.fee.{ FeeBaseMSat, FeeProportionalMillionths }
 import org.bitcoins.core.protocol.ln.routing.LnRoute
 import org.scalacheck.Gen
@@ -16,7 +17,7 @@ trait LnRouteGen {
 
   def feeBaseMSat: Gen[FeeBaseMSat] = for {
     //note that the feebase msat is only 4 bytes
-    p <- Gen.choose(0, UInt32.max.toLong).map(PicoBitcoins(_))
+    p <- Gen.choose(0, UInt32.max.toLong).map(MilliSatoshis(_))
   } yield FeeBaseMSat(p)
 
   def feeProportionalMillionths: Gen[FeeProportionalMillionths] = for {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePartTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePartTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.core.protocol.ln
 
 import org.bitcoins.core.config.{ MainNet, RegTest, TestNet3 }
 import org.bitcoins.core.protocol.ln.LnParams._
+import org.bitcoins.core.protocol.ln.currency.{ LnCurrencyUnits, MilliBitcoins }
 import org.scalatest.{ FlatSpec, MustMatchers }
 
 import scala.util.Try

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceTagsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceTagsTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.core.protocol.ln
 import org.bitcoins.core.crypto.{ ECPublicKey, Sha256Digest }
 import org.bitcoins.core.number.{ UInt32, UInt5, UInt64, UInt8 }
 import org.bitcoins.core.protocol.P2PKHAddress
+import org.bitcoins.core.protocol.ln.currency.{ MilliSatoshis, PicoBitcoins }
 import org.bitcoins.core.protocol.ln.fee.{ FeeBaseMSat, FeeProportionalMillionths }
 import org.bitcoins.core.protocol.ln.routing.LnRoute
 import org.bitcoins.core.protocol.ln.util.LnUtil
@@ -110,14 +111,14 @@ class LnTagsTest extends FlatSpec with MustMatchers {
     val route1 = LnRoute(
       pubkey = ECPublicKey.fromHex("029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"),
       shortChannelID = ShortChannelId.fromHex("0102030405060708"),
-      feeBaseMsat = FeeBaseMSat(PicoBitcoins.one),
+      feeBaseMsat = FeeBaseMSat(MilliSatoshis.one),
       feePropMilli = FeeProportionalMillionths(UInt32(20)),
       cltvExpiryDelta = 3)
 
     val route2 = LnRoute(
       pubkey = ECPublicKey.fromHex("039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"),
       shortChannelID = ShortChannelId.fromHex("030405060708090a"),
-      feeBaseMsat = FeeBaseMSat(PicoBitcoins(2)),
+      feeBaseMsat = FeeBaseMSat(MilliSatoshis(2)),
       feePropMilli = FeeProportionalMillionths(UInt32(30)),
       cltvExpiryDelta = 4)
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
@@ -5,6 +5,7 @@ import org.bitcoins.core.gen.ln.LnInvoiceGen
 import org.bitcoins.core.number.{ UInt32, UInt64, UInt8 }
 import org.bitcoins.core.protocol.{ Bech32Address, P2PKHAddress, P2SHAddress }
 import org.bitcoins.core.protocol.ln.LnParams.{ LnBitcoinMainNet, LnBitcoinTestNet }
+import org.bitcoins.core.protocol.ln.currency.{ MicroBitcoins, MilliBitcoins, MilliSatoshis, PicoBitcoins }
 import org.bitcoins.core.protocol.ln.fee.{ FeeBaseMSat, FeeProportionalMillionths }
 import org.bitcoins.core.protocol.ln.routing.LnRoute
 import org.bitcoins.core.util.CryptoUtil
@@ -177,14 +178,14 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers with PropertyChecks {
     val route1 = LnRoute(
       pubkey = ECPublicKey.fromHex("029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"),
       shortChannelID = ShortChannelId.fromHex("0102030405060708"),
-      feeBaseMsat = FeeBaseMSat(PicoBitcoins.one),
+      feeBaseMsat = FeeBaseMSat(MilliSatoshis.one),
       feePropMilli = FeeProportionalMillionths(UInt32(20)),
       cltvExpiryDelta = 3)
 
     val route2 = LnRoute(
       pubkey = ECPublicKey.fromHex("039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"),
       shortChannelID = ShortChannelId.fromHex("030405060708090a"),
-      feeBaseMsat = FeeBaseMSat(PicoBitcoins(2)),
+      feeBaseMsat = FeeBaseMSat(MilliSatoshis(2)),
       feePropMilli = FeeProportionalMillionths(UInt32(30)),
       cltvExpiryDelta = 4)
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnitSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnitSpec.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.core.protocol.ln
+package org.bitcoins.core.protocol.ln.currency
 
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.gen.ln.LnCurrencyUnitGen
@@ -41,7 +41,7 @@ class LnCurrencyUnitSpec extends Properties("LnCurrencyUnitSpec") {
 
   property("Multiplicative identity for LnCurrencyUnits") =
     Prop.forAll(LnCurrencyUnitGen.lnCurrencyUnit) { lnUnit =>
-      lnUnit * LnCurrencyUnits.onePicoBTC == lnUnit
+      lnUnit * PicoBitcoins.one == lnUnit
     }
 
   property("Multiply two LnCurrencyUnit values") =
@@ -54,7 +54,7 @@ class LnCurrencyUnitSpec extends Properties("LnCurrencyUnitSpec") {
 
   property("Convert negative LnCurrencyUnit value to Satoshis") =
     Prop.forAll(LnCurrencyUnitGen.negativeLnCurrencyUnit) { lnUnit =>
-      lnUnit.toSatoshis == Satoshis.zero
+      lnUnit.toSatoshis <= Satoshis.zero
     }
 
   property("< & >=") =

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnitTest.scala
@@ -72,7 +72,7 @@ class LnCurrencyUnitTest extends FlatSpec with MustMatchers {
 
   it must "have the correct maximum and minimum number representation for NanoBitcoins" in {
     NanoBitcoins.max must be(NanoBitcoins(9223372036854775L))
-    NanoBitcoins.min must be(NanoBitcoins(-9223372036854775L)
+    NanoBitcoins.min must be(NanoBitcoins(-9223372036854775L))
   }
 
   it must "have the correct maximum and minimum number representation for PicoBitcoins" in {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnitTest.scala
@@ -72,7 +72,7 @@ class LnCurrencyUnitTest extends FlatSpec with MustMatchers {
 
   it must "have the correct maximum and minimum number representation for NanoBitcoins" in {
     NanoBitcoins.max must be(NanoBitcoins(9223372036854775L))
-    NanoBitcoins.min must be(NanoBitcoins(-9223372036854775L))
+    NanoBitcoins.min must be(NanoBitcoins(-9223372036854775L)
   }
 
   it must "have the correct maximum and minimum number representation for PicoBitcoins" in {
@@ -83,11 +83,11 @@ class LnCurrencyUnitTest extends FlatSpec with MustMatchers {
   it must "round pico bitcoins to satoshis correctly" in {
     PicoBitcoins.one.toSatoshis must be(Satoshis.zero)
 
-    PicoBitcoins(999).toSatoshis must be(Satoshis.zero)
+    PicoBitcoins(9999).toSatoshis must be(Satoshis.zero)
 
-    PicoBitcoins(1000).toSatoshis must be(Satoshis.one)
+    PicoBitcoins(10000).toSatoshis must be(Satoshis.one)
 
-    PicoBitcoins(1999).toSatoshis must be(Satoshis.one)
+    PicoBitcoins(19999).toSatoshis must be(Satoshis.one)
   }
 
   it must "convert units to the correct pico bitcoins amount" in {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnitTest.scala
@@ -1,5 +1,7 @@
-package org.bitcoins.core.protocol.ln
+package org.bitcoins.core.protocol.ln.currency
 
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.protocol.ln.LnPolicy
 import org.scalatest.{ FlatSpec, MustMatchers }
 
 class LnCurrencyUnitTest extends FlatSpec with MustMatchers {
@@ -78,6 +80,28 @@ class LnCurrencyUnitTest extends FlatSpec with MustMatchers {
     PicoBitcoins.min must be(PicoBitcoins(-9223372036854775808L))
   }
 
+  it must "round pico bitcoins to satoshis correctly" in {
+    PicoBitcoins.one.toSatoshis must be(Satoshis.zero)
+
+    PicoBitcoins(999).toSatoshis must be(Satoshis.zero)
+
+    PicoBitcoins(1000).toSatoshis must be(Satoshis.one)
+
+    PicoBitcoins(1999).toSatoshis must be(Satoshis.one)
+  }
+
+  it must "convert units to the correct pico bitcoins amount" in {
+
+    val expectedNano = BigInt(10).pow(3)
+    NanoBitcoins.one.toPicoBitcoins must be(PicoBitcoins(expectedNano))
+
+    val expectedMicro = BigInt(10).pow(6)
+    MicroBitcoins.one.toPicoBitcoins must be(PicoBitcoins(expectedMicro))
+
+    val expectedMilli = BigInt(10).pow(9)
+    MilliBitcoins.one.toPicoBitcoins must be(PicoBitcoins(expectedMilli))
+  }
+
   it must "fail to create a MilliBitcoin outside of the maximum range" in {
     intercept[IllegalArgumentException] {
       MilliBitcoins(LnPolicy.maxMilliBitcoins + 1)
@@ -139,9 +163,5 @@ class LnCurrencyUnitTest extends FlatSpec with MustMatchers {
     MicroBitcoins.one must be(MicroBitcoins(1))
     NanoBitcoins.one must be(NanoBitcoins(1))
     PicoBitcoins.one must be(PicoBitcoins(1))
-    LnCurrencyUnits.oneMilliBTC must be(MilliBitcoins(1))
-    LnCurrencyUnits.oneMicroBTC must be(MicroBitcoins(1))
-    LnCurrencyUnits.oneNanoBTC must be(NanoBitcoins(1))
-    LnCurrencyUnits.onePicoBTC must be(PicoBitcoins(1))
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshisTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshisTest.scala
@@ -1,0 +1,50 @@
+package org.bitcoins.core.protocol.ln.currency
+
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ FlatSpec, MustMatchers }
+import org.slf4j.LoggerFactory
+
+class MilliSatoshisTest extends FlatSpec with MustMatchers {
+  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
+  behavior of "MilliSatoshis"
+
+  it must "convert pico bitcoins to msat correctly" in {
+
+    MilliSatoshis.fromPico(PicoBitcoins.zero) must be(MilliSatoshis.zero)
+    MilliSatoshis.fromPico(PicoBitcoins.one) must be(MilliSatoshis.zero)
+    MilliSatoshis.fromPico(PicoBitcoins(9)) must be(MilliSatoshis.zero)
+
+    MilliSatoshis.fromPico(PicoBitcoins(10)) must be(MilliSatoshis.one)
+
+    MilliSatoshis.fromPico(PicoBitcoins(19)) must be(MilliSatoshis.one)
+
+    MilliSatoshis.fromPico(PicoBitcoins(20)) must be(MilliSatoshis(2))
+
+    MilliSatoshis.fromPico(PicoBitcoins(101)) must be(MilliSatoshis(10))
+
+    MilliSatoshis.fromPico(PicoBitcoins(110)) must be(MilliSatoshis(11))
+  }
+
+  it must "covert from a ln currency unit -> millisatoshis -> lnCurrencyUnit" in {
+    def gen(): Gen[Long] = {
+      Gen.choose(0, PicoBitcoins.max.toLong)
+    }
+
+    PropertyChecks.forAll(gen) { underlying =>
+      //we lose the last digit of precision converting
+      //PicoBitcoins -> MilliSatoshis
+      //this is the expected answer
+      val expected = (underlying / 10) * 10
+      val expectedPico = PicoBitcoins(expected)
+
+      val pico = PicoBitcoins(underlying)
+
+      val msat = MilliSatoshis(pico)
+
+      val lnCurrencyUnit = msat.toLnCurrencyUnit
+
+      assert(expectedPico == lnCurrencyUnit)
+    }
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshisTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshisTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.ln.currency
 
+import org.bitcoins.core.gen.CurrencyUnitGenerator
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{ FlatSpec, MustMatchers }
@@ -45,6 +46,14 @@ class MilliSatoshisTest extends FlatSpec with MustMatchers {
       val lnCurrencyUnit = msat.toLnCurrencyUnit
 
       assert(expectedPico == lnCurrencyUnit)
+    }
+  }
+
+  it must "convert sat -> msat -> sat" in {
+    PropertyChecks.forAll(CurrencyUnitGenerator.positiveRealistic) { sat =>
+      val msat = MilliSatoshis(sat)
+      assert(msat.toSatoshis == sat)
+
     }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePart.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePart.scala
@@ -4,6 +4,7 @@ import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.number.{ UInt5, UInt8 }
 import org.bitcoins.core.protocol.{ HumanReadablePart, NetworkElement }
 import org.bitcoins.core.protocol.ln.LnParams._
+import org.bitcoins.core.protocol.ln.currency.{ LnCurrencyUnit, LnCurrencyUnits }
 import org.bitcoins.core.util.Bech32
 import org.slf4j.LoggerFactory
 import scodec.bits.ByteVector

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.core.protocol.ln
 
 import org.bitcoins.core.number.{ UInt5, UInt64 }
+import org.bitcoins.core.protocol.ln.currency.{ LnCurrencyUnit, PicoBitcoins }
 import org.bitcoins.core.protocol.ln.util.LnUtil
 import org.bitcoins.core.util._
 import org.slf4j.LoggerFactory

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnPolicy.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnPolicy.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.core.protocol.ln
 
 import org.bitcoins.core.number.Int64
+import org.bitcoins.core.protocol.ln.currency.MilliBitcoins
 
 sealed abstract class LnPolicy {
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnit.scala
@@ -201,8 +201,9 @@ object PicoBitcoins extends BaseNumbers[PicoBitcoins] {
 }
 
 object LnCurrencyUnits {
-
-  val zero: LnCurrencyUnit = PicoBitcoins(0)
+  val PICO_TO_SATOSHIS = 10000
+  val MSAT_TO_PICO = 10
+  val zero: LnCurrencyUnit = PicoBitcoins.zero
 
   /**
    * For information regarding the rounding of sub-Satoshi values, please visit:
@@ -210,8 +211,15 @@ object LnCurrencyUnits {
    */
   def toSatoshi(lnCurrencyUnits: LnCurrencyUnit): Satoshis = {
     val pico = lnCurrencyUnits.toPicoBitcoins
-    val sat = pico.toBigInt / 1000
+    val sat = pico.toBigInt / PICO_TO_SATOSHIS
     Satoshis(Int64(sat))
+  }
+
+  def fromMSat(msat: MilliSatoshis): PicoBitcoins = {
+    //msat are technically 10^-11
+    //while pico are 10^-12, so we need to convert
+    val underlying = msat.toBigInt * MSAT_TO_PICO
+    PicoBitcoins(underlying)
   }
 
   def fromEncodedString(input: String): Try[LnCurrencyUnit] = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnit.scala
@@ -1,20 +1,19 @@
-package org.bitcoins.core.protocol.ln
+package org.bitcoins.core.protocol.ln.currency
 
 import org.bitcoins.core.currency.{ Bitcoins, Satoshis }
-import org.bitcoins.core.number.{ BaseNumbers, Int64, UInt5, UInt8 }
+import org.bitcoins.core.number.{ BaseNumbers, Int64, UInt5 }
 import org.bitcoins.core.protocol.NetworkElement
+import org.bitcoins.core.protocol.ln._
 import org.bitcoins.core.util.Bech32
 import scodec.bits.ByteVector
 
 import scala.math.BigDecimal.RoundingMode
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Try }
 
 sealed abstract class LnCurrencyUnit extends NetworkElement {
   type A
 
   def character: Char
-
-  def multiplier: BigDecimal
 
   def >=(ln: LnCurrencyUnit): Boolean = {
     toPicoBitcoinValue >= ln.toPicoBitcoinValue
@@ -61,19 +60,19 @@ sealed abstract class LnCurrencyUnit extends NetworkElement {
 
   def toBigInt: BigInt
 
-  def toLong: Long = toBigInt.toLong
+  def toLong: Long = toBigInt.bigInteger.longValueExact()
 
-  def toInt: Int = {
-    require(this.toBigInt >= Int.MinValue, "Number was too small for Int, got: " + underlying)
-    require(this.toBigInt <= Int.MaxValue, "Number was too big for Int, got: " + underlying)
-    toBigInt.toInt
-  }
+  def toInt: Int = toBigInt.bigInteger.intValueExact()
 
   protected def underlying: A
 
-  def toSatoshis: Satoshis
+  def toSatoshis: Satoshis = {
+    LnCurrencyUnits.toSatoshi(this)
+  }
 
-  def toPicoBitcoinValue: BigInt
+  def toPicoBitcoinValue: BigInt = {
+    toBigInt * toPicoBitcoinMultiplier
+  }
 
   def toPicoBitcoinDecimal: BigDecimal = {
     BigDecimal(toPicoBitcoinValue.bigInteger)
@@ -87,6 +86,8 @@ sealed abstract class LnCurrencyUnit extends NetworkElement {
     ByteVector(toEncodedString.map(_.toByte))
   }
 
+  def toMSat: MilliSatoshis = MilliSatoshis.fromPico(toPicoBitcoins)
+
   def toEncodedString: String = {
     toBigInt + character.toString()
   }
@@ -97,15 +98,10 @@ sealed abstract class MilliBitcoins extends LnCurrencyUnit {
 
   override def character: Char = 'm'
 
-  override def multiplier: BigDecimal = LnPolicy.milliMultiplier
-
   override def toPicoBitcoinMultiplier: Int = 1000000000
 
   override def toBigInt: A = underlying
 
-  override def toSatoshis: Satoshis = LnCurrencyUnits.toSatoshi(this)
-
-  override def toPicoBitcoinValue: BigInt = LnCurrencyUnits.toPicoBitcoinValue(this)
 }
 
 object MilliBitcoins extends BaseNumbers[MilliBitcoins] {
@@ -129,15 +125,10 @@ sealed abstract class MicroBitcoins extends LnCurrencyUnit {
 
   override def character: Char = 'u'
 
-  override def multiplier: BigDecimal = LnPolicy.microMultiplier
-
   override def toPicoBitcoinMultiplier: Int = 1000000
 
   override def toBigInt: A = underlying
 
-  override def toSatoshis: Satoshis = LnCurrencyUnits.toSatoshi(this)
-
-  override def toPicoBitcoinValue: BigInt = LnCurrencyUnits.toPicoBitcoinValue(this)
 }
 
 object MicroBitcoins extends BaseNumbers[MicroBitcoins] {
@@ -161,15 +152,10 @@ sealed abstract class NanoBitcoins extends LnCurrencyUnit {
 
   override def character: Char = 'n'
 
-  override def multiplier: BigDecimal = LnPolicy.nanoMultiplier
-
   override def toPicoBitcoinMultiplier: Int = 1000
 
   override def toBigInt: A = underlying
 
-  override def toSatoshis: Satoshis = LnCurrencyUnits.toSatoshi(this)
-
-  override def toPicoBitcoinValue: BigInt = LnCurrencyUnits.toPicoBitcoinValue(this)
 }
 
 object NanoBitcoins extends BaseNumbers[NanoBitcoins] {
@@ -193,15 +179,9 @@ sealed abstract class PicoBitcoins extends LnCurrencyUnit {
 
   override def character: Char = 'p'
 
-  override def multiplier: BigDecimal = LnPolicy.picoMultiplier
-
   override def toPicoBitcoinMultiplier: Int = 1
 
   override def toBigInt: A = underlying
-
-  override def toSatoshis: Satoshis = LnCurrencyUnits.toSatoshi(this)
-
-  override def toPicoBitcoinValue: BigInt = this.toBigInt
 }
 
 object PicoBitcoins extends BaseNumbers[PicoBitcoins] {
@@ -221,31 +201,17 @@ object PicoBitcoins extends BaseNumbers[PicoBitcoins] {
 }
 
 object LnCurrencyUnits {
-  val oneMilliBTC: LnCurrencyUnit = MilliBitcoins.one
-  val oneMicroBTC: LnCurrencyUnit = MicroBitcoins.one
-  val oneNanoBTC: LnCurrencyUnit = NanoBitcoins.one
-  val onePicoBTC: LnCurrencyUnit = PicoBitcoins.one
-  val zero = PicoBitcoins(0)
 
-  val milliMultiplier: BigDecimal = LnPolicy.milliMultiplier
-  val microMultiplier: BigDecimal = LnPolicy.microMultiplier
-  val nanoMultiplier: BigDecimal = LnPolicy.nanoMultiplier
-  val picoMultiplier: BigDecimal = LnPolicy.picoMultiplier
-
-  def toPicoBitcoinValue(lnCurrencyUnits: LnCurrencyUnit): BigInt = {
-    lnCurrencyUnits.toBigInt * lnCurrencyUnits.toPicoBitcoinMultiplier
-  }
+  val zero: LnCurrencyUnit = PicoBitcoins(0)
 
   /**
    * For information regarding the rounding of sub-Satoshi values, please visit:
    * https://github.com/lightningnetwork/lightning-rfc/blob/master/03-transactions.md#commitment-transaction-outputs
    */
   def toSatoshi(lnCurrencyUnits: LnCurrencyUnit): Satoshis = {
-    val sat = BigDecimal(lnCurrencyUnits.toBigInt) * Bitcoins.one.satoshis.toBigDecimal * lnCurrencyUnits.multiplier
-    val rounded = sat.setScale(0, RoundingMode.DOWN)
-    if (rounded >= 1) {
-      Satoshis(Int64(rounded.toBigIntExact().get))
-    } else Satoshis.zero
+    val pico = lnCurrencyUnits.toPicoBitcoins
+    val sat = pico.toBigInt / 1000
+    Satoshis(Int64(sat))
   }
 
   def fromEncodedString(input: String): Try[LnCurrencyUnit] = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshis.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshis.scala
@@ -1,10 +1,11 @@
 package org.bitcoins.core.protocol.ln.currency
 
-import org.bitcoins.core.number.BaseNumbers
+import org.bitcoins.core.number.UInt64
+import org.bitcoins.core.protocol.NetworkElement
 
 import scala.math.BigDecimal.RoundingMode
 
-sealed abstract class MilliSatoshis {
+sealed abstract class MilliSatoshis extends NetworkElement {
   protected def underlying: BigInt
 
   def toBigInt: BigInt = underlying
@@ -26,6 +27,28 @@ sealed abstract class MilliSatoshis {
     toLnCurrencyUnit != lnCurrencyUnit
   }
 
+  def >=(ln: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit >= ln
+  }
+
+  def >(ln: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit > ln
+  }
+
+  def <(ln: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit < ln
+  }
+
+  def <=(ln: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit <= ln
+  }
+
+  def toUInt64: UInt64 = {
+    UInt64(underlying)
+  }
+
+  override def bytes = toUInt64.bytes.reverse
+
 }
 
 object MilliSatoshis {
@@ -41,7 +64,7 @@ object MilliSatoshis {
 
   def fromPico(picoBitcoins: PicoBitcoins): MilliSatoshis = {
     val pico = picoBitcoins.toPicoBitcoinDecimal
-    // we need to divide by 10
+    // we need to divide by 10 to get to msat
     val msatDec = pico / BigDecimal(10)
 
     //now we need to round, we are going to round the same way round

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshis.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshis.scala
@@ -1,0 +1,59 @@
+package org.bitcoins.core.protocol.ln.currency
+
+import org.bitcoins.core.number.BaseNumbers
+
+import scala.math.BigDecimal.RoundingMode
+
+sealed abstract class MilliSatoshis {
+  protected def underlying: BigInt
+
+  def toBigInt: BigInt = underlying
+
+  def toLong: Long = toBigInt.bigInteger.longValueExact()
+
+  def toBigDecimal: BigDecimal = BigDecimal(toBigInt)
+
+  def toLnCurrencyUnit: LnCurrencyUnit = {
+    val underlying = toBigInt * BigInt(10)
+    PicoBitcoins(underlying)
+  }
+
+  def ==(lnCurrencyUnit: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit == lnCurrencyUnit
+  }
+
+  def !=(lnCurrencyUnit: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit != lnCurrencyUnit
+  }
+
+}
+
+object MilliSatoshis {
+
+  private case class MilliSatoshisImpl(underlying: BigInt) extends MilliSatoshis
+
+  val zero: MilliSatoshis = MilliSatoshis(0)
+  val one: MilliSatoshis = MilliSatoshis(1)
+
+  def apply(underlying: BigInt): MilliSatoshis = {
+    MilliSatoshisImpl(underlying)
+  }
+
+  def fromPico(picoBitcoins: PicoBitcoins): MilliSatoshis = {
+    val pico = picoBitcoins.toPicoBitcoinDecimal
+    // we need to divide by 10
+    val msatDec = pico / BigDecimal(10)
+
+    //now we need to round, we are going to round the same way round
+    //outputs when publishing txs to the blockchain
+    //https://github.com/lightningnetwork/lightning-rfc/blob/master/03-transactions.md#commitment-transaction-outputs
+
+    val rounded = msatDec.setScale(0, RoundingMode.DOWN)
+
+    MilliSatoshis(rounded.toBigIntExact().get)
+  }
+
+  def apply(lnCurrencyUnit: LnCurrencyUnit): MilliSatoshis = {
+    fromPico(picoBitcoins = lnCurrencyUnit.toPicoBitcoins)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/fee/FeeBaseMSat.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/fee/FeeBaseMSat.scala
@@ -2,7 +2,7 @@ package org.bitcoins.core.protocol.ln.fee
 
 import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.NetworkElement
-import org.bitcoins.core.protocol.ln.{ LnCurrencyUnit, PicoBitcoins }
+import org.bitcoins.core.protocol.ln.currency.{ MilliSatoshis, PicoBitcoins }
 import scodec.bits.ByteVector
 
 /**
@@ -11,7 +11,7 @@ import scodec.bits.ByteVector
  * [[https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#the-channel_update-message]]
  * [[https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#on-mainnet-with-fallback-address-1rustyrx2oai4eyydpqgwvel62bbgqn9t-with-extra-routing-info-to-go-via-nodes-029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255-then-039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255]]
  */
-case class FeeBaseMSat(msat: PicoBitcoins) extends NetworkElement {
+case class FeeBaseMSat(msat: MilliSatoshis) extends NetworkElement {
   require(msat.toLong <= UInt32.max.toLong, s"Value too large for FeeBaseMSat ${msat}")
   require(msat.toLong >= 0, s"Value cannot be negative for FeeBaseMSat ${msat}")
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/routing/LnRoute.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/routing/LnRoute.scala
@@ -5,7 +5,8 @@ import java.math.BigInteger
 import org.bitcoins.core.crypto.ECPublicKey
 import org.bitcoins.core.number.{ Int64, UInt32, UInt5 }
 import org.bitcoins.core.protocol.NetworkElement
-import org.bitcoins.core.protocol.ln.{ PicoBitcoins, ShortChannelId }
+import org.bitcoins.core.protocol.ln.ShortChannelId
+import org.bitcoins.core.protocol.ln.currency.{ MilliSatoshis, PicoBitcoins }
 import org.bitcoins.core.protocol.ln.fee.{ FeeBaseMSat, FeeProportionalMillionths }
 import org.bitcoins.core.util.BitcoinSUtil
 import org.slf4j.LoggerFactory
@@ -49,9 +50,9 @@ object LnRoute {
     //if we parse directly to an i64 we risk having the largest big endian byte
     //be signed -- which will give us a negative number possibly
     val feeBaseU32 = UInt32.fromBytes(bytes.slice(41, 45))
-    val feeBaseI64 = Int64(feeBaseU32.toLong)
+    val feeBase = feeBaseU32.toLong
 
-    val feeBaseMSat = FeeBaseMSat(PicoBitcoins(feeBaseI64))
+    val feeBaseMSat = FeeBaseMSat(MilliSatoshis(feeBase))
 
     val u32 = UInt32.fromBytes(bytes.slice(45, 49))
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/api/EclairApi.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/api/EclairApi.scala
@@ -1,9 +1,10 @@
 package org.bitcoins.eclair.rpc.api
 
-import org.bitcoins.core.crypto.{ ECPublicKey, Sha256Digest }
+import org.bitcoins.core.crypto.Sha256Digest
 import org.bitcoins.core.currency.CurrencyUnit
-import org.bitcoins.core.protocol.ln.{ LnCurrencyUnit, LnInvoice }
+import org.bitcoins.core.protocol.ln.LnInvoice
 import org.bitcoins.core.protocol.ln.channel.{ ChannelId, FundedChannelId }
+import org.bitcoins.core.protocol.ln.currency.{ LnCurrencyUnit, MilliSatoshis }
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.eclair.rpc.json._
@@ -46,7 +47,7 @@ trait EclairApi {
   def open(
     nodeId: NodeId,
     fundingSatoshis: CurrencyUnit,
-    pushMsat: Option[LnCurrencyUnit],
+    pushMsat: Option[MilliSatoshis],
     feerateSatPerByte: Option[SatoshisPerByte],
     channelFlags: Option[Byte]): Future[FundedChannelId]
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.eclair.rpc.json
 
 import org.bitcoins.core.crypto.{ DoubleSha256Digest, ECDigitalSignature, Sha256Digest }
-import org.bitcoins.core.protocol.ln.PicoBitcoins
 import org.bitcoins.core.protocol.ln.channel.{ ChannelState, FundedChannelId }
+import org.bitcoins.core.protocol.ln.currency.{ LnCurrencyUnit, MilliSatoshis, PicoBitcoins }
 import org.bitcoins.eclair.rpc.network.{ NodeId, PeerState }
 import play.api.libs.json.{ JsArray, JsObject }
 
@@ -42,7 +42,7 @@ case class ChannelUpdate(
   flags: String,
   cltvExpiryDelta: Int,
   htlcMinimumMsat: Long,
-  feeBaseMsat: PicoBitcoins,
+  feeBaseMsat: MilliSatoshis,
   feeProportionalMillionths: Long)
 
 /* ChannelResult starts here, some of this may be useful but it seems that data is different at different times
@@ -165,7 +165,7 @@ case class ChannelResult(
 
 case class PaymentRequest(
   prefix: String,
-  amount: Option[Long],
+  amount: Option[MilliSatoshis],
   timestamp: Long,
   nodeId: NodeId,
   tags: Vector[JsObject],
@@ -174,7 +174,7 @@ case class PaymentRequest(
 
 sealed abstract class PaymentResult
 case class PaymentSucceeded(
-  amountMsat: PicoBitcoins,
+  amountMsat: MilliSatoshis,
   paymentHash: Sha256Digest,
   paymentPreimage: String,
   route: JsArray) extends PaymentResult

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/JsonReaders.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/JsonReaders.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.eclair.rpc.json
 
-import org.bitcoins.core.protocol.ln.PicoBitcoins
 import org.bitcoins.core.protocol.ln.channel.{ ChannelState, FundedChannelId }
+import org.bitcoins.core.protocol.ln.currency.{ MilliSatoshis, PicoBitcoins }
 import org.bitcoins.eclair.rpc.network.{ NodeId, PeerState }
 import org.bitcoins.rpc.serializers.SerializerUtil
 import org.slf4j.LoggerFactory
@@ -26,6 +26,13 @@ object JsonReaders {
   implicit val picoBitcoinsReads: Reads[PicoBitcoins] = {
     Reads { jsValue: JsValue =>
       SerializerUtil.processJsNumberBigInt(PicoBitcoins.apply)(jsValue)
+    }
+  }
+
+  implicit val msatReads: Reads[MilliSatoshis] = {
+    Reads { jsValue: JsValue =>
+      SerializerUtil.processJsNumberBigInt(MilliSatoshis.apply)(jsValue)
+
     }
   }
 
@@ -75,7 +82,7 @@ object JsonReaders {
   private def parsePaymentReq(obj: JsObject): JsResult[PaymentRequest] = {
     val prefix = obj("prefix").validate[String].get
     val amountOpt = obj("amount") match {
-      case o: JsObject => o("amount").validate[Long].asOpt
+      case o: JsObject => o("amount").validate[MilliSatoshis].asOpt
       case x @ (_: JsArray | _: JsNumber | _: JsString | _: JsBoolean | JsNull) => None
     }
     val timestamp = obj("timestamp").validate[Long].get

--- a/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtil.scala
+++ b/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtil.scala
@@ -7,8 +7,8 @@ import akka.actor.ActorSystem
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.currency.CurrencyUnit
-import org.bitcoins.core.protocol.ln.PicoBitcoins
 import org.bitcoins.core.protocol.ln.channel.{ ChannelId, ChannelState, FundedChannelId }
+import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
 import org.bitcoins.eclair.rpc.config.EclairInstance
@@ -268,7 +268,7 @@ trait EclairTestUtil extends BitcoinSLogger {
     n1: EclairRpcClient,
     n2: EclairRpcClient,
     amt: CurrencyUnit,
-    pushMSat: PicoBitcoins)(implicit system: ActorSystem): Future[FundedChannelId] = {
+    pushMSat: MilliSatoshis)(implicit system: ActorSystem): Future[FundedChannelId] = {
 
     val bitcoindRpcClient = getBitcoindRpc(n1)
     implicit val ec = system.dispatcher

--- a/testkit/src/main/scala/org/bitcoins/core/gen/CurrencyUnitGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/core/gen/CurrencyUnitGenerator.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.core.gen
 
 import org.bitcoins.core.currency.{ Bitcoins, CurrencyUnit, CurrencyUnits, Satoshis }
-import org.bitcoins.core.number.{ Int32, Int64 }
-import org.bitcoins.core.protocol.ln._
+import org.bitcoins.core.number.Int64
+import org.bitcoins.core.protocol.ln.currency._
 import org.scalacheck.Gen
 
 /**

--- a/testkit/src/main/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtil.scala
@@ -7,8 +7,8 @@ import akka.actor.ActorSystem
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.currency.CurrencyUnit
-import org.bitcoins.core.protocol.ln.PicoBitcoins
 import org.bitcoins.core.protocol.ln.channel.{ ChannelId, ChannelState, FundedChannelId }
+import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
 import org.bitcoins.eclair.rpc.config.EclairInstance
@@ -270,7 +270,7 @@ trait EclairTestUtil extends BitcoinSLogger {
     n1: EclairRpcClient,
     n2: EclairRpcClient,
     amt: CurrencyUnit,
-    pushMSat: PicoBitcoins)(implicit system: ActorSystem): Future[FundedChannelId] = {
+    pushMSat: MilliSatoshis)(implicit system: ActorSystem): Future[FundedChannelId] = {
 
     val bitcoindRpcClient = getBitcoindRpc(n1)
     implicit val ec = system.dispatcher


### PR DESCRIPTION
This PR 

- Simplifies `LnCurrencyUnit`s
- Adds a `MilliSatoshis` case class
- Replaces some uses of `LnCurrencyUnit` with `MilliSatoshis`. 

Basically there is a difference between `LnCurrencyUnit` which is defined in BOLT11 and `MilliSatoshis` which are in other protocol specifications like BOLT2/BOLT3. 