### PR TITLE
Fix comparison operators for millisatoshis, add Writes for MilliSatos…

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -142,7 +142,6 @@ trait TransactionSignatureChecker extends BitcoinSLogger {
    * [[https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#NULLFAIL]]
    */
   private def nullFailCheck(sigs: Seq[ECDigitalSignature], result: TransactionSignatureCheckerResult, flags: Seq[ScriptFlag]): TransactionSignatureCheckerResult = {
-    logger.info("Result before nullfail check:" + result)
     val nullFailEnabled = ScriptFlagUtil.requireScriptVerifyNullFail(flags)
     if (nullFailEnabled && !result.isValid && sigs.exists(_.bytes.nonEmpty)) {
       //we need to check that all signatures were empty byte vectors, else this fails because of BIP146 and nullfail

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshis.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshis.scala
@@ -26,28 +26,28 @@ sealed abstract class MilliSatoshis extends NetworkElement {
     LnCurrencyUnits.fromMSat(this)
   }
 
-  def ==(lnCurrencyUnit: LnCurrencyUnit): Boolean = {
-    toLnCurrencyUnit == lnCurrencyUnit
+  def ==(ms: MilliSatoshis): Boolean = {
+    toLnCurrencyUnit == ms.toLnCurrencyUnit
   }
 
-  def !=(lnCurrencyUnit: LnCurrencyUnit): Boolean = {
-    toLnCurrencyUnit != lnCurrencyUnit
+  def !=(ms: MilliSatoshis): Boolean = {
+    toLnCurrencyUnit != ms.toLnCurrencyUnit
   }
 
-  def >=(ln: LnCurrencyUnit): Boolean = {
-    toLnCurrencyUnit >= ln
+  def >=(ms: MilliSatoshis): Boolean = {
+    toLnCurrencyUnit >= ms.toLnCurrencyUnit
   }
 
-  def >(ln: LnCurrencyUnit): Boolean = {
-    toLnCurrencyUnit > ln
+  def >(ms: MilliSatoshis): Boolean = {
+    toLnCurrencyUnit > ms.toLnCurrencyUnit
   }
 
-  def <(ln: LnCurrencyUnit): Boolean = {
-    toLnCurrencyUnit < ln
+  def <(ms: MilliSatoshis): Boolean = {
+    toLnCurrencyUnit < ms.toLnCurrencyUnit
   }
 
-  def <=(ln: LnCurrencyUnit): Boolean = {
-    toLnCurrencyUnit <= ln
+  def <=(ms: MilliSatoshis): Boolean = {
+    toLnCurrencyUnit <= ms.toLnCurrencyUnit
   }
 
   def toUInt64: UInt64 = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshis.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshis.scala
@@ -26,6 +26,30 @@ sealed abstract class MilliSatoshis extends NetworkElement {
     LnCurrencyUnits.fromMSat(this)
   }
 
+  def ==(lnCurrencyUnit: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit == lnCurrencyUnit
+  }
+
+  def !=(lnCurrencyUnit: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit != lnCurrencyUnit
+  }
+
+  def >=(ln: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit >= ln
+  }
+
+  def >(ln: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit > ln
+  }
+
+  def <(ln: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit < ln
+  }
+
+  def <=(ln: LnCurrencyUnit): Boolean = {
+    toLnCurrencyUnit <= ln
+  }
+
   def ==(ms: MilliSatoshis): Boolean = {
     toLnCurrencyUnit == ms.toLnCurrencyUnit
   }

--- a/rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonWriters.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonWriters.scala
@@ -4,6 +4,7 @@ import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.{ Transaction, TransactionInput }
 import org.bitcoins.core.util.BitcoinSUtil
@@ -50,5 +51,9 @@ object JsonWriters {
     override def writes(o: Map[K, V]): JsValue = {
       Json.toJson(o.map { case (k, v) => (keyString(k), v) })
     }
+  }
+
+  implicit object MilliSatoshisWrites extends Writes[MilliSatoshis] {
+    override def writes(o: MilliSatoshis): JsValue = JsNumber(o.toBigDecimal)
   }
 }


### PR DESCRIPTION
…his in JsonWriters

Fixes mistake of making comoparison operators for `MilliSatoshis` take `LnCurrencyUnit` rather than `MilliSatoshis`, adds a way to write MilliSatoshis to `JsonWriters`. 