### PR TITLE
Derive nodeId from ln invoice signature, move nodeid case class into …

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
@@ -60,7 +60,7 @@ class ECPublicKeyTest extends FlatSpec with MustMatchers {
     PropertyChecks.forAll(CryptoGenerators.publicKey) { pubKey =>
       val p = pubKey.toPoint
       val pub2 = ECPublicKey.fromPoint(p, pubKey.isCompressed)
-      pubKey == pub2
+      assert(pubKey == pub2)
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
@@ -3,7 +3,9 @@ package org.bitcoins.core.crypto
 import java.math.BigInteger
 
 import org.bitcoinj.core.Sha256Hash
+import org.bitcoins.core.gen.CryptoGenerators
 import org.bitcoins.core.util.BitcoinSUtil
+import org.scalatest.prop.PropertyChecks
 import org.scalatest.{ FlatSpec, MustMatchers }
 import scodec.bits.ByteVector
 
@@ -54,4 +56,11 @@ class ECPublicKeyTest extends FlatSpec with MustMatchers {
       bitcoinsSignature.bytes.toArray) must be(true)
   }
 
+  it must "have serialization symmetry from ECPublicKey -> ECPoint -> ECPublicKey" in {
+    PropertyChecks.forAll(CryptoGenerators.publicKey) { pubKey =>
+      val p = pubKey.toPoint
+      val pub2 = ECPublicKey.fromPoint(p, pubKey.isCompressed)
+      pubKey == pub2
+    }
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
@@ -45,11 +45,16 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers with PropertyChecks {
       paymentHash = paymentTag,
       descriptionOrHash = descriptionTagE)
 
+    val sigData = "6c6e62630b25fe64410d00004080c1014181c20240004080c1014181c20240004080c1014181c202404081a1fa83632b0b9b29031b7b739b4b232b91039bab83837b93a34b733903a3434b990383937b532b1ba0"
+    val hashSigData = Sha256Digest.fromHex("c3d4e83f646fa79a393d75277b1d858db1d1f7ab7137dcb7835db2ecd518e1c9")
+
     val signature = ECDigitalSignature.fromRS("38ec6891345e204145be8a3a99de38e98a39d6a569434e1845c8af7205afcfcc7f425fcd1463e93c32881ead0d6e356d467ec8c02553f9aab15e5738b11f127f")
     val version = UInt8.zero
     val lnSig = LnInvoiceSignature(version, signature)
 
     val invoice = LnInvoice(hrpEmpty, time, lnTags, lnSig)
+
+    invoice.signatureData.toHex must be(sigData)
 
     val serialized = invoice.toString
     serialized must be("lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w")

--- a/core-test/src/test/scala/org/bitcoins/core/util/CryptoUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/CryptoUtilTest.scala
@@ -1,12 +1,16 @@
 package org.bitcoins.core.util
 
+import org.bitcoins.core.gen.{ CryptoGenerators, NumberGenerator }
+import org.scalatest.prop.PropertyChecks
 import org.scalatest.{ FlatSpec, MustMatchers }
+import org.slf4j.LoggerFactory
+import scodec.bits.ByteVector
 
 /**
  * Created by chris on 1/26/16.
  */
 class CryptoUtilTest extends FlatSpec with MustMatchers {
-
+  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
   "CryptoUtil" must "perform a SHA-1 hash" in {
     val hash = CryptoUtil.sha1("")
     val expected = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
@@ -54,5 +58,15 @@ class CryptoUtilTest extends FlatSpec with MustMatchers {
     CryptoUtil.sha256Hash160(strBytes).hex must be(expected)
     CryptoUtil.sha256Hash160(hex).hex must be(expected)
     CryptoUtil.sha256Hash160(hex).flip.flip.hex must be(expected)
+  }
+
+  it must "recover the two public keys used to sign a message" in {
+    PropertyChecks.forAll(CryptoGenerators.privateKey, CryptoGenerators.sha256Digest) {
+      case (privKey, hash) =>
+        val message = hash.bytes
+        val sig = privKey.sign(message)
+        val (recovPub1, recovPub2) = CryptoUtil.recoverPublicKey(sig, message)
+        assert(recovPub1.verify(message, sig) && recovPub2.verify(message, sig))
+    }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -12,6 +12,7 @@ import org.bouncycastle.crypto.digests.SHA256Digest
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator
 import org.bouncycastle.crypto.params.{ ECKeyGenerationParameters, ECPrivateKeyParameters, ECPublicKeyParameters }
 import org.bouncycastle.crypto.signers.{ ECDSASigner, HMacDSAKCalculator }
+import org.bouncycastle.math.ec.ECPoint
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
@@ -286,6 +287,10 @@ sealed abstract class ECPublicKey extends BaseECKey {
       ECPublicKey.fromBytes(ByteVector(decompressed))
     } else this
   }
+
+  def toPoint: ECPoint = {
+    CryptoParams.curve.getCurve.decodePoint(bytes.toArray)
+  }
 }
 
 object ECPublicKey extends Factory[ECPublicKey] {
@@ -320,4 +325,9 @@ object ECPublicKey extends Factory[ECPublicKey] {
    * [[https://github.com/bitcoin/bitcoin/blob/27765b6403cece54320374b37afb01a0cfe571c3/src/pubkey.h#L158]]
    */
   def isValid(bytes: ByteVector): Boolean = bytes.nonEmpty
+
+  def fromPoint(p: ECPoint, isCompressed: Boolean = true): ECPublicKey = {
+    val bytes = p.getEncoded(isCompressed)
+    ECPublicKey.fromBytes(ByteVector(bytes))
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
@@ -49,7 +49,7 @@ sealed abstract class LnInvoice {
    * We can either recover this with public key recovery from
    * the [[LnInvoiceSignature]] or if [[LnTag.NodeIdTag]] is
    * defined we MUST use that NodeId.
-   * [[https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#requirements-3]]
+   * [[https://github.com/lightningnetwork/lihtning-rfc/blob/master/11-payment-encoding.md#requirements-3]]
    */
   def nodeId: NodeId = {
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
@@ -1,10 +1,13 @@
 package org.bitcoins.core.protocol.ln
 
-import org.bitcoins.core.number.{ UInt5, UInt64 }
+import org.bitcoins.core.crypto.Sha256Digest
+import org.bitcoins.core.number.{ UInt5, UInt64, UInt8 }
 import org.bitcoins.core.protocol.ln.currency.{ LnCurrencyUnit, PicoBitcoins }
+import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.core.protocol.ln.util.LnUtil
 import org.bitcoins.core.util._
 import org.slf4j.LoggerFactory
+import scodec.bits.ByteVector
 
 import scala.util.{ Failure, Success, Try }
 
@@ -13,10 +16,20 @@ sealed abstract class LnInvoice {
     timestamp < UInt64(NumberUtil.pow2(35)),
     s"timestamp ${timestamp.toBigInt} < ${NumberUtil.pow2(35)}")
 
+  require(
+    nodeId.pubKey.verify(sigHash, signature.signature),
+    s"Did not receive a valid digital signature for the invoice ${toString}")
+
   private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
-  val bech32Separator: Char = Bech32.separator
+  private val bech32Separator: Char = Bech32.separator
 
   def hrp: LnHumanReadablePart
+
+  def timestamp: UInt64
+
+  def lnTags: LnTaggedFields
+
+  def signature: LnInvoiceSignature
 
   private def data: Vector[UInt5] = {
     val u5s: Vector[UInt5] = bech32TimeStamp ++ lnTags.data ++ signature.data
@@ -31,11 +44,43 @@ sealed abstract class LnInvoice {
     amount.map(_.toPicoBitcoins)
   }
 
-  def timestamp: UInt64
+  /**
+   * The [[NodeId]] that we are paying this invoice too
+   * We can either recover this with public key recovery from
+   * the [[LnInvoiceSignature]] or if [[LnTag.NodeIdTag]] is
+   * defined we MUST use that NodeId.
+   * [[https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#requirements-3]]
+   */
+  def nodeId: NodeId = {
 
-  def lnTags: LnTaggedFields
+    if (lnTags.nodeId.isDefined) {
+      lnTags.nodeId.get.nodeId
+    } else {
+      val recoverId = signature.bytes.last
+      val sigData = signatureData
+      val hashMsg = CryptoUtil.sha256(sigData)
+      val (pubKey1, pubKey2) = CryptoUtil.recoverPublicKey(signature.signature, hashMsg.bytes)
+      if (recoverId % 2 == 0) {
+        NodeId(pubKey1)
+      } else {
+        NodeId(pubKey2)
+      }
+    }
 
-  def signature: LnInvoiceSignature
+  }
+
+  /**
+   * The data that is hashed and then signed in the [[org.bitcoins.core.protocol.ln.LnInvoiceSignature]]
+   * @return
+   */
+  def signatureData: ByteVector = {
+    //remove the signature (520 bits, or 104 uint5s (520 / 5))
+    val noSig = data.dropRight(104)
+    val u8s = Bech32.from5bitTo8bit(noSig)
+    hrp.bytes ++ UInt8.toBytes(u8s)
+  }
+
+  private def sigHash: Sha256Digest = CryptoUtil.sha256(signatureData)
 
   def bech32Checksum: String = {
     val bytes: Vector[UInt5] = LnInvoice.createChecksum(hrp, data)
@@ -44,7 +89,7 @@ sealed abstract class LnInvoice {
   }
 
   //TODO: Refactor Into Bech32Address?
-  def uInt64ToBase32(input: UInt64): Vector[UInt5] = {
+  private def uInt64ToBase32(input: UInt64): Vector[UInt5] = {
     var numNoPadding = LnUtil.encodeNumber(input.toBigInt)
 
     while (numNoPadding.length < 7) {

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoiceSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoiceSignature.scala
@@ -6,6 +6,10 @@ import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.util.Bech32
 import scodec.bits.ByteVector
 
+/**
+ * 520 bit digital signature that signs the [[org.bitcoins.core.protocol.ln.LnInvoice]]
+ * https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#data-part
+ */
 sealed abstract class LnInvoiceSignature extends NetworkElement {
   require(version.toInt >= 0 && version.toInt <= 3, s"signature recovery byte must be 0,1,2,3, got ${version.toInt}")
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTaggedFields.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTaggedFields.scala
@@ -1,10 +1,12 @@
 package org.bitcoins.core.protocol.ln
 
-import org.bitcoins.core.number.UInt5
+import org.bitcoins.core.number.{ UInt5, UInt8 }
+import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.protocol.ln.LnTag.PaymentHashTag
 import org.bitcoins.core.protocol.ln.util.LnUtil
 import org.bitcoins.core.util.Bech32
 import org.slf4j.LoggerFactory
+import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -12,7 +14,7 @@ import scala.collection.mutable
 /**
  * An aggregation of all the individual tagged fields in a [[org.bitcoins.core.protocol.ln.LnInvoice]]
  */
-sealed abstract class LnTaggedFields {
+sealed abstract class LnTaggedFields extends NetworkElement {
 
   def paymentHash: LnTag.PaymentHashTag
 
@@ -39,6 +41,11 @@ sealed abstract class LnTaggedFields {
       cltvExpiry.map(_.data).getOrElse(Vector.empty) ++
       fallbackAddress.map(_.data).getOrElse(Vector.empty) ++
       routingInfo.map(_.data).getOrElse(Vector.empty)
+  }
+
+  override def bytes: ByteVector = {
+    val u8s = Bech32.from5bitTo8bit(data)
+    UInt8.toBytes(u8s)
   }
 
   override def toString: String = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTags.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTags.scala
@@ -6,6 +6,7 @@ import org.bitcoins.core.config.{ MainNet, NetworkParameters }
 import org.bitcoins.core.crypto.{ ECPublicKey, Sha256Digest, Sha256Hash160Digest }
 import org.bitcoins.core.number.{ UInt32, UInt5, UInt8 }
 import org.bitcoins.core.protocol._
+import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.core.protocol.ln.routing.LnRoute
 import org.bitcoins.core.protocol.ln.util.LnUtil
 import org.bitcoins.core.protocol.script.{ P2WPKHWitnessSPKV0, P2WSHWitnessSPKV0, WitnessScriptPubKeyV0 }
@@ -125,12 +126,12 @@ object LnTag {
 
   }
 
-  case class NodeIdTag(pubKey: ECPublicKey) extends LnTag {
+  case class NodeIdTag(nodeId: NodeId) extends LnTag {
 
     override val prefix: LnTagPrefix = LnTagPrefix.NodeId
 
     override val encoded: Vector[UInt5] = {
-      Bech32.from8bitTo5bit(pubKey.bytes)
+      Bech32.from8bitTo5bit(nodeId.bytes)
     }
   }
 
@@ -250,8 +251,8 @@ object LnTag {
 
       case LnTagPrefix.NodeId =>
 
-        val pubKey = ECPublicKey.fromBytes(bytes)
-        LnTag.NodeIdTag(pubKey)
+        val nodeId = NodeId.fromBytes(bytes)
+        LnTag.NodeIdTag(nodeId)
 
       case LnTagPrefix.ExpiryTime =>
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/node/NodeId.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/node/NodeId.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.eclair.rpc.network
+package org.bitcoins.core.protocol.ln.node
 
 import org.bitcoins.core.crypto.ECPublicKey
 import org.bitcoins.core.protocol.NetworkElement

--- a/core/src/main/scala/org/bitcoins/core/util/CryptoUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/CryptoUtil.scala
@@ -1,11 +1,13 @@
 package org.bitcoins.core.util
 
+import java.math.BigInteger
 import java.security.MessageDigest
 
 import org.bitcoins.core.crypto._
 import org.bouncycastle.crypto.digests.{ RIPEMD160Digest, SHA512Digest }
 import org.bouncycastle.crypto.macs.HMac
 import org.bouncycastle.crypto.params.KeyParameter
+import org.bouncycastle.math.ec.ECPoint
 import scodec.bits.ByteVector
 
 /**
@@ -72,6 +74,43 @@ trait CryptoUtil {
     val output = new Array[Byte](64)
     hmac512.doFinal(output, 0)
     ByteVector(output)
+  }
+
+  /**
+   *
+   * @param x x coordinate
+   * @return a tuple (p1, p2) where p1 and p2 are points on the curve and p1.x = p2.x = x
+   *         p1.y is even, p2.y is odd
+   */
+  def recoverPoint(x: BigInteger): (ECPoint, ECPoint) = {
+    val curve = CryptoParams.curve.getCurve()
+    val x1 = curve.fromBigInteger(x)
+    val square = x1.square().add(curve.getA).multiply(x1).add(curve.getB)
+    val y1 = square.sqrt()
+    val y2 = y1.negate()
+    val R1 = curve.createPoint(x1.toBigInteger, y1.toBigInteger).normalize()
+    val R2 = curve.createPoint(x1.toBigInteger, y2.toBigInteger).normalize()
+    if (y1.testBitZero()) (R2, R1) else (R1, R2)
+  }
+
+  /**
+   * Recover public keys from a signature and the message that was signed. This method will return 2 public keys, and the signature
+   * can be verified with both, but only one of them matches that private key that was used to generate the signature.
+   *
+   * @param signature       signature
+   * @param message message that was signed
+   * @return a (pub1, pub2) tuple where pub1 and pub2 are candidates public keys. If you have the recovery id  then use
+   *         pub1 if the recovery id is even and pub2 if it is odd
+   */
+  def recoverPublicKey(signature: ECDigitalSignature, message: ByteVector): (ECPublicKey, ECPublicKey) = {
+    val curve = CryptoParams.curve
+    val (r, s) = (signature.r.bigInteger, signature.s.bigInteger)
+    val m = new BigInteger(1, message.toArray)
+
+    val (p1, p2) = recoverPoint(r)
+    val Q1 = (p1.multiply(s).subtract(curve.getG.multiply(m))).multiply(r.modInverse(curve.getN))
+    val Q2 = (p2.multiply(s).subtract(curve.getG.multiply(m))).multiply(r.modInverse(curve.getN))
+    (ECPublicKey.fromPoint(Q1), ECPublicKey.fromPoint(Q2))
   }
 }
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/api/EclairApi.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/api/EclairApi.scala
@@ -5,10 +5,11 @@ import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.protocol.ln.LnInvoice
 import org.bitcoins.core.protocol.ln.channel.{ ChannelId, FundedChannelId }
 import org.bitcoins.core.protocol.ln.currency.{ LnCurrencyUnit, MilliSatoshis }
+import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.eclair.rpc.json._
-import org.bitcoins.eclair.rpc.network.{ NodeId, NodeUri }
+import org.bitcoins.eclair.rpc.network.{ NodeUri }
 
 import scala.concurrent.{ ExecutionContext, Future }
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -13,13 +13,14 @@ import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.protocol.ln.LnInvoice
 import org.bitcoins.core.protocol.ln.channel.{ ChannelId, FundedChannelId }
 import org.bitcoins.core.protocol.ln.currency.{ LnCurrencyUnit, MilliSatoshis }
+import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.util.BitcoinSUtil
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.eclair.rpc.api.EclairApi
 import org.bitcoins.eclair.rpc.config.EclairInstance
 import org.bitcoins.eclair.rpc.json._
-import org.bitcoins.eclair.rpc.network.{ NodeId, NodeUri, PeerState }
+import org.bitcoins.eclair.rpc.network.{ NodeUri, PeerState }
 import org.slf4j.LoggerFactory
 import play.api.libs.json._
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
@@ -3,7 +3,8 @@ package org.bitcoins.eclair.rpc.json
 import org.bitcoins.core.crypto.{ DoubleSha256Digest, ECDigitalSignature, Sha256Digest }
 import org.bitcoins.core.protocol.ln.channel.{ ChannelState, FundedChannelId }
 import org.bitcoins.core.protocol.ln.currency.{ LnCurrencyUnit, MilliSatoshis, PicoBitcoins }
-import org.bitcoins.eclair.rpc.network.{ NodeId, PeerState }
+import org.bitcoins.core.protocol.ln.node.NodeId
+import org.bitcoins.eclair.rpc.network.{ PeerState }
 import play.api.libs.json.{ JsArray, JsObject }
 
 sealed abstract class EclairModels

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/JsonReaders.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/JsonReaders.scala
@@ -2,7 +2,8 @@ package org.bitcoins.eclair.rpc.json
 
 import org.bitcoins.core.protocol.ln.channel.{ ChannelState, FundedChannelId }
 import org.bitcoins.core.protocol.ln.currency.{ MilliSatoshis, PicoBitcoins }
-import org.bitcoins.eclair.rpc.network.{ NodeId, PeerState }
+import org.bitcoins.core.protocol.ln.node.NodeId
+import org.bitcoins.eclair.rpc.network.PeerState
 import org.bitcoins.rpc.serializers.SerializerUtil
 import org.slf4j.LoggerFactory
 import play.api.libs.json._

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/network/NodeUri.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/network/NodeUri.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.eclair.rpc.network
 
+import org.bitcoins.core.protocol.ln.node.NodeId
 import org.slf4j.LoggerFactory
 
 import scala.util.{ Failure, Success, Try }

--- a/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -6,10 +6,10 @@ import org.bitcoins.core.currency.{ CurrencyUnit, Satoshis }
 import org.bitcoins.core.number.Int64
 import org.bitcoins.core.protocol.ln.channel.{ ChannelId, ChannelState }
 import org.bitcoins.core.protocol.ln.currency.{ MicroBitcoins, MilliBitcoins, NanoBitcoins, PicoBitcoins }
+import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
 import org.bitcoins.eclair.rpc.json._
-import org.bitcoins.eclair.rpc.network.NodeId
 import org.bitcoins.rpc.BitcoindRpcTestUtil
 import org.scalatest.{ Assertion, AsyncFlatSpec, BeforeAndAfterAll }
 


### PR DESCRIPTION
…the core project


BOLT11 specifies that if a `NodeIdTag` is not explicitly stated in the `LnInvoice` you need to derive it from the `LnInvoiceSignature` using some elliptic curve math. 

This also moves the `NodeId` into the `core` project. 