### PR TITLE
Optimize RawBitcoinSerializer.parseCmpctSizeUIntSeq to use a builder …

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/testprotocol/CoreTestCaseProtocol.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/testprotocol/CoreTestCaseProtocol.scala
@@ -39,7 +39,6 @@ object CoreTestCaseProtocol extends DefaultJsonProtocol {
         val scriptSignatureBytes: ByteVector = parseScriptSignature(elements.head)
         val scriptSignature: ScriptSignature = ScriptSignature(scriptSignatureBytes)
         val flags = elements(2).convertTo[String]
-        logger.info("Result: " + elements(3).convertTo[String])
         val expectedResult = ScriptResult(elements(3).convertTo[String])
         Some(CoreTestCaseImpl(scriptSignature, scriptPubKey, flags,
           expectedResult, "", elements.toString, None))
@@ -54,7 +53,6 @@ object CoreTestCaseProtocol extends DefaultJsonProtocol {
         val scriptSignatureBytes: ByteVector = parseScriptSignature(elements(1))
         val scriptSignature: ScriptSignature = ScriptSignature(scriptSignatureBytes)
         val flags = elements(3).convertTo[String]
-        logger.info("Result: " + elements(4).convertTo[String])
         val expectedResult = ScriptResult(elements(4).convertTo[String])
         Some(CoreTestCaseImpl(scriptSignature, scriptPubKey, flags,
           expectedResult, "", elements.toString, Some(witness, amount)))
@@ -64,7 +62,6 @@ object CoreTestCaseProtocol extends DefaultJsonProtocol {
         val scriptSignatureBytes: ByteVector = parseScriptSignature(elements.head)
         val scriptSignature: ScriptSignature = ScriptSignature(scriptSignatureBytes)
         val flags = elements(2).convertTo[String]
-        logger.info("Result: " + elements(3).convertTo[String])
         val expectedResult = ScriptResult(elements(3).convertTo[String])
         val comments = elements(4).convertTo[String]
         Some(CoreTestCaseImpl(scriptSignature, scriptPubKey, flags,
@@ -79,7 +76,6 @@ object CoreTestCaseProtocol extends DefaultJsonProtocol {
         val scriptSignatureBytes: ByteVector = parseScriptSignature(elements(1))
         val scriptSignature: ScriptSignature = ScriptSignature(scriptSignatureBytes)
         val flags = elements(3).convertTo[String]
-        logger.info("Result: " + elements(4).convertTo[String])
         val expectedResult = ScriptResult(elements(4).convertTo[String])
         val comments = elements(5).convertTo[String]
         Some(CoreTestCaseImpl(scriptSignature, scriptPubKey, flags,

--- a/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
@@ -185,11 +185,11 @@ sealed abstract class BloomFilter extends NetworkElement {
   def updateP2PKOnly(scriptPubKeysWithIndex: Seq[(ScriptPubKey, Int)], txId: DoubleSha256Digest): BloomFilter = {
     @tailrec
     def loop(constantsWithIndex: Seq[(ScriptToken, Int)], accumFilter: BloomFilter): BloomFilter = constantsWithIndex match {
-      case h :: t if (accumFilter.contains(h._1.bytes)) =>
+      case h +: t if (accumFilter.contains(h._1.bytes)) =>
         logger.debug("Found constant in bloom filter: " + h._1.hex)
         val filter = accumFilter.insert(TransactionOutPoint(txId, UInt32(h._2)))
         loop(t, filter)
-      case h :: t => loop(t, accumFilter)
+      case h +: t => loop(t, accumFilter)
       case Nil => accumFilter
     }
     val p2pkOrMultiSigScriptPubKeys: Seq[(ScriptPubKey, Int)] = scriptPubKeysWithIndex.filter {

--- a/core/src/main/scala/org/bitcoins/core/consensus/Merkle.scala
+++ b/core/src/main/scala/org/bitcoins/core/consensus/Merkle.scala
@@ -30,8 +30,8 @@ trait Merkle extends BitcoinSLogger {
    */
   def computeMerkleRoot(transactions: Seq[Transaction]): DoubleSha256Digest = transactions match {
     case Nil => throw new IllegalArgumentException("We cannot have zero transactions in the block. There always should be ATLEAST one - the coinbase tx")
-    case h :: Nil => h.txId
-    case h :: t =>
+    case h +: Nil => h.txId
+    case h +: t =>
       val leafs = transactions.map(tx => Leaf(tx.txId))
       val merkleTree = build(leafs, Nil)
       merkleTree.value.get
@@ -50,10 +50,10 @@ trait Merkle extends BitcoinSLogger {
       if (accum.size == 1) accum.head
       else if (accum.isEmpty) throw new IllegalArgumentException("Should never have sub tree size of zero, this implies there was zero hashes given")
       else build(accum.reverse, Nil)
-    case h :: h1 :: t =>
+    case h +: h1 +: t =>
       val newTree = computeTree(h, h1)
       build(t, newTree +: accum)
-    case h :: t =>
+    case h +: t =>
       //means that we have an odd amount of txids, this means we duplicate the last hash in the tree
       val newTree = computeTree(h, h)
       build(t, newTree +: accum)

--- a/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
@@ -5,6 +5,10 @@ import org.bitcoins.core.protocol.{ CompactSizeUInt, NetworkElement }
 import org.bitcoins.core.util.BitcoinSLogger
 import scodec.bits.ByteVector
 
+import scala.annotation.tailrec
+import scala.collection.immutable.VectorBuilder
+import scala.collection.mutable
+
 /**
  * Created by chris on 2/18/16.
  */
@@ -18,19 +22,27 @@ sealed abstract class RawSerializerHelper {
   def parseCmpctSizeUIntSeq[T <: NetworkElement](bytes: ByteVector, constructor: ByteVector => T): (Seq[T], ByteVector) = {
     val count = CompactSizeUInt.parse(bytes)
     val payload = bytes.splitAt(count.size.toInt)._2
-    def loop(accum: Seq[T], remaining: ByteVector): (Seq[T], ByteVector) = {
-      if (accum.size == count.num.toInt) {
-        (accum.reverse, remaining)
+    var counter = 0
+    val b = Vector.newBuilder[T]
+    @tailrec
+    def loop(remaining: ByteVector): ByteVector = {
+      if (counter == count.num.toInt) {
+        remaining
       } else {
         val parsed = constructor(remaining)
         val (_, newRemaining) = remaining.splitAt(parsed.size)
-        loop(parsed +: accum, newRemaining)
+
+        counter = counter + 1
+        b.+=(parsed)
+
+        loop(newRemaining)
       }
     }
 
-    val (parsed, remaining) = loop(Nil, payload)
-    require(parsed.size == count.num.toInt, "Could not parse the amount of required elements, got: " + parsed.size + " required: " + count)
-    (parsed, remaining)
+    val remaining = loop(payload)
+    val result = b.result()
+    require(result.size == count.num.toInt, s"Could not parse the amount of required elements, got: ${result.size} required: ${count}")
+    (result, remaining)
   }
 
   /** Writes a Seq[TransactionInput]/Seq[TransactionOutput]/Seq[Transaction] -> ByteVector */


### PR DESCRIPTION
…rather than just manually appending time. Seems to speed up performance on the two test vectors in BlockTests by ~1s