### PR TITLE
Add compiler options for the Compile scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,34 @@
 cancelable in Global := true
 
-lazy val compilerOpts =
-  List("-unchecked", "-deprecation", "-feature", "-Xmax-classfile-name", "128")
+lazy val commonCompilerOpts = {
+  List(
+    "-Xmax-classfile-name",
+    "128"
+  )
+}
+//https://docs.scala-lang.org/overviews/compiler-options/index.html
+lazy val compilerOpts = Seq(
+  "-target:jvm-1.8",
+  "-encoding",
+  "UTF-8",
+  "-unchecked",
+  "-feature",
+  "-deprecation",
+  "-Xfuture",
+  "-Ywarn-dead-code",
+  "-Ywarn-unused-import",
+  "-Ywarn-value-discard",
+  "-Ywarn-unused",
+  "-unchecked",
+  "-deprecation",
+  "-feature"
+) ++ commonCompilerOpts
+
+lazy val testCompilerOpts = commonCompilerOpts
 
 lazy val commonSettings = List(
-  scalacOptions := compilerOpts,
+  scalacOptions in Compile := compilerOpts,
+  scalacOptions in Test := testCompilerOpts,
   assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 )
 lazy val root = project

--- a/core-gen/src/test/scala/org/bitcoins/core/gen/ChannelGenerators.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/ChannelGenerators.scala
@@ -7,13 +7,11 @@ import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.core.wallet.builder.TxBuilderError
 import org.scalacheck.Gen
 
-import scala.annotation.tailrec
-import scala.concurrent.{ Await, Future }
-import scala.concurrent.duration.DurationInt
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ Await, Future }
 
 /**
  * Created by chris on 4/18/17.

--- a/core-gen/src/test/scala/org/bitcoins/core/gen/CreditingTxGen.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/CreditingTxGen.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.gen
 
 import org.bitcoins.core.crypto.Sign
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.crypto.HashType
-import org.scalacheck.Gen
 import org.bitcoins.core.wallet.utxo.BitcoinUTXOSpendingInfo
-import org.bitcoins.core.number.UInt32
+import org.scalacheck.Gen
 
 sealed abstract class CreditingTxGen {
   /** Minimum amount of outputs to generate */

--- a/core-gen/src/test/scala/org/bitcoins/core/gen/NumberGenerator.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/NumberGenerator.scala
@@ -4,8 +4,8 @@ import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.util.NumberUtil
-import org.scalacheck.Gen
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
 import scodec.bits.BitVector
 
 /**

--- a/core-gen/src/test/scala/org/bitcoins/core/gen/ScriptGenerators.scala
+++ b/core-gen/src/test/scala/org/bitcoins/core/gen/ScriptGenerators.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.gen
 
+import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.crypto.{ TransactionSignatureCreator, _ }
 import org.bitcoins.core.currency.{ CurrencyUnit, CurrencyUnits }
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script.{ P2SHScriptPubKey, _ }
 import org.bitcoins.core.protocol.transaction._
-import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.script.constant.{ ScriptNumber, _ }
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.util.BitcoinSLogger

--- a/core-test/src/test/java/org/bitcoin/NativeSecp256k1Test.java
+++ b/core-test/src/test/java/org/bitcoin/NativeSecp256k1Test.java
@@ -4,7 +4,8 @@ import org.junit.Test;
 
 import javax.xml.bind.DatatypeConverter;
 
-import static org.bitcoin.NativeSecp256k1Util.*;
+import static org.bitcoin.NativeSecp256k1Util.AssertFailException;
+import static org.bitcoin.NativeSecp256k1Util.assertEquals;
 
 /**
  * This class holds test cases defined for testing this library.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureTest.scala
@@ -113,7 +113,6 @@ class ScriptSignatureTest extends FlatSpec with MustMatchers {
     for {
       testCase <- testCases
     } yield {
-      logger.info("testCase: " + testCase)
       Transaction(testCase.transaction.hex) must be(testCase.transaction)
       val output = TransactionOutput(CurrencyUnits.zero, testCase.script)
       val txSigComponent = testCase.transaction match {

--- a/core-test/src/test/scala/org/bitcoins/core/util/Base58Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/Base58Test.scala
@@ -1,8 +1,5 @@
 package org.bitcoins.core.util
 
-import org.bitcoins.core.config.MainNet
-import org.bitcoins.core.crypto.{ ECPrivateKey, Sha256Hash160Digest }
-import org.bitcoins.core.protocol.Address
 import org.bitcoins.core.util.testprotocol._
 import org.scalatest.{ FlatSpec, MustMatchers }
 import spray.json._

--- a/core-test/src/test/scala/org/bitcoins/core/util/BinaryTreeTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BinaryTreeTest.scala
@@ -1,9 +1,7 @@
 package org.bitcoins.core.util
 
-import org.bitcoins.core.script.arithmetic.OP_ADD
-import org.bitcoins.core.script.bitwise.OP_EQUAL
-import org.bitcoins.core.script.constant.{ OP_2, ScriptToken, OP_0, OP_1 }
-import org.bitcoins.core.script.control.{ OP_RETURN, OP_ENDIF, OP_ELSE, OP_IF }
+import org.bitcoins.core.script.constant.{ OP_0, OP_1, OP_2, ScriptToken }
+import org.bitcoins.core.script.control.{ OP_ELSE, OP_ENDIF, OP_IF }
 import org.scalatest.{ FlatSpec, MustMatchers }
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/util/BitcoinJConversions.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BitcoinJConversions.scala
@@ -1,22 +1,14 @@
 package org.bitcoins.core.util
 
 import java.io.{ ByteArrayOutputStream, IOException }
-import java.util
 
-import org.bitcoinj.core.{ ECKey, Sha256Hash }
+import org.bitcoinj.core.ECKey
 import org.bitcoinj.params.TestNet3Params
-import org.bitcoins.core.config.TestNet3
 import org.bitcoins.core.crypto.ECPublicKey
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.protocol.script.{ ScriptPubKey, UpdateScriptPubKeyAsm }
-import org.bitcoins.core.protocol.transaction.{ Transaction, TransactionOutput }
-import org.bitcoins.core.script.ScriptOperationFactory
-import org.bitcoins.core.script.constant.ScriptToken
-import org.bitcoins.core.script.crypto.SIGHASH_ANYONECANPAY
+import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.slf4j.LoggerFactory
 import scodec.bits.ByteVector
-
-import scala.collection.JavaConversions._
 /**
  * Created by chris on 2/23/16.
  */

--- a/core-test/src/test/scala/org/bitcoins/core/util/BitcoinJTestUtil.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BitcoinJTestUtil.scala
@@ -3,8 +3,8 @@ package org.bitcoins.core.util
 import java.util
 
 import com.google.common.collect.ImmutableList
-import org.bitcoinj.core.{ ECKey, DumpedPrivateKey }
 import org.bitcoinj.core.Transaction.SigHash
+import org.bitcoinj.core.{ DumpedPrivateKey, ECKey }
 import org.bitcoinj.crypto.TransactionSignature
 import org.bitcoinj.params.TestNet3Params
 import org.bitcoinj.script.{ Script, ScriptBuilder }

--- a/core-test/src/test/scala/org/bitcoins/core/util/BitcoinSUtilSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BitcoinSUtilSpec.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.util
 
-import org.bitcoins.core.gen.{ CryptoGenerators, NumberGenerator, StringGenerators }
-import org.scalacheck.{ Gen, Prop, Properties }
+import org.bitcoins.core.gen.StringGenerators
+import org.scalacheck.{ Prop, Properties }
 /**
  * Created by chris on 6/20/16.
  */

--- a/core-test/src/test/scala/org/bitcoins/core/util/CryptoTestUtil.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/CryptoTestUtil.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.core.util
 
 import org.bitcoinj.core.DumpedPrivateKey
-import org.bitcoins.core.config.TestNet3
-import org.bitcoins.core.crypto.{ ECPrivateKey }
+import org.bitcoins.core.crypto.ECPrivateKey
 
 /**
  * Created by chris on 3/7/16.

--- a/core-test/src/test/scala/org/bitcoins/core/util/ScriptProgramTestUtil.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/ScriptProgramTestUtil.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.util
 
-import org.bitcoins.core.script.{ ExecutionInProgressScriptProgram, PreExecutionScriptProgram, ExecutedScriptProgram, ScriptProgram }
+import org.bitcoins.core.script.{ ExecutedScriptProgram, ExecutionInProgressScriptProgram, PreExecutionScriptProgram, ScriptProgram }
 
 /**
  * Created by chris on 4/20/16.

--- a/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
@@ -7,7 +7,7 @@ import org.bitcoins.core.protocol.transaction.{ Transaction, TransactionOutPoint
 import org.bitcoins.core.protocol.{ CompactSizeUInt, NetworkElement }
 import org.bitcoins.core.script.constant.{ ScriptConstant, ScriptToken }
 import org.bitcoins.core.serializers.bloom.RawBloomFilterSerializer
-import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinSUtil, Factory }
+import org.bitcoins.core.util.{ BitcoinSUtil, Factory }
 import scodec.bits.{ BitVector, ByteVector }
 
 import scala.annotation.tailrec

--- a/core/src/main/scala/org/bitcoins/core/channels/Channel.scala
+++ b/core/src/main/scala/org/bitcoins/core/channels/Channel.scala
@@ -159,8 +159,6 @@ sealed trait ChannelInProgress extends Channel with BaseInProgress {
   /** Increments a payment to the server in a [[ChannelInProgress]] */
   def clientSign(amount: CurrencyUnit, clientKey: ECPrivateKey)(implicit ec: ExecutionContext): Future[ChannelInProgressClientSigned] = {
     val outputs = current.transaction.outputs
-    val inputs = current.transaction.inputs
-    val inputIndex = current.inputIndex
     val client = clientOutput
     val newClient: Try[Option[TransactionOutput]] = client match {
       case Some(c) =>
@@ -195,7 +193,7 @@ sealed trait ChannelInProgress extends Channel with BaseInProgress {
   private def checkAmounts(outputs: Seq[TransactionOutput]): Try[Unit] = {
     @tailrec
     def loop(remaining: Seq[TransactionOutput]): Try[Unit] = {
-      if (remaining.isEmpty) Success(Unit)
+      if (remaining.isEmpty) Success(())
       else {
         val output = remaining.head
         if (output.value > lockedAmount) {
@@ -301,7 +299,7 @@ sealed trait ChannelInProgressClientSigned extends Channel with BaseInProgress {
       TxBuilderError.FeeToLarge
     } else if (fullOutputValue <= CurrencyUnits.zero) {
       TxBuilderError.UnknownError
-    } else Success(Unit)
+    } else Success(())
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/consensus/Consensus.scala
+++ b/core/src/main/scala/org/bitcoins/core/consensus/Consensus.scala
@@ -2,9 +2,6 @@ package org.bitcoins.core.consensus
 
 import org.bitcoins.core.currency.{ CurrencyUnit, Satoshis }
 import org.bitcoins.core.number.Int64
-import org.bitcoins.core.protocol.blockchain.Block
-import org.bitcoins.core.protocol.transaction.{ BaseTransaction, WitnessTransaction }
-import org.bitcoins.core.serializers.transaction.RawBaseTransactionParser
 
 /**
  * Created by chris on 5/13/16.

--- a/core/src/main/scala/org/bitcoins/core/crypto/DERSignatureUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/DERSignatureUtil.scala
@@ -40,14 +40,10 @@ sealed abstract class DERSignatureUtil {
       val thirdByteIs0x02 = bytes(2) == 0x02
       //this is the size of the r value in the signature
       val rSize = bytes(3)
-      //r value in the signature
-      val r = bytes.slice(3, rSize + 3)
+
       //this 0x02 separates the r and s value )in the signature
       val second0x02Exists = bytes(rSize + 4) == 0x02
-      //this is the size of the s value in the signature
-      val sSize = bytes(rSize + 4)
 
-      val s = bytes.slice(rSize + 4 + 1, bytes.size)
       firstByteIs0x30 && signatureLengthIsCorrect && thirdByteIs0x02 &&
         second0x02Exists
     } else true
@@ -222,7 +218,7 @@ sealed abstract class DERSignatureUtil {
    */
   def isLowS(signature: ByteVector): Boolean = {
     val result = Try {
-      val (r, s) = decodeSignature(signature)
+      val (_, s) = decodeSignature(signature)
       s.bigInteger.compareTo(CryptoParams.halfCurveOrder) <= 0
     }
     result match {

--- a/core/src/main/scala/org/bitcoins/core/crypto/ECDigitalSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ECDigitalSignature.scala
@@ -1,12 +1,11 @@
 package org.bitcoins.core.crypto
 
-import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinSUtil, Factory }
+import org.bitcoins.core.util.{ BitcoinSUtil, Factory }
 import scodec.bits.ByteVector
 /**
  * Created by chris on 2/26/16.
  */
 sealed abstract class ECDigitalSignature {
-  private val logger = BitcoinSLogger.logger
 
   def hex: String = BitcoinSUtil.encodeHex(bytes)
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -1,7 +1,5 @@
 package org.bitcoins.core.crypto
 
-import java.math.BigInteger
-
 import org.bitcoin.NativeSecp256k1
 import org.bitcoins.core.number.{ UInt32, UInt8 }
 import org.bitcoins.core.protocol.NetworkElement
@@ -193,7 +191,7 @@ sealed abstract class ExtPublicKey extends ExtKey {
         hmac.toArray,
         priv.isCompressed)
       val childPubKey = ECPublicKey(ByteVector(tweaked))
-      val bi = BigInt(new BigInteger(1, priv.bytes.toArray))
+
       //we do not handle this case since it is impossible
       //In case parse256(IL) ≥ n or Ki is the point at infinity, the resulting key is invalid,
       //and one should proceed with the next value for i.

--- a/core/src/main/scala/org/bitcoins/core/crypto/HashDigest.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/HashDigest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.crypto
 
 import org.bitcoins.core.protocol.NetworkElement
-import org.bitcoins.core.util.{ BitcoinSUtil, Factory }
+import org.bitcoins.core.util.Factory
 import scodec.bits.ByteVector
 /**
  * Created by chris on 5/24/16.

--- a/core/src/main/scala/org/bitcoins/core/crypto/Sign.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/Sign.scala
@@ -2,8 +2,8 @@ package org.bitcoins.core.crypto
 
 import scodec.bits.ByteVector
 
-import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ Await, Future }
 
 /**
  * This is meant to be an abstraction for a [[org.bitcoins.core.crypto.ECPrivateKey]], sometimes we will not

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -142,7 +142,6 @@ trait TransactionSignatureChecker extends BitcoinSLogger {
    * [[https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#NULLFAIL]]
    */
   private def nullFailCheck(sigs: Seq[ECDigitalSignature], result: TransactionSignatureCheckerResult, flags: Seq[ScriptFlag]): TransactionSignatureCheckerResult = {
-    logger.info("Result before nullfail check:" + result)
     val nullFailEnabled = ScriptFlagUtil.requireScriptVerifyNullFail(flags)
     if (nullFailEnabled && !result.isValid && sigs.exists(_.bytes.nonEmpty)) {
       //we need to check that all signatures were empty byte vectors, else this fails because of BIP146 and nullfail

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureCreator.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureCreator.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.core.crypto
 
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.util.BitcoinSLogger
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -10,7 +9,7 @@ import scala.concurrent.{ ExecutionContext, Future }
  * Created by chris on 7/21/16.
  */
 sealed abstract class TransactionSignatureCreator {
-  private val logger = BitcoinSLogger.logger
+
   /**
    * Creates a signature from a tx signature component
    *

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -73,7 +73,7 @@ sealed abstract class Number[T <: Number[T]] extends NetworkElement {
     if (num.toBigInt >= Int.MaxValue || num.toBigInt <= Int.MinValue) {
       Failure(new IllegalArgumentException("Num was not in range of int, got: " + num))
     } else {
-      Success(Unit)
+      Success(())
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -1,12 +1,9 @@
 package org.bitcoins.core.protocol
-import org.bitcoins.core.config._
-import org.bitcoins.core.config.{ MainNet, RegTest, TestNet3 }
+import org.bitcoins.core.config.{ MainNet, RegTest, TestNet3, _ }
 import org.bitcoins.core.crypto.{ ECPublicKey, HashDigest, Sha256Digest, Sha256Hash160Digest }
 import org.bitcoins.core.number.{ UInt32, UInt8 }
-import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.script.constant.ScriptConstant
-import org.bitcoins.core.serializers.script.ScriptParser
 import org.bitcoins.core.util._
 import scodec.bits.ByteVector
 
@@ -21,7 +18,7 @@ sealed abstract class Address {
   /** The string representation of this address */
   def value: String
 
-  /** Every address is derived from a [[HashDigest]] in a [[TransactionOutput]] */
+  /** Every address is derived from a [[HashDigest]] in a [[org.bitcoins.core.protocol.transaction.TransactionOutput]] */
   def hash: HashDigest
 
   /** The [[ScriptPubKey]] the address represents */
@@ -66,8 +63,6 @@ sealed abstract class P2SHAddress extends BitcoinAddress {
  */
 sealed abstract class Bech32Address extends BitcoinAddress {
 
-  private def logger = BitcoinSLogger.logger
-
   def hrp: HumanReadablePart
 
   def data: Seq[UInt8]
@@ -102,8 +97,6 @@ object Bech32Address extends AddressFactory[Bech32Address] {
   /** Separator used to separate the hrp & data parts of a bech32 addr */
   val separator = '1'
 
-  private val logger = BitcoinSLogger.logger
-
   def apply(
     witSPK: WitnessScriptPubKey,
     networkParameters: NetworkParameters): Try[Bech32Address] = {
@@ -129,8 +122,6 @@ object Bech32Address extends AddressFactory[Bech32Address] {
     val polymod: Long = polyMod(values ++ Seq(z, z, z, z, z, z)) ^ 1
     //[(polymod >> 5 * (5 - i)) & 31 for i in range(6)]
     val result: Seq[UInt8] = 0.until(6).map { i =>
-      val u = UInt8(i.toShort)
-      val five = UInt8(5.toShort)
       //((polymod >> five * (five - u)) & UInt8(31.toShort))
       UInt8(((polymod >> 5 * (5 - i)) & 31).toShort)
     }
@@ -419,8 +410,6 @@ object P2SHAddress extends AddressFactory[P2SHAddress] {
 }
 
 object BitcoinAddress extends AddressFactory[BitcoinAddress] {
-  private val logger = BitcoinSLogger.logger
-
   /** Creates a [[BitcoinAddress]] from the given string value */
   def apply(value: String): Try[BitcoinAddress] = fromString(value)
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.core.protocol.blockchain
 
 import org.bitcoins.core.number.UInt64
-import org.bitcoins.core.protocol.transaction.{ BaseTransaction, Transaction, WitnessTransaction }
+import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{ CompactSizeUInt, NetworkElement }
 import org.bitcoins.core.serializers.blockchain.RawBlockSerializer
-import org.bitcoins.core.util.{ BitcoinSLogger, Factory }
+import org.bitcoins.core.util.Factory
 import scodec.bits.ByteVector
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -4,7 +4,7 @@ import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.serializers.blockchain.RawBlockHeaderSerializer
-import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinSUtil, CryptoUtil, Factory }
+import org.bitcoins.core.util.{ CryptoUtil, Factory }
 import scodec.bits.ByteVector
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.protocol.blockchain
 import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.util._
-import scodec.bits.{ BitVector, ByteVector }
+import scodec.bits.BitVector
 
 import scala.annotation.tailrec
 import scala.math._
@@ -106,8 +106,6 @@ sealed trait PartialMerkleTree extends BitcoinSLogger {
 }
 
 object PartialMerkleTree {
-  private val logger = BitcoinSLogger.logger
-
   private case class PartialMerkleTreeImpl(tree: BinaryTree[DoubleSha256Digest], transactionCount: UInt32,
     bits: BitVector, hashes: Seq[DoubleSha256Digest]) extends PartialMerkleTree {
     require(bits.size % 8 == 0, "As per BIP37, bits must be padded to the nearest byte")

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -2,8 +2,6 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.protocol._
-import org.bitcoins.core.protocol.blockchain.Block
-import org.bitcoins.core.protocol.transaction.WitnessTransaction
 import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.script.bitwise.{ OP_EQUAL, OP_EQUALVERIFY }
 import org.bitcoins.core.script.constant.{ BytesToPushOntoStack, _ }
@@ -12,9 +10,8 @@ import org.bitcoins.core.script.crypto.{ OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIF
 import org.bitcoins.core.script.locktime.{ OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY }
 import org.bitcoins.core.script.reserved.UndefinedOP_NOP
 import org.bitcoins.core.script.stack.{ OP_DROP, OP_DUP }
-import org.bitcoins.core.serializers.script.{ RawScriptPubKeyParser, ScriptParser }
+import org.bitcoins.core.serializers.script.{ ScriptParser }
 import org.bitcoins.core.util._
-import org.slf4j.LoggerFactory
 import scodec.bits.ByteVector
 
 import scala.util.{ Failure, Success, Try }
@@ -504,8 +501,6 @@ sealed trait WitnessScriptPubKey extends ScriptPubKey {
 }
 
 object WitnessScriptPubKey {
-  private val logger = LoggerFactory.getLogger(this.getClass().getSimpleName)
-
   /** Witness scripts must begin with one of these operations, see BIP141 */
   val validWitVersions: Seq[ScriptNumberOperation] = Seq(OP_0, OP_1, OP_2, OP_3, OP_4, OP_5, OP_6, OP_7, OP_8,
     OP_9, OP_10, OP_11, OP_12, OP_13, OP_14, OP_15, OP_16)

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.protocol.script
 import org.bitcoins.core.crypto.{ ECDigitalSignature, ECPublicKey }
 import org.bitcoins.core.protocol.{ CompactSizeUInt, NetworkElement }
 import org.bitcoins.core.script.constant._
-import org.bitcoins.core.serializers.script.{ RawScriptSignatureParser, ScriptParser }
+import org.bitcoins.core.serializers.script.ScriptParser
 import org.bitcoins.core.util._
 import scodec.bits.ByteVector
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.protocol.script
 import org.bitcoins.core.crypto.{ ECDigitalSignature, ECPublicKey, EmptyDigitalSignature }
 import org.bitcoins.core.protocol.{ CompactSizeUInt, NetworkElement }
 import org.bitcoins.core.serializers.script.RawScriptWitnessParser
-import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinSUtil, BitcoinScriptUtil }
+import org.bitcoins.core.util.{ BitcoinSUtil, BitcoinScriptUtil }
 import scodec.bits.ByteVector
 
 /**
@@ -110,7 +110,7 @@ object P2WSHWitnessV0 {
 }
 
 object ScriptWitness {
-  private val logger = BitcoinSLogger.logger
+
   def apply(stack: Seq[ByteVector]): ScriptWitness = {
     //TODO: eventually only compressed public keys will be allowed in v0 scripts
     //https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#restrictions-on-public-key-type

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/WitnessVersion.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/WitnessVersion.scala
@@ -1,12 +1,10 @@
 package org.bitcoins.core.protocol.script
 
-import org.bitcoins.core.crypto.{ ECPublicKey, Sha256Digest, Sha256Hash160Digest }
+import org.bitcoins.core.crypto.{ Sha256Digest, Sha256Hash160Digest }
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.result._
 import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinSUtil, CryptoUtil }
-
-import scala.util.Try
 
 /**
  * Created by chris on 11/10/16.
@@ -52,7 +50,7 @@ case object WitnessVersion0 extends WitnessVersion {
             val compactSizeUInt = CompactSizeUInt.calculateCompactSizeUInt(stackTop)
             val scriptPubKey = ScriptPubKey(compactSizeUInt.bytes ++ stackTop)
             val stack = scriptWitness.stack.tail.map(ScriptConstant(_))
-            Left(stack, scriptPubKey)
+            Left((stack, scriptPubKey))
           }
         }
       case _ =>
@@ -75,8 +73,6 @@ case class UnassignedWitness(version: ScriptNumberOperation) extends WitnessVers
 }
 
 object WitnessVersion {
-
-  private val versions = Seq(WitnessVersion0, UnassignedWitness)
 
   def apply(scriptNumberOp: ScriptNumberOperation): WitnessVersion = scriptNumberOp match {
     case OP_0 | OP_FALSE => WitnessVersion0

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -5,7 +5,7 @@ import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.protocol.script.ScriptWitness
 import org.bitcoins.core.serializers.transaction.{ RawBaseTransactionParser, RawWitnessTransactionParser }
-import org.bitcoins.core.util.{ BitcoinSUtil, CryptoUtil, Factory }
+import org.bitcoins.core.util.{ CryptoUtil, Factory }
 import scodec.bits.ByteVector
 
 import scala.util.{ Failure, Success, Try }

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -1,10 +1,6 @@
 package org.bitcoins.core.script
 
 import org.bitcoins.core.crypto._
-import org.bitcoins.core.currency.CurrencyUnit
-import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction.{ BaseTransaction, Transaction, TransactionOutput, WitnessTransaction }
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.flag.ScriptFlag
 import org.bitcoins.core.script.result._
@@ -15,7 +11,9 @@ import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinScriptUtil }
  */
 sealed trait ScriptProgram {
   /**
-   * This contains all relevant information for hashing and checking a [[org.bitcoins.core.protocol.script.ScriptSignature]] for a [[Transaction]].
+   * This contains all relevant information for hashing and checking a
+   * [[org.bitcoins.core.protocol.script.ScriptSignature]] for
+   * a [[org.bitcoins.core.protocol.transaction.Transaction]].
    */
   def txSignatureComponent: TxSigComponent
 

--- a/core/src/main/scala/org/bitcoins/core/script/constant/ConstantInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/ConstantInterpreter.scala
@@ -4,7 +4,6 @@ import org.bitcoins.core.script.ScriptProgram
 import org.bitcoins.core.script.flag.ScriptFlagUtil
 import org.bitcoins.core.script.result._
 import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinSUtil, BitcoinScriptUtil }
-import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
 

--- a/core/src/main/scala/org/bitcoins/core/script/constant/ScriptNumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/ScriptNumberUtil.scala
@@ -155,8 +155,6 @@ trait ScriptNumberUtil {
 
   def firstByteAllZeros(hex: String): Boolean = firstByteAllZeros(BitcoinSUtil.decodeHex(hex))
 
-  private def parseLong(byte: Byte): Long = parseLong(ByteVector.fromByte(byte))
-
 }
 
 object ScriptNumberUtil extends ScriptNumberUtil

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
@@ -117,7 +117,7 @@ sealed abstract class StackInterpreter {
   def opPick(program: ScriptProgram): ScriptProgram = {
     require(program.script.headOption.contains(OP_PICK), "Top of script stack must be OP_PICK")
     executeOpWithStackTopAsNumberArg(program, { number: ScriptNumber =>
-      logger.info("Script number for OP_PICK: " + number)
+
       //check if n is within the bound of the script
       if (program.stack.size < 2) ScriptProgram(program, ScriptErrorInvalidStackOperation)
       else if (number.toLong >= 0 && number.toLong < program.stack.tail.size) {

--- a/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
@@ -2,7 +2,6 @@ package org.bitcoins.core.serializers
 
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.{ CompactSizeUInt, NetworkElement }
-import org.bitcoins.core.util.BitcoinSLogger
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
@@ -13,7 +12,6 @@ import scala.collection.mutable
  * Created by chris on 2/18/16.
  */
 sealed abstract class RawSerializerHelper {
-  private val logger = BitcoinSLogger.logger
 
   /**
    * Used parse a byte sequence to a Seq[TransactionInput], Seq[TransactionOutput], etc

--- a/core/src/main/scala/org/bitcoins/core/serializers/blockchain/RawMerkleBlockSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/blockchain/RawMerkleBlockSerializer.scala
@@ -6,7 +6,6 @@ import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.blockchain.MerkleBlock
 import org.bitcoins.core.serializers.RawBitcoinSerializer
 import org.bitcoins.core.util.BitcoinSUtil
-import org.slf4j.LoggerFactory
 import scodec.bits.{ BitVector, ByteVector }
 
 import scala.annotation.tailrec
@@ -16,8 +15,6 @@ import scala.annotation.tailrec
  * [[https://bitcoin.org/en/developer-reference#merkleblock]]
  */
 sealed abstract class RawMerkleBlockSerializer extends RawBitcoinSerializer[MerkleBlock] {
-
-  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
 
   def read(bytes: ByteVector): MerkleBlock = {
     val blockHeader = RawBlockHeaderSerializer.read(bytes.take(80))

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
@@ -4,10 +4,7 @@ import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.serializers.RawBitcoinSerializer
-import org.bitcoins.core.util.BitcoinSLogger
 import scodec.bits.ByteVector
-
-import scala.util.Try
 
 /**
  * Created by chris on 1/12/16.

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptWitnessParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptWitnessParser.scala
@@ -4,8 +4,6 @@ import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.script.ScriptWitness
 import org.bitcoins.core.serializers.RawBitcoinSerializer
-import org.bitcoins.core.util.BitcoinSUtil
-import org.slf4j.LoggerFactory
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
@@ -14,8 +12,6 @@ import scala.annotation.tailrec
  * Created by chris on 12/14/16.
  */
 sealed abstract class RawScriptWitnessParser extends RawBitcoinSerializer[ScriptWitness] {
-
-  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
 
   def read(bytes: ByteVector): ScriptWitness = {
     //first byte is the number of stack items

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.serializers.script
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.script._
 import org.bitcoins.core.script.constant._
-import org.bitcoins.core.util.{ BitcoinSLogger, BitcoinSUtil, Factory }
+import org.bitcoins.core.util.{ BitcoinSUtil, Factory }
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec

--- a/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionInputParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionInputParser.scala
@@ -5,7 +5,6 @@ import org.bitcoins.core.protocol.script.ScriptSignature
 import org.bitcoins.core.protocol.transaction.{ TransactionInput, TransactionOutPoint }
 import org.bitcoins.core.serializers.RawBitcoinSerializer
 import org.bitcoins.core.serializers.script.RawScriptSignatureParser
-import org.bitcoins.core.util.BitcoinSUtil
 import scodec.bits.ByteVector
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParser.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.core.serializers.transaction
 
 import org.bitcoins.core.currency.{ CurrencyUnits, Satoshis }
-import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.serializers.script.RawScriptPubKeyParser
 import org.bitcoins.core.serializers.{ RawBitcoinSerializer, RawSatoshisSerializer }
@@ -21,7 +20,7 @@ sealed abstract class RawTransactionOutputParser extends RawBitcoinSerializer[Tr
 
   /**
    * Reads a single output from the given bytes, note this is different than [[org.bitcoins.core.serializers.transaction.RawTransactionOutputParser.read]]
-   * because it does NOT expect a [[CompactSizeUInt]] to be the first element in the byte array indicating how many outputs we have
+   * because it does NOT expect a [[org.bitcoins.core.protocol.CompactSizeUInt]] to be the first element in the byte array indicating how many outputs we have
    */
   override def read(bytes: ByteVector): TransactionOutput = {
     val satoshisBytes = bytes.take(8)

--- a/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionWitnessParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawTransactionWitnessParser.scala
@@ -3,7 +3,6 @@ package org.bitcoins.core.serializers.transaction
 import org.bitcoins.core.protocol.script.ScriptWitness
 import org.bitcoins.core.protocol.transaction.TransactionWitness
 import org.bitcoins.core.serializers.script.RawScriptWitnessParser
-import org.slf4j.LoggerFactory
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
@@ -15,7 +14,7 @@ import scala.annotation.tailrec
  * [[https://github.com/bitcoin/bitcoin/blob/b4e4ba475a5679e09f279aaf2a83dcf93c632bdb/src/primitives/transaction.h#L232-L268]]
  */
 sealed abstract class RawTransactionWitnessParser {
-  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
+
   /**
    * We can only tell how many [[ScriptWitness]]
    * we have if we have the number of inputs the transaction creates

--- a/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawWitnessTransactionParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/transaction/RawWitnessTransactionParser.scala
@@ -4,15 +4,13 @@ import org.bitcoins.core.number.{ Int32, UInt32 }
 import org.bitcoins.core.protocol.script.EmptyScriptWitness
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.serializers.{ RawBitcoinSerializer, RawSerializerHelper }
-import org.bitcoins.core.util.BitcoinSUtil
-import org.slf4j.LoggerFactory
 import scodec.bits.ByteVector
 
 /**
  * Created by chris on 11/21/16.
  */
 sealed abstract class RawWitnessTransactionParser extends RawBitcoinSerializer[WitnessTransaction] {
-  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
+
   /**
    * This read function is unique to [[org.bitcoins.core.serializers.transaction.RawBaseTransactionParser]]
    * in the fact that it reads a 'marker' and 'flag' byte to indicate that this tx is a [[WitnessTransaction]]

--- a/core/src/main/scala/org/bitcoins/core/util/Base58.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/Base58.scala
@@ -15,7 +15,7 @@ sealed abstract class Base58 {
   import Base58Type._
   val base58Characters = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
   val base58Pairs = base58Characters.zipWithIndex.toMap
-  private val logger = BitcoinSLogger.logger
+
   /** Verifies a given [[Base58Type]] string against its checksum (last 4 decoded bytes). */
   def decodeCheck(input: String): Try[ByteVector] = {
     val decodedTry: Try[ByteVector] = Try(decode(input))

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinSLogger.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinSLogger.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.core.util
 
-import org.slf4j.LoggerFactory
-import org.slf4j.Logger
+import org.slf4j.{ Logger, LoggerFactory }
 
 /**
  * Created by chris on 3/11/16.

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
@@ -9,7 +9,7 @@ import scala.math.BigInt
  * Created by chris on 2/26/16.
  */
 trait BitcoinSUtil {
-  private val logger = BitcoinSLogger.logger
+
   def decodeHex(hex: String): ByteVector = {
     if (hex.isEmpty) ByteVector.empty else ByteVector.fromHex(hex).get
   }

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -9,7 +9,7 @@ import org.bitcoins.core.script.crypto.{ OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIF
 import org.bitcoins.core.script.flag.{ ScriptFlag, ScriptFlagUtil }
 import org.bitcoins.core.script.result.{ ScriptError, ScriptErrorPubKeyType, ScriptErrorWitnessPubKeyType }
 import org.bitcoins.core.script.{ ExecutionInProgressScriptProgram, ScriptProgram }
-import scodec.bits.{ BitVector, ByteVector }
+import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
 

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -13,12 +13,6 @@ import scala.util.{ Failure, Success, Try }
  */
 trait NumberUtil extends BitcoinSLogger {
 
-  private def parseLong(hex: String): Long = java.lang.Long.parseLong(hex, 16)
-
-  private def parseLong(bytes: ByteVector): Long = parseLong(BitcoinSUtil.encodeHex(bytes))
-
-  private def parseLong(byte: Byte): Long = parseLong(ByteVector.fromByte(byte))
-
   /** Takes 2^^num. */
   def pow2(exponent: Int): BigInt = {
     require(exponent < 64, "We cannot have anything larger than 2^64 - 1 in a long, you tried to do 2^" + exponent)

--- a/core/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/EscrowTimeoutHelper.scala
@@ -6,7 +6,6 @@ import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.wallet.builder.TxBuilderError
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -16,8 +15,6 @@ import scala.util.{ Failure, Success, Try }
  * Created by chris on 5/9/17.
  */
 sealed abstract class EscrowTimeoutHelper {
-
-  private val logger = BitcoinSLogger.logger
 
   /**
    * Signs a [[org.bitcoins.core.protocol.transaction.WitnessTransaction]] with the given private key

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -15,7 +15,6 @@ import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.signer._
 import org.bitcoins.core.wallet.utxo.{ BitcoinUTXOSpendingInfo, UTXOSpendingInfo }
-import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 import scala.concurrent.{ ExecutionContext, Future }
@@ -31,7 +30,6 @@ import scala.util.{ Failure, Success, Try }
  * For usage examples see TxBuilderSpec
  */
 sealed abstract class TxBuilder {
-  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
 
   /** The outputs which we are spending bitcoins to */
   def destinations: Seq[TransactionOutput]
@@ -590,7 +588,7 @@ object TxBuilder {
     } else if (hasExtraOutPoints) {
       TxBuilderError.ExtraOutPoints
     } else {
-      Success(Unit)
+      Success(())
     }
   }
 
@@ -650,7 +648,7 @@ object TxBuilder {
 
       TxBuilderError.LowFee
     } else {
-      Success(Unit)
+      Success(())
     }
   }
 }
@@ -664,8 +662,6 @@ object BitcoinTxBuilder {
     feeRate: FeeUnit,
     changeSPK: ScriptPubKey,
     network: BitcoinNetwork) extends BitcoinTxBuilder
-
-  private val logger = BitcoinSLogger.logger
 
   /**
    * @param destinations where the money is going in the signed tx

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -6,9 +6,7 @@ import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.wallet.builder.TxBuilderError
-import org.slf4j.LoggerFactory
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -54,7 +52,7 @@ sealed abstract class P2PKSigner extends BitcoinSigner {
       val sign: ByteVector => Future[ECDigitalSignature] = signers.head.signFunction
       val unsignedInput = unsignedTx.inputs(inputIndex.toInt)
       val flags = Policy.standardFlags
-      val amount = output.value
+
       val signed: Future[TxSigComponent] = spk match {
         case p2wshSPK: P2WSHWitnessSPKV0 =>
           val wtx = unsignedTx match {
@@ -132,8 +130,6 @@ object P2PKSigner extends P2PKSigner
 /** Used to sign a [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey]] */
 sealed abstract class P2PKHSigner extends BitcoinSigner {
 
-  private val logger = LoggerFactory.getLogger(this.getClass().getSimpleName)
-
   override def sign(signers: Seq[Sign], output: TransactionOutput, unsignedTx: Transaction,
     inputIndex: UInt32, hashType: HashType, isDummySignature: Boolean)(implicit ec: ExecutionContext): Future[TxSigComponent] = {
     val spk = output.scriptPubKey
@@ -144,7 +140,7 @@ sealed abstract class P2PKHSigner extends BitcoinSigner {
       val pubKey = signers.head.publicKey
       val unsignedInput = unsignedTx.inputs(inputIndex.toInt)
       val flags = Policy.standardFlags
-      val amount = output.value
+
       val signed: Future[TxSigComponent] = spk match {
         case p2wshSPK: P2WSHWitnessSPKV0 =>
           val wtx = unsignedTx match {
@@ -254,7 +250,6 @@ sealed abstract class P2PKHSigner extends BitcoinSigner {
 object P2PKHSigner extends P2PKHSigner
 
 sealed abstract class MultiSigSigner extends BitcoinSigner {
-  private val logger = BitcoinSLogger.logger
 
   override def sign(signersWithPubKeys: Seq[Sign], output: TransactionOutput, unsignedTx: Transaction,
     inputIndex: UInt32, hashType: HashType, isDummySignature: Boolean)(implicit ec: ExecutionContext): Future[TxSigComponent] = {
@@ -262,7 +257,7 @@ sealed abstract class MultiSigSigner extends BitcoinSigner {
     val signers = signersWithPubKeys.map(_.signFunction)
     val unsignedInput = unsignedTx.inputs(inputIndex.toInt)
     val flags = Policy.standardFlags
-    val amount = output.value
+
     val signed: Future[TxSigComponent] = spk match {
       case p2wshSPK: P2WSHWitnessSPKV0 =>
         val wtx = unsignedTx match {

--- a/rpc/src/main/scala/org/bitcoins/rpc/client/RpcOpts.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/client/RpcOpts.scala
@@ -6,9 +6,11 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import play.api.libs.json.{ Json, Writes }
-import org.bitcoins.rpc.serializers.JsonSerializers._
 
 object RpcOpts {
+
+  import org.bitcoins.rpc.serializers.JsonWriters._
+
   case class FundRawTransactionOptions(
     changeAddress: Option[BitcoinAddress] = None,
     changePosition: Option[Int] = None,

--- a/rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/OtherResult.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/OtherResult.scala
@@ -1,10 +1,6 @@
 package org.bitcoins.rpc.jsonmodels
 
-import org.bitcoins.core.crypto.{
-  DoubleSha256Digest,
-  ECPublicKey,
-  Sha256Hash160Digest
-}
+import org.bitcoins.core.crypto.{ DoubleSha256Digest, ECPublicKey, Sha256Hash160Digest }
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress

--- a/rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/RawTransactionResult.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/RawTransactionResult.scala
@@ -3,9 +3,9 @@ package org.bitcoins.rpc.jsonmodels
 import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.{ BitcoinAddress, P2PKHAddress, P2SHAddress }
 import org.bitcoins.core.protocol.script.{ ScriptPubKey, ScriptSignature }
 import org.bitcoins.core.protocol.transaction.{ Transaction, TransactionInput }
+import org.bitcoins.core.protocol.{ BitcoinAddress, P2PKHAddress, P2SHAddress }
 
 sealed abstract class RawTransactionResult
 

--- a/rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
@@ -3,22 +3,13 @@ package org.bitcoins.rpc.serializers
 import java.io.File
 import java.net.{ InetAddress, URI }
 
-import org.bitcoins.core.crypto.{
-  DoubleSha256Digest,
-  ECPublicKey,
-  Sha256Hash160Digest
-}
+import org.bitcoins.core.crypto.{ DoubleSha256Digest, ECPublicKey, Sha256Hash160Digest }
 import org.bitcoins.core.currency.{ Bitcoins, Satoshis }
 import org.bitcoins.core.number.{ Int32, Int64, UInt32, UInt64 }
-import org.bitcoins.core.protocol.{
-  Address,
-  BitcoinAddress,
-  P2PKHAddress,
-  P2SHAddress
-}
 import org.bitcoins.core.protocol.blockchain.{ Block, BlockHeader, MerkleBlock }
 import org.bitcoins.core.protocol.script.{ ScriptPubKey, ScriptSignature }
 import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.{ Address, BitcoinAddress, P2PKHAddress, P2SHAddress }
 import org.bitcoins.core.wallet.fee.{ BitcoinFeeUnit, SatoshisPerByte }
 import org.bitcoins.rpc.jsonmodels.RpcAddress
 import play.api.libs.json._
@@ -142,7 +133,7 @@ object JsonReaders {
 
   // Errors for Unit return types are caught in RpcClient::checkUnit
   implicit object UnitReads extends Reads[Unit] {
-    override def reads(json: JsValue): JsResult[Unit] = JsSuccess(Unit)
+    override def reads(json: JsValue): JsResult[Unit] = JsSuccess(())
   }
 
   implicit object InetAddressReads extends Reads[InetAddress] {

--- a/rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
+++ b/rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
@@ -3,32 +3,19 @@ package org.bitcoins.rpc.serializers
 import java.io.File
 import java.net.{ InetAddress, URI }
 
-import org.bitcoins.core.crypto.{
-  DoubleSha256Digest,
-  ECPublicKey,
-  Sha256Hash160Digest
-}
+import org.bitcoins.core.crypto.{ DoubleSha256Digest, ECPublicKey, Sha256Hash160Digest }
 import org.bitcoins.core.currency.{ Bitcoins, Satoshis }
 import org.bitcoins.core.number.{ Int32, UInt32, UInt64 }
-import org.bitcoins.core.protocol.{
-  Address,
-  BitcoinAddress,
-  P2PKHAddress,
-  P2SHAddress
-}
 import org.bitcoins.core.protocol.blockchain.{ Block, BlockHeader, MerkleBlock }
 import org.bitcoins.core.protocol.script.{ ScriptPubKey, ScriptSignature }
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionInput,
-  TransactionOutPoint
-}
+import org.bitcoins.core.protocol.transaction.{ Transaction, TransactionInput, TransactionOutPoint }
+import org.bitcoins.core.protocol.{ Address, BitcoinAddress, P2PKHAddress, P2SHAddress }
 import org.bitcoins.core.wallet.fee.BitcoinFeeUnit
 import org.bitcoins.rpc.jsonmodels._
 import org.bitcoins.rpc.serializers.JsonReaders._
 import org.bitcoins.rpc.serializers.JsonWriters._
-import play.api.libs.json._
 import play.api.libs.functional.syntax._
+import play.api.libs.json._
 
 object JsonSerializers {
   implicit val bigIntReads: Reads[BigInt] = BigIntReads

--- a/rpc/src/test/scala/org/bitcoins/rpc/BitcoindRpcClientTest.scala
+++ b/rpc/src/test/scala/org/bitcoins/rpc/BitcoindRpcClientTest.scala
@@ -8,30 +8,18 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import org.bitcoins.core.crypto.{ DoubleSha256Digest, ECPrivateKey, ECPublicKey }
 import org.bitcoins.core.currency.{ Bitcoins, Satoshis }
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionInput,
-  TransactionOutPoint
-}
-import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.rpc.client.{ BitcoindRpcClient, RpcOpts }
-import org.scalatest.{ AsyncFlatSpec, BeforeAndAfter, BeforeAndAfterAll }
 import org.bitcoins.core.number.{ Int64, UInt32 }
+import org.bitcoins.core.protocol.script.{ P2SHScriptSignature, ScriptPubKey, ScriptSignature }
+import org.bitcoins.core.protocol.transaction.{ Transaction, TransactionInput, TransactionOutPoint }
 import org.bitcoins.core.protocol.{ BitcoinAddress, P2PKHAddress }
-import org.bitcoins.core.protocol.script.{
-  P2SHScriptSignature,
-  ScriptPubKey,
-  ScriptSignature
-}
+import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
-import org.bitcoins.rpc.jsonmodels.{
-  GetBlockWithTransactionsResult,
-  GetTransactionResult,
-  RpcAddress
-}
+import org.bitcoins.rpc.client.{ BitcoindRpcClient, RpcOpts }
+import org.bitcoins.rpc.jsonmodels.{ GetBlockWithTransactionsResult, GetTransactionResult, RpcAddress }
+import org.scalatest.{ AsyncFlatSpec, BeforeAndAfter, BeforeAndAfterAll }
 
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ Await, Future }
 import scala.util.Try
 
 class BitcoindRpcClientTest

--- a/rpc/src/test/scala/org/bitcoins/rpc/RpcUtilTest.scala
+++ b/rpc/src/test/scala/org/bitcoins/rpc/RpcUtilTest.scala
@@ -4,12 +4,11 @@ import java.io.File
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.rpc.client.BitcoindRpcClient
 import org.scalatest.{ AsyncFlatSpec, BeforeAndAfterAll }
 
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ Await, Future }
 import scala.util.{ Success, Try }
 
 class RpcUtilTest extends AsyncFlatSpec with BeforeAndAfterAll {

--- a/rpc/src/test/scala/org/bitcoins/rpc/TestUtil.scala
+++ b/rpc/src/test/scala/org/bitcoins/rpc/TestUtil.scala
@@ -10,8 +10,8 @@ import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.rpc.client.BitcoindRpcClient
 import org.bitcoins.rpc.config.{ BitcoindAuthCredentials, BitcoindInstance }
 
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.{ DurationInt, FiniteDuration }
+import scala.concurrent.{ Await, Future }
 import scala.util.Try
 
 trait TestUtil extends BitcoinSLogger {


### PR DESCRIPTION
This adds sane compiler options and supersedes #222. 

Right now this PR scopes our compiler options to the `Compile` scope only, as suggested by others we might want to consider having more strict compile policies for `Compile` rather than `Test`. We should consider applying some of these compiler options to test in the future.

The reason this diff is so large is because I removed all unused imports and unused local `val`s in this PR.

https://docs.scala-lang.org/overviews/compiler-options/index.html