### PR TITLE
2018 11 18 rework script data structure

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -8,11 +8,7 @@ import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.number.{Int32, Int64, UInt32}
 import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptSignature}
 import org.bitcoins.core.protocol.transaction._
-import org.bitcoins.core.script.constant.{
-  BytesToPushOntoStack,
-  ScriptConstant,
-  ScriptNumber
-}
+import org.bitcoins.core.script.constant.{BytesToPushOntoStack, ScriptConstant}
 import org.bitcoins.core.script.crypto.OP_CHECKSIG
 import org.bitcoins.core.util.{BitcoinSUtil, BitcoinScriptUtil}
 import scodec.bits.ByteVector
@@ -108,12 +104,19 @@ sealed abstract class ChainParams {
     //see https://bitcoin.stackexchange.com/questions/13122/scriptsig-coinbase-structure-of-the-genesis-block
     //for a full breakdown of the genesis block & its script signature
     val const = ScriptConstant(timestampBytes)
-    val scriptSignature = ScriptSignature.fromAsm(
-      Seq(BytesToPushOntoStack(4),
-          ScriptNumber(486604799),
-          BytesToPushOntoStack(1),
-          ScriptNumber(4)) ++ BitcoinScriptUtil.calculatePushOp(const) ++ Seq(
-        const))
+
+    val asm = {
+      List(
+        BytesToPushOntoStack(4),
+        ScriptConstant("ffff001d"),
+        BytesToPushOntoStack(1),
+        ScriptConstant("04")) ++
+        BitcoinScriptUtil.calculatePushOp(const) ++
+        List(const)
+    }
+
+    val scriptSignature = ScriptSignature.fromAsm(asm)
+
     val input = CoinbaseInput(scriptSignature, TransactionConstants.sequence)
     val output = TransactionOutput(amount, scriptPubKey)
     val tx = BaseTransaction(TransactionConstants.version,

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/Script.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/Script.scala
@@ -1,0 +1,37 @@
+
+package org.bitcoins.core.protocol.script
+
+import org.bitcoins.core.protocol.{ CompactSizeUInt, NetworkElement }
+import org.bitcoins.core.script.constant.ScriptToken
+import scodec.bits.ByteVector
+
+
+/** This is meant to be a super type for
+  * scripts in the bitcoin protocol. This gives us
+  * access to the asm representation, and how to serialize the script
+  */
+abstract class Script extends NetworkElement {
+
+  /**
+    * Representation of a script in a parsed assembly format
+    * this data structure can be run through the script interpreter to
+    * see if a script evaluates to true
+    * used to represent the size of the script serialization
+    */
+  def asm: Seq[ScriptToken]
+
+  /**
+    * The byte representation of [[asm]], this does NOT have the bytes
+    * for the [[org.bitcoins.core.protocol.CompactSizeUInt]] in the script
+    */
+  val asmBytes: ByteVector = {
+    asm.foldLeft(ByteVector.empty)(_ ++ _.bytes)
+  }
+
+  /** The size of the script, this is used for network serialization */
+  val compactSizeUInt: CompactSizeUInt = CompactSizeUInt.calc(asmBytes)
+
+  /** The full byte serialization for a script on the network */
+  override val bytes: ByteVector = compactSizeUInt.bytes ++ asmBytes
+
+}

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptFactory.scala
@@ -2,25 +2,19 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.script.constant.ScriptToken
-import org.bitcoins.core.serializers.script.ScriptParser
-import org.bitcoins.core.util.{BitcoinSUtil, Factory}
+import org.bitcoins.core.util.{BitcoinSUtil, BitcoinScriptUtil, Factory}
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 12/9/16.
   */
-trait ScriptFactory[T] extends Factory[T] {
+trait ScriptFactory[T <: Script] extends Factory[T] {
 
   /** Builds a script from the given asm with the given constructor if the invariant holds true, else throws an error */
-  def buildScript(
-      asm: Seq[ScriptToken],
-      constructor: ByteVector => T,
-      invariant: Seq[ScriptToken] => Boolean,
-      errorMsg: String): T = {
+  def buildScript(asm: Vector[ScriptToken], constructor: Vector[ScriptToken] => T,
+                  invariant: Seq[ScriptToken] => Boolean, errorMsg: String): T = {
     if (invariant(asm)) {
-      val asmBytes = BitcoinSUtil.toByteVector(asm)
-      val compactSizeUInt = CompactSizeUInt.calc(asmBytes)
-      constructor(compactSizeUInt.bytes ++ asmBytes)
+      constructor(asm)
     } else throw new IllegalArgumentException(errorMsg)
   }
 
@@ -28,10 +22,9 @@ trait ScriptFactory[T] extends Factory[T] {
   def fromAsm(asm: Seq[ScriptToken]): T
 
   def fromBytes(bytes: ByteVector): T = {
-    val cpmct = CompactSizeUInt.parseCompactSizeUInt(bytes)
-    val (_, noCmpctUInt) = bytes.splitAt(cpmct.bytes.size)
-    val asm = ScriptParser.fromBytes(noCmpctUInt)
-    fromAsm(asm)
+    BitcoinScriptUtil.parseScript(
+      bytes = bytes,
+      f = fromAsm)
   }
 
   /**

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -2,7 +2,6 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.crypto._
-import org.bitcoins.core.protocol._
 import org.bitcoins.core.script.bitwise.{OP_EQUAL, OP_EQUALVERIFY}
 import org.bitcoins.core.script.constant.{BytesToPushOntoStack, _}
 import org.bitcoins.core.script.control.OP_RETURN
@@ -10,38 +9,14 @@ import org.bitcoins.core.script.crypto.{OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY
 import org.bitcoins.core.script.locktime.{OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY}
 import org.bitcoins.core.script.reserved.UndefinedOP_NOP
 import org.bitcoins.core.script.stack.{OP_DROP, OP_DUP}
-import org.bitcoins.core.serializers.script.ScriptParser
 import org.bitcoins.core.util._
-import scodec.bits.ByteVector
 
 import scala.util.{Failure, Success, Try}
 
 /**
   * Created by chris on 12/26/15.
   */
-sealed trait ScriptPubKey extends NetworkElement {
-
-  /** The size of the script, this is used for network serialization */
-  def compactSizeUInt: CompactSizeUInt =
-    CompactSizeUInt.parseCompactSizeUInt(bytes)
-
-  /**
-    * Representation of a scriptPubKey in a parsed assembly format
-    * this data structure can be run through the script interpreter to
-    * see if a script evaluates to true
-    * Note: The first byte(s) inside the byte array is the [[CompactSizeUInt]]
-    * used to represent the size of the script serialization
-    */
-  lazy val asm: Seq[ScriptToken] =
-    ScriptParser.fromBytes(bytes.splitAt(compactSizeUInt.size.toInt)._2)
-
-  /**
-    * The byte representation of [[asm]], this does NOT have the bytes
-    * for the [[org.bitcoins.core.protocol.CompactSizeUInt]] in the [[org.bitcoins.core.protocol.script.ScriptPubKey]]
-    */
-  lazy val asmBytes: ByteVector = BitcoinSUtil.toByteVector(asm)
-
-}
+sealed abstract class ScriptPubKey extends Script
 
 /**
   * Represents a pay-to-pubkey hash script pubkey
@@ -49,14 +24,11 @@ sealed trait ScriptPubKey extends NetworkElement {
   * Format: OP_DUP OP_HASH160 <PubKeyHash> OP_EQUALVERIFY OP_CHECKSIG
   */
 sealed trait P2PKHScriptPubKey extends ScriptPubKey {
-
-  def pubKeyHash: Sha256Hash160Digest =
-    Sha256Hash160Digest(asm(asm.length - 3).bytes)
+  def pubKeyHash: Sha256Hash160Digest = Sha256Hash160Digest(asm(asm.length - 3).bytes)
 }
 
 object P2PKHScriptPubKey extends ScriptFactory[P2PKHScriptPubKey] {
-  private case class P2PKHScriptPubKeyImpl(bytes: ByteVector)
-      extends P2PKHScriptPubKey {
+  private case class P2PKHScriptPubKeyImpl(override val asm: Vector[ScriptToken]) extends P2PKHScriptPubKey {
     override def toString = "P2PKHScriptPubKeyImpl(" + hex + ")"
   }
 
@@ -67,32 +39,22 @@ object P2PKHScriptPubKey extends ScriptFactory[P2PKHScriptPubKey] {
 
   def apply(hash: Sha256Hash160Digest): P2PKHScriptPubKey = {
     val pushOps = BitcoinScriptUtil.calculatePushOp(hash.bytes)
-    val asm = Seq(OP_DUP, OP_HASH160) ++ pushOps ++ Seq(
-      ScriptConstant(hash.bytes),
-      OP_EQUALVERIFY,
-      OP_CHECKSIG)
+    val asm = Seq(OP_DUP, OP_HASH160) ++ pushOps ++ Seq(ScriptConstant(hash.bytes), OP_EQUALVERIFY, OP_CHECKSIG)
     P2PKHScriptPubKey(asm)
   }
 
   def fromAsm(asm: Seq[ScriptToken]): P2PKHScriptPubKey = {
-    buildScript(asm,
-                P2PKHScriptPubKeyImpl(_),
-                isP2PKHScriptPubKey(_),
-                "Given asm was not a p2pkh scriptPubKey, got: " + asm)
+    buildScript(asm.toVector, P2PKHScriptPubKeyImpl(_), isP2PKHScriptPubKey(_), "Given asm was not a p2pkh scriptPubKey, got: " + asm)
   }
 
   def apply(asm: Seq[ScriptToken]): P2PKHScriptPubKey = fromAsm(asm)
 
   /** Checks if the given asm matches the pattern for [[P2PKHScriptPubKey]] */
-  def isP2PKHScriptPubKey(asm: Seq[ScriptToken]): Boolean = asm match {
-    case Seq(OP_DUP,
-             OP_HASH160,
-             _: BytesToPushOntoStack,
-             _: ScriptConstant,
-             OP_EQUALVERIFY,
-             OP_CHECKSIG) =>
-      true
-    case _ => false
+  def isP2PKHScriptPubKey(asm: Seq[ScriptToken]): Boolean = {
+    asm match {
+      case Seq(OP_DUP, OP_HASH160, _: BytesToPushOntoStack, _: ScriptConstant, OP_EQUALVERIFY, OP_CHECKSIG) => true
+      case _ => false
+    }
   }
 }
 
@@ -106,23 +68,16 @@ sealed trait MultiSignatureScriptPubKey extends ScriptPubKey {
   /** Returns the amount of required signatures for this multisignature script pubkey output */
   def requiredSigs: Int = {
     val asmWithoutPushOps = asm.filterNot(_.isInstanceOf[BytesToPushOntoStack])
-    val opCheckMultiSigIndex =
-      if (asm.indexOf(OP_CHECKMULTISIG) != -1)
-        asmWithoutPushOps.indexOf(OP_CHECKMULTISIG)
-      else asmWithoutPushOps.indexOf(OP_CHECKMULTISIGVERIFY)
+    val opCheckMultiSigIndex = if (asm.indexOf(OP_CHECKMULTISIG) != -1) asmWithoutPushOps.indexOf(OP_CHECKMULTISIG) else asmWithoutPushOps.indexOf(OP_CHECKMULTISIGVERIFY)
     //magic number 2 represents the maxSig operation and the OP_CHECKMULTISIG operation at the end of the asm
-    val numSigsRequired = asmWithoutPushOps(
-      opCheckMultiSigIndex - maxSigs.toInt - 2)
+    val numSigsRequired = asmWithoutPushOps(opCheckMultiSigIndex - maxSigs.toInt - 2)
     numSigsRequired match {
       case x: ScriptNumber => x.toInt
-      case c: ScriptConstant
-          if ScriptNumber(c.hex).toLong <= Consensus.maxPublicKeysPerMultiSig =>
+      case c: ScriptConstant if ScriptNumber(c.hex).toLong <= Consensus.maxPublicKeysPerMultiSig =>
         ScriptNumber(c.hex).toInt
-      case _ =>
-        throw new RuntimeException(
-          "The first element of the multisignature pubkey must be a script number operation\n" +
-            "operation: " + numSigsRequired +
-            "\nscriptPubKey: " + this)
+      case _ => throw new RuntimeException("The first element of the multisignature pubkey must be a script number operation\n" +
+        "operation: " + numSigsRequired +
+        "\nscriptPubKey: " + this)
     }
   }
 
@@ -134,50 +89,35 @@ sealed trait MultiSignatureScriptPubKey extends ScriptPubKey {
     } else {
       asm(checkMultiSigIndex - 1) match {
         case x: ScriptNumber => x.toInt
-        case c: ScriptConstant
-            if ScriptNumber(c.hex).toLong <= Consensus.maxPublicKeysPerMultiSig =>
+        case c: ScriptConstant if ScriptNumber(c.hex).toLong <= Consensus.maxPublicKeysPerMultiSig =>
           ScriptNumber(c.hex).toInt
-        case x =>
-          throw new RuntimeException(
-            "The element preceding a OP_CHECKMULTISIG operation in a  multisignature pubkey must be a script number operation, got: " + x)
+        case x => throw new RuntimeException("The element preceding a OP_CHECKMULTISIG operation in a  multisignature pubkey must be a script number operation, got: " + x)
       }
     }
   }
 
   /** Gives the OP_CHECKMULTISIG or OP_CHECKMULTISIGVERIFY index inside of asm */
   private def checkMultiSigIndex: Int = {
-    if (asm.indexOf(OP_CHECKMULTISIG) != -1) asm.indexOf(OP_CHECKMULTISIG)
-    else asm.indexOf(OP_CHECKMULTISIGVERIFY)
+    if (asm.indexOf(OP_CHECKMULTISIG) != -1) asm.indexOf(OP_CHECKMULTISIG) else asm.indexOf(OP_CHECKMULTISIGVERIFY)
   }
 
   /** Returns the public keys encoded into the scriptPubKey */
   def publicKeys: Seq[ECPublicKey] = {
-    asm
-      .filter(_.isInstanceOf[ScriptConstant])
-      .slice(1, maxSigs + 1)
-      .map(key => ECPublicKey(key.hex))
+    asm.filter(_.isInstanceOf[ScriptConstant]).slice(1, maxSigs + 1).map(key => ECPublicKey(key.hex))
   }
 }
 
-object MultiSignatureScriptPubKey
-    extends ScriptFactory[MultiSignatureScriptPubKey] {
+object MultiSignatureScriptPubKey extends ScriptFactory[MultiSignatureScriptPubKey] {
 
-  private case class MultiSignatureScriptPubKeyImpl(bytes: ByteVector)
-      extends MultiSignatureScriptPubKey {
+  private case class MultiSignatureScriptPubKeyImpl(override val asm: Vector[ScriptToken]) extends MultiSignatureScriptPubKey {
     override def toString = "MultiSignatureScriptPubKeyImpl(" + hex + ")"
   }
 
-  def apply(
-      requiredSigs: Int,
-      pubKeys: Seq[ECPublicKey]): MultiSignatureScriptPubKey = {
-    require(
-      requiredSigs <= Consensus.maxPublicKeysPerMultiSig,
-      "We cannot have more required signatures than: " +
-        Consensus.maxPublicKeysPerMultiSig + " got: " + requiredSigs
-    )
-    require(pubKeys.length <= Consensus.maxPublicKeysPerMultiSig,
-            "We cannot have more public keys than " +
-              Consensus.maxPublicKeysPerMultiSig + " got: " + pubKeys.length)
+  def apply(requiredSigs: Int, pubKeys: Seq[ECPublicKey]): MultiSignatureScriptPubKey = {
+    require(requiredSigs <= Consensus.maxPublicKeysPerMultiSig, "We cannot have more required signatures than: " +
+      Consensus.maxPublicKeysPerMultiSig + " got: " + requiredSigs)
+    require(pubKeys.length <= Consensus.maxPublicKeysPerMultiSig, "We cannot have more public keys than " +
+      Consensus.maxPublicKeysPerMultiSig + " got: " + pubKeys.length)
 
     val required = ScriptNumberOperation.fromNumber(requiredSigs) match {
       case Some(scriptNumOp) => Seq(scriptNumOp)
@@ -198,16 +138,12 @@ object MultiSignatureScriptPubKey
       pushOps = BitcoinScriptUtil.calculatePushOp(pubKey.bytes)
       constant = ScriptConstant(pubKey.bytes)
     } yield pushOps ++ Seq(constant)
-    val asm: Seq[ScriptToken] = required ++ pubKeysWithPushOps.flatten ++ possible ++ Seq(
-      OP_CHECKMULTISIG)
+    val asm: Seq[ScriptToken] = required ++ pubKeysWithPushOps.flatten ++ possible ++ Seq(OP_CHECKMULTISIG)
     MultiSignatureScriptPubKey(asm)
   }
 
   def fromAsm(asm: Seq[ScriptToken]): MultiSignatureScriptPubKey = {
-    buildScript(asm,
-                MultiSignatureScriptPubKeyImpl(_),
-                isMultiSignatureScriptPubKey(_),
-                "Given asm was not a MultSignatureScriptPubKey, got: " + asm)
+    buildScript(asm.toVector, MultiSignatureScriptPubKeyImpl(_), isMultiSignatureScriptPubKey(_), "Given asm was not a MultSignatureScriptPubKey, got: " + asm)
   }
 
   def apply(asm: Seq[ScriptToken]): MultiSignatureScriptPubKey = fromAsm(asm)
@@ -215,17 +151,15 @@ object MultiSignatureScriptPubKey
   /** Determines if the given script tokens are a multisignature scriptPubKey */
   def isMultiSignatureScriptPubKey(asm: Seq[ScriptToken]): Boolean = {
     val isNotEmpty = asm.size > 0
-    val containsMultiSigOp = asm.contains(OP_CHECKMULTISIG) || asm.contains(
-      OP_CHECKMULTISIGVERIFY)
+    val containsMultiSigOp = asm.contains(OP_CHECKMULTISIG) || asm.contains(OP_CHECKMULTISIGVERIFY)
     //we need either the first or second asm operation to indicate how many signatures are required
     val hasRequiredSignaturesTry = Try {
       asm.headOption match {
-        case None        => false
+        case None => false
         case Some(token) =>
           //this is for the case that we have more than 16 public keys, the
           //first operation will be a push op, the second operation being the actual number of keys
-          if (token.isInstanceOf[BytesToPushOntoStack])
-            isValidPubKeyNumber(asm.tail.head)
+          if (token.isInstanceOf[BytesToPushOntoStack]) isValidPubKeyNumber(asm.tail.head)
           else isValidPubKeyNumber(token)
       }
     }
@@ -236,11 +170,8 @@ object MultiSignatureScriptPubKey
       }
     }
 
-    val standardOps = asm.filter(
-      op =>
-        op.isInstanceOf[ScriptNumber] || op == OP_CHECKMULTISIG ||
-          op == OP_CHECKMULTISIGVERIFY || op.isInstanceOf[ScriptConstant] || op
-          .isInstanceOf[BytesToPushOntoStack])
+    val standardOps = asm.filter(op => op.isInstanceOf[ScriptNumber] || op == OP_CHECKMULTISIG ||
+      op == OP_CHECKMULTISIGVERIFY || op.isInstanceOf[ScriptConstant] || op.isInstanceOf[BytesToPushOntoStack])
     (hasRequiredSignaturesTry, hasMaximumSignaturesTry) match {
       case (Success(hasRequiredSignatures), Success(hasMaximumSignatures)) =>
         val result = isNotEmpty && containsMultiSigOp && hasRequiredSignatures &&
@@ -259,8 +190,7 @@ object MultiSignatureScriptPubKey
   private def isValidPubKeyNumber(token: ScriptToken): Boolean = token match {
     case constant: ScriptConstant =>
       constant.isInstanceOf[ScriptNumber] ||
-        ScriptNumber(constant.bytes) <= ScriptNumber(
-          Consensus.maxPublicKeysPerMultiSig)
+        ScriptNumber(constant.bytes) <= ScriptNumber(Consensus.maxPublicKeysPerMultiSig)
     case _: ScriptToken => false
   }
 }
@@ -271,15 +201,12 @@ object MultiSignatureScriptPubKey
   * Format: OP_HASH160 <Hash160(redeemScript)> OP_EQUAL
   */
 sealed trait P2SHScriptPubKey extends ScriptPubKey {
-
   /** The hash of the script for which this scriptPubKey is being created from */
-  def scriptHash: Sha256Hash160Digest =
-    Sha256Hash160Digest(asm(asm.length - 2).bytes)
+  def scriptHash: Sha256Hash160Digest = Sha256Hash160Digest(asm(asm.length - 2).bytes)
 }
 
 object P2SHScriptPubKey extends ScriptFactory[P2SHScriptPubKey] {
-  private case class P2SHScriptPubKeyImpl(bytes: ByteVector)
-      extends P2SHScriptPubKey {
+  private case class P2SHScriptPubKeyImpl(override val asm: Vector[ScriptToken]) extends P2SHScriptPubKey {
     override def toString = "P2SHScriptPubKeyImpl(" + hex + ")"
   }
 
@@ -290,26 +217,18 @@ object P2SHScriptPubKey extends ScriptFactory[P2SHScriptPubKey] {
 
   def apply(hash: Sha256Hash160Digest): P2SHScriptPubKey = {
     val pushOps = BitcoinScriptUtil.calculatePushOp(hash.bytes)
-    val asm = Seq(OP_HASH160) ++ pushOps ++ Seq(ScriptConstant(hash.bytes),
-                                                OP_EQUAL)
+    val asm = Seq(OP_HASH160) ++ pushOps ++ Seq(ScriptConstant(hash.bytes), OP_EQUAL)
     P2SHScriptPubKey(asm)
   }
 
   /** Checks if the given asm matches the pattern for [[P2SHScriptPubKey]] */
   def isP2SHScriptPubKey(asm: Seq[ScriptToken]): Boolean = asm match {
-    case Seq(OP_HASH160,
-             _: BytesToPushOntoStack,
-             _: ScriptConstant,
-             OP_EQUAL) =>
-      true
+    case Seq(OP_HASH160, _: BytesToPushOntoStack, _: ScriptConstant, OP_EQUAL) => true
     case _ => false
   }
 
   def fromAsm(asm: Seq[ScriptToken]): P2SHScriptPubKey = {
-    buildScript(asm,
-                P2SHScriptPubKeyImpl(_),
-                isP2SHScriptPubKey(_),
-                "Given asm was not a p2sh scriptPubkey, got: " + asm)
+    buildScript(asm.toVector, P2SHScriptPubKeyImpl(_), isP2SHScriptPubKey(_), "Given asm was not a p2sh scriptPubkey, got: " + asm)
   }
 
   def apply(asm: Seq[ScriptToken]): P2SHScriptPubKey = fromAsm(asm)
@@ -321,15 +240,12 @@ object P2SHScriptPubKey extends ScriptFactory[P2SHScriptPubKey] {
   * Format: <pubkey> OP_CHECKSIG
   */
 sealed trait P2PKScriptPubKey extends ScriptPubKey {
-
-  def publicKey: ECPublicKey =
-    ECPublicKey(BitcoinScriptUtil.filterPushOps(asm).head.bytes)
+  def publicKey: ECPublicKey = ECPublicKey(BitcoinScriptUtil.filterPushOps(asm).head.bytes)
 }
 
 object P2PKScriptPubKey extends ScriptFactory[P2PKScriptPubKey] {
 
-  private case class P2PKScriptPubKeyImpl(bytes: ByteVector)
-      extends P2PKScriptPubKey {
+  private case class P2PKScriptPubKeyImpl(override val asm: Vector[ScriptToken]) extends P2PKScriptPubKey {
     override def toString = "P2PKScriptPubKeyImpl(" + hex + ")"
   }
 
@@ -340,10 +256,7 @@ object P2PKScriptPubKey extends ScriptFactory[P2PKScriptPubKey] {
   }
 
   def fromAsm(asm: Seq[ScriptToken]): P2PKScriptPubKey = {
-    buildScript(asm,
-                P2PKScriptPubKeyImpl(_),
-                isP2PKScriptPubKey(_),
-                "Given asm was not a p2pk scriptPubKey, got: " + asm)
+    buildScript(asm.toVector, P2PKScriptPubKeyImpl(_), isP2PKScriptPubKey(_), "Given asm was not a p2pk scriptPubKey, got: " + asm)
   }
 
   def apply(asm: Seq[ScriptToken]): P2PKScriptPubKey = fromAsm(asm)
@@ -351,18 +264,17 @@ object P2PKScriptPubKey extends ScriptFactory[P2PKScriptPubKey] {
   /** Sees if the given asm matches the [[P2PKHScriptPubKey]] pattern */
   def isP2PKScriptPubKey(asm: Seq[ScriptToken]): Boolean = asm match {
     case Seq(_: BytesToPushOntoStack, _: ScriptConstant, OP_CHECKSIG) => true
-    case _                                                            => false
+    case _ => false
   }
 
 }
 
 sealed trait LockTimeScriptPubKey extends ScriptPubKey {
-
   /** Determines the nested ScriptPubKey inside the LockTimeScriptPubKey */
   def nestedScriptPubKey: ScriptPubKey = {
     val bool: Boolean = asm.head.isInstanceOf[ScriptNumberOperation]
     bool match {
-      case true  => ScriptPubKey(asm.slice(3, asm.length))
+      case true => ScriptPubKey(asm.slice(3, asm.length))
       case false => ScriptPubKey(asm.slice(4, asm.length))
     }
   }
@@ -370,13 +282,12 @@ sealed trait LockTimeScriptPubKey extends ScriptPubKey {
   /** The relative locktime value (i.e. the amount of time the output should remain unspendable) */
   def locktime: ScriptNumber = {
     asm.head match {
-      case scriptNumOp: ScriptNumberOperation =>
-        ScriptNumber(scriptNumOp.toLong)
+      case scriptNumOp: ScriptNumberOperation => ScriptNumber(scriptNumOp.toLong)
       case _: BytesToPushOntoStack => ScriptNumber(asm(1).hex)
       case _: ScriptConstant | _: ScriptOperation =>
-        throw new IllegalArgumentException(
-          "In a LockTimeScriptPubKey, " +
-            "the first asm must be either a ScriptNumberOperation (i.e. OP_5), or the BytesToPushOntoStack for the proceeding ScriptConstant.")
+        throw new IllegalArgumentException("In a LockTimeScriptPubKey, " +
+        "the first asm must be either a ScriptNumberOperation (i.e. OP_5), or the BytesToPushOntoStack " +
+          "for the proceeding ScriptConstant.")
     }
   }
 }
@@ -387,14 +298,11 @@ object LockTimeScriptPubKey extends ScriptFactory[LockTimeScriptPubKey] {
     require(isValidLockTimeScriptPubKey(asm))
     if (asm.contains(OP_CHECKLOCKTIMEVERIFY)) CLTVScriptPubKey(asm)
     else if (asm.contains(OP_CHECKSEQUENCEVERIFY)) CSVScriptPubKey(asm)
-    else
-      throw new IllegalArgumentException(
-        "Given asm was not a LockTimeScriptPubKey, got: " + asm)
+    else throw new IllegalArgumentException("Given asm was not a LockTimeScriptPubKey, got: " + asm)
   }
 
   def isValidLockTimeScriptPubKey(asm: Seq[ScriptToken]): Boolean = {
-    CLTVScriptPubKey.isCLTVScriptPubKey(asm) || CSVScriptPubKey
-      .isCSVScriptPubKey(asm)
+    CLTVScriptPubKey.isCLTVScriptPubKey(asm) || CSVScriptPubKey.isCSVScriptPubKey(asm)
   }
 }
 
@@ -407,32 +315,25 @@ object LockTimeScriptPubKey extends ScriptFactory[LockTimeScriptPubKey] {
 sealed trait CLTVScriptPubKey extends LockTimeScriptPubKey
 
 object CLTVScriptPubKey extends ScriptFactory[CLTVScriptPubKey] {
-  private case class CLTVScriptPubKeyImpl(bytes: ByteVector)
-      extends CLTVScriptPubKey {
+  private case class CLTVScriptPubKeyImpl(override val asm: Vector[ScriptToken]) extends CLTVScriptPubKey {
     override def toString = "CLTVScriptPubKeyImpl(" + hex + ")"
   }
 
   def fromAsm(asm: Seq[ScriptToken]): CLTVScriptPubKey = {
-    buildScript(asm,
-                CLTVScriptPubKeyImpl(_),
-                isCLTVScriptPubKey(_),
-                "Given asm was not a CLTVScriptPubKey, got: " + asm)
+    buildScript(asm.toVector, CLTVScriptPubKeyImpl(_), isCLTVScriptPubKey(_), "Given asm was not a CLTVScriptPubKey, got: " + asm)
   }
 
   def apply(asm: Seq[ScriptToken]): CLTVScriptPubKey = fromAsm(asm)
 
-  def apply(
-      locktime: ScriptNumber,
-      scriptPubKey: ScriptPubKey): CLTVScriptPubKey = {
+  def apply(locktime: ScriptNumber, scriptPubKey: ScriptPubKey): CLTVScriptPubKey = {
     val scriptOp = BitcoinScriptUtil.minimalScriptNumberRepresentation(locktime)
 
-    val scriptNum: Seq[ScriptToken] =
-      if (scriptOp.isInstanceOf[ScriptNumberOperation]) {
-        Seq(scriptOp)
-      } else {
-        val pushOpsLockTime = BitcoinScriptUtil.calculatePushOp(locktime.bytes)
-        pushOpsLockTime ++ Seq(ScriptConstant(locktime.bytes))
-      }
+    val scriptNum: Seq[ScriptToken] = if (scriptOp.isInstanceOf[ScriptNumberOperation]) {
+      Seq(scriptOp)
+    } else {
+      val pushOpsLockTime = BitcoinScriptUtil.calculatePushOp(locktime.bytes)
+      pushOpsLockTime ++ Seq(ScriptConstant(locktime.bytes))
+    }
 
     val cltvAsm = Seq(OP_CHECKLOCKTIMEVERIFY, OP_DROP)
     val scriptPubKeyAsm = scriptPubKey.asm
@@ -443,20 +344,15 @@ object CLTVScriptPubKey extends ScriptFactory[CLTVScriptPubKey] {
   def isCLTVScriptPubKey(asm: Seq[ScriptToken]): Boolean = {
     if (asm.head.isInstanceOf[BytesToPushOntoStack]) {
       val tailTokens = asm.slice(4, asm.length)
-      if (P2SHScriptPubKey.isP2SHScriptPubKey(tailTokens) || tailTokens
-            .contains(OP_CHECKLOCKTIMEVERIFY)) return false
+      if (P2SHScriptPubKey.isP2SHScriptPubKey(tailTokens) || tailTokens.contains(OP_CHECKLOCKTIMEVERIFY)) return false
       asm.slice(0, 4) match {
-        case Seq(_: BytesToPushOntoStack,
-                 _: ScriptConstant,
-                 OP_CHECKLOCKTIMEVERIFY,
-                 OP_DROP) =>
+        case Seq(_: BytesToPushOntoStack, _: ScriptConstant, OP_CHECKLOCKTIMEVERIFY, OP_DROP) =>
           validScriptAfterLockTime(tailTokens)
         case _ => false
       }
     } else {
       val tailTokens = asm.slice(3, asm.length)
-      if (P2SHScriptPubKey.isP2SHScriptPubKey(tailTokens) || tailTokens
-            .contains(OP_CHECKLOCKTIMEVERIFY)) return false
+      if (P2SHScriptPubKey.isP2SHScriptPubKey(tailTokens) || tailTokens.contains(OP_CHECKLOCKTIMEVERIFY)) return false
       asm.slice(0, 3) match {
         case Seq(_: ScriptNumberOperation, OP_CHECKLOCKTIMEVERIFY, OP_DROP) =>
           validScriptAfterLockTime(tailTokens)
@@ -468,7 +364,7 @@ object CLTVScriptPubKey extends ScriptFactory[CLTVScriptPubKey] {
   /**
     * We need this check because sometimes we can get very lucky in having a non valid
     * lock time script that has the first 4 bytes as a valid locktime script
-    * and then the bytes after the first 4 bytes gets lucky and is parsed by our [[ScriptParser]]
+    * and then the bytes after the first 4 bytes gets lucky and is parsed by our [[org.bitcoins.core.serializers.script.ScriptParser]]
     * A good way to see if this is _actually_ a valid script is by checking if we have any
     * [[UndefinedOP_NOP]] in the script, which means we definitely don't have a valid locktime script
     * See this example of what happened before we added this check:
@@ -489,34 +385,25 @@ object CLTVScriptPubKey extends ScriptFactory[CLTVScriptPubKey] {
 sealed trait CSVScriptPubKey extends LockTimeScriptPubKey
 
 object CSVScriptPubKey extends ScriptFactory[CSVScriptPubKey] {
-  private case class CSVScriptPubKeyImpl(bytes: ByteVector)
-      extends CSVScriptPubKey {
+  private case class CSVScriptPubKeyImpl(override val asm: Vector[ScriptToken]) extends CSVScriptPubKey {
     override def toString = "CSVScriptPubKeyImpl(" + hex + ")"
   }
 
   def fromAsm(asm: Seq[ScriptToken]): CSVScriptPubKey = {
-    buildScript(asm,
-                CSVScriptPubKeyImpl(_),
-                isCSVScriptPubKey(_),
-                "Given asm was not a CSVScriptPubKey, got: " + asm)
+    buildScript(asm.toVector, CSVScriptPubKeyImpl(_), isCSVScriptPubKey(_), "Given asm was not a CSVScriptPubKey, got: " + asm)
   }
 
   def apply(asm: Seq[ScriptToken]): CSVScriptPubKey = fromAsm(asm)
 
-  def apply(
-      relativeLockTime: ScriptNumber,
-      scriptPubKey: ScriptPubKey): CSVScriptPubKey = {
-    val scriptOp =
-      BitcoinScriptUtil.minimalScriptNumberRepresentation(relativeLockTime)
+  def apply(relativeLockTime: ScriptNumber, scriptPubKey: ScriptPubKey): CSVScriptPubKey = {
+    val scriptOp = BitcoinScriptUtil.minimalScriptNumberRepresentation(relativeLockTime)
 
-    val scriptNum: Seq[ScriptToken] =
-      if (scriptOp.isInstanceOf[ScriptNumberOperation]) {
-        Seq(scriptOp)
-      } else {
-        val pushOpsLockTime =
-          BitcoinScriptUtil.calculatePushOp(relativeLockTime.bytes)
-        pushOpsLockTime ++ Seq(ScriptConstant(relativeLockTime.bytes))
-      }
+    val scriptNum: Seq[ScriptToken] = if (scriptOp.isInstanceOf[ScriptNumberOperation]) {
+      Seq(scriptOp)
+    } else {
+      val pushOpsLockTime = BitcoinScriptUtil.calculatePushOp(relativeLockTime.bytes)
+      pushOpsLockTime ++ Seq(ScriptConstant(relativeLockTime.bytes))
+    }
 
     val csvAsm = Seq(OP_CHECKSEQUENCEVERIFY, OP_DROP)
     val scriptPubKeyAsm = scriptPubKey.asm
@@ -527,20 +414,15 @@ object CSVScriptPubKey extends ScriptFactory[CSVScriptPubKey] {
   def isCSVScriptPubKey(asm: Seq[ScriptToken]): Boolean = {
     if (asm.head.isInstanceOf[BytesToPushOntoStack]) {
       val tailTokens = asm.slice(4, asm.length)
-      if (P2SHScriptPubKey.isP2SHScriptPubKey(tailTokens) || tailTokens
-            .contains(OP_CHECKSEQUENCEVERIFY)) return false
+      if (P2SHScriptPubKey.isP2SHScriptPubKey(tailTokens) || tailTokens.contains(OP_CHECKSEQUENCEVERIFY)) return false
       asm.slice(0, 4) match {
-        case Seq(_: BytesToPushOntoStack,
-                 _: ScriptConstant,
-                 OP_CHECKSEQUENCEVERIFY,
-                 OP_DROP) =>
+        case Seq(_: BytesToPushOntoStack, _: ScriptConstant, OP_CHECKSEQUENCEVERIFY, OP_DROP) =>
           CLTVScriptPubKey.validScriptAfterLockTime(tailTokens)
         case _ => false
       }
     } else {
       val tailTokens = asm.slice(3, asm.length)
-      if (P2SHScriptPubKey.isP2SHScriptPubKey(tailTokens) || tailTokens
-            .contains(OP_CHECKSEQUENCEVERIFY)) return false
+      if (P2SHScriptPubKey.isP2SHScriptPubKey(tailTokens) || tailTokens.contains(OP_CHECKSEQUENCEVERIFY)) return false
       asm.slice(0, 3) match {
         case Seq(_: ScriptNumberOperation, OP_CHECKSEQUENCEVERIFY, OP_DROP) =>
           CLTVScriptPubKey.validScriptAfterLockTime(tailTokens)
@@ -554,16 +436,13 @@ object CSVScriptPubKey extends ScriptFactory[CSVScriptPubKey] {
 sealed trait NonStandardScriptPubKey extends ScriptPubKey
 
 object NonStandardScriptPubKey extends ScriptFactory[NonStandardScriptPubKey] {
-  private case class NonStandardScriptPubKeyImpl(bytes: ByteVector)
-      extends NonStandardScriptPubKey {
+  private case class NonStandardScriptPubKeyImpl(override val asm: Vector[ScriptToken]) extends NonStandardScriptPubKey {
     override def toString = "NonStandardScriptPubKeyImpl(" + hex + ")"
   }
 
   def fromAsm(asm: Seq[ScriptToken]): NonStandardScriptPubKey = {
     //everything can be a NonStandardScriptPubkey, thus the trivially true function
-    buildScript(asm, NonStandardScriptPubKeyImpl(_), { _ =>
-      true
-    }, "")
+    buildScript(asm.toVector, NonStandardScriptPubKeyImpl(_), { _ => true }, "")
   }
 
   def apply(asm: Seq[ScriptToken]): NonStandardScriptPubKey = fromAsm(asm)
@@ -571,7 +450,7 @@ object NonStandardScriptPubKey extends ScriptFactory[NonStandardScriptPubKey] {
 
 /** Represents the empty ScriptPubKey */
 case object EmptyScriptPubKey extends ScriptPubKey {
-  override def bytes = ByteVector.low(1)
+  override def asm: Seq[ScriptToken] = Vector.empty
 }
 
 /** Factory companion object used to create ScriptPubKey objects */
@@ -581,18 +460,14 @@ object ScriptPubKey extends ScriptFactory[ScriptPubKey] {
   /** Creates a scriptPubKey from its asm representation */
   def fromAsm(asm: Seq[ScriptToken]): ScriptPubKey = asm match {
     case Nil => EmptyScriptPubKey
-    case _ if P2PKHScriptPubKey.isP2PKHScriptPubKey(asm) =>
-      P2PKHScriptPubKey(asm)
+    case _ if P2PKHScriptPubKey.isP2PKHScriptPubKey(asm) => P2PKHScriptPubKey(asm)
     case _ if P2SHScriptPubKey.isP2SHScriptPubKey(asm) => P2SHScriptPubKey(asm)
     case _ if P2PKScriptPubKey.isP2PKScriptPubKey(asm) => P2PKScriptPubKey(asm)
-    case _ if MultiSignatureScriptPubKey.isMultiSignatureScriptPubKey(asm) =>
-      MultiSignatureScriptPubKey(asm)
+    case _ if MultiSignatureScriptPubKey.isMultiSignatureScriptPubKey(asm) => MultiSignatureScriptPubKey(asm)
     case _ if CLTVScriptPubKey.isCLTVScriptPubKey(asm) => CLTVScriptPubKey(asm)
-    case _ if CSVScriptPubKey.isCSVScriptPubKey(asm)   => CSVScriptPubKey(asm)
-    case _ if WitnessScriptPubKey.isWitnessScriptPubKey(asm) =>
-      WitnessScriptPubKey(asm).get
-    case _ if WitnessCommitment.isWitnessCommitment(asm) =>
-      WitnessCommitment(asm)
+    case _ if CSVScriptPubKey.isCSVScriptPubKey(asm) => CSVScriptPubKey(asm)
+    case _ if WitnessScriptPubKey.isWitnessScriptPubKey(asm) => WitnessScriptPubKey(asm).get
+    case _ if WitnessCommitment.isWitnessCommitment(asm) => WitnessCommitment(asm)
     case _ => NonStandardScriptPubKey(asm)
   }
 
@@ -606,37 +481,18 @@ sealed trait WitnessScriptPubKey extends ScriptPubKey {
 }
 
 object WitnessScriptPubKey {
-
   /** Witness scripts must begin with one of these operations, see BIP141 */
-  val validWitVersions: Seq[ScriptNumberOperation] = Seq(OP_0,
-                                                         OP_1,
-                                                         OP_2,
-                                                         OP_3,
-                                                         OP_4,
-                                                         OP_5,
-                                                         OP_6,
-                                                         OP_7,
-                                                         OP_8,
-                                                         OP_9,
-                                                         OP_10,
-                                                         OP_11,
-                                                         OP_12,
-                                                         OP_13,
-                                                         OP_14,
-                                                         OP_15,
-                                                         OP_16)
+  val validWitVersions: Seq[ScriptNumberOperation] = Seq(OP_0, OP_1, OP_2, OP_3, OP_4, OP_5, OP_6, OP_7, OP_8,
+    OP_9, OP_10, OP_11, OP_12, OP_13, OP_14, OP_15, OP_16)
 
   val unassignedWitVersions = validWitVersions.tail
 
   def apply(asm: Seq[ScriptToken]): Option[WitnessScriptPubKey] = fromAsm(asm)
 
   def fromAsm(asm: Seq[ScriptToken]): Option[WitnessScriptPubKey] = asm match {
-    case _ if P2WPKHWitnessSPKV0.isValid(asm) =>
-      Some(P2WPKHWitnessSPKV0.fromAsm(asm))
-    case _ if P2WSHWitnessSPKV0.isValid(asm) =>
-      Some(P2WSHWitnessSPKV0.fromAsm(asm))
-    case _ if WitnessScriptPubKey.isWitnessScriptPubKey(asm) =>
-      Some(UnassignedWitnessScriptPubKey(asm))
+    case _ if P2WPKHWitnessSPKV0.isValid(asm) => Some(P2WPKHWitnessSPKV0.fromAsm(asm))
+    case _ if P2WSHWitnessSPKV0.isValid(asm) => Some(P2WSHWitnessSPKV0.fromAsm(asm))
+    case _ if WitnessScriptPubKey.isWitnessScriptPubKey(asm) => Some(UnassignedWitnessScriptPubKey(asm))
     case _ => None
   }
 
@@ -656,8 +512,7 @@ object WitnessScriptPubKey {
 
     //we can also have a LockTimeScriptPubKey with a nested 0 public key multisig script, need to check that as well
     val bytes = BitcoinSUtil.toByteVector(asm)
-    val isMultiSig =
-      MultiSignatureScriptPubKey.isMultiSignatureScriptPubKey(asm)
+    val isMultiSig = MultiSignatureScriptPubKey.isMultiSignatureScriptPubKey(asm)
     val isLockTimeSPK = {
       LockTimeScriptPubKey.isValidLockTimeScriptPubKey(asm)
     }
@@ -686,8 +541,7 @@ object WitnessScriptPubKeyV0 {
     * [[https://github.com/bitcoin/bitcoin/blob/449f9b8debcceb61a92043bc7031528a53627c47/src/script/script.cpp#L215-L229]]
     */
   def isValid(asm: Seq[ScriptToken]): Boolean = {
-    WitnessScriptPubKey.isWitnessScriptPubKey(asm) && asm.headOption == Some(
-      OP_0)
+    WitnessScriptPubKey.isWitnessScriptPubKey(asm) && asm.headOption == Some(OP_0)
   }
 }
 
@@ -701,20 +555,16 @@ sealed abstract class P2WPKHWitnessSPKV0 extends WitnessScriptPubKeyV0 {
 }
 
 object P2WPKHWitnessSPKV0 extends ScriptFactory[P2WPKHWitnessSPKV0] {
-  private case class P2WPKHWitnessSPKV0Impl(bytes: ByteVector)
-      extends P2WPKHWitnessSPKV0
+  private case class P2WPKHWitnessSPKV0Impl(override val asm: Vector[ScriptToken]) extends P2WPKHWitnessSPKV0
 
   override def fromAsm(asm: Seq[ScriptToken]): P2WPKHWitnessSPKV0 = {
-    buildScript(asm,
-                P2WPKHWitnessSPKV0Impl(_),
-                isValid(_),
-                s"Given asm was not a P2WPKHWitnessSPKV0, got $asm")
+    buildScript(asm.toVector, P2WPKHWitnessSPKV0Impl(_), isValid(_), s"Given asm was not a P2WPKHWitnessSPKV0, got $asm")
   }
 
   def isValid(asm: Seq[ScriptToken]): Boolean = {
     val asmBytes = BitcoinSUtil.toByteVector(asm)
     WitnessScriptPubKeyV0.isValid(asm) &&
-    asmBytes.size == 22
+      asmBytes.size == 22
   }
 
   def fromHash(hash: Sha256Hash160Digest): P2WPKHWitnessSPKV0 = {
@@ -725,11 +575,10 @@ object P2WPKHWitnessSPKV0 extends ScriptFactory[P2WPKHWitnessSPKV0] {
   /** Creates a P2WPKH witness script pubkey */
   def apply(pubKey: ECPublicKey): P2WPKHWitnessSPKV0 = {
     //https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#restrictions-on-public-key-type
-    require(
-      pubKey.isCompressed,
-      s"Public key must be compressed to be used in a segwit script, see BIP143")
+    require(pubKey.isCompressed, s"Public key must be compressed to be used in a segwit script, see BIP143")
     val hash = CryptoUtil.sha256Hash160(pubKey.bytes)
-    fromHash(hash)
+    val pushop = BitcoinScriptUtil.calculatePushOp(hash.bytes)
+    fromAsm(Seq(OP_0) ++ pushop ++ Seq(ScriptConstant(hash.bytes)))
   }
 }
 
@@ -743,20 +592,16 @@ sealed abstract class P2WSHWitnessSPKV0 extends WitnessScriptPubKeyV0 {
 }
 
 object P2WSHWitnessSPKV0 extends ScriptFactory[P2WSHWitnessSPKV0] {
-  private case class P2WSHWitnessSPKV0Impl(bytes: ByteVector)
-      extends P2WSHWitnessSPKV0
+  private case class P2WSHWitnessSPKV0Impl(override val asm: Vector[ScriptToken]) extends P2WSHWitnessSPKV0
 
   override def fromAsm(asm: Seq[ScriptToken]): P2WSHWitnessSPKV0 = {
-    buildScript(asm,
-                P2WSHWitnessSPKV0Impl(_),
-                isValid(_),
-                s"Given asm was not a P2WSHWitnessSPKV0, got $asm")
+    buildScript(asm.toVector, P2WSHWitnessSPKV0Impl(_), isValid(_), s"Given asm was not a P2WSHWitnessSPKV0, got $asm")
   }
 
   def isValid(asm: Seq[ScriptToken]): Boolean = {
     val asmBytes = BitcoinSUtil.toByteVector(asm)
     WitnessScriptPubKeyV0.isValid(asm) &&
-    asmBytes.size == 34
+      asmBytes.size == 34
   }
 
   def fromHash(hash: Sha256Digest): P2WSHWitnessSPKV0 = {
@@ -765,11 +610,10 @@ object P2WSHWitnessSPKV0 extends ScriptFactory[P2WSHWitnessSPKV0] {
   }
 
   def apply(spk: ScriptPubKey): P2WSHWitnessSPKV0 = {
-    require(
-      BitcoinScriptUtil.isOnlyCompressedPubKey(spk),
-      s"Public key must be compressed to be used in a segwit script, see BIP143")
+    require(BitcoinScriptUtil.isOnlyCompressedPubKey(spk), s"Public key must be compressed to be used in a segwit script, see BIP143")
     val hash = CryptoUtil.sha256(spk.asmBytes)
-    fromHash(hash)
+    val pushop = BitcoinScriptUtil.calculatePushOp(hash.bytes)
+    fromAsm(Seq(OP_0) ++ pushop ++ Seq(ScriptConstant(hash.bytes)))
   }
 }
 
@@ -778,18 +622,14 @@ sealed trait UnassignedWitnessScriptPubKey extends WitnessScriptPubKey {
   override def witnessProgram: Seq[ScriptToken] = asm.tail.tail
 }
 
-object UnassignedWitnessScriptPubKey
-    extends ScriptFactory[UnassignedWitnessScriptPubKey] {
-  private case class UnassignedWitnessScriptPubKeyImpl(bytes: ByteVector)
-      extends UnassignedWitnessScriptPubKey {
+object UnassignedWitnessScriptPubKey extends ScriptFactory[UnassignedWitnessScriptPubKey] {
+  private case class UnassignedWitnessScriptPubKeyImpl(override val asm: Vector[ScriptToken]) extends UnassignedWitnessScriptPubKey {
     override def toString = "UnassignedWitnessScriptPubKeyImpl(" + hex + ")"
   }
 
   override def fromAsm(asm: Seq[ScriptToken]): UnassignedWitnessScriptPubKey = {
-    buildScript(asm,
-                UnassignedWitnessScriptPubKeyImpl(_),
-                WitnessScriptPubKey.isWitnessScriptPubKey(_),
-                "Given asm was not a valid witness script pubkey: " + asm)
+    buildScript(asm.toVector, UnassignedWitnessScriptPubKeyImpl(_), WitnessScriptPubKey.isWitnessScriptPubKey(_),
+      "Given asm was not a valid witness script pubkey: " + asm)
   }
   def apply(asm: Seq[ScriptToken]): UnassignedWitnessScriptPubKey = fromAsm(asm)
 }
@@ -802,15 +642,12 @@ object UnassignedWitnessScriptPubKey
   * [[https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#commitment-structure]]
   */
 sealed trait WitnessCommitment extends ScriptPubKey {
-
   /** The commitment to the [[WitnessTransaction]]s in the [[Block]] */
-  def witnessRootHash: DoubleSha256Digest =
-    DoubleSha256Digest(asm(2).bytes.splitAt(4)._2)
+  def witnessRootHash: DoubleSha256Digest = DoubleSha256Digest(asm(2).bytes.splitAt(4)._2)
 }
 
 object WitnessCommitment extends ScriptFactory[WitnessCommitment] {
-  private case class WitnessCommitmentImpl(bytes: ByteVector)
-      extends WitnessCommitment {
+  private case class WitnessCommitmentImpl(override val asm: Vector[ScriptToken]) extends WitnessCommitment {
     override def toString = "WitnessCommitmentImpl(" + hex + ")"
   }
 
@@ -820,19 +657,12 @@ object WitnessCommitment extends ScriptFactory[WitnessCommitment] {
   def apply(asm: Seq[ScriptToken]): WitnessCommitment = fromAsm(asm)
 
   override def fromAsm(asm: Seq[ScriptToken]): WitnessCommitment = {
-    buildScript(asm,
-                WitnessCommitmentImpl(_),
-                isWitnessCommitment(_),
-                "Given asm was not a valid witness commitment, got: " + asm)
+    buildScript(asm.toVector, WitnessCommitmentImpl(_), isWitnessCommitment(_), "Given asm was not a valid witness commitment, got: " + asm)
   }
 
   def apply(hash: DoubleSha256Digest): WitnessCommitment = {
-    WitnessCommitment(
-      Seq(OP_RETURN,
-          BytesToPushOntoStack(36),
-          ScriptConstant(commitmentHeader + hash.hex)))
+    WitnessCommitment(Seq(OP_RETURN, BytesToPushOntoStack(36), ScriptConstant(commitmentHeader + hash.hex)))
   }
-
   /**
     * This determines if the given asm has the correct witness structure according to BIP141
     * [[https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#commitment-structure]]
@@ -844,7 +674,7 @@ object WitnessCommitment extends ScriptFactory[WitnessCommitment] {
       val asmBytes = BitcoinSUtil.toByteVector(asm)
       val Seq(opReturn, pushOp, constant) = asm.take(3)
       opReturn == OP_RETURN && pushOp == BytesToPushOntoStack(36) &&
-      constant.hex.take(8) == commitmentHeader && asmBytes.size >= minCommitmentSize
+        constant.hex.take(8) == commitmentHeader && asmBytes.size >= minCommitmentSize
     }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParser.scala
@@ -1,12 +1,9 @@
 package org.bitcoins.core.serializers.script
 
-import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.script.{EmptyScriptPubKey, ScriptPubKey}
-import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.util.BitcoinScriptUtil
 import scodec.bits.ByteVector
-
-import scala.util.Try
 
 /**
   * Created by chris on 1/12/16.
@@ -16,19 +13,13 @@ trait RawScriptPubKeyParser extends RawBitcoinSerializer[ScriptPubKey] {
   override def read(bytes: ByteVector): ScriptPubKey = {
     if (bytes.isEmpty) EmptyScriptPubKey
     else {
-      val compactSizeUInt = CompactSizeUInt.parseCompactSizeUInt(bytes)
-      //TODO: Figure out a better way to do this, we can theoretically have numbers larger than Int.MaxValue,
-      //but scala collections don't allow you to use 'slice' with longs
-      val len = Try(compactSizeUInt.num.toInt).getOrElse(Int.MaxValue)
-      val scriptPubKeyBytes = bytes.slice(compactSizeUInt.size.toInt,
-                                          len + compactSizeUInt.size.toInt)
-      val script: List[ScriptToken] = ScriptParser.fromBytes(scriptPubKeyBytes)
-      ScriptPubKey.fromAsm(script)
+      BitcoinScriptUtil.parseScript(
+        bytes = bytes,
+        f = ScriptPubKey.fromAsm)
     }
   }
 
-  override def write(scriptPubKey: ScriptPubKey): ByteVector =
-    scriptPubKey.bytes
+  override def write(scriptPubKey: ScriptPubKey): ByteVector = scriptPubKey.bytes
 }
 
 object RawScriptPubKeyParser extends RawScriptPubKeyParser

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
@@ -1,28 +1,21 @@
 package org.bitcoins.core.serializers.script
 
-import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.util.BitcoinScriptUtil
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 1/12/16.
   */
-sealed abstract class RawScriptSignatureParser
-    extends RawBitcoinSerializer[ScriptSignature] {
+sealed abstract class RawScriptSignatureParser extends RawBitcoinSerializer[ScriptSignature] {
 
   def read(bytes: ByteVector): ScriptSignature = {
     if (bytes.isEmpty) EmptyScriptSignature
     else {
-      val compactSizeUInt = CompactSizeUInt.parseCompactSizeUInt(bytes)
-      //TODO: Figure out a better way to do this, we can theoretically have numbers larger than Int.MaxValue,
-      val scriptSigBytes = bytes.slice(
-        compactSizeUInt.size.toInt,
-        compactSizeUInt.num.toInt + compactSizeUInt.size.toInt)
-      val scriptTokens: List[ScriptToken] =
-        ScriptParser.fromBytes(scriptSigBytes)
-      ScriptSignature.fromAsm(scriptTokens)
+      BitcoinScriptUtil.parseScript(
+        bytes = bytes,
+        f = ScriptSignature.fromAsm)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -398,7 +398,7 @@ sealed abstract class MultiSigSigner extends BitcoinSigner {
                     case m: MultiSignatureScriptPubKey =>
                       Future.successful((m, lock))
                     case _: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-                        _: P2SHScriptPubKey | _: P2WPKHWitnessV0 |
+                        _: P2SHScriptPubKey | _: P2WPKHWitnessSPKV0 |
                         _: P2WSHWitnessSPKV0 | _: WitnessCommitment| _: CSVScriptPubKey |
                         _: CLTVScriptPubKey | _: NonStandardScriptPubKey |
                         _: UnassignedWitnessScriptPubKey |
@@ -407,7 +407,7 @@ sealed abstract class MultiSigSigner extends BitcoinSigner {
                   }
                 case m: MultiSignatureScriptPubKey => Future.successful((m, m))
                 case _: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-                    _: P2SHScriptPubKey | _: P2WPKHWitnessV0 |
+                    _: P2SHScriptPubKey | _: P2WPKHWitnessSPKV0 |
                     _: P2WSHWitnessSPKV0 | _: WitnessCommitment| _: NonStandardScriptPubKey |
                     _: P2WPKHWitnessSPKV0 | _: UnassignedWitnessScriptPubKey |
                     EmptyScriptPubKey =>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.2-SNAPSHOT"
+version in ThisBuild := "0.0.4-SNAPSHOT"


### PR DESCRIPTION
This PR does two things

1. Creates a `Script` trait that is extended by both `ScriptSignature` and `ScriptPubKey`
2. Changes the internal storage type of a Script from `ByteVector` -> `Vector[ScriptToken]`.

During parsing -- since we aim to type scripts in bitcoin-s -- we MUST deserialize the `ByteVector` representation of a Script to `Vector[ScriptToken]`. Previously we were discarding the parsed format after we correctly typed the Script. This is wasteful since parsing is expensive, so now we cache the `Vector[ScriptToken]` so we can use that for other things internally. 