### PR TITLE
2018 11 21 performance improvements

### DIFF
--- a/bench/src/main/scala/BlockBench.scala
+++ b/bench/src/main/scala/BlockBench.scala
@@ -28,6 +28,7 @@ object BlockBench extends App {
     require(time <= 15000)
   }
 
-  bench1()
+  0.until(10).foreach(_ => bench1())
+
   //bench2()
 }

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptOperationFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptOperationFactoryTest.scala
@@ -18,30 +18,29 @@ class ScriptOperationFactoryTest extends FlatSpec with MustMatchers {
 
   "ScriptOperationFactory" must "match operations with their byte representation" in {
 
-    ScriptOperation(0x00.toByte) must be(Some(OP_0))
-    ScriptOperation(0x51.toByte) must be(Some(OP_1))
+    ScriptOperation(0x00.toByte) must be(OP_0)
+    ScriptOperation(0x51.toByte) must be(OP_1)
 
-    ScriptOperation(0x63.toByte) must be(Some(OP_IF))
-    ScriptOperation(0x6b.toByte) must be(Some(OP_TOALTSTACK))
+    ScriptOperation(0x63.toByte) must be(OP_IF)
+    ScriptOperation(0x6b.toByte) must be(OP_TOALTSTACK)
 
-    ScriptOperation(135.toByte) must be(Some(OP_EQUAL))
+    ScriptOperation(135.toByte) must be(OP_EQUAL)
 
-    ScriptOperation(139.toByte) must be(Some(OP_1ADD))
+    ScriptOperation(139.toByte) must be(OP_1ADD)
 
-    ScriptOperation(166.toByte) must be(Some(OP_RIPEMD160))
-    ScriptOperation(177.toByte) must be(Some(OP_CHECKLOCKTIMEVERIFY))
+    ScriptOperation(166.toByte) must be(OP_RIPEMD160)
+    ScriptOperation(177.toByte) must be(OP_CHECKLOCKTIMEVERIFY)
 
   }
 
   it must "find OP_4 from it's byte representation" in {
     val byteRepresentation = BitcoinSUtil.decodeHex("54").head
-    ScriptOperation(byteRepresentation) must be(Some(OP_4))
+    ScriptOperation(byteRepresentation) must be(OP_4)
   }
 
   it must "find a byte to push onto stack from its byte representation" in {
     val result = ScriptOperation(2.toByte)
-    result.isDefined must be(true)
-    result.get must be(BytesToPushOntoStack(2))
+    result must be(BytesToPushOntoStack(2))
   }
 
   it must "find a script number from its hex representation" in {
@@ -62,6 +61,8 @@ class ScriptOperationFactoryTest extends FlatSpec with MustMatchers {
   }
 
   it must "find OP_1NEGATE from its hex representation" in {
+    OP_1NEGATE.opCode must be(79)
+    OP_1NEGATE.toByte must be(79)
     val negateOperation = ScriptOperation("4f")
     negateOperation.isDefined must be(true)
     negateOperation.get must be(OP_1NEGATE)

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantsTest.scala
@@ -36,6 +36,7 @@ class ConstantsTest extends FlatSpec with MustMatchers {
   it must "define an OP_1NEGATE" in {
     OP_1NEGATE.opCode must be(79)
     OP_1NEGATE.hex must be("4f")
+    OP_1NEGATE.underlying must be(-1)
 
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceOperationFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceOperationFactoryTest.scala
@@ -13,7 +13,7 @@ class SpliceOperationFactoryTest extends FlatSpec with MustMatchers {
   }
 
   it must "instantiate splice operations from their byte values" in {
-    SpliceOperation(126.toByte) must be(Some(OP_CAT))
-    SpliceOperation(127.toByte) must be(Some(OP_SUBSTR))
+    SpliceOperation(126.toByte) must be(OP_CAT)
+    SpliceOperation(127.toByte) must be(OP_SUBSTR)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/NetworkElement.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/NetworkElement.scala
@@ -14,7 +14,7 @@ abstract class NetworkElement {
   def size: Long = bytes.size
 
   /** The hexadecimal representation of the NetworkElement */
-  def hex: String = BitcoinSUtil.encodeHex(bytes)
+  def hex: String = bytes.toHex
 
   /** The byte representation of the NetworkElement */
   def bytes: ByteVector

--- a/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticOperations.scala
@@ -4,7 +4,7 @@ import org.bitcoins.core.script.ScriptOperationFactory
 import org.bitcoins.core.script.constant.ScriptOperation
 
 /** Created by chris on 1/6/16. */
-sealed trait ArithmeticOperation extends ScriptOperation
+sealed abstract class ArithmeticOperation extends ScriptOperation
 
 /** 1 is added to the input. */
 case object OP_1ADD extends ArithmeticOperation {
@@ -145,7 +145,7 @@ case object OP_RSHIFT extends ArithmeticOperation {
 }
 
 object ArithmeticOperation extends ScriptOperationFactory[ArithmeticOperation] {
-  override def operations = Seq(OP_0NOTEQUAL, OP_1ADD, OP_1SUB, OP_ABS, OP_ADD, OP_BOOLAND, OP_BOOLOR,
+  override val operations = Seq(OP_0NOTEQUAL, OP_1ADD, OP_1SUB, OP_ABS, OP_ADD, OP_BOOLAND, OP_BOOLOR,
     OP_GREATERTHAN, OP_GREATERTHANOREQUAL, OP_LESSTHAN, OP_LESSTHANOREQUAL, OP_MAX, OP_MIN, OP_NEGATE,
     OP_NEGATE, OP_NOT, OP_NUMEQUAL, OP_NUMEQUALVERIFY, OP_NUMNOTEQUAL, OP_SUB, OP_WITHIN,
     OP_2MUL, OP_2DIV, OP_MUL, OP_DIV, OP_MOD, OP_LSHIFT, OP_RSHIFT)

--- a/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticOperations.scala
@@ -8,140 +8,140 @@ sealed trait ArithmeticOperation extends ScriptOperation
 
 /** 1 is added to the input. */
 case object OP_1ADD extends ArithmeticOperation {
-  override def opCode = 139
+  override val opCode: Int = 139
 }
 
 /** 1 is subtracted from the input. */
 case object OP_1SUB extends ArithmeticOperation {
-  override def opCode = 140
+  override val opCode: Int = 140
 }
 
 /** The sign of the input is flipped. */
 case object OP_NEGATE extends ArithmeticOperation {
-  override def opCode = 143
+  override val opCode: Int = 143
 }
 
 /** The input is made positive. */
 case object OP_ABS extends ArithmeticOperation {
-  override def opCode = 144
+  override val opCode: Int = 144
 }
 
 /** If the input is 0 or 1, it is flipped. Otherwise the output will be 0. */
 
 case object OP_NOT extends ArithmeticOperation {
-  override def opCode = 145
+  override val opCode: Int = 145
 }
 
 /** Returns 0 if the input is 0. 1 otherwise. */
 case object OP_0NOTEQUAL extends ArithmeticOperation {
-  override def opCode = 146
+  override val opCode: Int = 146
 }
 
 /** a is added to b. */
 case object OP_ADD extends ArithmeticOperation {
-  override def opCode = 147
+  override val opCode: Int = 147
 }
 
 /** b is subtracted from a. */
 case object OP_SUB extends ArithmeticOperation {
-  override def opCode = 148
+  override val opCode: Int = 148
 }
 
 /** If both a and b are not 0, the output is 1. Otherwise 0. */
 case object OP_BOOLAND extends ArithmeticOperation {
-  override def opCode = 154
+  override val opCode: Int = 154
 }
 
 /** If a or b is not 0, the output is 1. Otherwise 0. */
 case object OP_BOOLOR extends ArithmeticOperation {
-  override def opCode = 155
+  override val opCode: Int = 155
 }
 
 /** Returns 1 if the numbers are equal, 0 otherwise. */
 case object OP_NUMEQUAL extends ArithmeticOperation {
-  override def opCode = 156
+  override val opCode: Int = 156
 }
 
 /** Same as OP_NUMEQUAL, but runs OP_VERIFY afterward. */
 case object OP_NUMEQUALVERIFY extends ArithmeticOperation {
-  override def opCode = 157
+  override val opCode: Int = 157
 }
 
 /** Returns 1 if the numbers are not equal, 0 otherwise. */
 case object OP_NUMNOTEQUAL extends ArithmeticOperation {
-  override def opCode = 158
+  override val opCode: Int = 158
 }
 
 /** Returns 1 if a is less than b, 0 otherwise. */
 case object OP_LESSTHAN extends ArithmeticOperation {
-  override def opCode = 159
+  override val opCode: Int = 159
 }
 
 /** Returns 1 if a is greater than b, 0 otherwise. */
 case object OP_GREATERTHAN extends ArithmeticOperation {
-  override def opCode = 160
+  override val opCode: Int = 160
 }
 
 /** Returns 1 if a is less than or equal to b, 0 otherwise. */
 case object OP_LESSTHANOREQUAL extends ArithmeticOperation {
-  override def opCode = 161
+  override val opCode: Int = 161
 }
 
 /** 	Returns 1 if a is greater than or equal to b, 0 otherwise. */
 case object OP_GREATERTHANOREQUAL extends ArithmeticOperation {
-  override def opCode = 162
+  override val opCode: Int = 162
 }
 
 /** Returns the smaller of a and b. */
 case object OP_MIN extends ArithmeticOperation {
-  override def opCode = 163
+  override val opCode: Int = 163
 }
 
 /** Returns the larger of a and b. */
 case object OP_MAX extends ArithmeticOperation {
-  override def opCode = 164
+  override val opCode: Int = 164
 }
 
 /** Returns 1 if x is within the specified range (left-inclusive), 0 otherwise. */
 case object OP_WITHIN extends ArithmeticOperation {
-  override def opCode = 165
+  override val opCode: Int = 165
 }
 
 //currently disabled operations
 
 /** The input is multiplied by 2. disabled. */
 case object OP_2MUL extends ArithmeticOperation {
-  override def opCode = 141
+  override val opCode: Int = 141
 }
 
 /** The input is divided by 2. disabled. */
 case object OP_2DIV extends ArithmeticOperation {
-  override def opCode = 142
+  override val opCode: Int = 142
 }
 
 /** a is multiplied by b. disabled. */
 case object OP_MUL extends ArithmeticOperation {
-  override def opCode = 149
+  override val opCode: Int = 149
 }
 
 /** a is divided by b. disabled. */
 case object OP_DIV extends ArithmeticOperation {
-  override def opCode = 150
+  override val opCode: Int = 150
 }
 
 /** Returns the remainder after dividing a by b. disabled. */
 case object OP_MOD extends ArithmeticOperation {
-  override def opCode = 151
+  override val opCode: Int = 151
 }
 
 /** Shifts a left b bits, preserving sign. disabled. */
 case object OP_LSHIFT extends ArithmeticOperation {
-  override def opCode = 152
+  override val opCode: Int = 152
 }
 
 /** Shifts a right b bits, preserving sign. disabled. */
 case object OP_RSHIFT extends ArithmeticOperation {
-  override def opCode = 153
+  override val opCode: Int = 153
 }
 
 object ArithmeticOperation extends ScriptOperationFactory[ArithmeticOperation] {

--- a/core/src/main/scala/org/bitcoins/core/script/bitwise/BitwiseOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/bitwise/BitwiseOperations.scala
@@ -10,32 +10,32 @@ sealed trait BitwiseOperation extends ScriptOperation
 
 /** Returns 1 if the inputs are exactly equal, 0 otherwise. */
 case object OP_EQUAL extends BitwiseOperation {
-  override def opCode = 135
+  override val opCode: Int = 135
 }
 
 /** Same as [[OP_EQUAL]], but runs [[org.bitcoins.core.script.control.OP_VERIFY]] afterward. */
 case object OP_EQUALVERIFY extends BitwiseOperation {
-  override def opCode = 136
+  override val opCode: Int = 136
 }
 
 /** Flips all of the bits in the input. disabled. */
 case object OP_INVERT extends BitwiseOperation {
-  override def opCode = 131
+  override val opCode: Int = 131
 }
 
 /** Boolean and between each bit in the inputs. disabled. */
 case object OP_AND extends BitwiseOperation {
-  override def opCode = 132
+  override val opCode: Int = 132
 }
 
 /** Boolean or between each bit in the inputs. disabled. */
 case object OP_OR extends BitwiseOperation {
-  override def opCode = 133
+  override val opCode: Int = 133
 }
 
 /** Boolean exclusive or between each bit in the inputs. disabled. */
 case object OP_XOR extends BitwiseOperation {
-  override def opCode = 134
+  override val opCode: Int = 134
 }
 
 object BitwiseOperation extends ScriptOperationFactory[BitwiseOperation] {

--- a/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
@@ -19,7 +19,7 @@ object BytesToPushOntoStack extends ScriptOperationFactory[BytesToPushOntoStack]
     /*  //see the 'Constants; section in https://en.bitcoin.it/wiki/Script
       require(num >= -1 && num <= 75, "A valid script number is between 1 and 75, the number passed in was: " + num)*/
     require(num >= 0, "BytesToPushOntoStackImpl cannot be negative")
-    override def opCode = num
+    override val opCode = num
   }
 
   override def operations: Seq[BytesToPushOntoStack] =

--- a/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
@@ -21,7 +21,7 @@ sealed trait ScriptToken extends NetworkElement {
   def bytes: ByteVector
 
   /** The conversion from the byte representation of a [[ScriptToken]] to a number. */
-  def toLong = ScriptNumberUtil.toLong(hex)
+  def toLong: Long = ScriptNumberUtil.toLong(bytes)
 }
 
 /**
@@ -31,7 +31,9 @@ sealed trait ScriptToken extends NetworkElement {
 trait ScriptOperation extends ScriptToken {
   def opCode: Int
 
-  def bytes: ByteVector = ByteVector.fromByte(opCode.toByte)
+  override def bytes: ByteVector = ByteVector.fromByte(toByte)
+
+  def toByte: Byte = opCode.toByte
 }
 
 /** A constant in the Script language for instance as String or a number. */
@@ -88,7 +90,7 @@ sealed abstract class ScriptNumber extends ScriptConstant {
   override def toLong = underlying
 
   /** The underlying number of the [[ScriptNumber]]. */
-  protected def underlying: Long
+  protected val underlying: Long
 }
 
 object ScriptNumber extends Factory[ScriptNumber] {
@@ -146,7 +148,7 @@ object ScriptNumber extends Factory[ScriptNumber] {
 
 /** The next byte contains the number of bytes to be pushed onto the stack. */
 case object OP_PUSHDATA1 extends ScriptOperation {
-  override def opCode = 76
+  override val opCode: Int = 76
 
   /** The maximum amount of bytes OP_PUSHDATA1 can push onto the stack. */
   def max = 255
@@ -154,7 +156,7 @@ case object OP_PUSHDATA1 extends ScriptOperation {
 
 /** The next two bytes contain the number of bytes to be pushed onto the stack. */
 case object OP_PUSHDATA2 extends ScriptOperation {
-  override def opCode = 77
+  override val opCode: Int = 77
 
   /** The max amount of data that OP_PUSHDATA2 can push onto the stack. */
   def max = 65535
@@ -162,7 +164,7 @@ case object OP_PUSHDATA2 extends ScriptOperation {
 
 /** The next four bytes contain the number of bytes to be pushed onto the stack. */
 case object OP_PUSHDATA4 extends ScriptOperation {
-  override def opCode = 78
+  override val opCode: Int = 78
 
   /** The maximum amount of data that OP_PUSHDATA4 can be push on the stack. */
   def max = 4294967295L
@@ -178,148 +180,148 @@ sealed abstract class ScriptNumberOperation extends ScriptNumber with ScriptOper
 
 /** An empty array of bytes is pushed onto the stack. (This is not a no-op: an item is added to the stack.) */
 case object OP_0 extends ScriptNumberOperation {
-  override def opCode = 0
+  override val opCode: Int = 0
 
-  override def hex = "00"
+  override val hex: String = "00"
 
-  override def underlying = 0
+  override val underlying: Long = 0
 }
 
 /** An empty array of bytes is pushed onto the stack. (This is not a no-op: an item is added to the stack.) */
 case object OP_FALSE extends ScriptNumberOperation {
-  override def opCode = OP_0.opCode
+  override val opCode = OP_0.opCode
 
-  override def hex = OP_0.hex
+  override val hex = OP_0.hex
 
-  override def underlying = OP_0.underlying
+  override val underlying = OP_0.underlying
 
-  override def bytes = OP_0.bytes
+  override val bytes = OP_0.bytes
 }
 
 /** The number 1 is pushed onto the stack. */
 case object OP_TRUE extends ScriptNumberOperation {
-  override def opCode = 81
+  override val opCode = 81
 
-  override def underlying = 1
+  override val underlying: Long = 1
 }
 
 /** The number -1 is pushed onto the stack. */
 case object OP_1NEGATE extends ScriptNumberOperation {
-  override def opCode = 79
+  override val opCode: Int = 79
 
-  override def underlying = -1
+  override val underlying: Long = -1
 }
 
 /** The number 1 is pushed onto the stack. */
 case object OP_1 extends ScriptNumberOperation {
-  override def opCode = OP_TRUE.opCode
+  override val opCode: Int = OP_TRUE.opCode
 
-  override def underlying = OP_TRUE.underlying
+  override val underlying: Long = OP_TRUE.underlying
 }
 
 /** The number 2 is pushed onto the stack. */
 case object OP_2 extends ScriptNumberOperation {
-  override def opCode = 82
+  override val opCode: Int = 82
 
-  override def underlying = 2
+  override val underlying: Long = 2
 }
 
 /** The number 3 is pushed onto the stack. */
 case object OP_3 extends ScriptNumberOperation {
-  override def opCode = 83
+  override val opCode: Int = 83
 
-  override def underlying = 3
+  override val underlying: Long = 3
 }
 
 /** The number 4 is pushed onto the stack. */
 case object OP_4 extends ScriptNumberOperation {
-  override def opCode = 84
+  override val opCode: Int = 84
 
-  override def underlying = 4
+  override val underlying: Long = 4
 }
 
 /** The number 5 is pushed onto the stack. */
 case object OP_5 extends ScriptNumberOperation {
-  override def opCode = 85
+  override val opCode: Int = 85
 
-  override def underlying = 5
+  override val underlying: Long = 5
 }
 
 /** The number 6 is pushed onto the stack. */
 case object OP_6 extends ScriptNumberOperation {
-  override def opCode = 86
+  override val opCode: Int = 86
 
-  override def underlying = 6
+  override val underlying: Long = 6
 }
 
 /** The number 7 is pushed onto the stack. */
 case object OP_7 extends ScriptNumberOperation {
-  override def opCode = 87
+  override val opCode: Int = 87
 
-  override def underlying = 7
+  override val underlying: Long = 7
 }
 
 /** The number 8 is pushed onto the stack. */
 case object OP_8 extends ScriptNumberOperation {
-  override def opCode = 88
+  override val opCode: Int = 88
 
-  override def underlying = 8
+  override val underlying: Long = 8
 }
 
 /** The number 9 is pushed onto the stack. */
 case object OP_9 extends ScriptNumberOperation {
-  override def opCode = 89
+  override val opCode: Int = 89
 
-  override def underlying = 9
+  override val underlying: Long = 9
 }
 
 /** The number 10 is pushed onto the stack. */
 case object OP_10 extends ScriptNumberOperation {
-  override def opCode = 90
+  override val opCode: Int = 90
 
-  override def underlying = 10
+  override val underlying: Long = 10
 }
 
 /** The number 11 is pushed onto the stack. */
 case object OP_11 extends ScriptNumberOperation {
-  override def opCode = 91
+  override val opCode: Int = 91
 
-  override def underlying = 11
+  override val underlying: Long = 11
 }
 
 /** The number 12 is pushed onto the stack. */
 case object OP_12 extends ScriptNumberOperation {
-  override def opCode = 92
+  override val opCode: Int = 92
 
-  override def underlying = 12
+  override val underlying: Long = 12
 }
 
 /** The number 13 is pushed onto the stack. */
 case object OP_13 extends ScriptNumberOperation {
-  override def opCode = 93
+  override val opCode: Int = 93
 
-  override def underlying = 13
+  override val underlying: Long = 13
 }
 
 /** The number 14 is pushed onto the stack. */
 case object OP_14 extends ScriptNumberOperation {
-  override def opCode = 94
+  override val opCode: Int = 94
 
-  override def underlying = 14
+  override val underlying: Long = 14
 }
 
 /** The number 15 is pushed onto the stack. */
 case object OP_15 extends ScriptNumberOperation {
-  override def opCode = 95
+  override val opCode: Int = 95
 
-  override def underlying = 15
+  override val underlying: Long = 15
 }
 
 /** The number 16 is pushed onto the stack. */
 case object OP_16 extends ScriptNumberOperation {
-  override def opCode = 96
+  override val opCode: Int = 96
 
-  override def underlying = 16
+  override val underlying: Long = 16
 }
 
 object ScriptNumberOperation extends ScriptOperationFactory[ScriptNumberOperation] {
@@ -327,7 +329,7 @@ object ScriptNumberOperation extends ScriptOperationFactory[ScriptNumberOperatio
   /** Finds the [[ScriptNumberOperation]] based on the given integer. */
   def fromNumber(underlying: Long): Option[ScriptNumberOperation] = operations.find(_.underlying == underlying)
 
-  def operations = Seq(OP_0, OP_1, OP_1NEGATE, OP_2, OP_3, OP_4, OP_5, OP_6, OP_7, OP_8, OP_9, OP_10, OP_11, OP_12, OP_13, OP_14, OP_15, OP_16)
+  val operations = Seq(OP_0, OP_1, OP_1NEGATE, OP_2, OP_3, OP_4, OP_5, OP_6, OP_7, OP_8, OP_9, OP_10, OP_11, OP_12, OP_13, OP_14, OP_15, OP_16)
 
 }
 

--- a/core/src/main/scala/org/bitcoins/core/script/control/ControlOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/control/ControlOperations.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.script.constant.ScriptOperation
 /**
  * Created by chris on 1/6/16.
  */
-sealed trait ControlOperations extends ScriptOperation
+sealed abstract class ControlOperations extends ScriptOperation
 
 /** If the top stack value is not 0, the statements are executed. The top stack value is removed. */
 case object OP_IF extends ControlOperations {
@@ -52,5 +52,5 @@ case object OP_RETURN extends ControlOperations {
 }
 
 object ControlOperations extends ScriptOperationFactory[ControlOperations] {
-  override def operations = Seq(OP_ELSE, OP_ENDIF, OP_IF, OP_NOTIF, OP_RETURN, OP_VERIFY)
+  override val operations = Seq(OP_ELSE, OP_ENDIF, OP_IF, OP_NOTIF, OP_RETURN, OP_VERIFY)
 }

--- a/core/src/main/scala/org/bitcoins/core/script/control/ControlOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/control/ControlOperations.scala
@@ -10,12 +10,12 @@ sealed trait ControlOperations extends ScriptOperation
 
 /** If the top stack value is not 0, the statements are executed. The top stack value is removed. */
 case object OP_IF extends ControlOperations {
-  override def opCode = 99
+  override val opCode: Int = 99
 }
 
 /** If the top stack value is 0, the statements are executed. The top stack value is removed. */
 case object OP_NOTIF extends ControlOperations {
-  override def opCode = 100
+  override val opCode: Int = 100
 }
 
 /**
@@ -23,7 +23,7 @@ case object OP_NOTIF extends ControlOperations {
  * if the preceding OP_IF or OP_NOTIF or OP_ELSE was executed then these statements are not.
  */
 case object OP_ELSE extends ControlOperations {
-  override def opCode = 103
+  override val opCode: Int = 103
 }
 
 /**
@@ -31,12 +31,12 @@ case object OP_ELSE extends ControlOperations {
  * An OP_ENDIF without OP_IF earlier is also invalid.
  */
 case object OP_ENDIF extends ControlOperations {
-  override def opCode = 104
+  override val opCode: Int = 104
 }
 
 /** Marks transaction as invalid if top stack value is not true. */
 case object OP_VERIFY extends ControlOperations {
-  override def opCode = 105
+  override val opCode: Int = 105
 }
 
 /**
@@ -48,7 +48,7 @@ case object OP_VERIFY extends ControlOperations {
  * with more than one pushdata op.
  */
 case object OP_RETURN extends ControlOperations {
-  override def opCode = 106
+  override val opCode: Int = 106
 }
 
 object ControlOperations extends ScriptOperationFactory[ControlOperations] {

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoOperations.scala
@@ -14,27 +14,27 @@ sealed trait CryptoSignatureEvaluation extends CryptoOperation
 
 /** The input is hashed using RIPEMD-160. */
 case object OP_RIPEMD160 extends CryptoOperation {
-  override def opCode = 166
+  override val opCode: Int = 166
 }
 
 /** The input is hashed using SHA-1. */
 case object OP_SHA1 extends CryptoOperation {
-  override def opCode = 167
+  override val opCode: Int = 167
 }
 
 /** The input is hashed using SHA-256. */
 case object OP_SHA256 extends CryptoOperation {
-  override def opCode = 168
+  override val opCode: Int = 168
 }
 
 /** The input is hashed twice: first with SHA-256 and then with RIPEMD-160. */
 case object OP_HASH160 extends CryptoOperation {
-  override def opCode = 169
+  override val opCode: Int = 169
 }
 
 /** The input is hashed two times with SHA-256. */
 case object OP_HASH256 extends CryptoOperation {
-  override def opCode = 170
+  override val opCode: Int = 170
 }
 
 /**
@@ -42,7 +42,7 @@ case object OP_HASH256 extends CryptoOperation {
  * the data after the most recently-executed OP_CODESEPARATOR.
  */
 case object OP_CODESEPARATOR extends CryptoOperation {
-  override def opCode = 171
+  override val opCode: Int = 171
 }
 
 /**
@@ -52,12 +52,12 @@ case object OP_CODESEPARATOR extends CryptoOperation {
  * If it is, 1 is returned, 0 otherwise.
  */
 case object OP_CHECKSIG extends CryptoSignatureEvaluation {
-  override def opCode = 172
+  override val opCode: Int = 172
 }
 
 /** Same as OP_CHECKSIG, but OP_VERIFY is executed afterward. */
 case object OP_CHECKSIGVERIFY extends CryptoSignatureEvaluation {
-  override def opCode = 173
+  override val opCode: Int = 173
 }
 
 /**
@@ -72,12 +72,12 @@ case object OP_CHECKSIGVERIFY extends CryptoSignatureEvaluation {
  * Due to a bug, one extra unused value is removed from the stack.
  */
 case object OP_CHECKMULTISIG extends CryptoSignatureEvaluation {
-  override def opCode = 174
+  override val opCode: Int = 174
 }
 
 /** Same as OP_CHECKMULTISIG, but OP_VERIFY is executed afterward. */
 case object OP_CHECKMULTISIGVERIFY extends CryptoSignatureEvaluation {
-  override def opCode = 175
+  override val opCode: Int = 175
 }
 
 object CryptoOperation extends ScriptOperationFactory[CryptoOperation] {

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LocktimeOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LocktimeOperations.scala
@@ -18,7 +18,7 @@ sealed trait LocktimeOperation extends ScriptOperation
  * The precise semantics are described in BIP 0065
  */
 case object OP_CHECKLOCKTIMEVERIFY extends LocktimeOperation {
-  override def opCode = 177
+  override val opCode: Int = 177
 }
 
 /**
@@ -35,7 +35,7 @@ case object OP_CHECKLOCKTIMEVERIFY extends LocktimeOperation {
  * https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki
  */
 case object OP_CHECKSEQUENCEVERIFY extends LocktimeOperation {
-  override def opCode = 178
+  override val opCode: Int = 178
 }
 
 object LocktimeOperation extends ScriptOperationFactory[LocktimeOperation] {

--- a/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala
@@ -18,42 +18,42 @@ sealed trait ReservedOperation extends ScriptOperation
  * Transaction is invalid unless occuring in an unexecuted OP_IF branch
  */
 case object OP_RESERVED extends ReservedOperation {
-  override def opCode = 80
+  override val opCode: Int = 80
 }
 
 /**
  * Transaction is invalid unless occuring in an unexecuted OP_IF branch
  */
 case object OP_VER extends ReservedOperation {
-  override def opCode = 98
+  override val opCode: Int = 98
 }
 
 /**
  * Transaction is invalid even when occuring in an unexecuted OP_IF branch
  */
 case object OP_VERIF extends ReservedOperation {
-  override def opCode = 101
+  override val opCode: Int = 101
 }
 
 /**
  * 	Transaction is invalid even when occuring in an unexecuted OP_IF branch
  */
 case object OP_VERNOTIF extends ReservedOperation {
-  override def opCode = 102
+  override val opCode: Int = 102
 }
 
 /**
  * Transaction is invalid unless occuring in an unexecuted OP_IF branch
  */
 case object OP_RESERVED1 extends ReservedOperation {
-  override def opCode = 137
+  override val opCode: Int = 137
 }
 
 /**
  * Transaction is invalid unless occuring in an unexecuted OP_IF branch
  */
 case object OP_RESERVED2 extends ReservedOperation {
-  override def opCode = 138
+  override val opCode: Int = 138
 }
 
 /**
@@ -63,33 +63,33 @@ case object OP_RESERVED2 extends ReservedOperation {
 sealed trait NOP extends ReservedOperation
 
 case object OP_NOP extends NOP {
-  override def opCode = 97
+  override val opCode: Int = 97
 }
 
 case object OP_NOP1 extends NOP {
-  override def opCode = 176
+  override val opCode: Int = 176
 }
 
 case object OP_NOP4 extends NOP {
-  override def opCode = 179
+  override val opCode: Int = 179
 }
 case object OP_NOP5 extends NOP {
-  override def opCode = 180
+  override val opCode: Int = 180
 }
 case object OP_NOP6 extends NOP {
-  override def opCode = 181
+  override val opCode: Int = 181
 }
 case object OP_NOP7 extends NOP {
-  override def opCode = 182
+  override val opCode: Int = 182
 }
 case object OP_NOP8 extends NOP {
-  override def opCode = 183
+  override val opCode: Int = 183
 }
 case object OP_NOP9 extends NOP {
-  override def opCode = 184
+  override val opCode: Int = 184
 }
 case object OP_NOP10 extends NOP {
-  override def opCode = 185
+  override val opCode: Int = 185
 }
 
 case class UndefinedOP_NOP(opCode: Int) extends ReservedOperation

--- a/core/src/main/scala/org/bitcoins/core/script/splice/SpliceOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/splice/SpliceOperations.scala
@@ -9,23 +9,23 @@ import org.bitcoins.core.script.constant.ScriptOperation
 sealed trait SpliceOperation extends ScriptOperation
 
 case object OP_CAT extends SpliceOperation {
-  override def opCode = 126
+  override val opCode: Int = 126
 }
 
 case object OP_SUBSTR extends SpliceOperation {
-  override def opCode = 127
+  override val opCode: Int = 127
 }
 
 case object OP_LEFT extends SpliceOperation {
-  override def opCode = 128
+  override val opCode: Int = 128
 }
 
 case object OP_RIGHT extends SpliceOperation {
-  override def opCode = 129
+  override val opCode: Int = 129
 }
 
 case object OP_SIZE extends SpliceOperation {
-  override def opCode = 130
+  override val opCode: Int = 130
 }
 
 object SpliceOperation extends ScriptOperationFactory[SpliceOperation] {

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackOperations.scala
@@ -12,133 +12,133 @@ sealed trait StackOperation extends ScriptOperation
  * Puts the input onto the top of the alt stack. Removes it from the main stack.
  */
 case object OP_TOALTSTACK extends StackOperation {
-  override def opCode = 107
+  override val opCode: Int = 107
 }
 
 /**
  * Puts the input onto the top of the main stack. Removes it from the alt stack.
  */
 case object OP_FROMALTSTACK extends StackOperation {
-  override def opCode = 108
+  override val opCode: Int = 108
 }
 
 /**
  * If the top stack value is not 0, duplicate it.
  */
 case object OP_IFDUP extends StackOperation {
-  override def opCode = 115
+  override val opCode: Int = 115
 }
 
 /**
  * Puts the number of stack items onto the stack.
  */
 case object OP_DEPTH extends StackOperation {
-  override def opCode = 116
+  override val opCode: Int = 116
 }
 
 /**
  * Removes the top stack item
  */
 case object OP_DROP extends StackOperation {
-  override def opCode = 117
+  override val opCode: Int = 117
 }
 
 /**
  * 	Duplicates the top stack item.
  */
 case object OP_DUP extends StackOperation {
-  override def opCode = 118
+  override val opCode: Int = 118
 }
 
 /**
  * Removes the second-to-top stack item.
  */
 case object OP_NIP extends StackOperation {
-  override def opCode = 119
+  override val opCode: Int = 119
 }
 
 /**
  * 	Copies the second-to-top stack item to the top.
  */
 case object OP_OVER extends StackOperation {
-  override def opCode = 120
+  override val opCode: Int = 120
 }
 
 /**
  * The item n back in the stack is copied to the top.
  */
 case object OP_PICK extends StackOperation {
-  override def opCode = 121
+  override val opCode: Int = 121
 }
 
 /**
  * The item n back in the stack is moved to the top.
  */
 case object OP_ROLL extends StackOperation {
-  override def opCode = 122
+  override val opCode: Int = 122
 }
 
 /**
  * The top three items on the stack are rotated to the left.
  */
 case object OP_ROT extends StackOperation {
-  override def opCode = 123
+  override val opCode: Int = 123
 }
 
 /**
  * 	The top two items on the stack are swapped.
  */
 case object OP_SWAP extends StackOperation {
-  override def opCode = 124
+  override val opCode: Int = 124
 }
 
 /**
  * The item at the top of the stack is copied and inserted before the second-to-top item.
  */
 case object OP_TUCK extends StackOperation {
-  override def opCode = 125
+  override val opCode: Int = 125
 }
 
 /**
  * 	Removes the top two stack items.
  */
 case object OP_2DROP extends StackOperation {
-  override def opCode = 109
+  override val opCode: Int = 109
 }
 
 /**
  * Duplicates the top two stack items
  */
 case object OP_2DUP extends StackOperation {
-  override def opCode = 110
+  override val opCode: Int = 110
 }
 
 /**
  * Duplicates the top 3 stack items
  */
 case object OP_3DUP extends StackOperation {
-  override def opCode = 111
+  override val opCode: Int = 111
 }
 
 /**
  * Copies the pair of items two spaces back in the stack to the front.
  */
 case object OP_2OVER extends StackOperation {
-  override def opCode = 112
+  override val opCode: Int = 112
 }
 
 /**
  * The fifth and sixth items back are moved to the top of the stack.
  */
 case object OP_2ROT extends StackOperation {
-  override def opCode = 113
+  override val opCode: Int = 113
 }
 
 /**
  * 	Swaps the top two pairs of items.
  */
 case object OP_2SWAP extends StackOperation {
-  override def opCode = 114
+  override val opCode: Int = 114
 }
 
 object StackOperation extends ScriptOperationFactory[StackOperation] {

--- a/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
@@ -45,8 +45,11 @@ sealed abstract class RawSerializerHelper {
 
   /** Writes a Seq[TransactionInput]/Seq[TransactionOutput]/Seq[Transaction] -> ByteVector */
   def writeCmpctSizeUInt[T](ts: Seq[T], serializer: T => ByteVector): ByteVector = {
-    val serializedSeq: Seq[ByteVector] = ts.map(serializer(_))
-    val serialized = serializedSeq.foldLeft(ByteVector.empty)(_ ++ _)
+    val serialized = ts.foldLeft(ByteVector.empty) {
+      case (accum, t) =>
+        val ser = serializer(t)
+        accum ++ ser
+    }
     val cmpct = CompactSizeUInt(UInt64(ts.size))
     cmpct.bytes ++ serialized
   }

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -131,7 +131,7 @@ sealed abstract class ScriptParser extends Factory[List[ScriptToken]] {
     def loop(bytes: ByteVector, accum: List[ScriptToken]): List[ScriptToken] = {
       //logger.debug("Byte to be parsed: " + bytes.headOption)
       if (bytes.nonEmpty) {
-        val op = ScriptOperation(bytes.head).get
+        val op = ScriptOperation.fromByte(bytes.head)
         val parsingHelper: ParsingHelper = parseOperationByte(op, accum, bytes.tail)
         loop(parsingHelper.tail, parsingHelper.accum)
       } else {


### PR DESCRIPTION
This seems to improve performance by roughly 2x with rudimentary bench markets 

```
2018-11-21 16:28:52.323 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 1593ms
2018-11-21 16:28:53.052 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 712ms
2018-11-21 16:28:53.729 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 648ms
2018-11-21 16:28:54.072 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 328ms
2018-11-21 16:28:54.459 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 372ms
2018-11-21 16:28:54.793 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 320ms
2018-11-21 16:28:55.200 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 394ms
2018-11-21 16:28:55.528 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 315ms
2018-11-21 16:28:56.002 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 460ms
2018-11-21 16:28:56.407 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 388ms

Flat profile of 5.97 secs (533 total ticks): main

  Interpreted + native   Method                        
  0.9%     4  +     1    java.lang.ClassLoader.defineClass1
  0.6%     3  +     0    java.lang.Integer.toString
  0.6%     3  +     0    org.bitcoins.core.util.BitcoinScriptUtil$class.castToBool
  0.6%     3  +     0    java.math.BigInteger.toByteArray
  0.4%     0  +     2    java.util.zip.ZipFile.getEntryTime
  0.4%     0  +     2    org.bitcoin.NativeSecp256k1.secp256k1_ec_pubkey_decompress
  0.4%     2  +     0    org.bitcoins.core.script.reserved.UndefinedOP_NOP.bytes
  0.4%     2  +     0    org.bitcoins.core.script.constant.StackPushOperationFactory$class.operations
  0.2%     0  +     1    java.lang.Class.isInterface
  0.2%     0  +     1    org.bitcoin.Secp256k1Context.secp256k1_init_context
  0.2%     1  +     0    java.util.zip.Inflater.reset
  0.2%     0  +     1    java.security.AccessController.doPrivileged
  0.2%     1  +     0    org.bitcoins.core.protocol.script.ScriptPubKey$.fromAsm
  0.2%     1  +     0    org.bitcoins.core.number.Int64$$anonfun$fromBytes$4.<init>
  0.2%     1  +     0    org.bitcoins.core.script.stack.OP_3DUP$.bytes
  0.2%     1  +     0    org.bitcoins.core.script.stack.OP_2ROT$.bytes
  0.2%     1  +     0    org.bitcoins.core.script.stack.OP_SWAP$.bytes
  0.2%     1  +     0    org.bitcoins.core.script.stack.OP_TUCK$.bytes
  0.2%     1  +     0    ch.qos.logback.core.subst.Parser.makeNewLiteralNode
  0.2%     1  +     0    org.bitcoins.core.crypto.ECPublicKey$.fromBytes
  0.2%     1  +     0    org.bitcoins.core.protocol.script.P2PKHScriptSignature$$anonfun$fromAsm$4.apply
  0.2%     1  +     0    org.bitcoins.core.crypto.DoubleSha256Digest$.fromBytes
  0.2%     1  +     0    scodec.bits.ByteVector.toArray
  0.2%     1  +     0    scala.LowPriorityImplicits.wrapByteArray
  0.2%     1  +     0    org.bitcoins.core.script.stack.OP_IFDUP$.<init>
 12.8%    59  +     9    Total interpreted (including elided)

     Compiled + native   Method                        
  3.2%    13  +     4    scodec.bits.ByteVector$.fromHexInternal
  2.3%    12  +     0    scala.collection.IndexedSeqOptimized$class.foreach
  2.1%    11  +     0    org.bitcoins.core.serializers.script.ScriptParser.loop$2
  1.9%    10  +     0    org.bitcoins.core.util.BitcoinSUtil$class.encodeHex
  1.7%     9  +     0    scodec.bits.ByteVector.go$5
  1.7%     9  +     0    java.math.BigInteger.<init>
  1.5%     7  +     1    scala.collection.TraversableOnce$$anonfun$addString$1.apply
  1.3%     7  +     0    scodec.bits.ByteVector$Buffer.$plus$plus
  1.1%     6  +     0    org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey$.isMultiSignatureScriptPubKey
  0.9%     5  +     0    scala.collection.AbstractIterable.foreach
  0.9%     0  +     5    scala.reflect.ManifestFactory$$anon$6.newArray
  0.9%     5  +     0    org.bitcoins.core.script.constant.ScriptNumberOperation.toByte
  0.9%     5  +     0    org.bitcoins.core.util.BitcoinSUtil$$anonfun$toByteVector$1.apply
  0.9%     5  +     0    scala.collection.TraversableLike$class.$plus$plus
  0.8%     4  +     0    org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey$.org$bitcoins$core$protocol$script$MultiSignatureScriptPubKey$$isValidPubKeyNumber
  0.8%     3  +     1    org.bitcoins.core.serializers.RawSerializerHelper.writeCmpctSizeUInt
  0.8%     4  +     0    org.bitcoins.core.protocol.CompactSizeUInt.hex
  0.6%     3  +     0    org.bitcoins.core.script.constant.ScriptNumberOperation.bytes
  0.6%     3  +     0    scala.collection.mutable.StringBuilder.appendAll
  0.6%     2  +     1    scala.collection.immutable.List.foreach
  0.6%     2  +     1    org.bitcoins.core.script.constant.ScriptNumberUtil$class.toLong
  0.4%     2  +     0    scala.collection.immutable.List.find
  0.4%     2  +     0    scodec.bits.ByteVector$Buffer.getImpl
  0.4%     2  +     0    scala.runtime.ScalaRunTime$._toString
  0.4%     2  +     0    org.bitcoins.core.protocol.script.ScriptFactory$class.buildScript
 40.0%   176  +    37    Total compiled (including elided)

         Stub + native   Method                        
 27.8%     0  +   148    org.bitcoin.NativeSecp256k1.secp256k1_ec_pubkey_decompress
  6.0%     0  +    32    java.lang.Throwable.fillInStackTrace
  3.8%     0  +    20    java.lang.reflect.Array.newArray
  3.4%     0  +    18    java.lang.Object.clone
  2.3%     0  +    12    sun.misc.Unsafe.copyMemory
  1.9%     0  +    10    java.util.zip.Inflater.inflateBytes
  1.1%     5  +     1    java.lang.ClassLoader.defineClass1
  0.2%     0  +     1    java.lang.Class.isInterface
  0.2%     0  +     1    java.security.AccessController.doPrivileged
  0.2%     0  +     1    java.lang.ClassLoader.findBootstrapClass
  0.2%     0  +     1    java.lang.ClassLoader.findLoadedClass0
  0.2%     0  +     1    java.lang.System.arraycopy
  0.2%     0  +     1    java.util.zip.ZipFile.getEntry
 47.3%     5  +   247    Total stub


Global summary of 5.99 seconds:
100.0%   542             Received ticks
  1.3%     7             Received GC ticks
142.8%   774             Compilation

```