### PR TITLE
Add ability to publish snapshots for bitcoin-s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+import sbt.Credentials
+import sbt.Keys.publishTo
+
 cancelable in Global := true
 
 lazy val commonCompilerOpts = {
@@ -26,6 +29,8 @@ lazy val compilerOpts = Seq(
 
 lazy val testCompilerOpts = commonCompilerOpts
 
+
+
 lazy val commonSettings = List(
   scalacOptions in Compile := compilerOpts,
   scalacOptions in Test := testCompilerOpts,
@@ -38,7 +43,39 @@ lazy val commonSettings = List(
 
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
 
-  resolvers += Resolver.bintrayRepo("bitcoin-s", "bitcoin-s-core")
+  resolvers += Resolver.bintrayRepo("bitcoin-s", "bitcoin-s-core"),
+
+  resolvers += Resolver.jcenterRepo,
+
+  resolvers += "oss-jfrog-artifactory-snapshot" at "https://oss.jfrog.org/artifactory/oss-snapshot-local",
+
+  credentials ++= List(
+    //for snapshot publishing
+    //http://szimano.org/automatic-deployments-to-jfrog-oss-and-bintrayjcentermaven-central-via-travis-ci-from-sbt/
+    Credentials(Path.userHome / ".bintray" / ".artifactory"),
+
+    //sbt bintray plugin
+    //release publshing
+    Credentials(Path.userHome / ".bintray" / ".credentials")
+  ),
+
+
+  publishTo := {
+    //preserve the old bintray publishing stuff here
+    //we need to preserve it for the publishTo settings below
+    val bintrayPublish = publishTo.value
+    if (isSnapshot.value) {
+      Some("Artifactory Realm" at
+        "https://oss.jfrog.org/artifactory/oss-snapshot-local;build.timestamp=" + new java.util.Date().getTime)
+    } else {
+      bintrayPublish
+    }
+  },
+
+  bintrayReleaseOnPublish := !isSnapshot.value,
+
+  //fix for https://github.com/sbt/sbt/issues/3519
+  updateOptions := updateOptions.value.withGigahorse(false)
 
 )
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -16,7 +16,7 @@ object Deps {
     val junitV = "0.11"
     val nativeLoaderV = "2.3.2"
 
-    val bitcoinsV = "0.0.1"
+    val bitcoinsV = "0.0.1-SNAPSHOT"
   }
 
   object Compile {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1"
+version in ThisBuild := "0.0.2-SNAPSHOT"


### PR DESCRIPTION
This allows us to publish bitcoin-s snapshots to oss.jfrog.org. You can see the snapshots here:

https://oss.jfrog.org/webapp/#/artifacts/browse/tree/General/oss-snapshot-local/org/bitcoins

I've bumped the version of bitcoin-s to 0.0.2-SNAPSHOT, because we get a weird dependency resolution error if if we depend on the same version as we have specified in version.sbt. 

I.e. if we need `0.0.1-SNAPSHOT` for `bitcoinsV` in `Deps.scala`, we cannot have the version be `0.0.1-SNAPSHOT` in version.sbt.  