### PR TITLE
Fix BOLT11 incompatibility with byte boundaries and sigdata when recovering public key

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ECDigitalSignatureSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ECDigitalSignatureSpec.scala
@@ -36,4 +36,11 @@ class ECDigitalSignatureSpec extends Properties("ECDigitalSignatureSpec") {
         sig1.r != sig2.r
     }
   }
+
+  property("must have serialization symmetry with r,s") = {
+    Prop.forAll(CryptoGenerators.digitalSignature) {
+      case sig: ECDigitalSignature =>
+        ECDigitalSignature.fromRS(sig.r, sig.s) == sig
+    }
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
@@ -22,17 +22,16 @@ class TransactionWitnessSpec extends FlatSpec with MustMatchers {
   it must "be able to resize a witness to the given index" in {
     val empty = EmptyWitness
     val pubKey = ECPrivateKey.freshPrivateKey.publicKey
-    val p2pkh = P2PKHScriptSignature(EmptyDigitalSignature,pubKey)
+    val p2pkh = P2PKHScriptSignature(EmptyDigitalSignature, pubKey)
     val scriptWit = P2WPKHWitnessV0.fromP2PKHScriptSig(p2pkh)
-    val updated = empty.updated(2,scriptWit)
+    val updated = empty.updated(2, scriptWit)
 
-    updated.witnesses.length must be (3)
+    updated.witnesses.length must be(3)
   }
-
 
   it must "fail to update a negative index witness" in {
     intercept[IndexOutOfBoundsException] {
-      EmptyWitness.updated(-1,EmptyScriptWitness)
+      EmptyWitness.updated(-1, EmptyScriptWitness)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/ECDigitalSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ECDigitalSignature.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.crypto
 
-import org.bitcoins.core.util.{BitcoinSUtil, Factory}
+import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, Factory}
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 2/26/16.
   */
-sealed abstract class ECDigitalSignature {
+sealed abstract class ECDigitalSignature extends BitcoinSLogger {
 
   def hex: String = BitcoinSUtil.encodeHex(bytes)
 
@@ -37,27 +37,42 @@ sealed abstract class ECDigitalSignature {
   def decodeSignature: (BigInt, BigInt) = DERSignatureUtil.decodeSignature(this)
 
   /** Represents the r value found in a elliptic curve digital signature */
-  def r: BigInt = decodeSignature._1
+  def r: BigInt = {
+    decodeSignature._1
+  }
 
-  /** Represents the s value found in a elliptic curve digital signature */
-  def s: BigInt = decodeSignature._2
+  /** If we need to do serialization with the
+    * r value, you should use this. It will pad
+    * the byte vector so we have exactly 32 bytes
+    * @return
+    */
+  def rBytes: ByteVector = {
+    val bytes = r.bigInteger.toByteArray.takeRight(32)
+    val padded = ByteVector(bytes).padLeft(32)
+    padded
+  }
 
+  /** If we need to do serialization with the
+    * s value, you should use this. It will pad
+    * the byte vector so we have exactly 32 bytes
+    * @return
+    */
+  def s: BigInt = {
+    decodeSignature._2
+  }
+
+  def sBytes:ByteVector = {
+    val bytes = s.bigInteger.toByteArray.takeRight(32)
+    val padded = ByteVector(bytes).padLeft(32)
+    padded
+  }
   /**
     * Creates a ByteVector with only
     * the 32byte r value and 32 byte s value
     * in the vector
     */
   def toRawRS: ByteVector = {
-
-    val rBytes = r.toByteArray.takeRight(32)
-    val sBytes = s.toByteArray.takeRight(32)
-
-    val rPadded = ByteVector(rBytes).padLeft(32)
-    val sPadded = ByteVector(sBytes).padLeft(32)
-
-    require(rPadded.size == 32, s"rPadded.size ${rPadded.size}")
-    require(sPadded.size == 32, s"sPadded.size ${sPadded.size}")
-    rPadded ++ sPadded
+    rBytes ++ sBytes
   }
 
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTags.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTags.scala
@@ -133,8 +133,7 @@ object LnTag {
     }
 
     override val encoded: Vector[UInt5] = {
-      val bytes = ByteVector(string.getBytes("UTF-8"))
-      Bech32.from8bitTo5bit(bytes)
+      Bech32.from8bitTo5bit(descBytes)
     }
 
   }

--- a/core/src/main/scala/org/bitcoins/core/util/CryptoUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/CryptoUtil.scala
@@ -14,7 +14,7 @@ import scodec.bits.ByteVector
   * Created by chris on 1/14/16.
   * Utility cryptographic functions
   */
-trait CryptoUtil {
+trait CryptoUtil extends BitcoinSLogger {
 
   /** Does the following computation: RIPEMD160(SHA256(hex)).*/
   def sha256Hash160(hex: String): Sha256Hash160Digest =
@@ -109,11 +109,14 @@ trait CryptoUtil {
   def recoverPublicKey(
       signature: ECDigitalSignature,
       message: ByteVector): (ECPublicKey, ECPublicKey) = {
+
     val curve = CryptoParams.curve
     val (r, s) = (signature.r.bigInteger, signature.s.bigInteger)
+
     val m = new BigInteger(1, message.toArray)
 
     val (p1, p2) = recoverPoint(r)
+
     val Q1 = (p1
       .multiply(s)
       .subtract(curve.getG.multiply(m)))
@@ -122,7 +125,10 @@ trait CryptoUtil {
       .multiply(s)
       .subtract(curve.getG.multiply(m)))
       .multiply(r.modInverse(curve.getN))
-    (ECPublicKey.fromPoint(Q1), ECPublicKey.fromPoint(Q2))
+
+    val pub1 = ECPublicKey.fromPoint(Q1)
+    val pub2 = ECPublicKey.fromPoint(Q2)
+    (pub1,pub2)
   }
 }
 


### PR DESCRIPTION
WIP2

Fix bug where we weren't padding byte boundary on signature data


This fixes #277 

There is a very peculiar requirement in BOLT11 related to signature data. When you are converting signature data from `u5s: Vector[UInt5]` -> `u8s: Vector[UInt8]` you need to pad to the nearest byte boundary. This makes sense since the `u5s` is not guaranteed to line up on a byte boundary. 

However the [BOLT11 standard](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#requirements-2) says in the case where it DOES line up on a byte boundary, you need to pad the signature data with ANOTHER byte. 

> ... represented as UTF-8 bytes, concatenated with the data part (excluding the signature) with zero bits appended to pad the data to the next byte boundary, with a trailing byte containing the recovery ID (0, 1, 2 or 3)

This commit checks if the `u5s` line up at a byte boundary, and if they do it appends another zero byte. This should make us compatible with other lightning implementations. 

