### PR TITLE
Add sbt-git plugin, reformat snapshot versioning scheme

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,9 @@ lazy val commonSettings = List(
   bintrayReleaseOnPublish := !isSnapshot.value,
 
   //fix for https://github.com/sbt/sbt/issues/3519
-  updateOptions := updateOptions.value.withGigahorse(false)
+  updateOptions := updateOptions.value.withGigahorse(false),
+
+  git.formattedShaVersion := git.gitHeadCommit.value.map { sha => s"${sha.take(6)}-${new java.util.Date().getTime}-SNAPSHOT" }
 
 )
 
@@ -98,7 +100,7 @@ lazy val root = project
   )
   .settings(commonSettings: _*)
   .settings(crossScalaVersions := Nil)
-  .enablePlugins(ScalaUnidocPlugin, GhpagesPlugin)
+  .enablePlugins(ScalaUnidocPlugin, GhpagesPlugin, GitVersioning)
   .settings(
     ScalaUnidoc / siteSubdirName := "latest/api",
     addMappingsToSiteDir(ScalaUnidoc / packageDoc / mappings, ScalaUnidoc / siteSubdirName),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,3 +26,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 // ensure proper linkage across libraries in Scaladoc
 addSbtPlugin(
   "com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "latest.release")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.0.4.1-SNAPSHOT"


### PR DESCRIPTION
This integrates the [`sbt-git`](https://github.com/sbt/sbt-git) plugin that allows us to make snapshot versions based on our latest commit. As this PR currently stands, the scheme for the snapshot name is 

```scala
s"${sha.take(6)}-${new java.util.Date().getTime}-SNAPSHOT"
```

an example of a published snapshot version would look like 

```
f5ac79-1548177994910-SNAPSHOT 
```