### PR TITLE
Make timestamp a lazy val outside of versioning code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,8 @@ import com.typesafe.sbt.SbtGit.GitKeys._
 
 cancelable in Global := true
 
+lazy val timestamp = new java.util.Date().getTime
+
 lazy val commonCompilerOpts = {
   List(
     "-Xmax-classfile-name",
@@ -70,7 +72,7 @@ lazy val commonSettings = List(
     val bintrayPublish = publishTo.value
     if (isSnapshot.value) {
       Some("Artifactory Realm" at
-        "https://oss.jfrog.org/artifactory/oss-snapshot-local;build.timestamp=" + new java.util.Date().getTime)
+        "https://oss.jfrog.org/artifactory/oss-snapshot-local;build.timestamp=" + timestamp)
     } else {
       bintrayPublish
     }
@@ -81,7 +83,7 @@ lazy val commonSettings = List(
   //fix for https://github.com/sbt/sbt/issues/3519
   updateOptions := updateOptions.value.withGigahorse(false),
 
-  git.formattedShaVersion := git.gitHeadCommit.value.map { sha => s"${sha.take(6)}-${new java.util.Date().getTime}-SNAPSHOT" }
+  git.formattedShaVersion := git.gitHeadCommit.value.map { sha => s"${sha.take(6)}-${timestamp}-SNAPSHOT" }
 
 )
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -17,7 +17,7 @@ object Deps {
     val nativeLoaderV = "2.3.2"
     val typesafeConfigV = "1.3.3"
 
-    val bitcoinsV = "5d3bf4-1548681478579-SNAPSHOT"
+    val bitcoinsV = "0.0.4.1-SNAPSHOT"
   }
 
   object Compile {


### PR DESCRIPTION
Previously we would get different versions for published versions of bitcoin-s between `2.11` and `2.12` since a timestamp computation was done inside of the versioning scheme. This PR factors out that timestamp so it is consistent across versions 

```
    ├── bitcoin-s-zmq_2.11
    │   └── 5d3bf4-1548803222875-SNAPSHOT
    │       ├── docs
    │       │   ├── bitcoin-s-zmq_2.11-javadoc.jar
    │       │   ├── bitcoin-s-zmq_2.11-javadoc.jar.md5
    │       │   └── bitcoin-s-zmq_2.11-javadoc.jar.sha1
    │       ├── ivys
    │       │   ├── ivy.xml
    │       │   ├── ivy.xml.md5
    │       │   └── ivy.xml.sha1
    │       ├── jars
    │       │   ├── bitcoin-s-zmq_2.11.jar
    │       │   ├── bitcoin-s-zmq_2.11.jar.md5
    │       │   └── bitcoin-s-zmq_2.11.jar.sha1
    │       ├── poms
    │       │   ├── bitcoin-s-zmq_2.11.pom
    │       │   ├── bitcoin-s-zmq_2.11.pom.md5
    │       │   └── bitcoin-s-zmq_2.11.pom.sha1
    │       └── srcs
    │           ├── bitcoin-s-zmq_2.11-sources.jar
    │           ├── bitcoin-s-zmq_2.11-sources.jar.md5
    │           └── bitcoin-s-zmq_2.11-sources.jar.sha1
    └── bitcoin-s-zmq_2.12
        └── 5d3bf4-1548803222875-SNAPSHOT
            ├── docs
            │   ├── bitcoin-s-zmq_2.12-javadoc.jar
            │   ├── bitcoin-s-zmq_2.12-javadoc.jar.md5
            │   └── bitcoin-s-zmq_2.12-javadoc.jar.sha1
            ├── ivys
            │   ├── ivy.xml
            │   ├── ivy.xml.md5
            │   └── ivy.xml.sha1
            ├── jars
            │   ├── bitcoin-s-zmq_2.12.jar
            │   ├── bitcoin-s-zmq_2.12.jar.md5
            │   └── bitcoin-s-zmq_2.12.jar.sha1
            ├── poms
            │   ├── bitcoin-s-zmq_2.12.pom
            │   ├── bitcoin-s-zmq_2.12.pom.md5
            │   └── bitcoin-s-zmq_2.12.pom.sha1
            └── srcs
                ├── bitcoin-s-zmq_2.12-sources.jar
                ├── bitcoin-s-zmq_2.12-sources.jar.md5
                └── bitcoin-s-zmq_2.12-sources.jar.sha1
```