### PR TITLE
Fixes conversion bug when sending with Eclair RPC 

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnit.scala
@@ -122,6 +122,9 @@ object MilliBitcoins extends BaseNumbers[MilliBitcoins] {
             "Number was too small for MilliBitcoins, got: " + underlying)
     require(underlying <= LnPolicy.maxMilliBitcoins,
             "Number was too big for MilliBitcoins, got: " + underlying)
+
+    override def toString: String =
+      s"${underlying / toPicoBitcoinMultiplier} mBTC"
   }
 }
 
@@ -151,6 +154,9 @@ object MicroBitcoins extends BaseNumbers[MicroBitcoins] {
             "Number was too small for MicroBitcoins, got: " + underlying)
     require(underlying <= LnPolicy.maxMicroBitcoins,
             "Number was too big for MicroBitcoins, got: " + underlying)
+
+    override def toString: String =
+      s"${underlying / toPicoBitcoinMultiplier} uBTC"
   }
 }
 
@@ -179,6 +185,9 @@ object NanoBitcoins extends BaseNumbers[NanoBitcoins] {
             "Number was too small for NanoBitcoins, got: " + underlying)
     require(underlying <= LnPolicy.maxNanoBitcoins,
             "Number was too big for NanoBitcoins, got: " + underlying)
+
+    override def toString: String =
+      s"${underlying / toPicoBitcoinMultiplier} nBTC"
   }
 }
 
@@ -205,6 +214,8 @@ object PicoBitcoins extends BaseNumbers[PicoBitcoins] {
             "Number was too small for PicoBitcoins, got: " + underlying)
     require(underlying <= LnPolicy.maxPicoBitcoins,
             "Number was too big for PicoBitcoins, got: " + underlying)
+
+    override def toString: String = s"$toBigInt pBTC"
   }
 }
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -411,7 +411,7 @@ class EclairRpcClient(val instance: EclairInstance)(
       paymentHash: Sha256Digest,
       nodeId: NodeId): Future[PaymentResult] = {
     eclairCall[PaymentResult]("send",
-                              List(JsNumber(amountMsat.toPicoBitcoinDecimal),
+                              List(JsNumber(amountMsat.toMSat.toLong),
                                    JsString(paymentHash.hex),
                                    JsString(nodeId.toString)))
   }
@@ -425,7 +425,7 @@ class EclairRpcClient(val instance: EclairInstance)(
         List(JsString(invoice.toString))
       } else {
         List(JsString(invoice.toString),
-             JsNumber(amountMsat.get.toPicoBitcoinDecimal))
+             JsNumber(amountMsat.get.toMSat.toLong))
       }
     }
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -17,7 +17,7 @@ object Deps {
     val nativeLoaderV = "2.3.2"
     val typesafeConfigV = "1.3.3"
 
-    val bitcoinsV = "0.0.4.1-SNAPSHOT"
+    val bitcoinsV = "4addc1-1549033158959-SNAPSHOT"
   }
 
   object Compile {

--- a/testkit/src/main/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtil.scala
@@ -12,7 +12,7 @@ import org.bitcoins.core.protocol.ln.channel.{
   ChannelState,
   FundedChannelId
 }
-import org.bitcoins.core.protocol.ln.currency.{MilliSatoshis, PicoBitcoins}
+import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
 import org.bitcoins.eclair.rpc.config.EclairInstance
@@ -383,11 +383,13 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
       c2: EclairRpcClient,
       numPayments: Int = 10)(
       implicit ec: ExecutionContext): Future[Seq[PaymentResult]] = {
-    val payments = (1 to numPayments).map(
-      n =>
-        c1.receive(s"this is a note $n")
-          .flatMap(invoice => c2.send(invoice, PicoBitcoins(n)))
-    )
+    val payments = (1 to numPayments)
+      .map(MilliSatoshis(_))
+      .map(
+        sats =>
+          c1.receive(s"this is a note for $sats")
+            .flatMap(invoice => c2.send(invoice, sats.toLnCurrencyUnit))
+      )
 
     Future.sequence(payments)
   }


### PR DESCRIPTION
Eclair expects msat integers in the send method, we were providing pBTC