### PR TITLE
2019 02 04 testkit future refactor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,8 @@ lazy val commonSettings = List(
 
   scalacOptions in Test := testCompilerOpts,
 
+  testOptions in Test += Tests.Argument("-oF"),
+
   assemblyOption in assembly := (assemblyOption in assembly).value
     .copy(includeScala = false),
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -11,10 +11,10 @@ import akka.stream.ActorMaterializer
 import akka.util.ByteString
 import org.bitcoins.core.crypto.Sha256Digest
 import org.bitcoins.core.currency.CurrencyUnit
-import org.bitcoins.core.protocol.ln.{LnInvoice, LnParams, ShortChannelId}
 import org.bitcoins.core.protocol.ln.channel.{ChannelId, FundedChannelId}
 import org.bitcoins.core.protocol.ln.currency.{LnCurrencyUnit, MilliSatoshis}
 import org.bitcoins.core.protocol.ln.node.NodeId
+import org.bitcoins.core.protocol.ln.{LnInvoice, LnParams, ShortChannelId}
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.util.BitcoinSUtil
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
@@ -23,13 +23,14 @@ import org.bitcoins.eclair.rpc.config.EclairInstance
 import org.bitcoins.eclair.rpc.json._
 import org.bitcoins.eclair.rpc.network.{NodeUri, PeerState}
 import org.bitcoins.rpc.serializers.JsonReaders._
+import org.bitcoins.rpc.util.AsyncUtil
 import org.slf4j.LoggerFactory
 import play.api.libs.json._
 
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.sys.process._
-import scala.util.{Failure, Properties, Success, Try}
+import scala.util.{Failure, Properties, Success}
 
 class EclairRpcClient(val instance: EclairInstance)(
     implicit system: ActorSystem)
@@ -560,27 +561,51 @@ class EclairRpcClient(val instance: EclairInstance)(
 
   private var process: Option[Process] = None
 
-  def start(): Unit = {
+  /** Starts eclair on the local system.
+    *
+    * @return a future that completes when eclair is fully started.
+    *         If eclair has not successfully started in 60 seconds
+    *         the future times out.
+    */
+  def start(): Future[Unit] = {
 
-    if (process.isEmpty) {
-      val p = Process(
-        s"java -jar -Declair.datadir=${instance.authCredentials.datadir.get} $pathToEclairJar &")
-      val result = p.run()
-      logger.info(
-        s"Starting eclair with datadir ${instance.authCredentials.datadir.get}")
+    val _ = {
 
-      process = Some(result)
-      ()
-    } else {
-      logger.info(s"Eclair was already started!")
-      ()
+      require(instance.authCredentials.datadir.isDefined, s"A datadir needs to be provided to start eclair")
+
+      if (process.isEmpty) {
+        val p = Process(
+          s"java -jar -Declair.datadir=${instance.authCredentials.datadir.get} $pathToEclairJar &")
+        val result = p.run()
+        logger.info(
+          s"Starting eclair with datadir ${instance.authCredentials.datadir.get}")
+
+        process = Some(result)
+        ()
+      } else {
+        logger.info(s"Eclair was already started!")
+        ()
+      }
     }
 
+    val started = AsyncUtil.retryUntilSatisfiedF(
+      () => isStarted,
+      duration = 1.seconds,
+      maxTries = 60)
+
+
+    started
   }
 
-  def isStarted(): Boolean = {
-    val t = Try(Await.result(getInfo, 1.second))
-    t.isSuccess
+  def isStarted(): Future[Boolean] = {
+    val p = Promise[Boolean]()
+
+    getInfo.onComplete {
+      case Success(_) => p.success(true)
+      case Failure(_) => p.success(false)
+    }
+
+    p.future
   }
 
   def stop(): Option[Unit] = {

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/network/PeerState.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/network/PeerState.scala
@@ -5,9 +5,11 @@ sealed abstract class PeerState
 object PeerState {
   case object CONNECTED extends PeerState
 
+  case object INITIALIZING extends PeerState
+
   case object DISCONNECTED extends PeerState
 
-  private val all = List(CONNECTED, DISCONNECTED)
+  private val all = List(CONNECTED, INITIALIZING, DISCONNECTED)
 
   def fromString(str: String): Option[PeerState] = {
     all.find(_.toString == str)

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -17,7 +17,7 @@ object Deps {
     val nativeLoaderV = "2.3.2"
     val typesafeConfigV = "1.3.3"
 
-    val bitcoinsV = "0.0.4.1-SNAPSHOT"
+    val bitcoinsV = "236041-1549541584036-SNAPSHOT"
   }
 
   object Compile {

--- a/rpc/src/test/scala/org/bitcoins/rpc/RpcUtilTest.scala
+++ b/rpc/src/test/scala/org/bitcoins/rpc/RpcUtilTest.scala
@@ -111,15 +111,12 @@ class RpcUtilTest extends AsyncFlatSpec with BeforeAndAfterAll {
 
     val instance = BitcoindRpcTestUtil.instance()
     val client = new BitcoindRpcClient(instance)
-    client.start()
-    RpcUtil.awaitCondition(client.isStarted)
-    assert(client.isStarted)
-    client.stop()
-    RpcUtil.awaitServerShutdown(client)
-    assert(!client.isStarted)
+    val startedF = client.start()
 
-    val t = Try(Await.result(client.getNetworkInfo, 1000.milliseconds))
-    assert(t.isFailure)
+    startedF.map { _ =>
+      client.stop()
+      succeed
+    }
   }
 
   it should "be able to create a connected node pair with 100 blocks and then delete them" in {


### PR DESCRIPTION
This PR does a few things

1. Refactors the `start()` method on `BitcoindRpcClient` and `EclairRpcClient` to return a `Future[Unit]`. This future is completed when the RpcClient is fully started and you can send requests and expect responses in a timely manner.
2. Refactors `EclairRpcTestUtil` to return Futures than using hard blocking `Await`. This should theoretically boost performance of tests.
3. Remove 2 instances of `EclairRpcClient` that were being spun up in the eclair tests. It is very expensive to spin up new eclair nodes and we should avoid doing so unless there is a good reason. In most cases we can re-use already running eclair nodes