### PR TITLE
Change Factory to an abstract class

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.script.ScriptOperationFactory
 import org.bitcoins.core.util.{BitcoinSUtil, BitcoinScriptUtil, Factory}
 import scodec.bits.ByteVector
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Try}
 
 /**
   * Created by chris on 1/6/16.

--- a/core/src/main/scala/org/bitcoins/core/util/Factory.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/Factory.scala
@@ -7,7 +7,7 @@ import scodec.bits.ByteVector
   * Created by chris on 2/26/16.
   * Trait to implement ubiquitous factory functions across our codebase
   */
-trait Factory[T] {
+abstract class Factory[+T] {
 
   /** Creates a T out of a hex string. */
   def fromHex(hex: String): T = fromBytes(BitcoinSUtil.decodeHex(hex))
@@ -21,7 +21,7 @@ trait Factory[T] {
   /** Creates a T from a hex string. */
   def apply(hex: String): T = fromHex(hex)
 
-  def logger: Logger = BitcoinSLogger.logger
+  lazy val logger: Logger = BitcoinSLogger.logger
 
   /** Allows a `def foo[C: Factory]()` construction. */
   implicit def self: Factory[T] = this


### PR DESCRIPTION
There is no reason to have `Factory` as a trait, and we should default to abstract class if things don't matter.