### PR TITLE
Fix initialization problem with LnInvoice and the separator char

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
@@ -19,8 +19,6 @@ sealed abstract class LnInvoice {
     isValidSignature(),
     s"Did not receive a valid digital signature for the invoice ${toString}")
 
-  private val bech32Separator: Char = Bech32.separator
-
   def hrp: LnHumanReadablePart
 
   def timestamp: UInt64
@@ -101,7 +99,7 @@ sealed abstract class LnInvoice {
   override def toString: String = {
     val b = new StringBuilder
     b.append(hrp.toString)
-    b.append(bech32Separator)
+    b.append(Bech32.separator)
 
     val dataToString = Bech32.encode5bitToString(data)
     b.append(dataToString)


### PR DESCRIPTION
If you look at the failed invoice examples on #297, you see that they do not have the bech32 character separator `1`. This is because of a weirdly initialization problem with using the `val` in the abstract class. This PR moves the seperator down into the `toString` method which is the only point it is used.