### PR TITLE
Add bitcoin-s unit test class, all unit tests going forward should ex…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,11 @@ lazy val commonSettings = List(
 
   scalacOptions in Test := testCompilerOpts,
 
-  testOptions in Test += Tests.Argument("-oF"),
+  //show full stack trace of failed tests
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
+
+  //show duration of tests
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oD"),
 
   assemblyOption in assembly := (assemblyOption in assembly).value
     .copy(includeScala = false),
@@ -127,36 +131,33 @@ lazy val secp256k1jni = project
 
 lazy val core = project
   .in(file("core"))
-  .enablePlugins()
   .settings(commonSettings: _*)
   .dependsOn(
     secp256k1jni
-  )
+  ).enablePlugins()
 
 lazy val coreTest = project
   .in(file("core-test"))
-  .enablePlugins()
   .settings(commonSettings: _*)
   .settings(skip in publish := true)
   .dependsOn(
     core,
-  )
+  ).enablePlugins()
 
 lazy val zmq = project
   .in(file("zmq"))
-  .enablePlugins()
   .settings(commonSettings: _*)
   .dependsOn(
     core
-  )
+  ).enablePlugins()
 
 lazy val rpc = project
   .in(file("rpc"))
-  .enablePlugins()
+
   .settings(commonSettings: _*)
   .dependsOn(
     core
-  )
+  ).enablePlugins()
 
 lazy val bench = project
   .in(file("bench"))

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitUnitTest.scala
@@ -3,31 +3,18 @@ package org.bitcoins.core.protocol.ln
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.gen.ln.LnInvoiceGen
 import org.bitcoins.core.number.{UInt32, UInt64, UInt8}
-import org.bitcoins.core.protocol.ln.LnParams.{
-  LnBitcoinMainNet,
-  LnBitcoinTestNet
-}
-import org.bitcoins.core.protocol.ln.currency.{
-  MicroBitcoins,
-  MilliBitcoins,
-  MilliSatoshis
-}
-import org.bitcoins.core.protocol.ln.fee.{
-  FeeBaseMSat,
-  FeeProportionalMillionths
-}
+import org.bitcoins.core.protocol.ln.LnParams.{LnBitcoinMainNet, LnBitcoinTestNet}
+import org.bitcoins.core.protocol.ln.currency.{MicroBitcoins, MilliBitcoins, MilliSatoshis}
+import org.bitcoins.core.protocol.ln.fee.{FeeBaseMSat, FeeProportionalMillionths}
 import org.bitcoins.core.protocol.ln.routing.LnRoute
 import org.bitcoins.core.protocol.{Bech32Address, P2PKHAddress, P2SHAddress}
-import org.bitcoins.core.util.CryptoUtil
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, MustMatchers}
-import org.slf4j.LoggerFactory
+import org.bitcoins.core.util.{BitcoinSUnitTest, CryptoUtil}
 import scodec.bits.ByteVector
 
-class LnInvoiceUnitTest extends FlatSpec with MustMatchers with PropertyChecks {
+class LnInvoiceUnitTest extends BitcoinSUnitTest {
   behavior of "LnInvoice"
 
-  private val logger = LoggerFactory.getLogger(getClass)
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration = generatorDrivenConfigNewCode
 
   val hrpEmpty = LnHumanReadablePart(LnBitcoinMainNet)
 
@@ -449,4 +436,5 @@ class LnInvoiceUnitTest extends FlatSpec with MustMatchers with PropertyChecks {
 
     invoice.nodeId.hex must be(expected)
   }
+
 }

--- a/core-test/src/test/scala/org/bitcoins/core/util/BitcoinSUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BitcoinSUnitTest.scala
@@ -1,0 +1,57 @@
+package org.bitcoins.core.util
+
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, MustMatchers}
+import org.slf4j.LoggerFactory
+
+/** A wrapper for boiler plate testing procesures in bitcoin-s */
+abstract class BitcoinSUnitTest extends FlatSpec with MustMatchers with PropertyChecks {
+
+  lazy val logger = LoggerFactory.getLogger(getClass)
+
+  /** The configuration for property based tests in our testing suite
+    * See: http://www.scalatest.org/user_guide/writing_scalacheck_style_properties
+    */
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration = {
+    generatorDriveConfigOldCode
+  }
+
+  private def buildConfig(executions: Int): PropertyCheckConfiguration = {
+    PropertyCheckConfig(
+      minSuccessful = executions,
+      minSize = executions,
+      maxSize = executions
+    )
+  }
+
+  /** Property based tests that have been around a long time
+    * have a less of a chance failing, so execute them less
+    * @return
+    */
+  def generatorDriveConfigOldCode: PropertyCheckConfiguration = {
+    buildConfig(BitcoinSUnitTest.OLD_CODE_EXECUTIONS)
+  }
+
+  /** Property based tests that are new have a higher chance of failing
+    * so execute them more
+    * @return
+    */
+  def generatorDrivenConfigNewCode: PropertyCheckConfiguration = {
+    buildConfig(BitcoinSUnitTest.NEW_CODE_EXECUTIONS)
+  }
+
+}
+
+object BitcoinSUnitTest {
+
+  /** The number of times new code
+    * should be executed in a property based test
+    */
+  val NEW_CODE_EXECUTIONS = 100
+
+  /** The number of times old code should be executed
+    * in a property based test
+    */
+  val OLD_CODE_EXECUTIONS = 20
+
+}


### PR DESCRIPTION
…tend this

Creates a common test abstract class for bitcoin unit tests. This PR does not go through the code base and extend this abstract class, it just extends it in one called `LnInvoiceUnitTest`. 

One interesting thing about property based testing is that the longer the code lives, the surer you are that it is correct. This PR also introduces the concept of "old code" and "new code". New code should be executed more often in property based tests, while old code can be executed less times. 

See this talk by Bill Venners (creator of ScalaTest) for more info on this:

https://youtu.be/lKtg-CDVDsI?t=2293