### PR TITLE
Fix bench project configuration

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -8,10 +8,30 @@ You can assembly the jar like this
 
 ```
 sbt bench/assembly
+[info] Updating secp256k1jni...
+[info] Done updating.
+[info] Updating core...
+[info] Done updating.
+[warn] There may be incompatibilities among your library dependencies.
+[warn] Run 'evicted' to see detailed eviction warnings
+[info] Updating ...
+[info] Done updating.
+[warn] There may be incompatibilities among your library dependencies.
+[warn] Run 'evicted' to see detailed eviction warnings
+[info] Compiling 4 Scala sources to /home/chris/dev/bitcoin-s-core/core/target/scala-2.12/classes ...
+[info] Done compiling.
+[info] Compiling 56 Scala sources to /home/chris/dev/bitcoin-s-core/core/target/scala-2.12/classes ...
+[info] Done compiling.
+[info] Strategy 'discard' was applied to 11 files (Run the task at debug level to see details)
+[info] Packaging /home/chris/dev/bitcoin-s-core/bench/target/scala-2.12/bitcoin-s-bench-assembly-f85fcf-1550326975891-SNAPSHOT.jar ...
+[info] Done packaging.
 ```
+
 
 and then run with
 
 ```
-$ java -Xprof -jar bench/target/scala-2.11/bench-assembly-0.0.1-SNAPSHOT.jar > output.txt
+$ java -Xprof -jar /home/chris/dev/bitcoin-s-core/bench/target/scala-2.12/bitcoin-s-bench-assembly-f85fcf-1550326975891-SNAPSHOT.jar > output.txt
 ```
+
+The `hash` and `timestamp` are in the console output above. In this example it is `f85fcf` and `1550326975891`

--- a/build.sbt
+++ b/build.sbt
@@ -162,9 +162,9 @@ lazy val rpc = project
 lazy val bench = project
   .in(file("bench"))
   .enablePlugins()
+  .settings(commonSettings: _*)
   .settings(assemblyOption in assembly := (assemblyOption in assembly).value
     .copy(includeScala = true))
-  .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Deps.bench,
     name := "bitcoin-s-bench",


### PR DESCRIPTION
This fixes #284 

Output from the latest bench run for those that are curious

```
2019-02-16 08:47:54.207 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 1367ms
2019-02-16 08:47:54.650 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 424ms
2019-02-16 08:47:55.090 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 426ms
2019-02-16 08:47:55.426 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 324ms
2019-02-16 08:47:55.774 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 336ms
2019-02-16 08:47:56.170 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 382ms
2019-02-16 08:47:56.525 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 342ms
2019-02-16 08:47:56.890 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 352ms
2019-02-16 08:47:57.188 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 287ms
2019-02-16 08:47:57.584 INFO  BlockBench$.timeBlockParsing(14) - Elapsed time: 385ms

Flat profile of 5.08 secs (470 total ticks): main

  Interpreted + native   Method                        
  2.6%    12  +     0    java.lang.ClassLoader.defineClass1
  0.6%     0  +     3    sun.misc.Unsafe.copyMemory
  0.4%     0  +     2    sun.misc.Unsafe.defineAnonymousClass
  0.4%     2  +     0    org.bitcoins.core.util.BitcoinSUtil.toByteVector$
  0.4%     2  +     0    jdk.internal.org.objectweb.asm.ByteVector.<init>
  0.4%     2  +     0    java.lang.String.replace
  0.2%     0  +     1    java.lang.Class.getName0
  0.2%     0  +     1    java.lang.String.intern
  0.2%     0  +     1    java.lang.Thread.currentThread
  0.2%     0  +     1    org.bitcoin.Secp256k1Context.secp256k1_init_context
  0.2%     1  +     0    org.bitcoins.core.script.constant.OP_PUSHDATA1$.toString
  0.2%     1  +     0    org.bitcoins.core.util.BitcoinSUtil.encodeHex$
  0.2%     1  +     0    scala.collection.TraversableLike.filterImpl$
  0.2%     1  +     0    scala.collection.immutable.VectorPointer.gotoNextBlockStartWritable$
  0.2%     0  +     1    sun.misc.Unsafe.getIntVolatile
  0.2%     1  +     0    scala.collection.immutable.VectorPointer.initFrom$
  0.2%     1  +     0    org.bitcoins.core.util.BitcoinSUtil.encodeHex$
  0.2%     1  +     0    org.bitcoins.core.script.ScriptOperationFactory.fromByte$
  0.2%     1  +     0    scala.math.Ordered.$greater$
  0.2%     1  +     0    scala.collection.LinearSeqOptimized.lengthCompare$
  0.2%     1  +     0    org.bitcoins.core.script.constant.ScriptNumberUtil.changeSignBitToPositive$
  0.2%     1  +     0    org.bitcoins.core.protocol.script.ScriptFactory.fromBytes$
  0.2%     1  +     0    scala.collection.TraversableLike.to$
  0.2%     1  +     0    scala.collection.IterableLike.find$
  0.2%     0  +     1    sun.misc.Unsafe.compareAndSwapInt
 15.1%    57  +    14    Total interpreted (including elided)

     Compiled + native   Method                        
  4.7%    22  +     0    scala.collection.IndexedSeqOptimized.foreach
  2.1%     7  +     3    org.bitcoins.core.script.arithmetic.ArithmeticOperation.toByte
  2.1%    10  +     0    org.bitcoins.core.number.UInt64.encodeHex
  2.1%     1  +     9    scodec.bits.ByteVector$.fromHexInternal
  1.9%     9  +     0    org.bitcoins.core.script.ScriptOperationFactory.$anonfun$fromByte$1$adapted
  1.3%     6  +     0    org.bitcoins.core.script.constant.ScriptNumberOperation.toByte
  1.3%     5  +     1    scala.collection.TraversableLike.$plus$plus
  1.1%     5  +     0    scala.collection.AbstractIterator.foreach
  1.1%     5  +     0    org.bitcoins.core.util.BitcoinSUtil.addPadding
  0.9%     4  +     0    org.bitcoins.core.script.ScriptOperationFactory$$Lambda$43.apply
  0.9%     4  +     0    org.bitcoins.core.protocol.script.P2SHScriptSignature$.isRedeemScript
  0.6%     2  +     1    scala.collection.AbstractTraversable.filterImpl
  0.6%     3  +     0    scala.collection.AbstractIterable.foreach
  0.6%     3  +     0    org.bitcoins.core.protocol.script.Script$$Lambda$53.apply
  0.6%     3  +     0    scala.collection.TraversableOnce$$Lambda$57.apply
  0.6%     3  +     0    org.bitcoins.core.util.BitcoinScriptUtil.parseScript
  0.6%     3  +     0    org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey$.isValidPubKeyNumber
  0.6%     3  +     0    org.bitcoins.core.protocol.script.P2SHScriptPubKey$.isP2SHScriptPubKey
  0.6%     3  +     0    scodec.bits.ByteVector.go$4
  0.4%     2  +     0    scala.collection.immutable.List.find
  0.4%     2  +     0    scala.collection.AbstractTraversable.genericBuilder
  0.4%     2  +     0    scala.collection.AbstractSeq.toString
  0.4%     1  +     1    scala.collection.TraversableLike$$Lambda$40.apply
  0.4%     1  +     1    org.bitcoins.core.serializers.transaction.RawWitnessTransactionParser$$Lambda$83.apply
  0.4%     2  +     0    scala.collection.immutable.Range.foreach
 37.9%   145  +    33    Total compiled (including elided)

         Stub + native   Method                        
 29.1%     0  +   137    org.bitcoin.NativeSecp256k1.secp256k1_ec_pubkey_decompress
  5.3%     0  +    25    java.lang.Throwable.fillInStackTrace
  4.0%     0  +    19    java.lang.Object.clone
  3.0%     0  +    14    sun.misc.Unsafe.copyMemory
  2.8%     0  +    13    java.util.zip.Inflater.inflateBytes
  0.4%     0  +     2    java.util.zip.ZipFile.getEntry
  0.4%     2  +     0    java.lang.ClassLoader.defineClass1
  0.2%     0  +     1    java.lang.ClassLoader.findBootstrapClass
  0.2%     0  +     1    sun.misc.Unsafe.compareAndSwapInt
  0.2%     0  +     1    java.util.zip.ZipFile.read
  0.2%     0  +     1    sun.misc.Unsafe.compareAndSwapLong
 46.0%     2  +   214    Total stub

  Thread-local ticks:
  1.1%     5             Class loader


Global summary of 5.10 seconds:
100.0%   479             Received ticks
  1.5%     7             Received GC ticks
111.1%   532             Compilation
  1.0%     5             Class loader
```