### PR TITLE
Integrate big endian hashes, integrate them into the bitcoind-rpc pro…

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/RpcOpts.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/RpcOpts.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.rpc.client
 
-import org.bitcoins.core.crypto.{DoubleSha256Digest, ECPrivateKey}
+import org.bitcoins.core.crypto.{
+  DoubleSha256Digest,
+  DoubleSha256DigestBE,
+  ECPrivateKey
+}
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -24,7 +28,7 @@ object RpcOpts {
     FundRawTransactionOptions] = Json.writes[FundRawTransactionOptions]
 
   case class SignRawTransactionOutputParameter(
-      txid: DoubleSha256Digest,
+      txid: DoubleSha256DigestBE,
       vout: Int,
       scriptPubKey: ScriptPubKey,
       redeemScript: Option[ScriptPubKey] = None,
@@ -46,7 +50,7 @@ object RpcOpts {
 
   case class ImportMultiAddress(address: BitcoinAddress)
 
-  case class LockUnspentOutputParameter(txid: DoubleSha256Digest, vout: Int)
+  case class LockUnspentOutputParameter(txid: DoubleSha256DigestBE, vout: Int)
 
   implicit val lockUnspentParameterWrites: Writes[LockUnspentOutputParameter] =
     Json.writes[LockUnspentOutputParameter]

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.rpc.jsonmodels
 
-import org.bitcoins.core.crypto.DoubleSha256Digest
+import org.bitcoins.core.crypto.{DoubleSha256DigestBE}
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.wallet.fee.BitcoinFeeUnit
@@ -8,7 +8,7 @@ import org.bitcoins.core.wallet.fee.BitcoinFeeUnit
 sealed abstract class BlockchainResult
 
 case class GetBlockResult(
-    hash: DoubleSha256Digest,
+    hash: DoubleSha256DigestBE,
     confirmations: Int,
     strippedsize: Int,
     size: Int,
@@ -16,20 +16,20 @@ case class GetBlockResult(
     height: Int,
     version: Int,
     versionHex: Int32,
-    merkleroot: DoubleSha256Digest,
-    tx: Vector[DoubleSha256Digest],
+    merkleroot: DoubleSha256DigestBE,
+    tx: Vector[DoubleSha256DigestBE],
     time: UInt32,
     mediantime: UInt32,
     nonce: UInt32,
     bits: UInt32,
     difficulty: BigDecimal,
     chainwork: String,
-    previousblockhash: Option[DoubleSha256Digest],
-    nextblockhash: Option[DoubleSha256Digest])
+    previousblockhash: Option[DoubleSha256DigestBE],
+    nextblockhash: Option[DoubleSha256DigestBE])
     extends BlockchainResult
 
 case class GetBlockWithTransactionsResult(
-    hash: DoubleSha256Digest,
+    hash: DoubleSha256DigestBE,
     confirmations: Int,
     strippedsize: Int,
     size: Int,
@@ -37,7 +37,7 @@ case class GetBlockWithTransactionsResult(
     height: Int,
     version: Int,
     versionHex: Int32,
-    merkleroot: DoubleSha256Digest,
+    merkleroot: DoubleSha256DigestBE,
     tx: Vector[RpcTransaction],
     time: UInt32,
     mediantime: UInt32,
@@ -45,15 +45,15 @@ case class GetBlockWithTransactionsResult(
     bits: UInt32,
     difficulty: BigDecimal,
     chainwork: String,
-    previousblockhash: Option[DoubleSha256Digest],
-    nextblockhash: Option[DoubleSha256Digest])
+    previousblockhash: Option[DoubleSha256DigestBE],
+    nextblockhash: Option[DoubleSha256DigestBE])
     extends BlockchainResult
 
 case class GetBlockChainInfoResult(
     chain: String,
     blocks: Int,
     headers: Int,
-    bestblockhash: DoubleSha256Digest,
+    bestblockhash: DoubleSha256DigestBE,
     difficulty: BigDecimal,
     mediantime: Int,
     verificationprogress: BigDecimal,
@@ -90,25 +90,25 @@ case class Bip9Softfork(
     extends BlockchainResult
 
 case class GetBlockHeaderResult(
-    hash: DoubleSha256Digest,
+    hash: DoubleSha256DigestBE,
     confirmations: Int,
     height: Int,
     version: Int,
     versionHex: Int32,
-    merkleroot: DoubleSha256Digest,
+    merkleroot: DoubleSha256DigestBE,
     time: UInt32,
     mediantime: UInt32,
     nonce: UInt32,
     bits: UInt32,
     difficulty: BigDecimal,
     chainwork: String,
-    previousblockhash: Option[DoubleSha256Digest],
-    nextblockhash: Option[DoubleSha256Digest])
+    previousblockhash: Option[DoubleSha256DigestBE],
+    nextblockhash: Option[DoubleSha256DigestBE])
     extends BlockchainResult
 
 case class ChainTip(
     height: Int,
-    hash: DoubleSha256Digest,
+    hash: DoubleSha256DigestBE,
     branchlen: Int,
     status: String)
     extends BlockchainResult
@@ -134,8 +134,8 @@ case class GetMemPoolResult(
     ancestorcount: Int,
     ancestorsize: Int,
     ancestorfees: Option[Bitcoins],
-    wtxid: DoubleSha256Digest,
-    depends: Vector[DoubleSha256Digest])
+    wtxid: DoubleSha256DigestBE,
+    depends: Vector[DoubleSha256DigestBE])
     extends BlockchainResult
 
 case class GetMemPoolEntryResult(
@@ -150,7 +150,7 @@ case class GetMemPoolEntryResult(
     ancestorcount: Int,
     ancestorsize: Int,
     ancestorfees: Bitcoins, // Should be BitcoinFeeUnit
-    depends: Option[Vector[DoubleSha256Digest]])
+    depends: Option[Vector[DoubleSha256DigestBE]])
     extends BlockchainResult
 
 case class GetMemPoolInfoResult(
@@ -163,7 +163,7 @@ case class GetMemPoolInfoResult(
     extends BlockchainResult
 
 case class GetTxOutResult(
-    bestblock: DoubleSha256Digest,
+    bestblock: DoubleSha256DigestBE,
     confirmations: Int,
     value: Bitcoins,
     scriptPubKey: RpcScriptPubKey,
@@ -172,11 +172,11 @@ case class GetTxOutResult(
 
 case class GetTxOutSetInfoResult(
     height: Int,
-    bestblock: DoubleSha256Digest,
+    bestblock: DoubleSha256DigestBE,
     transactions: Int,
     txouts: Int,
     bogosize: Int,
-    hash_serialized_2: DoubleSha256Digest,
+    hash_serialized_2: DoubleSha256DigestBE,
     disk_size: Int,
     total_amount: Bitcoins)
     extends BlockchainResult

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/RawTransactionResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/RawTransactionResult.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.rpc.jsonmodels
 
-import org.bitcoins.core.crypto.DoubleSha256Digest
+import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptSignature}
@@ -10,8 +10,8 @@ import org.bitcoins.core.protocol.{BitcoinAddress, P2PKHAddress, P2SHAddress}
 sealed abstract class RawTransactionResult
 
 case class RpcTransaction(
-    txid: DoubleSha256Digest,
-    hash: DoubleSha256Digest,
+    txid: DoubleSha256DigestBE,
+    hash: DoubleSha256DigestBE,
     version: Int,
     size: Int,
     vsize: Int,
@@ -52,22 +52,22 @@ case class FundRawTransactionResult(
 case class GetRawTransactionResult(
     in_active_blockchain: Option[Boolean],
     hex: Transaction,
-    txid: DoubleSha256Digest,
-    hash: DoubleSha256Digest,
+    txid: DoubleSha256DigestBE,
+    hash: DoubleSha256DigestBE,
     size: Int,
     vsize: Int,
     version: Int,
     locktime: UInt32,
     vin: Vector[GetRawTransactionVin],
     vout: Vector[RpcTransactionOutput],
-    blockhash: DoubleSha256Digest,
+    blockhash: DoubleSha256DigestBE,
     confirmations: Int,
     time: UInt32,
     blocktime: UInt32)
     extends RawTransactionResult
 
 case class GetRawTransactionVin(
-    txid: Option[DoubleSha256Digest],
+    txid: Option[DoubleSha256DigestBE],
     vout: Option[Int],
     scriptSig: Option[GetRawTransactionScriptSig],
     sequence: Option[BigDecimal],
@@ -84,7 +84,7 @@ case class SignRawTransactionResult(
     extends RawTransactionResult
 
 case class SignRawTransactionError(
-    txid: DoubleSha256Digest,
+    txid: DoubleSha256DigestBE,
     vout: Int,
     scriptSig: ScriptPubKey,
     sequence: UInt32,

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/WalletResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/WalletResult.scala
@@ -2,7 +2,7 @@ package org.bitcoins.rpc.jsonmodels
 
 import java.io.File
 
-import org.bitcoins.core.crypto.{DoubleSha256Digest, Sha256Hash160Digest}
+import org.bitcoins.core.crypto.{DoubleSha256DigestBE, Sha256Hash160Digest}
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -16,7 +16,7 @@ case class MultiSigResult(address: BitcoinAddress, redeemScript: ScriptPubKey)
     extends WalletResult
 
 case class BumpFeeResult(
-    txid: DoubleSha256Digest,
+    txid: DoubleSha256DigestBE,
     origfee: Bitcoins,
     fee: Bitcoins, // TODO: Should be BitcoinFeeUnit
     errors: Vector[String])
@@ -27,11 +27,11 @@ case class GetTransactionResult(
     fee: Option[Bitcoins],
     confirmations: Int,
     generated: Option[Boolean],
-    blockhash: Option[DoubleSha256Digest],
+    blockhash: Option[DoubleSha256DigestBE],
     blockindex: Option[Int],
     blocktime: Option[UInt32],
-    txid: DoubleSha256Digest,
-    walletconflicts: Vector[DoubleSha256Digest],
+    txid: DoubleSha256DigestBE,
+    walletconflicts: Vector[DoubleSha256DigestBE],
     time: UInt32,
     timereceived: UInt32,
     bip125_replaceable: String,
@@ -97,7 +97,7 @@ case class ReceivedAddress(
     amount: Bitcoins,
     confirmations: Int,
     label: String,
-    txids: Vector[DoubleSha256Digest])
+    txids: Vector[DoubleSha256DigestBE])
     extends WalletResult
 
 case class ReceivedAccount(
@@ -110,7 +110,7 @@ case class ReceivedAccount(
 
 case class ListSinceBlockResult(
     transactions: Vector[Payment],
-    lastblock: DoubleSha256Digest)
+    lastblock: DoubleSha256DigestBE)
     extends WalletResult
 
 case class Payment(
@@ -123,11 +123,11 @@ case class Payment(
     fee: Option[Bitcoins],
     confirmations: Int,
     generated: Option[Boolean],
-    blockhash: Option[DoubleSha256Digest],
+    blockhash: Option[DoubleSha256DigestBE],
     blockindex: Option[Int],
     blocktime: Option[UInt32],
-    txid: DoubleSha256Digest,
-    walletconflicts: Vector[DoubleSha256Digest],
+    txid: DoubleSha256DigestBE,
+    walletconflicts: Vector[DoubleSha256DigestBE],
     time: UInt32,
     timereceived: UInt32,
     bip125_replaceable: String,
@@ -146,11 +146,11 @@ case class ListTransactionsResult(
     confirmations: Option[Int],
     trusted: Option[Boolean],
     generated: Option[Boolean],
-    blockhash: Option[DoubleSha256Digest],
+    blockhash: Option[DoubleSha256DigestBE],
     blockindex: Option[Int],
     blocktime: Option[UInt32],
-    txid: Option[DoubleSha256Digest],
-    walletconflicts: Option[Vector[DoubleSha256Digest]],
+    txid: Option[DoubleSha256DigestBE],
+    walletconflicts: Option[Vector[DoubleSha256DigestBE]],
     time: UInt32,
     timereceived: Option[UInt32],
     comment: Option[String],
@@ -161,7 +161,7 @@ case class ListTransactionsResult(
     extends WalletResult
 
 case class UnspentOutput(
-    txid: DoubleSha256Digest,
+    txid: DoubleSha256DigestBE,
     vout: Int,
     address: Option[BitcoinAddress],
     account: Option[String],

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
@@ -39,6 +39,13 @@ object JsonReaders {
         DoubleSha256Digest.fromHex)(json)
   }
 
+  implicit object DoubleSha256DigestBEReads
+      extends Reads[DoubleSha256DigestBE] {
+    override def reads(json: JsValue): JsResult[DoubleSha256DigestBE] =
+      SerializerUtil.processJsString[DoubleSha256DigestBE](
+        DoubleSha256DigestBE.fromHex)(json)
+  }
+
   implicit object BitcoinsReads extends Reads[Bitcoins] {
     override def reads(json: JsValue): JsResult[Bitcoins] =
       SerializerUtil.processJsNumber[Bitcoins](Bitcoins(_))(json)
@@ -198,7 +205,7 @@ object JsonReaders {
             JsSuccess(
               CoinbaseInput(ScriptSignature.fromAsmHex(s.value), sequence))
           case _ =>
-            (json \ "txid").validate[DoubleSha256Digest].flatMap { txid =>
+            (json \ "txid").validate[DoubleSha256DigestBE].flatMap { txid =>
               (json \ "vout").validate[UInt32].flatMap { vout =>
                 (json \ "scriptSig" \ "hex").validate[ScriptSignature].flatMap {
                   scriptSig =>
@@ -239,7 +246,7 @@ object JsonReaders {
   }
 
   implicit object TransactionOutPointReads extends Reads[TransactionOutPoint] {
-    private case class OutPoint(txid: DoubleSha256Digest, vout: UInt32)
+    private case class OutPoint(txid: DoubleSha256DigestBE, vout: UInt32)
     override def reads(json: JsValue): JsResult[TransactionOutPoint] = {
       implicit val outPointReads: Reads[OutPoint] = Json.reads[OutPoint]
       json.validate[OutPoint] match {

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
@@ -5,6 +5,7 @@ import java.net.{InetAddress, URI}
 
 import org.bitcoins.core.crypto.{
   DoubleSha256Digest,
+  DoubleSha256DigestBE,
   ECPublicKey,
   Sha256Hash160Digest
 }
@@ -36,6 +37,8 @@ object JsonSerializers {
   // Internal Types
   implicit val doubleSha256DigestReads: Reads[DoubleSha256Digest] =
     DoubleSha256DigestReads
+  implicit val doubleSha256DigestBEReads: Reads[DoubleSha256DigestBE] =
+    DoubleSha256DigestBEReads
   implicit val bitcoinsReads: Reads[Bitcoins] = BitcoinsReads
   implicit val satoshisReads: Reads[Satoshis] = SatoshisReads
   implicit val blockHeaderReads: Reads[BlockHeader] = BlockHeaderReads
@@ -193,11 +196,11 @@ object JsonSerializers {
       (__ \ "fee").readNullable[Bitcoins] and
       (__ \ "confirmations").read[Int] and
       (__ \ "generated").readNullable[Boolean] and
-      (__ \ "blockhash").readNullable[DoubleSha256Digest] and
+      (__ \ "blockhash").readNullable[DoubleSha256DigestBE] and
       (__ \ "blockindex").readNullable[Int] and
       (__ \ "blocktime").readNullable[UInt32] and
-      (__ \ "txid").read[DoubleSha256Digest] and
-      (__ \ "walletconflicts").read[Vector[DoubleSha256Digest]] and
+      (__ \ "txid").read[DoubleSha256DigestBE] and
+      (__ \ "walletconflicts").read[Vector[DoubleSha256DigestBE]] and
       (__ \ "time").read[UInt32] and
       (__ \ "timereceived").read[UInt32] and
       (__ \ "bip125-replaceable").read[String] and
@@ -240,11 +243,11 @@ object JsonSerializers {
       (__ \ "fee").readNullable[Bitcoins] and
       (__ \ "confirmations").read[Int] and
       (__ \ "generated").readNullable[Boolean] and
-      (__ \ "blockhash").readNullable[DoubleSha256Digest] and
+      (__ \ "blockhash").readNullable[DoubleSha256DigestBE] and
       (__ \ "blockindex").readNullable[Int] and
       (__ \ "blocktime").readNullable[UInt32] and
-      (__ \ "txid").read[DoubleSha256Digest] and
-      (__ \ "walletconflicts").read[Vector[DoubleSha256Digest]] and
+      (__ \ "txid").read[DoubleSha256DigestBE] and
+      (__ \ "walletconflicts").read[Vector[DoubleSha256DigestBE]] and
       (__ \ "time").read[UInt32] and
       (__ \ "timereceived").read[UInt32] and
       (__ \ "bip125-replaceable").read[String] and
@@ -264,11 +267,11 @@ object JsonSerializers {
       (__ \ "confirmations").readNullable[Int] and
       (__ \ "trusted").readNullable[Boolean] and
       (__ \ "generated").readNullable[Boolean] and
-      (__ \ "blockhash").readNullable[DoubleSha256Digest] and
+      (__ \ "blockhash").readNullable[DoubleSha256DigestBE] and
       (__ \ "blockindex").readNullable[Int] and
       (__ \ "blocktime").readNullable[UInt32] and
-      (__ \ "txid").readNullable[DoubleSha256Digest] and
-      (__ \ "walletconflicts").readNullable[Vector[DoubleSha256Digest]] and
+      (__ \ "txid").readNullable[DoubleSha256DigestBE] and
+      (__ \ "walletconflicts").readNullable[Vector[DoubleSha256DigestBE]] and
       (__ \ "time").read[UInt32] and
       (__ \ "timereceived").readNullable[UInt32] and
       (__ \ "comment").readNullable[String] and
@@ -305,6 +308,11 @@ object JsonSerializers {
     Map[DoubleSha256Digest, GetMemPoolResult]] =
     Reads.mapReads[DoubleSha256Digest, GetMemPoolResult](s =>
       JsSuccess(DoubleSha256Digest.fromHex(s)))
+
+  implicit def mapDoubleSha256DigestBEReads: Reads[
+    Map[DoubleSha256DigestBE, GetMemPoolResult]] =
+    Reads.mapReads[DoubleSha256DigestBE, GetMemPoolResult](s =>
+      JsSuccess(DoubleSha256DigestBE.fromHex(s)))
 
   implicit val outputMapWrites: Writes[Map[BitcoinAddress, Bitcoins]] =
     mapWrites[BitcoinAddress, Bitcoins](_.value)

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonWriters.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonWriters.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.rpc.serializers
 
-import org.bitcoins.core.crypto.DoubleSha256Digest
+import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -23,6 +23,11 @@ object JsonWriters {
     override def writes(o: DoubleSha256Digest): JsValue = JsString(o.hex)
   }
 
+  implicit object DoubleSha256DigestBEWrites
+      extends Writes[DoubleSha256DigestBE] {
+    override def writes(o: DoubleSha256DigestBE): JsValue = JsString(o.hex)
+  }
+
   implicit object ScriptPubKeyWrites extends Writes[ScriptPubKey] {
     override def writes(o: ScriptPubKey): JsValue =
       JsString(BitcoinSUtil.encodeHex(o.asmBytes))
@@ -31,7 +36,7 @@ object JsonWriters {
   implicit object TransactionInputWrites extends Writes[TransactionInput] {
     override def writes(o: TransactionInput): JsValue =
       JsObject(
-        Seq(("txid", JsString(o.previousOutput.txId.flip.hex)),
+        Seq(("txid", JsString(o.previousOutput.txIdBE.hex)),
             ("vout", JsNumber(o.previousOutput.vout.toLong)),
             ("sequence", JsNumber(o.sequence.toLong))))
   }

--- a/core/src/main/scala/org/bitcoins/core/crypto/HashDigest.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/HashDigest.scala
@@ -25,7 +25,7 @@ sealed abstract class HashDigest extends NetworkElement {
   * Represents the result of SHA1()
   */
 sealed abstract class Sha1Digest extends HashDigest {
-  override def flip: Sha1Digest = Sha1Digest(bytes.reverse)
+  override def flip: Sha1DigestBE = Sha1DigestBE(bytes.reverse)
 }
 
 object Sha1Digest extends Factory[Sha1Digest] {
@@ -37,11 +37,25 @@ object Sha1Digest extends Factory[Sha1Digest] {
   override def fromBytes(bytes: ByteVector): Sha1Digest = Sha1DigestImpl(bytes)
 }
 
+sealed abstract class Sha1DigestBE extends HashDigest {
+  override def flip: Sha1Digest = Sha1Digest(bytes.reverse)
+}
+
+object Sha1DigestBE extends Factory[Sha1DigestBE] {
+  private case class Sha1DigestBEImpl(bytes: ByteVector) extends Sha1DigestBE {
+    // $COVERAGE-OFF$
+    override def toString = s"Sha1DigestBEImpl($hex)"
+    // $COVERAGE-ON$
+  }
+  override def fromBytes(bytes: ByteVector): Sha1DigestBE =
+    Sha1DigestBEImpl(bytes)
+}
+
 /**
   * Represents the result of SHA256()
   */
 sealed abstract class Sha256Digest extends HashDigest {
-  override def flip: Sha256Digest = Sha256Digest(bytes.reverse)
+  override def flip: Sha256DigestBE = Sha256DigestBE(bytes.reverse)
 }
 
 object Sha256Digest extends Factory[Sha256Digest] {
@@ -57,10 +71,30 @@ object Sha256Digest extends Factory[Sha256Digest] {
 }
 
 /**
+  * Represents the result of SHA256()
+  */
+sealed abstract class Sha256DigestBE extends HashDigest {
+  override def flip: Sha256Digest = Sha256Digest(bytes.reverse)
+}
+
+object Sha256DigestBE extends Factory[Sha256DigestBE] {
+  private case class Sha256DigestBEImpl(bytes: ByteVector)
+      extends Sha256DigestBE {
+    require(bytes.length == 32,
+            // $COVERAGE-OFF$
+            "Sha256Digest must be 32 bytes in size, got: " + bytes.length)
+    override def toString = s"Sha256DigestBEImpl($hex)"
+    // $COVERAGE-ON$
+  }
+  override def fromBytes(bytes: ByteVector): Sha256DigestBE =
+    Sha256DigestBEImpl(bytes)
+}
+
+/**
   * Represents the result of SHA256(SHA256())
   */
 sealed abstract class DoubleSha256Digest extends HashDigest {
-  def flip: DoubleSha256Digest = DoubleSha256Digest(bytes.reverse)
+  def flip: DoubleSha256DigestBE = DoubleSha256DigestBE(bytes.reverse)
 }
 
 object DoubleSha256Digest extends Factory[DoubleSha256Digest] {
@@ -77,11 +111,30 @@ object DoubleSha256Digest extends Factory[DoubleSha256Digest] {
 
 }
 
+/** The big endian version of [[org.bitcoins.core.crypto.DoubleSha256Digest DoubleSha256Digest]] */
+sealed abstract class DoubleSha256DigestBE extends HashDigest {
+  def flip: DoubleSha256Digest = DoubleSha256Digest.fromBytes(bytes.reverse)
+}
+
+object DoubleSha256DigestBE extends Factory[DoubleSha256DigestBE] {
+  private case class DoubleSha256DigestBEImpl(bytes: ByteVector)
+      extends DoubleSha256DigestBE {
+    require(bytes.length == 32,
+            // $COVERAGE-OFF$
+            "DoubleSha256Digest must always be 32 bytes, got: " + bytes.length)
+    override def toString = s"DoubleSha256BDigestBEImpl($hex)"
+    // $COVERAGE-ON$
+  }
+  override def fromBytes(bytes: ByteVector): DoubleSha256DigestBE =
+    DoubleSha256DigestBEImpl(bytes)
+
+}
+
 /**
   * Represents the result of RIPEMD160()
   */
 sealed abstract class RipeMd160Digest extends HashDigest {
-  override def flip: RipeMd160Digest = RipeMd160Digest(bytes.reverse)
+  override def flip: RipeMd160DigestBE = RipeMd160DigestBE(bytes.reverse)
 }
 
 object RipeMd160Digest extends Factory[RipeMd160Digest] {
@@ -98,10 +151,31 @@ object RipeMd160Digest extends Factory[RipeMd160Digest] {
 }
 
 /**
+  * Represents the result of RIPEMD160() big endian
+  */
+sealed abstract class RipeMd160DigestBE extends HashDigest {
+  override def flip: RipeMd160Digest = RipeMd160Digest(bytes.reverse)
+}
+
+object RipeMd160DigestBE extends Factory[RipeMd160DigestBE] {
+  private case class RipeMd160DigestBEImpl(bytes: ByteVector)
+      extends RipeMd160DigestBE {
+    require(bytes.length == 20,
+            // $COVERAGE-OFF$
+            "RIPEMD160Digest must always be 20 bytes, got: " + bytes.length)
+    override def toString = s"RipeMd160DigestBEImpl($hex)"
+    // $COVERAGE-ON$
+  }
+  override def fromBytes(bytes: ByteVector): RipeMd160DigestBE =
+    RipeMd160DigestBEImpl(bytes)
+}
+
+/**
   * Represents the result of RIPEMD160(SHA256())
   */
 sealed abstract class Sha256Hash160Digest extends HashDigest {
-  override def flip: Sha256Hash160Digest = Sha256Hash160Digest(bytes.reverse)
+  override def flip: Sha256Hash160DigestBE =
+    Sha256Hash160DigestBE(bytes.reverse)
 }
 
 object Sha256Hash160Digest extends Factory[Sha256Hash160Digest] {
@@ -115,4 +189,24 @@ object Sha256Hash160Digest extends Factory[Sha256Hash160Digest] {
   }
   override def fromBytes(bytes: ByteVector): Sha256Hash160Digest =
     Sha256Hash160DigestImpl(bytes)
+}
+
+/**
+  * Represents the result of RIPEMD160(SHA256()) big endian
+  */
+sealed abstract class Sha256Hash160DigestBE extends HashDigest {
+  override def flip: Sha256Hash160Digest = Sha256Hash160Digest(bytes.reverse)
+}
+
+object Sha256Hash160DigestBE extends Factory[Sha256Hash160DigestBE] {
+  private case class Sha256Hash160DigestBEImpl(bytes: ByteVector)
+      extends Sha256Hash160DigestBE {
+    require(bytes.length == 20,
+            // $COVERAGE-OFF$
+            "Sha256Hash160Digest must always be 20 bytes, got: " + bytes.length)
+    override def toString = s"Sha256Hash160DigestBEImpl($hex)"
+    // $COVERAGE-ON$
+  }
+  override def fromBytes(bytes: ByteVector): Sha256Hash160DigestBE =
+    Sha256Hash160DigestBEImpl(bytes)
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.protocol.blockchain
 
-import org.bitcoins.core.crypto.DoubleSha256Digest
+import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.serializers.blockchain.RawBlockHeaderSerializer
@@ -47,7 +47,7 @@ sealed trait BlockHeader extends NetworkElement {
     * [[https://bitcoin.stackexchange.com/questions/2063/why-does-the-bitcoin-protocol-use-the-little-endian-notation]]
     * @return
     */
-  def previousBlockHashBE: DoubleSha256Digest = previousBlockHash.flip
+  def previousBlockHashBE: DoubleSha256DigestBE = previousBlockHash.flip
 
   /**
     * A SHA256(SHA256()) hash in internal byte order.
@@ -66,7 +66,7 @@ sealed trait BlockHeader extends NetworkElement {
     * [[https://bitcoin.stackexchange.com/questions/2063/why-does-the-bitcoin-protocol-use-the-little-endian-notation]]
     * @return
     */
-  def merkleRootHashBE: DoubleSha256Digest = merkleRootHash.flip
+  def merkleRootHashBE: DoubleSha256DigestBE = merkleRootHash.flip
 
   /**
     * The block time is a Unix epoch time when the miner started hashing the header (according to the miner).
@@ -105,7 +105,7 @@ sealed trait BlockHeader extends NetworkElement {
     * [[https://bitcoin.stackexchange.com/questions/2063/why-does-the-bitcoin-protocol-use-the-little-endian-notation]]
     * @return
     */
-  def hashBE: DoubleSha256Digest = hash.flip
+  def hashBE: DoubleSha256DigestBE = hash.flip
 
   override def bytes: ByteVector = RawBlockHeaderSerializer.write(this)
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.protocol.transaction
 
-import org.bitcoins.core.crypto.DoubleSha256Digest
+import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.protocol.script.ScriptWitness
@@ -33,7 +33,7 @@ sealed abstract class Transaction extends NetworkElement {
     * For more info see:
     * [[https://bitcoin.stackexchange.com/questions/2063/why-does-the-bitcoin-protocol-use-the-little-endian-notation]]
     */
-  def txIdBE: DoubleSha256Digest = txId.flip
+  def txIdBE: DoubleSha256DigestBE = txId.flip
 
   /** The version number for this transaction */
   def version: Int32
@@ -141,7 +141,7 @@ sealed abstract class WitnessTransaction extends Transaction {
   def wTxId: DoubleSha256Digest = CryptoUtil.doubleSHA256(bytes)
 
   /** Returns the big endian encoding of the wtxid */
-  def wTxIdBE: DoubleSha256Digest = wTxId.flip
+  def wTxIdBE: DoubleSha256DigestBE = wTxId.flip
 
   /**
     * Weight calculation in bitcoin for witness txs

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutPoint.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutPoint.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.protocol.transaction
 
-import org.bitcoins.core.crypto.DoubleSha256Digest
+import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.serializers.transaction.RawTransactionOutPointParser
@@ -16,6 +16,8 @@ sealed abstract class TransactionOutPoint extends NetworkElement {
   /** The transaction id for the crediting transaction for this input */
   def txId: DoubleSha256Digest
 
+  def txIdBE: DoubleSha256DigestBE = txId.flip
+
   /** The output index in the parent transaction for the output we are spending */
   def vout: UInt32
 
@@ -28,13 +30,13 @@ sealed abstract class TransactionOutPoint extends NetworkElement {
   * https://github.com/bitcoin/bitcoin/blob/d612837814020ae832499d18e6ee5eb919a87907/src/primitives/transaction.h
   * http://stackoverflow.com/questions/2711522/what-happens-if-i-assign-a-negative-value-to-an-unsigned-variable
   */
-case object EmptyTransactionOutPoint extends TransactionOutPoint {
+final case object EmptyTransactionOutPoint extends TransactionOutPoint {
 
-  def txId =
+  override val txId: DoubleSha256Digest =
     DoubleSha256Digest(
       BitcoinSUtil.decodeHex(
         "0000000000000000000000000000000000000000000000000000000000000000"))
-  def vout = UInt32("ffffffff")
+  override val vout: UInt32 = UInt32("ffffffff")
 }
 
 object TransactionOutPoint extends Factory[TransactionOutPoint] {
@@ -51,5 +53,9 @@ object TransactionOutPoint extends Factory[TransactionOutPoint] {
     if (txId == EmptyTransactionOutPoint.txId && index == EmptyTransactionOutPoint.vout) {
       EmptyTransactionOutPoint
     } else TransactionOutPointImpl(txId, index)
+  }
+
+  def apply(txId: DoubleSha256DigestBE, index: UInt32): TransactionOutPoint = {
+    TransactionOutPoint(txId.flip, index)
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.typesafe.config.{Config, ConfigFactory}
 import org.bitcoins.core.config.RegTest
-import org.bitcoins.core.crypto.DoubleSha256Digest
+import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.rpc.client.BitcoindRpcClient
 import org.bitcoins.rpc.config.{
@@ -280,12 +280,17 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
       implicit ec: ExecutionContext): Future[Boolean] = {
     val p = Promise[Boolean]()
 
-    client1.getBlock(hash).onComplete {
+    client1.getBlock(hash.flip).onComplete {
       case Success(_) => p.success(true)
       case Failure(_) => p.success(false)
     }
 
     p.future
+  }
+
+  def hasSeenBlock(client1: BitcoindRpcClient, hash: DoubleSha256DigestBE)(
+      implicit ec: ExecutionContext): Future[Boolean] = {
+    hasSeenBlock(client1, hash.flip)
   }
 
   def startedBitcoindRpcClient(


### PR DESCRIPTION
…ject

This integrates the `BE` (big endian) hash type. 

We now have big endian versions of hash digests such as `DoubleSha256DigestBE`. Due to how satoshis built the bitcoin protocol hashes are little endian at the protocol level, but big endian at the rpc level. This is a source of confusion for developers we make an explicit type for the big endian hash digests. 

This is needed for the node project, as we will be dealing with a lot of endianness issues with databases. I want the endianess to be encoded explicitly in the type. 