### PR TITLE
Make the doublesha256digest generator more random

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CryptoGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CryptoGenerators.scala
@@ -174,8 +174,8 @@ sealed abstract class CryptoGenerators {
   /** Generates a random [[org.bitcoins.core.crypto.DoubleSha256Digest DoubleSha256Digest]] */
   def doubleSha256Digest: Gen[DoubleSha256Digest] =
     for {
-      hex <- StringGenerators.hexString
-      digest = CryptoUtil.doubleSHA256(hex)
+      key <- privateKey
+      digest = CryptoUtil.doubleSHA256(key.bytes)
     } yield digest
 
   /**


### PR DESCRIPTION
This makes the doublesha256digest generator more random, previously it was just hashing hex chars from `StringGenerators.hexString` which really wasn't that random at all