### PR TITLE
Move BitcoinSUnitTest abstract class to the testkit project so it can…

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/BIP39SeedTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/BIP39SeedTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.crypto
-import org.bitcoins.core.util.BitcoinSUnitTest
 import org.bitcoins.testkit.core.gen.CryptoGenerators
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.HexStringSyntax
 
 import scala.util.{Failure, Try}

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ECDigitalSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ECDigitalSignatureTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.crypto
 
 import org.bitcoins.testkit.core.gen.CryptoGenerators
-import org.bitcoins.core.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/MnemonicCodeTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/MnemonicCodeTest.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.core.crypto
 
 import com.fasterxml.jackson.databind.JsonNode
-import org.bitcoins.core.util.BitcoinSUnitTest
 import org.bitcoins.testkit.core.gen.CryptoGenerators
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import org.scalatest.Assertion
 import play.api.libs.json._
 import play.api.libs.json.jackson.JacksonJson

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/SignTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/SignTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.crypto
 
 import org.bitcoins.testkit.core.gen.CryptoGenerators
-import org.bitcoins.core.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/core-test/src/test/scala/org/bitcoins/core/number/BasicArithmeticSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/number/BasicArithmeticSpec.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.number
 import org.bitcoins.testkit.core.gen.NumberGenerator
-import org.bitcoins.core.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import org.scalatest.prop.PropertyChecks
 
 class BasicArithmeticSpec extends BitcoinSUnitTest {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/AddressTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/AddressTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol
 
-import org.bitcoins.core.util.BitcoinSUnitTest
 import org.bitcoins.testkit.core.gen.AddressGenerator
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 import scala.util.{Failure, Success}
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
@@ -6,8 +6,9 @@ import org.bitcoins.core.number.{UInt5, UInt8}
 import org.bitcoins.core.protocol.ln.LnHumanReadablePart
 import org.bitcoins.core.protocol.ln.currency.PicoBitcoins
 import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.util.{Bech32, BitcoinSUnitTest}
+import org.bitcoins.core.util.Bech32
 import org.bitcoins.testkit.core.gen.NumberGenerator
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 import scala.util.{Failure, Success}
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceSignatureTest.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.protocol.ln
 import org.bitcoins.core.crypto.ECPrivateKey
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.testkit.core.gen.ln.LnInvoiceGen
-import org.bitcoins.core.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 class LnInvoiceSignatureTest extends BitcoinSUnitTest {
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
@@ -18,7 +18,8 @@ import org.bitcoins.core.protocol.ln.fee.{
 }
 import org.bitcoins.core.protocol.ln.routing.LnRoute
 import org.bitcoins.core.protocol.{Bech32Address, P2PKHAddress, P2SHAddress}
-import org.bitcoins.core.util.{BitcoinSUnitTest, CryptoUtil}
+import org.bitcoins.core.util.CryptoUtil
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 class LnInvoiceUnitTest extends BitcoinSUnitTest {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnUtilTest.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.protocol.ln
 import org.bitcoins.testkit.core.gen.NumberGenerator
 import org.bitcoins.core.number.{UInt5, UInt64}
 import org.bitcoins.core.protocol.ln.util.LnUtil
-import org.bitcoins.core.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 class LnUtilTest extends BitcoinSUnitTest {
   override implicit val generatorDrivenConfig: PropertyCheckConfiguration =

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshisTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshisTest.scala
@@ -2,7 +2,7 @@ package org.bitcoins.core.protocol.ln.currency
 
 import org.bitcoins.testkit.core.gen.{CurrencyUnitGenerator, NumberGenerator}
 import org.bitcoins.testkit.core.gen.ln.LnCurrencyUnitGen
-import org.bitcoins.core.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import org.scalatest.prop.PropertyChecks
 
 class MilliSatoshisTest extends BitcoinSUnitTest {

--- a/core-test/src/test/scala/org/bitcoins/core/util/CryptoUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/CryptoUtilTest.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.core.util
 
 import org.bitcoins.testkit.core.gen.CryptoGenerators
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.BinStringSyntax
 
 /**

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSUnitTest.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.core.util
+package org.bitcoins.testkit.util
 
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, MustMatchers}


### PR DESCRIPTION
… be reused across our codebase