### PR TITLE
2019 03 20 chainparams add mining consensus rules

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/ChainParamsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/ChainParamsTest.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.core.protocol.blockchain
 
+import java.math.BigInteger
+
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.Int64
 import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptSignature}
@@ -177,5 +179,18 @@ class ChainParamsTest extends BitcoinSUnitTest {
     MainNetChainParams.allowMinDifficultyBlocks must be(false)
     TestNetChainParams.allowMinDifficultyBlocks must be(true)
     RegTestNetChainParams.allowMinDifficultyBlocks must be(true)
+  }
+
+  it must "compute the correct pow limits" in {
+    val expectedTestMain = new BigInteger(
+      "26959946667150639794667015087019630673637144422540572481103610249215",
+      10)
+
+    val expectedRegTest = new BigInteger(
+      "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+      10)
+    MainNetChainParams.powLimit must be(expectedTestMain)
+    TestNetChainParams.powLimit must be(expectedTestMain)
+    RegTestNetChainParams.powLimit must be(expectedRegTest)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/ChainParamsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/ChainParamsTest.scala
@@ -8,15 +8,13 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionConstants,
   TransactionOutput
 }
-import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.core.util.BitcoinSUtil
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 5/24/16.
   */
-class ChainParamsTest extends FlatSpec with MustMatchers {
-  private def logger = BitcoinSLogger.logger
-
+class ChainParamsTest extends BitcoinSUnitTest {
   val genesisBlock = MainNetChainParams.genesisBlock
   val genesisTransaction = genesisBlock.transactions.head
 
@@ -161,5 +159,23 @@ class ChainParamsTest extends FlatSpec with MustMatchers {
       "043587CF".toLowerCase)
     BitcoinSUtil.encodeHex(RegTestNetChainParams.base58Prefixes(ExtSecretKey)) must be(
       "04358394".toLowerCase)
+  }
+
+  it must "determine the correct POW intervals for bitcoin networks" in {
+    MainNetChainParams.difficultyChangeInterval must be(2016)
+    TestNetChainParams.difficultyChangeInterval must be(2016)
+    RegTestNetChainParams.difficultyChangeInterval must be(2016)
+  }
+
+  it must "determine what networks allow retargeting of proof of work" in {
+    MainNetChainParams.noRetargeting must be(false)
+    TestNetChainParams.noRetargeting must be(false)
+    RegTestNetChainParams.noRetargeting must be(true)
+  }
+
+  it must "allow/not allow minimum difficulty blocks on certain networks" in {
+    MainNetChainParams.allowMinDifficultyBlocks must be(false)
+    TestNetChainParams.allowMinDifficultyBlocks must be(true)
+    RegTestNetChainParams.allowMinDifficultyBlocks must be(true)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -11,8 +11,8 @@ import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptSignature}
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.{BytesToPushOntoStack, ScriptConstant}
 import org.bitcoins.core.script.crypto.OP_CHECKSIG
-import org.bitcoins.core.util.{BitcoinSUtil, BitcoinScriptUtil}
-import scodec.bits.ByteVector
+import org.bitcoins.core.util.BitcoinScriptUtil
+import scodec.bits.{ByteVector, _}
 
 import scala.concurrent.duration.{Duration, DurationInt}
 
@@ -164,45 +164,37 @@ sealed abstract class ChainParams {
   def powTargetTimeSpan: Duration
 
   /**
-    * Not sure what this value is right now, but it is constant across bitcoin
+    * The targeted interval between blocks
     * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L74 mainnet]]
     * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L191 testnet]]
     * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L286 regtest]]
     * @return
     */
-  def powTargetSpacing: Int
+  def powTargetSpacing: Duration
 
   /** In bitcoin [[MainNetChainParams mainnet]], the network recalculates the difficulty for the network every 2016 blocks
     * [[https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/consensus/params.h#L75 bitcoin core implementation]]
     * */
   def difficultyChangeInterval: Long = {
-    powTargetTimeSpan.toSeconds / powTargetSpacing
+    powTargetTimeSpan.toSeconds / powTargetSpacing.toSeconds
   }
 }
 
 sealed abstract class BitcoinChainParams extends ChainParams {
 
-  /** The targetted timespan between difficulty adjustments
-    * As of this implementation, all of these are the same in bitcoin core
-    *
-    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L73 mainnet]]
-    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L190 testnet]]
-    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L285 regtest]]
+  /**
+    * @inheritdoc
     * */
   override lazy val powTargetTimeSpan: Duration = {
-    val time = 14 * 24 * 60 * 60 //two weeks
-    time.seconds
+    14.days
   }
 
   /**
-    * Not sure what this value is right now, but it is constant across bitcoin
-    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L74 mainnet]]
-    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L191 testnet]]
-    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L286 regtest]]
-    * @return
+    * @inheritdoc
     */
-  override lazy val powTargetSpacing: Int = {
-    10 * 60 //what are these magic numbers?
+  override lazy val powTargetSpacing: Duration = {
+    val time = 10 * 60 //10 minutes * 60 seconds
+    time.seconds
   }
 
   /** The best chain should have this amount of work */
@@ -239,17 +231,11 @@ object MainNetChainParams extends BitcoinChainParams {
 
   override lazy val base58Prefixes: Map[Base58Type, ByteVector] =
     Map(
-      Base58Type.PubKeyAddress -> BitcoinSUtil.decodeHex("00"),
-      Base58Type.ScriptAddress -> BitcoinSUtil.decodeHex("05"),
-      Base58Type.SecretKey -> BitcoinSUtil.decodeHex("80"),
-      Base58Type.ExtPublicKey -> ByteVector(BitcoinSUtil.hexToByte("04"),
-                                            BitcoinSUtil.hexToByte("88"),
-                                            BitcoinSUtil.hexToByte("b2"),
-                                            BitcoinSUtil.hexToByte("1e")),
-      Base58Type.ExtSecretKey -> ByteVector(BitcoinSUtil.hexToByte("04"),
-                                            BitcoinSUtil.hexToByte("88"),
-                                            BitcoinSUtil.hexToByte("ad"),
-                                            BitcoinSUtil.hexToByte("e4"))
+      Base58Type.PubKeyAddress -> hex"00",
+      Base58Type.ScriptAddress -> hex"05",
+      Base58Type.SecretKey -> hex"80",
+      Base58Type.ExtPublicKey -> hex"0488b21e",
+      Base58Type.ExtSecretKey -> hex"0488ade4"
     )
 
   /**
@@ -270,8 +256,8 @@ object MainNetChainParams extends BitcoinChainParams {
     * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L94 mainnet chain work]]
     */
   override lazy val minimumChainWork: BigInteger = {
-    val bytes = ByteVector.fromValidHex(
-      "0000000000000000000000000000000000000000051dc8b82f450202ecb3d471")
+    val bytes =
+      hex"0000000000000000000000000000000000000000051dc8b82f450202ecb3d471"
     new BigInteger(1, bytes.toArray)
   }
 
@@ -301,17 +287,11 @@ object TestNetChainParams extends BitcoinChainParams {
 
   override lazy val base58Prefixes: Map[Base58Type, ByteVector] =
     Map(
-      Base58Type.PubKeyAddress -> BitcoinSUtil.decodeHex("6f"),
-      Base58Type.ScriptAddress -> BitcoinSUtil.decodeHex("c4"),
-      Base58Type.SecretKey -> BitcoinSUtil.decodeHex("ef"),
-      Base58Type.ExtPublicKey -> ByteVector(BitcoinSUtil.hexToByte("04"),
-                                            BitcoinSUtil.hexToByte("35"),
-                                            BitcoinSUtil.hexToByte("87"),
-                                            BitcoinSUtil.hexToByte("cf")),
-      Base58Type.ExtSecretKey -> ByteVector(BitcoinSUtil.hexToByte("04"),
-                                            BitcoinSUtil.hexToByte("35"),
-                                            BitcoinSUtil.hexToByte("83"),
-                                            BitcoinSUtil.hexToByte("94"))
+      Base58Type.PubKeyAddress -> hex"6f",
+      Base58Type.ScriptAddress -> hex"c4",
+      Base58Type.SecretKey -> hex"ef",
+      Base58Type.ExtPublicKey -> hex"043587cf",
+      Base58Type.ExtSecretKey -> hex"04358394"
     )
 
   /**
@@ -324,8 +304,8 @@ object TestNetChainParams extends BitcoinChainParams {
     * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L211 testnet min chain work]]
     * */
   override lazy val minimumChainWork: BigInteger = {
-    val bytes = ByteVector.fromValidHex(
-      "00000000000000000000000000000000000000000000007dbe94253893cbd463")
+    val bytes =
+      hex"00000000000000000000000000000000000000000000007dbe94253893cbd463"
     new BigInteger(1, bytes.toArray)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -207,6 +207,22 @@ sealed abstract class BitcoinChainParams extends ChainParams {
 
   /** The best chain should have this amount of work */
   def minimumChainWork: BigInteger
+
+  /**
+    * Whether we should allow minimum difficulty blocks or not
+    * As an example you can trivially mine blocks on [[RegTestNetChainParams]] and [[TestNetChainParams]]
+    * but not the [[MainNetChainParams]]
+    * @return
+    */
+  def allowMinDifficultyBlocks: Boolean
+
+  /**
+    * Whether this chain supports
+    * proof of work retargeting or not
+    * [[https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/consensus/params.h#L72 link]]
+    * @return
+    */
+  def noRetargeting: Boolean
 }
 
 /** The Main Network parameters. */
@@ -258,6 +274,18 @@ object MainNetChainParams extends BitcoinChainParams {
       "0000000000000000000000000000000000000000051dc8b82f450202ecb3d471")
     new BigInteger(1, bytes.toArray)
   }
+
+  /**
+    * Mainnet does not allow trivial difficulty blocks
+    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L287 mainnet min difficulty]]
+    */
+  override lazy val allowMinDifficultyBlocks: Boolean = false
+
+  /**
+    * Mainnet allows pow retargetting
+    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L76 mainnet pow retargetting]]
+    */
+  override lazy val noRetargeting: Boolean = false
 }
 
 object TestNetChainParams extends BitcoinChainParams {
@@ -300,6 +328,18 @@ object TestNetChainParams extends BitcoinChainParams {
       "00000000000000000000000000000000000000000000007dbe94253893cbd463")
     new BigInteger(1, bytes.toArray)
   }
+
+  /**
+    * Testnet allows trivial difficulty blocks
+    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L192 testnet min difficulty]]
+    */
+  override lazy val allowMinDifficultyBlocks: Boolean = true
+
+  /**
+    * Testnet allows pow retargetting
+    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L193 testnet pow retargetting]]
+    */
+  override lazy val noRetargeting: Boolean = false
 }
 
 object RegTestNetChainParams extends BitcoinChainParams {
@@ -330,6 +370,18 @@ object RegTestNetChainParams extends BitcoinChainParams {
   override lazy val minimumChainWork: BigInteger = {
     BigInteger.valueOf(0)
   }
+
+  /**
+    * Regtest allows trivial difficulty blocks
+    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L287 regtest min difficulty]]
+    */
+  override lazy val allowMinDifficultyBlocks: Boolean = true
+
+  /**
+    * Regtest allows pow retargetting
+    * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L288 regtest pow retargetting]]
+    */
+  override lazy val noRetargeting: Boolean = false
 }
 
 sealed abstract class Base58Type

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -381,7 +381,7 @@ object RegTestNetChainParams extends BitcoinChainParams {
     * Regtest allows pow retargetting
     * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L288 regtest pow retargetting]]
     */
-  override lazy val noRetargeting: Boolean = false
+  override lazy val noRetargeting: Boolean = true
 }
 
 sealed abstract class Base58Type


### PR DESCRIPTION
This adds mining related consensus parameters to `ChainParams`. These parameters can be found here

https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/consensus/params.h#L70-L76

The implementation of this struct is found in this file

https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp

This will be needed for block header validation in the node project.