### PR TITLE
Implement nbits compression encoding for the difficulty threshold in …

### DIFF
--- a/core-test/src/test/resources/logback-test.xml
+++ b/core-test/src/test/resources/logback-test.xml
@@ -14,7 +14,7 @@
     </appender>
 
 
-    <root level="OFF">
+    <root level="ERROR">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE"/>
     </root>

--- a/core-test/src/test/resources/logback-test.xml
+++ b/core-test/src/test/resources/logback-test.xml
@@ -14,7 +14,7 @@
     </appender>
 
 
-    <root level="ERROR">
+    <root level="OFF">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE"/>
     </root>

--- a/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilTest.scala
@@ -158,15 +158,15 @@ class NumberUtilTest extends BitcoinSUnitTest {
 
     NumberUtil.targetCompression(expanded10) must be(UInt32.fromHex("01120000"))
 
-    NumberUtil.targetCompression(BigInt(0x80).bigInteger, false) must be(
+    NumberUtil.targetCompression(bigInt = BigInt(0x80), isNegative = false) must be(
       UInt32.fromHex("02008000"))
     val expanded11 = NumberUtil.targetExpansion(UInt32.fromHex("01fedcba"))
 
-    BigInt(expanded11.difficulty) must be(126)
+    expanded11.difficulty must be(126)
     expanded11.isNegative must be(true)
     NumberUtil.targetCompression(expanded11) must be(UInt32.fromHex("01fe0000"))
 
-    NumberUtil.targetCompression(BigInt(0x80).bigInteger, false) must be(
+    NumberUtil.targetCompression(bigInt = BigInt(0x80), isNegative = false) must be(
       UInt32.fromHex("02008000"))
 
     val expanded12 = NumberUtil.targetExpansion(UInt32.fromHex("02123456"))

--- a/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilTest.scala
@@ -3,10 +3,9 @@ package org.bitcoins.core.util
 import java.math.BigInteger
 
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.testkit.core.gen.NumberGenerator
+import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 import org.scalatest.Assertion
-import scodec.bits.ByteVector
 
 class NumberUtilTest extends BitcoinSUnitTest {
 
@@ -18,33 +17,69 @@ class NumberUtilTest extends BitcoinSUnitTest {
     //https://bitcoin.org/en/developer-reference#target-nbits
     val nBits1 = UInt32.fromHex("01003456")
     val expected1 = BigInteger.valueOf(0)
-
-    runTest(nBits1, expected1)
+    val diffHelper1 = {
+      BlockHeader.TargetDifficultyHelper(
+        difficulty = expected1,
+        isNegative = false,
+        isOverflow = false
+      )
+    }
+    runTest(nBits1, diffHelper1)
 
     val nBits2 = UInt32.fromHex("01123456")
     val expected2 = BigInteger.valueOf(18)
-
-    runTest(nBits2, expected2)
+    val diffHelper2 = {
+      BlockHeader.TargetDifficultyHelper(
+        difficulty = expected2,
+        isNegative = false,
+        isOverflow = false
+      )
+    }
+    runTest(nBits2, diffHelper2)
 
     val nBits3 = UInt32.fromHex("02008000")
     val expected3 = BigInteger.valueOf(128)
-
-    runTest(nBits3, expected3)
+    val diffHelper3 = {
+      BlockHeader.TargetDifficultyHelper(
+        difficulty = expected3,
+        isNegative = false,
+        isOverflow = false
+      )
+    }
+    runTest(nBits3, diffHelper3)
 
     val nBits4 = UInt32.fromHex("05009234")
     val expected4 = BigInteger.valueOf(2452881408L)
-
-    runTest(nBits4, expected4)
+    val diffHelper4 = {
+      BlockHeader.TargetDifficultyHelper(
+        difficulty = expected4,
+        isNegative = false,
+        isOverflow = false
+      )
+    }
+    runTest(nBits4, diffHelper4)
 
     val nBits6 = UInt32.fromHex("04123456")
     val expected6 = BigInteger.valueOf(305419776)
-
-    runTest(nBits6, expected6)
+    val diffHelper6 = {
+      BlockHeader.TargetDifficultyHelper(
+        difficulty = expected6,
+        isNegative = false,
+        isOverflow = false
+      )
+    }
+    runTest(nBits6, diffHelper6)
 
     val nBits5 = UInt32.fromHex("04923456")
-    val expected5 = BigInteger.valueOf(-305419776)
-
-    runTest(nBits5, expected5)
+    val expected5 = BigInteger.valueOf(305419776)
+    val diffHelper5 = {
+      BlockHeader.TargetDifficultyHelper(
+        difficulty = expected5,
+        isNegative = true,
+        isOverflow = false
+      )
+    }
+    runTest(nBits5, diffHelper5)
   }
 
   it must "expand the minimum difficulty on bitcoin main network" in {
@@ -53,8 +88,14 @@ class NumberUtilTest extends BitcoinSUnitTest {
     val expected = new BigInteger(
       "00ffff0000000000000000000000000000000000000000000000000000",
       16)
-
-    runTest(nBits, expected)
+    val diffHelper = {
+      BlockHeader.TargetDifficultyHelper(
+        expected,
+        false,
+        false
+      )
+    }
+    runTest(nBits, diffHelper)
   }
 
   it must "expand the minimum difficulty correctly on bitcoin regtest" in {
@@ -64,7 +105,15 @@ class NumberUtilTest extends BitcoinSUnitTest {
       10
     )
 
-    runTest(nBits, expected)
+    val diffHelper = {
+      BlockHeader.TargetDifficultyHelper(
+        expected,
+        false,
+        false
+      )
+    }
+
+    runTest(nBits, diffHelper)
   }
 
   behavior of "NumberUtil.targetCompression"
@@ -72,79 +121,78 @@ class NumberUtilTest extends BitcoinSUnitTest {
   it must "handle all cases as enumerated in bitcoin core" in {
     //https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/test/arith_uint256_tests.cpp#L405
     val expanded = NumberUtil.targetExpansion(UInt32.zero)
-    NumberUtil.targetCompression(expanded, false) must be(UInt32.zero)
+    NumberUtil.targetCompression(expanded) must be(UInt32.zero)
 
     val expanded1 = NumberUtil.targetExpansion(UInt32.fromHex("00123456"))
-    NumberUtil.targetCompression(expanded1, false) must be(UInt32.zero)
+    NumberUtil.targetCompression(expanded1) must be(UInt32.zero)
 
     val expanded2 = NumberUtil.targetExpansion(UInt32.fromHex("01003456"))
-    NumberUtil.targetCompression(expanded2, false) must be(UInt32.zero)
+    NumberUtil.targetCompression(expanded2) must be(UInt32.zero)
 
     val expanded3 = NumberUtil.targetExpansion(UInt32.fromHex("02000056"))
-    NumberUtil.targetCompression(expanded3, false) must be(UInt32.zero)
+    NumberUtil.targetCompression(expanded3) must be(UInt32.zero)
 
     val expanded4 = NumberUtil.targetExpansion(UInt32.fromHex("03000000"))
-    NumberUtil.targetCompression(expanded4, false) must be(UInt32.zero)
+    NumberUtil.targetCompression(expanded4) must be(UInt32.zero)
 
     val expanded5 = NumberUtil.targetExpansion(UInt32.fromHex("04000000"))
-    NumberUtil.targetCompression(expanded5, false) must be(UInt32.zero)
+    NumberUtil.targetCompression(expanded5) must be(UInt32.zero)
 
     val expanded6 = NumberUtil.targetExpansion(UInt32.fromHex("01803456"))
 
-    NumberUtil.targetCompression(expanded6, false) must be(UInt32.zero)
+    NumberUtil.targetCompression(expanded6) must be(UInt32.zero)
 
     val expanded7 = NumberUtil.targetExpansion(UInt32.fromHex("02800056"))
 
-    NumberUtil.targetCompression(expanded7, isNegative = false) must be(
-      UInt32.zero)
+    NumberUtil.targetCompression(expanded7) must be(UInt32.zero)
 
     val expanded8 = NumberUtil.targetExpansion(UInt32.fromHex("03800000"))
 
-    NumberUtil.targetCompression(expanded8, false) must be(UInt32.zero)
+    NumberUtil.targetCompression(expanded8) must be(UInt32.zero)
 
     val expanded9 = NumberUtil.targetExpansion(UInt32.fromHex("04800000"))
 
-    NumberUtil.targetCompression(expanded9, false) must be(UInt32.zero)
+    NumberUtil.targetCompression(expanded9) must be(UInt32.zero)
 
     val expanded10 = NumberUtil.targetExpansion(UInt32.fromHex("01123456"))
 
-    NumberUtil.targetCompression(expanded10, false) must be(
-      UInt32.fromHex("01120000"))
+    NumberUtil.targetCompression(expanded10) must be(UInt32.fromHex("01120000"))
+
+    NumberUtil.targetCompression(BigInt(0x80).bigInteger, false) must be(
+      UInt32.fromHex("02008000"))
+    val expanded11 = NumberUtil.targetExpansion(UInt32.fromHex("01fedcba"))
+
+    BigInt(expanded11.difficulty) must be(126)
+    expanded11.isNegative must be(true)
+    NumberUtil.targetCompression(expanded11) must be(UInt32.fromHex("01fe0000"))
 
     NumberUtil.targetCompression(BigInt(0x80).bigInteger, false) must be(
       UInt32.fromHex("02008000"))
 
-    //ignoring this negative test case for now
-    //https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/test/arith_uint256_tests.cpp#L486
-
     val expanded12 = NumberUtil.targetExpansion(UInt32.fromHex("02123456"))
-    NumberUtil.targetCompression(expanded12, false) must be(
-      UInt32.fromHex("02123400"))
+    NumberUtil.targetCompression(expanded12) must be(UInt32.fromHex("02123400"))
 
     val expanded13 = NumberUtil.targetExpansion(UInt32.fromHex("03123456"))
-    NumberUtil.targetCompression(expanded13, false) must be(
-      UInt32.fromHex("03123456"))
+    NumberUtil.targetCompression(expanded13) must be(UInt32.fromHex("03123456"))
 
     val expanded14 = NumberUtil.targetExpansion(UInt32.fromHex("04123456"))
-    NumberUtil.targetCompression(expanded14, false) must be(
-      UInt32.fromHex("04123456"))
+    NumberUtil.targetCompression(expanded14) must be(UInt32.fromHex("04123456"))
 
-    //skipping this negative test case for now
-    //https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/test/arith_uint256_tests.cpp#L510
+    val expanded15 = NumberUtil.targetExpansion(UInt32.fromHex("04923456"))
+    NumberUtil.targetCompression(expanded15) must be(UInt32.fromHex("04923456"))
 
-    val expanded15 = NumberUtil.targetExpansion(UInt32.fromHex("05009234"))
-    NumberUtil.targetCompression(expanded15, false) must be(
-      UInt32.fromHex("05009234"))
+    val expanded16 = NumberUtil.targetExpansion(UInt32.fromHex("05009234"))
+    NumberUtil.targetCompression(expanded16) must be(UInt32.fromHex("05009234"))
 
-    val expanded16 = NumberUtil.targetExpansion(UInt32.fromHex("20123456"))
-    NumberUtil.targetCompression(expanded16, false) must be(
-      UInt32.fromHex("20123456"))
-
-    //skipping overflow test case for now
-    //https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/test/arith_uint256_tests.cpp#L528
+    val expanded17 = NumberUtil.targetExpansion(UInt32.fromHex("20123456"))
+    NumberUtil.targetCompression(expanded17) must be(UInt32.fromHex("20123456"))
+    val expanded18 = NumberUtil.targetExpansion(UInt32.fromHex("ff123456"))
+    expanded18.isOverflow must be(true)
   }
 
-  private def runTest(nBits: UInt32, expected: BigInteger): Assertion = {
+  private def runTest(
+      nBits: UInt32,
+      expected: BlockHeader.TargetDifficultyHelper): Assertion = {
     val expansion = NumberUtil.targetExpansion(nBits)
     assert(expansion == expected)
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -99,7 +99,7 @@ sealed trait BlockHeader extends NetworkElement {
     * to be considered a valid block on the network
     */
   def difficulty: BigInteger = {
-    NumberUtil.targetExpansion(nBits = nBits)
+    NumberUtil.targetExpansion(nBits = nBits).difficulty
   }
 
   /**
@@ -159,4 +159,16 @@ object BlockHeader extends Factory[BlockHeader] {
   def fromBytes(bytes: ByteVector): BlockHeader =
     RawBlockHeaderSerializer.read(bytes)
 
+  /** Return type used to carry around extra information
+    * about the difficulty required to mine a block. Unfortunately
+    * there is weird corner cases like it being an overflow or negative
+    * which is returned by [[https://github.com/bitcoin/bitcoin/blob/2068f089c8b7b90eb4557d3f67ea0f0ed2059a23/src/arith_uint256.cpp#L206 arith_uint256#SetCompact()]] in bitcoin core
+    * @param difficulty
+    * @param isNegative
+    * @param isOverflow
+    */
+  case class TargetDifficultyHelper(
+      difficulty: BigInteger,
+      isNegative: Boolean,
+      isOverflow: Boolean)
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -1,7 +1,5 @@
 package org.bitcoins.core.protocol.blockchain
 
-import java.math.BigInteger
-
 import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.NetworkElement
@@ -98,7 +96,7 @@ sealed trait BlockHeader extends NetworkElement {
     * The hash of this block needs to be _less than_ this difficulty
     * to be considered a valid block on the network
     */
-  def difficulty: BigInteger = {
+  def difficulty: BigInt = {
     NumberUtil.targetExpansion(nBits = nBits).difficulty
   }
 
@@ -168,7 +166,7 @@ object BlockHeader extends Factory[BlockHeader] {
     * @param isOverflow
     */
   case class TargetDifficultyHelper(
-      difficulty: BigInteger,
+      difficulty: BigInt,
       isNegative: Boolean,
       isOverflow: Boolean)
 }


### PR DESCRIPTION
…a block header

This is required for implementing more block header checks in #378 

Bitcoin core implementation: https://github.com/bitcoin/bitcoin/blob/2068f089c8b7b90eb4557d3f67ea0f0ed2059a23/src/arith_uint256.cpp#L226-L247

Still need to implement 
- [x] Overflow check flag check
- [x] negative number flag check

These two methods are needed to implement [`GetNextWorkRequired()` and `CalculateNextWorkRequired()` in bitcoin core](https://github.com/bitcoin/bitcoin/blob/master/src/pow.cpp#L13-L72)