### PR TITLE
Add coverage minimum for chain project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install:
 script:
   - sbt ++$TRAVIS_SCALA_VERSION coverage test &&
     sbt ++$TRAVIS_SCALA_VERSION core/coverageReport &&
+    sbt ++$TRAVIS_SCALA_VERSION chain/coverageReport &&
     sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
 after_success:
   - sbt ++$TRAVIS_SCALA_VERSION coveralls

--- a/chain-test/src/test/resources/logback-test.xml
+++ b/chain-test/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
 
 
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE"/>
     </root>

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -12,8 +12,7 @@ class BlockchainTest extends ChainUnitTest {
     bhDAO: BlockHeaderDAO =>
       val blockchain = Blockchain.fromHeaders(
         headers = Vector(genesisHeaderDb),
-        blockHeaderDAO = bhDAO,
-        chainParams = chainParam
+        blockHeaderDAO = bhDAO
       )
 
       val newHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -1,0 +1,31 @@
+package org.bitcoins.chain.blockchain
+
+import org.bitcoins.chain.models.BlockHeaderDAO
+import org.bitcoins.chain.util.ChainUnitTest
+import org.bitcoins.testkit.chain.BlockHeaderHelper
+
+class BlockchainTest extends ChainUnitTest {
+
+  behavior of "Blockchain"
+
+  it must "connect a new header to the current tip of a blockchain" in withBlockHeaderDAO {
+    bhDAO: BlockHeaderDAO =>
+      val blockchain = Blockchain.fromHeaders(
+        headers = Vector(genesisHeaderDb),
+        blockHeaderDAO = bhDAO,
+        chainParams = chainParam
+      )
+
+      val newHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
+
+      val connectTipF = blockchain.connectTip(newHeader.blockHeader)
+
+      connectTipF.map {
+        case BlockchainUpdate.Successful(_, connectedHeader) =>
+          assert(newHeader == connectedHeader)
+
+        case fail: BlockchainUpdate.Failed =>
+          assert(false)
+      }
+  }
+}

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -1,0 +1,22 @@
+package org.bitcoins.chain.blockchain
+
+import org.bitcoins.chain.util.ChainUnitTest
+import org.bitcoins.testkit.chain.BlockHeaderHelper
+
+class ChainHandlerTest extends ChainUnitTest {
+
+  behavior of "ChainHandler"
+
+  it must "process a new valid block header, and then be able to fetch that header" in withChainHandler {
+    case chainHandler: ChainHandler =>
+      val newValidHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
+      val processedHeaderF =
+        chainHandler.processHeader(newValidHeader.blockHeader)
+
+      val foundHeaderF =
+        processedHeaderF.flatMap(_.getHeader(newValidHeader.hashBE))
+
+      foundHeaderF.map(found => assert(found.get == newValidHeader))
+  }
+
+}

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
@@ -1,199 +1,166 @@
 package org.bitcoins.chain.models
 
-import org.bitcoins.chain.db.ChainDbManagement
 import org.bitcoins.chain.util.ChainUnitTest
-import org.bitcoins.core.crypto.{DoubleSha256Digest, ECPrivateKey}
-import org.bitcoins.core.number.{Int32, UInt32}
-import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.testkit.chain.ChainTestUtil
+import org.bitcoins.testkit.chain.BlockHeaderHelper
 
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.Future
 
 /**
   * Created by chris on 9/8/16.
   */
 class BlockHeaderDAOTest extends ChainUnitTest {
 
-  val blockHeaderDAO = BlockHeaderDAO(chainParams =
-                                        ChainTestUtil.regTestChainParams,
-                                      dbConfig = dbConfig)
-  before {
-    //Awaits need to be used to make sure this is fully executed before the next test case starts
-    //TODO: Figure out a way to make this asynchronous
-    Await.result(ChainDbManagement.createHeaderTable(dbConfig), timeout)
-    Await.result(blockHeaderDAO.create(genesisHeader), timeout)
-  }
-
   behavior of "BlockHeaderDAO"
 
-  it should "insert and read the genesis block header back" in {
-    val readF = blockHeaderDAO.read(genesisHeader.hashBE)
+  it should "insert and read the genesis block header back" in withBlockHeaderDAO {
+    blockHeaderDAO: BlockHeaderDAO =>
+      val readF = blockHeaderDAO.read(genesisHeaderDb.hashBE)
 
-    val assert1 = readF.map { readHeader =>
-      assert(readHeader.get.blockHeader.hashBE == genesisHeader.hashBE)
-    }
-    val read1F = blockHeaderDAO.getAtHeight(0)
-
-    val assert2 = {
-      read1F.map { headersAtHeight0 =>
-        assert(headersAtHeight0 == List(genesisHeader))
+      val assert1 = readF.map { readHeader =>
+        assert(readHeader.get.blockHeader.hashBE == genesisHeaderDb.hashBE)
       }
-    }
+      val read1F = blockHeaderDAO.getAtHeight(0)
 
-    assert1.flatMap(_ => assert2.map(_ => succeed))
+      val assert2 = {
+        read1F.map { headersAtHeight0 =>
+          assert(headersAtHeight0 == List(genesisHeaderDb))
+        }
+      }
+
+      assert1.flatMap(_ => assert2.map(_ => succeed))
 
   }
 
-  it must "delete a block header in the database" in {
+  it must "delete a block header in the database" in withBlockHeaderDAO {
+    blockHeaderDAO: BlockHeaderDAO =>
+      val blockHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
 
-    val blockHeader = buildHeader(genesisHeader)
-
-    val createdF = blockHeaderDAO.create(blockHeader)
-    //delete the header in the db
-    val deletedF = {
-      createdF.flatMap { _ =>
-        blockHeaderDAO.delete(blockHeader)
+      val createdF = blockHeaderDAO.create(blockHeader)
+      //delete the header in the db
+      val deletedF = {
+        createdF.flatMap { _ =>
+          blockHeaderDAO.delete(blockHeader)
+        }
       }
-    }
 
-    deletedF.flatMap { _ =>
-      blockHeaderDAO
-        .read(blockHeader.blockHeader.hashBE)
-        .map(opt => assert(opt.isEmpty))
-    }
+      deletedF.flatMap { _ =>
+        blockHeaderDAO
+          .read(blockHeader.blockHeader.hashBE)
+          .map(opt => assert(opt.isEmpty))
+      }
 
   }
 
-  it must "retrieve the chain tip saved in the database" in {
+  it must "retrieve the chain tip saved in the database" in withBlockHeaderDAO {
+    blockHeaderDAO: BlockHeaderDAO =>
+      val blockHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
 
-    val blockHeader = buildHeader(genesisHeader)
+      val createdF = blockHeaderDAO.create(blockHeader)
 
-    val createdF = blockHeaderDAO.create(blockHeader)
+      val chainTip1F = createdF.flatMap { _ =>
+        blockHeaderDAO.chainTips
+      }
 
-    val chainTip1F = createdF.flatMap { _ =>
-      blockHeaderDAO.chainTips
-    }
-
-    val assert1F = chainTip1F.map { tips =>
-      assert(tips.length == 1)
-      assert(tips.head.blockHeader.hash == blockHeader.blockHeader.hash)
-    }
-
-    val blockHeader2 = buildHeader(blockHeader)
-
-    //insert another header and make sure that is the new last header
-    assert1F.flatMap { _ =>
-      val created2F = blockHeaderDAO.create(blockHeader2)
-      val chainTip2F = created2F.flatMap(_ => blockHeaderDAO.chainTips)
-
-      chainTip2F.map { tips =>
+      val assert1F = chainTip1F.map { tips =>
         assert(tips.length == 1)
-        assert(tips.head.blockHeader.hash == blockHeader2.blockHeader.hash)
+        assert(tips.head.blockHeader.hash == blockHeader.blockHeader.hash)
       }
-    }
 
-  }
+      val blockHeader2 = BlockHeaderHelper.buildNextHeader(blockHeader)
 
-  it must "return the genesis block when retrieving block headers from an empty database" in {
-    val chainTipsF = blockHeaderDAO.chainTips
-    chainTipsF.map { tips =>
-      assert(tips.headOption == Some(genesisHeader))
-    }
-  }
+      //insert another header and make sure that is the new last header
+      assert1F.flatMap { _ =>
+        val created2F = blockHeaderDAO.create(blockHeader2)
+        val chainTip2F = created2F.flatMap(_ => blockHeaderDAO.chainTips)
 
-  it must "retrieve a block header by height" in {
-    val blockHeader = buildHeader(genesisHeader)
-
-    val createdF = blockHeaderDAO.create(blockHeader)
-
-    val getAtHeightF: Future[Vector[BlockHeaderDb]] = {
-      createdF.flatMap { _ =>
-        blockHeaderDAO.getAtHeight(1)
+        chainTip2F.map { tips =>
+          assert(tips.length == 1)
+          assert(tips.head.blockHeader.hash == blockHeader2.blockHeader.hash)
+        }
       }
-    }
 
-    val assert1F = getAtHeightF.map {
-      case headers =>
-        assert(headers.head == blockHeader)
-        assert(headers.head.height == 1)
-    }
-
-    //create one at height 2
-    val blockHeader2 = buildHeader(blockHeader)
-
-    val created2F = blockHeaderDAO.create(blockHeader2)
-
-    val getAtHeight2F: Future[Vector[BlockHeaderDb]] = {
-      created2F.flatMap(_ => blockHeaderDAO.getAtHeight(2))
-    }
-
-    val assert2F = getAtHeight2F.map { headers =>
-      assert(headers.head == blockHeader2)
-    }
-
-    assert1F.flatMap(_ => assert2F.map(_ => succeed))
   }
 
-  it must "find the height of the longest chain" in {
-    val blockHeader = buildHeader(genesisHeader)
-    val createdF = blockHeaderDAO.create(blockHeader)
-
-    val maxHeightF = createdF.flatMap(_ => blockHeaderDAO.maxHeight)
-
-    val blockHeader2 = buildHeader(blockHeader)
-
-    val created2F = maxHeightF.flatMap(_ => blockHeaderDAO.create(blockHeader2))
-
-    val maxHeight2F = created2F.flatMap(_ => blockHeaderDAO.maxHeight)
-
-    maxHeightF.flatMap { h1 =>
-      maxHeight2F.map { h2 =>
-        assert(h1 == 1)
-        assert(h2 == 2)
-
+  it must "return the genesis block when retrieving block headers from an empty database" in withBlockHeaderDAO {
+    blockHeaderDAO: BlockHeaderDAO =>
+      val chainTipsF = blockHeaderDAO.chainTips
+      chainTipsF.map { tips =>
+        assert(tips.headOption == Some(genesisHeaderDb))
       }
-    }
+  }
+
+  it must "retrieve a block header by height" in withBlockHeaderDAO {
+    blockHeaderDAO: BlockHeaderDAO =>
+      val blockHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
+
+      val createdF = blockHeaderDAO.create(blockHeader)
+
+      val getAtHeightF: Future[Vector[BlockHeaderDb]] = {
+        createdF.flatMap { _ =>
+          blockHeaderDAO.getAtHeight(1)
+        }
+      }
+
+      val assert1F = getAtHeightF.map {
+        case headers =>
+          assert(headers.head == blockHeader)
+          assert(headers.head.height == 1)
+      }
+
+      //create one at height 2
+      val blockHeader2 = BlockHeaderHelper.buildNextHeader(blockHeader)
+
+      val created2F = blockHeaderDAO.create(blockHeader2)
+
+      val getAtHeight2F: Future[Vector[BlockHeaderDb]] = {
+        created2F.flatMap(_ => blockHeaderDAO.getAtHeight(2))
+      }
+
+      val assert2F = getAtHeight2F.map { headers =>
+        assert(headers.head == blockHeader2)
+      }
+
+      assert1F.flatMap(_ => assert2F.map(_ => succeed))
+  }
+
+  it must "find the height of the longest chain" in withBlockHeaderDAO {
+    blockHeaderDAO: BlockHeaderDAO =>
+      val blockHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
+      val createdF = blockHeaderDAO.create(blockHeader)
+
+      val maxHeightF = createdF.flatMap(_ => blockHeaderDAO.maxHeight)
+
+      val blockHeader2 = BlockHeaderHelper.buildNextHeader(blockHeader)
+
+      val created2F =
+        maxHeightF.flatMap(_ => blockHeaderDAO.create(blockHeader2))
+
+      val maxHeight2F = created2F.flatMap(_ => blockHeaderDAO.maxHeight)
+
+      maxHeightF.flatMap { h1 =>
+        maxHeight2F.map { h2 =>
+          assert(h1 == 1)
+          assert(h2 == 2)
+
+        }
+      }
 
   }
 
-  it must "find the height of two headers that are competing to be the longest chain" in {
-    val blockHeader = buildHeader(genesisHeader)
-    val createdF = blockHeaderDAO.create(blockHeader)
+  it must "find the height of two headers that are competing to be the longest chain" in withBlockHeaderDAO {
+    blockHeaderDAO: BlockHeaderDAO =>
+      val blockHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
+      val createdF = blockHeaderDAO.create(blockHeader)
 
-    val blockHeader1 = buildHeader(genesisHeader)
-    val created2F = createdF.flatMap(_ => blockHeaderDAO.create(blockHeader1))
+      val blockHeader1 = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
+      val created2F = createdF.flatMap(_ => blockHeaderDAO.create(blockHeader1))
 
-    //now make sure they are both at height 1
-    val getHeightF = created2F.flatMap(_ => blockHeaderDAO.getAtHeight(1))
+      //now make sure they are both at height 1
+      val getHeightF = created2F.flatMap(_ => blockHeaderDAO.getAtHeight(1))
 
-    getHeightF.map {
-      case headers =>
-        assert(headers == Seq(blockHeader, blockHeader1))
-    }
+      getHeightF.map {
+        case headers =>
+          assert(headers == Seq(blockHeader, blockHeader1))
+      }
   }
-
-  after {
-    //Awaits need to be used to make sure this is fully executed before the next test case starts
-    //TODO: Figure out a way to make this asynchronous
-    Await.result(ChainDbManagement.dropHeaderTable(dbConfig), timeout)
-  }
-
-  private def buildHeader(prevHeader: BlockHeaderDb): BlockHeaderDb = {
-    val prevHash = prevHeader.blockHeader.previousBlockHash
-    val blockHeader = {
-      BlockHeader(
-        version = Int32.one,
-        previousBlockHash = prevHash,
-        //get random 32 bytes
-        merkleRootHash =
-          DoubleSha256Digest.fromBytes(ECPrivateKey.freshPrivateKey.bytes),
-        time = UInt32.one,
-        nBits = UInt32.one,
-        nonce = UInt32.one
-      )
-    }
-
-    BlockHeaderDbHelper.fromBlockHeader(prevHeader.height + 1, blockHeader)
-  }
-
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
@@ -1,30 +1,62 @@
 package org.bitcoins.chain.util
 
-import org.bitcoins.chain.models.BlockHeaderDb
-import org.bitcoins.core.protocol.blockchain.RegTestNetChainParams
+import org.bitcoins.chain.db.ChainDbManagement
+import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
+import org.bitcoins.core.protocol.blockchain.{
+  ChainParams,
+  RegTestNetChainParams
+}
+import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.db.{DbConfig, UnitTestDbConfig}
 import org.bitcoins.testkit.chain.ChainTestUtil
-import org.scalatest.{
-  AsyncFlatSpec,
-  BeforeAndAfter,
-  BeforeAndAfterAll,
-  MustMatchers
-}
+import org.scalatest._
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
 
 trait ChainUnitTest
     extends AsyncFlatSpec
     with MustMatchers
+    with BitcoinSLogger
     with BeforeAndAfter
     with BeforeAndAfterAll {
 
   val timeout = 10.seconds
   def dbConfig: DbConfig = UnitTestDbConfig
-  val genesisHeader: BlockHeaderDb = ChainTestUtil.regTestGenesisHeaderDb
-  val networkParam: RegTestNetChainParams.type = RegTestNetChainParams
+
+  val genesisHeaderDb: BlockHeaderDb = ChainTestUtil.regTestGenesisHeaderDb
+  val chainParam: ChainParams = RegTestNetChainParams
+
+  lazy val blockHeaderDAO = BlockHeaderDAO(chainParams =
+                                             ChainTestUtil.regTestChainParams,
+                                           dbConfig = dbConfig)
 
   implicit def ec: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global
+
+  /** Fixture that creates a [[org.bitcoins.chain.models.BlockHeaderTable]]
+    * with one row inserted into it, the [[RegTestNetChainParams]]
+    * genesis block
+    * @param test
+    * @return
+    */
+  def withBlockHeaderDAO(
+      test: BlockHeaderDAO => Future[Assertion]): Future[Assertion] = {
+    val tableSetupF = ChainDbManagement.createHeaderTable(dbConfig = dbConfig,
+                                                          createIfNotExists =
+                                                            true)
+
+    val genesisHeaderF = tableSetupF.flatMap { _ =>
+      blockHeaderDAO.create(genesisHeaderDb)
+    }
+
+    val blockHeaderDAOF = genesisHeaderF.map(_ => blockHeaderDAO)
+    val testExecutionF = blockHeaderDAOF.flatMap(test(_))
+
+    //this isn't async safe, the completion of `testExecutionF`
+    //isn't dependent on successful completion of dropHeaderTable
+    testExecutionF.onComplete(_ => ChainDbManagement.dropHeaderTable(dbConfig))
+
+    testExecutionF
+  }
 }

--- a/chain/build.sbt
+++ b/chain/build.sbt
@@ -1,0 +1,3 @@
+coverageMinimum := 90
+
+coverageFailOnMinimum := true

--- a/chain/src/main/resources/reference.conf
+++ b/chain/src/main/resources/reference.conf
@@ -1,0 +1,41 @@
+
+commonNodeDbSettings = ${commonDbSettings}
+commonNodeDbSettings {
+  dbName = "chaindb.sqlite"
+  db {
+    user = "chaindb"
+  }
+}
+
+mainnetDb = ${commonNodeDbSettings}
+mainnetDb {
+  dbPath = ${HOME}"/.bitcoin-s/mainnet/"
+  db {
+    url="jdbc:sqlite:"${mainnetDb.dbPath}${mainnetDb.dbName}
+  }
+}
+
+testnet3Db = ${commonNodeDbSettings}
+testnet3Db {
+  dbPath = ${HOME}"/.bitcoin-s/testnet3/"
+  db {
+    url="jdbc:sqlite:"${testnet3Db.dbPath}${testnet3Db.dbName}
+  }
+}
+regtestDb = ${commonNodeDbSettings}
+regtestDb {
+  dbPath = ${HOME}"/.bitcoin-s/regtest/"
+  db {
+    url="jdbc:sqlite:"${regtestDb.dbPath}${regtestDb.dbName}
+  }
+}
+
+unittestDb = ${commonNodeDbSettings}
+unittestDb {
+  dbPath = ${HOME}"/.bitcoin-s/unittest/"
+  db {
+    url="jdbc:sqlite::memory:"
+    connectionPool = disabled
+    keepAliveConnection = true
+  }
+}

--- a/chain/src/main/resources/reference.conf
+++ b/chain/src/main/resources/reference.conf
@@ -1,13 +1,13 @@
 
-commonNodeDbSettings = ${commonDbSettings}
-commonNodeDbSettings {
+commonChainDbSettings = ${commonDbSettings}
+commonChainDbSettings {
   dbName = "chaindb.sqlite"
   db {
     user = "chaindb"
   }
 }
 
-mainnetDb = ${commonNodeDbSettings}
+mainnetDb = ${commonChainDbSettings}
 mainnetDb {
   dbPath = ${HOME}"/.bitcoin-s/mainnet/"
   db {
@@ -15,14 +15,14 @@ mainnetDb {
   }
 }
 
-testnet3Db = ${commonNodeDbSettings}
+testnet3Db = ${commonChainDbSettings}
 testnet3Db {
   dbPath = ${HOME}"/.bitcoin-s/testnet3/"
   db {
     url="jdbc:sqlite:"${testnet3Db.dbPath}${testnet3Db.dbName}
   }
 }
-regtestDb = ${commonNodeDbSettings}
+regtestDb = ${commonChainDbSettings}
 regtestDb {
   dbPath = ${HOME}"/.bitcoin-s/regtest/"
   db {
@@ -30,7 +30,7 @@ regtestDb {
   }
 }
 
-unittestDb = ${commonNodeDbSettings}
+unittestDb = ${commonChainDbSettings}
 unittestDb {
   dbPath = ${HOME}"/.bitcoin-s/unittest/"
   db {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainUpdate.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainUpdate.scala
@@ -20,7 +20,7 @@ object BlockchainUpdate {
 
   /** The key thing we receive here is [[org.bitcoins.chain.models.BlockHeaderDb BlockHeaderDb]]
     * with a height assigned to it this happens after
-    * calling [[org.bitcoins.chain.ChainHandler.processHeader() ChainHandler.processHeader]]
+    * calling [[ChainHandler.processHeader() ChainHandler.processHeader]]
     */
   case class Successful(blockchain: Blockchain, updatedHeader: BlockHeaderDb)
       extends BlockchainUpdate {

--- a/chain/src/main/scala/org/bitcoins/chain/db/ChainDbManagement.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/db/ChainDbManagement.scala
@@ -17,9 +17,9 @@ sealed abstract class ChainDbManagement extends DbManagement {
 
   override val allTables = List(chainTable)
 
-  def createHeaderTable(dbConfig: DbConfig)(
+  def createHeaderTable(dbConfig: DbConfig, createIfNotExists: Boolean = true)(
       implicit ec: ExecutionContext): Future[Unit] = {
-    createTable(chainTable, dbConfig)
+    createTable(chainTable, dbConfig, createIfNotExists)
   }
 
   def dropHeaderTable(dbConfig: DbConfig): Future[Unit] = {

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -88,7 +88,7 @@ sealed abstract class TipValidation extends BitcoinSLogger {
     * Mimics this
     * @see [[https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/pow.cpp#L74]]
     * */
-  private def isBadNonce(header: BlockHeader): Boolean = {
+  def isBadNonce(header: BlockHeader): Boolean = {
     //convert hash into a big integer
     val headerWork = BigInt(1, header.hashBE.bytes.toArray)
     if (headerWork <= 0 || NumberUtil.isNBitsOverflow(nBits = header.nBits)) {

--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -17,10 +17,17 @@ abstract class DbManagement {
     Future.sequence(allTables.reverse.map(dropTable(_, dbConfig)))
   }
 
-  def createTable(table: TableQuery[_ <: Table[_]], dbConfig: DbConfig)(
+  def createTable(
+      table: TableQuery[_ <: Table[_]],
+      dbConfig: DbConfig,
+      createIfNotExists: Boolean = false)(
       implicit ec: ExecutionContext): Future[Unit] = {
     val database = dbConfig.database
-    val result = database.run(table.schema.create)
+    val result = if (createIfNotExists) {
+      database.run(table.schema.createIfNotExists)
+    } else {
+      database.run(table.schema.create)
+    }
     result
   }
 
@@ -28,7 +35,7 @@ abstract class DbManagement {
       table: TableQuery[_ <: Table[_]],
       dbConfig: DbConfig): Future[Unit] = {
     val database = dbConfig.database
-    val result = database.run(table.schema.drop)
+    val result = database.run(table.schema.dropIfExists)
     result
   }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
@@ -17,6 +17,7 @@ import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.scalatest._
 
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 
 /**
   * Created by chris on 6/7/16.
@@ -86,7 +87,8 @@ class ClientTest
       //disconnect here
       client ! Tcp.Abort
       val isDisconnectedF =
-        TestAsyncUtil.retryUntilSatisfied(peerMessageReceiver.isDisconnected)
+        TestAsyncUtil.retryUntilSatisfied(peerMessageReceiver.isDisconnected,
+                                          duration = 500.millis)
 
       isDisconnectedF.map { _ =>
         succeed

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -23,7 +23,7 @@ object Deps {
     val jodaV = "2.9.4"
     val postgresV = "9.4.1210"
     val akkaActorV = akkaStreamv
-    val slickV = "3.2.3"
+    val slickV = "3.3.0"
     val sqliteV = "3.8.11.2"
   }
 


### PR DESCRIPTION


This PR 
- Adds a requirement of 90% test coverage on the chain project for builds to pass
- creates a chain database [`reference.conf`](chain/src/main/resources/reference.conf) file
- moves the chain unit test database to be a in memory database
- creates fixtures for `BlockHeaderDAO` and `ChainHandler` inside of [`ChainUnitTest.scala`](https://github.com/bitcoin-s/bitcoin-s-core/blob/d8385e2dee0a8d8e71bbe5b4fb45aced2f28a515/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala)