### PR TITLE
Add integration test between bitcoind <-> zmq <-> bitcoin-s-chain pro…

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/ZmqConfig.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/ZmqConfig.scala
@@ -1,30 +1,31 @@
 package org.bitcoins.rpc.config
-import java.net.URI
+import java.net.{InetAddress, InetSocketAddress, URI}
 
 import com.typesafe.config.Config
+import org.bitcoins.core.util.BitcoinSLogger
 
 import scala.util.Try
 
 sealed trait ZmqConfig {
-  def hashBlock: Option[URI]
-  def rawBlock: Option[URI]
-  def hashTx: Option[URI]
-  def rawTx: Option[URI]
+  def hashBlock: Option[InetSocketAddress]
+  def rawBlock: Option[InetSocketAddress]
+  def hashTx: Option[InetSocketAddress]
+  def rawTx: Option[InetSocketAddress]
 }
 
-object ZmqConfig {
+object ZmqConfig extends BitcoinSLogger {
   private case class ZmqConfigImpl(
-      hashBlock: Option[URI],
-      rawBlock: Option[URI],
-      hashTx: Option[URI],
-      rawTx: Option[URI]
+      hashBlock: Option[InetSocketAddress],
+      rawBlock: Option[InetSocketAddress],
+      hashTx: Option[InetSocketAddress],
+      rawTx: Option[InetSocketAddress]
   ) extends ZmqConfig
 
   def apply(
-      hashBlock: Option[URI] = None,
-      rawBlock: Option[URI] = None,
-      hashTx: Option[URI] = None,
-      rawTx: Option[URI] = None
+      hashBlock: Option[InetSocketAddress] = None,
+      rawBlock: Option[InetSocketAddress] = None,
+      hashTx: Option[InetSocketAddress] = None,
+      rawTx: Option[InetSocketAddress] = None
   ): ZmqConfig =
     ZmqConfigImpl(hashBlock = hashBlock,
                   rawBlock = rawBlock,
@@ -36,7 +37,7 @@ object ZmqConfig {
     * `localhost` and the same port
     */
   def fromPort(port: Int): ZmqConfig = {
-    val uri = new URI(s"tcp://localhost:$port")
+    val uri = new InetSocketAddress("tcp://127.0.0.1", port)
     ZmqConfig(hashBlock = Some(uri),
               rawBlock = Some(uri),
               hashTx = Some(uri),
@@ -60,14 +61,22 @@ object ZmqConfig {
   private def isValidZmqConfigKey(key: String): Boolean =
     ZMQ_CONFIG_KEYS.contains(key)
 
-  private def getZmqUri(config: Config, path: String): Option[URI] = {
+  private def getZmqUri(
+      config: Config,
+      path: String): Option[InetSocketAddress] = {
     require(
       isValidZmqConfigKey(path),
       s"$path is not a valid ZMQ config key. Valid keys: ${ZMQ_CONFIG_KEYS.mkString(", ")}")
 
     if (config.hasPath(path)) {
       Try(config.getString(path))
-        .map(str => Some(new URI(str)))
+        .map { str =>
+          val hostAndPort = str.split(":")
+          val host = hostAndPort(0) + ":" + hostAndPort(1)
+          val socket =
+            new InetSocketAddress(host, hostAndPort(2).toInt)
+          Some(socket)
+        }
         .getOrElse(throw new IllegalArgumentException(
           s"$path (${config.getString(path)}) in config is not a valid URI"))
     } else {
@@ -75,16 +84,16 @@ object ZmqConfig {
     }
   }
 
-  private def rawBlockUri(config: Config): Option[URI] =
+  private def rawBlockUri(config: Config): Option[InetSocketAddress] =
     getZmqUri(config, RAW_BLOCK_KEY)
 
-  private def rawTxUri(config: Config): Option[URI] =
+  private def rawTxUri(config: Config): Option[InetSocketAddress] =
     getZmqUri(config, RAW_TX_KEY)
 
-  private def hashBlockUri(config: Config): Option[URI] =
+  private def hashBlockUri(config: Config): Option[InetSocketAddress] =
     getZmqUri(config, HASH_BLOCK_KEY)
 
-  private def hashTxUri(config: Config): Option[URI] =
+  private def hashTxUri(config: Config): Option[InetSocketAddress] =
     getZmqUri(config, HASH_TX_KEY)
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -197,7 +197,7 @@ lazy val chainTest = project
     name := "bitcoin-s-chain-test",
     libraryDependencies ++= Deps.chainTest,
     parallelExecution in Test := false
-  ).dependsOn(chain, core, testkit)
+  ).dependsOn(chain, core, testkit, zmq)
   .enablePlugins(FlywayPlugin)
 
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -1,11 +1,19 @@
 package org.bitcoins.chain.blockchain
 
+import akka.actor.ActorSystem
 import org.bitcoins.chain.util.ChainUnitTest
+import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.chain.BlockHeaderHelper
+
+import scala.concurrent.Future
 
 class ChainHandlerTest extends ChainUnitTest {
 
   behavior of "ChainHandler"
+
+  implicit val system = ActorSystem("ChainHandlerTest")
+
+  import system.dispatcher
 
   it must "process a new valid block header, and then be able to fetch that header" in withChainHandler {
     case chainHandler: ChainHandler =>
@@ -17,6 +25,34 @@ class ChainHandlerTest extends ChainUnitTest {
         processedHeaderF.flatMap(_.getHeader(newValidHeader.hashBE))
 
       foundHeaderF.map(found => assert(found.get == newValidHeader))
+  }
+
+  it must "peer with bitcoind via zmq and have blockchain info relayed" in bitcoindZmqChainHandler {
+    case bitcoindChainHandler: BitcoindChainHandler =>
+      val bitcoind = bitcoindChainHandler.bitcoindRpc
+
+      val chainHandler = bitcoindChainHandler.chainHandler
+
+      val assert1F = chainHandler.getBlockCount
+        .map(count => assert(count == 0))
+
+      //mine a block on bitcoind
+      val generatedF = assert1F.flatMap(_ => bitcoind.generate(1))
+
+      generatedF.flatMap { headers =>
+        val hash = headers.head
+        val foundHeaderF: Future[Unit] = {
+          //test case is totally async since we
+          //can't monitor processing flow for zmq
+          //so we just need to await until we
+          //have fully processed the header
+          RpcUtil.awaitConditionF(() =>
+            chainHandler.getHeader(hash).map(_.isDefined))
+        }
+        val bitcoinsHeader =
+          foundHeaderF.flatMap(_ => chainHandler.getHeader(hash))
+        bitcoinsHeader.map(header => assert(header.get.hashBE == hash))
+      }
   }
 
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -27,7 +27,7 @@ class ChainHandlerTest extends ChainUnitTest {
       foundHeaderF.map(found => assert(found.get == newValidHeader))
   }
 
-  it must "peer with bitcoind via zmq and have blockchain info relayed" in bitcoindZmqChainHandler {
+  it must "peer with bitcoind via zmq and have blockchain info relayed" in withBitcoindZmqChainHandler {
     case bitcoindChainHandler: BitcoindChainHandler =>
       val bitcoind = bitcoindChainHandler.bitcoindRpc
 
@@ -49,9 +49,11 @@ class ChainHandlerTest extends ChainUnitTest {
           RpcUtil.awaitConditionF(() =>
             chainHandler.getHeader(hash).map(_.isDefined))
         }
-        val bitcoinsHeader =
-          foundHeaderF.flatMap(_ => chainHandler.getHeader(hash))
-        bitcoinsHeader.map(header => assert(header.get.hashBE == hash))
+
+        for {
+          _ <- foundHeaderF
+          header <- chainHandler.getHeader(hash)
+        } yield assert(header.get.hashBE == hash)
       }
   }
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.chain.util
 
+import java.net.InetSocketAddress
+
 import akka.actor.ActorSystem
 import org.bitcoins.chain.api.ChainApi
 import org.bitcoins.chain.blockchain.{Blockchain, ChainHandler}
@@ -105,15 +107,26 @@ trait ChainUnitTest
       bitcoindRpc: BitcoindRpcClient,
       chainHandler: ChainHandler)
 
-  def bitcoindZmqChainHandler(test: BitcoindChainHandler => Future[Assertion])(
-      implicit system: ActorSystem): Future[Assertion] = {
-    val instance = BitcoindRpcTestUtil.instance()
-    val bitcoindF = {
-      val bitcoind = new BitcoindRpcClient(instance)
-      bitcoind.start().map(_ => bitcoind)
-    }
-    val zmqRawBlockUriF = bitcoindF.map(_ => instance.zmqConfig.rawBlock)
-    val f: ChainHandler => Future[Assertion] = { chainHandler: ChainHandler =>
+  /** A helper method to transform a test case
+    * that takes in a
+    * {{{
+    *   BitcoindChainHandler => Future[Assertion]
+    * }}}
+    * and transforms it to return a test case of type
+    * {{{
+    *   ChainHandler => Future[Assertion]
+    * }}}
+    * @param bitcoindF
+    * @param zmqRawBlockUriF
+    * @param test
+    * @return
+    */
+  private def toChainHandlerTest(
+      bitcoindF: Future[BitcoindRpcClient],
+      zmqRawBlockUriF: Future[Option[InetSocketAddress]],
+      test: BitcoindChainHandler => Future[Assertion])(
+      implicit system: ActorSystem): ChainHandler => Future[Assertion] = {
+    chainHandler: ChainHandler =>
       val handleRawBlock: ByteVector => Unit = { bytes: ByteVector =>
         val block = Block.fromBytes(bytes)
         chainHandler.processHeader(block.blockHeader)
@@ -124,7 +137,11 @@ trait ChainUnitTest
       val zmqSubscriberF = zmqRawBlockUriF.map { uriOpt =>
         val socket = uriOpt.get
         val z =
-          new ZMQSubscriber(socket, None, None, None, Some(handleRawBlock))
+          new ZMQSubscriber(socket = socket,
+                            hashTxListener = None,
+                            hashBlockListener = None,
+                            rawTxListener = None,
+                            rawBlockListener = Some(handleRawBlock))
         z.start()
         Thread.sleep(1000)
         z
@@ -149,9 +166,25 @@ trait ChainUnitTest
       }
 
       testExecutionF
-    }
+  }
 
-    withChainHandler(f)
+  def withBitcoindZmqChainHandler(
+      test: BitcoindChainHandler => Future[Assertion])(
+      implicit system: ActorSystem): Future[Assertion] = {
+    val instance = BitcoindRpcTestUtil.instance()
+    val bitcoindF = {
+      val bitcoind = new BitcoindRpcClient(instance)
+      bitcoind.start().map(_ => bitcoind)
+    }
+    val zmqRawBlockUriF: Future[Option[InetSocketAddress]] =
+      bitcoindF.map(_ => instance.zmqConfig.rawBlock)
+
+    val chainHandlerTestF: ChainHandler => Future[Assertion] = {
+      toChainHandlerTest(bitcoindF = bitcoindF,
+                         zmqRawBlockUriF = zmqRawBlockUriF,
+                         test = test)
+    }
+    withChainHandler(chainHandlerTestF)
 
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
@@ -21,4 +21,6 @@ trait ChainApi {
   /** Get's a [[org.bitcoins.chain.models.BlockHeaderDb]] from the chain's database */
   def getHeader(hash: DoubleSha256DigestBE): Future[Option[BlockHeaderDb]]
 
+  /** Gets the number of blocks in the database */
+  def getBlockCount: Future[Long]
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -24,6 +24,10 @@ case class ChainHandler(blockchain: Blockchain)(implicit ec: ExecutionContext)
 
   def dbConfig: DbConfig = blockchain.blockHeaderDAO.dbConfig
 
+  override def getBlockCount: Future[Long] = {
+    blockHeaderDAO.maxHeight
+  }
+
   override def getHeader(
       hash: DoubleSha256DigestBE): Future[Option[BlockHeaderDb]] = {
     blockHeaderDAO.findByHash(hash)

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/BlockHeaderHelper.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/BlockHeaderHelper.scala
@@ -8,10 +8,7 @@ import org.bitcoins.core.crypto.{
   ECPrivateKey
 }
 import org.bitcoins.core.number.{Int32, UInt32}
-import org.bitcoins.core.protocol.blockchain.{
-  BlockHeader,
-  RegTestNetChainParams
-}
+import org.bitcoins.core.protocol.blockchain.BlockHeader
 
 import scala.annotation.tailrec
 

--- a/zmq/src/main/scala/org/bitcoins/zmq/ZMQSubscriber.scala
+++ b/zmq/src/main/scala/org/bitcoins/zmq/ZMQSubscriber.scala
@@ -23,8 +23,8 @@ class ZMQSubscriber(
     hashTxListener: Option[ByteVector => Unit],
     hashBlockListener: Option[ByteVector => Unit],
     rawTxListener: Option[ByteVector => Unit],
-    rawBlockListener: Option[ByteVector => Unit]) {
-  private val logger = BitcoinSLogger.logger
+    rawBlockListener: Option[ByteVector => Unit])
+    extends BitcoinSLogger {
 
   private var running = true
   private val context = ZMQ.context(1)


### PR DESCRIPTION
…ject. Test that we can relay a header from bitcoind over zmq into the bitcoin-s chain project. Redo ZmqConfig to use InetSocketAddress


This PR

- Adds a fixture for `bitcoindZmqChainHandler`
- Changes ZmqConfig to use InetSocketAddress

This makes it much easier to test our integration with bitcoind and our zmq project. This PR should be looked as a fundamental PR for making sure we correctly implement chain handling logic in bitcoin-s