### PR TITLE
Add Bloop config, documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,62 @@ It's possible to communicate with other developers through a variety of communic
 - [Bitcoin-S Gitter](https://gitter.im/bitcoin-s-core/)
 - [#bitcoin-scala](https://webchat.freenode.net/?channels=bitcoin-scala) on IRC Freenode
 
+## Developer productivity
+
+### Bloop
+
+If you're tired of waiting around for sbt all day, there's a new,
+cool kid on the block. It is called [Bloop](https://scalacenter.github.io/bloop/),
+and it makes compilations in general faster, and in particular
+incremental, small compilation units (which greatly help editor
+performance). Bloop is a server that runs in the background of
+your computer, and keeps several "hot" JVMs running at all
+times. These JVMs serve compilation requests. Because the JVMs
+are running in the background you avoid the startup lag, and you
+also get code that's already [JIT compiled](https://en.wikipedia.org/wiki/Just-in-time_compilation)
+for you.
+
+The documentation on Bloops [site](https://scalacenter.github.io/bloop/) is good, but here is the highlights:
+
+1. Install Bloop by doing step 1 & 2 in the [official guide](https://scalacenter.github.io/bloop/setup#universal)
+2. Enable the Bloop background daemon
+   1. macOS:
+   ```bash
+   $ brew services start bloop
+   ```
+   2. Ubuntu:
+   ```bash
+   $ systemctl --user enable $HOME/.bloop/systemd/bloop.service
+   $ systemctl --user daemon-reload
+   $ systemctl --user start bloop
+   ```
+3. Enable shell completion for the Bloop CLI
+   1. Bash:
+   ```bash
+   $ echo '. $HOME/.bloop/bash/bloop' >> $HOME/.bash_profile
+   ```
+   2. Zsh:
+   ```bash
+   $ echo 'autoload -U compinit' >> $HOME/.zshrc
+   $ echo 'fpath=($HOME/.bloop/zsh $fpath)' >> $HOME/.bashrc
+   $ echo 'compinit' >> $HOME/.bashrc
+   ```
+   3. Fish:
+   ```bash
+   $ ln -s $HOME/.bloop/fish/bloop.fish ~/.config/fish/completions/bloop.fish
+   ```
+4. Generate configuration files
+   ```bash
+   $ sbt bloopInstall
+   ```
+5. Import Bitcoin-S into IntelliJ again, as a bsp (Build Server Protocol) project (instead of a sbt project). Make sure you're running on the most recent IntelliJ and Scala plugin. See [official docs](https://scalacenter.github.io/bloop/docs/ides/intellij) for details.
+6. _(Bonus step):_ Lightning fast recompilations on file save:
+   ```bash
+   $ bloop compile --project <name of module your're working on> --watch
+   ```
+
+Your editor should now be much faster and require less resources :tada:
+
 ## Documentation
 
 One of the goals of Bitcoin-S is having useful and well-formatted Scaladoc comments on classes,

--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,14 @@ lazy val commonSettings = List(
     .isDefined)
 )
 
+lazy val commonTestSettings = Seq(
+  publish / skip := true,
+) ++ commonSettings
+
+lazy val commonProdSettings = Seq(
+  Test / bloopGenerate := None
+) ++ commonSettings
+
 lazy val root = project
   .in(file("."))
   .aggregate(
@@ -152,16 +160,15 @@ lazy val secp256k1jni = project
 
 lazy val core = project
   .in(file("core"))
-  .settings(commonSettings: _*)
+  .settings(commonProdSettings: _*)
   .dependsOn(
     secp256k1jni
   ).enablePlugins()
 
 lazy val coreTest = project
   .in(file("core-test"))
-  .settings(commonSettings: _*)
+  .settings(commonTestSettings: _*)
   .settings(
-    skip in publish := true,
     name := "bitcoin-s-core-test"
   ).dependsOn(
     core,
@@ -180,7 +187,7 @@ lazy val zmq = project
 
 lazy val bitcoindRpc = project
   .in(file("bitcoind-rpc"))
-  .settings(commonSettings: _*)
+  .settings(commonProdSettings: _*)
   .settings(
     name := "bitcoin-s-bitcoind-rpc",
     libraryDependencies ++= Deps.bitcoindRpc)
@@ -189,10 +196,10 @@ lazy val bitcoindRpc = project
 
 lazy val bitcoindRpcTest = project
   .in(file("bitcoind-rpc-test"))
-  .settings(commonSettings: _*)
-  .settings(libraryDependencies ++= Deps.bitcoindRpcTest,
-    name := "bitcoin-s-bitcoind-rpc-test",
-    skip in publish := true)
+  .settings(commonTestSettings: _*)
+  .settings(
+    libraryDependencies ++= Deps.bitcoindRpcTest,
+    name := "bitcoin-s-bitcoind-rpc-test")
   .dependsOn(testkit)
   .enablePlugins()
 
@@ -212,7 +219,7 @@ lazy val bench = project
 
 lazy val eclairRpc = project
   .in(file("eclair-rpc"))
-  .settings(commonSettings: _*)
+  .settings(commonProdSettings: _*)
   .settings(
     name := "bitcoin-s-eclair-rpc",
     libraryDependencies ++= Deps.eclairRpc)
@@ -223,17 +230,16 @@ lazy val eclairRpc = project
 
 lazy val eclairRpcTest = project
   .in(file("eclair-rpc-test"))
-  .settings(commonSettings: _*)
+  .settings(commonTestSettings: _*)
   .settings(libraryDependencies ++= Deps.eclairRpcTest,
     name := "bitcoin-s-eclair-rpc-test",
-    skip in publish := true
   )
   .dependsOn(testkit)
   .enablePlugins()
 
 lazy val testkit = project
   .in(file("testkit"))
-  .settings(commonSettings: _*)
+  .settings(commonProdSettings: _*)
   .dependsOn(
     core,
     bitcoindRpc,
@@ -243,10 +249,10 @@ lazy val testkit = project
 
 lazy val doc = project
   .in(file("doc"))
+  .settings(commonTestSettings: _*)
   .settings(
     name := "bitcoin-s-doc",
     libraryDependencies ++= Deps.doc,
-    skip in publish := true
   )
   .dependsOn(
     secp256k1jni,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,3 +28,6 @@ addSbtPlugin(
   "com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "latest.release")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+
+// bloop is a build server, enabling faster builds and more rapid dev feedback
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.2.5")


### PR DESCRIPTION
From the added section in `CONTRIBUTING.md`: 

If you're tired of waiting around for sbt all day, there's a new,
cool kid on the block. It is called [Bloop](https://scalacenter.github.io/bloop/),
and it makes compilations in general faster, and in particular
incremental, small compilation units (which greatly help editor
performance). Bloop is a server that runs in the background of
your computer, and keeps several "hot" JVMs running at all
times. These JVMs serve compilation requests. Because the JVMs
are running in the background you avoid the startup lag, and you
also get code that's already [JIT compiled](https://en.wikipedia.org/wiki/Just-in-time_compilation)
for you.