### PR TITLE
Multi fixture file

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
@@ -10,40 +10,46 @@ import org.scalatest.FutureOutcome
 
 class BitcoinPowTest extends ChainUnitTest {
 
-  override type FixtureParam = Unit
+  override type FixtureParam = ChainFixture
 
-  override def withFixture(test: OneArgAsyncTest): FutureOutcome = test(())
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+    withChainFixture(test)
 
   override implicit val system: ActorSystem = ActorSystem("BitcoinPowTest")
 
   behavior of "BitcoinPow"
 
-  it must "NOT calculate a POW change when one is not needed" in { _ =>
-    val chainParams = MainNetChainParams
-    val blockHeaderDAO = BlockHeaderDAO(chainParams, UnitTestDbConfig)
-    val header1 = ChainTestUtil.ValidPOWChange.blockHeaderDb566494
-    val header2 = ChainTestUtil.ValidPOWChange.blockHeaderDb566495
+  it must "NOT calculate a POW change when one is not needed" inFixtured {
+    case ChainFixture.Empty =>
+      val chainParams = MainNetChainParams
+      val blockHeaderDAO = BlockHeaderDAO(chainParams, UnitTestDbConfig)
+      val header1 = ChainTestUtil.ValidPOWChange.blockHeaderDb566494
+      val header2 = ChainTestUtil.ValidPOWChange.blockHeaderDb566495
 
-    val nextWorkF = Pow.getNetworkWorkRequired(header1,
-                                               header2.blockHeader,
-                                               blockHeaderDAO,
-                                               chainParams)
+      val nextWorkF = Pow.getNetworkWorkRequired(header1,
+                                                 header2.blockHeader,
+                                                 blockHeaderDAO,
+                                                 chainParams)
 
-    nextWorkF.map(nextWork => assert(nextWork == header1.nBits))
+      nextWorkF.map(nextWork => assert(nextWork == header1.nBits))
   }
 
-  it must "calculate a pow change as per the bitcoin network" in { _ =>
-    val firstBlockDb = ChainTestUtil.ValidPOWChange.blockHeaderDb564480
-    val currentTipDb = ChainTestUtil.ValidPOWChange.blockHeaderDb566495
-    val expectedNextWork = ChainTestUtil.ValidPOWChange.blockHeader566496.nBits
-    val calculatedWorkF =
-      Pow.calculateNextWorkRequired(currentTipDb,
-                                    firstBlockDb,
-                                    MainNetChainParams)
+  it must "calculate a pow change as per the bitcoin network" inFixtured {
+    case ChainFixture.Empty =>
+      val firstBlockDb = ChainTestUtil.ValidPOWChange.blockHeaderDb564480
+      val currentTipDb = ChainTestUtil.ValidPOWChange.blockHeaderDb566495
+      val expectedNextWork =
+        ChainTestUtil.ValidPOWChange.blockHeader566496.nBits
+      val calculatedWorkF =
+        Pow.calculateNextWorkRequired(currentTipDb,
+                                      firstBlockDb,
+                                      MainNetChainParams)
 
-    calculatedWorkF.map(calculatedWork =>
-      assert(calculatedWork == expectedNextWork))
+      calculatedWorkF.map(calculatedWork =>
+        assert(calculatedWork == expectedNextWork))
   }
 
-  it must "calculate a GetNextWorkRequired correctly"
+  it must "calculate a GetNextWorkRequired correctly" taggedAs FixtureTag.PopulatedBlockHeaderDAO inFixtured {
+    case ChainFixture.PopulatedBlockHeaderDAO(blockHeaderDAO) => succeed
+  }
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
@@ -99,7 +99,7 @@ trait ChainUnitTest
     * All untagged tests will be given this tag. Override this if you are using
     * ChainFixture and the plurality of tests use some fixture other than Empty.
     */
-  def defaultTag: FixtureTag = FixtureTag.Empty
+  val defaultTag: FixtureTag = FixtureTag.Empty
 
   /**
     * This ADT represents all Chain test fixtures. If you set this type to be your

--- a/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
@@ -59,6 +59,12 @@ trait ChainUnitTest
   implicit def ec: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global
 
+  /**
+    * If a test file uses ChainFixture as its FixtureParam, then
+    * using these tags will determine which fixture the test will get.
+    *
+    * Simply add taggedAs FixtureTag._ to your test before calling inFixtured.
+    */
   sealed abstract class FixtureTag(name: String) extends Tag(name)
 
   object FixtureTag {
@@ -89,8 +95,19 @@ trait ChainUnitTest
     }
   }
 
+  /**
+    * All untagged tests will be given this tag. Override this if you are using
+    * ChainFixture and the plurality of tests use some fixture other than Empty.
+    */
   def defaultTag: FixtureTag = FixtureTag.Empty
 
+  /**
+    * This ADT represents all Chain test fixtures. If you set this type to be your
+    * FixtureParam and override withFixture to be withChainFixutre, then simply tag
+    * tests to specify which fixture that test should receive and then use inFixutred
+    * which takes a PartialFunction[ChainFixture, Future[Assertion] ] (i.e. just
+    * specify the relevant case for your expected fixture)
+    */
   sealed trait ChainFixture
 
   object ChainFixture {
@@ -154,6 +171,16 @@ trait ChainUnitTest
     new FutureOutcome(fixtureTakeDownF)
   }
 
+  /**
+    * This is a wrapper for a tagged test statement that adds a def inFixtured
+    * to replace the use of in, which only accepts a FixtureParam => Future[Assertion],
+    * whereas inFixtured accepts a PartialFunction and fails the test if it is not
+    * defined on the input.
+    *
+    * This is nothing more than syntactic sugar.
+    *
+    * This functionality is added using language.implicitConversions below
+    */
   final class SugaryItVerbStringTaggedAs(
       itVerbStringTaggedAs: ItVerbStringTaggedAs) {
 
@@ -174,6 +201,16 @@ trait ChainUnitTest
     }
   }
 
+  /**
+    * This is a wrapper for a tagged test statement that adds a def inFixtured
+    * to replace the use of in, which only accepts a FixtureParam => Future[Assertion],
+    * whereas inFixtured accepts a PartialFunction and fails the test if it is not
+    * defined on the input.
+    *
+    * This is nothing more than syntactic sugar.
+    *
+    * This functionality is added using language.implicitConversions below
+    */
   final class SugaryItVerbString(itVerbString: ItVerbString) {
 
     def inFixtured(

--- a/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
@@ -59,6 +59,150 @@ trait ChainUnitTest
   implicit def ec: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global
 
+  sealed abstract class FixtureTag(name: String) extends Tag(name)
+
+  object FixtureTag {
+    case object Empty extends FixtureTag("Empty")
+
+    case object GenisisBlockHeaderDAO
+        extends FixtureTag("GenisisBlockHeaderDAO")
+
+    case object PopulatedBlockHeaderDAO
+        extends FixtureTag("PopulatedBlockHeaderDAO")
+
+    case object GenisisChainHandler extends FixtureTag("GenisisChainHandler")
+
+    case object BitcoindZmqChainHandlerWithBlock
+        extends FixtureTag("BitcoindZmqChainHandlerWithBlock")
+
+    def from(tag: String): FixtureTag = {
+      tag match {
+        case Empty.name                   => Empty
+        case GenisisBlockHeaderDAO.name   => GenisisBlockHeaderDAO
+        case PopulatedBlockHeaderDAO.name => PopulatedBlockHeaderDAO
+        case GenisisChainHandler.name     => GenisisChainHandler
+        case BitcoindZmqChainHandlerWithBlock.name =>
+          BitcoindZmqChainHandlerWithBlock
+        case _: String =>
+          throw new IllegalArgumentException(s"$tag is not a valid tag")
+      }
+    }
+  }
+
+  def defaultTag: FixtureTag = FixtureTag.Empty
+
+  sealed trait ChainFixture
+
+  object ChainFixture {
+    case object Empty extends ChainFixture
+
+    case class GenisisBlockHeaderDAO(dao: BlockHeaderDAO) extends ChainFixture
+
+    case class PopulatedBlockHeaderDAO(dao: BlockHeaderDAO) extends ChainFixture
+
+    case class GenisisChainHandler(chainHandler: ChainHandler)
+        extends ChainFixture
+
+    case class BitcoindZmqChainHandlerWithBlock(
+        bitcoindChainHandler: BitcoindChainHandler)
+        extends ChainFixture
+
+    def create(tag: FixtureTag): Future[ChainFixture] = {
+      tag match {
+        case FixtureTag.Empty => Future.successful(ChainFixture.Empty)
+        case FixtureTag.GenisisBlockHeaderDAO =>
+          createBlockHeaderDAO().map(GenisisBlockHeaderDAO.apply)
+        case FixtureTag.PopulatedBlockHeaderDAO =>
+          createPopulatedBlockHeaderDAO().map(PopulatedBlockHeaderDAO.apply)
+        case FixtureTag.GenisisChainHandler =>
+          createChainHandler().map(GenisisChainHandler.apply)
+        case FixtureTag.BitcoindZmqChainHandlerWithBlock =>
+          createBitcoindChainHandler().map(
+            BitcoindZmqChainHandlerWithBlock.apply)
+      }
+    }
+
+    def destroy(fixture: ChainFixture): Future[Any] = {
+      fixture match {
+        case Empty                      => Future.successful(())
+        case GenisisBlockHeaderDAO(_)   => destroyHeaderTable()
+        case PopulatedBlockHeaderDAO(_) => destroyHeaderTable()
+        case GenisisChainHandler(_)     => destroyHeaderTable()
+        case BitcoindZmqChainHandlerWithBlock(bitcoindHandler) =>
+          destroyBitcoindChainHandler(bitcoindHandler)
+      }
+    }
+  }
+
+  def withChainFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val stringTag = test.tags.headOption.getOrElse(defaultTag.name)
+
+    val fixtureTag: FixtureTag = FixtureTag.from(stringTag)
+
+    val fixtureF: Future[ChainFixture] = ChainFixture.create(fixtureTag)
+
+    val outcomeF = fixtureF.flatMap(fixture =>
+      test(fixture.asInstanceOf[FixtureParam]).toFuture)
+
+    val fixtureTakeDownF = outcomeF.flatMap { outcome =>
+      val destroyedF =
+        fixtureF.flatMap(fixture => ChainFixture.destroy(fixture))
+
+      destroyedF.map(_ => outcome)
+    }
+
+    new FutureOutcome(fixtureTakeDownF)
+  }
+
+  final class SugaryItVerbStringTaggedAs(
+      itVerbStringTaggedAs: ItVerbStringTaggedAs) {
+
+    def inFixtured(
+        partialTestFun: PartialFunction[
+          FixtureParam,
+          Future[compatible.Assertion]])(
+        implicit pos: org.scalactic.source.Position): Unit = {
+      val testFun: FixtureParam => Future[compatible.Assertion] = {
+        fixture: FixtureParam =>
+          partialTestFun.applyOrElse[FixtureParam, Future[Assertion]](fixture, {
+            _: FixtureParam =>
+              Future.successful(fail("Incorrect tag/fixture for this test"))
+          })
+      }
+
+      itVerbStringTaggedAs.in(testFun)(pos)
+    }
+  }
+
+  final class SugaryItVerbString(itVerbString: ItVerbString) {
+
+    def inFixtured(
+        partialTestFun: PartialFunction[
+          FixtureParam,
+          Future[compatible.Assertion]])(
+        implicit pos: org.scalactic.source.Position): Unit = {
+      val testFun: FixtureParam => Future[compatible.Assertion] = {
+        fixture: FixtureParam =>
+          partialTestFun.applyOrElse[FixtureParam, Future[Assertion]](fixture, {
+            _: FixtureParam =>
+              Future.successful(fail("Incorrect tag/fixture for this test"))
+          })
+      }
+
+      itVerbString.in(testFun)(pos)
+    }
+  }
+
+  import language.implicitConversions
+
+  implicit def itVerbStringTaggedAsToSugaryItVerbStringTaggedAs(
+      itVerbStringTaggedAs: ItVerbStringTaggedAs): SugaryItVerbStringTaggedAs =
+    new SugaryItVerbStringTaggedAs(itVerbStringTaggedAs)
+
+  implicit def itVerbStringToSugaryItVerbString(
+      itVerbString: ItVerbString): SugaryItVerbString =
+    new SugaryItVerbString(itVerbString)
+
   def createBlockHeaderDAO(): Future[BlockHeaderDAO] = {
     val genesisHeaderF = setupHeaderTableWithGenesisHeader()
 
@@ -208,6 +352,12 @@ trait ChainUnitTest
     Thread.sleep(1000)
 
     genesisHeaderF.map(_ => (chainHandler, zmqSubscriber))
+  }
+
+  def createBitcoindChainHandler(): Future[BitcoindChainHandler] = {
+    composeBuildersAndWrap(createBitcoind,
+                           createChainHandlerWithBitcoindZmq,
+                           BitcoindChainHandler.apply)()
   }
 
   def destroyBitcoindChainHandler(


### PR DESCRIPTION
Implements a framework for having as many different fixtures used as needed in a single test file.

In order to use this, one must `override type FIxtureParam = ChainFixture` and then tag each test with the correct `FixtureTag` and begin each test with `inFixtured { case ExpectedFixture(...) =>`

Optionally, one can also `override def defaultTag` if the plurality of tests use some fixture other than `Empty`.

I have not implemented this but we could make using this framework mandatory by adding `override type FixtureParam = ChainFixture` in `ChainUnitTest.scala`. Doing this would get rid of all casting and all `with...` defs other than `withChainFixture`. On the other hand it would add a tiny bit to test files that are only using one fixture. Thoughts?