### PR TITLE
Basic Coin Selection

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/TxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/TxBuilderTest.scala
@@ -1,16 +1,16 @@
 package org.bitcoins.core.wallet.builder
 
-import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.currency._
 import org.bitcoins.core.number.Int64
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class TxBuilderTest extends FlatSpec with MustMatchers {
+class TxBuilderTest extends BitcoinSUnitTest {
 
   "TxBuilder" must "detect a bad fee on the tx" in {
-    val estimatedFee = Satoshis(Int64(1000))
-    val actualFee = Satoshis.one
-    val feeRate = SatoshisPerVirtualByte(Satoshis.one)
+    val estimatedFee = 1000.sats
+    val actualFee = 1.sat
+    val feeRate = SatoshisPerVirtualByte(1.sat)
     TxBuilder
       .isValidFeeRange(estimatedFee, actualFee, feeRate)
       .isFailure must be(true)

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -934,7 +934,7 @@ object BitcoinTxBuilder {
     def loop(utxos: Seq[UTXOSpendingInfo], accum: UTXOMap): UTXOMap =
       utxos match {
         case Nil => accum
-        case h :: t =>
+        case h +: t =>
           val u = BitcoinUTXOSpendingInfo(outPoint = h.outPoint,
                                           output = h.output,
                                           signers = h.signers,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
@@ -1,0 +1,94 @@
+package org.bitcoins.wallet.api
+
+import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
+import org.bitcoins.core.number.Int64
+import org.bitcoins.core.protocol.script.ScriptPubKey
+import org.bitcoins.core.protocol.transaction.TransactionOutput
+import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerByte}
+import org.bitcoins.testkit.core.gen.{TransactionGenerators, WitnessGenerators}
+import org.bitcoins.wallet.models.{
+  NativeV0UTXOSpendingInfoDb,
+  UTXOSpendingInfoDb
+}
+import org.bitcoins.wallet.util.{BitcoinSWalletTest, WalletTestUtil}
+import org.scalatest.FutureOutcome
+
+class CoinSelectorTest extends BitcoinSWalletTest {
+  case class CoinSelectionFixture(
+      output: TransactionOutput,
+      feeRate: FeeUnit,
+      utxo1: UTXOSpendingInfoDb,
+      utxo2: UTXOSpendingInfoDb,
+      utxo3: UTXOSpendingInfoDb) {
+    val utxoSet: Vector[UTXOSpendingInfoDb] = Vector(utxo1, utxo2, utxo3)
+  }
+
+  override type FixtureParam = CoinSelectionFixture
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val output = TransactionOutput(Satoshis(Int64(99L)), ScriptPubKey.empty)
+    val feeRate = SatoshisPerByte(CurrencyUnits.zero)
+
+    val utxo1 = NativeV0UTXOSpendingInfoDb(
+      id = Some(1),
+      outPoint = TransactionGenerators.outPoint.sample.get,
+      output = TransactionOutput(Satoshis(Int64(10)), ScriptPubKey.empty),
+      privKeyPath = WalletTestUtil.sampleSegwitPath,
+      scriptWitness = WitnessGenerators.scriptWitness.sample.get
+    )
+    val utxo2 = NativeV0UTXOSpendingInfoDb(
+      id = Some(2),
+      outPoint = TransactionGenerators.outPoint.sample.get,
+      output = TransactionOutput(Satoshis(Int64(90)), ScriptPubKey.empty),
+      privKeyPath = WalletTestUtil.sampleSegwitPath,
+      scriptWitness = WitnessGenerators.scriptWitness.sample.get
+    )
+    val utxo3 = NativeV0UTXOSpendingInfoDb(
+      id = Some(3),
+      outPoint = TransactionGenerators.outPoint.sample.get,
+      output = TransactionOutput(Satoshis(Int64(20)), ScriptPubKey.empty),
+      privKeyPath = WalletTestUtil.sampleSegwitPath,
+      scriptWitness = WitnessGenerators.scriptWitness.sample.get
+    )
+
+    test(CoinSelectionFixture(output, feeRate, utxo1, utxo2, utxo3))
+  }
+
+  behavior of "CoinSelector"
+
+  it must "accumulate largest outputs" in { fixture =>
+    val selection =
+      CoinSelector.accumulateLargest(walletUtxos = fixture.utxoSet,
+                                     outputs = Vector(fixture.output),
+                                     feeRate = fixture.feeRate)
+
+    assert(selection == Vector(fixture.utxo2, fixture.utxo3))
+  }
+
+  it must "accumulate smallest outputs" in { fixture =>
+    val selection =
+      CoinSelector.accumulateSmallestViable(walletUtxos = fixture.utxoSet,
+                                            outputs = Vector(fixture.output),
+                                            feeRate = fixture.feeRate)
+
+    assert(selection == Vector(fixture.utxo1, fixture.utxo3, fixture.utxo2))
+  }
+
+  it must "accumulate outputs in order" in { fixture =>
+    val selection = CoinSelector.accumulate(walletUtxos = fixture.utxoSet,
+                                            outputs = Vector(fixture.output),
+                                            feeRate = fixture.feeRate)
+
+    assert(selection == Vector(fixture.utxo1, fixture.utxo2))
+  }
+
+  it must "correctly approximate transaction input size" in { fixture =>
+    val expected1 = 32 + 4 + 1 + 4 + fixture.utxo1.scriptWitnessOpt.get.bytes.length
+    val expected2 = 32 + 4 + 1 + 4 + fixture.utxo2.scriptWitnessOpt.get.bytes.length
+    val expected3 = 32 + 4 + 1 + 4 + fixture.utxo3.scriptWitnessOpt.get.bytes.length
+
+    assert(CoinSelector.approximateUtxoSize(fixture.utxo1) == expected1)
+    assert(CoinSelector.approximateUtxoSize(fixture.utxo2) == expected2)
+    assert(CoinSelector.approximateUtxoSize(fixture.utxo3) == expected3)
+  }
+}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet.api
 
-import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
+import org.bitcoins.core.currency._
 import org.bitcoins.core.number.Int64
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutput
@@ -10,7 +10,7 @@ import org.bitcoins.wallet.models.{
   NativeV0UTXOSpendingInfoDb,
   UTXOSpendingInfoDb
 }
-import org.bitcoins.wallet.util.{BitcoinSWalletTest, WalletTestUtil}
+import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 import org.scalatest.FutureOutcome
 
 class CoinSelectorTest extends BitcoinSWalletTest {
@@ -26,27 +26,27 @@ class CoinSelectorTest extends BitcoinSWalletTest {
   override type FixtureParam = CoinSelectionFixture
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    val output = TransactionOutput(Satoshis(Int64(99L)), ScriptPubKey.empty)
+    val output = TransactionOutput(99.sats, ScriptPubKey.empty)
     val feeRate = SatoshisPerByte(CurrencyUnits.zero)
 
     val utxo1 = NativeV0UTXOSpendingInfoDb(
       id = Some(1),
       outPoint = TransactionGenerators.outPoint.sample.get,
-      output = TransactionOutput(Satoshis(Int64(10)), ScriptPubKey.empty),
+      output = TransactionOutput(10.sats, ScriptPubKey.empty),
       privKeyPath = WalletTestUtil.sampleSegwitPath,
       scriptWitness = WitnessGenerators.scriptWitness.sample.get
     )
     val utxo2 = NativeV0UTXOSpendingInfoDb(
       id = Some(2),
       outPoint = TransactionGenerators.outPoint.sample.get,
-      output = TransactionOutput(Satoshis(Int64(90)), ScriptPubKey.empty),
+      output = TransactionOutput(90.sats, ScriptPubKey.empty),
       privKeyPath = WalletTestUtil.sampleSegwitPath,
       scriptWitness = WitnessGenerators.scriptWitness.sample.get
     )
     val utxo3 = NativeV0UTXOSpendingInfoDb(
       id = Some(3),
       outPoint = TransactionGenerators.outPoint.sample.get,
-      output = TransactionOutput(Satoshis(Int64(20)), ScriptPubKey.empty),
+      output = TransactionOutput(20.sats, ScriptPubKey.empty),
       privKeyPath = WalletTestUtil.sampleSegwitPath,
       scriptWitness = WitnessGenerators.scriptWitness.sample.get
     )

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
@@ -1,0 +1,101 @@
+package org.bitcoins.wallet.api
+
+import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
+import org.bitcoins.core.protocol.transaction.TransactionOutput
+import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.wallet.models.UTXOSpendingInfoDb
+
+import scala.annotation.tailrec
+
+/** Implements algorithms for selecting from a UTXO set to spend to an output set at a given fee rate. */
+trait CoinSelector {
+
+  /**
+    * Greedily selects from walletUtxos starting with the largest outputs, skipping outputs with values
+    * below their fees. Better for high fee environments than accumulateSmallestViable.
+    */
+  def accumulateLargest(
+      walletUtxos: Vector[UTXOSpendingInfoDb],
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit): Vector[UTXOSpendingInfoDb] = {
+    val sortedUtxos =
+      walletUtxos.sortBy(_.value.satoshis.toLong).reverse
+
+    accumulate(sortedUtxos, outputs, feeRate)
+  }
+
+  /**
+    * Greedily selects from walletUtxos starting with the smallest outputs, skipping outputs with values
+    * below their fees. Good for low fee environments to consolidate UTXOs.
+    *
+    * Has the potential privacy breach of connecting a ton of UTXOs to one address.
+    */
+  def accumulateSmallestViable(
+      walletUtxos: Vector[UTXOSpendingInfoDb],
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit): Vector[UTXOSpendingInfoDb] = {
+    val sortedUtxos = walletUtxos.sortBy(_.value.satoshis.toLong)
+
+    accumulate(sortedUtxos, outputs, feeRate)
+  }
+
+  /** Greedily selects from walletUtxos in order, skipping outputs with values below their fees */
+  def accumulate(
+      walletUtxos: Vector[UTXOSpendingInfoDb],
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit): Vector[UTXOSpendingInfoDb] = {
+    val totalValue = outputs.foldLeft(CurrencyUnits.zero) {
+      case (totVal, output) => totVal + output.value
+    }
+
+    @tailrec
+    def addUtxos(
+        alreadyAdded: Vector[UTXOSpendingInfoDb],
+        valueSoFar: CurrencyUnit,
+        bytesSoFar: Long,
+        utxosLeft: Vector[UTXOSpendingInfoDb]): Vector[UTXOSpendingInfoDb] = {
+      val fee = feeRate.currencyUnit * bytesSoFar
+      if (valueSoFar > totalValue + fee) {
+        alreadyAdded
+      } else if (utxosLeft.isEmpty) {
+        throw new RuntimeException(
+          s"Not enough value in given outputs ($valueSoFar) to make transaction spending $totalValue")
+      } else {
+        val nextUtxo = utxosLeft.head
+        val approxUtxoSize = CoinSelector.approximateUtxoSize(nextUtxo)
+        val nextUtxoFee = feeRate.currencyUnit * approxUtxoSize
+        if (nextUtxo.value < nextUtxoFee) {
+          addUtxos(alreadyAdded, valueSoFar, bytesSoFar, utxosLeft.tail)
+        } else {
+          val newAdded = alreadyAdded.:+(nextUtxo)
+          val newValue = valueSoFar + nextUtxo.value
+
+          addUtxos(newAdded,
+                   newValue,
+                   bytesSoFar + approxUtxoSize,
+                   utxosLeft.tail)
+        }
+      }
+    }
+
+    addUtxos(Vector.empty, CurrencyUnits.zero, bytesSoFar = 0L, walletUtxos)
+  }
+}
+
+object CoinSelector extends CoinSelector {
+
+  /** Cribbed from [[https://github.com/bitcoinjs/coinselect/blob/master/utils.js]] */
+  def approximateUtxoSize(utxo: UTXOSpendingInfoDb): Long = {
+    val inputBase = 32 + 4 + 1 + 4
+    val scriptSize = utxo.redeemScriptOpt match {
+      case Some(script) => script.bytes.length
+      case None =>
+        utxo.scriptWitnessOpt match {
+          case Some(script) => script.bytes.length
+          case None         => 25 // PUBKEYHASH
+        }
+    }
+
+    inputBase + scriptSize
+  }
+}


### PR DESCRIPTION
Implements greedy coin selection (taking smallest or largest UTXOs first).

Replaces current "fail if there is no big enough UTXO" with greedy large UTXOs first coin selection in `Wallet.sendToAddress`.

Closes #406 
