### PR TITLE
Introduce AppConfig that combines ChainParams and DbConfig

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.chain.util.ChainUnitTest
 import org.bitcoins.core.protocol.blockchain.MainNetChainParams
-import org.bitcoins.db.UnitTestDbConfig
+import org.bitcoins.db.{AppConfig, UnitTestDbConfig}
 import org.bitcoins.testkit.chain.ChainTestUtil
 import org.scalatest.FutureOutcome
 
@@ -22,14 +22,14 @@ class BitcoinPowTest extends ChainUnitTest {
   it must "NOT calculate a POW change when one is not needed" inFixtured {
     case ChainFixture.Empty =>
       val chainParams = MainNetChainParams
-      val blockHeaderDAO = BlockHeaderDAO(chainParams, UnitTestDbConfig)
+      val appConfig = AppConfig(UnitTestDbConfig,chainParams)
+      val blockHeaderDAO = BlockHeaderDAO(appConfig)
       val header1 = ChainTestUtil.ValidPOWChange.blockHeaderDb566494
       val header2 = ChainTestUtil.ValidPOWChange.blockHeaderDb566495
 
       val nextWorkF = Pow.getNetworkWorkRequired(header1,
                                                  header2.blockHeader,
-                                                 blockHeaderDAO,
-                                                 chainParams)
+                                                 blockHeaderDAO)
 
       nextWorkF.map(nextWork => assert(nextWork == header1.nBits))
   }

--- a/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
@@ -5,19 +5,10 @@ import java.net.InetSocketAddress
 import akka.actor.ActorSystem
 import org.bitcoins.chain.blockchain.{Blockchain, ChainHandler}
 import org.bitcoins.chain.db.ChainDbManagement
-import org.bitcoins.chain.models.{
-  BlockHeaderDAO,
-  BlockHeaderDb,
-  BlockHeaderDbHelper
-}
-import org.bitcoins.core.protocol.blockchain.{
-  Block,
-  BlockHeader,
-  ChainParams,
-  RegTestNetChainParams
-}
+import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb, BlockHeaderDbHelper}
+import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader, ChainParams, RegTestNetChainParams}
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.db.{DbConfig, UnitTestDbConfig}
+import org.bitcoins.db.{AppConfig, DbConfig, UnitTestDbConfig}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.chain.ChainTestUtil
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
@@ -47,9 +38,8 @@ trait ChainUnitTest
   val genesisHeaderDb: BlockHeaderDb = ChainTestUtil.regTestGenesisHeaderDb
   val chainParam: ChainParams = RegTestNetChainParams
 
-  private lazy val blockHeaderDAO = BlockHeaderDAO(
-    chainParams = ChainTestUtil.regTestChainParams,
-    dbConfig = dbConfig)
+  lazy val appConfig = AppConfig(dbConfig,chainParam)
+  private lazy val blockHeaderDAO = BlockHeaderDAO(appConfig)
 
   lazy val blockchain: Blockchain =
     Blockchain.fromHeaders(Vector(genesisHeaderDb), blockHeaderDAO)

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -85,8 +85,7 @@ class TipValidationTest extends ChainUnitTest {
       currentTipDbDefault: BlockHeaderDb = currentTipDb): Future[Assertion] = {
     val checkTipF = TipValidation.checkNewTip(header,
                                               currentTipDbDefault,
-                                              blockHeaderDAO,
-                                              chainParam)
+                                              blockHeaderDAO)
 
     checkTipF.map(validationResult => assert(validationResult == expected))
   }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
@@ -26,7 +26,7 @@ case class Blockchain(
   //TODO: Think about not exposing the headers to world, encapsulate them and
   //provide methods like `.map` and `.foreach` on this data structure.
 
-  def chainParams: ChainParams = blockHeaderDAO.chainParams
+  def chainParams: ChainParams = blockHeaderDAO.appConfig.chain
 
   def connectTip(header: BlockHeader)(
       implicit ec: ExecutionContext): Future[BlockchainUpdate] = {
@@ -35,8 +35,7 @@ case class Blockchain(
     val tipResultF =
       TipValidation.checkNewTip(newPotentialTip = header,
                                 currentTip = headers.head,
-                                blockHeaderDAO = blockHeaderDAO,
-                                chainParams = chainParams)
+                                blockHeaderDAO = blockHeaderDAO)
 
     tipResultF.map { tipResult =>
       tipResult match {

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.chain.models
 
 import org.bitcoins.core.crypto.DoubleSha256DigestBE
-import org.bitcoins.core.protocol.blockchain.ChainParams
-import org.bitcoins.db.{CRUD, DbConfig, SlickUtil}
+import org.bitcoins.db.{AppConfig, CRUD, DbConfig, SlickUtil}
 import slick.jdbc.SQLiteProfile
 import slick.jdbc.SQLiteProfile.api._
 
@@ -18,7 +17,9 @@ sealed abstract class BlockHeaderDAO
 
   import org.bitcoins.db.DbCommonsColumnMappers._
 
-  def chainParams: ChainParams
+  def appConfig: AppConfig
+
+  override def dbConfig: DbConfig = appConfig.dbConfig
 
   override val table: TableQuery[BlockHeaderTable] =
     TableQuery[BlockHeaderTable]
@@ -117,13 +118,12 @@ sealed abstract class BlockHeaderDAO
 
 object BlockHeaderDAO {
   private case class BlockHeaderDAOImpl(
-      chainParams: ChainParams,
-      dbConfig: DbConfig)(override implicit val ec: ExecutionContext)
+      appConfig: AppConfig)(override implicit val ec: ExecutionContext)
       extends BlockHeaderDAO
 
-  def apply(chainParams: ChainParams, dbConfig: DbConfig)(
+  def apply(appConfig: AppConfig)(
       implicit ec: ExecutionContext): BlockHeaderDAO = {
-    BlockHeaderDAOImpl(chainParams, dbConfig)(ec)
+    BlockHeaderDAOImpl(appConfig)(ec)
   }
 
 }

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -18,15 +18,14 @@ sealed abstract class Pow {
     * @see [[https://github.com/bitcoin/bitcoin/blob/35477e9e4e3f0f207ac6fa5764886b15bf9af8d0/src/pow.cpp#L13 Mimics bitcoin core implmentation]]
     * @param tip
     * @param newPotentialTip
-    * @param chainParams
     * @return
     */
   def getNetworkWorkRequired(
       tip: BlockHeaderDb,
       newPotentialTip: BlockHeader,
-      blockHeaderDAO: BlockHeaderDAO,
-      chainParams: ChainParams)(
+      blockHeaderDAO: BlockHeaderDAO)(
       implicit ec: ExecutionContext): Future[UInt32] = {
+    val chainParams = blockHeaderDAO.appConfig.chain
     val currentHeight = tip.height
 
     val powLimit = NumberUtil.targetCompression(bigInteger =

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -1,13 +1,9 @@
 package org.bitcoins.chain.validation
 
-import org.bitcoins.chain.models.{
-  BlockHeaderDAO,
-  BlockHeaderDb,
-  BlockHeaderDbHelper
-}
+import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb, BlockHeaderDbHelper}
 import org.bitcoins.chain.pow.Pow
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.blockchain.{BlockHeader, ChainParams}
+import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.util.{BitcoinSLogger, NumberUtil}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -29,8 +25,7 @@ sealed abstract class TipValidation extends BitcoinSLogger {
   def checkNewTip(
       newPotentialTip: BlockHeader,
       currentTip: BlockHeaderDb,
-      blockHeaderDAO: BlockHeaderDAO,
-      chainParams: ChainParams)(
+      blockHeaderDAO: BlockHeaderDAO)(
       implicit ec: ExecutionContext): Future[TipUpdateResult] = {
     val header = newPotentialTip
     logger.info(
@@ -38,8 +33,7 @@ sealed abstract class TipValidation extends BitcoinSLogger {
 
     val powCheckF = isBadPow(newPotentialTip = newPotentialTip,
                              currentTip = currentTip,
-                             blockHeaderDAO,
-                             chainParams)
+                             blockHeaderDAO)
 
     val connectTipResultF: Future[TipUpdateResult] = {
       powCheckF.map { expectedWork =>
@@ -101,13 +95,11 @@ sealed abstract class TipValidation extends BitcoinSLogger {
   private def isBadPow(
       newPotentialTip: BlockHeader,
       currentTip: BlockHeaderDb,
-      blockHeaderDAO: BlockHeaderDAO,
-      chainParams: ChainParams)(
+      blockHeaderDAO: BlockHeaderDAO)(
       implicit ec: ExecutionContext): Future[UInt32] = {
     Pow.getNetworkWorkRequired(tip = currentTip,
                                newPotentialTip = newPotentialTip,
-                               blockHeaderDAO = blockHeaderDAO,
-                               chainParams)
+                               blockHeaderDAO = blockHeaderDAO)
 
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -3,6 +3,7 @@ package org.bitcoins.core.protocol.blockchain
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 
+import org.bitcoins.core.config.{BitcoinNetwork, MainNet, NetworkParameters, RegTest, TestNet3}
 import org.bitcoins.core.consensus.Merkle
 import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
@@ -194,6 +195,9 @@ sealed abstract class ChainParams {
     * @return
     */
   def noRetargeting: Boolean
+
+  /** The [[org.bitcoins.core.config.BitcoinNetwork network]] that corresponds to this chain param */
+  def network: NetworkParameters
 }
 
 sealed abstract class BitcoinChainParams extends ChainParams {
@@ -215,6 +219,12 @@ sealed abstract class BitcoinChainParams extends ChainParams {
 
   /** The best chain should have this amount of work */
   def minimumChainWork: BigInteger
+
+
+  /**
+    * @inheritdoc
+    */
+  def network: BitcoinNetwork
 }
 
 /** The Main Network parameters. */
@@ -272,6 +282,11 @@ object MainNetChainParams extends BitcoinChainParams {
     * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L76 mainnet pow retargetting]]
     */
   override lazy val noRetargeting: Boolean = false
+
+  /**
+    * @inheritdoc
+    */
+  override lazy val network: BitcoinNetwork = MainNet
 }
 
 object TestNetChainParams extends BitcoinChainParams {
@@ -320,6 +335,11 @@ object TestNetChainParams extends BitcoinChainParams {
     * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L193 testnet pow retargetting]]
     */
   override lazy val noRetargeting: Boolean = false
+
+  /**
+    * @inheritdoc
+    */
+  override lazy val network: BitcoinNetwork = TestNet3
 }
 
 object RegTestNetChainParams extends BitcoinChainParams {
@@ -362,6 +382,11 @@ object RegTestNetChainParams extends BitcoinChainParams {
     * [[https://github.com/bitcoin/bitcoin/blob/a083f75ba79d465f15fddba7b00ca02e31bb3d40/src/chainparams.cpp#L288 regtest pow retargetting]]
     */
   override lazy val noRetargeting: Boolean = true
+
+  /**
+    * @inheritdoc
+    */
+  override lazy val network: BitcoinNetwork = RegTest
 }
 
 sealed abstract class Base58Type

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -1,0 +1,8 @@
+package org.bitcoins.db
+
+import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.protocol.blockchain.ChainParams
+
+case class AppConfig(dbConfig: DbConfig, chain: ChainParams) {
+  val network: NetworkParameters = chain.network
+}

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
@@ -6,8 +6,9 @@ import akka.actor.ActorSystem
 import akka.io.Tcp
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import org.bitcoins.core.config.RegTest
+import org.bitcoins.core.protocol.blockchain.RegTestNetChainParams
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.db.UnitTestDbConfig
+import org.bitcoins.db.{AppConfig, UnitTestDbConfig}
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.PeerMessageReceiver
 import org.bitcoins.node.networking.peer.PeerMessageReceiverState.Preconnection
@@ -32,7 +33,11 @@ class ClientTest
     s"Client-Test-System-${System.currentTimeMillis()}")
   val dbConfig = UnitTestDbConfig
 
-  implicit val np = RegTest
+
+
+  private val appConfig = AppConfig(dbConfig,RegTestNetChainParams)
+
+  implicit val np = appConfig.network
 
   val bitcoindRpcF = BitcoindRpcTestUtil.startedBitcoindRpcClient()
 
@@ -74,7 +79,7 @@ class ClientTest
   def connectAndDisconnect(peer: Peer): Future[Assertion] = {
     val probe = TestProbe()
     val remote = peer.socket
-    val peerMessageReceiver = PeerMessageReceiver(Preconnection, dbConfig)
+    val peerMessageReceiver = PeerMessageReceiver(Preconnection, appConfig = appConfig)
     val client =
       TestActorRef(Client.props(peer, peerMessageReceiver), probe.ref)
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -6,8 +6,9 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import akka.util.Timeout
 import org.bitcoins.core.config.{NetworkParameters, RegTest}
+import org.bitcoins.core.protocol.blockchain.RegTestNetChainParams
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.db.UnitTestDbConfig
+import org.bitcoins.db.{AppConfig, UnitTestDbConfig}
 import org.bitcoins.node.NetworkMessage
 import org.bitcoins.node.constant.Constants
 import org.bitcoins.node.messages._
@@ -37,12 +38,11 @@ class PeerMessageHandlerTest
 
   implicit val ec: ExecutionContext = system.dispatcher
 
-  implicit val np: NetworkParameters = RegTest
-
-  private val dbConfig = UnitTestDbConfig
+  private val appConfig = AppConfig(UnitTestDbConfig,RegTestNetChainParams)
+  implicit val np: NetworkParameters = appConfig.network
 
   private def buildPeerMessageReceiver(): PeerMessageReceiver = {
-    val receiver = PeerMessageReceiver.newReceiver(dbConfig)
+    val receiver = PeerMessageReceiver.newReceiver(appConfig)
     receiver
   }
 
@@ -53,7 +53,7 @@ class PeerMessageHandlerTest
       //that can handle the handshake
       val peerMsgSender: PeerMessageSender = {
         val client = NodeTestUtil.client(peer, peerMsgReceiver)
-        PeerMessageSender(client)
+        PeerMessageSender(client,np)
       }
 
       PeerHandler(peerMsgReceiver, peerMsgSender)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorRef, ActorRefFactory, Props}
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.db.DbConfig
+import org.bitcoins.db.{AppConfig, DbConfig}
 import org.bitcoins.node.messages.{DataPayload, HeadersMessage}
 import org.bitcoins.node.util.BitcoinSpvNodeUtil
 
@@ -14,11 +14,11 @@ import scala.concurrent.ExecutionContext
   * that a peer to sent to us on the p2p network, for instance, if we a receive a
   * [[HeadersMessage]] we should store those headers in our database
   */
-class DataMessageHandler(np: NetworkParameters, dbConfig: DbConfig)(
+class DataMessageHandler(appConfig: AppConfig)(
     implicit ec: ExecutionContext)
     extends BitcoinSLogger {
 
-  private val blockHeaderDAO = BlockHeaderDAO(np.chainParams, dbConfig)
+  private val blockHeaderDAO = BlockHeaderDAO(appConfig)
 
   def handleDataPayload(
       payload: DataPayload,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -79,8 +79,7 @@ object PeerMessageSender {
       networkMsgs: Vector[(ActorRef, NetworkMessage)],
       peerHandler: ActorRef)
 
-  def apply(client: Client)(
-      implicit np: NetworkParameters): PeerMessageSender = {
-    PeerMessageSenderImpl(client)
+  def apply(client: Client, np: NetworkParameters): PeerMessageSender = {
+    PeerMessageSenderImpl(client)(np)
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/networking/sync/BlockHeaderSyncActor.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/sync/BlockHeaderSyncActor.scala
@@ -7,15 +7,11 @@ import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.db.DbConfig
+import org.bitcoins.db.{AppConfig, DbConfig}
 import org.bitcoins.node.constant.Constants
 import org.bitcoins.node.messages.HeadersMessage
 import org.bitcoins.node.messages.data.GetHeadersMessage
-import org.bitcoins.node.networking.sync.BlockHeaderSyncActor.{
-  CheckHeaderResult,
-  GetHeaders,
-  StartAtLastSavedHeader
-}
+import org.bitcoins.node.networking.sync.BlockHeaderSyncActor.{CheckHeaderResult, GetHeaders, StartAtLastSavedHeader}
 import org.bitcoins.node.util.BitcoinSpvNodeUtil
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
@@ -43,7 +39,8 @@ trait BlockHeaderSyncActor extends Actor with BitcoinSLogger {
 
   /** Helper function to provide a fresh instance of a [[BlockHeaderDAO]] actor */
   private val blockHeaderDAO: BlockHeaderDAO = {
-    BlockHeaderDAO(networkParameters.chainParams, dbConfig)(context.dispatcher)
+    val appConfig = AppConfig(dbConfig, networkParameters.chainParams)
+    BlockHeaderDAO(appConfig)(context.dispatcher)
   }
 
   def maxHeightF: Future[Long] = blockHeaderDAO.maxHeight

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/util/BitcoinSWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/util/BitcoinSWalletTest.scala
@@ -5,15 +5,11 @@ import akka.testkit.TestKit
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.protocol.blockchain.ChainParams
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.db.UnitTestDbConfig
+import org.bitcoins.db.{AppConfig, UnitTestDbConfig}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.wallet.Wallet
-import org.bitcoins.wallet.api.{
-  InitializeWalletError,
-  InitializeWalletSuccess,
-  UnlockedWalletApi
-}
+import org.bitcoins.wallet.api.{InitializeWalletError, InitializeWalletSuccess, UnlockedWalletApi}
 import org.bitcoins.wallet.config.WalletDbManagement
 import org.scalatest._
 
@@ -29,7 +25,8 @@ trait BitcoinSWalletTest
   implicit val ec: ExecutionContext = actorSystem.dispatcher
 
   protected lazy val dbConfig: UnitTestDbConfig.type = UnitTestDbConfig
-  protected val chainParams: ChainParams = WalletTestUtil.chainParams
+  protected lazy val chainParams: ChainParams = WalletTestUtil.chainParams
+  protected lazy val appConfig = AppConfig(dbConfig = dbConfig,chain = chainParams)
 
   /** Timeout for async operations */
   protected val timeout: FiniteDuration = 10.seconds
@@ -47,7 +44,7 @@ trait BitcoinSWalletTest
 
     for {
       _ <- WalletDbManagement.createAll(dbConfig)
-      wallet <- Wallet.initialize(chainParams, dbConfig).map {
+      wallet <- Wallet.initialize(appConfig).map {
         case InitializeWalletSuccess(wallet) => wallet
         case err: InitializeWalletError      => fail(err)
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -6,16 +6,12 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.blockchain.ChainParams
 import org.bitcoins.core.protocol.script.ScriptPubKey
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionOutPoint,
-  TransactionOutput
-}
+import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint, TransactionOutput}
 import org.bitcoins.core.util.{BitcoinSLogger, EitherUtil}
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.BitcoinUTXOSpendingInfo
-import org.bitcoins.db.DbConfig
+import org.bitcoins.db.{AppConfig, DbConfig}
 import org.bitcoins.wallet.api.AddUtxoError.{AddressNotFound, BadSPK}
 import org.bitcoins.wallet.api._
 import org.bitcoins.wallet.models._
@@ -264,14 +260,14 @@ object Wallet extends CreateWalletApi with BitcoinSLogger {
 
   // todo fix signature
   override protected def initializeWithEntropy(
-      entropy: BitVector,
-      chainParams: ChainParams,
-      dbConfig: Option[DbConfig])(
+      entropy: BitVector, appConfig: AppConfig)(
       implicit ec: ExecutionContext): Future[InitializeWalletResult] = {
+
+    val chainParams = appConfig.chain
+
+    val actualDbConf = appConfig.dbConfig
     logger.info(s"Initializing wallet on chain $chainParams")
 
-    val actualDbConf =
-      dbConfig.getOrElse(DbConfig.fromChainParams(chainParams))
 
     val mnemonicT = Try(MnemonicCode.fromEntropy(entropy))
     val mnemonicE: Either[InitializeWalletError, MnemonicCode] =

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/CreateWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/CreateWalletApi.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.wallet.api
 
 import org.bitcoins.core.crypto.MnemonicCode
-import org.bitcoins.core.protocol.blockchain.ChainParams
-import org.bitcoins.db.DbConfig
+import org.bitcoins.db.AppConfig
 import scodec.bits.BitVector
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -26,59 +25,23 @@ trait CreateWalletApi {
 
   /**
     */
-  private def initializeInternal(
-      chainParams: ChainParams,
-      dbConfig: Option[DbConfig])(
+  private def initializeInternal(appConfig: AppConfig)(
       implicit executionContext: ExecutionContext): Future[
     InitializeWalletResult] =
     initializeWithEntropy(entropy = MnemonicCode.getEntropy256Bits,
-                          chainParams = chainParams,
-                          dbConfig = dbConfig)
+      appConfig)
 
   /**
     * $initialize
     */
-  final def initialize(chainParams: ChainParams)(
+  final def initialize(appConfig: AppConfig)(
       implicit executionContext: ExecutionContext): Future[
     InitializeWalletResult] =
-    initializeInternal(chainParams = chainParams, dbConfig = None)
-
-  /**
-    * $initialize
-    */
-  final def initialize(chainParams: ChainParams, dbConfig: DbConfig)(
-      implicit executionContext: ExecutionContext): Future[
-    InitializeWalletResult] =
-    initializeInternal(chainParams = chainParams, dbConfig = Some(dbConfig))
+    initializeInternal(appConfig)
 
   protected def initializeWithEntropy(
       entropy: BitVector,
-      chainParams: ChainParams,
-      dbConfig: Option[DbConfig])(
+      appConfig: AppConfig)(
       implicit executionContext: ExecutionContext): Future[
     InitializeWalletResult]
-
-  /**
-    * $initializeWithEnt
-    */
-  final def initializeWithEntropy(
-      entropy: BitVector,
-      chainParams: ChainParams,
-  )(implicit executionContext: ExecutionContext): Future[
-    InitializeWalletResult] =
-    initializeWithEntropy(entropy = entropy,
-                          chainParams = chainParams,
-                          dbConfig = None)
-
-  /**
-    * $initializeWithEnt
-    */
-  final def initializeWithEntropy(
-      entropy: BitVector,
-      chainParams: ChainParams,
-      dbConfig: DbConfig)(implicit executionContext: ExecutionContext): Future[
-    InitializeWalletResult] =
-    initializeWithEntropy(entropy = entropy,
-                          chainParams = chainParams,
-                          dbConfig = Some(dbConfig))
 }


### PR DESCRIPTION
Create a utility case class that combines `DbConfig`, `ChainParams` and `NetworkParameters` so we don't need to individually specify all of these things. 