### PR TITLE
BlockchainBuilder

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -26,7 +26,7 @@ class BlockchainTest extends ChainUnitTest {
 
       val newHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
 
-      val connectTipF = blockchain.connectTip(newHeader.blockHeader)
+      val connectTipF = Blockchain.connectTip(newHeader.blockHeader,blockchain)
 
       connectTipF.map {
         case BlockchainUpdate.Successful(_, connectedHeader) =>

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -20,13 +20,12 @@ class BlockchainTest extends ChainUnitTest {
   it must "connect a new header to the current tip of a blockchain" in {
     bhDAO: BlockHeaderDAO =>
       val blockchain = Blockchain.fromHeaders(
-        headers = Vector(genesisHeaderDb),
-        blockHeaderDAO = bhDAO
+        headers = Vector(genesisHeaderDb)
       )
 
       val newHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
 
-      val connectTipF = Blockchain.connectTip(newHeader.blockHeader,blockchain)
+      val connectTipF = Blockchain.connectTip(header = newHeader.blockHeader,blockHeaderDAO = bhDAO)
 
       connectTipF.map {
         case BlockchainUpdate.Successful(_, connectedHeader) =>

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -96,20 +96,19 @@ class ChainHandlerTest extends ChainUnitTest {
       val firstThreeBlocks =
         Vector(firstBlockHeaderDb, secondBlockHeaderDb, thirdBlockHeaderDb)
 
-      chainHandler.blockchain.blockHeaderDAO
-        .createAll(firstThreeBlocks)
-        .flatMap { _ =>
-          val processorF = Future.successful(
-            chainHandler.copy(blockchain =
-              chainHandler.blockchain.copy(headers = firstThreeBlocks.reverse)))
+      val createdF = chainHandler.blockHeaderDAO.createAll(firstThreeBlocks)
 
+      createdF.flatMap { _ =>
+          val processorF = Future.successful(chainHandler)
           // Takes way too long to do all blocks
           val blockHeadersToTest = blockHeaders.tail
             .take(
               (2 * chainHandler.chainParams.difficultyChangeInterval + 1).toInt)
             .toList
 
-          processHeaders(processorF, blockHeadersToTest, FIRST_POW_CHANGE + 1)
+          processHeaders(processorF = processorF,
+            remainingHeaders = blockHeadersToTest,
+            height = FIRST_POW_CHANGE + 1)
         }
   }
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
@@ -57,6 +57,7 @@ trait ChainUnitTest
     ChainHandler(blockchain)
   }
 
+
   implicit def ec: ExecutionContext =
     system.dispatcher
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
@@ -239,7 +239,7 @@ trait ChainUnitTest
             Future.successful[Vector[BlockHeaderDb]](Vector.empty)) {
             case (fut, batch) =>
               fut.flatMap(_ =>
-                chainHandler.blockchain.blockHeaderDAO.createAll(batch))
+                chainHandler.blockHeaderDAO.createAll(batch))
           }
         }
 
@@ -286,10 +286,11 @@ trait ChainUnitTest
 
     val chainHandler = makeChainHandler()
 
-    val genesisHeaderF = tableSetupF.flatMap(_ =>
-      chainHandler.blockchain.blockHeaderDAO.create(genesisHeaderDb))
+    val genesisHeaderF = tableSetupF.flatMap { _ =>
+      chainHandler.blockHeaderDAO.create(genesisHeaderDb)
+    }
 
-    (chainHandler, genesisHeaderF)
+    (chainHandler,genesisHeaderF)
   }
 
   def createChainHandlerWithBitcoindZmq(

--- a/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/util/ChainUnitTest.scala
@@ -51,10 +51,7 @@ trait ChainUnitTest
       firstHeader: BlockHeaderDb = genesisHeaderDb): ChainHandler = {
     lazy val blockHeaderDAO = BlockHeaderDAO(appConfig)
 
-    lazy val blockchain: Blockchain =
-      Blockchain.fromHeaders(Vector(firstHeader), blockHeaderDAO)
-
-    ChainHandler(blockchain)
+    ChainHandler(blockHeaderDAO = blockHeaderDAO,chainAppConfig = appConfig)
   }
 
 
@@ -160,7 +157,7 @@ trait ChainUnitTest
   def createBlockHeaderDAO(): Future[BlockHeaderDAO] = {
     val (chainHandler, genesisHeaderF) = setupHeaderTableWithGenesisHeader()
 
-    genesisHeaderF.map(_ => chainHandler.blockchain.blockHeaderDAO)
+    genesisHeaderF.map(_ => chainHandler.blockHeaderDAO)
   }
 
   def destroyHeaderTable(): Future[Unit] = {
@@ -243,7 +240,7 @@ trait ChainUnitTest
           }
         }
 
-        insertedF.map(_ => chainHandler.blockchain.blockHeaderDAO)
+        insertedF.map(_ => chainHandler.blockHeaderDAO)
     }
   }
 
@@ -264,8 +261,7 @@ trait ChainUnitTest
   def createPopulatedChainHandler(): Future[ChainHandler] = {
     for {
       blockHeaderDAO <- createPopulatedBlockHeaderDAO()
-      blockHeaderVec <- blockHeaderDAO.getAtHeight(FIRST_BLOCK_HEIGHT)
-    } yield ChainHandler(Blockchain(blockHeaderVec, blockHeaderDAO))
+    } yield ChainHandler(blockHeaderDAO = blockHeaderDAO,chainAppConfig = appConfig)
   }
 
   def withPopulatedChainHandler(test: OneArgAsyncTest): FutureOutcome = {

--- a/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.chain.api
 
+import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.BlockHeaderDb
 import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.protocol.blockchain.BlockHeader
@@ -10,6 +11,8 @@ import scala.concurrent.{ExecutionContext, Future}
   * Entry api to the chain project for adding new things to our blockchain
   */
 trait ChainApi {
+
+  def chainAppConfig: ChainAppConfig
 
   /**
     * Adds a block header to our chain project

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
@@ -35,14 +35,21 @@ object Blockchain extends BitcoinSLogger {
 
   /**
     * Attempts to connect the given block header with the given blockchain
-    * @param header
-    * @param blockHeaderDAO
+    * This is done via the companion object for blockchain because
+    * we query [[BlockHeaderDAO block header dao]] for the chain tips
+    * We then attempt to connect this block header to all of our current
+    * chain tips.
+    * @param header the block header to connect to our chain
+    * @param blockHeaderDAO where we can find our blockchain
     * @param ec
-    * @return
+    * @return a [[Future future]] that contains a [[BlockchainUpdate update]] indicating
+    *         we [[BlockchainUpdate.Successful successfully]] connected the tip,
+    *         or [[BlockchainUpdate.Failed failed]] to connect to a tip
     */
   def connectTip(header: BlockHeader, blockHeaderDAO: BlockHeaderDAO)(
     implicit ec: ExecutionContext): Future[BlockchainUpdate] = {
 
+    //get all competing chains we have
     val blockchainsF: Future[Vector[Blockchain]] = blockHeaderDAO.getBlockchains()
 
     val tipResultF: Future[BlockchainUpdate] = blockchainsF.flatMap { blockchains =>

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainBuilder.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainBuilder.scala
@@ -1,0 +1,22 @@
+package org.bitcoins.chain.blockchain
+
+import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
+
+import scala.collection.mutable
+
+case class BlockchainBuilder(blockHeaderDAO: BlockHeaderDAO) extends mutable.ReusableBuilder[BlockHeaderDb, Blockchain] {
+  private val internal = Vector.newBuilder[BlockHeaderDb]
+
+
+  override def result(): Blockchain = {
+    Blockchain.fromHeaders(internal.result(), blockHeaderDAO)
+  }
+
+  override def +=(blockHeaderDb: BlockHeaderDb): this.type = {
+    internal.+=(blockHeaderDb)
+    this
+  }
+
+
+  override def clear(): Unit = internal.clear()
+}

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainBuilder.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainBuilder.scala
@@ -13,7 +13,7 @@ case class BlockchainBuilder(blockHeaderDAO: BlockHeaderDAO) extends mutable.Bui
 
 
   override def result(): Blockchain = {
-    Blockchain.fromHeaders(internal.result(), blockHeaderDAO)
+    Blockchain.fromHeaders(internal.result())
   }
 
   override def +=(blockHeaderDb: BlockHeaderDb): this.type = {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainBuilder.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainBuilder.scala
@@ -4,7 +4,11 @@ import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
 
 import scala.collection.mutable
 
-case class BlockchainBuilder(blockHeaderDAO: BlockHeaderDAO) extends mutable.ReusableBuilder[BlockHeaderDb, Blockchain] {
+/**
+  * @inheritdoc
+  * @param blockHeaderDAO
+  */
+case class BlockchainBuilder(blockHeaderDAO: BlockHeaderDAO) extends mutable.Builder[BlockHeaderDb, Blockchain] {
   private val internal = Vector.newBuilder[BlockHeaderDb]
 
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainBuilder.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainBuilder.scala
@@ -13,7 +13,7 @@ case class BlockchainBuilder(blockHeaderDAO: BlockHeaderDAO) extends mutable.Bui
 
 
   override def result(): Blockchain = {
-    Blockchain.fromHeaders(internal.result())
+    Blockchain.fromHeaders(internal.result().reverse)
   }
 
   override def +=(blockHeaderDb: BlockHeaderDb): this.type = {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -2,7 +2,8 @@ package org.bitcoins.chain.blockchain
 
 import org.bitcoins.chain.api.ChainApi
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.chain.models.BlockHeaderDb
+import org.bitcoins.chain.db.ChainDbConfig
+import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
 import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.protocol.blockchain.{BlockHeader, ChainParams}
 import org.bitcoins.core.util.BitcoinSLogger
@@ -15,15 +16,13 @@ import scala.concurrent.{ExecutionContext, Future}
   * of [[ChainApi]], this is the entry point in to the
   * chain project.
   */
-case class ChainHandler(blockchain: Blockchain, chainAppConfig: ChainAppConfig)(implicit ec: ExecutionContext)
+case class ChainHandler(blockHeaderDAO: BlockHeaderDAO, chainAppConfig: ChainAppConfig)(implicit ec: ExecutionContext)
     extends ChainApi
     with BitcoinSLogger {
 
-  private val blockHeaderDAO = blockchain.blockHeaderDAO
-
   def chainParams: ChainParams = chainAppConfig.chain
 
-  def dbConfig: DbConfig = blockchain.blockHeaderDAO.dbConfig
+  def dbConfig: ChainDbConfig = chainAppConfig.dbConfig
 
   override def getBlockCount: Future[Long] = {
     blockHeaderDAO.maxHeight
@@ -35,14 +34,15 @@ case class ChainHandler(blockchain: Blockchain, chainAppConfig: ChainAppConfig)(
   }
 
   override def processHeader(header: BlockHeader): Future[ChainHandler] = {
-    val blockchainUpdateF = Blockchain.connectTip(header,blockchain)
+
+    val blockchainUpdateF = Blockchain.connectTip(header, blockHeaderDAO)
 
     val newHandlerF = blockchainUpdateF.flatMap {
       case BlockchainUpdate.Successful(blockchain, updatedHeader) =>
         //now we have successfully connected the header, we need to insert
         //it into the database
         val createdF = blockHeaderDAO.create(updatedHeader)
-        createdF.map(_ => ChainHandler(blockchain, chainAppConfig))
+        createdF.map(_ => ChainHandler(blockHeaderDAO, chainAppConfig))
       case BlockchainUpdate.Failed(_, _, reason) =>
         val errMsg =
           s"Failed to add header to chain, header=${header.hashBE.hex} reason=${reason}"

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -15,7 +15,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * of [[ChainApi]], this is the entry point in to the
   * chain project.
   */
-case class ChainHandler(blockHeaderDAO: BlockHeaderDAO, chainAppConfig: ChainAppConfig)(implicit ec: ExecutionContext)
+case class ChainHandler(blockHeaderDAO: BlockHeaderDAO, chainAppConfig: ChainAppConfig)
     extends ChainApi
     with BitcoinSLogger {
 
@@ -32,7 +32,7 @@ case class ChainHandler(blockHeaderDAO: BlockHeaderDAO, chainAppConfig: ChainApp
     blockHeaderDAO.findByHash(hash)
   }
 
-  override def processHeader(header: BlockHeader): Future[ChainHandler] = {
+  override def processHeader(header: BlockHeader)(implicit ec: ExecutionContext): Future[ChainHandler] = {
 
     val blockchainUpdateF = Blockchain.connectTip(header, blockHeaderDAO)
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -7,7 +7,6 @@ import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
 import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.protocol.blockchain.{BlockHeader, ChainParams}
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.db.DbConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -38,7 +37,7 @@ case class ChainHandler(blockHeaderDAO: BlockHeaderDAO, chainAppConfig: ChainApp
     val blockchainUpdateF = Blockchain.connectTip(header, blockHeaderDAO)
 
     val newHandlerF = blockchainUpdateF.flatMap {
-      case BlockchainUpdate.Successful(blockchain, updatedHeader) =>
+      case BlockchainUpdate.Successful(_, updatedHeader) =>
         //now we have successfully connected the header, we need to insert
         //it into the database
         val createdF = blockHeaderDAO.create(updatedHeader)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
@@ -24,7 +24,7 @@ trait ChainSync extends BitcoinSLogger {
            getBlockHeaderFunc: DoubleSha256DigestBE => Future[BlockHeader],
            getBestBlockHashFunc: () => Future[DoubleSha256DigestBE])(implicit ec: ExecutionContext): Future[ChainApi] = {
     val currentTipsF: Future[Vector[BlockHeaderDb]] = {
-      chainHandler.blockchain.blockHeaderDAO.chainTips
+      chainHandler.blockHeaderDAO.chainTips
     }
 
     //TODO: We are implicitly trusting whatever

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -168,6 +168,15 @@ sealed abstract class BlockHeaderDAO
     database.runVec(aggregate)
   }
 
+  /** Returns competing blockchains that are contained in our BlockHeaderDAO
+    * Each chain returns the last [[org.bitcoins.core.protocol.blockchain.ChainParams.difficultyChangeInterval difficutly interval]]
+    * as defined by the network we are on. For instance, on bitcoin mainnet this will be 2016 block headers.
+    * If no competing tips are found, we only return one [[Blockchain blockchain]], else we
+    * return n chains for the number of competing [[chainTips tips]] we have
+    * @see [[Blockchain]]
+    * @param ec
+    * @return
+    */
   def getBlockchains()(implicit ec: ExecutionContext): Future[Vector[Blockchain]] = {
     val chainTipsF = chainTips
     val diffInterval = appConfig.chain.difficultyChangeInterval

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -168,8 +168,6 @@ sealed abstract class BlockHeaderDAO
     database.runVec(aggregate)
   }
 
-  def getBetweenHeights(from: Long, to: Long): Future[Vector[BlockHeaderDb]] = ???
-
   def getBlockchains()(implicit ec: ExecutionContext): Future[Vector[Blockchain]] = {
     val chainTipsF = chainTips
     val diffInterval = appConfig.chain.difficultyChangeInterval
@@ -178,7 +176,7 @@ sealed abstract class BlockHeaderDAO
 
         val height = Math.max(0,tip.height - diffInterval)
         val headersF = getBetweenHeights(from = height, to = tip.height)
-        headersF.map(Blockchain.fromHeaders(_))
+        headersF.map(headers => Blockchain.fromHeaders(headers.reverse))
       }
       Future.sequence(nestedFuture)
     }


### PR DESCRIPTION
Closes #428 

This creates a class called `BlockchainBuilder` and implements the `mutable.ReusableBuilder` api that is provided as a part of scala collections. 

This PR also moves the `connectTip` method into the companion object for Blockchain and forces the `connectTip` method to take a `Blockchain` as an argument.

I think there is an open question here about how much validation we want `BlockchainBuilder` to do. Do we want to do any validation at all? Do we want to do a full `connectTip`? I'm not sure.