### PR TITLE
2019 04 29 client test

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
@@ -78,7 +78,7 @@ class ClientTest
     client ! Tcp.Connect(remote)
 
     val isConnectedF =
-      TestAsyncUtil.retryUntilSatisfied(peerMessageReceiver.isConnected)
+      TestAsyncUtil.retryUntilSatisfied(peerMessageReceiver.isInitialized)
 
     isConnectedF.flatMap { _ =>
       //disconnect here

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
@@ -85,7 +85,7 @@ class ClientTest
       client ! Tcp.Abort
       val isDisconnectedF =
         TestAsyncUtil.retryUntilSatisfied(peerMessageReceiver.isDisconnected,
-                                          duration = 500.millis)
+                                          duration = 1.seconds)
 
       isDisconnectedF.map { _ =>
         succeed


### PR DESCRIPTION
We are having this annoying test failure on CI spuriously where we have a condition timing out when try to disconnect from a bitcoind node in our bitcoin-s node project. This doubles the timeout from 25 seconds to 50 seconds

https://travis-ci.org/bitcoin-s/bitcoin-s-core/jobs/526480942#L1390