### PR TITLE
WIP: Create ChainSync, BitcoindChainHandlerViaRpc, add simple ChainSyncTes…

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
@@ -1,8 +1,9 @@
 package org.bitcoins.rpc.jsonmodels
 
-import org.bitcoins.core.crypto.{DoubleSha256DigestBE}
+import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.{Int32, UInt32}
+import org.bitcoins.core.protocol.blockchain.{BlockHeader, ChainParams}
 import org.bitcoins.core.wallet.fee.BitcoinFeeUnit
 
 sealed abstract class BlockchainResult
@@ -104,7 +105,25 @@ case class GetBlockHeaderResult(
     chainwork: String,
     previousblockhash: Option[DoubleSha256DigestBE],
     nextblockhash: Option[DoubleSha256DigestBE])
-    extends BlockchainResult
+    extends BlockchainResult {
+  def blockHeader(implicit cp: ChainParams): BlockHeader = {
+
+    val prevHash = {
+      if (height == 0 && previousblockhash.isEmpty) {
+        cp.genesisBlock.blockHeader.previousBlockHashBE
+      } else {
+        previousblockhash.get
+      }
+    }
+    BlockHeader(version = Int32(version),
+      //i think the only exception here is the genesis block? Why is this a option?
+      previousBlockHash = prevHash.flip,
+      merkleRootHash = merkleroot.flip,
+      time = time,
+      nBits = bits,
+      nonce = nonce)
+  }
+}
 
 case class ChainTip(
     height: Int,

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
@@ -3,7 +3,7 @@ package org.bitcoins.rpc.jsonmodels
 import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.{Int32, UInt32}
-import org.bitcoins.core.protocol.blockchain.{BlockHeader, ChainParams}
+import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.wallet.fee.BitcoinFeeUnit
 
 sealed abstract class BlockchainResult
@@ -106,17 +106,18 @@ case class GetBlockHeaderResult(
     previousblockhash: Option[DoubleSha256DigestBE],
     nextblockhash: Option[DoubleSha256DigestBE])
     extends BlockchainResult {
-  def blockHeader(implicit cp: ChainParams): BlockHeader = {
+  def blockHeader: BlockHeader = {
 
+    //prevblockhash is only empty if we have the genesis block
+    //we assume the prevhash of the gensis block is the empty hash
     val prevHash = {
       if (height == 0 && previousblockhash.isEmpty) {
-        cp.genesisBlock.blockHeader.previousBlockHashBE
+        DoubleSha256DigestBE.empty
       } else {
         previousblockhash.get
       }
     }
     BlockHeader(version = Int32(version),
-      //i think the only exception here is the genesis block? Why is this a option?
       previousBlockHash = prevHash.flip,
       merkleRootHash = merkleroot.flip,
       time = time,

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
@@ -1,0 +1,49 @@
+package org.bitcoins.chain.blockchain.sync
+
+import akka.actor.ActorSystem
+import org.bitcoins.chain.api.ChainApi
+import org.bitcoins.chain.util.{BitcoindChainHandlerViaRpc, ChainUnitTest}
+import org.bitcoins.core.crypto.DoubleSha256DigestBE
+import org.scalatest.FutureOutcome
+
+import scala.concurrent.Future
+
+class ChainSyncTest extends ChainUnitTest {
+  override type FixtureParam = BitcoindChainHandlerViaRpc
+
+  override implicit val system = ActorSystem(s"chain-sync-test-${System.currentTimeMillis()}")
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    withBitcoindChainHandlerViaRpc(test)
+  }
+
+  behavior of "ChainSync"
+
+  it must "sync our chain handler when it is not synced with bitcoind" in {
+    bitcoindWithChainHandler: BitcoindChainHandlerViaRpc =>
+      val bitcoind = bitcoindWithChainHandler.bitcoindRpc
+      val chainHandler = bitcoindWithChainHandler.chainHandler
+      //first we need to implement the 'getBestBlockHashFunc' and 'getBlockHeaderFunc' functions
+        val getBestBlockHashFunc = { () =>
+          bitcoind.getBestBlockHash
+        }
+
+        val getBlockHeaderFunc = { hash: DoubleSha256DigestBE =>
+          bitcoind.getBlockHeader(hash).map(_.blockHeader)
+        }
+
+        //let's generate a block on bitcoind
+        val block1F = bitcoind.generate(1)
+        val newChainHandlerF: Future[ChainApi] = block1F.flatMap { hashes =>
+          ChainSync.sync(chainHandler = chainHandler,
+            getBlockHeaderFunc = getBlockHeaderFunc,
+            getBestBlockHashFunc = getBestBlockHashFunc)
+        }
+
+      newChainHandlerF.flatMap { chainHandler =>
+
+        chainHandler.getBlockCount.map(count => assert(count == 1))
+
+      }
+  }
+}

--- a/chain-test/src/test/scala/org/bitcoins/chain/util/BitcoindChainHandlerViaRpc.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/util/BitcoindChainHandlerViaRpc.scala
@@ -1,0 +1,9 @@
+package org.bitcoins.chain.util
+
+import org.bitcoins.chain.blockchain.ChainHandler
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+
+/** Represents a bitcoind instance paired with a chain handler via zmq */
+case class BitcoindChainHandlerViaRpc(
+                                       bitcoindRpc: BitcoindRpcClient,
+                                       chainHandler: ChainHandler)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * of [[ChainApi]], this is the entry point in to the
   * chain project.
   */
-case class ChainHandler(blockchain: Blockchain)(implicit ec: ExecutionContext)
+case class ChainHandler(blockchain: Blockchain)
     extends ChainApi
     with BitcoinSLogger {
 
@@ -33,7 +33,7 @@ case class ChainHandler(blockchain: Blockchain)(implicit ec: ExecutionContext)
     blockHeaderDAO.findByHash(hash)
   }
 
-  override def processHeader(header: BlockHeader): Future[ChainHandler] = {
+  override def processHeader(header: BlockHeader)(implicit ec: ExecutionContext): Future[ChainHandler] = {
     val blockchainUpdateF = blockchain.connectTip(header)
 
     val newHandlerF = blockchainUpdateF.flatMap {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
@@ -1,0 +1,110 @@
+package org.bitcoins.chain.blockchain.sync
+
+import org.bitcoins.chain.api.ChainApi
+import org.bitcoins.chain.blockchain.ChainHandler
+import org.bitcoins.chain.models.BlockHeaderDb
+import org.bitcoins.core.crypto.DoubleSha256DigestBE
+import org.bitcoins.core.protocol.blockchain.BlockHeader
+import org.bitcoins.core.util.BitcoinSLogger
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait ChainSync extends BitcoinSLogger {
+
+  /** This method checks if our chain handler has the tip of the blockchain as an external source
+    * If we do not have the same chain, we sync our chain handler until we are at the same best block hash
+    * @param chainHandler our internal chain handler
+    * @param getBlockHeaderFunc a function that we can call to retrieve a block
+    * @param getBestBlockHashFunc a function that can call a third party source (bitcoind, block explorer etc)
+    *                             to retrieve what the best block is on the blockchain
+    * @param ec
+    * @return
+    */
+  def sync(chainHandler: ChainHandler,
+           getBlockHeaderFunc: DoubleSha256DigestBE => Future[BlockHeader],
+           getBestBlockHashFunc: () => Future[DoubleSha256DigestBE])(implicit ec: ExecutionContext): Future[ChainApi] = {
+    val currentTipsF: Future[Vector[BlockHeaderDb]] = {
+      chainHandler.blockchain.blockHeaderDAO.chainTips
+    }
+
+    //TODO: We are implicitly trusting whatever
+    // getBestBlockHashFunc returns as the best chain
+    // and we don't ever even have to have this connect
+    // with our current best tips
+    // do we some how want to mitigate against the divergence
+    // in chains here?
+    val bitcoindBestBlockHashF = {
+      getBestBlockHashFunc()
+    }
+
+    val updatedChainApi = bitcoindBestBlockHashF.flatMap { bitcoindBestBlockHash =>
+      currentTipsF.flatMap { tips =>
+        syncTips(chainApi = chainHandler,
+          tips = tips,
+          bestBlockHash = bitcoindBestBlockHash,
+          getBlockHeaderFunc = getBlockHeaderFunc)
+      }
+    }
+
+    updatedChainApi
+
+  }
+
+
+  /**
+    * Keeps walking backwards on the chain until we match one
+    * of the tips we have in our chain
+    * @param chainApi the chain api that represents our current chain state
+    * @param tips the best block header we know about
+    * @param bestBlockHash the best block header seen by our third party data source
+    * @param getBlockHeaderFunc how we can retrieve block headers
+    * @param ec
+    * @return
+    */
+  private def syncTips(chainApi: ChainApi,
+                       tips: Vector[BlockHeaderDb],
+                       bestBlockHash: DoubleSha256DigestBE,
+                       getBlockHeaderFunc: DoubleSha256DigestBE => Future[BlockHeader])(implicit ec: ExecutionContext): Future[ChainApi] = {
+    require(tips.nonEmpty, s"Cannot sync without the gensis block")
+
+    //we need to walk backwards on the chain until we get to one of our tips
+
+    val tipsBH = tips.map(_.blockHeader)
+
+    def loop(lastHeaderF: Future[BlockHeader], accum: List[BlockHeader]): Future[List[BlockHeader]] = {
+      lastHeaderF.flatMap { lastHeader =>
+        if (tipsBH.contains(lastHeader)) {
+          //means we have synced back to a block that we know
+          Future.successful(accum)
+        } else {
+
+          logger.debug(s"Last header=${lastHeader.hashBE.hex}")
+          //we don't know this block, so we need to keep walking backwards
+          //to find a block a we know
+          val newLastHeaderF = getBlockHeaderFunc(lastHeader.previousBlockHashBE)
+
+          loop(newLastHeaderF,lastHeader +: accum)
+        }
+      }
+    }
+
+    val bestHeaderF = getBlockHeaderFunc(bestBlockHash)
+
+    bestHeaderF.map { bestHeader =>
+      logger.info(s"Best tip from third party=${bestHeader.hashBE.hex} currentTips=${tips.map(_.hashBE.hex)}")
+    }
+
+    //this represents all headers we have received from our external data source
+    //and need to process with our chain handler
+    val headersToSyncF = loop(bestHeaderF, List.empty)
+
+    //now we are going to add them to our chain and return the chain api
+    headersToSyncF.flatMap { headers =>
+      logger.info(s"Attempting to sync ${headers.length} blockheader to our chainstate")
+      chainApi.processHeaders(headers.toVector)
+    }
+  }
+}
+
+
+object ChainSync extends ChainSync

--- a/testkit/src/main/resources/common-logback.xml
+++ b/testkit/src/main/resources/common-logback.xml
@@ -39,6 +39,9 @@
     <!-- see what statements are executed by setting to DEBUG -->
     <logger name="slick.jdbc.JdbcBackend.statement" level="INFO"/>
 
+    <!-- see what slick is compiling to in sql -->
+    <logger name="slick.compiler" level="INFO"/>
+
     <!-- Get rid of messages like this: 
 
     Connection attempt failed. Backing off new connection 


### PR DESCRIPTION
This PR is creating a way to sync our blockchain with a third party data source. This can be a normal REST api, a bitcoind rpc client, or by directly hooking into the bitcoin p2p network. 

The most important file in this PR is [`ChainSync.scala`](https://github.com/Christewart/bitcoin-s-core/blob/54f1f759eae73fe70a8019570bc03cac4e79d66c/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala) this trait current has one method called `sync`. The parameters for this method are 

- `chainHandler: ChainHandler` -- we use this to figure out the current chain state we have
- `getBlockHeaderFunc: DoubleSha256DigestBe => Future[BlockHeader]` -- this function allows us to arbitrarily query block headers. In this PR this is implemented as [`getBlockHeader`](https://github.com/bitcoin-s/bitcoin-s-core/blob/master/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BlockchainRpc.scala#L42) on the rpc client
- `getBestBlockHashFunc: () => Future[DoubleSha256DigestBE]` -- this function allows us to query a 3rd party data source and figure what their best block hash is. In this PR this is implemented as [`getBestBlockHash`](https://github.com/bitcoin-s/bitcoin-s-core/blob/master/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BlockchainRpc.scala#L16) on our rpc client

The basic idea then is that if we are _not_ in sync with what is returned by `getBestBlockHash`, we walk the chain backwards with our `getBlockHeaderFunc` until we get to one of our chain tips. 


TODO:

- [ ] Add more complex test cases like reorgs
- [x] Consider the situtation where our third party data source has some how fallen behind us
- [ ] make traits for the function signatures above and move them to core so they are accessible to all projects

