### PR TITLE
Ignore eclair test case for now as it almost always fails on CI

### DIFF
--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -714,7 +714,7 @@ class EclairRpcClientTest extends AsyncFlatSpec with BeforeAndAfterAll {
 
   }
 
-  it must "receive gossip messages about channel updates for nodes we do not have a direct channel with" in {
+  it must "receive gossip messages about channel updates for nodes we do not have a direct channel with" ignore  {
     //make sure we see payments outside of our immediate peers
     //this is important because these gossip messages contain
     //information about channel fees, so we need to get updates


### PR DESCRIPTION
This test case has been failing for a long time now on CI, but seems to always pass locally. This has been causing us CI failures for close to 6 months now and there doesn't seem to be a good way to fix it.