### PR TITLE
2019 05 05 sync chain

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
@@ -56,7 +56,7 @@ object Blockchain extends BitcoinSLogger {
       val nested: Vector[Future[BlockchainUpdate]] = blockchains.map { blockchain =>
         val tip = blockchain.tip
         logger.debug(
-          s"Attempting to add new tip=${header.hashBE.hex} to chain with current tips=${tip.hashBE.hex}")
+          s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain with current tips=${tip.hashBE.hex}")
         val tipResultF = TipValidation.checkNewTip(newPotentialTip = header,
           currentTip = tip,
           blockHeaderDAO = blockHeaderDAO)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
@@ -65,7 +65,7 @@ trait ChainSync extends BitcoinSLogger {
                        tips: Vector[BlockHeaderDb],
                        bestBlockHash: DoubleSha256DigestBE,
                        getBlockHeaderFunc: DoubleSha256DigestBE => Future[BlockHeader])(implicit ec: ExecutionContext): Future[ChainApi] = {
-    require(tips.nonEmpty, s"Cannot sync without the gensis block")
+    require(tips.nonEmpty, s"Cannot sync without the genesis block")
 
     //we need to walk backwards on the chain until we get to one of our tips
 

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -1,7 +1,24 @@
 package org.bitcoins.chain.config
 
 import org.bitcoins.chain.db.ChainDbConfig
+import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.db.AppConfig
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success}
 
-case class ChainAppConfig(dbConfig: ChainDbConfig)
-    extends AppConfig[ChainDbConfig]
+case class ChainAppConfig(dbConfig: ChainDbConfig) extends AppConfig[ChainDbConfig] {
+
+  def isDbInitialized()(implicit ec: ExecutionContext): Future[Boolean] = {
+    val bhDAO = BlockHeaderDAO(this)
+    val p = Promise[Boolean]()
+    val isDefinedOptF = {
+      bhDAO.read(chain.genesisBlock.blockHeader.hashBE).map(_.isDefined)
+    }
+    isDefinedOptF.onComplete {
+      case Success(bool) => p.success(bool)
+      case Failure(err) => p.success(false)
+    }
+
+    p.future
+  }
+}

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -16,7 +16,9 @@ case class ChainAppConfig(dbConfig: ChainDbConfig) extends AppConfig[ChainDbConf
     }
     isDefinedOptF.onComplete {
       case Success(bool) => p.success(bool)
-      case Failure(err) => p.success(false)
+      case Failure(err) =>
+        logger.info(s"Failed to init chain app err=${err.getMessage}")
+        p.success(false)
     }
 
     p.future

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -53,7 +53,7 @@ sealed abstract class Pow extends BitcoinSLogger {
       }
     } else {
       val firstHeight = currentHeight - (chainParams.difficultyChangeInterval - 1)
-      
+
       require(firstHeight >= 0, s"We must have our first height be postive, got=${firstHeight}")
 
       val firstBlockAtIntervalF: Future[Option[BlockHeaderDb]] = {

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -3,7 +3,7 @@ package org.bitcoins.chain.pow
 import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.{BlockHeader, ChainParams}
-import org.bitcoins.core.util.NumberUtil
+import org.bitcoins.core.util.{BitcoinSLogger, NumberUtil}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * Implements functions found inside of bitcoin core's
   * @see [[https://github.com/bitcoin/bitcoin/blob/35477e9e4e3f0f207ac6fa5764886b15bf9af8d0/src/pow.cpp pow.cpp]]
   */
-sealed abstract class Pow {
+sealed abstract class Pow extends BitcoinSLogger {
 
   /**
     * Gets the next proof of work requirement for a block
@@ -52,9 +52,9 @@ sealed abstract class Pow {
         Future.successful(tip.blockHeader.nBits)
       }
     } else {
-      val firstHeight = tip.height - chainParams.difficultyChangeInterval - 1
-
-      require(firstHeight >= 0)
+      val firstHeight = currentHeight - (chainParams.difficultyChangeInterval - 1)
+      
+      require(firstHeight >= 0, s"We must have our first height be postive, got=${firstHeight}")
 
       val firstBlockAtIntervalF: Future[Option[BlockHeaderDb]] = {
         blockHeaderDAO.getAncestorAtHeight(tip, firstHeight)

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -33,7 +33,7 @@ sealed abstract class TipValidation extends BitcoinSLogger {
 
     val powCheckF = isBadPow(newPotentialTip = newPotentialTip,
                              currentTip = currentTip,
-                             blockHeaderDAO)
+                             blockHeaderDAO = blockHeaderDAO)
 
     val connectTipResultF: Future[TipUpdateResult] = {
       powCheckF.map { expectedWork =>

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -78,7 +78,7 @@ sealed abstract class TipValidation extends BitcoinSLogger {
     ()
   }
 
-  /** Checks if [[header.nonce]] hashes to meet the POW requirements for this block (nBits)
+  /** Checks if [[header]] hashes to meet the POW requirements for this block (nBits)
     * Mimics this
     * @see [[https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/pow.cpp#L74]]
     * */

--- a/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
@@ -1,0 +1,8 @@
+package org.bitcoins.core.util
+
+import scala.concurrent.Future
+
+object FutureUtil {
+
+  val unit: Future[Unit] = Future.successful(())
+}

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -2,9 +2,10 @@ package org.bitcoins.db
 
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.protocol.blockchain.ChainParams
+import org.bitcoins.core.util.BitcoinSLogger
 
 
-trait AppConfig[C <: DbConfig] {
+trait AppConfig[C <: DbConfig] extends BitcoinSLogger {
   def dbConfig: C
 
   def chain: ChainParams = dbConfig.networkDb.chain

--- a/doc/src/main/scala/org/bitcoins/doc/chain/persist-chain.sc
+++ b/doc/src/main/scala/org/bitcoins/doc/chain/persist-chain.sc
@@ -1,0 +1,70 @@
+import org.bitcoins.rpc.config._
+
+import akka.actor.ActorSystem
+import org.bitcoins.chain.db._
+import org.bitcoins.chain.config._
+import org.bitcoins.chain.blockchain._
+import org.bitcoins.chain.blockchain.sync._
+import org.bitcoins.chain.models._
+
+import org.bitcoins.core.protocol.blockchain._
+import org.bitcoins.rpc.client.common._
+import org.bitcoins.testkit.chain._
+import org.bitcoins.wallet._
+import org.bitcoins.wallet.api._
+
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import scala.concurrent._
+import scala.concurrent.duration.DurationInt
+import scala.util._
+
+//the goal for this script is to create a chain and persist it
+//to disk after creation
+
+//we should be able to read this chain on subsequent runs
+//assuming we are connected to the same bitcoind instance
+
+//boring config stuff
+val logger = LoggerFactory.getLogger("org.bitcoins.doc.chain.PersistChain")
+val time = System.currentTimeMillis()
+implicit val system = ActorSystem(s"persist-chain-${time}")
+import system.dispatcher
+
+//first we are assuming that a bitcoind regtest node is running in
+//the background, you can see 'connect_bitcoind.sc' script
+//to see how to bind to a local/remote bitcoind node
+val bitcoindInstance = BitcoindInstance.fromDatadir()
+val rpcCli = new BitcoindRpcClient(bitcoindInstance)
+
+logger.info(s"Done configuring rpc client")
+//next we need to create a way to monitor the chain
+val getBestBlockHash = ChainTestUtil.bestBlockHashFnRpc(Future.successful(rpcCli))
+
+val getBlockHeader = ChainTestUtil.getBlockHeaderFnRpc(Future.successful(rpcCli))
+
+val chainDbConfig = ChainDbConfig.RegTestDbConfig
+val chainAppConfig = ChainAppConfig(chainDbConfig)
+
+logger.info(s"Creating chain tables")
+//initialize chain tables in bitcoin-s if they do not exist
+val chainProjectInitF = ChainTestUtil.initializeIfNeeded(chainAppConfig)
+
+val blockHeaderDAO = BlockHeaderDAO(appConfig = chainAppConfig)
+
+val chainHandler = ChainHandler(blockHeaderDAO, chainAppConfig)
+chainProjectInitF.onComplete(t => logger.info(s"Chain table result=${t}"))
+val syncedChainApiF = chainProjectInitF.flatMap { _ =>
+  logger.info(s"Beginning sync to bitcoin-s chain state")
+  ChainSync.sync(chainHandler, getBlockHeader, getBestBlockHash)
+}
+
+syncedChainApiF.flatMap { chainApi =>
+  chainApi.getBlockCount.map(count => logger.info(s"chain api blockcount=${count}"))
+
+  rpcCli.getBlockCount.map(count => logger.info(s"bitcoind blockcount=${count}"))
+
+  system.terminate()
+}
+

--- a/doc/src/main/scala/org/bitcoins/doc/chain/persist-chain.sc
+++ b/doc/src/main/scala/org/bitcoins/doc/chain/persist-chain.sc
@@ -60,11 +60,15 @@ val syncedChainApiF = chainProjectInitF.flatMap { _ =>
   ChainSync.sync(chainHandler, getBlockHeader, getBestBlockHash)
 }
 
-syncedChainApiF.flatMap { chainApi =>
+val syncResultF = syncedChainApiF.flatMap { chainApi =>
   chainApi.getBlockCount.map(count => logger.info(s"chain api blockcount=${count}"))
 
   rpcCli.getBlockCount.map(count => logger.info(s"bitcoind blockcount=${count}"))
+}
 
+syncResultF.onComplete { case result =>
+
+  logger.info(s"Sync result=${result}")
   system.terminate()
 }
 

--- a/doc/src/main/scala/org/bitcoins/doc/chain/sync-chain.sc
+++ b/doc/src/main/scala/org/bitcoins/doc/chain/sync-chain.sc
@@ -20,16 +20,20 @@ import scala.concurrent._
 import scala.concurrent.duration.DurationInt
 import scala.util._
 
-//the goal for this script is to create a chain and persist it
+//the goal for this script is to create a chain and sync it
 //to disk after creation
 
 //we should be able to read this chain on subsequent runs
 //assuming we are connected to the same bitcoind instance
 
+//you can run this script with
+//$ sbt "doc/run doc/src/main/scala/org/bitcoins/doc/chain/sync-chain.sc"
+
+
 //boring config stuff
-val logger = LoggerFactory.getLogger("org.bitcoins.doc.chain.PersistChain")
+val logger = LoggerFactory.getLogger("org.bitcoins.doc.chain.SyncChain")
 val time = System.currentTimeMillis()
-implicit val system = ActorSystem(s"persist-chain-${time}")
+implicit val system = ActorSystem(s"sync-chain-${time}")
 import system.dispatcher
 
 //first we are assuming that a bitcoind regtest node is running in
@@ -54,7 +58,7 @@ val chainProjectInitF = ChainTestUtil.initializeIfNeeded(chainAppConfig)
 val blockHeaderDAO = BlockHeaderDAO(appConfig = chainAppConfig)
 
 val chainHandler = ChainHandler(blockHeaderDAO, chainAppConfig)
-chainProjectInitF.onComplete(t => logger.info(s"Chain table result=${t}"))
+
 val syncedChainApiF = chainProjectInitF.flatMap { _ =>
   logger.info(s"Beginning sync to bitcoin-s chain state")
   ChainSync.sync(chainHandler, getBlockHeader, getBestBlockHash)

--- a/doc/src/main/scala/org/bitcoins/doc/chain/sync-chain.sc
+++ b/doc/src/main/scala/org/bitcoins/doc/chain/sync-chain.sc
@@ -39,6 +39,10 @@ import system.dispatcher
 //first we are assuming that a bitcoind regtest node is running in
 //the background, you can see 'connect_bitcoind.sc' script
 //to see how to bind to a local/remote bitcoind node
+//This script assumes that you have a bitcoind instance running in the
+//background and that you have ~/.bitcoin/bitcoin.conf setup.
+//you need to have 'rpcuser' and 'rpcpassword' set in that bitcoin.conf file
+//You can pass in an alternative datadir if you wish by construct a new java.io.File()
 val bitcoindInstance = BitcoindInstance.fromDatadir()
 val rpcCli = new BitcoindRpcClient(bitcoindInstance)
 

--- a/doc/src/main/scala/org/bitcoins/doc/wallet/create-wallet.sc
+++ b/doc/src/main/scala/org/bitcoins/doc/wallet/create-wallet.sc
@@ -47,6 +47,8 @@ import scala.util._
   * popular databases like postgres, sqlite etc
   */
 
+//you can run this script with the following command
+//$ sbt "doc/run doc/src/main/scala/org/bitcoins/doc/wallet/create-wallet.sc"
 
 val logger = LoggerFactory.getLogger("org.bitcoins.doc.wallet.CreateWallet")
 val time = System.currentTimeMillis()

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainTestUtil.scala
@@ -6,6 +6,7 @@ import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb, BlockHeaderDbHe
 import org.bitcoins.core.crypto
 import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.protocol.blockchain.{BlockHeader, MainNetChainParams, RegTestNetChainParams}
+import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -86,14 +87,14 @@ sealed abstract class ChainTestUtil {
     val isInitF = chainAppConfig.isDbInitialized()
     isInitF.flatMap { isInit =>
       if (isInit) {
-        Future.unit
+        FutureUtil.unit
       } else {
         val createdF = ChainDbManagement.createAll(chainDbConfig)
         val genesisHeader = BlockHeaderDbHelper.fromBlockHeader(
           height = 0,
           bh = chainAppConfig.chain.genesisBlock.blockHeader)
         val bhCreatedF = createdF.flatMap(_ => blockHeaderDAO.create(genesisHeader))
-        bhCreatedF.flatMap(_ => Future.unit)
+        bhCreatedF.flatMap(_ => FutureUtil.unit)
       }
     }
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainTestUtil.scala
@@ -65,10 +65,12 @@ sealed abstract class ChainTestUtil {
   }
 
 
+  /** Creates a best block header function for [[org.bitcoins.chain.blockchain.sync.ChainSync.sync() ChainSync.sync]] */
   def bestBlockHashFnRpc(bitcoindF: Future[BitcoindRpcClient])(implicit ec: ExecutionContext): () => Future[DoubleSha256DigestBE] = {
     () => bitcoindF.flatMap(_.getBestBlockHash)
   }
 
+  /** Creates a getBlocKHeader function for [[org.bitcoins.chain.blockchain.sync.ChainSync.sync() ChainSync.sync]] */
   def getBlockHeaderFnRpc(bitcoindF: Future[BitcoindRpcClient])(implicit ec: ExecutionContext): DoubleSha256DigestBE => Future[BlockHeader] = {
     hash: crypto.DoubleSha256DigestBE => bitcoindF.flatMap(_.getBlockHeader(hash).map(_.blockHeader))
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainTestUtil.scala
@@ -81,7 +81,8 @@ sealed abstract class ChainTestUtil {
   def initializeIfNeeded(chainAppConfig: ChainAppConfig)(implicit ec: ExecutionContext): Future[Unit] = {
     val chainDbConfig = chainAppConfig.dbConfig
     val blockHeaderDAO = BlockHeaderDAO(chainAppConfig)
-    chainAppConfig.isDbInitialized().flatMap { isInit =>
+    val isInitF = chainAppConfig.isDbInitialized()
+    isInitF.flatMap { isInit =>
       if (isInit) {
         Future.unit
       } else {

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -6,41 +6,21 @@ import java.nio.file.Paths
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.{Config, ConfigFactory}
 import org.bitcoins.core.config.RegTest
-import org.bitcoins.core.crypto.{
-  DoubleSha256Digest,
-  DoubleSha256DigestBE,
-  ECPublicKey
-}
+import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE, ECPublicKey}
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.script.ScriptSignature
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionInput,
-  TransactionOutPoint
-}
+import org.bitcoins.core.protocol.transaction.{Transaction, TransactionInput, TransactionOutPoint}
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.rpc.client.common.RpcOpts.AddNodeArgument
-import org.bitcoins.rpc.client.common.{
-  BitcoindRpcClient,
-  BitcoindVersion,
-  RpcOpts
-}
+import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion, RpcOpts}
 import org.bitcoins.rpc.client.v16.BitcoindV16RpcClient
 import org.bitcoins.rpc.client.v17.BitcoindV17RpcClient
-import org.bitcoins.rpc.config.{
-  BitcoindAuthCredentials,
-  BitcoindInstance,
-  ZmqConfig
-}
-import org.bitcoins.rpc.jsonmodels.{
-  GetBlockWithTransactionsResult,
-  GetTransactionResult,
-  SignRawTransactionResult
-}
+import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstance, ZmqConfig}
+import org.bitcoins.rpc.jsonmodels.{GetBlockWithTransactionsResult, GetTransactionResult, SignRawTransactionResult}
 import org.bitcoins.rpc.util.{AsyncUtil, RpcUtil}
 import org.bitcoins.util.ListUtil
 


### PR DESCRIPTION
This builds ontop of #452 

The creates a new file called `sync-chain.sc` in the doc project which is intended to be a script to show you can sync the chain from a external data source -- such as bitcoind -- to our own local chain state. 

The second time you run the script only _new_ blocks will be synced to our local chain state. 

This is a convenient script to run if your bitcoin-s instance does not always have direct communicate with a bitcoind node, this allows you to quickly sync the block headers that you missed in the time that the chain project was offline.

EDIT: 

This script assumes that you have a `bitcoind` instance running in the background and that you have `~/.bitcoin/bitcoin.conf` setup. You can pass in an alternative datadir if you wish by construct a `new java.io.File()` that points to that datadir [here](https://github.com/bitcoin-s/bitcoin-s-core/pull/460/files#diff-ee0d37fbe3c0a832b861f81c99bb061bR42)

How to run the script
```
$  sbt "doc/run doc/src/main/scala/org/bitcoins/doc/chain/sync-chain.sc"
```
