### PR TITLE
2019 05 04 sbt ci release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,25 @@ install:
   - wget https://github.com/ACINQ/eclair/releases/download/v0.2-beta8/eclair-node-0.2-beta8-52821b8.jar
   - export ECLAIR_PATH=$(pwd)
 
-script:
-  - sbt ++$TRAVIS_SCALA_VERSION coverage test &&
-    sbt ++$TRAVIS_SCALA_VERSION core/coverageReport &&
-    sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+before_script:
+  - git fetch --tags
+
+stages:
+  - name: test
+  - name: release
+    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+
+
+jobs:
+  include:
+    - env: TEST="bitcoin-s test suite"
+      script:
+        sbt ++$TRAVIS_SCALA_VERSION coverage test &&
+        sbt ++$TRAVIS_SCALA_VERSION core/coverageReport &&
+        sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+    # run ci-release only if previous stages passed
+    - stage: release
+      script: sbt ci-release
+
 after_success:
   - sbt ++$TRAVIS_SCALA_VERSION coveralls

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import sbt.Credentials
-import sbt.Keys.publishTo
 import com.typesafe.sbt.SbtGit.GitKeys._
 
 import scala.util.Properties

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,19 @@ lazy val testCompilerOpts = commonCompilerOpts
 
 
 lazy val commonSettings = List(
+
+  organization := "org.bitcoin-s",
+  homepage := Some(url("https://bitcoin-s.org")),
+
+  developers := List(
+    Developer(
+      "christewart",
+      "Chris Stewart",
+      "stewart.chris1234@gmail.com",
+      url("https://twitter.com/Chris_Stewart_5")
+    )
+  ),
+
   scalacOptions in Compile := compilerOpts,
 
   scalacOptions in Test := testCompilerOpts,
@@ -52,46 +65,8 @@ lazy val commonSettings = List(
   assemblyOption in assembly := (assemblyOption in assembly).value
     .copy(includeScala = false),
 
-  bintrayOrganization := Some("bitcoin-s"),
-
-  bintrayRepository := "bitcoin-s-core",
-
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
 
-  resolvers += Resolver.bintrayRepo("bitcoin-s", "bitcoin-s-core"),
-
-  resolvers += Resolver.jcenterRepo,
-
-  resolvers += "oss-jfrog-artifactory-snapshot" at "https://oss.jfrog.org/artifactory/oss-snapshot-local",
-
-  credentials ++= List(
-    //for snapshot publishing
-    //http://szimano.org/automatic-deployments-to-jfrog-oss-and-bintrayjcentermaven-central-via-travis-ci-from-sbt/
-    Credentials(Path.userHome / ".bintray" / ".artifactory"),
-
-    //sbt bintray plugin
-    //release publshing
-    Credentials(Path.userHome / ".bintray" / ".credentials")
-  ),
-
-
-  publishTo := {
-    //preserve the old bintray publishing stuff here
-    //we need to preserve it for the publishTo settings below
-    val bintrayPublish = publishTo.value
-    if (isSnapshot.value) {
-      Some("Artifactory Realm" at
-        "https://oss.jfrog.org/artifactory/oss-snapshot-local;build.timestamp=" + timestamp)
-    } else {
-      bintrayPublish
-    }
-  },
-  bintrayReleaseOnPublish := !isSnapshot.value,
-  //fix for https://github.com/sbt/sbt/issues/3519
-  updateOptions := updateOptions.value.withGigahorse(false),
-  git.formattedShaVersion := git.gitHeadCommit.value.map { sha =>
-    s"${sha.take(6)}-$timestamp-SNAPSHOT"
-  },
 
   /**
     * Adding Ammonite REPL to test scope, can access both test and compile

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,10 +10,6 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
-
 // sbt plugin to unify scaladoc/javadoc across multiple projects
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 
@@ -27,7 +23,9 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 addSbtPlugin(
   "com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "latest.release")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
-
 // bloop is a build server, enabling faster builds and more rapid dev feedback
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.2.5")
+
+//tool to publish snapshots to sonatype after CI builds finish
+//https://github.com/olafurpg/sbt-ci-release
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.6")


### PR DESCRIPTION
This PR attempts to integrate the [`sbt-ci-release`](https://github.com/olafurpg/sbt-ci-release) built by @olafurpg.

The basic idea is to have travis ci automatically publish snaphots and releases to our sonatype repository. If a build runs successfully, travis will automatically publish. 