### PR TITLE
update readmes

### DIFF
--- a/bitcoind-rpc/README.md
+++ b/bitcoind-rpc/README.md
@@ -1,2 +1,21 @@
 See the `bitcoind`/Bitcoin Core section on the 
 Bitcoin-S [website](https://bitcoin-s.org/docs/rpc/rpc-bitcoind).
+
+## Testing
+
+To test the Bitcoin-S RPC project you need both version 0.16 and 0.17 of Bitcoin Core. A list of current and previous releases can be found [here](https://bitcoincore.org/en/releases/).
+
+You then need to set environment variables to indicate where Bitcoin-S can find the different versions: 
+
+```bash
+$ export BITCOIND_V16_PATH=/path/to/v16/bitcoind
+$ export BITCOIND_V17_PATH=/path/to/v17/bitcoind
+```
+
+If you just run tests testing common functionality it's enough to have either version 0.16 or 0.17 on your `PATH`.
+
+To run all RPC related tests:
+
+```bash
+$ bloop test bitcoindRpcTest
+```

--- a/core-test/README.md
+++ b/core-test/README.md
@@ -5,11 +5,7 @@
 To run the entire `core` test suite:
 
 ```bash
-chris@chris:~/dev/bitcoins-core$ sbt coreTest/test
-# lots of output, should end up with something like this
-[info] All tests passed.
-[info] Passed: Total 1008, Failed 0, Errors 0, Passed 1008
-[success] Total time: 38 s, completed Dec 23, 2018 4:39:58 PM
+chris@chris:~/dev/bitcoins-core$ bloop test coreTest
 ```
 
 ## Coverage

--- a/testkit/README.md
+++ b/testkit/README.md
@@ -1,3 +1,16 @@
 [ ![Download](https://api.bintray.com/packages/bitcoin-s/bitcoin-s-core/bitcoin-s-testkit/images/download.svg) ](https://bintray.com/bitcoin-s/bitcoin-s-core/bitcoin-s-testkit/_latestVersion)
 
-TODO
+### Philosphy of testkit
+
+The high level of of the bitcoin-s testkit is to mimic provide functionality to test 3rd party applications.
+
+There are other examples of these in the Scala ecosystem like the `akka-testkit` and `slick-testkit`. 
+
+We use this testkit to test bitcoin-s it self. For instance, our [BitcoindRpcClient](../bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala) is tested with the functionality provided in the testkit. A quick example of a useful utility method is [BitcoindRpcTestUtil.startedBitcoindRpcClient()](src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala). This spins up a bitcoind regtest instance on machine and generates 101 blocks on that node. This gives you the abililty to start spending money immediately with that bitcoind node.
+
+We have similar utility methods for eclair. 
+
+### Property based testing
+There is also a robust set of generators available in the [org.bitcoins.testkit.gen](src/main/scala/org/bitcoins/testkit/core/gen) package. This allows you to integrate property based testing into your library and feel confident about implementing your application specific logic correctly. 
+
+You can see examples of us using these generators inside of testkit in our [Private Key test cases](../core-test/src/test/scala/org/bitcoins/core/crypto/ECPrivateKeySpec.scala)


### PR DESCRIPTION
This updates some READMEs on bitcoin-s and also fixes the version of the `sbt-api-mappings` plugin. Using `latest.release` as the version requires a network connection to resolve what the latest version is. This means we cannot develop offline