### PR TITLE
Creates a package for the bench project, moves BlockBench into that p…

### DIFF
--- a/bench/src/main/scala/org/bitcoins/bench/core/BlockBench.scala
+++ b/bench/src/main/scala/org/bitcoins/bench/core/BlockBench.scala
@@ -1,3 +1,5 @@
+package org.bitcoins.bench.core
+
 import org.bitcoins.core.protocol.blockchain.Block
 import org.slf4j.LoggerFactory
 


### PR DESCRIPTION
…ackage

Now `BlockBench` won't show up in the root package for our scaladocs