### PR TITLE
Downgrade sbt-api-mappings plugin to try and get it to work with mac osx

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,8 @@ addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 
 // ensure proper linkage across libraries in Scaladoc
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.0")
+addSbtPlugin(
+  "com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "1.1.0")
 
 // bloop is a build server, enabling faster builds and more rapid dev feedback
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.2.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,8 +14,7 @@ addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 
 // ensure proper linkage across libraries in Scaladoc
-addSbtPlugin(
-  "com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "1.1.0")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.1.0")
 
 // bloop is a build server, enabling faster builds and more rapid dev feedback
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.2.5")

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSUnitTest.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.testkit.util
 
+import java.math.BigInteger
+
 import org.scalactic.anyvals.PosInt
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, MustMatchers}


### PR DESCRIPTION
Unfortunately it looks like the `2.0.0` version of `sbt-api-mappings` does not work with mac osx on CI. Try to downgrade to `1.1.0` https://travis-ci.org/bitcoin-s/bitcoin-s/jobs/539253631#L1913