### PR TITLE
Add scalameter test dependency and sbt settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,25 @@ lazy val commonTestWithDbSettings = Seq(
 
 lazy val commonProdSettings = commonSettings
 
+lazy val Benchmark = config("bench") extend Test
+lazy val benchSettings: Seq[Def.SettingsDefinition] = {
+  //for scalameter
+  //https://scalameter.github.io/home/download/
+  //you can add benchmarking to a project by adding these to lines
+  //to the projects build definition
+  //  .settings(benchSettings: _*)
+  //  .configs(Benchmark)
+  List(
+    unmanagedSourceDirectories in Test += baseDirectory.value / "src" / "bench" / "scala",
+    testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
+    parallelExecution in Benchmark := false,
+    outputStrategy in Benchmark := Some(StdoutOutput),
+    fork in Benchmark := true,
+    connectInput in Benchmark := true,
+    inConfig(Benchmark)(Defaults.testSettings)
+  )
+}
+
 lazy val bitcoins = project
   .in(file("."))
   .aggregate(
@@ -130,6 +149,7 @@ lazy val bitcoins = project
     zmq
   )
   .settings(commonSettings: _*)
+  // crossScalaVersions must be set to Nil on the aggregating project
   .settings(crossScalaVersions := Nil)
   .settings(libraryDependencies ++= Deps.root)
   .enablePlugins(ScalaUnidocPlugin, GitVersioning)

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -26,6 +26,7 @@ object Deps {
     val slickV = "3.3.1"
     val sqliteV = "3.27.2.1"
     val uJsonV = "0.7.1"
+    val scalameterV = "0.17"
   }
 
   object Compile {
@@ -73,6 +74,7 @@ object Deps {
     val ammonite = Compile.ammonite % "test"
     val playJson = Compile.playJson % "test"
     val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % V.akkaActorV withSources () withJavadoc ()
+    val scalameter = "com.storm-enroute" %% "scalameter" % V.scalameterV % "test" withSources () withJavadoc ()
   }
 
   val root = List(


### PR DESCRIPTION
Closes #442 

This introduces the [scalameter benchmarking framework](https://scalameter.github.io/) to bitcoin-s.

This PR does not implement any actual benchmarks, it just implements the project settings to be able to do this. We should be able to execute the benchmarks with the sbt command 

`bench:test`

This does _not_ currently work with bloop. 

You can add scalameter to the project by adding these two lines on the sbt project definition

```
  .settings(benchSettings: _*)
  .configs(Benchmark)
```

and then you need to place your benchmarks under the directory 

```
[project]/src/bench/scala/org/bitcoins/[package....]/[BenchmarkName.scala]
```

