### PR TITLE
 Initial SPV node and wallet integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -351,6 +351,16 @@ lazy val nodeTest = {
   ).enablePlugins(FlywayPlugin)
 }
 
+lazy val spvWalletKit =
+  project
+    .in(file("spv-wallet-kit"))
+    .settings(commonTestWithDbSettings: _*)
+    .settings(
+      name := "bitcoin-s-spv-wallet-kit",
+      libraryDependencies ++= Deps.spvWalletKit
+    )
+    .dependsOn(node, wallet, testkit % "test")
+
 lazy val testkit = project
   .in(file("testkit"))
   .settings(commonProdSettings: _*)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
@@ -54,7 +54,7 @@ object Blockchain extends BitcoinSLogger {
         val nested: Vector[Future[BlockchainUpdate]] = blockchains.map {
           blockchain =>
             val tip = blockchain.tip
-            logger.info(
+            logger.debug(
               s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain with current tips=${tip.hashBE.hex}")
             val tipResultF = TipValidation.checkNewTip(newPotentialTip = header,
                                                        currentTip = tip,

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -34,7 +34,7 @@ case class ChainAppConfig(val confs: Config*) extends AppConfig {
       case Success(bool) =>
         logger.debug(s"Chain project is initialized")
         p.success(bool)
-      case Failure(err) =>
+      case Failure(_) =>
         logger.info(s"Chain project is not initialized")
         p.success(false)
     }

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -19,6 +19,11 @@ case class ChainAppConfig(val confs: Config*) extends AppConfig {
   override protected def newConfigOfType(
       configs: List[Config]): ChainAppConfig = ChainAppConfig(configs: _*)
 
+  /**
+    * Checks whether or not the chain project is initialized by
+    * trying to read the genesis block header from our block
+    * header table
+    */
   def isInitialized()(implicit ec: ExecutionContext): Future[Boolean] = {
     val bhDAO = BlockHeaderDAO(this)
     val p = Promise[Boolean]()
@@ -27,10 +32,10 @@ case class ChainAppConfig(val confs: Config*) extends AppConfig {
     }
     isDefinedOptF.onComplete {
       case Success(bool) =>
-        logger.info(s"Chain project is initialized")
+        logger.debug(s"Chain project is initialized")
         p.success(bool)
       case Failure(err) =>
-        logger.info(s"Failed to init chain app err=${err.getMessage}")
+        logger.info(s"Chain project is not initialized")
         p.success(false)
     }
 
@@ -41,8 +46,7 @@ case class ChainAppConfig(val confs: Config*) extends AppConfig {
     * This creates the necessary tables for the chain project
     * and inserts preliminary data like the genesis block header
     * */
-  def initialize(implicit ec: ExecutionContext): Future[Unit] = {
-    val blockHeaderDAO = BlockHeaderDAO(this)
+  override def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
     val isInitF = isInitialized()
     isInitF.flatMap { isInit =>
       if (isInit) {
@@ -53,9 +57,13 @@ case class ChainAppConfig(val confs: Config*) extends AppConfig {
           BlockHeaderDbHelper.fromBlockHeader(height = 0,
                                               bh =
                                                 chain.genesisBlock.blockHeader)
+        val blockHeaderDAO = BlockHeaderDAO(this)
         val bhCreatedF =
           createdF.flatMap(_ => blockHeaderDAO.create(genesisHeader))
-        bhCreatedF.flatMap(_ => FutureUtil.unit)
+        bhCreatedF.flatMap { _ =>
+          logger.info(s"Inserted genesis block header into DB")
+          FutureUtil.unit
+        }
       }
     }
   }

--- a/chain/src/main/scala/org/bitcoins/chain/db/ChainDbManagement.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/db/ChainDbManagement.scala
@@ -3,7 +3,7 @@ package org.bitcoins.chain.db
 import org.bitcoins.db._
 import org.bitcoins.chain.models.BlockHeaderTable
 import org.bitcoins.db.{DbManagement}
-import slick.lifted.TableQuery
+import slick.jdbc.SQLiteProfile.api._
 
 import scala.concurrent.Future
 

--- a/chain/src/main/scala/org/bitcoins/chain/db/ChainDbManagement.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/db/ChainDbManagement.scala
@@ -6,6 +6,7 @@ import org.bitcoins.db.{DbManagement}
 import slick.jdbc.SQLiteProfile.api._
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 
 /**
   * Responsible for creating and destroying database
@@ -19,7 +20,8 @@ sealed abstract class ChainDbManagement extends DbManagement {
   override val allTables = List(chainTable)
 
   def createHeaderTable(createIfNotExists: Boolean = true)(
-      implicit config: AppConfig): Future[Unit] = {
+      implicit config: AppConfig,
+      ec: ExecutionContext): Future[Unit] = {
     createTable(chainTable, createIfNotExists)
   }
 

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.chain.validation
 
-import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb, BlockHeaderDbHelper}
+import org.bitcoins.chain.models.{
+  BlockHeaderDAO,
+  BlockHeaderDb,
+  BlockHeaderDbHelper
+}
 import org.bitcoins.chain.pow.Pow
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.BlockHeader
@@ -28,7 +32,7 @@ sealed abstract class TipValidation extends BitcoinSLogger {
       blockHeaderDAO: BlockHeaderDAO)(
       implicit ec: ExecutionContext): Future[TipUpdateResult] = {
     val header = newPotentialTip
-    logger.info(
+    logger.debug(
       s"Checking header=${header.hashBE.hex} to try to connect to currentTip=${currentTip.hashBE.hex} with height=${currentTip.height}")
 
     val powCheckF = isBadPow(newPotentialTip = newPotentialTip,
@@ -66,7 +70,7 @@ sealed abstract class TipValidation extends BitcoinSLogger {
       currentTip: BlockHeaderDb)(implicit ec: ExecutionContext): Unit = {
     connectTipResultF.map {
       case TipUpdateResult.Success(tipDb) =>
-        logger.info(
+        logger.debug(
           s"Successfully connected ${tipDb.hashBE.hex} with height=${tipDb.height} to block=${currentTip.hashBE.hex} with height=${currentTip.height}")
 
       case bad: TipUpdateResult.Failure =>

--- a/core-test/src/test/scala/org/bitcoins/core/bloom/BloomFilterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/bloom/BloomFilterTest.scala
@@ -87,6 +87,26 @@ class BloomFilterTest extends FlatSpec with MustMatchers {
     filter2.hex must be("038fc16b080000000000000001")
   }
 
+  it must "insert a public key" in {
+    // each key inserted inserts both the pubkey and
+    // the hashed pubkey, therefore we need 4 elements
+    // for 2 keys
+    val numElements = 4
+    val bloom = BloomFilter(numElements = numElements,
+                            falsePositiveRate = 0.001,
+                            tweak = UInt32(100),
+                            BloomUpdateNone)
+
+    val firstKey = ECPrivateKey().publicKey
+    val secondKey = ECPrivateKey().publicKey
+    val withKeys = bloom.insert(firstKey).insert(secondKey)
+    assert(withKeys.contains(firstKey))
+    assert(withKeys.contains(secondKey))
+
+    val thirdKey = ECPrivateKey().publicKey
+    assert(!withKeys.contains(thirdKey))
+  }
+
   it must "test the isRelevant part of isRelevantAndUpdate inside of core" in {
     //mimics this test case in core
     //https://github.com/bitcoin/bitcoin/blob/master/src/test/bloom_tests.cpp#L114

--- a/core/src/main/resources/common-logback.xml
+++ b/core/src/main/resources/common-logback.xml
@@ -8,7 +8,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{5}.%M\(%line\) - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss} %-5level %logger{0} - %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -45,8 +45,6 @@
     <!-- see what's returned by Slick -->
     <logger name="slick.jdbc.StatementInvoker.result" level="INFO" />
 
-
-    <logger name="slick" level="INFO"/>
     <!-- Get rid of messages like this: 
     Connection attempt failed. Backing off new connection 
     attempts for at least 800 milliseconds. -->

--- a/core/src/main/resources/common-logback.xml
+++ b/core/src/main/resources/common-logback.xml
@@ -14,7 +14,7 @@
 
 
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE" />
         <appender-ref ref="STDOUT" />
     </root>
@@ -23,7 +23,7 @@
     <logger name="akka.event.slf4j.Slf4jLogger" level="OFF" />
 
     <!-- get rid of annoying warning messages from tests -->
-    <logger name="org.bitcoins.chain.validation" level="OFF" />
+    <logger name="org.bitcoins.chain.validation" level="INFO" />
 
     <!-- inspect resolved config -->
     <logger name="org.bitcoins.chain.config" level="INFO" />

--- a/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
@@ -21,6 +21,7 @@ import scodec.bits.{BitVector, ByteVector}
 import scala.annotation.tailrec
 import scala.util.hashing.MurmurHash3
 import org.bitcoins.core.crypto.ECPublicKey
+import org.bitcoins.core.util.CryptoUtil
 
 /**
   * Created by chris on 8/2/16.
@@ -87,8 +88,14 @@ sealed abstract class BloomFilter extends NetworkElement {
   def insert(outPoint: TransactionOutPoint): BloomFilter =
     insert(outPoint.bytes)
 
-  /** Inserts a public key into the bloom filter */
-  def insert(pubkey: ECPublicKey): BloomFilter = insert(pubkey.bytes)
+  /**
+    * Inserts a public key and it's corresponding hash into the bloom filter
+    */
+  def insert(pubkey: ECPublicKey): BloomFilter = {
+    val pubkeyBytes = pubkey.bytes
+    val hash = CryptoUtil.sha256Hash160(pubkeyBytes)
+    insert(pubkeyBytes).insert(hash)
+  }
 
   /** Checks if `data` contains the given sequence of bytes */
   def contains(bytes: ByteVector): Boolean = {

--- a/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
@@ -20,6 +20,7 @@ import scodec.bits.{BitVector, ByteVector}
 
 import scala.annotation.tailrec
 import scala.util.hashing.MurmurHash3
+import org.bitcoins.core.crypto.ECPublicKey
 
 /**
   * Created by chris on 8/2/16.
@@ -85,6 +86,9 @@ sealed abstract class BloomFilter extends NetworkElement {
   /** Inserts a [[org.bitcoins.core.protocol.transaction.TransactionOutPoint TransactionOutPoint]] into `data` */
   def insert(outPoint: TransactionOutPoint): BloomFilter =
     insert(outPoint.bytes)
+
+  /** Inserts a public key into the bloom filter */
+  def insert(pubkey: ECPublicKey): BloomFilter = insert(pubkey.bytes)
 
   /** Checks if `data` contains the given sequence of bytes */
   def contains(bytes: ByteVector): Boolean = {
@@ -281,7 +285,10 @@ object BloomFilter extends Factory[BloomFilter] {
       flags: BloomFlag)
       extends BloomFilter
 
-  /** Max bloom filter size as per [[https://bitcoin.org/en/developer-reference#filterload]] */
+  /**
+    * Max bloom filter size
+    * @see [[https://bitcoin.org/en/developer-reference#filterload]]
+    */
   val maxSize = UInt32(36000)
 
   /** Max hashFunc size as per [[https://bitcoin.org/en/developer-reference#filterload]] */

--- a/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
@@ -119,6 +119,9 @@ sealed abstract class BloomFilter extends NetworkElement {
   /** Checks if `data` contains a [[org.bitcoins.core.crypto.DoubleSha256Digest Sha256Hash160Digest]] */
   def contains(hash: Sha256Hash160Digest): Boolean = contains(hash.bytes)
 
+  /** Checks if the filter contains the given public key */
+  def contains(pubkey: ECPublicKey): Boolean = contains(pubkey.bytes)
+
   /**
     * Checks if the transaction's txid, or any of the constants in it's scriptPubKeys/scriptSigs match our BloomFilter
     * See [[https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki#filter-matching-algorithm BIP37]]

--- a/core/src/main/scala/org/bitcoins/core/crypto/HashDigest.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/HashDigest.scala
@@ -99,6 +99,17 @@ object Sha256DigestBE extends Factory[Sha256DigestBE] {
   * Represents the result of SHA256(SHA256())
   */
 sealed abstract class DoubleSha256Digest extends HashDigest {
+
+  /**
+    * @note The string representation of this is given in
+    *       big endian style. This is in order to make it
+    *       easier to scan logs for mentions of the hash.
+    *       (Bitcoin Core exposes all human facing hashes
+    *       in big endian style).
+    */
+  override def toString(): String =
+    s"DoubleSha256Digest(${flip.hex})"
+
   def flip: DoubleSha256DigestBE = DoubleSha256DigestBE(bytes.reverse)
 }
 
@@ -108,7 +119,6 @@ object DoubleSha256Digest extends Factory[DoubleSha256Digest] {
     require(bytes.length == 32,
             // $COVERAGE-OFF$
             "DoubleSha256Digest must always be 32 bytes, got: " + bytes.length)
-    override def toString = s"DoubleSha256DigestImpl($hex)"
     // $COVERAGE-ON$
   }
   override def fromBytes(bytes: ByteVector): DoubleSha256Digest =
@@ -121,6 +131,8 @@ object DoubleSha256Digest extends Factory[DoubleSha256Digest] {
 
 /** The big endian version of [[org.bitcoins.core.crypto.DoubleSha256Digest DoubleSha256Digest]] */
 sealed abstract class DoubleSha256DigestBE extends HashDigest {
+
+  override def toString(): String = s"DoubleSha256DigestBE($hex)"
   def flip: DoubleSha256Digest = DoubleSha256Digest.fromBytes(bytes.reverse)
 }
 
@@ -130,7 +142,6 @@ object DoubleSha256DigestBE extends Factory[DoubleSha256DigestBE] {
     require(bytes.length == 32,
             // $COVERAGE-OFF$
             "DoubleSha256Digest must always be 32 bytes, got: " + bytes.length)
-    override def toString = s"DoubleSha256BDigestBEImpl($hex)"
     // $COVERAGE-ON$
   }
   override def fromBytes(bytes: ByteVector): DoubleSha256DigestBE =

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -8,5 +8,13 @@ bitcoin-s {
         # todo(torkelrogstad): I have no idea what a fitting 
         # default value here is 
         bloomFalsePositiveRate = 0.01
+
+
+        # settings for how we interact with the P2P network
+        p2p {
+            # if set to true, all raw P2P messages are 
+            # dumped to file
+            dumpRawBytes = true # todo: change me to false
+        }
     }
 }

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -1,4 +1,12 @@
 bitcoin-s {
     datadir = ${HOME}/.bitcoin-s
     network = regtest # regtest, testnet3, mainnet
+
+    # settings for node module
+    node {
+        # False positive rate for our Bloom filters
+        # todo(torkelrogstad): I have no idea what a fitting 
+        # default value here is 
+        bloomFalsePositiveRate = 0.01
+    }
 }

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -2,6 +2,11 @@ bitcoin-s {
     datadir = ${HOME}/.bitcoin-s
     network = regtest # regtest, testnet3, mainnet
 
+    # settings for wallet module
+    wallet {
+        defaultAccountType = legacy # legacy,, segwit, nested-segwit
+    }
+
     # settings for node module
     node {
         # False positive rate for our Bloom filters

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -133,7 +133,7 @@ abstract class AppConfig extends BitcoinSLogger {
       }
     }
 
-    logger.trace(s"Resolved DB config: ${dbConfig.config}")
+    logger.debug(s"Resolved DB config: ${dbConfig.config}")
 
     val _ = createDbFileIfDNE()
 
@@ -146,7 +146,7 @@ abstract class AppConfig extends BitcoinSLogger {
   }
 
   /** The path where our DB is located */
-  // todo: what happens when to this if we
+  // todo: what happens to this if we
   // dont use SQLite?
   lazy val dbPath: Path = {
     val pathStr = config.getString("database.dbPath")
@@ -155,11 +155,24 @@ abstract class AppConfig extends BitcoinSLogger {
     path
   }
 
+  /** The name of our database */
+  // todo: what happens to this if we
+  // dont use SQLite?
+  lazy val dbName: String = {
+    config.getString("database.name")
+  }
+
   private def createDbFileIfDNE(): Unit = {
     //should add a check in here that we are using sqlite
     if (!Files.exists(dbPath)) {
-      logger.debug(s"Creating database directory=$dbPath")
-      val _ = Files.createDirectories(dbPath)
+      val _ = {
+        logger.debug(s"Creating database directory=$dbPath")
+        Files.createDirectories(dbPath)
+        val dbFilePath = dbPath.resolve(dbName)
+        logger.debug(s"Creating database file=$dbFilePath")
+        Files.createFile(dbFilePath)
+      }
+
       ()
     }
   }

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
@@ -30,7 +30,10 @@ abstract class CRUD[T, PrimaryKeyType] extends BitcoinSLogger {
     * @param t - the record to be inserted
     * @return the inserted record
     */
-  def create(t: T): Future[T] = createAll(Vector(t)).map(_.head)
+  def create(t: T): Future[T] = {
+    logger.info(s"Writing $t to DB with config: ${appConfig.config}")
+    createAll(Vector(t)).map(_.head)
+  }
 
   def createAll(ts: Vector[T]): Future[Vector[T]]
 
@@ -41,6 +44,7 @@ abstract class CRUD[T, PrimaryKeyType] extends BitcoinSLogger {
     * @return Option[T] - the record if found, else none
     */
   def read(id: PrimaryKeyType): Future[Option[T]] = {
+    logger.info(s"Reading from DB with config: ${appConfig.config}")
     val query = findByPrimaryKey(id)
     val rows: Future[Seq[T]] = database.run(query.result)
     rows.map(_.headOption)

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
@@ -118,6 +118,10 @@ abstract class CRUD[T, PrimaryKeyType] extends BitcoinSLogger {
 
   protected def findAll(ts: Vector[T]): Query[Table[_], T, Seq]
 
+  /** Finds all elements in the table */
+  def findAll(): Future[Vector[T]] =
+    database.run(table.result).map(_.toVector)
+
 }
 
 case class SafeDatabase(config: AppConfig) extends BitcoinSLogger {

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
@@ -31,7 +31,7 @@ abstract class CRUD[T, PrimaryKeyType] extends BitcoinSLogger {
     * @return the inserted record
     */
   def create(t: T): Future[T] = {
-    logger.info(s"Writing $t to DB with config: ${appConfig.config}")
+    logger.trace(s"Writing $t to DB with config: ${appConfig.config}")
     createAll(Vector(t)).map(_.head)
   }
 
@@ -44,7 +44,7 @@ abstract class CRUD[T, PrimaryKeyType] extends BitcoinSLogger {
     * @return Option[T] - the record if found, else none
     */
   def read(id: PrimaryKeyType): Future[Option[T]] = {
-    logger.info(s"Reading from DB with config: ${appConfig.config}")
+    logger.trace(s"Reading from DB with config: ${appConfig.config}")
     val query = findByPrimaryKey(id)
     val rows: Future[Seq[T]] = database.run(query.result)
     rows.map(_.headOption)

--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.db
 
-import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.core.util.{BitcoinSLogger, FutureUtil}
 import slick.jdbc.SQLiteProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -18,14 +18,14 @@ abstract class DbManagement extends BitcoinSLogger {
 
   def createAll()(
       implicit config: AppConfig,
-      ec: ExecutionContext): Future[List[Unit]] = {
-    Future.sequence(allTables.map(createTable(_)))
+      ec: ExecutionContext): Future[Unit] = {
+    Future.sequence(allTables.map(createTable(_))).map(_ => FutureUtil.unit)
   }
 
   def dropAll()(
       implicit config: AppConfig,
-      ec: ExecutionContext): Future[List[Unit]] = {
-    Future.sequence(allTables.reverse.map(dropTable(_)))
+      ec: ExecutionContext): Future[Unit] = {
+    Future.sequence(allTables.reverse.map(dropTable(_))).map(_ => FutureUtil.unit)
   }
 
   def createTable(

--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -19,13 +19,15 @@ abstract class DbManagement extends BitcoinSLogger {
   def createAll()(
       implicit config: AppConfig,
       ec: ExecutionContext): Future[Unit] = {
-    Future.sequence(allTables.map(createTable(_))).map(_ => FutureUtil.unit)
+    Future.sequence(allTables.map(createTable(_))).flatMap(_ => FutureUtil.unit)
   }
 
   def dropAll()(
       implicit config: AppConfig,
       ec: ExecutionContext): Future[Unit] = {
-    Future.sequence(allTables.reverse.map(dropTable(_))).map(_ => FutureUtil.unit)
+    Future
+      .sequence(allTables.reverse.map(dropTable(_)))
+      .flatMap(_ => FutureUtil.unit)
   }
 
   def createTable(

--- a/node-test/src/main/scala/org/bitcoins/node/Bloom.scala
+++ b/node-test/src/main/scala/org/bitcoins/node/Bloom.scala
@@ -1,0 +1,90 @@
+package org.bitcoins.node
+
+import java.net.{InetAddress, InetSocketAddress}
+
+import org.bitcoins.chain.blockchain.ChainHandler
+import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderTable}
+import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.node.config.NodeAppConfig
+import org.bitcoins.node.constant.Constants
+import org.bitcoins.node.models.Peer
+import slick.jdbc.SQLiteProfile.api._
+
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+import org.bitcoins.wallet.LockedWallet
+import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.config.BitcoindInstance
+import org.bitcoins.wallet.config.WalletAppConfig
+import org.bitcoins.wallet.Wallet
+import org.bitcoins.core.crypto.ECPublicKey
+import scodec.bits._
+import org.bitcoins.wallet.api.CreateWalletApi
+import org.bitcoins.wallet.api.InitializeWalletSuccess
+import org.bitcoins.wallet.api.InitializeWalletError
+import org.bitcoins.core.bloom.BloomFilter
+import org.bitcoins.core.protocol.CompactSizeUInt
+import org.bitcoins.core.number.UInt32
+
+object Bloom extends App with BitcoinSLogger {
+  implicit val system = Constants.actorSystem
+  import system.dispatcher
+
+  implicit val nodeConfig = NodeAppConfig()
+  implicit val chainAppConfig = ChainAppConfig()
+  implicit val walletConf = WalletAppConfig()
+
+  logger.info(s"Chain config: ${chainAppConfig.dbConfig.config}")
+
+  val bhDAO = BlockHeaderDAO(chainAppConfig)
+  val chainApi = ChainHandler(bhDAO, chainAppConfig)
+  val table = TableQuery[BlockHeaderTable]
+
+  val chainInitF = chainAppConfig.initialize
+  Await.result(chainInitF, 3.seconds)
+
+  val instance = BitcoindInstance.fromDatadir()
+  val rpc = new BitcoindRpcClient(instance)
+
+  val peer = Peer.fromBitcoind(instance)
+
+  logger.info(s"Starting spv node")
+
+  val startF = for {
+    // bech32
+    // address bcrt1qvkvchs2w5r65rfhg56gv7mfxqmc6lu55v05e8p
+    // pubkey 0398adca219da43bfe040ec1c5b65525c219608b54613cae2fb0ca6fcd4f9d3885
+
+    // legacy
+    // address mijojbWyYiR4np8nQQ3gs3tu9Lw5CzQatm
+    // pubkey 0261c9b1e3f0671abdf6d129fce75fde4a071c1a45b7f63743522d533586a729f5
+
+    // wallet <- LockedWallet()
+    // wallet <- Wallet.initialize().map {
+    // case InitializeWalletSuccess(wallet) => wallet
+    // case err: InitializeWalletError =>
+    // throw err
+    // }
+
+    // address <- wallet.getNewAddress()
+    // _ = logger.info(s"Address: $address")
+    // info <- wallet.getAddressInfo(address)
+    // _ = logger.info(s"Info: $info")
+    spv <- SpvNode(peer, chainApi).start()
+    _ = logger.info(s"Starting SPV node sync")
+    _ <- spv.sync()
+    _ = logger.info(s"Started syncing SPV node successfully")
+
+  } yield ()
+
+  startF.onComplete {
+    case Failure(exception) =>
+      logger.error(s"${exception.getMessage}")
+    case Success(_) =>
+      logger.info(s"startF complete")
+  }
+
+}

--- a/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
@@ -8,10 +8,17 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
 import org.scalatest.FutureOutcome
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
+import org.bitcoins.testkit.BitcoinSAppConfig
 import org.bitcoins.wallet.config.WalletAppConfig
 
 import scala.concurrent.Future
 import org.bitcoins.node.networking.peer.DataMessageHandler
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import org.scalatest.compatible.Assertion
+import org.scalatest.exceptions.TestFailedException
+import org.bitcoins.core.crypto.DoubleSha256Digest
+import org.bitcoins.rpc.util.AsyncUtil
 
 class NodeWithWalletTest extends BitcoinSWalletTest {
 
@@ -24,14 +31,14 @@ class NodeWithWalletTest extends BitcoinSWalletTest {
     param =>
       val WalletWithBitcoind(wallet, rpc) = param
 
-      implicit val walletConfig: WalletAppConfig = WalletAppConfig()
-      implicit val nodeConfig: NodeAppConfig = NodeAppConfig()
-      implicit val chainConfig: ChainAppConfig = ChainAppConfig()
-
       val chainHandler = {
-        val bhDao = BlockHeaderDAO(chainConfig)
-        ChainHandler(bhDao, chainConfig)
+        val bhDao = BlockHeaderDAO(config)
+        ChainHandler(bhDao, config)
       }
+
+      var txidFromBitcoind: Option[DoubleSha256Digest] = None
+
+      val completionP = Promise[Assertion]
 
       val peer = Peer.fromBitcoind(rpc.instance)
 
@@ -39,21 +46,37 @@ class NodeWithWalletTest extends BitcoinSWalletTest {
         onBlockReceived = { block =>
           logger.error(s"Received a block")
           // for some reason this isn't triggered?
-          fail(s"Received a block! We are only expecting merkle blocks")
+          completionP.failure(
+            new TestFailedException(
+              s"Received a block! We are only expecting merkle blocks",
+              failedCodeStackDepth = 0))
+
         },
         onMerkleBlockReceived =
           block => logger.info(s"Received merkle block: $block"),
-        onTxReceived = tx => logger.info(s"Received TX: $tx"),
+        onTxReceived = { tx =>
+          logger.info(s"Received TX: $tx")
+          if (txidFromBitcoind.contains(tx.txId)) {
+            completionP.success(succeed)
+          }
+        },
       )
 
-      val spv = SpvNode(peer, chainHandler, callbacks = callbacks)
+      /**
+        * This is not ideal, how do we get one implicit value (`config`)
+        * to resolve to multiple implicit parameters?
+        */
+      implicit val nodeConfig: NodeAppConfig = config
+      implicit val chainConfig: ChainAppConfig = config
+      val spv =
+        SpvNode(peer, chainHandler, callbacks = callbacks)
 
       logger.info(
         s"Bitcoind instance has datadir: ${rpc.instance.authCredentials.datadir}")
 
       for {
-        _ <- nodeConfig.initialize()
-        _ = logger.info(s"Node config initialized")
+        _ <- config.initialize()
+        _ = logger.info(s"Initialized")
 
         address <- wallet.getNewAddress()
         info <- wallet.getAddressInfo(address).map {
@@ -64,32 +87,43 @@ class NodeWithWalletTest extends BitcoinSWalletTest {
         _ = logger.info(s"Added pubkey from wallet to SPV node")
 
         started <- spv.start()
+        _ <- spv.sync()
+        bitcoindHash <- rpc.getBestBlockHash
+        _ <- {
+          val isSyncedF =
+            () => spv.chainApi.getBestBlockHash.map(_ == bitcoindHash)
+          AsyncUtil.awaitConditionF(isSyncedF)
+        }
+        _ = logger.info(s"SPV node is synced")
+
         bloom = started.bloomFilter match {
           case Some(b) => b
           case None    => fail(s"Wallet had no bloom filter")
         }
 
-        _ = assert(bloom.contains(info.pubkey.bytes))
-        _ = logger.info(s"Bloom matches pubkey")
+        txid <- rpc.sendToAddress(address, 1.bitcoin).map { tx =>
+          txidFromBitcoind = Some(tx.flip)
+          val delay = 30.seconds
+          val runnable: Runnable = { () =>
+            val msg =
+              s"Did not receive sent transaction within $delay"
+            logger.error(msg)
+            completionP.failure(new TestFailedException(msg, 0))
+          }
 
-        _ = logger.info(s"SPV node started")
-        txid <- rpc.sendToAddress(address, 1.bitcoin)
-        _ = logger.info(s"Sent money to wallet address")
+          actorSystem.scheduler.scheduleOnce(delay, runnable)
+          tx
+        }
+        _ = logger.info(s"bitcoind sent TX $txid")
 
         rpcAddress <- rpc.getNewAddress
-        _ = logger.info(s"About to generate a block")
         block +: _ <- rpc.generateToAddress(blocks = 1, rpcAddress)
+        _ = logger.info(s"Generated a block")
         txInfo <- rpc.getTransaction(txid)
         _ = assert(txInfo.confirmations > 0 && txInfo.blockhash.contains(block))
-        _ = logger.info(s"Generated a block: ${block}")
-        balance <- wallet.getBalance()
-        _ = logger.info(s"wallet balance: $balance")
 
-        _ <- Future {
-          // this is to make the test hang, so you have time to investigate logs and whatnot
-          Thread.sleep(100000)
-        }
-      } yield fail
+        assertion <- completionP.future
+      } yield assertion
 
   }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
@@ -1,0 +1,95 @@
+package org.bitcoins.node
+
+import org.bitcoins.core.currency._
+import org.bitcoins.chain.blockchain.ChainHandler
+import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.chain.models.BlockHeaderDAO
+import org.bitcoins.node.config.NodeAppConfig
+import org.bitcoins.node.models.Peer
+import org.scalatest.FutureOutcome
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
+import org.bitcoins.wallet.config.WalletAppConfig
+
+import scala.concurrent.Future
+import org.bitcoins.node.networking.peer.DataMessageHandler
+
+class NodeWithWalletTest extends BitcoinSWalletTest {
+
+  override type FixtureParam = WalletWithBitcoind
+
+  def withFixture(test: OneArgAsyncTest): FutureOutcome =
+    withNewWalletAndBitcoind(test)
+
+  it must "load a bloom filter and receive information about received payments" in {
+    param =>
+      val WalletWithBitcoind(wallet, rpc) = param
+
+      implicit val walletConfig: WalletAppConfig = WalletAppConfig()
+      implicit val nodeConfig: NodeAppConfig = NodeAppConfig()
+      implicit val chainConfig: ChainAppConfig = ChainAppConfig()
+
+      val chainHandler = {
+        val bhDao = BlockHeaderDAO(chainConfig)
+        ChainHandler(bhDao, chainConfig)
+      }
+
+      val peer = Peer.fromBitcoind(rpc.instance)
+
+      val callbacks = SpvNodeCallbacks(
+        onBlockReceived = { block =>
+          logger.error(s"Received a block")
+          // for some reason this isn't triggered?
+          fail(s"Received a block! We are only expecting merkle blocks")
+        },
+        onMerkleBlockReceived =
+          block => logger.info(s"Received merkle block: $block"),
+        onTxReceived = tx => logger.info(s"Received TX: $tx"),
+      )
+
+      val spv = SpvNode(peer, chainHandler, callbacks = callbacks)
+
+      logger.info(
+        s"Bitcoind instance has datadir: ${rpc.instance.authCredentials.datadir}")
+
+      for {
+        _ <- nodeConfig.initialize()
+        _ = logger.info(s"Node config initialized")
+
+        address <- wallet.getNewAddress()
+        info <- wallet.getAddressInfo(address).map {
+          case Some(info) => info
+          case None       => fail(s"Didn't get address info")
+        }
+        _ <- spv.addPubKey(info.pubkey)
+        _ = logger.info(s"Added pubkey from wallet to SPV node")
+
+        started <- spv.start()
+        bloom = started.bloomFilter match {
+          case Some(b) => b
+          case None    => fail(s"Wallet had no bloom filter")
+        }
+
+        _ = assert(bloom.contains(info.pubkey.bytes))
+        _ = logger.info(s"Bloom matches pubkey")
+
+        _ = logger.info(s"SPV node started")
+        txid <- rpc.sendToAddress(address, 1.bitcoin)
+        _ = logger.info(s"Sent money to wallet address")
+
+        rpcAddress <- rpc.getNewAddress
+        _ = logger.info(s"About to generate a block")
+        block +: _ <- rpc.generateToAddress(blocks = 1, rpcAddress)
+        txInfo <- rpc.getTransaction(txid)
+        _ = assert(txInfo.confirmations > 0 && txInfo.blockhash.contains(block))
+        _ = logger.info(s"Generated a block: ${block}")
+        balance <- wallet.getBalance()
+        _ = logger.info(s"wallet balance: $balance")
+
+        _ <- Future {
+          // this is to make the test hang, so you have time to investigate logs and whatnot
+          Thread.sleep(100000)
+        }
+      } yield fail
+
+  }
+}

--- a/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
@@ -71,8 +71,7 @@ class NodeWithWalletTest extends BitcoinSWalletTest {
       val spv =
         SpvNode(peer, chainHandler, callbacks = callbacks)
 
-      logger.info(
-        s"Bitcoind instance has datadir: ${rpc.instance.authCredentials.datadir}")
+      logger.info(s"Bitcoind instance has datadir: ${rpc.instance.datadir}")
 
       for {
         _ <- config.initialize()

--- a/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
@@ -59,7 +59,7 @@ class NodeWithWalletTest extends BitcoinSWalletTest {
           if (txidFromBitcoind.contains(tx.txId)) {
             completionP.success(succeed)
           }
-        },
+        }
       )
 
       /**
@@ -103,11 +103,13 @@ class NodeWithWalletTest extends BitcoinSWalletTest {
         txid <- rpc.sendToAddress(address, 1.bitcoin).map { tx =>
           txidFromBitcoind = Some(tx.flip)
           val delay = 30.seconds
-          val runnable: Runnable = { () =>
-            val msg =
-              s"Did not receive sent transaction within $delay"
-            logger.error(msg)
-            completionP.failure(new TestFailedException(msg, 0))
+          val runnable: Runnable = new Runnable {
+            override def run = {
+              val msg =
+                s"Did not receive sent transaction within $delay"
+              logger.error(msg)
+              completionP.failure(new TestFailedException(msg, 0))
+            }
           }
 
           actorSystem.scheduler.scheduleOnce(delay, runnable)

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
@@ -28,9 +28,9 @@ class ClientTest
   implicit val system = ActorSystem(
     s"Client-Test-System-${System.currentTimeMillis()}")
 
-  private val appConfig = NodeTestUtil.nodeAppConfig
+  private implicit val appConfig = NodeTestUtil.nodeAppConfig
 
-  private val chainAppConfig = ChainAppConfig()
+  private implicit val chainAppConfig = ChainAppConfig()
 
   implicit val np = appConfig.network
 
@@ -75,9 +75,7 @@ class ClientTest
     val probe = TestProbe()
     val remote = peer.socket
     val peerMessageReceiver =
-      PeerMessageReceiver(state = Preconnection,
-                          nodeAppConfig = appConfig,
-                          chainAppConfig = chainAppConfig)
+      PeerMessageReceiver(state = Preconnection)
     val client =
       TestActorRef(Client.props(peer, peerMessageReceiver), probe.ref)
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ClientTest.scala
@@ -15,6 +15,7 @@ import org.scalatest._
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
+import org.bitcoins.testkit.BitcoinSAppConfig
 
 /**
   * Created by chris on 6/7/16.
@@ -28,21 +29,22 @@ class ClientTest
   implicit val system = ActorSystem(
     s"Client-Test-System-${System.currentTimeMillis()}")
 
-  private implicit val appConfig = NodeTestUtil.nodeAppConfig
+  implicit private val config =
+    BitcoinSAppConfig.getConfigWithTmpDatadir()
+  implicit private val chainConf = config.chainConf
+  implicit private val nodeConf = config.nodeConf
 
-  private implicit val chainAppConfig = ChainAppConfig()
+  implicit val np = config.chainConf.network
 
-  implicit val np = appConfig.network
+  lazy val bitcoindRpcF = BitcoindRpcTestUtil.startedBitcoindRpcClient()
 
-  val bitcoindRpcF = BitcoindRpcTestUtil.startedBitcoindRpcClient()
-
-  val bitcoindPeerF = bitcoindRpcF.map { bitcoind =>
+  lazy val bitcoindPeerF = bitcoindRpcF.map { bitcoind =>
     NodeTestUtil.getBitcoindPeer(bitcoind)
   }
 
-  val bitcoindRpc2F = BitcoindRpcTestUtil.startedBitcoindRpcClient()
+  lazy val bitcoindRpc2F = BitcoindRpcTestUtil.startedBitcoindRpcClient()
 
-  val bitcoindPeer2F = bitcoindRpcF.map { bitcoind =>
+  lazy val bitcoindPeer2F = bitcoindRpcF.map { bitcoind =>
     NodeTestUtil.getBitcoindPeer(bitcoind)
   }
 

--- a/node/src/main/scala/org/bitcoins/node/NetworkMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/NetworkMessage.scala
@@ -12,8 +12,7 @@ import org.bitcoins.node.serializers.RawNetworkMessageSerializer
 import scodec.bits.ByteVector
 
 /**
-  * Created by chris on 6/10/16.
-  * Represents an entire p2p network message in bitcoins
+  * Represents an entire P2P network message in Bitcoin-S
   */
 sealed abstract class NetworkMessage extends NetworkElement {
   def header: NetworkHeader

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -97,6 +97,7 @@ case class SpvNode(
     * and then connect to our peer
     */
   def start(): Future[SpvNode] = {
+    logger.info(s"Starting SPV node with datadir ${nodeAppConfig.datadir}")
     for {
       _ <- nodeAppConfig.initialize()
       _ <- {

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -39,7 +39,7 @@ case class SpvNode(
     peer: Peer,
     chainApi: ChainApi,
     bloomFilter: Option[BloomFilter] = None,
-    callbacks: SpvNodeCallbacks = SpvNodeCallbacks())(
+    callbacks: Vector[SpvNodeCallbacks] = SpvNodeCallbacks.empty)(
     implicit system: ActorSystem,
     nodeAppConfig: NodeAppConfig,
     chainAppConfig: ChainAppConfig)

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -50,8 +50,8 @@ case class SpvNode(
 
   /** Random UInt32 value used in constructing bloom filter */
   private val tweak: UInt32 = {
-    val randomLong = math
-      .floor(UInt32.max.toLong * math.random())
+    val randomLong = Math
+      .floor(UInt32.max.toLong * Math.random())
       // why does math.floor return a double???
       .toLong
     UInt32(randomLong)

--- a/node/src/main/scala/org/bitcoins/node/SpvNodeCallbacks.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNodeCallbacks.scala
@@ -1,0 +1,15 @@
+package org.bitcoins.node
+
+import org.bitcoins.node.networking.peer.DataMessageHandler._
+
+/**
+  * Callbacks for responding to events in the SPV node.
+  * The approriate callback is executed whenver the node receives
+  * a `getdata` message matching it.
+  *
+  */
+case class SpvNodeCallbacks(
+    onTxReceived: OnTxReceived = noopTxReceived,
+    onBlockReceived: OnBlockReceived = noopBlockReceived,
+    onMerkleBlockReceived: OnMerkleBlockReceived = noopMerkleBlockReceived,
+)

--- a/node/src/main/scala/org/bitcoins/node/SpvNodeCallbacks.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNodeCallbacks.scala
@@ -13,3 +13,9 @@ case class SpvNodeCallbacks(
     onBlockReceived: OnBlockReceived = noopBlockReceived,
     onMerkleBlockReceived: OnMerkleBlockReceived = noopMerkleBlockReceived
 )
+
+object SpvNodeCallbacks {
+
+  /** No-op callbacks */
+  val empty: Vector[SpvNodeCallbacks] = Vector.empty
+}

--- a/node/src/main/scala/org/bitcoins/node/SpvNodeCallbacks.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNodeCallbacks.scala
@@ -11,5 +11,5 @@ import org.bitcoins.node.networking.peer.DataMessageHandler._
 case class SpvNodeCallbacks(
     onTxReceived: OnTxReceived = noopTxReceived,
     onBlockReceived: OnBlockReceived = noopBlockReceived,
-    onMerkleBlockReceived: OnMerkleBlockReceived = noopMerkleBlockReceived,
+    onMerkleBlockReceived: OnMerkleBlockReceived = noopMerkleBlockReceived
 )

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -10,4 +10,7 @@ case class NodeAppConfig(confs: Config*) extends AppConfig {
   override protected def newConfigOfType(configs: List[Config]): NodeAppConfig =
     NodeAppConfig(configs: _*)
 
+  val bloomFalsePositiveRate: Double =
+    config.getDouble("node.bloomFalsePositiveRate")
+
 }

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -5,6 +5,9 @@ import org.bitcoins.db.AppConfig
 import org.bitcoins.node.db.NodeDbManagement
 
 import scala.concurrent.{ExecutionContext, Future}
+import java.nio.file.Path
+import scala.util.Failure
+import scala.util.Success
 
 case class NodeAppConfig(confs: Config*) extends AppConfig {
   override val configOverrides: List[Config] = confs.toList
@@ -13,15 +16,31 @@ case class NodeAppConfig(confs: Config*) extends AppConfig {
   override protected def newConfigOfType(configs: List[Config]): NodeAppConfig =
     NodeAppConfig(configs: _*)
 
-  val bloomFalsePositiveRate: Double =
+  /** The desirable false positive rate for our bloom filter */
+  lazy val bloomFalsePositiveRate: Double =
     config.getDouble("node.bloomFalsePositiveRate")
+
+  /** Whether or not we should dump P2P messages to file  */
+  lazy val dumpP2PBytesToFile: Boolean =
+    config.getBoolean("node.p2p.dumpRawBytes")
+
+  /** The file we dump our P2P messages to */
+  lazy val p2pDumpFile: Path = datadir.resolve("p2p.dump")
 
   /**
     * Ensures correct tables and other required information is in
     * place for our node.
     */
-  def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
-    NodeDbManagement.createAll()(config = this, ec)
+  override def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
+    logger.debug(s"Initializing node setup")
+    val initF = NodeDbManagement.createAll()(config = this, ec)
+    initF.onComplete {
+      case Failure(err) =>
+        logger.error(s"Error when initializing node: ${err.getMessage}")
+      case Success(_) =>
+        logger.debug(s"Initializing node setup: done")
+    }
+    initF
   }
 
 }

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -2,6 +2,9 @@ package org.bitcoins.node.config
 
 import com.typesafe.config.Config
 import org.bitcoins.db.AppConfig
+import org.bitcoins.node.db.NodeDbManagement
+
+import scala.concurrent.{ExecutionContext, Future}
 
 case class NodeAppConfig(confs: Config*) extends AppConfig {
   override val configOverrides: List[Config] = confs.toList
@@ -12,5 +15,13 @@ case class NodeAppConfig(confs: Config*) extends AppConfig {
 
   val bloomFalsePositiveRate: Double =
     config.getDouble("node.bloomFalsePositiveRate")
+
+  /**
+    * Ensures correct tables and other required information is in
+    * place for our node.
+    */
+  def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
+    NodeDbManagement.createAll()(config = this, ec)
+  }
 
 }

--- a/node/src/main/scala/org/bitcoins/node/constant/Constants.scala
+++ b/node/src/main/scala/org/bitcoins/node/constant/Constants.scala
@@ -13,9 +13,11 @@ import org.bitcoins.node.versions.ProtocolVersion70013
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.duration.DurationInt
+import com.typesafe.config.ConfigFactory
 
 case object Constants {
-  lazy val actorSystem = ActorSystem("BitcoinSpvNode")
+  val emptyConfig = ConfigFactory.parseString("")
+  lazy val actorSystem = ActorSystem("BitcoinSpvNode", emptyConfig)
   def networkParameters: NetworkParameters = appConfig.network
   def version = ProtocolVersion70013
 

--- a/node/src/main/scala/org/bitcoins/node/db/NodeDbManagement.scala
+++ b/node/src/main/scala/org/bitcoins/node/db/NodeDbManagement.scala
@@ -1,8 +1,13 @@
 package org.bitcoins.node.db
 
 import org.bitcoins.db.DbManagement
+import org.bitcoins.node.models.InterestingPubKeyTable
+import slick.lifted.TableQuery
 
 object NodeDbManagement extends DbManagement {
 
-  override val allTables = List.empty
+  private val pubKeyTable = TableQuery[InterestingPubKeyTable]
+
+  override val allTables = List(pubKeyTable)
+
 }

--- a/node/src/main/scala/org/bitcoins/node/messages/NetworkPayload.scala
+++ b/node/src/main/scala/org/bitcoins/node/messages/NetworkPayload.scala
@@ -167,9 +167,11 @@ trait GetHeadersMessage extends DataPayload {
 /**
   * The headers message sends one or more block headers to a node
   * which previously requested certain headers with a getheaders message.
-  * [[https://bitcoin.org/en/developer-reference#headers]]
+  * @see [[https://bitcoin.org/en/developer-reference#headers]]
   */
 trait HeadersMessage extends DataPayload {
+
+  override def toString(): String = s"HeadersMessage(${count.toInt} headers)"
 
   /**
     * Number of block headers up to a maximum of 2,000.

--- a/node/src/main/scala/org/bitcoins/node/messages/TypeIdentifier.scala
+++ b/node/src/main/scala/org/bitcoins/node/messages/TypeIdentifier.scala
@@ -8,9 +8,9 @@ import org.bitcoins.node.serializers.messages.RawTypeIdentifierSerializer
 import scodec.bits.ByteVector
 
 /**
-  * Created by chris on 5/31/16.
   * This indicates the type of the object that has been hashed for an inventory
-  * https://bitcoin.org/en/developer-reference#data-messages
+
+  * @see https://bitcoin.org/en/developer-reference#data-messages
   */
 sealed trait TypeIdentifier extends NetworkElement {
   def num: UInt32
@@ -21,14 +21,23 @@ sealed trait MsgUnassigned extends TypeIdentifier
 
 object TypeIdentifier extends Factory[TypeIdentifier] {
 
+  /** The corresponding hash is a TXID */
   final case object MsgTx extends TypeIdentifier {
     override val num = UInt32.one
   }
 
+  /** The corresponding hash is a block header */
   final case object MsgBlock extends TypeIdentifier {
     override val num = UInt32(2)
   }
 
+  /**
+    * The corresponding hash is a block header
+    * When used in a `getdata` message, this indicates
+    * the response should be a merkleblock message
+    * rather than a block message (but this only works
+    * if a bloom filter was previously configured).
+    */
   final case object MsgFilteredBlock extends TypeIdentifier {
     override val num = UInt32(3)
   }
@@ -41,9 +50,9 @@ object TypeIdentifier extends Factory[TypeIdentifier] {
   def apply(num: Long): TypeIdentifier = TypeIdentifier(UInt32(num))
 
   def apply(uInt32: UInt32): TypeIdentifier = uInt32 match {
-    case UInt32.one                 => MsgTx
-    case _ if (uInt32 == UInt32(2)) => MsgBlock
-    case _ if (uInt32 == UInt32(3)) => MsgFilteredBlock
-    case x: UInt32                  => MsgUnassignedImpl(x)
+    case MsgTx.num            => MsgTx
+    case MsgBlock.num         => MsgBlock
+    case MsgFilteredBlock.num => MsgFilteredBlock
+    case x: UInt32            => MsgUnassignedImpl(x)
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/messages/control/FilterAddMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/messages/control/FilterAddMessage.scala
@@ -2,28 +2,27 @@ package org.bitcoins.node.messages.control
 
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.util.Factory
-import org.bitcoins.node.messages.FilterAddMessage
 import org.bitcoins.node.serializers.messages.control.RawFilterAddMessageSerializer
-import org.bitcoins.node.messages.FilterAddMessage
+import org.bitcoins.node.messages
 import scodec.bits.ByteVector
 
 /**
-  * Created by chris on 8/26/16.
   * Factory object for a [[FilterAddMessage]]
-  * [[https://bitcoin.org/en/developer-reference#filteradd]]
+  * @see [[https://bitcoin.org/en/developer-reference#filteradd]]
   */
-object FilterAddMessage extends Factory[FilterAddMessage] {
+object FilterAddMessage extends Factory[messages.FilterAddMessage] {
 
   private case class FilterAddMessageImpl(
       elementSize: CompactSizeUInt,
       element: ByteVector)
-      extends FilterAddMessage
-  override def fromBytes(bytes: ByteVector): FilterAddMessage =
+      extends messages.FilterAddMessage
+
+  override def fromBytes(bytes: ByteVector): messages.FilterAddMessage =
     RawFilterAddMessageSerializer.read(bytes)
 
   def apply(
       elementSize: CompactSizeUInt,
-      element: ByteVector): FilterAddMessage = {
+      element: ByteVector): messages.FilterAddMessage = {
     FilterAddMessageImpl(elementSize, element)
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/messages/control/FilterLoadMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/messages/control/FilterLoadMessage.scala
@@ -4,19 +4,17 @@ import org.bitcoins.core.bloom.{BloomFilter, BloomFlag}
 import org.bitcoins.core.number.{UInt32, UInt64}
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.util.Factory
-import org.bitcoins.node.messages.FilterLoadMessage
 import org.bitcoins.node.serializers.messages.control.RawFilterLoadMessageSerializer
-import org.bitcoins.node.messages.FilterLoadMessage
+import org.bitcoins.node.messages
 import org.bitcoins.node.serializers.messages.control.RawFilterLoadMessageSerializer
 import scodec.bits.ByteVector
 
 /**
-  * Created by chris on 7/19/16.
-  * [[https://bitcoin.org/en/developer-reference#filterload]]
+  * @see [[https://bitcoin.org/en/developer-reference#filterload]]
   */
-object FilterLoadMessage extends Factory[FilterLoadMessage] {
+object FilterLoadMessage extends Factory[messages.FilterLoadMessage] {
   private case class FilterLoadMessageImpl(bloomFilter: BloomFilter)
-      extends FilterLoadMessage {
+      extends messages.FilterLoadMessage {
     require(
       bloomFilter.filterSize.num.toLong <= BloomFilter.maxSize.toLong,
       "Can only have a maximum of 36,000 bytes in our filter, got: " + bloomFilter.data.size)
@@ -30,7 +28,7 @@ object FilterLoadMessage extends Factory[FilterLoadMessage] {
     )
   }
 
-  override def fromBytes(bytes: ByteVector): FilterLoadMessage =
+  override def fromBytes(bytes: ByteVector): messages.FilterLoadMessage =
     RawFilterLoadMessageSerializer.read(bytes)
 
   def apply(
@@ -38,7 +36,7 @@ object FilterLoadMessage extends Factory[FilterLoadMessage] {
       filter: ByteVector,
       hashFuncs: UInt32,
       tweak: UInt32,
-      flags: BloomFlag): FilterLoadMessage = {
+      flags: BloomFlag): messages.FilterLoadMessage = {
     val bloomFilter = BloomFilter(filterSize, filter, hashFuncs, tweak, flags)
     FilterLoadMessage(bloomFilter)
   }
@@ -47,12 +45,12 @@ object FilterLoadMessage extends Factory[FilterLoadMessage] {
       filter: ByteVector,
       hashFuncs: UInt32,
       tweak: UInt32,
-      flags: BloomFlag): FilterLoadMessage = {
+      flags: BloomFlag): messages.FilterLoadMessage = {
     val filterSize = CompactSizeUInt(UInt64(filter.length))
     FilterLoadMessage(filterSize, filter, hashFuncs, tweak, flags)
   }
 
-  def apply(bloomFilter: BloomFilter): FilterLoadMessage = {
+  def apply(bloomFilter: BloomFilter): messages.FilterLoadMessage = {
     FilterLoadMessageImpl(bloomFilter)
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/messages/control/VersionMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/messages/control/VersionMessage.scala
@@ -14,9 +14,8 @@ import org.joda.time.DateTime
 import scodec.bits.ByteVector
 
 /**
-  * Created by chris on 6/3/16.
   * Companion object responsible for creating VersionMessages on the p2p network
-  * https://bitcoin.org/en/developer-reference#version
+  * @see https://bitcoin.org/en/developer-reference#version
   */
 object VersionMessage extends Factory[VersionMessage] {
 
@@ -88,6 +87,9 @@ object VersionMessage extends Factory[VersionMessage] {
     val nonce = UInt64.zero
     val userAgent = Constants.userAgent
     val startHeight = Int32.zero
+
+    // we only want messages that match the bloom filters we provide
+    // otherwise we would get flooded by every message about every TX
     val relay = false
     VersionMessage(
       version = Constants.version,

--- a/node/src/main/scala/org/bitcoins/node/messages/data/Inventory.scala
+++ b/node/src/main/scala/org/bitcoins/node/messages/data/Inventory.scala
@@ -28,6 +28,8 @@ trait Inventory extends NetworkElement {
     */
   def hash: DoubleSha256Digest
 
+  override def toString(): String = s"Inventory($typeIdentifier, $hash)"
+
   override def bytes: ByteVector = RawInventorySerializer.write(this)
 }
 

--- a/node/src/main/scala/org/bitcoins/node/messages/data/MerkleBlockMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/messages/data/MerkleBlockMessage.scala
@@ -9,8 +9,7 @@ import org.bitcoins.node.serializers.messages.data.RawMerkleBlockMessageSerializ
 import scodec.bits.ByteVector
 
 /**
-  * Created by chris on 6/2/16.
-  * https://bitcoin.org/en/developer-reference#merkleblock
+  * @see https://bitcoin.org/en/developer-reference#merkleblock
   */
 object MerkleBlockMessage extends Factory[MerkleBlockMessage] {
 

--- a/node/src/main/scala/org/bitcoins/node/models/InterestingPubKeyDAO.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/InterestingPubKeyDAO.scala
@@ -1,0 +1,28 @@
+package org.bitcoins.node.models
+
+import slick.jdbc.SQLiteProfile.api._
+import org.bitcoins.db.CRUD
+import org.bitcoins.node.config.NodeAppConfig
+import scala.concurrent.ExecutionContext
+import org.bitcoins.core.crypto.ECPublicKey
+import scala.concurrent.Future
+
+case class InterestingPubKeyDAO()(
+    implicit val appConfig: NodeAppConfig,
+    val ec: ExecutionContext)
+    extends CRUD[ECPublicKey, ECPublicKey] {
+  import org.bitcoins.db.DbCommonsColumnMappers._
+
+  def createAll(ts: Vector[ECPublicKey]): Future[Vector[ECPublicKey]] = {
+    val actions = ts.map(table += _)
+    database.run(DBIO.sequence(actions)).map(_ => ts)
+  }
+
+  protected def findAll(
+      ts: Vector[ECPublicKey]): Query[Table[_], ECPublicKey, Seq] = ???
+
+  protected def findByPrimaryKeys(
+      ids: Vector[ECPublicKey]): Query[Table[_], ECPublicKey, Seq] = ???
+
+  val table = TableQuery[InterestingPubKeyTable]
+}

--- a/node/src/main/scala/org/bitcoins/node/models/InterestingPubKeyTable.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/InterestingPubKeyTable.scala
@@ -1,0 +1,15 @@
+package org.bitcoins.node.models
+
+import slick.jdbc.SQLiteProfile.api._
+import org.bitcoins.core.crypto.ECPublicKey
+import slick.lifted.ProvenShape
+
+class InterestingPubKeyTable(tag: Tag)
+    extends Table[ECPublicKey](tag, "interesting_pubkeys") {
+  import org.bitcoins.db.DbCommonsColumnMappers._
+
+  val pubkey = column[ECPublicKey]("pubkey")
+
+  def * : ProvenShape[ECPublicKey] =
+    pubkey <> ((pub => pub), ((pub: ECPublicKey) => Some(pub)))
+}

--- a/node/src/main/scala/org/bitcoins/node/models/Peer.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/Peer.scala
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress
 
 import org.bitcoins.db.DbRowAutoInc
 import org.bitcoins.node.util.NetworkIpAddress
+import org.bitcoins.rpc.config.BitcoindInstance
 
 case class Peer(networkIpAddress: NetworkIpAddress, id: Option[Long] = None)
     extends DbRowAutoInc[Peer] {
@@ -21,6 +22,14 @@ case class Peer(networkIpAddress: NetworkIpAddress, id: Option[Long] = None)
 }
 
 object Peer {
+
+  /**
+    * Constructs a peer from the given `bitcoind` instance
+    */
+  def fromBitcoind(bitcoind: BitcoindInstance): Peer = {
+    val socket = new InetSocketAddress(bitcoind.uri.getHost, bitcoind.p2pPort)
+    fromSocket(socket)
+  }
 
   def fromNetworkIpAddress(networkIpAddress: NetworkIpAddress): Peer = {
     Peer(networkIpAddress)

--- a/node/src/main/scala/org/bitcoins/node/models/Peer.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/Peer.scala
@@ -15,6 +15,9 @@ case class Peer(networkIpAddress: NetworkIpAddress, id: Option[Long] = None)
     this.copy(id = Some(id))
   }
 
+  override def toString(): String =
+    s"Peer(${networkIpAddress.address}:${networkIpAddress.port})"
+
 }
 
 object Peer {

--- a/node/src/main/scala/org/bitcoins/node/networking/Client.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/Client.scala
@@ -96,8 +96,12 @@ sealed abstract class ClientActor extends Actor with BitcoinSLogger {
     case msg: NetworkMessage =>
       self.forward(msg.payload)
     case payload: NetworkPayload =>
-      logger.error(
-        s"Cannot send a message to our peer when we are not connected! payload=${payload} peer=${peer}")
+      logger.error({
+        val first =
+          s"Cannot send a message to our peer when we are not connected!"
+        val second = s"payload=$payload peer=$peer"
+        s"$first $second"
+      })
   }
 
   /**

--- a/node/src/main/scala/org/bitcoins/node/networking/Client.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/Client.scala
@@ -67,7 +67,7 @@ sealed abstract class ClientActor extends Actor with BitcoinSLogger {
     * i.e. [[org.bitcoins.core.config.MainNet]] or [[org.bitcoins.core.config.TestNet3]]
     * @return
     */
-  def network: NetworkParameters = Constants.networkParameters
+  def network: NetworkParameters = config.network
 
   /**
     * This actor signifies the node we are connected to on the p2p network

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -95,7 +95,7 @@ class DataMessageHandler(callbacks: SpvNodeCallbacks)(
             Some(
               Inventory(TypeIdentifier.MsgFilteredBlock, hash = inventory.hash))
           case MsgFilteredBlock => Some(inventory)
-          case MsgTx            => None
+          case MsgTx            => Some(inventory)
           case _: MsgUnassigned => None
         }
       }
@@ -116,24 +116,33 @@ class DataMessageHandler(callbacks: SpvNodeCallbacks)(
   }
 }
 
-object DataMessageHandler {
+object DataMessageHandler extends BitcoinSLogger {
 
   /** Callback for handling a received block */
   type OnBlockReceived = Block => Unit
 
-  /** Does nothing with the received block */
-  val noopBlockReceived: OnBlockReceived = _ => ()
+  /** Does nothing with the received block except log it at debug level  */
+  val noopBlockReceived: OnBlockReceived = { block =>
+    logger.debug(s"Received block ${block.blockHeader.hash}")
+    ()
+  }
 
   /** Callback for handling a received Merkle block */
   type OnMerkleBlockReceived = MerkleBlock => Unit
 
-  /** Does nothing with the received Merkle block */
-  val noopMerkleBlockReceived: OnMerkleBlockReceived = _ => ()
+  /** Does nothing with the received Merkle block except log it at debug level */
+  val noopMerkleBlockReceived: OnMerkleBlockReceived = { merkleBlock =>
+    logger.debug(s"Received merkle block ${merkleBlock.blockHeader.hash}")
+    ()
+  }
 
   /** Callback for handling a received transaction */
   type OnTxReceived = Transaction => Unit
 
-  /** Does nothing with the received transaction */
-  val noopTxReceived: OnTxReceived = _ => ()
+  /** Does nothing with the received transaction except log it at debug level */
+  val noopTxReceived: OnTxReceived = { tx =>
+    logger.debug(s"Received TX ${tx.txId}")
+    ()
+  }
 
 }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -33,7 +33,7 @@ import org.bitcoins.node.messages.TypeIdentifier
   * that a peer to sent to us on the p2p network, for instance, if we a receive a
   * [[HeadersMessage]] we should store those headers in our database
   */
-class DataMessageHandler(callbacks: SpvNodeCallbacks)(
+class DataMessageHandler(callbacks: Vector[SpvNodeCallbacks])(
     implicit ec: ExecutionContext,
     appConfig: ChainAppConfig)
     extends BitcoinSLogger {
@@ -57,13 +57,13 @@ class DataMessageHandler(callbacks: SpvNodeCallbacks)(
           peerMsgSender.sendGetHeadersMessage(lastHash)
         }
       case msg: BlockMessage =>
-        callbacks.onBlockReceived(msg.block)
+        callbacks.foreach(_.onBlockReceived(msg.block))
         FutureUtil.unit
       case msg: TransactionMessage =>
-        callbacks.onTxReceived(msg.transaction)
+        callbacks.foreach(_.onTxReceived(msg.transaction))
         FutureUtil.unit
       case msg: MerkleBlockMessage =>
-        callbacks.onMerkleBlockReceived(msg.merkleBlock)
+        callbacks.foreach(_.onMerkleBlockReceived(msg.merkleBlock))
         FutureUtil.unit
       case invMsg: InventoryMessage =>
         handleInventoryMsg(invMsg = invMsg, peerMsgSender = peerMsgSender)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -27,7 +27,7 @@ import org.bitcoins.node.SpvNodeCallbacks
   */
 class PeerMessageReceiver(
     state: PeerMessageReceiverState,
-    callbacks: SpvNodeCallbacks)(
+    callbacks: Vector[SpvNodeCallbacks])(
     implicit
     nodeAppConfig: NodeAppConfig,
     chainAppConfig: ChainAppConfig,
@@ -231,7 +231,7 @@ object PeerMessageReceiver {
 
   def apply(
       state: PeerMessageReceiverState,
-      callbacks: SpvNodeCallbacks = SpvNodeCallbacks()
+      callbacks: Vector[SpvNodeCallbacks] = SpvNodeCallbacks.empty
   )(
       implicit ref: ActorRefFactory,
       nodeAppConfig: NodeAppConfig,
@@ -240,7 +240,7 @@ object PeerMessageReceiver {
     new PeerMessageReceiver(state, callbacks)
   }
 
-  def newReceiver(callbacks: SpvNodeCallbacks = SpvNodeCallbacks())(
+  def newReceiver(callbacks: Vector[SpvNodeCallbacks] = SpvNodeCallbacks.empty)(
       implicit
       nodeAppConfig: NodeAppConfig,
       chainAppConfig: ChainAppConfig,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -56,7 +56,11 @@ class PeerMessageSender(client: Client)(implicit np: NetworkParameters)
     sendMsg(sendHeadersMsg)
   }
 
-  private def sendMsg(msg: NetworkPayload): Unit = {
+  /**
+    * @note Method is kept `private[node]` to make it easier to debug
+    *       and develop P2P functionality
+    */
+  private[node] def sendMsg(msg: NetworkPayload): Unit = {
     logger.debug(
       s"PeerMessageSender sending to peer=${socket} msg=${msg.commandName}")
     val newtworkMsg = NetworkMessage(np, msg)

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -191,6 +191,7 @@ object Deps {
     Compile.slf4j,
     Compile.scalacheck,
     Compile.scalaTest,
+    Test.akkaTestkit,
     Test.ammonite
   )
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -195,6 +195,8 @@ object Deps {
     Test.ammonite
   )
 
+  val spvWalletKit = List(Test.ammonite)
+
   val scripts = List(
     Compile.ammonite,
     Compile.logback

--- a/spv-wallet-kit/src/test/scala/org/bitcoins/kit/NodeWithWalletTest.scala
+++ b/spv-wallet-kit/src/test/scala/org/bitcoins/kit/NodeWithWalletTest.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.node
+package org.bitcoins.kit
 
 import org.bitcoins.core.currency._
 import org.bitcoins.chain.blockchain.ChainHandler
@@ -19,6 +19,8 @@ import org.scalatest.compatible.Assertion
 import org.scalatest.exceptions.TestFailedException
 import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.rpc.util.AsyncUtil
+import org.bitcoins.node.SpvNodeCallbacks
+import org.bitcoins.node.SpvNode
 
 class NodeWithWalletTest extends BitcoinSWalletTest {
 
@@ -69,7 +71,7 @@ class NodeWithWalletTest extends BitcoinSWalletTest {
       implicit val nodeConfig: NodeAppConfig = config
       implicit val chainConfig: ChainAppConfig = config
       val spv =
-        SpvNode(peer, chainHandler, callbacks = callbacks)
+        SpvNode(peer, chainHandler, callbacks = Vector(callbacks))
 
       logger.info(s"Bitcoind instance has datadir: ${rpc.instance.datadir}")
 
@@ -102,7 +104,7 @@ class NodeWithWalletTest extends BitcoinSWalletTest {
 
         txid <- rpc.sendToAddress(address, 1.bitcoin).map { tx =>
           txidFromBitcoind = Some(tx.flip)
-          val delay = 30.seconds
+          val delay = 3.seconds
           val runnable: Runnable = new Runnable {
             override def run = {
               val msg =

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSAppConfig.scala
@@ -1,0 +1,65 @@
+package org.bitcoins.testkit
+
+import com.typesafe.config.Config
+import org.bitcoins.wallet.config.WalletAppConfig
+import org.bitcoins.node.config.NodeAppConfig
+import org.bitcoins.chain.config.ChainAppConfig
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+/**
+  * A unified config class for all submodules of Bitcoin-S
+  * that accepts configuration. Thanks to implicit definitions
+  * in this case class' companion object an instance
+  * of this class can be passed in anywhere a wallet,
+  * chain or node config is required.
+  */
+case class BitcoinSAppConfig(confs: Config*) {
+  val walletConf = WalletAppConfig(confs: _*)
+  val nodeConf = NodeAppConfig(confs: _*)
+  val chainConf = ChainAppConfig(confs: _*)
+
+  /** Initializes the wallet, node and chain projects */
+  def initialize()(implicit ec: ExecutionContext) = {
+    val futures = List(walletConf.initialize(),
+                       nodeConf.initialize(),
+                       chainConf.initialize())
+
+    Future.sequence(futures)
+  }
+}
+
+/**
+  * Implicit conversions that allow a unified configuration
+  * to be passed in wherever a specializes one is required
+  */
+object BitcoinSAppConfig {
+  import scala.language.implicitConversions
+
+  /** Converts the given implicit config to a wallet config */
+  implicit def implicitToWalletConf(
+      implicit conf: BitcoinSAppConfig): WalletAppConfig =
+    conf.walletConf
+
+  /** Converts the given config to a wallet config */
+  implicit def toWalletConf(conf: BitcoinSAppConfig): WalletAppConfig =
+    conf.walletConf
+
+  /** Converts the given implicit config to a chain config */
+  implicit def implicitToChainConf(
+      implicit conf: BitcoinSAppConfig): ChainAppConfig =
+    conf.chainConf
+
+  /** Converts the given config to a chain config */
+  implicit def toChainConf(conf: BitcoinSAppConfig): ChainAppConfig =
+    conf.chainConf
+
+  /** Converts the given implicit config to a node config */
+  implicit def implicitToNodeConf(
+      implicit conf: BitcoinSAppConfig): NodeAppConfig =
+    conf.nodeConf
+
+  /** Converts the given config to a node config */
+  implicit def toNodeConf(conf: BitcoinSAppConfig): NodeAppConfig =
+    conf.nodeConf
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSAppConfig.scala
@@ -66,7 +66,7 @@ object BitcoinSAppConfig {
     conf.nodeConf
 
   /** App configuration with data directory to user temp directory */
-  lazy val configWithTmpDatadir = {
+  def getConfigWithTmpDatadir() = {
     val tmpDir = Files.createTempDirectory("bitcoin-s-")
     val conf = ConfigFactory.parseString(s"bitcoin-s.datadir = $tmpDir")
     BitcoinSAppConfig(conf)

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSAppConfig.scala
@@ -6,6 +6,8 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.chain.config.ChainAppConfig
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import java.nio.file.Files
+import com.typesafe.config.ConfigFactory
 
 /**
   * A unified config class for all submodules of Bitcoin-S
@@ -62,4 +64,12 @@ object BitcoinSAppConfig {
   /** Converts the given config to a node config */
   implicit def toNodeConf(conf: BitcoinSAppConfig): NodeAppConfig =
     conf.nodeConf
+
+  /** App configuration with data directory to user temp directory */
+  lazy val configWithTmpDatadir = {
+    val tmpDir = Files.createTempDirectory("bitcoin-s-")
+    val conf = ConfigFactory.parseString(s"bitcoin-s.datadir = $tmpDir")
+    BitcoinSAppConfig(conf)
+  }
+
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/async/TestAsyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/async/TestAsyncUtil.scala
@@ -6,7 +6,9 @@ import org.scalatest.exceptions.{StackDepthException, TestFailedException}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
 
-abstract class TestAsyncUtil extends org.bitcoins.rpc.util.AsyncUtil {
+abstract class TestAsyncUtil
+    extends org.bitcoins.rpc.util.AsyncUtil
+    with Serializable {
   override protected def retryUntilSatisfiedWithCounter(
       conditionF: () => Future[Boolean],
       duration: FiniteDuration,

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -21,6 +21,7 @@ import org.bitcoins.testkit.chain.fixture._
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.zmq.ZMQSubscriber
+import org.bitcoins.testkit.BitcoinSAppConfig
 import org.scalatest._
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import scodec.bits.ByteVector
@@ -44,7 +45,8 @@ trait ChainUnitTest
 
   implicit lazy val chainParam: ChainParams = appConfig.chain
 
-  implicit lazy val appConfig: ChainAppConfig = ChainAppConfig()
+  implicit lazy val appConfig: ChainAppConfig =
+    BitcoinSAppConfig.configWithTmpDatadir
 
   /**
     * Behaves exactly like the default conf, execpt

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -46,7 +46,7 @@ trait ChainUnitTest
   implicit lazy val chainParam: ChainParams = appConfig.chain
 
   implicit lazy val appConfig: ChainAppConfig =
-    BitcoinSAppConfig.configWithTmpDatadir
+    BitcoinSAppConfig.getConfigWithTmpDatadir()
 
   /**
     * Behaves exactly like the default conf, execpt
@@ -391,7 +391,8 @@ object ChainUnitTest extends BitcoinSLogger {
 
   /** Creates the [[org.bitcoins.chain.models.BlockHeaderTable]] */
   private def setupHeaderTable()(
-      implicit appConfig: AppConfig): Future[Unit] = {
+      implicit appConfig: AppConfig,
+      ec: ExecutionContext): Future[Unit] = {
     ChainDbManagement.createHeaderTable(createIfNotExists = true)
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -71,7 +71,7 @@ abstract class NodeTestUtil {
     )
   }
 
-  def nodeAppConfig: NodeAppConfig = NodeAppConfig()
+  implicit val nodeAppConfig: NodeAppConfig = NodeAppConfig()
 
   def client(peer: Peer, peerMsgReceiver: PeerMessageReceiver)(
       implicit ref: ActorRefFactory): Client = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -14,6 +14,7 @@ import org.bitcoins.node.networking.Client
 import org.bitcoins.node.networking.peer.PeerMessageReceiver
 import org.bitcoins.node.util.NetworkIpAddress
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.testkit.BitcoinSAppConfig
 
 /**
   * Created by chris on 6/2/16.
@@ -71,7 +72,8 @@ abstract class NodeTestUtil {
     )
   }
 
-  implicit val nodeAppConfig: NodeAppConfig = NodeAppConfig()
+  implicit val nodeAppConfig: NodeAppConfig =
+    BitcoinSAppConfig.configWithTmpDatadir
 
   def client(peer: Peer, peerMsgReceiver: PeerMessageReceiver)(
       implicit ref: ActorRefFactory): Client = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -73,7 +73,7 @@ abstract class NodeTestUtil {
   }
 
   implicit val nodeAppConfig: NodeAppConfig =
-    BitcoinSAppConfig.configWithTmpDatadir
+    BitcoinSAppConfig.getConfigWithTmpDatadir()
 
   def client(peer: Peer, peerMsgReceiver: PeerMessageReceiver)(
       implicit ref: ActorRefFactory): Client = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -32,6 +32,7 @@ import org.scalatest.{
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import org.bitcoins.node.SpvNodeCallbacks
 
 trait NodeUnitTest
     extends BitcoinSFixture
@@ -68,7 +69,7 @@ trait NodeUnitTest
 
   def buildPeerMessageReceiver(): PeerMessageReceiver = {
     val receiver =
-      PeerMessageReceiver.newReceiver(nodeAppConfig, chainAppConfig)
+      PeerMessageReceiver.newReceiver()
     receiver
   }
 
@@ -114,12 +115,14 @@ trait NodeUnitTest
   def withNodeAndBitcoindAndWallet(test: OneArgAsyncTest)(
       implicit system: ActorSystem): FutureOutcome = {
     type Triple = (SpvNode, BitcoindRpcClient, UnlockedWalletApi)
+
     val create: () => Future[Triple] = () =>
       for {
         wallet <- BitcoinSWalletTest.createNewWallet()
         bitcoind <- createBitcoindWithFunds()
         spv <- createSpvNode(bitcoind)
       } yield (spv, bitcoind, wallet)
+
     val destroy: Triple => Future[Unit] = {
       case (spv, bitcoind, wallet) =>
         val spvWithBitcoind = SpvNodeConnectedWithBitcoind(spv, bitcoind)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -3,7 +3,6 @@ package org.bitcoins.testkit.node
 import java.net.InetSocketAddress
 
 import akka.actor.ActorSystem
-import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.db.AppConfig
@@ -32,7 +31,8 @@ import org.scalatest.{
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import org.bitcoins.node.SpvNodeCallbacks
+import org.bitcoins.testkit.BitcoinSAppConfig
+import org.bitcoins.testkit.BitcoinSAppConfig._
 
 trait NodeUnitTest
     extends BitcoinSFixture
@@ -42,7 +42,7 @@ trait NodeUnitTest
     with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
-    AppConfig.throwIfDefaultDatadir(nodeAppConfig)
+    AppConfig.throwIfDefaultDatadir(config.nodeConf)
   }
 
   override def afterAll(): Unit = {
@@ -59,9 +59,11 @@ trait NodeUnitTest
 
   val timeout: FiniteDuration = 10.seconds
 
-  implicit lazy val nodeAppConfig: NodeAppConfig = NodeAppConfig()
-  implicit lazy val chainAppConfig: ChainAppConfig = ChainAppConfig()
-  implicit val np: NetworkParameters = nodeAppConfig.network
+  /** Wallet config with data directory set to user temp directory */
+  implicit protected lazy val config: BitcoinSAppConfig =
+    BitcoinSAppConfig.configWithTmpDatadir
+
+  implicit lazy val np: NetworkParameters = config.nodeConf.network
 
   lazy val startedBitcoindF = BitcoindRpcTestUtil.startedBitcoindRpcClient()
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -61,7 +61,7 @@ trait NodeUnitTest
 
   /** Wallet config with data directory set to user temp directory */
   implicit protected lazy val config: BitcoinSAppConfig =
-    BitcoinSAppConfig.configWithTmpDatadir
+    BitcoinSAppConfig.getConfigWithTmpDatadir()
 
   implicit lazy val np: NetworkParameters = config.nodeConf.network
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -1,9 +1,8 @@
-package org.bitcoins.wallet.util
+package org.bitcoins.testkit.wallet
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import org.bitcoins.core.config.RegTest
-import org.bitcoins.core.crypto.MnemonicCode
 import org.bitcoins.core.protocol.blockchain.ChainParams
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
@@ -27,8 +26,9 @@ trait BitcoinSWalletTest
     with BitcoinSFixture
     with BeforeAndAfterAll
     with BitcoinSLogger {
-  implicit val actorSystem: ActorSystem = ActorSystem(getClass.getSimpleName)
-  implicit val ec: ExecutionContext = actorSystem.dispatcher
+  implicit lazy val actorSystem: ActorSystem = ActorSystem(
+    getClass.getSimpleName)
+  implicit lazy val ec: ExecutionContext = actorSystem.dispatcher
 
   protected lazy val chainParams: ChainParams = WalletTestUtil.chainParams
   protected implicit lazy val appConfig: WalletAppConfig = WalletAppConfig()
@@ -61,7 +61,8 @@ trait BitcoinSWalletTest
   }
 
   def withNewWallet(test: OneArgAsyncTest): FutureOutcome =
-    makeDependentFixture(build = createNewWallet, destroy = destroyWallet)(test)
+    makeDependentFixture(build = createNewWallet _, destroy = destroyWallet)(
+      test)
 
   case class WalletWithBitcoind(
       wallet: UnlockedWalletApi,
@@ -86,7 +87,7 @@ trait BitcoinSWalletTest
 
   def withNewWalletAndBitcoind(test: OneArgAsyncTest): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind] = composeBuildersAndWrap(
-      createNewWallet,
+      createNewWallet _,
       createWalletWithBitcoind,
       (_: UnlockedWalletApi, walletWithBitcoind: WalletWithBitcoind) =>
         walletWithBitcoind
@@ -94,5 +95,6 @@ trait BitcoinSWalletTest
 
     makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
   }
-
 }
+
+object BitcoinSWalletTest extends BitcoinSWalletTest

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -26,8 +26,13 @@ trait BitcoinSWalletTest
     with BitcoinSFixture
     with BeforeAndAfterAll
     with BitcoinSLogger {
-  implicit lazy val actorSystem: ActorSystem = ActorSystem(
-    getClass.getSimpleName)
+  implicit lazy val actorSystem: ActorSystem = ActorSystem({
+    // Akka doesn't like funky characters like '$' (which the
+    // compiler often generate)
+    val regex = "[a-zA-Z0-9]"
+    getClass.getSimpleName.filter(_.toString.matches(regex))
+  })
+
   implicit lazy val ec: ExecutionContext = actorSystem.dispatcher
 
   protected lazy val chainParams: ChainParams = WalletTestUtil.chainParams
@@ -97,4 +102,12 @@ trait BitcoinSWalletTest
   }
 }
 
-object BitcoinSWalletTest extends BitcoinSWalletTest
+object BitcoinSWalletTest extends BitcoinSWalletTest {
+
+  // This method has to be here to have this accessible as an object
+  def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val msg =
+      s"Someone called BitcoinSWalletTest.withFixture. This is not what's supposed to happen!"
+    throw new RuntimeException(msg)
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -69,10 +69,12 @@ trait BitcoinSWalletTest
     implicit val walletConf: WalletAppConfig = config.walletConf
 
     for {
-      _ <- WalletDbManagement.createAll()
+      _ <- walletConf.initialize()
       wallet <- Wallet.initialize().map {
         case InitializeWalletSuccess(wallet) => wallet
-        case err: InitializeWalletError      => fail(err)
+        case err: InitializeWalletError =>
+          logger.error(s"Could not initialize wallet: $err")
+          fail(err)
       }
     } yield wallet
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -41,11 +41,8 @@ trait BitcoinSWalletTest
   protected lazy val chainParams: ChainParams = WalletTestUtil.chainParams
 
   /** Wallet config with data directory set to user temp directory */
-  protected implicit lazy val config: BitcoinSAppConfig = {
-    val tmpDir = Files.createTempDirectory("bitcoin-s-")
-    val conf = ConfigFactory.parseString(s"bitcoin-s.datadir = $tmpDir")
-    BitcoinSAppConfig(conf)
-  }
+  implicit protected lazy val config: BitcoinSAppConfig =
+    BitcoinSAppConfig.configWithTmpDatadir
 
   /** Timeout for async operations */
   protected val timeout: FiniteDuration = 10.seconds

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -42,7 +42,7 @@ trait BitcoinSWalletTest
 
   /** Wallet config with data directory set to user temp directory */
   implicit protected lazy val config: BitcoinSAppConfig =
-    BitcoinSAppConfig.configWithTmpDatadir
+    BitcoinSAppConfig.getConfigWithTmpDatadir()
 
   /** Timeout for async operations */
   protected val timeout: FiniteDuration = 10.seconds

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.wallet.util
+package org.bitcoins.testkit.wallet
 
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.crypto._
@@ -10,7 +10,6 @@ import org.bitcoins.core.protocol.blockchain.{
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.wallet.models.AccountDb
-import org.bitcoins.wallet.HDUtil
 import scodec.bits.HexStringSyntax
 import org.bitcoins.core.hd._
 import org.bitcoins.core.protocol.script.ScriptWitness

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -47,6 +47,12 @@ object WalletTestUtil {
                  HDChainType.External,
                  addressIndex = 0)
 
+  /** Sample legacy HD path */
+  lazy val sampleLegacyPath = LegacyHDPath(hdCoinType,
+                                           accountIndex = 0,
+                                           HDChainType.Change,
+                                           addressIndex = 0)
+
   def freshXpub: ExtPublicKey =
     CryptoGenerators.extPublicKey.sample.getOrElse(freshXpub)
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -5,7 +5,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoSuccess, WalletApi}
-import org.bitcoins.wallet.util.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletStorageTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletStorageTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.wallet.util.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest.FutureOutcome
 import org.bitcoins.testkit.fixtures.EmptyFixture
 import org.bitcoins.testkit.core.gen.CryptoGenerators

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletStorageTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletStorageTest.scala
@@ -19,15 +19,21 @@ import java.nio.file.Paths
 import org.bitcoins.wallet.ReadMnemonicError.DecryptionError
 import java.{util => ju}
 import org.bitcoins.wallet.ReadMnemonicError.JsonParsingError
+import org.bitcoins.testkit.BitcoinSAppConfig._
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class WalletStorageTest
     extends BitcoinSWalletTest
     with BeforeAndAfterEach
     with EmptyFixture {
 
-  val datadir = appConfig.datadir
+  val datadir = config.walletConf.datadir
 
   override def beforeEach(): Unit = {
+    // make sure datadir is created for reading/writing mnemonics
+    Await.result(config.walletConf.initialize(), 5.seconds)
+
     Files
       .walk(datadir)
       .iterator()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.wallet
 
 import org.bitcoins.wallet.api.UnlockedWalletApi
-import org.bitcoins.wallet.util.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest.FutureOutcome
 import org.bitcoins.wallet.api.UnlockWalletError.BadPassword
 import org.bitcoins.wallet.api.UnlockWalletError.JsonParsingError

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -23,7 +23,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
       accounts <- wallet.listAccounts()
       addresses <- wallet.listAddresses()
     } yield {
-      assert(accounts.length == 1)
+      assert(accounts.length == 3) // legacy, segwit and nested segwit
       assert(addresses.isEmpty)
     }
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/AccountDAOFixture.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/AccountDAOFixture.scala
@@ -2,7 +2,7 @@ package org.bitcoins.wallet.fixtures
 
 import org.bitcoins.wallet.db.WalletDbManagement
 import org.bitcoins.wallet.models.AccountDAO
-import org.bitcoins.wallet.util.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest._
 
 import scala.concurrent.Future

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/AccountDAOFixture.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/AccountDAOFixture.scala
@@ -6,9 +6,14 @@ import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest._
 
 import scala.concurrent.Future
+import org.bitcoins.wallet.config.WalletAppConfig
 
 trait AccountDAOFixture extends fixture.AsyncFlatSpec with BitcoinSWalletTest {
   override final type FixtureParam = AccountDAO
+
+  // to get around the config in `BitcoinSWalletTest` not resolving
+  // as an AppConfig
+  private implicit val walletConfig: WalletAppConfig = config.walletConf
 
   override final def withFixture(test: OneArgAsyncTest): FutureOutcome =
     makeDependentFixture(createAccountTable, dropAccountTable)(test)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/AddressDAOFixture.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/AddressDAOFixture.scala
@@ -4,7 +4,7 @@ import scala.concurrent.Future
 
 import org.bitcoins.wallet.db.WalletDbManagement
 import org.bitcoins.wallet.models.{AccountDAO, AddressDAO}
-import org.bitcoins.wallet.util.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest._
 
 /**

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/AddressDAOFixture.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/AddressDAOFixture.scala
@@ -6,6 +6,7 @@ import org.bitcoins.wallet.db.WalletDbManagement
 import org.bitcoins.wallet.models.{AccountDAO, AddressDAO}
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest._
+import org.bitcoins.wallet.config.WalletAppConfig
 
 /**
   * This fixture has a tuple of DAOs, because
@@ -17,6 +18,10 @@ trait AddressDAOFixture extends fixture.AsyncFlatSpec with BitcoinSWalletTest {
 
   override final def withFixture(test: OneArgAsyncTest): FutureOutcome =
     makeDependentFixture(createTables, dropTables)(test)
+
+  // to get around the config in `BitcoinSWalletTest` not resolving
+  // as an AppConfig
+  private implicit val walletConfig: WalletAppConfig = config.walletConf
 
   private def dropTables(daos: FixtureParam): Future[Unit] = {
     val (account, address) = daos

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/DAOFixture.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/DAOFixture.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.wallet.fixtures
 
 import org.bitcoins.wallet.db.WalletDbManagement
-import org.bitcoins.wallet.util.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest._
 import slick.jdbc.SQLiteProfile.api._
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/DAOFixture.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/DAOFixture.scala
@@ -7,6 +7,7 @@ import slick.jdbc.SQLiteProfile.api._
 
 import scala.language.reflectiveCalls
 import scala.concurrent.{Await, Future}
+import org.bitcoins.wallet.config.WalletAppConfig
 
 private[fixtures] trait DAOFixture
     extends fixture.AsyncFlatSpec
@@ -16,6 +17,10 @@ private[fixtures] trait DAOFixture
 
   private[fixtures] val daoAccumulator =
     Vector.newBuilder[HasTable]
+
+  // to get around the config in `BitcoinSWalletTest` not resolving
+  // as an AppConfig
+  private implicit val walletConfig: WalletAppConfig = config.walletConf
 
   override def beforeAll(): Unit = {
     val tables = daoAccumulator.result()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/UtxoDAOFixture.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/UtxoDAOFixture.scala
@@ -2,7 +2,7 @@ package org.bitcoins.wallet.fixtures
 
 import org.bitcoins.wallet.db.WalletDbManagement
 import org.bitcoins.wallet.models.UTXOSpendingInfoDAO
-import org.bitcoins.wallet.util.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest._
 
 import scala.concurrent.Future

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/UtxoDAOFixture.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/fixtures/UtxoDAOFixture.scala
@@ -6,6 +6,7 @@ import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest._
 
 import scala.concurrent.Future
+import org.bitcoins.wallet.config.WalletAppConfig
 
 trait UtxoDAOFixture extends fixture.AsyncFlatSpec with BitcoinSWalletTest {
 
@@ -13,6 +14,10 @@ trait UtxoDAOFixture extends fixture.AsyncFlatSpec with BitcoinSWalletTest {
 
   override final def withFixture(test: OneArgAsyncTest): FutureOutcome =
     makeDependentFixture(createUtxoTable, dropUtxoTable)(test)
+
+  // to get around the config in `BitcoinSWalletTest` not resolving
+  // as an AppConfig
+  private implicit val walletConfig: WalletAppConfig = config.walletConf
 
   private def dropUtxoTable(utxoDAO: FixtureParam): Future[Unit] = {
     WalletDbManagement.dropTable(utxoDAO.table)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/AccountDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/AccountDAOTest.scala
@@ -2,7 +2,8 @@ package org.bitcoins.wallet.models
 
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.wallet.fixtures.AccountDAOFixture
-import org.bitcoins.wallet.util.{BitcoinSWalletTest, WalletTestUtil}
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.WalletTestUtil
 
 class AccountDAOTest extends BitcoinSWalletTest with AccountDAOFixture {
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/AddressDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/AddressDAOTest.scala
@@ -8,7 +8,7 @@ import org.bitcoins.core.protocol.P2SHAddress
 import org.bitcoins.core.script.ScriptType
 import org.bitcoins.core.util.CryptoUtil
 import org.bitcoins.wallet.fixtures.AddressDAOFixture
-import org.bitcoins.wallet.util.{BitcoinSWalletTest, WalletTestUtil}
+import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 import org.bitcoins.core.hd.HDChainType
 import org.bitcoins.core.hd.SegWitHDPath
 import org.bitcoins.wallet.Wallet

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/UTXOSpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/UTXOSpendingInfoDAOTest.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.wallet.fixtures.UtxoDAOFixture
-import org.bitcoins.wallet.util.{BitcoinSWalletTest, WalletTestUtil}
+import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 
 class UTXOSpendingInfoDAOTest extends BitcoinSWalletTest with UtxoDAOFixture {
   behavior of "UTXOSpendingInfoDAO"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/UTXOSpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/UTXOSpendingInfoDAOTest.scala
@@ -1,12 +1,13 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.core.currency.Bitcoins
+import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
 import org.bitcoins.wallet.fixtures.UtxoDAOFixture
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
+import org.bitcoins.wallet.Wallet
 
 class UTXOSpendingInfoDAOTest extends BitcoinSWalletTest with UtxoDAOFixture {
   behavior of "UTXOSpendingInfoDAO"
@@ -14,11 +15,11 @@ class UTXOSpendingInfoDAOTest extends BitcoinSWalletTest with UtxoDAOFixture {
   it should "insert a segwit UTXO and read it" in { utxoDAO =>
     val outpoint =
       TransactionOutPoint(WalletTestUtil.sampleTxid, WalletTestUtil.sampleVout)
-    val output = TransactionOutput(Bitcoins.one, WalletTestUtil.sampleSPK)
+    val output = TransactionOutput(1.bitcoin, WalletTestUtil.sampleSPK)
     val scriptWitness = WalletTestUtil.sampleScriptWitness
     val privkeyPath = WalletTestUtil.sampleSegwitPath
     val utxo =
-      SegWitUTOXSpendingInfodb(
+      SegWitUTOXSpendingInfoDb(
         id = None,
         outPoint = outpoint,
         output = output,
@@ -31,8 +32,19 @@ class UTXOSpendingInfoDAOTest extends BitcoinSWalletTest with UtxoDAOFixture {
     } yield assert(read.contains(created))
   }
 
-  it should "insert a legacy UTXO and read it" ignore { _ =>
-    ???
+  it should "insert a legacy UTXO and read it" in { utxoDAO =>
+    val outpoint =
+      TransactionOutPoint(WalletTestUtil.sampleTxid, WalletTestUtil.sampleVout)
+    val output = TransactionOutput(1.bitcoin, WalletTestUtil.sampleSPK)
+    val privKeyPath = WalletTestUtil.sampleLegacyPath
+    val utxo = LegacyUTXOSpendingInfoDb(id = None,
+                                        outPoint = outpoint,
+                                        output = output,
+                                        privKeyPath = privKeyPath)
+    for {
+      created <- utxoDAO.create(utxo)
+      read <- utxoDAO.read(created.id.get)
+    } yield assert(read.contains(created))
   }
 
   it should "insert a nested segwit UTXO and read it" ignore { _ =>

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -41,7 +41,7 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
       case MainNetChainParams                         => HDCoinType.Bitcoin
       case RegTestNetChainParams | TestNetChainParams => HDCoinType.Testnet
     }
-    HDCoin(Wallet.DEFAULT_HD_PURPOSE, coinType)
+    HDCoin(walletConfig.defaultAccountKind, coinType)
   }
 
   /**

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -224,7 +224,7 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
         }
       val writeF = addressDAO.create(addressDb)
       writeF.foreach { written =>
-        logger.info(
+        logger.debug(
           s"Got ${chainType} address ${written.address} at key path ${written.path} with pubkey ${written.ecPublicKey}")
       }
 
@@ -239,6 +239,19 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
     */
   override def getNewAddress(account: AccountDb): Future[BitcoinAddress] = {
     getNewAddressHelper(account, HDChainType.External)
+  }
+
+  override def getAddressInfo(
+      address: BitcoinAddress): Future[Option[AddressInfo]] = {
+
+    val addressOptF = addressDAO.findAddress(address)
+    addressOptF.map { addressOpt =>
+      addressOpt.map { address =>
+        AddressInfo(pubkey = address.ecPublicKey,
+                    network = address.address.networkParameters,
+                    path = address.path)
+      }
+    }
   }
 
   /** Generates a new change address */

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -95,16 +95,21 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
 
     val utxo: UTXOSpendingInfoDb = addressDb match {
       case segwitAddr: SegWitAddressDb =>
-        SegWitUTOXSpendingInfodb(
+        SegWitUTOXSpendingInfoDb(
           id = None,
           outPoint = outPoint,
           output = output,
           privKeyPath = segwitAddr.path,
           scriptWitness = segwitAddr.witnessScript
         )
-      case otherAddr @ (_: LegacyAddressDb | _: NestedSegWitAddressDb) =>
+      case LegacyAddressDb(path, _, _, _) =>
+        LegacyUTXOSpendingInfoDb(id = None,
+                                 outPoint = outPoint,
+                                 output = output,
+                                 privKeyPath = path)
+      case nested: NestedSegWitAddressDb =>
         throw new IllegalArgumentException(
-          s"Bad utxo $otherAddr. Note: Only Segwit is implemented")
+          s"Bad utxo $nested. Note: nested segwit is not implemented")
     }
 
     utxoDAO.create(utxo).map { written =>
@@ -201,27 +206,34 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
           address.toPath
       }
 
-      val addressDb =
+      val addressDb = {
+        val pathDiff =
+          account.hdAccount.diff(addrPath) match {
+            case Some(value) => value
+            case None =>
+              throw new RuntimeException(
+                s"Could not diff ${account.hdAccount} and $addrPath")
+          }
+
+        val pubkey = account.xpub.deriveChildPubKey(pathDiff) match {
+          case Failure(exception) => throw exception
+          case Success(value)     => value.key
+        }
+
         addrPath match {
           case segwitPath: SegWitHDPath =>
-            val pathDiff = account.hdAccount.diff(segwitPath) match {
-              case Some(value) => value
-              case None =>
-                throw new RuntimeException(
-                  s"Could not diff ${account.hdAccount} and $segwitPath")
-            }
-
-            val pubkey = account.xpub.deriveChildPubKey(pathDiff) match {
-              case Failure(exception) => throw exception
-              case Success(value)     => value.key
-            }
-
             AddressDbHelper
-              .getP2WPKHAddress(pubkey, segwitPath, networkParameters)
-          case _: HDPath =>
-            throw new IllegalArgumentException(
-              "P2PKH and nested segwit P2PKH not yet implemented")
+              .getSegwitAddress(pubkey, segwitPath, networkParameters)
+          case legacyPath: LegacyHDPath =>
+            AddressDbHelper.getLegacyAddress(pubkey,
+                                             legacyPath,
+                                             networkParameters)
+          case nestedPath: NestedSegWitHDPath =>
+            AddressDbHelper.getNestedSegwitAddress(pubkey,
+                                                   nestedPath,
+                                                   networkParameters)
         }
+      }
       val writeF = addressDAO.create(addressDb)
       writeF.foreach { written =>
         logger.debug(

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -200,8 +200,8 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
         case Some(addr) =>
           addr.path.next
         case None =>
-          val account = HDAccount(DEFAULT_HD_COIN, accountIndex)
-          val chain = account.toChain(chainType)
+          val hdAccount = HDAccount(DEFAULT_HD_COIN, accountIndex)
+          val chain = hdAccount.toChain(chainType)
           val address = HDAddress(chain, 0)
           address.toPath
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -16,7 +16,7 @@ import scodec.bits.BitVector
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 import org.bitcoins.core.hd._
-import org.bitcoins.db.AppConfig
+import org.bitcoins.wallet.config.WalletAppConfig
 
 sealed abstract class Wallet
     extends LockedWallet
@@ -26,7 +26,7 @@ sealed abstract class Wallet
   /**
     * @inheritdoc
     */
-  override def lock(): LockedWalletApi = {
+  override def lock(): Future[LockedWallet] = {
     logger.debug(s"Locking wallet")
     val encryptedT = EncryptedMnemonicHelper.encrypt(mnemonicCode, passphrase)
     val encrypted = encryptedT match {
@@ -108,7 +108,7 @@ object Wallet extends CreateWalletApi with BitcoinSLogger {
   private case class WalletImpl(
       mnemonicCode: MnemonicCode
   )(
-      implicit override val walletConfig: AppConfig,
+      implicit override val walletConfig: WalletAppConfig,
       override val ec: ExecutionContext)
       extends Wallet {
 
@@ -117,7 +117,7 @@ object Wallet extends CreateWalletApi with BitcoinSLogger {
   }
 
   def apply(mnemonicCode: MnemonicCode)(
-      implicit config: AppConfig,
+      implicit config: WalletAppConfig,
       ec: ExecutionContext): Wallet =
     WalletImpl(mnemonicCode)
 
@@ -126,7 +126,7 @@ object Wallet extends CreateWalletApi with BitcoinSLogger {
 
   // todo fix signature
   override def initializeWithEntropy(entropy: BitVector)(
-      implicit config: AppConfig,
+      implicit config: WalletAppConfig,
       ec: ExecutionContext): Future[InitializeWalletResult] = {
     import org.bitcoins.core.util.EitherUtil.EitherOps._
 
@@ -182,6 +182,7 @@ object Wallet extends CreateWalletApi with BitcoinSLogger {
         logger.debug(s"Saved encrypted wallet mnemonic to $mnemonicPath")
 
         for {
+          _ <- config.initialize()
           _ <- wallet.accountDAO
             .create(accountDb)
             .map(_ => logger.trace(s"Saved account to DB"))

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -165,25 +165,23 @@ object Wallet extends CreateWalletApi with BitcoinSLogger {
         mnemonic <- mnemonicE
         encrypted <- encryptedMnemonicE
       } yield {
-        val wallet = WalletImpl(mnemonic)
-        val coin =
-          HDCoin(config.defaultAccountKind, HDUtil.getCoinType(config.network))
-        val account = HDAccount(coin, 0)
-        val xpriv = wallet.xprivForPurpose(config.defaultAccountKind)
-
-        // safe since we're deriving from a priv
-        val xpub = xpriv.deriveChildPubKey(account).get
-        val accountDb = AccountDb(xpub, account)
-
         val mnemonicPath =
           WalletStorage.writeMnemonicToDisk(encrypted)
         logger.debug(s"Saved encrypted wallet mnemonic to $mnemonicPath")
 
+        val wallet = WalletImpl(mnemonic)
+
         for {
           _ <- config.initialize()
-          _ <- wallet.accountDAO
-            .create(accountDb)
-            .map(_ => logger.trace(s"Saved account to DB"))
+          _ <- {
+            // We want to make sure all level 0 accounts are created,
+            // so the user can change the default account kind later
+            // and still have their wallet work
+            val createAccountFutures =
+              HDPurposes.all.map(createRootAccount(wallet, _))
+
+            Future.sequence(createAccountFutures)
+          }
         } yield wallet
       }
 
@@ -196,5 +194,26 @@ object Wallet extends CreateWalletApi with BitcoinSLogger {
         InitializeWalletSuccess(wallet)
       case Left(err) => err
     }
+  }
+
+  /** Creates the level 0 account for the given HD purpose */
+  private def createRootAccount(wallet: Wallet, purpose: HDPurpose)(
+      implicit config: WalletAppConfig,
+      ec: ExecutionContext): Future[AccountDb] = {
+    val coin =
+      HDCoin(purpose, HDUtil.getCoinType(config.network))
+    val account = HDAccount(coin, 0)
+    val xpriv = wallet.xprivForPurpose(purpose)
+    // safe since we're deriving from a priv
+    val xpub = xpriv.deriveChildPubKey(account).get
+    val accountDb = AccountDb(xpub, account)
+
+    wallet.accountDAO
+      .create(accountDb)
+      .map { written =>
+        logger.debug(s"Saved account with constant prefix $purpose to DB")
+        written
+      }
+
   }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletStorage.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletStorage.scala
@@ -14,6 +14,7 @@ import java.nio.file.Paths
 import java.nio.file.Path
 import scala.util.Try
 import org.bitcoins.db.AppConfig
+import org.bitcoins.wallet.config.WalletAppConfig
 
 // what do we do if seed exists? error if they aren't equal?
 object WalletStorage extends BitcoinSLogger {
@@ -35,7 +36,7 @@ object WalletStorage extends BitcoinSLogger {
     * the file name.
     */
   def writeMnemonicToDisk(mnemonic: EncryptedMnemonic)(
-      implicit config: AppConfig): Path = {
+      implicit config: WalletAppConfig): Path = {
     import mnemonic.{value => encrypted}
 
     val jsObject = {
@@ -175,7 +176,7 @@ object WalletStorage extends BitcoinSLogger {
     */
   def decryptMnemonicFromDisk(passphrase: AesPassword)(
       implicit
-      config: AppConfig): ReadMnemonicResult = {
+      config: WalletAppConfig): ReadMnemonicResult = {
     val encryptedEither = readEncryptedMnemonicFromDisk()
 
     import org.bitcoins.core.util.EitherUtil.EitherOps._

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/AddressInfo.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/AddressInfo.scala
@@ -1,0 +1,14 @@
+package org.bitcoins.wallet.api
+
+import org.bitcoins.core.crypto.ECPublicKey
+import org.bitcoins.core.hd.HDPath
+import org.bitcoins.core.config.NetworkParameters
+
+/**
+  * This class represents the result of querying for address info
+  * from our wallet
+  */
+case class AddressInfo(
+    pubkey: ECPublicKey,
+    network: NetworkParameters,
+    path: HDPath)

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/CreateWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/CreateWalletApi.scala
@@ -4,7 +4,7 @@ import org.bitcoins.core.crypto.MnemonicCode
 import scodec.bits.BitVector
 
 import scala.concurrent.{ExecutionContext, Future}
-import org.bitcoins.db.AppConfig
+import org.bitcoins.wallet.config.WalletAppConfig
 
 /**
   * @define initialize
@@ -25,7 +25,7 @@ trait CreateWalletApi {
 
   private def initializeInternal()(
       implicit executionContext: ExecutionContext,
-      appConfig: AppConfig): Future[InitializeWalletResult] =
+      config: WalletAppConfig): Future[InitializeWalletResult] =
     initializeWithEntropy(entropy = MnemonicCode.getEntropy256Bits)
 
   /**
@@ -33,19 +33,19 @@ trait CreateWalletApi {
     */
   final def initialize()(
       implicit executionContext: ExecutionContext,
-      appConfig: AppConfig): Future[InitializeWalletResult] =
+      config: WalletAppConfig): Future[InitializeWalletResult] =
     initializeInternal()
 
   /**
     * $initializeWithEnt
     */
   def initializeWithEntropy(entropy: BitVector)(
-      implicit config: AppConfig,
+      implicit config: WalletAppConfig,
       executionContext: ExecutionContext): Future[InitializeWalletResult]
 
   // todo: scaladoc
   final def initializeWithMnemonic(mnemonicCode: MnemonicCode)(
-      implicit config: AppConfig,
+      implicit config: WalletAppConfig,
       executionContext: ExecutionContext): Future[InitializeWalletResult] = {
     val entropy = mnemonicCode.toEntropy
     initializeWithEntropy(entropy)

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -14,7 +14,7 @@ import org.bitcoins.wallet.models.{AccountDb, AddressDb, UTXOSpendingInfoDb}
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
-import org.bitcoins.db.AppConfig
+import org.bitcoins.wallet.config.WalletAppConfig
 
 /**
   * API for the wallet project.
@@ -25,7 +25,7 @@ import org.bitcoins.db.AppConfig
   */
 sealed trait WalletApi {
 
-  implicit val walletConfig: AppConfig
+  implicit val walletConfig: WalletAppConfig
   implicit val ec: ExecutionContext
 
   def chainParams: ChainParams = walletConfig.chain
@@ -149,7 +149,7 @@ trait UnlockedWalletApi extends LockedWalletApi {
     * all sensitive material in the wallet should be
     * encrypted and unaccessible
     */
-  def lock(): LockedWalletApi
+  def lock(): Future[LockedWalletApi]
 
   /**
     *

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -81,6 +81,14 @@ trait LockedWalletApi extends WalletApi {
     } yield address
   }
 
+  /**
+    * Mimics the `getaddressinfo` RPC call in Bitcoin Core
+    *
+    * @return If the address is found in our database `Some(address)`
+    *         is returned, otherwise `None`
+    */
+  def getAddressInfo(address: BitcoinAddress): Future[Option[AddressInfo]]
+
   /** Generates a new change address */
   protected[wallet] def getNewChangeAddress(
       account: AccountDb): Future[BitcoinAddress]

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -8,6 +8,7 @@ import scala.util.Failure
 import scala.util.Success
 import org.bitcoins.core.hd.HDPurpose
 import org.bitcoins.core.hd.HDPurposes
+import java.nio.file.Files
 
 case class WalletAppConfig(conf: Config*) extends AppConfig {
   override val configOverrides: List[Config] = conf.toList
@@ -28,6 +29,11 @@ case class WalletAppConfig(conf: Config*) extends AppConfig {
 
   override def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
     logger.debug(s"Initializing wallet setup")
+
+    if (Files.notExists(datadir)) {
+      Files.createDirectories(datadir)
+    }
+
     val initF = {
       WalletDbManagement.createAll()(this, ec)
     }

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -27,8 +27,7 @@ case class WalletAppConfig(conf: Config*) extends AppConfig {
     }
 
   override def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
-    logger.info(s"Initializing wallet setup")
-    logger.info(s"DB: ${dbConfig.config}")
+    logger.debug(s"Initializing wallet setup")
     val initF = WalletDbManagement.createAll()(this, ec)
     initF.onComplete {
       case Failure(exception) =>

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -2,6 +2,10 @@ package org.bitcoins.wallet.config
 
 import com.typesafe.config.Config
 import org.bitcoins.db.AppConfig
+import scala.concurrent.{ExecutionContext, Future}
+import org.bitcoins.wallet.db.WalletDbManagement
+import scala.util.Failure
+import scala.util.Success
 
 case class WalletAppConfig(conf: Config*) extends AppConfig {
   override val configOverrides: List[Config] = conf.toList
@@ -9,4 +13,19 @@ case class WalletAppConfig(conf: Config*) extends AppConfig {
   override type ConfigType = WalletAppConfig
   override def newConfigOfType(configs: List[Config]): WalletAppConfig =
     WalletAppConfig(configs: _*)
+
+  override def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
+    logger.info(s"Initializing wallet setup")
+    logger.info(s"DB: ${dbConfig.config}")
+    val initF = WalletDbManagement.createAll()(this, ec)
+    initF.onComplete {
+      case Failure(exception) =>
+        logger.error(s"Error on wallet setup: ${exception.getMessage}")
+      case Success(_) =>
+        logger.debug(s"Initializing wallet setup: done")
+    }
+
+    initF
+  }
+
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -28,7 +28,9 @@ case class WalletAppConfig(conf: Config*) extends AppConfig {
 
   override def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
     logger.debug(s"Initializing wallet setup")
-    val initF = WalletDbManagement.createAll()(this, ec)
+    val initF = {
+      WalletDbManagement.createAll()(this, ec)
+    }
     initF.onComplete {
       case Failure(exception) =>
         logger.error(s"Error on wallet setup: ${exception.getMessage}")

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -6,6 +6,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import org.bitcoins.wallet.db.WalletDbManagement
 import scala.util.Failure
 import scala.util.Success
+import org.bitcoins.core.hd.HDPurpose
+import org.bitcoins.core.hd.HDPurposes
 
 case class WalletAppConfig(conf: Config*) extends AppConfig {
   override val configOverrides: List[Config] = conf.toList
@@ -13,6 +15,16 @@ case class WalletAppConfig(conf: Config*) extends AppConfig {
   override type ConfigType = WalletAppConfig
   override def newConfigOfType(configs: List[Config]): WalletAppConfig =
     WalletAppConfig(configs: _*)
+
+  lazy val defaultAccountKind: HDPurpose =
+    config.getString("wallet.defaultAccountType") match {
+      case "legacy"        => HDPurposes.Legacy
+      case "segwit"        => HDPurposes.SegWit
+      case "nested-segwit" => HDPurposes.NestedSegWit
+      // todo: validate this pre-app startup
+      case other: String =>
+        throw new RuntimeException(s"$other is not a valid account type!")
+    }
 
   override def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
     logger.info(s"Initializing wallet setup")

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
@@ -39,8 +39,4 @@ case class AccountDAO()(implicit val ec: ExecutionContext)
     findByPrimaryKeys(
       accounts.map(acc => (acc.hdAccount.coin, acc.hdAccount.index)))
 
-  def findAll(): Future[Vector[AccountDb]] = {
-    val query = table.result
-    database.run(query).map(_.toVector)
-  }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
@@ -10,12 +10,12 @@ import org.bitcoins.db.SlickUtil
 import org.bitcoins.db.AppConfig
 import scala.concurrent.ExecutionContext
 
-case class AccountDAO()(implicit val ec: ExecutionContext)
+case class AccountDAO()(
+    implicit val ec: ExecutionContext,
+    val appConfig: WalletAppConfig)
     extends CRUD[AccountDb, (HDCoin, Int)] {
 
   import org.bitcoins.db.DbCommonsColumnMappers._
-
-  override def appConfig: WalletAppConfig = WalletAppConfig()
 
   override val table: TableQuery[AccountTable] = TableQuery[AccountTable]
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AccountTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AccountTable.scala
@@ -46,5 +46,5 @@ class AccountTable(tag: Tag) extends Table[AccountDb](tag, "wallet_accounts") {
     (purpose, xpub, coinType, index) <> (fromTuple, toTuple)
 
   def primaryKey: PrimaryKey =
-    primaryKey("pk_account", (coinType, index))
+    primaryKey("pk_account", sourceColumns = (purpose, coinType, index))
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressDAO.scala
@@ -37,11 +37,6 @@ case class AddressDAO()(
     database.run(query).map(_.headOption)
   }
 
-  def findAll(): Future[Vector[AddressDb]] = {
-    val query = table.result
-    database.run(query).map(_.toVector)
-  }
-
   private def addressesForAccountQuery(
       accountIndex: Int): Query[AddressTable, AddressDb, Seq] =
     table.filter(_.accountIndex === accountIndex)

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressDAO.scala
@@ -13,11 +13,10 @@ import org.bitcoins.db.AppConfig
 import org.bitcoins.wallet.config.WalletAppConfig
 
 case class AddressDAO()(
-    implicit val ec: ExecutionContext
+    implicit val ec: ExecutionContext,
+    val appConfig: WalletAppConfig
 ) extends CRUD[AddressDb, BitcoinAddress] {
   import org.bitcoins.db.DbCommonsColumnMappers._
-
-  override def appConfig: WalletAppConfig = WalletAppConfig()
 
   override val table: TableQuery[AddressTable] = TableQuery[AddressTable]
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTable.scala
@@ -15,6 +15,7 @@ import slick.lifted.ProvenShape
 import org.bitcoins.core.protocol.P2SHAddress
 import org.bitcoins.core.protocol.P2PKHAddress
 import org.bitcoins.core.protocol.script.P2PKHScriptPubKey
+import org.slf4j.LoggerFactory
 
 sealed trait AddressDb {
   protected type PathType <: HDPath
@@ -244,6 +245,9 @@ class AddressTable(tag: Tag) extends Table[AddressDb](tag, "addresses") {
 
   // for some reason adding a type annotation here causes compile error
   def fk =
-    foreignKey("fk_account", (accountCoin, accountIndex), accounts)(
-      accountTable => (accountTable.coinType, accountTable.index))
+    foreignKey("fk_account",
+               sourceColumns = (purpose, accountCoin, accountIndex),
+               targetTableQuery = accounts) { accountTable =>
+      (accountTable.purpose, accountTable.coinType, accountTable.index)
+    }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/UTXOSpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/UTXOSpendingInfoDAO.scala
@@ -6,12 +6,11 @@ import slick.jdbc.SQLiteProfile.api._
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
-import org.bitcoins.db.AppConfig
 
-case class UTXOSpendingInfoDAO()(implicit val ec: ExecutionContext)
+case class UTXOSpendingInfoDAO()(
+    implicit val ec: ExecutionContext,
+    val appConfig: WalletAppConfig)
     extends CRUDAutoInc[UTXOSpendingInfoDb] {
-
-  override def appConfig: WalletAppConfig = WalletAppConfig()
 
   /** The table inside our database we are inserting into */
   override val table = TableQuery[UTXOSpendingInfoTable]

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/UTXOSpendingInfoTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/UTXOSpendingInfoTable.scala
@@ -18,26 +18,39 @@ import org.bitcoins.core.hd.SegWitHDPath
 import org.bitcoins.core.crypto.BIP39Seed
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.hd.LegacyHDPath
-import org.bitcoins.core.hd.NestedSegWitHDPath
 
-case class SegWitUTOXSpendingInfodb(
+case class SegWitUTOXSpendingInfoDb(
     id: Option[Long],
     outPoint: TransactionOutPoint,
     output: TransactionOutput,
     privKeyPath: SegWitHDPath,
     scriptWitness: ScriptWitness
 ) extends UTXOSpendingInfoDb {
-  override def redeemScriptOpt: Option[ScriptPubKey] = None
-  override def scriptWitnessOpt: Option[ScriptWitness] = Some(scriptWitness)
+  override val redeemScriptOpt: Option[ScriptPubKey] = None
+  override val scriptWitnessOpt: Option[ScriptWitness] = Some(scriptWitness)
 
   override type PathType = SegWitHDPath
 
-  override def copyWithId(id: Long): SegWitUTOXSpendingInfodb =
+  override def copyWithId(id: Long): SegWitUTOXSpendingInfoDb =
+    copy(id = Some(id))
+}
+
+case class LegacyUTXOSpendingInfoDb(
+    id: Option[Long],
+    outPoint: TransactionOutPoint,
+    output: TransactionOutput,
+    privKeyPath: LegacyHDPath
+) extends UTXOSpendingInfoDb {
+  override val redeemScriptOpt: Option[ScriptPubKey] = None
+  override def scriptWitnessOpt: Option[ScriptWitness] = None
+
+  override type PathType = LegacyHDPath
+
+  override def copyWithId(id: Long): LegacyUTXOSpendingInfoDb =
     copy(id = Some(id))
 }
 
 // TODO add case for nested segwit
-// and legacy
 sealed trait UTXOSpendingInfoDb
     extends DbRowAutoInc[UTXOSpendingInfoDb]
     with BitcoinSLogger {
@@ -114,20 +127,22 @@ case class UTXOSpendingInfoTable(tag: Tag)
           outpoint,
           output,
           path: SegWitHDPath,
-          None,
+          None, // ScriptPubKey
           Some(scriptWitness)) =>
-      SegWitUTOXSpendingInfodb(id, outpoint, output, path, scriptWitness)
-        .asInstanceOf[UTXOSpendingInfoDb]
+      SegWitUTOXSpendingInfoDb(id, outpoint, output, path, scriptWitness)
 
     case (id,
           outpoint,
           output,
-          path @ (_: LegacyHDPath | _: NestedSegWitHDPath),
-          spkOpt,
-          swOpt) =>
+          path: LegacyHDPath,
+          None, // RedeemScript
+          None // ScriptWitness
+        ) =>
+      LegacyUTXOSpendingInfoDb(id, outpoint, output, path)
+    case (id, outpoint, output, path, spkOpt, swOpt) =>
       throw new IllegalArgumentException(
         "Could not construct UtxoSpendingInfoDb from bad tuple:"
-          + s" ($id, $outpoint, $output, $path, $spkOpt, $swOpt) . Note: Only Segwit is implemented")
+          + s" ($id, $outpoint, $output, $path, $spkOpt, $swOpt) . Note: Nested Segwit is not implemented")
 
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/UTXOSpendingInfoTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/UTXOSpendingInfoTable.scala
@@ -111,6 +111,7 @@ case class UTXOSpendingInfoTable(tag: Tag)
   def redeemScriptOpt: Rep[Option[ScriptPubKey]] =
     column[Option[ScriptPubKey]]("nullable_redeem_script")
 
+  // TODO foreign key to address?
   def scriptWitnessOpt: Rep[Option[ScriptWitness]] =
     column[Option[ScriptWitness]]("script_witness")
 


### PR DESCRIPTION
In this PR we:

- Add a table of interesting public keys to our SPV node, and a method for external users of the node to add keys to that table. The contents of the table is used to construct a bloom filter we send to our peer. In the future we want to expand the range of "interesting things" you can add. Transactions come to mind, probably also scripts. 
- Add a set of callbacks to our SPV node that get executed on certain events. First of is when receiving blocks, merkle blocks and transactions. 
- Add a new method to our wallet API, `getAddressInfo`. It's similar to the `getaddressinfo` Bitcoin Core RPC call, although less ambitious in scope. It is used to get the public key we insert into our bloom filter. 

We also add a WIP test for integrating our SPV node and wallet.


~~We are not receiving `tx` messages after receiving our merkle block, which we can expect to do, according to the Bitcoin.org dev guide:~~

> ~~The `merkleblock` message is a reply to a `getdata` message which requested a block using the inventory type `MSG_MERKLEBLOCK`. It is only part of the reply: if any matching transactions are found, they will be sent separately as `tx` messages.~~

~~I have a memory of seeing `tx` messages in `debug.log` that we were not picking up on our node, but that might be me misremembering. So will have to do some digging there, on why we're not getting the messages.~~

## Update June 3.: 

We also implement legacy address derivation in this PR, as well as legacy UTXO storing and spening. This had to be added to this PR because we do not have Segwit P2P messages implemented in `node`.

## Further update: 

In an effort to further debug this, I add an option to dump all raw P2P messages to file, at `$HOME/.bitcoin-s/NETWORK/p2p.dump`

I also add a file `node-test/src/main/scala/org/bitcoins/node/Bloom.scala` that's a runnable Main method, which has some functionality for spinning up a node and add pubkeys/load bloom filters. This is intended to be left out before merging, leaving it here so you guys can see what I've tried.

## Latest update June 3 before signing off: 

We're now receiving `tx` messages. This PR is balooning out to be really big though, so I'm not sure how much more it makes sense to add to this. 

The current functionality added in this PR:

- Make default account type in wallet configurable
- Create all three account kinds on wallet creation
- Add derivation and spending of legacy addresses in wallet
- Add `getAddressInfo` to wallet API, giving us information about what oublic keys belong to an address (this should be expanded in the future, similar to how the `getaddressinfo` RPC call for Bitcoin Core works)
- Add functionality in SPV node to mark pubkeys as interesting, this causes bloom filters to be generated and sent to our peer
- Add callbacks in SPV node that get triggered on receiving transactions, blocks and merkle blocks (TODO: these callbacks should probably only be triggered if verification of sent data passes. I.e. don't call TX callback if we're sent an invalid transaction)
- Add configuration for dumping all raw P2P messages to file, for debugging purposes