### PR TITLE
Make TestAsyncUtil serializable

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/async/TestAsyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/async/TestAsyncUtil.scala
@@ -6,7 +6,9 @@ import org.scalatest.exceptions.{StackDepthException, TestFailedException}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
 
-abstract class TestAsyncUtil extends org.bitcoins.rpc.util.AsyncUtil {
+abstract class TestAsyncUtil
+    extends org.bitcoins.rpc.util.AsyncUtil
+    with Serializable {
   override protected def retryUntilSatisfiedWithCounter(
       conditionF: () => Future[Boolean],
       duration: FiniteDuration,


### PR DESCRIPTION
Every now and then the Scalatest framework
has crashed when reporting errors, with
failure to serialize this. There should
be no downside to having the trait here,
and we avoid the nasty Scalatest failure.