### PR TITLE
Legacy addresses

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -12,12 +12,12 @@ import scala.concurrent.Promise
 import scala.util.Success
 import scala.util.Failure
 
-case class ChainAppConfig(val confs: Config*) extends AppConfig {
+case class ChainAppConfig(private val confs: Config*) extends AppConfig {
   override protected val configOverrides: List[Config] = confs.toList
   override protected val moduleName: String = "chain"
   override protected type ConfigType = ChainAppConfig
-  override protected def newConfigOfType(
-      configs: List[Config]): ChainAppConfig = ChainAppConfig(configs: _*)
+  override protected def newConfigOfType(configs: Seq[Config]): ChainAppConfig =
+    ChainAppConfig(configs: _*)
 
   /**
     * Checks whether or not the chain project is initialized by

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -1,4 +1,9 @@
 bitcoin-s {
     datadir = ${HOME}/.bitcoin-s
     network = regtest # regtest, testnet3, mainnet
+
+    # settings for wallet module
+    wallet {
+        defaultAccountType = legacy # legacy, segwit, nested-segwit
+    }
 }

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -8,11 +8,11 @@ import org.bitcoins.node.db.NodeDbManagement
 import scala.util.Failure
 import scala.util.Success
 
-case class NodeAppConfig(confs: Config*) extends AppConfig {
+case class NodeAppConfig(private val confs: Config*) extends AppConfig {
   override val configOverrides: List[Config] = confs.toList
   override protected def moduleName: String = "node"
   override protected type ConfigType = NodeAppConfig
-  override protected def newConfigOfType(configs: List[Config]): NodeAppConfig =
+  override protected def newConfigOfType(configs: Seq[Config]): NodeAppConfig =
     NodeAppConfig(configs: _*)
 
   /**

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/LegacyWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/LegacyWalletTest.scala
@@ -10,26 +10,23 @@ import org.bitcoins.core.crypto.AesPassword
 import org.bitcoins.wallet.api.UnlockWalletError.MnemonicNotFound
 import com.typesafe.config.ConfigFactory
 import org.bitcoins.core.protocol.P2PKHAddress
+import org.bitcoins.core.hd.HDPurposes
 
 class LegacyWalletTest extends BitcoinSWalletTest {
 
   override type FixtureParam = UnlockedWalletApi
 
-  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    val confOverride =
-      ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = legacy")
-    withNewConfiguredWallet(confOverride)(test)
-  }
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+    withLegacyWallet(test)
 
-  // eventually this test should NOT succeed, as BIP44
-  // requires a limit to addresses being generated when
-  // they haven't received any funds
   it should "generate legacy addresses" in { wallet: UnlockedWalletApi =>
     for {
       addr <- wallet.getNewAddress()
+      account <- wallet.getDefaultAccount()
       otherAddr <- wallet.getNewAddress()
       allAddrs <- wallet.listAddresses()
     } yield {
+      assert(account.hdAccount.purpose == HDPurposes.Legacy)
       assert(allAddrs.forall(_.address.isInstanceOf[P2PKHAddress]))
       assert(allAddrs.length == 2)
       assert(allAddrs.exists(_.address == addr))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/LegacyWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/LegacyWalletTest.scala
@@ -1,0 +1,39 @@
+package org.bitcoins.wallet
+
+import org.bitcoins.wallet.api.UnlockedWalletApi
+import org.bitcoins.wallet.util.BitcoinSWalletTest
+import org.scalatest.FutureOutcome
+import org.bitcoins.wallet.api.UnlockWalletError.BadPassword
+import org.bitcoins.wallet.api.UnlockWalletError.JsonParsingError
+import org.bitcoins.wallet.api.UnlockWalletSuccess
+import org.bitcoins.core.crypto.AesPassword
+import org.bitcoins.wallet.api.UnlockWalletError.MnemonicNotFound
+import com.typesafe.config.ConfigFactory
+import org.bitcoins.core.protocol.P2PKHAddress
+
+class LegacyWalletTest extends BitcoinSWalletTest {
+
+  override type FixtureParam = UnlockedWalletApi
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val confOverride =
+      ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = legacy")
+    withNewConfiguredWallet(confOverride)(test)
+  }
+
+  // eventually this test should NOT succeed, as BIP44
+  // requires a limit to addresses being generated when
+  // they haven't received any funds
+  it should "generate legacy addresses" in { wallet: UnlockedWalletApi =>
+    for {
+      addr <- wallet.getNewAddress()
+      otherAddr <- wallet.getNewAddress()
+      allAddrs <- wallet.listAddresses()
+    } yield {
+      assert(allAddrs.forall(_.address.isInstanceOf[P2PKHAddress]))
+      assert(allAddrs.length == 2)
+      assert(allAddrs.exists(_.address == addr))
+      assert(allAddrs.exists(_.address == otherAddr))
+    }
+  }
+}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/SegwitWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/SegwitWalletTest.scala
@@ -1,0 +1,41 @@
+package org.bitcoins.wallet
+
+import org.bitcoins.wallet.api.UnlockedWalletApi
+import org.bitcoins.wallet.util.BitcoinSWalletTest
+import org.scalatest.FutureOutcome
+import org.bitcoins.wallet.api.UnlockWalletError.BadPassword
+import org.bitcoins.wallet.api.UnlockWalletError.JsonParsingError
+import org.bitcoins.wallet.api.UnlockWalletSuccess
+import org.bitcoins.core.crypto.AesPassword
+import org.bitcoins.wallet.api.UnlockWalletError.MnemonicNotFound
+import com.typesafe.config.ConfigFactory
+import org.bitcoins.core.protocol.P2PKHAddress
+import org.bitcoins.core.protocol.Bech32Address
+
+class SegwitWalletTest extends BitcoinSWalletTest {
+
+  override type FixtureParam = UnlockedWalletApi
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val confOverride =
+      ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = segwit")
+    val conf = config.walletConf.withOverrides(confOverride)
+    withNewConfiguredWallet(confOverride)(test)
+  }
+
+  // eventually this test should NOT succeed, as BIP44
+  // requires a limit to addresses being generated when
+  // they haven't received any funds
+  it should "generate segwit addresses" in { wallet: UnlockedWalletApi =>
+    for {
+      addr <- wallet.getNewAddress()
+      otherAddr <- wallet.getNewAddress()
+      allAddrs <- wallet.listAddresses()
+    } yield {
+      assert(allAddrs.forall(_.address.isInstanceOf[Bech32Address]))
+      assert(allAddrs.length == 2)
+      assert(allAddrs.exists(_.address == addr))
+      assert(allAddrs.exists(_.address == otherAddr))
+    }
+  }
+}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
@@ -8,6 +8,8 @@ import com.typesafe.config.ConfigFactory
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.config.MainNet
 import org.bitcoins.wallet.config.WalletAppConfig
+import java.nio.file.Paths
+import org.bitcoins.core.hd.HDPurposes
 
 class WalletAppConfigTest extends BitcoinSUnitTest {
   val config = WalletAppConfig()
@@ -22,6 +24,40 @@ class WalletAppConfigTest extends BitcoinSUnitTest {
     val mainnetConf = ConfigFactory.parseString("bitcoin-s.network = mainnet")
     val mainnet: WalletAppConfig = withOther.withOverrides(mainnetConf)
     assert(mainnet.network == MainNet)
+  }
+
+  it should "not matter how the overrides are passed in" in {
+    val dir = Paths.get("/", "bar", "biz")
+    val overrider = ConfigFactory.parseString(s"""
+    |bitcoin-s {
+    |  datadir = $dir 
+    |  network = mainnet
+    |}
+    |""".stripMargin)
+
+    val throughConstuctor = WalletAppConfig(overrider)
+    val throughWithOverrides = config.withOverrides(overrider)
+    assert(throughWithOverrides.network == MainNet)
+    assert(throughWithOverrides.network == throughConstuctor.network)
+
+    assert(throughWithOverrides.datadir.startsWith(dir))
+    assert(throughWithOverrides.datadir == throughConstuctor.datadir)
+
+  }
+
+  it must "be overridable without screwing up other options" in {
+    val dir = Paths.get("/", "foo", "bar")
+    val otherConf = ConfigFactory.parseString(s"bitcoin-s.datadir = $dir")
+    val thirdConf = ConfigFactory.parseString(
+      s"bitcoin-s.wallet.defaultAccountType = nested-segwit")
+
+    val overriden = config.withOverrides(otherConf)
+
+    val twiceOverriden = overriden.withOverrides(thirdConf)
+
+    assert(overriden.datadir.startsWith(dir))
+    assert(twiceOverriden.datadir.startsWith(dir))
+    assert(twiceOverriden.defaultAccountKind == HDPurposes.NestedSegWit)
   }
 
   it must "be overridable with multiple levels" in {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -28,9 +28,6 @@ class WalletUnitTest extends BitcoinSWalletTest {
     }
   }
 
-  // eventually this test should NOT succeed, as BIP44
-  // requires a limit to addresses being generated when
-  // they haven't received any funds
   it should "generate addresses" in { wallet: UnlockedWalletApi =>
     for {
       addr <- wallet.getNewAddress()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -23,7 +23,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
       accounts <- wallet.listAccounts()
       addresses <- wallet.listAddresses()
     } yield {
-      assert(accounts.length == 1)
+      assert(accounts.length == 3) // legacy, segwit and nested segwit
       assert(addresses.isEmpty)
     }
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/UTXOSpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/UTXOSpendingInfoDAOTest.scala
@@ -20,7 +20,7 @@ class UTXOSpendingInfoDAOTest extends BitcoinSWalletTest with UtxoDAOFixture {
     val scriptWitness = WalletTestUtil.sampleScriptWitness
     val privkeyPath = WalletTestUtil.sampleSegwitPath
     val utxo =
-      SegWitUTOXSpendingInfoDb(
+      NativeV0UTXOSpendingInfoDb(
         id = None,
         outPoint = outpoint,
         output = output,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/UTXOSpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/UTXOSpendingInfoDAOTest.scala
@@ -1,12 +1,14 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.core.currency.Bitcoins
+import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
 import org.bitcoins.wallet.fixtures.UtxoDAOFixture
-import org.bitcoins.wallet.util.{BitcoinSWalletTest, WalletTestUtil}
+import org.bitcoins.wallet.Wallet
+import org.bitcoins.wallet.util.WalletTestUtil
+import org.bitcoins.wallet.util.BitcoinSWalletTest
 
 class UTXOSpendingInfoDAOTest extends BitcoinSWalletTest with UtxoDAOFixture {
   behavior of "UTXOSpendingInfoDAO"
@@ -14,11 +16,11 @@ class UTXOSpendingInfoDAOTest extends BitcoinSWalletTest with UtxoDAOFixture {
   it should "insert a segwit UTXO and read it" in { utxoDAO =>
     val outpoint =
       TransactionOutPoint(WalletTestUtil.sampleTxid, WalletTestUtil.sampleVout)
-    val output = TransactionOutput(Bitcoins.one, WalletTestUtil.sampleSPK)
+    val output = TransactionOutput(1.bitcoin, WalletTestUtil.sampleSPK)
     val scriptWitness = WalletTestUtil.sampleScriptWitness
     val privkeyPath = WalletTestUtil.sampleSegwitPath
     val utxo =
-      SegWitUTOXSpendingInfodb(
+      SegWitUTOXSpendingInfoDb(
         id = None,
         outPoint = outpoint,
         output = output,
@@ -31,8 +33,19 @@ class UTXOSpendingInfoDAOTest extends BitcoinSWalletTest with UtxoDAOFixture {
     } yield assert(read.contains(created))
   }
 
-  it should "insert a legacy UTXO and read it" ignore { _ =>
-    ???
+  it should "insert a legacy UTXO and read it" in { utxoDAO =>
+    val outpoint =
+      TransactionOutPoint(WalletTestUtil.sampleTxid, WalletTestUtil.sampleVout)
+    val output = TransactionOutput(1.bitcoin, WalletTestUtil.sampleSPK)
+    val privKeyPath = WalletTestUtil.sampleLegacyPath
+    val utxo = LegacyUTXOSpendingInfoDb(id = None,
+                                        outPoint = outpoint,
+                                        output = output,
+                                        privKeyPath = privKeyPath)
+    for {
+      created <- utxoDAO.create(utxo)
+      read <- utxoDAO.read(created.id.get)
+    } yield assert(read.contains(created))
   }
 
   it should "insert a nested segwit UTXO and read it" ignore { _ =>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/util/WalletTestUtil.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/util/WalletTestUtil.scala
@@ -48,6 +48,12 @@ object WalletTestUtil {
                  HDChainType.External,
                  addressIndex = 0)
 
+  /** Sample legacy HD path */
+  lazy val sampleLegacyPath = LegacyHDPath(hdCoinType,
+                                           accountIndex = 0,
+                                           HDChainType.Change,
+                                           addressIndex = 0)
+
   def freshXpub: ExtPublicKey =
     CryptoGenerators.extPublicKey.sample.getOrElse(freshXpub)
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -41,7 +41,7 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
       case MainNetChainParams                         => HDCoinType.Bitcoin
       case RegTestNetChainParams | TestNetChainParams => HDCoinType.Testnet
     }
-    HDCoin(Wallet.DEFAULT_HD_PURPOSE, coinType)
+    HDCoin(walletConfig.defaultAccountKind, coinType)
   }
 
   /**
@@ -95,16 +95,21 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
 
     val utxo: UTXOSpendingInfoDb = addressDb match {
       case segwitAddr: SegWitAddressDb =>
-        SegWitUTOXSpendingInfodb(
+        SegWitUTOXSpendingInfoDb(
           id = None,
           outPoint = outPoint,
           output = output,
           privKeyPath = segwitAddr.path,
           scriptWitness = segwitAddr.witnessScript
         )
-      case otherAddr @ (_: LegacyAddressDb | _: NestedSegWitAddressDb) =>
+      case LegacyAddressDb(path, _, _, _) =>
+        LegacyUTXOSpendingInfoDb(id = None,
+                                 outPoint = outPoint,
+                                 output = output,
+                                 privKeyPath = path)
+      case nested: NestedSegWitAddressDb =>
         throw new IllegalArgumentException(
-          s"Bad utxo $otherAddr. Note: Only Segwit is implemented")
+          s"Bad utxo $nested. Note: nested segwit is not implemented")
     }
 
     utxoDAO.create(utxo).map { written =>
@@ -201,27 +206,34 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
           address.toPath
       }
 
-      val addressDb =
+      val addressDb = {
+        val pathDiff =
+          account.hdAccount.diff(addrPath) match {
+            case Some(value) => value
+            case None =>
+              throw new RuntimeException(
+                s"Could not diff ${account.hdAccount} and $addrPath")
+          }
+
+        val pubkey = account.xpub.deriveChildPubKey(pathDiff) match {
+          case Failure(exception) => throw exception
+          case Success(value)     => value.key
+        }
+
         addrPath match {
           case segwitPath: SegWitHDPath =>
-            val pathDiff = account.hdAccount.diff(segwitPath) match {
-              case Some(value) => value
-              case None =>
-                throw new RuntimeException(
-                  s"Could not diff ${account.hdAccount} and $segwitPath")
-            }
-
-            val pubkey = account.xpub.deriveChildPubKey(pathDiff) match {
-              case Failure(exception) => throw exception
-              case Success(value)     => value.key
-            }
-
             AddressDbHelper
-              .getP2WPKHAddress(pubkey, segwitPath, networkParameters)
-          case _: HDPath =>
-            throw new IllegalArgumentException(
-              "P2PKH and nested segwit P2PKH not yet implemented")
+              .getSegwitAddress(pubkey, segwitPath, networkParameters)
+          case legacyPath: LegacyHDPath =>
+            AddressDbHelper.getLegacyAddress(pubkey,
+                                             legacyPath,
+                                             networkParameters)
+          case nestedPath: NestedSegWitHDPath =>
+            AddressDbHelper.getNestedSegwitAddress(pubkey,
+                                                   nestedPath,
+                                                   networkParameters)
         }
+      }
       val writeF = addressDAO.create(addressDb)
       writeF.foreach { written =>
         logger.info(

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -88,6 +88,7 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
       case Failure(_) => Future.successful(Left(BadSPK))
     }
 
+  /** Constructs a DB level representation of the given UTXO, and persist it to disk */
   private def writeUtxo(
       output: TransactionOutput,
       outPoint: TransactionOutPoint,
@@ -95,7 +96,7 @@ abstract class LockedWallet extends LockedWalletApi with BitcoinSLogger {
 
     val utxo: UTXOSpendingInfoDb = addressDb match {
       case segwitAddr: SegWitAddressDb =>
-        SegWitUTOXSpendingInfoDb(
+        NativeV0UTXOSpendingInfoDb(
           id = None,
           outPoint = outPoint,
           output = output,

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -181,9 +181,16 @@ object Wallet extends CreateWalletApi with BitcoinSLogger {
             val createAccountFutures =
               HDPurposes.all.map(createRootAccount(wallet, _))
 
-            Future
-              .sequence(createAccountFutures)
-              .map(_ => logger.debug(s"Created root level accounts for wallet"))
+            val accountCreationF = Future.sequence(createAccountFutures)
+
+            accountCreationF.foreach(_ =>
+              logger.debug(s"Created root level accounts for wallet"))
+
+            accountCreationF.failed.foreach { err =>
+              logger.error(s"Failed to create root level accounts: $err")
+            }
+
+            accountCreationF
           }
 
         } yield wallet

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -10,11 +10,11 @@ import java.nio.file.Files
 import org.bitcoins.core.hd.HDPurpose
 import org.bitcoins.core.hd.HDPurposes
 
-case class WalletAppConfig(conf: Config*) extends AppConfig {
+case class WalletAppConfig(private val conf: Config*) extends AppConfig {
   override val configOverrides: List[Config] = conf.toList
   override def moduleName: String = "wallet"
   override type ConfigType = WalletAppConfig
-  override def newConfigOfType(configs: List[Config]): WalletAppConfig =
+  override def newConfigOfType(configs: Seq[Config]): WalletAppConfig =
     WalletAppConfig(configs: _*)
 
   lazy val defaultAccountKind: HDPurpose =

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -7,6 +7,8 @@ import org.bitcoins.wallet.db.WalletDbManagement
 import scala.util.Failure
 import scala.util.Success
 import java.nio.file.Files
+import org.bitcoins.core.hd.HDPurpose
+import org.bitcoins.core.hd.HDPurposes
 
 case class WalletAppConfig(conf: Config*) extends AppConfig {
   override val configOverrides: List[Config] = conf.toList
@@ -14,6 +16,16 @@ case class WalletAppConfig(conf: Config*) extends AppConfig {
   override type ConfigType = WalletAppConfig
   override def newConfigOfType(configs: List[Config]): WalletAppConfig =
     WalletAppConfig(configs: _*)
+
+  lazy val defaultAccountKind: HDPurpose =
+    config.getString("wallet.defaultAccountType") match {
+      case "legacy"        => HDPurposes.Legacy
+      case "segwit"        => HDPurposes.SegWit
+      case "nested-segwit" => HDPurposes.NestedSegWit
+      // todo: validate this pre-app startup
+      case other: String =>
+        throw new RuntimeException(s"$other is not a valid account type!")
+    }
 
   override def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
     logger.debug(s"Initializing wallet setup")

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AccountTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AccountTable.scala
@@ -46,5 +46,5 @@ class AccountTable(tag: Tag) extends Table[AccountDb](tag, "wallet_accounts") {
     (purpose, xpub, coinType, index) <> (fromTuple, toTuple)
 
   def primaryKey: PrimaryKey =
-    primaryKey("pk_account", (coinType, index))
+    primaryKey("pk_account", sourceColumns = (purpose, coinType, index))
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTable.scala
@@ -244,6 +244,9 @@ class AddressTable(tag: Tag) extends Table[AddressDb](tag, "addresses") {
 
   // for some reason adding a type annotation here causes compile error
   def fk =
-    foreignKey("fk_account", (accountCoin, accountIndex), accounts)(
-      accountTable => (accountTable.coinType, accountTable.index))
+    foreignKey("fk_account",
+               sourceColumns = (purpose, accountCoin, accountIndex),
+               targetTableQuery = accounts) { accountTable =>
+      (accountTable.purpose, accountTable.coinType, accountTable.index)
+    }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/UTXOSpendingInfoTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/UTXOSpendingInfoTable.scala
@@ -18,26 +18,39 @@ import org.bitcoins.core.hd.SegWitHDPath
 import org.bitcoins.core.crypto.BIP39Seed
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.hd.LegacyHDPath
-import org.bitcoins.core.hd.NestedSegWitHDPath
 
-case class SegWitUTOXSpendingInfodb(
+case class SegWitUTOXSpendingInfoDb(
     id: Option[Long],
     outPoint: TransactionOutPoint,
     output: TransactionOutput,
     privKeyPath: SegWitHDPath,
     scriptWitness: ScriptWitness
 ) extends UTXOSpendingInfoDb {
-  override def redeemScriptOpt: Option[ScriptPubKey] = None
-  override def scriptWitnessOpt: Option[ScriptWitness] = Some(scriptWitness)
+  override val redeemScriptOpt: Option[ScriptPubKey] = None
+  override val scriptWitnessOpt: Option[ScriptWitness] = Some(scriptWitness)
 
   override type PathType = SegWitHDPath
 
-  override def copyWithId(id: Long): SegWitUTOXSpendingInfodb =
+  override def copyWithId(id: Long): SegWitUTOXSpendingInfoDb =
+    copy(id = Some(id))
+}
+
+case class LegacyUTXOSpendingInfoDb(
+    id: Option[Long],
+    outPoint: TransactionOutPoint,
+    output: TransactionOutput,
+    privKeyPath: LegacyHDPath
+) extends UTXOSpendingInfoDb {
+  override val redeemScriptOpt: Option[ScriptPubKey] = None
+  override def scriptWitnessOpt: Option[ScriptWitness] = None
+
+  override type PathType = LegacyHDPath
+
+  override def copyWithId(id: Long): LegacyUTXOSpendingInfoDb =
     copy(id = Some(id))
 }
 
 // TODO add case for nested segwit
-// and legacy
 sealed trait UTXOSpendingInfoDb
     extends DbRowAutoInc[UTXOSpendingInfoDb]
     with BitcoinSLogger {
@@ -114,20 +127,22 @@ case class UTXOSpendingInfoTable(tag: Tag)
           outpoint,
           output,
           path: SegWitHDPath,
-          None,
+          None, // ScriptPubKey
           Some(scriptWitness)) =>
-      SegWitUTOXSpendingInfodb(id, outpoint, output, path, scriptWitness)
-        .asInstanceOf[UTXOSpendingInfoDb]
+      SegWitUTOXSpendingInfoDb(id, outpoint, output, path, scriptWitness)
 
     case (id,
           outpoint,
           output,
-          path @ (_: LegacyHDPath | _: NestedSegWitHDPath),
-          spkOpt,
-          swOpt) =>
+          path: LegacyHDPath,
+          None, // RedeemScript
+          None // ScriptWitness
+        ) =>
+      LegacyUTXOSpendingInfoDb(id, outpoint, output, path)
+    case (id, outpoint, output, path, spkOpt, swOpt) =>
       throw new IllegalArgumentException(
         "Could not construct UtxoSpendingInfoDb from bad tuple:"
-          + s" ($id, $outpoint, $output, $path, $spkOpt, $swOpt) . Note: Only Segwit is implemented")
+          + s" ($id, $outpoint, $output, $path, $spkOpt, $swOpt) . Note: Nested Segwit is not implemented")
 
   }
 


### PR DESCRIPTION
In this PR we add the ability to generate
legacy addresses in the wallet. We also make
the default accound kind (legacy, segwit,
nested segwit) configurable.

We also fix (and add a test for) a bug
where overriding a value in our configuration
reset the rest of the configuration to the
default values. This is in the second commit.