### PR TITLE
Don't run Travis tests on merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,11 @@ before_script:
 
 stages:
   - name: test
-    if: commit_message !~ /^Docs:/
+    if:
+      commit_message !~ /^Docs:/ AND NOT
+      ((branch = master AND type = push) OR (tag IS present))
+      # don't run tests on merge builds, just publish library
+      # and website
   - name: release
     if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 


### PR DESCRIPTION
Due to flaky tests snapshot and website publishing frequently gets aborted. This is not desirable, as we want snapshots to be published for all builds.