### PR TITLE
Default to file based databases in tests

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -15,15 +15,20 @@ import org.scalatest.{Assertion, FutureOutcome}
 import play.api.libs.json.Json
 
 import scala.concurrent.Future
+import org.bitcoins.testkit.BitcoinSAppConfig
 
 class ChainHandlerTest extends ChainUnitTest {
 
   override type FixtureParam = ChainHandler
 
-  override implicit val system = ActorSystem("ChainUnitTest")
+  implicit override val system = ActorSystem("ChainUnitTest")
 
   // we're working with mainnet data
-  override lazy implicit val appConfig: ChainAppConfig = mainnetAppConfig
+  implicit override lazy val appConfig: ChainAppConfig = {
+    val memoryDb = BitcoinSAppConfig.configWithMemoryDb(
+      Some(BitcoinSAppConfig.ProjectType.Chain))
+    mainnetAppConfig.withOverrides(memoryDb)
+  }
 
   override val defaultTag: ChainFixtureTag = ChainFixtureTag.GenisisChainHandler
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
@@ -9,12 +9,17 @@ import org.bitcoins.testkit.chain.{ChainTestUtil, ChainUnitTest}
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future
+import org.bitcoins.testkit.BitcoinSAppConfig
 
 class BitcoinPowTest extends ChainUnitTest {
 
   override type FixtureParam = ChainFixture
 
-  implicit override lazy val appConfig: ChainAppConfig = mainnetAppConfig
+  implicit override lazy val appConfig: ChainAppConfig = {
+    val memoryDb = BitcoinSAppConfig.configWithMemoryDb(
+      Some(BitcoinSAppConfig.ProjectType.Chain))
+    mainnetAppConfig.withOverrides(memoryDb)
+  }
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withChainFixture(test)

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -18,6 +18,7 @@ import org.scalatest.{Assertion, FutureOutcome}
 import scala.concurrent.Future
 import org.bitcoins.chain.config.ChainAppConfig
 import com.typesafe.config.ConfigFactory
+import org.bitcoins.testkit.BitcoinSAppConfig
 
 class TipValidationTest extends ChainUnitTest {
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSAppConfig.scala
@@ -67,37 +67,59 @@ object BitcoinSAppConfig {
 
   /**
     * App configuration suitable for test purposes:
-
+    *
     * 1) Data directory is set to user temp directory
-    * 2) All databases are in-memory
     */
   def getTestConfig(config: Config*) = {
     val tmpDir = Files.createTempDirectory("bitcoin-s-")
     val confStr = s"""
     | bitcoin-s {
     |   datadir = $tmpDir
-    |
-    |   wallet.db {
-    |     url = "jdbc:sqlite:file::memory:?cache=shared" 
-    |     connectionPool = disabled
-    |     keepAliveConnection = true 
-    |   }
-    |   node.db {
-    |     url = "jdbc:sqlite:file::memory:?cache=shared" 
-    |     connectionPool = disabled
-    |     keepAliveConnection = true 
-    |   }
-    |   chain.db {
-    |     url = "jdbc:sqlite:file::memory:?cache=shared" 
-    |     connectionPool = disabled
-    |     keepAliveConnection = true 
-    |   }
     | }
     |
     |""".stripMargin
     val conf = ConfigFactory.parseString(confStr)
     val allConfs = conf +: config
     BitcoinSAppConfig(allConfs: _*)
+  }
+
+  sealed trait ProjectType
+
+  object ProjectType {
+    case object Wallet extends ProjectType
+    case object Node extends ProjectType
+    case object Chain extends ProjectType
+
+    val all = List(Wallet, Node, Chain)
+  }
+
+  /** Generates a Typesafe config with DBs set to memory
+    * databases for the given project (or all, if no
+    * project is given). This configuration can then be
+    * given as a override to other configs.
+    */
+  def configWithMemoryDb(project: Option[ProjectType]): Config = {
+    def memConfigForProject(project: ProjectType): String = {
+      val name = project.toString().toLowerCase()
+      s"""
+        | $name.db {
+        |   url = "jdbc:sqlite:file:$name.db:?mode=memory&cache=shared"
+        |   connectionPool = disabled
+        |   keepAliveConnection = true
+        | }
+        |""".stripMargin
+    }
+
+    val confStr = project match {
+      case None    => ProjectType.all.map(memConfigForProject).mkString("\n")
+      case Some(p) => memConfigForProject(p)
+    }
+    val nestedConfStr = s"""
+    | bitcoin-s {
+    | $confStr
+    | }
+    |""".stripMargin
+    ConfigFactory.parseString(nestedConfStr)
   }
 
 }


### PR DESCRIPTION
This commit is extracted from #514. Without it CI is going to fail on both #514 and #516, so this should go in first, and then the other PRs should be rebased. 

---

This is due to issues with deadlocks with
in-memory based databases. We need DBs
to stay alive between connections, but
not across tests.

In DB intensive chain validation tests we
use in-memory databases instead. This
seems like a reasonable tradeoff between
simplicity and speed.