### PR TITLE
Fix issue where bloop didn't pick up test resources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,9 +105,7 @@ lazy val commonTestWithDbSettings = Seq(
   Test / parallelExecution := false
 ) ++ commonTestSettings
 
-lazy val commonProdSettings = Seq(
-  Test / bloopGenerate := None
-) ++ commonSettings
+lazy val commonProdSettings = commonSettings
 
 lazy val bitcoins = project
   .in(file("."))


### PR DESCRIPTION
In this PR we fix the issue that's been bothering us for a while, where sbt picks up the logback configuration, but not Bloop. 

The problem was that we skipped generating test projects for projects that contained just main sources. This causes test resources to be ignored as well, which I didn't think of when enabling the setting I'm removing in this PR. 