### PR TITLE
SipHashKey

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
@@ -239,7 +239,7 @@ class GCSTest extends BitcoinSUnitTest {
       }
     }
 
-    def genKey: Gen[ByteVector] =
+    def genKey: Gen[SipHashKey] =
       Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_))
 
     forAll(genPM, genItems, genKey) {

--- a/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
@@ -240,7 +240,7 @@ class GCSTest extends BitcoinSUnitTest {
     }
 
     def genKey: Gen[SipHashKey] =
-      Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_))
+      Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_).map(SipHashKey(_)))
 
     forAll(genPM, genItems, genKey) {
       case ((p, m), items, k) =>

--- a/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
@@ -240,7 +240,7 @@ class GCSTest extends BitcoinSUnitTest {
     }
 
     def genKey: Gen[SipHashKey] =
-      Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_).map(SipHashKey(_)))
+      Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_)).map(SipHashKey(_))
 
     forAll(genPM, genItems, genKey) {
       case ((p, m), items, k) =>

--- a/core-test/src/test/scala/org/bitcoins/core/gcs/GolombFilterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/gcs/GolombFilterTest.scala
@@ -12,7 +12,7 @@ class GolombFilterTest extends BitcoinSUnitTest {
 
   it must "match encoded data for arbitrary GCS parameters" in {
     def genKey: Gen[SipHashKey] =
-      Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_))
+      Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_)).map(SipHashKey(_))
 
     def genPMRand: Gen[(UInt8, UInt64, UInt64)] = NumberGenerator.genP.flatMap {
       p =>
@@ -49,7 +49,7 @@ class GolombFilterTest extends BitcoinSUnitTest {
 
   it must "match arbitrary encoded data for bip 158 GCS parameters" in {
     val genKey: Gen[SipHashKey] =
-      Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_))
+      Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_)).map(SipHashKey(_))
 
     val genData: Gen[Vector[ByteVector]] = Gen.chooseNum(1, 10000).flatMap {
       size =>

--- a/core-test/src/test/scala/org/bitcoins/core/gcs/GolombFilterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/gcs/GolombFilterTest.scala
@@ -11,7 +11,7 @@ class GolombFilterTest extends BitcoinSUnitTest {
   behavior of "GolombFilter"
 
   it must "match encoded data for arbitrary GCS parameters" in {
-    def genKey: Gen[ByteVector] =
+    def genKey: Gen[SipHashKey] =
       Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_))
 
     def genPMRand: Gen[(UInt8, UInt64, UInt64)] = NumberGenerator.genP.flatMap {
@@ -48,7 +48,7 @@ class GolombFilterTest extends BitcoinSUnitTest {
   }
 
   it must "match arbitrary encoded data for bip 158 GCS parameters" in {
-    val genKey: Gen[ByteVector] =
+    val genKey: Gen[SipHashKey] =
       Gen.listOfN(16, NumberGenerator.byte).map(ByteVector(_))
 
     val genData: Gen[Vector[ByteVector]] = Gen.chooseNum(1, 10000).flatMap {

--- a/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -387,7 +387,8 @@ object ECPublicKey extends Factory[ECPublicKey] {
     * [[https://github.com/bitcoin/bitcoin/blob/27765b6403cece54320374b37afb01a0cfe571c3/src/pubkey.cpp#L207-L212]]
     */
   def isFullyValid(bytes: ByteVector): Boolean =
-    Try(NativeSecp256k1.isValidPubKey(bytes.toArray)).getOrElse(false) && isValid(bytes)
+    Try(NativeSecp256k1.isValidPubKey(bytes.toArray))
+      .getOrElse(false) && isValid(bytes)
 
   /**
     * Mimics the CPubKey::IsValid function in Bitcoin core, this is a consensus rule

--- a/core/src/main/scala/org/bitcoins/core/gcs/GCS.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/GCS.scala
@@ -51,10 +51,7 @@ object GCS {
       key: SipHashKey): GolombFilter = {
     buildGolombFilter(data, key, BlockFilter.P, BlockFilter.M)
   }
-
-  //item remains bytevector key to be changed create new file in GCS folder that redefines sipkeyhash
-  //will probably have a require statement bytevector length of 16 bytes or 128 bits. Add a couple methods
-  //to turn the key into an array of bytes (look to toArray method on line 65)
+  
   private def sipHash(item: ByteVector, key: SipHashKey): UInt64 = {
     // https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki#hashing-data-objects
     val sipHashCParam = 2
@@ -62,7 +59,7 @@ object GCS {
 
     val sh = new SipHash(sipHashCParam, sipHashDParam)
 
-    val keyParam = new KeyParameter(key.toArray)
+    val keyParam = new KeyParameter(key.bytes.toArray)
 
     sh.init(keyParam)
 

--- a/core/src/main/scala/org/bitcoins/core/gcs/GCS.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/GCS.scala
@@ -51,7 +51,7 @@ object GCS {
       key: SipHashKey): GolombFilter = {
     buildGolombFilter(data, key, BlockFilter.P, BlockFilter.M)
   }
-  
+
   private def sipHash(item: ByteVector, key: SipHashKey): UInt64 = {
     // https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki#hashing-data-objects
     val sipHashCParam = 2

--- a/core/src/main/scala/org/bitcoins/core/gcs/GCS.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/GCS.scala
@@ -21,7 +21,7 @@ object GCS {
     */
   def buildGCS(
       data: Vector[ByteVector],
-      key: ByteVector,
+      key: SipHashKey,
       p: UInt8,
       m: UInt64): BitVector = {
     val hashedValues = hashedSetConstruct(data, key, m)
@@ -34,7 +34,7 @@ object GCS {
     */
   def buildGolombFilter(
       data: Vector[ByteVector],
-      key: ByteVector,
+      key: SipHashKey,
       p: UInt8,
       m: UInt64): GolombFilter = {
     val encodedData = buildGCS(data, key, p, m)
@@ -48,14 +48,14 @@ object GCS {
     */
   def buildBasicBlockFilter(
       data: Vector[ByteVector],
-      key: ByteVector): GolombFilter = {
+      key: SipHashKey): GolombFilter = {
     buildGolombFilter(data, key, BlockFilter.P, BlockFilter.M)
   }
 
   //item remains bytevector key to be changed create new file in GCS folder that redefines sipkeyhash
   //will probably have a require statement bytevector length of 16 bytes or 128 bits. Add a couple methods
   //to turn the key into an array of bytes (look to toArray method on line 65)
-  private def sipHash(item: ByteVector, key: ByteVector): UInt64 = {
+  private def sipHash(item: ByteVector, key: SipHashKey): UInt64 = {
     // https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki#hashing-data-objects
     val sipHashCParam = 2
     val sipHashDParam = 4
@@ -79,7 +79,7 @@ object GCS {
     * Hashes the item to the range [0, f)
     * @see [[https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki#hashing-data-objects]]
     */
-  def hashToRange(item: ByteVector, f: UInt64, key: ByteVector): UInt64 = {
+  def hashToRange(item: ByteVector, f: UInt64, key: SipHashKey): UInt64 = {
     val hash = sipHash(item, key)
 
     val bigInt = (hash.toBigInt * f.toBigInt) >> 64
@@ -93,7 +93,7 @@ object GCS {
     */
   def hashedSetConstruct(
       rawItems: Vector[ByteVector],
-      key: ByteVector,
+      key: SipHashKey,
       m: UInt64): Vector[UInt64] = {
     val n = rawItems.length
     val f = m * n

--- a/core/src/main/scala/org/bitcoins/core/gcs/GCS.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/GCS.scala
@@ -52,6 +52,9 @@ object GCS {
     buildGolombFilter(data, key, BlockFilter.P, BlockFilter.M)
   }
 
+  //item remains bytevector key to be changed create new file in GCS folder that redefines sipkeyhash
+  //will probably have a require statement bytevector length of 16 bytes or 128 bits. Add a couple methods
+  //to turn the key into an array of bytes (look to toArray method on line 65)
   private def sipHash(item: ByteVector, key: ByteVector): UInt64 = {
     // https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki#hashing-data-objects
     val sipHashCParam = 2

--- a/core/src/main/scala/org/bitcoins/core/gcs/GolombFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/GolombFilter.scala
@@ -24,7 +24,7 @@ import scala.annotation.tailrec
   * TODO: Replace ByteVector with a type for keys
   */
 case class GolombFilter(
-    key: ByteVector,
+    key: SipHashKey,
     m: UInt64,
     p: UInt8,
     n: CompactSizeUInt,
@@ -149,7 +149,7 @@ object BlockFilter {
   def apply(
       block: Block,
       prevOutputScripts: Vector[ScriptPubKey]): GolombFilter = {
-    val key = block.blockHeader.hash.bytes.take(16)
+    val key: SipHashKey = block.blockHeader.hash.bytes.take(16)
 
     val newScriptPubKeys: Vector[ByteVector] =
       getOutputScriptPubKeysFromBlock(block).map(_.asmBytes)

--- a/core/src/main/scala/org/bitcoins/core/gcs/GolombFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/GolombFilter.scala
@@ -171,8 +171,10 @@ object BlockFilter {
       blockHash: DoubleSha256Digest): GolombFilter = {
     val (size, filterBytes) = bytes.splitAt(1)
     val n = CompactSizeUInt.fromBytes(size)
+    val keyBytes: ByteVector = blockHash.bytes.take(16)
+    val key: SipHashKey = SipHashKey(keyBytes)
 
-    GolombFilter(SipHashKey(blockHash.bytes.take(16)),
+    GolombFilter(key,
                  BlockFilter.M,
                  BlockFilter.P,
                  n,

--- a/core/src/main/scala/org/bitcoins/core/gcs/GolombFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/GolombFilter.scala
@@ -174,11 +174,7 @@ object BlockFilter {
     val keyBytes: ByteVector = blockHash.bytes.take(16)
     val key: SipHashKey = SipHashKey(keyBytes)
 
-    GolombFilter(key,
-                 BlockFilter.M,
-                 BlockFilter.P,
-                 n,
-                 filterBytes.toBitVector)
+    GolombFilter(key, BlockFilter.M, BlockFilter.P, n, filterBytes.toBitVector)
   }
 
   def fromHex(hex: String, blockHash: DoubleSha256Digest): GolombFilter = {

--- a/core/src/main/scala/org/bitcoins/core/gcs/GolombFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/GolombFilter.scala
@@ -149,7 +149,9 @@ object BlockFilter {
   def apply(
       block: Block,
       prevOutputScripts: Vector[ScriptPubKey]): GolombFilter = {
-    val key: SipHashKey = block.blockHeader.hash.bytes.take(16)
+    val keyBytes: ByteVector = block.blockHeader.hash.bytes.take(16)
+
+    val key: SipHashKey = SipHashKey(keyBytes)
 
     val newScriptPubKeys: Vector[ByteVector] =
       getOutputScriptPubKeysFromBlock(block).map(_.asmBytes)
@@ -170,7 +172,7 @@ object BlockFilter {
     val (size, filterBytes) = bytes.splitAt(1)
     val n = CompactSizeUInt.fromBytes(size)
 
-    GolombFilter(blockHash.bytes.take(16),
+    GolombFilter(SipHashKey(blockHash.bytes.take(16)),
                  BlockFilter.M,
                  BlockFilter.P,
                  n,

--- a/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.core.gcs
 import scodec.bits.ByteVector
 import org.bitcoins.core.protocol.NetworkElement
-case class SipHashKey(bytes: ByteVector) extends NetworkElement{
-  require(
-    bytes.size == 16,
-    "Can only use a key length of 16 bytes, got: " + bytes.size)
+case class SipHashKey(bytes: ByteVector) extends NetworkElement {
+  require(bytes.size == 16,
+          "Can only use a key length of 16 bytes, got: " + bytes.size)
 }

--- a/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
@@ -4,7 +4,7 @@ case class SipHashKey(bytes: ByteVector) {
     bytes.size == 16,
     "Can only use a key length of 16 bytes, got: " + bytes.size)
 
-  def toArray: Array[bytes] {
+  def toArray: Array[Byte] = {
     bytes.toArray
   }
 

--- a/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
@@ -1,3 +1,4 @@
+package org.bitcoins.core.gcs
 import scodec.bits.ByteVector
 case class SipHashKey(bytes: ByteVector) {
   require(

--- a/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
@@ -1,4 +1,4 @@
-
+import scodec.bits.ByteVector
 case class SipHashKey(bytes: ByteVector) {
   require(
     bytes.size == 16,

--- a/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
@@ -1,17 +1,8 @@
 package org.bitcoins.core.gcs
 import scodec.bits.ByteVector
-case class SipHashKey(bytes: ByteVector) {
+import org.bitcoins.core.protocol.NetworkElement
+case class SipHashKey(bytes: ByteVector) extends NetworkElement{
   require(
     bytes.size == 16,
     "Can only use a key length of 16 bytes, got: " + bytes.size)
-
-  def toArray: Array[Byte] = {
-    bytes.toArray
-  }
-
 }
-
-
-
-
-

--- a/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/SipHashKey.scala
@@ -1,0 +1,16 @@
+
+case class SipHashKey(bytes: ByteVector) {
+  require(
+    bytes.size == 16,
+    "Can only use a key length of 16 bytes, got: " + bytes.size)
+
+  def toArray: Array[bytes] {
+    bytes.toArray
+  }
+
+}
+
+
+
+
+

--- a/core/src/main/scala/org/bitcoins/core/hd/package.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/package.scala
@@ -11,4 +11,3 @@ package org.bitcoins.core
   *     Hierarchical Deterministic Wallets
   */
 package object hd
-

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
@@ -51,7 +51,7 @@ sealed abstract class Block extends NetworkElement {
   */
 object Block extends Factory[Block] {
 
-  private sealed case class BlockImpl(
+  sealed private case class BlockImpl(
       blockHeader: BlockHeader,
       txCount: CompactSizeUInt,
       transactions: Seq[Transaction])

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -3,7 +3,13 @@ package org.bitcoins.core.protocol.blockchain
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 
-import org.bitcoins.core.config.{BitcoinNetwork, MainNet, NetworkParameters, RegTest, TestNet3}
+import org.bitcoins.core.config.{
+  BitcoinNetwork,
+  MainNet,
+  NetworkParameters,
+  RegTest,
+  TestNet3
+}
 import org.bitcoins.core.consensus.Merkle
 import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
@@ -219,7 +225,6 @@ sealed abstract class BitcoinChainParams extends ChainParams {
 
   /** The best chain should have this amount of work */
   def minimumChainWork: BigInteger
-
 
   /**
     * @inheritdoc

--- a/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
@@ -49,21 +49,23 @@ sealed abstract class RawSerializerHelper {
   def writeCmpctSizeUInt[T](
       ts: Seq[T],
       serializer: T => ByteVector): ByteVector = {
-    val serialized = write(ts,serializer)
+    val serialized = write(ts, serializer)
     val cmpct = CompactSizeUInt(UInt64(ts.size))
     cmpct.bytes ++ serialized
   }
 
-
   /** Serializes a [[Seq]] of [[org.bitcoins.core.protocol.NetworkElement]] to a [[scodec.bits.ByteVector]] */
   def writeNetworkElements[T <: NetworkElement](ts: Seq[T]): ByteVector = {
-    val f = {t : T => t.bytes}
+    val f = { t: T =>
+      t.bytes
+    }
     write(ts, f)
   }
 
   def write[T](ts: Seq[T], serializer: T => ByteVector): ByteVector = {
-    ts.foldLeft(ByteVector.empty) { case (accum, t) =>
-      accum ++ serializer(t)
+    ts.foldLeft(ByteVector.empty) {
+      case (accum, t) =>
+        accum ++ serializer(t)
     }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -201,7 +201,7 @@ sealed abstract class ScriptParser extends Factory[List[ScriptToken]] {
     scriptConstants.toList
   }
 
-  private sealed case class ParsingHelper(
+  sealed private case class ParsingHelper(
       tail: ByteVector,
       accum: List[ScriptToken])
 

--- a/core/src/test/resources/common-logback.xml
+++ b/core/src/test/resources/common-logback.xml
@@ -1,6 +1,6 @@
 <included>
     <!-- Stop output INFO at start -->
-    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
 
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
@@ -18,8 +18,8 @@
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="FILE" />
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="STDOUT"/>
     </root>
 
     <!-- ╔═══════════════════════╗ -->
@@ -31,28 +31,28 @@
     <!-- ╚═══════════════════╝ -->
 
     <!-- inspect resolved DB connection -->
-    <logger name="org.bitcoins.db.SafeDatabase" level="INFO" />
+    <logger name="org.bitcoins.db.SafeDatabase" level="INFO"/>
 
     <!-- inspect resolved config -->
-    <logger name="org.bitcoins.chain.config" level="INFO" />
-    <logger name="org.bitcoins.node.config" level="INFO" />
-    <logger name="org.bitcoins.wallet.config" level="INFO" />
+    <logger name="org.bitcoins.chain.config" level="INFO"/>
+    <logger name="org.bitcoins.node.config" level="INFO"/>
+    <logger name="org.bitcoins.wallet.config" level="INFO"/>
 
     <!-- ╔═════════════════╗ -->
     <!-- ║   Node module   ║ -->
     <!-- ╚═════════════════╝ -->
 
     <!-- See incoming message names and the peer it's sent from -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO" />
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="INFO" />
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="INFO"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO" /> 
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>
 
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.Client" level="INFO" />
+    <logger name="org.bitcoins.node.networking.Client" level="INFO"/>
 
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->
@@ -60,10 +60,10 @@
 
     <!-- See queries received by chain handler, as well as result of  -->
     <!-- connecting new block headers to chain -->
-    <logger name="org.bitcoins.chain.blockchain.ChainHandler" level="INFO" />
+    <logger name="org.bitcoins.chain.blockchain.ChainHandler" level="INFO"/>
 
     <!-- Set to TRACE to inspect details of chain vaidation -->
-    <logger name="org.bitcoins.chain.validation" level="INFO" />
+    <logger name="org.bitcoins.chain.validation" level="INFO"/>
 
     <!-- ╔═════════════════════╗ -->
     <!-- ║   Wallet module     ║ -->
@@ -87,7 +87,7 @@
     <logger name="slick.compiler" level="INFO"/>
 
     <!-- see what's returned by Slick -->
-    <logger name="slick.jdbc.StatementInvoker.result" level="INFO" />
+    <logger name="slick.jdbc.StatementInvoker.result" level="INFO"/>
 
     <!-- Get rid of messages like this: 
     Connection attempt failed. Backing off new connection 
@@ -95,5 +95,5 @@
     <logger name="akka.http.impl.engine.client.PoolGateway" level="OFF"/>
 
     <!-- get rid of "Slf4jLogger started" messages -->
-    <logger name="akka.event.slf4j.Slf4jLogger" level="OFF" />
+    <logger name="akka.event.slf4j.Slf4jLogger" level="OFF"/>
 </included>

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -3,5 +3,5 @@
     we exclude all XML files from being included in published 
     artifacts. This way users of Bitcoin-S won't get our config
     pushed on them. -->
-    <include resource="common-logback.xml" />
+    <include resource="common-logback.xml"/>
 </configuration>


### PR DESCRIPTION
Currently replacing ByteVector with SipHashKey to ensure only 16 byte length keys are passed. Trying to fix compiler errors.
Closes #521 