### PR TITLE
Reorg handling in chain project

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
@@ -50,6 +50,15 @@ trait ChainApi {
   /** Gets the best block header we have */
   def getBestBlockHeader(
       implicit ec: ExecutionContext): Future[BlockHeaderDb] = {
-    getBestBlockHash.flatMap(getHeader).map(_.get)
+    for {
+      hash <- getBestBlockHash
+      headerOpt <- getHeader(hash)
+    } yield
+      headerOpt match {
+        case None =>
+          throw new RuntimeException(
+            s"We found best hash=${hash.hex} but could not retrieve the full header!!!")
+        case Some(header) => header
+      }
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
@@ -46,4 +46,10 @@ trait ChainApi {
   /** Gets the hash of the block that is what we consider "best" */
   def getBestBlockHash(
       implicit ec: ExecutionContext): Future[DoubleSha256DigestBE]
+
+  /** Gets the best block header we have */
+  def getBestBlockHeader(
+      implicit ec: ExecutionContext): Future[BlockHeaderDb] = {
+    getBestBlockHash.flatMap(getHeader).map(_.get)
+  }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
@@ -5,6 +5,7 @@ import org.bitcoins.chain.validation.{TipUpdateResult, TipValidation}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.util.BitcoinSLogger
 
+import scala.collection.{IndexedSeqLike, IterableLike, SeqLike, mutable}
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -19,8 +20,25 @@ import scala.concurrent.{ExecutionContext, Future}
   * }}}
   *
   */
-case class Blockchain(headers: Vector[BlockHeaderDb]) extends BitcoinSLogger {
+case class Blockchain(headers: Vector[BlockHeaderDb])
+    extends IndexedSeqLike[BlockHeaderDb, Vector[BlockHeaderDb]]
+    with BitcoinSLogger {
   val tip: BlockHeaderDb = headers.head
+
+  /** @inheritdoc */
+  override def newBuilder: mutable.Builder[
+    BlockHeaderDb,
+    Vector[BlockHeaderDb]] = Vector.newBuilder[BlockHeaderDb]
+
+  /** @inheritdoc */
+  override def seq: IndexedSeq[BlockHeaderDb] = headers
+
+  /** @inheritdoc */
+  override def length: Int = headers.length
+
+  /** @inheritdoc */
+  override def apply(idx: Int): BlockHeaderDb = headers(idx)
+
 }
 
 object Blockchain extends BitcoinSLogger {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -52,7 +52,7 @@ case class ChainHandler(
         val createdF = blockHeaderDAO.create(updatedHeader)
         createdF.map { header =>
           logger.debug(
-            s"Connected new header to blockchain, heigh=${header.height} hash=${header.hashBE}")
+            s"Connected new header to blockchain, height=${header.height} hash=${header.hashBE}")
           ChainHandler(blockHeaderDAO, chainConfig)
         }
       case BlockchainUpdate.Failed(_, _, reason) =>


### PR DESCRIPTION
This begins to address #453 

This starts adding re-org logic for our chain handling. This PR does two things


1. Makes our Blockchain data structure extend `IndexedSeqLike` in the scala std library so we get all of the operations we know and love from scala collections
2. Implements re-orgs in the chain project. 

The re-org logic is still fairly dumb. This will traverse back in time until the genesis block and see if we can connect the block we just received to any block. In theory this is the desired behavior -- if a miner is mining a _very_ old chain we shouldn't outright reject the block in terms of consesus, but it should _not_ force a re-org and be the new best tip.

In practice, as a lite client, we may want to consider rejecting this block since it has no chance in practice to catch up with the best POW chain -- unless there is some sort of crazy selfish mining attack happening. 

TODO: 

- [x] - test case where we receive a new block on a shorter chain that does _not_ force that shorter chain pass the longer chain in terms of height (negative test case). We should assert that the best hash is still the same. 
