### PR TITLE
 implement Ordered[T] instead of creating custom methods

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -9,26 +9,14 @@ import scodec.bits.ByteVector
 
 sealed abstract class CurrencyUnit
     extends NetworkElement
+    with Ordered[CurrencyUnit]
     with BasicArithmetic[CurrencyUnit] {
   type A
 
   def satoshis: Satoshis
 
-  def >=(c: CurrencyUnit): Boolean = {
-    satoshis.underlying >= c.satoshis.underlying
-  }
 
-  def >(c: CurrencyUnit): Boolean = {
-    satoshis.underlying > c.satoshis.underlying
-  }
-
-  def <(c: CurrencyUnit): Boolean = {
-    satoshis.underlying < c.satoshis.underlying
-  }
-
-  def <=(c: CurrencyUnit): Boolean = {
-    satoshis.underlying <= c.satoshis.underlying
-  }
+  override def compare(c: CurrencyUnit): Int = satoshis.underlying compare c.satoshis.underlying
 
   def !=(c: CurrencyUnit): Boolean = !(this == c)
 

--- a/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -15,7 +15,6 @@ sealed abstract class CurrencyUnit
 
   def satoshis: Satoshis
 
-
   override def compare(c: CurrencyUnit): Int = satoshis.underlying compare c.satoshis.underlying
 
   def !=(c: CurrencyUnit): Boolean = !(this == c)

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -16,6 +16,7 @@ import scala.util.{Failure, Success, Try}
   */
 sealed abstract class Number[T <: Number[T]]
     extends NetworkElement
+    with Ordered[T]
     with BasicArithmetic[T] {
   type A = BigInt
 
@@ -41,10 +42,8 @@ sealed abstract class Number[T <: Number[T]]
   override def *(factor: BigInt): T = apply(checkResult(underlying * factor))
   override def *(num: T): T = apply(checkResult(underlying * num.underlying))
 
-  def >(num: T): Boolean = underlying > num.underlying
-  def >=(num: T): Boolean = underlying >= num.underlying
-  def <(num: T): Boolean = underlying < num.underlying
-  def <=(num: T): Boolean = underlying <= num.underlying
+
+  override def compare(num: T): Int = underlying compare num.underlying
 
   def <<(num: Int): T = this.<<(apply(num))
   def >>(num: Int): T = this.>>(apply(num))

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -42,7 +42,6 @@ sealed abstract class Number[T <: Number[T]]
   override def *(factor: BigInt): T = apply(checkResult(underlying * factor))
   override def *(num: T): T = apply(checkResult(underlying * num.underlying))
 
-
   override def compare(num: T): Int = underlying compare num.underlying
 
   def <<(num: Int): T = this.<<(apply(num))

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/LnCurrencyUnit.scala
@@ -11,24 +11,11 @@ import scala.util.{Failure, Try}
 
 sealed abstract class LnCurrencyUnit
     extends NetworkElement
+    with Ordered[LnCurrencyUnit]
     with BasicArithmetic[LnCurrencyUnit] {
   def character: Char
 
-  def >=(ln: LnCurrencyUnit): Boolean = {
-    toPicoBitcoinValue >= ln.toPicoBitcoinValue
-  }
-
-  def >(ln: LnCurrencyUnit): Boolean = {
-    toPicoBitcoinValue > ln.toPicoBitcoinValue
-  }
-
-  def <(ln: LnCurrencyUnit): Boolean = {
-    toPicoBitcoinValue < ln.toPicoBitcoinValue
-  }
-
-  def <=(ln: LnCurrencyUnit): Boolean = {
-    toPicoBitcoinValue <= ln.toPicoBitcoinValue
-  }
+  override def compare(ln: LnCurrencyUnit): Int = toPicoBitcoinValue compare ln.toPicoBitcoinValue
 
   def !=(ln: LnCurrencyUnit): Boolean = !(this == ln)
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshis.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/currency/MilliSatoshis.scala
@@ -15,6 +15,7 @@ import scala.math.BigDecimal.RoundingMode
   */
 sealed abstract class MilliSatoshis
     extends NetworkElement
+    with Ordered[MilliSatoshis]
     with BasicArithmetic[MilliSatoshis] {
   require(toBigInt >= 0, s"Millisatoshis cannot be negative, got $toBigInt")
 
@@ -75,21 +76,7 @@ sealed abstract class MilliSatoshis
     toBigInt != ms.toBigInt
   }
 
-  def >=(ms: MilliSatoshis): Boolean = {
-    toBigInt >= ms.toBigInt
-  }
-
-  def >(ms: MilliSatoshis): Boolean = {
-    toBigInt > ms.toBigInt
-  }
-
-  def <(ms: MilliSatoshis): Boolean = {
-    toBigInt < ms.toBigInt
-  }
-
-  def <=(ms: MilliSatoshis): Boolean = {
-    toBigInt <= ms.toBigInt
-  }
+  override def compare(ms: MilliSatoshis): Int = toBigInt compare ms.toBigInt
 
   override def +(ms: MilliSatoshis): MilliSatoshis = {
     MilliSatoshis(toBigInt + ms.toBigInt)

--- a/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
@@ -44,7 +44,9 @@ sealed abstract class ScriptConstant extends ScriptToken {
 }
 
 /** Represents a [[ScriptNumber]] in the Script language. */
-sealed abstract class ScriptNumber extends ScriptConstant {
+sealed abstract class ScriptNumber
+    extends ScriptConstant
+    with Ordered[ScriptNumber] {
 
   def +(that: ScriptNumber): ScriptNumber =
     ScriptNumber(underlying + that.underlying)
@@ -57,13 +59,7 @@ sealed abstract class ScriptNumber extends ScriptConstant {
   def *(that: ScriptNumber): ScriptNumber =
     ScriptNumber(underlying * that.underlying)
 
-  def <(that: ScriptNumber): Boolean = underlying < that.underlying
-
-  def <=(that: ScriptNumber): Boolean = underlying <= that.underlying
-
-  def >(that: ScriptNumber): Boolean = underlying > that.underlying
-
-  def >=(that: ScriptNumber): Boolean = underlying >= that.underlying
+  override def compare(that: ScriptNumber): Int = underlying compare that.underlying
 
   def <(that: Int64): Boolean = underlying < that.toLong
 


### PR DESCRIPTION
Closes #436 

Scala provides the trait [Ordered](https://www.scala-lang.org/api/2.12.1/scala/math/Ordered.html).

We can implement `compare(that: A): Int ` from it and get the same functions currently written out (eg. `<=`, `>`).