### PR TITLE
Add case for empty bloom filter

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/bloom/BloomFilterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/bloom/BloomFilterTest.scala
@@ -277,4 +277,11 @@ class BloomFilterTest extends BitcoinSUnitTest {
 
     }
   }
+
+  it must "be able to instantiate a empty bloom filter" in {
+    val empty = BloomFilter.empty
+
+    empty.data must be(ByteVector.empty)
+    BloomFilter.fromBytes(empty.bytes) must be(empty)
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala
@@ -40,6 +40,7 @@ object CompactSizeUInt extends Factory[CompactSizeUInt] {
   private case class CompactSizeUIntImpl(num: UInt64, override val size: Long)
       extends CompactSizeUInt
 
+  val zero: CompactSizeUInt = CompactSizeUInt(UInt64.zero)
   override def fromBytes(bytes: ByteVector): CompactSizeUInt = {
     parseCompactSizeUInt(bytes)
   }


### PR DESCRIPTION
This can throw a divide by zero exception in the case where `numElements` is zero, this protects against that.