### PR TITLE
Add windows compatability to bitcoind RPC client

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindConfig.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindConfig.scala
@@ -331,7 +331,12 @@ object BitcoindConfig extends BitcoinSLogger {
                 "Library",
                 "Application Support",
                 "Bitcoin")
-    } else {
+    } else if (Properties.isWin) {
+      Paths.get("C:",
+        "Program Files",
+                        "Bitcoin")
+    }
+    else {
       Paths.get(Properties.userHome, ".bitcoin")
     }
     path.toFile

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -88,15 +88,15 @@ object BitcoindInstance {
 
   lazy val DEFAULT_BITCOIND_LOCATION: File = {
 
-    val cmd = Try(
+    val cmd =
       if (Properties.isWin) {
         "bitcoind.exe".!!
       } else {
         "bitcoind".!!
       }
-    ).getOrElse(
+
+    val path = Try(cmd).getOrElse(
       throw new RuntimeException("Could not locate bitcoind on user PATH"))
-    val path = cmd
     new File(path.trim)
   }
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -90,9 +90,9 @@ object BitcoindInstance {
 
     val cmd =
       if (Properties.isWin) {
-        "bitcoind.exe".!!
+        "which bitcoind.exe".!!
       } else {
-        "bitcoind".!!
+        "which bitcoind".!!
       }
 
     val path = cmd

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -9,7 +9,8 @@ import org.bitcoins.rpc.client.common.BitcoindVersion
 import scala.sys.process._
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.config.NetworkParameters
-import scala.util.Try
+
+import scala.util.{Properties, Try}
 import java.nio.file.Files
 
 /**
@@ -38,9 +39,13 @@ sealed trait BitcoindInstance extends BitcoinSLogger {
   def getVersion: BitcoindVersion = {
 
     val binaryPath = binary.getAbsolutePath
-    val foundVersion = Seq(binaryPath, "--version").!!.split("\n").head
-      .split(" ")
-      .last
+    val foundVersion = if(Properties.isWin)
+      {Seq(binaryPath, "--version").!!.split("\r\n").head.split(" ").last}
+    else{
+        Seq(binaryPath, "--version").!!.split("\n").head
+          .split(" ")
+          .last
+      }
 
     foundVersion match {
       case _: String if foundVersion.startsWith(BitcoindVersion.V16.toString) =>
@@ -84,9 +89,16 @@ object BitcoindInstance {
   }
 
   lazy val DEFAULT_BITCOIND_LOCATION: File = {
-    val path = Try("which bitcoind.exe".!!)
-      .getOrElse(
-        throw new RuntimeException("Could not locate bitcoind on user PATH"))
+
+
+    val path = if (Properties.isWin) {
+      "which bitcoind.exe".!!
+    }
+    else {
+      Try("which bitcoind".!!)
+        .getOrElse(
+          throw new RuntimeException("Could not locate bitcoind on user PATH"))
+    }
     new File(path.trim)
   }
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -39,13 +39,11 @@ sealed trait BitcoindInstance extends BitcoinSLogger {
   def getVersion: BitcoindVersion = {
 
     val binaryPath = binary.getAbsolutePath
-    val foundVersion = if(Properties.isWin)
-      {Seq(binaryPath, "--version").!!.split("\r\n").head.split(" ").last}
-    else{
-        Seq(binaryPath, "--version").!!.split("\n").head
-          .split(" ")
-          .last
-      }
+
+    val foundVersion =
+      Seq(binaryPath, "--version").!!.split(Properties.lineSeparator).head
+        .split(" ")
+        .last
 
     foundVersion match {
       case _: String if foundVersion.startsWith(BitcoindVersion.V16.toString) =>
@@ -90,15 +88,15 @@ object BitcoindInstance {
 
   lazy val DEFAULT_BITCOIND_LOCATION: File = {
 
-
-    val path = if (Properties.isWin) {
-      "which bitcoind.exe".!!
-    }
-    else {
-      Try("which bitcoind".!!)
-        .getOrElse(
-          throw new RuntimeException("Could not locate bitcoind on user PATH"))
-    }
+    val cmd = Try(
+      if (Properties.isWin) {
+        "bitcoind.exe".!!
+      } else {
+        "bitcoind".!!
+      }
+    ).getOrElse(
+      throw new RuntimeException("Could not locate bitcoind on user PATH"))
+    val path = cmd
     new File(path.trim)
   }
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -84,7 +84,7 @@ object BitcoindInstance {
   }
 
   lazy val DEFAULT_BITCOIND_LOCATION: File = {
-    val path = Try("which bitcoind".!!)
+    val path = Try("which bitcoind.exe".!!)
       .getOrElse(
         throw new RuntimeException("Could not locate bitcoind on user PATH"))
     new File(path.trim)

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -95,8 +95,7 @@ object BitcoindInstance {
         "bitcoind".!!
       }
 
-    val path = Try(cmd).getOrElse(
-      throw new RuntimeException("Could not locate bitcoind on user PATH"))
+    val path = cmd
     new File(path.trim)
   }
 


### PR DESCRIPTION
Currently trying to fix implementation to create Bitcoind instance on a windows machine. Default Directory is handled for Windows installation of bitcoin currently trying to fix issues with Regex difference between linux and DOS/Powershell. I will need to just commit to a format for or the other and try to get that working. Currently setting up Windows Terminal to see if you can just do it through that.

closes:#562