### PR TITLE
Add main method for running Mdoc

### DIFF
--- a/bitcoin-s-docs/docs.sbt
+++ b/bitcoin-s-docs/docs.sbt
@@ -1,0 +1,37 @@
+lazy val bitcoins = RootProject(file("."))
+
+lazy val publishWebsite = taskKey[Unit]("Publish website")
+
+publishWebsite := Def
+  .sequential(
+    bitcoins / Compile / unidoc,
+    Compile / docusaurusPublishGhpages
+  )
+  .value
+
+name := "bitcoin-s-docs"
+
+publish / skip := true
+
+////////
+/// Mdoc
+
+// Without this we get errors on bad links,
+// but those links are to other parts of
+// the website, AKA false errors.
+// See this issue: https://github.com/scalameta/mdoc/issues/94
+mdocExtraArguments := List("--no-link-hygiene")
+
+mdocVariables := Map(
+  "STABLE_VERSION" -> previousStableVersion.value.get,
+  "UNSTABLE_VERSION" -> version.value
+)
+
+enablePlugins(MdocPlugin, DocusaurusPlugin, BuildInfoPlugin)
+buildInfoKeys := Seq[BuildInfoKey](mdocVariables, mdocExtraArguments)
+buildInfoPackage := "org.bitcoins.docs"
+
+// Mdoc end
+///////
+
+libraryDependencies ++= Deps.docs

--- a/bitcoin-s-docs/src/main/scala/org/bitcoins/docs/DocsGen.scala
+++ b/bitcoin-s-docs/src/main/scala/org/bitcoins/docs/DocsGen.scala
@@ -1,0 +1,25 @@
+package org.bitcoins.docs
+
+import mdoc.MainSettings
+import scala.meta.io.AbsolutePath
+
+/** This is cribbed from how Bloop does
+  * docs generation: https://github.com/scalacenter/bloop/blob/6c8dc54b7bdf5a6145b31f94b73456693c0d1230/docs-gen/src/main/scala/bloop/Docs.scala#L8-L35
+  */
+object DocsGen extends App {
+  val cwd0 = AbsolutePath.workingDirectory
+
+  // Depending on who runs it (sbt vs bloop), the current working directory is different
+  val cwd =
+    if (!cwd0.resolve("docs").isDirectory) cwd0.toNIO.getParent else cwd0.toNIO
+
+  val settings = MainSettings()
+    .withSiteVariables(BuildInfo.mdocVariables)
+    .withArgs((BuildInfo.mdocExtraArguments ++ args).toList)
+    // it should work with mdoc when run inside bloop but it doesn't, let's wait until it's fixed
+    .withIn(cwd.resolve("docs"))
+    .withOut(cwd.resolve("bitcoin-s-docs").resolve("target").resolve("mdoc"))
+
+  val exitCode = mdoc.Main.process(settings)
+  if (exitCode != 0) sys.exit(exitCode)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -439,27 +439,10 @@ lazy val testkit = project
   )
   .enablePlugins(GitVersioning)
 
-lazy val publishWebsite = taskKey[Unit]("Publish website")
 
 lazy val docs = project
   .in(file("bitcoin-s-docs")) // important: it must not be docs/
   .settings(commonTestSettings: _*)
-  .settings(
-    // come back to visit this setting later
-    mdocExtraArguments := List("--no-link-hygiene"),
-    name := "bitcoin-s-docs",
-    mdocVariables := Map(
-      "STABLE_VERSION" -> previousStableVersion.value.get,
-      "UNSTABLE_VERSION" -> version.value
-    ),
-    publishWebsite := Def
-      .sequential(
-        bitcoins / Compile / unidoc,
-        Compile / docusaurusPublishGhpages
-      )
-      .value,
-    libraryDependencies ++= Deps.docs
-  )
   .dependsOn(
     bitcoindRpc,
     core,
@@ -468,7 +451,6 @@ lazy val docs = project
     testkit,
     zmq
   )
-  .enablePlugins(MdocPlugin, DocusaurusPlugin)
 
 lazy val walletDbSettings = dbFlywaySettings("walletdb")
 lazy val wallet = project

--- a/docs/contributing-website.md
+++ b/docs/contributing-website.md
@@ -52,8 +52,7 @@ yarn start
 In a separate shell:
 
 ```bash
-$ sbt
-> docs/mdoc --watch
+$ bloop run docs -- --watch
 ```
 
 The above commands compiles our Mdoc Markdown files every time you change

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,6 +13,8 @@ addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 // sbt plugin to unify scaladoc/javadoc across multiple projects
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+
 // ensure proper linkage across libraries in Scaladoc
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.1.0")
 


### PR DESCRIPTION
Closes #471 

This allows working on the website without
opening sbt at all. `bloop run docs -- --watch`
compiles all Mdoc sources and outputs it into
the correct directory.

We add a sbt plugin `sbt-buildinfo` (https://github.com/sbt/sbt-buildinfo) that allows reading values from sbt into Scala sources. This way we avoid duplication of settings logic. This plugin is hosted under the `sbt` organization on GitHub, so it should be OK to use. 