### PR TITLE
Remove useless unit test in eclair project

### DIFF
--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtilTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtilTest.scala
@@ -28,17 +28,6 @@ class EclairRpcTestUtilTest extends AsyncFlatSpec with BeforeAndAfterAll {
 
   behavior of "EclairRpcTestUtilTest"
 
-  it must "spawn a V16 bitcoind instance" in {
-    for {
-      bitcoind <- EclairRpcTestUtil.startedBitcoindRpcClient()
-      _ <- bitcoind.getNetworkInfo
-      _ <- BitcoindRpcTestUtil.stopServer(bitcoind)
-      _ <- bitcoind.getNetworkInfo
-        .map(_ => fail("got info from stopped bitcoind!"))
-        .recover { case _: StreamTcpException => }
-    } yield succeed
-  }
-
   it must "spawn four nodes and create a channel link between them" in {
     val nodes4F = bitcoindRpcF.flatMap { bitcoindRpc =>
       val nodes = EclairRpcTestUtil.createNodeLink(bitcoindRpc)


### PR DESCRIPTION
This unit test was misnamed, and doesn't really test anything useful for us. This is more than adequately covered in the bitcoindRpcTest project. The new version of eclair only supports bitcoind nodes v17+

https://github.com/ACINQ/eclair/releases/tag/v0.3