### PR TITLE
Fix issue with testkit not being able to be resolved since we could n…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,6 +135,7 @@ lazy val bitcoins = project
     chainTest,
     core,
     coreTest,
+    dbCommons,
     bitcoindRpc,
     bitcoindRpcTest,
     bench,
@@ -297,9 +298,7 @@ lazy val chain = project
   .settings(chainDbSettings: _*)
   .settings(
     name := "bitcoin-s-chain",
-    libraryDependencies ++= Deps.chain,
-    // don't publish while such a heavy WIP
-    publish / skip := true
+    libraryDependencies ++= Deps.chain
   ).dependsOn(core, dbCommons)
   .enablePlugins(FlywayPlugin)
 
@@ -389,9 +388,7 @@ lazy val node = {
     .settings(nodeDbSettings: _*)
     .settings(
       name := "bitcoin-s-node",
-      libraryDependencies ++= Deps.node,
-      // don't publish while such a heavy WIP
-      publish / skip := true
+      libraryDependencies ++= Deps.node
     )
     .dependsOn(
       core,
@@ -459,9 +456,7 @@ lazy val wallet = project
   .settings(walletDbSettings: _*)
   .settings(
     name := "bitcoin-s-wallet",
-    libraryDependencies ++= Deps.wallet,
-    // don't publish while such a heavy WIP
-    publish / skip := true
+    libraryDependencies ++= Deps.wallet
   )
   .dependsOn(core, dbCommons)
   .enablePlugins(FlywayPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -214,7 +214,8 @@ lazy val bitcoins = project
   )
   .settings(
     name := "bitcoin-s",
-    gitRemoteRepo := "git@github.com:bitcoin-s/bitcoin-s-core.git"
+    gitRemoteRepo := "git@github.com:bitcoin-s/bitcoin-s-core.git",
+    publish / skip := true
   )
 
 lazy val secp256k1jni = project


### PR DESCRIPTION
…ot find db-commons dep

This fixes #578 

This also removes the flag to skip publishing

- node 
- wallet
- chain

The origin of the bug was the fact that we didn't have `dbCommons` project in the `.aggregate` call on the root project

EDIT:

This still does not successfully publish everything, this error still occurs: 

```
[info]     published ivy to /Users/roman/.ivy2/local/org.bitcoin-s/bitcoin-s-core_2.12/0.1.0+152-d00dff56+20190708-1257-SNAPSHOT/ivys/ivy.xml
[error] java.lang.IllegalStateException: Ivy file not found in cache for org.bitcoin-s#bitcoin-s_2.12;0.1.0+152-d00dff56+20190708-1257-SNAPSHOT!
[error]     at sbt.internal.librarymanagement.ResolutionCache.getResolvedModuleDescriptor(ResolutionCache.scala:66)
[error]     at org.apache.ivy.core.deliver.DeliverEngine.deliver(DeliverEngine.java:111)
[error]     at org.apache.ivy.Ivy.deliver(Ivy.java:596)
```