### PR TITLE
Change size_on_disk to a Long

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
@@ -60,7 +60,7 @@ case class GetBlockChainInfoResult(
     verificationprogress: BigDecimal,
     initialblockdownload: Boolean,
     chainwork: String, // How should this be handled?
-    size_on_disk: Int,
+    size_on_disk: Long,
     pruned: Boolean,
     pruneheight: Option[Int],
     softforks: Vector[Softfork],


### PR DESCRIPTION
If the blockchain is above a certain size `Int` is too small, happened to me today