### PR TITLE
Add functionality for updating SPV node bloom filter 

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
@@ -18,7 +18,10 @@ object TipUpdateResult {
   }
 
   /** Means that [[org.bitcoins.core.protocol.blockchain.BlockHeader.previousBlockHashBE previousBlockHashBE]] was incorrect */
-  case class BadPreviousBlockHash(header: BlockHeader) extends Failure
+  case class BadPreviousBlockHash(header: BlockHeader) extends Failure {
+    override def toString: String =
+      s"BadPreviousBlockHash(hash=${header.hashBE}, previous=${header.previousBlockHashBE})"
+  }
 
   /** Means that [[org.bitcoins.core.protocol.blockchain.BlockHeader.nBits nBits]] was invalid */
   case class BadPOW(header: BlockHeader) extends Failure

--- a/core/src/main/scala/org/bitcoins/core/p2p/Inventory.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/Inventory.scala
@@ -8,40 +8,21 @@ import scodec.bits.ByteVector
 
 /**
   * These are used as unique identifiers inside the peer-to-peer network
+  *
+  * @param typeIdentifier The type of object which was hashed
+  * @param hash SHA256(SHA256()) hash of the object in internal byte order.
+  *
   * @see [[https://bitcoin.org/en/developer-reference#term-inventory]]
   */
-trait Inventory extends NetworkElement {
-
-  /**
-    * The type of object which was hashed
-    * @return
-    */
-  def typeIdentifier: TypeIdentifier
-
-  /**
-    * SHA256(SHA256()) hash of the object in internal byte order.
-    * @return
-    */
-  def hash: DoubleSha256Digest
+case class Inventory(typeIdentifier: TypeIdentifier, hash: DoubleSha256Digest)
+    extends NetworkElement {
 
   override def bytes: ByteVector = RawInventorySerializer.write(this)
-
-  override def toString(): String = s"Inventory($typeIdentifier, $hash)"
 }
 
 object Inventory extends Factory[Inventory] {
 
-  private case class InventoryImpl(
-      typeIdentifier: TypeIdentifier,
-      hash: DoubleSha256Digest)
-      extends Inventory
-
   override def fromBytes(bytes: ByteVector): Inventory =
     RawInventorySerializer.read(bytes)
 
-  def apply(
-      typeIdentifier: TypeIdentifier,
-      hash: DoubleSha256Digest): Inventory = {
-    InventoryImpl(typeIdentifier, hash)
-  }
 }

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -153,6 +153,18 @@ case class GetDataMessage(
   override def commandName = NetworkPayload.getDataCommandName
 
   override def bytes: ByteVector = RawGetDataMessageSerializer.write(this)
+
+  override def toString(): String = {
+
+    val count = s"inventoryCount=${inventoryCount.toInt}"
+    val invs = s"inventories=${
+      val base = inventories.toString
+      val cutoff = 100
+      if (base.length() > cutoff) base.take(cutoff) + "..."
+      else base
+    }"
+    s"GetDataMessage($count, $invs)"
+  }
 }
 
 object GetDataMessage extends Factory[GetDataMessage] {
@@ -273,9 +285,17 @@ case class HeadersMessage(count: CompactSizeUInt, headers: Vector[BlockHeader])
 
 object HeadersMessage extends Factory[HeadersMessage] {
 
+  /** The maximum amount of headers sent in one `headers` message
+    *
+    * @see [[https://bitcoin.org/en/developer-reference#getheaders bitcoin.org]]
+    *      developer reference
+    */
+  val MaxHeadersCount: Int = 2000
+
   def fromBytes(bytes: ByteVector): HeadersMessage =
     RawHeadersMessageSerializer.read(bytes)
 
+  /** Constructs a `headers` message from the given headers */
   def apply(headers: Vector[BlockHeader]): HeadersMessage = {
     val count = CompactSizeUInt(UInt64(headers.length))
     HeadersMessage(count, headers)
@@ -363,7 +383,7 @@ case object MemPoolMessage extends DataPayload {
   *
   * @see [[https://bitcoin.org/en/developer-reference#merkleblock]]
   *
-  * @param merkleBlock The actual [[org.bitcoins.core.protocol.blockchain.MerkleBlock MerkleBlock]] that this message represents 
+  * @param merkleBlock The actual [[org.bitcoins.core.protocol.blockchain.MerkleBlock MerkleBlock]] that this message represents
   */
 case class MerkleBlockMessage(merkleBlock: MerkleBlock) extends DataPayload {
 

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -17,6 +17,7 @@ import org.bitcoins.core.config.NetworkParameters
 import java.net.InetSocketAddress
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.bloom.BloomFlag
+import org.bitcoins.core.crypto.HashDigest
 
 /**
   * Trait that represents a payload for a message on the Bitcoin p2p network
@@ -617,6 +618,12 @@ object FilterAddMessage extends Factory[FilterAddMessage] {
       element: ByteVector): FilterAddMessage = {
     FilterAddMessageImpl(elementSize, element)
   }
+
+  /** Constructs a `FilterAddMessage` from the given hash digest */
+  def fromHash(hash: HashDigest): FilterAddMessage = {
+    FilterAddMessageImpl(CompactSizeUInt(UInt64(hash.bytes.length)), hash.bytes)
+  }
+
 }
 
 /**

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -1,0 +1,190 @@
+package org.bitcoins.node
+
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
+import org.scalatest.FutureOutcome
+import org.bitcoins.node.models.Peer
+import org.bitcoins.chain.models.BlockHeaderDAO
+import org.bitcoins.chain.blockchain.ChainHandler
+import org.bitcoins.testkit.node.NodeTestUtil
+import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.node.config.NodeAppConfig
+import org.bitcoins.node.networking.peer.DataMessageHandler
+import org.bitcoins.core.protocol.transaction.Transaction
+import scala.concurrent._
+import scala.concurrent.duration._
+import org.scalatest.compatible.Assertion
+import org.bitcoins.core.currency._
+import scala.util.Try
+import akka.actor.Cancellable
+import org.scalatest.run
+import org.scalatest.exceptions.TestFailedException
+import org.bitcoins.core.wallet.fee.SatoshisPerByte
+
+class UpdateBloomFilterTest extends BitcoinSWalletTest {
+  override type FixtureParam = WalletWithBitcoind
+
+  def withFixture(test: OneArgAsyncTest): FutureOutcome =
+    withFundedWalletAndBitcoind(test)
+
+  it must "update the bloom filter with an address" in { param =>
+    val WalletWithBitcoind(wallet, rpc) = param
+    implicit val chainConf: ChainAppConfig = config
+    implicit val nodeConf: NodeAppConfig = config
+
+    val assertionP = Promise[Assertion]
+    val assertionF = assertionP.future
+
+    // we want to schedule a runnable that aborts
+    // the test after a timeout, but then
+    // we need to cancel that runnable once
+    // we get a result
+    var cancelable: Option[Cancellable] = None
+    val timeout = 15.seconds
+
+    for {
+      _ <- config.initialize()
+
+      firstBloom <- wallet.getBloomFilter()
+
+      // this has to be generated after our bloom filter
+      // is calculated
+      addressFromWallet <- wallet.getNewAddress()
+      _ = logger.info(s"Address from wallet: $addressFromWallet")
+
+      spv <- {
+        val callback = SpvNodeCallbacks.onTxReceived { tx =>
+          logger.info(s"Received tx=${tx.txId} from node")
+          rpc.getRawTransaction(tx.txIdBE).foreach { res =>
+            val paysToOurAddress =
+              // we check if any of the addresses in the TX
+              // pays to our wallet address
+              res.vout.exists(_.scriptPubKey.addresses match {
+                case None            => false
+                case Some(addresses) => addresses.exists(_ == addressFromWallet)
+              })
+            cancelable.forall(_.cancel())
+            assertionP.complete {
+              Try {
+                assert(paysToOurAddress)
+              }
+            }
+          }
+        }
+
+        val peer = Peer.fromBitcoind(rpc.instance)
+        val chain = {
+          val dao = BlockHeaderDAO()
+          ChainHandler(dao, config)
+        }
+        val spv =
+          SpvNode(peer, chain, bloomFilter = firstBloom, callbacks = callback)
+        spv.start()
+      }
+      _ <- spv.sync()
+      _ <- NodeTestUtil.awaitSync(spv, rpc)
+
+      _ = spv.updateBloomFilter(addressFromWallet)
+      _ = {
+        val runnable = new Runnable {
+          override def run: Unit = {
+            logger.error(s"Failing assertionP after $timeout")
+            assertionP.failure(
+              new TestFailedException(
+                s"Did not receive a TX message after $timeout!",
+                failedCodeStackDepth = 0))
+          }
+        }
+        cancelable = Some {
+          actorSystem.scheduler.scheduleOnce(timeout, runnable)
+        }
+      }
+      _ <- rpc.sendToAddress(addressFromWallet, 1.bitcoin)
+      assertion <- assertionF
+    } yield assertion
+  }
+
+  it must "update the bloom filter with a TX" in { param =>
+    val WalletWithBitcoind(wallet, rpc) = param
+    logger.info(s"RPC datadir: ${rpc.instance.datadir}")
+    implicit val chainConf: ChainAppConfig = config
+    implicit val nodeConf: NodeAppConfig = config
+
+    val assertionP = Promise[Assertion]
+    val assertionF = assertionP.future
+
+    // we want to schedule a runnable that aborts
+    // the test after a timeout, but then
+    // we need to cancel that runnable once
+    // we get a result
+    var cancelable: Option[Cancellable] = None
+    val timeout = 1.minute
+
+    for {
+      _ <- config.initialize()
+
+      firstBloom <- wallet.getBloomFilter()
+
+      spv <- {
+        val callback = SpvNodeCallbacks.onMerkleBlockReceived { block =>
+          logger.info(s"Received merkleBlock=${block} from node")
+          ???
+        }
+
+        val peer = Peer.fromBitcoind(rpc.instance)
+        val chain = {
+          val dao = BlockHeaderDAO()
+          ChainHandler(dao, config)
+        }
+        val spv =
+          SpvNode(peer, chain, bloomFilter = firstBloom, callbacks = callback)
+        spv.start()
+      }
+      _ <- spv.sync()
+      _ <- NodeTestUtil.awaitSync(spv, rpc)
+
+      addressFromBitcoind <- rpc.getNewAddress
+      tx <- wallet.sendToAddress(addressFromBitcoind,
+                                 5.bitcoin,
+                                 SatoshisPerByte(100.sats))
+
+      _ = spv.broadcastTransaction(tx)
+      SpvNode(_, _, newBloom, _) = spv.updateBloomFilter(tx)
+      _ = assert(newBloom.contains(tx.txId))
+      _ = {
+        val runnable = new Runnable {
+          override def run: Unit = {
+            logger.error(s"Failing assertionP after $timeout")
+            assertionP.failure(
+              new TestFailedException(
+                s"Did not receive a merkle block message after $timeout!",
+                failedCodeStackDepth = 0))
+          }
+        }
+        cancelable = Some {
+          actorSystem.scheduler.scheduleOnce(timeout, runnable)
+        }
+      }
+      // this should confirm our TX
+      // since we updated the bloom filter
+      // we should get notified about the block
+      blockhash +: _ <- rpc.getNewAddress.flatMap(rpc.generateToAddress(1, _))
+      _ <- rpc.getRawTransaction(tx.txIdBE).flatMap { tx =>
+        assert(tx.confirmations.exists(_ > 0))
+        assert(tx.blockhash.contains(blockhash))
+      }
+
+      // inv message we shouldn't get
+      tx1 <- rpc.getNewAddress.flatMap(rpc.sendToAddress(_, 3.BTC))
+      _ = logger.info(s"tx1: $tx1")
+
+      // inv message we should get
+      tx2 <- wallet.getNewAddress().flatMap(rpc.sendToAddress(_, 7.bitcoin))
+      _ = logger.info(s"tx2: $tx2")
+
+      _ = logger.info(s"bitcoind generated block with hash $blockhash")
+      block <- rpc.getBlock(blockhash)
+      assertion <- assertionF
+    } yield assertion
+
+  }
+}

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -105,7 +105,6 @@ class UpdateBloomFilterTest extends BitcoinSWalletTest {
 
   it must "update the bloom filter with a TX" in { param =>
     val WalletWithBitcoind(wallet, rpc) = param
-    logger.info(s"RPC datadir: ${rpc.instance.datadir}")
     implicit val chainConf: ChainAppConfig = config
     implicit val nodeConf: NodeAppConfig = config
 
@@ -125,7 +124,7 @@ class UpdateBloomFilterTest extends BitcoinSWalletTest {
       firstBloom <- wallet.getBloomFilter()
 
       spv <- {
-        val callback = SpvNodeCallbacks.onMerkleBlockReceived { block =>
+        val callback = SpvNodeCallbacks.onMerkleBlockReceived { (block, txs) =>
           logger.info(s"Received merkleBlock=${block} from node")
           ???
         }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/MerkleBuffersTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/MerkleBuffersTest.scala
@@ -1,0 +1,82 @@
+package org.bitcoins.node.networking.peer
+
+import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.Implicits._
+import org.bitcoins.core.protocol.blockchain.MerkleBlock
+import org.bitcoins.testkit.core.gen.BlockchainElementsGenerator
+import org.bitcoins.testkit.core.gen.TransactionGenerators
+import org.scalacheck.Gen
+import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.core.protocol.blockchain.Block
+import _root_.org.scalatest.compatible.Assertion
+import scala.concurrent.Future
+import scala.util.Success
+import scala.util.Try
+import scala.util.Failure
+
+class MerkleBuffersTest extends BitcoinSUnitTest {
+  behavior of "MerkleBuffers"
+
+  /** Generating blocks and transactions take a little while,
+    * this is to prevent the test from taking a _really_ long
+    * time
+    */
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    customGenDrivenConfig(executions = 3)
+
+  it must "match a merkle block with its corresponding transactions" in {
+
+    val txsAndBlockGen: Gen[(Seq[Transaction], Seq[Transaction], Block)] = for {
+      txs <- Gen.nonEmptyListOf(TransactionGenerators.transaction)
+      otherTxs <- Gen.nonEmptyListOf(TransactionGenerators.transaction)
+      block <- BlockchainElementsGenerator.block(txs)
+    } yield (txs, otherTxs, block)
+
+    forAll(txsAndBlockGen) {
+
+      case (txs, otherTxs, block) =>
+        var receivedExpectedTXs: Option[Try[Assertion]] = None
+        var callbackCount: Int = 0
+        val callback: DataMessageHandler.OnMerkleBlockReceived = {
+          (_, merkleTxs) =>
+            receivedExpectedTXs = Some(
+              Try(
+                assert(txs == merkleTxs,
+                       "Received TXs in callback was not the ones we put in")))
+            callbackCount = callbackCount + 1
+        }
+
+        val merkle = MerkleBlock(block, txs.map(_.txId))
+        val _ = MerkleBuffers.putMerkle(merkle)
+
+        txs.map { tx =>
+          val matches = MerkleBuffers.putTx(tx, Seq(callback))
+          assert(
+            matches,
+            s"TX ${tx.txIdBE} did not match any merkle block in MerkleBuffers")
+        }
+
+        otherTxs.map { tx =>
+          val matches = MerkleBuffers.putTx(tx, Seq(callback))
+          assert(
+            !matches,
+            s"Unrelated TX ${tx.txIdBE} did match merkle block in MerkleBuffers")
+
+        }
+
+        assert(callbackCount != 0,
+               "Callback was not called after processing all TXs!")
+
+        assert(callbackCount == 1,
+               s"Callback was called multiple times: $callbackCount")
+
+        receivedExpectedTXs match {
+          case None                     => fail("Callback was never called")
+          case Some(Success(assertion)) => assertion
+          case Some(Failure(exc))       => fail(exc)
+        }
+
+    }
+
+  }
+}

--- a/node/src/main/scala/org/bitcoins/node/SpvNodeCallbacks.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNodeCallbacks.scala
@@ -16,6 +16,18 @@ case class SpvNodeCallbacks(
 
 object SpvNodeCallbacks {
 
+  /** Constructs a set of callbacks that only acts on TX received */
+  def onTxReceived(f: OnTxReceived): SpvNodeCallbacks =
+    SpvNodeCallbacks(onTxReceived = Seq(f))
+
+  /** Constructs a set of callbacks that only acts on block received */
+  def onBlockReceived(f: OnBlockReceived): SpvNodeCallbacks =
+    SpvNodeCallbacks(onBlockReceived = Seq(f))
+
+  /** Constructs a set of callbacks that only acts on merkle block received */
+  def onMerkleBlockReceived(f: OnMerkleBlockReceived): SpvNodeCallbacks =
+    SpvNodeCallbacks(onMerkleBlockReceived = Seq(f))
+
   /** Empty callbacks that does nothing with the received data */
   val empty: SpvNodeCallbacks =
     SpvNodeCallbacks(

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -287,10 +287,10 @@ object P2PClient extends P2PLogger {
                 remainingBytes.length)
               loop(newRemainingBytes, message :: accum)
             }
-          case Failure(exception) =>
+          case Failure(exc) =>
             logger.error(
-              "Failed to parse network message, could be because TCP frame isn't aligned",
-              exception)
+              s"Failed to parse network message, could be because TCP frame isn't aligned: $exc")
+
             //this case means that our TCP frame was not aligned with bitcoin protocol
             //return the unaligned bytes so we can apply them to the next tcp frame of bytes we receive
             //http://stackoverflow.com/a/37979529/967713

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -66,10 +66,10 @@ class DataMessageHandler(callbacks: SpvNodeCallbacks, chainHandler: ChainApi)(
 
         }
         FutureUtil.unit
-      case headersMsg: HeadersMessage =>
+      case HeadersMessage(count, headers) =>
+        logger.debug(s"Received headers message with ${count.toInt} headers")
         logger.trace(
-          s"Received headers message with ${headersMsg.count.toInt} headers")
-        val headers = headersMsg.headers
+          s"Received headers=${headers.map(_.hashBE.hex).mkString("[", ",", "]")}")
         val chainApiF = chainHandler.processHeaders(headers)
 
         chainApiF

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -19,6 +19,7 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.core.p2p.TypeIdentifier
 import org.bitcoins.core.p2p.MsgUnassigned
 import org.bitcoins.db.P2PLogger
+import org.bitcoins.core.p2p.Inventory
 
 /** This actor is meant to handle a [[org.bitcoins.core.p2p.DataPayload DataPayload]]
   * that a peer to sent to us on the p2p network, for instance, if we a receive a
@@ -28,9 +29,6 @@ class DataMessageHandler(callbacks: SpvNodeCallbacks, chainHandler: ChainApi)(
     implicit ec: ExecutionContext,
     appConfig: NodeAppConfig)
     extends P2PLogger {
-
-  private val callbackNum = callbacks.onBlockReceived.length + callbacks.onMerkleBlockReceived.length + callbacks.onTxReceived.length
-  logger.debug(s"Given $callbackNum of callback(s)")
 
   private val txDAO = BroadcastAbleTransactionDAO(SQLiteProfile)
 
@@ -74,23 +72,40 @@ class DataMessageHandler(callbacks: SpvNodeCallbacks, chainHandler: ChainApi)(
         val headers = headersMsg.headers
         val chainApiF = chainHandler.processHeaders(headers)
 
-        chainApiF.map { newApi =>
-          val lastHeader = headers.last
-          val lastHash = lastHeader.hash
-          newApi.getBlockCount.map { count =>
-            logger.trace(
-              s"Processed headers, most recent has height=$count and hash=$lastHash.")
+        chainApiF
+          .map { newApi =>
+            if (headers.nonEmpty) {
+
+              val lastHeader = headers.last
+              val lastHash = lastHeader.hash
+              newApi.getBlockCount.map { count =>
+                logger.trace(
+                  s"Processed headers, most recent has height=$count and hash=$lastHash.")
+              }
+              peerMsgSender.sendGetHeadersMessage(lastHash)
+            }
           }
-          peerMsgSender.sendGetHeadersMessage(lastHash)
-        }
+          .failed
+          .map { err =>
+            logger.error(s"Error when processing headers message", err)
+          }
       case msg: BlockMessage =>
         Future { callbacks.onBlockReceived.foreach(_.apply(msg.block)) }
-      case msg: TransactionMessage =>
-        Future { callbacks.onTxReceived.foreach(_.apply(msg.transaction)) }
-      case msg: MerkleBlockMessage =>
-        Future {
-          callbacks.onMerkleBlockReceived.foreach(_.apply(msg.merkleBlock))
+      case TransactionMessage(tx) =>
+        val belongsToMerkle =
+          MerkleBuffers.putTx(tx, callbacks.onMerkleBlockReceived)
+        if (belongsToMerkle) {
+          logger.trace(
+            s"Transaction=${tx.txIdBE} belongs to merkleblock, not calling callbacks")
+          FutureUtil.unit
+        } else {
+          logger.trace(
+            s"Transaction=${tx.txIdBE} does not belong to merkleblock, processing given callbacks")
+          Future { callbacks.onTxReceived.foreach(_.apply(tx)) }
         }
+      case MerkleBlockMessage(merkleBlock) =>
+        MerkleBuffers.putMerkle(merkleBlock)
+        FutureUtil.unit
       case invMsg: InventoryMessage =>
         handleInventoryMsg(invMsg = invMsg, peerMsgSender = peerMsgSender)
     }
@@ -100,7 +115,11 @@ class DataMessageHandler(callbacks: SpvNodeCallbacks, chainHandler: ChainApi)(
       invMsg: InventoryMessage,
       peerMsgSender: PeerMessageSender): Future[Unit] = {
     logger.info(s"Received inv=${invMsg}")
-    val getData = GetDataMessage(invMsg.inventories)
+    val getData = GetDataMessage(invMsg.inventories.map {
+      case Inventory(TypeIdentifier.MsgBlock, hash) =>
+        Inventory(TypeIdentifier.MsgFilteredBlock, hash)
+      case other: Inventory => other
+    })
     peerMsgSender.sendMsg(getData)
     FutureUtil.unit
 
@@ -112,8 +131,8 @@ object DataMessageHandler {
   /** Callback for handling a received block */
   type OnBlockReceived = Block => Unit
 
-  /** Callback for handling a received Merkle block */
-  type OnMerkleBlockReceived = MerkleBlock => Unit
+  /** Callback for handling a received Merkle block with its corresponding TXs */
+  type OnMerkleBlockReceived = (MerkleBlock, Vector[Transaction]) => Unit
 
   /** Callback for handling a received transaction */
   type OnTxReceived = Transaction => Unit

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -83,6 +83,11 @@ class DataMessageHandler(callbacks: SpvNodeCallbacks, chainHandler: ChainApi)(
                   s"Processed headers, most recent has height=$count and hash=$lastHash.")
               }
               peerMsgSender.sendGetHeadersMessage(lastHash)
+
+              if (headers.length == 1) {
+                peerMsgSender.sendGetDataMessage(headers: _*)
+              }
+
             }
           }
           .failed

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/MerkleBuffers.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/MerkleBuffers.scala
@@ -31,7 +31,11 @@ private[peer] object MerkleBuffers extends BitcoinSLogger {
 
     if (matches.nonEmpty) {
       logger.trace(s"Adding merkleBlock=${merkle.blockHeader.hashBE} to buffer")
-      underlyingMap.put(merkle, Vector.newBuilder)
+      underlyingMap.put(merkle,
+                        // it's important to use a collection
+                        // type that can call .result() without
+                        // clearing the builder
+                        Vector.newBuilder)
     } else {
       logger.trace(
         s"Merkleblock=${merkle.blockHeader.hashBE} has no matches, not adding to buffer")

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/MerkleBuffers.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/MerkleBuffers.scala
@@ -1,0 +1,111 @@
+package org.bitcoins.node.networking.peer
+
+import org.bitcoins.core.util.BitcoinSLogger
+import scala.collection.mutable
+import org.bitcoins.core.protocol.blockchain.MerkleBlock
+import org.bitcoins.core.protocol.transaction.Transaction
+
+/**
+  * A buffer of merkleblocks and the transactions associated with them.
+  *
+  * When receiving a merkleblock message over the P2P network, the
+  * corresponding transactions are sent immediately after. That means
+  * we have to correlate the received merkleblocks with the matching
+  * transactions.
+  *
+  * This buffer is responsible for calling the approriate callbacks
+  * once a merkle block has received all its transactions.
+  */
+private[peer] object MerkleBuffers extends BitcoinSLogger {
+  private type MerkleBlocksWithTransactions =
+    mutable.Map[MerkleBlock, mutable.Builder[Transaction, Vector[Transaction]]]
+
+  private val underlyingMap: MerkleBlocksWithTransactions = mutable.Map.empty
+
+  /** Adds the given merkleblock to the buffer */
+  def putMerkle(merkle: MerkleBlock): Unit = {
+    val tree = merkle.partialMerkleTree
+    val matches = tree.extractMatches
+
+    logger.debug(s"Received merkle block, expecting ${matches.length} TX(s)")
+
+    if (matches.nonEmpty) {
+      logger.trace(s"Adding merkleBlock=${merkle.blockHeader.hashBE} to buffer")
+      underlyingMap.put(merkle, Vector.newBuilder)
+    } else {
+      logger.trace(
+        s"Merkleblock=${merkle.blockHeader.hashBE} has no matches, not adding to buffer")
+    }
+
+    ()
+  }
+
+  /** Attempts to add the given transaction to a corresponding
+    * merkleblock in the buffer.
+    *
+    * @param tx The transaction to (maybe) add to the buffer
+    * @param callbacks The callbacks to execute if we're
+    *        finished processing a merkleblock
+    *
+    * @return If the transaction matches a merkle block, returns true.
+    *         Otherwise, false.
+    */
+  def putTx(
+      tx: Transaction,
+      callbacks: Seq[DataMessageHandler.OnMerkleBlockReceived]): Boolean = {
+    val blocksInBuffer = underlyingMap.keys.toList
+    logger.trace(s"Looking for transaction=${tx.txIdBE} in merkleblock buffer")
+    logger.trace(s"Merkleblocks in buffer: ${blocksInBuffer.length}")
+    blocksInBuffer.find { block =>
+      val matches = block.partialMerkleTree.extractMatches
+
+      logger.trace(
+        s"Block=${block.blockHeader.hashBE} has matches=${matches.map(_.flip)}")
+
+      matches.exists(_ == tx.txId)
+    } match {
+      case None =>
+        logger.debug(
+          s"Transaction=${tx.txIdBE} does not belong to any merkle block")
+        false
+      case Some(key) =>
+        handleMerkleMatch(tx, merkleBlock = key, callbacks = callbacks)
+    }
+  }
+
+  // TODO Scaladoc
+  private def handleMerkleMatch(
+      transaction: Transaction,
+      merkleBlock: MerkleBlock,
+      callbacks: Seq[DataMessageHandler.OnMerkleBlockReceived]) = {
+    val merkleBlockMatches = merkleBlock.partialMerkleTree.extractMatches
+    val merkleHash = merkleBlock.blockHeader.hashBE
+
+    val txHash = transaction.txIdBE
+
+    logger.debug(s"Transaction=$txHash matched merkleBlock=$merkleHash")
+
+    logger.trace(s"Adding transaction=$txHash to buffer")
+    val builder = underlyingMap(merkleBlock) // TODO: error handling
+    builder += transaction
+
+    val transactionSoFar = builder.result()
+    val transactionSoFarCount = transactionSoFar.length
+    val matchesCount = merkleBlockMatches.length
+    if (transactionSoFarCount == matchesCount) {
+      logger.debug(
+        s"We've received all transactions ($transactionSoFarCount) for merkleBlock=$merkleHash")
+
+      logger.trace(s"Removing merkle block from buffer")
+      underlyingMap.remove(merkleBlock) // TODO: error handling
+
+      logger.trace(s"Calling merkle block callback(s)")
+      callbacks.foreach(_.apply(merkleBlock, transactionSoFar))
+    } else {
+      logger.trace(
+        s"We've received $transactionSoFarCount, expecting $matchesCount")
+      assert(transactionSoFarCount < matchesCount)
+    }
+    true
+  }
+}

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -11,6 +11,7 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.db.P2PLogger
 import org.bitcoins.core.crypto.HashDigest
 import org.bitcoins.core.bloom.BloomFilter
+import org.bitcoins.core.protocol.blockchain.BlockHeader
 
 case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     extends P2PLogger {
@@ -88,6 +89,16 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
   def sendTransactionMessage(transaction: Transaction): Unit = {
     val message = TransactionMessage(transaction)
     logger.trace(s"Sending txmessage=$message to peer=${client.peer}")
+    sendMsg(message)
+  }
+
+  /** Sends a request for filtered blocks matching the given headers */
+  def sendGetDataMessage(headers: BlockHeader*): Unit = {
+    val inventories =
+      headers.map(header =>
+        Inventory(TypeIdentifier.MsgFilteredBlock, header.hash))
+    val message = GetDataMessage(inventories)
+    logger.info(s"Sending getdata=$message to peer=${client.peer}")
     sendMsg(message)
   }
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -9,6 +9,8 @@ import org.bitcoins.node.networking.P2PClient
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.db.P2PLogger
+import org.bitcoins.core.crypto.HashDigest
+import org.bitcoins.core.bloom.BloomFilter
 
 case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     extends P2PLogger {
@@ -64,6 +66,22 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
       transactions.map(tx => Inventory(TypeIdentifier.MsgTx, tx.txId))
     val message = InventoryMessage(inventories)
     logger.trace(s"Sending inv=$message to peer=${client.peer}")
+    sendMsg(message)
+  }
+
+  def sendFilterClearMessage(): Unit = {
+    sendMsg(FilterClearMessage)
+  }
+
+  def sendFilterAddMessage(hash: HashDigest): Unit = {
+    val message = FilterAddMessage.fromHash(hash)
+    logger.trace(s"Sending filteradd=$message to peer=${client.peer}")
+    sendMsg(message)
+  }
+
+  def sendFilterLoadMessage(bloom: BloomFilter): Unit = {
+    val message = FilterLoadMessage(bloom)
+    logger.trace(s"Sending filterload=$message to peer=${client.peer}")
     sendMsg(message)
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -116,12 +116,30 @@ abstract class NodeTestUtil extends BitcoinSLogger {
     }
   }
 
-  /** Awaits sync between the given SPV node and bitcoind client */
+  /** Checks if the given light client and bitcoind
+    * has the same number of blocks in their blockchains
+    */
+  def isSameBlockCount(spv: SpvNode, rpc: BitcoindRpcClient)(
+      implicit ec: ExecutionContext): Future[Boolean] = {
+    val rpcCountF = rpc.getBlockCount
+    val spvCountF = spv.chainApi.getBlockCount
+    for {
+      spvCount <- spvCountF
+      rpcCount <- rpcCountF
+    } yield rpcCount == spvCount
+  }
+
+  /** Awaits sync between the given SPV node and bitcoind client
+    *
+    * TODO: We should check for hash, not block height. however,
+    * our way of determining what the best hash is when having
+    * multiple tips is not good enough yet
+    */
   def awaitSync(node: SpvNode, rpc: BitcoindRpcClient)(
       implicit sys: ActorSystem): Future[Unit] = {
     import sys.dispatcher
     TestAsyncUtil
-      .retryUntilSatisfiedF(() => isSameBestHash(node, rpc), 500.milliseconds)
+      .retryUntilSatisfiedF(() => isSameBlockCount(node, rpc), 500.milliseconds)
   }
 
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -19,7 +19,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.rpc.util.AsyncUtil
+import org.bitcoins.testkit.async.TestAsyncUtil
 import org.bitcoins.core.bloom.BloomFilter
 import org.bitcoins.core.bloom.BloomUpdateAll
 
@@ -120,7 +120,7 @@ abstract class NodeTestUtil extends BitcoinSLogger {
   def awaitSync(node: SpvNode, rpc: BitcoindRpcClient)(
       implicit sys: ActorSystem): Future[Unit] = {
     import sys.dispatcher
-    AsyncUtil
+    TestAsyncUtil
       .retryUntilSatisfiedF(() => isSameBestHash(node, rpc), 500.milliseconds)
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletBloomTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletBloomTest.scala
@@ -15,7 +15,7 @@ class WalletBloomTest extends BitcoinSWalletTest {
   override type FixtureParam = WalletWithBitcoind
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withNewWalletAndBitcoind(test)
+    withFundedWalletAndBitcoind(test)
 
   it should "generate a bloom filter that matches the pubkeys in our wallet" in {
     param =>
@@ -32,19 +32,12 @@ class WalletBloomTest extends BitcoinSWalletTest {
       }
   }
 
-  // TODO: change fixture to withFundedWalletAndBitcoind once #577 goes in
-  // https://github.com/bitcoin-s/bitcoin-s/pull/577/files#diff-0fb6ac004fe1e550b7c13258d7d0706cR154
   it should "generate a bloom filter that matches the outpoints in our wallet" in {
     param =>
       val WalletWithBitcoind(walletApi, bitcoind) = param
       val wallet = walletApi.asInstanceOf[Wallet]
 
       for {
-        address <- wallet.getNewAddress()
-        tx <- bitcoind
-          .sendToAddress(address, 5.bitcoins)
-          .flatMap(bitcoind.getRawTransaction(_))
-        _ <- wallet.processTransaction(tx.hex, confirmations = 0)
         outpoints <- wallet.listOutpoints()
 
         bloom <- wallet.getBloomFilter()

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -28,7 +28,7 @@ private[wallet] trait TransactionProcessing extends KeyHandlingLogger {
     logger.info(
       s"Processing transaction=${transaction.txIdBE} with confirmations=$confirmations")
     processTransactionImpl(transaction, confirmations).map {
-      case ProcessTxResult(outgoing, incoming) =>
+      case ProcessTxResult(incoming, outgoing) =>
         logger.info(
           s"Finished processing of transaction=${transaction.txIdBE}. Relevant incomingTXOs=${incoming.length}, outgoingTXOs=${outgoing.length}")
         this


### PR DESCRIPTION
Int this PR we add functionality in the SPV node for updating its bloom filter. I _believe_ this is done correctly, although there's a failing test here where we try and verify we're receiving filtered blocks from our peer. The block is never sent to us, but I _think_ that's because we need to explicitly request it when receiving a `headers` message. 

UPDATE: Added MerkleBuffers and changed the logic for how to process merkleblocks and transactions. From the latest commit message: 

In this commit we add MerkleBuffers, which is an object
that lets us aggreagate merkleblocks with their corresponding
transactions before sending them out. This is global, mutable
state (bad!) but it's a working solution for now;
