### PR TITLE
Fixed Incorrect Windows Default Datadir

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindConfig.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindConfig.scala
@@ -333,10 +333,12 @@ object BitcoindConfig extends BitcoinSLogger {
                 "Bitcoin")
     } else if (Properties.isWin) {
       Paths.get("C:",
-        "Program Files",
-                        "Bitcoin")
-    }
-    else {
+                "Users",
+                Properties.userName,
+                "Appdata",
+                "Roaming",
+                "Bitcoin")
+    } else {
       Paths.get(Properties.userHome, ".bitcoin")
     }
     path.toFile


### PR DESCRIPTION
Originally when testing I pointed the datadir to an incorrect directory which passed tests because I had a bitcoin.conf file to read from there. This fix is the true default datadir and will read the place most users have their bitcoin.conf file stored. 