### PR TITLE
Fix ImplicitsTest

### DIFF
--- a/testkit/src/test/scala/org/bitcoins/testkit/ImplicitsTest.scala
+++ b/testkit/src/test/scala/org/bitcoins/testkit/ImplicitsTest.scala
@@ -3,7 +3,6 @@ package org.bitcoins.testkit
 import util.BitcoinSUnitTest
 import Implicits._
 import org.scalatest.exceptions.TestFailedException
-import ammonite.terminal.LazyList
 
 class ImplicitsTest extends BitcoinSUnitTest {
 
@@ -42,7 +41,7 @@ class ImplicitsTest extends BitcoinSUnitTest {
   }
 
   it should "fail to flatten an empty list" in {
-    intercept[IllegalArgumentException] {
+    intercept[TestFailedException] {
       val xs = List.empty[org.scalatest.Assertion]
       xs.toAssertion
     }

--- a/testkit/src/test/scala/org/bitcoins/testkit/db/AppConfigTest.scala
+++ b/testkit/src/test/scala/org/bitcoins/testkit/db/AppConfigTest.scala
@@ -19,7 +19,6 @@ import org.bitcoins.core.hd.HDCoin
 import org.bitcoins.core.hd.HDPurposes
 import org.bitcoins.core.hd.HDCoinType
 import org.bitcoins.testkit.core.gen.CryptoGenerators
-import os.write
 import org.bitcoins.node.db.NodeDbManagement
 import org.bitcoins.db.DbManagement
 import org.bitcoins.wallet.db.WalletDbManagement


### PR DESCRIPTION
So we recently merged a PR that changed the type of exception thrown by `AssertionSeqOps#toAssertion` without updating the corresponding test. That's what happens when CI is unreliable:-(