### PR TITLE
Add more P2P type identifiers

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/p2p/TypeIdentifierTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/TypeIdentifierTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.p2p
 
-import org.bitcoins.core.p2p.TypeIdentifier.{MsgBlock, MsgFilteredBlock, MsgTx}
+import org.bitcoins.core.p2p.TypeIdentifier._
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 class TypeIdentifierTest extends BitcoinSUnitTest {
@@ -9,11 +9,24 @@ class TypeIdentifierTest extends BitcoinSUnitTest {
     MsgTx.hex must be("01000000")
   }
 
+  "MsgWitnessTx" must "serialize to 01000040" in {
+    MsgWitnessTx.hex must be("01000040")
+  }
+
   "MsgBlock" must "serialize to 02000000" in {
     MsgBlock.hex must be("02000000")
+  }
+
+  "MsgWitnessBlock" must "serialize to 02000040" in {
+    MsgWitnessBlock.hex must be("02000040")
   }
 
   "MsgFilteredBlock" must "serialize to 03000000" in {
     MsgFilteredBlock.hex must be("03000000")
   }
+
+  "MsgFilteredWitnessBlock" must "serialize to 03000040" in {
+    MsgFilteredWitnessBlock.hex must be("03000040")
+  }
+
 }

--- a/core/src/main/scala/org/bitcoins/core/p2p/TypeIdentifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/TypeIdentifier.scala
@@ -32,6 +32,51 @@ object TypeIdentifier extends Factory[TypeIdentifier] {
     override val num = UInt32(3)
   }
 
+  /**
+    * The hash is of a block header; identical to `MsgBlock`. When used in
+    * a `getdata` message, this indicates the response should be a `cmpctblock`
+    * message. Only for use in `getdata` messages.
+    */
+  final case object MsgCompactBlock extends TypeIdentifier {
+    val num: UInt32 = UInt32(4)
+  }
+
+  /**
+    * The hash is a TXID. When used in a `getdata` message, this indicates
+    * the response should be a transaction message, if the witness structure
+    * is nonempty, the witness serialization will be used. Only for use in
+    * `getdata` messages.
+    */
+  final case object MsgWitnessTx extends TypeIdentifier {
+
+    val num: UInt32 = MsgTx.num | MsgWitnessFlag
+  }
+
+  /**
+    * The hash is of a block header; identical to `MsgBlock`. When
+    * used in a `getdata` message, this indicates the response should
+    * be a block message with transactions that have a witness using
+    * witness serialization. Only for use in `getdata` messages.
+    */
+  final case object MsgWitnessBlock extends TypeIdentifier {
+    val num: UInt32 = MsgBlock.num | MsgWitnessFlag
+  }
+
+  /**
+    * Reserved for future use, not used as of Protocol Version 70015.
+    */
+  final case object MsgFilteredWitnessBlock extends TypeIdentifier {
+    val num: UInt32 = MsgFilteredBlock.num | MsgWitnessFlag
+  }
+
+  /**
+    * from the docs at https://bitcoin.org/en/developer-reference#data-messages
+    * These (witness block and tx) are the same as their respective type
+    * identifier but with their 30th bit set to indicate witness.
+    * For example MSG_WITNESS_TX = 0x01000040.
+    */
+  private val MsgWitnessFlag = UInt32(1 << 30)
+
   private case class MsgUnassignedImpl(num: UInt32) extends MsgUnassigned
 
   override def fromBytes(bytes: ByteVector): TypeIdentifier =


### PR DESCRIPTION
In this PR we add type identifers for P2P
messages we hadn't previously implemented. Note
that these aren't used anywhere yet.