### PR TITLE
 Clean up build config and fix CI errors

### DIFF
--- a/app/picklers/picklers.sbt
+++ b/app/picklers/picklers.sbt
@@ -2,4 +2,4 @@ name := "bitcoin-s-app-picklers"
 
 publish / skip := true
 
-libraryDependencies := Deps.picklers
+libraryDependencies ++= Deps.picklers

--- a/bitcoin-s-docs/docs.sbt
+++ b/bitcoin-s-docs/docs.sbt
@@ -1,10 +1,10 @@
-lazy val bitcoins = RootProject(file("."))
+lazy val `bitcoin-s` = RootProject(file("."))
 
 lazy val publishWebsite = taskKey[Unit]("Publish website")
 
 publishWebsite := Def
   .sequential(
-    bitcoins / Compile / unidoc,
+    `bitcoin-s` / Compile / unidoc,
     Compile / docusaurusPublishGhpages
   )
   .value
@@ -22,12 +22,17 @@ publish / skip := true
 // See this issue: https://github.com/scalameta/mdoc/issues/94
 mdocExtraArguments := List("--no-link-hygiene")
 
+// these variables gets passed to mdoc, and can be read
+// from there
 mdocVariables := Map(
   "STABLE_VERSION" -> previousStableVersion.value.get,
   "UNSTABLE_VERSION" -> version.value
 )
 
-enablePlugins(MdocPlugin, DocusaurusPlugin, BuildInfoPlugin)
+enablePlugins(MdocPlugin, DocusaurusPlugin)
+
+// this expoes the values below as typed values in Scala sources
+enablePlugins(BuildInfoPlugin)
 buildInfoKeys := Seq[BuildInfoKey](mdocVariables, mdocExtraArguments)
 buildInfoPackage := "org.bitcoins.docs"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,18 +1,17 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.8")
-
+// bundle up Scala applications into packaging formats such as Docker,
+// GraalVM native-image, executable JARs etc
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.14")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0-M5")
+// collect code coverage when executing tests
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
+// report code coverage to Coveralls
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
-
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 
 // sbt plugin to unify scaladoc/javadoc across multiple projects
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 
+// export typed values from sbt configuration into Scala sources
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 // ensure proper linkage across libraries in Scaladoc
@@ -28,4 +27,5 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.6")
 // write markdown files with type-checked Scala
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.3.0")
 
+// SQL migrations
 addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % "5.2.0")


### PR DESCRIPTION
In this PR we:
1) Fix a bug where picklers.sbt did `libraryDependencies := ...`
    instead of `libraryDependencies ++= ...`. This caused Scoverage
    to error, because a dependency it needed got removed.
2) Remove some unused sbt plugins and tasks/settings
3) Add more comments, that cleary explain what's happening.

Point 1) fixes the issues we've been having with CI lately. 