### PR TITLE
Replace akka-http with sttp

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
@@ -9,7 +9,6 @@ import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoindRpcTest
 
 import scala.io.Source
-import akka.stream.StreamTcpException
 import java.nio.file.Paths
 import scala.util.Properties
 import org.bitcoins.rpc.config.BitcoindConfig
@@ -142,7 +141,7 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
           fail("Was able to connect to bitcoind after shutting down")
         }
         .recover {
-          case _: StreamTcpException =>
+          case _: java.net.ConnectException =>
             ()
         }
     } yield assert(balance > Bitcoins(0))

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -2,8 +2,8 @@ package org.bitcoins.rpc.client.common
 
 import java.io.File
 
-import akka.actor.ActorSystem
 import org.bitcoins.rpc.config.{BitcoindConfig, BitcoindInstance}
+import scala.concurrent.ExecutionContext
 
 /**
   * This class is not guaranteed to be compatible with any particular
@@ -20,8 +20,7 @@ import org.bitcoins.rpc.config.{BitcoindConfig, BitcoindInstance}
   * on the errors, and handle them as you see fit.
   */
 class BitcoindRpcClient(val instance: BitcoindInstance)(
-    implicit
-    override val system: ActorSystem)
+    implicit ec: ExecutionContext)
     extends Client
     with BlockchainRpc
     with MessageRpc
@@ -49,7 +48,7 @@ object BitcoindRpcClient {
     * the default datadir if no directory is provided
     */
   def fromDatadir(datadir: File = BitcoindConfig.DEFAULT_DATADIR)(
-      implicit system: ActorSystem): BitcoindRpcClient = {
+      implicit ec: ExecutionContext): BitcoindRpcClient = {
     val instance = BitcoindInstance.fromDatadir(datadir)
     val cli = new BitcoindRpcClient(instance)
     cli

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v16/BitcoindV16RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v16/BitcoindV16RpcClient.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.rpc.client.v16
 
-import akka.actor.ActorSystem
 import org.bitcoins.core.crypto.ECPrivateKey
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.script.crypto.HashType
@@ -17,6 +16,7 @@ import play.api.libs.json._
 
 import scala.concurrent.Future
 import scala.util.Try
+import scala.concurrent.ExecutionContext
 
 /**
   * This class is compatible with version 0.16 of Bitcoin Core.
@@ -24,8 +24,7 @@ import scala.util.Try
   * @see [[org.bitcoins.rpc.client.common.BitcoindRpcClient BitcoindRpcClient Scaladocs]]
   */
 class BitcoindV16RpcClient(override val instance: BitcoindInstance)(
-    implicit
-    actorSystem: ActorSystem)
+    implicit ec: ExecutionContext)
     extends BitcoindRpcClient(instance)
     with V16AccountRpc
     with V16SendRpc {
@@ -78,7 +77,7 @@ class BitcoindV16RpcClient(override val instance: BitcoindInstance)(
 object BitcoindV16RpcClient {
 
   def fromUnknownVersion(rpcClient: BitcoindRpcClient)(
-      implicit actorSystem: ActorSystem): Try[BitcoindV16RpcClient] =
+      implicit ec: ExecutionContext): Try[BitcoindV16RpcClient] =
     Try {
       new BitcoindV16RpcClient(rpcClient.instance)
     }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v17/BitcoindV17RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v17/BitcoindV17RpcClient.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.rpc.client.v17
 
-import akka.actor.ActorSystem
 import org.bitcoins.core.crypto.ECPrivateKey
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.Transaction
@@ -22,6 +21,7 @@ import play.api.libs.json.{JsArray, JsBoolean, JsString, Json}
 
 import scala.concurrent.Future
 import scala.util.Try
+import scala.concurrent.ExecutionContext
 
 /**
   * This class is compatible with version 0.17 of Bitcoin Core.
@@ -35,8 +35,7 @@ import scala.util.Try
   *                   These RPC calls are now separated out into two distinct calls.
   */
 class BitcoindV17RpcClient(override val instance: BitcoindInstance)(
-    implicit
-    actorSystem: ActorSystem)
+    implicit ec: ExecutionContext)
     extends BitcoindRpcClient(instance)
     with V17LabelRpc
     with V17PsbtRpc {
@@ -98,7 +97,7 @@ class BitcoindV17RpcClient(override val instance: BitcoindInstance)(
 object BitcoindV17RpcClient {
 
   def fromUnknownVersion(rpcClient: BitcoindRpcClient)(
-      implicit actorSystem: ActorSystem): Try[BitcoindV17RpcClient] =
+      implicit ec: ExecutionContext): Try[BitcoindV17RpcClient] =
     Try {
       new BitcoindV17RpcClient(rpcClient.instance)
     }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -10,8 +10,8 @@ import scala.sys.process._
 import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.config.NetworkParameters
 
-import scala.util.{Properties, Try}
 import java.nio.file.Files
+import scala.util.Properties
 
 /**
   * Created by chris on 4/29/17.

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/RpcUtil.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/RpcUtil.scala
@@ -2,7 +2,6 @@ package org.bitcoins.rpc.util
 
 import java.net.ServerSocket
 
-import akka.actor.ActorSystem
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 
 import scala.annotation.tailrec
@@ -10,13 +9,14 @@ import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Random, Success, Try}
+import scala.concurrent.ExecutionContext
 
 abstract class RpcUtil extends AsyncUtil {
 
   def awaitServerShutdown(
       server: BitcoindRpcClient,
       duration: FiniteDuration = 300.milliseconds,
-      maxTries: Int = 50)(implicit system: ActorSystem): Future[Unit] = {
+      maxTries: Int = 50)(implicit ec: ExecutionContext): Future[Unit] = {
     retryUntilSatisfiedF(() => server.isStoppedF, duration, maxTries)
   }
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.blockchain
 
-import akka.actor.ActorSystem
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.chain.fixture.BitcoindChainHandlerViaZmq
@@ -11,8 +10,6 @@ import scala.concurrent.Future
 class BitcoindChainHandlerViaZmqTest extends ChainUnitTest {
 
   override type FixtureParam = BitcoindChainHandlerViaZmq
-
-  override implicit val system: ActorSystem = ActorSystem("ChainUnitTest")
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBitcoindChainHandlerViaZmq(test)

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.blockchain
 
-import akka.actor.ActorSystem
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainUnitTest}
 import org.scalatest.FutureOutcome
@@ -11,8 +10,6 @@ class BlockchainTest extends ChainUnitTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBlockHeaderDAO(test)
-
-  override implicit val system: ActorSystem = ActorSystem("BlockchainTest")
 
   behavior of "Blockchain"
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.blockchain
 
-import akka.actor.ActorSystem
 import org.bitcoins.chain.api.ChainApi
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.{
@@ -26,8 +25,6 @@ import org.bitcoins.testkit.BitcoinSTestAppConfig
 class ChainHandlerTest extends ChainUnitTest {
 
   override type FixtureParam = ChainHandler
-
-  implicit override val system = ActorSystem("ChainUnitTest")
 
   // we're working with mainnet data
   implicit override lazy val appConfig: ChainAppConfig = {

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.blockchain.sync
 
-import akka.actor.ActorSystem
 import org.bitcoins.chain.api.ChainApi
 import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.testkit.chain.ChainUnitTest
@@ -11,9 +10,6 @@ import scala.concurrent.Future
 
 class ChainSyncTest extends ChainUnitTest {
   override type FixtureParam = BitcoindChainHandlerViaRpc
-
-  override implicit val system = ActorSystem(
-    s"chain-sync-test-${System.currentTimeMillis()}")
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     withBitcoindChainHandlerViaRpc(test)

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.models
 
-import akka.actor.ActorSystem
 import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainUnitTest}
 import org.scalatest.FutureOutcome
 
@@ -15,8 +14,6 @@ class BlockHeaderDAOTest extends ChainUnitTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBlockHeaderDAO(test)
-
-  override implicit val system: ActorSystem = ActorSystem("BlockHeaderDAOTest")
 
   behavior of "BlockHeaderDAO"
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.pow
 
-import akka.actor.ActorSystem
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.core.protocol.blockchain.MainNetChainParams
@@ -25,8 +24,6 @@ class BitcoinPowTest extends ChainUnitTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withChainFixture(test)
-
-  implicit override val system: ActorSystem = ActorSystem("BitcoinPowTest")
 
   behavior of "BitcoinPow"
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.validation
 
-import akka.actor.ActorSystem
 import org.bitcoins.chain.db.ChainDbManagement
 import org.bitcoins.chain.models.{
   BlockHeaderDAO,
@@ -29,8 +28,6 @@ class TipValidationTest extends ChainUnitTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBlockHeaderDAO(test)
-
-  implicit override val system: ActorSystem = ActorSystem("TipValidationTest")
 
   behavior of "TipValidation"
 

--- a/core-test/src/test/scala/org/bitcoins/core/util/FutureUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/FutureUtilTest.scala
@@ -5,14 +5,9 @@ import scala.concurrent.duration._
 import scala.concurrent._
 import org.scalatest.compatible.Assertion
 import org.scalatest.AsyncFlatSpec
-import akka.actor.ActorSystem
 
 class FutureUtilTest extends AsyncFlatSpec with BitcoinSLogger {
   it must "execute futures sequentially in the correct order" in {
-
-    val actorSystem = ActorSystem()
-    implicit val ec = actorSystem.dispatcher
-    val scheduler = actorSystem.scheduler
 
     val assertionP = Promise[Assertion]()
     val assertionF = assertionP.future

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -1,8 +1,5 @@
 package org.bitcoins.eclair.rpc
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.testkit.TestKit
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits, Satoshis}
 import org.bitcoins.core.number.{Int64, UInt64}
@@ -23,17 +20,13 @@ import org.slf4j.Logger
 import scala.concurrent._
 import scala.concurrent.duration.DurationInt
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import akka.stream.StreamTcpException
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.ln.{LnHumanReadablePart, LnInvoice, PaymentPreimage}
 import scala.concurrent.duration._
+import java.net.ConnectException
 
 class EclairRpcClientTest extends AsyncFlatSpec with BeforeAndAfterAll {
 
-  implicit val system: ActorSystem =
-    ActorSystem("EclairRpcClient", BitcoindRpcTestUtil.AKKA_CONFIG)
-  implicit val m: ActorMaterializer = ActorMaterializer.create(system)
-  implicit val ec: ExecutionContext = m.executionContext
   implicit val bitcoinNp: RegTest.type = EclairRpcTestUtil.network
 
   val logger: Logger = BitcoinSLogger.logger
@@ -308,7 +301,7 @@ class EclairRpcClientTest extends AsyncFlatSpec with BeforeAndAfterAll {
       _ <- eclair.getInfo
         .map(_ => fail("Got info from a closed node!"))
         .recover {
-          case _: StreamTcpException => ()
+          case _: ConnectException => ()
         }
     } yield succeed
   }
@@ -1052,6 +1045,5 @@ class EclairRpcClientTest extends AsyncFlatSpec with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {
     clients.result().foreach(EclairRpcTestUtil.shutdown)
-    TestKit.shutdownActorSystem(system)
   }
 }

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtilTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtilTest.scala
@@ -1,16 +1,10 @@
 package org.bitcoins.eclair.rpc
-import akka.actor.ActorSystem
-import akka.testkit.TestKit
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
 import org.bitcoins.testkit.eclair.rpc.EclairRpcTestUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.scalatest.{AsyncFlatSpec, BeforeAndAfterAll}
-import akka.stream.StreamTcpException
 
 class EclairRpcTestUtilTest extends AsyncFlatSpec with BeforeAndAfterAll {
-
-  implicit private val actorSystem: ActorSystem =
-    ActorSystem("EclairRpcTestUtilTest", BitcoindRpcTestUtil.AKKA_CONFIG)
 
   private lazy val bitcoindRpcF = {
     val cliF = EclairRpcTestUtil.startedBitcoindRpcClient()
@@ -23,7 +17,6 @@ class EclairRpcTestUtilTest extends AsyncFlatSpec with BeforeAndAfterAll {
 
   override def afterAll: Unit = {
     clients.result().foreach(EclairRpcTestUtil.shutdown)
-    TestKit.shutdownActorSystem(actorSystem)
   }
 
   behavior of "EclairRpcTestUtilTest"

--- a/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
@@ -29,8 +29,11 @@ import scala.util.Success
 import scala.concurrent.Await
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.bloom.BloomFilter
+import akka.actor.ActorSystem
 
 class NodeWithWalletTest extends BitcoinSWalletTest {
+
+  implicit private val system = ActorSystem()
 
   override type FixtureParam = WalletWithBitcoind
 
@@ -117,7 +120,7 @@ class NodeWithWalletTest extends BitcoinSWalletTest {
         }
 
         logger.debug(s"Setting timeout for receiving TX in thru node")
-        cancellable = Some(actorSystem.scheduler.scheduleOnce(delay, runnable))
+        cancellable = Some(system.scheduler.scheduleOnce(delay, runnable))
         tx
       }
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -15,10 +15,8 @@ import org.scalatest._
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
+import akka.actor.ActorSystem
 
-/**
-  * Created by chris on 6/7/16.
-  */
 class ClientTest
     extends BitcoindRpcTest
     with MustMatchers
@@ -30,7 +28,8 @@ class ClientTest
   implicit private val chainConf = config.chainConf
   implicit private val nodeConf = config.nodeConf
 
-  implicit val np = config.chainConf.network
+  implicit private val np = config.chainConf.network
+  implicit private val system = ActorSystem()
 
   lazy val bitcoindRpcF =
     BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
@@ -71,7 +70,7 @@ class ClientTest
     * @param port the port we are binding on our machine
     * @return
     */
-  def connectAndDisconnect(peer: Peer): Future[Assertion] = {
+  private def connectAndDisconnect(peer: Peer): Future[Assertion] = {
     val probe = TestProbe()
     val remote = peer.socket
     val peerMessageReceiver =

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -34,7 +34,7 @@ object Deps {
 
     // CLI deps
     val scoptV = "4.0.0-RC2"
-    val sttpV = "1.6.0"
+    val sttpV = "1.6.2"
   }
 
   object Compile {
@@ -76,6 +76,7 @@ object Deps {
 
     // HTTP client lib
     val sttp = "com.softwaremill.sttp" %% "core" % V.sttpV
+    val sttpFuture = "com.softwaremill.sttp" %% "async-http-client-backend-future" % V.sttpV
 
     val scalacheck = "org.scalacheck" %% "scalacheck" % V.scalacheck withSources () withJavadoc ()
     val scalaTest = "org.scalatest" %% "scalatest" % V.scalaTest withSources () withJavadoc ()
@@ -135,16 +136,14 @@ object Deps {
   )
 
   val bitcoindRpc = List(
-    Compile.akkaHttp,
-    Compile.akkaStream,
+    Compile.sttp,
+    Compile.sttpFuture,
     Compile.playJson,
     Compile.slf4j,
     Compile.typesafeConfig
   )
 
   val bitcoindRpcTest = List(
-    Test.akkaHttp,
-    Test.akkaStream,
     Test.logback,
     Test.scalaTest,
     Test.scalacheck,
@@ -181,15 +180,13 @@ object Deps {
   )
 
   val eclairRpc = List(
-    Compile.akkaHttp,
-    Compile.akkaStream,
-    Compile.playJson,
+    Compile.sttp,
+    Compile.sttpFuture,
+    Compile.akkaActor,
     Compile.slf4j
   )
 
   val eclairRpcTest = List(
-    Test.akkaHttp,
-    Test.akkaStream,
     Test.logback,
     Test.scalaTest,
     Test.scalacheck

--- a/testkit/src/main/scala/org/bitcoins/testkit/async/TestAsyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/async/TestAsyncUtil.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.testkit.async
 
-import akka.actor.ActorSystem
 import org.scalatest.exceptions.{StackDepthException, TestFailedException}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -15,7 +14,7 @@ abstract class TestAsyncUtil
       counter: Int,
       maxTries: Int,
       stackTrace: Array[StackTraceElement])(
-      implicit system: ActorSystem): Future[Unit] = {
+      implicit ec: ExecutionContext): Future[Unit] = {
     val retryF = super
       .retryUntilSatisfiedWithCounter(conditionF,
                                       duration,
@@ -23,7 +22,7 @@ abstract class TestAsyncUtil
                                       maxTries,
                                       stackTrace)
 
-    TestAsyncUtil.transformRetryToTestFailure(retryF)(system.dispatcher)
+    TestAsyncUtil.transformRetryToTestFailure(retryF)
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.testkit.fixtures
 
-import akka.actor.ActorSystem
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.scalatest._
@@ -111,8 +110,7 @@ trait BitcoinSFixture extends fixture.AsyncFlatSpec {
     }
   }
 
-  def createBitcoindWithFunds()(
-      implicit system: ActorSystem): Future[BitcoindRpcClient] = {
+  def createBitcoindWithFunds(): Future[BitcoindRpcClient] = {
     for {
       bitcoind <- createBitcoind()
       address <- bitcoind.getNewAddress
@@ -121,8 +119,7 @@ trait BitcoinSFixture extends fixture.AsyncFlatSpec {
   }
 
   /** Creates a new bitcoind instance */
-  def createBitcoind()(
-      implicit system: ActorSystem): Future[BitcoindRpcClient] = {
+  def createBitcoind(): Future[BitcoindRpcClient] = {
     val instance = BitcoindRpcTestUtil.instance()
     val bitcoind = new BitcoindRpcClient(instance)
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -108,8 +108,7 @@ trait NodeUnitTest
               bloomFilter = NodeTestUtil.emptyBloomFilter)
   }
 
-  def withSpvNode(test: OneArgAsyncTest)(
-      implicit system: ActorSystem): FutureOutcome = {
+  def withSpvNode(test: OneArgAsyncTest): FutureOutcome = {
 
     val spvBuilder: () => Future[SpvNode] = { () =>
       val bitcoindF = createBitcoind()

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/TestRpcUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/TestRpcUtil.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.testkit.rpc
 
-import akka.actor.ActorSystem
 import org.bitcoins.testkit.async.TestAsyncUtil
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.ExecutionContext
 
 abstract class TestRpcUtil extends org.bitcoins.rpc.util.RpcUtil {
   override protected def retryUntilSatisfiedWithCounter(
@@ -13,7 +13,7 @@ abstract class TestRpcUtil extends org.bitcoins.rpc.util.RpcUtil {
       counter: Int,
       maxTries: Int,
       stackTrace: Array[StackTraceElement])(
-      implicit system: ActorSystem): Future[Unit] = {
+      implicit ec: ExecutionContext): Future[Unit] = {
     val retryF = super
       .retryUntilSatisfiedWithCounter(conditionF,
                                       duration,
@@ -21,7 +21,7 @@ abstract class TestRpcUtil extends org.bitcoins.rpc.util.RpcUtil {
                                       maxTries,
                                       stackTrace)
 
-    TestAsyncUtil.transformRetryToTestFailure(retryF)(system.dispatcher)
+    TestAsyncUtil.transformRetryToTestFailure(retryF)
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -1,7 +1,5 @@
 package org.bitcoins.testkit.wallet
 
-import akka.actor.ActorSystem
-import akka.testkit.TestKit
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.protocol.blockchain.ChainParams
 import org.bitcoins.core.util.BitcoinSLogger
@@ -29,8 +27,6 @@ trait BitcoinSWalletTest
     with BitcoinSFixture
     with BeforeAndAfterAll
     with BitcoinSLogger {
-  implicit val actorSystem: ActorSystem = ActorSystem(getClass.getSimpleName)
-  implicit val ec: ExecutionContext = actorSystem.dispatcher
 
   protected lazy val chainParams: ChainParams = WalletTestUtil.chainParams
 
@@ -42,10 +38,6 @@ trait BitcoinSWalletTest
   protected val timeout: FiniteDuration = 10.seconds
 
   protected val networkParam: RegTest.type = WalletTestUtil.networkParam
-
-  override protected def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(actorSystem)
-  }
 
   override def beforeAll(): Unit = {
     AppConfig.throwIfDefaultDatadir(config.walletConf)

--- a/testkit/src/test/scala/org/bitcoins/testkit/db/AppConfigTest.scala
+++ b/testkit/src/test/scala/org/bitcoins/testkit/db/AppConfigTest.scala
@@ -7,7 +7,6 @@ import org.bitcoins.server.BitcoinSAppConfig._
 import com.typesafe.config.ConfigFactory
 import org.bitcoins.core.config.TestNet3
 import org.bitcoins.chain.models.BlockHeaderDAO
-import akka.actor.ActorSystem
 import scala.concurrent.ExecutionContext
 import org.bitcoins.wallet.models.AccountDAO
 import org.bitcoins.testkit.chain.ChainTestUtil
@@ -30,8 +29,7 @@ import org.bitcoins.testkit.BitcoinSTestAppConfig
 
 class AppConfigTest extends BitcoinSUnitTest {
 
-  val system = ActorSystem()
-  implicit val ec: ExecutionContext = system.dispatcher
+  implicit private val ec = ExecutionContext.Implicits.global
 
   behavior of "BitcoinSAppConfig"
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -24,7 +24,6 @@ import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import akka.actor.ActorSystem
 import scala.concurrent.Future
 import org.bitcoins.wallet.api.InitializeWalletSuccess
 import org.scalatest.AsyncFlatSpec

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletStorageTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletStorageTest.scala
@@ -9,8 +9,6 @@ import org.bitcoins.core.crypto.MnemonicCode
 import org.bitcoins.core.crypto.AesPassword
 import scala.util.Success
 import java.nio.file.Files
-import akka.compat.Future
-import akka.compat.Future
 import scala.concurrent.Future
 import scala.collection.JavaConverters._
 import java.nio.file.Path


### PR DESCRIPTION
Closes #589.

In this PR we replace `akka-http` in the Eclair
RPC client and the `bitcoind` RPC client with with
Sttp. Sttp is a Scala HTTP library that acts as a wrapper around other HTTP clients, giving a nice and user friendly interface. For our use case, we have two choices: 

1) Go with the default HTTP client include in Sttp Core, [`java.net.HttpURLConnection`](https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html). This gives a _very_ small classpath, but it is a blocking HTTP client that doesn't handle errors very well. 
2) Use the provided `async-http-client-backend-future`. This wraps [`async-http-client`](https://github.com/AsyncHttpClient/async-http-client) which again is built on Netty. 

I went with choice number 2. I can do some investigating on whether or not choice 1 or 2 is best. Regardless of going with 1 or 2, there are some benefits here compared to using Akka: 
    1) Smaller classpath. `akka-http` pulls in `akka-streams`,
        leading to a very big classpath
    2) No need for 3rd parties to provide a `ActorSystem`.
        Now the only thing that's needed is an
        `ExecutionContext`!

For some reason, Eclair tests run very slowly. There's also a warning message printed (see below). I believe the warnings and slow Eclair tests might be related to my reimplementation of AsyncUtil: https://github.com/bitcoin-s/bitcoin-s/compare/master...torkelrogstad:2019-07-12-sttp?expand=1#diff-a9be7d4ae386bc69045a2f8b014f0e12R98. Open to suggestions here. 

Todo: 
 - [ ] Update documentation
 - [ ] Figure out why Eclair tests are taking so long to instantiate
 - [ ] Investigate warnings printed by our retry mechanism:
```
16:03:25.969 ERROR HashedWheelTimer - You are creating too many HashedWheelTimer instances. HashedWheelTimer is a shared resource that must be reused across the JVM,so that only a few instances are created.
```