### PR TITLE
Replace Bitcoins params in RPC client with CurrencyUnit

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/TransactionRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/TransactionRpc.scala
@@ -1,12 +1,13 @@
 package org.bitcoins.rpc.client.common
 
 import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
-import org.bitcoins.core.currency.{Bitcoins, Satoshis}
+import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit, Satoshis}
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.blockchain.MerkleBlock
 import org.bitcoins.rpc.client.common.RpcOpts.{AddressType, FeeEstimationMode}
 import org.bitcoins.rpc.jsonmodels._
 import org.bitcoins.rpc.serializers.JsonSerializers._
+import org.bitcoins.rpc.serializers.JsonWriters.CurrencyUnitWrites
 import play.api.libs.json._
 
 import scala.concurrent.Future
@@ -148,7 +149,7 @@ trait TransactionRpc { self: Client =>
 
   def sendToAddress(
       address: BitcoinAddress,
-      amount: Bitcoins,
+      amount: CurrencyUnit,
       localComment: String = "",
       toComment: String = "",
       subractFeeFromAmount: Boolean = false): Future[DoubleSha256DigestBE] = {

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v16/V16SendRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v16/V16SendRpc.scala
@@ -9,6 +9,8 @@ import org.bitcoins.rpc.serializers.JsonSerializers._
 import play.api.libs.json.{JsNumber, JsString}
 
 import scala.concurrent.Future
+import org.bitcoins.core.currency.CurrencyUnit
+import play.api.libs.json.Json
 
 /**
   * RPC calls related to transaction sending
@@ -19,12 +21,12 @@ trait V16SendRpc { self: Client =>
   def move(
       fromAccount: String,
       toAccount: String,
-      amount: Bitcoins,
+      amount: CurrencyUnit,
       comment: String = ""): Future[Boolean] = {
     bitcoindCall[Boolean]("move",
                           List(JsString(fromAccount),
                                JsString(toAccount),
-                               JsNumber(amount.toBigDecimal),
+                               Json.toJson(Bitcoins(amount.satoshis)),
                                JsNumber(6),
                                JsString(comment)))
   }
@@ -32,15 +34,15 @@ trait V16SendRpc { self: Client =>
   def sendFrom(
       fromAccount: String,
       toAddress: BitcoinAddress,
-      amount: Bitcoins,
+      amount: CurrencyUnit,
       confirmations: Int = 1,
       comment: String = "",
       toComment: String = ""): Future[DoubleSha256DigestBE] = {
     bitcoindCall[DoubleSha256DigestBE](
       "sendfrom",
       List(JsString(fromAccount),
-           JsString(toAddress.value),
-           JsNumber(amount.toBigDecimal),
+           Json.toJson(toAddress),
+           Json.toJson(Bitcoins(amount.satoshis)),
            JsNumber(confirmations),
            JsString(comment),
            JsString(toComment))

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonWriters.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonWriters.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.rpc.serializers
 
 import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
-import org.bitcoins.core.currency.Bitcoins
+import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
@@ -87,6 +87,11 @@ object JsonWriters {
 
   implicit object AddressTypeWrites extends Writes[AddressType] {
     override def writes(addr: AddressType): JsValue = JsString(addr.toString)
+  }
+
+  implicit object CurrencyUnitWrites extends Writes[CurrencyUnit] {
+    override def writes(amount: CurrencyUnit): JsValue =
+      JsNumber(amount.toBigDecimal)
   }
 
   implicit object WalletCreateFundedPsbtOptionsWrites

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonWriters.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonWriters.scala
@@ -89,11 +89,6 @@ object JsonWriters {
     override def writes(addr: AddressType): JsValue = JsString(addr.toString)
   }
 
-  implicit object CurrencyUnitWrites extends Writes[CurrencyUnit] {
-    override def writes(amount: CurrencyUnit): JsValue =
-      JsNumber(amount.toBigDecimal)
-  }
-
   implicit object WalletCreateFundedPsbtOptionsWrites
       extends Writes[WalletCreateFundedPsbtOptions] {
     override def writes(opts: WalletCreateFundedPsbtOptions): JsValue = {


### PR DESCRIPTION
Changed `amount` from `Bitcoins` to `CurrencyUnit` in `sendToAddress` and implemented the implicit writer associated. 

Addresses Issue #539