### PR TITLE
If we don't publish these three subprojects, testkit cannot be used a…

### DIFF
--- a/app/cli/cli.sbt
+++ b/app/cli/cli.sbt
@@ -2,8 +2,6 @@ name := "bitcoin-s-cli"
 
 libraryDependencies ++= Deps.cli
 
-publish / skip := true
-
 graalVMNativeImageOptions += "-H:EnableURLProtocols=http"
 
 enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin)

--- a/app/picklers/picklers.sbt
+++ b/app/picklers/picklers.sbt
@@ -1,5 +1,3 @@
 name := "bitcoin-s-app-picklers"
 
-publish / skip := true
-
 libraryDependencies ++= Deps.picklers

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -4,6 +4,4 @@ name := "bitcoin-s-server"
 // when server is quit
 Compile / fork := true
 
-publish / skip := true
-
 libraryDependencies ++= Deps.server


### PR DESCRIPTION
…s a dependency for other applications


we get unresolved dependency exceptions when trying to use SNAPSHOTs off of master with the `bitcoin-s-testkit` dependency because we are not publishing these three sub projects. 