### PR TITLE
Make sure our secp256k1jni package is compiled against java 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ lazy val commonSettings = List(
   ////
   scalacOptions in Compile := compilerOpts,
   scalacOptions in Test := testCompilerOpts,
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   //show full stack trace of failed tests
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
   //show duration of tests


### PR DESCRIPTION
This is an attempt to avoid incompatabilities with published `secp256k1jni`. The SNAPSHOT `155-b5aed58e-SNAPSHOT` seems to be published with java 11 rather than java 8, which leads to this error when it is used with a java 8 project. 


>Uncaught error from thread [NbaStreamShapesTest-akka.actor.default-dispatcher-6]: org/bitcoin/NativeSecp256k1 has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0, shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for 
