### PR TITLE
Scope the targetting of code only to compiling code, instead of inclu…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val commonSettings = List(
   ////
   scalacOptions in Compile := compilerOpts,
   scalacOptions in Test := testCompilerOpts,
-  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+  Compile / compile / javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   //show full stack trace of failed tests
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
   //show duration of tests


### PR DESCRIPTION
…ding things like javadoc generation

This is an attempt to resolve this warning that is occurring during our publishing of snapshots which can be found here: 

https://travis-ci.org/bitcoin-s/bitcoin-s/jobs/559498417#L2428

```[warn] bootstrap class path not set in conjunction with -source 8
[warn] Unexpected javac output: javadoc: error - invalid flag: -target
[warn] Usage:
[warn]     javadoc [options] [packagenames] [sourcefiles] [@files]
[warn] where options include:
[warn]     --add-modules <module>(,<module>)*
```

Now our options should only be passed to `javac`, not other auxiliary tools like `javadoc`

This does resolve the problem for me locally.