### PR TITLE
Cleaning up Publish Logs

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -2,16 +2,14 @@ package org.bitcoins.rpc.config
 
 import java.io.File
 import java.net.URI
-import java.nio.file.Paths
+import java.nio.file.{Files, Paths}
 
+import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.rpc.client.common.BitcoindVersion
 
 import scala.sys.process._
-import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.core.config.NetworkParameters
-
-import scala.util.{Properties, Try}
-import java.nio.file.Files
+import scala.util.Properties
 
 /**
   * Created by chris on 4/29/17.
@@ -123,7 +121,7 @@ object BitcoindInstance {
     * Construct a `bitcoind` from the given config file. If no `datadir` setting
     * is found, the parent directory to the given file is used.
     *
-    * @throws IllegalArgumentException if the given config file does not exist
+    * @throws  IllegalArgumentException if the given config file does not exist
     */
   def fromConfigFile(
       file: File = BitcoindConfig.DEFAULT_CONF_FILE): BitcoindInstance = {

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,8 @@ lazy val commonSettings = List(
     "-doc-title",
     "Bitcoin-S",
     "-doc-version",
-    version.value
+    version.value,
+    "-no-link-warnings"
   ),
   // Set apiURL to define the base URL for the Scaladocs for our library.
   // This will enable clients of our library to automatically link against

--- a/build.sbt
+++ b/build.sbt
@@ -61,8 +61,7 @@ lazy val commonSettings = List(
     "-doc-title",
     "Bitcoin-S",
     "-doc-version",
-    version.value,
-    "-no-link-warnings"
+    version.value
   ),
   // Set apiURL to define the base URL for the Scaladocs for our library.
   // This will enable clients of our library to automatically link against

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
@@ -1,12 +1,11 @@
 package org.bitcoins.chain.blockchain
 
 import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
-import org.bitcoins.chain.validation.TipUpdateResult.BadPreviousBlockHash
 import org.bitcoins.chain.validation.{TipUpdateResult, TipValidation}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.util.BitcoinSLogger
 
-import scala.collection.{IndexedSeqLike, IterableLike, SeqLike, mutable}
+import scala.collection.{IndexedSeqLike, mutable}
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -51,15 +50,15 @@ object Blockchain extends BitcoinSLogger {
   /**
     * Attempts to connect the given block header with the given blockchain
     * This is done via the companion object for blockchain because
-    * we query [[BlockHeaderDAO block header dao]] for the chain tips
+    * we query [[org.bitcoins.chain.models.BlockHeaderDAO BlockHeaderDAO]] for the chain tips
     * We then attempt to connect this block header to all of our current
     * chain tips.
     * @param header the block header to connect to our chain
     * @param blockHeaderDAO where we can find our blockchain
     * @param ec
-    * @return a [[Future future]] that contains a [[BlockchainUpdate update]] indicating
-    *         we [[BlockchainUpdate.Successful successfully]] connected the tip,
-    *         or [[BlockchainUpdate.Failed failed]] to connect to a tip
+    * @return a [[scala.concurrent.Future Future]] that contains a [[org.bitcoins.chain.blockchain.BlockchainUpdate BlockchainUpdate]] indicating
+    *         we [[org.bitcoins.chain.blockchain.BlockchainUpdate.Successful successful]] connected the tip,
+    *         or [[org.bitcoins.chain.blockchain.BlockchainUpdate.Failed Failed]] to connect to a tip
     */
   def connectTip(header: BlockHeader, blockHeaderDAO: BlockHeaderDAO)(
       implicit ec: ExecutionContext): Future[BlockchainUpdate] = {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainBuilder.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainBuilder.scala
@@ -5,12 +5,12 @@ import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
 import scala.collection.mutable
 
 /**
-  * @inheritdoc
+  *
   * @param blockHeaderDAO
   */
-case class BlockchainBuilder(blockHeaderDAO: BlockHeaderDAO) extends mutable.Builder[BlockHeaderDb, Blockchain] {
+case class BlockchainBuilder(blockHeaderDAO: BlockHeaderDAO)
+    extends mutable.Builder[BlockHeaderDb, Blockchain] {
   private val internal = Vector.newBuilder[BlockHeaderDb]
-
 
   override def result(): Blockchain = {
     Blockchain.fromHeaders(internal.result().reverse)
@@ -20,7 +20,6 @@ case class BlockchainBuilder(blockHeaderDAO: BlockHeaderDAO) extends mutable.Bui
     internal.+=(blockHeaderDb)
     this
   }
-
 
   override def clear(): Unit = internal.clear()
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainUpdate.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainUpdate.scala
@@ -5,11 +5,11 @@ import org.bitcoins.chain.validation.TipUpdateResult
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 
 /** Represents the state of an update to our [[org.bitcoins.chain.blockchain.Blockchain Blockchain]]
-  * An example of a successful update is receiving a [[BlockHeader BlockHeader]] and successfully
+  * An example of a successful update is receiving a [[org.bitcoins.core.protocol.blockchain.BlockHeader BlockHeader]] and successfully
   * adding it to our database.
   *
   * An example of a [[org.bitcoins.chain.blockchain.BlockchainUpdate.Failed Failed]] update
-  * is when we receive a [[BlockHeader]] that is invalid and because of a
+  * is when we receive a [[org.bitcoins.core.protocol.blockchain.BlockHeader BlockHeader]] that is invalid and because of a
   * [[org.bitcoins.chain.validation.TipUpdateResult.Failure TipUpdateFailure]]
   * because of [[org.bitcoins.chain.validation.TipUpdateResult.BadPOW BadPOW]] or a
   * [[org.bitcoins.chain.validation.TipUpdateResult.BadNonce BadNonce]] etc
@@ -20,7 +20,7 @@ object BlockchainUpdate {
 
   /** The key thing we receive here is [[org.bitcoins.chain.models.BlockHeaderDb BlockHeaderDb]]
     * with a height assigned to it this happens after
-    * calling [[ChainHandler.processHeader() ChainHandler.processHeader]]
+    * calling [[org.bitcoins.chain.blockchain.ChainHandler.processHeader ChainHandler.processHeader]]
     */
   case class Successful(blockchain: Blockchain, updatedHeader: BlockHeaderDb)
       extends BlockchainUpdate {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Chain Handler is meant to be the reference implementation
-  * of [[ChainApi]], this is the entry point in to the
+  * of [[org.bitcoins.chain.api.ChainApi ChainApi]], this is the entry point in to the
   * chain project.
   */
 case class ChainHandler(

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -175,9 +175,9 @@ case class BlockHeaderDAO()(
   /** Returns competing blockchains that are contained in our BlockHeaderDAO
     * Each chain returns the last [[org.bitcoins.core.protocol.blockchain.ChainParams.difficultyChangeInterval difficutly interval]]
     * block headers as defined by the network we are on. For instance, on bitcoin mainnet this will be 2016 block headers.
-    * If no competing tips are found, we only return one [[Blockchain blockchain]], else we
+    * If no competing tips are found, we only return one [[[org.bitcoins.chain.blockchain.Blockchain Blockchain]], else we
     * return n chains for the number of competing [[chainTips tips]] we have
-    * @see [[Blockchain]]
+    * @see [[org.bitcoins.chain.blockchain.Blockchain Blockchain]]
     * @param ec
     * @return
     */

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
@@ -17,12 +17,12 @@ object TipUpdateResult {
     def header: BlockHeader
   }
 
-  /** Means that [[header.previousBlockHashBE]] was incorrect */
+  /** Means that [[org.bitcoins.core.protocol.blockchain.BlockHeader.previousBlockHashBE previousBlockHashBE]] was incorrect */
   case class BadPreviousBlockHash(header: BlockHeader) extends Failure
 
-  /** Means that [[header.nBits]] was invalid */
+  /** Means that [[org.bitcoins.core.protocol.blockchain.BlockHeader.nBits nBits]] was invalid */
   case class BadPOW(header: BlockHeader) extends Failure
 
-  /** Means that [[header.nonce]] was invalid */
+  /** Means that [[org.bitcoins.core.protocol.blockchain.BlockHeader.nonce nonce]] was invalid */
   case class BadNonce(header: BlockHeader) extends Failure
 }

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -21,9 +21,9 @@ import scala.concurrent.{ExecutionContext, Future}
 sealed abstract class TipValidation extends BitcoinSLogger {
 
   /** Checks if the given header can be connected to the current tip
-    * This is the method where a [[BlockHeader]] is transformed into a
-    * [[BlockHeaderDb]]. What this really means is that a height is
-    * assigned to a [[BlockHeader header]] after all these
+    * This is the method where a [[org.bitcoins.core.protocol.blockchain.BlockHeader BlockHeader]] is transformed into a
+    * [[org.bitcoins.chain.models.BlockHeaderDb BlockHeaderDb]]. What this really means is that a height is
+    * assigned to a [[org.bitcoins.core.protocol.blockchain.BlockHeader BlockHeader]] after all these
     * validation checks occur
     * */
   def checkNewTip(

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkHeader.scala
@@ -40,8 +40,22 @@ object NetworkHeader extends Factory[NetworkHeader] {
     RawNetworkHeaderSerializer.read(bytes)
 
   /**
-    * Creates a [[NetworkHeader]] from it's [[NetworkParameters]] and [[NetworkPayload]]
-    * @param network the [[NetworkParameters]] object that indicates what network the payload needs to be sent on
+    * Creates a [[NetworkHeader]] from all of its individual components
+    * @param network the [[org.bitcoins.core.config.NetworkParameters NetworkParameters]] object indicating what network this header is sent on
+    * @param commandName the name of the command being sent in the header
+    * @param payloadSize the size of the payload being sent by this header
+    * @param checksum the checksum of the payload to ensure that the entire payload was sent
+    */
+  def apply(
+      network: NetworkParameters,
+      commandName: String,
+      payloadSize: UInt32,
+      checksum: ByteVector): NetworkHeader =
+    NetworkHeader(network, commandName, payloadSize, checksum)
+
+  /**
+    * Creates a [[NetworkHeader]] from it's [[org.bitcoins.core.config.NetworkParameters NetworkParameters]] and [[NetworkPayload]]
+    * @param network the [[org.bitcoins.core.config.NetworkParameters NetworkParameters]] object that indicates what network the payload needs to be sent on
     * @param payload the [[NetworkPayload]] object that needs to be sent on the network
     */
   def apply(

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkHeader.scala
@@ -40,23 +40,9 @@ object NetworkHeader extends Factory[NetworkHeader] {
     RawNetworkHeaderSerializer.read(bytes)
 
   /**
-    * Creates a [[NetworkHeader]] from all of its individual components
-    * @param network the [[org.bitcoins.core.config.NetworkParameters NetworkParameters]] object indicating what network this header is sent on
-    * @param commandName the name of the command being sent in the header
-    * @param payloadSize the size of the payload being sent by this header
-    * @param checksum the checksum of the payload to ensure that the entire payload was sent
-    */
-  def apply(
-      network: NetworkParameters,
-      commandName: String,
-      payloadSize: UInt32,
-      checksum: ByteVector): NetworkHeader =
-    NetworkHeader(network, commandName, payloadSize, checksum)
-
-  /**
-    * Creates a [[NetworkHeader]] from it's [[org.bitcoins.core.config.NetworkParameters NetworkParameters]] and [[NetworkPayload]]
+    * Creates a network header from it's [[org.bitcoins.core.config.NetworkParameters NetworkParameters]] and [[NetworkPayload]]
     * @param network the [[org.bitcoins.core.config.NetworkParameters NetworkParameters]] object that indicates what network the payload needs to be sent on
-    * @param payload the [[NetworkPayload]] object that needs to be sent on the network
+    * @param payload the payload object that needs to be sent on the network
     */
   def apply(
       network: NetworkParameters,

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkMessage.scala
@@ -38,7 +38,7 @@ object NetworkMessage extends Factory[NetworkMessage] {
 
   /**
     * Creates a [[NetworkMessage]] out of it's [[NetworkPayload]]
-    * @param network the [[NetworkParameters]] indicating the network which the message is going to be sent on
+    * @param network the [[org.bitcoins.core.config.NetworkParameters NetworkParameters]] indicating the network which the message is going to be sent on
     * @param payload the payload that needs to be sent across the network
     * @return
     */

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -384,7 +384,7 @@ case object MemPoolMessage extends DataPayload {
   *
   * @see [[https://bitcoin.org/en/developer-reference#merkleblock]]
   *
-  * @param merkleBlock The actual [[MerkleBlock]] that this message represents
+  * @param merkleBlock The actual [[org.bitcoins.core.protocol.blockchain.MerkleBlock MerkleBlock]] that this message represents 
   */
 case class MerkleBlockMessage(merkleBlock: MerkleBlock) extends DataPayload {
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
@@ -168,10 +168,11 @@ object PartialMerkleTree {
 
     /**
       * This loops through our merkle tree building `bits` so we can instruct another node how to create the partial merkle tree
-      * [[https://github.com/bitcoin/bitcoin/blob/b7b48c8bbdf7a90861610b035d8b0a247ef78c45/src/merkleblock.cpp#L78]]
+      * @see [[https://github.com/bitcoin/bitcoin/blob/b7b48c8bbdf7a90861610b035d8b0a247ef78c45/src/merkleblock.cpp#L78]]
       * @param bits the accumulator for bits indicating how to reconsctruct the partial merkle tree
       * @param hashes the relevant hashes used with bits to reconstruct the merkle tree
       * @param height the transaction index we are currently looking at -- if it was matched in our bloom filter we need the entire merkle branch
+      * @param pos the position in the loop represented as an int
       * @return the binary tree that represents the partial merkle tree, the bits needed to reconstruct this partial merkle tree, and the hashes needed to be inserted
       *         according to the flags inside of bits
       */

--- a/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
@@ -54,7 +54,7 @@ sealed abstract class RawSerializerHelper {
     cmpct.bytes ++ serialized
   }
 
-  /** Serializes a [[Seq]] of [[org.bitcoins.core.protocol.NetworkElement]] to a [[scodec.bits.ByteVector]] */
+  /** Serializes a [[scala.Seq Seq]] of [[org.bitcoins.core.protocol.NetworkElement]] to a [[scodec.bits.ByteVector]] */
   def writeNetworkElements[T <: NetworkElement](ts: Seq[T]): ByteVector = {
     val f = { t: T =>
       t.bytes

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkIpAddressSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkIpAddressSerializer.scala
@@ -3,9 +3,9 @@ package org.bitcoins.core.serializers.p2p
 import java.net.InetAddress
 
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.serializers.RawBitcoinSerializer
-import org.bitcoins.core.util.{BitcoinSLogger, NumberUtil}
 import org.bitcoins.core.p2p._
+import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.util.BitcoinSLogger
 import scodec.bits.ByteVector
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawFilterAddMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawFilterAddMessageSerializer.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.p2p._
 import scodec.bits.ByteVector
 
 /**
-  * Responsible for serializing and deserializing a [[FilterAddMessage]]
+  * Responsible for serializing and deserializing a [[org.bitcoins.core.p2p.FilterAddMessage FilterAddMessage]]
   * @see [[https://bitcoin.org/en/developer-reference#filteradd]]
   */
 trait RawFilterAddMessageSerializer

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawFilterLoadMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawFilterLoadMessageSerializer.scala
@@ -6,8 +6,8 @@ import org.bitcoins.core.p2p.FilterLoadMessage
 import scodec.bits.ByteVector
 
 /**
-  * Serializes and deserializes a [[FilterLoadMessage]]
-  * @see https://bitcoin.org/en/developer-reference#filterload
+  * Serializes and deserializes a [[org.bitcoins.core.p2p.FilterLoadMessage FilterLoadMessage]]
+  * @see [[https://bitcoin.org/en/developer-reference#filterload]]
   */
 trait RawFilterLoadMessageSerializer
     extends RawBitcoinSerializer[FilterLoadMessage] {

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -72,7 +72,7 @@ abstract class DbCommonsColumnMappers {
     MappedColumnType
       .base[Sha256Hash160Digest, String](_.hex, Sha256Hash160Digest.fromHex)
 
-  /** Responsible for mapping a [[UInt32]] to a long in Slick, and vice versa */
+  /** Responsible for mapping a [[org.bitcoins.core.number.UInt32 UInt32]] to a long in Slick, and vice versa */
   implicit val uInt32Mapper: BaseColumnType[UInt32] =
     MappedColumnType.base[UInt32, Long](
       tmap = _.toLong,
@@ -83,7 +83,7 @@ abstract class DbCommonsColumnMappers {
     MappedColumnType.base[Int32, Long](tmap = _.toLong, tcomap = Int32(_))
   }
 
-  /** Responsible for mapping a [[TransactionOutput]] to hex in Slick, and vice versa */
+  /** Responsible for mapping a [[org.bitcoins.core.protocol.transaction.TransactionOutput TransactionOutput]] to hex in Slick, and vice versa */
   implicit val transactionOutputMapper: BaseColumnType[TransactionOutput] = {
     MappedColumnType.base[TransactionOutput, String](
       _.hex,

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/api/EclairApi.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/api/EclairApi.scala
@@ -190,7 +190,7 @@ trait EclairApi {
   /**
     * Pings eclair to see if a invoice has been paid and returns [[org.bitcoins.eclair.rpc.json.PaymentResult PaymentResult]]
     *
-    * @param paymentId the payment id returnned by [[org.bitcoins.eclair.rpc.api.EclairApi.payInvoice()]]
+    * @param paymentId the payment id returnned by [[org.bitcoins.eclair.rpc.api.EclairApi.payInvoice payInvoice]]
     * @param interval the ping interval
     * @param maxAttempts the maximum number of pings
     *

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
@@ -1,12 +1,22 @@
 package org.bitcoins.eclair.rpc.json
 
-import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE, ECDigitalSignature, Sha256Digest}
+import org.bitcoins.core.crypto.{
+  DoubleSha256Digest,
+  DoubleSha256DigestBE,
+  ECDigitalSignature,
+  Sha256Digest
+}
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.protocol.ln.channel.{ChannelState, FundedChannelId}
 import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
 import org.bitcoins.core.protocol.ln.fee.FeeProportionalMillionths
 import org.bitcoins.core.protocol.ln.node.NodeId
-import org.bitcoins.core.protocol.ln.{LnHumanReadablePart, LnInvoiceSignature, PaymentPreimage, ShortChannelId}
+import org.bitcoins.core.protocol.ln.{
+  LnHumanReadablePart,
+  LnInvoiceSignature,
+  PaymentPreimage,
+  ShortChannelId
+}
 import org.bitcoins.eclair.rpc.network.PeerState
 import play.api.libs.json.JsObject
 
@@ -265,19 +275,20 @@ case class ChannelResult(
     feeProportionalMillionths: Option[FeeProportionalMillionths],
     data: JsObject) {
   import JsonReaders._
-  lazy val shortChannelId: Option[ShortChannelId] = (data \ "shortChannelId").validate[ShortChannelId].asOpt
+  lazy val shortChannelId: Option[ShortChannelId] =
+    (data \ "shortChannelId").validate[ShortChannelId].asOpt
 }
 
 // ChannelResult ends here
 
 case class InvoiceResult(
-  prefix: LnHumanReadablePart,
-  timestamp: FiniteDuration,
-  nodeId: NodeId,
-  serialized: String,
-  description: String,
-  paymentHash: Sha256Digest,
-  expiry: FiniteDuration)
+    prefix: LnHumanReadablePart,
+    timestamp: FiniteDuration,
+    nodeId: NodeId,
+    serialized: String,
+    description: String,
+    paymentHash: Sha256Digest,
+    expiry: FiniteDuration)
 
 case class PaymentRequest(
     prefix: LnHumanReadablePart,
@@ -288,30 +299,33 @@ case class PaymentRequest(
     signature: LnInvoiceSignature)
 
 case class PaymentResult(
-  id: String,
-  paymentHash: Sha256Digest,
-  preimage: Option[PaymentPreimage],
-  amountMsat: MilliSatoshis,
-  createdAt: FiniteDuration,
-  completedAt: Option[FiniteDuration],
-  status: PaymentStatus)
+    id: String,
+    paymentHash: Sha256Digest,
+    preimage: Option[PaymentPreimage],
+    amountMsat: MilliSatoshis,
+    createdAt: FiniteDuration,
+    completedAt: Option[FiniteDuration],
+    status: PaymentStatus)
 
 case class ReceivedPaymentResult(
-  paymentHash: Sha256Digest,
-  amountMsat: MilliSatoshis,
-  receivedAt: FiniteDuration)
+    paymentHash: Sha256Digest,
+    amountMsat: MilliSatoshis,
+    receivedAt: FiniteDuration)
 
 sealed trait PaymentStatus
+
 object PaymentStatus {
   case object PENDING extends PaymentStatus
   case object SUCCEEDED extends PaymentStatus
   case object FAILED extends PaymentStatus
 
   def apply(s: String): PaymentStatus = s match {
-    case "PENDING" => PENDING
+    case "PENDING"   => PENDING
     case "SUCCEEDED" => SUCCEEDED
-    case "FAILED" => FAILED
-    case err => throw new IllegalArgumentException(s"Unknown payment status code `${err}`")
+    case "FAILED"    => FAILED
+    case err =>
+      throw new IllegalArgumentException(
+        s"Unknown payment status code `${err}`")
   }
 }
 
@@ -319,11 +333,9 @@ case class PaymentId(value: String) {
   override def toString: String = value
 }
 
-
 sealed trait WebSocketEvent
 
 object WebSocketEvent {
-
 
   case class PaymentRelayed(
       amountIn: MilliSatoshis,
@@ -331,17 +343,18 @@ object WebSocketEvent {
       paymentHash: Sha256Digest,
       fromChannelId: FundedChannelId,
       toChannelId: FundedChannelId,
-      timestamp: FiniteDuration) extends WebSocketEvent
+      timestamp: FiniteDuration)
+      extends WebSocketEvent
 
   case class PaymentReceived(
       amount: MilliSatoshis,
       paymentHash: Sha256Digest,
       fromChannelId: FundedChannelId,
-      timestamp: FiniteDuration) extends WebSocketEvent
+      timestamp: FiniteDuration)
+      extends WebSocketEvent
 
-  case class PaymentFailed(
-      paymentHash: Sha256Digest,
-      failures: Vector[String]) extends WebSocketEvent
+  case class PaymentFailed(paymentHash: Sha256Digest, failures: Vector[String])
+      extends WebSocketEvent
 
   case class PaymentSent(
       amount: MilliSatoshis,
@@ -349,11 +362,13 @@ object WebSocketEvent {
       paymentHash: Sha256Digest,
       paymentPreimage: PaymentPreimage,
       toChannelId: FundedChannelId,
-      timestamp: FiniteDuration) extends WebSocketEvent
+      timestamp: FiniteDuration)
+      extends WebSocketEvent
 
   case class PaymentSettlingOnchain(
       amount: MilliSatoshis,
       paymentHash: Sha256Digest,
-      timestamp: FiniteDuration) extends WebSocketEvent
+      timestamp: FiniteDuration)
+      extends WebSocketEvent
 
 }

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/json/EclairModels.scala
@@ -1,22 +1,12 @@
 package org.bitcoins.eclair.rpc.json
 
-import org.bitcoins.core.crypto.{
-  DoubleSha256Digest,
-  DoubleSha256DigestBE,
-  ECDigitalSignature,
-  Sha256Digest
-}
+import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE, ECDigitalSignature, Sha256Digest}
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.protocol.ln.channel.{ChannelState, FundedChannelId}
 import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
 import org.bitcoins.core.protocol.ln.fee.FeeProportionalMillionths
 import org.bitcoins.core.protocol.ln.node.NodeId
-import org.bitcoins.core.protocol.ln.{
-  LnHumanReadablePart,
-  LnInvoiceSignature,
-  PaymentPreimage,
-  ShortChannelId
-}
+import org.bitcoins.core.protocol.ln.{LnHumanReadablePart, LnInvoiceSignature, PaymentPreimage, ShortChannelId}
 import org.bitcoins.eclair.rpc.network.PeerState
 import play.api.libs.json.JsObject
 
@@ -275,20 +265,19 @@ case class ChannelResult(
     feeProportionalMillionths: Option[FeeProportionalMillionths],
     data: JsObject) {
   import JsonReaders._
-  lazy val shortChannelId: Option[ShortChannelId] =
-    (data \ "shortChannelId").validate[ShortChannelId].asOpt
+  lazy val shortChannelId: Option[ShortChannelId] = (data \ "shortChannelId").validate[ShortChannelId].asOpt
 }
 
 // ChannelResult ends here
 
 case class InvoiceResult(
-    prefix: LnHumanReadablePart,
-    timestamp: FiniteDuration,
-    nodeId: NodeId,
-    serialized: String,
-    description: String,
-    paymentHash: Sha256Digest,
-    expiry: FiniteDuration)
+  prefix: LnHumanReadablePart,
+  timestamp: FiniteDuration,
+  nodeId: NodeId,
+  serialized: String,
+  description: String,
+  paymentHash: Sha256Digest,
+  expiry: FiniteDuration)
 
 case class PaymentRequest(
     prefix: LnHumanReadablePart,
@@ -299,33 +288,30 @@ case class PaymentRequest(
     signature: LnInvoiceSignature)
 
 case class PaymentResult(
-    id: String,
-    paymentHash: Sha256Digest,
-    preimage: Option[PaymentPreimage],
-    amountMsat: MilliSatoshis,
-    createdAt: FiniteDuration,
-    completedAt: Option[FiniteDuration],
-    status: PaymentStatus)
+  id: String,
+  paymentHash: Sha256Digest,
+  preimage: Option[PaymentPreimage],
+  amountMsat: MilliSatoshis,
+  createdAt: FiniteDuration,
+  completedAt: Option[FiniteDuration],
+  status: PaymentStatus)
 
 case class ReceivedPaymentResult(
-    paymentHash: Sha256Digest,
-    amountMsat: MilliSatoshis,
-    receivedAt: FiniteDuration)
+  paymentHash: Sha256Digest,
+  amountMsat: MilliSatoshis,
+  receivedAt: FiniteDuration)
 
 sealed trait PaymentStatus
-
 object PaymentStatus {
   case object PENDING extends PaymentStatus
   case object SUCCEEDED extends PaymentStatus
   case object FAILED extends PaymentStatus
 
   def apply(s: String): PaymentStatus = s match {
-    case "PENDING"   => PENDING
+    case "PENDING" => PENDING
     case "SUCCEEDED" => SUCCEEDED
-    case "FAILED"    => FAILED
-    case err =>
-      throw new IllegalArgumentException(
-        s"Unknown payment status code `${err}`")
+    case "FAILED" => FAILED
+    case err => throw new IllegalArgumentException(s"Unknown payment status code `${err}`")
   }
 }
 
@@ -333,9 +319,11 @@ case class PaymentId(value: String) {
   override def toString: String = value
 }
 
+
 sealed trait WebSocketEvent
 
 object WebSocketEvent {
+
 
   case class PaymentRelayed(
       amountIn: MilliSatoshis,
@@ -343,18 +331,17 @@ object WebSocketEvent {
       paymentHash: Sha256Digest,
       fromChannelId: FundedChannelId,
       toChannelId: FundedChannelId,
-      timestamp: FiniteDuration)
-      extends WebSocketEvent
+      timestamp: FiniteDuration) extends WebSocketEvent
 
   case class PaymentReceived(
       amount: MilliSatoshis,
       paymentHash: Sha256Digest,
       fromChannelId: FundedChannelId,
-      timestamp: FiniteDuration)
-      extends WebSocketEvent
+      timestamp: FiniteDuration) extends WebSocketEvent
 
-  case class PaymentFailed(paymentHash: Sha256Digest, failures: Vector[String])
-      extends WebSocketEvent
+  case class PaymentFailed(
+      paymentHash: Sha256Digest,
+      failures: Vector[String]) extends WebSocketEvent
 
   case class PaymentSent(
       amount: MilliSatoshis,
@@ -362,13 +349,11 @@ object WebSocketEvent {
       paymentHash: Sha256Digest,
       paymentPreimage: PaymentPreimage,
       toChannelId: FundedChannelId,
-      timestamp: FiniteDuration)
-      extends WebSocketEvent
+      timestamp: FiniteDuration) extends WebSocketEvent
 
   case class PaymentSettlingOnchain(
       amount: MilliSatoshis,
       paymentHash: Sha256Digest,
-      timestamp: FiniteDuration)
-      extends WebSocketEvent
+      timestamp: FiniteDuration) extends WebSocketEvent
 
 }

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -22,7 +22,7 @@ import akka.util.CompactByteString
   * with the p2p network. It's responsibly is to deal with low
   * level .TCP messages.
   *
-  * If the client receives a [[NetworkMessage]], from a
+  * If the client receives a [[org.bitcoins.core.p2p.NetworkMessage NetworkMessage]], from a
   * [[org.bitcoins.node.networking.peer.PeerMessageSender PeerMessageSender]]
   * it serializes the message to it to a [[akka.util.ByteString]] and then
   * sends it to the internal `manager` which streams the data to our peer

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -22,9 +22,9 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.core.p2p.TypeIdentifier
 import org.bitcoins.core.p2p.MsgUnassigned
 
-/** This actor is meant to handle a [[org.bitcoins.node.messages.DataPayload]]
+/** This actor is meant to handle a [[org.bitcoins.core.p2p.DataPayload DataPayload]]
   * that a peer to sent to us on the p2p network, for instance, if we a receive a
-  * [[HeadersMessage]] we should store those headers in our database
+  * [[org.bitcoins.core.p2p.HeadersMessage HeadersMessage]] we should store those headers in our database
   */
 class DataMessageHandler(callbacks: SpvNodeCallbacks)(
     implicit ec: ExecutionContext,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -20,10 +20,10 @@ import org.bitcoins.node.SpvNodeCallbacks
 
 /**
   * Responsible for receiving messages from a peer on the
-  * p2p network. This is called by [[Client]] when doing the p2p
+  * p2p network. This is called by [[org.bitcoins.rpc.client.common.Client Client]] when doing the p2p
   * handshake and during the [[PeerMessageReceiverState.Normal Normal]]
   * operations. This is the entry point for handling all received
-  * [[NetworkMessage]]
+  * [[org.bitcoins.core.p2p.NetworkMessage NetworkMessage]]
   */
 class PeerMessageReceiver(
     state: PeerMessageReceiverState,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverState.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverState.scala
@@ -9,18 +9,18 @@ import scala.concurrent.{Future, Promise}
 sealed abstract class PeerMessageReceiverState extends BitcoinSLogger {
 
   /** This promise gets completed when we receive a
-    * [[akka.io.Tcp.Connected]] message from [[Client]]
+    * [[akka.io.Tcp.Connected]] message from [[org.bitcoins.node.networking.P2PClient P2PClient]]
     */
   def clientConnectP: Promise[P2PClient]
 
-  /** The [[org.bitcoins.node.networking.Client]] we are
+  /** The [[org.bitcoins.node.networking.P2PClient P2PClient]] we are
     * connected to. This isn't initiated until the client
-    * has called [[PeerMessageReceiver.connect()]]
+    * has called [[org.bitcoins.node.networking.peer.PeerMessageReceiver.connect() connect()]]
     */
   private val clientConnectF: Future[P2PClient] = clientConnectP.future
 
-  /** This promise is completed in the [[PeerMessageReceiver.disconnect()]]
-    * when a [[Client]] initiates a disconnections from
+  /** This promise is completed in the [[org.bitcoins.node.networking.peer.PeerMessageReceiver.disconnect() disconnect()]]
+    * when a [[org.bitcoins.node.networking.P2PClient P2PClient]] initiates a disconnections from
     * our peer on the p2p network
     */
   def clientDisconnectP: Promise[Unit]
@@ -31,7 +31,7 @@ sealed abstract class PeerMessageReceiverState extends BitcoinSLogger {
     * connected to our client. Note, there is
     * no timeout on this future and no guarantee
     * that some one has actually initiated
-    * a connection with a [[Client]]
+    * a connection with a [[org.bitcoins.node.networking.P2PClient P2PClient]]
     * @return
     */
   def isConnected: Boolean = {
@@ -45,7 +45,7 @@ sealed abstract class PeerMessageReceiverState extends BitcoinSLogger {
   def versionMsgP: Promise[VersionMessage]
 
   /** This future is completed when our peer has sent
-    * us their [[VersionMessage]] indicating what protocol
+    * us their [[org.bitcoins.core.p2p.VersionMessage VersionMessage]] indicating what protocol
     * features they support
     */
   def hasReceivedVersionMsg: Future[VersionMessage] = {
@@ -55,8 +55,8 @@ sealed abstract class PeerMessageReceiverState extends BitcoinSLogger {
   def verackMsgP: Promise[VerAckMessage.type]
 
   /** This future completes when we have received a
-    * [[VerAckMessage]] from our peer. This means our
-    * peer has accepted our [[VersionMessage]] and is
+    * [[org.bitcoins.core.p2p.VerAckMessage VerAckMessage]] from our peer. This means our
+    * peer has accepted our [[org.bitcoins.core.p2p.VersionMessage VersionMessage]] and is
     * willing to connect with us
     * @return
     */
@@ -67,7 +67,7 @@ sealed abstract class PeerMessageReceiverState extends BitcoinSLogger {
   /** Indicates we have connected and completed the initial
     * handshake that is required to connect to the bitcoin p2p network
     * If this is true, we can start sending and receiving normal
-    * [[NetworkMessage]] with our peer on the network
+    * [[org.bitcoins.core.p2p.NetworkMessage NetworkMessage]] with our peer on the network
     * @return
     */
   def isInitialized: Boolean = {
@@ -77,7 +77,7 @@ sealed abstract class PeerMessageReceiverState extends BitcoinSLogger {
 
 object PeerMessageReceiverState {
 
-  /** Represents a [[org.bitcoins.node.networking.peer.PeerMessageReceiverState]]
+  /** Represents a [[org.bitcoins.node.networking.peer.PeerMessageReceiverState PeerMessageReceiverState]]
     * where the peer is not connected to the p2p network
     */
   final case object Preconnection extends PeerMessageReceiverState {
@@ -88,7 +88,7 @@ object PeerMessageReceiverState {
     def versionMsgP: Promise[VersionMessage] = Promise[VersionMessage]()
     def verackMsgP: Promise[VerAckMessage.type] = Promise[VerAckMessage.type]()
 
-    /** Converts [[org.bitcoins.node.networking.peer.PeerMessageReceiverState.Preconnection]] to [[Initializing]] */
+    /** Converts [[org.bitcoins.node.networking.peer.PeerMessageReceiverState.Preconnection Preconnection]] to [[Initializing]] */
     def toInitializing(client: P2PClient): Initializing = {
       val p = clientConnectP
       p.success(client)
@@ -103,7 +103,7 @@ object PeerMessageReceiverState {
 
   /** Means that our [[org.bitcoins.node.networking.peer.PeerMessageReceiver]]
     * is still going through the initilization process. This means
-    * we still need to receive a [[VersionMessage]] or [[VerAckMessage]]
+    * we still need to receive a [[org.bitcoins.core.p2p.VersionMessage VersionMessage]] or [[org.bitcoins.core.p2p.VerAckMessage VerAckMessage]]
     * from our peer on the p2p network
     */
   case class Initializing(
@@ -117,7 +117,7 @@ object PeerMessageReceiverState {
       "We cannot have a PeerMessageReceiverState.Initializng if we are not connected")
 
     /** Helper method to modifing the state of [[org.bitcoins.node.networking.peer.PeerMessageReceiverState.Initializing]]
-      * when we receive a [[VersionMessage]]. This completes versoinMsgP
+      * when we receive a [[org.bitcoins.core.p2p.VersionMessage VersionMessage]]. This completes versoinMsgP
       * @return
       */
     def withVersionMsg(versionMsg: VersionMessage): Initializing = {
@@ -130,7 +130,7 @@ object PeerMessageReceiverState {
     }
 
     /** Completes the verack message promise and transitions
-      * our [[PeerMessageReceiverState]] to [[PeerMessageReceiverState.Normal]]
+      * our [[org.bitcoins.node.networking.peer.PeerMessageReceiverState PeerMessageReceiverState]] to [[org.bitcoins.node.networking.peer.PeerMessageReceiverState.Normal PeerMessageReceiverState.Normal]]
       */
     def toNormal(verAckMessage: VerAckMessage.type): Normal = {
       Normal(

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -26,7 +26,7 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     (client.actor ! Tcp.Close)
   }
 
-  /** Sends a [[org.bitcoins.node.messages.VersionMessage VersionMessage]] to our peer */
+  /** Sends a [[org.bitcoins.core.p2p.VersionMessage VersionMessage]] to our peer */
   def sendVersionMessage(): Unit = {
     val versionMsg = VersionMessage(client.peer.socket, conf.network)
     logger.trace(s"Sending versionMsg=$versionMsg to peer=${client.peer}")

--- a/node/src/main/scala/org/bitcoins/node/util/BitcoinSpvNodeUtil.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/BitcoinSpvNodeUtil.scala
@@ -13,7 +13,7 @@ trait BitcoinSpvNodeUtil extends BitcoinSLogger {
     * Akka sends messages as one byte stream. There is not a 1 to 1 relationship between byte streams received and
     * bitcoin protocol messages. This function parses our byte stream into individual network messages
     * @param bytes the bytes that need to be parsed into individual messages
-    * @return the parsed [[NetworkMessage]]'s and the unaligned bytes that did not parse to a message
+    * @return the parsed [[org.bitcoins.core.p2p.NetworkMessage NetworkMessage]]'s and the unaligned bytes that did not parse to a message
     */
   def parseIndividualMessages(
       bytes: ByteVector): (List[NetworkMessage], ByteVector) = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/BlockHeaderHelper.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/BlockHeaderHelper.scala
@@ -99,10 +99,10 @@ abstract class BlockHeaderHelper {
                 nonce = bh.nonce)
   }
 
-  /** Buidls a block header on top the given prev header
+  /** Builds a block header on top the given prev header
     * The only consensus requirement that this method adheres to
-    * with the returned [[BlockHeaderDb]] is that
-    * 1. We reference the [[prevHeader.blockHeader.hash]] correct
+    * with the returned [[org.bitcoins.chain.models.BlockHeaderDb]] is that
+    * 1. We reference the [[org.bitcoins.chain.models.BlockHeaderDb.blockHeader.hash]] correct
     * 2. We increment the height of [[prevHeader]] by one
     * @param prevHeader
     * @return

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -259,7 +259,7 @@ trait ChainUnitTest
   }
 
   /**
-    * Creates a [[BitcoindRpcClient bitcoind]] that is linked to our [[ChainHandler bitcoin-s chain handler]]
+    * Creates a [[org.bitcoins.rpc.client.common.BitcoindRpcClient BitcoindRpcClient]] that is linked to our [[org.bitcoins.chain.blockchain.ChainHandler ChainHandler]]
     * via a [[org.bitcoins.zmq.ZMQSubscriber zmq]]. This means messages are passed between bitcoin and our chain handler
     * with a zmq pub/sub message passing
     * @param test the test to be executed with bitcoind and chain handler via zmq

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
@@ -17,9 +17,6 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 
-/**
-  * Created by chris on 6/22/16.
-  */
 //TODO: Need to provide generators for [[NonStandardScriptSignature]] and [[NonStandardScriptPubKey]]
 sealed abstract class ScriptGenerators extends BitcoinSLogger {
   val timeout = 5.seconds
@@ -51,8 +48,9 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   def emptyScriptSignature = p2pkhScriptSignature.map(_ => EmptyScriptSignature)
 
   /**
-    * Generates a [[org.bitcoins.core.protocol.script.P2SHScriptSignature]]
-    * WARNING: the redeem script and the script signature DO NOT evaluate to true
+    * Generates a P2SH script signature
+    *
+    * @note the redeem script and the script signature DO NOT evaluate to true
     * if executed by [[org.bitcoins.core.script.interpreter.ScriptInterpreter]]
     */
   def p2shScriptSignature: Gen[P2SHScriptSignature] =
@@ -159,9 +157,9 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     Gen.oneOf(p2wpkhSPKV0, p2wshSPKV0)
 
   /**
-    * Creates an [[org.bitcoins.core.protocol.script.UnassignedWitnessScriptPubKey]],
-    * currently this is any witness script pubkey besides
-    * [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0]]
+    * Creates an unassigned witness scriptPubKey.
+    * Currently this is any witness script pubkey besides
+    * [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 WitnessScriptPubKeyV0]]
     */
   def unassignedWitnessScriptPubKey: Gen[
     (UnassignedWitnessScriptPubKey, Seq[ECPrivateKey])] =
@@ -171,7 +169,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       unassignedAsm = version +: witV0.asm.tail
     } yield (UnassignedWitnessScriptPubKey(unassignedAsm), privKeys)
 
-  /** Generates an arbitrary [[org.bitcoins.core.protocol.script.WitnessScriptPubKey]] */
+  /** Generates an arbitrary `WitnessScriptPubKey` */
   def witnessScriptPubKey: Gen[(WitnessScriptPubKey, Seq[ECPrivateKey])] =
     Gen.oneOf(assignedWitnessScriptPubKey, unassignedWitnessScriptPubKey)
 
@@ -224,7 +222,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   def lockTimeScriptSig: Gen[LockTimeScriptSignature] =
     Gen.oneOf(csvScriptSignature, cltvScriptSignature)
 
-  /** Generates an arbitrary [[org.bitcoins.core.protocol.script.ScriptPubKey]] */
+  /** Generates an arbitrary `ScriptPubKey` */
   def scriptPubKey: Gen[(ScriptPubKey, Seq[ECPrivateKey])] = {
     Gen.oneOf(
       p2pkScriptPubKey.map(privKeyToSeq(_)),
@@ -241,7 +239,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     )
   }
 
-  /** Generates an arbitrary [[org.bitcoins.core.protocol.script.ScriptSignature]] */
+  /** Generates an arbitrary `ScriptSignature` */
   def scriptSignature: Gen[ScriptSignature] = {
     Gen.oneOf(
       p2pkScriptSignature,
@@ -256,8 +254,8 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   }
 
   /**
-    * Generates a [[org.bitcoins.core.protocol.script.ScriptSignature]] corresponding to the type of
-    * [[org.bitcoins.core.protocol.script.ScriptPubKey]] given.
+    * Generates a `ScriptSignature` corresponding to the type of
+    * `ScriptPubKey` given.
     * Note: Does NOT generate a correct/valid signature
     */
   private def pickCorrespondingScriptSignature(
@@ -278,12 +276,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   }
 
   /**
-    * Generates a signed [[org.bitcoins.core.protocol.script.P2PKScriptSignature]] that spends the
-    * [[org.bitcoins.core.protocol.script.P2PKScriptPubKey]] correctly
+    * Generates a signed `P2PKScriptSignature` that spends the
+    * `P2PKScriptPubKey` correctly
     *
-    * @return the signed [[org.bitcoins.core.protocol.script.P2PKScriptSignature]],
-    *         the [[org.bitcoins.core.protocol.script.P2PKScriptPubKey]] it spends, and the
-    *         [[org.bitcoins.core.crypto.ECPrivateKey]] used to sign the scriptSig
+    * @return the signed `P2PKScriptSignature`,
+    *         the `P2PKScriptPubKey` it spends, and the
+    *         `ECPrivateKey` used to sign the scriptSig
     */
   def signedP2PKScriptSignature: Gen[
     (P2PKScriptSignature, P2PKScriptPubKey, ECPrivateKey)] =
@@ -313,12 +311,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     } yield (signedScriptSig, scriptPubKey, privateKey)
 
   /**
-    * Generates a signed [[org.bitcoins.core.protocol.script.P2PKHScriptSignature]] that
-    * spends the [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey]] correctly
+    * Generates a signed `P2PKHScriptSignature` that
+    * spends the `P2PKHScriptPubKey` correctly
     *
-    * @return the signed [[org.bitcoins.core.protocol.script.P2PKHScriptSignature]], the
-    *         [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey]] it spends, and the
-    *         [[org.bitcoins.core.crypto.ECPrivateKey]] used to sign the scriptSig
+    * @return the signed `P2PKHScriptSignature`, the
+    *         `P2PKHScriptPubKey` it spends, and the
+    *         `ECPrivateKey` used to sign the scriptSig
     */
   def signedP2PKHScriptSignature: Gen[
     (P2PKHScriptSignature, P2PKHScriptPubKey, ECPrivateKey)] =
@@ -347,12 +345,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
 
   /**
     * Generates a signed
-    * [[org.bitcoins.core.protocol.script.MultiSignatureScriptSignature]] that spends the
-    * [[org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey]] correctly
+    * `MultiSignatureScriptSignature` that spends the
+    * `MultiSignatureScriptPubKey` correctly
     * ti
-    * @return the signed [[org.bitcoins.core.protocol.script.MultiSignatureScriptSignature]],
-    *         the [[org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey]] it spends and the
-    *         sequence of [[org.bitcoins.core.crypto.ECPrivateKey]] used to sign the scriptSig
+    * @return the signed `MultiSignatureScriptSignature`,
+    *         the `MultiSignatureScriptPubKey` it spends and the
+    *         sequence of `ECPrivateKey` used to sign the scriptSig
     */
   def signedMultiSignatureScriptSignature: Gen[(
       MultiSignatureScriptSignature,
@@ -385,12 +383,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     } yield (signedScriptSig, multiSigScriptPubKey, privateKeys)
 
   /**
-    * Generates a signed [[org.bitcoins.core.protocol.script.P2SHScriptSignature]]
-    * that spends from a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey]] correctly
+    * Generates a signed `P2SHScriptSignature`
+    * that spends from a `P2SHScriptPubKey` correctly
     *
-    * @return the signed [[org.bitcoins.core.protocol.script.P2SHScriptSignature]],
-    *         the [[org.bitcoins.core.protocol.script.P2SHScriptPubKey]] it spends, and the
-    *         sequence of [[org.bitcoins.core.crypto.ECPrivateKey]]
+    * @return the signed `P2SHScriptSignature`,
+    *         the `P2SHScriptPubKey` it spends, and the
+    *         sequence of `ECPrivateKey`
     *         used to sign the scriptSig
     */
   def signedP2SHScriptSignature: Gen[
@@ -402,12 +400,9 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     } yield (p2SHScriptSignature, p2SHScriptPubKey, privateKeys)
 
   /**
-    * Generates a signed [[org.bitcoins.core.protocol.script.P2SHScriptSignature]] that spends
-    * from a [[org.bitcoins.core.protocol.script.P2SHScriptSignature]] correctly
-    *
-    * @return the signed [[org.bitcoins.core.protocol.script.CLTVScriptSignature]], the
-    *         [[org.bitcoins.core.protocol.script.CLTVScriptPubKey]] it spends, and the
-    *         sequences of [[org.bitcoins.core.crypto.ECPrivateKey]]
+    * @return the signed `CLTVScriptSignature`, the
+    *         `CLTVScriptPubKey` it spends, and the
+    *         sequences of `ECPrivateKey`
     *         used to sign the scriptSig
     */
   def signedCLTVScriptSignature(
@@ -450,12 +445,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       }
 
   /**
-    * Generates a signed [[org.bitcoins.core.protocol.script.CLTVScriptSignature]] that spends
-    * from a [[org.bitcoins.core.protocol.script.CLTVScriptSignature]] correctly
+    * Generates a signed `CLTVScriptSignature` that spends
+    * from a `CLTVScriptSignature` correctly
     *
-    * @return the signed [[org.bitcoins.core.protocol.script.CSVScriptSignature]], the
-    *         [[org.bitcoins.core.protocol.script.CSVScriptPubKey]] it spends, and the
-    *         sequences of [[org.bitcoins.core.crypto.ECPrivateKey]]
+    * @return the signed `CSVScriptSignature`, the
+    *         `CSVScriptPubKey` it spends, and the
+    *         sequences of `ECPrivateKey`
     *         used to sign the scriptSig
     */
   def signedCSVScriptSignature(
@@ -511,15 +506,15 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
                                              sequence)
     } yield scriptSig
 
-  /** Generates a [[org.bitcoins.core.protocol.script.LockTimeScriptSignature LockTimeScriptSignature]] and
-    * [[org.bitcoins.core.protocol.script.LockTimeScriptPubKey LockTimeScriptPubKey]] pair that are valid when
+  /** Generates a `LockTimeScriptSignature` and
+    * `LockTimeScriptPubKey` pair that are valid when
     * run through the interpreter */
   def signedLockTimeScriptSignature: Gen[
     (LockTimeScriptSignature, LockTimeScriptPubKey, Seq[ECPrivateKey])] = {
     Gen.oneOf(signedCSVScriptSignature, signedCLTVScriptSignature)
   }
 
-  /** Helper function to generate [[org.bitcoins.core.protocol.script.LockTimeScriptSignature LockTimeScriptSignature]]s */
+  /** Helper function to generate LockTimeScriptSignatures */
   private def lockTimeHelper(
       lockTime: Option[UInt32],
       sequence: UInt32,
@@ -603,14 +598,14 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
        wtxSigComponent.amount)
 
   /**
-    * This function chooses a random signed [[org.bitcoins.core.protocol.script.ScriptSignature ScriptSignature]]
-    * that is NOT a [[org.bitcoins.core.protocol.script.P2SHScriptSignature P2SHScriptSignature]],
-    * [[org.bitcoins.core.protocol.script.CSVScriptSignature CSVScriptSignature]],
-    * [[org.bitcoins.core.protocol.script.CLTVScriptSignature CLTVScriptSignature]], or any witness type
+    * This function chooses a random signed `ScriptSignature`
+    * that is NOT a `P2SHScriptSignature`,
+    * `CSVScriptSignature`,
+    * `CLTVScriptSignature`, or any witness type
     *
-    * @return the signed [[org.bitcoins.core.protocol.script.ScriptSignature ScriptSignature]],
-    *         the [[org.bitcoins.core.protocol.script.ScriptPubKey ScriptPubKey]] it is spending,
-    *         and the sequence of [[org.bitcoins.core.crypto.ECPublicKey ECPrivateKey]] used to sign it
+    * @return the signed `ScriptSignature`,
+    *         the `ScriptPubKey` it is spending,
+    *         and the sequence of `ECPrivateKey` used to sign it
     */
   def chooseSignedScriptSig: Gen[
     (ScriptSignature, ScriptPubKey, Seq[ECPrivateKey])] = {
@@ -621,9 +616,9 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     )
   }
 
-  /** Generates a random [[org.bitcoins.core.protocol.script.ScriptSignature ScriptSignature]], the
-    * [[org.bitcoins.core.protocol.script.ScriptPubKey ScriptPubKey]] it is spending, and the
-    * [[org.bitcoins.core.crypto.ECPrivateKey ECPrivateKey]] needed to spend it. */
+  /** Generates a random `ScriptSignature`, the
+    * `ScriptPubKey` it is spending, and the
+    * `ECPrivateKey` needed to spend it. */
   def randomScriptSig: Gen[(ScriptSignature, ScriptPubKey, Seq[ECPrivateKey])] = {
     val witP2SHP2WPKH =
       signedP2SHP2WPKHScriptSignature.map(x => (x._1, x._2, x._3))

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
@@ -51,9 +51,9 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   def emptyScriptSignature = p2pkhScriptSignature.map(_ => EmptyScriptSignature)
 
   /**
-    * Generates a [[org.bitcoins.core.protocol.script.P2SHScriptSignature P2SHScriptSignature]]
+    * Generates a [[org.bitcoins.core.protocol.script.P2SHScriptSignature]]
     * WARNING: the redeem script and the script signature DO NOT evaluate to true
-    * if executed by [[org.bitcoins.core.script.interpreter.ScriptInterpreter ScriptInterpreter]]
+    * if executed by [[org.bitcoins.core.script.interpreter.ScriptInterpreter]]
     */
   def p2shScriptSignature: Gen[P2SHScriptSignature] =
     for {
@@ -159,9 +159,9 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     Gen.oneOf(p2wpkhSPKV0, p2wshSPKV0)
 
   /**
-    * Creates an [[org.bitcoins.core.protocol.script.UnassignedWitnessScriptPubKey UnassignedWitnessScriptPubKey]],
+    * Creates an [[org.bitcoins.core.protocol.script.UnassignedWitnessScriptPubKey]],
     * currently this is any witness script pubkey besides
-    * [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 WitnessScriptPubKeyV0]]
+    * [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0]]
     */
   def unassignedWitnessScriptPubKey: Gen[
     (UnassignedWitnessScriptPubKey, Seq[ECPrivateKey])] =
@@ -171,7 +171,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       unassignedAsm = version +: witV0.asm.tail
     } yield (UnassignedWitnessScriptPubKey(unassignedAsm), privKeys)
 
-  /** Generates an arbitrary [[org.bitcoins.core.protocol.script.WitnessScriptPubKey WitnessScriptPubKey]] */
+  /** Generates an arbitrary [[org.bitcoins.core.protocol.script.WitnessScriptPubKey]] */
   def witnessScriptPubKey: Gen[(WitnessScriptPubKey, Seq[ECPrivateKey])] =
     Gen.oneOf(assignedWitnessScriptPubKey, unassignedWitnessScriptPubKey)
 
@@ -224,7 +224,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   def lockTimeScriptSig: Gen[LockTimeScriptSignature] =
     Gen.oneOf(csvScriptSignature, cltvScriptSignature)
 
-  /** Generates an arbitrary [[org.bitcoins.core.protocol.script.ScriptPubKey ScriptPubKey]] */
+  /** Generates an arbitrary [[org.bitcoins.core.protocol.script.ScriptPubKey]] */
   def scriptPubKey: Gen[(ScriptPubKey, Seq[ECPrivateKey])] = {
     Gen.oneOf(
       p2pkScriptPubKey.map(privKeyToSeq(_)),
@@ -241,7 +241,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     )
   }
 
-  /** Generates an arbitrary [[org.bitcoins.core.protocol.script.ScriptSignature ScriptSignature]] */
+  /** Generates an arbitrary [[org.bitcoins.core.protocol.script.ScriptSignature]] */
   def scriptSignature: Gen[ScriptSignature] = {
     Gen.oneOf(
       p2pkScriptSignature,
@@ -256,8 +256,8 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   }
 
   /**
-    * Generates a [[org.bitcoins.core.protocol.script.ScriptSignature ScriptSignature]] corresponding to the type of
-    * [[org.bitcoins.core.protocol.script.ScriptPubKey ScriptPubKey]] given.
+    * Generates a [[org.bitcoins.core.protocol.script.ScriptSignature]] corresponding to the type of
+    * [[org.bitcoins.core.protocol.script.ScriptPubKey]] given.
     * Note: Does NOT generate a correct/valid signature
     */
   private def pickCorrespondingScriptSignature(
@@ -278,12 +278,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   }
 
   /**
-    * Generates a signed [[org.bitcoins.core.protocol.script.P2PKScriptSignature P2PKScriptSignature]] that spends the
-    * [[org.bitcoins.core.protocol.script.P2PKScriptPubKey P2PKScriptPubKey]] correctly
+    * Generates a signed [[org.bitcoins.core.protocol.script.P2PKScriptSignature]] that spends the
+    * [[org.bitcoins.core.protocol.script.P2PKScriptPubKey]] correctly
     *
-    * @return the signed [[org.bitcoins.core.protocol.script.P2PKScriptSignature P2PKScriptSignature]],
-    *         the [[org.bitcoins.core.protocol.script.P2PKScriptPubKey P2PKScriptPubKey]] it spends, and the
-    *         [[org.bitcoins.core.crypto.ECPrivateKey ECPrivateKey]] used to sign the scriptSig
+    * @return the signed [[org.bitcoins.core.protocol.script.P2PKScriptSignature]],
+    *         the [[org.bitcoins.core.protocol.script.P2PKScriptPubKey]] it spends, and the
+    *         [[org.bitcoins.core.crypto.ECPrivateKey]] used to sign the scriptSig
     */
   def signedP2PKScriptSignature: Gen[
     (P2PKScriptSignature, P2PKScriptPubKey, ECPrivateKey)] =
@@ -313,12 +313,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     } yield (signedScriptSig, scriptPubKey, privateKey)
 
   /**
-    * Generates a signed [[org.bitcoins.core.protocol.script.P2PKHScriptSignature P2PKHScriptSignature]] that
-    * spends the [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey P2PKHScriptPubKey]] correctly
+    * Generates a signed [[org.bitcoins.core.protocol.script.P2PKHScriptSignature]] that
+    * spends the [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey]] correctly
     *
-    * @return the signed [[org.bitcoins.core.protocol.script.P2PKHScriptSignature P2PKHScriptSignature]], the
-    *         [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey P2PKHScriptPubKey]] it spends, and the
-    *         [[org.bitcoins.core.crypto.ECPrivateKey ECPrivateKey]] used to sign the scriptSig
+    * @return the signed [[org.bitcoins.core.protocol.script.P2PKHScriptSignature]], the
+    *         [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey]] it spends, and the
+    *         [[org.bitcoins.core.crypto.ECPrivateKey]] used to sign the scriptSig
     */
   def signedP2PKHScriptSignature: Gen[
     (P2PKHScriptSignature, P2PKHScriptPubKey, ECPrivateKey)] =
@@ -347,12 +347,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
 
   /**
     * Generates a signed
-    * [[org.bitcoins.core.protocol.script.MultiSignatureScriptSignature MultiSignatureScriptSignature]] that spends the
-    * [[org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey MultiSignatureScriptPubKey]] correctly
+    * [[org.bitcoins.core.protocol.script.MultiSignatureScriptSignature]] that spends the
+    * [[org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey]] correctly
     * ti
-    * @return the signed [[org.bitcoins.core.protocol.script.MultiSignatureScriptSignature MultiSignatureScriptSignature]],
-    *         the [[org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey MultiSignatureScriptPubKey]] it spends and the
-    *         sequence of [[org.bitcoins.core.crypto.ECPrivateKey ECPrivateKey]] used to sign the scriptSig
+    * @return the signed [[org.bitcoins.core.protocol.script.MultiSignatureScriptSignature]],
+    *         the [[org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey]] it spends and the
+    *         sequence of [[org.bitcoins.core.crypto.ECPrivateKey]] used to sign the scriptSig
     */
   def signedMultiSignatureScriptSignature: Gen[(
       MultiSignatureScriptSignature,
@@ -385,12 +385,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     } yield (signedScriptSig, multiSigScriptPubKey, privateKeys)
 
   /**
-    * Generates a signed [[org.bitcoins.core.protocol.script.P2SHScriptSignature P2SHScriptSignature]]
-    * that spends from a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey P2SHScriptPubKey]] correctly
+    * Generates a signed [[org.bitcoins.core.protocol.script.P2SHScriptSignature]]
+    * that spends from a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey]] correctly
     *
-    * @return the signed [[org.bitcoins.core.protocol.script.P2SHScriptSignature P2SHScriptSignature]],
-    *         the [[org.bitcoins.core.protocol.script.P2SHScriptPubKey P2SHScriptPubKey]] it spends, and the
-    *         sequence of [[org.bitcoins.core.crypto.ECPrivateKey ECPrivateKey]]
+    * @return the signed [[org.bitcoins.core.protocol.script.P2SHScriptSignature]],
+    *         the [[org.bitcoins.core.protocol.script.P2SHScriptPubKey]] it spends, and the
+    *         sequence of [[org.bitcoins.core.crypto.ECPrivateKey]]
     *         used to sign the scriptSig
     */
   def signedP2SHScriptSignature: Gen[
@@ -402,12 +402,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     } yield (p2SHScriptSignature, p2SHScriptPubKey, privateKeys)
 
   /**
-    * Generates a signed [[org.bitcoins.core.protocol.script.P2SHScriptSignature CLTVScriptSignature]] that spends
-    * from a [[org.bitcoins.core.protocol.script.P2SHScriptSignature CLTVScriptPubKey]] correctly
+    * Generates a signed [[org.bitcoins.core.protocol.script.P2SHScriptSignature]] that spends
+    * from a [[org.bitcoins.core.protocol.script.P2SHScriptSignature]] correctly
     *
-    * @return the signed [[org.bitcoins.core.protocol.script.CLTVScriptSignature CLTVScriptSignature]], the
-    *         [[org.bitcoins.core.protocol.script.CLTVScriptPubKey CLTVScriptPubKey]] it spends, and the
-    *         sequences of [[org.bitcoins.core.crypto.ECPrivateKey ECPrivateKey]]
+    * @return the signed [[org.bitcoins.core.protocol.script.CLTVScriptSignature]], the
+    *         [[org.bitcoins.core.protocol.script.CLTVScriptPubKey]] it spends, and the
+    *         sequences of [[org.bitcoins.core.crypto.ECPrivateKey]]
     *         used to sign the scriptSig
     */
   def signedCLTVScriptSignature(
@@ -450,12 +450,12 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       }
 
   /**
-    * Generates a signed [[org.bitcoins.core.protocol.script.CLTVScriptSignature CSVScriptSignature]] that spends
-    * from a [[org.bitcoins.core.protocol.script.CLTVScriptSignature CSVScriptPubKey]] correctly
+    * Generates a signed [[org.bitcoins.core.protocol.script.CLTVScriptSignature]] that spends
+    * from a [[org.bitcoins.core.protocol.script.CLTVScriptSignature]] correctly
     *
-    * @return the signed [[org.bitcoins.core.protocol.script.CSVScriptSignature CSVScriptSignature]], the
-    *         [[org.bitcoins.core.protocol.script.CSVScriptPubKey CSVScriptPubKey]] it spends, and the
-    *         sequences of [[org.bitcoins.core.crypto.ECPrivateKey ECPrivateKey]]
+    * @return the signed [[org.bitcoins.core.protocol.script.CSVScriptSignature]], the
+    *         [[org.bitcoins.core.protocol.script.CSVScriptPubKey]] it spends, and the
+    *         sequences of [[org.bitcoins.core.crypto.ECPrivateKey]]
     *         used to sign the scriptSig
     */
   def signedCSVScriptSignature(

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/WitnessGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/WitnessGenerators.scala
@@ -15,7 +15,7 @@ import org.scalacheck.Gen
   */
 sealed abstract class WitnessGenerators extends BitcoinSLogger {
 
-  /** Generates a random [[org.bitcoins.core.protocol.script.ScriptWitness ScriptWitness]] */
+  /** Generates a random [[org.bitcoins.core.protocol.script.ScriptWitness]] */
   def scriptWitness: Gen[ScriptWitness] = {
 
     //TODO: I need to come back and uncomment out this code after fixing
@@ -38,7 +38,7 @@ sealed abstract class WitnessGenerators extends BitcoinSLogger {
     Gen.oneOf(p2wpkhWitnessV0, p2wshWitnessV0)
   }
 
-  /** Generates a [[org.bitcoins.core.protocol.transaction.TransactionWitness TransactionWitness]] with
+  /** Generates a [[org.bitcoins.core.protocol.transaction.TransactionWitness]] with
     * the specified number of witnesses */
   def transactionWitness(numWitnesses: Int): Gen[TransactionWitness] =
     for {
@@ -51,7 +51,7 @@ sealed abstract class WitnessGenerators extends BitcoinSLogger {
       wit <- transactionWitness(num)
     } yield wit
 
-  /** Generates a validly signed [[org.bitcoins.core.protocol.transaction.TransactionWitness TransactionWitness]] */
+  /** Generates a validly signed [[org.bitcoins.core.protocol.transaction.TransactionWitness]] */
   def signedP2WPKHTransactionWitness: Gen[
     (TransactionWitness, WitnessTxSigComponent, Seq[ECPrivateKey])] =
     for {
@@ -173,7 +173,7 @@ sealed abstract class WitnessGenerators extends BitcoinSLogger {
   /**
     * Generates a random signed [[org.bitcoins.core.protocol.transaction.TransactionWitness TransactionWitness]]
     * with the corresponding [[org.bitcoins.core.crypto.WitnessTxSigComponent WitnessTxSigComponent]]
-    * and [[org.bitcoins.core.crypto.ECPrivateKey ECPrivateKey]]s
+    * and [[org.bitcoins.core.crypto.ECPrivateKey ECPrivateKey]]
     */
   def signedP2WSHTransactionWitness: Gen[
     (TransactionWitness, WitnessTxSigComponentRaw, Seq[ECPrivateKey])] = {
@@ -202,14 +202,14 @@ sealed abstract class WitnessGenerators extends BitcoinSLogger {
     signedScriptSig
   }
 
-  /** Generates a random [[org.bitcoins.core.protocol.script.P2WPKHWitnessV0 P2WPKHWitnessV0]] */
+  /** Generates a random [[org.bitcoins.core.protocol.script.P2WPKHWitnessV0 P2PWPKHWitnessV0]] */
   def p2wpkhWitnessV0: Gen[P2WPKHWitnessV0] =
     for {
       publicKey <- CryptoGenerators.publicKey
       sig <- CryptoGenerators.digitalSignature
     } yield P2WPKHWitnessV0(publicKey, sig)
 
-  /** Generates a random [[org.bitcoins.core.protocol.script.P2WSHWitnessV0 P2WSHWitnessV0]] */
+  /** Generates a random [[org.bitcoins.core.protocol.script.P2WPKHWitnessV0 P2PWPKHWitnessV0]] */
   def p2wshWitnessV0: Gen[P2WSHWitnessV0] =
     for {
       (redeem, _) <- ScriptGenerators.scriptPubKey
@@ -247,7 +247,7 @@ sealed abstract class WitnessGenerators extends BitcoinSLogger {
     (signedTxWitness, signedWtxSigComponent)
   }
 
-  /** Creates a unsigned [[org.bitcoins.core.crypto.WitnessTxSigComponent WitnessTxSigComponent]] from
+  /** Creates a unsigned [[org.bitcoins.core.crypto.WitnessTxSigComponent]] from
     * the given parameters */
   def createUnsignedRawWTxSigComponent(
       witScriptPubKey: WitnessScriptPubKey,

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
@@ -48,7 +48,7 @@ object ControlMessageGenerator {
   }
 
   /**
-    * Generates a random [[VersionMessage]]
+    * Generates a random [[org.bitcoins.core.p2p.VersionMessage VersionMessage]]
     *
     * @see [[https://bitcoin.org/en/developer-reference#version]]
     */
@@ -85,7 +85,7 @@ object ControlMessageGenerator {
       )
 
   /**
-    * Generates a [[PingMessage]]
+    * Generates a [[org.bitcoins.core.p2p.PingMessage]]
     *
     * @see [[https://bitcoin.org/en/developer-reference#ping]]
     */
@@ -95,7 +95,7 @@ object ControlMessageGenerator {
     } yield PingMessage(uInt64)
 
   /**
-    * Generates a [[PongMessage]]
+    * Generates a [[org.bitcoins.core.p2p.PongMessage]]
     *
     * @see [[https://bitcoin.org/en/developer-reference#pong]]
     */
@@ -111,7 +111,7 @@ object ControlMessageGenerator {
   }
 
   /**
-    * Generates a random [[ProtocolVersion]]
+    * Generates a random [[org.bitcoins.core.p2p.ProtocolVersion]]
     *
     * @see [[https://bitcoin.org/en/developer-reference#protocol-versions]]
     */
@@ -121,7 +121,7 @@ object ControlMessageGenerator {
     } yield ProtocolVersion.versions(randomNum)
 
   /**
-    * Generates a [[ServiceIdentifier]]
+    * Generates a [[org.bitcoins.core.p2p.ServiceIdentifier]]
     *
     * @see [[https://bitcoin.org/en/developer-reference#version]]
     */
@@ -144,7 +144,7 @@ object ControlMessageGenerator {
   def portNumber: Gen[Int] = Gen.choose(0, 65535)
 
   /**
-    * Creates a [[FilterLoadMessage]]
+    * Creates a [[org.bitcoins.core.p2p.FilterLoadMessage]]
     *
     * @see [[https://bitcoin.org/en/developer-reference#filterload]]
     */
@@ -158,7 +158,7 @@ object ControlMessageGenerator {
       FilterLoadMessage(ByteVector(filter), UInt32(hashFuncs), tweak, flags)
 
   /**
-    * Creates a [[FilterAddMessage]]
+    * Creates a [[org.bitcoins.core.p2p.FilterAddMessage]]
     *
     * @see [[https://bitcoin.org/en/developer-reference#filteradd]]
     */
@@ -169,7 +169,7 @@ object ControlMessageGenerator {
     } yield FilterAddMessage(elementSize, element.bytes)
 
   /**
-    * Creates a [[RejectMessage]]
+    * Creates a [[org.bitcoins.core.p2p.RejectMessage]]
     *
     * @see [[https://bitcoin.org/en/developer-reference#reject]]
     */

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/DataMessageGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/DataMessageGenerator.scala
@@ -47,7 +47,7 @@ trait DataMessageGenerator {
   }
 
   /**
-    * Generates a random [[GetHeadersMessage]]
+    * Generates a random [[org.bitcoins.core.p2p.GetHeadersMessage]]
     *
     * @see [[https://bitcoin.org/en/developer-reference#getheaders]]
     */
@@ -78,7 +78,7 @@ trait DataMessageGenerator {
     } yield HeadersMessage(blockHeaders.toVector)
 
   /**
-    * Generates a random [[TypeIdentifier]]
+    * Generates a random [[org.bitcoins.core.p2p.TypeIdentifier]]
     *
     * @see [[https://bitcoin.org/en/developer-reference#data-messages]]
     */
@@ -88,7 +88,7 @@ trait DataMessageGenerator {
     } yield TypeIdentifier(UInt32(num))
 
   /**
-    * Generates a random [[Inventory]]
+    * Generates a random [[org.bitcoins.core.p2p.Inventory]]
     * @see [[https://bitcoin.org/en/developer-reference#term-inventory]]
     */
   def inventory: Gen[Inventory] =
@@ -98,7 +98,7 @@ trait DataMessageGenerator {
     } yield Inventory(identifier, hash)
 
   /**
-    * Generates a random [[InventoryMessage]]
+    * Generates a random [[org.bitcoins.core.p2p.InventoryMessage]]
     * @see [[https://bitcoin.org/en/developer-reference#inv]]
     */
   def inventoryMessages: Gen[InventoryMessage] =
@@ -114,7 +114,7 @@ trait DataMessageGenerator {
   }
 
   /**
-    * Generate a random [[GetDataMessage]]
+    * Generate a random [[org.bitcoins.core.p2p.GetDataMessage]]
     * @see [[https://bitcoin.org/en/developer-reference#getdata]]
     */
   def getDataMessages: Gen[GetDataMessage] =
@@ -123,7 +123,7 @@ trait DataMessageGenerator {
     } yield GetDataMessage(invMsgs.inventoryCount, invMsgs.inventories)
 
   /**
-    * Generates a random [[MerkleBlockMessage]]
+    * Generates a random [[org.bitcoins.core.p2p.MerkleBlockMessage]]
     * @see [[https://bitcoin.org/en/developer-reference#merkleblock]]
     */
   def merkleBlockMessage: Gen[MerkleBlockMessage] =
@@ -131,7 +131,7 @@ trait DataMessageGenerator {
       (merkleBlock, _, _) <- MerkleGenerator.merkleBlockWithInsertedTxIds
     } yield MerkleBlockMessage(merkleBlock)
 
-  /** Generates a [[TransactionMessage]]
+  /** Generates a [[org.bitcoins.core.p2p.TransactionMessage]]
     * @see [[https://bitcoin.org/en/developer-reference#tx]]
     * */
   def transactionMessage: Gen[TransactionMessage] =

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -96,7 +96,7 @@ abstract class NodeTestUtil extends BitcoinSLogger {
     new InetSocketAddress(instance.uri.getHost, instance.p2pPort)
   }
 
-  /** Gets the [[Peer]] that
+  /** Gets the [[org.bitcoins.node.models.Peer]] that
     * corresponds to [[org.bitcoins.rpc.client.common.BitcoindRpcClient]] */
   def getBitcoindPeer(bitcoindRpcClient: BitcoindRpcClient): Peer = {
     val socket = getBitcoindSocketAddress(bitcoindRpcClient)

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -609,7 +609,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
   }
 
   /**
-    * Returns a triple of [[org.bitcoins.rpc.client.common.BitcoindRpcClient BitcoindRpcClient]]
+    * Returns a triple of org.bitcoins.rpc.client.common.BitcoindRpcClient BitcoindRpcClient
     * that are connected with some blocks in the chain
     */
   def createNodeTriple(
@@ -620,7 +620,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
   }
 
   /**
-    * Returns a triple of [[org.bitcoins.rpc.client.v17.BitcoindV17RpcClient BitcoindV17RpcClient]]
+    * @return a triple of [[org.bitcoins.rpc.client.v17.BitcoindV17RpcClient BitcoindV17RpcClient]]
     * that are connected with some blocks in the chain
     */
   def createNodeTripleV17(
@@ -662,7 +662,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     * or a [[org.bitcoins.rpc.client.v16.BitcoindV16RpcClient BitcoindV16RpcClient]]
     * from the provided `signer`, and then calls the appropriate method on the result.
     *
-    * Throws a [[RuntimeException]] if no versioned
+    * @throws RuntimeException if no versioned
     * [[org.bitcoins.rpc.client.common.BitcoindRpcClient BitcoindRpcClient]]
     * can be constructed.
     */

--- a/wallet/src/main/scala/org/bitcoins/wallet/EncryptedMnemonic.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/EncryptedMnemonic.scala
@@ -1,20 +1,13 @@
 package org.bitcoins.wallet
 
-import java.nio.charset.StandardCharsets
-
-import org.bitcoins.core.crypto.{AesCrypt, AesEncryptedData, MnemonicCode}
+import org.bitcoins.core.crypto._
+import org.bitcoins.core.util.BitcoinSLogger
 import scodec.bits.ByteVector
 
-import scala.util.Try
-import org.bitcoins.core.crypto.AesSalt
-import org.bitcoins.core.crypto.AesPassword
-import org.bitcoins.core.util.BitcoinSLogger
-import scala.util.Success
-import scala.util.Failure
+import scala.util.{Failure, Success, Try}
 
 case class EncryptedMnemonic(value: AesEncryptedData, salt: AesSalt)
     extends BitcoinSLogger {
-  import org.bitcoins.core.util.EitherUtil.EitherOps._
 
   def toMnemonic(password: AesPassword): Try[MnemonicCode] = {
     val key = password.toKey(salt)

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency._
 import org.bitcoins.wallet.api._

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet
 
+import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency._
 import org.bitcoins.wallet.api._

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -3,6 +3,7 @@ package org.bitcoins.wallet
 import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency._
+import org.bitcoins.core.hd._
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.util.{BitcoinSLogger, EitherUtil}
@@ -10,13 +11,12 @@ import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.BitcoinUTXOSpendingInfo
 import org.bitcoins.wallet.api._
+import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.models._
 import scodec.bits.BitVector
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
-import org.bitcoins.core.hd._
-import org.bitcoins.wallet.config.WalletAppConfig
 
 sealed abstract class Wallet
     extends LockedWallet
@@ -165,7 +165,6 @@ object Wallet extends CreateWalletApi with BitcoinSLogger {
   override def initializeWithEntropy(entropy: BitVector)(
       implicit config: WalletAppConfig,
       ec: ExecutionContext): Future[InitializeWalletResult] = {
-    import org.bitcoins.core.util.EitherUtil.EitherOps._
 
     logger.info(s"Initializing wallet on chain ${config.network}")
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -47,8 +47,8 @@ trait LockedWalletApi extends WalletApi {
 
   /**
     * Processes the given transaction, updating our DB state if it's relevant to us.
-    * @param transaction The transacton we're processing
-    * @param confirmation How many confirmations the TX has
+    * @param transaction The transaction we're processing
+    * @param confirmations How many confirmations the TX has
     */
   def processTransaction(
       transaction: Transaction,
@@ -78,7 +78,9 @@ trait LockedWalletApi extends WalletApi {
     */
   // def updateUtxo: Future[WalletApi]
 
-  /** Lists unspent transaction outputs in the wallet */
+  /** Lists unspent transaction outputs in the wallet
+    * @return Vector[SpendingInfoDb]
+    * */
   def listUtxos(): Future[Vector[SpendingInfoDb]]
 
   def listAddresses(): Future[Vector[AddressDb]]
@@ -88,10 +90,10 @@ trait LockedWalletApi extends WalletApi {
     * type. Calling this method multiple
     * times will return the same address, until it has
     * received funds.
-    *
+    *  TODO: Last sentence is not true, implement that
+    *  https://github.com/bitcoin-s/bitcoin-s/issues/628
+    *  @param addressType
     */
-  // TODO: Last sentence is not true, implement that
-  // https://github.com/bitcoin-s/bitcoin-s/issues/628
   def getNewAddress(addressType: AddressType): Future[BitcoinAddress]
 
   /**
@@ -109,6 +111,7 @@ trait LockedWalletApi extends WalletApi {
   /**
     * Mimics the `getaddressinfo` RPC call in Bitcoin Core
     *
+    * @param address
     * @return If the address is found in our database `Some(address)`
     *         is returned, otherwise `None`
     */
@@ -129,10 +132,13 @@ trait LockedWalletApi extends WalletApi {
 
   /**
     * Fetches the default account from the DB
+    * @return Future[AccountDb]
     */
   protected[wallet] def getDefaultAccount(): Future[AccountDb]
 
-  /** Fetches the default account for the given address/acount kind  */
+  /** Fetches the default account for the given address/account kind
+    * @param addressType
+    * */
   protected[wallet] def getDefaultAccountForType(
       addressType: AddressType): Future[AccountDb]
 
@@ -144,7 +150,10 @@ trait LockedWalletApi extends WalletApi {
 
   def listAccounts(): Future[Vector[AccountDb]]
 
-  /** Lists all wallet accounts with the given type */
+  /** Lists all wallet accounts with the given type
+    * @param purpose
+    * @return [[Future[Vector[AccountDb]]
+    * */
   def listAccounts(purpose: HDPurpose): Future[Vector[AccountDb]] =
     listAccounts().map(_.filter(_.hdAccount.purpose == purpose))
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -31,7 +31,7 @@ import org.bitcoins.core.crypto.DoubleSha256DigestBE
   */
 private[wallet] trait UtxoHandling { self: LockedWallet =>
 
-  /** $inheritdoc */
+  /** @inheritdoc */
   override def listUtxos(): Future[Vector[SpendingInfoDb]] =
     spendingInfoDAO.findAllUnspent()
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoTable.scala
@@ -160,14 +160,10 @@ sealed trait SpendingInfoDb
 
 /**
   * This table stores the necessary information to spend
-  * a TXO at a later point in time.
-  *
-  * It does not contain informations about whether or not
-  * it is spent, how many (if any) confirmations it has
-  * or which block/transaction it was included in.
-  *
-  * That is rather handled by
-  * [[org.bitcoins.wallet.models.WalletTXOTable WalletTXOTable]].
+  * a transaction output (TXO) at a later point in time. It
+  * also stores how many confirmations it has, whether
+  * or not it is spent (i.e. if it is a UTXO or not) and the
+  * TXID of the transaction that created this output.
   */
 case class SpendingInfoTable(tag: Tag)
     extends TableAutoInc[SpendingInfoDb](tag, "txo_spending_info") {


### PR DESCRIPTION
I tried reformatting some of the scaladoc comment blocks we have set up but it seems there are two issues here. First is that scaladocs does not recognize links that are within the java language and next is that the @throws tag does not work the way its intended. This issue with links as highlighted in issue #622 seems to be rather common and issues just get closed after being told to edit the `build.sbt` file to include `"-no-link-warnings"` in your `scaladoc` settings. I am a bit worried though as some of this is open source and has multiple people contributing the link warnings might be useful. 

I have double checked the `scaladocs` formatting that is required and in instances we are following them but it still throws a warning. There are a few things that could create an issue, 1. I don't think `scaladocs` handles `@throws` the same way that `javadocs` does so it struggles. 2. `scaladocs` doesn't seem to be very good at giving descriptive warnings so there might be an issue deeper in the chain of the doc but it will report them at the top. I have also noticed that it processes the `scaladocs` from the bottom up in a file. Many people seem to have similar issues with scaladocs and they just close the issues and recommend turning off the flags. [[https://github.com/scala/bug/issues/10182]]  [[https://github.com/akka/akka/issues/19998]]  [[https://github.com/scala/bug/issues/9311]] 

I did some more sanity checks and I have no clue why `@inheritdocs` does not work in the code base,
its isolated to `TransactionProcessing` the others instances have been fixed but for whatever reason it is not finding the `scaladocs` written in the `superclass` that the `defs` are overriding. The `superclass` is the `walletApi.scala` file if anyone wants to take a look and I'm missing anything obvious. There has been some removal of warnings so I think this PR is still worthy of being merged and I also fixed some documentation so there is content but it has not solved the problem in its entirety.

So as this pull request stands there has been added scaladocs in locations that lacked them or some scaladocs were expanded on. Some had directed links to their directory. I have removed the no link warning flag so this PR is just added documentation and fixing a few of the publish log errors we ran into but I can't seem to fix a persistent few. Hopefully in a update of scaladocs a lot of these will go away.