### PR TITLE
Call BitcoindRpcTestUtil.stopServer inside of EclairRpcTestUtil.shutdown

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -269,10 +269,10 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
   def deleteTmpDir(dir: File): Boolean = {
     val isTemp = dir.getPath startsWith Properties.tmpDir
     if (!isTemp) {
-      throw new IllegalArgumentException(
+      logger.warn(
         s"Directory $dir is not in the system temp dir location! You most likely didn't mean to delete this directory.")
-    }
-    if (!dir.isDirectory) {
+      false
+    } else if (!dir.isDirectory) {
       dir.delete()
     } else {
       dir.listFiles().foreach(deleteTmpDir)
@@ -832,7 +832,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
       clientAccum: RpcClientAccum = Vector.newBuilder)(
       implicit system: ActorSystem): Future[BitcoindRpcClient] = {
     implicit val ec: ExecutionContextExecutor = system.dispatcher
-    assert(
+    require(
       instance.datadir.getPath().startsWith(Properties.tmpDir),
       s"${instance.datadir} is not in user temp dir! This could lead to bad things happening.")
 


### PR DESCRIPTION
First off, sorry for the formatting stuff. It appears we need to get @rorp 's scalafmt working in conjunction with ours.

The biggest thing this PR does is delegate the shutting down of a bitcoind in the eclair project to [`BitcoindRpcTestUtil.stopServer`](https://github.com/bitcoin-s/bitcoin-s/compare/master...Christewart:2019-07-17-stop-server?expand=1#diff-cd4058c31bbecd58de56f25a7973e8e4R623).

This does bring up an issue we have with `BitcoindInstance`, if we do not specify a `datadir` it defaults to the `BitcoindConfig.DEFAULT_DATADIR`. When finding the appropriate bitcoind to shutdown, we do _not_ know the actual datadir for that bitcoind location since it could theoretically be remote. If you look at [`EclairRpcTestUtil.getBitcoindRpc`](https://github.com/bitcoin-s/bitcoin-s/blob/master/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala#L583) we leave the parameter as the default value, which means we _attempt_ to destroy the default data directory on our machine. This is less than ideal, but in this [PR I also switched from throwing an exception to log a warning and return false](https://github.com/bitcoin-s/bitcoin-s/compare/master...Christewart:2019-07-17-stop-server?expand=1#diff-1dce72c4af9ad8ab428f8e7f3cd4600dR272).

I'm not sure if this is the best thing to do, the alternative seems to be adding a `Option[BitcoindInstance]` to the `EclairInstance` class. 