### PR TITLE
Add the -Xfatal-warnings compiler option to make sure we get compile …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ lazy val compilerOpts = Seq(
   "-feature",
   "-deprecation",
   "-Xfuture",
+  "-Xfatal-warnings",
   "-Ywarn-dead-code",
   "-Ywarn-unused-import",
   "-Ywarn-value-discard",

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkIpAddressSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkIpAddressSerializer.scala
@@ -3,9 +3,9 @@ package org.bitcoins.core.serializers.p2p
 import java.net.InetAddress
 
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.serializers.RawBitcoinSerializer
-import org.bitcoins.core.util.{BitcoinSLogger, NumberUtil}
 import org.bitcoins.core.p2p._
+import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.util.BitcoinSLogger
 import scodec.bits.ByteVector
 
 /**


### PR DESCRIPTION
…errors if we have warnings

https://docs.scala-lang.org/overviews/compiler-options/index.html

```
 -Xfatal-warnings

    Fail the compilation if there are any warnings.
```

there are errors currently, i'm not sure what this one really is 

```
[error] sbt-api: Unhandled type class scala.reflect.internal.Types$MethodType : ($this: org.bitcoins.core.crypto.AesPassword)String
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
[error] Total time: 4 s, completed Jul 20, 2019 1:01:43 PM

```