### PR TITLE
Implement missing branch on POW validation for testnet, implement Blo…

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
@@ -16,7 +16,7 @@ class BlockHeaderDAOTest extends ChainUnitTest {
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBlockHeaderDAO(test)
 
-  override implicit val system: ActorSystem = ActorSystem("BlockHeaderDAOTest")
+  implicit override val system: ActorSystem = ActorSystem("BlockHeaderDAOTest")
 
   behavior of "BlockHeaderDAO"
 
@@ -171,5 +171,21 @@ class BlockHeaderDAOTest extends ChainUnitTest {
         case headers =>
           assert(headers == Seq(blockHeader, blockHeader1))
       }
+  }
+
+  it must "find a header with height 1" in { blockHeaderDAO: BlockHeaderDAO =>
+    val blockHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
+    val createdF = blockHeaderDAO.create(blockHeader)
+
+    val f: BlockHeaderDb => Boolean = { bh =>
+      bh.height == 1
+    }
+
+    val foundF = createdF.flatMap(created => blockHeaderDAO.find(f))
+
+    for {
+      created <- createdF
+      found <- foundF
+    } yield assert(found.get == created)
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -195,7 +195,7 @@ case class BlockHeaderDAO()(
     }
   }
 
-  /** Finds a [[BlockHeaderDb block header]] that satisfies the given predicate, else returns None */
+  /** Finds a [[org.bitcoins.chain.models.BlockHeaderDb block header]] that satisfies the given predicate, else returns None */
   def find(f: BlockHeaderDb => Boolean)(
       implicit ec: ExecutionContext): Future[Option[BlockHeaderDb]] = {
     val chainsF = getBlockchains()
@@ -203,7 +203,13 @@ case class BlockHeaderDAO()(
       val headersOpt: Vector[Option[BlockHeaderDb]] =
         chains.map(_.headers.find(f))
       //if there are multiple, we just choose the first one for now
-      headersOpt.find(_.isDefined).flatten
+      val result = headersOpt.filter(_.isDefined).flatten
+      if (result.length > 1) {
+        logger.warn(
+          s"Discarding other matching headers for predicate headers=${result
+            .map(_.hashBE.hex)}")
+      }
+      result.headOption
     }
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -174,7 +174,7 @@ case class BlockHeaderDAO()(
 
   /** Returns competing blockchains that are contained in our BlockHeaderDAO
     * Each chain returns the last [[org.bitcoins.core.protocol.blockchain.ChainParams.difficultyChangeInterval difficutly interval]]
-    * as defined by the network we are on. For instance, on bitcoin mainnet this will be 2016 block headers.
+    * block headers as defined by the network we are on. For instance, on bitcoin mainnet this will be 2016 block headers.
     * If no competing tips are found, we only return one [[Blockchain blockchain]], else we
     * return n chains for the number of competing [[chainTips tips]] we have
     * @see [[Blockchain]]
@@ -192,6 +192,18 @@ case class BlockHeaderDAO()(
         headersF.map(headers => Blockchain.fromHeaders(headers.reverse))
       }
       Future.sequence(nestedFuture)
+    }
+  }
+
+  /** Finds a [[BlockHeaderDb block header]] that satisfies the given predicate, else returns None */
+  def find(f: BlockHeaderDb => Boolean)(
+      implicit ec: ExecutionContext): Future[Option[BlockHeaderDb]] = {
+    val chainsF = getBlockchains()
+    chainsF.map { chains =>
+      val headersOpt: Vector[Option[BlockHeaderDb]] =
+        chains.map(_.headers.find(f))
+      //if there are multiple, we just choose the first one for now
+      headersOpt.find(_.isDefined).flatten
     }
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -40,13 +40,15 @@ sealed abstract class Pow extends BitcoinSLogger {
           Future.successful(powLimit)
         } else {
           // Return the last non-special-min-difficulty-rules-block
+          val nonMinDiffF = blockHeaderDAO.find(_.nBits != powLimit)
 
-          // this is complex to implement and requires walking the
-          //chain until we find a block header that does not have
-          //the minimum difficulty rule on testnet
-
-          //TODO: This is not correctly implemented, come back and fix this when BlockHeaderDAO has a predicate to satisfy
-          Future.successful(powLimit)
+          nonMinDiffF.map {
+            case Some(bh) => bh.nBits
+            case None     =>
+              //if we can't find a non min diffulty block, let's just fail
+              throw new RuntimeException(
+                s"Could not find non mindiffulty block in chain! hash=${tip.hashBE.hex} height=${currentHeight}")
+          }
         }
       } else {
         Future.successful(tip.blockHeader.nBits)
@@ -54,7 +56,8 @@ sealed abstract class Pow extends BitcoinSLogger {
     } else {
       val firstHeight = currentHeight - (chainParams.difficultyChangeInterval - 1)
 
-      require(firstHeight >= 0, s"We must have our first height be postive, got=${firstHeight}")
+      require(firstHeight >= 0,
+              s"We must have our first height be postive, got=${firstHeight}")
 
       val firstBlockAtIntervalF: Future[Option[BlockHeaderDb]] = {
         blockHeaderDAO.getAncestorAtHeight(tip, firstHeight)

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -40,7 +40,11 @@ sealed abstract class Pow extends BitcoinSLogger {
           Future.successful(powLimit)
         } else {
           // Return the last non-special-min-difficulty-rules-block
-          val nonMinDiffF = blockHeaderDAO.find(_.nBits != powLimit)
+          //while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 && pindex->nBits == nProofOfWorkLimit)
+          //                    pindex = pindex->pprev;
+          val nonMinDiffF = blockHeaderDAO.find { h =>
+            h.nBits != powLimit || h.height % chainParams.difficultyChangeInterval == 0
+          }
 
           nonMinDiffF.map {
             case Some(bh) => bh.nBits


### PR DESCRIPTION
…ckHeaderDAO.find

This PR implements a missing branch in our POW validation logic that is found [here](https://github.com/bitcoin/bitcoin/blob/35477e9e4e3f0f207ac6fa5764886b15bf9af8d0/src/pow.cpp#L29-L35). I believe this code is needed to properly sync our spv node with testnet.

This PR also introduces the `find` method to `BlockHeaderDAO`. This is similar to the `find()` method in the scala collections library that allows you to pass in a `f: BlockHeaderDb => Boolean` and returns a `Future[Option[BlockHeaderDb]]`. I think this will be useful later on down the line, and I would be interested in trying to add something like this to `CRUD` 