### PR TITLE
POC: UInt32 optimization

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ExtKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ExtKeyTest.scala
@@ -15,7 +15,7 @@ import scala.util.{Failure, Success, Try}
 
 class ExtKeyTest extends BitcoinSUnitTest {
 
-  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     generatorDrivenConfigNewCode
 
   behavior of "ExtKey"
@@ -30,7 +30,7 @@ class ExtKeyTest extends BitcoinSUnitTest {
         val pub = priv.extPublicKey
         val derivedPubUInt32: Try[ExtPublicKey] = pub.deriveChildPubKey(index)
         val derivedPubPrimitive: Try[ExtPublicKey] =
-          pub.deriveChildPubKey(index.toLong)
+          pub.deriveChildPubKey(index)
         (derivedPubUInt32, derivedPubPrimitive) match {
           case (Success(_), Success(_)) => succeed
           case (Failure(exc1), Failure(exc2)) =>

--- a/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilSpec.scala
@@ -8,7 +8,6 @@ import org.scalacheck.{Prop, Properties}
   * Created by chris on 6/20/16.
   */
 class NumberUtilSpec extends Properties("NumberUtilSpec") {
-  private val logger = BitcoinSLogger.logger
 
   property("Serialization symmetry for BigInt") =
     Prop.forAll(NumberGenerator.bigInts) { bigInt: BigInt =>
@@ -20,7 +19,7 @@ class NumberUtilSpec extends Properties("NumberUtilSpec") {
   }
 
   property("serialization symmetry for longs") = Prop.forAll { long: Long =>
-    NumberUtil.toLong(BitcoinSUtil.encodeHex(long)) == long
+    NumberUtil.toLongSigned(BitcoinSUtil.encodeHex(long)) == long
   }
 
   property("convertBits symmetry") = {

--- a/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
@@ -15,13 +15,17 @@ import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
 import org.bitcoins.core.protocol.{CompactSizeUInt, NetworkElement}
 import org.bitcoins.core.script.constant.{ScriptConstant, ScriptToken}
 import org.bitcoins.core.serializers.bloom.RawBloomFilterSerializer
-import org.bitcoins.core.util.{BitcoinSUtil, Factory}
+import org.bitcoins.core.util.{
+  BitcoinSLogger,
+  BitcoinSUtil,
+  CryptoUtil,
+  Factory
+}
 import scodec.bits.{BitVector, ByteVector}
 
 import scala.annotation.tailrec
 import scala.util.hashing.MurmurHash3
 import org.bitcoins.core.crypto.ECPublicKey
-import org.bitcoins.core.util.CryptoUtil
 
 /**
   * Implements a bloom filter that abides by the semantics of BIP37
@@ -29,7 +33,7 @@ import org.bitcoins.core.util.CryptoUtil
   * @see [[https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki BIP37]].
   * @see [[https://github.com/bitcoin/bitcoin/blob/master/src/bloom.h Bitcoin Core bloom.h]]
   */
-sealed abstract class BloomFilter extends NetworkElement {
+sealed abstract class BloomFilter extends NetworkElement with BitcoinSLogger {
 
   /** How large the bloom filter is, in Bytes */
   def filterSize: CompactSizeUInt

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -57,13 +57,6 @@ sealed abstract class ExtKey extends NetworkElement {
   }
 
   /**
-    * Derives the child pubkey at the specified index
-    */
-  def deriveChildPubKey(idx: Long): Try[ExtPublicKey] = {
-    Try(UInt32(idx)).flatMap(deriveChildPubKey)
-  }
-
-  /**
     * Derives the child pubkey at the specified index and
     * hardening value
     */

--- a/core/src/main/scala/org/bitcoins/core/number/BasicArithmetic.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/BasicArithmetic.scala
@@ -9,7 +9,7 @@ import scala.util.Try
   * operator to throw. This method wraps it in a `Try`
   * block.
   */
-trait BasicArithmetic[N] {
+trait BasicArithmetic[N] extends Any {
 
   def +(n: N): N
 

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -129,11 +129,75 @@ sealed abstract class UInt8 extends UnsignedNumber[UInt8] {
 /**
   * Represents a uint32_t in C
   */
-sealed abstract class UInt32 extends UnsignedNumber[UInt32] {
-  override def apply: A => UInt32 = UInt32(_)
-  override def hex: String = BitcoinSUtil.encodeHex(toLong).slice(8, 16)
+final case class UInt32(underlying: Long)
+    extends AnyVal
+    with NetworkElement
+    with BasicArithmetic[UInt32]
+    with Ordered[UInt32] {
+  override def hex: String = BitcoinSUtil.encodeHex(underlying).slice(8, 16)
 
-  override def andMask = 0xffffffffL
+  override def bytes: ByteVector = ByteVector.fromValidHex(hex)
+
+  override def +(y: UInt32): UInt32 = {
+    UInt32(underlying + y.underlying)
+  }
+
+  override def -(y: UInt32): UInt32 = {
+    UInt32(underlying - y.underlying)
+  }
+
+  override def *(y: UInt32): UInt32 = {
+    UInt32(underlying * y.underlying)
+  }
+
+  override def *(factor: BigInt): UInt32 = ???
+
+  def |(u32: UInt32): UInt32 = {
+    UInt32(underlying | u32.underlying)
+  }
+
+  def &(u32: UInt32): UInt32 = {
+    UInt32(underlying & u32.underlying)
+  }
+
+  def <<(u32: UInt32): UInt32 = {
+    UInt32(underlying << u32.underlying)
+  }
+
+  def <<(int: Int): UInt32 = {
+    this.<<(UInt32(int))
+  }
+
+  def >>(u32: UInt32): UInt32 = {
+    UInt32(underlying >> u32.underlying)
+  }
+
+  def >>(int: Int): UInt32 = {
+    UInt32(underlying >> int)
+  }
+
+  def toInt: Int = {
+    val i = underlying.toInt
+    require(underlying == i,
+            s"Rounded when converting long=${underlying} toInt=${i}")
+    i
+  }
+
+  def toLong: Long = underlying
+
+  def toBigInt: BigInt = toLong
+
+  def toDouble(x: UInt32): Double = x.underlying.toDouble
+  def toFloat(x: UInt32): Float = x.underlying.toFloat
+
+  def toInt(x: UInt32): Int = {
+    val i = x.underlying.toInt
+    require(x.underlying == i)
+    i
+  }
+  def toLong(x: UInt32): Long = x.underlying
+
+  override def compare(that: UInt32): Int = underlying.compare(that.underlying)
 }
 
 /**
@@ -308,35 +372,35 @@ object UInt8
 
 object UInt32
     extends Factory[UInt32]
-    with NumberObject[UInt32]
+    /*    with NumberObject[UInt32]*/
     with Bounded[UInt32] {
-  private case class UInt32Impl(underlying: BigInt) extends UInt32 {
+  /*  private case class UInt32Impl(underlying: BigInt) extends UInt32 {
     require(isInBound(underlying),
             s"Cannot create ${super.getClass.getSimpleName} from $underlying")
-  }
+  }*/
 
   lazy val zero = UInt32(0)
   lazy val one = UInt32(1)
 
-  private lazy val minUnderlying: A = 0
-  private lazy val maxUnderlying: A = 4294967295L
+  private lazy val minUnderlying = 0
+  private lazy val maxUnderlying = 4294967295L
 
   lazy val min = UInt32(minUnderlying)
   lazy val max = UInt32(maxUnderlying)
 
-  override def isInBound(num: A): Boolean =
-    num <= maxUnderlying && num >= minUnderlying
+  /*  override def isInBound(num: A): Boolean =
+    num <= maxUnderlying && num >= minUnderlying*/
 
   override def fromBytes(bytes: ByteVector): UInt32 = {
     require(
       bytes.size <= 4,
       "UInt32 byte array was too large, got: " + BitcoinSUtil.encodeHex(bytes))
-    UInt32(NumberUtil.toUnsignedInt(bytes))
+    UInt32(NumberUtil.toLongUnsigned(bytes))
   }
 
-  def apply(long: Long): UInt32 = UInt32(BigInt(long))
-
-  def apply(bigInt: BigInt): UInt32 = UInt32Impl(bigInt)
+  def apply(bigInt: BigInt): UInt32 = {
+    UInt32(bigInt.bigInteger.longValueExact())
+  }
 }
 
 object UInt64

--- a/core/src/main/scala/org/bitcoins/core/p2p/TypeIdentifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/TypeIdentifier.scala
@@ -82,8 +82,6 @@ object TypeIdentifier extends Factory[TypeIdentifier] {
   override def fromBytes(bytes: ByteVector): TypeIdentifier =
     RawTypeIdentifierSerializer.read(bytes)
 
-  def apply(num: Long): TypeIdentifier = TypeIdentifier(UInt32(num))
-
   def apply(uInt32: UInt32): TypeIdentifier = uInt32 match {
     case UInt32.one                 => MsgTx
     case _ if (uInt32 == UInt32(2)) => MsgBlock

--- a/core/src/main/scala/org/bitcoins/core/protocol/NetworkElement.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/NetworkElement.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.core.protocol
 
-import org.bitcoins.core.util.BitcoinSLogger
 import scodec.bits.ByteVector
 
 /**
@@ -8,7 +7,7 @@ import scodec.bits.ByteVector
   * This represents a element that can be serialized to
   * be sent over the network
   */
-abstract class NetworkElement {
+trait NetworkElement extends Any {
 
   /** The size of the NetworkElement in bytes. */
   def size: Long = bytes.size
@@ -18,6 +17,4 @@ abstract class NetworkElement {
 
   /** The byte representation of the NetworkElement */
   def bytes: ByteVector
-
-  lazy val logger = BitcoinSLogger.logger
 }

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -63,10 +63,25 @@ sealed abstract class NumberUtil extends BitcoinSLogger {
   def toInt(hex: String): Int = toInt(BitcoinSUtil.decodeHex(hex))
 
   /** Converts a sequence of [[scala.Byte Byte]] to a [[scala.Long Long]]. */
-  def toLong(bytes: ByteVector): Long = toBigInt(bytes).toLong
+  def toLongUnsigned(bytes: ByteVector): Long = {
+    toLong(bytes, false)
+  }
 
   /** Converts a hex string to a [[scala.Long Long]]. */
-  def toLong(hex: String): Long = toLong(BitcoinSUtil.decodeHex(hex))
+  def toLongUnsigned(hex: String): Long =
+    toLongUnsigned(BitcoinSUtil.decodeHex(hex))
+
+  def toLongSigned(bytes: ByteVector): Long = {
+    toLong(bytes, true)
+  }
+
+  def toLongSigned(hex: String): Long = {
+    toLong(BitcoinSUtil.decodeHex(hex), true)
+  }
+
+  private def toLong(bytes: ByteVector, signed: Boolean): Long = {
+    bytes.toLong(signed)
+  }
 
   /**
     *
@@ -112,7 +127,7 @@ sealed abstract class NumberUtil extends BitcoinSLogger {
           val r: Long = ((acc << (to - bits) & maxv)).toLong
           ret.+=(f(UInt8(r.toShort)))
         }
-      } else if (bits >= from || ((acc << (to - bits)) & maxv) != UInt8.zero) {
+      } else if (bits >= from || ((acc << (to - bits)) & maxv) != UInt32.zero) {
         Failure(new IllegalArgumentException("Invalid padding in encoding"))
       }
       Success(ret.result())


### PR DESCRIPTION
In wake of #653 I think some of the lowest hanging fruit that will improve the library overall is optimize our Number implementations.

To do this, I think we will have to get rid of the `Number` trait. I can't figure how to to get the underlying implementation -- defined as `A` in `Number` -- to be different for each concrete type. I.e. a `UInt8` should _not_ have a `BigInt` backing it, it should be a `Short` (maybe a `Byte` if we are ambitious!) The underlying implementation of `UInt64` _should_ be a `BigInteger`, and a `UInt32` should be a `Long` etc.

This PR optimizes our `UInt32` type. It turns `UInt32` into a case class and we extend [`AnyVal`](https://docs.scala-lang.org/overviews/core/value-classes.html) to avoid runtime allocations. This should improve performance and memory usage.

I think this is going to come at the cost of having redundant code for each number implementation we do, but as far as i can tell this is what Scala does with their number types [`Int`](https://github.com/scala/scala/blob/2.13.x/src/library/scala/Int.scala)/[`Long`](https://github.com/scala/scala/blob/2.13.x/src/library/scala/Long.scala) etc

If the overall design is acceptable, I think we should extend this to the rest of Number implementations.

The only unit tests not passing in `coreTest` are the ones that are checking that `UInt32` is not a negative number, unfortunately we cannot preserve the invariant `require()` in the body of the case class while extending `AnyVal`