### PR TITLE
Start the process of refactoring our ChainHandler to be able to avoid…

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -12,7 +12,7 @@ class BlockchainTest extends ChainUnitTest {
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBlockHeaderDAO(test)
 
-  override implicit val system: ActorSystem = ActorSystem("BlockchainTest")
+  implicit override val system: ActorSystem = ActorSystem("BlockchainTest")
 
   behavior of "Blockchain"
 
@@ -26,7 +26,8 @@ class BlockchainTest extends ChainUnitTest {
         BlockHeaderHelper.buildNextHeader(ChainUnitTest.genesisHeaderDb)
 
       val connectTipF = Blockchain.connectTip(header = newHeader.blockHeader,
-                                              blockHeaderDAO = bhDAO)
+                                              blockHeaderDAO = bhDAO,
+                                              Vector(blockchain))
 
       connectTipF.map {
         case BlockchainUpdate.Successful(_, connectedHeader) =>

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -120,7 +120,9 @@ class ChainHandlerTest extends ChainUnitTest {
       val createdF = chainHandler.blockHeaderDAO.createAll(firstThreeBlocks)
 
       createdF.flatMap { _ =>
-        val processorF = Future.successful(chainHandler)
+        val blockchain = Blockchain.fromHeaders(firstThreeBlocks.reverse)
+        val handler = ChainHandler(chainHandler.blockHeaderDAO, blockchain)
+        val processorF = Future.successful(handler)
         // Takes way too long to do all blocks
         val blockHeadersToTest = blockHeaders.tail
           .take(

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -19,9 +19,11 @@ import org.bitcoins.chain.validation.TipUpdateResult
   * of [[org.bitcoins.chain.api.ChainApi ChainApi]], this is the entry point in to the
   * chain project.
   */
-case class ChainHandler(blockHeaderDAO: BlockHeaderDAO)(
-    implicit private[chain] val chainConfig: ChainAppConfig
-) extends ChainApi
+case class ChainHandler(
+    blockHeaderDAO: BlockHeaderDAO,
+    blockchains: Vector[Blockchain])(
+    implicit private[chain] val chainConfig: ChainAppConfig)
+    extends ChainApi
     with ChainVerificationLogger {
 
   override def getBlockCount(implicit ec: ExecutionContext): Future[Long] = {
@@ -49,18 +51,40 @@ case class ChainHandler(blockHeaderDAO: BlockHeaderDAO)(
     logger.debug(
       s"Processing header=${header.hashBE.hex}, previousHash=${header.previousBlockHashBE.hex}")
 
-    val blockchainUpdateF =
-      Blockchain.connectTip(header, blockHeaderDAO)
+    val blockchainUpdateF = Blockchain.connectTip(header = header,
+                                                  blockHeaderDAO =
+                                                    blockHeaderDAO,
+                                                  blockchains = blockchains)
 
     val newHandlerF = blockchainUpdateF.flatMap {
-      case BlockchainUpdate.Successful(_, updatedHeader) =>
+      case BlockchainUpdate.Successful(newChain, updatedHeader) =>
         //now we have successfully connected the header, we need to insert
         //it into the database
         val createdF = blockHeaderDAO.create(updatedHeader)
         createdF.map { header =>
           logger.debug(
-            s"Connected new header to blockchain, height=${header.height} hash=${header.hashBE.hex}")
-          ChainHandler(blockHeaderDAO)
+            s"Connected new header to blockchain, height=${header.height} hash=${header.hashBE}")
+          val chainIdxOpt = blockchains.zipWithIndex.find {
+            case (chain, _) =>
+              val oldTip = newChain(1) //should be safe, even with genesis header as we just connected a tip
+              oldTip == chain.tip
+          }
+
+          val updatedChains = {
+            chainIdxOpt match {
+              case Some((_, idx)) =>
+                logger.trace(
+                  s"Updating chain at idx=${idx} out of competing chains=${blockchains.length} with new tip=${header.hashBE.hex}")
+                blockchains.updated(idx, newChain)
+
+              case None =>
+                logger.info(
+                  s"New competing blockchain with tip=${newChain.tip}")
+                blockchains.:+(newChain)
+            }
+          }
+
+          ChainHandler(blockHeaderDAO, updatedChains)
         }
       case BlockchainUpdate.Failed(_, _, reason) =>
         val errMsg =
@@ -117,11 +141,42 @@ case class ChainHandler(blockHeaderDAO: BlockHeaderDAO)(
     //this does _not_ mean that it is on the chain that has the most work
     //TODO: Enhance this in the future to return the "heaviest" header
     //https://bitcoin.org/en/glossary/block-chain
-    blockHeaderDAO.chainTips.map { tips =>
-      val sorted = tips.sortBy(header => header.blockHeader.difficulty)
-      val hash = sorted.head.hashBE
-      logger.debug(s"getBestBlockHash result: hash=$hash")
-      hash
+    val groupedChains = blockchains.groupBy(_.tip.height)
+    val maxHeight = groupedChains.keys.max
+    val chains = groupedChains(maxHeight)
+
+    val hashBE: DoubleSha256DigestBE = chains match {
+      case Vector() =>
+        val errMsg = s"Did not find blockchain with height $maxHeight"
+        logger.error(errMsg)
+        throw new RuntimeException(errMsg)
+      case chain +: Vector() =>
+        chain.tip.hashBE
+      case chain +: rest =>
+        logger.warn(
+          s"We have multiple competing blockchains: ${(chain +: rest).map(_.tip.hashBE.hex).mkString(", ")}")
+        chain.tip.hashBE
     }
+    Future.successful(hashBE)
+  }
+}
+
+object ChainHandler {
+
+  /** Constructs a [[ChainHandler chain handler]] from the state in the database
+    * This gives us the guaranteed latest state we have in the database
+    * */
+  def fromDatabase(blockHeaderDAO: BlockHeaderDAO)(
+      implicit ec: ExecutionContext,
+      chainConfig: ChainAppConfig): Future[ChainHandler] = {
+    val bestChainsF = blockHeaderDAO.getBlockchains()
+
+    bestChainsF.map(chains =>
+      new ChainHandler(blockHeaderDAO = blockHeaderDAO, blockchains = chains))
+  }
+
+  def apply(blockHeaderDAO: BlockHeaderDAO, blockchains: Blockchain)(
+      implicit chainConfig: ChainAppConfig): ChainHandler = {
+    new ChainHandler(blockHeaderDAO, Vector(blockchains))
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
@@ -23,4 +23,21 @@ object FutureUtil {
   }
 
   val unit: Future[Unit] = Future.successful(())
+
+  /**
+    * Folds over the given elements sequentially in a non-blocking async way
+    * @param init the initialized value for the accumulator
+    * @param items the items we are folding over
+    * @param fun the function we are applying to every element that returns a future
+    * @return
+    */
+  def foldLeftAsync[T, U](init: T, items: Seq[U])(fun: (T, U) => Future[T])(
+      implicit ec: ExecutionContext): Future[T] = {
+    items.foldLeft(Future.successful(init)) {
+      case (accumF, elem) =>
+        accumF.flatMap { accum =>
+          fun(accum, elem)
+        }
+    }
+  }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -58,16 +58,10 @@ class BroadcastTransactionTest extends BitcoinSWalletTest {
 
       address <- rpc.getNewAddress
       bloom <- wallet.getBloomFilter()
-
       spv <- {
         val peer = Peer.fromBitcoind(rpc.instance)
-        val chainHandler = {
-          val bhDao = BlockHeaderDAO()
-          ChainHandler(bhDao)
-        }
 
-        val spv =
-          SpvNode(peer, chainHandler, bloomFilter = bloom)
+        val spv = SpvNode(peer, bloomFilter = bloom)
         spv.start()
       }
       _ <- spv.sync()

--- a/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeWithWalletTest.scala
@@ -90,7 +90,7 @@ class NodeWithWalletTest extends NodeUnitTest {
         bloom <- wallet.getBloomFilter()
         address <- wallet.getNewAddress()
         spv <- initSpv.start()
-        updatedBloom = spv.updateBloomFilter(address).bloomFilter
+        updatedBloom <- spv.updateBloomFilter(address).map(_.bloomFilter)
         _ <- spv.sync()
         _ <- NodeTestUtil.awaitSync(spv, rpc)
 

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -88,7 +88,7 @@ class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
       addressFromWallet <- wallet.getNewAddress()
       _ = addressFromWalletP.success(addressFromWallet)
       spv <- initSpv.start()
-      _ = spv.updateBloomFilter(addressFromWallet)
+      _ <- spv.updateBloomFilter(addressFromWallet)
       _ <- spv.sync()
       _ <- rpc.sendToAddress(addressFromWallet, 1.bitcoin)
       _ <- NodeTestUtil.awaitSync(spv, rpc)
@@ -130,11 +130,11 @@ class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
                        5.bitcoin,
                        SatoshisPerByte(100.sats))
       _ = txFromWalletP.success(tx)
-      spvNewBloom = spv.updateBloomFilter(tx)
+      updatedBloom <- spv.updateBloomFilter(tx).map(_.bloomFilter)
       _ = spv.broadcastTransaction(tx)
       _ <- spv.sync()
       _ <- NodeTestUtil.awaitSync(spv, rpc)
-      _ = assert(spvNewBloom.bloomFilter.contains(tx.txId))
+      _ = assert(updatedBloom.contains(tx.txId))
       _ = {
         cancelable = Some {
           system.scheduler.scheduleOnce(

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -22,7 +22,8 @@ class PeerMessageHandlerTest extends NodeUnitTest {
   behavior of "PeerHandler"
 
   it must "be able to fully initialize a PeerMessageReceiver" in { _ =>
-    val peerHandlerF = bitcoindPeerF.map(p => NodeUnitTest.buildPeerHandler(p))
+    val peerHandlerF =
+      bitcoindPeerF.flatMap(p => NodeUnitTest.buildPeerHandler(p))
     val peerMsgSenderF = peerHandlerF.map(_.peerMsgSender)
     val p2pClientF = peerHandlerF.map(_.p2pClient)
 

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -2,76 +2,115 @@ package org.bitcoins.node
 
 import akka.actor.ActorSystem
 import org.bitcoins.chain.api.ChainApi
-import org.bitcoins.node.models.Peer
+import org.bitcoins.chain.blockchain.ChainHandler
+import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.chain.models.BlockHeaderDAO
+import org.bitcoins.core.bloom.BloomFilter
+import org.bitcoins.core.p2p.NetworkPayload
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.db.P2PLogger
+import org.bitcoins.node.config.NodeAppConfig
+import org.bitcoins.node.models.{
+  BroadcastAbleTransaction,
+  BroadcastAbleTransactionDAO,
+  Peer
+}
 import org.bitcoins.node.networking.P2PClient
 import org.bitcoins.node.networking.peer.{
   PeerMessageReceiver,
   PeerMessageSender
 }
 import org.bitcoins.rpc.util.AsyncUtil
+import slick.jdbc.SQLiteProfile
 
 import scala.concurrent.Future
-import org.bitcoins.core.bloom.BloomFilter
-import org.bitcoins.core.p2p.NetworkPayload
-import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.node.models.BroadcastAbleTransaction
-import org.bitcoins.node.models.BroadcastAbleTransactionDAO
-import slick.jdbc.SQLiteProfile
-import scala.util.Failure
-import scala.util.Success
-import org.bitcoins.db.P2PLogger
-import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.core.protocol.BitcoinAddress
+import scala.concurrent.duration.DurationInt
+import scala.util.{Failure, Success}
 
 case class SpvNode(
     peer: Peer,
-    chainApi: ChainApi,
     bloomFilter: BloomFilter,
     callbacks: SpvNodeCallbacks = SpvNodeCallbacks.empty
-)(implicit system: ActorSystem, nodeAppConfig: NodeAppConfig)
+)(
+    implicit system: ActorSystem,
+    nodeAppConfig: NodeAppConfig,
+    chainAppConfig: ChainAppConfig)
     extends P2PLogger {
   import system.dispatcher
 
+  /** This implicit is required for using the [[akka.pattern.ask akka ask]]
+    * to query what the state of our node is, like [[isConnected isConnected]]
+    * */
+  implicit private val timeout = akka.util.Timeout(10.seconds)
   private val txDAO = BroadcastAbleTransactionDAO(SQLiteProfile)
 
-  private val peerMsgRecv =
-    PeerMessageReceiver.newReceiver(chainApi, callbacks)
+  /** This is constructing a chain api from disk every time we call this method
+    * This involves database calls which can be slow and expensive to construct
+    * our [[org.bitcoins.chain.blockchain.Blockchain Blockchain]]
+    * */
+  def chainApiFromDb(): Future[ChainApi] = {
+    ChainHandler.fromDatabase(BlockHeaderDAO())
+  }
 
-  private val client: P2PClient =
-    P2PClient(context = system, peer = peer, peerMessageReceiver = peerMsgRecv)
+  /** Unlike our chain api, this is cached inside our spv node
+    * object. Internally in [[org.bitcoins.node.networking.P2PClient p2p client]] you will see that
+    * the [[org.bitcoins.chain.api.ChainApi chain api]] is updated inside of the p2p client
+    * */
+  private val clientF: Future[P2PClient] = {
+    for {
+      chainApi <- chainApiFromDb()
+    } yield {
+      val peerMsgRecv: PeerMessageReceiver =
+        PeerMessageReceiver.newReceiver(chainApi = chainApi,
+                                        peer = peer,
+                                        callbacks = callbacks)
+      val p2p = P2PClient(context = system,
+                          peer = peer,
+                          peerMessageReceiver = peerMsgRecv)
+      p2p
+    }
+  }
 
-  private val peerMsgSender: PeerMessageSender = {
-    PeerMessageSender(client)
+  private val peerMsgSenderF: Future[PeerMessageSender] = {
+    clientF.map { client =>
+      PeerMessageSender(client)
+    }
   }
 
   /** Updates our bloom filter to match the given TX
     *
     * @return SPV node with the updated bloom filter
     */
-  def updateBloomFilter(transaction: Transaction): SpvNode = {
-    logger.info(s"Updating bloom filter with transaction=${transaction.txIdBE}")
+  def updateBloomFilter(transaction: Transaction): Future[SpvNode] = {
+    logger(nodeAppConfig).info(
+      s"Updating bloom filter with transaction=${transaction.txIdBE}")
     val newBloom = bloomFilter.update(transaction)
 
     // we could send filteradd messages, but we would
     // then need to calculate all the new elements in
     // the filter. this is easier:-)
-    peerMsgSender.sendFilterClearMessage()
-    peerMsgSender.sendFilterLoadMessage(newBloom)
+    val newBloomLoadF = peerMsgSenderF.map { p =>
+      p.sendFilterClearMessage()
+      p.sendFilterLoadMessage(newBloom)
+    }
 
-    copy(bloomFilter = newBloom)
+    newBloomLoadF.map(_ => copy(bloomFilter = newBloom))
   }
 
   /** Updates our bloom filter to match the given address
     *
     * @return SPV node with the updated bloom filter
     */
-  def updateBloomFilter(address: BitcoinAddress): SpvNode = {
-    logger.info(s"Updating bloom filter with address=$address")
+  def updateBloomFilter(address: BitcoinAddress): Future[SpvNode] = {
+    logger(nodeAppConfig).info(s"Updating bloom filter with address=$address")
     val hash = address.hash
     val newBloom = bloomFilter.insert(hash)
-    peerMsgSender.sendFilterAddMessage(hash)
+    val sentFilterAddF = peerMsgSenderF.map(_.sendFilterAddMessage(hash))
 
-    copy(bloomFilter = newBloom)
+    sentFilterAddF.map { _ =>
+      copy(bloomFilter = newBloom)
+    }
   }
 
   /**
@@ -80,8 +119,8 @@ case class SpvNode(
     * with P2P messages, therefore marked as
     * `private[node]`.
     */
-  private[node] def send(msg: NetworkPayload): Unit = {
-    peerMsgSender.sendMsg(msg)
+  private[node] def send(msg: NetworkPayload): Future[Unit] = {
+    peerMsgSenderF.map(_.sendMsg(msg))
   }
 
   /** Starts our spv node */
@@ -89,59 +128,72 @@ case class SpvNode(
     for {
       _ <- nodeAppConfig.initialize()
       node <- {
-        peerMsgSender.connect()
+        val isInitializedF = for {
+          _ <- peerMsgSenderF.map(_.connect())
+          _ <- AsyncUtil.retryUntilSatisfiedF(() => isInitialized)
+        } yield ()
 
-        val isInitializedF =
-          AsyncUtil.retryUntilSatisfied(peerMsgRecv.isInitialized)
-
-        isInitializedF.failed.foreach(err =>
-          logger.error(s"Failed to connect with peer=$peer with err=${err}"))
+        isInitializedF.failed.foreach(
+          err =>
+            logger(nodeAppConfig).error(
+              s"Failed to connect with peer=$peer with err=${err}"))
 
         isInitializedF.map { _ =>
-          logger.info(s"Our peer=${peer} has been initialized")
+          logger(nodeAppConfig).info(s"Our peer=${peer} has been initialized")
           this
         }
       }
+      _ <- peerMsgSenderF.map(_.sendFilterLoadMessage(bloomFilter))
     } yield {
-      logger.info(s"Sending bloomfilter=${bloomFilter.hex} to $peer")
-      val _ = peerMsgSender.sendFilterLoadMessage(bloomFilter)
+      logger(nodeAppConfig).info(
+        s"Sending bloomfilter=${bloomFilter.hex} to $peer")
       node
     }
   }
 
   /** Stops our spv node */
   def stop(): Future[SpvNode] = {
-    peerMsgSender.disconnect()
+    logger(nodeAppConfig).info(s"Stopping spv node")
+    val disconnectF = peerMsgSenderF.map(_.disconnect())
 
-    val isStoppedF = AsyncUtil.retryUntilSatisfied(peerMsgRecv.isDisconnected)
+    val isStoppedF = disconnectF.flatMap { _ =>
+      logger(nodeAppConfig).info(s"Awaiting disconnect")
+      AsyncUtil.retryUntilSatisfiedF(() => isDisconnected)
+    }
 
-    isStoppedF.map(_ => this)
+    isStoppedF.map { _ =>
+      logger(nodeAppConfig).info(s"Spv node stopped!")
+      this
+    }
   }
 
   /** Broadcasts the given transaction over the P2P network */
-  def broadcastTransaction(transaction: Transaction): Unit = {
+  def broadcastTransaction(transaction: Transaction): Future[Unit] = {
     val broadcastTx = BroadcastAbleTransaction(transaction)
 
     txDAO.create(broadcastTx).onComplete {
       case Failure(exception) =>
-        logger.error(s"Error when writing broadcastable TX to DB", exception)
+        logger(nodeAppConfig)
+          .error(s"Error when writing broadcastable TX to DB", exception)
       case Success(written) =>
-        logger.debug(
+        logger(nodeAppConfig).debug(
           s"Wrote tx=${written.transaction.txIdBE} to broadcastable table")
     }
 
-    logger.info(s"Sending out inv for tx=${transaction.txIdBE}")
-    peerMsgSender.sendInventoryMessage(transaction)
+    logger(nodeAppConfig).info(s"Sending out inv for tx=${transaction.txIdBE}")
+    peerMsgSenderF.map(_.sendInventoryMessage(transaction))
   }
 
   /** Checks if we have a tcp connection with our peer */
-  def isConnected: Boolean = peerMsgRecv.isConnected
+  def isConnected: Future[Boolean] = clientF.flatMap(_.isConnected)
 
   /** Checks if we are fully initialized with our peer and have executed the handshake
     * This means we can now send arbitrary messages to our peer
     * @return
     */
-  def isInitialized: Boolean = peerMsgRecv.isInitialized
+  def isInitialized: Future[Boolean] = clientF.flatMap(_.isInitialized)
+
+  def isDisconnected: Future[Boolean] = clientF.flatMap(_.isDisconnected)
 
   /** Starts to sync our spv node with our peer
     * If our local best block hash is the same as our peers
@@ -151,13 +203,15 @@ case class SpvNode(
     */
   def sync(): Future[Unit] = {
     for {
+      chainApi <- chainApiFromDb()
       hash <- chainApi.getBestBlockHash
       header <- chainApi
         .getHeader(hash)
         .map(_.get) // .get is safe since this is an internal call
     } yield {
-      peerMsgSender.sendGetHeadersMessage(hash.flip)
-      logger.info(s"Starting sync node, height=${header.height} hash=$hash")
+      peerMsgSenderF.map(_.sendGetHeadersMessage(hash.flip))
+      logger(nodeAppConfig).info(
+        s"Starting sync node, height=${header.height} hash=$hash")
     }
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerHandler.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.node.networking.peer
 
+import org.bitcoins.node.networking.P2PClient
+
 /*
 abstract class PeerHandler extends BitcoinSLogger {
   implicit val system: ActorSystem
@@ -58,6 +60,4 @@ object PeerHandler {
 }
  */
 
-case class PeerHandler(
-    peerMsgRecv: PeerMessageReceiver,
-    peerMsgSender: PeerMessageSender)
+case class PeerHandler(p2pClient: P2PClient, peerMsgSender: PeerMessageSender)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -107,9 +107,9 @@ abstract class NodeTestUtil extends BitcoinSLogger {
   def isSameBestHash(node: SpvNode, rpc: BitcoindRpcClient)(
       implicit ec: ExecutionContext): Future[Boolean] = {
     val hashF = rpc.getBestBlockHash
-    val spvHashF = node.chainApi.getBestBlockHash
     for {
-      spvBestHash <- spvHashF
+      chainApi <- node.chainApiFromDb()
+      spvBestHash <- chainApi.getBestBlockHash
       hash <- hashF
     } yield {
       spvBestHash == hash
@@ -122,9 +122,8 @@ abstract class NodeTestUtil extends BitcoinSLogger {
   def isSameBlockCount(spv: SpvNode, rpc: BitcoindRpcClient)(
       implicit ec: ExecutionContext): Future[Boolean] = {
     val rpcCountF = rpc.getBlockCount
-    val spvCountF = spv.chainApi.getBlockCount
     for {
-      spvCount <- spvCountF
+      spvCount <- spv.chainApiFromDb().flatMap(_.getBlockCount)
       rpcCount <- rpcCountF
     } yield rpcCount == spvCount
   }


### PR DESCRIPTION
… database calls on TipValidation

This part of addressing #653 

A problem we have during TipValidation is that we don't cache our blockchain inside of `ChainHandler`. This means we have to call [`BlockHeaderDAO.getBlockchains()`](https://github.com/bitcoin-s/bitcoin-s/blob/master/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala#L64) every time we want to validate a new tip which is an expensive call.

The idea behind this PR is to cache our set of chains inside of `ChainHandler` to avoid this call. This comes at the risk of us having a stale `ChainHandler` instance lying around that does _not have the real best tip in it's `blockchain` val_. 

I'm particularly concerned about how to handle this inside of `DataMessageHandler`, as currently our [`PeerMessageReceiver` spawns a new one](https://github.com/bitcoin-s/bitcoin-s/blob/master/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala#L141) (does not cache it!) for every message received. This circumvents this optimization. 