### PR TITLE
Removing Evicted Dependency Warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -340,7 +340,8 @@ lazy val chain = project
   .settings(chainDbSettings: _*)
   .settings(
     name := "bitcoin-s-chain",
-    libraryDependencies ++= Deps.chain
+    libraryDependencies ++= Deps.chain,
+    dependencyOverrides += Deps.Overrides.slf4j
   )
   .dependsOn(core, dbCommons)
   .enablePlugins(FlywayPlugin)
@@ -361,14 +362,17 @@ lazy val dbCommons = project
   .settings(commonSettings: _*)
   .settings(
     name := "bitcoin-s-db-commons",
-    libraryDependencies ++= Deps.dbCommons
+    libraryDependencies ++= Deps.dbCommons,
+    dependencyOverrides += Deps.Overrides.typesafeconfig
   )
   .dependsOn(core)
 
 lazy val zmq = project
   .in(file("zmq"))
   .settings(commonSettings: _*)
-  .settings(name := "bitcoin-s-zmq", libraryDependencies ++= Deps.bitcoindZmq)
+  .settings(name := "bitcoin-s-zmq",
+            libraryDependencies ++= Deps.bitcoindZmq,
+            dependencyOverrides += Deps.Overrides.slf4j)
   .dependsOn(
     core % testAndCompile
   )
@@ -376,15 +380,27 @@ lazy val zmq = project
 lazy val bitcoindRpc = project
   .in(file("bitcoind-rpc"))
   .settings(commonProdSettings: _*)
-  .settings(name := "bitcoin-s-bitcoind-rpc",
-            libraryDependencies ++= Deps.bitcoindRpc)
+  .settings(
+    name := "bitcoin-s-bitcoind-rpc",
+    libraryDependencies ++= Deps.bitcoindRpc,
+    dependencyOverrides += Deps.Overrides.slf4j,
+    dependencyOverrides += Deps.Overrides.typesafeakka,
+    dependencyOverrides += Deps.Overrides.typesafeconfig,
+    dependencyOverrides += Deps.Overrides.jackson
+  )
   .dependsOn(core)
 
 lazy val bitcoindRpcTest = project
   .in(file("bitcoind-rpc-test"))
   .settings(commonTestSettings: _*)
-  .settings(libraryDependencies ++= Deps.bitcoindRpcTest,
-            name := "bitcoin-s-bitcoind-rpc-test")
+  .settings(
+    libraryDependencies ++= Deps.bitcoindRpcTest,
+    dependencyOverrides += Deps.Overrides.slf4j,
+    dependencyOverrides += Deps.Overrides.typesafeakka,
+    dependencyOverrides += Deps.Overrides.typesafeconfig,
+    dependencyOverrides += Deps.Overrides.jackson,
+    name := "bitcoin-s-bitcoind-rpc-test"
+  )
   .dependsOn(core % testAndCompile, testkit)
 
 lazy val bench = project
@@ -392,6 +408,7 @@ lazy val bench = project
   .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Deps.bench,
+    dependencyOverrides += Deps.Overrides.slf4j,
     name := "bitcoin-s-bench",
     skip in publish := true
   )
@@ -400,8 +417,14 @@ lazy val bench = project
 lazy val eclairRpc = project
   .in(file("eclair-rpc"))
   .settings(commonProdSettings: _*)
-  .settings(name := "bitcoin-s-eclair-rpc",
-            libraryDependencies ++= Deps.eclairRpc)
+  .settings(
+    name := "bitcoin-s-eclair-rpc",
+    libraryDependencies ++= Deps.eclairRpc,
+    dependencyOverrides += Deps.Overrides.slf4j,
+    dependencyOverrides += Deps.Overrides.typesafeakka,
+    dependencyOverrides += Deps.Overrides.typesafeconfig,
+    dependencyOverrides += Deps.Overrides.jackson
+  )
   .dependsOn(
     core,
     bitcoindRpc
@@ -410,8 +433,13 @@ lazy val eclairRpc = project
 lazy val eclairRpcTest = project
   .in(file("eclair-rpc-test"))
   .settings(commonTestSettings: _*)
-  .settings(libraryDependencies ++= Deps.eclairRpcTest,
-            name := "bitcoin-s-eclair-rpc-test")
+  .settings(
+    libraryDependencies ++= Deps.eclairRpcTest,
+    dependencyOverrides += Deps.Overrides.slf4j,
+    dependencyOverrides += Deps.Overrides.typesafeakka,
+    dependencyOverrides += Deps.Overrides.typesafeconfig,
+    name := "bitcoin-s-eclair-rpc-test"
+  )
   .dependsOn(core % testAndCompile, testkit)
 
 lazy val nodeDbSettings = dbFlywaySettings("nodedb")
@@ -422,7 +450,10 @@ lazy val node =
     .settings(nodeDbSettings: _*)
     .settings(
       name := "bitcoin-s-node",
-      libraryDependencies ++= Deps.node
+      libraryDependencies ++= Deps.node,
+      dependencyOverrides += Deps.Overrides.slf4j,
+      dependencyOverrides += Deps.Overrides.typesafeakka,
+      dependencyOverrides += Deps.Overrides.typesafeconfig
     )
     .dependsOn(
       core,
@@ -446,7 +477,10 @@ lazy val nodeTest =
       // Scalatest issue:
       // https://github.com/scalatest/scalatest/issues/556
       Test / fork := false,
-      libraryDependencies ++= Deps.nodeTest
+      libraryDependencies ++= Deps.nodeTest,
+      dependencyOverrides += Deps.Overrides.slf4j,
+      dependencyOverrides += Deps.Overrides.typesafeakka,
+      dependencyOverrides += Deps.Overrides.typesafeconfig
     )
     .dependsOn(
       core % testAndCompile,

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -81,6 +81,15 @@ object Deps {
     val scalaTest = "org.scalatest" %% "scalatest" % V.scalaTest withSources () withJavadoc ()
   }
 
+  object Overrides {
+    val slf4j = "org.slf4j" % "slf4j-api" % "1.7.26"
+    val typesafeconfig = "com.typesafe" % "config" % "1.3.4"
+    val jackson = "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.8"
+    val scalalangcompat = "org.scala-lang.modules" % "scala-collection-compat_2.12" % "2.0.0"
+    val typesafeakka = "com.typesafe.akka" % "akka-http_2.12" % "10.1.9"
+    val scalalangxml = "org.scala-lang.modules" % "scala-xml_2.12" % "1.2.0"
+  }
+
   object Test {
     val async = "org.scala-lang.modules" %% "scala-async" % V.asyncV % "test" withSources () withJavadoc ()
     val junitInterface = "com.novocode" % "junit-interface" % V.junitV % "test" withSources () withJavadoc ()


### PR DESCRIPTION
We get many evicted dependency warnings from performing compilation on `sbt` and when running `evicted` in the `sbt` shell there are many instances. There are often multiple things that depend on different versions of packages. I am working on cleaning this up so that way the sbt console is not so clogged up. I created an object in the `Deps.scala` file and am implementing `dependencyOverrides` which is found in `key` object for `sbt` and is part of the underlying code. Since there are many differing versions required I am working on making the code more efficient so updating will only require making changes to the version when needed.

https://medium.com/zendesk-engineering/maintaining-binary-compatibility-in-scala-6e07157aac23

Okay so just to keep this updated it seems as though the eviction warnings are a normal accepted part of scala. The only problem is at run time if there is an error but neither Nadav nor I have seen anything that would look like that is occurring in the code base. The `dependencyOverrides` stuff is only useful for going back to an older version of the dep that you want to use. That being said in the Medium article there is an sbt plugin that looks pretty cool called `MiMa` and could be useful in the future should we run into problems with dep incompatibilities not working together. 