### PR TITLE
WIP Number Optimization

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ExtKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ExtKeyTest.scala
@@ -15,7 +15,7 @@ import scala.util.{Failure, Success, Try}
 
 class ExtKeyTest extends BitcoinSUnitTest {
 
-  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     generatorDrivenConfigNewCode
 
   behavior of "ExtKey"
@@ -30,7 +30,7 @@ class ExtKeyTest extends BitcoinSUnitTest {
         val pub = priv.extPublicKey
         val derivedPubUInt32: Try[ExtPublicKey] = pub.deriveChildPubKey(index)
         val derivedPubPrimitive: Try[ExtPublicKey] =
-          pub.deriveChildPubKey(index.toLong)
+          pub.deriveChildPubKey(index)
         (derivedPubUInt32, derivedPubPrimitive) match {
           case (Success(_), Success(_)) => succeed
           case (Failure(exc1), Failure(exc2)) =>

--- a/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilSpec.scala
@@ -8,7 +8,6 @@ import org.scalacheck.{Prop, Properties}
   * Created by chris on 6/20/16.
   */
 class NumberUtilSpec extends Properties("NumberUtilSpec") {
-  private val logger = BitcoinSLogger.logger
 
   property("Serialization symmetry for BigInt") =
     Prop.forAll(NumberGenerator.bigInts) { bigInt: BigInt =>
@@ -20,7 +19,7 @@ class NumberUtilSpec extends Properties("NumberUtilSpec") {
   }
 
   property("serialization symmetry for longs") = Prop.forAll { long: Long =>
-    NumberUtil.toLong(BitcoinSUtil.encodeHex(long)) == long
+    NumberUtil.toLongSigned(BitcoinSUtil.encodeHex(long)) == long
   }
 
   property("convertBits symmetry") = {

--- a/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
@@ -15,13 +15,17 @@ import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
 import org.bitcoins.core.protocol.{CompactSizeUInt, NetworkElement}
 import org.bitcoins.core.script.constant.{ScriptConstant, ScriptToken}
 import org.bitcoins.core.serializers.bloom.RawBloomFilterSerializer
-import org.bitcoins.core.util.{BitcoinSUtil, Factory}
+import org.bitcoins.core.util.{
+  BitcoinSLogger,
+  BitcoinSUtil,
+  CryptoUtil,
+  Factory
+}
 import scodec.bits.{BitVector, ByteVector}
 
 import scala.annotation.tailrec
 import scala.util.hashing.MurmurHash3
 import org.bitcoins.core.crypto.ECPublicKey
-import org.bitcoins.core.util.CryptoUtil
 
 /**
   * Implements a bloom filter that abides by the semantics of BIP37
@@ -29,7 +33,7 @@ import org.bitcoins.core.util.CryptoUtil
   * @see [[https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki BIP37]].
   * @see [[https://github.com/bitcoin/bitcoin/blob/master/src/bloom.h Bitcoin Core bloom.h]]
   */
-sealed abstract class BloomFilter extends NetworkElement {
+sealed abstract class BloomFilter extends NetworkElement with BitcoinSLogger {
 
   /** How large the bloom filter is, in Bytes */
   def filterSize: CompactSizeUInt

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -57,13 +57,6 @@ sealed abstract class ExtKey extends NetworkElement {
   }
 
   /**
-    * Derives the child pubkey at the specified index
-    */
-  def deriveChildPubKey(idx: Long): Try[ExtPublicKey] = {
-    Try(UInt32(idx)).flatMap(deriveChildPubKey)
-  }
-
-  /**
     * Derives the child pubkey at the specified index and
     * hardening value
     */

--- a/core/src/main/scala/org/bitcoins/core/number/BasicArithmetic.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/BasicArithmetic.scala
@@ -9,7 +9,7 @@ import scala.util.Try
   * operator to throw. This method wraps it in a `Try`
   * block.
   */
-trait BasicArithmetic[N] {
+trait BasicArithmetic[N] extends Any {
 
   def +(n: N): N
 

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -242,7 +242,11 @@ final case class UInt64 private (private val underlying: java.math.BigInteger)
     i
   }
 
-  def toBigInt: BigInteger = underlying
+  def toInt: Int = underlying.intValueExact()
+
+  def toFloat: Float = underlying.floatValue()
+
+  def toDouble: Double = underlying.doubleValue()
 
   def toLong: Long = underlying.longValueExact()
 
@@ -257,7 +261,7 @@ final case class UInt64 private (private val underlying: java.math.BigInteger)
     * @param bigInt The number to encode
     * @return The hex encoded number
     */
-  private def encodeHex(bigInt: BigInt): String = {
+  private def encodeHex(bigInt: BigInteger): String = {
     val hex = BitcoinSUtil.encodeHex(bigInt)
     if (hex.length == 18) {
       //means that encodeHex(BigInt) padded an extra byte, giving us 9 bytes instead of 8
@@ -307,16 +311,8 @@ final case class Int32 private (private val underlying: Int)
     Int32(underlying << s32.underlying)
   }
 
-  def <<(int: Int): Int32 = {
-    this.<<(Int32(int))
-  }
-
   def >>(s32: Int32): Int32 = {
     Int32(underlying >> s32.underlying)
-  }
-
-  def >>(int: Int): Int32 = {
-    Int32(underlying >> int)
   }
 
   def toInt: Int = {
@@ -501,7 +497,7 @@ object UInt32
 
 object UInt64
     extends Factory[UInt64]
-    /* with NumberObject[UInt64] */
+    //withNumberObject[UInt64]
     with Bounded[UInt64] {
   /* private case class UInt64Impl(underlying: BigInt) extends UInt64 {
     require(isInBound(underlying),
@@ -511,14 +507,15 @@ object UInt64
   lazy val zero = UInt64(BigInt(0))
   lazy val one = UInt64(BigInt(1))
 
-  private lazy val minUnderlying = 0
+  private lazy val minUnderlying = BigInt(0)
   private lazy val maxUnderlying = BigInt("18446744073709551615")
 
   lazy val min = UInt64(minUnderlying)
   lazy val max = UInt64(maxUnderlying)
 
-  override def isInBound(num: BigInteger): Boolean =
-    num <= maxUnderlying && num >= minUnderlying
+  def isInBound(num: BigInteger): Boolean =
+    (num.compareTo(maxUnderlying) == (-1 | 0))
+      .&&(num.compareTo(minUnderlying) == (0 | 1))
 
   override def fromBytes(bytes: ByteVector): UInt64 = {
     require(bytes.size <= 8)
@@ -529,6 +526,17 @@ object UInt64
     require(isInBound(num), "UInt64 number is not within the min/max bounds")
     UInt64(num)
   }
+
+  def apply(longnum: Long): UInt64 = {
+    require(longnum >= 0)
+    UInt64(longnum)
+  }
+
+  def apply(bigintnum: BigInt): UInt64 = {
+    require(bigintnum < maxUnderlying && bigintnum > 0)
+    UInt64(bigintnum)
+  }
+
 }
 
 object Int32

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -236,19 +236,19 @@ final case class UInt64(underlying: BigInt)
   }
 
   def <<(u64: UInt64): UInt64 = {
-    UInt64(underlying << u64.underlying)
+    UInt64(underlying.shiftleft() u64.underlying)
   }
 
   def <<(int: Int): UInt64 = {
-    this.<<(UInt64(int))
+    this.shiftleft()(UInt64(int))
   }
 
   def >>(u64: UInt64): UInt64 = {
-    UInt64(underlying >> u64.underlying)
+    UInt64(underlying u64.underlying)
   }
 
   def >>(int: Int): UInt64 = {
-    UInt64(underlying >> int)
+    this.UInt64(underlying >> int)
   }
 
   def toBigInt: BigInt = {

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -189,16 +189,6 @@ final case class UInt32 private (private val underlying: Long)
 
   def toBigInt: BigInt = toLong
 
-  def toDouble(x: UInt32): Double = x.underlying.toDouble
-  def toFloat(x: UInt32): Float = x.underlying.toFloat
-
-  def toInt(x: UInt32): Int = {
-    val i = x.underlying.toInt
-    require(x.underlying == i)
-    i
-  }
-  def toLong(x: UInt32): Long = x.underlying
-
   override def compare(that: UInt32): Int = underlying.compare(that.underlying)
 }
 
@@ -255,11 +245,6 @@ final case class UInt64 private (private val underlying: java.math.BigInteger)
   def toBigInt: BigInteger = underlying
 
   def toLong: Long = underlying.longValueExact()
-
-  def toDouble(x: UInt64): Double = x.underlying.doubleValue()
-  def toFloat(x: UInt64): Float = x.underlying.floatValue()
-
-  def toBigInt(x: UInt64): BigInt = x.underlying
 
   override def compare(that: UInt64): Int =
     underlying.compareTo(that.underlying)
@@ -342,16 +327,6 @@ final case class Int32 private (private val underlying: Int)
   }
 
   def toBigInt: BigInt = toInt
-
-  def toDouble(x: Int32): Double = x.underlying.toDouble
-  def toFloat(x: Int32): Float = x.underlying.toFloat
-
-  def toInt(x: Int32): Int = {
-    val i = x.underlying
-    require(x.underlying == i)
-    i
-  }
-  def toLong(x: Int32): Long = x.underlying
 
   override def compare(that: Int32): Int = underlying.compare(that.underlying)
 }
@@ -514,12 +489,13 @@ object UInt32
     require(
       bytes.size <= 4,
       "UInt32 byte array was too large, got: " + BitcoinSUtil.encodeHex(bytes))
+    UInt32(NumberUtil.toLongUnsigned(bytes))
   }
 
-  def apply(bigInt: BigInt): UInt32 = {
-    require(isInBound(bigInt.toLong),
+  def apply(longnum: Long): UInt32 = {
+    require(isInBound(longnum.toLong),
             "UInt32 number is not within the max/min bounds allowed")
-    UInt32(bigInt.bigInteger.longValueExact())
+    UInt32(longnum)
   }
 }
 
@@ -541,7 +517,7 @@ object UInt64
   lazy val min = UInt64(minUnderlying)
   lazy val max = UInt64(maxUnderlying)
 
-  override def isInBound(num: A): Boolean =
+  override def isInBound(num: BigInteger): Boolean =
     num <= maxUnderlying && num >= minUnderlying
 
   override def fromBytes(bytes: ByteVector): UInt64 = {
@@ -549,10 +525,9 @@ object UInt64
     UInt64(NumberUtil.toUnsignedInt(bytes))
   }
 
-  def apply(num: BigInt): UInt64 = {
-    require(isInBound(num) == true,
-            "UInt64 number is not within the min/max bounds")
-    UInt64(num.bigInteger)
+  def apply(num: BigInteger): UInt64 = {
+    require(isInBound(num), "UInt64 number is not within the min/max bounds")
+    UInt64(num)
   }
 }
 
@@ -574,17 +549,18 @@ object Int32
   lazy val min = Int32(minUnderlying)
   lazy val max = Int32(maxUnderlying)
 
-  override def isInBound(num: A): Boolean =
-    num <= maxUnderlying && num >= minUnderlying */
+  def isInBound(num: Int): Boolean =
+    num <= maxUnderlying && num >= minUnderlying
 
   override def fromBytes(bytes: ByteVector): Int32 = {
     require(bytes.size <= 4, "We cannot have an Int32 be larger than 4 bytes")
     Int32(BigInt(bytes.toArray).toInt)
   }
 
-  def apply(bigInt: BigInt): Int32 = {
-    require(isInBound(bigInt) == true)
-    Int32(bigInt.bigInteger.intValueExact())
+  def apply(num: Int): Int32 = {
+    require(isInBound(num.toInt),
+            "Int 32 number is not within the max/min bounds allowed")
+    Int32(num)
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -209,9 +209,65 @@ final case class UInt64(underlying: BigInt)
     with BasicArithmetic[UInt64]
     with Ordered[UInt64] {
 
-  override def hex: String = BitcoinSUtil.encodeHex(underlying)
+  override def hex: String = encodeHex(underlying)
 
   override def bytes: ByteVector = ByteVector.fromValidHex(hex)
+
+  override def +(y: UInt64): UInt64 = {
+    UInt64(underlying + y.underlying)
+  }
+
+  override def -(y: UInt64): UInt64 = {
+    UInt64(underlying - y.underlying)
+  }
+
+  override def *(y: UInt64): UInt64 = {
+    UInt64(underlying * y.underlying)
+  }
+
+  override def *(factor: BigInt): UInt64 = ???
+
+  def |(u64: UInt64): UInt64 = {
+    UInt64(underlying | u64.underlying)
+  }
+
+  def &(u64: UInt64): UInt64 = {
+    UInt64(underlying & u64.underlying)
+  }
+
+  def <<(u64: UInt64): UInt64 = {
+    UInt64(underlying << u64.underlying)
+  }
+
+  def <<(int: Int): UInt64 = {
+    this.<<(UInt64(int))
+  }
+
+  def >>(u64: UInt64): UInt64 = {
+    UInt64(underlying >> u64.underlying)
+  }
+
+  def >>(int: Int): UInt64 = {
+    UInt64(underlying >> int)
+  }
+
+  def toInt: Int = {
+    val i = underlying.toInt
+    require(underlying == i,
+            s"Rounded when converting long=${underlying} toInt=${i}")
+    i
+  }
+
+  def toBigInt: BigInt = underlying
+
+  def toLong: Long = toBigInt
+
+  def toDouble(x: UInt64): Double = x.underlying.toDouble
+  def toFloat(x: UInt64): Float = x.underlying.toFloat
+
+  def toBigInt(x: UInt64): BigInt = x.underlying
+
+  override def compare(that: UInt64): Int = underlying.compare(that.underlying)
 
   /**
     * Converts a [[BigInt]] to a 8 byte hex representation.
@@ -473,31 +529,34 @@ object UInt32
 
 object UInt64
     extends Factory[UInt64]
-    with NumberObject[UInt64]
+    /* with NumberObject[UInt64] */
     with Bounded[UInt64] {
-  private case class UInt64Impl(underlying: BigInt) extends UInt64 {
+  /* private case class UInt64Impl(underlying: BigInt) extends UInt64 {
     require(isInBound(underlying),
             s"Cannot create ${super.getClass.getSimpleName} from $underlying")
   }
-
+   */
   lazy val zero = UInt64(BigInt(0))
   lazy val one = UInt64(BigInt(1))
 
-  private lazy val minUnderlying: A = 0
-  private lazy val maxUnderlying: A = BigInt("18446744073709551615")
+  private lazy val minUnderlying = 0
+  private lazy val maxUnderlying = BigInt("18446744073709551615")
 
   lazy val min = UInt64(minUnderlying)
   lazy val max = UInt64(maxUnderlying)
 
-  override def isInBound(num: A): Boolean =
+  /* override def isInBound(num: A): Boolean =
     num <= maxUnderlying && num >= minUnderlying
 
+   */
   override def fromBytes(bytes: ByteVector): UInt64 = {
     require(bytes.size <= 8)
     UInt64(NumberUtil.toUnsignedInt(bytes))
   }
 
-  def apply(num: BigInt): UInt64 = UInt64Impl(num)
+  def apply(num: BigInt): UInt64 = {
+    UInt64(num.bigInteger)
+  }
 }
 
 object Int32

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -497,33 +497,33 @@ object UInt64
 
 object Int32
     extends Factory[Int32]
-    with NumberObject[Int32]
+    //with NumberObject[Int32]
     with Bounded[Int32] {
-  private case class Int32Impl(underlying: BigInt) extends Int32 {
+  /*private case class Int32Impl(underlying: BigInt) extends Int32 {
     require(isInBound(underlying),
             s"Cannot create ${super.getClass.getSimpleName} from $underlying")
   }
-
+   */
   lazy val zero = Int32(0)
   lazy val one = Int32(1)
 
-  private lazy val minUnderlying: A = -2147483648
-  private lazy val maxUnderlying: A = 2147483647
+  private lazy val minUnderlying = -2147483648
+  private lazy val maxUnderlying = 2147483647
 
   lazy val min = Int32(minUnderlying)
   lazy val max = Int32(maxUnderlying)
 
-  override def isInBound(num: A): Boolean =
-    num <= maxUnderlying && num >= minUnderlying
+  /*override def isInBound(num: A): Boolean =
+    num <= maxUnderlying && num >= minUnderlying*/
 
   override def fromBytes(bytes: ByteVector): Int32 = {
     require(bytes.size <= 4, "We cannot have an Int32 be larger than 4 bytes")
     Int32(BigInt(bytes.toArray).toInt)
   }
 
-  def apply(int: Int): Int32 = Int32(BigInt(int))
-
-  def apply(bigInt: BigInt): Int32 = Int32Impl(bigInt)
+  def apply(bigInt: BigInt): Int32 = {
+    Int32(bigInt.bigInteger.intValueExact())
+  }
 }
 
 object Int64

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -129,11 +129,75 @@ sealed abstract class UInt8 extends UnsignedNumber[UInt8] {
 /**
   * Represents a uint32_t in C
   */
-sealed abstract class UInt32 extends UnsignedNumber[UInt32] {
-  override def apply: A => UInt32 = UInt32(_)
-  override def hex: String = BitcoinSUtil.encodeHex(toLong).slice(8, 16)
+final case class UInt32(underlying: Long)
+    extends AnyVal
+    with NetworkElement
+    with BasicArithmetic[UInt32]
+    with Ordered[UInt32] {
+  override def hex: String = BitcoinSUtil.encodeHex(underlying).slice(8, 16)
 
-  override def andMask = 0xffffffffL
+  override def bytes: ByteVector = ByteVector.fromValidHex(hex)
+
+  override def +(y: UInt32): UInt32 = {
+    UInt32(underlying + y.underlying)
+  }
+
+  override def -(y: UInt32): UInt32 = {
+    UInt32(underlying - y.underlying)
+  }
+
+  override def *(y: UInt32): UInt32 = {
+    UInt32(underlying * y.underlying)
+  }
+
+  override def *(factor: BigInt): UInt32 = ???
+
+  def |(u32: UInt32): UInt32 = {
+    UInt32(underlying | u32.underlying)
+  }
+
+  def &(u32: UInt32): UInt32 = {
+    UInt32(underlying & u32.underlying)
+  }
+
+  def <<(u32: UInt32): UInt32 = {
+    UInt32(underlying << u32.underlying)
+  }
+
+  def <<(int: Int): UInt32 = {
+    this.<<(UInt32(int))
+  }
+
+  def >>(u32: UInt32): UInt32 = {
+    UInt32(underlying >> u32.underlying)
+  }
+
+  def >>(int: Int): UInt32 = {
+    UInt32(underlying >> int)
+  }
+
+  def toInt: Int = {
+    val i = underlying.toInt
+    require(underlying == i,
+            s"Rounded when converting long=${underlying} toInt=${i}")
+    i
+  }
+
+  def toLong: Long = underlying
+
+  def toBigInt: BigInt = toLong
+
+  def toDouble(x: UInt32): Double = x.underlying.toDouble
+  def toFloat(x: UInt32): Float = x.underlying.toFloat
+
+  def toInt(x: UInt32): Int = {
+    val i = x.underlying.toInt
+    require(x.underlying == i)
+    i
+  }
+  def toLong(x: UInt32): Long = x.underlying
+
+  override def compare(that: UInt32): Int = underlying.compare(that.underlying)
 }
 
 /**
@@ -308,35 +372,35 @@ object UInt8
 
 object UInt32
     extends Factory[UInt32]
-    with NumberObject[UInt32]
+    /*    with NumberObject[UInt32]*/
     with Bounded[UInt32] {
-  private case class UInt32Impl(underlying: BigInt) extends UInt32 {
+  /*  private case class UInt32Impl(underlying: BigInt) extends UInt32 {
     require(isInBound(underlying),
             s"Cannot create ${super.getClass.getSimpleName} from $underlying")
-  }
+  }*/
 
   lazy val zero = UInt32(0)
   lazy val one = UInt32(1)
 
-  private lazy val minUnderlying: A = 0
-  private lazy val maxUnderlying: A = 4294967295L
+  private lazy val minUnderlying = 0
+  private lazy val maxUnderlying = 4294967295L
 
   lazy val min = UInt32(minUnderlying)
   lazy val max = UInt32(maxUnderlying)
 
-  override def isInBound(num: A): Boolean =
-    num <= maxUnderlying && num >= minUnderlying
+  /*  override def isInBound(num: A): Boolean =
+    num <= maxUnderlying && num >= minUnderlying*/
 
   override def fromBytes(bytes: ByteVector): UInt32 = {
     require(
       bytes.size <= 4,
       "UInt32 byte array was too large, got: " + BitcoinSUtil.encodeHex(bytes))
-    UInt32(NumberUtil.toUnsignedInt(bytes))
+    UInt32(NumberUtil.toLongUnsigned(bytes))
   }
 
-  def apply(long: Long): UInt32 = UInt32(BigInt(long))
-
-  def apply(bigInt: BigInt): UInt32 = UInt32Impl(bigInt)
+  def apply(bigInt: BigInt): UInt32 = {
+    UInt32(bigInt.bigInteger.longValueExact())
+  }
 }
 
 object UInt64

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -231,10 +231,73 @@ sealed abstract class UInt64 extends UnsignedNumber[UInt64] {
 /**
   * Represents a int32_t in C
   */
-sealed abstract class Int32 extends SignedNumber[Int32] {
-  override def apply: A => Int32 = Int32(_)
-  override def andMask = 0xffffffff
-  override def hex: String = BitcoinSUtil.encodeHex(toInt)
+final case class Int32(underlying: Int)
+    extends AnyVal
+    with NetworkElement
+    with BasicArithmetic[Int32]
+    with Ordered[Int32] {
+  override def hex: String = BitcoinSUtil.encodeHex(underlying).slice(-8, 8)
+
+  override def bytes: ByteVector = ByteVector.fromValidHex(hex)
+
+  override def +(y: Int32): Int32 = {
+    Int32(underlying + y.underlying)
+  }
+
+  override def -(y: Int32): Int32 = {
+    Int32(underlying - y.underlying)
+  }
+
+  override def *(y: Int32): Int32 = {
+    Int32(underlying * y.underlying)
+  }
+
+  override def *(factor: BigInt): Int32 = ???
+
+  def |(s32: Int32): Int32 = {
+    Int32(underlying | s32.underlying)
+  }
+
+  def &(s32: Int32): Int32 = {
+    Int32(underlying & s32.underlying)
+  }
+
+  def <<(s32: Int32): Int32 = {
+    Int32(underlying << s32.underlying)
+  }
+
+  def <<(int: Int): Int32 = {
+    this.<<(Int32(int))
+  }
+
+  def >>(s32: Int32): Int32 = {
+    Int32(underlying >> s32.underlying)
+  }
+
+  def >>(int: Int): Int32 = {
+    Int32(underlying >> int)
+  }
+
+  def toInt: Int = {
+    val i = underlying.toInt
+    require(underlying == i,
+            s"Rounded when converting int=${underlying} toInt=${i}")
+    i
+  }
+
+  def toBigInt: BigInt = toInt
+
+  def toDouble(x: Int32): Double = x.underlying.toDouble
+  def toFloat(x: Int32): Float = x.underlying.toFloat
+
+  def toInt(x: Int32): Int = {
+    val i = x.underlying
+    require(x.underlying == i)
+    i
+  }
+  def toLong(x: Int32): Long = x.underlying
+
+  override def compare(that: Int32): Int = underlying.compare(that.underlying)
 }
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -203,7 +203,7 @@ final case class UInt32(underlying: Long)
 /**
   * Represents a uint64_t in C
   */
-final case class UInt64(underlying: BigInt)
+final case class UInt64(underlying: java.math.BigInteger)
     extends AnyVal
     with NetworkElement
     with BasicArithmetic[UInt64]
@@ -236,19 +236,11 @@ final case class UInt64(underlying: BigInt)
   }
 
   def <<(u64: UInt64): UInt64 = {
-    UInt64(underlying.u64.underlying)
-  }
-
-  def <<(int: Int): UInt64 = {
-    this.shiftleft()(UInt64(int))
+    UInt64(underlying.shiftLeft(u64))
   }
 
   def >>(u64: UInt64): UInt64 = {
-    UInt64(underlying underlying)
-  }
-
-  def >>(int: Int): UInt64 = {
-    UInt64(underlying.shiftright() int)
+    UInt64(underlying.shiftRight(u64))
   }
 
   def toBigInt: BigInt = {
@@ -260,10 +252,10 @@ final case class UInt64(underlying: BigInt)
 
   def toBigInt: BigInt = underlying
 
-  def toLong: Long = underlying.toLong
+  def toLong: Long = underlying.longValueExact()
 
-  def toDouble(x: UInt64): Double = x.underlying.toDouble
-  def toFloat(x: UInt64): Float = x.underlying.toFloat
+  def toDouble(x: UInt64): Double = x.underlying.doubleValueExact()
+  def toFloat(x: UInt64): Float = x.underlying.floatValueExact()
 
   def toBigInt(x: UInt64): BigInt = x.underlying
 

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.core.number
 
+import java.math.BigInteger
+
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.util.{BitcoinSUtil, Factory, NumberUtil}
 import scodec.bits.ByteVector
@@ -129,7 +131,7 @@ sealed abstract class UInt8 extends UnsignedNumber[UInt8] {
 /**
   * Represents a uint32_t in C
   */
-final case class UInt32 private (private underlying: Long)
+final case class UInt32 private (private val underlying: Long)
     extends AnyVal
     with NetworkElement
     with BasicArithmetic[UInt32]
@@ -243,14 +245,14 @@ final case class UInt64 private (private val underlying: java.math.BigInteger)
     UInt64(underlying.shiftRight(u64.underlying.intValueExact()))
   }
 
-  def toBigInt: BigInt = {
+  def toBigInt: BigInteger = {
     val i = underlying
     require(underlying == i,
             s"Rounded when converting long=${underlying} toBigInt=${i}")
     i
   }
 
-  def toBigInt: BigInt = underlying
+  def toBigInt: BigInteger = underlying
 
   def toLong: Long = underlying.longValueExact()
 
@@ -285,7 +287,7 @@ final case class UInt64 private (private val underlying: java.math.BigInteger)
 /**
   * Represents a int32_t in C
   */
-final case class Int32 private (private underlying: Int)
+final case class Int32 private (private val underlying: Int)
     extends AnyVal
     with NetworkElement
     with BasicArithmetic[Int32]
@@ -505,7 +507,7 @@ object UInt32
   lazy val min = UInt32(minUnderlying)
   lazy val max = UInt32(maxUnderlying)
 
-  override def isInBound(num: A): Boolean =
+  def isInBound(num: Long): Boolean =
     num <= maxUnderlying && num >= minUnderlying
 
   override def fromBytes(bytes: ByteVector): UInt32 = {
@@ -515,7 +517,7 @@ object UInt32
   }
 
   def apply(bigInt: BigInt): UInt32 = {
-    require(isInBound(bigInt) == true,
+    require(isInBound(bigInt.toLong),
             "UInt32 number is not within the max/min bounds allowed")
     UInt32(bigInt.bigInteger.longValueExact())
   }

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -203,10 +203,15 @@ final case class UInt32(underlying: Long)
 /**
   * Represents a uint64_t in C
   */
-sealed abstract class UInt64 extends UnsignedNumber[UInt64] {
-  override def hex: String = encodeHex(underlying)
-  override def apply: A => UInt64 = UInt64(_)
-  override def andMask = 0xffffffffffffffffL
+final case class UInt64(underlying: BigInt)
+    extends AnyVal
+    with NetworkElement
+    with BasicArithmetic[UInt64]
+    with Ordered[UInt64] {
+
+  override def hex: String = BitcoinSUtil.encodeHex(underlying)
+
+  override def bytes: ByteVector = ByteVector.fromValidHex(hex)
 
   /**
     * Converts a [[BigInt]] to a 8 byte hex representation.
@@ -236,7 +241,7 @@ final case class Int32(underlying: Int)
     with NetworkElement
     with BasicArithmetic[Int32]
     with Ordered[Int32] {
-  override def hex: String = BitcoinSUtil.encodeHex(underlying).slice(-8, 8)
+  override def hex: String = BitcoinSUtil.encodeHex(underlying).slice(8, 16)
 
   override def bytes: ByteVector = ByteVector.fromValidHex(hex)
 

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -129,7 +129,7 @@ sealed abstract class UInt8 extends UnsignedNumber[UInt8] {
 /**
   * Represents a uint32_t in C
   */
-final case class UInt32(underlying: Long)
+final case class UInt32 private (private underlying: Long)
     extends AnyVal
     with NetworkElement
     with BasicArithmetic[UInt32]
@@ -203,7 +203,7 @@ final case class UInt32(underlying: Long)
 /**
   * Represents a uint64_t in C
   */
-final case class UInt64(underlying: java.math.BigInteger)
+final case class UInt64 private (private val underlying: java.math.BigInteger)
     extends AnyVal
     with NetworkElement
     with BasicArithmetic[UInt64]
@@ -214,33 +214,33 @@ final case class UInt64(underlying: java.math.BigInteger)
   override def bytes: ByteVector = ByteVector.fromValidHex(hex)
 
   override def +(y: UInt64): UInt64 = {
-    UInt64(underlying + y.underlying)
+    UInt64(underlying.add(y.underlying))
   }
 
   override def -(y: UInt64): UInt64 = {
-    UInt64(underlying - y.underlying)
+    UInt64(underlying.subtract(y.underlying))
   }
 
   override def *(y: UInt64): UInt64 = {
-    UInt64(underlying * y.underlying)
+    UInt64(underlying.multiply(y.underlying))
   }
 
   override def *(factor: BigInt): UInt64 = ???
 
   def |(u64: UInt64): UInt64 = {
-    UInt64(underlying | u64.underlying)
+    UInt64(underlying.or(u64.underlying))
   }
 
   def &(u64: UInt64): UInt64 = {
-    UInt64(underlying & u64.underlying)
+    UInt64(underlying.and(u64.underlying))
   }
 
   def <<(u64: UInt64): UInt64 = {
-    UInt64(underlying.shiftLeft(u64))
+    UInt64(underlying.shiftLeft(u64.underlying.intValueExact()))
   }
 
   def >>(u64: UInt64): UInt64 = {
-    UInt64(underlying.shiftRight(u64))
+    UInt64(underlying.shiftRight(u64.underlying.intValueExact()))
   }
 
   def toBigInt: BigInt = {
@@ -254,12 +254,13 @@ final case class UInt64(underlying: java.math.BigInteger)
 
   def toLong: Long = underlying.longValueExact()
 
-  def toDouble(x: UInt64): Double = x.underlying.doubleValueExact()
-  def toFloat(x: UInt64): Float = x.underlying.floatValueExact()
+  def toDouble(x: UInt64): Double = x.underlying.doubleValue()
+  def toFloat(x: UInt64): Float = x.underlying.floatValue()
 
   def toBigInt(x: UInt64): BigInt = x.underlying
 
-  override def compare(that: UInt64): Int = underlying.compare(that.underlying)
+  override def compare(that: UInt64): Int =
+    underlying.compareTo(that.underlying)
 
   /**
     * Converts a [[BigInt]] to a 8 byte hex representation.
@@ -284,7 +285,7 @@ final case class UInt64(underlying: java.math.BigInteger)
 /**
   * Represents a int32_t in C
   */
-final case class Int32(underlying: Int)
+final case class Int32 private (private underlying: Int)
     extends AnyVal
     with NetworkElement
     with BasicArithmetic[Int32]
@@ -504,17 +505,18 @@ object UInt32
   lazy val min = UInt32(minUnderlying)
   lazy val max = UInt32(maxUnderlying)
 
-  /*  override def isInBound(num: A): Boolean =
-    num <= maxUnderlying && num >= minUnderlying*/
+  override def isInBound(num: A): Boolean =
+    num <= maxUnderlying && num >= minUnderlying
 
   override def fromBytes(bytes: ByteVector): UInt32 = {
     require(
       bytes.size <= 4,
       "UInt32 byte array was too large, got: " + BitcoinSUtil.encodeHex(bytes))
-    UInt32(NumberUtil.toLongUnsigned(bytes))
   }
 
   def apply(bigInt: BigInt): UInt32 = {
+    require(isInBound(bigInt) == true,
+            "UInt32 number is not within the max/min bounds allowed")
     UInt32(bigInt.bigInteger.longValueExact())
   }
 }
@@ -537,16 +539,17 @@ object UInt64
   lazy val min = UInt64(minUnderlying)
   lazy val max = UInt64(maxUnderlying)
 
-  /* override def isInBound(num: A): Boolean =
+  override def isInBound(num: A): Boolean =
     num <= maxUnderlying && num >= minUnderlying
 
-   */
   override def fromBytes(bytes: ByteVector): UInt64 = {
     require(bytes.size <= 8)
     UInt64(NumberUtil.toUnsignedInt(bytes))
   }
 
   def apply(num: BigInt): UInt64 = {
+    require(isInBound(num) == true,
+            "UInt64 number is not within the min/max bounds")
     UInt64(num.bigInteger)
   }
 }
@@ -569,8 +572,8 @@ object Int32
   lazy val min = Int32(minUnderlying)
   lazy val max = Int32(maxUnderlying)
 
-  /*override def isInBound(num: A): Boolean =
-    num <= maxUnderlying && num >= minUnderlying*/
+  override def isInBound(num: A): Boolean =
+    num <= maxUnderlying && num >= minUnderlying */
 
   override def fromBytes(bytes: ByteVector): Int32 = {
     require(bytes.size <= 4, "We cannot have an Int32 be larger than 4 bytes")
@@ -578,6 +581,7 @@ object Int32
   }
 
   def apply(bigInt: BigInt): Int32 = {
+    require(isInBound(bigInt) == true)
     Int32(bigInt.bigInteger.intValueExact())
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -251,16 +251,16 @@ final case class UInt64(underlying: BigInt)
     UInt64(underlying >> int)
   }
 
-  def toInt: Int = {
-    val i = underlying.toInt
+  def toBigInt: BigInt = {
+    val i = underlying
     require(underlying == i,
-            s"Rounded when converting long=${underlying} toInt=${i}")
+            s"Rounded when converting long=${underlying} toBigInt=${i}")
     i
   }
 
   def toBigInt: BigInt = underlying
 
-  def toLong: Long = toBigInt
+  def toLong: Long = underlying.toLong
 
   def toDouble(x: UInt64): Double = x.underlying.toDouble
   def toFloat(x: UInt64): Float = x.underlying.toFloat

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -236,7 +236,7 @@ final case class UInt64(underlying: BigInt)
   }
 
   def <<(u64: UInt64): UInt64 = {
-    UInt64(underlying.shiftleft() u64.underlying)
+    UInt64(underlying.u64.underlying)
   }
 
   def <<(int: Int): UInt64 = {
@@ -244,11 +244,11 @@ final case class UInt64(underlying: BigInt)
   }
 
   def >>(u64: UInt64): UInt64 = {
-    UInt64(underlying u64.underlying)
+    UInt64(underlying underlying)
   }
 
   def >>(int: Int): UInt64 = {
-    this.UInt64(underlying >> int)
+    UInt64(underlying.shiftright() int)
   }
 
   def toBigInt: BigInt = {

--- a/core/src/main/scala/org/bitcoins/core/p2p/TypeIdentifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/TypeIdentifier.scala
@@ -82,8 +82,6 @@ object TypeIdentifier extends Factory[TypeIdentifier] {
   override def fromBytes(bytes: ByteVector): TypeIdentifier =
     RawTypeIdentifierSerializer.read(bytes)
 
-  def apply(num: Long): TypeIdentifier = TypeIdentifier(UInt32(num))
-
   def apply(uInt32: UInt32): TypeIdentifier = uInt32 match {
     case UInt32.one                 => MsgTx
     case _ if (uInt32 == UInt32(2)) => MsgBlock

--- a/core/src/main/scala/org/bitcoins/core/protocol/NetworkElement.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/NetworkElement.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.core.protocol
 
-import org.bitcoins.core.util.BitcoinSLogger
 import scodec.bits.ByteVector
 
 /**
@@ -8,7 +7,7 @@ import scodec.bits.ByteVector
   * This represents a element that can be serialized to
   * be sent over the network
   */
-abstract class NetworkElement {
+trait NetworkElement extends Any {
 
   /** The size of the NetworkElement in bytes. */
   def size: Long = bytes.size
@@ -18,6 +17,4 @@ abstract class NetworkElement {
 
   /** The byte representation of the NetworkElement */
   def bytes: ByteVector
-
-  lazy val logger = BitcoinSLogger.logger
 }

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -63,10 +63,25 @@ sealed abstract class NumberUtil extends BitcoinSLogger {
   def toInt(hex: String): Int = toInt(BitcoinSUtil.decodeHex(hex))
 
   /** Converts a sequence of [[scala.Byte Byte]] to a [[scala.Long Long]]. */
-  def toLong(bytes: ByteVector): Long = toBigInt(bytes).toLong
+  def toLongUnsigned(bytes: ByteVector): Long = {
+    toLong(bytes, false)
+  }
 
   /** Converts a hex string to a [[scala.Long Long]]. */
-  def toLong(hex: String): Long = toLong(BitcoinSUtil.decodeHex(hex))
+  def toLongUnsigned(hex: String): Long =
+    toLongUnsigned(BitcoinSUtil.decodeHex(hex))
+
+  def toLongSigned(bytes: ByteVector): Long = {
+    toLong(bytes, true)
+  }
+
+  def toLongSigned(hex: String): Long = {
+    toLong(BitcoinSUtil.decodeHex(hex), true)
+  }
+
+  private def toLong(bytes: ByteVector, signed: Boolean): Long = {
+    bytes.toLong(signed)
+  }
 
   /**
     *
@@ -112,7 +127,7 @@ sealed abstract class NumberUtil extends BitcoinSLogger {
           val r: Long = ((acc << (to - bits) & maxv)).toLong
           ret.+=(f(UInt8(r.toShort)))
         }
-      } else if (bits >= from || ((acc << (to - bits)) & maxv) != UInt8.zero) {
+      } else if (bits >= from || ((acc << (to - bits)) & maxv) != UInt32.zero) {
         Failure(new IllegalArgumentException("Invalid padding in encoding"))
       }
       Success(ret.result())


### PR DESCRIPTION
Looking to optimize the number implementation in the code base. Look to PR: #654  and issue: #653 to hopefully optimize and setup the underlying typing more efficiently so less bits have to be used for each number type. This is currently the implementation of the signed 32 bit int which is backed by Scala.Int type as per https://www.scala-lang.org/api/current/scala/Int.html. 