### PR TITLE
WIP: Initial BIP157 support

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawCompactFilterHeadersMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawCompactFilterHeadersMessageSerializerTest.scala
@@ -1,0 +1,22 @@
+package org.bitcoins.core.serializers.p2p.messages
+
+import org.bitcoins.testkit.util.BitcoinSUnitTest
+import scodec.bits._
+import org.bitcoins.core.p2p.CompactFilterHeadersMessage
+import org.bitcoins.core.p2p.NetworkHeader
+import org.bitcoins.core.gcs.FilterType
+
+class RawCompactFilterHeadersMessageSerializerTest extends BitcoinSUnitTest {
+  it must "parse a message" in {
+    // cribbed from a P2P log dump with Bitcoin-S node
+    val bytes =
+      hex"00226f1acd30ec19b541dba2478b673a142283bb39ccddef75015e3caf0ec89f480000000000000000000000000000000000000000000000000000000000000000031f30de30fabb7892d15eb985cc5d6c34c54a11b7e4c51f3da498f16255a27bb157965194aaa7ad3890c977d1b3c738d0a43a357ec645df28dc5c21876fb529c487eb3f35daf3b6adba13b40c2f0d0e99dee59b624b0e09d870894e1a0d6d3bb0"
+    val message = CompactFilterHeadersMessage.fromBytes(bytes)
+
+    assert(message.filterType == FilterType.Basic)
+    assert(message.filterHashes.length == 3)
+  }
+
+  // TODO, create generator
+  it must "have serialization symmetry" ignore ???
+}

--- a/core/src/main/scala/org/bitcoins/core/gcs/FilterType.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/FilterType.scala
@@ -1,0 +1,36 @@
+package org.bitcoins.core.gcs
+
+import org.bitcoins.core.protocol.NetworkElement
+import scodec.bits._
+import org.bitcoins.core.number.UInt64
+import org.bitcoins.core.number.UInt8
+import org.bitcoins.core.util.Factory
+
+/**
+  * Filter types for BIP157 block content filters
+  *
+  * @see [[https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki#block-filters BIP158]]
+  */
+sealed abstract class FilterType extends NetworkElement {
+  val M: UInt64
+  val P: UInt8
+}
+
+object FilterType extends Factory[FilterType] {
+
+  def fromBytes(bytes: ByteVector): FilterType = bytes match {
+    case Basic.bytes => Basic
+    case other: ByteVector =>
+      throw new IllegalArgumentException(
+        s"'${other.toHex}' is not a known filter type")
+  }
+
+  /** Currently the only defined filter type */
+  final case object Basic extends FilterType {
+    val bytes: ByteVector = hex"0x00"
+
+    val M: UInt64 = UInt64(784931)
+    val P: UInt8 = UInt8(19)
+  }
+
+}

--- a/core/src/main/scala/org/bitcoins/core/gcs/GCS.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/GCS.scala
@@ -49,7 +49,7 @@ object GCS {
   def buildBasicBlockFilter(
       data: Vector[ByteVector],
       key: SipHashKey): GolombFilter = {
-    buildGolombFilter(data, key, BlockFilter.P, BlockFilter.M)
+    buildGolombFilter(data, key, FilterType.Basic.P, FilterType.Basic.M)
   }
 
   private def sipHash(item: ByteVector, key: SipHashKey): UInt64 = {

--- a/core/src/main/scala/org/bitcoins/core/gcs/GolombFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/gcs/GolombFilter.scala
@@ -88,10 +88,6 @@ case class GolombFilter(
 
 object BlockFilter {
 
-  /** @see [[https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki#block-filters]] */
-  val M: UInt64 = UInt64(784931)
-  val P: UInt8 = UInt8(19)
-
   /**
     * Returns all ScriptPubKeys from a Block's outputs that are relevant
     * to BIP 158 Basic Block Filters
@@ -173,7 +169,11 @@ object BlockFilter {
     val keyBytes: ByteVector = blockHash.bytes.take(16)
     val key: SipHashKey = SipHashKey(keyBytes)
 
-    GolombFilter(key, BlockFilter.M, BlockFilter.P, n, filterBytes.toBitVector)
+    GolombFilter(key,
+                 FilterType.Basic.M,
+                 FilterType.Basic.P,
+                 n,
+                 filterBytes.toBitVector)
   }
 
   def fromHex(hex: String, blockHash: DoubleSha256Digest): GolombFilter = {

--- a/core/src/main/scala/org/bitcoins/core/p2p/ServiceIdentifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/ServiceIdentifier.scala
@@ -70,6 +70,19 @@ sealed abstract class ServiceIdentifier extends NetworkElement {
   lazy val nodeXthin: Boolean = reversedBits(4) // 1 << 4
 
   /**
+    * NODE_COMPACT_FILTERS means the node will service basic
+    * block filter requests.
+    *
+    * @see [[https://github.com/bitcoin/bips/blob/master/bip-0157 BIP157]] and
+    *   [https://github.com/bitcoin/bips/blob/master/bip-0158 BIP158]
+    *   for details on how this is implemented.
+    *
+    * @note This is not yet supported by any Core release. Currently
+    *       (aug. 1 2019) is a open PR by jimpo: https://github.com/bitcoin/bitcoin/pull/16442
+    */
+  lazy val nodeCompactFilters: Boolean = reversedBits(6) // 1 << 6
+
+  /**
     * this means the same as `nodeNetwork` with the limitation of only
     * serving the last 288 (2 days) blocks
     *
@@ -82,7 +95,7 @@ sealed abstract class ServiceIdentifier extends NetworkElement {
     val innerText =
       if (nodeNone) "none"
       else
-        s"network=$nodeNetwork, getUtxo=$nodeGetUtxo, bloom=$nodeBloom, witness=$nodeWitness, xthin=$nodeXthin, networkLimited=$nodeNetworkLimited"
+        s"network=$nodeNetwork, compactFilters=$nodeCompactFilters getUtxo=$nodeGetUtxo, bloom=$nodeBloom, witness=$nodeWitness, xthin=$nodeXthin, networkLimited=$nodeNetworkLimited"
     s"ServiceIdentifier($innerText)"
   }
 }
@@ -142,6 +155,8 @@ object ServiceIdentifier extends Factory[ServiceIdentifier] {
     * Bitcoin node.
     */
   val NODE_XTHIN: ServiceIdentifier = ServiceIdentifier(1 << 4)
+
+  val NODE_COMPACT_FILTERS = ServiceIdentifier(1 << 6)
 
   /**
     * This means the same as `NODE_NETWORK` with the limitation of only

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawCompactFilterCheckpointMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawCompactFilterCheckpointMessageSerializer.scala
@@ -1,0 +1,11 @@
+package org.bitcoins.core.serializers.p2p.messages
+
+import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.p2p.CompactFilterCheckPointMessage
+import scodec.bits.ByteVector
+
+object RawCompactFilterCheckpointMessageSerializer
+    extends RawBitcoinSerializer[CompactFilterCheckPointMessage] {
+  def read(bytes: ByteVector): CompactFilterCheckPointMessage = ???
+  def write(t: CompactFilterCheckPointMessage): ByteVector = ???
+}

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawCompactFilterHeadersMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawCompactFilterHeadersMessageSerializer.scala
@@ -1,0 +1,60 @@
+package org.bitcoins.core.serializers.p2p.messages
+
+import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.p2p.CompactFilterHeadersMessage
+import scodec.bits.ByteVector
+import org.bitcoins.core.crypto.DoubleSha256Digest
+import org.bitcoins.core.gcs.FilterType
+import scala.annotation.tailrec
+import org.bitcoins.core.protocol.CompactSizeUInt
+
+object RawCompactFilterHeadersMessageSerializer
+    extends RawBitcoinSerializer[CompactFilterHeadersMessage] {
+
+  def read(bytes: ByteVector): CompactFilterHeadersMessage = {
+    val filterType = FilterType.fromBytes(bytes.take(1))
+
+    val (stopHashBytes, afterStopHash) = bytes.drop(1).splitAt(32)
+    val stopHash = DoubleSha256Digest.fromBytes(stopHashBytes)
+
+    val (previousFilterHeaderBytes, afterPreviousFilterHeader) =
+      afterStopHash.splitAt(32)
+    val previousFilterHeaderHash =
+      DoubleSha256Digest.fromBytes(previousFilterHeaderBytes)
+
+    val filterHashesLength = CompactSizeUInt.parse(afterPreviousFilterHeader)
+
+    val filterHashesBytes = afterStopHash
+      .drop(filterHashesLength.bytes.length)
+      .take(filterHashesLength.toInt * 32)
+
+    @tailrec
+    def loop(
+        hashes: Vector[DoubleSha256Digest],
+        bytes: ByteVector): (Vector[DoubleSha256Digest], ByteVector) =
+      if (bytes.isEmpty) (hashes, ByteVector.empty)
+      else {
+        val (hashBytes, remainingBytes) = bytes.splitAt(32)
+        loop(hashes :+ DoubleSha256Digest.fromBytes(hashBytes), remainingBytes)
+      }
+
+    val (hashes, remainingBytes) = loop(Vector.empty, filterHashesBytes)
+
+    assert(hashes.length == filterHashesLength.toInt)
+    assert(remainingBytes.isEmpty)
+
+    val message = CompactFilterHeadersMessage(filterType,
+                                              stopHash,
+                                              previousFilterHeaderHash,
+                                              hashes)
+
+    message
+  }
+
+  def write(message: CompactFilterHeadersMessage): ByteVector = {
+    import message._
+    filterType.bytes ++ stopHash.bytes ++ previousFilterHeader.bytes ++ filterHashesLength.bytes ++ filterHashes
+      .foldLeft(ByteVector.empty)(_ ++ _.bytes)
+  }
+
+}

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawCompactFilterMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawCompactFilterMessageSerializer.scala
@@ -1,0 +1,12 @@
+package org.bitcoins.core.serializers.p2p.messages
+
+import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.p2p.CompactFilterMessage
+import scodec.bits.ByteVector
+
+object RawCompactFilterMessageSerializer
+    extends RawBitcoinSerializer[CompactFilterMessage] {
+
+  def read(bytes: ByteVector): CompactFilterMessage = ???
+  def write(t: CompactFilterMessage): ByteVector = ???
+}

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawGetCompactFilterCheckpointMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawGetCompactFilterCheckpointMessageSerializer.scala
@@ -1,0 +1,11 @@
+package org.bitcoins.core.serializers.p2p.messages
+
+import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.p2p.GetCompactFilterCheckPointMessage
+import scodec.bits.ByteVector
+
+object RawGetCompactFilterCheckpointMessageSerializer
+    extends RawBitcoinSerializer[GetCompactFilterCheckPointMessage] {
+  def read(bytes: ByteVector): GetCompactFilterCheckPointMessage = ???
+  def write(t: GetCompactFilterCheckPointMessage): ByteVector = ???
+}

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawGetCompactFiltersMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawGetCompactFiltersMessageSerializer.scala
@@ -1,0 +1,24 @@
+package org.bitcoins.core.serializers.p2p.messages
+
+import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.p2p.GetCompactFiltersMessage
+import scodec.bits.ByteVector
+import org.bitcoins.core.gcs.FilterType
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.crypto.DoubleSha256Digest
+
+object RawGetCompactFiltersMessageSerializer
+    extends RawBitcoinSerializer[GetCompactFiltersMessage] {
+
+  def read(bytes: ByteVector): GetCompactFiltersMessage = {
+    val filterType = FilterType.fromBytes(bytes.take(1))
+    val (startHeightBytes, rest) = bytes.drop(1).splitAt(5)
+    val startHeight = UInt32.fromBytes(startHeightBytes)
+    val stopHash = DoubleSha256Digest.fromBytes(rest.take(32))
+    GetCompactFiltersMessage(filterType, startHeight, stopHash)
+  }
+
+  def write(message: GetCompactFiltersMessage): ByteVector =
+    message.filterType.bytes ++ message.startHeight.bytes ++ message.stopHash.bytes
+
+}

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawGetcompactFilterHeadersMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawGetcompactFilterHeadersMessageSerializer.scala
@@ -1,0 +1,13 @@
+package org.bitcoins.core.serializers.p2p.messages
+
+import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.core.p2p.GetCompactFilterHeadersMessage
+import scodec.bits.ByteVector
+
+object RawGetcompactFilterHeadersMessageSerializer
+    extends RawBitcoinSerializer[GetCompactFilterHeadersMessage] {
+  def read(bytes: ByteVector): GetCompactFilterHeadersMessage = ???
+
+  def write(message: GetCompactFilterHeadersMessage): ByteVector =
+    message.filterType.bytes ++ message.startHeight.bytes ++ message.stopHash.bytes
+}

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -37,6 +37,11 @@ bitcoin-s {
         disable-console = false
     }
 
+    node {
+        spv-mode = yes # yes, no, true, false
+        neutrino-mode = yes # yes, no, true, false
+    }
+
     # settings for wallet module
     wallet {
         defaultAccountType = legacy # legacy, segwit, nested-segwit

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -41,6 +41,18 @@ case class NodeAppConfig(
     }
     initF
   }
+
+  /**
+    * Whether or not SPV (simplified payment verification)
+    * mode is enabled.
+    */
+  lazy val isSPVEnabled = config.getBoolean("node.spv-mode")
+
+  /**
+    * Whether or not Neutrino (compact block filters) mode
+    * is enabled
+    */
+  lazy val isNeutrinoEnabled = config.getBoolean("node.neutrino-mode")
 }
 
 object NodeAppConfig {

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -20,6 +20,15 @@ import org.bitcoins.core.p2p.TypeIdentifier
 import org.bitcoins.core.p2p.MsgUnassigned
 import org.bitcoins.db.P2PLogger
 import org.bitcoins.core.p2p.Inventory
+import org.bitcoins.core.p2p.CompactFilterCheckPointMessage
+import org.bitcoins.core.p2p.CompactFilterHeadersMessage
+import org.bitcoins.core.p2p.CompactFilterMessage
+import org.bitcoins.core.p2p.GetBlocksMessage
+import org.bitcoins.core.p2p.MemPoolMessage
+import org.bitcoins.core.p2p.GetHeadersMessage
+import org.bitcoins.core.p2p.GetCompactFiltersMessage
+import org.bitcoins.core.p2p.GetCompactFilterHeadersMessage
+import org.bitcoins.core.p2p.GetCompactFilterCheckPointMessage
 
 /** This actor is meant to handle a [[org.bitcoins.core.p2p.DataPayload DataPayload]]
   * that a peer to sent to us on the p2p network, for instance, if we a receive a
@@ -37,6 +46,24 @@ class DataMessageHandler(callbacks: SpvNodeCallbacks, chainHandler: ChainApi)(
       peerMsgSender: PeerMessageSender): Future[Unit] = {
 
     payload match {
+      case checkpoint: CompactFilterCheckPointMessage =>
+        logger.debug(
+          s"Received ${checkpoint.commandName} message, this is not implemented yet")
+        FutureUtil.unit
+      case filterHeader: CompactFilterHeadersMessage =>
+        logger.debug(
+          s"Received ${filterHeader.commandName} message, this is not implemented yet")
+        FutureUtil.unit
+      case filter: CompactFilterMessage =>
+        logger.debug(
+          s"Received ${filter.commandName}, this is not implemented yet")
+        FutureUtil.unit
+      case notHandling @ (MemPoolMessage | _: GetHeadersMessage |
+          _: GetBlocksMessage | _: GetCompactFiltersMessage |
+          _: GetCompactFilterHeadersMessage |
+          _: GetCompactFilterCheckPointMessage) =>
+        logger.debug(s"Received ${notHandling.commandName} message, skipping ")
+        FutureUtil.unit
       case getData: GetDataMessage =>
         logger.debug(
           s"Received a getdata message for inventories=${getData.inventories}")

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -159,6 +159,16 @@ class PeerMessageReceiver(
         logger.trace(
           s"Received versionMsg=${versionMsg}from peer=${peerOpt.get}")
 
+        if (nodeAppConfig.isNeutrinoEnabled && !versionMsg.services.nodeCompactFilters) {
+          logger.warn(
+            s"Neutrino mode is enabled, but connected peer (${peerOpt.get}) does not serve compact block filters")
+        }
+
+        if (nodeAppConfig.isSPVEnabled && !versionMsg.services.nodeBloom) {
+          logger.warn(
+            s"SPV mode is enabled, but connected peer (${peerOpt.get}) does not servce bloom filters")
+        }
+
         internalState match {
           case bad @ (_: Disconnected | _: Normal | Preconnection) =>
             Failure(

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -102,6 +102,16 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     sendMsg(message)
   }
 
+  def sendGetCompactFilterHeadersMessage(
+      startHeight: Int,
+      stopHash: DoubleSha256Digest): Unit = {
+    val message =
+      GetCompactFilterHeadersMessage(startHeight, stopHash)
+    logger.trace(s"Sending getcfheaders=$message to peer ${client.peer}")
+    sendMsg(message)
+
+  }
+
   private[node] def sendMsg(msg: NetworkPayload): Unit = {
     logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
     val newtworkMsg = NetworkMessage(conf.network, msg)


### PR DESCRIPTION
In this PR we: 

- Add basic support for BIP157 P2P messages 
- Introduce SPV mode and Neutrino mode to node
- Enhance logging and error handling in server main method 
- Improve error handling of logging configuration levels 
- Add trace logging of P2P message parsing 

To test this PR/do dev work on BIP157 you need to compile Jimpo's fork of Core, PR/branch is here: https://github.com/bitcoin/bitcoin/pull/16442/

TODO: 
- [x] Request compact filter headers if neutrino mode is enabled
- [x] Parse compact filter headers response
- [ ] Handle (store to disk, at least) received filter headers
- [ ] Add hard coded + symmetry tests to `getcfheaders` and `cfheaders` messages
- [ ] Copy documentation from BIP157 to new P2P messages