### PR TITLE
2019 08 09 Don't use BlockHeaderDAO in TipValidation

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -26,7 +26,6 @@ class BlockchainTest extends ChainUnitTest {
         BlockHeaderHelper.buildNextHeader(ChainUnitTest.genesisHeaderDb)
 
       val connectTip = Blockchain.connectTip(header = newHeader.blockHeader,
-                                             blockHeaderDAO = bhDAO,
                                              Vector(blockchain))
 
       connectTip match {

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -25,11 +25,11 @@ class BlockchainTest extends ChainUnitTest {
       val newHeader =
         BlockHeaderHelper.buildNextHeader(ChainUnitTest.genesisHeaderDb)
 
-      val connectTipF = Blockchain.connectTip(header = newHeader.blockHeader,
-                                              blockHeaderDAO = bhDAO,
-                                              Vector(blockchain))
+      val connectTip = Blockchain.connectTip(header = newHeader.blockHeader,
+                                             blockHeaderDAO = bhDAO,
+                                             Vector(blockchain))
 
-      connectTipF.map {
+      connectTip match {
         case BlockchainUpdate.Successful(_, connectedHeader) =>
           assert(newHeader == connectedHeader)
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -18,6 +18,7 @@ import org.scalatest.{Assertion, FutureOutcome}
 import scala.concurrent.Future
 import org.bitcoins.chain.config.ChainAppConfig
 import com.typesafe.config.ConfigFactory
+import org.bitcoins.chain.blockchain.Blockchain
 import org.bitcoins.server.BitcoinSAppConfig
 
 class TipValidationTest extends ChainUnitTest {
@@ -37,13 +38,14 @@ class TipValidationTest extends ChainUnitTest {
   //blocks 566,092 and 566,093
   val newValidTip = BlockHeaderHelper.header1
   val currentTipDb = BlockHeaderHelper.header2Db
+  val blockchain = Blockchain.fromHeaders(Vector(currentTipDb))
 
   it must "connect two blocks with that are valid" in { bhDAO =>
     val newValidTipDb =
       BlockHeaderDbHelper.fromBlockHeader(566093, newValidTip)
     val expected = TipUpdateResult.Success(newValidTipDb)
 
-    runTest(newValidTip, expected, bhDAO)
+    runTest(newValidTip, expected, blockchain)
   }
 
   it must "fail to connect two blocks that do not reference prev block hash correctly" in {
@@ -52,30 +54,27 @@ class TipValidationTest extends ChainUnitTest {
 
       val expected = TipUpdateResult.BadPreviousBlockHash(badPrevHash)
 
-      runTest(badPrevHash, expected, bhDAO)
+      runTest(badPrevHash, expected, blockchain)
   }
 
   it must "fail to connect two blocks with two different POW requirements at the wrong interval" in {
     bhDAO =>
       val badPOW = BlockHeaderHelper.badNBits
       val expected = TipUpdateResult.BadPOW(badPOW)
-      runTest(badPOW, expected, bhDAO)
+      runTest(badPOW, expected, blockchain)
   }
 
   it must "fail to connect two blocks with a bad nonce" in { bhDAO =>
     val badNonce = BlockHeaderHelper.badNonce
     val expected = TipUpdateResult.BadNonce(badNonce)
-    runTest(badNonce, expected, bhDAO)
+    runTest(badNonce, expected, blockchain)
   }
 
   private def runTest(
       header: BlockHeader,
       expected: TipUpdateResult,
-      blockHeaderDAO: BlockHeaderDAO,
-      currentTipDbDefault: BlockHeaderDb = currentTipDb): Future[Assertion] = {
-    val checkTipF =
-      TipValidation.checkNewTip(header, currentTipDbDefault, blockHeaderDAO)
-
-    checkTipF.map(validationResult => assert(validationResult == expected))
+      blockchain: Blockchain): Assertion = {
+    val result = TipValidation.checkNewTip(header, blockchain)
+    assert(result == expected)
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.chain.blockchain
 
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
+import org.bitcoins.chain.models.BlockHeaderDb
 import org.bitcoins.chain.validation.{TipUpdateResult, TipValidation}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.db.ChainVerificationLogger
@@ -69,16 +69,12 @@ object Blockchain extends ChainVerificationLogger {
     * We then attempt to connect this block header to all of our current
     * chain tips.
     * @param header the block header to connect to our chain
-    * @param blockHeaderDAO where we can find our blockchain
-    * @param ec
+    * @param blockchains the blockchain we are attempting to connect to
     * @return a [[scala.concurrent.Future Future]] that contains a [[org.bitcoins.chain.blockchain.BlockchainUpdate BlockchainUpdate]] indicating
     *         we [[org.bitcoins.chain.blockchain.BlockchainUpdate.Successful successful]] connected the tip,
     *         or [[org.bitcoins.chain.blockchain.BlockchainUpdate.Failed Failed]] to connect to a tip
     */
-  def connectTip(
-      header: BlockHeader,
-      blockHeaderDAO: BlockHeaderDAO,
-      blockchains: Vector[Blockchain])(
+  def connectTip(header: BlockHeader, blockchains: Vector[Blockchain])(
       implicit conf: ChainAppConfig): BlockchainUpdate = {
     logger.debug(
       s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain")

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
@@ -1,13 +1,12 @@
 package org.bitcoins.chain.blockchain
 
+import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
 import org.bitcoins.chain.validation.{TipUpdateResult, TipValidation}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
+import org.bitcoins.db.ChainVerificationLogger
 
 import scala.collection.{IndexedSeqLike, mutable}
-import scala.concurrent.{ExecutionContext, Future}
-import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.db.ChainVerificationLogger
 
 /**
   * In memory implementation of a blockchain
@@ -37,7 +36,22 @@ case class Blockchain(headers: Vector[BlockHeaderDb])
   override def length: Int = headers.length
 
   /** @inheritdoc */
-  override def apply(idx: Int): BlockHeaderDb = headers(idx)
+  override def apply(idx: Int): BlockHeaderDb = headers.apply(idx)
+
+  /** Finds a block header at a given height */
+  def findAtHeight(height: Int): Option[BlockHeaderDb] =
+    find(_.height == height)
+
+  /** Splits the blockchain at the header, returning a new blockchain where the best tip is the given header */
+  def fromHeader(header: BlockHeaderDb): Option[Blockchain] = {
+    val headerIdxOpt = headers.zipWithIndex.find(_._1 == header)
+    headerIdxOpt.map {
+      case (header, idx) =>
+        val newChain = Blockchain.fromHeaders(headers.splitAt(idx)._2)
+        require(newChain.tip == header)
+        newChain
+    }
+  }
 
 }
 
@@ -65,90 +79,81 @@ object Blockchain extends ChainVerificationLogger {
       header: BlockHeader,
       blockHeaderDAO: BlockHeaderDAO,
       blockchains: Vector[Blockchain])(
-      implicit ec: ExecutionContext,
-      conf: ChainAppConfig): Future[BlockchainUpdate] = {
+      implicit conf: ChainAppConfig): BlockchainUpdate = {
     logger.debug(
       s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain")
 
-    val tipResultF: Future[BlockchainUpdate] = {
-      val nested: Vector[Future[BlockchainUpdate]] = blockchains.map {
-        blockchain =>
-          val prevBlockHeaderIdxOpt =
-            blockchain.headers.zipWithIndex.find {
-              case (headerDb, _) =>
-                headerDb.hashBE == header.previousBlockHashBE
-            }
-          prevBlockHeaderIdxOpt match {
-            case None =>
-              logger.warn(
-                s"No common ancestor found in the chain to connect to ${header.hashBE}")
-              val err = TipUpdateResult.BadPreviousBlockHash(header)
-              val failed = BlockchainUpdate.Failed(blockchain = blockchain,
-                                                   failedHeader = header,
-                                                   tipUpdateFailure = err)
-              Future.successful(failed)
-
-            case Some((prevBlockHeader, prevHeaderIdx)) =>
-              //found a header to connect to!
-              logger.debug(
-                s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain")
-              val tipResultF =
-                TipValidation.checkNewTip(newPotentialTip = header,
-                                          currentTip = prevBlockHeader,
-                                          blockHeaderDAO = blockHeaderDAO)
-
-              tipResultF.map { tipResult =>
-                tipResult match {
-                  case TipUpdateResult.Success(headerDb) =>
-                    logger.debug(
-                      s"Successfully verified=${headerDb.hashBE.hex}, connecting to chain")
-                    val oldChain =
-                      blockchain.takeRight(blockchain.length - prevHeaderIdx)
-                    val newChain =
-                      Blockchain.fromHeaders(headerDb +: oldChain)
-                    BlockchainUpdate.Successful(newChain, headerDb)
-                  case fail: TipUpdateResult.Failure =>
-                    logger.warn(
-                      s"Could not verify header=${header.hashBE.hex}, reason=$fail")
-                    BlockchainUpdate.Failed(blockchain, header, fail)
-                }
-              }
+    val tipResult: BlockchainUpdate = {
+      val nested: Vector[BlockchainUpdate] = blockchains.map { blockchain =>
+        val prevBlockHeaderIdxOpt =
+          blockchain.headers.zipWithIndex.find {
+            case (headerDb, _) =>
+              headerDb.hashBE == header.previousBlockHashBE
           }
+        prevBlockHeaderIdxOpt match {
+          case None =>
+            logger.warn(
+              s"No common ancestor found in the chain to connect to ${header.hashBE}")
+            val err = TipUpdateResult.BadPreviousBlockHash(header)
+            val failed = BlockchainUpdate.Failed(blockchain = blockchain,
+                                                 failedHeader = header,
+                                                 tipUpdateFailure = err)
+            failed
+
+          case Some((prevBlockHeader, prevHeaderIdx)) =>
+            //found a header to connect to!
+            logger.debug(
+              s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain")
+            val chain = blockchain.fromHeader(prevBlockHeader)
+            val tipResult =
+              TipValidation.checkNewTip(newPotentialTip = header, chain.get)
+
+            tipResult match {
+              case TipUpdateResult.Success(headerDb) =>
+                logger.debug(
+                  s"Successfully verified=${headerDb.hashBE.hex}, connecting to chain")
+                val oldChain =
+                  blockchain.takeRight(blockchain.length - prevHeaderIdx)
+                val newChain =
+                  Blockchain.fromHeaders(headerDb +: oldChain)
+                BlockchainUpdate.Successful(newChain, headerDb)
+              case fail: TipUpdateResult.Failure =>
+                logger.warn(
+                  s"Could not verify header=${header.hashBE.hex}, reason=$fail")
+                BlockchainUpdate.Failed(blockchain, header, fail)
+            }
+        }
       }
-      parseSuccessOrFailure(nested = nested)
+      parseSuccessOrFailure(nested)
     }
 
-    tipResultF
+    tipResult
   }
 
   /** Takes in a vector of blockchain updates being executed asynchronously, we can only connect one [[BlockHeader header]]
     * to a tip successfully, which means _all_ other [[BlockchainUpdate updates]] must fail. This is a helper method
     * to find the one [[BlockchainUpdate.Successful successful]] update, or else returns one of the [[BlockchainUpdate.Failed failures]]
-    * @param nested
-    * @param ec
     * @return
     */
-  private def parseSuccessOrFailure(nested: Vector[Future[BlockchainUpdate]])(
-      implicit ec: ExecutionContext): Future[BlockchainUpdate] = {
-    require(nested.nonEmpty,
+  private def parseSuccessOrFailure(
+      updates: Vector[BlockchainUpdate]): BlockchainUpdate = {
+    require(updates.nonEmpty,
             s"Cannot parse success or failure if we don't have any updates!")
-    val successfulTipOptF: Future[Option[BlockchainUpdate]] = {
-      Future.find(nested) {
+    val successfulTipOpt: Option[BlockchainUpdate] = {
+      updates.find {
         case update: BlockchainUpdate =>
           update.isInstanceOf[BlockchainUpdate.Successful]
       }
     }
 
-    successfulTipOptF.flatMap {
-      case Some(update) => Future.successful(update)
+    successfulTipOpt match {
+      case Some(update) => update
       case None         =>
         //if we didn't successfully connect a tip, just take the first failure we see
-        Future
-          .find(nested) {
-            case update: BlockchainUpdate =>
-              update.isInstanceOf[BlockchainUpdate.Failed]
-          }
-          .map(_.get)
+        updates.find {
+          case update: BlockchainUpdate =>
+            update.isInstanceOf[BlockchainUpdate.Failed]
+        }.get
     }
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -51,12 +51,12 @@ case class ChainHandler(
     logger.debug(
       s"Processing header=${header.hashBE.hex}, previousHash=${header.previousBlockHashBE.hex}")
 
-    val blockchainUpdateF = Blockchain.connectTip(header = header,
-                                                  blockHeaderDAO =
-                                                    blockHeaderDAO,
-                                                  blockchains = blockchains)
+    val blockchainUpdate = Blockchain.connectTip(
+      header = header,
+      blockHeaderDAO = blockHeaderDAO,
+      blockchains = blockchains)
 
-    val newHandlerF = blockchainUpdateF.flatMap {
+    val newHandlerF = blockchainUpdate match {
       case BlockchainUpdate.Successful(newChain, updatedHeader) =>
         //now we have successfully connected the header, we need to insert
         //it into the database
@@ -94,12 +94,6 @@ case class ChainHandler(
         logTipConnectionFailure(reason).flatMap { _ =>
           Future.failed(new RuntimeException(errMsg))
         }
-    }
-
-    blockchainUpdateF.failed.foreach { err =>
-      logger.error(
-        s"Failed to connect header=${header.hashBE.hex} err=${err.getMessage}")
-
     }
 
     newHandlerF

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -3,16 +3,18 @@ package org.bitcoins.chain.blockchain
 import org.bitcoins.chain.api.ChainApi
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
+import org.bitcoins.chain.validation.TipUpdateResult
+import org.bitcoins.chain.validation.TipUpdateResult.{
+  BadNonce,
+  BadPOW,
+  BadPreviousBlockHash
+}
 import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.protocol.blockchain.BlockHeader
+import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.db.ChainVerificationLogger
 
 import scala.concurrent.{ExecutionContext, Future}
-import org.bitcoins.db.ChainVerificationLogger
-import org.bitcoins.chain.validation.TipUpdateResult.BadNonce
-import org.bitcoins.chain.validation.TipUpdateResult.BadPOW
-import org.bitcoins.chain.validation.TipUpdateResult.BadPreviousBlockHash
-import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.chain.validation.TipUpdateResult
 
 /**
   * Chain Handler is meant to be the reference implementation
@@ -51,10 +53,8 @@ case class ChainHandler(
     logger.debug(
       s"Processing header=${header.hashBE.hex}, previousHash=${header.previousBlockHashBE.hex}")
 
-    val blockchainUpdate = Blockchain.connectTip(
-      header = header,
-      blockHeaderDAO = blockHeaderDAO,
-      blockchains = blockchains)
+    val blockchainUpdate =
+      Blockchain.connectTip(header = header, blockchains = blockchains)
 
     val newHandlerF = blockchainUpdate match {
       case BlockchainUpdate.Successful(newChain, updatedHeader) =>

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -1,13 +1,11 @@
 package org.bitcoins.chain.pow
 
 import org.bitcoins.chain.blockchain.Blockchain
-import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
+import org.bitcoins.chain.models.{BlockHeaderDb}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.protocol.blockchain.{BlockHeader, ChainParams}
 import org.bitcoins.core.util.NumberUtil
-
-import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Implements functions found inside of bitcoin core's

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -29,52 +29,44 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
     * assigned to a [[org.bitcoins.core.protocol.blockchain.BlockHeader BlockHeader]] after all these
     * validation checks occur
     * */
-  def checkNewTip(
-      newPotentialTip: BlockHeader,
-      currentTip: BlockHeaderDb,
-      blockHeaderDAO: BlockHeaderDAO)(
-      implicit ec: ExecutionContext,
-      conf: ChainAppConfig): Future[TipUpdateResult] = {
+  def checkNewTip(newPotentialTip: BlockHeader, blockchain: Blockchain)(
+      implicit conf: ChainAppConfig): TipUpdateResult = {
     val header = newPotentialTip
+    val currentTip = blockchain.tip
     logger.trace(
       s"Checking header=${header.hashBE.hex} to try to connect to currentTip=${currentTip.hashBE.hex} with height=${currentTip.height}")
 
-    val powCheckF = isBadPow(newPotentialTip = newPotentialTip,
-                             currentTip = currentTip,
-                             blockHeaderDAO = blockHeaderDAO)
+    val expectedWork: UInt32 =
+      isBadPow(newPotentialTip = newPotentialTip, blockchain = blockchain)(conf)
 
-    val connectTipResultF: Future[TipUpdateResult] = {
-      powCheckF.map { expectedWork =>
-        if (header.previousBlockHashBE != currentTip.hashBE) {
-          logger.warn(
-            s"Failed to connect tip=${header.hashBE.hex} to current chain")
-          TipUpdateResult.BadPreviousBlockHash(newPotentialTip)
-        } else if (header.nBits != expectedWork) {
-          //https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/pow.cpp#L19
-          TipUpdateResult.BadPOW(newPotentialTip)
-        } else if (isBadNonce(newPotentialTip)) {
-          TipUpdateResult.BadNonce(newPotentialTip)
-        } else {
-          val headerDb = BlockHeaderDbHelper.fromBlockHeader(
-            height = currentTip.height + 1,
-            bh = newPotentialTip
-          )
-          TipUpdateResult.Success(headerDb)
-        }
+    val connectTipResult: TipUpdateResult = {
+      if (header.previousBlockHashBE != currentTip.hashBE) {
+        logger.warn(
+          s"Failed to connect tip=${header.hashBE.hex} to current chain")
+        TipUpdateResult.BadPreviousBlockHash(newPotentialTip)
+      } else if (header.nBits != expectedWork) {
+        //https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/pow.cpp#L19
+        TipUpdateResult.BadPOW(newPotentialTip)
+      } else if (isBadNonce(newPotentialTip)) {
+        TipUpdateResult.BadNonce(newPotentialTip)
+      } else {
+        val headerDb = BlockHeaderDbHelper.fromBlockHeader(
+          height = currentTip.height + 1,
+          bh = newPotentialTip
+        )
+        TipUpdateResult.Success(headerDb)
       }
     }
 
-    logTipResult(connectTipResultF, currentTip)
-    connectTipResultF
+    logTipResult(connectTipResult, currentTip)
+    connectTipResult
   }
 
   /** Logs the result of [[org.bitcoins.chain.validation.TipValidation.checkNewTip() checkNewTip]] */
   private def logTipResult(
-      connectTipResultF: Future[TipUpdateResult],
-      currentTip: BlockHeaderDb)(
-      implicit ec: ExecutionContext,
-      conf: ChainAppConfig): Unit = {
-    connectTipResultF.map {
+      connectTipResult: TipUpdateResult,
+      currentTip: BlockHeaderDb)(implicit conf: ChainAppConfig): Unit = {
+    connectTipResult match {
       case TipUpdateResult.Success(tipDb) =>
         logger.trace(
           s"Successfully connected ${tipDb.hashBE.hex} with height=${tipDb.height} to block=${currentTip.hashBE.hex} with height=${currentTip.height}")
@@ -84,7 +76,6 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
           s"Failed to connect ${bad.header.hashBE.hex} to ${currentTip.hashBE.hex} with height=${currentTip.height}, reason=${bad}")
 
     }
-
     ()
   }
 
@@ -104,14 +95,10 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
     }
   }
 
-  private def isBadPow(
-      newPotentialTip: BlockHeader,
-      currentTip: BlockHeaderDb,
-      blockchain: Blockchain)(
-      implicit ec: ExecutionContext,
-      config: ChainAppConfig): Future[UInt32] = {
+  private def isBadPow(newPotentialTip: BlockHeader, blockchain: Blockchain)(
+      config: ChainAppConfig): UInt32 = {
     Pow.getNetworkWorkRequired(newPotentialTip = newPotentialTip,
-                               blockchain = blockchain)
+                               blockchain = blockchain)(config)
 
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -1,17 +1,12 @@
 package org.bitcoins.chain.validation
 
 import org.bitcoins.chain.blockchain.Blockchain
-import org.bitcoins.chain.models.{
-  BlockHeaderDAO,
-  BlockHeaderDb,
-  BlockHeaderDbHelper
-}
+import org.bitcoins.chain.models.{BlockHeaderDb, BlockHeaderDbHelper}
 import org.bitcoins.chain.pow.Pow
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.util.NumberUtil
 
-import scala.concurrent.{ExecutionContext, Future}
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.db.ChainVerificationLogger
 

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.chain.validation
 
+import org.bitcoins.chain.blockchain.Blockchain
 import org.bitcoins.chain.models.{
   BlockHeaderDAO,
   BlockHeaderDb,
@@ -106,12 +107,11 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
   private def isBadPow(
       newPotentialTip: BlockHeader,
       currentTip: BlockHeaderDb,
-      blockHeaderDAO: BlockHeaderDAO)(
+      blockchain: Blockchain)(
       implicit ec: ExecutionContext,
       config: ChainAppConfig): Future[UInt32] = {
-    Pow.getNetworkWorkRequired(tip = currentTip,
-                               newPotentialTip = newPotentialTip,
-                               blockHeaderDAO = blockHeaderDAO)
+    Pow.getNetworkWorkRequired(newPotentialTip = newPotentialTip,
+                               blockchain = blockchain)
 
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -2,7 +2,6 @@ package org.bitcoins.core.protocol.blockchain
 
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
-
 import org.bitcoins.core.config.{
   BitcoinNetwork,
   MainNet,
@@ -18,7 +17,7 @@ import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptSignature}
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.{BytesToPushOntoStack, ScriptConstant}
 import org.bitcoins.core.script.crypto.OP_CHECKSIG
-import org.bitcoins.core.util.BitcoinScriptUtil
+import org.bitcoins.core.util.{BitcoinScriptUtil, NumberUtil}
 import scodec.bits.{ByteVector, _}
 
 import scala.concurrent.duration.{Duration, DurationInt}
@@ -160,6 +159,12 @@ sealed abstract class ChainParams {
     * @return
     */
   def powLimit: BigInteger
+
+  /** The minimum proof of required for a block as specified by [[org.bitcoins.core.protocol.blockchain.ChainParams.powLimit powLimit]], compressed to a UInt32 */
+  lazy val compressedPowLimit: UInt32 = {
+    NumberUtil.targetCompression(bigInteger = powLimit, isNegative = false)
+
+  }
 
   /** The targetted timespan between difficulty adjustments
     * As of this implementation, all of these are the same in bitcoin core

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -3,7 +3,7 @@ bitcoin-s {
     network = regtest # regtest, testnet3, mainnet
 
     logging {
-        level = info # trace, debug, info, warn, error, off
+        level = INFO # trace, debug, info, warn, error, off
 
         # You can also tune specific module loggers.
         # They each take the same levels as above.


### PR DESCRIPTION
This builds off of #655 

This uses our in memory blockchain to do tip validation instead of having to _possibly_ hit the database when validating a new tip. The downside here is is that we need to keep more chain in m

A side effect of this PR is it makes it much easier to benchmark our tip validation logic now that there is any async computation happening in this code path, which allows us to make progress on #653