### PR TITLE
2019 08 08 tip validation bench

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -345,13 +345,15 @@ lazy val chain = project
 
 lazy val chainTest = project
   .in(file("chain-test"))
+  .dependsOn(chain, core % testAndCompile, testkit, zmq)
   .settings(commonTestWithDbSettings: _*)
   .settings(chainDbSettings: _*)
+  .settings(benchSettings: _*)
   .settings(
     name := "bitcoin-s-chain-test",
     libraryDependencies ++= Deps.chainTest
   )
-  .dependsOn(chain, core % testAndCompile, testkit, zmq)
+  .configs(Benchmark)
   .enablePlugins(FlywayPlugin)
 
 lazy val dbCommons = project

--- a/chain-test/src/bench/scala/org/bitcoins/chain/blockchain/BlockchainBench.scala
+++ b/chain-test/src/bench/scala/org/bitcoins/chain/blockchain/BlockchainBench.scala
@@ -1,7 +1,6 @@
-package org.bitcoins.chain.validation
+package org.bitcoins.chain.blockchain
 
 import com.typesafe.config.ConfigFactory
-import org.bitcoins.chain.blockchain.Blockchain
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.testkit.BitcoinSTestAppConfig
@@ -9,11 +8,7 @@ import org.bitcoins.testkit.chain.BlockHeaderHelper
 import org.scalameter
 import org.scalameter.Bench
 
-import scala.concurrent.ExecutionContext
-
-object TipValidationBench
-    extends Bench.OfflineReport
-    with java.io.Serializable {
+object BlockchainBench extends Bench.OfflineReport {
   import org.scalameter.api._
   import org.scalameter.picklers.noPickler._
 
@@ -36,20 +31,19 @@ object TipValidationBench
     scalameter.Gen.single("header")(newValidTip, blockchain)
   }
 
-  performance of "TipValidation" in {
-    measure method "checkNewTip" in {
+  performance of "Blockchain" in {
+    measure method "connectTip" in {
       using(headerToConnect)
         .config(
           exec.jvmflags -> List("-Xmx128m")
         )
         .in {
           case (header: BlockHeader, blockchain: Blockchain) =>
-            val result = TipValidation.checkNewTip(header, blockchain)
+            Blockchain.connectTip(header, Vector(blockchain))
         }
     }
   }
 
-  // GZIPJSONSerializationPersistor is default but we want to choose custom path for regression data
   override def persistor: Persistor =
     new SerializationPersistor("target/results")
 }

--- a/chain-test/src/bench/scala/org/bitcoins/chain/validation/TipValidationBench.scala
+++ b/chain-test/src/bench/scala/org/bitcoins/chain/validation/TipValidationBench.scala
@@ -16,7 +16,6 @@ object TipValidationBench
     with java.io.Serializable {
   import org.scalameter.api._
   import org.scalameter.picklers.noPickler._
-
   /**
     * Behaves exactly like the default conf, execpt
     * network is set to mainnet

--- a/chain-test/src/bench/scala/org/bitcoins/chain/validation/TipValidationBench.scala
+++ b/chain-test/src/bench/scala/org/bitcoins/chain/validation/TipValidationBench.scala
@@ -1,0 +1,54 @@
+package org.bitcoins.chain.validation
+
+import com.typesafe.config.ConfigFactory
+import org.bitcoins.chain.blockchain.Blockchain
+import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.core.protocol.blockchain.BlockHeader
+import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.chain.BlockHeaderHelper
+import org.scalameter
+import org.scalameter.Bench
+
+import scala.concurrent.ExecutionContext
+
+object TipValidationBench
+    extends Bench.OfflineReport
+    with java.io.Serializable {
+  import org.scalameter.api._
+  import org.scalameter.picklers.noPickler._
+
+  /**
+    * Behaves exactly like the default conf, execpt
+    * network is set to mainnet
+    */
+  lazy val mainnetAppConfig: ChainAppConfig = {
+    val mainnetConf = ConfigFactory.parseString("bitcoin-s.network = mainnet")
+    BitcoinSTestAppConfig.getTestConfig(mainnetConf)
+  }
+  // we're working with mainnet data
+  implicit lazy val appConfig: ChainAppConfig = mainnetAppConfig
+
+  val newValidTip = BlockHeaderHelper.header1
+  val currentTipDb = BlockHeaderHelper.header2Db
+
+  val headerToConnect: scalameter.Gen[(BlockHeader, Blockchain)] = {
+    val blockchain = Blockchain.fromHeaders(Vector(currentTipDb))
+    scalameter.Gen.single("header")(newValidTip, blockchain)
+  }
+
+  performance of "TipValidation" in {
+    measure method "checkNewTip" in {
+      using(headerToConnect)
+        .config(
+          )
+        .in {
+          case (header: BlockHeader, blockchain: Blockchain) =>
+            val result = TipValidation.checkNewTip(header, blockchain)
+        }
+    }
+  }
+
+  // GZIPJSONSerializationPersistor is default but we want to choose custom path for regression data
+  override def persistor: Persistor =
+    new SerializationPersistor("target/results")
+}

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -33,7 +33,7 @@ import scala.concurrent.duration.{Duration, DurationInt}
   *      [[https://github.com/bitcoin/bitcoin/blob/master/src/chainparams.h#L42 this C++ interface]]
   *      in Bitcoin Core
   */
-sealed abstract class ChainParams {
+sealed abstract class ChainParams extends java.io.Serializable {
 
   /** Return the BIP70 network string (
     * [[org.bitcoins.core.protocol.blockchain.MainNetChainParams MainNetChainParams]],

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -35,7 +35,7 @@ import ch.qos.logback.classic.Level
   * @see [[https://github.com/bitcoin-s/bitcoin-s-core/blob/master/doc/configuration.md `configuration.md`]]
   *      for more information.
   */
-abstract class AppConfig extends BitcoinSLogger {
+abstract class AppConfig extends BitcoinSLogger with java.io.Serializable {
 
   /**
     * Initializes this project.

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -24,7 +24,7 @@ object Deps {
     val akkaActorV = akkaStreamv
     val slickV = "3.3.2"
     val sqliteV = "3.28.0"
-    val scalameterV = "0.17"
+    val scalameterV = "0.19"
 
     // Wallet/node/chain server deps
     val uPickleV = "0.7.4"

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -99,7 +99,7 @@ object Deps {
     Compile.logback
   )
 
-  val chainTest = List()
+  val chainTest = List(Test.scalameter)
 
   val core = List(
     Compile.bouncycastle,

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -4,7 +4,7 @@ import java.net.InetSocketAddress
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
-import org.bitcoins.chain.blockchain.ChainHandler
+import org.bitcoins.chain.blockchain.{Blockchain, ChainHandler}
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.db.ChainDbManagement
 import org.bitcoins.chain.models.{

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -2,7 +2,7 @@ package org.bitcoins.testkit.chain
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
-import org.bitcoins.chain.blockchain.{Blockchain, ChainHandler}
+import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.db.ChainDbManagement
 import org.bitcoins.chain.models.{
@@ -10,11 +10,11 @@ import org.bitcoins.chain.models.{
   BlockHeaderDb,
   BlockHeaderDbHelper
 }
-import org.bitcoins.chain.validation.{TipUpdateResult, TipValidation}
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader, ChainParams}
 import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.db.AppConfig
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.testkit.chain
+import org.bitcoins.testkit.{BitcoinSTestAppConfig, chain}
 import org.bitcoins.testkit.chain.fixture._
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
@@ -26,8 +26,6 @@ import scodec.bits.ByteVector
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import org.bitcoins.db.AppConfig
-import org.bitcoins.testkit.BitcoinSTestAppConfig
 
 trait ChainUnitTest
     extends org.scalatest.fixture.AsyncFlatSpec
@@ -438,18 +436,5 @@ object ChainUnitTest extends BitcoinSLogger {
 
     ChainHandler.fromDatabase(blockHeaderDAO = blockHeaderDAO)
 
-  }
-
-  def runCheckNewTip(
-      header: BlockHeader,
-      expected: TipUpdateResult,
-      blockHeaderDAO: BlockHeaderDAO,
-      currentTipDbDefault: BlockHeaderDb)(
-      implicit chainAppConfig: ChainAppConfig,
-      ec: ExecutionContext): Future[Boolean] = {
-    val checkTipF =
-      TipValidation.checkNewTip(header, currentTipDbDefault, blockHeaderDAO)
-
-    checkTipF.map(validationResult => validationResult == expected)
   }
 }


### PR DESCRIPTION
This PR introduces chain validation benchmarks with [scalameter](https://scalameter.github.io/home/gettingstarted/0.7/index.html)

This builds off of #688 and address #653 

The goal for this PR is to introduce formal benchmarks to [`Blockchain.connectTip()`](https://github.com/bitcoin-s/bitcoin-s/blob/c82197934a8d4544b3301acf596c42c9674a5810/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala#L64) and [`TipValidation.checkNewTip()`](https://github.com/bitcoin-s/bitcoin-s/blob/c82197934a8d4544b3301acf596c42c9674a5810/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala#L31)

- [x] TipValidation.checkNewTip() benchmark
- [x] Blockchain.connectTip() benchmark

Preliminary results indicate it takes roughly 1ms for us to execute a _valid_ `TipValidation.checkNewTip()` call. 


```
[info] :::Summary of regression test results - Accepter():::
[info] Test group: TipValidation.checkNewTip
[info] - TipValidation.checkNewTip.Test-0 measurements:
[info]   - at header -> (BlockHeaderImpl(Int32Impl(536870912),DoubleSha256DigestImpl(b45e33a345ad08ad2902cdd4101632fcbec009694b0c25000000000000000000),DoubleSha256DigestImpl(16c99a795d8e0105d86f361341c7858d223fac261718bd608052822c5b4ae3cf),UInt32Impl(1551991511),UInt32Impl(388914000),UInt32Impl(196701093)),Blockchain(BlockHeaderDb(566092,DoubleSha256BDigestBEImpl(000000000000000000250c4b6909c0befc321610d4cd0229ad08ad45a3335eb4),Int32Impl(536870912),DoubleSha256BDigestBEImpl(00000000000000000005639aa533713cdac99a2a7f7b27edcba6692ec6f92fa8),DoubleSha256BDigestBEImpl(a92a26de4ae0c694189913bdc9dce82736b9e5b4b5021550d838baa60857cdf6),UInt32Impl(1551991445),UInt32Impl(388914000),UInt32Impl(460692039),00000020a82ff9c62e69a6cbed277b7f2a9ac9da3c7133a59a6305000000000000000000f6cd5708a6ba38d8501502b5b4e5b93627e8dcc9bd13991894c6e04ade262aa99582815c505b2e17479a751b))): passed
[info]     (mean = 0.92 ms, ci = <0.58 ms, 1.26 ms>, significance = 1.0E-10)
[info] Summary: 1 tests passed, 0 tests failed.
[info] ScalaTest
[info] Run completed in 16 seconds, 215 milliseconds.
[info] Total number of tests run: 0
[info] Suites: completed 0, aborted 0
[info] Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
[info] No tests were executed.
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 18 s, completed Aug 12, 2019 8:05:49 AM

sbt:bitcoin-s> chainTest/bench:test
[info] :::Summary of regression test results - Accepter():::
[info] Test group: TipValidation.checkNewTip
[info] - TipValidation.checkNewTip.Test-0 measurements:
[info]   - at header -> (BlockHeaderImpl(Int32Impl(536870912),DoubleSha256DigestImpl(b45e33a345ad08ad2902cdd4101632fcbec009694b0c25000000000000000000),DoubleSha256DigestImpl(16c99a795d8e0105d86f361341c7858d223fac261718bd608052822c5b4ae3cf),UInt32Impl(1551991511),UInt32Impl(388914000),UInt32Impl(196701093)),Blockchain(BlockHeaderDb(566092,DoubleSha256BDigestBEImpl(000000000000000000250c4b6909c0befc321610d4cd0229ad08ad45a3335eb4),Int32Impl(536870912),DoubleSha256BDigestBEImpl(00000000000000000005639aa533713cdac99a2a7f7b27edcba6692ec6f92fa8),DoubleSha256BDigestBEImpl(a92a26de4ae0c694189913bdc9dce82736b9e5b4b5021550d838baa60857cdf6),UInt32Impl(1551991445),UInt32Impl(388914000),UInt32Impl(460692039),00000020a82ff9c62e69a6cbed277b7f2a9ac9da3c7133a59a6305000000000000000000f6cd5708a6ba38d8501502b5b4e5b93627e8dcc9bd13991894c6e04ade262aa99582815c505b2e17479a751b))): passed
[info]     (mean = 0.98 ms, ci = <0.49 ms, 1.48 ms>, significance = 1.0E-10)
[info] Summary: 1 tests passed, 0 tests failed.

```

of course this is specific to my machine, which is a higher end development laptop. 

You should be able to re-produce running this command in sbt 

```
 chainTest/bench:testOnly *TipValidation*
```