### PR TITLE
2019 08 16 process header optimization

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -25,12 +25,13 @@ class BlockchainTest extends ChainUnitTest {
       val newHeader =
         BlockHeaderHelper.buildNextHeader(ChainUnitTest.genesisHeaderDb)
 
-      val connectTip = Blockchain.connectTip(header = newHeader.blockHeader,
-                                             Vector(blockchain))
+      val connectTip =
+        Blockchain.connectTip(header = newHeader.blockHeader, blockchain)
 
       connectTip match {
         case BlockchainUpdate.Successful(_, connectedHeader) =>
-          assert(newHeader == connectedHeader)
+          assert(connectedHeader.length == 1)
+          assert(newHeader == connectedHeader.head)
 
         case fail: BlockchainUpdate.Failed =>
           assert(false)

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -29,11 +29,10 @@ class BlockchainTest extends ChainUnitTest {
         Blockchain.connectTip(header = newHeader.blockHeader, blockchain)
 
       connectTip match {
-        case BlockchainUpdate.Successful(_, connectedHeader) =>
-          assert(connectedHeader.length == 1)
-          assert(newHeader == connectedHeader.head)
+        case ConnectTipResult.ExtendChain(_, newChain) =>
+          assert(newHeader == newChain.tip)
 
-        case fail: BlockchainUpdate.Failed =>
+        case fail @ (_: ConnectTipResult.Reorg | _: ConnectTipResult.BadTip) =>
           assert(false)
       }
   }

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -38,6 +38,13 @@ class ChainHandlerTest extends ChainUnitTest {
     mainnetAppConfig.withOverrides(memoryDb)
   }
 
+  val source = FileUtil.getFileAsSource("block_headers.json")
+  val arrStr = source.getLines.next
+  source.close()
+
+  import org.bitcoins.rpc.serializers.JsonReaders.BlockHeaderReads
+  val headersResult = Json.parse(arrStr).validate[Vector[BlockHeader]].get
+
   override val defaultTag: ChainFixtureTag = ChainFixtureTag.GenisisChainHandler
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
@@ -83,18 +90,8 @@ class ChainHandlerTest extends ChainUnitTest {
 
   it must "be able to process and fetch real headers from mainnet" in {
     chainHandler: ChainHandler =>
-      val source = FileUtil.getFileAsSource("block_headers.json")
-      val arrStr = source.getLines.next
-      source.close()
-
-      import org.bitcoins.rpc.serializers.JsonReaders.BlockHeaderReads
-      val headersResult = Json.parse(arrStr).validate[Vector[BlockHeader]]
-      if (headersResult.isError) {
-        fail(headersResult.toString)
-      }
-
       val blockHeaders =
-        headersResult.get.drop(
+        headersResult.drop(
           ChainUnitTest.FIRST_POW_CHANGE - ChainUnitTest.FIRST_BLOCK_HEIGHT)
 
       val firstBlockHeaderDb =
@@ -132,6 +129,52 @@ class ChainHandlerTest extends ChainUnitTest {
         processHeaders(processorF = processorF,
                        remainingHeaders = blockHeadersToTest,
                        height = ChainUnitTest.FIRST_POW_CHANGE + 1)
+      }
+  }
+
+  it must "benchmark ChainHandler.processHeaders()" in {
+    chainHandler: ChainHandler =>
+      val blockHeaders =
+        headersResult.drop(
+          ChainUnitTest.FIRST_POW_CHANGE - ChainUnitTest.FIRST_BLOCK_HEIGHT)
+
+      val firstBlockHeaderDb =
+        BlockHeaderDbHelper.fromBlockHeader(ChainUnitTest.FIRST_POW_CHANGE - 2,
+                                            ChainTestUtil.blockHeader562462)
+
+      val secondBlockHeaderDb =
+        BlockHeaderDbHelper.fromBlockHeader(ChainUnitTest.FIRST_POW_CHANGE - 1,
+                                            ChainTestUtil.blockHeader562463)
+
+      val thirdBlockHeaderDb =
+        BlockHeaderDbHelper.fromBlockHeader(ChainUnitTest.FIRST_POW_CHANGE,
+                                            ChainTestUtil.blockHeader562464)
+
+      /*
+       * We need to insert one block before the first POW check because it is used on the next
+       * POW check. We then need to insert the next to blocks to circumvent a POW check since
+       * that would require we have an old block in the Blockchain that we don't have.
+       */
+      val firstThreeBlocks =
+        Vector(firstBlockHeaderDb, secondBlockHeaderDb, thirdBlockHeaderDb)
+
+      val createdF = chainHandler.blockHeaderDAO.createAll(firstThreeBlocks)
+
+      createdF.flatMap { _ =>
+        val blockchain = Blockchain.fromHeaders(firstThreeBlocks.reverse)
+        val handler = ChainHandler(chainHandler.blockHeaderDAO, blockchain)
+
+        // Takes way too long to do all blocks
+        val blockHeadersToTest = blockHeaders.tail
+          .take(
+            (2 * chainHandler.chainConfig.chain.difficultyChangeInterval + 1))
+
+        val processedF = handler.processHeaders(blockHeadersToTest)
+
+        for {
+          ch <- processedF
+          bestHash <- ch.getBestBlockHash
+        } yield assert(bestHash == blockHeadersToTest.last.hashBE)
       }
   }
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -214,7 +214,7 @@ class ChainHandlerTest extends ChainUnitTest {
   }
 
   final def processHeaders(
-      processorF: Future[ChainHandler],
+      processorF: Future[ChainApi],
       remainingHeaders: List[BlockHeader],
       height: Int): Future[Assertion] = {
     remainingHeaders match {

--- a/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
@@ -20,7 +20,9 @@ trait ChainApi {
     * @return
     */
   def processHeader(header: BlockHeader)(
-      implicit ec: ExecutionContext): Future[ChainApi]
+      implicit ec: ExecutionContext): Future[ChainApi] = {
+    processHeaders(Vector(header))
+  }
 
   /** Process all of the given headers and returns a new [[ChainApi chain api]]
     * that contains these headers. This method processes headers in the order
@@ -29,12 +31,7 @@ trait ChainApi {
     * @return
     */
   def processHeaders(headers: Vector[BlockHeader])(
-      implicit ec: ExecutionContext): Future[ChainApi] = {
-    headers.foldLeft(Future.successful(this)) {
-      case (chainF, header) =>
-        chainF.flatMap(_.processHeader(header))
-    }
-  }
+      implicit ec: ExecutionContext): Future[ChainApi]
 
   /** Get's a [[org.bitcoins.chain.models.BlockHeaderDb]] from the chain's database */
   def getHeader(hash: DoubleSha256DigestBE)(

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainUpdate.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainUpdate.scala
@@ -40,7 +40,10 @@ object BlockchainUpdate {
       successfulHeaders: Vector[BlockHeaderDb])
       extends BlockchainUpdate {
     if (successfulHeaders.nonEmpty) {
-      require(blockchain.tip == successfulHeaders.head)
+      require(
+        blockchain.tip == successfulHeaders.head,
+        s"Tip did not equal last successful header, tip=${blockchain.tip.hashBE} lastSuccessfulHeader=${successfulHeaders.head.hashBE}"
+      )
     }
     def height: Long = blockchain.height
   }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainUpdate.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainUpdate.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.chain.blockchain
 
+import org.bitcoins.chain.blockchain.BlockchainUpdate.{Failed, Successful}
 import org.bitcoins.chain.models.BlockHeaderDb
 import org.bitcoins.chain.validation.TipUpdateResult
 import org.bitcoins.core.protocol.blockchain.BlockHeader
@@ -14,22 +15,56 @@ import org.bitcoins.core.protocol.blockchain.BlockHeader
   * because of [[org.bitcoins.chain.validation.TipUpdateResult.BadPOW BadPOW]] or a
   * [[org.bitcoins.chain.validation.TipUpdateResult.BadNonce BadNonce]] etc
   */
-sealed abstract class BlockchainUpdate
+sealed abstract class BlockchainUpdate {
+  def successfulHeaders: Vector[BlockHeaderDb]
+
+  def blockchain: Blockchain
+
+  def withSuccessfulHeaders(headers: Vector[BlockHeaderDb]): BlockchainUpdate =
+    this match {
+      case s: Successful =>
+        s.copy(successfulHeaders = headers)
+      case f: Failed =>
+        f.copy(successfulHeaders = headers)
+    }
+}
 
 object BlockchainUpdate {
 
   /** The key thing we receive here is [[org.bitcoins.chain.models.BlockHeaderDb BlockHeaderDb]]
     * with a height assigned to it this happens after
-    * calling [[org.bitcoins.chain.blockchain.ChainHandler.processHeader ChainHandler.processHeader]]
+    * calling [[org.bitcoins.chain.blockchain.ChainHandler.processHeaders ChainHandler.processHeaders]]
     */
-  case class Successful(blockchain: Blockchain, updatedHeader: BlockHeaderDb)
+  case class Successful(
+      blockchain: Blockchain,
+      successfulHeaders: Vector[BlockHeaderDb])
       extends BlockchainUpdate {
-    def height: Long = updatedHeader.height
+    if (successfulHeaders.nonEmpty) {
+      require(blockchain.tip == successfulHeaders.head)
+    }
+    def height: Long = blockchain.height
   }
 
+  /**
+    * Means we failed to update the given blockchain with _ALL_ given headers
+    * This means we could have had a partially successful update, with the headers/blockchain
+    * returned in this case class
+    */
   case class Failed(
       blockchain: Blockchain,
+      successfulHeaders: Vector[BlockHeaderDb],
       failedHeader: BlockHeader,
       tipUpdateFailure: TipUpdateResult.Failure)
-      extends BlockchainUpdate
+      extends BlockchainUpdate {
+    require(
+      !blockchain.contains(failedHeader),
+      s"Our blockchain should not contain the failed header=${failedHeader}")
+
+    if (successfulHeaders.nonEmpty) {
+      require(
+        successfulHeaders.head == blockchain.tip,
+        s"Our blockchain.tip should be the first successful header, got=${blockchain.tip} expected=${successfulHeaders.head}"
+      )
+    }
+  }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainUpdate.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BlockchainUpdate.scala
@@ -5,9 +5,7 @@ import org.bitcoins.chain.models.BlockHeaderDb
 import org.bitcoins.chain.validation.TipUpdateResult
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 
-/** Represents the state of an update to our [[org.bitcoins.chain.blockchain.Blockchain Blockchain]]
-  * An example of a successful update is receiving a [[org.bitcoins.core.protocol.blockchain.BlockHeader BlockHeader]] and successfully
-  * adding it to our database.
+/** Represens the state of a batch of [[org.bitcoins.core.protocol.blockchain.BlockHeader BlockHeaders]] being added to our blockchain
   *
   * An example of a [[org.bitcoins.chain.blockchain.BlockchainUpdate.Failed Failed]] update
   * is when we receive a [[org.bitcoins.core.protocol.blockchain.BlockHeader BlockHeader]] that is invalid and because of a
@@ -16,8 +14,11 @@ import org.bitcoins.core.protocol.blockchain.BlockHeader
   * [[org.bitcoins.chain.validation.TipUpdateResult.BadNonce BadNonce]] etc
   */
 sealed abstract class BlockchainUpdate {
+
+  /** The successful headers in this batch blockchain update that need to be persisted */
   def successfulHeaders: Vector[BlockHeaderDb]
 
+  /** Our current blockchain */
   def blockchain: Blockchain
 
   def withSuccessfulHeaders(headers: Vector[BlockHeaderDb]): BlockchainUpdate =

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -49,10 +49,10 @@ case class ChainHandler(
     }
 
     val headersToBeCreated = {
-      blockchainUpdates.map(_.successfulHeaders).flatten.distinct.toVector
+      blockchainUpdates.flatMap(_.successfulHeaders).distinct
     }
 
-    val chains = blockchainUpdates.map(_.blockchain).toVector
+    val chains = blockchainUpdates.map(_.blockchain)
 
     val createdF = blockHeaderDAO.createAll(headersToBeCreated)
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ConnectTipResult.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ConnectTipResult.scala
@@ -4,10 +4,20 @@ import org.bitcoins.chain.models.BlockHeaderDb
 import org.bitcoins.chain.validation.TipUpdateResult
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 
+/** The result indicating how the [[org.bitcoins.chain.validation.TipUpdateResult TipUpdateResult]]
+  * modified the chain.
+  *
+  * We can
+  *
+  * 1. Extend the chain
+  * 2. Reorg the chain
+  * 3. Fail to connect to anything in the chain
+  *
+  * */
 sealed trait ConnectTipResult {
   def tipUpdateResult: TipUpdateResult
 
-  def header: BlockHeader = tipUpdateResult.header
+  lazy val header: BlockHeader = tipUpdateResult.header
 
 }
 
@@ -22,9 +32,15 @@ object ConnectTipResult {
       headerDb == newChain.tip,
       s"Cannot extend chain without having tipUpdate be our best tip, tipUpdateResult=${tipUpdateResult.header} chain.tip=${newChain.tip}"
     )
-    def headerDb: BlockHeaderDb = tipUpdateResult.headerDb
+    lazy val headerDb: BlockHeaderDb = tipUpdateResult.headerDb
   }
 
+  /**
+    * Means we had a reorg happen, aka the header was connected to
+    * something that was _not_ our previous best tip
+    * @param tipUpdateResult the successful connection
+    * @param newChain the new chain where the best tip is the header we passed in
+    */
   case class Reorg(
       tipUpdateResult: TipUpdateResult.Success,
       newChain: Blockchain)
@@ -33,9 +49,10 @@ object ConnectTipResult {
       headerDb == newChain.tip,
       s"Cannot reorg without having tipUpdate be our best tip, tipUpdateResult=${tipUpdateResult.header} chain.tip=${newChain.tip}")
 
-    def headerDb: BlockHeaderDb = tipUpdateResult.headerDb
+    lazy val headerDb: BlockHeaderDb = tipUpdateResult.headerDb
   }
 
+  /** Means we could not connect the header to anything in the given blockchain */
   case class BadTip(tipUpdateResult: TipUpdateResult.Failure)
       extends ConnectTipResult
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ConnectTipResult.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ConnectTipResult.scala
@@ -1,0 +1,42 @@
+package org.bitcoins.chain.blockchain
+
+import org.bitcoins.chain.models.BlockHeaderDb
+import org.bitcoins.chain.validation.TipUpdateResult
+import org.bitcoins.core.protocol.blockchain.BlockHeader
+
+sealed trait ConnectTipResult {
+  def tipUpdateResult: TipUpdateResult
+
+  def header: BlockHeader = tipUpdateResult.header
+
+}
+
+object ConnectTipResult {
+
+  /** Indicates we sucuessfully extended our chain by one block */
+  case class ExtendChain(
+      tipUpdateResult: TipUpdateResult.Success,
+      newChain: Blockchain)
+      extends ConnectTipResult {
+    require(
+      headerDb == newChain.tip,
+      s"Cannot extend chain without having tipUpdate be our best tip, tipUpdateResult=${tipUpdateResult.header} chain.tip=${newChain.tip}"
+    )
+    def headerDb: BlockHeaderDb = tipUpdateResult.headerDb
+  }
+
+  case class Reorg(
+      tipUpdateResult: TipUpdateResult.Success,
+      newChain: Blockchain)
+      extends ConnectTipResult {
+    require(
+      headerDb == newChain.tip,
+      s"Cannot reorg without having tipUpdate be our best tip, tipUpdateResult=${tipUpdateResult.header} chain.tip=${newChain.tip}")
+
+    def headerDb: BlockHeaderDb = tipUpdateResult.headerDb
+  }
+
+  case class BadTip(tipUpdateResult: TipUpdateResult.Failure)
+      extends ConnectTipResult
+
+}

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
@@ -6,26 +6,29 @@ import org.bitcoins.core.protocol.blockchain.BlockHeader
 /** Represents the result of updating the chain with
   * the given header
   */
-sealed abstract class TipUpdateResult
+sealed abstract class TipUpdateResult {
+  def header: BlockHeader
+}
 
 object TipUpdateResult {
 
   /** Indicates we successfully update the chain tip with this header */
-  case class Success(header: BlockHeaderDb) extends TipUpdateResult
-
-  sealed abstract class Failure extends TipUpdateResult {
-    def header: BlockHeader
+  case class Success(headerDb: BlockHeaderDb) extends TipUpdateResult {
+    override def header = headerDb.blockHeader
   }
 
+  sealed abstract class Failure extends TipUpdateResult
+
   /** Means that [[org.bitcoins.core.protocol.blockchain.BlockHeader.previousBlockHashBE previousBlockHashBE]] was incorrect */
-  case class BadPreviousBlockHash(header: BlockHeader) extends Failure {
+  case class BadPreviousBlockHash(override val header: BlockHeader)
+      extends Failure {
     override def toString: String =
       s"BadPreviousBlockHash(hash=${header.hashBE}, previous=${header.previousBlockHashBE})"
   }
 
   /** Means that [[org.bitcoins.core.protocol.blockchain.BlockHeader.nBits nBits]] was invalid */
-  case class BadPOW(header: BlockHeader) extends Failure
+  case class BadPOW(override val header: BlockHeader) extends Failure
 
   /** Means that [[org.bitcoins.core.protocol.blockchain.BlockHeader.nonce nonce]] was invalid */
-  case class BadNonce(header: BlockHeader) extends Failure
+  case class BadNonce(override val header: BlockHeader) extends Failure
 }

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -16,7 +16,7 @@ bitcoin-s {
         # p2p = info
 
         # verification of block headers, merkle trees
-        chain-verification = TRACE
+        # chain-verification = info
 
         # generation of addresses, signing of TXs
         # key-handling = info

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -16,7 +16,7 @@ bitcoin-s {
         # p2p = info
 
         # verification of block headers, merkle trees
-        # chain-verification = info
+        chain-verification = TRACE
 
         # generation of addresses, signing of TXs
         # key-handling = info


### PR DESCRIPTION
This is part of #653 

Previously, we were inserting [block headers after every tip validation](https://github.com/bitcoin-s/bitcoin-s/blob/8ba9626500c5bbe0a2ba52b9217c01467d52fef8/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala#L63) instead of batching them. The goal of this PR is to batch these headers to insert them into the database all at once, to reduce database latency in our tip validation process.

8ba9626500c5bbe0a2ba52b9217c01467d52fef8 (current master)
```
[info] ScalaTest
[info] Run completed in 2 minutes.
[info] Total number of tests run: 27
[info] Suites: completed 8, aborted 0
[info] Tests: succeeded 27, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```
31d9e31bd36ce9e9f08c57dd2e22136cfae8763f
```
[info] ScalaTest
[info] Run completed in 2 minutes, 5 seconds.
[info] Total number of tests run: 27
[info] Suites: completed 8, aborted 0
[info] Tests: succeeded 27, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 27, Failed 0, Errors 0, Passed 27
[success] Total time: 128 s, completed Aug 20, 2019 9:16:11 AM
```

As the tests indicate, it seems like we have slightly regressed in at least running the test suite. I don't think this will be true when syncing the _real_ chain though. Our chain tests sync insert roughly 10,000 headers, which is a relatively small sample size to a real chain. 

It also looks like @nkohen found that the optimal insert size is _not_ 2,000 -- which is the default number a node will send to us one the network at one time -- but has used batch sizes of 500 in our [`ChainUnitTest`](https://github.com/bitcoin-s/bitcoin-s/blob/8ba9626500c5bbe0a2ba52b9217c01467d52fef8/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala#L376)