### PR TITLE
Use transactionally when inserting data into our database with createAll

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
@@ -18,9 +18,9 @@ abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](
     val query = table
       .returning(table.map(_.id))
       .into((t, id) => t.copyWithId(id = id))
-    val actions: Vector[DBIOAction[query.SingleInsertResult, NoStream, Write]] =
-      ts.map(r => query.+=(r))
-    database.runVec(DBIO.sequence(actions))
+    val actions: DBIOAction[query.MultiInsertResult, NoStream, Write] =
+      query.++=(ts)
+    database.runVec(actions)
   }
 
   override def findByPrimaryKeys(ids: Vector[Long]): Query[Table[_], T, Seq] = {

--- a/db-commons/src/main/scala/org/bitcoins/db/SlickUtil.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/SlickUtil.scala
@@ -12,8 +12,8 @@ sealed abstract class SlickUtil {
       database: SafeDatabase,
       table: TableQuery[U])(
       implicit ec: ExecutionContext): Future[Vector[T]] = {
-    val actions = ts.map(t => (table += t).andThen(DBIO.successful(t)))
-    val result = database.run(DBIO.sequence(actions))
+    val actions = (table ++= ts).andThen(DBIO.successful(ts)).transactionally
+    val result = database.run(actions)
     result
   }
 }


### PR DESCRIPTION
Implement 'transactionally' on all createAll inside of *DAO. This improves performance of inserts into the database. This is because we do not 'commit' after every write, we only commit after the entire batch is written

More information about commits and transactions:

https://en.wikipedia.org/wiki/Database_transaction
https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_4010.htm

This should also help address #653, and hopefully improves performance of the changes in #701 as well
