### PR TITLE
(WIP) Createwallet rpc from V17

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -234,4 +234,12 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
       assert(list.forall(_.label != unusedLabel))
     }
   }
+
+  it should "create a wallet" in {
+    for {
+      (client, otherClient) <- clientsF
+      wallet <- client.createWallet("suredbits")
+    } yield {}
+
+  }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -237,9 +237,12 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
 
   it should "create a wallet" in {
     for {
-      (client, otherClient) <- clientsF
-      wallet <- client.createWallet("suredbits")
-    } yield {}
+      (client, _) <- clientsF
+      _ <- client.createWallet("suredbits")
+      wallets <- client.listWallets
+    } yield {
+      assert(wallets.head.contains("suredbits"))
+    }
 
   }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -241,7 +241,7 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
       _ <- client.createWallet("suredbits")
       wallets <- client.listWallets
     } yield {
-      assert(wallets.head.contains("suredbits"))
+      assert(wallets.head.exists(_ == 's'))
     }
 
   }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -241,7 +241,7 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
       _ <- client.createWallet("suredbits")
       wallets <- client.listWallets
     } yield {
-      assert(wallets.head.exists(_ == 's'))
+      assert(wallets.exists(_ == "suredbits"))
     }
 
   }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v17/BitcoindV17RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v17/BitcoindV17RpcClient.scala
@@ -13,6 +13,7 @@ import org.bitcoins.rpc.client.common.{
 import org.bitcoins.rpc.config.BitcoindInstance
 import org.bitcoins.rpc.jsonmodels.{
   AddressInfoResult,
+  CreateWalletResult,
   SignRawTransactionResult,
   TestMempoolAcceptResult
 }
@@ -93,6 +94,13 @@ class BitcoindV17RpcClient(override val instance: BitcoindInstance)(
       .map(_.head)
   }
 
+  def createWallet(
+      walletName: String,
+      disablePrivateKeys: Boolean = false): Future[CreateWalletResult] = {
+    bitcoindCall[CreateWalletResult](
+      "createwallet",
+      List(JsString(walletName), Json.toJson(disablePrivateKeys)))
+  }
 }
 
 object BitcoindV17RpcClient {

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/WalletResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/WalletResult.scala
@@ -224,3 +224,8 @@ case class EmbeddedResult(
     extends WalletResult
 
 case class LabelResult(name: String, purpose: LabelPurpose) extends WalletResult
+
+final case class CreateWalletResult(
+    name: String,
+    warning: String
+) extends WalletResult

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
@@ -379,6 +379,9 @@ object JsonSerializers {
   implicit val testMempoolAcceptResultReads: Reads[TestMempoolAcceptResult] =
     TestMempoolAcceptResultReads
 
+  implicit val createWalletResultReads: Reads[CreateWalletResult] =
+    Json.reads[CreateWalletResult]
+
   // Map stuff
   implicit def mapDoubleSha256DigestReads: Reads[
     Map[DoubleSha256Digest, GetMemPoolResult]] =


### PR DESCRIPTION
This pull request adds the createwallet RPC call from V17 that was missing from our code base. It takes in a name and a boolean option if the user would like to disable private keys.  

https://bitcoincore.org/en/doc/0.17.0/rpc/wallet/createwallet/