### PR TITLE
Remove untyped CryptoUtil methods

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -39,7 +39,7 @@ class TransactionTest extends BitcoinSUnitTest {
 
   it must "always have TXID of a base transaction be SHA256(SHA256(hex))" in {
     forAll(TransactionGenerators.baseTransaction) { btx: BaseTransaction =>
-      assert(btx.txId == CryptoUtil.doubleSHA256(btx.hex))
+      assert(btx.txId == CryptoUtil.doubleSHA256(btx.bytes))
     }
   }
 
@@ -48,7 +48,7 @@ class TransactionTest extends BitcoinSUnitTest {
       "wtxid and txid are not the same for witness transactions" in {
     forAll(TransactionGenerators.witnessTransaction) {
       wtx: WitnessTransaction =>
-        assert(wtx.wTxId == CryptoUtil.doubleSHA256(wtx.hex))
+        assert(wtx.wTxId == CryptoUtil.doubleSHA256(wtx.bytes))
         assert(wtx.wTxId != wtx.txId)
     }
   }
@@ -95,12 +95,12 @@ class TransactionTest extends BitcoinSUnitTest {
 
   it must "calculate the correct txid and wtxid for a witness transaction" in {
     //from http://tapi.qbit.ninja/tx/d869f854e1f8788bcff294cc83b280942a8c728de71eb709a2c29d10bfe21b7c
-    val hex =
-      "0100000000010115e180dc28a2327e687facc33f10f2a20da717e5548406f7ae8b4c811072f8560100000000ffffffff0100b4f505000000001976a9141d7cd6c75c2e86f4cbf98eaed221b30bd9a0b92888ac02483045022100df7b7e5cda14ddf91290e02ea10786e03eb11ee36ec02dd862fe9a326bbcb7fd02203f5b4496b667e6e281cc654a2da9e4f08660c620a1051337fa8965f727eb19190121038262a6c6cec93c2d3ecd6c6072efea86d02ff8e3328bbd0242b20af3425990ac00000000"
-    val wtx = WitnessTransaction(hex)
+    val bytes =
+      hex"0100000000010115e180dc28a2327e687facc33f10f2a20da717e5548406f7ae8b4c811072f8560100000000ffffffff0100b4f505000000001976a9141d7cd6c75c2e86f4cbf98eaed221b30bd9a0b92888ac02483045022100df7b7e5cda14ddf91290e02ea10786e03eb11ee36ec02dd862fe9a326bbcb7fd02203f5b4496b667e6e281cc654a2da9e4f08660c620a1051337fa8965f727eb19190121038262a6c6cec93c2d3ecd6c6072efea86d02ff8e3328bbd0242b20af3425990ac00000000"
+    val wtx = WitnessTransaction.fromBytes(bytes)
     val expected =
       "d869f854e1f8788bcff294cc83b280942a8c728de71eb709a2c29d10bfe21b7c"
-    val wTxExpected = CryptoUtil.doubleSHA256(hex)
+    val wTxExpected = CryptoUtil.doubleSHA256(bytes)
     wtx.txId.flip.hex must be(expected)
     wtx.txIdBE.hex must be(expected)
     wtx.wTxId must be(wTxExpected)

--- a/core-test/src/test/scala/org/bitcoins/core/util/CryptoUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/CryptoUtilTest.scala
@@ -2,7 +2,7 @@ package org.bitcoins.core.util
 
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.testkit.util.BitcoinSUnitTest
-import scodec.bits.BinStringSyntax
+import scodec.bits._
 
 /**
   * Created by chris on 1/26/16.
@@ -10,35 +10,35 @@ import scodec.bits.BinStringSyntax
 class CryptoUtilTest extends BitcoinSUnitTest {
 
   "CryptoUtil" must "perform a SHA-1 hash" in {
-    val hash = CryptoUtil.sha1("")
+    val hash = CryptoUtil.sha1(hex"")
     val expected = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
     hash.hex must be(expected)
     hash.flip.flip.hex must be(expected)
   }
 
   it must "perform the correct RIPEMD160 on a string" in {
-    val str = ""
+    val bytes = hex""
     val expectedDigest = "9c1185a5c5e9fc54612808977ee8f548b2258d31"
-    CryptoUtil.ripeMd160(str).hex must be(expectedDigest)
-    CryptoUtil.ripeMd160(str).flip.flip.hex must be(expectedDigest)
+    CryptoUtil.ripeMd160(bytes).hex must be(expectedDigest)
+    CryptoUtil.ripeMd160(bytes).flip.flip.hex must be(expectedDigest)
   }
 
   it must "perform a RIPEMD160 on a SHA256 hash to generate a bitcoin address" in {
     //https://bitcoin.stackexchange.com/questions/37040/ripemd160sha256publickey-where-am-i-going-wrong
-    val str = "ea571f53cb3a9865d3dc74735e0c16643d319c6ad81e199b9c8408cecbcec7bb"
+    val bytes =
+      hex"ea571f53cb3a9865d3dc74735e0c16643d319c6ad81e199b9c8408cecbcec7bb"
     val expected = "5238c71458e464d9ff90299abca4a1d7b9cb76ab"
-    CryptoUtil.ripeMd160(str).hex must be(expected)
-    CryptoUtil.ripeMd160(str).flip.flip.hex must be(expected)
+    CryptoUtil.ripeMd160(bytes).hex must be(expected)
+    CryptoUtil.ripeMd160(bytes).flip.flip.hex must be(expected)
   }
 
   it must "perform a single SHA256 hash on a byte vector" in {
-    val hex = ""
-    val strBytes = BitcoinSUtil.decodeHex(hex)
+    val bytes = hex""
     val expected =
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    CryptoUtil.sha256(strBytes).hex must be(expected)
-    CryptoUtil.sha256(hex).hex must be(expected)
-    CryptoUtil.sha256(hex).flip.flip.hex must be(expected)
+    CryptoUtil.sha256(bytes).hex must be(expected)
+    CryptoUtil.sha256(bytes).hex must be(expected)
+    CryptoUtil.sha256(bytes).flip.flip.hex must be(expected)
   }
 
   it must "perform a single SHA256 hash on a bit vector" in {
@@ -55,22 +55,20 @@ class CryptoUtilTest extends BitcoinSUnitTest {
   }
 
   it must "perform a double SHA256 hash" in {
-    val hex = ""
-    val strBytes = BitcoinSUtil.decodeHex(hex)
+    val bytes = hex""
     val expected =
       "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456"
-    CryptoUtil.doubleSHA256(strBytes).hex must be(expected)
-    CryptoUtil.doubleSHA256(hex).hex must be(expected)
-    CryptoUtil.doubleSHA256(hex).flip.flip.hex must be(expected)
+    CryptoUtil.doubleSHA256(bytes).hex must be(expected)
+    CryptoUtil.doubleSHA256(bytes).hex must be(expected)
+    CryptoUtil.doubleSHA256(bytes).flip.flip.hex must be(expected)
   }
 
   it must "perform a double SHA256RIPEMD160 hash" in {
-    val hex = ""
-    val strBytes = BitcoinSUtil.decodeHex(hex)
+    val bytes = hex""
     val expected = "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb"
-    CryptoUtil.sha256Hash160(strBytes).hex must be(expected)
-    CryptoUtil.sha256Hash160(hex).hex must be(expected)
-    CryptoUtil.sha256Hash160(hex).flip.flip.hex must be(expected)
+    CryptoUtil.sha256Hash160(bytes).hex must be(expected)
+    CryptoUtil.sha256Hash160(bytes).hex must be(expected)
+    CryptoUtil.sha256Hash160(bytes).flip.flip.hex must be(expected)
   }
 
   it must "recover the 2 public keys from a digital signature" in {

--- a/core/src/main/scala/org/bitcoins/core/consensus/Merkle.scala
+++ b/core/src/main/scala/org/bitcoins/core/consensus/Merkle.scala
@@ -92,7 +92,7 @@ trait Merkle extends BitcoinSLogger {
     * [[https://github.com/bitcoin/bitcoin/blob/7490ae8b699d2955b665cf849d86ff5bb5245c28/src/consensus/merkle.cpp#L168]]
     */
   def computeBlockWitnessMerkleTree(block: Block): MerkleTree = {
-    val coinbaseWTxId = CryptoUtil.emptyDoubleSha256Hash
+    val coinbaseWTxId = DoubleSha256Digest.empty
     val hashes = block.transactions.tail.map {
       case wtx: WitnessTransaction => wtx.wTxId
       case btx: BaseTransaction    => btx.txId

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -174,7 +174,7 @@ sealed abstract class TransactionSignatureSerializer {
         val isNotSigHashSingle = !(HashType.isSigHashSingle(hashType.num))
         val isNotSigHashNone = !(HashType.isSigHashNone(hashType.num))
         val inputIndexInt = inputIndex.toInt
-        val emptyHash = CryptoUtil.emptyDoubleSha256Hash
+        val emptyHash = DoubleSha256Digest.empty
 
         val outPointHash: ByteVector = if (isNotAnyoneCanPay) {
           val prevOuts = spendingTransaction.inputs.map(_.previousOutput)

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -111,7 +111,7 @@ sealed abstract class BaseTransaction extends Transaction {
 }
 
 case object EmptyTransaction extends BaseTransaction {
-  override def txId = CryptoUtil.emptyDoubleSha256Hash
+  override def txId = DoubleSha256Digest.empty
   override def version = TransactionConstants.version
   override def inputs = Nil
   override def outputs = Nil

--- a/core/src/main/scala/org/bitcoins/core/util/CryptoUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/CryptoUtil.scala
@@ -11,32 +11,21 @@ import org.bouncycastle.math.ec.ECPoint
 import scodec.bits.{BitVector, ByteVector}
 
 /**
-  * Created by chris on 1/14/16.
   * Utility cryptographic functions
   */
 trait CryptoUtil extends BitcoinSLogger {
 
   /** Does the following computation: RIPEMD160(SHA256(hex)).*/
-  def sha256Hash160(hex: String): Sha256Hash160Digest =
-    sha256Hash160(BitcoinSUtil.decodeHex(hex))
-
   def sha256Hash160(bytes: ByteVector): Sha256Hash160Digest = {
     val hash = ripeMd160(sha256(bytes).bytes).bytes
     Sha256Hash160Digest(hash)
   }
-
-  /** Performs sha256(sha256(hex)). */
-  def doubleSHA256(hex: String): DoubleSha256Digest =
-    doubleSHA256(BitcoinSUtil.decodeHex(hex))
 
   /** Performs sha256(sha256(bytes)). */
   def doubleSHA256(bytes: ByteVector): DoubleSha256Digest = {
     val hash: ByteVector = sha256(sha256(bytes).bytes).bytes
     DoubleSha256Digest(hash)
   }
-
-  /** Takes sha256(hex). */
-  def sha256(hex: String): Sha256Digest = sha256(BitcoinSUtil.decodeHex(hex))
 
   /** Takes sha256(bytes). */
   def sha256(bytes: ByteVector): Sha256Digest = {
@@ -55,13 +44,6 @@ trait CryptoUtil extends BitcoinSLogger {
     Sha1Digest(ByteVector(hash))
   }
 
-  /** Performs SHA1(hex). */
-  def sha1(hex: String): Sha1Digest = sha1(BitcoinSUtil.decodeHex(hex))
-
-  /** Performs RIPEMD160(hex). */
-  def ripeMd160(hex: String): RipeMd160Digest =
-    ripeMd160(BitcoinSUtil.decodeHex(hex))
-
   /** Performs RIPEMD160(bytes). */
   def ripeMd160(bytes: ByteVector): RipeMd160Digest = {
     //from this tutorial http://rosettacode.org/wiki/RIPEMD-160#Scala
@@ -72,9 +54,6 @@ trait CryptoUtil extends BitcoinSLogger {
     messageDigest.doFinal(out, 0)
     RipeMd160Digest(ByteVector(out))
   }
-
-  val emptyDoubleSha256Hash = DoubleSha256Digest(
-    "0000000000000000000000000000000000000000000000000000000000000000")
 
   /**
     * Calculates `HMAC-SHA512(key, data)`

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CryptoGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CryptoGenerators.scala
@@ -167,8 +167,8 @@ sealed abstract class CryptoGenerators {
 
   def sha256Digest: Gen[Sha256Digest] =
     for {
-      hex <- StringGenerators.hexString
-      digest = CryptoUtil.sha256(hex)
+      bytes <- NumberGenerator.bytevector
+      digest = CryptoUtil.sha256(bytes)
     } yield digest
 
   /** Generates a random [[org.bitcoins.core.crypto.DoubleSha256Digest DoubleSha256Digest]] */


### PR DESCRIPTION
Types are our friends:-)

Also removes a roundabout way of accessing `DoubleSha256Digest.empty`