### PR TITLE
Deprecate generate

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
@@ -133,7 +133,7 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
 
     for {
       _ <- client.start()
-      _ <- client.generate(101)
+      _ <- client.getNewAddress.flatMap(client.generateToAddress(101, _))
       balance <- client.getBalance
       _ <- BitcoindRpcTestUtil.stopServers(Vector(client))
       _ <- client.getBalance

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
@@ -91,7 +91,7 @@ class MempoolRpcTest extends BitcoindRpcTest {
   it should "be able to get mem pool info" in {
     for {
       (client, otherClient) <- clientsF
-      _ <- client.generate(1)
+      _ <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
       info <- client.getMemPoolInfo
       _ <- BitcoindRpcTestUtil
         .sendCoinbaseTransaction(client, otherClient)
@@ -122,7 +122,7 @@ class MempoolRpcTest extends BitcoindRpcTest {
   it should "be able to find mem pool ancestors and descendants" in {
     for {
       (client, _) <- clientsF
-      _ <- client.generate(1)
+      _ <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
       address1 <- client.getNewAddress
       txid1 <- BitcoindRpcTestUtil.fundMemPoolTransaction(client,
                                                           address1,

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MiningRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MiningRpcTest.scala
@@ -31,7 +31,7 @@ class MiningRpcTest extends BitcoindRpcTest {
   it should "be able to generate blocks" in {
     for {
       (client, _) <- clientsF
-      blocks <- client.generate(3)
+      blocks <- client.getNewAddress.flatMap(client.generateToAddress(3, _))
     } yield assert(blocks.length == 3)
   }
 
@@ -65,7 +65,7 @@ class MiningRpcTest extends BitcoindRpcTest {
   it should "be able to generate blocks and then get their serialized headers" in {
     for {
       (client, _) <- clientsF
-      blocks <- client.generate(2)
+      blocks <- client.getNewAddress.flatMap(client.generateToAddress(2, _))
       header <- client.getBlockHeaderRaw(blocks(1))
     } yield assert(header.previousBlockHashBE == blocks(0))
   }
@@ -73,7 +73,7 @@ class MiningRpcTest extends BitcoindRpcTest {
   it should "be able to generate blocks and then get their headers" in {
     for {
       (client, _) <- clientsF
-      blocks <- client.generate(2)
+      blocks <- client.getNewAddress.flatMap(client.generateToAddress(2, _))
       firstHeader <- client.getBlockHeader(blocks(0))
       secondHeader <- client.getBlockHeader(blocks(1))
     } yield {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/NodeRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/NodeRpcTest.scala
@@ -17,13 +17,15 @@ class NodeRpcTest extends BitcoindRpcTest {
   it should "be able to abort a rescan of the blockchain" in {
     clientF.flatMap { client =>
       // generate some extra blocks so rescan isn't too quick
-      client.generate(3000).flatMap { _ =>
-        val rescanFailedF =
-          recoverToSucceededIf[MiscError](client.rescanBlockChain())
-        client.abortRescan().flatMap { _ =>
-          rescanFailedF
+      client.getNewAddress
+        .flatMap(client.generateToAddress(3000, _))
+        .flatMap { _ =>
+          val rescanFailedF =
+            recoverToSucceededIf[MiscError](client.rescanBlockChain())
+          client.abortRescan().flatMap { _ =>
+            rescanFailedF
+          }
         }
-      }
     }
   }
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/P2PRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/P2PRpcTest.scala
@@ -187,7 +187,7 @@ class P2PRpcTest extends BitcoindRpcTest {
 
       (client1, client2) <- BitcoindRpcTestUtil.createUnconnectedNodePair(
         clientAccum = clientAccum)
-      hash <- client2.generate(1)
+      hash <- client2.getNewAddress.flatMap(client2.generateToAddress(1, _))
       block <- client2.getBlockRaw(hash.head)
       preCount1 <- client1.getBlockCount
       preCount2 <- client2.getBlockCount

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/RawTransactionRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/RawTransactionRpcTest.scala
@@ -88,7 +88,7 @@ class RawTransactionRpcTest extends BitcoindRpcTest {
   it should "be able to create a raw transaction" in {
     for {
       (client, otherClient) <- clientsF
-      blocks <- client.generate(2)
+      blocks <- client.getNewAddress.flatMap(client.generateToAddress(2, _))
       firstBlock <- client.getBlock(blocks(0))
       transaction0 <- client.getTransaction(firstBlock.tx(0))
       secondBlock <- client.getBlock(blocks(1))
@@ -123,7 +123,7 @@ class RawTransactionRpcTest extends BitcoindRpcTest {
                                                                 otherClient)
       signedTransaction <- BitcoindRpcTestUtil.signRawTransaction(client, rawTx)
 
-      _ <- client.generate(100) // Can't spend coinbase until depth 100
+      _ <- client.getNewAddress.flatMap(client.generateToAddress(100, _)) // Can't spend coinbase until depth 100
 
       _ <- client.sendRawTransaction(signedTransaction.hex,
                                      allowHighFees = true)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -39,7 +39,8 @@ class WalletRpcTest extends BitcoindRpcTest {
 
     for {
       _ <- walletClient.start()
-      _ <- walletClient.generate(200)
+      _ <- walletClient.getNewAddress.flatMap(
+        walletClient.generateToAddress(200, _))
       _ <- walletClient.encryptWallet(password)
       _ <- walletClient.stop()
       _ <- RpcUtil.awaitServerShutdown(walletClient)
@@ -219,7 +220,7 @@ class WalletRpcTest extends BitcoindRpcTest {
         .fundBlockChainTransaction(client, address, Bitcoins(1.5))
     val txid = await(txidF)
 
-    await(client.generate(1))
+    await(client.getNewAddress.flatMap(client.generateToAddress(1, _)))
 
     val tx = await(client.getTransaction(txid))
 
@@ -343,7 +344,7 @@ class WalletRpcTest extends BitcoindRpcTest {
     for {
       (client, _, _) <- clientsF
       balance <- client.getBalance
-      _ <- client.generate(1)
+      _ <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
       newBalance <- client.getBalance
     } yield {
       assert(balance.toBigDecimal > 0)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
@@ -42,7 +42,8 @@ class BitcoindV16RpcClientTest extends BitcoindRpcTest {
       (client, otherClient) <- clientsF
       addr <- client.getNewAddress
       _ <- otherClient.sendToAddress(addr, Bitcoins.one)
-      _ <- otherClient.generate(6)
+      _ <- otherClient.getNewAddress.flatMap(
+        otherClient.generateToAddress(6, _))
       peers <- client.getPeerInfo
       _ = assert(peers.exists(_.networkInfo.addr == otherClient.getDaemon.uri))
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -213,7 +213,8 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
       addressNoLabel <- client.getNewAddress
       _ <- otherClient.sendToAddress(addressNoLabel, Bitcoins.one)
       _ <- otherClient.sendToAddress(addressWithLabel, Bitcoins.one)
-      newBlock +: _ <- otherClient.generate(1)
+      newBlock +: _ <- client.getNewAddress.flatMap(
+        otherClient.generateToAddress(1, _))
       _ <- AsyncUtil.retryUntilSatisfiedF(() =>
         BitcoindRpcTestUtil.hasSeenBlock(client, newBlock))
       list <- client.listReceivedByLabel()

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MiningRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MiningRpc.scala
@@ -15,6 +15,7 @@ import scala.concurrent.Future
   */
 trait MiningRpc { self: Client =>
 
+  @deprecated("use generateToAddress instead", since = "0.18.0")
   def generate(
       blocks: Int,
       maxTries: Int = 1000000): Future[Vector[DoubleSha256DigestBE]] = {

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
@@ -12,7 +12,7 @@ class BitcoindChainHandlerViaZmqTest extends ChainUnitTest {
 
   override type FixtureParam = BitcoindChainHandlerViaZmq
 
-  override implicit val system: ActorSystem = ActorSystem("ChainUnitTest")
+  implicit override val system: ActorSystem = ActorSystem("ChainUnitTest")
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBitcoindChainHandlerViaZmq(test)
@@ -25,27 +25,23 @@ class BitcoindChainHandlerViaZmqTest extends ChainUnitTest {
 
       val chainHandler = bitcoindChainHandler.chainHandler
 
-      val assert1F = chainHandler.getBlockCount
-        .map(count => assert(count == 0))
-
-      //mine a block on bitcoind
-      val generatedF = assert1F.flatMap(_ => bitcoind.generate(1))
-
-      generatedF.flatMap { headers =>
-        val hash = headers.head
-        val foundHeaderF: Future[Unit] = {
+      for {
+        _ <- chainHandler.getBlockCount
+          .map(count => assert(count == 0))
+        address <- bitcoind.getNewAddress
+        hash +: _ <- bitcoind.generateToAddress(1, address)
+        _ <- {
           //test case is totally async since we
           //can't monitor processing flow for zmq
           //so we just need to await until we
           //have fully processed the header
-          RpcUtil.awaitConditionF(() =>
-            chainHandler.getHeader(hash).map(_.isDefined))
+          RpcUtil.awaitConditionF(
+            () => chainHandler.getHeader(hash).map(_.isDefined)
+          )
         }
 
-        for {
-          _ <- foundHeaderF
-          header <- chainHandler.getHeader(hash)
-        } yield assert(header.get.hashBE == hash)
-      }
+        header <- chainHandler.getHeader(hash)
+      } yield assert(header.get.hashBE == hash)
   }
+
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 class ChainSyncTest extends ChainUnitTest {
   override type FixtureParam = BitcoindChainHandlerViaRpc
 
-  override implicit val system = ActorSystem(
+  implicit override val system = ActorSystem(
     s"chain-sync-test-${System.currentTimeMillis()}")
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
@@ -35,7 +35,8 @@ class ChainSyncTest extends ChainUnitTest {
       }
 
       //let's generate a block on bitcoind
-      val block1F = bitcoind.generate(1)
+      val block1F =
+        bitcoind.getNewAddress.flatMap(bitcoind.generateToAddress(1, _))
       val newChainHandlerF: Future[ChainApi] = block1F.flatMap { hashes =>
         ChainSync.sync(chainHandler = chainHandler,
                        getBlockHeaderFunc = getBlockHeaderFunc,

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtilTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtilTest.scala
@@ -12,11 +12,12 @@ class EclairRpcTestUtilTest extends AsyncFlatSpec with BeforeAndAfterAll {
   implicit private val actorSystem: ActorSystem =
     ActorSystem("EclairRpcTestUtilTest", BitcoindRpcTestUtil.AKKA_CONFIG)
 
-  private lazy val bitcoindRpcF = {
-    val cliF = EclairRpcTestUtil.startedBitcoindRpcClient()
-    val blocksF = cliF.flatMap(_.generate(200))
-    blocksF.flatMap(_ => cliF)
-  }
+  private lazy val bitcoindRpcF =
+    for {
+      cli <- EclairRpcTestUtil.startedBitcoindRpcClient()
+      address <- cli.getNewAddress
+      blocks <- cli.generateToAddress(200, address)
+    } yield cli
 
   private val clients =
     Vector.newBuilder[EclairRpcClient]

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -148,16 +148,25 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
 
   lazy val network: RegTest.type = RegTest
 
+  /** The base directory where binaries needed in tests
+    * are located. */
+  private[bitcoins] val baseBinaryDirectory = {
+    val cwd = Paths.get(Properties.userDir)
+    val pathsToGoBackFrom = List("eclair-rpc-test",
+                                 "bitcoind-rpc-test",
+                                 "node-test",
+                                 "wallet-test",
+                                 "chain-test")
+
+    val rootDir = if (pathsToGoBackFrom.exists(cwd.endsWith)) {
+      cwd.getParent()
+    } else cwd
+    rootDir.resolve("binaries")
+  }
+
   /** The directory that sbt downloads bitcoind binaries into */
   private[bitcoins] val binaryDirectory = {
-    val baseDirectory = {
-      val cwd = Paths.get(Properties.userDir)
-      if (cwd.endsWith("bitcoind-rpc-test") || cwd.endsWith("eclair-rpc-test")) {
-        cwd.getParent()
-      } else cwd
-    }
-
-    baseDirectory.resolve("binaries").resolve("bitcoind")
+    baseBinaryDirectory.resolve("bitcoind")
   }
 
   private def getBinary(version: BitcoindVersion): File = version match {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -101,7 +101,7 @@ class WalletIntegrationTest extends BitcoinSWalletTest {
       }
 
       txid <- bitcoind.sendRawTransaction(signedTx)
-      _ <- bitcoind.generate(1)
+      _ <- bitcoind.getNewAddress.flatMap(bitcoind.generateToAddress(1, _))
       tx <- bitcoind.getRawTransaction(txid)
 
       _ <- wallet.listUtxos().map {


### PR DESCRIPTION
In this PR we deprecate the `generate` RPC call in our bitcoind RPC client. It is also removed from the code base. As far as I understand, this is helpful for getting #550 in