### PR TITLE
Add receiver param to BitcoindRpcTestUtil.fundBlockChainTransaction()

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/RawTransactionRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/RawTransactionRpcTest.scala
@@ -132,13 +132,16 @@ class RawTransactionRpcTest extends BitcoindRpcTest {
 
   it should "be able to sign a raw transaction" in {
     for {
-      (client, _) <- clientsF
+      (client, server) <- clientsF
       address <- client.getNewAddress
       pubkey <- BitcoindRpcTestUtil.getPubkey(client, address)
       multisig <- client
         .addMultiSigAddress(1, Vector(Left(pubkey.get)))
       txid <- BitcoindRpcTestUtil
-        .fundBlockChainTransaction(client, multisig.address, Bitcoins(1.2))
+        .fundBlockChainTransaction(client,
+                                   server,
+                                   multisig.address,
+                                   Bitcoins(1.2))
       rawTx <- client.getTransaction(txid)
 
       tx <- client.decodeRawTransaction(rawTx.hex)
@@ -187,6 +190,7 @@ class RawTransactionRpcTest extends BitcoindRpcTest {
       _ <- otherClient.addMultiSigAddress(2, keys)
 
       txid <- BitcoindRpcTestUtil.fundBlockChainTransaction(client,
+                                                            otherClient,
                                                             multisig.address,
                                                             Bitcoins(1.2))
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
@@ -147,8 +147,12 @@ class BitcoindV16RpcClientTest extends BitcoindRpcTest {
     val emptyAccount = "empty_account"
 
     val ourAccountAddress = await(client.getNewAddress(ourAccount))
-    await(BitcoindRpcTestUtil
-      .fundBlockChainTransaction(otherClient, ourAccountAddress, Bitcoins(1.5)))
+    await(
+      BitcoindRpcTestUtil
+        .fundBlockChainTransaction(otherClient,
+                                   client,
+                                   ourAccountAddress,
+                                   Bitcoins(1.5)))
 
     val accountlessAddress = await(client.getNewAddress)
 
@@ -156,7 +160,10 @@ class BitcoindV16RpcClientTest extends BitcoindRpcTest {
 
     val _ = await(
       BitcoindRpcTestUtil
-        .fundBlockChainTransaction(otherClient, accountlessAddress, sendAmt))
+        .fundBlockChainTransaction(otherClient,
+                                   client,
+                                   accountlessAddress,
+                                   sendAmt))
 
     if (Properties.isMac) Thread.sleep(10000)
     val ourAccountAmount = await(client.getReceivedByAccount(ourAccount))

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -153,10 +153,10 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
 
   it should "be able to get the amount received by a label" in {
     for {
-      (client, _) <- clientsF
+      (client, otherClient) <- clientsF
       address <- client.getNewAddress(usedLabel)
       _ <- BitcoindRpcTestUtil
-        .fundBlockChainTransaction(client, address, Bitcoins(1.5))
+        .fundBlockChainTransaction(client, otherClient, address, Bitcoins(1.5))
 
       amount <- client.getReceivedByLabel(usedLabel)
     } yield assert(amount == Bitcoins(1.5))
@@ -204,7 +204,10 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
     for {
       (client, otherClient) <- clientsF
       addr <- client.getNewAddress
-      _ <- BitcoindRpcTestUtil.fundBlockChainTransaction(otherClient, addr, btc)
+      _ <- BitcoindRpcTestUtil.fundBlockChainTransaction(otherClient,
+                                                         client,
+                                                         addr,
+                                                         btc)
 
       newestBlock <- otherClient.getBestBlockHash
       _ <- AsyncUtil.retryUntilSatisfiedF(() =>

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/PsbtRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/PsbtRpcTest.scala
@@ -60,9 +60,10 @@ class PsbtRpcTest extends BitcoindRpcTest {
 
   it should "finalize a simple PSBT" in {
     for {
-      (client, _, _) <- clientsF
+      (client, otherClient, _) <- clientsF
       addr <- client.getNewAddress
       txid <- BitcoindRpcTestUtil.fundBlockChainTransaction(client,
+                                                            otherClient,
                                                             addr,
                                                             Bitcoins.one)
       vout <- BitcoindRpcTestUtil.findOutput(client, txid, Bitcoins.one)

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -818,10 +818,14 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
       implicit system: ActorSystem): Future[DoubleSha256DigestBE] = {
     implicit val mat: ActorMaterializer = ActorMaterializer.create(system)
     implicit val ec: ExecutionContextExecutor = mat.executionContext
-    fundMemPoolTransaction(sender, address, amount).flatMap { txid =>
-      sender.getNewAddress.flatMap(sender.generateToAddress(1, _)).map { _ =>
-        txid
-      }
+
+    for {
+      txid <- fundMemPoolTransaction(sender, address, amount)
+      addr <- sender.getNewAddress
+      blockHash <- sender.generateToAddress(1, addr).map(_.head)
+      _ <- hasSeenBlock(receiver, blockHash)
+    } yield {
+      txid
     }
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -812,6 +812,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     */
   def fundBlockChainTransaction(
       sender: BitcoindRpcClient,
+      receiver: BitcoindRpcClient,
       address: BitcoinAddress,
       amount: Bitcoins)(
       implicit system: ActorSystem): Future[DoubleSha256DigestBE] = {


### PR DESCRIPTION
We have a helper method called `fundBlockChainTransaction()` that is used in our test suite.

In this method, we fund a tx, and then generate a block to confirm that tx. There is an implicit requirement here that both peers have seen the block. What this PR does is add a `receiver` parameter to this method and then makes sure the `sender` and `receiver` have seen the same block. 