### PR TITLE
(WIP)Changes to client start() 

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/NodeRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/NodeRpc.scala
@@ -7,7 +7,6 @@ import org.bitcoins.rpc.serializers.JsonSerializers._
 import play.api.libs.json._
 
 import scala.concurrent.Future
-import org.bitcoins.core.util.FutureUtil
 
 /**
   * RPC calls related to administration of a given node
@@ -70,16 +69,5 @@ trait NodeRpc { self: Client =>
 
   def help(rpcName: String = ""): Future[String] = {
     bitcoindCall[String]("help", List(JsString(rpcName)))
-  }
-
-  def stop(): Future[String] = {
-    for {
-      res <- bitcoindCall[String]("stop")
-      _ <- {
-        if (system.name == BitcoindRpcClient.ActorSystemName) {
-          system.terminate()
-        } else FutureUtil.unit
-      }
-    } yield res
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/util/StartStop.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/StartStop.scala
@@ -1,0 +1,13 @@
+package org.bitcoins.core.util
+import scala.concurrent.Future
+
+/**
+  * This StartStop trait will be used by methods that require broad start stop methods.
+  * Provides structure for new clients to implement. Currently implemented by
+  * BitcoindRpcClient and EclairRpcClient.
+  * @tparam T
+  */
+trait StartStop[T] {
+  def start(): Future[T]
+  def stop(): Future[T]
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -68,7 +68,6 @@ import java.nio.file.Files
 import org.bitcoins.testkit.util.FileUtil
 import org.bitcoins.rpc.BitcoindException
 
-
 //noinspection AccessorLikeMethodIsEmptyParen
 trait BitcoindRpcTestUtil extends BitcoinSLogger {
   import BitcoindRpcTestUtil.DEFAULT_LONG_DURATION

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -56,6 +56,18 @@ import scala.collection.mutable
 import scala.concurrent._
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util._
+import org.bitcoins.rpc.config.BitcoindConfig
+import java.io.File
+import java.nio.file.Path
+import org.bitcoins.rpc.client.common.BitcoindVersion.Unknown
+import org.bitcoins.rpc.client.common.BitcoindVersion.V16
+import org.bitcoins.rpc.client.common.BitcoindVersion.V17
+import org.bitcoins.rpc.client.common.BitcoindVersion.V18
+import java.nio.file.Files
+
+import org.bitcoins.testkit.util.FileUtil
+import org.bitcoins.rpc.BitcoindException
+
 
 //noinspection AccessorLikeMethodIsEmptyParen
 trait BitcoindRpcTestUtil extends BitcoinSLogger {
@@ -104,7 +116,6 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
                   |regtest=1
                   |daemon=1
                   |server=1
-                  |
                   |rpcuser=$username
                   |rpcpassword=$pass
                   |rpcport=${rpcUri.getPort}


### PR DESCRIPTION
This PR hopes to address #405 and to also create a start() method that can be called by EclairRpc client as well. Currently returns a unit instead of a the started `BitcoindRpcClient`. This PR will also spread to be a broad `client` interaction that should be usable across clients.

9/19/2019
Implemented changes for it to return a `bitcoindrpcclient`