### PR TITLE
Downgrade sbt to 1.2.8 to hopefully fix CI

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.2.8


### PR DESCRIPTION
It seems that sbt `1.3.x` is causing us CI failures, this downgrades back to 1.2.x