### PR TITLE
Fix bug where we were sending messages before we were fully initialized

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -139,17 +139,18 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
 
   private[node] def sendMsg(msg: NetworkPayload)(
       implicit ec: ExecutionContext): Future[Unit] = {
-    isInitialized().map { isInit =>
-      msg match {
-        case _: VersionMessage | VerAckMessage =>
-          //version or verack messages are the only messages that
-          //can be sent before we are fully initialized
-          //as they are needed to complete our handshake with our peer
-          logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
-          val newtworkMsg = NetworkMessage(conf.network, msg)
-          client.actor ! newtworkMsg
+    msg match {
+      case _: VersionMessage | VerAckMessage =>
+        //version or verack messages are the only messages that
+        //can be sent before we are fully initialized
+        //as they are needed to complete our handshake with our peer
+        logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
+        val newtworkMsg = NetworkMessage(conf.network, msg)
+        client.actor ! newtworkMsg
+        FutureUtil.unit
+      case _: NetworkPayload =>
 
-        case _: NetworkPayload =>
+        isInitialized().map { isInit =>
           if (isInit) {
             logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
             val newtworkMsg = NetworkMessage(conf.network, msg)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -139,10 +139,26 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
 
   private[node] def sendMsg(msg: NetworkPayload)(
       implicit ec: ExecutionContext): Future[Unit] = {
-    isInitialized().map { _ =>
-      logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
-      val newtworkMsg = NetworkMessage(conf.network, msg)
-      client.actor ! newtworkMsg
+    isInitialized().map { isInit =>
+      msg match {
+        case _: VersionMessage | VerAckMessage =>
+          //version or verack messages are the only messages that
+          //can be sent before we are fully initialized
+          //as they are needed to complete our handshake with our peer
+          logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
+          val newtworkMsg = NetworkMessage(conf.network, msg)
+          client.actor ! newtworkMsg
+
+        case _: NetworkPayload =>
+          if (isInit) {
+            logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
+            val newtworkMsg = NetworkMessage(conf.network, msg)
+            client.actor ! newtworkMsg
+          } else {
+            logger.warn(s"Cannot send msg=${msg.commandName} to peer=${socket} because we aren't initialized!")
+            ()
+          }
+      }
     }
   }
 }


### PR DESCRIPTION
This should begin to fix #749 

We were not actually checking that we were fully initialized before starting to send messages to our peers. 