### PR TITLE
Remove hard coded log level in test app config

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -3,7 +3,7 @@ bitcoin-s {
     network = regtest # regtest, testnet3, mainnet
 
     logging {
-        level = INFO # trace, debug, info, warn, error, off
+        level = WARN # trace, debug, info, warn, error, off
 
         # You can also tune specific module loggers.
         # They each take the same levels as above.

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -18,9 +18,6 @@ object BitcoinSTestAppConfig {
     val overrideConf = ConfigFactory.parseString {
       """
         |bitcoin-s {
-        |  logging {
-        |     level = WARN
-        |  } 
         |  node {
         |     mode = spv
         |  }
@@ -35,9 +32,6 @@ object BitcoinSTestAppConfig {
     val overrideConf = ConfigFactory.parseString {
       """
         |bitcoin-s {
-        |  logging {
-        |     level = WARN
-        |  }
         |  node {
         |     mode = neutrino
         |  }


### PR DESCRIPTION
#756 

Allows us to control logging for test apps that are spun up in our testing framework. Previously this logging could not be controlled via a `logback-test.xml` or `reference.conf` file. 