### PR TITLE
Remove isInitialized() check in sendMsg, which was causing a deadlock

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -12,7 +12,6 @@ import org.scalatest.{DoNotDiscover, FutureOutcome}
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
-@DoNotDiscover
 class NeutrinoNodeTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -168,10 +168,28 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
 
   private[node] def sendMsg(msg: NetworkPayload)(
       implicit ec: ExecutionContext): Future[Unit] = {
-    logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
-    val newtworkMsg = NetworkMessage(conf.network, msg)
-    client.actor ! newtworkMsg
-    FutureUtil.unit
+    msg match {
+      case _: VersionMessage | VerAckMessage =>
+        //version or verack messages are the only messages that
+        //can be sent before we are fully initialized
+        //as they are needed to complete our handshake with our peer
+        logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
+        val newtworkMsg = NetworkMessage(conf.network, msg)
+        client.actor ! newtworkMsg
+        FutureUtil.unit
+      case _: NetworkPayload =>
+        isInitialized().map { isInit =>
+          if (isInit) {
+            logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
+            val newtworkMsg = NetworkMessage(conf.network, msg)
+            client.actor ! newtworkMsg
+          } else {
+            logger.warn(
+              s"Cannot send msg=${msg.commandName} to peer=${socket} because we aren't initialized!")
+            ()
+          }
+        }
+    }
   }
 }
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -150,7 +150,8 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     sendMsg(message)
   }
 
-  def sendGetCompactFilterCheckPointMessage(stopHash: DoubleSha256Digest): Future[Unit] = {
+  def sendGetCompactFilterCheckPointMessage(
+      stopHash: DoubleSha256Digest): Future[Unit] = {
     val message = GetCompactFilterCheckPointMessage(stopHash)
     logger.debug(s"Sending getcfcheckpt=$message to peer ${client.peer}")
     sendMsg(message)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -58,33 +58,31 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
   }
 
   /** Sends a [[org.bitcoins.core.p2p.VersionMessage VersionMessage]] to our peer */
-  def sendVersionMessage()(implicit ec: ExecutionContext): Future[Unit] = {
+  def sendVersionMessage(): Future[Unit] = {
     val versionMsg = VersionMessage(client.peer.socket, conf.network)
     logger.trace(s"Sending versionMsg=$versionMsg to peer=${client.peer}")
     sendMsg(versionMsg)
   }
 
-  def sendVerackMessage()(implicit ec: ExecutionContext): Future[Unit] = {
+  def sendVerackMessage(): Future[Unit] = {
     val verackMsg = VerAckMessage
     sendMsg(verackMsg)
   }
 
   /** Responds to a ping message */
-  def sendPong(ping: PingMessage)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+  def sendPong(ping: PingMessage): Future[Unit] = {
     val pong = PongMessage(ping.nonce)
     logger.trace(s"Sending pong=$pong to peer=${client.peer}")
     sendMsg(pong)
   }
 
-  def sendGetHeadersMessage(lastHash: DoubleSha256Digest)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+  def sendGetHeadersMessage(lastHash: DoubleSha256Digest): Future[Unit] = {
     val headersMsg = GetHeadersMessage(lastHash)
     logger.trace(s"Sending getheaders=$headersMsg to peer=${client.peer}")
     sendMsg(headersMsg)
   }
 
-  def sendHeadersMessage()(implicit ec: ExecutionContext): Future[Unit] = {
+  def sendHeadersMessage(): Future[Unit] = {
     val sendHeadersMsg = SendHeadersMessage
     sendMsg(sendHeadersMsg)
   }
@@ -92,8 +90,7 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
   /**
     * Sends a inventory message with the given transactions
     */
-  def sendInventoryMessage(transactions: Transaction*)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+  def sendInventoryMessage(transactions: Transaction*): Future[Unit] = {
     val inventories =
       transactions.map(tx => Inventory(TypeIdentifier.MsgTx, tx.txId))
     val message = InventoryMessage(inventories)
@@ -101,34 +98,30 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     sendMsg(message)
   }
 
-  def sendFilterClearMessage()(implicit ec: ExecutionContext): Future[Unit] = {
+  def sendFilterClearMessage(): Future[Unit] = {
     sendMsg(FilterClearMessage)
   }
 
-  def sendFilterAddMessage(hash: HashDigest)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+  def sendFilterAddMessage(hash: HashDigest): Future[Unit] = {
     val message = FilterAddMessage.fromHash(hash)
     logger.trace(s"Sending filteradd=$message to peer=${client.peer}")
     sendMsg(message)
   }
 
-  def sendFilterLoadMessage(bloom: BloomFilter)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+  def sendFilterLoadMessage(bloom: BloomFilter): Future[Unit] = {
     val message = FilterLoadMessage(bloom)
     logger.trace(s"Sending filterload=$message to peer=${client.peer}")
     sendMsg(message)
   }
 
-  def sendTransactionMessage(transaction: Transaction)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+  def sendTransactionMessage(transaction: Transaction): Future[Unit] = {
     val message = TransactionMessage(transaction)
     logger.trace(s"Sending txmessage=$message to peer=${client.peer}")
     sendMsg(message)
   }
 
   /** Sends a request for filtered blocks matching the given headers */
-  def sendGetDataMessage(headers: BlockHeader*)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+  def sendGetDataMessage(headers: BlockHeader*): Future[Unit] = {
     val inventories =
       headers.map(header =>
         Inventory(TypeIdentifier.MsgFilteredBlock, header.hash))
@@ -139,8 +132,7 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
 
   def sendGetCompactFiltersMessage(
       startHeight: Int,
-      stopHash: DoubleSha256Digest)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+      stopHash: DoubleSha256Digest): Future[Unit] = {
     val message =
       GetCompactFiltersMessage(if (startHeight < 0) 0 else startHeight,
                                stopHash)
@@ -150,8 +142,7 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
 
   def sendGetCompactFilterHeadersMessage(
       startHeight: Int,
-      stopHash: DoubleSha256Digest)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+      stopHash: DoubleSha256Digest): Future[Unit] = {
     val message =
       GetCompactFilterHeadersMessage(if (startHeight < 0) 0 else startHeight,
                                      stopHash)
@@ -159,37 +150,20 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     sendMsg(message)
   }
 
-  def sendGetCompactFilterCheckPointMessage(stopHash: DoubleSha256Digest)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+  def sendGetCompactFilterCheckPointMessage(stopHash: DoubleSha256Digest): Future[Unit] = {
     val message = GetCompactFilterCheckPointMessage(stopHash)
     logger.debug(s"Sending getcfcheckpt=$message to peer ${client.peer}")
     sendMsg(message)
   }
 
-  private[node] def sendMsg(msg: NetworkPayload)(
-      implicit ec: ExecutionContext): Future[Unit] = {
-    msg match {
-      case _: VersionMessage | VerAckMessage =>
-        //version or verack messages are the only messages that
-        //can be sent before we are fully initialized
-        //as they are needed to complete our handshake with our peer
-        logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
-        val newtworkMsg = NetworkMessage(conf.network, msg)
-        client.actor ! newtworkMsg
-        FutureUtil.unit
-      case _: NetworkPayload =>
-        isInitialized().map { isInit =>
-          if (isInit) {
-            logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
-            val newtworkMsg = NetworkMessage(conf.network, msg)
-            client.actor ! newtworkMsg
-          } else {
-            logger.warn(
-              s"Cannot send msg=${msg.commandName} to peer=${socket} because we aren't initialized!")
-            ()
-          }
-        }
-    }
+  private[node] def sendMsg(msg: NetworkPayload): Future[Unit] = {
+    //version or verack messages are the only messages that
+    //can be sent before we are fully initialized
+    //as they are needed to complete our handshake with our peer
+    logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
+    val newtworkMsg = NetworkMessage(conf.network, msg)
+    client.actor ! newtworkMsg
+    FutureUtil.unit
   }
 }
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -168,28 +168,10 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
 
   private[node] def sendMsg(msg: NetworkPayload)(
       implicit ec: ExecutionContext): Future[Unit] = {
-    msg match {
-      case _: VersionMessage | VerAckMessage =>
-        //version or verack messages are the only messages that
-        //can be sent before we are fully initialized
-        //as they are needed to complete our handshake with our peer
-        logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
-        val newtworkMsg = NetworkMessage(conf.network, msg)
-        client.actor ! newtworkMsg
-        FutureUtil.unit
-      case _: NetworkPayload =>
-        isInitialized().map { isInit =>
-          if (isInit) {
-            logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
-            val newtworkMsg = NetworkMessage(conf.network, msg)
-            client.actor ! newtworkMsg
-          } else {
-            logger.warn(
-              s"Cannot send msg=${msg.commandName} to peer=${socket} because we aren't initialized!")
-            ()
-          }
-        }
-    }
+    logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
+    val newtworkMsg = NetworkMessage(conf.network, msg)
+    client.actor ! newtworkMsg
+    FutureUtil.unit
   }
 }
 

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -58,8 +58,8 @@ bitcoin-s {
 
 
 akka {
-    loglevel = "OFF"
-    stdout-loglevel = "OFF"
+    loglevel = "DEBUG"
+    stdout-loglevel = "DEBUG"
     http {
         client {
             # The time after which an idle connection will be automatically closed.

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -58,8 +58,8 @@ bitcoin-s {
 
 
 akka {
-    loglevel = "DEBUG"
-    stdout-loglevel = "DEBUG"
+    loglevel = "OFF"
+    stdout-loglevel = "OFF"
     http {
         client {
             # The time after which an idle connection will be automatically closed.


### PR DESCRIPTION
This PR removes the `isInitialized()` check from `PeerMessageSender.sendMsg()`. This was introduced in #680

This check was put there in the first place with the intention of preventing us from sending bitcoin p2p messages to our peers before we had completed the handshake on the p2p network. If we send messages to our peer before we are initialized we can be banned by that peer.

However, as @rorp discovered, this can lead to issues with deadlocking when the `P2PClientActor`'s mailbox has a significant amount of messages in the queue. Since the queue is processed FIFO, the [P2PClient](https://github.com/bitcoin-s/bitcoin-s/blob/4ee36e84e9216928d03b3df97d3296a15c6d0e2c/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala#L306) ask request sent to `P2PClientActor` can sit in the queue until our timeout is reached. Once the timeout is reached, an `AskTimeoutException` is thrown to `P2PClient`, which we recover with this

```scala

  def isInitialized()(
      implicit timeout: Timeout,
      ec: ExecutionContext): Future[Boolean] = {
    val isInitF = actor.ask(P2PClient.IsInitialized).mapTo[Boolean]
    isInitF.recoverWith {
      case _: Throwable => Future.successful(false)
    }
  }
```

It is a little concerning that it is taking that long to process a message in the queue (10 seconds) but this is an issue either way. Presumably the message will now get sent at _some point_, since it is queued in the actor's mailbox rather than not being queued at all.

As @rorp has talked about, there really is an architectural issue here. We need to think about how to segregate these meta messages from the actual actor itself so we can't have them be blocked by a message that is taking a long time to process inside of the `P2PClientActor`. 