### PR TITLE
Reduce GCSTest by more, remove unused warnings when using scala conso…

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
@@ -189,7 +189,7 @@ class GCSTest extends BitcoinSUnitTest {
 
     def items: Gen[(Vector[UInt64], UInt8)] = {
       NumberGenerator.genP.flatMap { p =>
-        Gen.choose(1, 500).flatMap { size =>
+        Gen.choose(1, 250).flatMap { size =>
           // If hash's quotient when divided by 2^p is too large, we hang converting to unary
           val upperBound: Long = 1L << (p.toInt * 1.75).toInt
 

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -36,8 +36,18 @@ object CommonSettings {
     apiURL := homepage.value.map(_.toString + "/api").map(url(_)),
     // scaladoc settings end
     ////
+
     scalacOptions in Compile := compilerOpts(scalaVersion.value),
+    //remove annoying import unused things in the scala console
+    //https://stackoverflow.com/questions/26940253/in-sbt-how-do-you-override-scalacoptions-for-console-in-all-configurations
+    scalacOptions in (Compile, console) ~= (_ filterNot (s =>
+      s == "-Ywarn-unused-import"
+        || s =="-Ywarn-unused"
+        //for 2.13 -- they use different compiler opts
+        || s == "-Xlint:unused")),
+    scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
     scalacOptions in Test := testCompilerOpts,
+
     Compile / compile / javacOptions ++= {
       if (isCI) {
         //jdk11 is used on CI, we need to use the --release flag to make sure


### PR DESCRIPTION
…le from sbt

This should hopefully fix #768 for good, it reduces the size of our set to only 250 elements. We were still experiencing test failures with this in #776 

I also took the liberty to remove compiler warnings for the scala console when things are unused. Now when you import something in the scala console you should not get a warning saying that value is unused:

Old:

```scala
sbt:bitcoin-s> core/console
[info] Starting scala interpreter...
Welcome to Scala 2.13.0 (OpenJDK 64-Bit GraalVM CE 19.1.0, Java 1.8.0_212).
Type in expressions for evaluation. Or try :help.

scala> import scodec.bits._
                          ^
       warning: Unused import
import scodec.bits._

scala> :q

```

new:

```scala
[info] Starting scala interpreter...
Welcome to Scala 2.13.0 (OpenJDK 64-Bit GraalVM CE 19.1.0, Java 1.8.0_212).
Type in expressions for evaluation. Or try :help.

scala> import scodec.bits._
import scodec.bits._
  | => core / Compile / externalHooks 0s

```

No warnings! :tada: 