### PR TITLE
2019 10 01 script program cleanup

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
@@ -20,11 +20,15 @@ class ScriptProgramFactoryTest extends FlatSpec with MustMatchers {
     val altStack = List(OP_1)
 
     val modifiedStackProgram =
-      ScriptProgram(TestUtil.testProgram, stack, ScriptProgram.Stack)
+      ScriptProgram(TestUtil.testProgramExecutionInProgress,
+                    stack,
+                    ScriptProgram.Stack)
     modifiedStackProgram.stack must be(stack)
 
     val modifiedAltStack =
-      ScriptProgram(TestUtil.testProgram, altStack, ScriptProgram.AltStack)
+      ScriptProgram(TestUtil.testProgramExecutionInProgress,
+                    altStack,
+                    ScriptProgram.AltStack)
 
     modifiedAltStack.altStack must be(altStack)
   }

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramTest.scala
@@ -12,14 +12,16 @@ class ScriptProgramTest extends FlatSpec with MustMatchers {
   "ScriptProgram" must "determine if the stack top is true" in {
     val stack = List(ScriptNumber(1))
     val script = List()
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     program.stackTopIsTrue must be(true)
   }
 
   it must "determine if the stack stop is false" in {
     val stack = List(ScriptNumber.zero)
     val script = List()
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     program.stackTopIsTrue must be(false)
 
     val program2 = ScriptProgram(program, List(OP_0), ScriptProgram.Stack)

--- a/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
@@ -23,7 +23,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   "ArithmeticInterpreter" must "perform an OP_ADD correctly" in {
     val stack = List(ScriptNumber.one, ScriptNumber(2))
     val script = List(OP_ADD)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opAdd(program)
     newProgram.stack.head must be(ScriptNumber(3))
     newProgram.script.isEmpty must be(true)
@@ -32,7 +33,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_1ADD correctly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_1ADD)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.op1Add(program)
 
     newProgram.stack.head must be(ScriptNumber.one)
@@ -54,7 +56,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_1SUB corectly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_1SUB)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.op1Sub(program)
 
     newProgram.stack.head must be(ScriptNumber(-1))
@@ -75,7 +78,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_SUB corectly" in {
     val stack = List(ScriptNumber.one, ScriptNumber.zero)
     val script = List(OP_SUB)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opSub(program)
 
     newProgram.stack.head must be(ScriptNumber(-1))
@@ -95,7 +99,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_ABS on a negative number corectly" in {
     val stack = List(ScriptNumber(-1))
     val script = List(OP_ABS)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opAbs(program)
 
     newProgram.stack.head must be(ScriptNumber.one)
@@ -105,7 +110,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform OP_ABS on zero correctly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_ABS)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opAbs(program)
 
     newProgram.stack.head must be(ScriptNumber.zero)
@@ -124,7 +130,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_NEGATE on a zero correctly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_NEGATE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNegate(program)
 
     newProgram.stack.head must be(ScriptNumber.zero)
@@ -134,7 +141,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_NEGATE on a positive number correctly" in {
     val stack = List(ScriptNumber.one)
     val script = List(OP_NEGATE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNegate(program)
 
     newProgram.stack.head must be(ScriptNumber(-1))
@@ -144,7 +152,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_NEGATE on a negative number correctly" in {
     val stack = List(ScriptNumber(-1))
     val script = List(OP_NEGATE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNegate(program)
 
     newProgram.stack.head must be(ScriptNumber.one)
@@ -164,7 +173,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_NOT correctly where 0 is the stack top" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_NOT)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNot(program)
 
     newProgram.stackTopIsTrue must be(true)
@@ -175,7 +185,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_NOT correctly where 1 is the stack top" in {
     val stack = List(ScriptNumber.one)
     val script = List(OP_NOT)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNot(program)
 
     newProgram.stackTopIsFalse must be(true)
@@ -186,7 +197,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_0NOTEQUAL correctly where 0 is the stack top" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_0NOTEQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.op0NotEqual(program)
 
     newProgram.stack.head must be(OP_FALSE)
@@ -196,7 +208,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "perform an OP_0NOTEQUAL correctly where 1 is the stack top" in {
     val stack = List(ScriptNumber.one)
     val script = List(OP_0NOTEQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.op0NotEqual(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -206,7 +219,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "have an OP_BOOLAND correctly for two 0s" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.zero)
     val script = List(OP_BOOLAND)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opBoolAnd(program)
 
     newProgram.stackTopIsFalse must be(true)
@@ -215,7 +229,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack1 = List(OP_0, OP_0)
     val script1 = List(OP_BOOLAND)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram1 = AI.opBoolAnd(program)
 
     newProgram.stackTopIsFalse must be(true)
@@ -226,7 +241,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "have an OP_BOOLAND correctly for one 0" in {
     val stack = List(ScriptNumber.zero, OP_1)
     val script = List(OP_BOOLAND)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opBoolAnd(program)
 
     newProgram.stackTopIsTrue must be(false)
@@ -237,7 +253,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "have an OP_BOOLOR correctly for two 1s" in {
     val stack = List(ScriptNumber.one, ScriptNumber.one)
     val script = List(OP_BOOLOR)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opBoolOr(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -247,7 +264,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "have an OP_BOOLOR correctly for two 0s" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.zero)
     val script = List(OP_BOOLOR)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opBoolOr(program)
 
     newProgram.stack.head must be(OP_FALSE)
@@ -257,7 +275,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "have an OP_BOOLOR correctly for one OP_0" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_BOOLOR)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opBoolOr(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -267,7 +286,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaulate an OP_NUMEQUAL for two zeros" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.zero)
     val script = List(OP_NUMEQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNumEqual(program)
 
     newProgram.stackTopIsTrue must be(true)
@@ -310,7 +330,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_NUMNOTEQUAL for two numbers that are the same" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.zero)
     val script = List(OP_NUMNOTEQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNumNotEqual(program)
 
     newProgram.stack.head must be(OP_FALSE)
@@ -320,7 +341,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_NUMNOTEQUAL for two numbers that are not the same" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_NUMNOTEQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opNumNotEqual(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -330,7 +352,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_LESSTHAN correctly" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_LESSTHAN)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opLessThan(program)
 
     newProgram.stack.head must be(OP_FALSE)
@@ -338,8 +361,9 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack1 = List(ScriptNumber.zero, ScriptNumber.zero)
     val script1 = List(OP_LESSTHAN)
-    ScriptProgram(TestUtil.testProgram, stack, script)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script1)
+    ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1)
     val newProgram1 = AI.opLessThan(program1)
 
     newProgram1.stack.head must be(OP_FALSE)
@@ -347,7 +371,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack2 = List(ScriptNumber.one, ScriptNumber.zero)
     val script2 = List(OP_LESSTHAN)
-    val program2 = ScriptProgram(TestUtil.testProgram, stack2, script2)
+    val program2 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2)
     val newProgram2 = AI.opLessThan(program2)
 
     newProgram2.stack.head must be(OP_TRUE)
@@ -357,7 +382,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_LESSTHANOREQUAL correctly" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_LESSTHANOREQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opLessThanOrEqual(program)
 
     newProgram.stack.head must be(OP_FALSE)
@@ -365,8 +391,9 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack1 = List(ScriptNumber.zero, ScriptNumber.zero)
     val script1 = List(OP_LESSTHANOREQUAL)
-    ScriptProgram(TestUtil.testProgram, stack, script)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script1)
+    ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1)
     val newProgram1 = AI.opLessThanOrEqual(program1)
 
     newProgram1.stack.head must be(OP_TRUE)
@@ -374,7 +401,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack2 = List(ScriptNumber.one, ScriptNumber.zero)
     val script2 = List(OP_LESSTHANOREQUAL)
-    val program2 = ScriptProgram(TestUtil.testProgram, stack2, script2)
+    val program2 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2)
     val newProgram2 = AI.opLessThanOrEqual(program2)
 
     newProgram2.stack.head must be(OP_TRUE)
@@ -384,7 +412,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_GREATERTHAN correctly" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_GREATERTHAN)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opGreaterThan(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -392,7 +421,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack1 = List(ScriptNumber.zero, ScriptNumber.zero)
     val script1 = List(OP_GREATERTHAN)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script1)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1)
     val newProgram1 = AI.opGreaterThan(program1)
 
     newProgram1.stack.head must be(OP_FALSE)
@@ -400,7 +430,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack2 = List(ScriptNumber.one, ScriptNumber.zero)
     val script2 = List(OP_GREATERTHAN)
-    val program2 = ScriptProgram(TestUtil.testProgram, stack2, script2)
+    val program2 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2)
     val newProgram2 = AI.opGreaterThan(program2)
 
     newProgram2.stack.head must be(OP_FALSE)
@@ -410,7 +441,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_GREATERTHANOREQUAL correctly" in {
     val stack = List(ScriptNumber.zero, ScriptNumber.one)
     val script = List(OP_GREATERTHANOREQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opGreaterThanOrEqual(program)
 
     newProgram.stack.head must be(OP_TRUE)
@@ -418,7 +450,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack1 = List(ScriptNumber.zero, ScriptNumber.zero)
     val script1 = List(OP_GREATERTHANOREQUAL)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script1)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1)
     val newProgram1 = AI.opGreaterThanOrEqual(program1)
 
     newProgram1.stack.head must be(OP_TRUE)
@@ -426,7 +459,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
 
     val stack2 = List(ScriptNumber.one, ScriptNumber.zero)
     val script2 = List(OP_GREATERTHANOREQUAL)
-    val program2 = ScriptProgram(TestUtil.testProgram, stack2, script2)
+    val program2 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2)
     val newProgram2 = AI.opGreaterThanOrEqual(program2)
 
     newProgram2.stack.head must be(OP_FALSE)
@@ -538,7 +572,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
     val scriptConstant2 = ScriptConstant("ffffff7f")
     val stack = List(scriptConstant1, scriptConstant2)
     val script = List(OP_ADD)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = AI.opAdd(program)
     newProgram.stack must be(List(ScriptNumber.zero))
     newProgram.script.isEmpty must be(true)
@@ -547,7 +582,8 @@ class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
   it must "fail to evaluate all OP codes if the script stack is empty" in {
     val stack = List(ScriptNumber.zero)
     val script = List()
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     Try(AI.opAdd(program)).isFailure must be(true)
     Try(AI.op1Add(program)).isFailure must be(true)
     Try(AI.op1Sub(program)).isFailure must be(true)

--- a/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseInterpreterTest.scala
@@ -16,7 +16,8 @@ class BitwiseInterpreterTest extends FlatSpec with MustMatchers {
   "BitwiseInterpreter" must "evaluate OP_EQUAL" in {
     val stack = List(pubKeyHash, pubKeyHash)
     val script = List(OP_EQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = BI.opEqual(program)
     newProgram.stack.head must be(OP_TRUE)
   }
@@ -24,20 +25,23 @@ class BitwiseInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate OP_1 and OP_TRUE to equal" in {
     val stack = List(OP_1, OP_TRUE)
     val script = List(OP_EQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = BI.opEqual(program)
     newProgram.stack.head must be(OP_TRUE)
   }
 
   it must "throw an exception for OP_EQUAL when we don't have enough items on the stack" in {
     intercept[IllegalArgumentException] {
-      BI.opEqual(ScriptProgram(TestUtil.testProgram, List(), List()))
+      BI.opEqual(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, List(), List()))
     }
   }
 
   it must "throw an exception for OP_EQUAL when we don't have enough items on the script stack" in {
     intercept[IllegalArgumentException] {
-      BI.opEqual(ScriptProgram(TestUtil.testProgram, List(), List()))
+      BI.opEqual(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, List(), List()))
     }
   }
 
@@ -64,19 +68,22 @@ class BitwiseInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate a ScriptNumber & ScriptConstant to true if they are the same" in {
     val stack = List(ScriptNumber(2), ScriptConstant("02"))
     val script = List(OP_EQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     BI.opEqual(program).stack.head must be(OP_TRUE)
 
     val stack1 = List(ScriptConstant("02"), ScriptNumber(2))
     val script1 = List(OP_EQUAL)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script1)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1)
     BI.opEqual(program1).stack.head must be(OP_TRUE)
   }
 
   it must "evaluate an OP_0 and ScriptNumberImpl(0) to equal" in {
     val stack = List(OP_0, ScriptNumber.zero)
     val script = List(OP_EQUAL)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     BI.opEqual(program).stack.head must be(OP_TRUE)
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
@@ -68,7 +68,8 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
   it must "push a constant 2 bytes onto the stack" in {
     val stack = List()
     val script = List(BytesToPushOntoStack(2), ScriptNumber.one, OP_0)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.pushScriptNumberBytesToStack(program)
     newProgram.script.isEmpty must be(true)
     newProgram.stack must be(List(ScriptConstant("0100")))
@@ -78,8 +79,9 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
     val stack = List()
     val script = List(OP_PUSHDATA1, BytesToPushOntoStack(0))
     val program =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack, script),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script),
+        Seq[ScriptFlag]())
     val newProgram = CI.opPushData1(program)
     newProgram.stackTopIsFalse must be(true)
     newProgram.stack must be(List(ScriptNumber.zero))
@@ -87,16 +89,18 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
     val stack1 = List()
     val script1 = List(OP_PUSHDATA2, BytesToPushOntoStack(0))
     val program1 =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack1, script1),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1),
+        Seq[ScriptFlag]())
     val newProgram1 = CI.opPushData2(program1)
     newProgram1.stack must be(List(ScriptNumber.zero))
 
     val stack2 = List()
     val script2 = List(OP_PUSHDATA4, BytesToPushOntoStack(0))
     val program2 =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack2, script2),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2),
+        Seq[ScriptFlag]())
     val newProgram2 = CI.opPushData4(program2)
     newProgram2.stack must be(List(ScriptNumber.zero))
   }
@@ -117,20 +121,23 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
     val stack1 = List()
     val script1 = List(OP_PUSHDATA1, BytesToPushOntoStack(0))
     val program1 =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack1, script1),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script1),
+        Seq[ScriptFlag]())
 
     val stack2 = List()
     val script2 = List(OP_PUSHDATA2, BytesToPushOntoStack(0))
     val program2 =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack2, script2),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack2, script2),
+        Seq[ScriptFlag]())
 
     val stack4 = List()
     val script4 = List(OP_PUSHDATA4, BytesToPushOntoStack(0))
     val program4 =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack4, script4),
-                    Seq[ScriptFlag]())
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack4, script4),
+        Seq[ScriptFlag]())
 
     //purposely call incorrect functions to mismatch opCodes
     intercept[IllegalArgumentException] {
@@ -150,7 +157,8 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
     "BytesToPushOntoStack, ScriptNumber, or ScriptConstant" in {
     val stack = List()
     val script = List(OP_CHECKMULTISIGVERIFY, ScriptNumber.one, OP_0)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
 
     intercept[IllegalArgumentException] {
       CI.pushScriptNumberBytesToStack(program)
@@ -161,8 +169,9 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
     val stack = List()
     val script = List(OP_PUSHDATA4, ScriptNumber.zero)
     val program =
-      ScriptProgram(ScriptProgram(TestUtil.testProgram, stack, script),
-                    Seq[ScriptFlag](ScriptVerifyMinimalData))
+      ScriptProgram(
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script),
+        Seq[ScriptFlag](ScriptVerifyMinimalData))
     val newProgram =
       ScriptProgramTestUtil.toExecutedScriptProgram(CI.opPushData4(program))
     newProgram.error must be(Some(ScriptErrorMinimalData))
@@ -174,7 +183,8 @@ class ConstantInterpreterTest extends FlatSpec with MustMatchers {
         "ffffffff00ffffffff014a7afa8f7d52fd9e17a914b167f19394cd656c34f843ac2387e602007fd15b8700000000")
     val stack = Nil
     val script = List(OP_PUSHDATA1, OP_3, constant)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opPushData1(program)
     newProgram.stack must be(Seq(constant))
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoInterpreterTest.scala
@@ -30,7 +30,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   "CryptoInterpreter" must "evaluate OP_HASH160 correctly when it is on top of the script stack" in {
 
     val script = List(OP_HASH160)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opHash160(program)
 
     newProgram.stack.head must be(
@@ -51,7 +52,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
 
   it must "fail to evaluate all OP codes when the script stack is empty" in {
     val script = List()
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     Try(CI.opHash160(program)).isFailure must be(true)
     Try(CI.opRipeMd160(program)).isFailure must be(true)
     Try(CI.opSha256(program)).isFailure must be(true)
@@ -67,7 +69,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_RIPEMD160 correctly" in {
     val stack = List(ScriptConstant(""))
     val script = List(OP_RIPEMD160)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opRipeMd160(program)
     newProgram.stack must be(
       List(ScriptConstant("9c1185a5c5e9fc54612808977ee8f548b2258d31")))
@@ -77,7 +80,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate a OP_SHA1 correctly" in {
     val stack = List(ScriptConstant("ab"))
     val script = List(OP_SHA1)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opSha1(program)
     newProgram.stack.head must be(
       ScriptConstant("fe83f217d464f6fdfa5b2b1f87fe3a1a47371196"))
@@ -87,7 +91,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_SHA256 correctly" in {
     val stack = List(ScriptConstant(""))
     val script = List(OP_SHA256)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opSha256(program)
     newProgram.stack must be(
       List(ScriptConstant(
@@ -98,7 +103,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_HASH256 correctly" in {
     val stack = List(ScriptConstant(""))
     val script = List(OP_HASH256)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = CI.opHash256(program)
     newProgram.stack must be(
       List(ScriptConstant(
@@ -109,7 +115,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_CHECKMULTISIG with zero signatures and zero pubkeys" in {
     val stack = List(OP_0, OP_0, OP_0)
     val script = List(OP_CHECKMULTISIG)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val programNoFlags = ScriptProgram(program, ScriptFlagFactory.empty)
     val newProgram = CI.opCheckMultiSig(programNoFlags)
     newProgram.stack must be(List(OP_TRUE))
@@ -119,7 +126,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_CHECKMULTISIG and leave the remaining operations on the stack" in {
     val stack = List(OP_0, OP_0, OP_0, OP_16, OP_16, OP_16)
     val script = List(OP_CHECKMULTISIG, OP_16, OP_16, OP_16, OP_16)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val programNoFlags = ScriptProgram(program, ScriptFlagFactory.empty)
     val newProgram = CI.opCheckMultiSig(programNoFlags)
     newProgram.stack must be(List(OP_TRUE, OP_16, OP_16, OP_16))
@@ -154,7 +162,8 @@ class CryptoInterpreterTest extends FlatSpec with MustMatchers {
     //0 0 0 1 CHECKMULTISIG VERIFY DEPTH 0 EQUAL
     val stack = List(OP_1, OP_0, OP_0, OP_0)
     val script = List(OP_CHECKMULTISIG)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val programNoFlags = ScriptProgram(program, ScriptFlagFactory.empty)
     val newProgram = CI.opCheckMultiSig(programNoFlags)
     newProgram.stack must be(List(OP_TRUE))

--- a/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
@@ -146,7 +146,8 @@ class LockTimeInterpreterTest extends FlatSpec with MustMatchers {
                                              txAdjustedSequenceNumber.outputs,
                                              UInt32.zero)
     val t = buildTxSigComponent(adjustedLockTimeTx)
-    val baseProgram = PreExecutionScriptProgram(t)
+    val basePreProgram = PreExecutionScriptProgram(t)
+    val baseProgram = ScriptProgram.toExecutionInProgress(basePreProgram)
     val program = ScriptProgram(baseProgram, stack, script)
     val newProgram = LTI.opCheckLockTimeVerify(program)
     //if an error is hit, the newProgram will be an instance of ExecutedScriptProgram
@@ -175,7 +176,8 @@ class LockTimeInterpreterTest extends FlatSpec with MustMatchers {
                                              txAdjustedSequenceNumber.outputs,
                                              UInt32.zero)
     val t = buildTxSigComponent(adjustedLockTimeTx)
-    val baseProgram = PreExecutionScriptProgram(t)
+    val basePreProgram = PreExecutionScriptProgram(t)
+    val baseProgram = ScriptProgram.toExecutionInProgress(basePreProgram)
     val program = ScriptProgram(baseProgram, stack, script)
     val newProgram = LTI.opCheckLockTimeVerify(program)
     //if an error is hit, the newProgram will be an instance of ExecutedScriptProgram
@@ -202,7 +204,8 @@ class LockTimeInterpreterTest extends FlatSpec with MustMatchers {
                                              txAdjustedSequenceNumber.outputs,
                                              UInt32(500000000))
     val t = buildTxSigComponent(adjustedLockTimeTx)
-    val baseProgram = PreExecutionScriptProgram(t)
+    val basePreProgram = PreExecutionScriptProgram(t)
+    val baseProgram = ScriptProgram.toExecutionInProgress(basePreProgram)
     val program = ScriptProgram(baseProgram, stack, script)
     val newProgram = LTI.opCheckLockTimeVerify(program)
     //if an error is hit, the newProgram will be an instance of ExecutedScriptProgram

--- a/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceInterpreterTest.scala
@@ -15,7 +15,8 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers {
   "SpliceInterpreter" must "evaluate an OP_SIZE on OP_0 correctly" in {
     val stack = List(OP_0)
     val script = List(OP_SIZE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSize(program)
     newProgram.stack must be(List(OP_0, OP_0))
     newProgram.script.isEmpty must be(true)
@@ -25,7 +26,8 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers {
   it must "deterine the size of script number 0 correctly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_SIZE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSize(program)
     newProgram.stack must be(List(ScriptNumber.zero, ScriptNumber.zero))
     newProgram.script.isEmpty must be(true)
@@ -34,7 +36,8 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_SIZE correctly with 0x7f" in {
     val stack = List(ScriptConstant("7f"))
     val script = List(OP_SIZE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSize(program)
     newProgram.stack must be(List(ScriptNumber(1), ScriptConstant("7f")))
     newProgram.script.isEmpty must be(true)
@@ -44,7 +47,8 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers {
     //0x8000 == 128 in bitcoin
     val stack = List(ScriptNumber(128))
     val script = List(OP_SIZE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSize(program)
     newProgram.stack must be(List(ScriptNumber(2), ScriptNumber(128)))
     newProgram.script.isEmpty must be(true)
@@ -53,7 +57,8 @@ class SpliceInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_SIZE correctly with a negative number" in {
     val stack = List(ScriptNumber(-1))
     val script = List(OP_SIZE)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSize(program)
     newProgram.stack must be(List(ScriptNumber.one, ScriptNumber(-1)))
     newProgram.script.isEmpty must be(true)

--- a/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
@@ -17,7 +17,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   "StackInterpreter" must "duplicate elements on top of the stack" in {
 
     val script = List(OP_DUP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opDup(program)
 
     newProgram.stack.head must be(element1)
@@ -28,7 +29,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "throw an exception when calling opDup without an OP_DUP on top of the script stack" in {
     intercept[IllegalArgumentException] {
       val script = List()
-      val program = ScriptProgram(TestUtil.testProgram, stack, script)
+      val program =
+        ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
       SI.opDup(program)
     }
   }
@@ -46,7 +48,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
 
   it must "evaluate the OP_DEPTH operator correctly" in {
     val script = List(OP_DEPTH)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opDepth(program)
 
     newProgram.stack.head.hex must be(BitcoinSUtil.encodeHex(stack.size.toByte))
@@ -55,7 +58,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate OP_DEPTH operator correctly when there are zero items on the stack" in {
     val stack = List()
     val script = List(OP_DEPTH)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opDepth(program)
     newProgram.stack.head must be(ScriptNumber.zero)
   }
@@ -63,7 +67,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_TOALTSTACK operator correctly" in {
     val stack = List(OP_0)
     val script = List(OP_TOALTSTACK)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opToAltStack(program)
 
     newProgram.stack.isEmpty must be(true)
@@ -75,7 +80,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_DROP operator correctly" in {
     val stack = List(OP_0)
     val script = List(OP_DROP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opDrop(program)
 
     newProgram.stack.isEmpty must be(true)
@@ -96,14 +102,16 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_IFDUP correctly" in {
     val stack = List(ScriptNumber.zero)
     val script = List(OP_IFDUP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opIfDup(program)
 
     newProgram.stack must be(stack)
     newProgram.script.isEmpty must be(true)
 
     val stack1 = List(OP_1)
-    val program1 = ScriptProgram(TestUtil.testProgram, stack1, script)
+    val program1 =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack1, script)
     val newProgram1 = SI.opIfDup(program1)
     newProgram1.stack must be(List(OP_1, OP_1))
     newProgram1.script.isEmpty must be(true)
@@ -114,7 +122,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
     val stack = List(OP_0, OP_1)
     val script = List(OP_NIP)
 
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
 
     val newProgram = SI.opNip(program)
 
@@ -148,7 +157,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
   it must "evaluate an OP_OVER correctly" in {
     val stack = List(OP_0, OP_1)
     val script = List(OP_OVER)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opOver(program)
     newProgram.stack must be(List(OP_1, OP_0, OP_1))
     newProgram.script.isEmpty must be(true)
@@ -184,7 +194,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("15"),
                      ScriptConstant("16"))
     val script = List(OP_PICK)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opPick(program)
 
     newProgram.stack must be(
@@ -250,7 +261,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
     val stack =
       List(ScriptConstant("14"), ScriptConstant("15"), ScriptConstant("16"))
     val script = List(OP_ROT)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opRot(program)
 
     newProgram.stack must be(
@@ -277,7 +289,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_2ROT)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op2Rot(program)
 
     newProgram.stack must be(
@@ -313,7 +326,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_2DROP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op2Drop(program)
 
     newProgram.stack must be(
@@ -342,7 +356,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_SWAP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opSwap(program)
     newProgram.stack must be(
       List(ScriptConstant("15"),
@@ -373,7 +388,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_TUCK)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.opTuck(program)
     newProgram.stack must be(
       List(ScriptConstant("14"),
@@ -406,7 +422,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_2DUP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op2Dup(program)
     newProgram.stack must be(
       List(
@@ -442,7 +459,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_3DUP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op3Dup(program)
 
     newProgram.stack must be(
@@ -479,7 +497,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_2OVER)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op2Over(program)
 
     newProgram.stack must be(
@@ -516,7 +535,8 @@ class StackInterpreterTest extends FlatSpec with MustMatchers {
                      ScriptConstant("18"),
                      ScriptConstant("19"))
     val script = List(OP_2SWAP)
-    val program = ScriptProgram(TestUtil.testProgram, stack, script)
+    val program =
+      ScriptProgram(TestUtil.testProgramExecutionInProgress, stack, script)
     val newProgram = SI.op2Swap(program)
 
     newProgram.stack must be(

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -157,27 +157,28 @@ object ScriptProgram extends BitcoinSLogger {
                             Some(error))
   }
 
-  def apply(oldProgram: ScriptProgram, flags: Seq[ScriptFlag]): ScriptProgram =
-    oldProgram match {
-      case program: PreExecutionScriptProgram =>
-        PreExecutionScriptProgram(program.txSignatureComponent,
-                                  program.stack,
-                                  program.script,
-                                  program.originalScript,
-                                  program.altStack,
-                                  flags)
-      case program: ExecutionInProgressScriptProgram =>
-        ExecutionInProgressScriptProgram(program.txSignatureComponent,
-                                         program.stack,
-                                         program.script,
-                                         program.originalScript,
-                                         program.altStack,
-                                         flags,
-                                         program.lastCodeSeparator)
-      case _: ExecutedScriptProgram =>
-        throw new RuntimeException(
-          "Cannot update the script flags on a program that has been executed")
-    }
+  def apply(
+      oldProgram: PreExecutionScriptProgram,
+      flags: Seq[ScriptFlag]): PreExecutionScriptProgram = {
+    PreExecutionScriptProgram(oldProgram.txSignatureComponent,
+                              oldProgram.stack,
+                              oldProgram.script,
+                              oldProgram.originalScript,
+                              oldProgram.altStack,
+                              flags)
+  }
+
+  def apply(
+      oldProgram: ExecutionInProgressScriptProgram,
+      flags: Seq[ScriptFlag]): ExecutionInProgressScriptProgram = {
+    ExecutionInProgressScriptProgram(oldProgram.txSignatureComponent,
+                                     oldProgram.stack,
+                                     oldProgram.script,
+                                     oldProgram.originalScript,
+                                     oldProgram.altStack,
+                                     flags,
+                                     oldProgram.lastCodeSeparator)
+  }
 
   def apply(
       oldProgram: PreExecutionScriptProgram,

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -77,6 +77,9 @@ object PreExecutionScriptProgram {
   }
 }
 
+/** This represents any ScriptProgram that is not PreExecution */
+sealed trait StartedScriptProgram extends ScriptProgram
+
 /**
   * Type for a [[org.bitcoins.core.script.ScriptProgram ScriptProgram]] that is currently being
   * evaluated by the [[org.bitcoins.core.script.interpreter.ScriptInterpreter ScriptInterpreter]].
@@ -91,7 +94,7 @@ case class ExecutionInProgressScriptProgram(
     altStack: List[ScriptToken],
     flags: Seq[ScriptFlag],
     lastCodeSeparator: Option[Int])
-    extends ScriptProgram
+    extends StartedScriptProgram
 
 /**
   * Type for a [[org.bitcoins.core.script.ScriptProgram ScriptProgram]] that has been
@@ -109,7 +112,7 @@ case class ExecutedScriptProgram(
     altStack: List[ScriptToken],
     flags: Seq[ScriptFlag],
     error: Option[ScriptError])
-    extends ScriptProgram
+    extends StartedScriptProgram
 
 /**
   * Factory companion object for [[org.bitcoins.core.script.ScriptProgram ScriptProgram]]
@@ -177,103 +180,102 @@ object ScriptProgram extends BitcoinSLogger {
     }
 
   def apply(
-      oldProgram: ScriptProgram,
+      oldProgram: PreExecutionScriptProgram,
       tokens: Seq[ScriptToken],
-      indicator: UpdateIndicator): ScriptProgram = {
+      indicator: UpdateIndicator): PreExecutionScriptProgram = {
     indicator match {
       case Stack =>
-        oldProgram match {
-          case program: PreExecutionScriptProgram =>
-            PreExecutionScriptProgram(program.txSignatureComponent,
-                                      tokens.toList,
-                                      program.script,
-                                      program.originalScript,
-                                      program.altStack,
-                                      program.flags)
-          case program: ExecutionInProgressScriptProgram =>
-            ExecutionInProgressScriptProgram(program.txSignatureComponent,
-                                             tokens.toList,
-                                             program.script,
-                                             program.originalScript,
-                                             program.altStack,
-                                             program.flags,
-                                             program.lastCodeSeparator)
-          case _: ExecutedScriptProgram =>
-            throw new RuntimeException(
-              "Cannot update stack for program that has been fully executed")
-        }
+        PreExecutionScriptProgram(oldProgram.txSignatureComponent,
+                                  tokens.toList,
+                                  oldProgram.script,
+                                  oldProgram.originalScript,
+                                  oldProgram.altStack,
+                                  oldProgram.flags)
       case Script =>
-        oldProgram match {
-          case program: PreExecutionScriptProgram =>
-            PreExecutionScriptProgram(program.txSignatureComponent,
-                                      program.stack,
-                                      tokens.toList,
-                                      program.originalScript,
-                                      program.altStack,
-                                      program.flags)
-          case program: ExecutionInProgressScriptProgram =>
-            ExecutionInProgressScriptProgram(program.txSignatureComponent,
-                                             program.stack,
-                                             tokens.toList,
-                                             program.originalScript,
-                                             program.altStack,
-                                             program.flags,
-                                             program.lastCodeSeparator)
-          case _: ExecutedScriptProgram =>
-            throw new RuntimeException(
-              "Cannot update the script for a program that has been fully executed")
-        }
+        PreExecutionScriptProgram(oldProgram.txSignatureComponent,
+                                  oldProgram.stack,
+                                  tokens.toList,
+                                  oldProgram.originalScript,
+                                  oldProgram.altStack,
+                                  oldProgram.flags)
       case AltStack =>
-        oldProgram match {
-          case program: PreExecutionScriptProgram =>
-            PreExecutionScriptProgram(program.txSignatureComponent,
-                                      program.stack,
-                                      program.script,
-                                      program.originalScript,
-                                      tokens.toList,
-                                      program.flags)
-          case program: ExecutionInProgressScriptProgram =>
-            ExecutionInProgressScriptProgram(program.txSignatureComponent,
-                                             program.stack,
-                                             program.script,
-                                             program.originalScript,
-                                             tokens.toList,
-                                             program.flags,
-                                             program.lastCodeSeparator)
-          case _: ExecutedScriptProgram =>
-            throw new RuntimeException(
-              "Cannot update the alt stack for a program that has been fully executed")
-        }
-
+        PreExecutionScriptProgram(oldProgram.txSignatureComponent,
+                                  oldProgram.stack,
+                                  oldProgram.script,
+                                  oldProgram.originalScript,
+                                  tokens.toList,
+                                  oldProgram.flags)
       case OriginalScript =>
-        oldProgram match {
-          case program: PreExecutionScriptProgram =>
-            PreExecutionScriptProgram(program.txSignatureComponent,
-                                      program.stack,
-                                      program.script,
-                                      tokens.toList,
-                                      program.altStack,
-                                      program.flags)
-          case program: ExecutionInProgressScriptProgram =>
-            ExecutionInProgressScriptProgram(program.txSignatureComponent,
-                                             program.stack,
-                                             program.script,
-                                             tokens.toList,
-                                             program.altStack,
-                                             program.flags,
-                                             program.lastCodeSeparator)
-          case _: ExecutedScriptProgram =>
-            throw new RuntimeException(
-              "Cannot update the original script for a program that has been fully executed")
-        }
-
+        PreExecutionScriptProgram(oldProgram.txSignatureComponent,
+                                  oldProgram.stack,
+                                  oldProgram.script,
+                                  tokens.toList,
+                                  oldProgram.altStack,
+                                  oldProgram.flags)
     }
   }
 
   def apply(
-      oldProgram: ScriptProgram,
+      oldProgram: ExecutionInProgressScriptProgram,
+      tokens: Seq[ScriptToken],
+      indicator: UpdateIndicator): ExecutionInProgressScriptProgram = {
+    indicator match {
+      case Stack =>
+        ExecutionInProgressScriptProgram(
+          oldProgram.txSignatureComponent,
+          tokens.toList,
+          oldProgram.script,
+          oldProgram.originalScript,
+          oldProgram.altStack,
+          oldProgram.flags,
+          oldProgram.lastCodeSeparator
+        )
+      case Script =>
+        ExecutionInProgressScriptProgram(
+          oldProgram.txSignatureComponent,
+          oldProgram.stack,
+          tokens.toList,
+          oldProgram.originalScript,
+          oldProgram.altStack,
+          oldProgram.flags,
+          oldProgram.lastCodeSeparator
+        )
+      case AltStack =>
+        ExecutionInProgressScriptProgram(
+          oldProgram.txSignatureComponent,
+          oldProgram.stack,
+          oldProgram.script,
+          oldProgram.originalScript,
+          tokens.toList,
+          oldProgram.flags,
+          oldProgram.lastCodeSeparator
+        )
+      case OriginalScript =>
+        ExecutionInProgressScriptProgram(oldProgram.txSignatureComponent,
+                                         oldProgram.stack,
+                                         oldProgram.script,
+                                         tokens.toList,
+                                         oldProgram.altStack,
+                                         oldProgram.flags,
+                                         oldProgram.lastCodeSeparator)
+    }
+  }
+
+  def apply(
+      oldProgram: PreExecutionScriptProgram,
       stackTokens: Seq[ScriptToken],
-      scriptTokens: Seq[ScriptToken]): ScriptProgram = {
+      scriptTokens: Seq[ScriptToken]): PreExecutionScriptProgram = {
+    val updatedStack = ScriptProgram(oldProgram, stackTokens, Stack)
+    val updatedScript = ScriptProgram(updatedStack, scriptTokens, Script)
+    require(updatedStack.stack == stackTokens)
+    require(updatedScript.script == scriptTokens)
+    updatedScript
+  }
+
+  def apply(
+      oldProgram: ExecutionInProgressScriptProgram,
+      stackTokens: Seq[ScriptToken],
+      scriptTokens: Seq[ScriptToken]): ExecutionInProgressScriptProgram = {
     val updatedStack = ScriptProgram(oldProgram, stackTokens, Stack)
     val updatedScript = ScriptProgram(updatedStack, scriptTokens, Script)
     require(updatedStack.stack == stackTokens)
@@ -305,13 +307,7 @@ object ScriptProgram extends BitcoinSLogger {
       indicator: UpdateIndicator,
       lastCodeSeparator: Int): ExecutionInProgressScriptProgram = {
     val updatedIndicator = ScriptProgram(oldProgram, tokens, indicator)
-    updatedIndicator match {
-      case e: ExecutionInProgressScriptProgram =>
-        ScriptProgram(e, lastCodeSeparator)
-      case _: PreExecutionScriptProgram | _: ExecutedScriptProgram =>
-        throw new RuntimeException(
-          "We must have a ExecutionInProgressScriptProgram to update the last OP_CODESEPARATOR index")
-    }
+    ScriptProgram(updatedIndicator, lastCodeSeparator)
   }
 
   /** Updates the [[org.bitcoins.core.script.ScriptProgram.Stack Stack]],
@@ -319,10 +315,27 @@ object ScriptProgram extends BitcoinSLogger {
     * [[org.bitcoins.core.script.ScriptProgram.AltStack AltStack]] of the given
     * [[org.bitcoins.core.script.ScriptProgram ScriptProgram]]. */
   def apply(
-      oldProgram: ScriptProgram,
+      oldProgram: PreExecutionScriptProgram,
       stack: Seq[ScriptToken],
       script: Seq[ScriptToken],
-      altStack: Seq[ScriptToken]): ScriptProgram = {
+      altStack: Seq[ScriptToken]): PreExecutionScriptProgram = {
+    val updatedProgramStack = ScriptProgram(oldProgram, stack, Stack)
+    val updatedProgramScript =
+      ScriptProgram(updatedProgramStack, script, Script)
+    val updatedProgramAltStack =
+      ScriptProgram(updatedProgramScript, altStack, AltStack)
+    updatedProgramAltStack
+  }
+
+  /** Updates the [[org.bitcoins.core.script.ScriptProgram.Stack Stack]],
+    * [[org.bitcoins.core.script.ScriptProgram.Script Script]],
+    * [[org.bitcoins.core.script.ScriptProgram.AltStack AltStack]] of the given
+    * [[org.bitcoins.core.script.ScriptProgram ScriptProgram]]. */
+  def apply(
+      oldProgram: ExecutionInProgressScriptProgram,
+      stack: Seq[ScriptToken],
+      script: Seq[ScriptToken],
+      altStack: Seq[ScriptToken]): ExecutionInProgressScriptProgram = {
     val updatedProgramStack = ScriptProgram(oldProgram, stack, Stack)
     val updatedProgramScript =
       ScriptProgram(updatedProgramStack, script, Script)

--- a/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
@@ -10,8 +10,8 @@ import org.bitcoins.core.script.result._
 import org.bitcoins.core.script.{
   ExecutedScriptProgram,
   ExecutionInProgressScriptProgram,
-  PreExecutionScriptProgram,
-  ScriptProgram
+  ScriptProgram,
+  StartedScriptProgram
 }
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinScriptUtil}
 
@@ -24,35 +24,37 @@ sealed abstract class ArithmeticInterpreter {
   private def logger = BitcoinSLogger.logger
 
   /** a is added to b. */
-  def opAdd(program: ScriptProgram): ScriptProgram = {
+  def opAdd(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_ADD),
             "Script top must be OP_ADD")
     performBinaryArithmeticOperation(program, (x, y) => x + y)
   }
 
   /** Increments the stack top by 1. */
-  def op1Add(program: ScriptProgram): ScriptProgram = {
+  def op1Add(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_1ADD),
             "Script top must be OP_1ADD")
     performUnaryArithmeticOperation(program, x => x + ScriptNumber.one)
   }
 
   /** Decrements the stack top by 1. */
-  def op1Sub(program: ScriptProgram): ScriptProgram = {
+  def op1Sub(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_1SUB),
             "Script top must be OP_1SUB")
     performUnaryArithmeticOperation(program, x => x - ScriptNumber.one)
   }
 
   /** b is subtracted from a. */
-  def opSub(program: ScriptProgram): ScriptProgram = {
+  def opSub(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_SUB),
             "Script top must be OP_SUB")
     performBinaryArithmeticOperation(program, (x, y) => y - x)
   }
 
   /** Takes the absolute value of the stack top. */
-  def opAbs(program: ScriptProgram): ScriptProgram = {
+  def opAbs(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_ABS),
             "Script top must be OP_ABS")
     performUnaryArithmeticOperation(
@@ -65,14 +67,15 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Negates the stack top. */
-  def opNegate(program: ScriptProgram): ScriptProgram = {
+  def opNegate(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NEGATE),
             "Script top must be OP_NEGATE")
     performUnaryArithmeticOperation(program, x => -x)
   }
 
   /** If the input is 0 or 1, it is flipped. Otherwise the output will be 0. */
-  def opNot(program: ScriptProgram): ScriptProgram = {
+  def opNot(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NOT),
             "Script top must be OP_NOT")
     performUnaryArithmeticOperation(
@@ -81,7 +84,8 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Returns 0 if the input is 0. 1 otherwise. */
-  def op0NotEqual(program: ScriptProgram): ScriptProgram = {
+  def op0NotEqual(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_0NOTEQUAL),
             "Script top must be OP_0NOTEQUAL")
     performUnaryArithmeticOperation(
@@ -90,7 +94,8 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** If both a and b are not 0, the output is 1. Otherwise 0. */
-  def opBoolAnd(program: ScriptProgram): ScriptProgram = {
+  def opBoolAnd(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_BOOLAND),
             "Script top must be OP_BOOLAND")
     performBinaryBooleanOperation(program, (x, y) => {
@@ -101,7 +106,8 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** If a or b is not 0, the output is 1. Otherwise 0. */
-  def opBoolOr(program: ScriptProgram): ScriptProgram = {
+  def opBoolOr(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_BOOLOR),
             "Script top must be OP_BOOLOR")
     performBinaryBooleanOperation(program, (x, y) => {
@@ -110,7 +116,8 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Returns 1 if the numbers are equal, 0 otherwise. */
-  def opNumEqual(program: ScriptProgram): ScriptProgram = {
+  def opNumEqual(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NUMEQUAL),
             "Script top must be OP_NUMEQUAL")
     performBinaryBooleanOperation(program, (x, y) => x.numEqual(y))
@@ -118,7 +125,8 @@ sealed abstract class ArithmeticInterpreter {
 
   /** Same as [[org.bitcoins.core.script.arithmetic.OP_NUMEQUAL OP_NUMEQUAL]], but runs
     * [[org.bitcoins.core.script.control.OP_VERIFY OP_VERIFY]] afterward. */
-  def opNumEqualVerify(program: ScriptProgram): ScriptProgram = {
+  def opNumEqualVerify(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NUMEQUALVERIFY),
             "Script top must be OP_NUMEQUALVERIFY")
     if (program.stack.size < 2) {
@@ -128,23 +136,24 @@ sealed abstract class ArithmeticInterpreter {
       val numEqualProgram = ScriptProgram(program,
                                           program.stack,
                                           OP_NUMEQUAL :: program.script.tail)
-      val numEqualResult = opNumEqual(numEqualProgram)
-      numEqualResult match {
-        case _: ExecutionInProgressScriptProgram =>
+      val numEqualResultOrError = opNumEqual(numEqualProgram)
+      numEqualResultOrError match {
+        case numEqualResult: ExecutionInProgressScriptProgram =>
           val verifyProgram = ScriptProgram(numEqualResult,
                                             numEqualResult.stack,
                                             OP_VERIFY :: numEqualResult.script)
           val verifyResult =
             ControlOperationsInterpreter.opVerify(verifyProgram)
           verifyResult
-        case _: PreExecutionScriptProgram | _: ExecutedScriptProgram =>
-          numEqualResult
+        case err: ExecutedScriptProgram =>
+          err
       }
     }
   }
 
   /** Returns 1 if the numbers are not equal, 0 otherwise. */
-  def opNumNotEqual(program: ScriptProgram): ScriptProgram = {
+  def opNumNotEqual(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NUMNOTEQUAL),
             "Script top must be OP_NUMNOTEQUAL")
     performBinaryBooleanOperation(program, (x, y) => {
@@ -153,35 +162,39 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Returns 1 if a is less than b, 0 otherwise. */
-  def opLessThan(program: ScriptProgram): ScriptProgram = {
+  def opLessThan(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_LESSTHAN),
             "Script top must be OP_LESSTHAN")
     performBinaryBooleanOperation(program, (x, y) => y < x)
   }
 
   /** Returns 1 if a is greater than b, 0 otherwise. */
-  def opGreaterThan(program: ScriptProgram): ScriptProgram = {
+  def opGreaterThan(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_GREATERTHAN),
             "Script top must be OP_GREATERTHAN")
     performBinaryBooleanOperation(program, (x, y) => y > x)
   }
 
   /** Returns 1 if a is less than or equal to b, 0 otherwise. */
-  def opLessThanOrEqual(program: ScriptProgram): ScriptProgram = {
+  def opLessThanOrEqual(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_LESSTHANOREQUAL),
             "Script top must be OP_LESSTHANOREQUAL")
     performBinaryBooleanOperation(program, (x, y) => y <= x)
   }
 
   /** Returns 1 if a is greater than or equal to b, 0 otherwise. */
-  def opGreaterThanOrEqual(program: ScriptProgram): ScriptProgram = {
+  def opGreaterThanOrEqual(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_GREATERTHANOREQUAL),
             "Script top must be OP_GREATERTHANOREQUAL")
     performBinaryBooleanOperation(program, (x, y) => y >= x)
   }
 
   /** Returns the smaller of a and b. */
-  def opMin(program: ScriptProgram): ScriptProgram = {
+  def opMin(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_MIN),
             "Script top must be OP_MIN")
     if (program.stack.size < 2) {
@@ -195,7 +208,7 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Returns the larger of a and b. */
-  def opMax(program: ScriptProgram): ScriptProgram = {
+  def opMax(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_MAX),
             "Script top must be OP_MAX")
     if (program.stack.size < 2) {
@@ -209,7 +222,8 @@ sealed abstract class ArithmeticInterpreter {
   }
 
   /** Returns 1 if x is within the specified range (left-inclusive), 0 otherwise. */
-  def opWithin(program: ScriptProgram): ScriptProgram = {
+  def opWithin(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_WITHIN),
             "Script top must be OP_WITHIN")
     if (program.stack.size < 3) {
@@ -260,8 +274,8 @@ sealed abstract class ArithmeticInterpreter {
     */
   @tailrec
   private def performUnaryArithmeticOperation(
-      program: ScriptProgram,
-      op: ScriptNumber => ScriptNumber): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      op: ScriptNumber => ScriptNumber): StartedScriptProgram = {
     program.stack.headOption match {
       case None =>
         logger.error(
@@ -316,8 +330,8 @@ sealed abstract class ArithmeticInterpreter {
     */
   @tailrec
   private def performBinaryArithmeticOperation(
-      program: ScriptProgram,
-      op: (ScriptNumber, ScriptNumber) => ScriptNumber): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      op: (ScriptNumber, ScriptNumber) => ScriptNumber): StartedScriptProgram = {
     if (program.stack.size < 2) {
       logger.error(
         "We must have two elements to perform a binary arithmetic operation")
@@ -384,8 +398,8 @@ sealed abstract class ArithmeticInterpreter {
     * @return the program with either OP_FALSE or OP_TRUE on the stack top
     */
   private def performBinaryBooleanOperation(
-      program: ScriptProgram,
-      op: (ScriptNumber, ScriptNumber) => Boolean): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      op: (ScriptNumber, ScriptNumber) => Boolean): StartedScriptProgram = {
     if (program.stack.size < 2) {
       logger.error("We need two stack elements for a binary boolean operation")
       ScriptProgram(program, ScriptErrorInvalidStackOperation)
@@ -420,8 +434,8 @@ sealed abstract class ArithmeticInterpreter {
     * @return the program with the result of op pushed onto the top of the stack
     */
   private def performComparisonOnTwoStackTopItems(
-      program: ScriptProgram,
-      op: (ScriptNumber, ScriptNumber) => ScriptNumber): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      op: (ScriptNumber, ScriptNumber) => ScriptNumber): StartedScriptProgram = {
     performBinaryArithmeticOperation(program, op)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/script/constant/ConstantInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/ConstantInterpreter.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.core.script.constant
 
-import org.bitcoins.core.script.ScriptProgram
+import org.bitcoins.core.script.{
+  ExecutionInProgressScriptProgram,
+  ScriptProgram,
+  StartedScriptProgram
+}
 import org.bitcoins.core.script.flag.ScriptFlagUtil
 import org.bitcoins.core.script.result._
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, BitcoinScriptUtil}
@@ -14,28 +18,32 @@ sealed abstract class ConstantInterpreter {
   private def logger = BitcoinSLogger.logger
 
   /** The next byte contains the number of bytes to be pushed onto the stack. */
-  def opPushData1(program: ScriptProgram): ScriptProgram = {
+  def opPushData1(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_PUSHDATA1),
             "Top of script stack must be OP_PUSHDATA1")
     opPushData(program)
   }
 
   /** The next two bytes contain the number of bytes to be pushed onto the stack. */
-  def opPushData2(program: ScriptProgram): ScriptProgram = {
+  def opPushData2(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_PUSHDATA2),
             "Top of script stack must be OP_PUSHDATA2")
     opPushData(program)
   }
 
   /** The next four bytes contain the number of bytes to be pushed onto the stack. */
-  def opPushData4(program: ScriptProgram): ScriptProgram = {
+  def opPushData4(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_PUSHDATA4),
             "Top of script stack must be OP_PUSHDATA4")
     opPushData(program)
   }
 
   /** Pushes the number of bytes onto the stack that is specified by script number on the script stack. */
-  def pushScriptNumberBytesToStack(program: ScriptProgram): ScriptProgram = {
+  def pushScriptNumberBytesToStack(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     val bytesNeeded: Long = program.script.head match {
       case OP_PUSHDATA1 | OP_PUSHDATA2 | OP_PUSHDATA4 =>
         bytesNeededForPushOp(program.script(1))
@@ -108,7 +116,8 @@ sealed abstract class ConstantInterpreter {
     * Checks if the MINIMALDATA script flag is set, if so checks if we are using the minimal push operation
     * if we are, then we push the bytes onto the stack.
     */
-  private def opPushData(program: ScriptProgram): ScriptProgram = {
+  private def opPushData(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     //for the case when we have the minimal data flag and the bytes to push onto stack is represented by the
     //constant telling OP_PUSHDATA how many bytes need to go onto the stack
     //for instance OP_PUSHDATA1 OP_0

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
@@ -13,8 +13,6 @@ import org.bitcoins.core.script.{ScriptProgram, _}
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinScriptUtil, CryptoUtil}
 import scodec.bits.ByteVector
 
-import scala.annotation.tailrec
-
 /**
   * Created by chris on 1/6/16.
   */
@@ -23,35 +21,40 @@ sealed abstract class CryptoInterpreter {
   private def logger = BitcoinSLogger.logger
 
   /** The input is hashed twice: first with SHA-256 and then with RIPEMD-160. */
-  def opHash160(program: ScriptProgram): ScriptProgram = {
+  def opHash160(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_HASH160),
             "Script operation must be OP_HASH160")
     executeHashFunction(program, CryptoUtil.sha256Hash160(_: ByteVector))
   }
 
   /** The input is hashed using RIPEMD-160. */
-  def opRipeMd160(program: ScriptProgram): ScriptProgram = {
+  def opRipeMd160(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_RIPEMD160),
             "Script operation must be OP_RIPEMD160")
     executeHashFunction(program, CryptoUtil.ripeMd160(_: ByteVector))
   }
 
   /** The input is hashed using SHA-256. */
-  def opSha256(program: ScriptProgram): ScriptProgram = {
+  def opSha256(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_SHA256),
             "Script operation must be OP_SHA256")
     executeHashFunction(program, CryptoUtil.sha256(_: ByteVector))
   }
 
   /** The input is hashed two times with SHA-256. */
-  def opHash256(program: ScriptProgram): ScriptProgram = {
+  def opHash256(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_HASH256),
             "Script operation must be OP_HASH256")
     executeHashFunction(program, CryptoUtil.doubleSHA256(_: ByteVector))
   }
 
   /** The input is hashed using SHA-1. */
-  def opSha1(program: ScriptProgram): ScriptProgram = {
+  def opSha1(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_SHA1),
             "Script top must be OP_SHA1")
     executeHashFunction(program, CryptoUtil.sha1(_: ByteVector))
@@ -65,47 +68,38 @@ sealed abstract class CryptoInterpreter {
     * must be a valid signature for this hash and public key.
     * [[https://github.com/bitcoin/bitcoin/blob/528472111b4965b1a99c4bcf08ac5ec93d87f10f/src/script/interpreter.cpp#L880]]
     */
-  def opCheckSig(program: ScriptProgram): ScriptProgram = {
+  def opCheckSig(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CHECKSIG),
             "Script top must be OP_CHECKSIG")
-    program match {
-      case preExecutionScriptProgram: PreExecutionScriptProgram =>
-        opCheckSig(
-          ScriptProgram.toExecutionInProgress(preExecutionScriptProgram))
-      case executedScriptprogram: ExecutedScriptProgram =>
-        executedScriptprogram
-      case executionInProgressScriptProgram: ExecutionInProgressScriptProgram =>
-        if (executionInProgressScriptProgram.stack.size < 2) {
-          logger.error("OP_CHECKSIG requires at lest two stack elements")
-          ScriptProgram(program, ScriptErrorInvalidStackOperation)
-        } else {
-          val pubKey = ECPublicKey(
-            executionInProgressScriptProgram.stack.head.bytes)
-          val signature = ECDigitalSignature(
-            executionInProgressScriptProgram.stack.tail.head.bytes)
-          val flags = executionInProgressScriptProgram.flags
-          val restOfStack = executionInProgressScriptProgram.stack.tail.tail
-          logger.debug(
-            "Program before removing OP_CODESEPARATOR: " + program.originalScript)
-          val removedOpCodeSeparatorsScript =
-            BitcoinScriptUtil.removeOpCodeSeparator(
-              executionInProgressScriptProgram)
-          logger.debug(
-            "Program after removing OP_CODESEPARATOR: " + removedOpCodeSeparatorsScript)
-          val result = TransactionSignatureChecker.checkSignature(
-            executionInProgressScriptProgram.txSignatureComponent,
-            removedOpCodeSeparatorsScript,
-            pubKey,
-            signature,
-            flags)
-          handleSignatureValidation(program, result, restOfStack)
-        }
+    if (program.stack.size < 2) {
+      logger.error("OP_CHECKSIG requires at lest two stack elements")
+      ScriptProgram(program, ScriptErrorInvalidStackOperation)
+    } else {
+      val pubKey = ECPublicKey(program.stack.head.bytes)
+      val signature = ECDigitalSignature(program.stack.tail.head.bytes)
+      val flags = program.flags
+      val restOfStack = program.stack.tail.tail
+      logger.debug(
+        "Program before removing OP_CODESEPARATOR: " + program.originalScript)
+      val removedOpCodeSeparatorsScript =
+        BitcoinScriptUtil.removeOpCodeSeparator(program)
+      logger.debug(
+        "Program after removing OP_CODESEPARATOR: " + removedOpCodeSeparatorsScript)
+      val result = TransactionSignatureChecker.checkSignature(
+        program.txSignatureComponent,
+        removedOpCodeSeparatorsScript,
+        pubKey,
+        signature,
+        flags)
+      handleSignatureValidation(program, result, restOfStack)
     }
   }
 
   /** Runs [[org.bitcoins.core.script.crypto.OP_CHECKSIG OP_CHECKSIG]] with an
     * [[org.bitcoins.core.script.control.OP_VERIFY OP_VERIFY]] afterwards. */
-  def opCheckSigVerify(program: ScriptProgram): ScriptProgram = {
+  def opCheckSigVerify(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CHECKSIGVERIFY),
             "Script top must be OP_CHECKSIGVERIFY")
     if (program.stack.size < 2) {
@@ -118,10 +112,10 @@ sealed abstract class CryptoInterpreter {
       logger.debug(
         "Stack after OP_CHECKSIG execution: " + programFromOpCheckSig.stack)
       programFromOpCheckSig match {
-        case _: PreExecutionScriptProgram | _: ExecutedScriptProgram =>
+        case _: ExecutedScriptProgram =>
           programFromOpCheckSig
-        case _: ExecutionInProgressScriptProgram =>
-          ControlOperationsInterpreter.opVerify(programFromOpCheckSig)
+        case p: ExecutionInProgressScriptProgram =>
+          ControlOperationsInterpreter.opVerify(p)
       }
     }
   }
@@ -131,22 +125,16 @@ sealed abstract class CryptoInterpreter {
     * after the most recently-executed
     * [[org.bitcoins.core.script.crypto.OP_CODESEPARATOR OP_CODESEPARATOR]].
     */
-  def opCodeSeparator(program: ScriptProgram): ScriptProgram = {
+  def opCodeSeparator(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CODESEPARATOR),
             "Script top must be OP_CODESEPARATOR")
-    val e = program match {
-      case e: PreExecutionScriptProgram =>
-        opCodeSeparator(ScriptProgram.toExecutionInProgress(e))
-      case e: ExecutionInProgressScriptProgram =>
-        val indexOfOpCodeSeparator = program.originalScript.size - program.script.size
-        ScriptProgram(e,
-                      program.script.tail,
-                      ScriptProgram.Script,
-                      indexOfOpCodeSeparator)
-      case e: ExecutedScriptProgram =>
-        ScriptProgram(e, ScriptErrorUnknownError)
-    }
-    e
+
+    val indexOfOpCodeSeparator = program.originalScript.size - program.script.size
+    ScriptProgram(program,
+                  program.script.tail,
+                  ScriptProgram.Script,
+                  indexOfOpCodeSeparator)
   }
 
   /**
@@ -160,130 +148,114 @@ sealed abstract class CryptoInterpreter {
     * were placed in the scriptPubKey or redeemScript. If all signatures are valid, 1 is returned, 0 otherwise.
     * Due to a bug, one extra unused value is removed from the stack.
     */
-  @tailrec
-  final def opCheckMultiSig(program: ScriptProgram): ScriptProgram = {
+  final def opCheckMultiSig(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CHECKMULTISIG),
             "Script top must be OP_CHECKMULTISIG")
     val flags = program.flags
-    program match {
-      case preExecutionScriptProgram: PreExecutionScriptProgram =>
-        opCheckMultiSig(
-          ScriptProgram.toExecutionInProgress(preExecutionScriptProgram))
-      case executedScriptProgram: ExecutedScriptProgram =>
-        executedScriptProgram
-      case executionInProgressScriptProgram: ExecutionInProgressScriptProgram =>
-        if (program.stack.size < 1) {
-          logger.error("OP_CHECKMULTISIG requires at least 1 stack elements")
-          ScriptProgram(executionInProgressScriptProgram,
-                        ScriptErrorInvalidStackOperation)
-        } else {
-          //these next lines remove the appropriate stack/script values after the signatures have been checked
-          val nPossibleSignatures: ScriptNumber =
-            BitcoinScriptUtil.numPossibleSignaturesOnStack(program)
-          if (nPossibleSignatures < ScriptNumber.zero) {
-            logger.error(
-              "We cannot have the number of pubkeys in the script be negative")
-            ScriptProgram(program, ScriptErrorPubKeyCount)
-          } else if (ScriptFlagUtil.requireMinimalData(flags) && !nPossibleSignatures.isShortestEncoding) {
-            logger.error(
-              "The required signatures and the possible signatures must be encoded as the shortest number possible")
-            ScriptProgram(executionInProgressScriptProgram,
-                          ScriptErrorUnknownError)
-          } else if (program.stack.size < 2) {
-            logger.error("We need at least 2 operations on the stack")
-            ScriptProgram(executionInProgressScriptProgram,
-                          ScriptErrorInvalidStackOperation)
-          } else {
-            val mRequiredSignatures: ScriptNumber =
-              BitcoinScriptUtil.numRequiredSignaturesOnStack(program)
 
-            if (ScriptFlagUtil.requireMinimalData(flags) && !mRequiredSignatures.isShortestEncoding) {
-              logger.error(
-                "The required signatures val must be the shortest encoding as possible")
-              return ScriptProgram(executionInProgressScriptProgram,
-                                   ScriptErrorUnknownError)
-            }
+    if (program.stack.size < 1) {
+      logger.error("OP_CHECKMULTISIG requires at least 1 stack elements")
+      ScriptProgram(program, ScriptErrorInvalidStackOperation)
+    } else {
+      //these next lines remove the appropriate stack/script values after the signatures have been checked
+      val nPossibleSignatures: ScriptNumber =
+        BitcoinScriptUtil.numPossibleSignaturesOnStack(program)
+      if (nPossibleSignatures < ScriptNumber.zero) {
+        logger.error(
+          "We cannot have the number of pubkeys in the script be negative")
+        ScriptProgram(program, ScriptErrorPubKeyCount)
+      } else if (ScriptFlagUtil.requireMinimalData(flags) && !nPossibleSignatures.isShortestEncoding) {
+        logger.error(
+          "The required signatures and the possible signatures must be encoded as the shortest number possible")
+        ScriptProgram(program, ScriptErrorUnknownError)
+      } else if (program.stack.size < 2) {
+        logger.error("We need at least 2 operations on the stack")
+        ScriptProgram(program, ScriptErrorInvalidStackOperation)
+      } else {
+        val mRequiredSignatures: ScriptNumber =
+          BitcoinScriptUtil.numRequiredSignaturesOnStack(program)
 
-            if (mRequiredSignatures < ScriptNumber.zero) {
-              logger.error(
-                "We cannot have the number of signatures specified in the script be negative")
-              return ScriptProgram(executionInProgressScriptProgram,
-                                   ScriptErrorSigCount)
-            }
-            logger.debug("nPossibleSignatures: " + nPossibleSignatures)
-            val (pubKeysScriptTokens, stackWithoutPubKeys) =
-              (program.stack.tail.slice(0, nPossibleSignatures.toInt),
-               program.stack.tail
-                 .slice(nPossibleSignatures.toInt, program.stack.tail.size))
-
-            val pubKeys = pubKeysScriptTokens.map(key => ECPublicKey(key.bytes))
-            logger.debug("Public keys on the stack: " + pubKeys)
-            logger.debug("Stack without pubkeys: " + stackWithoutPubKeys)
-            logger.debug("mRequiredSignatures: " + mRequiredSignatures)
-
-            //+1 is for the fact that we have the # of sigs + the script token indicating the # of sigs
-            val signaturesScriptTokens = program.stack.tail.slice(
-              nPossibleSignatures.toInt + 1,
-              nPossibleSignatures.toInt + mRequiredSignatures.toInt + 1)
-            val signatures = signaturesScriptTokens.map(token =>
-              ECDigitalSignature(token.bytes))
-            logger.debug("Signatures on the stack: " + signatures)
-
-            //this contains the extra Script OP that is required for OP_CHECKMULTISIG
-            val stackWithoutPubKeysAndSignatures = stackWithoutPubKeys.tail
-              .slice(mRequiredSignatures.toInt, stackWithoutPubKeys.tail.size)
-            logger.debug(
-              "stackWithoutPubKeysAndSignatures: " + stackWithoutPubKeysAndSignatures)
-            if (pubKeys.size > Consensus.maxPublicKeysPerMultiSig) {
-              logger.error(
-                "We have more public keys than the maximum amount of public keys allowed")
-              ScriptProgram(executionInProgressScriptProgram,
-                            ScriptErrorPubKeyCount)
-            } else if (signatures.size > pubKeys.size) {
-              logger.error(
-                "We have more signatures than public keys inside OP_CHECKMULTISIG")
-              ScriptProgram(executionInProgressScriptProgram,
-                            ScriptErrorSigCount)
-            } else if (stackWithoutPubKeysAndSignatures.size < 1) {
-              logger.error(
-                "OP_CHECKMULTISIG must have a remaining element on the stack afterk execution")
-              //this is because of a bug in bitcoin core for the implementation of OP_CHECKMULTISIG
-              //https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L966
-              ScriptProgram(executionInProgressScriptProgram,
-                            ScriptErrorInvalidStackOperation)
-            } else if (ScriptFlagUtil.requireNullDummy(flags) &&
-                       (stackWithoutPubKeysAndSignatures.nonEmpty && stackWithoutPubKeysAndSignatures.head.bytes.nonEmpty)) {
-              logger.error(
-                "Script flag null dummy was set however the first element in the script signature was not an OP_0, stackWithoutPubKeysAndSignatures: " + stackWithoutPubKeysAndSignatures)
-              ScriptProgram(executionInProgressScriptProgram,
-                            ScriptErrorSigNullDummy)
-            } else {
-              //remove the last OP_CODESEPARATOR
-              val removedOpCodeSeparatorsScript =
-                BitcoinScriptUtil.removeOpCodeSeparator(
-                  executionInProgressScriptProgram)
-              val isValidSignatures: TransactionSignatureCheckerResult =
-                TransactionSignatureChecker.multiSignatureEvaluator(
-                  executionInProgressScriptProgram.txSignatureComponent,
-                  removedOpCodeSeparatorsScript,
-                  signatures,
-                  pubKeys,
-                  flags,
-                  mRequiredSignatures.toLong)
-
-              //remove the extra OP_0 (null dummy) for OP_CHECKMULTISIG from the stack
-              val restOfStack = stackWithoutPubKeysAndSignatures.tail
-              handleSignatureValidation(program, isValidSignatures, restOfStack)
-            }
-          }
+        if (ScriptFlagUtil.requireMinimalData(flags) && !mRequiredSignatures.isShortestEncoding) {
+          logger.error(
+            "The required signatures val must be the shortest encoding as possible")
+          return ScriptProgram(program, ScriptErrorUnknownError)
         }
+
+        if (mRequiredSignatures < ScriptNumber.zero) {
+          logger.error(
+            "We cannot have the number of signatures specified in the script be negative")
+          return ScriptProgram(program, ScriptErrorSigCount)
+        }
+        logger.debug("nPossibleSignatures: " + nPossibleSignatures)
+        val (pubKeysScriptTokens, stackWithoutPubKeys) =
+          (program.stack.tail.slice(0, nPossibleSignatures.toInt),
+           program.stack.tail
+             .slice(nPossibleSignatures.toInt, program.stack.tail.size))
+
+        val pubKeys = pubKeysScriptTokens.map(key => ECPublicKey(key.bytes))
+        logger.debug("Public keys on the stack: " + pubKeys)
+        logger.debug("Stack without pubkeys: " + stackWithoutPubKeys)
+        logger.debug("mRequiredSignatures: " + mRequiredSignatures)
+
+        //+1 is for the fact that we have the # of sigs + the script token indicating the # of sigs
+        val signaturesScriptTokens = program.stack.tail.slice(
+          nPossibleSignatures.toInt + 1,
+          nPossibleSignatures.toInt + mRequiredSignatures.toInt + 1)
+        val signatures =
+          signaturesScriptTokens.map(token => ECDigitalSignature(token.bytes))
+        logger.debug("Signatures on the stack: " + signatures)
+
+        //this contains the extra Script OP that is required for OP_CHECKMULTISIG
+        val stackWithoutPubKeysAndSignatures = stackWithoutPubKeys.tail
+          .slice(mRequiredSignatures.toInt, stackWithoutPubKeys.tail.size)
+        logger.debug(
+          "stackWithoutPubKeysAndSignatures: " + stackWithoutPubKeysAndSignatures)
+        if (pubKeys.size > Consensus.maxPublicKeysPerMultiSig) {
+          logger.error(
+            "We have more public keys than the maximum amount of public keys allowed")
+          ScriptProgram(program, ScriptErrorPubKeyCount)
+        } else if (signatures.size > pubKeys.size) {
+          logger.error(
+            "We have more signatures than public keys inside OP_CHECKMULTISIG")
+          ScriptProgram(program, ScriptErrorSigCount)
+        } else if (stackWithoutPubKeysAndSignatures.size < 1) {
+          logger.error(
+            "OP_CHECKMULTISIG must have a remaining element on the stack afterk execution")
+          //this is because of a bug in bitcoin core for the implementation of OP_CHECKMULTISIG
+          //https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L966
+          ScriptProgram(program, ScriptErrorInvalidStackOperation)
+        } else if (ScriptFlagUtil.requireNullDummy(flags) &&
+                   (stackWithoutPubKeysAndSignatures.nonEmpty && stackWithoutPubKeysAndSignatures.head.bytes.nonEmpty)) {
+          logger.error(
+            "Script flag null dummy was set however the first element in the script signature was not an OP_0, stackWithoutPubKeysAndSignatures: " + stackWithoutPubKeysAndSignatures)
+          ScriptProgram(program, ScriptErrorSigNullDummy)
+        } else {
+          //remove the last OP_CODESEPARATOR
+          val removedOpCodeSeparatorsScript =
+            BitcoinScriptUtil.removeOpCodeSeparator(program)
+          val isValidSignatures: TransactionSignatureCheckerResult =
+            TransactionSignatureChecker.multiSignatureEvaluator(
+              program.txSignatureComponent,
+              removedOpCodeSeparatorsScript,
+              signatures,
+              pubKeys,
+              flags,
+              mRequiredSignatures.toLong)
+
+          //remove the extra OP_0 (null dummy) for OP_CHECKMULTISIG from the stack
+          val restOfStack = stackWithoutPubKeysAndSignatures.tail
+          handleSignatureValidation(program, isValidSignatures, restOfStack)
+        }
+      }
     }
   }
 
   /** Runs
     * [[org.bitcoins.core.script.crypto.OP_CHECKMULTISIG OP_CHECKMULTISIG]] with an
     * [[org.bitcoins.core.script.control.OP_VERIFY OP_VERIFY]] afterwards */
-  def opCheckMultiSigVerify(program: ScriptProgram): ScriptProgram = {
+  def opCheckMultiSigVerify(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CHECKMULTISIGVERIFY),
             "Script top must be OP_CHECKMULTISIGVERIFY")
     if (program.stack.size < 3) {
@@ -297,10 +269,10 @@ sealed abstract class CryptoInterpreter {
       logger.debug(
         "Stack after OP_CHECKMULTSIG execution: " + programFromOpCheckMultiSig.stack)
       programFromOpCheckMultiSig match {
-        case _: PreExecutionScriptProgram | _: ExecutedScriptProgram =>
+        case _: ExecutedScriptProgram =>
           programFromOpCheckMultiSig
-        case _: ExecutionInProgressScriptProgram =>
-          ControlOperationsInterpreter.opVerify(programFromOpCheckMultiSig)
+        case p: ExecutionInProgressScriptProgram =>
+          ControlOperationsInterpreter.opVerify(p)
       }
     }
   }
@@ -314,8 +286,8 @@ sealed abstract class CryptoInterpreter {
     * @return
     */
   private def executeHashFunction(
-      program: ScriptProgram,
-      hashFunction: ByteVector => HashDigest): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      hashFunction: ByteVector => HashDigest): StartedScriptProgram = {
     if (program.stack.nonEmpty) {
       val stackTop = program.stack.head
       val hash = ScriptConstant(hashFunction(stackTop.bytes).bytes)
@@ -328,9 +300,9 @@ sealed abstract class CryptoInterpreter {
   }
 
   private def handleSignatureValidation(
-      program: ScriptProgram,
+      program: ExecutionInProgressScriptProgram,
       result: TransactionSignatureCheckerResult,
-      restOfStack: Seq[ScriptToken]): ScriptProgram = result match {
+      restOfStack: Seq[ScriptToken]): StartedScriptProgram = result match {
     case SignatureValidationSuccess =>
       //means that all of the signatures were correctly encoded and
       //that all of the signatures were valid signatures for the given

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
@@ -2,7 +2,11 @@ package org.bitcoins.core.script.locktime
 
 import org.bitcoins.core.number.{Int64, UInt32}
 import org.bitcoins.core.protocol.transaction.TransactionConstants
-import org.bitcoins.core.script.ScriptProgram
+import org.bitcoins.core.script.{
+  ExecutionInProgressScriptProgram,
+  ScriptProgram,
+  StartedScriptProgram
+}
 import org.bitcoins.core.script.constant.{
   ScriptConstant,
   ScriptNumber,
@@ -32,7 +36,8 @@ sealed abstract class LockTimeInterpreter {
     * The precise semantics are described in BIP 0065
     */
   @tailrec
-  final def opCheckLockTimeVerify(program: ScriptProgram): ScriptProgram = {
+  final def opCheckLockTimeVerify(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_CHECKLOCKTIMEVERIFY),
             "Script top must be OP_CHECKLOCKTIMEVERIFY")
     val input = program.txSignatureComponent.transaction
@@ -98,7 +103,8 @@ sealed abstract class LockTimeInterpreter {
     * See [[https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki BIP112]] for more information
     */
   @tailrec
-  final def opCheckSequenceVerify(program: ScriptProgram): ScriptProgram = {
+  final def opCheckSequenceVerify(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     if (program.stack.isEmpty) {
       logger.error("Cannot execute OP_CHECKSEQUENCEVERIFY on an empty stack")
       ScriptProgram(program, ScriptErrorInvalidStackOperation)

--- a/core/src/main/scala/org/bitcoins/core/script/splice/SpliceInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/splice/SpliceInterpreter.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.core.script.splice
 
-import org.bitcoins.core.script.ScriptProgram
+import org.bitcoins.core.script.{
+  ExecutionInProgressScriptProgram,
+  ScriptProgram,
+  StartedScriptProgram
+}
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.result.ScriptErrorInvalidStackOperation
 import org.bitcoins.core.util.BitcoinSLogger
@@ -13,7 +17,8 @@ sealed abstract class SpliceInterpreter {
   private def logger = BitcoinSLogger.logger
 
   /** Pushes the string length of the top element of the stack (without popping it). */
-  def opSize(program: ScriptProgram): ScriptProgram = {
+  def opSize(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_SIZE),
             "Script top must be OP_SIZE")
     if (program.stack.nonEmpty) {

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.core.script.stack
 
-import org.bitcoins.core.script.ScriptProgram
+import org.bitcoins.core.script.{
+  ExecutionInProgressScriptProgram,
+  ScriptProgram,
+  StartedScriptProgram
+}
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.flag.ScriptFlagUtil
 import org.bitcoins.core.script.result._
@@ -20,7 +24,7 @@ sealed abstract class StackInterpreter {
     * Duplicates the element on top of the stack
     * expects the first element in script to be the OP_DUP operation.
     */
-  def opDup(program: ScriptProgram): ScriptProgram = {
+  def opDup(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_DUP),
             "Top of the script stack must be OP_DUP")
     program.stack match {
@@ -33,7 +37,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** If the top stack value is not 0, duplicate it. */
-  def opIfDup(program: ScriptProgram): ScriptProgram = {
+  def opIfDup(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_IFDUP),
             "Top of the script stack must be OP_DUP")
     if (program.stack.nonEmpty) {
@@ -49,7 +54,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Puts the number of stack items onto the stack. */
-  def opDepth(program: ScriptProgram): ScriptProgram = {
+  def opDepth(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_DEPTH),
             "Top of script stack must be OP_DEPTH")
     val stackSize = program.stack.size
@@ -58,7 +64,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Puts the input onto the top of the alt stack. Removes it from the main stack. */
-  def opToAltStack(program: ScriptProgram): ScriptProgram = {
+  def opToAltStack(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_TOALTSTACK),
             "Top of script stack must be OP_TOALTSTACK")
     if (program.stack.nonEmpty) {
@@ -73,7 +80,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Puts the input onto the top of the main stack. Removes it from the alt stack. */
-  def opFromAltStack(program: ScriptProgram): ScriptProgram = {
+  def opFromAltStack(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_FROMALTSTACK),
             "Top of script stack must be OP_FROMALTSTACK")
     if (program.altStack.nonEmpty) {
@@ -89,7 +97,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Removes the top stack item. */
-  def opDrop(program: ScriptProgram): ScriptProgram = {
+  def opDrop(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_DROP),
             "Top of script stack must be OP_DROP")
     if (program.stack.nonEmpty) {
@@ -101,7 +110,7 @@ sealed abstract class StackInterpreter {
   }
 
   /** Removes the second-to-top stack item. */
-  def opNip(program: ScriptProgram): ScriptProgram = {
+  def opNip(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NIP),
             "Top of script stack must be OP_NIP")
     program.stack match {
@@ -116,7 +125,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Copies the second-to-top stack item to the top. */
-  def opOver(program: ScriptProgram): ScriptProgram = {
+  def opOver(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_OVER),
             "Top of script stack must be OP_OVER")
     program.stack match {
@@ -132,7 +142,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** The item n back in the stack is copied to the top. */
-  def opPick(program: ScriptProgram): ScriptProgram = {
+  def opPick(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_PICK),
             "Top of script stack must be OP_PICK")
     executeOpWithStackTopAsNumberArg(
@@ -155,7 +166,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** The item n back in the stack is moved to the top. */
-  def opRoll(program: ScriptProgram): ScriptProgram = {
+  def opRoll(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_ROLL),
             "Top of script stack must be OP_ROLL")
     executeOpWithStackTopAsNumberArg(
@@ -181,7 +193,7 @@ sealed abstract class StackInterpreter {
     * The top three items on the stack are rotated to the left.
     * Ex: x1 x2 x3 -> x2 x3 x1
     */
-  def opRot(program: ScriptProgram): ScriptProgram = {
+  def opRot(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_ROT),
             "Top of script stack must be OP_ROT")
     program.stack match {
@@ -198,7 +210,8 @@ sealed abstract class StackInterpreter {
     * The fifth and sixth items back are moved to the top of the stack.
     * Ex. x1 x2 x3 x4 x5 x6 -> x3 x4 x5 x6 x1 x2
     */
-  def op2Rot(program: ScriptProgram): ScriptProgram = {
+  def op2Rot(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_2ROT),
             "Top of script stack must be OP_2ROT")
     program.stack match {
@@ -212,7 +225,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Removes the top two stack items. */
-  def op2Drop(program: ScriptProgram): ScriptProgram = {
+  def op2Drop(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_2DROP),
             "Top of script stack must be OP_2DROP")
     if (program.stack.size > 1) {
@@ -224,7 +238,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** The top two items on the stack are swapped. */
-  def opSwap(program: ScriptProgram): ScriptProgram = {
+  def opSwap(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_SWAP),
             "Top of script stack must be OP_SWAP")
     if (program.stack.size > 1) {
@@ -237,7 +252,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** The item at the top of the stack is copied and inserted before the second-to-top item. */
-  def opTuck(program: ScriptProgram): ScriptProgram = {
+  def opTuck(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_TUCK),
             "Top of script stack must be OP_TUCK")
     program.stack match {
@@ -251,7 +267,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Duplicates the top two stack items. */
-  def op2Dup(program: ScriptProgram): ScriptProgram = {
+  def op2Dup(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_2DUP),
             "Top of script stack must be OP_2DUP")
     program.stack match {
@@ -265,7 +282,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Duplicates the top three stack items. */
-  def op3Dup(program: ScriptProgram): ScriptProgram = {
+  def op3Dup(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_3DUP),
             "Top of script stack must be OP_3DUP")
     program.stack match {
@@ -279,7 +297,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Copies the pair of items two spaces back in the stack to the front. */
-  def op2Over(program: ScriptProgram): ScriptProgram = {
+  def op2Over(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_2OVER),
             "Top of script stack must be OP_2OVER")
     program.stack match {
@@ -293,7 +312,8 @@ sealed abstract class StackInterpreter {
   }
 
   /** Swaps the top two pairs of items. */
-  def op2Swap(program: ScriptProgram): ScriptProgram = {
+  def op2Swap(
+      program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_2SWAP),
             "Top of script stack must be OP_2SWAP")
     program.stack match {
@@ -313,8 +333,8 @@ sealed abstract class StackInterpreter {
     * @return the program with the result of the op pushed onto to the top of the stack
     */
   private def executeOpWithStackTopAsNumberArg(
-      program: ScriptProgram,
-      op: ScriptNumber => ScriptProgram): ScriptProgram = {
+      program: ExecutionInProgressScriptProgram,
+      op: ScriptNumber => StartedScriptProgram): StartedScriptProgram = {
     program.stack.head match {
       case scriptNum: ScriptNumber => op(scriptNum)
       case _: ScriptToken          =>


### PR DESCRIPTION
In order of commits, this PR:

1) Does a major refactor to the ScriptProgram ADT so that most operations can no longer be performed on PreExecutionScriptPrograms or ExecutedScriptPrograms and can only be performed on ExecutionInProgressScriptPrograms. It also tightens up the input and output types of functions so that not everything is just ScriptProgram => ScriptProgram (this removed a lot of throws!). It replaces methods that are ScriptProgram => ScriptProgram that match on the three types and return the same type as the input into multiple methods with nicer types. Lastly, it refactors ScriptInterpreter.loop to be much nicer and only take in ExecutionInProgressScriptPrograms.
2) Fixes the problem I now had with ScriptInterpreter.loop where it cannot recognize that it is tailrec by moving all calls to loop and loopOrComplete to the bottom of the method.
3) Fix all tests that are now broken by simply turning all PreExecutionScriptPrograms into ExecutionInProgressScriptPrograms.

Formerly the last 3 commits of #771