### PR TITLE
P2WSH Signer!

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -433,21 +433,35 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
                                          dummySignatures)
           result.map(_.transaction)
         case p2wshSPK: P2WSHWitnessSPKV0 =>
-          val p2wshScriptWit = scriptWitnessOpt match {
-            case Some(wit) =>
-              wit match {
-                case EmptyScriptWitness | _: P2WPKHWitnessV0 =>
-                  Future.fromTry(TxBuilderError.WrongWitness)
-                case x: P2WSHWitnessV0 => Future.successful(x)
-              }
-            case None => Future.fromTry(TxBuilderError.NoWitness)
+          val p2wshScriptWitF = scriptWitnessOpt match {
+            case Some(EmptyScriptWitness | _: P2WPKHWitnessV0) =>
+              Future.fromTry(TxBuilderError.WrongWitness)
+            case Some(x: P2WSHWitnessV0) => Future.successful(x)
+            case None                    => Future.fromTry(TxBuilderError.NoWitness)
           }
-          val redeemScriptEither = p2wshScriptWit.map(_.redeemScript)
-          val result = redeemScriptEither.flatMap { redeemScript =>
+          val redeemScriptF = p2wshScriptWitF.map(_.redeemScript)
+          val validatedRedeemScriptF = redeemScriptF.flatMap { redeemScript =>
             if (P2WSHWitnessSPKV0(redeemScript) != p2wshSPK) {
               Future.fromTry(TxBuilderError.WrongWitness)
             } else {
-              redeemScript match {
+              Future.successful(redeemScript)
+            }
+          }
+          val sigComponentF = validatedRedeemScriptF.flatMap {
+            case _: P2PKScriptPubKey | _: P2PKHScriptPubKey |
+                _: MultiSignatureScriptPubKey =>
+              P2WSHSigner.sign(signers,
+                               output,
+                               unsignedTx,
+                               inputIndex,
+                               hashType,
+                               dummySignatures)
+            case _: P2WPKHWitnessSPKV0 | _: P2WSHWitnessSPKV0 =>
+              Future.fromTry(TxBuilderError.NestedWitnessSPK)
+            case _: P2SHScriptPubKey =>
+              Future.fromTry(TxBuilderError.NestedP2SHSPK)
+            case lock: LockTimeScriptPubKey =>
+              lock.nestedScriptPubKey match {
                 case _: P2PKScriptPubKey | _: P2PKHScriptPubKey |
                     _: MultiSignatureScriptPubKey =>
                   P2WSHSigner.sign(signers,
@@ -456,43 +470,20 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
                                    inputIndex,
                                    hashType,
                                    dummySignatures)
-                case _: P2WPKHWitnessSPKV0 | _: P2WSHWitnessSPKV0 =>
-                  Future.fromTry(TxBuilderError.NestedWitnessSPK)
                 case _: P2SHScriptPubKey =>
                   Future.fromTry(TxBuilderError.NestedP2SHSPK)
-                case lock: LockTimeScriptPubKey =>
-                  lock.nestedScriptPubKey match {
-                    case _: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-                        _: MultiSignatureScriptPubKey =>
-                      P2WSHSigner.sign(signers,
-                                       output,
-                                       unsignedTx,
-                                       inputIndex,
-                                       hashType,
-                                       dummySignatures)
-                    case _: P2WPKHWitnessSPKV0 =>
-                      P2WPKHSigner.sign(signers,
-                                        output,
-                                        unsignedTx,
-                                        inputIndex,
-                                        hashType,
-                                        dummySignatures)
-                    case _: P2SHScriptPubKey =>
-                      Future.fromTry(TxBuilderError.NestedP2SHSPK)
-                    case _: P2WSHWitnessSPKV0 =>
-                      Future.fromTry(TxBuilderError.NestedWitnessSPK)
-                    case _: CSVScriptPubKey | _: CLTVScriptPubKey |
-                        _: NonStandardScriptPubKey | _: WitnessCommitment |
-                        EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey =>
-                      Future.fromTry(TxBuilderError.NoSigner)
-                  }
-                case _: NonStandardScriptPubKey | _: WitnessCommitment |
+                case _: P2WSHWitnessSPKV0 | _: P2WPKHWitnessSPKV0 =>
+                  Future.fromTry(TxBuilderError.NestedWitnessSPK)
+                case _: CSVScriptPubKey | _: CLTVScriptPubKey |
+                    _: NonStandardScriptPubKey | _: WitnessCommitment |
                     EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey =>
                   Future.fromTry(TxBuilderError.NoSigner)
               }
-            }
+            case _: NonStandardScriptPubKey | _: WitnessCommitment |
+                EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey =>
+              Future.fromTry(TxBuilderError.NoSigner)
           }
-          result.map(_.transaction)
+          sigComponentF.map(_.transaction)
         case _: NonStandardScriptPubKey | _: WitnessCommitment |
             EmptyScriptPubKey | _: UnassignedWitnessScriptPubKey =>
           Future.fromTry(TxBuilderError.NoSigner)

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -458,17 +458,10 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
               Future.fromTry(TxBuilderError.WrongWitness)
             } else {
               redeemScript match {
-                case _: P2PKScriptPubKey =>
-                  P2PKSigner.sign(signers,
-                                  output,
-                                  unsignedWTx,
-                                  inputIndex,
-                                  hashType,
-                                  dummySignatures)
-                case _: P2PKHScriptPubKey =>
-                  P2PKHSigner.sign(signers,
+                case _: P2PKScriptPubKey | _: P2PKHScriptPubKey =>
+                  P2WSHSigner.sign(signers,
                                    output,
-                                   unsignedWTx,
+                                   unsignedTx,
                                    inputIndex,
                                    hashType,
                                    dummySignatures)
@@ -485,15 +478,8 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
                   Future.fromTry(TxBuilderError.NestedP2SHSPK)
                 case lock: LockTimeScriptPubKey =>
                   lock.nestedScriptPubKey match {
-                    case _: P2PKScriptPubKey =>
-                      P2PKSigner.sign(signers,
-                                      output,
-                                      unsignedTx,
-                                      inputIndex,
-                                      hashType,
-                                      dummySignatures)
-                    case _: P2PKHScriptPubKey =>
-                      P2PKHSigner.sign(signers,
+                    case _: P2PKScriptPubKey | _: P2PKHScriptPubKey =>
+                      P2WSHSigner.sign(signers,
                                        output,
                                        unsignedTx,
                                        inputIndex,

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -76,17 +76,28 @@ sealed abstract class Signer {
   }
 }
 
+/** For use when signing nested ScriptPubKeys.
+  *
+  * This will require the hash to be signed to come from some external
+  * (to the Signer being used) TxSigComponent (think P2SH, P2WSH).
+  *
+  * This will also require that the ScriptPubKey that the nested Signer
+  * looks at needs to be overriden (not output.scriptPubKey)
+  */
 sealed abstract class OverridesForNestedSigning {
   def txSigComponentOpt: Option[TxSigComponent]
   def scriptPubKeyOpt: Option[ScriptPubKey]
 }
 
 object NestedSigning {
+
+  /** The NoOverrides case where a Signer is used raw, without nesting */
   case object NoOverrides extends OverridesForNestedSigning {
     override val txSigComponentOpt: Option[TxSigComponent] = None
     override val scriptPubKeyOpt: Option[ScriptPubKey] = None
   }
 
+  /** For P2WSH signing, this will be passed to the nested Signer */
   case class P2WSHOverrides(
       externalSigComponent: TxSigComponent,
       nestedSPK: ScriptPubKey)


### PR DESCRIPTION
This PR is the first of what will be a fun series of PRs that clean up TxBuilder's signing logic. The end goal of this series will be to clean up technical debt and introduce script signing for scripts containing `OP_IF`. This will require better modularity than we currently have.

This PR specifically creates a new `Signer` for `P2WSHWitnessSPKV0`s. It was previously the responsibility of ever `Signer` to cover this case and this lead to a lot of redundancy as well as just being suboptimal design. Now, `P2WSHSigner` delegates work to the other `Signer`s who no longer need to understand `P2WSH`.

Future PRs will do similar things with `LockTimeScriptPubKey`, `P2SHScriptPubKey` and of eventually add `ConditionalScriptPubKey`