### PR TITLE
Refactor old test cases to use `BitcoinSUnitTest`

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/bloom/BloomFilterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/bloom/BloomFilterTest.scala
@@ -5,7 +5,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
 import org.bitcoins.core.util.{BitcoinSLogger, CryptoUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits._
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 

--- a/core-test/src/test/scala/org/bitcoins/core/config/NetworkParametersTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/config/NetworkParametersTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.config
 
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 6/10/16.
   */
-class NetworkParametersTest extends FlatSpec with MustMatchers {
+class NetworkParametersTest extends BitcoinSUnitTest {
 
   //test case answers are from this link
   //https://en.bitcoin.it/wiki/Protocol_documentation#Common_structures

--- a/core-test/src/test/scala/org/bitcoins/core/consensus/MerkleTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/consensus/MerkleTest.scala
@@ -4,14 +4,14 @@ import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.protocol.blockchain.{Block, MainNetChainParams}
 import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
 import org.bitcoins.core.util.{BitcoinSUtil, CryptoUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 import scala.util.Try
 
 /**
   * Created by chris on 5/24/16.
   */
-class MerkleTest extends FlatSpec with MustMatchers {
+class MerkleTest extends BitcoinSUnitTest {
 
   "Merkle" must "compute the merkle root for the genesis block" in {
     Merkle.computeBlockMerkleRoot(MainNetChainParams.genesisBlock).hex must be

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/DERSignatureUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/DERSignatureUtilTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.crypto
 
 import org.bitcoins.core.util.NumberUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/23/16.
   */
-class DERSignatureUtilTest extends FlatSpec with MustMatchers {
+class DERSignatureUtilTest extends BitcoinSUnitTest {
 
   val p2shSignature = ECDigitalSignature(
     "304402205b7d2c2f177ae76cfbbf14d589c113b0b35db753d305d5562dd0b61cbf366cfb02202e56f93c4f08a27f986cd424ffc48a462c3202c4902104d4d0ff98ed28f4bf8001")

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerResultTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerResultTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.crypto
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/31/16.
   */
-class TransactionSignatureCheckerResultTest extends FlatSpec with MustMatchers {
+class TransactionSignatureCheckerResultTest extends BitcoinSUnitTest {
 
   "TransactionSignatureCheckerResult" must "have isValid set correctly for the different outcomes of TransactionSignatureCheckerResult" in {
     SignatureValidationErrorIncorrectSignatures.isValid must be(false)

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.core.crypto
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 2/29/16.
   */
-class TransactionSignatureCheckerTest extends FlatSpec with MustMatchers {}
+class TransactionSignatureCheckerTest extends BitcoinSUnitTest {}

--- a/core-test/src/test/scala/org/bitcoins/core/number/Int32Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/number/Int32Test.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.number
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 6/15/16.
   */
-class Int32Test extends FlatSpec with MustMatchers {
+class Int32Test extends BitcoinSUnitTest {
 
   "Int32" must "create the number zero" in {
     val int32 = Int32(ByteVector.low(1))

--- a/core-test/src/test/scala/org/bitcoins/core/number/Int64Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/number/Int64Test.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.number
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 6/15/16.
   */
-class Int64Test extends FlatSpec with MustMatchers {
+class Int64Test extends BitcoinSUnitTest {
 
   "Int64" must "represent the nubmer zero" in {
     val int64 = Int64(ByteVector.low(1))

--- a/core-test/src/test/scala/org/bitcoins/core/number/UInt32Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/number/UInt32Test.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.number
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 6/14/16.
   */
-class UInt32Test extends FlatSpec with MustMatchers {
+class UInt32Test extends BitcoinSUnitTest {
 
   "UInt32" must "create the number zero as an unsigned 32 bit integer" in {
     val zero = UInt32(ByteVector(0x0.toByte))

--- a/core-test/src/test/scala/org/bitcoins/core/number/UInt64Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/number/UInt64Test.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.number
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 6/15/16.
   */
-class UInt64Test extends FlatSpec with MustMatchers {
+class UInt64Test extends BitcoinSUnitTest {
 
   "UInt64" must "hold the number 0" in {
     val uInt64 = UInt64(ByteVector.low(1))

--- a/core-test/src/test/scala/org/bitcoins/core/number/UInt8Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/number/UInt8Test.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.core.number
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
-class UInt8Test extends FlatSpec with MustMatchers {
+class UInt8Test extends BitcoinSUnitTest {
 
   "UInt8" must "convert a byte to a UInt8 correctly" in {
     UInt8.toUInt8(0.toByte) must be(UInt8.zero)

--- a/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkHeaderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkHeaderTest.scala
@@ -4,12 +4,12 @@ import org.bitcoins.core.config.TestNet3
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.util.{BitcoinSUtil, CryptoUtil}
 import org.bitcoins.testkit.node.NodeTestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import org.bitcoins.core.config.MainNet
 import scala.util.Random
 import scodec.bits.ByteVector
 
-class NetworkHeaderTest extends FlatSpec with MustMatchers {
+class NetworkHeaderTest extends BitcoinSUnitTest {
 
   "MessageHeader" must "must create a message header for a message" in {
     val messageHeader = NetworkHeader(TestNet3, NodeTestUtil.versionMessage)

--- a/core-test/src/test/scala/org/bitcoins/core/policy/PolicyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/policy/PolicyTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.policy
 
 import org.bitcoins.core.script.flag._
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 5/2/16.
   */
-class PolicyTest extends FlatSpec with MustMatchers {
+class PolicyTest extends BitcoinSUnitTest {
 
   "Policy" must "determine what the mandatory script verify flags are" in {
     Policy.mandatoryScriptVerifyFlags must be(Seq(ScriptVerifyP2SH))

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/AddressFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/AddressFactoryTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.protocol
 
 import org.bitcoins.core.util.{Base58, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/30/16.
   */
-class AddressFactoryTest extends FlatSpec with MustMatchers {
+class AddressFactoryTest extends BitcoinSUnitTest {
 
   "AddressFactory" must "create an address from a base58 encoded string" in {
     Address(TestUtil.bitcoinAddress.get.value) must be(TestUtil.bitcoinAddress)

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/BitcoinAddressTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/BitcoinAddressTest.scala
@@ -3,11 +3,11 @@ package org.bitcoins.core.protocol
 import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
 import org.bitcoins.core.crypto.Sha256Hash160Digest
 import org.bitcoins.core.protocol.script.ScriptPubKey
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 import scala.util.{Failure, Success, Try}
 
-class BitcoinAddressTest extends FlatSpec with MustMatchers {
+class BitcoinAddressTest extends BitcoinSUnitTest {
 
   "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy" must "be a valid bitcoin address" in {
     val address = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/BtcHumanReadablePartTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/BtcHumanReadablePartTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.protocol
 
 import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 import scala.util.Success
 
-class BtcHumanReadablePartTest extends FlatSpec with MustMatchers {
+class BtcHumanReadablePartTest extends BitcoinSUnitTest {
   import BtcHumanReadablePart._
 
   "HumanReadablePart" must "match the correct hrp with the correct string" in {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/CompactSizeUIntTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/CompactSizeUIntTest.scala
@@ -3,13 +3,13 @@ package org.bitcoins.core.protocol
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.script.ScriptSignature
 import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 7/26/15.
   */
-class CompactSizeUIntTest extends FlatSpec with MustMatchers {
+class CompactSizeUIntTest extends BitcoinSUnitTest {
 
   "CompactSizeUInt" must "serialize a VarInt with size 1 correctly" in {
     val varInt = CompactSizeUInt(UInt64(139), 1)

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/MerkleBlockTests.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/MerkleBlockTests.scala
@@ -5,12 +5,12 @@ import org.bitcoins.core.crypto.{DoubleSha256Digest, ECPublicKey}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.transaction.TransactionOutPoint
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 8/9/16.
   */
-class MerkleBlockTests extends FlatSpec with MustMatchers {
+class MerkleBlockTests extends BitcoinSUnitTest {
 
   "MerkleBlocks" must "create merkle block from a block and a bloom filter" in {
     val block = Block(

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTreeTests.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTreeTests.scala
@@ -4,13 +4,13 @@ import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
 import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.util.{BitcoinSUtil, Leaf, Node}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.BitVector
 
 /**
   * Created by chris on 8/9/16.
   */
-class PartialMerkleTreeTests extends FlatSpec with MustMatchers {
+class PartialMerkleTreeTests extends BitcoinSUnitTest {
   "PartialMerkleTree" must "from a list of txs and a bit indicating if the tx matched the filter" in {
     //https://github.com/bitcoin/bitcoin/blob/master/src/test/bloom_tests.cpp#L185
     val block = Block(

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePartTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePartTest.scala
@@ -3,11 +3,11 @@ package org.bitcoins.core.protocol.ln
 import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
 import org.bitcoins.core.protocol.ln.LnParams._
 import org.bitcoins.core.protocol.ln.currency.{LnCurrencyUnits, MilliBitcoins}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 import scala.util.Try
 
-class LnHumanReadablePartTest extends FlatSpec with MustMatchers {
+class LnHumanReadablePartTest extends BitcoinSUnitTest {
   val mBtc = MilliBitcoins(1)
   val mBtcOpt = Some(mBtc)
   it must "match the correct hrp with the correct network" in {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/ShortChannelIdTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/ShortChannelIdTest.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.core.protocol.ln
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class ShortChannelIdTest extends FlatSpec with MustMatchers {
+class ShortChannelIdTest extends BitcoinSUnitTest {
 
   it must "convert short channel id to and from human readable form" in {
     // BOLT example

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/CLTVScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/CLTVScriptPubKeyTest.scala
@@ -12,12 +12,12 @@ import org.bitcoins.core.script.crypto.{OP_CHECKSIG, OP_HASH160}
 import org.bitcoins.core.script.locktime.OP_CHECKLOCKTIMEVERIFY
 import org.bitcoins.core.script.stack.{OP_DROP, OP_DUP}
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by tom on 9/21/16.
   */
-class CLTVScriptPubKeyTest extends FlatSpec with MustMatchers {
+class CLTVScriptPubKeyTest extends BitcoinSUnitTest {
 
   val expectedAsm: Seq[ScriptToken] =
     List(OP_DUP,

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/CSVScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/CSVScriptPubKeyTest.scala
@@ -12,12 +12,12 @@ import org.bitcoins.core.script.crypto.{OP_CHECKSIG, OP_HASH160}
 import org.bitcoins.core.script.locktime.OP_CHECKSEQUENCEVERIFY
 import org.bitcoins.core.script.stack.{OP_DROP, OP_DUP}
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by tom on 9/21/16.
   */
-class CSVScriptPubKeyTest extends FlatSpec with MustMatchers {
+class CSVScriptPubKeyTest extends BitcoinSUnitTest {
 
   val expectedAsm: Seq[ScriptToken] =
     List(OP_DUP,

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/MultiSignatureScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/MultiSignatureScriptPubKeyTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECPublicKey
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/8/16.
   */
-class MultiSignatureScriptPubKeyTest extends FlatSpec with MustMatchers {
+class MultiSignatureScriptPubKeyTest extends BitcoinSUnitTest {
 
   "MultiSignatureScriptPubKey" must "derive the amount of required signatures from a multisignature script" in {
     val multiSigRawScriptPubKeyHex = TestUtil.multiSigScriptPubKeyHex

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/MultiSignatureScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/MultiSignatureScriptSignatureTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.util.TransactionTestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/8/16.
   */
-class MultiSignatureScriptSignatureTest extends FlatSpec with MustMatchers {
+class MultiSignatureScriptSignatureTest extends BitcoinSUnitTest {
 
   "MultiSignatureScriptSignature" must "find all of the digital signatures for a multisignature scriptSig" in {
     val (spendingTx, inputIndex, _, _) =

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKHScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKHScriptPubKeyTest.scala
@@ -2,9 +2,9 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.testkit.Implicits._
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class P2PKHScriptPubKeyTest extends FlatSpec with MustMatchers {
+class P2PKHScriptPubKeyTest extends BitcoinSUnitTest {
 
   "P2PKHScriptPubKey" must "return the pubkeyhash" in {
     val hash = CryptoGenerators.sha256Hash160Digest.sampleSome

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKHScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKHScriptSignatureTest.scala
@@ -3,13 +3,13 @@ package org.bitcoins.core.protocol.script
 import org.bitcoins.core.crypto.ECDigitalSignature
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 4/1/16.
   */
-class P2PKHScriptSignatureTest extends FlatSpec with MustMatchers {
+class P2PKHScriptSignatureTest extends BitcoinSUnitTest {
 
   "P2PKHScriptSignature" must "be able to identify it's own hash type" in {
     val p2pkhScriptSig = TestUtil.p2pkhScriptSig match {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKScriptPubKeyTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECPublicKey
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 4/1/16.
   */
-class P2PKScriptPubKeyTest extends FlatSpec with MustMatchers {
+class P2PKScriptPubKeyTest extends BitcoinSUnitTest {
 
   "P2PKScriptPubKeyTest" must "find the public key in a p2pk scriptPubKey" in {
     val p2pkScriptPubKey = TestUtil.p2pkScriptPubKey match {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKScriptSignatureTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECDigitalSignature
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/16/16.
   */
-class P2PKScriptSignatureTest extends FlatSpec with MustMatchers {
+class P2PKScriptSignatureTest extends BitcoinSUnitTest {
 
   "P2PKScriptSignature" must "find the signature inside of a p2pk scriptSig" in {
     val p2pkScriptSig = TestUtil.p2pkScriptSig match {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2WPKHWitnessSPKV0Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2WPKHWitnessSPKV0Test.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECPrivateKey
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class P2WPKHWitnessSPKV0Test extends FlatSpec with MustMatchers {
+class P2WPKHWitnessSPKV0Test extends BitcoinSUnitTest {
 
   "P2WPKHWitnessSPKV0" must "fail to be created with an uncompressed public key" in {
     val uncompressed = ECPrivateKey(false).publicKey

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2WSHWitnessSPKV0Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2WSHWitnessSPKV0Test.scala
@@ -2,9 +2,9 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECPrivateKey
 import org.bitcoins.core.script.constant.ScriptNumber
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class P2WSHWitnessSPKV0Test extends FlatSpec with MustMatchers {
+class P2WSHWitnessSPKV0Test extends BitcoinSUnitTest {
   val uncompressed = ECPrivateKey(false).publicKey
   val p2pk = P2PKScriptPubKey(uncompressed)
   val multisig = MultiSignatureScriptPubKey(1, Vector(uncompressed))

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyFactoryTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/2/16.
   */
-class ScriptPubKeyFactoryTest extends FlatSpec with MustMatchers {
+class ScriptPubKeyFactoryTest extends BitcoinSUnitTest {
 
   "ScriptPubKeyFactory" must "create a scriptPubKey from a sequences of bytes and hex and get the same thing" in {
     //from b30d3148927f620f5b1228ba941c211fdabdae75d0ba0b688a58accbf018f3cc

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
@@ -7,12 +7,12 @@ import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.crypto.{OP_CHECKSIG, OP_HASH160}
 import org.bitcoins.core.script.stack.OP_DUP
 import org.bitcoins.core.util.{CryptoUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/14/16.
   */
-class ScriptPubKeyTest extends FlatSpec with MustMatchers {
+class ScriptPubKeyTest extends BitcoinSUnitTest {
 
   val expectedAsm: Seq[ScriptToken] =
     List(OP_DUP,

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureFactoryTest.scala
@@ -2,13 +2,13 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 2/17/16.
   */
-class ScriptSignatureFactoryTest extends FlatSpec with MustMatchers {
+class ScriptSignatureFactoryTest extends BitcoinSUnitTest {
 
   "ScriptSignatureFactory" must "give the exact same result whether parsing bytes or parsing hex" in {
     val signatureHex = "30450221008949f0cb400094ad2b5eb399d59d01c14d73d8fe6e96df1a7150deb388ab8935022079656090d7" +

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/WitnessCommitmentTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/WitnessCommitmentTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.protocol.script
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 12/23/16.
   */
-class WitnessCommitmentTest extends FlatSpec with MustMatchers {
+class WitnessCommitmentTest extends BitcoinSUnitTest {
 
   //witness commitment from https://www.blocktrail.com/tBTC/block/00000000000002f59cc8b806b2cf6bbe37a367a085de60f9e5e3386081abbb48
   val hex =

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionInputTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionInputTest.scala
@@ -5,12 +5,12 @@ import org.bitcoins.core.protocol.script.{
   P2PKScriptSignature
 }
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/30/16.
   */
-class TransactionInputTest extends FlatSpec with MustMatchers {
+class TransactionInputTest extends BitcoinSUnitTest {
 
   "TransactionInput" must "define an empty transaction input" in {
     EmptyTransactionInput.previousOutput must be(EmptyTransactionOutPoint)

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionOutPointTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionOutPointTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.protocol.transaction
 
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/30/16.
   */
-class TransactionOutPointTest extends FlatSpec with MustMatchers {
+class TransactionOutPointTest extends BitcoinSUnitTest {
   "TransactionOutPoint" must "define an empty transaction outpoint" in {
     EmptyTransactionOutPoint.txId.hex must be(
       "0000000000000000000000000000000000000000000000000000000000000000")

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionOutputTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionOutputTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.protocol.transaction
 
 import org.bitcoins.core.currency.CurrencyUnits
 import org.bitcoins.core.protocol.script.EmptyScriptPubKey
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/30/16.
   */
-class TransactionOutputTest extends FlatSpec with MustMatchers {
+class TransactionOutputTest extends BitcoinSUnitTest {
 
   "TransactionOutput" must "define an empty transaction output" in {
     EmptyTransactionOutput.scriptPubKey must be(EmptyScriptPubKey)

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
@@ -4,12 +4,12 @@ import org.bitcoins.core.crypto.{ECPrivateKey, EmptyDigitalSignature}
 import org.bitcoins.testkit.core.gen.WitnessGenerators
 import org.bitcoins.core.protocol.script._
 import org.scalacheck.Prop
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 11/28/16.
   */
-class TransactionWitnessSpec extends FlatSpec with MustMatchers {
+class TransactionWitnessSpec extends BitcoinSUnitTest {
 
   behavior of "TransactionWitness"
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptConstantFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptConstantFactoryTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.script
 
 import org.bitcoins.core.script.constant.ScriptConstant
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 4/1/16.
   */
-class ScriptConstantFactoryTest extends FlatSpec with MustMatchers {
+class ScriptConstantFactoryTest extends BitcoinSUnitTest {
 
   "ScriptConstantFactory" must "create a constant from bytes" in {
     val bytes = BitcoinSUtil.decodeHex("abc123")

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptOperationFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptOperationFactoryTest.scala
@@ -9,12 +9,12 @@ import org.bitcoins.core.script.locktime.OP_CHECKLOCKTIMEVERIFY
 import org.bitcoins.core.script.splice.OP_SUBSTR
 import org.bitcoins.core.script.stack.OP_TOALTSTACK
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/9/16.
   */
-class ScriptOperationFactoryTest extends FlatSpec with MustMatchers {
+class ScriptOperationFactoryTest extends BitcoinSUnitTest {
 
   "ScriptOperationFactory" must "match operations with their byte representation" in {
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
@@ -7,12 +7,12 @@ import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.script.constant.{OP_0, OP_1}
 import org.bitcoins.core.script.flag.ScriptFlagFactory
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/31/16.
   */
-class ScriptProgramFactoryTest extends FlatSpec with MustMatchers {
+class ScriptProgramFactoryTest extends BitcoinSUnitTest {
 
   "ScriptProgramFactory" must "update a field depending on its indicator" in {
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.script
 
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 2/6/16.
   */
-class ScriptProgramTest extends FlatSpec with MustMatchers {
+class ScriptProgramTest extends BitcoinSUnitTest {
 
   "ScriptProgram" must "determine if the stack top is true" in {
     val stack = List(ScriptNumber(1))

--- a/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
@@ -9,14 +9,14 @@ import org.bitcoins.core.script.{
   ScriptProgram
 }
 import org.bitcoins.core.util.{ScriptProgramTestUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 import scala.util.Try
 
 /**
   * Created by chris on 1/25/16.
   */
-class ArithmeticInterpreterTest extends FlatSpec with MustMatchers {
+class ArithmeticInterpreterTest extends BitcoinSUnitTest {
 
   val AI = ArithmeticInterpreter
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticOperationsFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticOperationsFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.arithmetic
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/8/16.
   */
-class ArithmeticOperationsFactoryTest extends FlatSpec with MustMatchers {
+class ArithmeticOperationsFactoryTest extends BitcoinSUnitTest {
   "ArithmeticOperationsFactory" must "match strings with arithmetic operations" in {
     ArithmeticOperation.fromString("OP_1ADD") must be(Some(OP_1ADD))
     ArithmeticOperation.fromString("OP_ADD") must be(Some(OP_ADD))

--- a/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticOperationsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticOperationsTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.arithmetic
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/6/16.
   */
-class ArithmeticOperationsTest extends FlatSpec with MustMatchers {
+class ArithmeticOperationsTest extends BitcoinSUnitTest {
 
   "ArithmeticOperatoins" must "define OP_1ADD" in {
     OP_1ADD.opCode must be(139)

--- a/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseInterpreterTest.scala
@@ -4,12 +4,12 @@ import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.result.ScriptErrorInvalidStackOperation
 import org.bitcoins.core.script.{ExecutedScriptProgram, ScriptProgram}
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/6/16.
   */
-class BitwiseInterpreterTest extends FlatSpec with MustMatchers {
+class BitwiseInterpreterTest extends BitcoinSUnitTest {
   private val pubKeyHash = ScriptConstant(
     "5238C71458E464D9FF90299ABCA4A1D7B9CB76AB".toLowerCase)
   val BI = BitwiseInterpreter

--- a/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseOperationsFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseOperationsFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.bitwise
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/8/16.
   */
-class BitwiseOperationsFactoryTest extends FlatSpec with MustMatchers {
+class BitwiseOperationsFactoryTest extends BitcoinSUnitTest {
 
   "BitwiseOperationsFactory" must "match strings with bitwise operations" in {
     BitwiseOperation.fromString("OP_EQUAL") must be(Some(OP_EQUAL))

--- a/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseOperationsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseOperationsTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.bitwise
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/6/16.
   */
-class BitwiseOperationsTest extends FlatSpec with MustMatchers {
+class BitwiseOperationsTest extends BitcoinSUnitTest {
 
   "BitwiseOperations" must "define OP_EQUAL" in {
     OP_EQUAL.opCode must be(135)

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/BytesToPushOntoStackFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/BytesToPushOntoStackFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.constant
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/9/16.
   */
-class BytesToPushOntoStackFactoryTest extends FlatSpec with MustMatchers {
+class BytesToPushOntoStackFactoryTest extends BitcoinSUnitTest {
 
   "ScriptNumberFactory" must "represent the number 1" in {
     BytesToPushOntoStack.operations.exists(_ == BytesToPushOntoStack(1)) must be(

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
@@ -9,13 +9,13 @@ import org.bitcoins.core.script.result.{
   ScriptErrorMinimalData
 }
 import org.bitcoins.core.util.{ScriptProgramTestUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 1/24/16.
   */
-class ConstantInterpreterTest extends FlatSpec with MustMatchers {
+class ConstantInterpreterTest extends BitcoinSUnitTest {
   val CI = ConstantInterpreter
   "ConstantInterpreter" must "interpret OP_PUSHDATA1 correctly" in {
     val byteConstantSize = 76

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantsTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.script.constant
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 import scala.util.Try
@@ -8,7 +8,7 @@ import scala.util.Try
 /**
   * Created by chris on 1/6/16.
   */
-class ConstantsTest extends FlatSpec with MustMatchers {
+class ConstantsTest extends BitcoinSUnitTest {
 
   "Constants" must "define an OP_FALSE" in {
     OP_FALSE.opCode must be(0)

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ScriptNumberFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ScriptNumberFactoryTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.script.constant
 
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 4/4/16.
   */
-class ScriptNumberFactoryTest extends FlatSpec with MustMatchers {
+class ScriptNumberFactoryTest extends BitcoinSUnitTest {
 
   "ScriptNumber" must "create the same number using from hex and from bytes" in {
     val hex = "ff7f"

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ScriptNumberTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ScriptNumberTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.script.constant
 
 import org.bitcoins.core.number.Int64
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/25/16.
   */
-class ScriptNumberTest extends FlatSpec with MustMatchers {
+class ScriptNumberTest extends BitcoinSUnitTest {
 
   val zero = ScriptNumber.zero
   val one = ScriptNumber.one

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ScriptNumberUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ScriptNumberUtilTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.script.constant
 
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 6/5/16.
   */
-class ScriptNumberUtilTest extends FlatSpec with MustMatchers {
+class ScriptNumberUtilTest extends BitcoinSUnitTest {
   "ScriptNumberUtil" must "convert a positive hex number to its corresponding long number" in {
     val hex = "01"
     val long = ScriptNumberUtil.toLong(hex)

--- a/core-test/src/test/scala/org/bitcoins/core/script/control/ControlOperationsFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/control/ControlOperationsFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.control
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/8/16.
   */
-class ControlOperationsFactoryTest extends FlatSpec with MustMatchers {
+class ControlOperationsFactoryTest extends BitcoinSUnitTest {
 
   "ControlOperationsFactory" must "match a string with a control operation" in {
     ControlOperations.fromString("OP_ELSE") must be(Some(OP_ELSE))

--- a/core-test/src/test/scala/org/bitcoins/core/script/control/ControlOperationsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/control/ControlOperationsTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.control
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/6/16.
   */
-class ControlOperationsTest extends FlatSpec with MustMatchers {
+class ControlOperationsTest extends BitcoinSUnitTest {
 
   "ControlOperations" must "define an OP_IF" in {
     OP_IF.opCode must be(99)

--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoOperationsFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoOperationsFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.crypto
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/8/16.
   */
-class CryptoOperationsFactoryTest extends FlatSpec with MustMatchers {
+class CryptoOperationsFactoryTest extends BitcoinSUnitTest {
 
   "CryptoOperationsFactory" must "match strings with crypto operations" in {
     CryptoOperation.fromString("OP_CHECKSIG") must be(Some(OP_CHECKSIG))

--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoOperationsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoOperationsTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.crypto
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/6/16.
   */
-class CryptoOperationsTest extends FlatSpec with MustMatchers {
+class CryptoOperationsTest extends BitcoinSUnitTest {
 
   "CryptoOperations" must "define OP_RIPEMD160" in {
     OP_RIPEMD160.opCode must be(166)

--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoSignatureEvaluationFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoSignatureEvaluationFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.crypto
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 4/2/16.
   */
-class CryptoSignatureEvaluationFactoryTest extends FlatSpec with MustMatchers {
+class CryptoSignatureEvaluationFactoryTest extends BitcoinSUnitTest {
 
   "CryptoSignatureEvaluationFactory" must "have all of the Script operations that involve checking signatures" in {
     CryptoSignatureEvaluationFactory.operations must be(

--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/HashTypeTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/HashTypeTest.scala
@@ -1,13 +1,13 @@
 package org.bitcoins.core.script.crypto
 
 import org.bitcoins.core.number.Int32
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 2/27/16.
   */
-class HashTypeTest extends FlatSpec with MustMatchers {
+class HashTypeTest extends BitcoinSUnitTest {
 
   "HashType" must "combine hash types with SIGHASH_ANYONECANPAY" in {
     HashType.sigHashAllAnyoneCanPay.num must be(Int32(0x81))

--- a/core-test/src/test/scala/org/bitcoins/core/script/flag/ScriptFlagFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/flag/ScriptFlagFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.flag
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/23/16.
   */
-class ScriptFlagFactoryTest extends FlatSpec with MustMatchers {
+class ScriptFlagFactoryTest extends BitcoinSUnitTest {
 
   "ScriptFlagFactory" must "find a NONE script flag" in {
     ScriptFlagFactory.fromString("NONE").get must be(ScriptVerifyNone)

--- a/core-test/src/test/scala/org/bitcoins/core/script/flag/ScriptFlagUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/flag/ScriptFlagUtilTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.flag
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 4/6/16.
   */
-class ScriptFlagUtilTest extends FlatSpec with MustMatchers {
+class ScriptFlagUtilTest extends BitcoinSUnitTest {
 
   "ScriptFlagUtil" must "check if strict der encoding check is required" in {
     ScriptFlagUtil.requiresStrictDerEncoding(Seq(ScriptVerifyDerSig)) must be(

--- a/core-test/src/test/scala/org/bitcoins/core/script/flag/ScriptFlagsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/flag/ScriptFlagsTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.flag
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/23/16.
   */
-class ScriptFlagsTest extends FlatSpec with MustMatchers {
+class ScriptFlagsTest extends BitcoinSUnitTest {
 
   "ScriptVerifyNone" must "have the flag zero" in {
     ScriptVerifyNone.flag must be(0)

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -10,7 +10,7 @@ import org.bitcoins.core.script.interpreter.testprotocol.CoreTestCase
 import org.bitcoins.core.script.interpreter.testprotocol.CoreTestCaseProtocol._
 import org.bitcoins.core.util._
 import org.bitcoins.testkit.util.BitcoinSUnitTest
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import org.slf4j.LoggerFactory
 import spray.json._
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
@@ -12,12 +12,12 @@ import org.bitcoins.core.script.{
   ScriptProgram
 }
 import org.bitcoins.core.util.{ScriptProgramTestUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 3/30/16.
   */
-class LockTimeInterpreterTest extends FlatSpec with MustMatchers {
+class LockTimeInterpreterTest extends BitcoinSUnitTest {
   val LTI = LockTimeInterpreter
   "LockTimeInterpreter" must "mark the transaction invalid if the stack is empty" in {
     val stack = Seq()

--- a/core-test/src/test/scala/org/bitcoins/core/script/locktime/LocktimeOperationFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/locktime/LocktimeOperationFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.locktime
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/8/16.
   */
-class LocktimeOperationFactoryTest extends FlatSpec with MustMatchers {
+class LocktimeOperationFactoryTest extends BitcoinSUnitTest {
 
   "LocktimeOperationFactory" must "match lock time operations from strings" in {
     LocktimeOperation.fromString("OP_CHECKLOCKTIMEVERIFY") must be(

--- a/core-test/src/test/scala/org/bitcoins/core/script/locktime/LocktimeOperationTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/locktime/LocktimeOperationTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.locktime
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/6/16.
   */
-class LocktimeOperationTest extends FlatSpec with MustMatchers {
+class LocktimeOperationTest extends BitcoinSUnitTest {
 
   "LocktimeOperations" must "define OP_CHECKLOCKTIMEVERIFY" in {
     OP_CHECKLOCKTIMEVERIFY.opCode must be(177)

--- a/core-test/src/test/scala/org/bitcoins/core/script/reserved/ReservedOperationsFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/reserved/ReservedOperationsFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.reserved
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/22/16.
   */
-class ReservedOperationsFactoryTest extends FlatSpec with MustMatchers {
+class ReservedOperationsFactoryTest extends BitcoinSUnitTest {
 
   "ReservedOperationsFactory" must "instantiate reserved operations" in {
     ReservedOperation("50") must be(Some(OP_RESERVED))

--- a/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceInterpreterTest.scala
@@ -4,12 +4,12 @@ import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.result.ScriptErrorInvalidStackOperation
 import org.bitcoins.core.script.{ExecutedScriptProgram, ScriptProgram}
 import org.bitcoins.core.util.TestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 2/4/16.
   */
-class SpliceInterpreterTest extends FlatSpec with MustMatchers {
+class SpliceInterpreterTest extends BitcoinSUnitTest {
   val SI = SpliceInterpreter
 
   "SpliceInterpreter" must "evaluate an OP_SIZE on OP_0 correctly" in {

--- a/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceOperationFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceOperationFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.splice
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/22/16.
   */
-class SpliceOperationFactoryTest extends FlatSpec with MustMatchers {
+class SpliceOperationFactoryTest extends BitcoinSUnitTest {
 
   "SpliceOperationFactory" must "instantiate the splice operations from hex" in {
     SpliceOperation("7e") must be(Some(OP_CAT))

--- a/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
@@ -4,12 +4,12 @@ import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.result._
 import org.bitcoins.core.script.{ExecutedScriptProgram, ScriptProgram}
 import org.bitcoins.core.util.{BitcoinSUtil, ScriptProgramTestUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/6/16.
   */
-class StackInterpreterTest extends FlatSpec with MustMatchers {
+class StackInterpreterTest extends BitcoinSUnitTest {
   val element1 = ScriptConstant("1234")
   val element2 = ScriptConstant("abcd")
   val stack = List(element1, element2)

--- a/core-test/src/test/scala/org/bitcoins/core/script/stack/StackOperationFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/stack/StackOperationFactoryTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.stack
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/8/16.
   */
-class StackOperationFactoryTest extends FlatSpec with MustMatchers {
+class StackOperationFactoryTest extends BitcoinSUnitTest {
 
   "StackOperationFactory" must "match correct operations with their strings" in {
     StackOperation.fromString("OP_DUP") must be(Some(OP_DUP))

--- a/core-test/src/test/scala/org/bitcoins/core/script/stack/StackOperationsTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/stack/StackOperationsTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.core.script.stack
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/6/16.
   */
-class StackOperationsTest extends FlatSpec with MustMatchers {
+class StackOperationsTest extends BitcoinSUnitTest {
 
   "StackOperations" must "define OP_TOALTSTACK" in {
     OP_TOALTSTACK.opCode must be(107)

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelperTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelperTest.scala
@@ -11,10 +11,10 @@ import org.bitcoins.core.serializers.transaction.{
   RawTransactionInputParser,
   RawTransactionOutputParser
 }
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
-class RawSerializerHelperTest extends FlatSpec with MustMatchers {
+class RawSerializerHelperTest extends BitcoinSUnitTest {
 
   "RawBitcoinSerializerHelper" must "serialize an empty vector" in {
     val bytes = ByteVector(0.toByte)

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawBlockHeaderSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawBlockHeaderSerializerTest.scala
@@ -3,14 +3,14 @@ package org.bitcoins.core.serializers.blockchain
 import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Values transmitted in the network are big-endian.
   * Created by tom on 6/3/16.
   */
-class RawBlockHeaderSerializerTest extends FlatSpec with MustMatchers {
+class RawBlockHeaderSerializerTest extends BitcoinSUnitTest {
   //genesis block
   //https://en.bitcoin.it/wiki/Genesis_block
   //https://insight.bitpay.com/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializerTest.scala
@@ -5,13 +5,13 @@ import org.bitcoins.core.number.{Int32, UInt32, UInt64}
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by tom on 6/3/16.
   */
-class RawBlockSerializerTest extends FlatSpec with MustMatchers {
+class RawBlockSerializerTest extends BitcoinSUnitTest {
   //genesis block
   //https://en.bitcoin.it/wiki/Genesis_block
   //https://webbtc.com/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawMerkleBlockSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawMerkleBlockSerializerTest.scala
@@ -8,13 +8,13 @@ import org.bitcoins.core.protocol.blockchain.{
   PartialMerkleTree
 }
 import org.bitcoins.core.util.{BitcoinSUtil, Leaf, Node}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.BitVector
 
 /**
   * Created by chris on 8/22/16.
   */
-class RawMerkleBlockSerializerTest extends FlatSpec with MustMatchers {
+class RawMerkleBlockSerializerTest extends BitcoinSUnitTest {
 
   "RawMerkleBlockSerializer" must "serialize a merkle block generated inside of scalacheck" in {
 

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawAddrMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawAddrMessageSerializerTest.scala
@@ -2,9 +2,9 @@ package org.bitcoins.core.serializers.p2p.messages
 
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class RawAddrMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawAddrMessageSerializerTest extends BitcoinSUnitTest {
 
   //from this bitcoin developer guide example
   //https://bitcoin.org/en/developer-reference#addr

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawFilterAddMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawFilterAddMessageSerializerTest.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.core.serializers.p2p.messages
 
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class RawFilterAddMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawFilterAddMessageSerializerTest extends BitcoinSUnitTest {
 
   //https://bitcoin.org/en/developer-reference#filteradd
   val hex = "20" + "fdacf9b3eb077412e7a968d2e4f11b9a9dee312d666187ed77ee7d26af16cb0b"

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawFilterLoadMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawFilterLoadMessageSerializerTest.scala
@@ -4,12 +4,12 @@ import org.bitcoins.core.bloom.BloomUpdateNone
 import org.bitcoins.core.number.{UInt32, UInt64}
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 7/20/16.
   */
-class RawFilterLoadMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawFilterLoadMessageSerializerTest extends BitcoinSUnitTest {
 
   "RawFilterLoadMessageSerializer" must "deserialize and serialize a filter load message" in {
     //example from the bitcoin developer reference

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawGetBlocksMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawGetBlocksMessageSerializerTest.scala
@@ -5,12 +5,12 @@ import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.util.BitcoinSUtil
 import org.bitcoins.core.p2p._
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 6/1/16.
   */
-class RawGetBlocksMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawGetBlocksMessageSerializerTest extends BitcoinSUnitTest {
 
   val hex = "7111010002d39f608a7775b537729884d4e6633bb2105e55a16a14d31b0000000000000000" +
     "5c3e6403d40837110a2e8afb602b1c01714bda7ce23bea0a0000000000000000" +

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawGetDataMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawGetDataMessageSerializerTest.scala
@@ -5,12 +5,12 @@ import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.p2p.Inventory
 import org.bitcoins.core.p2p.TypeIdentifier.MsgTx
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 7/8/16.
   */
-class RawGetDataMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawGetDataMessageSerializerTest extends BitcoinSUnitTest {
 
   //from bitcoin developer reference
   //a getdata message is essentially an inv message

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawGetHeadersMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawGetHeadersMessageSerializerTest.scala
@@ -5,12 +5,12 @@ import org.bitcoins.core.p2p._
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.testkit.node.NodeTestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 6/29/16.
   */
-class RawGetHeadersMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawGetHeadersMessageSerializerTest extends BitcoinSUnitTest {
   val hex = NodeTestUtil.rawGetHeadersMsg
 
   "RawGetHeadersMessageSerializer" must "read a hex string representing a GetHeaderMessage" in {

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawHeadersMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawHeadersMessageSerializerTest.scala
@@ -4,14 +4,13 @@ import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.number.{UInt32, UInt64}
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 7/5/16.
   */
 class RawHeadersMessageSerializerTest
-    extends FlatSpec
-    with MustMatchers
+    extends BitcoinSUnitTest
     with BitcoinSLogger {
 
   //from this example

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawInventoryMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawInventoryMessageSerializerTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.serializers.p2p.messages
 
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 6/1/16.
   */
-class RawInventoryMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawInventoryMessageSerializerTest extends BitcoinSUnitTest {
 
   //from bitcoin developer reference
   //https://bitcoin.org/en/developer-reference#inv

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawInventorySerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawInventorySerializerTest.scala
@@ -3,12 +3,12 @@ package org.bitcoins.core.serializers.p2p.messages
 import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.util.BitcoinSUtil
 import org.bitcoins.core.p2p.TypeIdentifier.MsgTx
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 6/1/16.
   */
-class RawInventorySerializerTest extends FlatSpec with MustMatchers {
+class RawInventorySerializerTest extends BitcoinSUnitTest {
 
   //from bitcoin developer reference example section
   //https://bitcoin.org/en/developer-reference#inv

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawMerkleBlockMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawMerkleBlockMessageSerializerTest.scala
@@ -4,10 +4,10 @@ import org.bitcoins.core.crypto.DoubleSha256Digest
 import org.bitcoins.core.number.{UInt32, UInt64}
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.BitVector
 
-class RawMerkleBlockMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawMerkleBlockMessageSerializerTest extends BitcoinSUnitTest {
 
   //from bitcoin developer reference
   //https://bitcoin.org/en/developer-reference#merkleblock

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawNetworkIpAddressSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawNetworkIpAddressSerializerTest.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.core.serializers.p2p
 
 import org.bitcoins.core.number.UInt32
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class RawNetworkIpAddressSerializerTest extends FlatSpec with MustMatchers {
+class RawNetworkIpAddressSerializerTest extends BitcoinSUnitTest {
 
   //from this bitcoin developer guide example
   //https://bitcoin.org/en/developer-reference#addr

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawNotFoundMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawNotFoundMessageSerializerTest.scala
@@ -2,9 +2,9 @@ package org.bitcoins.core.serializers.p2p.messages
 
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class RawNotFoundMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawNotFoundMessageSerializerTest extends BitcoinSUnitTest {
 
   //according to the developer reference, the format for inventory messages and
   //not found messages are the same

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawPingMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawPingMessageSerializerTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.serializers.p2p.messages
 
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.p2p.PingMessage
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 6/29/16.
   */
-class RawPingMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawPingMessageSerializerTest extends BitcoinSUnitTest {
 
   "RawPingMessageSerializer" must "read and write a uint64 representing the ping" in {
     val hex = "0094102111e2af4d"

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawRejectMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawRejectMessageSerializerTest.scala
@@ -3,12 +3,12 @@ package org.bitcoins.core.serializers.p2p.messages
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 8/31/16.
   */
-class RawRejectMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawRejectMessageSerializerTest extends BitcoinSUnitTest {
 
   //https://bitcoin.org/en/developer-reference#reject
   val hex = "02" + "7478" + "12" + "15" + "6261642d74786e732d696e707574732d7370656e74" +

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawServiceIdentifierSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawServiceIdentifierSerializerTest.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.core.serializers.p2p.messages
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class RawServiceIdentifierSerializerTest extends FlatSpec with MustMatchers {
+class RawServiceIdentifierSerializerTest extends BitcoinSUnitTest {
 
   "RawServiceIdentifierSerializer" must "read a unnamed service identfier from a hex string" in {
     val hex = "0000000000000000"

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawTransactionMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawTransactionMessageSerializerTest.scala
@@ -2,9 +2,9 @@ package org.bitcoins.core.serializers.p2p.messages
 
 import org.bitcoins.core.util.BitcoinSUtil
 import org.bitcoins.testkit.node.NodeTestUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class RawTransactionMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawTransactionMessageSerializerTest extends BitcoinSUnitTest {
 
   "RawTransactionMessageSerializer" must "read a TransactionMessage from a sequence of bytes" in {
     val txMessage =

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawTypeIdentifierSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawTypeIdentifierSerializerTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.serializers.p2p.messages
 
 import org.bitcoins.core.p2p.TypeIdentifier.{MsgBlock, MsgFilteredBlock, MsgTx}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 5/31/16.
   */
-class RawTypeIdentifierSerializerTest extends FlatSpec with MustMatchers {
+class RawTypeIdentifierSerializerTest extends BitcoinSUnitTest {
   val msgTxHex = "01000000"
   val msgBlockHex = "02000000"
   val msgFilteredBlockHex = "03000000"

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawVersionMessageSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/p2p/messages/RawVersionMessageSerializerTest.scala
@@ -7,9 +7,9 @@ import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.util.BitcoinSUtil
 import org.bitcoins.core.p2p._
 import org.bitcoins.node.util.BitcoinSpvNodeUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class RawVersionMessageSerializerTest extends FlatSpec with MustMatchers {
+class RawVersionMessageSerializerTest extends BitcoinSUnitTest {
 
   //take from the bitcoin developer reference underneath this seciton
   //https://bitcoin.org/en/developer-reference#version

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParserTest.scala
@@ -6,13 +6,13 @@ import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.crypto.{OP_CHECKSIG, OP_HASH160}
 import org.bitcoins.core.script.stack.OP_DUP
 import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 1/12/16.
   */
-class RawScriptPubKeyParserTest extends FlatSpec with MustMatchers {
+class RawScriptPubKeyParserTest extends BitcoinSUnitTest {
   val encode = BitcoinSUtil.encodeHex(_: ByteVector)
   "RawScriptPubKeyParser" must "read then write the scriptPubKey and get the original scriptPubKey" in {
     val scriptPubKey: ScriptPubKey =

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParserTest.scala
@@ -3,13 +3,13 @@ package org.bitcoins.core.serializers.script
 import org.bitcoins.core.protocol.script.ScriptSignature
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 1/12/16.
   */
-class RawScriptSignatureParserTest extends FlatSpec with MustMatchers {
+class RawScriptSignatureParserTest extends BitcoinSUnitTest {
 
   //from bitcoin developer examples
   //https://bitcoin.org/en/developer-reference#raw-transaction-format

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/script/ScriptParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/script/ScriptParserTest.scala
@@ -14,13 +14,13 @@ import org.bitcoins.core.script.reserved.OP_NOP
 import org.bitcoins.core.script.splice.OP_SIZE
 import org.bitcoins.core.script.stack.{OP_DROP, OP_DUP, OP_PICK, OP_SWAP}
 import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 1/7/16.
   */
-class ScriptParserTest extends FlatSpec with MustMatchers {
+class ScriptParserTest extends BitcoinSUnitTest {
 
   "ScriptParser" must "parse 0x00 to a OP_0" in {
     ScriptParser.fromBytes(ByteVector(List(0.toByte))) must be(List(OP_0))

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawBaseTransactionParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawBaseTransactionParserTest.scala
@@ -6,13 +6,13 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionConstants
 }
 import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 1/14/16.
   */
-class RawBaseTransactionParserTest extends FlatSpec with MustMatchers {
+class RawBaseTransactionParserTest extends BitcoinSUnitTest {
   val encode = BitcoinSUtil.encodeHex(_: ByteVector)
   "RawBaseTransactionParser" must "parse a raw transaction" in {
     val tx: Transaction = RawBaseTransactionParser.read(TestUtil.rawTransaction)

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutPointParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutPointParserTest.scala
@@ -2,13 +2,13 @@ package org.bitcoins.core.serializers.transaction
 
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 1/11/16.
   */
-class RawTransactionOutPointParserTest extends FlatSpec with MustMatchers {
+class RawTransactionOutPointParserTest extends BitcoinSUnitTest {
 
   //txid cad1082e674a7bd3bc9ab1bc7804ba8a57523607c876b8eb2cbe645f2b1803d6
   val rawOutPoint =

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawTransactionOutputParserTest.scala
@@ -10,14 +10,14 @@ import org.bitcoins.core.script.bitwise.OP_EQUAL
 import org.bitcoins.core.script.constant.{BytesToPushOntoStack, ScriptConstant}
 import org.bitcoins.core.script.crypto.OP_HASH160
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
 /**
   * Created by chris on 1/11/16.
   * https://bitcoin.org/en/developer-reference#txout
   */
-class RawTransactionOutputParserTest extends FlatSpec with MustMatchers {
+class RawTransactionOutputParserTest extends BitcoinSUnitTest {
 
   //txid cad1082e674a7bd3bc9ab1bc7804ba8a57523607c876b8eb2cbe645f2b1803d6
   val rawTxOutput =

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawWitnessTransactionParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawWitnessTransactionParserTest.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.core.serializers.transaction
 
 import org.bitcoins.core.util.BitcoinSUtil
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
-class RawWitnessTransactionParserTest extends FlatSpec with MustMatchers {
+class RawWitnessTransactionParserTest extends BitcoinSUnitTest {
 
   "RawWitnessTransactionParser" must "serialize and deserialize a wtx" in {
     val hex =

--- a/core-test/src/test/scala/org/bitcoins/core/util/Base58Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/Base58Test.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.util
 
 import org.bitcoins.core.util.testprotocol._
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import spray.json._
 
 import scala.io.Source
@@ -9,7 +9,7 @@ import scala.io.Source
 /**
   * Created by tom on 5/17/16.
   */
-class Base58Test extends FlatSpec with MustMatchers {
+class Base58Test extends BitcoinSUnitTest {
   "Base58" must "encode byte value of 0 to character of 1" in {
     Base58.encode(0.toByte) must be("1")
   }

--- a/core-test/src/test/scala/org/bitcoins/core/util/BinaryTreeTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BinaryTreeTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.util
 
 import org.bitcoins.core.script.constant.{OP_0, OP_1, OP_2, ScriptToken}
 import org.bitcoins.core.script.control.{OP_ELSE, OP_ENDIF, OP_IF}
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 /**
   * Created by chris on 1/27/16.
   */
-class BinaryTreeTest extends FlatSpec with MustMatchers {
+class BinaryTreeTest extends BitcoinSUnitTest {
 
   "BinaryTree" must "convert a binary tree to a list with only leaf values" in {
     val bTree = Node(-1, Node(-1, Leaf(0), Leaf(1)), Node(-1, Leaf(2), Leaf(3)))

--- a/core-test/src/test/scala/org/bitcoins/core/util/BitcoinSUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BitcoinSUtilTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.core.util
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.BitVector
 
 /**
   * Created by chris on 4/1/16.
   */
-class BitcoinSUtilTest extends FlatSpec with MustMatchers {
+class BitcoinSUtilTest extends BitcoinSUnitTest {
 
   "BitcoinSUtil" must "determine if a string is a hex string" in {
     BitcoinSUtil.isHex("abcdef0123456789") must be(true)


### PR DESCRIPTION
This will be a lot to review, but most of it was able to be done through find and replace and then manually fixing the few errors.

Part of #769 