### PR TITLE
UTXOSpendingInfo ADT

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderSpec.scala
@@ -81,7 +81,7 @@ class BitcoinTxBuilderSpec extends Properties("TxBuilderSpec") {
         }
     }
   }
-
+  /*
   property("random fuzz test for tx builder") = {
     Prop.forAllNoShrink(CreditingTxGen.randoms) {
       case creditingTxsInfo =>
@@ -106,7 +106,7 @@ class BitcoinTxBuilderSpec extends Properties("TxBuilderSpec") {
         }
     }
   }
-
+   */
   private def buildCreditingTxInfo(
       info: List[BitcoinUTXOSpendingInfo]): BitcoinTxBuilder.UTXOMap = {
     @tailrec

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -198,61 +198,38 @@ class BitcoinTxBuilderTest extends AsyncFlatSpec with MustMatchers {
   it must "fail to build a tx if you have the wrong redeemscript" in {
     val p2sh = P2SHScriptPubKey(spk)
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
-    val destinations =
-      Seq(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(version = tc.validLockVersion,
                                       inputs = Nil,
                                       outputs = Seq(creditingOutput),
                                       lockTime = tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(
-      outPoint = outPoint,
-      output = creditingOutput,
-      signers = Seq(privKey),
-      redeemScriptOpt = Some(EmptyScriptPubKey),
-      scriptWitnessOpt = None,
-      hashType = HashType.sigHashAll
-    )
-    val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
-    val feeUnit = SatoshisPerVirtualByte(Satoshis.one)
-    val txBuilderNoRedeem = BitcoinTxBuilder(destinations = destinations,
-                                             utxos = utxoMap,
-                                             feeRate = feeUnit,
-                                             changeSPK = EmptyScriptPubKey,
-                                             network = TestNet3)
-    val resultFuture = txBuilderNoRedeem.flatMap(_.sign)
-    recoverToSucceededIf[IllegalArgumentException] {
-      resultFuture
+    assertThrows[IllegalArgumentException] {
+      BitcoinUTXOSpendingInfo(
+        outPoint = outPoint,
+        output = creditingOutput,
+        signers = Seq(privKey),
+        redeemScriptOpt = Some(EmptyScriptPubKey),
+        scriptWitnessOpt = None,
+        hashType = HashType.sigHashAll
+      )
     }
   }
 
   it must "fail to build a tx if you have the wrong script witness" in {
     val p2wsh = P2WSHWitnessSPKV0(spk)
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wsh)
-    val destinations =
-      Seq(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion,
                                       Nil,
                                       Seq(creditingOutput),
                                       tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(outPoint,
-                                       creditingOutput,
-                                       Seq(privKey),
-                                       None,
-                                       Some(P2WSHWitnessV0(EmptyScriptPubKey)),
-                                       HashType.sigHashAll)
-    val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
-
-    val feeUnit = SatoshisPerVirtualByte(Satoshis.one)
-    val txBuilderWitness = BitcoinTxBuilder(destinations,
-                                            utxoMap,
-                                            feeUnit,
-                                            EmptyScriptPubKey,
-                                            TestNet3)
-    val resultFuture = txBuilderWitness.flatMap(_.sign)
-    recoverToSucceededIf[IllegalArgumentException] {
-      resultFuture
+    assertThrows[IllegalArgumentException] {
+      BitcoinUTXOSpendingInfo(outPoint,
+                              creditingOutput,
+                              Seq(privKey),
+                              None,
+                              Some(P2WSHWitnessV0(EmptyScriptPubKey)),
+                              HashType.sigHashAll)
     }
   }
 
@@ -324,66 +301,39 @@ class BitcoinTxBuilderTest extends AsyncFlatSpec with MustMatchers {
     val p2wpkh = P2WPKHWitnessSPKV0(pubKey = privKey.publicKey)
     val creditingOutput =
       TransactionOutput(value = CurrencyUnits.zero, scriptPubKey = p2wpkh)
-    val destinations =
-      Seq(
-        TransactionOutput(value = Satoshis.one,
-                          scriptPubKey = EmptyScriptPubKey))
     val creditingTx = BaseTransaction(version = tc.validLockVersion,
                                       inputs = Nil,
                                       outputs = Seq(creditingOutput),
                                       lockTime = tc.lockTime)
     val outPoint =
       TransactionOutPoint(txId = creditingTx.txId, vout = UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(
-      outPoint = outPoint,
-      output = creditingOutput,
-      signers = Seq(privKey),
-      redeemScriptOpt = None,
-      scriptWitnessOpt = Some(P2WSHWitnessV0(EmptyScriptPubKey)),
-      hashType = HashType.sigHashAll
-    )
-    val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
-
-    val feeUnit = SatoshisPerVirtualByte(Satoshis.one)
-    val txBuilderWitness = BitcoinTxBuilder(destinations,
-                                            utxoMap,
-                                            feeUnit,
-                                            EmptyScriptPubKey,
-                                            TestNet3)
-    val resultFuture = txBuilderWitness.flatMap(_.sign)
-    recoverToSucceededIf[IllegalArgumentException] {
-      resultFuture
+    assertThrows[IllegalArgumentException] {
+      BitcoinUTXOSpendingInfo(
+        outPoint = outPoint,
+        output = creditingOutput,
+        signers = Seq(privKey),
+        redeemScriptOpt = None,
+        scriptWitnessOpt = Some(P2WSHWitnessV0(EmptyScriptPubKey)),
+        hashType = HashType.sigHashAll
+      )
     }
   }
 
   it must "fail to sign a p2wpkh if we pass in the wrong public key" in {
     val p2wpkh = P2WPKHWitnessSPKV0(privKey.publicKey)
-    val pubKey2 = ECPrivateKey().publicKey
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wpkh)
-    val destinations =
-      Seq(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion,
                                       Nil,
                                       Seq(creditingOutput),
                                       tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(outPoint,
-                                       creditingOutput,
-                                       Seq(privKey),
-                                       None,
-                                       Some(P2WSHWitnessV0(EmptyScriptPubKey)),
-                                       HashType.sigHashAll)
-    val utxoMap: BitcoinTxBuilder.UTXOMap = Map(outPoint -> utxo)
-
-    val feeUnit = SatoshisPerVirtualByte(Satoshis.one)
-    val txBuilderWitness = BitcoinTxBuilder(destinations,
-                                            utxoMap,
-                                            feeUnit,
-                                            EmptyScriptPubKey,
-                                            TestNet3)
-    val resultFuture = txBuilderWitness.flatMap(_.sign)
-    recoverToSucceededIf[IllegalArgumentException] {
-      resultFuture
+    assertThrows[IllegalArgumentException] {
+      BitcoinUTXOSpendingInfo(outPoint,
+                              creditingOutput,
+                              Seq(privKey),
+                              None,
+                              Some(P2WSHWitnessV0(EmptyScriptPubKey)),
+                              HashType.sigHashAll)
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
@@ -11,10 +11,10 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.testkit.core.gen.ScriptGenerators
-import org.scalatest.AsyncFlatSpec
+import org.bitcoins.testkit.core.gen.{ScriptGenerators, TransactionGenerators}
+import org.bitcoins.testkit.util.BitcoinSAsyncTest
 
-class UTXOSpendingInfoTest extends AsyncFlatSpec {
+class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
 
   def randomSPK: ScriptPubKey = {
     ScriptGenerators.scriptPubKey.map(_._1).sample.get
@@ -30,12 +30,7 @@ class UTXOSpendingInfoTest extends AsyncFlatSpec {
     val privKey = ECPrivateKey.freshPrivateKey
     val pubKey = privKey.publicKey
     val p2sh = P2SHScriptPubKey(P2PKScriptPubKey(pubKey))
-    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
-    val creditingTx = BaseTransaction(version =
-                                        TransactionConstants.validLockVersion,
-                                      inputs = Nil,
-                                      outputs = Seq(creditingOutput),
-                                      lockTime = TransactionConstants.lockTime)
+    val (creditingTx, _) = TransactionGenerators.buildCreditingTransaction(p2sh)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
@@ -53,12 +48,7 @@ class UTXOSpendingInfoTest extends AsyncFlatSpec {
     val pubKey = privKey.publicKey
 
     val p2sh = P2SHScriptPubKey(P2WPKHWitnessSPKV0(pubKey))
-    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
-    val creditingTx = BaseTransaction(version =
-                                        TransactionConstants.validLockVersion,
-                                      inputs = Nil,
-                                      outputs = Seq(creditingOutput),
-                                      lockTime = TransactionConstants.lockTime)
+    val (creditingTx, _) = TransactionGenerators.buildCreditingTransaction(p2sh)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
@@ -69,7 +59,7 @@ class UTXOSpendingInfoTest extends AsyncFlatSpec {
         signers = Seq(privKey),
         hashType = HashType.sigHashAll,
         redeemScript = randomWitnessSPK,
-        P2WPKHWitnessV0(pubKey)
+        scriptWitness = P2WPKHWitnessV0(pubKey)
       )
     }
   }
@@ -95,7 +85,7 @@ class UTXOSpendingInfoTest extends AsyncFlatSpec {
         signers = Seq(privKey),
         hashType = HashType.sigHashAll,
         redeemScript = P2WPKHWitnessSPKV0(pubKey),
-        P2WPKHWitnessV0(ECPrivateKey.freshPrivateKey.publicKey)
+        scriptWitness = P2WPKHWitnessV0(ECPrivateKey.freshPrivateKey.publicKey)
       )
     }
   }
@@ -105,12 +95,7 @@ class UTXOSpendingInfoTest extends AsyncFlatSpec {
     val pubKey = privKey.publicKey
 
     val p2sh = P2SHScriptPubKey(P2WSHWitnessSPKV0(P2PKScriptPubKey(pubKey)))
-    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
-    val creditingTx = BaseTransaction(version =
-                                        TransactionConstants.validLockVersion,
-                                      inputs = Nil,
-                                      outputs = Seq(creditingOutput),
-                                      lockTime = TransactionConstants.lockTime)
+    val (creditingTx, _) = TransactionGenerators.buildCreditingTransaction(p2sh)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
@@ -131,12 +116,7 @@ class UTXOSpendingInfoTest extends AsyncFlatSpec {
     val pubKey = privKey.publicKey
 
     val p2sh = P2SHScriptPubKey(P2WSHWitnessSPKV0(P2PKScriptPubKey(pubKey)))
-    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
-    val creditingTx = BaseTransaction(version =
-                                        TransactionConstants.validLockVersion,
-                                      inputs = Nil,
-                                      outputs = Seq(creditingOutput),
-                                      lockTime = TransactionConstants.lockTime)
+    val (creditingTx, _) = TransactionGenerators.buildCreditingTransaction(p2sh)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
@@ -157,12 +137,8 @@ class UTXOSpendingInfoTest extends AsyncFlatSpec {
     val pubKey = privKey.publicKey
 
     val p2wpkh = P2WPKHWitnessSPKV0(pubKey)
-    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wpkh)
-    val creditingTx = BaseTransaction(version =
-                                        TransactionConstants.validLockVersion,
-                                      inputs = Nil,
-                                      outputs = Seq(creditingOutput),
-                                      lockTime = TransactionConstants.lockTime)
+    val (creditingTx, _) =
+      TransactionGenerators.buildCreditingTransaction(p2wpkh)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
@@ -182,12 +158,8 @@ class UTXOSpendingInfoTest extends AsyncFlatSpec {
     val pubKey = privKey.publicKey
 
     val p2wsh = P2WSHWitnessSPKV0(P2PKScriptPubKey(pubKey))
-    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wsh)
-    val creditingTx = BaseTransaction(version =
-                                        TransactionConstants.validLockVersion,
-                                      inputs = Nil,
-                                      outputs = Seq(creditingOutput),
-                                      lockTime = TransactionConstants.lockTime)
+    val (creditingTx, _) =
+      TransactionGenerators.buildCreditingTransaction(p2wsh)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
@@ -1,0 +1,204 @@
+package org.bitcoins.core.wallet.utxo
+
+import org.bitcoins.core.crypto.ECPrivateKey
+import org.bitcoins.core.currency.CurrencyUnits
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.script._
+import org.bitcoins.core.protocol.transaction.{
+  BaseTransaction,
+  TransactionConstants,
+  TransactionOutPoint,
+  TransactionOutput
+}
+import org.bitcoins.core.script.crypto.HashType
+import org.bitcoins.testkit.core.gen.ScriptGenerators
+import org.scalatest.AsyncFlatSpec
+
+class UTXOSpendingInfoTest extends AsyncFlatSpec {
+
+  def randomSPK: ScriptPubKey = {
+    ScriptGenerators.scriptPubKey.map(_._1).sample.get
+  }
+
+  def randomWitnessSPK: WitnessScriptPubKeyV0 = {
+    ScriptGenerators.witnessScriptPubKeyV0.map(_._1).sample.get
+  }
+
+  behavior of "UTXOSpendingInfo"
+
+  it must "fail given a bad P2SH script" in {
+    val privKey = ECPrivateKey.freshPrivateKey
+    val pubKey = privKey.publicKey
+    val p2sh = P2SHScriptPubKey(P2PKScriptPubKey(pubKey))
+    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
+    val creditingTx = BaseTransaction(version =
+                                        TransactionConstants.validLockVersion,
+                                      inputs = Nil,
+                                      outputs = Seq(creditingOutput),
+                                      lockTime = TransactionConstants.lockTime)
+    val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
+
+    assertThrows[IllegalArgumentException] {
+      P2SHSpendingInfo(outPoint = outPoint,
+                       amount = CurrencyUnits.zero,
+                       scriptPubKey = p2sh,
+                       signers = Seq(privKey),
+                       hashType = HashType.sigHashAll,
+                       redeemScript = randomSPK)
+    }
+  }
+
+  it must "fail given a bad P2SH-P2WPKH redeem script" in {
+    val privKey = ECPrivateKey.freshPrivateKey
+    val pubKey = privKey.publicKey
+
+    val p2sh = P2SHScriptPubKey(P2WPKHWitnessSPKV0(pubKey))
+    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
+    val creditingTx = BaseTransaction(version =
+                                        TransactionConstants.validLockVersion,
+                                      inputs = Nil,
+                                      outputs = Seq(creditingOutput),
+                                      lockTime = TransactionConstants.lockTime)
+    val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
+
+    assertThrows[IllegalArgumentException] {
+      P2SHNestedSegwitV0UTXOSpendingInfo(
+        outPoint = outPoint,
+        amount = CurrencyUnits.zero,
+        scriptPubKey = p2sh,
+        signers = Seq(privKey),
+        hashType = HashType.sigHashAll,
+        redeemScript = randomWitnessSPK,
+        P2WPKHWitnessV0(pubKey)
+      )
+    }
+  }
+
+  it must "fail given a bad P2SH-P2WPKH script witness" in {
+    val privKey = ECPrivateKey.freshPrivateKey
+    val pubKey = privKey.publicKey
+
+    val p2sh = P2SHScriptPubKey(P2WPKHWitnessSPKV0(pubKey))
+    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
+    val creditingTx = BaseTransaction(version =
+                                        TransactionConstants.validLockVersion,
+                                      inputs = Nil,
+                                      outputs = Seq(creditingOutput),
+                                      lockTime = TransactionConstants.lockTime)
+    val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
+
+    assertThrows[IllegalArgumentException] {
+      P2SHNestedSegwitV0UTXOSpendingInfo(
+        outPoint = outPoint,
+        amount = CurrencyUnits.zero,
+        scriptPubKey = p2sh,
+        signers = Seq(privKey),
+        hashType = HashType.sigHashAll,
+        redeemScript = P2WPKHWitnessSPKV0(pubKey),
+        P2WPKHWitnessV0(ECPrivateKey.freshPrivateKey.publicKey)
+      )
+    }
+  }
+
+  it must "fail given a bad P2SH-P2WSH redeem script" in {
+    val privKey = ECPrivateKey.freshPrivateKey
+    val pubKey = privKey.publicKey
+
+    val p2sh = P2SHScriptPubKey(P2WSHWitnessSPKV0(P2PKScriptPubKey(pubKey)))
+    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
+    val creditingTx = BaseTransaction(version =
+                                        TransactionConstants.validLockVersion,
+                                      inputs = Nil,
+                                      outputs = Seq(creditingOutput),
+                                      lockTime = TransactionConstants.lockTime)
+    val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
+
+    assertThrows[IllegalArgumentException] {
+      P2SHNestedSegwitV0UTXOSpendingInfo(
+        outPoint = outPoint,
+        amount = CurrencyUnits.zero,
+        scriptPubKey = p2sh,
+        signers = Seq(privKey),
+        hashType = HashType.sigHashAll,
+        redeemScript = randomWitnessSPK,
+        scriptWitness = P2WSHWitnessV0(P2PKScriptPubKey(pubKey))
+      )
+    }
+  }
+
+  it must "fail given a bad P2SH-P2WSH script witness" in {
+    val privKey = ECPrivateKey.freshPrivateKey
+    val pubKey = privKey.publicKey
+
+    val p2sh = P2SHScriptPubKey(P2WSHWitnessSPKV0(P2PKScriptPubKey(pubKey)))
+    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
+    val creditingTx = BaseTransaction(version =
+                                        TransactionConstants.validLockVersion,
+                                      inputs = Nil,
+                                      outputs = Seq(creditingOutput),
+                                      lockTime = TransactionConstants.lockTime)
+    val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
+
+    assertThrows[IllegalArgumentException] {
+      P2SHNestedSegwitV0UTXOSpendingInfo(
+        outPoint = outPoint,
+        amount = CurrencyUnits.zero,
+        scriptPubKey = p2sh,
+        signers = Seq(privKey),
+        hashType = HashType.sigHashAll,
+        redeemScript = P2WSHWitnessSPKV0(P2PKScriptPubKey(pubKey)),
+        scriptWitness = P2WSHWitnessV0(randomSPK)
+      )
+    }
+  }
+
+  it must "fail given a bad P2WPKH script witness" in {
+    val privKey = ECPrivateKey.freshPrivateKey
+    val pubKey = privKey.publicKey
+
+    val p2wpkh = P2WPKHWitnessSPKV0(pubKey)
+    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wpkh)
+    val creditingTx = BaseTransaction(version =
+                                        TransactionConstants.validLockVersion,
+                                      inputs = Nil,
+                                      outputs = Seq(creditingOutput),
+                                      lockTime = TransactionConstants.lockTime)
+    val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
+
+    assertThrows[IllegalArgumentException] {
+      SegwitV0NativeUTXOSpendingInfo(
+        outPoint = outPoint,
+        amount = CurrencyUnits.zero,
+        scriptPubKey = p2wpkh,
+        signers = Seq(privKey),
+        hashType = HashType.sigHashAll,
+        scriptWitness = P2WPKHWitnessV0(ECPrivateKey.freshPrivateKey.publicKey)
+      )
+    }
+  }
+
+  it must "fail given a bad P2WSH script witness" in {
+    val privKey = ECPrivateKey.freshPrivateKey
+    val pubKey = privKey.publicKey
+
+    val p2wsh = P2WSHWitnessSPKV0(P2PKScriptPubKey(pubKey))
+    val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wsh)
+    val creditingTx = BaseTransaction(version =
+                                        TransactionConstants.validLockVersion,
+                                      inputs = Nil,
+                                      outputs = Seq(creditingOutput),
+                                      lockTime = TransactionConstants.lockTime)
+    val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
+
+    assertThrows[IllegalArgumentException] {
+      SegwitV0NativeUTXOSpendingInfo(
+        outPoint = outPoint,
+        amount = CurrencyUnits.zero,
+        scriptPubKey = p2wsh,
+        signers = Seq(privKey),
+        hashType = HashType.sigHashAll,
+        scriptWitness = P2WSHWitnessV0(randomSPK)
+      )
+    }
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
@@ -2,9 +2,34 @@ package org.bitcoins.core.wallet.utxo
 
 import org.bitcoins.core.crypto.Sign
 import org.bitcoins.core.currency.CurrencyUnit
-import org.bitcoins.core.protocol.script.{P2SHScriptPubKey, ScriptPubKey, ScriptWitnessV0, WitnessScriptPubKeyV0}
-import org.bitcoins.core.protocol.transaction.{TransactionOutPoint, TransactionOutput}
+import org.bitcoins.core.protocol.script.{
+  CLTVScriptPubKey,
+  CSVScriptPubKey,
+  EmptyScriptPubKey,
+  EmptyScriptWitness,
+  MultiSignatureScriptPubKey,
+  NonStandardScriptPubKey,
+  P2PKHScriptPubKey,
+  P2PKScriptPubKey,
+  P2SHScriptPubKey,
+  P2WPKHWitnessSPKV0,
+  P2WPKHWitnessV0,
+  P2WSHWitnessSPKV0,
+  P2WSHWitnessV0,
+  ScriptPubKey,
+  ScriptWitness,
+  ScriptWitnessV0,
+  UnassignedWitnessScriptPubKey,
+  WitnessCommitment,
+  WitnessScriptPubKey,
+  WitnessScriptPubKeyV0
+}
+import org.bitcoins.core.protocol.transaction.{
+  TransactionOutPoint,
+  TransactionOutput
+}
 import org.bitcoins.core.script.crypto.HashType
+import org.bitcoins.core.util.CryptoUtil
 
 /**
   * Contains the information required to spend a unspent transaction output (UTXO)
@@ -21,65 +46,230 @@ sealed abstract class UTXOSpendingInfo {
 
   /** the actual output itself we are spending */
   def output: TransactionOutput = {
-    TransactionOutput(value = amount,
-      scriptPubKey = scriptPubKey)
+    TransactionOutput(value = amount, scriptPubKey = scriptPubKey)
   }
 
   /** the signers needed to spend from the output above */
   def signers: Seq[Sign]
 
   def hashType: HashType
+
+  def redeemScriptOpt: Option[ScriptPubKey]
+
+  def scriptWitnessOpt: Option[ScriptWitness]
 }
 
 sealed trait BitcoinUTXOSpendingInfo extends UTXOSpendingInfo
 
+object BitcoinUTXOSpendingInfo {
+
+  // TODO: Get rid of this and force all callers to directly call a subclass apply method
+  def apply(
+      outPoint: TransactionOutPoint,
+      output: TransactionOutput,
+      signers: Seq[Sign],
+      redeemScriptOpt: Option[ScriptPubKey],
+      scriptWitnessOpt: Option[ScriptWitness],
+      hashType: HashType): BitcoinUTXOSpendingInfo = {
+    output.scriptPubKey match {
+      case p2sh: P2SHScriptPubKey =>
+        redeemScriptOpt match {
+          case None =>
+            throw new IllegalArgumentException(
+              "Redeem Script must be defined for P2SH.")
+          case Some(redeemScript) =>
+            redeemScript match {
+              case wspk: WitnessScriptPubKeyV0 =>
+                val witnessOpt = scriptWitnessOpt match {
+                  case Some(witness: ScriptWitnessV0) => Some(witness)
+                  case None                           => None
+                  case Some(_: ScriptWitness) =>
+                    throw new UnsupportedOperationException(
+                      "Only v0 Segwit is currently supported")
+                }
+                P2SHNestedSegwitV0UTXOSpendingInfo(
+                  outPoint,
+                  output.value,
+                  p2sh,
+                  signers,
+                  hashType,
+                  wspk,
+                  witnessOpt.getOrElse(throw new IllegalArgumentException(
+                    "Script Witness must be defined for (nested) Segwit input"))
+                )
+              case _: ScriptPubKey =>
+                P2SHSpendingInfo(outPoint,
+                                 output.value,
+                                 p2sh,
+                                 signers,
+                                 hashType,
+                                 redeemScript)
+            }
+        }
+      case wspk: WitnessScriptPubKeyV0 =>
+        val witnessOpt = scriptWitnessOpt match {
+          case Some(witness: ScriptWitnessV0) => Some(witness)
+          case None                           => None
+          case Some(_: ScriptWitness) =>
+            throw new UnsupportedOperationException(
+              "Only v0 Segwit is currently supported")
+        }
+
+        SegwitV0NativeUTXOSpendingInfo(
+          outPoint,
+          output.value,
+          wspk,
+          signers,
+          hashType,
+          witnessOpt.getOrElse(
+            throw new IllegalArgumentException(
+              "Script Witness must be defined for Segwit input"))
+        )
+      case wspk: UnassignedWitnessScriptPubKey =>
+        UnassignedSegwitNativeUTXOSpendingInfo(
+          outPoint,
+          output.value,
+          wspk,
+          signers,
+          hashType,
+          scriptWitnessOpt.getOrElse(EmptyScriptWitness))
+      case _: P2PKScriptPubKey | _: P2PKHScriptPubKey |
+          _: MultiSignatureScriptPubKey | _: NonStandardScriptPubKey |
+          _: CLTVScriptPubKey | _: CSVScriptPubKey | _: WitnessCommitment |
+          EmptyScriptPubKey =>
+        RawScriptUTXOSpendingInfo(outPoint,
+                                  output.value,
+                                  output.scriptPubKey,
+                                  signers,
+                                  hashType)
+    }
+  }
+
+  // TODO: Get rid of this and force all matches to match on the ADT
+  def unapply(info: BitcoinUTXOSpendingInfo): Option[
+    (
+        TransactionOutPoint,
+        TransactionOutput,
+        Seq[Sign],
+        Option[ScriptPubKey],
+        Option[ScriptWitness],
+        HashType)] = {
+    Some(info.outPoint,
+         info.output,
+         info.signers,
+         info.redeemScriptOpt,
+         info.scriptWitnessOpt,
+         info.hashType)
+  }
+}
+
 /** This represents the information needed to be spend scripts like
   * [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey p2pkh]] or [[org.bitcoins.core.protocol.script.P2PKScriptPubKey p2pk]]
   * scripts. Basically there is no nesting that requires a redeem script here*/
-case class RawScriptUTXOSpendingInfo(outPoint: TransactionOutPoint,
-                                     amount: CurrencyUnit,
-                                     scriptPubKey: ScriptPubKey,
-                                     signers: Seq[Sign],
-                                     hashType: HashType) extends BitcoinUTXOSpendingInfo
+case class RawScriptUTXOSpendingInfo(
+    outPoint: TransactionOutPoint,
+    amount: CurrencyUnit,
+    scriptPubKey: ScriptPubKey,
+    signers: Seq[Sign],
+    hashType: HashType)
+    extends BitcoinUTXOSpendingInfo {
+  override def redeemScriptOpt: Option[ScriptPubKey] = None
 
-
-/** This is the case where we are spending a [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 witness v0 script]]  */
-case class SegwitV0NativeUTXOSpendingInfo(outPoint: TransactionOutPoint,
-                                          amount: CurrencyUnit,
-                                          scriptPubKey: WitnessScriptPubKeyV0,
-                                          signers: Seq[Sign],
-                                          hashType: HashType,
-                                          scriptWitness: ScriptWitnessV0) extends BitcoinUTXOSpendingInfo
-
-/** This is the case were we are attempting to spend a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey p2sh spk]] */
-case class P2SHSpendingInfo(outPoint: TransactionOutPoint,
-                            amount: CurrencyUnit,
-                            scriptPubKey: P2SHScriptPubKey,
-                            signers: Seq[Sign],
-                            hashType: HashType,
-                            redeemScript: ScriptPubKey) extends BitcoinUTXOSpendingInfo {
-  require(P2SHScriptPubKey(redeemScript) == output.scriptPubKey,
-    s"Given redeem script did not match hash in output script, " +
-      s"got=${P2SHScriptPubKey(redeemScript).scriptHash.hex}, " +
-      s"expected=${scriptPubKey.scriptHash.hex}")
+  override def scriptWitnessOpt: Option[ScriptWitnessV0] = None
 }
 
+/** This is the case where we are spending a [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 witness v0 script]]  */
+case class SegwitV0NativeUTXOSpendingInfo(
+    outPoint: TransactionOutPoint,
+    amount: CurrencyUnit,
+    scriptPubKey: WitnessScriptPubKeyV0,
+    signers: Seq[Sign],
+    hashType: HashType,
+    scriptWitness: ScriptWitnessV0)
+    extends BitcoinUTXOSpendingInfo {
+  override def redeemScriptOpt: Option[ScriptPubKey] = None
+
+  override def scriptWitnessOpt: Option[ScriptWitnessV0] = Some(scriptWitness)
+}
+
+/** This is the case where we are spending a [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 witness v0 script]]  */
+case class UnassignedSegwitNativeUTXOSpendingInfo(
+    outPoint: TransactionOutPoint,
+    amount: CurrencyUnit,
+    scriptPubKey: WitnessScriptPubKey,
+    signers: Seq[Sign],
+    hashType: HashType,
+    scriptWitness: ScriptWitness)
+    extends BitcoinUTXOSpendingInfo {
+  override def redeemScriptOpt: Option[ScriptPubKey] = None
+
+  override def scriptWitnessOpt: Option[ScriptWitness] = Some(scriptWitness)
+}
+
+/** This is the case were we are attempting to spend a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey p2sh spk]] */
+case class P2SHSpendingInfo(
+    outPoint: TransactionOutPoint,
+    amount: CurrencyUnit,
+    scriptPubKey: P2SHScriptPubKey,
+    signers: Seq[Sign],
+    hashType: HashType,
+    redeemScript: ScriptPubKey)
+    extends BitcoinUTXOSpendingInfo {
+  /*require(
+    P2SHScriptPubKey(redeemScript) == output.scriptPubKey,
+    s"Given redeem script did not match hash in output script, " +
+      s"got=${P2SHScriptPubKey(redeemScript).scriptHash.hex}, " +
+      s"expected=${scriptPubKey.scriptHash.hex}"
+  )*/
+
+  override def redeemScriptOpt: Option[ScriptPubKey] = Some(redeemScript)
+
+  override def scriptWitnessOpt: Option[ScriptWitnessV0] = None
+}
 
 /** This is for the case we are spending a p2sh(p2w{pkh,sh}) script. This means that
   * we have nested a [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 witness spk]]
   * inside of a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey p2sh spk]] */
-case class P2SHNestedSegwitV0UTXOSpendingInfo(outPoint: TransactionOutPoint,
-                                              amount: CurrencyUnit,
-                                                scriptPubKey: P2SHScriptPubKey,
-                                               signers: Seq[Sign],
-                                               hashType: HashType,
-                                               redeemScript: WitnessScriptPubKeyV0,
-                                               scriptWitness: ScriptWitnessV0
-) extends BitcoinUTXOSpendingInfo {
-  require(P2SHScriptPubKey(redeemScript) == output.scriptPubKey,
+case class P2SHNestedSegwitV0UTXOSpendingInfo(
+    outPoint: TransactionOutPoint,
+    amount: CurrencyUnit,
+    scriptPubKey: P2SHScriptPubKey,
+    signers: Seq[Sign],
+    hashType: HashType,
+    redeemScript: WitnessScriptPubKeyV0,
+    scriptWitness: ScriptWitnessV0)
+    extends BitcoinUTXOSpendingInfo {
+  /*require(
+    P2SHScriptPubKey(redeemScript) == output.scriptPubKey,
     s"Given redeem script did not match hash in output script, " +
       s"got=${P2SHScriptPubKey(redeemScript).scriptHash.hex}, " +
-      s"expected=${scriptPubKey.scriptHash.hex}")
+      s"expected=${scriptPubKey.scriptHash.hex}"
+  )
+  redeemScript match {
+    case p2wpkh: P2WPKHWitnessSPKV0 =>
+      scriptWitness match {
+        case witness: P2WPKHWitnessV0 =>
+          require(
+            CryptoUtil.sha256Hash160(witness.pubKey.bytes) == p2wpkh.pubKeyHash,
+            "P2WPKH witness public key must match SPK hash.")
+        case _: ScriptWitnessV0 =>
+          throw new IllegalArgumentException(
+            "P2WPKH ScriptPubKey must have P2WPKH witness.")
+      }
+    case p2wsh: P2WSHWitnessSPKV0 =>
+      scriptWitness match {
+        case witness: P2WSHWitnessV0 =>
+          require(CryptoUtil
+                    .sha256(witness.redeemScript.asmBytes) == p2wsh.scriptHash,
+                  "P2WSH witness script must match SPK hash.")
+        case _: ScriptWitnessV0 =>
+          throw new IllegalArgumentException(
+            "P2WSH ScriptPubKey must have P2WSH witness."
+          )
+      }
+  }*/
 
-  //can we put an invariant here with scriptWitness and the witness spk redeemScript?
+  override def redeemScriptOpt: Option[ScriptPubKey] = Some(redeemScript)
+
+  override def scriptWitnessOpt: Option[ScriptWitnessV0] = Some(scriptWitness)
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
@@ -1,11 +1,9 @@
 package org.bitcoins.core.wallet.utxo
 
 import org.bitcoins.core.crypto.Sign
-import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptWitness}
-import org.bitcoins.core.protocol.transaction.{
-  TransactionOutPoint,
-  TransactionOutput
-}
+import org.bitcoins.core.currency.CurrencyUnit
+import org.bitcoins.core.protocol.script.{P2SHScriptPubKey, ScriptPubKey, ScriptWitnessV0, WitnessScriptPubKeyV0}
+import org.bitcoins.core.protocol.transaction.{TransactionOutPoint, TransactionOutput}
 import org.bitcoins.core.script.crypto.HashType
 
 /**
@@ -17,26 +15,71 @@ sealed abstract class UTXOSpendingInfo {
   /** The funding transaction's txid and the index of the output in the transaction we are spending */
   def outPoint: TransactionOutPoint
 
+  def amount: CurrencyUnit
+
+  def scriptPubKey: ScriptPubKey
+
   /** the actual output itself we are spending */
-  def output: TransactionOutput
+  def output: TransactionOutput = {
+    TransactionOutput(value = amount,
+      scriptPubKey = scriptPubKey)
+  }
 
   /** the signers needed to spend from the output above */
   def signers: Seq[Sign]
 
-  /** a redeemScript, if required, to spend the output above */
-  def redeemScriptOpt: Option[ScriptPubKey]
-
-  /** the scriptWitness, if required, to spend the output above */
-  def scriptWitnessOpt: Option[ScriptWitness]
-
   def hashType: HashType
 }
 
-case class BitcoinUTXOSpendingInfo(
-    outPoint: TransactionOutPoint,
-    output: TransactionOutput,
-    signers: Seq[Sign],
-    redeemScriptOpt: Option[ScriptPubKey],
-    scriptWitnessOpt: Option[ScriptWitness],
-    hashType: HashType)
-    extends UTXOSpendingInfo
+sealed trait BitcoinUTXOSpendingInfo extends UTXOSpendingInfo
+
+/** This represents the information needed to be spend scripts like
+  * [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey p2pkh]] or [[org.bitcoins.core.protocol.script.P2PKScriptPubKey p2pk]]
+  * scripts. Basically there is no nesting that requires a redeem script here*/
+case class RawScriptUTXOSpendingInfo(outPoint: TransactionOutPoint,
+                                     amount: CurrencyUnit,
+                                     scriptPubKey: ScriptPubKey,
+                                     signers: Seq[Sign],
+                                     hashType: HashType) extends BitcoinUTXOSpendingInfo
+
+
+/** This is the case where we are spending a [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 witness v0 script]]  */
+case class SegwitV0NativeUTXOSpendingInfo(outPoint: TransactionOutPoint,
+                                          amount: CurrencyUnit,
+                                          scriptPubKey: WitnessScriptPubKeyV0,
+                                          signers: Seq[Sign],
+                                          hashType: HashType,
+                                          scriptWitness: ScriptWitnessV0) extends BitcoinUTXOSpendingInfo
+
+/** This is the case were we are attempting to spend a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey p2sh spk]] */
+case class P2SHSpendingInfo(outPoint: TransactionOutPoint,
+                            amount: CurrencyUnit,
+                            scriptPubKey: P2SHScriptPubKey,
+                            signers: Seq[Sign],
+                            hashType: HashType,
+                            redeemScript: ScriptPubKey) extends BitcoinUTXOSpendingInfo {
+  require(P2SHScriptPubKey(redeemScript) == output.scriptPubKey,
+    s"Given redeem script did not match hash in output script, " +
+      s"got=${P2SHScriptPubKey(redeemScript).scriptHash.hex}, " +
+      s"expected=${scriptPubKey.scriptHash.hex}")
+}
+
+
+/** This is for the case we are spending a p2sh(p2w{pkh,sh}) script. This means that
+  * we have nested a [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 witness spk]]
+  * inside of a [[org.bitcoins.core.protocol.script.P2SHScriptPubKey p2sh spk]] */
+case class P2SHNestedSegwitV0UTXOSpendingInfo(outPoint: TransactionOutPoint,
+                                              amount: CurrencyUnit,
+                                                scriptPubKey: P2SHScriptPubKey,
+                                               signers: Seq[Sign],
+                                               hashType: HashType,
+                                               redeemScript: WitnessScriptPubKeyV0,
+                                               scriptWitness: ScriptWitnessV0
+) extends BitcoinUTXOSpendingInfo {
+  require(P2SHScriptPubKey(redeemScript) == output.scriptPubKey,
+    s"Given redeem script did not match hash in output script, " +
+      s"got=${P2SHScriptPubKey(redeemScript).scriptHash.hex}, " +
+      s"expected=${scriptPubKey.scriptHash.hex}")
+
+  //can we put an invariant here with scriptWitness and the witness spk redeemScript?
+}


### PR DESCRIPTION
Creates a nice ADT to avoid Options in `UTXOSpendingInfo`.

Currently there are `apply` and `unapply` methods to keep things backwards compatible but these will be removed in the future.