### PR TITLE
Revert "Update sbt-mdoc to 1.3.6"

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,7 +25,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.5")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")
 
 // write markdown files with type-checked Scala
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.3.6")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.3.2")
 
 // SQL migrations
 addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % "6.0.0")


### PR DESCRIPTION
Reverts bitcoin-s/bitcoin-s#831

I did not look closely enough at CI logs, this appears to break CI:

https://travis-ci.org/bitcoin-s/bitcoin-s/jobs/602824709#L525