### PR TITLE
Revert "Update scalafmt-core to 2.2.1"

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.2.1"
+version = "2.0.1"
 # See Documentation at https://scalameta.org/scalafmt/#Configuration
 trailingCommas = never
 maxColumn = 80


### PR DESCRIPTION
Reverts bitcoin-s/bitcoin-s#833

This causes us to have to format _all_ of our scala files. We don't want to do this for now since that would be a sizable diff and would cause a lot of rebase issues. We should merge this right before our next release.