### PR TITLE
RawScriptPubKey

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptWitnessSpec.scala
@@ -14,7 +14,7 @@ class ScriptWitnessSpec extends Properties("ScriptWitnessSpec") {
   }
 
   property("pull redeem script out of p2wsh witness") = {
-    Prop.forAll(ScriptGenerators.nonWitnessScriptPubKey) {
+    Prop.forAll(ScriptGenerators.rawScriptPubKey) {
       case (spk, _) =>
         P2WSHWitnessV0(spk).redeemScript == spk
     }

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
@@ -20,8 +20,8 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     ScriptGenerators.scriptPubKey.map(_._1).sample.get
   }
 
-  def randomNonWitnessSPK: NonWitnessScriptPubKey = {
-    ScriptGenerators.nonWitnessScriptPubKey.map(_._1).sample.get
+  def randomRawSPK: RawScriptPubKey = {
+    ScriptGenerators.rawScriptPubKey.map(_._1).sample.get
   }
 
   def randomWitnessSPK: WitnessScriptPubKeyV0 = {
@@ -43,7 +43,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
                              scriptPubKey = p2sh,
                              signers = Seq(privKey),
                              hashType = HashType.sigHashAll,
-                             redeemScript = randomNonWitnessSPK)
+                             redeemScript = randomRawSPK)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -26,8 +26,10 @@ import scala.util.{Failure, Success, Try}
   */
 sealed abstract class ScriptPubKey extends Script
 
+/** Trait for all Non-SegWit ScriptPubKeys  */
 sealed trait NonWitnessScriptPubKey extends ScriptPubKey
 
+/** Trait for all raw, non-nested ScriptPubKeys (no P2SH) */
 sealed trait RawScriptPubKey extends NonWitnessScriptPubKey
 
 /**
@@ -579,7 +581,7 @@ case object EmptyScriptPubKey extends RawScriptPubKey {
 }
 
 object RawScriptPubKey extends ScriptFactory[RawScriptPubKey] {
-  def empty: RawScriptPubKey = fromAsm(Nil)
+  val empty: RawScriptPubKey = fromAsm(Nil)
 
   def fromAsm(asm: Seq[ScriptToken]): RawScriptPubKey = asm match {
     case Nil => EmptyScriptPubKey
@@ -599,7 +601,7 @@ object RawScriptPubKey extends ScriptFactory[RawScriptPubKey] {
 }
 
 object NonWitnessScriptPubKey extends ScriptFactory[NonWitnessScriptPubKey] {
-  def empty: NonWitnessScriptPubKey = fromAsm(Nil)
+  val empty: NonWitnessScriptPubKey = fromAsm(Nil)
 
   def fromAsm(asm: Seq[ScriptToken]): NonWitnessScriptPubKey = {
     if (P2SHScriptPubKey.isP2SHScriptPubKey(asm)) {
@@ -615,7 +617,7 @@ object NonWitnessScriptPubKey extends ScriptFactory[NonWitnessScriptPubKey] {
 /** Factory companion object used to create
   * [[org.bitcoins.core.protocol.script.ScriptPubKey ScriptPubKey]] objects */
 object ScriptPubKey extends ScriptFactory[ScriptPubKey] {
-  def empty: ScriptPubKey = fromAsm(Nil)
+  val empty: ScriptPubKey = fromAsm(Nil)
 
   /** Creates a `scriptPubKey` from its asm representation */
   def fromAsm(asm: Seq[ScriptToken]): ScriptPubKey = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -86,9 +86,9 @@ object P2WPKHWitnessV0 {
   * Format: <redeem script> <scriptSig data1> <scriptSig data2> ... <scriptSig dataN>
   */
 sealed abstract class P2WSHWitnessV0 extends ScriptWitnessV0 {
-  lazy val redeemScript: NonWitnessScriptPubKey = {
+  lazy val redeemScript: RawScriptPubKey = {
     val cmpct = CompactSizeUInt.calc(stack.head)
-    NonWitnessScriptPubKey.fromBytes(cmpct.bytes ++ stack.head)
+    RawScriptPubKey.fromBytes(cmpct.bytes ++ stack.head)
   }
   override def toString =
     s"P2WSHWitnessV0(${stack.map(BitcoinSUtil.encodeHex(_)).toString})"

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
@@ -255,6 +255,17 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     )
   }
 
+  def rawScriptPubKey: Gen[(RawScriptPubKey, Seq[ECPrivateKey])] = {
+    Gen.oneOf(
+      p2pkScriptPubKey.map(privKeyToSeq),
+      p2pkhScriptPubKey.map(privKeyToSeq),
+      multiSigScriptPubKey,
+      emptyScriptPubKey,
+      lockTimeScriptPubKey,
+      witnessCommitment
+    )
+  }
+
   /** Generates an arbitrary `ScriptSignature` */
   def scriptSignature: Gen[ScriptSignature] = {
     Gen.oneOf(


### PR DESCRIPTION
Further elaborated the `NonWitnessScriptPubKey` type with a subtype `RawScriptPubKey` which excludes `P2SH`