### PR TITLE
GCSTest fix

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
@@ -189,7 +189,7 @@ class GCSTest extends BitcoinSUnitTest {
 
     def items: Gen[(Vector[UInt64], UInt8)] = {
       NumberGenerator.genP.flatMap { p =>
-        Gen.choose(1, 250).flatMap { size =>
+        Gen.choose(10, 250).flatMap { size =>
           // If hash's quotient when divided by 2^p is too large, we hang converting to unary
           val upperBound: Long = 1L << (p.toInt * 1.75).toInt
 

--- a/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/gcs/GCSTest.scala
@@ -189,7 +189,7 @@ class GCSTest extends BitcoinSUnitTest {
 
     def items: Gen[(Vector[UInt64], UInt8)] = {
       NumberGenerator.genP.flatMap { p =>
-        Gen.choose(10, 250).flatMap { size =>
+        Gen.choose(10, 50).flatMap { size =>
           // If hash's quotient when divided by 2^p is too large, we hang converting to unary
           val upperBound: Long = 1L << (p.toInt * 1.75).toInt
 


### PR DESCRIPTION
Raised the min p value in GCSTest to avoid large `x/2^p` values which causes long unary to happen.

I realize in the past we have lowered this number but I realize now that this likely hasn't had an effect as the issue is when 2^p is too small not too large. The reason this has effected this test and not the next one is because the next one already had a lower bound of 8 (and not 1) for the exponent p.