### PR TITLE
ScriptInterpreter Conditional Refactor

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
@@ -66,15 +66,16 @@ class ScriptProgramFactoryTest extends BitcoinSUnitTest {
       ScriptFlagFactory.empty)
     val program = PreExecutionScriptProgram(t)
     val inProgress =
-      ExecutionInProgressScriptProgram(t,
-                                       stack,
-                                       script,
-                                       Nil,
-                                       Nil,
-                                       Nil,
-                                       None,
-                                       0,
-                                       0)
+      ExecutionInProgressScriptProgram(
+        txSignatureComponent = t,
+        stack = stack,
+        script = script,
+        originalScript = Nil,
+        altStack = Nil,
+        flags = Nil,
+        lastCodeSeparator = None,
+        conditionalCounter = ConditionalCounter.empty
+      )
     inProgress.stack must be(stack)
     inProgress.script must be(script)
   }

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
@@ -73,7 +73,8 @@ class ScriptProgramFactoryTest extends BitcoinSUnitTest {
                                        Nil,
                                        Nil,
                                        None,
-                                       Vector.empty)
+                                       0,
+                                       0)
     inProgress.stack must be(stack)
     inProgress.script must be(script)
   }

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
@@ -66,7 +66,14 @@ class ScriptProgramFactoryTest extends BitcoinSUnitTest {
       ScriptFlagFactory.empty)
     val program = PreExecutionScriptProgram(t)
     val inProgress =
-      ExecutionInProgressScriptProgram(t, stack, script, Nil, Nil, Nil, None)
+      ExecutionInProgressScriptProgram(t,
+                                       stack,
+                                       script,
+                                       Nil,
+                                       Nil,
+                                       Nil,
+                                       None,
+                                       Vector.empty)
     inProgress.stack must be(stack)
     inProgress.script must be(script)
   }

--- a/core-test/src/test/scala/org/bitcoins/core/script/control/ControlOperationsInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/control/ControlOperationsInterpreterTest.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.core.script.control
 
-import org.bitcoins.core.script.ExecutionInProgressScriptProgram
+import org.bitcoins.core.script.{
+  ExecutedScriptProgram,
+  ExecutionInProgressScriptProgram,
+  StartedScriptProgram
+}
 import org.bitcoins.core.script.arithmetic.OP_ADD
 import org.bitcoins.core.script.bitwise.OP_EQUAL
 import org.bitcoins.core.script.constant._
@@ -75,434 +79,23 @@ class ControlOperationsInterpreterTest extends FlatSpec with MustMatchers {
     }
   }
 
-  it must "find the first index of our OP_ENDIF in a list of script tokens" in {
-    val l = List(OP_ENDIF)
-    COI.findFirstOpEndIf(l) must be(Some(0))
-    COI.findFirstOpEndIf(List(OP_IF, OP_ELSE, OP_ENDIF, OP_ENDIF)) must be(
-      Some(2))
-    COI.findFirstOpEndIf(List(OP_0, OP_1, OP_2)) must be(None)
-    COI.findFirstOpEndIf(List(OP_IF, OP_RESERVED, OP_ENDIF, OP_1)) must be(
-      Some(2))
-
-  }
-
-  it must "find the last index of our OP_ENDIF in a list of script tokens" in {
-    val l = List(OP_ENDIF)
-    COI.findLastOpEndIf(l) must be(Some(0))
-    COI.findLastOpEndIf(List(OP_IF, OP_ELSE, OP_ENDIF, OP_ENDIF)) must be(
-      Some(3))
-    COI.findLastOpEndIf(List(OP_0, OP_1, OP_2)) must be(None)
-    COI.findLastOpEndIf(List(OP_IF, OP_RESERVED, OP_ENDIF, OP_ENDIF, OP_1)) must be(
-      Some(3))
-
-  }
-
-  it must "find the first indexes of OP_ELSE in a list of script tokens" in {
-    COI.findFirstOpElse(List(OP_ELSE)) must be(Some(0))
-    COI.findFirstOpElse(List(OP_IF, OP_ELSE, OP_ENDIF, OP_ELSE)) must be(
-      Some(1))
-    COI.findFirstOpElse(List(OP_0, OP_1, OP_2)) must be(None)
-  }
-
-  it must "find the first indexes of OP_ELSE and OP_ENDIF in a list of script tokens" in {
-    COI.findFirstIndexesOpElseOpEndIf(List(OP_ELSE, OP_ENDIF)) must be(Some(0),
-                                                                       Some(1))
-    COI.findFirstIndexesOpElseOpEndIf(
-      List(OP_IF, OP_ELSE, OP_ENDIF, OP_IF, OP_ELSE, OP_ENDIF)) must be(Some(1),
-                                                                        Some(2))
-    COI.findFirstIndexesOpElseOpEndIf(List(OP_IF, OP_IF)) must be(None, None)
-  }
-
-  it must "remove the first OP_IF expression in a script" in {
-    COI.removeFirstOpIf(List(OP_IF, OP_ELSE, OP_ENDIF)) must be(
-      List(OP_ELSE, OP_ENDIF))
-    COI.removeFirstOpIf(
-      List(OP_IF, OP_1, OP_ELSE, OP_2, OP_ELSE, OP_3, OP_ENDIF)) must be(
-      List(OP_ELSE, OP_2, OP_ELSE, OP_3, OP_ENDIF))
-    COI.removeFirstOpIf(List(OP_IF, OP_ENDIF)) must be(List(OP_ENDIF))
-  }
-
-  it must "remove the first OP_ELSE expression in a script" in {
-    COI.removeFirstOpElse(List(OP_IF, OP_ELSE, OP_ENDIF)) must be(
-      List(OP_IF, OP_ENDIF))
-    COI.removeFirstOpElse(List(OP_IF, OP_ENDIF)) must be(List(OP_IF, OP_ENDIF))
-    COI.removeFirstOpElse(
-      List(OP_IF, OP_1, OP_ELSE, OP_2, OP_ELSE, OP_3, OP_ENDIF)) must be(
-      List(OP_IF, OP_1, OP_ELSE, OP_3, OP_ENDIF))
-  }
-
-  it must "remove the first OP_ELSE in a binary tree" in {
-    val script1 = List(OP_IF, OP_ELSE, OP_ENDIF)
-    val bTree1 = COI.parseBinaryTree(script1)
-    COI.removeFirstOpElse(bTree1).toSeq must be(List(OP_IF, OP_ENDIF))
-
-    val script2 = List(OP_IF, OP_ENDIF)
-    val bTree2 = COI.parseBinaryTree(script2)
-    bTree2 must be(Node(OP_IF, Empty, Leaf(OP_ENDIF)))
-    COI.removeFirstOpElse(bTree2).toSeq must be(script2)
-
-    val script3 = List(OP_IF, OP_1, OP_ELSE, OP_2, OP_ELSE, OP_3, OP_ENDIF)
-    val bTree3 = COI.parseBinaryTree(script3)
-    COI.removeFirstOpElse(bTree3).toSeq must be(
-      List(OP_IF, OP_1, OP_ELSE, OP_3, OP_ENDIF))
-  }
-
-  it must "find a matching OP_ENDIF for an OP_IF" in {
-    //https://gist.github.com/Christewart/381dc1dbbb07e62501c3
-    val script = List(
-      OP_IF,
-      OP_1,
-      OP_IF,
-      OP_RETURN,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ENDIF,
-      OP_ELSE,
-      OP_1,
-      OP_IF,
-      OP_1,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ELSE,
-      OP_1,
-      OP_ENDIF,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ENDIF,
-      OP_ADD,
-      OP_2,
-      OP_EQUAL
-    )
-    COI.findMatchingOpEndIf(script) must be(20)
-  }
-
-  it must "parse a script as a binary tree then convert it back to the original list" in {
-
-    val script0 = List(OP_IF, OP_ENDIF)
-    val bTree = COI.parseBinaryTree(script0)
-    bTree.right.get must be(Leaf(OP_ENDIF))
-    bTree.toSeq must be(script0)
-
-    val script1 = List(OP_IF, OP_0, OP_ELSE, OP_1, OP_ENDIF)
-    val bTree1 = COI.parseBinaryTree(script1)
-    bTree1.toSeq must be(script1)
-
-    val script2 = List(OP_IF, OP_ELSE, OP_ELSE, OP_ENDIF)
-    COI.parseBinaryTree(script2).toSeq must be(script2)
-
-    val script3 = List(OP_IF, OP_1, OP_ELSE, OP_0, OP_ENDIF)
-    val bTree3 = COI.parseBinaryTree(script3)
-    bTree3.toSeq must be(script3)
-
-    val script5 = List(OP_IF, OP_1, OP_ELSE, OP_2, OP_ELSE, OP_3, OP_ENDIF)
-    COI.parseBinaryTree(script5).toSeq must be(script5)
-
-    val script6 = List(OP_IF, OP_IF, OP_1, OP_ENDIF, OP_ELSE, OP_2, OP_ENDIF)
-    val tree6 = COI.parseBinaryTree(script6)
-    tree6.left.get must be(Node(OP_IF, Leaf(OP_1), Leaf(OP_ENDIF)))
-    tree6.right.get must be(Node(OP_ELSE, Leaf(OP_2), Leaf(OP_ENDIF)))
-    COI.parseBinaryTree(script6).toSeq must be(script6)
-
-    val script7 = List(OP_IF, OP_1, OP_ELSE, OP_IF, OP_2, OP_ENDIF, OP_ENDIF)
-    val tree7 = COI.parseBinaryTree(script7)
-    val expectedTree7 = Node(
-      OP_IF,
-      Leaf(OP_1),
-      Node(OP_ELSE, Node(OP_IF, Leaf(OP_2), Leaf(OP_ENDIF)), Leaf(OP_ENDIF)))
-    tree7 must be(expectedTree7)
-    tree7.left must be(expectedTree7.left)
-    tree7.right must be(expectedTree7.right)
-
-    val subTree1 =
-      Node(OP_IF, Leaf(OP_0), Node(OP_ELSE, Leaf(OP_1), Leaf(OP_ENDIF)))
-    val subTree2 =
-      Node(OP_ELSE,
-           Node(OP_IF, Leaf(OP_2), Node(OP_ELSE, Leaf(OP_3), Leaf(OP_ENDIF))),
-           Leaf(OP_ENDIF))
-    val expected: BinaryTree[ScriptToken] = Node(OP_IF, subTree1, subTree2)
-    val script4 = List(OP_IF,
-                       OP_IF,
-                       OP_0,
-                       OP_ELSE,
-                       OP_1,
-                       OP_ENDIF,
-                       OP_ELSE,
-                       OP_IF,
-                       OP_2,
-                       OP_ELSE,
-                       OP_3,
-                       OP_ENDIF,
-                       OP_ENDIF)
-    val bTree4 = COI.parseBinaryTree(script4)
-    bTree4.left.get must be(subTree1)
-    bTree4.right.get must be(subTree2)
-    bTree4 must be(expected)
-    logger.debug("bTree4: " + bTree4)
-    bTree4.toSeq must be(script4)
-
-    val script8 = List(OP_IF, OP_0, OP_ENDIF, OP_2)
-    val tree8 = COI.parseBinaryTree(script8)
-    tree8.toSeq must be(script8)
-
-  }
-  it must "parse a script into a binary tree and have the OP_IF expression on the left branch and the OP_ELSE expression on the right branch" in {
-    val script = List(OP_IF, OP_0, OP_ELSE, OP_1, OP_ENDIF)
-    val bTree = COI.parseBinaryTree(script)
-    bTree.value.get must be(OP_IF)
-
-    bTree.left.isDefined must be(true)
-    bTree.left.get.value must be(Some(OP_0))
-
-    bTree.right.isDefined must be(true)
-    bTree.right.get.value must be(Some(OP_ELSE))
-
-    bTree.right.get.left.isDefined must be(true)
-    bTree.right.get.left.get.value must be(Some(OP_1))
-
-    bTree.right.get.right.isDefined must be(true)
-    bTree.right.get.right.get.value must be(Some(OP_ENDIF))
-  }
-
-  it must "parse nested OP_ELSE statements into the same branch" in {
-    val script = List(OP_IF, OP_1, OP_ELSE, OP_2, OP_ELSE, OP_3, OP_ENDIF)
-    val bTree = COI.parseBinaryTree(script)
-    bTree.value.get must be(OP_IF)
-
-    bTree.left.isDefined must be(true)
-    bTree.left.get.value must be(Some(OP_1))
-
-    bTree.right.isDefined must be(true)
-    bTree.right.get.value must be(Some(OP_ELSE))
-
-    bTree.right.get.left.isDefined must be(true)
-    bTree.right.get.left.get.value must be(Some(OP_2))
-
-    bTree.right.get.right.isDefined must be(true)
-    bTree.right.get.right.get.value must be(Some(OP_ELSE))
-
-    bTree.right.get.right.get.left.isDefined must be(true)
-    bTree.right.get.right.get.left.get.value must be(Some(OP_3))
-
-    bTree.right.get.right.get.right.isDefined must be(true)
-    bTree.right.get.right.get.right.get.value must be(Some(OP_ENDIF))
-
-    bTree.toSeq must be(script)
-
-  }
-
-  it must "parse a binary tree from a script with nested OP_IFs and OP_ELSES on both branches" in {
-    val script = List(OP_IF,
-                      OP_IF,
-                      OP_0,
-                      OP_ELSE,
-                      OP_1,
-                      OP_ENDIF,
-                      OP_ELSE,
-                      OP_IF,
-                      OP_2,
-                      OP_ELSE,
-                      OP_3,
-                      OP_ENDIF,
-                      OP_ENDIF)
-    val bTree = COI.parseBinaryTree(script)
-
-    bTree.value must be(Some(OP_IF))
-
-    bTree.left.get.value must be(Some(OP_IF))
-    bTree.left.get.right.get.value must be(Some(OP_ELSE))
-    bTree.left.get.right.get.left.get.value must be(Some(OP_1))
-    bTree.left.get.right.get.right.get.value must be(Some(OP_ENDIF))
-
-    bTree.right.get.value must be(Some(OP_ELSE))
-    bTree.right.get.left.get.value must be(Some(OP_IF))
-    bTree.right.get.left.get.left.get.value must be(Some(OP_2))
-    bTree.right.get.left.get.right.get.value must be(Some(OP_ELSE))
-    bTree.right.get.left.get.right.get.left.get.value must be(Some(OP_3))
-    bTree.right.get.left.get.right.get.right.get.value must be(Some(OP_ENDIF))
-
-  }
-
-  it must "parse a binary tree from a script where constants are nested inside of OP_IF OP_ELSE branches" in {
-    val script =
-      List(OP_IF, OP_0, OP_IF, OP_1, OP_ENDIF, OP_ELSE, OP_2, OP_ENDIF)
-    val bTree = COI.parseBinaryTree(script)
-    bTree.left.get.value.get must be(OP_0)
-    bTree.left.get.left.get.value.get must be(OP_IF)
-    bTree.toSeq must be(script)
-
-    val script1 =
-      List(OP_IF, OP_1, OP_ELSE, OP_2, OP_IF, OP_3, OP_ENDIF, OP_ENDIF)
-    val bTree1 = COI.parseBinaryTree(script1)
-    bTree1.toSeq must be(script1)
-
-    val script2 =
-      List(OP_IF, OP_0, OP_ELSE, OP_1, OP_ELSE, OP_2, OP_ELSE, OP_3, OP_ENDIF)
-    val bTree2 = COI.parseBinaryTree(script2)
-    bTree2.left.get must be(Leaf(OP_0))
-    bTree2.right.get must be(
-      Node(
-        OP_ELSE,
-        Leaf(OP_1),
-        Node(OP_ELSE, Leaf(OP_2), Node(OP_ELSE, Leaf(OP_3), Leaf(OP_ENDIF)))))
-    bTree2.toSeq must be(script2)
-
-    val script3 =
-      List(OP_IF, OP_0, OP_ELSE, OP_IF, OP_1, OP_ENDIF, OP_ELSE, OP_2, OP_ENDIF)
-    val bTree3 = COI.parseBinaryTree(script3)
-    bTree3.toSeq must be(script3)
-    //"0" "IF 1 IF RETURN ELSE RETURN ELSE RETURN ENDIF ELSE 1 IF 1 ELSE RETURN ELSE 1 ENDIF ELSE RETURN ENDIF ADD 2 EQUAL"
-    val script4 = List(
-      OP_IF,
-      OP_0,
-      OP_IF,
-      OP_1,
-      OP_ELSE,
-      OP_2,
-      OP_ELSE,
-      OP_3,
-      OP_ENDIF,
-      OP_ELSE,
-      OP_4,
-      OP_IF,
-      OP_5,
-      OP_ELSE,
-      OP_6,
-      OP_ELSE,
-      OP_7,
-      OP_ENDIF,
-      OP_ELSE,
-      OP_8,
-      OP_ENDIF,
-      OP_ADD,
-      OP_9,
-      OP_EQUAL
-    )
-
-    val subTree40 =
-      Node(OP_IF,
-           Leaf(OP_1),
-           Node(OP_ELSE, Leaf(OP_2), Node(OP_ELSE, Leaf(OP_3), Leaf(OP_ENDIF))))
-    val subTree41 = Node(OP_0, subTree40, Empty)
-
-    val subTree42 =
-      Node(OP_IF,
-           Leaf(OP_5),
-           Node(OP_ELSE, Leaf(OP_6), Node(OP_ELSE, Leaf(OP_7), Leaf(OP_ENDIF))))
-
-    val subTree43 = Node(OP_ADD, Node(OP_9, Leaf(OP_EQUAL), Empty), Empty)
-    val subTree44 = Node(OP_ELSE, Leaf(OP_8), Node(OP_ENDIF, subTree43, Empty))
-    val subTree45 = Node(OP_ELSE, Node(OP_4, subTree42, Empty), subTree44)
-
-    val expectedBTree4 = Node(OP_IF, subTree41, subTree45)
-    val bTree4 = COI.parseBinaryTree(script4)
-    bTree4.left.get must be(subTree41)
-    bTree4.right.get.left.get must be(subTree45.l)
-    bTree4.right.get.right.get must be(subTree45.r)
-    bTree4 must be(expectedBTree4)
-    bTree4.toSeq must be(script4)
-    bTree4.right.get.right.get.right.get.left.get.value must be(Some(OP_ADD))
-    bTree4.right.get.right.get.right.get.left.get.left.get.value must be(
-      Some(OP_9))
-    bTree4.right.get.right.get.right.get.left.get.left.get.left.get.value must be(
-      Some(OP_EQUAL))
-  }
-
-  it must "parse a binary tree where there are nested OP_ELSES in the outer most OP_ELSE" in {
-    //https://gist.github.com/Christewart/a5253cf708903323ddc6
-    val script = List(
-      OP_IF,
-      OP_1,
-      OP_IF,
-      OP_RETURN,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ENDIF,
-      OP_ELSE,
-      OP_1,
-      OP_IF,
-      OP_1,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ELSE,
-      OP_1,
-      OP_ENDIF,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ENDIF,
-      OP_ADD,
-      OP_2,
-      OP_EQUAL
-    )
-
-    val bTree = COI.parseBinaryTree(script)
-
-    bTree.toSeq must be(script)
-
-    bTree.right.get.value must be(Some(OP_ELSE))
-    bTree.right.get.left.get.value must be(Some(OP_1))
-
-    bTree.right.get.right.get.value must be(Some(OP_ELSE))
-    bTree.right.get.right.get.left.get.value must be(Some(OP_RETURN))
-
-    bTree.right.get.right.get.right.get.value must be(Some(OP_ENDIF))
-    bTree.right.get.right.get.right.get.left.get.value must be(Some(OP_ADD))
-
-  }
-
-  it must "parse a binary tree that has OP_NOTIFs" in {
-    val script = List(OP_NOTIF, OP_1, OP_ELSE, OP_2, OP_ELSE, OP_3, OP_ENDIF)
-    val bTree = COI.parseBinaryTree(script)
-    bTree.value.get must be(OP_NOTIF)
-
-    bTree.left.get.value must be(Some(OP_1))
-
-    bTree.right.get.value must be(Some(OP_ELSE))
-
-    bTree.right.get.left.get.value must be(Some(OP_2))
-
-    bTree.right.get.right.get.value must be(Some(OP_ELSE))
-
-    bTree.right.get.right.get.left.get.value must be(Some(OP_3))
-
-    bTree.right.get.right.get.right.get.value must be(Some(OP_ENDIF))
-
-    bTree.toSeq must be(script)
-  }
-
-  it must "parse a binary tree with nested OP_NOTIFs" in {
-
-    val script = List(OP_NOTIF,
-                      OP_NOTIF,
-                      OP_0,
-                      OP_ELSE,
-                      OP_1,
-                      OP_ENDIF,
-                      OP_ELSE,
-                      OP_NOTIF,
-                      OP_2,
-                      OP_ELSE,
-                      OP_3,
-                      OP_ENDIF,
-                      OP_ENDIF)
-    val bTree = COI.parseBinaryTree(script)
-
-    bTree.value must be(Some(OP_NOTIF))
-    bTree.left.get.value must be(Some(OP_NOTIF))
-    bTree.left.get.right.get.value must be(Some(OP_ELSE))
-    bTree.left.get.right.get.left.get.value must be(Some(OP_1))
-    bTree.left.get.right.get.right.get.value must be(Some(OP_ENDIF))
-
-    bTree.right.get.value must be(Some(OP_ELSE))
-    bTree.right.get.left.get.value must be(Some(OP_NOTIF))
-    bTree.right.get.left.get.left.get.value must be(Some(OP_2))
-    bTree.right.get.left.get.right.get.value must be(Some(OP_ELSE))
-    bTree.right.get.left.get.right.get.left.get.value must be(Some(OP_3))
-    bTree.right.get.left.get.right.get.right.get.value must be(Some(OP_ENDIF))
-
+  private def programMustBe(
+      program: StartedScriptProgram,
+      stack: List[ScriptToken],
+      script: List[ScriptToken],
+      shouldExecuteNextOperation: Boolean,
+      isInExecutionBranch: Boolean): org.scalatest.Assertion = {
+    program.stack must be(stack)
+    program.script must be(script)
+
+    program match {
+      case programInProgress: ExecutionInProgressScriptProgram =>
+        programInProgress.shouldExecuteNextOperation must be(
+          shouldExecuteNextOperation)
+        programInProgress.isInExecutionBranch must be(isInExecutionBranch)
+      case executed: ExecutedScriptProgram =>
+        fail(s"Unexpected error: ${executed.error}")
+    }
   }
 
   it must "evaluate an OP_IF correctly" in {
@@ -512,8 +105,28 @@ class ControlOperationsInterpreterTest extends FlatSpec with MustMatchers {
       TestUtil.testProgramExecutionInProgress.updateStackAndScript(stack,
                                                                    script)
     val newProgram = COI.opIf(program)
-    newProgram.stack.isEmpty must be(true)
-    newProgram.script must be(List(OP_ENDIF, OP_1))
+    programMustBe(program = newProgram,
+                  stack = Nil,
+                  script = List(OP_RESERVED, OP_ENDIF, OP_1),
+                  shouldExecuteNextOperation = false,
+                  isInExecutionBranch = false)
+    val newProgramInProgress =
+      newProgram.asInstanceOf[ExecutionInProgressScriptProgram]
+
+    val newNewProgram =
+      newProgramInProgress.updateScript(newProgram.script.tail)
+    programMustBe(program = newNewProgram,
+                  stack = Nil,
+                  script = List(OP_ENDIF, OP_1),
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = false)
+
+    val afterIfProgram = COI.opEndIf(newNewProgram)
+    programMustBe(program = afterIfProgram,
+                  stack = Nil,
+                  script = List(OP_1),
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = true)
   }
 
   it must "evaluate an OP_IF OP_ELSE OP_ENDIF block" in {
@@ -523,52 +136,59 @@ class ControlOperationsInterpreterTest extends FlatSpec with MustMatchers {
       TestUtil.testProgramExecutionInProgress.updateStackAndScript(stack,
                                                                    script)
     val newProgram = COI.opIf(program)
-    newProgram.script must be(List(OP_ELSE, OP_1, OP_ENDIF))
-  }
+    programMustBe(program = newProgram,
+                  stack = Nil,
+                  script = List(OP_VER, OP_ELSE, OP_1, OP_ENDIF),
+                  shouldExecuteNextOperation = false,
+                  isInExecutionBranch = false)
+    val newProgramInProgress =
+      newProgram.asInstanceOf[ExecutionInProgressScriptProgram]
 
-  it must "check that every OP_IF has a matching OP_ENDIF" in {
-    val script0 = List()
-    COI.checkMatchingOpIfOpNotIfOpEndIf(script0) must be(true)
+    val elseProgram = newProgramInProgress.updateScript(newProgram.script.tail)
+    programMustBe(program = elseProgram,
+                  stack = Nil,
+                  script = List(OP_ELSE, OP_1, OP_ENDIF),
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = false)
 
-    val script1 = List(OP_IF, OP_ENDIF)
-    COI.checkMatchingOpIfOpNotIfOpEndIf(script1) must be(true)
-
-    val script2 = List(OP_IF)
-    COI.checkMatchingOpIfOpNotIfOpEndIf(script2) must be(false)
-
-    val script3 = List(OP_IF,
-                       OP_IF,
-                       OP_NOTIF,
-                       OP_ELSE,
-                       OP_ELSE,
-                       OP_ELSE,
-                       OP_ENDIF,
-                       OP_ENDIF,
-                       OP_ENDIF)
-    COI.checkMatchingOpIfOpNotIfOpEndIf(script3) must be(true)
+    val afterElseProgram = COI.opElse(elseProgram)
+    programMustBe(program = afterElseProgram,
+                  stack = Nil,
+                  script = List(OP_1, OP_ENDIF),
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = true)
   }
 
   it must "evaluate an OP_IF block correctly if the stack top is true" in {
-    val stack = List(OP_1)
+    val stack = List(ScriptNumber.one)
     val script = List(OP_IF, OP_1, OP_ELSE, OP_0, OP_ENDIF)
     val program =
       TestUtil.testProgramExecutionInProgress.updateStackAndScript(stack,
                                                                    script)
     val newProgram = COI.opIf(program)
+    programMustBe(program = newProgram,
+                  stack = Nil,
+                  script = List(OP_1, OP_ELSE, OP_0, OP_ENDIF),
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = true)
+    val newProgramInProgress =
+      newProgram.asInstanceOf[ExecutionInProgressScriptProgram]
 
-    newProgram.stack must be(Nil)
-    newProgram.script must be(List(OP_1, OP_ENDIF))
-  }
+    val elseProgram =
+      newProgramInProgress.updateStackAndScript(List(ScriptNumber.one),
+                                                newProgram.script.tail)
+    programMustBe(program = elseProgram,
+                  stack = List(ScriptNumber.one),
+                  script = List(OP_ELSE, OP_0, OP_ENDIF),
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = true)
 
-  it must "evalute an OP_IF block with and leave the remaining operations outside of the OP_IF" in {
-    val stack = List(OP_TRUE)
-    val script = List(OP_IF, OP_ELSE, OP_ENDIF, OP_1)
-    val program =
-      TestUtil.testProgramExecutionInProgress.updateStackAndScript(stack,
-                                                                   script)
-    val newProgram = COI.opIf(program)
-    newProgram.stack.isEmpty must be(true)
-    newProgram.script must be(List(OP_ENDIF, OP_1))
+    val afterElseProgram = COI.opElse(elseProgram)
+    programMustBe(program = afterElseProgram,
+                  stack = List(ScriptNumber.one),
+                  script = List(OP_0, OP_ENDIF),
+                  shouldExecuteNextOperation = false,
+                  isInExecutionBranch = false)
   }
 
   it must "evaluate a weird case using multiple OP_ELSEs" in {
@@ -578,13 +198,41 @@ class ControlOperationsInterpreterTest extends FlatSpec with MustMatchers {
       TestUtil.testProgramExecutionInProgress.updateStackAndScript(stack,
                                                                    script)
     val newProgram = COI.opIf(program)
+    programMustBe(program = newProgram,
+                  stack = Nil,
+                  script = List(OP_ELSE, OP_0, OP_ELSE, OP_1, OP_ENDIF),
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = true)
+    val newProgramInProgress =
+      newProgram.asInstanceOf[ExecutionInProgressScriptProgram]
 
-    newProgram.script must be(List(OP_ELSE, OP_1, OP_ENDIF))
+    val newNewProgram = COI.opElse(newProgramInProgress)
+    programMustBe(program = newNewProgram,
+                  stack = Nil,
+                  script = List(OP_0, OP_ELSE, OP_1, OP_ENDIF),
+                  shouldExecuteNextOperation = false,
+                  isInExecutionBranch = false)
+    val newNewProgramInProgress =
+      newNewProgram.asInstanceOf[ExecutionInProgressScriptProgram]
 
+    val elseProgram =
+      newNewProgramInProgress.updateScript(newNewProgram.script.tail)
+    programMustBe(program = elseProgram,
+                  stack = Nil,
+                  script = List(OP_ELSE, OP_1, OP_ENDIF),
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = false)
+
+    val afterElseProgram = COI.opElse(elseProgram)
+    programMustBe(program = afterElseProgram,
+                  stack = Nil,
+                  script = List(OP_1, OP_ENDIF),
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = true)
   }
 
   it must "evaluate nested OP_IFS correctly" in {
-    val stack = List(OP_1)
+    val stack = List(OP_0, OP_1)
     val script = List(OP_IF,
                       OP_IF,
                       OP_0,
@@ -601,122 +249,73 @@ class ControlOperationsInterpreterTest extends FlatSpec with MustMatchers {
     val program =
       TestUtil.testProgramExecutionInProgress.updateStackAndScript(stack,
                                                                    script)
-    val newProgram = COI.opIf(program)
+    val secondIfProgram = COI.opIf(program)
+    programMustBe(program = secondIfProgram,
+                  stack = List(ScriptNumber.one),
+                  script = script.tail,
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = false)
+    val secondIfProgramInProgress =
+      secondIfProgram.asInstanceOf[ExecutionInProgressScriptProgram]
 
-    newProgram.stack.isEmpty must be(true)
-    newProgram.script must be(
-      List(OP_IF, OP_0, OP_ELSE, OP_1, OP_ENDIF, OP_ENDIF))
-  }
+    val ignoreProgram0 = COI.opIf(secondIfProgramInProgress)
+    programMustBe(program = ignoreProgram0,
+                  stack = List(ScriptNumber.one),
+                  script = secondIfProgram.script.tail,
+                  shouldExecuteNextOperation = false,
+                  isInExecutionBranch = false)
+    val ignoreProgram0InProgress =
+      ignoreProgram0.asInstanceOf[ExecutionInProgressScriptProgram]
 
-  it must "evaluate a nested OP_IFs OP_ELSES correctly when the stack top is 0" in {
-    //https://gist.github.com/Christewart/381dc1dbbb07e62501c3
-    val stack = List(OP_0)
-    //"0", "IF 1 IF RETURN ELSE RETURN ELSE RETURN ENDIF ELSE 1 IF 1 ELSE
-    // RETURN ELSE 1 ENDIF ELSE RETURN ENDIF ADD 2 EQUAL"
-    val script = List(
-      OP_IF,
-      OP_1,
-      OP_IF,
-      OP_RETURN,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ENDIF,
-      OP_ELSE,
-      OP_1,
-      OP_IF,
-      OP_1,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ELSE,
-      OP_1,
-      OP_ENDIF,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ENDIF,
-      OP_ADD,
-      OP_2,
-      OP_EQUAL
-    )
+    val ignoreElseProgram =
+      ignoreProgram0InProgress.updateScript(ignoreProgram0.script.tail)
+    programMustBe(program = ignoreElseProgram,
+                  stack = List(ScriptNumber.one),
+                  script = ignoreProgram0.script.tail,
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = false)
 
-    val program =
-      TestUtil.testProgramExecutionInProgress.updateStackAndScript(stack,
-                                                                   script)
-    val newProgram = COI.opIf(program)
+    val ignoreProgram1 = COI.opElse(ignoreElseProgram)
+    programMustBe(program = ignoreProgram1,
+                  stack = List(ScriptNumber.one),
+                  script = ignoreElseProgram.script.tail,
+                  shouldExecuteNextOperation = false,
+                  isInExecutionBranch = false)
+    val ignoreProgram1InProgress =
+      ignoreProgram1.asInstanceOf[ExecutionInProgressScriptProgram]
 
-    newProgram.stack.isEmpty must be(true)
-    newProgram.script must be(
-      List(OP_ELSE,
-           OP_1,
-           OP_IF,
-           OP_1,
-           OP_ELSE,
-           OP_RETURN,
-           OP_ELSE,
-           OP_1,
-           OP_ENDIF,
-           OP_ELSE,
-           OP_RETURN,
-           OP_ENDIF,
-           OP_ADD,
-           OP_2,
-           OP_EQUAL))
+    val endIfProgram =
+      ignoreProgram1InProgress.updateScript(ignoreProgram1.script.tail)
+    programMustBe(program = endIfProgram,
+                  stack = List(ScriptNumber.one),
+                  script = ignoreProgram1.script.tail,
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = false)
 
-    newProgram.isInstanceOf[ExecutionInProgressScriptProgram] must be(true)
+    val elseProgram = COI.opEndIf(endIfProgram)
+    programMustBe(program = elseProgram,
+                  stack = List(ScriptNumber.one),
+                  script = endIfProgram.script.tail,
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = false)
+    val elseProgramInProgress =
+      elseProgram.asInstanceOf[ExecutionInProgressScriptProgram]
 
-    val newProgram1 =
-      COI.opElse(newProgram.asInstanceOf[ExecutionInProgressScriptProgram])
-    newProgram1.stack.isEmpty must be(true)
-    newProgram1.script must be(
-      List(OP_1,
-           OP_IF,
-           OP_1,
-           OP_ELSE,
-           OP_RETURN,
-           OP_ELSE,
-           OP_1,
-           OP_ENDIF,
-           OP_ENDIF,
-           OP_ADD,
-           OP_2,
-           OP_EQUAL))
+    val correctIfProgram = COI.opElse(elseProgramInProgress)
+    programMustBe(program = correctIfProgram,
+                  stack = List(ScriptNumber.one),
+                  script = elseProgram.script.tail,
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = true)
+    val correctIfProgramInProgress =
+      correctIfProgram.asInstanceOf[ExecutionInProgressScriptProgram]
 
-  }
-
-  it must "remove the first OP_ELSE if the stack top is true for an OP_IF" in {
-    val stack = List(ScriptNumber(1))
-    val script = List(OP_IF,
-                      OP_1,
-                      OP_ELSE,
-                      OP_RETURN,
-                      OP_ELSE,
-                      OP_1,
-                      OP_ENDIF,
-                      OP_ELSE,
-                      OP_RETURN,
-                      OP_ENDIF,
-                      OP_ADD,
-                      OP_2,
-                      OP_EQUAL)
-
-    val program =
-      TestUtil.testProgramExecutionInProgress.updateStackAndScript(stack,
-                                                                   script)
-    val newProgram = COI.opIf(program)
-
-    newProgram.stack.isEmpty must be(true)
-    newProgram.script must be(
-      List(OP_1,
-           OP_ELSE,
-           OP_1,
-           OP_ENDIF,
-           OP_ELSE,
-           OP_RETURN,
-           OP_ENDIF,
-           OP_ADD,
-           OP_2,
-           OP_EQUAL))
+    val correctBranchProgram = COI.opIf(correctIfProgramInProgress)
+    programMustBe(program = correctBranchProgram,
+                  stack = Nil,
+                  script = correctIfProgram.script.tail,
+                  shouldExecuteNextOperation = true,
+                  isInExecutionBranch = true)
   }
 
   it must "evaluate an OP_ENDIF correctly" in {
@@ -724,139 +323,13 @@ class ControlOperationsInterpreterTest extends FlatSpec with MustMatchers {
     val script =
       List(OP_ENDIF, OP_ELSE, OP_RETURN, OP_ENDIF, OP_ADD, OP_2, OP_EQUAL)
     val program =
-      TestUtil.testProgramExecutionInProgress.updateStackAndScript(stack,
-                                                                   script)
+      TestUtil.testProgramExecutionInProgress
+        .updateStackAndScript(stack, script)
+        .addCondition(true)
     val newProgram = COI.opEndIf(program)
 
     newProgram.stack must be(stack)
     newProgram.script must be(script.tail)
-  }
-
-  it must "parse a partially executed script correctly" in {
-    val script = List(OP_ENDIF, OP_ENDIF, OP_ADD, OP_2, OP_EQUAL)
-    val bTree = COI.parseBinaryTree(script)
-    bTree must be(
-      Node(OP_ENDIF,
-           Empty,
-           Node(OP_ENDIF,
-                Node(OP_ADD, Node(OP_2, Leaf(OP_EQUAL), Empty), Empty),
-                Empty)))
-    bTree.toSeq must be(script)
-  }
-
-  it must "mechanically evaluate this entire script correctly" in {
-    val stack = List(ScriptNumber.one)
-    val script = List(
-      OP_NOTIF,
-      OP_0,
-      OP_NOTIF,
-      OP_RETURN,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ENDIF,
-      OP_ELSE,
-      OP_0,
-      OP_NOTIF,
-      OP_1,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ELSE,
-      OP_1,
-      OP_ENDIF,
-      OP_ELSE,
-      OP_RETURN,
-      OP_ENDIF,
-      OP_ADD,
-      OP_2,
-      OP_EQUAL
-    )
-
-    val program =
-      TestUtil.testProgramExecutionInProgress.updateStackAndScript(stack,
-                                                                   script)
-    val newProgram = COI.opNotIf(program)
-
-    newProgram.stack.isEmpty must be(true)
-    newProgram.script must be(
-      List(OP_ELSE,
-           OP_0,
-           OP_NOTIF,
-           OP_1,
-           OP_ELSE,
-           OP_RETURN,
-           OP_ELSE,
-           OP_1,
-           OP_ENDIF,
-           OP_ELSE,
-           OP_RETURN,
-           OP_ENDIF,
-           OP_ADD,
-           OP_2,
-           OP_EQUAL))
-
-    newProgram.isInstanceOf[ExecutionInProgressScriptProgram] must be(true)
-
-    val newProgram1 =
-      COI.opElse(newProgram.asInstanceOf[ExecutionInProgressScriptProgram])
-    newProgram1.stack.isEmpty must be(true)
-    newProgram1.script must be(
-      List(OP_0,
-           OP_NOTIF,
-           OP_1,
-           OP_ELSE,
-           OP_RETURN,
-           OP_ELSE,
-           OP_1,
-           OP_ENDIF,
-           OP_ENDIF,
-           OP_ADD,
-           OP_2,
-           OP_EQUAL))
-
-    newProgram1.isInstanceOf[ExecutionInProgressScriptProgram] must be(true)
-
-    logger.info("newProgram1.script.tail: " + newProgram1.script.tail)
-    val tree = COI.parseBinaryTree(newProgram1.script.tail)
-
-    tree.toSeq must be(newProgram1.script.tail)
-    val newProgram2 = COI.opNotIf(
-      newProgram1
-        .asInstanceOf[ExecutionInProgressScriptProgram]
-        .updateStackAndScript(List(OP_0), newProgram1.script.tail))
-    newProgram2.stack.isEmpty must be(true)
-    newProgram2.script must be(
-      List(OP_1, OP_ELSE, OP_1, OP_ENDIF, OP_ENDIF, OP_ADD, OP_2, OP_EQUAL))
-
-    newProgram2.isInstanceOf[ExecutionInProgressScriptProgram] must be(true)
-
-    val newProgram3 = COI.opElse(
-      newProgram2
-        .asInstanceOf[ExecutionInProgressScriptProgram]
-        .updateStackAndScript(List(OP_1), newProgram2.script.tail))
-    newProgram3.stack must be(List(OP_1))
-    newProgram3.script must be(
-      List(OP_1, OP_ENDIF, OP_ENDIF, OP_ADD, OP_2, OP_EQUAL))
-
-    newProgram3.isInstanceOf[ExecutionInProgressScriptProgram] must be(true)
-
-    val newProgram4 = COI.opEndIf(
-      newProgram3
-        .asInstanceOf[ExecutionInProgressScriptProgram]
-        .updateStackAndScript(newProgram3.script.head :: newProgram3.stack,
-                              newProgram3.script.tail))
-    newProgram4.stack must be(List(OP_1, OP_1))
-    newProgram4.script must be(List(OP_ENDIF, OP_ADD, OP_2, OP_EQUAL))
-
-    newProgram4.isInstanceOf[ExecutionInProgressScriptProgram] must be(true)
-
-    val newProgram5 =
-      COI.opEndIf(newProgram4.asInstanceOf[ExecutionInProgressScriptProgram])
-    newProgram5.stack must be(List(OP_1, OP_1))
-    newProgram5.script must be(List(OP_ADD, OP_2, OP_EQUAL))
-
-    newProgram5.isInstanceOf[ExecutionInProgressScriptProgram] must be(true)
   }
 
   it must "mark a transaction as invalid if it is trying to spend an OP_RETURN output" in {
@@ -869,20 +342,5 @@ class ControlOperationsInterpreterTest extends FlatSpec with MustMatchers {
       ScriptProgramTestUtil.toExecutedScriptProgram(COI.opReturn(program))
 
     newProgram.error must be(Some(ScriptErrorOpReturn))
-  }
-
-  it must "remove nothing when trying to remove an OP_ELSE if the tree is empty" in {
-    COI.removeFirstOpElse(Empty) must be(Empty)
-  }
-
-  it must "remove an OP_ELSE from the left branch from a binary tree if an OP_IF DNE on the left branch" in {
-    val tree = Node(OP_0, Empty, Node(OP_ELSE, Empty, Empty))
-
-    COI.removeFirstOpElse(tree) must be(Node(OP_0, Empty, Empty))
-  }
-
-  it must "remove the first OP_IF expression a sequence" in {
-    val asm = List(OP_IF, OP_0, OP_ELSE, OP_1, OP_ENDIF)
-    COI.removeFirstOpIf(asm) must be(Seq(OP_ELSE, OP_1, OP_ENDIF))
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/script/control/ControlOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/control/ControlOperations.scala
@@ -8,13 +8,15 @@ import org.bitcoins.core.script.constant.ScriptOperation
   */
 sealed abstract class ControlOperations extends ScriptOperation
 
+sealed abstract class ConditionalOperation extends ControlOperations
+
 /** If the top stack value is not 0, the statements are executed. The top stack value is removed. */
-case object OP_IF extends ControlOperations {
+case object OP_IF extends ConditionalOperation {
   override val opCode: Int = 99
 }
 
 /** If the top stack value is 0, the statements are executed. The top stack value is removed. */
-case object OP_NOTIF extends ControlOperations {
+case object OP_NOTIF extends ConditionalOperation {
   override val opCode: Int = 100
 }
 

--- a/core/src/main/scala/org/bitcoins/core/script/control/ControlOperationsInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/control/ControlOperationsInterpreter.scala
@@ -22,53 +22,48 @@ sealed abstract class ControlOperationsInterpreter {
   def opIf(program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_IF),
             "Script top was not OP_IF")
-    val sigVersion = program.txSignatureComponent.sigVersion
-    val flags = program.flags
-    val minimalIfEnabled = ScriptFlagUtil.minimalIfEnabled(flags)
-    val binaryTree = parseBinaryTree(program.script)
-    val stackTop = program.stack.headOption
-    logger.debug("Parsed binary tree: " + binaryTree)
-    if (!checkMatchingOpIfOpNotIfOpEndIf(program.originalScript)) {
-      logger.error("We do not have a matching OP_ENDIF for every OP_IF we have")
-      program.failExecution(ScriptErrorUnbalancedConditional)
-    } else if (program.stack.isEmpty) {
-      logger.error("We do not have any stack elements for our OP_IF")
-      program.failExecution(ScriptErrorUnbalancedConditional)
-    } else if (isNotMinimalStackTop(stackTop, sigVersion, minimalIfEnabled)) {
-      logger.error("OP_IF argument was not minimally encoded, got: " + stackTop)
-      program.failExecution(ScriptErrorMinimalIf)
-    } else if (program.stackTopIsTrue) {
-      logger.debug("OP_IF stack top was true")
-      logger.debug("Stack top: " + program.stack)
-      //if the left branch contains and OP_IF & OP_ENDIF there must be a nested OP_IF
-      //remove OP_ELSE from binary tree
-      val newTreeWithoutOpElse = removeFirstOpElse(binaryTree)
-      val newScript = newTreeWithoutOpElse.toList
-      logger.debug("New script after removing OP_ELSE branch " + newScript.tail)
-      logger.debug(
-        "New stack after removing OP_ELSE branch: " + program.stack.tail)
-      program.updateStackAndScript(program.stack.tail, newScript.tail)
+
+    if (program.isInExecutionBranch) {
+      val sigVersion = program.txSignatureComponent.sigVersion
+      val flags = program.flags
+      val minimalIfEnabled = ScriptFlagUtil.minimalIfEnabled(flags)
+      val stackTopOpt = program.stack.headOption
+
+      stackTopOpt match {
+        case None =>
+          logger.error("We do not have any stack elements for our OP_IF")
+          program.failExecution(ScriptErrorUnbalancedConditional)
+        case Some(stackTop) =>
+          if (isNotMinimalStackTop(stackTop, sigVersion, minimalIfEnabled)) {
+            logger.error(
+              "OP_IF argument was not minimally encoded, got: " + stackTop)
+            program.failExecution(ScriptErrorMinimalIf)
+          } else {
+            val stackTopTrue: Boolean = program.stackTopIsTrue
+            logger.debug(s"OP_IF stack top was $stackTopTrue")
+            logger.debug(s"Stack top: ${program.stack}")
+
+            program
+              .updateStackAndScript(program.stack.tail, program.script.tail)
+              .addCondition(stackTopTrue)
+          }
+      }
     } else {
-      logger.debug("OP_IF stack top was false")
-      //remove the OP_IF
-      val scriptWithoutOpIf: BinaryTree[ScriptToken] = removeFirstOpIf(
-        binaryTree)
-      program.updateStackAndScript(program.stack.tail, scriptWithoutOpIf.toList)
+      // Doesn't matter which condition we use here,
+      // just that one gets added to keep track of depth
+      program.updateScript(program.script.tail).addCondition(condition = true)
     }
   }
 
   /** Checks if the stack top is NOT minimially encoded */
   private def isNotMinimalStackTop(
-      stackTopOpt: Option[ScriptToken],
+      stackTop: ScriptToken,
       sigVersion: SignatureVersion,
       minimalIfEnabled: Boolean): Boolean = {
     //see: https://github.com/bitcoin/bitcoin/blob/528472111b4965b1a99c4bcf08ac5ec93d87f10f/src/script/interpreter.cpp#L447-L452
     //https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2016-August/013014.html
-    val isNotMinimal = stackTopOpt.map { stackTop =>
-      (sigVersion == SigVersionWitnessV0 && minimalIfEnabled
-      && !BitcoinScriptUtil.isMinimalToken(stackTop))
-    }
-    isNotMinimal.isDefined && isNotMinimal.get
+    (sigVersion == SigVersionWitnessV0 && minimalIfEnabled
+    && !BitcoinScriptUtil.isMinimalToken(stackTop))
   }
 
   /** If the top stack value is 0, the statements are executed. The top stack value is removed. */
@@ -76,24 +71,37 @@ sealed abstract class ControlOperationsInterpreter {
       program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_NOTIF),
             "Script top was not OP_NOTIF")
-    val minimalIfEnabled = ScriptFlagUtil.minimalIfEnabled(program.flags)
-    val sigVersion = program.txSignatureComponent.sigVersion
-    val oldStackTop = program.stack.headOption
 
-    if (isNotMinimalStackTop(oldStackTop, sigVersion, minimalIfEnabled)) {
-      //need to duplicate minimal check, we cannot accurately invert the stack
-      //top for OP_IF otherwise
-      program.failExecution(ScriptErrorMinimalIf)
+    if (program.isInExecutionBranch) {
+      val sigVersion = program.txSignatureComponent.sigVersion
+      val flags = program.flags
+      val minimalIfEnabled = ScriptFlagUtil.minimalIfEnabled(flags)
+      val stackTopOpt = program.stack.headOption
+
+      stackTopOpt match {
+        case None =>
+          logger.error("We do not have any stack elements for our OP_NOTIF")
+          program.failExecution(ScriptErrorUnbalancedConditional)
+        case Some(stackTop) =>
+          if (isNotMinimalStackTop(stackTop, sigVersion, minimalIfEnabled)) {
+            logger.error(
+              "OP_NOTIF argument was not minimally encoded, got: " + stackTop)
+            program.failExecution(ScriptErrorMinimalIf)
+          } else {
+            val stackTopFalse: Boolean = program.stackTopIsFalse
+            logger.debug(s"OP_IF stack top was $stackTopFalse")
+            logger.debug(s"Stack top: ${program.stack}")
+
+            program
+              .updateStackAndScript(program.stack.tail, program.script.tail)
+              .addCondition(stackTopFalse)
+          }
+      }
     } else {
-      val script = OP_IF :: program.script.tail
-      val stackTop =
-        if (program.stackTopIsTrue) ScriptNumber.zero else ScriptNumber.one
-      val stack =
-        if (program.stack.nonEmpty) stackTop :: program.stack.tail else Nil
-      val newProgram = program.updateStackAndScript(stack, script)
-      opIf(newProgram)
+      // Doesn't matter which condition we use here,
+      // just that one gets added to keep track of depth
+      program.updateScript(program.script.tail).addCondition(condition = true)
     }
-
   }
 
   /** Evaluates the [[org.bitcoins.core.script.control.OP_ELSE OP_ELSE]] operator. */
@@ -101,19 +109,8 @@ sealed abstract class ControlOperationsInterpreter {
       program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_ELSE),
             "First script opt must be OP_ELSE")
-    if (!program.script.tail.contains(OP_ENDIF)) {
-      logger.error("OP_ELSE does not have a OP_ENDIF")
-      program.failExecution(ScriptErrorUnbalancedConditional)
-    } else {
-      val tree = parseBinaryTree(program.script)
-      val treeWithNextOpElseRemoved = tree match {
-        case Empty                   => Empty
-        case leaf: Leaf[ScriptToken] => leaf
-        case node: Node[ScriptToken] =>
-          removeFirstOpElse(node)
-      }
-      program.updateScript(treeWithNextOpElseRemoved.toList.tail)
-    }
+
+    program.updateScript(program.script.tail).invertCondition()
   }
 
   /** Evaluates an [[org.bitcoins.core.script.control.OP_ENDIF OP_ENDIF]] operator. */
@@ -121,12 +118,8 @@ sealed abstract class ControlOperationsInterpreter {
       program: ExecutionInProgressScriptProgram): StartedScriptProgram = {
     require(program.script.headOption.contains(OP_ENDIF),
             "Script top must be OP_ENDIF")
-    if (!checkMatchingOpIfOpNotIfOpEndIf(program.originalScript)) {
-      //means we do not have a matching OP_IF for our OP_ENDIF
-      logger.error(
-        "We do not have a matching OP_IF/OP_NOTIF for every OP_ENDIF we have")
-      program.failExecution(ScriptErrorUnbalancedConditional)
-    } else program.updateScript(program.script.tail)
+
+    program.updateScript(program.script.tail).removeCondition()
   }
 
   /**
@@ -160,199 +153,6 @@ sealed abstract class ControlOperationsInterpreter {
         logger.error("OP_VERIFY requires an element to be on the stack")
         program.failExecution(ScriptErrorInvalidStackOperation)
     }
-  }
-
-  /** Parses a list of [[org.bitcoins.core.script.constant.ScriptToken ScriptToken]]s
-    * into its corresponding [[org.bitcoins.core.util.BinaryTree BinaryTree]] */
-  def parseBinaryTree(script: List[ScriptToken]): BinaryTree[ScriptToken] = {
-    //@tailrec
-    def loop(
-        remaining: List[ScriptToken],
-        parentTree: BinaryTree[ScriptToken]): (
-        BinaryTree[ScriptToken],
-        List[ScriptToken]) = {
-      if (remaining.isEmpty) (parentTree, Nil)
-      else {
-        if (parentTree.right.isDefined && parentTree.right.get.value == Some(
-              OP_ELSE)) {
-          //for the case of OP_IF OP_1 OP_ELSE OP_2 OP_ELSE OP_3 ... OP_ELSE OP_N OP_ENDIF
-          val (elseTree, newRemaining) =
-            loop(remaining, parentTree.right.getOrElse(Empty))
-          (Node(parentTree.value.get,
-                parentTree.left.getOrElse(Empty),
-                elseTree),
-           newRemaining)
-        } else {
-          val (tree, newRemaining) = parse(remaining, parentTree)
-          loop(newRemaining, tree)
-        }
-      }
-    }
-    val (t, remaining) = loop(script, Empty)
-    require(
-      remaining.isEmpty,
-      "Should not have any script tokens after parsing a binary tree, got: " + remaining)
-    t
-  }
-
-  /** The loop that parses a list of [[org.bitcoins.core.script.constant.ScriptToken ScriptToken]]s into a
-    * [[org.bitcoins.core.util.BinaryTree BinaryTree]]. */
-  private def parse(script: List[ScriptToken], tree: BinaryTree[ScriptToken]): (
-      BinaryTree[ScriptToken],
-      List[ScriptToken]) = script match {
-    case OP_ENDIF :: t =>
-      val ifTree = insertSubTree(tree, Leaf(OP_ENDIF))
-      (ifTree, t)
-    case h :: t if (h == OP_IF || h == OP_NOTIF) =>
-      val (ifTree, remaining) = parse(t, Leaf(h))
-      val fullTree = insertSubTree(tree, ifTree)
-      (fullTree, remaining)
-    case h :: t if h == OP_ELSE =>
-      val (subTree, remaining) = parse(t, Node(OP_ELSE, Empty, Empty))
-      val opElseTree = tree match {
-        case Empty                => subTree
-        case l: Leaf[ScriptToken] => Node(l.v, Empty, subTree)
-        case n: Node[ScriptToken] => Node(n.v, n.l, insertSubTree(n.r, subTree))
-      }
-      (opElseTree, remaining)
-    case h :: t => parse(t, insertSubTree(tree, Leaf(h)))
-    case Nil =>
-      logger.debug("Done parsing tree, got: " + tree)
-      (tree, Nil)
-  }
-
-  /**
-    * Inserts a sub tree into the parse tree of Script.
-    * @param tree the parse tree of the control flow of the Script program
-    * @param subTree the parse tree that needs to be inserted into the control flow of the program
-    * @return the full parse tree combined
-    */
-  //@tailrec
-  private def insertSubTree(
-      tree: BinaryTree[ScriptToken],
-      subTree: BinaryTree[ScriptToken]): BinaryTree[ScriptToken] = tree match {
-    case Empty => subTree
-    case leaf: Leaf[ScriptToken] =>
-      if (subTree == Empty) leaf
-      else if (subTree == Leaf(OP_ENDIF)) Node(leaf.v, Empty, subTree)
-      else Node(leaf.v, subTree, Empty)
-    case node: Node[ScriptToken]
-        if (node.v == OP_IF || node.v == OP_NOTIF || node.v == OP_ELSE || node.v == OP_ENDIF) =>
-      if (subTree.value.isDefined && Seq(OP_ELSE, OP_ENDIF).contains(
-            subTree.value.get)) {
-        Node(node.v, node.l, insertSubTree(node.r, subTree))
-      } else if (node.r != Empty && Seq(OP_ELSE, OP_ENDIF).contains(
-                   node.r.value.get)) {
-        Node(node.v, node.l, insertSubTree(node.r, subTree))
-      } else {
-        Node(node.v, insertSubTree(node.l, subTree), node.r)
-      }
-    case node: Node[ScriptToken] =>
-      Node(node.v, insertSubTree(node.l, subTree), node.r)
-  }
-
-  /** Checks if an [[org.bitcoins.core.script.control.OP_IF OP_IF]]/
-    * [[org.bitcoins.core.script.control.OP_NOTIF OP_NOTIF]]
-    * [[org.bitcoins.core.script.constant.ScriptToken ScriptToken]] has a matching
-    * [[org.bitcoins.core.script.control.OP_ENDIF OP_ENDIF]] */
-  def checkMatchingOpIfOpNotIfOpEndIf(script: List[ScriptToken]): Boolean = {
-    @tailrec
-    def loop(script: List[ScriptToken], counter: Int): Boolean = script match {
-      case _ if (counter < 0)    => false
-      case OP_ENDIF :: t         => loop(t, counter - 1)
-      case OP_IF :: t            => loop(t, counter + 1)
-      case OP_NOTIF :: t         => loop(t, counter + 1)
-      case (_: ScriptToken) :: t => loop(t, counter)
-      case Nil                   => counter == 0
-    }
-    loop(script, 0)
-  }
-
-  /** Returns the first index of an [[org.bitcoins.core.script.control.OP_ENDIF OP_ENDIF]]. */
-  def findFirstOpEndIf(script: List[ScriptToken]): Option[Int] = {
-    val index = script.indexOf(OP_ENDIF)
-    index match {
-      case -1 => None
-      case _  => Some(index)
-    }
-  }
-
-  /** Finds the last [[org.bitcoins.core.script.control.OP_ENDIF OP_ENDIF]] in the given script. */
-  def findLastOpEndIf(script: List[ScriptToken]): Option[Int] = {
-    val lastOpEndIf = findFirstOpEndIf(script.reverse)
-    if (lastOpEndIf.isDefined) Some(script.size - lastOpEndIf.get - 1)
-    else None
-  }
-
-  /** Returns the first index of an [[org.bitcoins.core.script.control.OP_ENDIF OP_ENDIF]]. */
-  def findFirstOpElse(script: List[ScriptToken]): Option[Int] = {
-    val index = script.indexOf(OP_ELSE)
-    index match {
-      case -1 => None
-      case _  => Some(index)
-    }
-  }
-
-  /** Removes the first [[org.bitcoins.core.script.control.OP_ELSE OP_ELSE]] expression encountered in the script. */
-  def removeFirstOpElse(script: List[ScriptToken]): List[ScriptToken] = {
-    removeFirstOpElse(parseBinaryTree(script)).toList
-  }
-
-  /** Removes the first [[org.bitcoins.core.script.control.OP_ELSE OP_ELSE]] in a
-    * [[org.bitcoins.core.util.BinaryTree BinaryTree]]. */
-  def removeFirstOpElse(
-      tree: BinaryTree[ScriptToken]): BinaryTree[ScriptToken] = {
-    //@tailrec
-    def loop(child: BinaryTree[ScriptToken]): BinaryTree[ScriptToken] =
-      child match {
-        case Empty                => Empty
-        case l: Leaf[ScriptToken] => l
-        case Node(OP_ELSE, _, r)  => r
-        case n: Node[ScriptToken] =>
-          Node(n.v, n.l, loop(n.r))
-      }
-    tree match {
-      case Empty                => Empty
-      case l: Leaf[ScriptToken] => l
-      case n: Node[ScriptToken] =>
-        val result = Node(n.v, n.l, loop(n.r))
-        result
-    }
-  }
-
-  /** Removes the first [[org.bitcoins.core.script.control.OP_IF OP_IF]] encountered in the script. */
-  def removeFirstOpIf(script: List[ScriptToken]): List[ScriptToken] = {
-    removeFirstOpIf(parseBinaryTree(script)).toList
-  }
-
-  /** Removes the first occurrence of [[org.bitcoins.core.script.control.OP_IF OP_IF]] or
-    * [[org.bitcoins.core.script.control.OP_NOTIF OP_NOTIF]] in the
-    * [[org.bitcoins.core.util.BinaryTree BinaryTree]]. */
-  def removeFirstOpIf(
-      tree: BinaryTree[ScriptToken]): BinaryTree[ScriptToken] = {
-    require(
-      tree.value.isDefined && (tree.value.get == OP_IF || tree.value.get == OP_NOTIF),
-      "Top of the tree must be OP_IF or OP_NOTIF to remove the OP_IF or OP_NOTIF")
-    tree.right.getOrElse(Empty)
-  }
-
-  /** Finds the indexes of our
-    * [[org.bitcoins.core.script.control.OP_ELSE OP_ELSE]] (if it exists) and our
-    * [[org.bitcoins.core.script.control.OP_ENDIF OP_ENDIF]]. */
-  def findFirstIndexesOpElseOpEndIf(
-      script: List[ScriptToken]): (Option[Int], Option[Int]) = {
-    val indexOpElse = findFirstOpElse(script)
-    val indexOpEndIf = findFirstOpEndIf(script)
-    (indexOpElse, indexOpEndIf)
-  }
-
-  /** Returns the index of the matching [[org.bitcoins.core.script.control.OP_ENDIF OP_ENDIF]] for the
-    * [[org.bitcoins.core.script.control.OP_IF OP_IF]] statement. */
-  def findMatchingOpEndIf(script: List[ScriptToken]): Int = {
-    val matchingOpEndIfIndex = findLastOpEndIf(script)
-    require(matchingOpEndIfIndex.isDefined,
-            "Every OP_IF must have a matching OP_ENDIF: " + script)
-    matchingOpEndIfIndex.get
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/script/control/ControlOperationsInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/control/ControlOperationsInterpreter.scala
@@ -10,8 +10,6 @@ import org.bitcoins.core.script.flag.ScriptFlagUtil
 import org.bitcoins.core.script.result._
 import org.bitcoins.core.util._
 
-import scala.annotation.tailrec
-
 /**
   * Created by chris on 1/6/16.
   */

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -535,6 +535,13 @@ sealed abstract class ScriptInterpreter extends BitcoinSLogger {
             "We cannot have a stack + alt stack size larger than 1000 elements")
           (program.failExecution(ScriptErrorStackSize), opCount)
 
+        //no more script operations to run, return whether the program is valid and the final state of the program
+        case Nil =>
+          (program.toExecutedProgram, opCount)
+
+        case _ if !program.shouldExecuteNextOperation =>
+          (program.updateScript(program.script.tail), opCount)
+
         //stack operations
         case OP_DUP :: _ =>
           val programOrError = StackInterpreter.opDup(program)
@@ -1051,9 +1058,6 @@ sealed abstract class ScriptInterpreter extends BitcoinSLogger {
             (programOrError, newOpCount)
           }
 
-        //no more script operations to run, return whether the program is valid and the final state of the program
-        case Nil =>
-          (program.toExecutedProgram, opCount)
         case h :: _ => throw new RuntimeException(s"$h was unmatched")
       }
 


### PR DESCRIPTION
Rewrote all conditional handling so that we no longer use binary trees and instead, do something even better than what core currently does! Because as @benthecarman pointed out to me, this exists: https://github.com/bitcoin/bitcoin/pull/16902 and makes our `ScriptInterpreterTest` run faster because O(1) handling is good :)

In my personal opinion this is much simpler than what was being done and I'd also found bugs in the previous OP_IF handling on a local branch that is being blocked by this bug. (Tests for this will be added for free on that branch because it introduces nested conditionals which are then run through the ScriptInterpreter)