### PR TITLE
Pretty SPK and ScriptSigs

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSpec.scala
@@ -5,14 +5,16 @@ import org.scalacheck.{Prop, Properties}
 
 class ScriptSpec extends Properties("ScriptSpec") {
 
-  property("serialization symmetry for ScriptFactory.fromAsmBytes") = {
+  property(
+    "serialization symmetry for ScriptFactory.fromAsmBytes with ScriptPubKeys") = {
     Prop.forAllNoShrink(ScriptGenerators.scriptPubKey) {
       case (spk, _) =>
         ScriptPubKey.fromAsmBytes(spk.asmBytes) == spk
     }
   }
 
-  property("serialization symmetry for ScriptFactory.fromAsmBytes") = {
+  property(
+    "serialization symmetry for ScriptFactory.fromAsmBytes with ScriptSignatures") = {
     Prop.forAllNoShrink(ScriptGenerators.scriptSignature) {
       case ss =>
         ScriptSignature.fromAsmBytes(ss.asmBytes) == ss

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -60,7 +60,7 @@ object P2PKHScriptPubKey extends ScriptFactory[P2PKHScriptPubKey] {
   private case class P2PKHScriptPubKeyImpl(
       override val asm: Vector[ScriptToken])
       extends P2PKHScriptPubKey {
-    override def toString = "P2PKHScriptPubKeyImpl(" + hex + ")"
+    override def toString = s"P2PKHScriptPubKeyImpl($pubKeyHash)"
   }
 
   def apply(pubKey: ECPublicKey): P2PKHScriptPubKey = {
@@ -171,7 +171,8 @@ object MultiSignatureScriptPubKey
   private case class MultiSignatureScriptPubKeyImpl(
       override val asm: Vector[ScriptToken])
       extends MultiSignatureScriptPubKey {
-    override def toString = "MultiSignatureScriptPubKeyImpl(" + hex + ")"
+    override def toString =
+      s"MultiSignatureScriptPubKey($requiredSigs, $maxSigs, ${publicKeys.mkString(", ")})"
   }
 
   def apply(
@@ -288,7 +289,7 @@ object P2SHScriptPubKey extends ScriptFactory[P2SHScriptPubKey] {
 
   private case class P2SHScriptPubKeyImpl(override val asm: Vector[ScriptToken])
       extends P2SHScriptPubKey {
-    override def toString = "P2SHScriptPubKeyImpl(" + hex + ")"
+    override def toString = s"P2SHScriptPubKey($scriptHash)"
   }
 
   def apply(scriptPubKey: ScriptPubKey): P2SHScriptPubKey = {
@@ -338,7 +339,7 @@ object P2PKScriptPubKey extends ScriptFactory[P2PKScriptPubKey] {
 
   private case class P2PKScriptPubKeyImpl(override val asm: Vector[ScriptToken])
       extends P2PKScriptPubKey {
-    override def toString = "P2PKScriptPubKeyImpl(" + hex + ")"
+    override def toString = s"P2PKScriptPubKeyImpl($publicKey)"
   }
 
   def apply(pubKey: ECPublicKey): P2PKScriptPubKey = {
@@ -420,7 +421,7 @@ object CLTVScriptPubKey extends ScriptFactory[CLTVScriptPubKey] {
 
   private case class CLTVScriptPubKeyImpl(override val asm: Vector[ScriptToken])
       extends CLTVScriptPubKey {
-    override def toString = "CLTVScriptPubKeyImpl(" + hex + ")"
+    override def toString = s"CLTVScriptPubKey($locktime, $nestedScriptPubKey)"
   }
 
   def fromAsm(asm: Seq[ScriptToken]): CLTVScriptPubKey = {
@@ -506,7 +507,7 @@ object CSVScriptPubKey extends ScriptFactory[CSVScriptPubKey] {
 
   private case class CSVScriptPubKeyImpl(override val asm: Vector[ScriptToken])
       extends CSVScriptPubKey {
-    override def toString = "CSVScriptPubKeyImpl(" + hex + ")"
+    override def toString = s"CSVScriptPubKey($locktime, $nestedScriptPubKey)"
   }
 
   def fromAsm(asm: Seq[ScriptToken]): CSVScriptPubKey = {
@@ -774,7 +775,7 @@ object NonStandardScriptPubKey extends ScriptFactory[NonStandardScriptPubKey] {
   private case class NonStandardScriptPubKeyImpl(
       override val asm: Vector[ScriptToken])
       extends NonStandardScriptPubKey {
-    override def toString = "NonStandardScriptPubKeyImpl(" + hex + ")"
+    override def toString = s"NonStandardScriptPubKey($asm)"
   }
 
   def fromAsm(asm: Seq[ScriptToken]): NonStandardScriptPubKey = {
@@ -957,7 +958,7 @@ object WitnessScriptPubKeyV0 {
   */
 sealed abstract class P2WPKHWitnessSPKV0 extends WitnessScriptPubKeyV0 {
   def pubKeyHash: Sha256Hash160Digest = Sha256Hash160Digest(asm(2).bytes)
-  override def toString = s"P2WPKHWitnessSPKV0($hex)"
+  override def toString = s"P2WPKHWitnessSPKV0($pubKeyHash)"
 }
 
 object P2WPKHWitnessSPKV0 extends ScriptFactory[P2WPKHWitnessSPKV0] {
@@ -1002,7 +1003,7 @@ object P2WPKHWitnessSPKV0 extends ScriptFactory[P2WPKHWitnessSPKV0] {
   */
 sealed abstract class P2WSHWitnessSPKV0 extends WitnessScriptPubKeyV0 {
   def scriptHash: Sha256Digest = Sha256Digest(asm(2).bytes)
-  override def toString = s"P2WSHWitnessSPKV0($hex)"
+  override def toString = s"P2WSHWitnessSPKV0($scriptHash)"
 }
 
 object P2WSHWitnessSPKV0 extends ScriptFactory[P2WSHWitnessSPKV0] {
@@ -1052,7 +1053,7 @@ object UnassignedWitnessScriptPubKey
   private case class UnassignedWitnessScriptPubKeyImpl(
       override val asm: Vector[ScriptToken])
       extends UnassignedWitnessScriptPubKey {
-    override def toString = "UnassignedWitnessScriptPubKeyImpl(" + hex + ")"
+    override def toString = s"UnassignedWitnessScriptPubKey($asm)"
   }
 
   override def fromAsm(asm: Seq[ScriptToken]): UnassignedWitnessScriptPubKey = {
@@ -1088,7 +1089,7 @@ object WitnessCommitment extends ScriptFactory[WitnessCommitment] {
   private case class WitnessCommitmentImpl(
       override val asm: Vector[ScriptToken])
       extends WitnessCommitment {
-    override def toString = "WitnessCommitmentImpl(" + hex + ")"
+    override def toString = s"WitnessCommitment(${witnessRootHash.hex})"
   }
 
   /** Every witness commitment must start with this header, see

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -33,7 +33,7 @@ sealed abstract class ScriptSignature extends Script {
 
 sealed trait NonStandardScriptSignature extends ScriptSignature {
   def signatures: Seq[ECDigitalSignature] = Nil
-  override def toString = "NonStandardScriptSignature(" + hex + ")"
+  override def toString = s"NonStandardScriptSignature($asm)"
 }
 
 object NonStandardScriptSignature
@@ -70,7 +70,7 @@ sealed trait P2PKHScriptSignature extends ScriptSignature {
     Seq(ECDigitalSignature(asm(1).hex))
   }
 
-  override def toString = "P2PKHScriptSignature(" + hex + ")"
+  override def toString = s"P2PKHScriptSignature($publicKey, $signature)"
 
 }
 
@@ -177,7 +177,8 @@ sealed trait P2SHScriptSignature extends ScriptSignature {
     sigs.map(s => ECDigitalSignature(s.hex))
   }
 
-  override def toString = "P2SHScriptSignature(" + hex + ")"
+  override def toString =
+    s"P2SHScriptSignature($redeemScript, $scriptSignatureNoRedeemScript)"
 }
 
 object P2SHScriptSignature extends ScriptFactory[P2SHScriptSignature] {
@@ -262,7 +263,8 @@ sealed trait MultiSignatureScriptSignature extends ScriptSignature {
       .map(sig => ECDigitalSignature(sig.hex))
   }
 
-  override def toString = "MultiSignatureScriptSignature(" + hex + ")"
+  override def toString =
+    s"MultiSignatureScriptSignature(${signatures.mkString(", ")})"
 }
 
 object MultiSignatureScriptSignature
@@ -334,7 +336,7 @@ sealed trait P2PKScriptSignature extends ScriptSignature {
     Seq(ECDigitalSignature(BitcoinScriptUtil.filterPushOps(asm).head.hex))
   }
 
-  override def toString = s"P2PKScriptSignature($hex)"
+  override def toString = s"P2PKScriptSignature($signature)"
 }
 
 object P2PKScriptSignature extends ScriptFactory[P2PKScriptSignature] {
@@ -371,7 +373,7 @@ sealed trait LockTimeScriptSignature extends ScriptSignature {
 }
 
 sealed trait CLTVScriptSignature extends LockTimeScriptSignature {
-  override def toString: String = s"CLTVScriptSignature($hex)"
+  override def toString: String = s"CLTVScriptSignature($scriptSig)"
 }
 
 /**
@@ -403,7 +405,7 @@ object CLTVScriptSignature extends ScriptFactory[CLTVScriptSignature] {
 }
 
 sealed trait CSVScriptSignature extends LockTimeScriptSignature {
-  override def toString = s"CSVScriptSignature($hex)"
+  override def toString = s"CSVScriptSignature($scriptSig)"
 }
 
 object CSVScriptSignature extends ScriptFactory[CSVScriptSignature] {
@@ -457,7 +459,8 @@ object ConditionalScriptSignature
   private case class ConditionalScriptSignatureImpl(
       override val asm: Vector[ScriptToken])
       extends ConditionalScriptSignature {
-    override def toString: String = s"ConditionalScriptSignature($hex)"
+    override def toString: String =
+      s"ConditionalScriptSignature($isTrue, $nestedScriptSig)"
   }
 
   override def fromAsm(asm: Seq[ScriptToken]): ConditionalScriptSignature = {


### PR DESCRIPTION
Re-wrote the `toString` methods for `ScriptPubKey`s and `ScriptSignature`s to make them useful.

Also found and fixed a bug in `ScriptSpec` where two properties having the same name made only one test run.

Built on top of #858 (only one commit is new)