### PR TITLE
(WIP) isStarted isStopped trait implementation in clients

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -40,6 +40,7 @@ import org.bitcoins.rpc.BitcoindException
 trait Client extends BitcoinSLogger with StartStop[BitcoindRpcClient] {
   def version: BitcoindVersion
   protected val instance: BitcoindInstance
+  protected var isStarted = false
 
   /**
     * The log file of the Bitcoin Core daemon
@@ -169,6 +170,7 @@ trait Client extends BitcoinSLogger with StartStop[BitcoindRpcClient] {
           logger.info(s"Dumped bitcoin.conf to $otherTempfile")
         }
     }
+    isStarted = true
     started
   }
 
@@ -206,6 +208,10 @@ trait Client extends BitcoinSLogger with StartStop[BitcoindRpcClient] {
     }
   }
 
+  def isstarted(): Boolean = {
+    isStarted
+  }
+
   /**
     * Stop method for BitcoindRpcClient that is stopped, inherits from the StartStop trait
     * @return A future stopped bitcoindRPC client
@@ -215,6 +221,7 @@ trait Client extends BitcoinSLogger with StartStop[BitcoindRpcClient] {
       _ <- bitcoindCall[String]("stop")
       _ <- {
         if (system.name == BitcoindRpcClient.ActorSystemName) {
+          isStarted = false
           system.terminate()
         } else FutureUtil.unit
       }
@@ -227,6 +234,10 @@ trait Client extends BitcoinSLogger with StartStop[BitcoindRpcClient] {
     */
   def isStoppedF: Future[Boolean] = {
     isStartedF.map(started => !started)
+  }
+
+  def isstopped(): Boolean = {
+    isStarted
   }
 
   // This RPC call is here to avoid circular trait depedency

--- a/core/src/main/scala/org/bitcoins/core/util/StartStop.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/StartStop.scala
@@ -10,4 +10,7 @@ import scala.concurrent.Future
 trait StartStop[T] {
   def start(): Future[T]
   def stop(): Future[T]
+  def isstarted(): Boolean
+  def isstopped(): Boolean
+  private var isStarted = false
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -646,7 +646,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
     logger.debug(s"shutting down eclair")
     val stopEclairF = eclairRpcClient.stop()
     val killBitcoindF = BitcoindRpcTestUtil.stopServer(bitcoindRpc)
-    val iskilled = eclairRpcClient.isStopped
+    val iskilled = eclairRpcClient.isStoppedF
 
     val shutdownF = for {
       _ <- killBitcoindF


### PR DESCRIPTION
This PR hopes to implement `isStarted` and `isStopped` methods for the clients that we are hoping to use. Currently the way it is written the trait is not very useful and the usage of `var isStarted` is through the client files directly. Need to add unit tests still for it. I also rewrote a bit of the `eclairRPC` method names so the naming scheme matches up with the `client` file for bitcoin. 