### PR TITLE
Conditional Signing Tests

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -39,7 +39,7 @@ sealed abstract class ScriptInterpreter extends BitcoinSLogger {
   private lazy val MAX_SCRIPT_OPS = 201
 
   /** We cannot push an element larger than 520 bytes onto the stack */
-  private lazy val MAX_PUSH_SIZE = 520
+  val MAX_PUSH_SIZE: Int = 520
 
   /**
     * Runs an entire script though our script programming language and

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -537,13 +537,11 @@ trait BitcoinScriptUtil extends BitcoinSLogger {
   /** Since witnesses are not run through the interpreter, replace
     * `OP_0`/`OP_1` with `ScriptNumber.zero`/`ScriptNumber.one` */
   def minimalIfOp(asm: Seq[ScriptToken]): Seq[ScriptToken] = {
-    if (asm == Nil) asm
-    else if (asm.last == OP_0) {
-      asm.dropRight(1) ++ Seq(ScriptNumber.zero)
-    } else if (asm.last == OP_1) {
-      asm.dropRight(1) ++ Seq(ScriptNumber.one)
-    } else asm
-
+    asm.map {
+      case OP_0               => ScriptNumber.zero
+      case OP_1               => ScriptNumber.one
+      case token: ScriptToken => token
+    }
   }
 
   /** Replaces the [[org.bitcoins.core.script.constant.OP_0 OP_0]] dummy for

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -22,6 +22,7 @@ import org.bitcoins.core.wallet.signer._
 import org.bitcoins.core.wallet.utxo.{
   BitcoinUTXOSpendingInfo,
   ConditionalSpendingInfo,
+  EmptySpendingInfo,
   LockTimeSpendingInfo,
   MultiSignatureSpendingInfo,
   P2PKHSpendingInfo,
@@ -442,7 +443,8 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
                  currentLockTime)
           case _: P2WPKHV0SpendingInfo |
               _: UnassignedSegwitNativeUTXOSpendingInfo | _: P2PKSpendingInfo |
-              _: P2PKHSpendingInfo | _: MultiSignatureSpendingInfo =>
+              _: P2PKHSpendingInfo | _: MultiSignatureSpendingInfo |
+              _: EmptySpendingInfo =>
             // none of these scripts affect the locktime of a tx
             loop(newRemaining, currentLockTime)
         }
@@ -484,7 +486,8 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
             loop(conditional.nestedSpendingInfo +: newRemaining, accum)
           case _: P2WPKHV0SpendingInfo |
               _: UnassignedSegwitNativeUTXOSpendingInfo | _: P2PKSpendingInfo |
-              _: P2PKHSpendingInfo | _: MultiSignatureSpendingInfo =>
+              _: P2PKHSpendingInfo | _: MultiSignatureSpendingInfo |
+              _: EmptySpendingInfo =>
             //none of these script types affect the sequence number of a tx
             //the sequence only needs to be adjustd if we have replace by fee (RBF) enabled
             //see BIP125 for more information

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
@@ -287,15 +287,27 @@ object RawScriptUTXOSpendingInfo {
                                 signers.toVector,
                                 hashType,
                                 conditionalPath)
+      case EmptyScriptPubKey => EmptySpendingInfo(outPoint, amount, hashType)
       case _: P2SHScriptPubKey =>
         throw new IllegalArgumentException(
           "RawScriptUTXOSpendingInfo cannot contain a P2SH SPK")
-      case _: NonStandardScriptPubKey | _: WitnessCommitment |
-          EmptyScriptPubKey =>
+      case _: NonStandardScriptPubKey | _: WitnessCommitment =>
         throw new UnsupportedOperationException(
           s"Currently unsupported ScriptPubKey $scriptPubKey")
     }
   }
+}
+
+/** For spending EmptyScriptPubKeys in tests. Probably should not be used in real life */
+case class EmptySpendingInfo(
+    outPoint: TransactionOutPoint,
+    amount: CurrencyUnit,
+    hashType: HashType)
+    extends RawScriptUTXOSpendingInfo {
+  override def scriptPubKey: EmptyScriptPubKey.type = EmptyScriptPubKey
+  override def signers: Seq[Sign] = Vector.empty
+  override def conditionalPath: ConditionalPath =
+    ConditionalPath.NoConditionsLeft
 }
 
 case class P2PKSpendingInfo(

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CreditingTxGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CreditingTxGen.scala
@@ -1,12 +1,19 @@
 package org.bitcoins.testkit.core.gen
 
 import org.bitcoins.core.crypto.Sign
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{UInt32, UInt64}
+import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.wallet.utxo.{BitcoinUTXOSpendingInfo, ConditionalPath}
+import org.bitcoins.core.wallet.utxo.{
+  BitcoinUTXOSpendingInfo,
+  ConditionalPath,
+  P2SHNestedSegwitV0UTXOSpendingInfo
+}
 import org.scalacheck.Gen
+
+import scala.annotation.tailrec
 
 sealed abstract class CreditingTxGen {
 
@@ -22,15 +29,16 @@ sealed abstract class CreditingTxGen {
       Gen.listOfN(n, TransactionGenerators.realisticOutput)
     }
 
-  def rawOutput: Gen[BitcoinUTXOSpendingInfo] = {
+  def nonSHOutput: Gen[BitcoinUTXOSpendingInfo] = {
     Gen.oneOf(p2pkOutput,
               p2pkhOutput,
               multiSigOutput, /*cltvOutput,*/ csvOutput,
+              conditionalOutput,
               p2wpkhOutput)
   }
 
-  def rawOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
-    Gen.choose(min, max).flatMap(n => Gen.listOfN(n, rawOutput))
+  def nonSHOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
+    Gen.choose(min, max).flatMap(n => Gen.listOfN(n, nonSHOutput))
 
   def basicOutput: Gen[BitcoinUTXOSpendingInfo] = {
     Gen.oneOf(p2pkOutput, p2pkhOutput, multiSigOutput)
@@ -40,15 +48,34 @@ sealed abstract class CreditingTxGen {
     //note, cannot put a p2wpkh here
     Gen.oneOf(p2pkOutput,
               p2pkhOutput,
-              multiSigOutput, /*cltvOutput,*/ csvOutput)
+              multiSigOutput, /*cltvOutput,*/ csvOutput,
+              conditionalOutput)
   }
 
-  def nonP2SHOutput: Gen[BitcoinUTXOSpendingInfo] = {
-    Gen.oneOf(p2pkOutput,
-              p2pkhOutput,
-              multiSigOutput, /*cltvOutput,*/ csvOutput,
-              p2wpkhOutput,
-              p2wshOutput)
+  /** Only for use in constructing P2SH outputs */
+  private def nonP2SHOutput: Gen[BitcoinUTXOSpendingInfo] = {
+    Gen
+      .oneOf(p2pkOutput,
+             p2pkhOutput,
+             multiSigOutput, /*cltvOutput,*/ csvOutput,
+             conditionalOutput,
+             p2wpkhOutput,
+             p2wshOutput)
+      .suchThat(_.scriptPubKey.compactSizeUInt.toLong + CompactSizeUInt(
+        UInt64(520)).bytes.length < 520L)
+      .suchThat {
+        case P2SHNestedSegwitV0UTXOSpendingInfo(_,
+                                                _,
+                                                _,
+                                                _,
+                                                _,
+                                                _,
+                                                witness: P2WSHWitnessV0,
+                                                _) =>
+          witness.redeemScript.compactSizeUInt.toLong + CompactSizeUInt(
+            UInt64(520)).bytes.length < 520L
+        case _ => true
+      }
   }
 
   def output: Gen[BitcoinUTXOSpendingInfo] =
@@ -57,6 +84,7 @@ sealed abstract class CreditingTxGen {
               multiSigOutput,
               p2shOutput,
               csvOutput, /*cltvOutput,*/
+              conditionalOutput,
               p2wpkhOutput,
               p2wshOutput)
 
@@ -98,6 +126,31 @@ sealed abstract class CreditingTxGen {
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, multiSigOutput))
   }
 
+  @tailrec
+  private def noRelevantCLTV(spk: RawScriptPubKey): Boolean = {
+    spk match {
+      case _: CLTVScriptPubKey  => false
+      case csv: CSVScriptPubKey => noRelevantCLTV(csv.nestedScriptPubKey)
+      case conditional: ConditionalScriptPubKey =>
+        noRelevantCLTV(conditional.trueSPK)
+      case _: RawScriptPubKey => true
+    }
+  }
+
+  def conditionalOutput: Gen[BitcoinUTXOSpendingInfo] = {
+    ScriptGenerators
+      .nonLocktimeConditionalScriptPubKey(ScriptGenerators.defaultMaxDepth)
+      //.suchThat { case (spk, _) => noRelevantCLTV(spk) }
+      .flatMap {
+        case (conditional, keys) =>
+          build(conditional, keys, None, None)
+      }
+  }
+
+  def conditionalOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
+    Gen.choose(min, max).flatMap(n => Gen.listOfN(n, conditionalOutput))
+  }
+
   def p2shOutput: Gen[BitcoinUTXOSpendingInfo] = nonP2SHOutput.flatMap { o =>
     CryptoGenerators.hashType.map { hashType =>
       val oldOutput = o.output
@@ -111,7 +164,7 @@ sealed abstract class CreditingTxGen {
         Some(redeemScript),
         o.scriptWitnessOpt,
         hashType,
-        ConditionalPath.NoConditionsLeft
+        computeAllTrueConditionalPath(redeemScript, None, o.scriptWitnessOpt)
       )
     }
   }
@@ -177,13 +230,17 @@ sealed abstract class CreditingTxGen {
   def p2wpkhOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, p2wpkhOutput))
 
-  def p2wshOutput: Gen[BitcoinUTXOSpendingInfo] = nonP2WSHOutput.flatMap {
-    case BitcoinUTXOSpendingInfo(_, txOutput, signer, _, _, _, _) =>
-      val spk = txOutput.scriptPubKey
-      val scriptWit = P2WSHWitnessV0(spk)
-      val witSPK = P2WSHWitnessSPKV0(spk)
-      build(witSPK, signer, None, Some(scriptWit))
-  }
+  def p2wshOutput: Gen[BitcoinUTXOSpendingInfo] =
+    nonP2WSHOutput
+      .suchThat(_.scriptPubKey.compactSizeUInt.toLong + CompactSizeUInt(
+        UInt64(520)).bytes.length < 520L)
+      .flatMap {
+        case BitcoinUTXOSpendingInfo(_, txOutput, signer, _, _, _, _) =>
+          val spk = txOutput.scriptPubKey
+          val scriptWit = P2WSHWitnessV0(spk)
+          val witSPK = P2WSHWitnessSPKV0(spk)
+          build(witSPK, signer, None, Some(scriptWit))
+      }
 
   def p2wshOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, p2wshOutput))
@@ -230,6 +287,42 @@ sealed abstract class CreditingTxGen {
   def randoms: Gen[Seq[BitcoinUTXOSpendingInfo]] =
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, random))
 
+  private def computeAllTrueConditionalPath(
+      spk: ScriptPubKey,
+      redeemScript: Option[ScriptPubKey],
+      scriptWitness: Option[ScriptWitness]): ConditionalPath = {
+    spk match {
+      case conditional: ConditionalScriptPubKey =>
+        ConditionalPath.ConditionTrue(
+          computeAllTrueConditionalPath(conditional.trueSPK, None, None))
+      case lockTimeScriptPubKey: LockTimeScriptPubKey =>
+        computeAllTrueConditionalPath(lockTimeScriptPubKey.nestedScriptPubKey,
+                                      None,
+                                      None)
+      case _: RawScriptPubKey | _: P2WPKHWitnessSPKV0 =>
+        ConditionalPath.NoConditionsLeft
+      case _: P2SHScriptPubKey =>
+        redeemScript match {
+          case None =>
+            throw new IllegalArgumentException(
+              "Expected redeem script for P2SH")
+          case Some(script) =>
+            computeAllTrueConditionalPath(script, None, scriptWitness)
+        }
+      case _: P2WSHWitnessSPKV0 =>
+        scriptWitness match {
+          case Some(witness: P2WSHWitnessV0) =>
+            computeAllTrueConditionalPath(witness.redeemScript, None, None)
+          case _ =>
+            throw new IllegalArgumentException(
+              "Expected P2WSHWitness for P2WSH")
+        }
+      case _: UnassignedWitnessScriptPubKey =>
+        throw new IllegalArgumentException(
+          s"Unexpected unassigned witness SPK: $spk")
+    }
+  }
+
   private def build(
       spk: ScriptPubKey,
       signers: Seq[Sign],
@@ -249,7 +342,7 @@ sealed abstract class CreditingTxGen {
             redeemScript,
             scriptWitness,
             hashType,
-            ConditionalPath.NoConditionsLeft
+            computeAllTrueConditionalPath(spk, redeemScript, scriptWitness)
           )
         }
       }


### PR DESCRIPTION
Added `ConditionalScriptPubKey`s to `CreditingTxGen` so that we are actually testing Conditional signing now (apparently we weren't before).

Found and fixed some bugs that had not been activate-able previously:

1. `BitcoinScriptUtil.minimalIfOp` which is used to turn `ScriptSignature`s into `P2WSH` `ScriptWintess`es only changed a single `OP_0` or `OP_1` into a `ScriptNumber` rather than all of them.
2. `P2SH` and `P2WSH` nested scripts cannot be serialized to > 520 bytes. This is now possible because conditionals allow multiple large multisigs to appear at once. I fixed this by adding `suchThat` calls on the affected generators

I will also note that this PR should increase coverage by a full `0.21%` according to my local measurements!