### PR TITLE
MultiSignatureWithTimeoutScriptPubKey

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
@@ -11,21 +11,25 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.testkit.core.gen.{ScriptGenerators, TransactionGenerators}
+import org.bitcoins.testkit.core.gen.{
+  GenUtil,
+  ScriptGenerators,
+  TransactionGenerators
+}
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 
 class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
 
   def randomSPK: ScriptPubKey = {
-    ScriptGenerators.scriptPubKey.map(_._1).sample.get
+    GenUtil.sample(ScriptGenerators.scriptPubKey.map(_._1))
   }
 
   def randomRawSPK: RawScriptPubKey = {
-    ScriptGenerators.rawScriptPubKey.map(_._1).sample.get
+    GenUtil.sample(ScriptGenerators.rawScriptPubKey.map(_._1))
   }
 
   def randomWitnessSPK: WitnessScriptPubKeyV0 = {
-    ScriptGenerators.witnessScriptPubKeyV0.map(_._1).sample.get
+    GenUtil.sample(ScriptGenerators.witnessScriptPubKeyV0.map(_._1))
   }
 
   behavior of "UTXOSpendingInfo"

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -778,7 +778,7 @@ object MultiSignatureWithTimeoutScriptPubKey
       override val asm: Vector[ScriptToken])
       extends MultiSignatureWithTimeoutScriptPubKey {
     override def toString: String =
-      s"IfConditionalScriptPubKey($trueSPK, $falseSPK)"
+      s"MultiSignatureWithTimeoutScriptPubKey($trueSPK, $falseSPK)"
   }
 
   override def fromAsm(
@@ -787,7 +787,8 @@ object MultiSignatureWithTimeoutScriptPubKey
       asm = asm.toVector,
       constructor = MultiSignatureWithTimeoutScriptPubKeyImpl.apply,
       invariant = isMultiSignatureWithTimeoutScriptPubKey,
-      errorMsg = "Given asm was not a IfConditionalScriptPubKey, got: " + asm
+      errorMsg =
+        s"Given asm was not a MultiSignatureWithTimeoutScriptPubKey, got: $asm"
     )
   }
 


### PR DESCRIPTION
Introduces the explicit subtype of `IfConditional` which has a `MultiSignatureScriptPubKey` in the true case and a `CLTVScriptPubKey` in the false case. This will be used by DLCs.

Only the last couple commits are new as this is built on top of #859 