### PR TITLE
Fix runnable not being cancelled when payment fails

### DIFF
--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -404,7 +404,7 @@ class EclairRpcClient(val instance: EclairInstance, binary: Option[File] = None)
 
     val cancellable = system.scheduler.schedule(interval, interval, runnable)
 
-    p.future.map(_ => cancellable.cancel())
+    p.future.onComplete(_ => cancellable.cancel())
 
     p.future
   }


### PR DESCRIPTION
We need to cancel the runnable on the actor system for the eclair rpc client payAndMonitorInvoice() in the case that the payment succeeds AND the case where it fails