### PR TITLE
Add sanity tests for .hashCode() and .equals() for multiple instances…

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
@@ -23,12 +23,20 @@ class BitcoindV18RpcClientTest extends BitcoindRpcTest {
 
   behavior of "BitcoindV18RpcClient"
 
+  it must "have our BitcoindRpcClient work with .hashCode() and equals" in {
+    for {
+      (client1, client2) <- clientPairF
+    } yield {
+      assert(client1 != client2)
+      assert(client1.hashCode() != client2.hashCode())
+    }
+  }
+
   it should "be able to start a V18 bitcoind instance" in {
 
     clientF.map { client =>
       assert(client.version == BitcoindVersion.V18)
     }
-
   }
 
   it should "return active rpc commands" in {

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -126,7 +126,18 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
     }
   }
 
-  behavior of "RpcClient"
+  behavior of "EclairRpcClient"
+
+  it must "have our EclairRpcClient work with .hashCode() and equals" in {
+    val f = (client1: EclairApi, client2: EclairApi) => {
+      Future {
+        assert(client1 != client2)
+        assert(client1.hashCode() != client2.hashCode())
+      }
+    }
+
+    executeWithClientOtherClient(f)
+  }
 
   /**
     * Please keep this test the very first. All other tests rely on the propagated gossip messages.


### PR DESCRIPTION
… for EclairRpcClient/BitcoindRpcClient

Add sanity tests to make sure multiple bitcoind/eclair clients are not equal. 