### PR TITLE
Improve DLC Unit Test

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -608,7 +608,7 @@ trait BitcoinScriptUtil extends BitcoinSLogger {
       case (input: TransactionInput, idx: Int) =>
         val outpoint = input.previousOutput
 
-        val creditingTx = utxos.find(u => u.outPoint.txId == outpoint.txId).get
+        val creditingTx = utxos.find(u => u.outPoint == outpoint).get
 
         val output = creditingTx.output
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelf.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelf.scala
@@ -269,13 +269,7 @@ case class BinaryOutcomeDLCWithSelf(
     */
   def executeDLC(
       oracleSigF: Future[SchnorrDigitalSignature],
-      local: Boolean): Future[
-    (
-        (Transaction, Transaction, Transaction),
-        (
-            Vector[BitcoinUTXOSpendingInfo],
-            BitcoinUTXOSpendingInfo,
-            BitcoinUTXOSpendingInfo))] = {
+      local: Boolean): Future[DLCOutcome] = {
     // Construct Funding Transaction
     createFundingTransaction.flatMap { fundingTx =>
       logger.info(s"Funding Transaction: ${fundingTx.hex}\n")
@@ -369,14 +363,27 @@ case class BinaryOutcomeDLCWithSelf(
           // TODO Publish tx
 
           spendingTxF.map { spendingTx =>
-            val txs = (fundingTx, cet, spendingTx)
-            val spendingInfos =
-              (fundingUtxos, fundingSpendingInfo, cetSpendingInfo)
-
-            (txs, spendingInfos)
+            DLCOutcome(
+              fundingTx,
+              cet,
+              spendingTx,
+              fundingUtxos,
+              fundingSpendingInfo,
+              cetSpendingInfo
+            )
           }
         }
       }
     }
   }
 }
+
+/** Contains all DLC transactions and the BitcoinUTXOSpendingInfos they use. */
+case class DLCOutcome(
+    fundingTx: Transaction,
+    cet: Transaction,
+    closingTx: Transaction,
+    fundingUtxos: Vector[BitcoinUTXOSpendingInfo],
+    fundingSpendingInfo: BitcoinUTXOSpendingInfo,
+    cetSpendingInfo: BitcoinUTXOSpendingInfo
+)

--- a/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelf.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelf.scala
@@ -15,6 +15,7 @@ import org.bitcoins.core.protocol.script.{
   MultiSignatureScriptPubKey,
   MultiSignatureWithTimeoutScriptPubKey,
   P2PKHScriptPubKey,
+  P2PKHScriptSignature,
   ScriptPubKey
 }
 import org.bitcoins.core.protocol.transaction.{
@@ -268,7 +269,13 @@ case class BinaryOutcomeDLCWithSelf(
     */
   def executeDLC(
       oracleSigF: Future[SchnorrDigitalSignature],
-      local: Boolean): Future[(Transaction, BitcoinUTXOSpendingInfo)] = {
+      local: Boolean): Future[
+    (
+        (Transaction, Transaction, Transaction),
+        (
+            Vector[BitcoinUTXOSpendingInfo],
+            BitcoinUTXOSpendingInfo,
+            BitcoinUTXOSpendingInfo))] = {
     // Construct Funding Transaction
     createFundingTransaction.flatMap { fundingTx =>
       logger.info(s"Funding Transaction: ${fundingTx.hex}\n")
@@ -361,7 +368,13 @@ case class BinaryOutcomeDLCWithSelf(
 
           // TODO Publish tx
 
-          spendingTxF.map(tx => (tx, cetSpendingInfo))
+          spendingTxF.map { spendingTx =>
+            val txs = (fundingTx, cet, spendingTx)
+            val spendingInfos =
+              (fundingUtxos, fundingSpendingInfo, cetSpendingInfo)
+
+            (txs, spendingInfos)
+          }
         }
       }
     }

--- a/dlc/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelfTest.scala
+++ b/dlc/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelfTest.scala
@@ -68,8 +68,9 @@ class BinaryOutcomeDLCWithSelfTest extends BitcoinSAsyncTest {
     val changePubKey = changePrivKey.publicKey
     val changeSPK = P2PKHScriptPubKey(changePubKey)
 
-    def executeForCase(outcomeHash: Sha256DigestBE,
-                       local: Boolean): Future[Assertion] = {
+    def executeForCase(
+        outcomeHash: Sha256DigestBE,
+        local: Boolean): Future[Assertion] = {
       val oracleSig =
         Schnorr.signWithNonce(outcomeHash.bytes, oraclePrivKey, preCommittedK)
 
@@ -99,7 +100,14 @@ class BinaryOutcomeDLCWithSelfTest extends BitcoinSAsyncTest {
       )
 
       dlc.executeDLC(Future.successful(oracleSig), local).map {
-        case (closingTx, cetSpendingInfo) =>
+        case ((fundingTx, cet, closingTx),
+              (initialSpendingInfos, fundingSpendingInfo, cetSpendingInfo)) =>
+          assert(
+            BitcoinScriptUtil.verifyScript(fundingTx, initialSpendingInfos)
+          )
+          assert(
+            BitcoinScriptUtil.verifyScript(cet, Vector(fundingSpendingInfo))
+          )
           assert(
             BitcoinScriptUtil.verifyScript(closingTx, Vector(cetSpendingInfo))
           )

--- a/dlc/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelfTest.scala
+++ b/dlc/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelfTest.scala
@@ -100,8 +100,12 @@ class BinaryOutcomeDLCWithSelfTest extends BitcoinSAsyncTest {
       )
 
       dlc.executeDLC(Future.successful(oracleSig), local).map {
-        case ((fundingTx, cet, closingTx),
-              (initialSpendingInfos, fundingSpendingInfo, cetSpendingInfo)) =>
+        case DLCOutcome(fundingTx,
+                        cet,
+                        closingTx,
+                        initialSpendingInfos,
+                        fundingSpendingInfo,
+                        cetSpendingInfo) =>
           assert(
             BitcoinScriptUtil.verifyScript(fundingTx, initialSpendingInfos)
           )


### PR DESCRIPTION
Have `executeDLC` return all transactions and their respective `UTXOSpendingInfo`s so that all of them can be tested.