### PR TITLE
Enable bloom filters for v19

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -122,6 +122,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
                   |port=${uri.getPort}
                   |debug=1
                   |walletbroadcast=1
+                  |peerbloomfilters=1
                   |txindex=${if (pruneMode) 0 else 1 /* pruning and txindex are not compatible */}
                   |zmqpubhashtx=tcp://127.0.0.1:$zmqPort
                   |zmqpubhashblock=tcp://127.0.0.1:$zmqPort


### PR DESCRIPTION
0.19.0 disables bloom filters by default, we need to enable it for some tests