### PR TITLE
Make 'downloadBitcoind' command async, which reduces task time by ~2x

### DIFF
--- a/bitcoind-rpc/bitcoind-rpc.sbt
+++ b/bitcoind-rpc/bitcoind-rpc.sbt
@@ -1,5 +1,7 @@
 import scala.util.Properties
 import scala.collection.JavaConverters._
+import scala.concurrent.{Future, Await}
+import scala.concurrent.duration.DurationInt
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -35,7 +37,8 @@ TaskKeys.downloadBitcoind := {
     else if (Properties.isWin) ("win64", "zip")
     else sys.error(s"Unsupported OS: ${Properties.osName}")
 
-  versions.foreach { version =>
+  implicit val ec = scala.concurrent.ExecutionContext.global
+  val downloads = versions.map { version =>
     val versionDir = binaryDir resolve version
     val archiveLocation = binaryDir resolve s"$version.$suffix"
     val location =
@@ -45,6 +48,7 @@ TaskKeys.downloadBitcoind := {
         s"https://bitcoincore.org/bin/bitcoin-core-$version/bitcoin-$version-$platform.$suffix"
 
     val expectedEndLocation = binaryDir resolve s"bitcoin-$version"
+
     if (Files
           .list(binaryDir)
           .iterator
@@ -53,21 +57,28 @@ TaskKeys.downloadBitcoind := {
           .exists(expectedEndLocation.toString.startsWith(_))) {
       logger.debug(
         s"Directory $expectedEndLocation already exists, skipping download of version $version")
+      Future.unit
     } else {
-      logger.info(
-        s"Downloading bitcoind version $version from location: $location")
-      logger.info(s"Placing the file in $archiveLocation")
-      val downloadCommand = url(location) #> archiveLocation.toFile
-      downloadCommand.!!
+      Future {
+        logger.info(
+          s"Downloading bitcoind version $version from location: $location")
+        logger.info(s"Placing the file in $archiveLocation")
+        val downloadCommand = url(location) #> archiveLocation.toFile
+        downloadCommand.!!
 
-      logger.info(s"Download complete, unzipping result")
+        logger.info(s"Download complete, unzipping result")
 
-      val extractCommand = s"tar -xzf $archiveLocation --directory $binaryDir"
-      logger.info(s"Extracting archive with command: $extractCommand")
-      extractCommand.!!
+        val extractCommand = s"tar -xzf $archiveLocation --directory $binaryDir"
+        logger.info(s"Extracting archive with command: $extractCommand")
+        extractCommand.!!
 
-      logger.info(s"Deleting archive")
-      Files.delete(archiveLocation)
+        logger.info(s"Deleting archive")
+        Files.delete(archiveLocation)
+      }
+
     }
   }
+
+  //timeout if we cannot download in 60 seconds
+  Await.result(Future.sequence(downloads), 60.seconds)
 }


### PR DESCRIPTION
Locally this reduces the time for `downloadBitcoind` to run from ` 78 seconds` to ` 29 seconds`. So roughly 2x. 