### PR TITLE
DLC Refund Transaction Test

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/BlockStamp.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/BlockStamp.scala
@@ -6,6 +6,7 @@ import java.time.temporal.{ChronoField, TemporalAccessor}
 
 import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.script.constant.ScriptNumber
 
 import scala.util.{Failure, Try}
 
@@ -17,6 +18,7 @@ sealed trait BlockStamp {
 /** This trait represents a point on the blockchain, including future points */
 sealed trait BlockStampWithFuture extends BlockStamp {
   def toUInt32: UInt32
+  def toScriptNumber: ScriptNumber
 }
 
 object BlockStamp {
@@ -30,6 +32,7 @@ object BlockStamp {
     require(height >= 0, "block height must be a positive number")
     override def mkString: String = height.toString
     override def toUInt32: UInt32 = UInt32(height)
+    override def toScriptNumber: ScriptNumber = ScriptNumber(height)
   }
   case class BlockTime(time: UInt32) extends BlockStampWithFuture {
     override def mkString: String = {
@@ -37,6 +40,7 @@ object BlockStamp {
       DateTimeFormatter.ISO_INSTANT.format(instant)
     }
     override def toUInt32: UInt32 = time
+    override def toScriptNumber: ScriptNumber = ScriptNumber(time.toLong)
   }
 
   /** This is Tue Nov  5 00:53:20 1985 UTC

--- a/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelf.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelf.scala
@@ -11,6 +11,8 @@ import org.bitcoins.core.crypto.{
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.hd.{BIP32Node, BIP32Path}
 import org.bitcoins.core.number.{Int64, UInt32}
+import org.bitcoins.core.protocol.BlockStamp.{BlockHeight, BlockTime}
+import org.bitcoins.core.protocol.BlockStampWithFuture
 import org.bitcoins.core.protocol.script.{
   CLTVScriptPubKey,
   ConditionalScriptPubKey,
@@ -33,7 +35,8 @@ import org.bitcoins.core.wallet.utxo.{
   BitcoinUTXOSpendingInfo,
   ConditionalPath,
   ConditionalSpendingInfo,
-  MultiSignatureSpendingInfo
+  MultiSignatureSpendingInfo,
+  P2PKHSpendingInfo
 }
 import scodec.bits.ByteVector
 
@@ -48,9 +51,6 @@ import scala.concurrent.{ExecutionContext, Future}
   * referred to as Local and Remote. The two outcomes are called Win and Lose but
   * note that Win refers to the case where Local wins money and Remote loses money.
   * Likewise Lose refers to the case where Remote wins and Local loses money.
-  *
-  * TODO: Make timeouts actually work
-  * TODO: Add a time-locked refund transaction.
   *
   * @param outcomeWin The String whose hash is signed by the oracle in the Win case
   * @param outcomeLose The String whose hash is signed by the oracle in the Lose case
@@ -81,11 +81,12 @@ case class BinaryOutcomeDLCWithSelf(
     remoteFundingUtxos: Vector[BitcoinUTXOSpendingInfo],
     localWinPayout: CurrencyUnit,
     localLosePayout: CurrencyUnit,
-    timeout: Int,
+    timeout: BlockStampWithFuture,
     feeRate: FeeUnit,
     changeSPK: ScriptPubKey,
     network: BitcoinNetwork)(implicit ec: ExecutionContext)
     extends BitcoinSLogger {
+
   import BinaryOutcomeDLCWithSelf.subtractFeeAndSign
 
   /** Hash signed by oracle in Win case */
@@ -192,7 +193,7 @@ case class BinaryOutcomeDLCWithSelf(
       requiredSigs = 2,
       pubKeys = Vector(cetLocalPrivKey.publicKey, sigPubKey))
     val timeoutSPK = CLTVScriptPubKey(
-      locktime = ScriptNumber(timeout),
+      locktime = ScriptNumber(timeout.toUInt32.toInt),
       scriptPubKey = P2PKHScriptPubKey(cetRemotePrivKey.publicKey))
 
     val toLocalSPK = MultiSignatureWithTimeoutScriptPubKey(multiSig, timeoutSPK)
@@ -231,7 +232,7 @@ case class BinaryOutcomeDLCWithSelf(
       requiredSigs = 2,
       pubKeys = Vector(cetRemotePrivKey.publicKey, sigPubKey))
     val timeoutSPK = CLTVScriptPubKey(
-      locktime = ScriptNumber(timeout),
+      locktime = ScriptNumber(timeout.toUInt32.toInt),
       scriptPubKey = P2PKHScriptPubKey(cetLocalPrivKey.publicKey))
 
     val toLocalSPK = MultiSignatureWithTimeoutScriptPubKey(multiSig, timeoutSPK)
@@ -278,7 +279,7 @@ case class BinaryOutcomeDLCWithSelf(
                                       feeRate,
                                       changeSPK,
                                       network,
-                                      UInt32(timeout))
+                                      timeout.toUInt32)
 
     txBuilderF.flatMap(subtractFeeAndSign)
   }
@@ -323,15 +324,17 @@ case class BinaryOutcomeDLCWithSelf(
     )
   }
 
-  /** Constructs, signs and outputs the funding tx, all four CETs and the closing tx
-    * given the oracle's signature (can be executed for either Local or Remote).
-    *
-    * @return The closing transaction and the UTXOSpendingInfo for the CET it spends.
-    */
-  def executeDLC(
-      oracleSigF: Future[SchnorrDigitalSignature],
-      local: Boolean,
-      messengerOpt: Option[BitcoinP2PMessenger] = None): Future[DLCOutcome] = {
+  case class SetupDLC(
+      fundingTx: Transaction,
+      fundingSpendingInfo: MultiSignatureSpendingInfo,
+      cetWinLocal: Transaction,
+      cetLoseLocal: Transaction,
+      cetWinRemote: Transaction,
+      cetLoseRemote: Transaction,
+      refundTx: Transaction
+  )
+
+  def setupDLC(messengerOpt: Option[BitcoinP2PMessenger]): Future[SetupDLC] = {
     // Construct Funding Transaction
     createFundingTransaction.flatMap { fundingTx =>
       logger.info(s"Funding Transaction: ${fundingTx.hex}\n")
@@ -370,97 +373,253 @@ case class BinaryOutcomeDLCWithSelf(
         case None => FutureUtil.unit
       }
 
-      oracleSigF.flatMap { oracleSig =>
-        // Pick the CET to use and payout by checking which message was signed
-        val cetAndPrivKeyF =
-          if (Schnorr.verify(messageWin, oracleSig, oraclePubKey)) {
-            if (local) {
-              cetWinLocalF.map((_, cetLocalWinPrivKey))
-            } else {
-              cetWinRemoteF.map((_, cetRemoteWinPrivKey))
-            }
-          } else if (Schnorr.verify(messageLose, oracleSig, oraclePubKey)) {
-            if (local) {
-              cetLoseLocalF.map((_, cetLocalLosePrivKey))
-            } else {
-              cetLoseRemoteF.map((_, cetRemoteLosePrivKey))
-            }
-          } else {
-            Future.failed(???)
-          }
+      for {
+        cetWinLocal <- cetWinLocalF
+        cetLoseLocal <- cetLoseLocalF
+        cetWinRemote <- cetWinRemoteF
+        cetLoseRemote <- cetLoseRemoteF
+        refundTx <- refundTxF
+        _ <- fundingTxPublishedF
+      } yield {
+        SetupDLC(fundingTx,
+                 fundingSpendingInfo,
+                 cetWinLocal,
+                 cetLoseLocal,
+                 cetWinRemote,
+                 cetLoseRemote,
+                 refundTx)
+      }
+    }
+  }
 
-        val cetReadyForPublish =
-          fundingTxPublishedF.flatMap(_ => cetAndPrivKeyF)
+  def publishClosingTx(
+      cetPublishedF: Future[Unit],
+      cetOutput: TransactionOutput,
+      privKey: ECPrivateKey,
+      spendingInfo: BitcoinUTXOSpendingInfo,
+      isLocal: Boolean,
+      messengerOpt: Option[BitcoinP2PMessenger]): Future[Transaction] = {
+    // Construct Closing Transaction
+    val txBuilder = BitcoinTxBuilder(
+      Vector(
+        TransactionOutput(cetOutput.value,
+                          P2PKHScriptPubKey(privKey.publicKey))),
+      Vector(spendingInfo),
+      feeRate,
+      changeSPK,
+      network
+    )
 
-        cetReadyForPublish.flatMap {
-          case (cet, cetPrivKey) =>
-            val cetPublishedF = messengerOpt match {
-              case Some(messenger) =>
-                messenger
-                  .sendTransaction(cet)
-                  .flatMap(_ => messenger.waitForConfirmations(blocks = 6))
-              case None => FutureUtil.unit
-            }
+    val spendingTxF = txBuilder.flatMap(subtractFeeAndSign)
 
-            val output = cet.outputs.head
+    spendingTxF.foreach(
+      tx =>
+        logger.info(
+          s"${if (isLocal) "Local" else "Remote"} Closing Tx: ${tx.hex}"))
 
-            // Spend the true case on the correct CET
-            val cetSpendingInfo = ConditionalSpendingInfo(
-              TransactionOutPoint(cet.txIdBE, UInt32.zero),
-              output.value,
-              output.scriptPubKey.asInstanceOf[ConditionalScriptPubKey],
-              Vector(cetPrivKey, ECPrivateKey(oracleSig.s)),
-              HashType.sigHashAll,
-              ConditionalPath.nonNestedTrue
-            )
-
-            val finalPrivKey = if (local) {
-              finalLocalPrivKey
-            } else {
-              finalRemotePrivKey
-            }
-
-            // Construct Closing Transaction
-            val txBuilder = BitcoinTxBuilder(
-              Vector(
-                TransactionOutput(output.value,
-                                  P2PKHScriptPubKey(finalPrivKey.publicKey))),
-              Vector(cetSpendingInfo),
-              feeRate,
-              changeSPK,
-              network
-            )
-
-            val spendingTxF = txBuilder.flatMap(subtractFeeAndSign)
-
-            spendingTxF.foreach(tx => logger.info(s"Closing Tx: ${tx.hex}"))
-
-            val spendingTxPublishedF = spendingTxF.flatMap { spendingTx =>
-              cetPublishedF.flatMap { _ =>
-                messengerOpt match {
-                  case Some(messenger) =>
-                    messenger
-                      .sendTransaction(spendingTx)
-                      .flatMap(_ => messenger.waitForConfirmations(blocks = 6))
-                  case None => FutureUtil.unit
-                }
-              }
-            }
-
-            spendingTxF.flatMap { spendingTx =>
-              spendingTxPublishedF.map { _ =>
-                DLCOutcome(
-                  fundingTx,
-                  cet,
-                  spendingTx,
-                  fundingUtxos,
-                  fundingSpendingInfo,
-                  cetSpendingInfo
-                )
-              }
-            }
+    val spendingTxPublishedF = spendingTxF.flatMap { spendingTx =>
+      cetPublishedF.flatMap { _ =>
+        messengerOpt match {
+          case Some(messenger) =>
+            messenger
+              .sendTransaction(spendingTx)
+              .flatMap(_ => messenger.waitForConfirmations(blocks = 6))
+          case None => FutureUtil.unit
         }
       }
+    }
+
+    spendingTxF.flatMap { spendingTx =>
+      spendingTxPublishedF.map { _ =>
+        spendingTx
+      }
+    }
+  }
+
+  /** Constructs and executes on the unilateral spending branch of a DLC
+    *
+    * @return Each transaction published and its spending info
+    */
+  def executeUnilateralDLC(
+      oracleSigF: Future[SchnorrDigitalSignature],
+      local: Boolean,
+      messengerOpt: Option[BitcoinP2PMessenger] = None): Future[DLCOutcome] = {
+    setupDLC(messengerOpt).flatMap {
+      case SetupDLC(fundingTx,
+                    fundingSpendingInfo,
+                    cetWinLocal,
+                    cetLoseLocal,
+                    cetWinRemote,
+                    cetLoseRemote,
+                    _) =>
+        oracleSigF.flatMap { oracleSig =>
+          // Pick the CET to use and payout by checking which message was signed
+          val (cet, cetPrivKey, otherCetPrivKey) =
+            if (Schnorr.verify(messageWin, oracleSig, oraclePubKey)) {
+              if (local) {
+                (cetWinLocal, cetLocalWinPrivKey, cetRemoteWinPrivKey)
+              } else {
+                (cetWinRemote, cetRemoteWinPrivKey, cetLocalWinPrivKey)
+              }
+            } else if (Schnorr.verify(messageLose, oracleSig, oraclePubKey)) {
+              if (local) {
+                (cetLoseLocal, cetLocalLosePrivKey, cetRemoteLosePrivKey)
+              } else {
+                (cetLoseRemote, cetRemoteLosePrivKey, cetLocalLosePrivKey)
+              }
+            } else {
+              throw new IllegalStateException(
+                "Signature does not correspond to either possible outcome!")
+            }
+
+          val cetPublishedF = messengerOpt match {
+            case Some(messenger) =>
+              messenger
+                .sendTransaction(cet)
+                .flatMap(_ => messenger.waitForConfirmations(blocks = 6))
+            case None => FutureUtil.unit
+          }
+
+          // The prefix other refers to remote if local == true and local otherwise
+          val output = cet.outputs.head
+          val otherOutput = cet.outputs.last
+
+          // Spend the true case on the correct CET
+          val cetSpendingInfo = ConditionalSpendingInfo(
+            TransactionOutPoint(cet.txIdBE, UInt32.zero),
+            output.value,
+            output.scriptPubKey.asInstanceOf[ConditionalScriptPubKey],
+            Vector(cetPrivKey, ECPrivateKey(oracleSig.s)),
+            HashType.sigHashAll,
+            ConditionalPath.nonNestedTrue
+          )
+
+          val otherCetSpendingInfo = P2PKHSpendingInfo(
+            TransactionOutPoint(cet.txIdBE, UInt32.one),
+            otherOutput.value,
+            otherOutput.scriptPubKey.asInstanceOf[P2PKHScriptPubKey],
+            otherCetPrivKey,
+            HashType.sigHashAll
+          )
+
+          val (localOutput,
+               localCetSpendingInfo,
+               remoteOutput,
+               remoteCetSpendingInfo) = if (local) {
+            (output, cetSpendingInfo, otherOutput, otherCetSpendingInfo)
+          } else {
+            (otherOutput, otherCetSpendingInfo, output, cetSpendingInfo)
+          }
+
+          val localSpendingTxF = publishClosingTx(cetPublishedF,
+                                                  localOutput,
+                                                  finalLocalPrivKey,
+                                                  localCetSpendingInfo,
+                                                  isLocal = true,
+                                                  messengerOpt)
+          val remoteSpendingTxF = publishClosingTx(cetPublishedF,
+                                                   remoteOutput,
+                                                   finalRemotePrivKey,
+                                                   remoteCetSpendingInfo,
+                                                   isLocal = false,
+                                                   messengerOpt)
+
+          localSpendingTxF.flatMap { localSpendingTx =>
+            remoteSpendingTxF.map { remoteSpendingTx =>
+              DLCOutcome(
+                fundingTx,
+                cet,
+                localSpendingTx,
+                remoteSpendingTx,
+                fundingUtxos,
+                fundingSpendingInfo,
+                localCetSpendingInfo,
+                remoteCetSpendingInfo
+              )
+            }
+          }
+        }
+    }
+  }
+
+  /** Constructs and executes on the refund spending branch of a DLC
+    *
+    * @return Each transaction published and its spending info
+    */
+  def executeRefundDLC(
+      messengerOpt: Option[BitcoinP2PMessenger] = None): Future[DLCOutcome] = {
+    setupDLC(messengerOpt).flatMap {
+      case SetupDLC(fundingTx, fundingSpendingInfo, _, _, _, _, refundTx) =>
+        val waitForRefundF = messengerOpt match {
+          case Some(messenger) =>
+            timeout match {
+              case BlockHeight(height) => messenger.waitUntilBlockHeight(height)
+              case BlockTime(time) =>
+                Future {
+                  val timeToWait = System.currentTimeMillis - time.toInt * 1000
+
+                  Thread.sleep(timeToWait)
+                }
+            }
+          case None => FutureUtil.unit
+        }
+
+        waitForRefundF.flatMap { _ =>
+          val refundTxPublishedF = messengerOpt match {
+            case Some(messenger) =>
+              messenger
+                .sendTransaction(refundTx)
+                .flatMap(_ => messenger.waitForConfirmations(blocks = 6))
+            case None => FutureUtil.unit
+          }
+
+          val localOutput = refundTx.outputs.head
+          val remoteOutput = refundTx.outputs.last
+
+          val localRefundSpendingInfo = P2PKHSpendingInfo(
+            TransactionOutPoint(refundTx.txIdBE, UInt32.zero),
+            localOutput.value,
+            localOutput.scriptPubKey.asInstanceOf[P2PKHScriptPubKey],
+            cetLocalRefundPrivKey,
+            HashType.sigHashAll
+          )
+
+          val remoteRefundSpendingInfo = P2PKHSpendingInfo(
+            TransactionOutPoint(refundTx.txIdBE, UInt32.one),
+            remoteOutput.value,
+            remoteOutput.scriptPubKey.asInstanceOf[P2PKHScriptPubKey],
+            cetRemoteRefundPrivKey,
+            HashType.sigHashAll
+          )
+
+          val localSpendingTxF = publishClosingTx(refundTxPublishedF,
+                                                  localOutput,
+                                                  finalLocalPrivKey,
+                                                  localRefundSpendingInfo,
+                                                  isLocal = true,
+                                                  messengerOpt)
+          val remoteSpendingTxF = publishClosingTx(refundTxPublishedF,
+                                                   remoteOutput,
+                                                   finalRemotePrivKey,
+                                                   remoteRefundSpendingInfo,
+                                                   isLocal = false,
+                                                   messengerOpt)
+
+          localSpendingTxF.flatMap { localSpendingTx =>
+            remoteSpendingTxF.map { remoteSpendingTx =>
+              DLCOutcome(
+                fundingTx,
+                refundTx,
+                localSpendingTx,
+                remoteSpendingTx,
+                fundingUtxos,
+                fundingSpendingInfo,
+                localRefundSpendingInfo,
+                remoteRefundSpendingInfo
+              )
+            }
+          }
+        }
     }
   }
 }
@@ -502,8 +661,10 @@ object BinaryOutcomeDLCWithSelf {
 case class DLCOutcome(
     fundingTx: Transaction,
     cet: Transaction,
-    closingTx: Transaction,
+    localClosingTx: Transaction,
+    remoteClosingTx: Transaction,
     fundingUtxos: Vector[BitcoinUTXOSpendingInfo],
     fundingSpendingInfo: BitcoinUTXOSpendingInfo,
-    cetSpendingInfo: BitcoinUTXOSpendingInfo
+    localCetSpendingInfo: BitcoinUTXOSpendingInfo,
+    remoteCetSpendingInfo: BitcoinUTXOSpendingInfo
 )

--- a/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelf.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelf.scala
@@ -26,7 +26,6 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
-import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.util.{BitcoinSLogger, CryptoUtil, FutureUtil}
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
@@ -193,7 +192,7 @@ case class BinaryOutcomeDLCWithSelf(
       requiredSigs = 2,
       pubKeys = Vector(cetLocalPrivKey.publicKey, sigPubKey))
     val timeoutSPK = CLTVScriptPubKey(
-      locktime = ScriptNumber(timeout.toUInt32.toInt),
+      locktime = timeout.toScriptNumber,
       scriptPubKey = P2PKHScriptPubKey(cetRemotePrivKey.publicKey))
 
     val toLocalSPK = MultiSignatureWithTimeoutScriptPubKey(multiSig, timeoutSPK)
@@ -232,7 +231,7 @@ case class BinaryOutcomeDLCWithSelf(
       requiredSigs = 2,
       pubKeys = Vector(cetRemotePrivKey.publicKey, sigPubKey))
     val timeoutSPK = CLTVScriptPubKey(
-      locktime = ScriptNumber(timeout.toUInt32.toInt),
+      locktime = timeout.toScriptNumber,
       scriptPubKey = P2PKHScriptPubKey(cetLocalPrivKey.publicKey))
 
     val toLocalSPK = MultiSignatureWithTimeoutScriptPubKey(multiSig, timeoutSPK)
@@ -334,7 +333,8 @@ case class BinaryOutcomeDLCWithSelf(
       refundTx: Transaction
   )
 
-  def setupDLC(messengerOpt: Option[BitcoinP2PMessenger]): Future[SetupDLC] = {
+  def setupDLC(
+      messengerOpt: Option[BitcoinP2PMessenger] = None): Future[SetupDLC] = {
     // Construct Funding Transaction
     createFundingTransaction.flatMap { fundingTx =>
       logger.info(s"Funding Transaction: ${fundingTx.hex}\n")
@@ -441,104 +441,104 @@ case class BinaryOutcomeDLCWithSelf(
     * @return Each transaction published and its spending info
     */
   def executeUnilateralDLC(
+      dlcSetup: SetupDLC,
       oracleSigF: Future[SchnorrDigitalSignature],
       local: Boolean,
       messengerOpt: Option[BitcoinP2PMessenger] = None): Future[DLCOutcome] = {
-    setupDLC(messengerOpt).flatMap {
-      case SetupDLC(fundingTx,
-                    fundingSpendingInfo,
-                    cetWinLocal,
-                    cetLoseLocal,
-                    cetWinRemote,
-                    cetLoseRemote,
-                    _) =>
-        oracleSigF.flatMap { oracleSig =>
-          // Pick the CET to use and payout by checking which message was signed
-          val (cet, cetPrivKey, otherCetPrivKey) =
-            if (Schnorr.verify(messageWin, oracleSig, oraclePubKey)) {
-              if (local) {
-                (cetWinLocal, cetLocalWinPrivKey, cetRemoteWinPrivKey)
-              } else {
-                (cetWinRemote, cetRemoteWinPrivKey, cetLocalWinPrivKey)
-              }
-            } else if (Schnorr.verify(messageLose, oracleSig, oraclePubKey)) {
-              if (local) {
-                (cetLoseLocal, cetLocalLosePrivKey, cetRemoteLosePrivKey)
-              } else {
-                (cetLoseRemote, cetRemoteLosePrivKey, cetLocalLosePrivKey)
-              }
-            } else {
-              throw new IllegalStateException(
-                "Signature does not correspond to either possible outcome!")
-            }
+    val SetupDLC(fundingTx,
+                 fundingSpendingInfo,
+                 cetWinLocal,
+                 cetLoseLocal,
+                 cetWinRemote,
+                 cetLoseRemote,
+                 _) = dlcSetup
 
-          val cetPublishedF = messengerOpt match {
-            case Some(messenger) =>
-              messenger
-                .sendTransaction(cet)
-                .flatMap(_ => messenger.waitForConfirmations(blocks = 6))
-            case None => FutureUtil.unit
-          }
-
-          // The prefix other refers to remote if local == true and local otherwise
-          val output = cet.outputs.head
-          val otherOutput = cet.outputs.last
-
-          // Spend the true case on the correct CET
-          val cetSpendingInfo = ConditionalSpendingInfo(
-            TransactionOutPoint(cet.txIdBE, UInt32.zero),
-            output.value,
-            output.scriptPubKey.asInstanceOf[ConditionalScriptPubKey],
-            Vector(cetPrivKey, ECPrivateKey(oracleSig.s)),
-            HashType.sigHashAll,
-            ConditionalPath.nonNestedTrue
-          )
-
-          val otherCetSpendingInfo = P2PKHSpendingInfo(
-            TransactionOutPoint(cet.txIdBE, UInt32.one),
-            otherOutput.value,
-            otherOutput.scriptPubKey.asInstanceOf[P2PKHScriptPubKey],
-            otherCetPrivKey,
-            HashType.sigHashAll
-          )
-
-          val (localOutput,
-               localCetSpendingInfo,
-               remoteOutput,
-               remoteCetSpendingInfo) = if (local) {
-            (output, cetSpendingInfo, otherOutput, otherCetSpendingInfo)
+    oracleSigF.flatMap { oracleSig =>
+      // Pick the CET to use and payout by checking which message was signed
+      val (cet, cetPrivKey, otherCetPrivKey) =
+        if (Schnorr.verify(messageWin, oracleSig, oraclePubKey)) {
+          if (local) {
+            (cetWinLocal, cetLocalWinPrivKey, cetRemoteWinPrivKey)
           } else {
-            (otherOutput, otherCetSpendingInfo, output, cetSpendingInfo)
+            (cetWinRemote, cetRemoteWinPrivKey, cetLocalWinPrivKey)
           }
-
-          val localSpendingTxF = publishClosingTx(cetPublishedF,
-                                                  localOutput,
-                                                  finalLocalPrivKey,
-                                                  localCetSpendingInfo,
-                                                  isLocal = true,
-                                                  messengerOpt)
-          val remoteSpendingTxF = publishClosingTx(cetPublishedF,
-                                                   remoteOutput,
-                                                   finalRemotePrivKey,
-                                                   remoteCetSpendingInfo,
-                                                   isLocal = false,
-                                                   messengerOpt)
-
-          localSpendingTxF.flatMap { localSpendingTx =>
-            remoteSpendingTxF.map { remoteSpendingTx =>
-              DLCOutcome(
-                fundingTx,
-                cet,
-                localSpendingTx,
-                remoteSpendingTx,
-                fundingUtxos,
-                fundingSpendingInfo,
-                localCetSpendingInfo,
-                remoteCetSpendingInfo
-              )
-            }
+        } else if (Schnorr.verify(messageLose, oracleSig, oraclePubKey)) {
+          if (local) {
+            (cetLoseLocal, cetLocalLosePrivKey, cetRemoteLosePrivKey)
+          } else {
+            (cetLoseRemote, cetRemoteLosePrivKey, cetLocalLosePrivKey)
           }
+        } else {
+          throw new IllegalStateException(
+            "Signature does not correspond to either possible outcome!")
         }
+
+      val cetPublishedF = messengerOpt match {
+        case Some(messenger) =>
+          messenger
+            .sendTransaction(cet)
+            .flatMap(_ => messenger.waitForConfirmations(blocks = 6))
+        case None => FutureUtil.unit
+      }
+
+      // The prefix other refers to remote if local == true and local otherwise
+      val output = cet.outputs.head
+      val otherOutput = cet.outputs.last
+
+      // Spend the true case on the correct CET
+      val cetSpendingInfo = ConditionalSpendingInfo(
+        TransactionOutPoint(cet.txIdBE, UInt32.zero),
+        output.value,
+        output.scriptPubKey.asInstanceOf[ConditionalScriptPubKey],
+        Vector(cetPrivKey, ECPrivateKey(oracleSig.s)),
+        HashType.sigHashAll,
+        ConditionalPath.nonNestedTrue
+      )
+
+      val otherCetSpendingInfo = P2PKHSpendingInfo(
+        TransactionOutPoint(cet.txIdBE, UInt32.one),
+        otherOutput.value,
+        otherOutput.scriptPubKey.asInstanceOf[P2PKHScriptPubKey],
+        otherCetPrivKey,
+        HashType.sigHashAll
+      )
+
+      val (localOutput,
+           localCetSpendingInfo,
+           remoteOutput,
+           remoteCetSpendingInfo) = if (local) {
+        (output, cetSpendingInfo, otherOutput, otherCetSpendingInfo)
+      } else {
+        (otherOutput, otherCetSpendingInfo, output, cetSpendingInfo)
+      }
+
+      val localSpendingTxF = publishClosingTx(cetPublishedF,
+                                              localOutput,
+                                              finalLocalPrivKey,
+                                              localCetSpendingInfo,
+                                              isLocal = true,
+                                              messengerOpt)
+      val remoteSpendingTxF = publishClosingTx(cetPublishedF,
+                                               remoteOutput,
+                                               finalRemotePrivKey,
+                                               remoteCetSpendingInfo,
+                                               isLocal = false,
+                                               messengerOpt)
+
+      localSpendingTxF.flatMap { localSpendingTx =>
+        remoteSpendingTxF.map { remoteSpendingTx =>
+          DLCOutcome(
+            fundingTx,
+            cet,
+            localSpendingTx,
+            remoteSpendingTx,
+            fundingUtxos,
+            fundingSpendingInfo,
+            localCetSpendingInfo,
+            remoteCetSpendingInfo
+          )
+        }
+      }
     }
   }
 
@@ -547,79 +547,80 @@ case class BinaryOutcomeDLCWithSelf(
     * @return Each transaction published and its spending info
     */
   def executeRefundDLC(
+      dlcSetup: SetupDLC,
       messengerOpt: Option[BitcoinP2PMessenger] = None): Future[DLCOutcome] = {
-    setupDLC(messengerOpt).flatMap {
-      case SetupDLC(fundingTx, fundingSpendingInfo, _, _, _, _, refundTx) =>
-        val waitForRefundF = messengerOpt match {
-          case Some(messenger) =>
-            timeout match {
-              case BlockHeight(height) => messenger.waitUntilBlockHeight(height)
-              case BlockTime(time) =>
-                Future {
-                  val timeToWait = System.currentTimeMillis - time.toInt * 1000
+    val SetupDLC(fundingTx, fundingSpendingInfo, _, _, _, _, refundTx) =
+      dlcSetup
 
-                  Thread.sleep(timeToWait)
-                }
+    val waitForRefundF = messengerOpt match {
+      case Some(messenger) =>
+        timeout match {
+          case BlockHeight(height) => messenger.waitUntilBlockHeight(height)
+          case BlockTime(time) =>
+            Future {
+              val timeToWait = System.currentTimeMillis - time.toInt * 1000
+
+              Thread.sleep(timeToWait)
             }
-          case None => FutureUtil.unit
         }
+      case None => FutureUtil.unit
+    }
 
-        waitForRefundF.flatMap { _ =>
-          val refundTxPublishedF = messengerOpt match {
-            case Some(messenger) =>
-              messenger
-                .sendTransaction(refundTx)
-                .flatMap(_ => messenger.waitForConfirmations(blocks = 6))
-            case None => FutureUtil.unit
-          }
+    waitForRefundF.flatMap { _ =>
+      val refundTxPublishedF = messengerOpt match {
+        case Some(messenger) =>
+          messenger
+            .sendTransaction(refundTx)
+            .flatMap(_ => messenger.waitForConfirmations(blocks = 6))
+        case None => FutureUtil.unit
+      }
 
-          val localOutput = refundTx.outputs.head
-          val remoteOutput = refundTx.outputs.last
+      val localOutput = refundTx.outputs.head
+      val remoteOutput = refundTx.outputs.last
 
-          val localRefundSpendingInfo = P2PKHSpendingInfo(
-            TransactionOutPoint(refundTx.txIdBE, UInt32.zero),
-            localOutput.value,
-            localOutput.scriptPubKey.asInstanceOf[P2PKHScriptPubKey],
-            cetLocalRefundPrivKey,
-            HashType.sigHashAll
+      val localRefundSpendingInfo = P2PKHSpendingInfo(
+        TransactionOutPoint(refundTx.txIdBE, UInt32.zero),
+        localOutput.value,
+        localOutput.scriptPubKey.asInstanceOf[P2PKHScriptPubKey],
+        cetLocalRefundPrivKey,
+        HashType.sigHashAll
+      )
+
+      val remoteRefundSpendingInfo = P2PKHSpendingInfo(
+        TransactionOutPoint(refundTx.txIdBE, UInt32.one),
+        remoteOutput.value,
+        remoteOutput.scriptPubKey.asInstanceOf[P2PKHScriptPubKey],
+        cetRemoteRefundPrivKey,
+        HashType.sigHashAll
+      )
+
+      val localSpendingTxF = publishClosingTx(refundTxPublishedF,
+                                              localOutput,
+                                              finalLocalPrivKey,
+                                              localRefundSpendingInfo,
+                                              isLocal = true,
+                                              messengerOpt)
+      val remoteSpendingTxF = publishClosingTx(refundTxPublishedF,
+                                               remoteOutput,
+                                               finalRemotePrivKey,
+                                               remoteRefundSpendingInfo,
+                                               isLocal = false,
+                                               messengerOpt)
+
+      localSpendingTxF.flatMap { localSpendingTx =>
+        remoteSpendingTxF.map { remoteSpendingTx =>
+          DLCOutcome(
+            fundingTx,
+            refundTx,
+            localSpendingTx,
+            remoteSpendingTx,
+            fundingUtxos,
+            fundingSpendingInfo,
+            localRefundSpendingInfo,
+            remoteRefundSpendingInfo
           )
-
-          val remoteRefundSpendingInfo = P2PKHSpendingInfo(
-            TransactionOutPoint(refundTx.txIdBE, UInt32.one),
-            remoteOutput.value,
-            remoteOutput.scriptPubKey.asInstanceOf[P2PKHScriptPubKey],
-            cetRemoteRefundPrivKey,
-            HashType.sigHashAll
-          )
-
-          val localSpendingTxF = publishClosingTx(refundTxPublishedF,
-                                                  localOutput,
-                                                  finalLocalPrivKey,
-                                                  localRefundSpendingInfo,
-                                                  isLocal = true,
-                                                  messengerOpt)
-          val remoteSpendingTxF = publishClosingTx(refundTxPublishedF,
-                                                   remoteOutput,
-                                                   finalRemotePrivKey,
-                                                   remoteRefundSpendingInfo,
-                                                   isLocal = false,
-                                                   messengerOpt)
-
-          localSpendingTxF.flatMap { localSpendingTx =>
-            remoteSpendingTxF.map { remoteSpendingTx =>
-              DLCOutcome(
-                fundingTx,
-                refundTx,
-                localSpendingTx,
-                remoteSpendingTx,
-                fundingUtxos,
-                fundingSpendingInfo,
-                localRefundSpendingInfo,
-                remoteRefundSpendingInfo
-              )
-            }
-          }
         }
+      }
     }
   }
 }

--- a/dlc/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelfIntegrationTest.scala
+++ b/dlc/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelfIntegrationTest.scala
@@ -17,6 +17,7 @@ import org.bitcoins.core.currency.{
 }
 import org.bitcoins.core.number.{Int64, UInt32}
 import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.BlockStamp.BlockHeight
 import org.bitcoins.core.protocol.script.P2PKHScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutPoint
 import org.bitcoins.core.script.crypto.HashType
@@ -29,7 +30,6 @@ import org.scalatest.Assertion
 import scodec.bits.ByteVector
 
 import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
 
 class BinaryOutcomeDLCWithSelfIntegrationTest extends BitcoindRpcTest {
   private val clientsF = BitcoindRpcTestUtil.createNodePairV18(clientAccum)
@@ -67,12 +67,7 @@ class BinaryOutcomeDLCWithSelfIntegrationTest extends BitcoindRpcTest {
     val changePubKey = changePrivKey.publicKey
     val changeSPK = P2PKHScriptPubKey(changePubKey)
 
-    def executeForCase(
-        outcomeHash: Sha256DigestBE,
-        local: Boolean): Future[Assertion] = {
-      val oracleSig =
-        Schnorr.signWithNonce(outcomeHash.bytes, oraclePrivKey, preCommittedK)
-
+    def setupDLC(): Future[BinaryOutcomeDLCWithSelf] = {
       def fundingInput(input: CurrencyUnit): Bitcoins = {
         Bitcoins((input + Satoshis(Int64(200))).satoshis)
       }
@@ -147,10 +142,13 @@ class BinaryOutcomeDLCWithSelfIntegrationTest extends BitcoindRpcTest {
         .flatMap(_.getNetworkInfo.map(_.relayfee))
         .map(btc => SatoshisPerByte(btc.satoshis))
 
-      val dlcF = for {
+      for {
         localFundingUtxos <- localFundingUtxosF
         remoteFundingUtxos <- remoteFundingUtxosF
         feeRate <- feeRateF
+        client <- clientF
+        currentHeight <- client.getBlockCount
+        tomorrowInBlocks = BlockHeight(currentHeight + 144)
       } yield {
         BinaryOutcomeDLCWithSelf(
           outcomeWin = outcomeWin,
@@ -165,32 +163,65 @@ class BinaryOutcomeDLCWithSelfIntegrationTest extends BitcoindRpcTest {
           remoteFundingUtxos = remoteFundingUtxos,
           localWinPayout = localInput + CurrencyUnits.oneMBTC,
           localLosePayout = localInput - CurrencyUnits.oneMBTC,
-          timeout = 1.day.toMillis.toInt,
+          timeout = tomorrowInBlocks,
           feeRate = feeRate,
           changeSPK = changeSPK,
           network = RegTest
         )
       }
+    }
 
+    def validateOutcome(outcome: DLCOutcome): Future[Assertion] = {
       for {
         client <- clientF
-        dlc <- dlcF
-        messenger = BitcoindRpcMessengerRegtest(client)
-        outcome <- dlc.executeDLC(Future.successful(oracleSig),
-                                  local,
-                                  Some(messenger))
-        regtestClosingTx <- client.getRawTransaction(outcome.closingTx.txIdBE)
+        regtestLocalClosingTx <- client.getRawTransaction(
+          outcome.localClosingTx.txIdBE)
+        regtestRemoteClosingTx <- client.getRawTransaction(
+          outcome.remoteClosingTx.txIdBE)
       } yield {
-        assert(regtestClosingTx.hex == outcome.closingTx)
-        assert(regtestClosingTx.confirmations.contains(6))
+        assert(regtestLocalClosingTx.hex == outcome.localClosingTx)
+        assert(regtestLocalClosingTx.confirmations.isDefined)
+        assert(regtestLocalClosingTx.confirmations.get >= 6)
+
+        assert(regtestRemoteClosingTx.hex == outcome.remoteClosingTx)
+        assert(regtestRemoteClosingTx.confirmations.isDefined)
+        assert(regtestRemoteClosingTx.confirmations.get >= 6)
       }
     }
 
+    def executeForUnilateralCase(
+        outcomeHash: Sha256DigestBE,
+        local: Boolean): Future[Assertion] = {
+      val oracleSig =
+        Schnorr.signWithNonce(outcomeHash.bytes, oraclePrivKey, preCommittedK)
+
+      for {
+        client <- clientF
+        dlc <- setupDLC()
+        messenger = BitcoindRpcMessengerRegtest(client)
+        outcome <- dlc.executeUnilateralDLC(Future.successful(oracleSig),
+                                            local,
+                                            Some(messenger))
+        validation <- validateOutcome(outcome)
+      } yield validation
+    }
+
+    def executeForRefundCase(): Future[Assertion] = {
+      for {
+        client <- clientF
+        dlc <- setupDLC()
+        outcome <- dlc.executeRefundDLC(
+          Some(BitcoindRpcMessengerRegtest(client)))
+        assertion <- validateOutcome(outcome)
+      } yield assertion
+    }
+
     for {
-      _ <- executeForCase(outcomeWinHash, local = true)
-      _ <- executeForCase(outcomeLoseHash, local = true)
-      _ <- executeForCase(outcomeWinHash, local = false)
-      _ <- executeForCase(outcomeLoseHash, local = false)
+      _ <- executeForUnilateralCase(outcomeWinHash, local = true)
+      _ <- executeForUnilateralCase(outcomeLoseHash, local = true)
+      _ <- executeForUnilateralCase(outcomeWinHash, local = false)
+      _ <- executeForUnilateralCase(outcomeLoseHash, local = false)
+      _ <- executeForRefundCase()
     } yield succeed
   }
 }

--- a/dlc/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelfTest.scala
+++ b/dlc/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelfTest.scala
@@ -12,23 +12,18 @@ import org.bitcoins.core.crypto.{
 }
 import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
 import org.bitcoins.core.number.{Int64, UInt32}
+import org.bitcoins.core.protocol.BlockStamp.BlockTime
 import org.bitcoins.core.protocol.script.{EmptyScriptPubKey, P2PKHScriptPubKey}
-import org.bitcoins.core.protocol.transaction.{
-  TransactionOutPoint,
-  TransactionOutput
-}
+import org.bitcoins.core.protocol.transaction.TransactionOutPoint
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.util.{BitcoinScriptUtil, CryptoUtil}
-import org.bitcoins.core.wallet.builder.{BitcoinTxBuilder, TxBuilder}
-import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerByte}
+import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
+import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.core.wallet.utxo.{
   BitcoinUTXOSpendingInfo,
   P2PKHSpendingInfo
 }
-import org.bitcoins.testkit.core.gen.{
-  CurrencyUnitGenerator,
-  TransactionGenerators
-}
+import org.bitcoins.testkit.core.gen.TransactionGenerators
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import org.scalacheck.Gen
 import org.scalatest.Assertion
@@ -116,6 +111,8 @@ class BinaryOutcomeDLCWithSelfTest extends BitcoinSAsyncTest {
     val inputPrivKeyRemote = ECPrivateKey.freshPrivateKey
     val inputPubKeyRemote = inputPrivKeyRemote.publicKey
 
+    val blockTimeToday = BlockTime(UInt32(System.currentTimeMillis() / 1000))
+
     val localFundingUtxos = Vector(
       P2PKHSpendingInfo(
         outPoint = TransactionOutPoint(DoubleSha256DigestBE.empty, UInt32.zero),
@@ -140,55 +137,68 @@ class BinaryOutcomeDLCWithSelfTest extends BitcoinSAsyncTest {
     val changePubKey = changePrivKey.publicKey
     val changeSPK = P2PKHScriptPubKey(changePubKey)
 
-    def executeForCase(
+    val dlc = BinaryOutcomeDLCWithSelf(
+      outcomeWin = outcomeWin,
+      outcomeLose = outcomeLose,
+      oraclePubKey = oraclePubKey,
+      preCommittedR = preCommittedR,
+      localExtPrivKey = ExtPrivateKey.freshRootKey(LegacyTestNet3Priv),
+      remoteExtPrivKey = ExtPrivateKey.freshRootKey(LegacyTestNet3Priv),
+      localInput = localInput,
+      remoteInput = remoteInput,
+      localFundingUtxos = localFundingUtxos,
+      remoteFundingUtxos = remoteFundingUtxos,
+      localWinPayout = localInput + CurrencyUnits.oneMBTC,
+      localLosePayout = localInput - CurrencyUnits.oneMBTC,
+      timeout = blockTimeToday,
+      feeRate = SatoshisPerByte(Satoshis.one),
+      changeSPK = changeSPK,
+      network = RegTest
+    )
+
+    def validateOutcome(outcome: DLCOutcome): Assertion = {
+      val DLCOutcome(fundingTx,
+                     cet,
+                     localClosingTx,
+                     remoteClosingTx,
+                     initialSpendingInfos,
+                     fundingSpendingInfo,
+                     localCetSpendingInfo,
+                     remoteCetSpendingInfo) = outcome
+
+      assert(
+        BitcoinScriptUtil.verifyScript(fundingTx, initialSpendingInfos)
+      )
+      assert(
+        BitcoinScriptUtil.verifyScript(cet, Vector(fundingSpendingInfo))
+      )
+      assert(
+        BitcoinScriptUtil.verifyScript(localClosingTx,
+                                       Vector(localCetSpendingInfo))
+      )
+      assert(
+        BitcoinScriptUtil.verifyScript(remoteClosingTx,
+                                       Vector(remoteCetSpendingInfo))
+      )
+    }
+
+    def executeUnilateralForCase(
         outcomeHash: Sha256DigestBE,
         local: Boolean): Future[Assertion] = {
       val oracleSig =
         Schnorr.signWithNonce(outcomeHash.bytes, oraclePrivKey, preCommittedK)
 
-      val dlc = BinaryOutcomeDLCWithSelf(
-        outcomeWin = outcomeWin,
-        outcomeLose = outcomeLose,
-        oraclePubKey = oraclePubKey,
-        preCommittedR = preCommittedR,
-        localExtPrivKey = ExtPrivateKey.freshRootKey(LegacyTestNet3Priv),
-        remoteExtPrivKey = ExtPrivateKey.freshRootKey(LegacyTestNet3Priv),
-        localInput = localInput,
-        remoteInput = remoteInput,
-        localFundingUtxos = localFundingUtxos,
-        remoteFundingUtxos = remoteFundingUtxos,
-        localWinPayout = localInput + CurrencyUnits.oneMBTC,
-        localLosePayout = localInput - CurrencyUnits.oneMBTC,
-        timeout = 1.day.toMillis.toInt,
-        feeRate = SatoshisPerByte(Satoshis.one),
-        changeSPK = changeSPK,
-        network = RegTest
-      )
-
-      dlc.executeDLC(Future.successful(oracleSig), local).map {
-        case DLCOutcome(fundingTx,
-                        cet,
-                        closingTx,
-                        initialSpendingInfos,
-                        fundingSpendingInfo,
-                        cetSpendingInfo) =>
-          assert(
-            BitcoinScriptUtil.verifyScript(fundingTx, initialSpendingInfos)
-          )
-          assert(
-            BitcoinScriptUtil.verifyScript(cet, Vector(fundingSpendingInfo))
-          )
-          assert(
-            BitcoinScriptUtil.verifyScript(closingTx, Vector(cetSpendingInfo))
-          )
-      }
+      dlc
+        .executeUnilateralDLC(Future.successful(oracleSig), local)
+        .map(validateOutcome)
     }
 
     for {
-      _ <- executeForCase(outcomeWinHash, local = true)
-      _ <- executeForCase(outcomeLoseHash, local = true)
-      _ <- executeForCase(outcomeWinHash, local = false)
-      _ <- executeForCase(outcomeLoseHash, local = false)
+      _ <- executeUnilateralForCase(outcomeWinHash, local = true)
+      _ <- executeUnilateralForCase(outcomeLoseHash, local = true)
+      _ <- executeUnilateralForCase(outcomeWinHash, local = false)
+      _ <- executeUnilateralForCase(outcomeLoseHash, local = false)
+      _ <- dlc.executeRefundDLC().map(validateOutcome)
     } yield succeed
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
@@ -92,9 +92,9 @@ trait BaseAsyncTest
   }
 
   def sequenceTestRuns(
-      testRunFs: scala.collection.mutable.Builder[Future[Assertion],
-                                                  Vector[Future[Assertion]]])
-    : Future[Assertion] = {
+      testRunFs: scala.collection.mutable.Builder[
+        Future[Assertion],
+        Vector[Future[Assertion]]]): Future[Assertion] = {
     val testRunsF: Future[Vector[Assertion]] =
       Future.sequence(testRunFs.result())
 
@@ -139,10 +139,11 @@ trait BaseAsyncTest
     sequenceTestRuns(testRunFs)
   }
 
-  def forAllAsync[A, B, C, D](genA: Gen[A],
-                              genB: Gen[B],
-                              genC: Gen[C],
-                              genD: Gen[D])(
+  def forAllAsync[A, B, C, D](
+      genA: Gen[A],
+      genB: Gen[B],
+      genC: Gen[C],
+      genD: Gen[D])(
       func: (A, B, C, D) => Future[Assertion]): Future[Assertion] = {
     val testRunFs = Vector.newBuilder[Future[Assertion]]
 
@@ -155,11 +156,12 @@ trait BaseAsyncTest
     sequenceTestRuns(testRunFs)
   }
 
-  def forAllAsync[A, B, C, D, E](genA: Gen[A],
-                                 genB: Gen[B],
-                                 genC: Gen[C],
-                                 genD: Gen[D],
-                                 genE: Gen[E])(
+  def forAllAsync[A, B, C, D, E](
+      genA: Gen[A],
+      genB: Gen[B],
+      genC: Gen[C],
+      genD: Gen[D],
+      genE: Gen[E])(
       func: (A, B, C, D, E) => Future[Assertion]): Future[Assertion] = {
     val testRunFs = Vector.newBuilder[Future[Assertion]]
 
@@ -172,12 +174,13 @@ trait BaseAsyncTest
     sequenceTestRuns(testRunFs)
   }
 
-  def forAllAsync[A, B, C, D, E, F](genA: Gen[A],
-                                    genB: Gen[B],
-                                    genC: Gen[C],
-                                    genD: Gen[D],
-                                    genE: Gen[E],
-                                    genF: Gen[F])(
+  def forAllAsync[A, B, C, D, E, F](
+      genA: Gen[A],
+      genB: Gen[B],
+      genC: Gen[C],
+      genD: Gen[D],
+      genE: Gen[E],
+      genF: Gen[F])(
       func: (A, B, C, D, E, F) => Future[Assertion]): Future[Assertion] = {
     val testRunFs = Vector.newBuilder[Future[Assertion]]
 


### PR DESCRIPTION
This PR makes the `timeout` type a `BlockStamp` instead of an `Int`.

It also adds an execution case with new tests for spending the refund transaction.