### PR TITLE
Timelock bug fix

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkMessageTest.scala
@@ -10,7 +10,6 @@ class NetworkMessageTest extends BitcoinSUnitTest {
       NodeTestUtil.rawNetworkMessage)
   }
 
-
   it must "serialize and deserialize a version message example from the bitcoin wiki" in {
     val hex = {
       //taken from here with slight modifications
@@ -24,6 +23,6 @@ class NetworkMessageTest extends BitcoinSUnitTest {
         "00"
     }.toLowerCase
     val networkMsg = NetworkMessage.fromHex(hex)
-    networkMsg.hex must be (hex)
+    networkMsg.hex must be(hex)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/testprotocol/CoreTransactionTestCaseProtocol.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/testprotocol/CoreTransactionTestCaseProtocol.scala
@@ -31,8 +31,8 @@ object CoreTransactionTestCaseProtocol extends DefaultJsonProtocol {
 
       if (elements.size < 3) None
       else {
-        val creditingTxsInfo
-          : Seq[(TransactionOutPoint, ScriptPubKey, Option[CurrencyUnit])] =
+        val creditingTxsInfo: Seq[
+          (TransactionOutPoint, ScriptPubKey, Option[CurrencyUnit])] =
           elements.head match {
             case array: JsArray => parseOutPointsScriptPubKeysAmount(array)
             case _: JsValue =>
@@ -58,8 +58,8 @@ object CoreTransactionTestCaseProtocol extends DefaultJsonProtocol {
     * These are in the following format
     * [[prevout hash, prevout index, prevout scriptPubKey, amount], [input 2], ...]
     */
-  def parseOutPointsScriptPubKeysAmount(array: JsArray)
-    : Seq[(TransactionOutPoint, ScriptPubKey, Option[CurrencyUnit])] = {
+  def parseOutPointsScriptPubKeysAmount(array: JsArray): Seq[
+    (TransactionOutPoint, ScriptPubKey, Option[CurrencyUnit])] = {
     val result = array.elements.map {
       case array: JsArray =>
         val prevoutHashHex =

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -1,9 +1,16 @@
 package org.bitcoins.core.script.interpreter
 
-import org.bitcoins.core.crypto.{BaseTxSigComponent, WitnessTxSigComponentP2SH, WitnessTxSigComponentRaw}
+import org.bitcoins.core.crypto.{
+  BaseTxSigComponent,
+  WitnessTxSigComponentP2SH,
+  WitnessTxSigComponentRaw
+}
 import org.bitcoins.core.currency.CurrencyUnits
 import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction.{TransactionOutput, WitnessTransaction}
+import org.bitcoins.core.protocol.transaction.{
+  TransactionOutput,
+  WitnessTransaction
+}
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.flag.ScriptFlagFactory
 import org.bitcoins.core.script.interpreter.testprotocol.CoreTestCase
@@ -27,7 +34,7 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
     val source = Source.fromURL(getClass.getResource("/script_tests.json"))
 
     //use this to represent a single test case from script_valid.json
-/*        val lines =
+    /*        val lines =
       """
           | [["0x01 0x80", "DUP BOOLOR", "P2SH,STRICTENC", "EVAL_FALSE", "negative-0 negative-0 BOOLOR"]]
    """.stripMargin*/

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.core.wallet.builder
 import org.bitcoins.core.config.TestNet3
 import org.bitcoins.core.crypto.{
   BaseTxSigComponent,
+  DoubleSha256DigestBE,
   ECPrivateKey,
   WitnessTxSigComponentP2SH,
   WitnessTxSigComponentRaw
@@ -22,19 +23,18 @@ import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{
   BitcoinUTXOSpendingInfo,
   ConditionalPath,
+  LockTimeSpendingInfo,
   UTXOSpendingInfo
 }
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.script.PreExecutionScriptProgram
+import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder.UTXOMap
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
-import org.scalatest.Assertion
-
-import scala.concurrent.Future
 
 class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
   val tc = TransactionConstants
@@ -385,6 +385,36 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
         conditionalPath = ConditionalPath.NoConditionsLeft
       )
     }
+  }
+
+  it must "succeed to sign a cltv spk that uses a second-based locktime" in {
+    val fundingPrivKey = ECPrivateKey.freshPrivateKey
+
+    val cltvSPK =
+      CLTVScriptPubKey(ScriptNumber(System.currentTimeMillis / 1000),
+                       P2PKScriptPubKey(fundingPrivKey.publicKey))
+
+    val cltvSpendingInfo = LockTimeSpendingInfo(
+      TransactionOutPoint(DoubleSha256DigestBE.empty, UInt32.zero),
+      Bitcoins.one,
+      cltvSPK,
+      Vector(fundingPrivKey),
+      HashType.sigHashAll,
+      ConditionalPath.NoConditionsLeft
+    )
+
+    val txBuilderF =
+      BitcoinTxBuilder(
+        Vector(
+          TransactionOutput(Bitcoins.one - CurrencyUnits.oneMBTC,
+                            EmptyScriptPubKey)),
+        Vector(cltvSpendingInfo),
+        SatoshisPerByte(Satoshis.one),
+        EmptyScriptPubKey,
+        RegTest
+      )
+
+    txBuilderF.flatMap(_.sign).map(_ => succeed)
   }
 
   def verifyScript(tx: Transaction, utxos: Seq[UTXOSpendingInfo]): Boolean = {

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -410,47 +410,54 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     @tailrec
     def loop(
         remaining: Seq[BitcoinUTXOSpendingInfo],
-        currentLockTime: UInt32): Try[UInt32] = remaining match {
-      case Nil => Success(currentLockTime)
-      case spendingInfo +: newRemaining =>
-        spendingInfo match {
-          case lockTime: LockTimeSpendingInfo =>
-            lockTime.scriptPubKey match {
-              case _: CSVScriptPubKey => loop(newRemaining, currentLockTime)
-              case cltv: CLTVScriptPubKey =>
-                val lockTime =
-                  if (cltv.locktime.toLong > UInt32.max.toLong || cltv.locktime.toLong < 0) {
-                    TxBuilderError.IncompatibleLockTimes
-                  } else Success(UInt32(cltv.locktime.toLong))
-                val result = lockTime.flatMap { l: UInt32 =>
-                  if (currentLockTime < l) {
-                    val lockTimeThreshold = tc.locktimeThreshold
-                    if (currentLockTime < lockTimeThreshold && l >= lockTimeThreshold) {
-                      //means that we spend two different locktime types, one of the outputs spends a
-                      //OP_CLTV script by block height, the other spends one by time stamp
+        currentLockTimeOpt: Option[UInt32]): Try[UInt32] =
+      remaining match {
+        case Nil =>
+          Success(currentLockTimeOpt.getOrElse(TransactionConstants.lockTime))
+        case spendingInfo +: newRemaining =>
+          spendingInfo match {
+            case lockTime: LockTimeSpendingInfo =>
+              lockTime.scriptPubKey match {
+                case _: CSVScriptPubKey =>
+                  loop(newRemaining, currentLockTimeOpt)
+                case cltv: CLTVScriptPubKey =>
+                  val lockTime =
+                    if (cltv.locktime.toLong > UInt32.max.toLong || cltv.locktime.toLong < 0) {
                       TxBuilderError.IncompatibleLockTimes
-                    } else Success(l)
-                  } else Success(currentLockTime)
-                }
-                result
-            }
-          case p2sh: P2SHSpendingInfo =>
-            loop(p2sh.nestedSpendingInfo +: newRemaining, currentLockTime)
-          case p2wsh: P2WSHV0SpendingInfo =>
-            loop(p2wsh.nestedSpendingInfo +: newRemaining, currentLockTime)
-          case conditional: ConditionalSpendingInfo =>
-            loop(conditional.nestedSpendingInfo +: newRemaining,
-                 currentLockTime)
-          case _: P2WPKHV0SpendingInfo |
-              _: UnassignedSegwitNativeUTXOSpendingInfo | _: P2PKSpendingInfo |
-              _: P2PKHSpendingInfo | _: MultiSignatureSpendingInfo |
-              _: EmptySpendingInfo =>
-            // none of these scripts affect the locktime of a tx
-            loop(newRemaining, currentLockTime)
-        }
-    }
+                    } else Success(UInt32(cltv.locktime.toLong))
+                  val result = lockTime.flatMap { l: UInt32 =>
+                    currentLockTimeOpt match {
+                      case Some(currentLockTime) =>
+                        if (currentLockTime < l) {
+                          val lockTimeThreshold = tc.locktimeThreshold
+                          if (currentLockTime < lockTimeThreshold && l >= lockTimeThreshold) {
+                            //means that we spend two different locktime types, one of the outputs spends a
+                            //OP_CLTV script by block height, the other spends one by time stamp
+                            TxBuilderError.IncompatibleLockTimes
+                          } else Success(l)
+                        } else Success(currentLockTime)
+                      case None => Success(l)
+                    }
+                  }
+                  result
+              }
+            case p2sh: P2SHSpendingInfo =>
+              loop(p2sh.nestedSpendingInfo +: newRemaining, currentLockTimeOpt)
+            case p2wsh: P2WSHV0SpendingInfo =>
+              loop(p2wsh.nestedSpendingInfo +: newRemaining, currentLockTimeOpt)
+            case conditional: ConditionalSpendingInfo =>
+              loop(conditional.nestedSpendingInfo +: newRemaining,
+                   currentLockTimeOpt)
+            case _: P2WPKHV0SpendingInfo |
+                _: UnassignedSegwitNativeUTXOSpendingInfo |
+                _: P2PKSpendingInfo | _: P2PKHSpendingInfo |
+                _: MultiSignatureSpendingInfo | _: EmptySpendingInfo =>
+              // none of these scripts affect the locktime of a tx
+              loop(newRemaining, currentLockTimeOpt)
+          }
+      }
 
-    loop(utxos, TransactionConstants.lockTime)
+    loop(utxos, None)
   }
 
   /**

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -237,9 +237,10 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     signedTxWithFee
   }
 
-  private def loop(remaining: List[BitcoinUTXOSpendingInfo],
-                   txInProgress: Transaction,
-                   dummySignatures: Boolean)(
+  private def loop(
+      remaining: List[BitcoinUTXOSpendingInfo],
+      txInProgress: Transaction,
+      dummySignatures: Boolean)(
       implicit ec: ExecutionContext): Future[Transaction] = remaining match {
     case Nil => Future.successful(txInProgress)
     case info +: t =>
@@ -253,9 +254,10 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     * @param unsignedTx - the transaction that we are spending this output in
     * @return either the transaction with the signed input added, or a [[TxBuilderError]]
     */
-  private def signAndAddInput(utxo: BitcoinUTXOSpendingInfo,
-                              unsignedTx: Transaction,
-                              dummySignatures: Boolean)(
+  private def signAndAddInput(
+      utxo: BitcoinUTXOSpendingInfo,
+      unsignedTx: Transaction,
+      dummySignatures: Boolean)(
       implicit ec: ExecutionContext): Future[Transaction] = {
     val idx =
       unsignedTx.inputs.zipWithIndex.find(_._1.previousOutput == utxo.outPoint)
@@ -317,11 +319,12 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
   /** Signs P2SH(P2WSH) and non-segwit P2SH inputs by calling signAndAddInput on the altered
     * transaction without P2SH nesting and then re-wrapping with the tweaked ScriptSignature
     */
-  private def signAndAddInputForP2SH(spendingInfo: P2SHSpendingInfo,
-                                     unsignedTx: Transaction,
-                                     sequence: UInt32,
-                                     inputIndex: Int,
-                                     dummySignatures: Boolean)(
+  private def signAndAddInputForP2SH(
+      spendingInfo: P2SHSpendingInfo,
+      unsignedTx: Transaction,
+      sequence: UInt32,
+      inputIndex: Int,
+      dummySignatures: Boolean)(
       implicit ec: ExecutionContext): Future[Transaction] = {
     require(!spendingInfo.redeemScript.isInstanceOf[P2WPKHWitnessSPKV0],
             "Should call signP2SHP2WPKH")
@@ -405,8 +408,9 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     */
   private def calcLockTime(utxos: Seq[BitcoinUTXOSpendingInfo]): Try[UInt32] = {
     @tailrec
-    def loop(remaining: Seq[BitcoinUTXOSpendingInfo],
-             currentLockTimeOpt: Option[UInt32]): Try[UInt32] =
+    def loop(
+        remaining: Seq[BitcoinUTXOSpendingInfo],
+        currentLockTimeOpt: Option[UInt32]): Try[UInt32] =
       remaining match {
         case Nil =>
           Success(currentLockTimeOpt.getOrElse(TransactionConstants.lockTime))
@@ -441,7 +445,12 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
                       case None => Success(l)
                     }
                   }
-                  result
+
+                  result match {
+                    case Success(newLockTime) =>
+                      loop(newRemaining, Some(newLockTime))
+                    case _: Failure[UInt32] => result
+                  }
               }
             case p2sh: P2SHSpendingInfo =>
               loop(p2sh.nestedSpendingInfo +: newRemaining, currentLockTimeOpt)
@@ -472,8 +481,9 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
       utxos: Seq[UTXOSpendingInfo],
       isRBFEnabled: Boolean): Seq[TransactionInput] = {
     @tailrec
-    def loop(remaining: Seq[UTXOSpendingInfo],
-             accum: Seq[TransactionInput]): Seq[TransactionInput] =
+    def loop(
+        remaining: Seq[UTXOSpendingInfo],
+        accum: Seq[TransactionInput]): Seq[TransactionInput] =
       remaining match {
         case Nil => accum.reverse
         case spendingInfo +: newRemaining =>
@@ -513,13 +523,14 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     loop(utxos, Nil)
   }
 
-  def signP2SHP2WPKH(unsignedTx: WitnessTransaction,
-                     inputIndex: UInt32,
-                     p2wpkh: P2WPKHWitnessSPKV0,
-                     output: TransactionOutput,
-                     utxo: UTXOSpendingInfo,
-                     hashType: HashType,
-                     dummySignatures: Boolean): Future[Transaction] = {
+  def signP2SHP2WPKH(
+      unsignedTx: WitnessTransaction,
+      inputIndex: UInt32,
+      p2wpkh: P2WPKHWitnessSPKV0,
+      output: TransactionOutput,
+      utxo: UTXOSpendingInfo,
+      hashType: HashType,
+      dummySignatures: Boolean): Future[Transaction] = {
     //special rule for p2sh(p2wpkh)
     //https://bitcoincore.org/en/segwit_wallet_dev/#signature-generation-and-verification-for-p2sh-p2wpkh
     //we actually sign the fully expanded redeemScript
@@ -590,8 +601,9 @@ object TxBuilder {
 
   /** Checks that we did not lose a [[org.bitcoins.core.protocol.transaction.TransactionOutput TransactionOutput]]
     * in the signing process of this transaction */
-  def sanityDestinationChecks(txBuilder: TxBuilder,
-                              signedTx: Transaction): Try[Unit] = {
+  def sanityDestinationChecks(
+      txBuilder: TxBuilder,
+      signedTx: Transaction): Try[Unit] = {
     //make sure we send coins to the appropriate destinations
     val isMissingDestination = txBuilder.destinations
       .map(o => signedTx.outputs.contains(o))
@@ -624,8 +636,9 @@ object TxBuilder {
     * >= [[org.bitcoins.core.wallet.builder.TxBuilder.destinationAmount TxBuilder.destinationAmount]]
     * and then does a sanity check on the tx's fee
     */
-  def sanityAmountChecks(txBuilder: TxBuilder,
-                         signedTx: Transaction): Try[Unit] = {
+  def sanityAmountChecks(
+      txBuilder: TxBuilder,
+      signedTx: Transaction): Try[Unit] = {
     val spentAmount: CurrencyUnit =
       signedTx.outputs.map(_.value).fold(CurrencyUnits.zero)(_ + _)
     val creditingAmount = txBuilder.creditingAmount
@@ -654,9 +667,10 @@ object TxBuilder {
     * @param feeRate the fee rate in satoshis/vbyte we paid per byte on this tx
     * @return
     */
-  def isValidFeeRange(estimatedFee: CurrencyUnit,
-                      actualFee: CurrencyUnit,
-                      feeRate: FeeUnit): Try[Unit] = {
+  def isValidFeeRange(
+      estimatedFee: CurrencyUnit,
+      actualFee: CurrencyUnit,
+      feeRate: FeeUnit): Try[Unit] = {
 
     //what the number '40' represents is the allowed variance -- in bytes -- between the size of the two
     //versions of signed tx. I believe the two signed version can vary in size because the digital
@@ -693,11 +707,12 @@ object TxBuilder {
 object BitcoinTxBuilder {
   type UTXOMap = Map[TransactionOutPoint, BitcoinUTXOSpendingInfo]
 
-  private case class BitcoinTxBuilderImpl(destinations: Seq[TransactionOutput],
-                                          utxoMap: UTXOMap,
-                                          feeRate: FeeUnit,
-                                          changeSPK: ScriptPubKey,
-                                          network: BitcoinNetwork)
+  private case class BitcoinTxBuilderImpl(
+      destinations: Seq[TransactionOutput],
+      utxoMap: UTXOMap,
+      feeRate: FeeUnit,
+      changeSPK: ScriptPubKey,
+      network: BitcoinNetwork)
       extends BitcoinTxBuilder
 
   /**
@@ -710,11 +725,12 @@ object BitcoinTxBuilder {
     *         to generate a signed tx, or a
     *         [[org.bitcoins.core.wallet.builder.TxBuilderError TxBuilderError]]
     */
-  def apply(destinations: Seq[TransactionOutput],
-            utxos: BitcoinTxBuilder.UTXOMap,
-            feeRate: FeeUnit,
-            changeSPK: ScriptPubKey,
-            network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
+  def apply(
+      destinations: Seq[TransactionOutput],
+      utxos: BitcoinTxBuilder.UTXOMap,
+      feeRate: FeeUnit,
+      changeSPK: ScriptPubKey,
+      network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
     if (feeRate.toLong <= 0) {
       Future.fromTry(TxBuilderError.LowFee)
     } else {
@@ -723,11 +739,12 @@ object BitcoinTxBuilder {
     }
   }
 
-  def apply(destinations: Seq[TransactionOutput],
-            utxos: Seq[BitcoinUTXOSpendingInfo],
-            feeRate: FeeUnit,
-            changeSPK: ScriptPubKey,
-            network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
+  def apply(
+      destinations: Seq[TransactionOutput],
+      utxos: Seq[BitcoinUTXOSpendingInfo],
+      feeRate: FeeUnit,
+      changeSPK: ScriptPubKey,
+      network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
     @tailrec
     def loop(utxos: Seq[UTXOSpendingInfo], accum: UTXOMap): UTXOMap =
       utxos match {


### PR DESCRIPTION
Before this PR, the test case that is added here fails.

The problem was that the current default of `UInt32.zero` was being interpreted as a block height and since BIP 65 does not allow block height timelocks alongside timestamp ones this caused an error any time anyone tried using a second-timestamp timelock.

I also ran `test:scalafmt` and it seems a couple other files were hit by that in the diff