### PR TITLE
Refactor make dependent fixtures to use built in scalatest helper met…

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -40,6 +40,7 @@ trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
 
     val result: FutureOutcome = futOutcome.onOutcomeThen { _ =>
       fixtureF.flatMap(f => destroy(f))
+      ()
     }
 
     result

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -32,33 +32,17 @@ trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
       throw err
     }
 
-    val outcomeF = fixtureF.flatMap { fixture =>
+    val outcomeF: Future[Outcome] = fixtureF.flatMap { fixture =>
       test(fixture.asInstanceOf[FixtureParam]).toFuture
     }
 
-    outcomeF.failed.foreach(err =>
-      println(s"Failed fixture test execution=${err}"))
+    val futOutcome: FutureOutcome = new FutureOutcome(outcomeF)
 
-    val destroyP = Promise[Unit]()
-    outcomeF.onComplete { _ =>
-      fixtureF.foreach { fixture =>
-        destroy(fixture).onComplete {
-          case Success(_) => destroyP.success(())
-          case Failure(err) =>
-            logger.error(s"Failed to destroy fixture with err=${err}")
-            destroyP.failure(err)
-        }
-      }
+    val result: FutureOutcome = futOutcome.onOutcomeThen { _ =>
+      fixtureF.flatMap(f => destroy(f))
     }
 
-    val outcomeAfterDestroyF = destroyP.future.flatMap(_ => outcomeF)
-
-    outcomeAfterDestroyF.failed.foreach { err =>
-      println(s"err creating and destroying fixture")
-      throw err
-
-    }
-    new FutureOutcome(outcomeAfterDestroyF)
+    result
   }
 
   /**


### PR DESCRIPTION
Hopefully this makes errors easier to debug related to fixture code. I think the key thing here is using `onOutcomeThen` then to ensure that teardown does occur for the fixture. The `onOutcomeThen` scaladoc says 

```
   * Registers a callback function to be executed if this future completes with any
   * <code>Outcome</code> (<em>i.e.</em>, no run-aborting exception is thrown), returning
   * a new future that completes only after the callback has finished execution.
```