### PR TITLE
WIP: Fee Modes and Multiple Change SPKs

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = "2.0.1"
 # See Documentation at https://scalameta.org/scalafmt/#Configuration
-trailingCommas = never
+# trailingCommas = never
 maxColumn = 80
 docstrings = ScalaDoc
 continuationIndent {
@@ -14,10 +14,7 @@ align {
     openParenCallSite = true
 }
 
-danglingParentheses {
-    callSite = false    
-    defnSite = false
-}
+danglingParentheses = false
 
 newlines {
     alwaysBeforeTopLevelStatements = true

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeModeTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeModeTest.scala
@@ -1,0 +1,182 @@
+package org.bitcoins.core.wallet.fee
+
+import org.bitcoins.core.config.{BitcoinNetwork, RegTest}
+import org.bitcoins.core.crypto.{
+  DoubleSha256DigestBE,
+  ECPrivateKey,
+  ECPublicKey
+}
+import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits, Satoshis}
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.script.{EmptyScriptPubKey, P2PKHScriptPubKey}
+import org.bitcoins.core.protocol.transaction.{
+  Transaction,
+  TransactionOutPoint,
+  TransactionOutput
+}
+import org.bitcoins.core.script.crypto.HashType
+import org.bitcoins.core.wallet.builder.{BitcoinTxBuilder, OwnedTxData}
+import org.bitcoins.core.wallet.utxo.{
+  BitcoinUTXOSpendingInfo,
+  P2PKHSpendingInfo
+}
+import org.bitcoins.testkit.core.gen.{
+  CurrencyUnitGenerator,
+  TransactionGenerators
+}
+import org.bitcoins.testkit.util.BitcoinSAsyncTest
+import org.scalacheck.Gen
+import org.scalatest.Assertion
+
+import scala.concurrent.Future
+
+class FeeModeTest extends BitcoinSAsyncTest {
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = {
+    generatorDrivenConfigNewCode
+  }
+
+  behavior of "FeeMode"
+
+  // Can't use TransactionGenerators.realisiticOutputs as that can return List.empty
+  val nonEmptyRealisticOutputsGen: Gen[List[TransactionOutput]] = Gen
+    .choose(1, 5)
+    .flatMap(n => Gen.listOfN(n, TransactionGenerators.realisticOutput))
+    .suchThat(_.nonEmpty)
+
+  // TODO: What about if someone is getting paid?
+  /* Example:
+   *           all four inputs are of value 25
+   *           output 0: 35
+   *           outputs 1-3: 5
+   *
+   * This currently causes problems since owner 0 cannot be charged a fee
+   */
+  def executeTest(
+      feeMode: FeeMode,
+      outputs: List[TransactionOutput],
+      feeRate: FeeUnit)(
+      assertion: (Transaction, List[CurrencyUnit]) => Assertion): Future[
+    Assertion] = {
+    val maxInput = outputs
+      .reduce[TransactionOutput] {
+        case (a, b) =>
+          if (a.value > b.value) a else b
+      }
+      .value
+      .satoshis
+      .toLong
+
+    val inputKey = ECPrivateKey.freshPrivateKey
+    val perOwnerAmt = Satoshis(maxInput * 2)
+    val utxos = outputs.indices.map { owner =>
+      P2PKHSpendingInfo(
+        outPoint =
+          TransactionOutPoint(DoubleSha256DigestBE.empty, UInt32(owner)),
+        amount = perOwnerAmt,
+        scriptPubKey = P2PKHScriptPubKey(inputKey.publicKey),
+        signer = inputKey,
+        hashType = HashType.sigHashAll
+      )
+    }
+    val ownedUtxos: Vector[OwnedTxData[BitcoinUTXOSpendingInfo]] =
+      utxos.zipWithIndex.toVector.map {
+        case (utxo, owner) => OwnedTxData(utxo, owner)
+      }
+    val changePubKeys = outputs.indices.map(_ => ECPublicKey.freshPublicKey)
+    val changeSPK = outputs.indices
+      .map(owner => owner -> P2PKHScriptPubKey(changePubKeys(owner)))
+      .toMap
+    val network: BitcoinNetwork = RegTest
+
+    val ownedOutputs = outputs.zipWithIndex.toVector.map {
+      case (output, index) => OwnedTxData(output, index)
+    }
+
+    val txBuilder =
+      BitcoinTxBuilder(ownedOutputs,
+                       ownedUtxos,
+                       feeRate,
+                       changeSPK,
+                       network,
+                       feeMode)
+
+    txBuilder.sign.map { tx =>
+      val changeOutputs = tx.outputs.filterNot(outputs.contains)
+      val noFeeChanges = outputs.map(output => perOwnerAmt - output.value)
+      val withFeeChanges = changeOutputs.map { changeOutput =>
+        val owner =
+          changeSPK.find(_._2 == changeOutput.scriptPubKey).get._1
+        owner -> changeOutput.value
+      }.toMap
+      val fees = noFeeChanges.zipWithIndex.map {
+        case (noFeeChange, owner) =>
+          noFeeChange - withFeeChanges(owner)
+      }
+
+      assertion(tx, fees)
+    }
+  }
+
+  it should "correctly subtract fees evenly amongst outputs" in {
+    forAllAsync(nonEmptyRealisticOutputsGen, CurrencyUnitGenerator.smallFeeUnit) {
+      case (outputs, feeRate) =>
+        executeTest(FeeMode.EqualDistribution, outputs, feeRate) { (_, fees) =>
+          val firstFee = fees.head.satoshis.toLong
+          assert(
+            fees.forall(fee => Math.abs(fee.satoshis.toLong - firstFee) <= 1L))
+        }
+    }
+  }
+
+  def closeTogether(
+      num1: Double,
+      num2: Double,
+      percision: Double = 1.0e-6): Boolean = {
+    Math.abs(num1 - num2) < percision
+  }
+
+  it should "correctly subtract fees proportionally amongst outputs" in {
+    forAllAsync(nonEmptyRealisticOutputsGen, CurrencyUnitGenerator.smallFeeUnit) {
+      case (outputs, feeRate) =>
+        executeTest(FeeMode.DistributionByOutputValue, outputs, feeRate) {
+          (_, fees) =>
+            val firstFee = fees.head.satoshis.toLong
+            val firstSize = outputs.head.value.satoshis.toLong
+            val firstFeeProportion = firstFee.toDouble / firstSize
+
+            // Fee has been proportionally distributed by output (up to some small remainder)
+            val closeProportions = fees.zip(outputs).forall {
+              case (fee, output) =>
+                val feeProportion = fee.satoshis.toLong.toDouble / output.value.satoshis.toLong
+
+                closeTogether(feeProportion / firstFeeProportion, 1)
+            }
+
+            assert(closeProportions)
+        }
+    }
+  }
+
+  // TODO: This doesn't actually test anything yet, need a generator for owned tx stuff
+  it should "correctly subtract fees proportionally amongst inputs" in {
+    forAllAsync(nonEmptyRealisticOutputsGen, CurrencyUnitGenerator.smallFeeUnit) {
+      case (outputs, feeRate) =>
+        executeTest(FeeMode.DistributionByInputSize, outputs, feeRate) {
+          (tx, fees) =>
+            val firstFee = fees.head.satoshis.toLong
+            val firstSize = tx.inputs.head.bytes.size
+            val firstFeeProportion = firstFee.toDouble / firstSize
+
+            // Fee has been proportionally distributed by output (up to some small remainder)
+            val closeProportions = fees.zip(tx.inputs).forall {
+              case (fee, input) =>
+                val feeProportion = fee.satoshis.toLong.toDouble / input.bytes.size
+
+                closeTogether(feeProportion / firstFeeProportion, 1, 0.05)
+            }
+
+            assert(closeProportions)
+        }
+    }
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -73,32 +73,26 @@ sealed abstract class TxBuilder {
   def largestFee: CurrencyUnit = creditingAmount - destinationAmount
 
   /**
-    * The list of [[org.bitcoins.core.protocol.transaction.TransactionOutPoint TransactionOutPoint]]s we are
-    * attempting to spend
-    * and the signers, redeem scripts, and script witnesses that might be needed to spend this outpoint.
-    * This information is dependent on what the [[org.bitcoins.core.protocol.script.ScriptPubKey ScriptPubKey]]
-    * type is we are spending. For isntance, if we are spending a
-    * regular [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey P2PKHScriptPubKey]], we do not need a
-    * redeem script or script witness.
-    *
-    * If we are spending a [[org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0 P2WPKHWitnessSPKV0]] we do not
-    * need a redeem script, but we need a [[org.bitcoins.core.protocol.script.ScriptWitness ScriptWitness]]
+    * The list of [[org.bitcoins.core.wallet.utxo.UTXOSpendingInfo UTXOSpendingInfo]]s we are
+    * attempting to spend.
     */
-  def utxoMap: TxBuilder.UTXOMap
-
-  def utxos: Seq[UTXOSpendingInfo] = utxoMap.values.toSeq
+  def utxos: Vector[UTXOSpendingInfo]
 
   /** This represents the rate, in [[org.bitcoins.core.wallet.fee.FeeUnit FeeUnit]], we
     * should pay for this transaction */
   def feeRate: FeeUnit
+  require(feeRate.toLong > 0L, "Fee must be positive")
 
   /**
     * This is where all the money that is NOT sent to destination outputs is spent too.
     * If we don't specify a change output, a large miner fee may be paid as more than likely
     * the difference between  `creditingAmount` and `destinationAmount` is not a market rate miner fee
     */
-  def changeSPKs: Vector[ScriptPubKey]
+  def changeSPKs: Map[Int, ScriptPubKey]
   require(changeSPKs.nonEmpty, "Must specify at least one changeSPK")
+  require(
+    changeSPKs.keys.toVector.sorted.zipWithIndex.forall(x => x._1 == x._2),
+    "Keys must be indices")
 
   /**
     * The network that this [[org.bitcoins.core.wallet.builder.TxBuilder TxBuilder]] is signing a transaction for.
@@ -107,7 +101,7 @@ sealed abstract class TxBuilder {
   def network: NetworkParameters
 
   /** The outpoints that we are using in this transaction */
-  def outPoints: Seq[TransactionOutPoint] = utxoMap.keys.toSeq
+  def outPoints: Seq[TransactionOutPoint] = utxos.map(_.outPoint)
 
   /** The redeem scripts that are needed in this transaction */
   def redeemScriptOpt: Seq[Option[ScriptPubKey]] = utxos.map(_.redeemScriptOpt)
@@ -139,7 +133,7 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
 
   override def network: BitcoinNetwork
 
-  override def utxoMap: BitcoinTxBuilder.UTXOMap
+  override def utxos: Vector[BitcoinUTXOSpendingInfo]
 
   override def sign(implicit ec: ExecutionContext): Future[Transaction] = {
     val f: (Seq[BitcoinUTXOSpendingInfo], Transaction) => Boolean = { (_, _) =>
@@ -150,11 +144,10 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
 
   override def unsignedTx(
       implicit ec: ExecutionContext): Future[Transaction] = {
-    val utxos = utxoMap.values.toList
     val unsignedTxWit = TransactionWitness.fromWitOpt(scriptWitOpt.toVector)
     val lockTime = calcLockTime(utxos)
     val inputs = calcSequenceForInputs(utxos, Policy.isRBFEnabled)
-    val emptyChangeOutputs = changeSPKs.map(changeSPK =>
+    val emptyChangeOutputs = changeSPKs.values.map(changeSPK =>
       TransactionOutput(CurrencyUnits.zero, changeSPK))
     val unsignedTxNoFee = lockTime.map { l =>
       unsignedTxWit match {
@@ -179,7 +172,8 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
           val fee = feeRate.calc(dtx)
           logger.debug(s"fee $fee")
           val change = creditingAmount - destinationAmount - fee
-          val newChangeOutput = TransactionOutput(change, changeSPKs.head)
+          val newChangeOutput =
+            TransactionOutput(change, changeSPKs.values.head)
           logger.debug(s"newChangeOutput $newChangeOutput")
           //if the change output is below the dust threshold after calculating the fee, don't add it
           //to the tx
@@ -217,7 +211,6 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     */
   def sign(invariants: (Seq[BitcoinUTXOSpendingInfo], Transaction) => Boolean)(
       implicit ec: ExecutionContext): Future[Transaction] = {
-    val utxos = utxoMap.values.toList
     val signedTxWithFee = unsignedTx.flatMap { utx: Transaction =>
       //sign the tx for this time
       val signedTx = loop(utxos, utx, false)
@@ -240,11 +233,11 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
   }
 
   private def loop(
-      remaining: List[BitcoinUTXOSpendingInfo],
+      remaining: Seq[BitcoinUTXOSpendingInfo],
       txInProgress: Transaction,
       dummySignatures: Boolean)(
       implicit ec: ExecutionContext): Future[Transaction] = remaining match {
-    case Nil => Future.successful(txInProgress)
+    case Vector() => Future.successful(txInProgress)
     case info +: t =>
       val partiallySigned = signAndAddInput(info, txInProgress, dummySignatures)
       partiallySigned.flatMap(tx => loop(t, tx, dummySignatures))
@@ -585,10 +578,6 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
 }
 
 object TxBuilder {
-
-  /** This contains all the information needed to create a valid
-    * [[org.bitcoins.core.protocol.transaction.TransactionInput TransactionInput]] that spends this utxo */
-  type UTXOMap = Map[TransactionOutPoint, UTXOSpendingInfo]
   private val logger = BitcoinSLogger.logger
 
   /** Runs various sanity checks on the final version of the signed transaction from TxBuilder */
@@ -612,7 +601,7 @@ object TxBuilder {
         case (spk, spks) => spk -> spks.size
       }
 
-    val allOkaySPKs = requiredSPKs ++ txBuilder.changeSPKs
+    val allOkaySPKs = requiredSPKs ++ txBuilder.changeSPKs.values
     val okaySPKCounts =
       allOkaySPKs.groupBy(identity).map { case (spk, spks) => spk -> spks.size }
 
@@ -729,19 +718,17 @@ object TxBuilder {
 }
 
 object BitcoinTxBuilder {
-  type UTXOMap = Map[TransactionOutPoint, BitcoinUTXOSpendingInfo]
-
   private case class BitcoinTxBuilderImpl(
       destinations: Seq[TransactionOutput],
-      utxoMap: UTXOMap,
+      utxos: Vector[BitcoinUTXOSpendingInfo],
       feeRate: FeeUnit,
-      changeSPKs: Vector[ScriptPubKey],
+      changeSPKs: Map[Int, ScriptPubKey],
       network: BitcoinNetwork)
       extends BitcoinTxBuilder
 
   /**
     * @param destinations where the money is going in the signed tx
-    * @param utxos extra information needed to spend the outputs in the creditingTxs
+    * @param utxos information needed to spend the outputs in the creditingTxs
     * @param feeRate the desired fee rate for this tx
     * @param changeSPK where we should send the change from the creditingTxs
     * @return either a instance of a [[org.bitcoins.core.wallet.builder.TxBuilder TxBuilder]],
@@ -751,46 +738,14 @@ object BitcoinTxBuilder {
     */
   def apply(
       destinations: Seq[TransactionOutput],
-      utxos: BitcoinTxBuilder.UTXOMap,
-      feeRate: FeeUnit,
-      changeSPK: ScriptPubKey,
-      network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
-    if (feeRate.toLong <= 0) {
-      Future.fromTry(TxBuilderError.LowFee)
-    } else {
-      Future.successful(
-        BitcoinTxBuilderImpl(destinations,
-                             utxos,
-                             feeRate,
-                             Vector(changeSPK),
-                             network))
-    }
-  }
-
-  def apply(
-      destinations: Seq[TransactionOutput],
       utxos: Seq[BitcoinUTXOSpendingInfo],
       feeRate: FeeUnit,
       changeSPK: ScriptPubKey,
-      network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
-    @tailrec
-    def loop(utxos: Seq[UTXOSpendingInfo], accum: UTXOMap): UTXOMap =
-      utxos match {
-        case Nil => accum
-        case h +: t =>
-          val u = BitcoinUTXOSpendingInfo(
-            outPoint = h.outPoint,
-            output = h.output,
-            signers = h.signers,
-            redeemScriptOpt = h.redeemScriptOpt,
-            scriptWitnessOpt = h.scriptWitnessOpt,
-            hashType = h.hashType,
-            conditionalPath = h.conditionalPath
-          )
-          val result: BitcoinTxBuilder.UTXOMap = accum.updated(h.outPoint, u)
-          loop(t, result)
-      }
-    val map = loop(utxos, Map.empty)
-    BitcoinTxBuilder(destinations, map, feeRate, changeSPK, network)
+      network: BitcoinNetwork): BitcoinTxBuilder = {
+    BitcoinTxBuilderImpl(destinations,
+                         utxos.toVector,
+                         feeRate,
+                         Map(0 -> changeSPK),
+                         network)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeMode.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeMode.scala
@@ -1,0 +1,97 @@
+package org.bitcoins.core.wallet.fee
+
+import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
+import org.bitcoins.core.protocol.transaction.{
+  TransactionInput,
+  TransactionOutput
+}
+import org.bitcoins.core.wallet.builder.OwnedTxData
+
+sealed trait FeeMode {
+
+  def distributeFees(
+      inputs: Vector[OwnedTxData[TransactionInput]],
+      outputs: Vector[OwnedTxData[TransactionOutput]],
+      owners: Int,
+      totalFee: Satoshis
+  ): Map[Int, Satoshis]
+}
+
+object FeeMode {
+  case object EqualDistribution extends FeeMode {
+    override def distributeFees(
+        inputs: Vector[OwnedTxData[TransactionInput]],
+        outputs: Vector[OwnedTxData[TransactionOutput]],
+        owners: Int,
+        totalFee: Satoshis): Map[Int, Satoshis] = {
+      val feePerOwner = totalFee.toLong / owners
+      val remainder = totalFee.toLong % owners
+
+      (0 until owners).map { owner =>
+        val remainderToAdd = if (owner < remainder) 1 else 0
+        owner -> Satoshis(feePerOwner + remainderToAdd)
+      }.toMap
+    }
+  }
+
+  private def distributeByMetric(
+      metric: Map[Int, Long],
+      owners: Int,
+      totalFee: Satoshis): Map[Int, Satoshis] = {
+    val metricTotal = metric.values.foldLeft(0L)(_ + _)
+
+    val feesByOwner = metric.map {
+      case (owner, metricForOwner) =>
+        val proportionalBytes = metricForOwner.toDouble / metricTotal
+        val fee = Satoshis((proportionalBytes * totalFee.toLong).toLong)
+        owner -> fee
+    }
+    val feePaidSoFar = feesByOwner.values.foldLeft(CurrencyUnits.zero)(_ + _)
+    val remainder = totalFee - feePaidSoFar
+    val remainderFees = EqualDistribution.distributeFees(Vector.empty,
+                                                         Vector.empty,
+                                                         owners,
+                                                         remainder.satoshis)
+
+    val placeHolderOwnerMap = (0 until owners)
+      .filterNot(feesByOwner.keySet.contains)
+      .map(_ -> Satoshis.zero)
+      .toMap
+    (feesByOwner ++ placeHolderOwnerMap).map {
+      case (owner, ownerFee) =>
+        owner -> (ownerFee + remainderFees(owner)).satoshis
+    }
+  }
+
+  case object DistributionByInputSize extends FeeMode {
+    override def distributeFees(
+        inputs: Vector[OwnedTxData[TransactionInput]],
+        outputs: Vector[OwnedTxData[TransactionOutput]],
+        owners: Int,
+        totalFee: Satoshis): Map[Int, Satoshis] = {
+      val bytesByOwner = inputs.groupBy(_.owner).map {
+        case (owner, ownersData) =>
+          val bytes = ownersData.foldLeft(0L)(_ + _.data.bytes.size)
+          owner -> bytes
+      }
+
+      distributeByMetric(bytesByOwner, owners, totalFee)
+    }
+  }
+
+  case object DistributionByOutputValue extends FeeMode {
+    override def distributeFees(
+        inputs: Vector[OwnedTxData[TransactionInput]],
+        outputs: Vector[OwnedTxData[TransactionOutput]],
+        owners: Int,
+        totalFee: Satoshis): Map[Int, Satoshis] = {
+      val outputValueByOwner = outputs.groupBy(_.owner).map {
+        case (owner, ownersData) =>
+          val value = ownersData.foldLeft(0L)(_ + _.data.value.satoshis.toLong)
+          owner -> value
+      }
+
+      distributeByMetric(outputValueByOwner, owners, totalFee)
+    }
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
@@ -36,6 +36,11 @@ trait CurrencyUnitGenerator {
   def feeUnit: Gen[FeeUnit] =
     Gen.oneOf(satsPerByte, satsPerKiloByte, satsPerVirtualByte)
 
+  def smallFeeUnit: Gen[FeeUnit] =
+    Gen.choose(0, CurrencyUnits.oneBTC.satoshis.toLong).map { n =>
+      SatoshisPerByte(Satoshis(n))
+    }
+
   def satoshis: Gen[Satoshis] =
     for {
       int64 <- NumberGenerator.int64s

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -46,7 +46,7 @@ sealed abstract class Wallet extends LockedWallet with UnlockedWalletApi {
     for {
       change <- getNewChangeAddress(fromAccount)
       walletUtxos <- listUtxos()
-      txBuilder <- {
+      txBuilder = {
         val destinations = Vector(
           TransactionOutput(amount, address.scriptPubKey))
 


### PR DESCRIPTION
Introduces the notion of `OwnedTxData` where every input and output can be owned by some party (of which there can be multiple).

 There are still missing pieces of functionality including what is detailed in the TODOs of the test file and allowing TxBuilder to subtract fees from the given outputs