### PR TITLE
DLC CET Key derivation

### DIFF
--- a/dlc/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelfIntegrationTest.scala
+++ b/dlc/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCWithSelfIntegrationTest.scala
@@ -213,8 +213,9 @@ class BinaryOutcomeDLCWithSelfIntegrationTest extends BitcoindRpcTest {
     }
   }
 
-  def executeForUnilateralCase(outcomeHash: Sha256DigestBE,
-                               local: Boolean): Future[Assertion] = {
+  def executeForUnilateralCase(
+      outcomeHash: Sha256DigestBE,
+      local: Boolean): Future[Assertion] = {
     val oracleSig =
       Schnorr.signWithNonce(outcomeHash.bytes, oraclePrivKey, preCommittedK)
 
@@ -251,8 +252,9 @@ class BinaryOutcomeDLCWithSelfIntegrationTest extends BitcoindRpcTest {
     } yield assertion
   }
 
-  def executeForJusticeCase(fakeWin: Boolean,
-                            local: Boolean): Future[Assertion] = {
+  def executeForJusticeCase(
+      fakeWin: Boolean,
+      local: Boolean): Future[Assertion] = {
     def chooseCET(setup: SetupDLC): Transaction = {
       if (fakeWin) {
         if (local) {


### PR DESCRIPTION
Re-implemented key derivation as per the new [specification](https://github.com/bitcoin-s/dlcspecs/blob/master/KeyDerivation.md).

Specifically, the main change from what we already had was to stop using the same key in multiple CET outputs.