### PR TITLE
Add invariant to WitnessTransaction that says inputs.length == witnes…

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
@@ -160,7 +160,7 @@ class TransactionSignatureSerializerTest extends FlatSpec with MustMatchers {
       "01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000001976a9144c9c3dfac4207d5d8cb89df5722cb3d712385e3f88acd007000000000000ffffffff2d793f9722ac8cbea9b2e0a2929cda4007b8312c6ec3b997088439e48e7aa64e0000000083000000")
   }
 
-    it must "work with the p2sh(p2wpkh) example in BIP143" in {
+  it must "work with the p2sh(p2wpkh) example in BIP143" in {
     //https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#p2sh-p2wpkh
 
     val expected = {
@@ -205,8 +205,8 @@ class TransactionSignatureSerializerTest extends FlatSpec with MustMatchers {
                                         oldInput.sequence)
 
     val updatedInputs = ubtx.inputs.updated(inputIndex.toInt, updatedInput)
-    val witness = TransactionWitness.fromWitOpt(Vector.fill(updatedInputs.length)(None))
-    println(s"witness=${witness}")
+    val witness = EmptyWitness.fromInputs(updatedInputs)
+
     val uwtx = WitnessTransaction(version = ubtx.version,
                                   inputs = updatedInputs,
                                   outputs = ubtx.outputs,

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
@@ -160,7 +160,7 @@ class TransactionSignatureSerializerTest extends FlatSpec with MustMatchers {
       "01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000010000001976a9144c9c3dfac4207d5d8cb89df5722cb3d712385e3f88acd007000000000000ffffffff2d793f9722ac8cbea9b2e0a2929cda4007b8312c6ec3b997088439e48e7aa64e0000000083000000")
   }
 
-  it must "work with the p2sh(p2wpkh) example in BIP143" in {
+    it must "work with the p2sh(p2wpkh) example in BIP143" in {
     //https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#p2sh-p2wpkh
 
     val expected = {
@@ -205,12 +205,13 @@ class TransactionSignatureSerializerTest extends FlatSpec with MustMatchers {
                                         oldInput.sequence)
 
     val updatedInputs = ubtx.inputs.updated(inputIndex.toInt, updatedInput)
-
-    val uwtx = WitnessTransaction(ubtx.version,
-                                  updatedInputs,
-                                  ubtx.outputs,
-                                  ubtx.lockTime,
-                                  EmptyWitness)
+    val witness = TransactionWitness.fromWitOpt(Vector.fill(updatedInputs.length)(None))
+    println(s"witness=${witness}")
+    val uwtx = WitnessTransaction(version = ubtx.version,
+                                  inputs = updatedInputs,
+                                  outputs = ubtx.outputs,
+                                  lockTime = ubtx.lockTime,
+                                  witness = witness)
 
     val wtxSigComp = {
       WitnessTxSigComponentP2SH(transaction = uwtx,

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
@@ -20,7 +20,7 @@ class TransactionWitnessSpec extends BitcoinSUnitTest {
   }
 
   it must "be able to resize a witness to the given index" in {
-    val empty = EmptyWitness.empty
+    val empty = EmptyWitness.fromN(0)
     val pubKey = ECPrivateKey.freshPrivateKey.publicKey
     val p2pkh = P2PKHScriptSignature(EmptyDigitalSignature, pubKey)
     val scriptWit = P2WPKHWitnessV0.fromP2PKHScriptSig(p2pkh)
@@ -31,7 +31,7 @@ class TransactionWitnessSpec extends BitcoinSUnitTest {
 
   it must "fail to update a negative index witness" in {
     intercept[IndexOutOfBoundsException] {
-      EmptyWitness.empty.updated(-1, EmptyScriptWitness)
+      EmptyWitness.fromN(0).updated(-1, EmptyScriptWitness)
     }
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
@@ -20,7 +20,7 @@ class TransactionWitnessSpec extends BitcoinSUnitTest {
   }
 
   it must "be able to resize a witness to the given index" in {
-    val empty = EmptyWitness
+    val empty = EmptyWitness.empty
     val pubKey = ECPrivateKey.freshPrivateKey.publicKey
     val p2pkh = P2PKHScriptSignature(EmptyDigitalSignature, pubKey)
     val scriptWit = P2WPKHWitnessV0.fromP2PKHScriptSig(p2pkh)
@@ -31,7 +31,7 @@ class TransactionWitnessSpec extends BitcoinSUnitTest {
 
   it must "fail to update a negative index witness" in {
     intercept[IndexOutOfBoundsException] {
-      EmptyWitness.updated(-1, EmptyScriptWitness)
+      EmptyWitness.empty.updated(-1, EmptyScriptWitness)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -119,6 +119,10 @@ case object EmptyTransaction extends BaseTransaction {
 }
 
 sealed abstract class WitnessTransaction extends Transaction {
+  require(
+    inputs.length == witness.witnesses.length,
+    s"Must have same amount of inputs and witnesses in witness tx, inputs=${inputs.length} witnesses=${witness.witnesses.length}"
+  )
 
   /** The txId for the witness transaction from satoshi's original serialization */
   override def txId: DoubleSha256Digest = {
@@ -224,7 +228,7 @@ object WitnessTransaction extends Factory[WitnessTransaction] {
                          btx.inputs,
                          btx.outputs,
                          btx.lockTime,
-                         EmptyWitness)
+                         EmptyWitness.fromInputs(btx.inputs))
     case wtx: WitnessTransaction => wtx
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionWitness.scala
@@ -75,10 +75,6 @@ object EmptyWitness {
   def fromInputs(inputs: Seq[TransactionInput]): EmptyWitness = {
     fromN(inputs.length)
   }
-
-  /** Used in some test cases, this is only safe to use with transactions
-    * if your transaction has 0 inputs */
-  val empty: EmptyWitness = fromN(0)
 }
 
 object TransactionWitness {
@@ -90,7 +86,7 @@ object TransactionWitness {
       TransactionWitnessImpl(witnesses)
     } else {
       //means that everything must be a empty ScriptWitness
-      EmptyWitness(witnesses.map(_.asInstanceOf[EmptyScriptWitness.type]))
+      EmptyWitness.fromN(witnesses.length)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionWitness.scala
@@ -55,10 +55,30 @@ sealed abstract class TransactionWitness extends NetworkElement {
   }
 }
 
-/** Used to represent a transaction witness pre segwit, see BIP141 for details */
-case object EmptyWitness extends TransactionWitness {
-  override val bytes: ByteVector = ByteVector.low(1)
-  override val witnesses: Vector[ScriptWitness] = Vector.empty
+/** Each input (even if it does not spend a segwit output) needs to have a witness associated with it
+  * in a [[WitnessTransaction]]. This helper case class is used to "fill in" [[EmptyScriptWitness]] for
+  * the inputs that do not spend a [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 WitnessScriptPubKeyV0]]
+  *
+  * @see https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#specification
+  * */
+case class EmptyWitness(witnesses: Vector[EmptyScriptWitness.type])
+    extends TransactionWitness
+
+object EmptyWitness {
+
+  /** Generates an empty witness with n [[EmptyScriptWitness]] inside it */
+  def fromN(n: Int): EmptyWitness = {
+    val wits = Vector.fill(n)(EmptyScriptWitness)
+    new EmptyWitness(wits)
+  }
+
+  def fromInputs(inputs: Seq[TransactionInput]): EmptyWitness = {
+    fromN(inputs.length)
+  }
+
+  /** Used in some test cases, this is only safe to use with transactions
+    * if your transaction has 0 inputs */
+  val empty: EmptyWitness = fromN(0)
 }
 
 object TransactionWitness {
@@ -69,7 +89,8 @@ object TransactionWitness {
     if (witnesses.exists(_ != EmptyScriptWitness)) {
       TransactionWitnessImpl(witnesses)
     } else {
-      EmptyWitness
+      //means that everything must be a empty ScriptWitness
+      EmptyWitness(witnesses.map(_.asInstanceOf[EmptyScriptWitness.type]))
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -156,7 +156,7 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     val emptyChangeOutput = TransactionOutput(CurrencyUnits.zero, changeSPK)
     val unsignedTxNoFee = lockTime.map { l =>
       unsignedTxWit match {
-        case EmptyWitness =>
+        case _: EmptyWitness =>
           BaseTransaction(tc.validLockVersion,
                           inputs,
                           destinations ++ Seq(emptyChangeOutput),


### PR DESCRIPTION
…ses.length

From [BIP141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#specification) 

> The witness is a serialization of all witness data of the transaction. **Each txin is associated with a witness field**. A witness field starts with a var_int to indicate the number of stack items for the txin. It is followed by stack items, with each item starts with a var_int to indicate the length. Witness data is NOT script. 

This creates an invariant that enforces that inside of `WitnessTransaction`. 