### PR TITLE
2019 12 17 sign ext key

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ExtSignTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ExtSignTest.scala
@@ -1,15 +1,27 @@
 package org.bitcoins.core.crypto
 
-import org.bitcoins.testkit.core.gen.CryptoGenerators
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.core.gen.{CryptoGenerators, HDGenerators}
+import org.bitcoins.testkit.util.{BitcoinSAsyncTest, BitcoinSUnitTest}
 
-class ExtSignTest extends BitcoinSUnitTest {
+class ExtSignTest extends BitcoinSAsyncTest {
 
   it must "be able to sign something that extends ExtSignKey" in {
     forAll(CryptoGenerators.extPrivateKey, CryptoGenerators.sha256Digest) {
       case (extPrivKey, hash) =>
         val sig = extPrivKey.sign(hash.bytes)
         assert(extPrivKey.publicKey.verify(hash,sig))
+    }
+  }
+
+  it must "be able to sign a specific path of a ext key" in {
+    forAllAsync(CryptoGenerators.extPrivateKey, CryptoGenerators.sha256Digest, HDGenerators.bip32Path) {
+      case (extPrivKey, hash, path) =>
+        val sigF = extPrivKey.sign(hash.bytes,path)
+        val childPubKey = extPrivKey.deriveChildPubKey(path).get
+        sigF.map { sig =>
+          assert(childPubKey.key.verify(hash,sig))
+        }
+
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ExtSignTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ExtSignTest.scala
@@ -16,7 +16,7 @@ class ExtSignTest extends BitcoinSAsyncTest {
   it must "be able to sign a specific path of a ext key" in {
     forAllAsync(CryptoGenerators.extPrivateKey, CryptoGenerators.sha256Digest, HDGenerators.bip32Path) {
       case (extPrivKey, hash, path) =>
-        val sigF = extPrivKey.sign(hash.bytes,path)
+        val sigF = extPrivKey.deriveAndSignFuture(hash.bytes,path)
         val childPubKey = extPrivKey.deriveChildPubKey(path).get
         sigF.map { sig =>
           assert(childPubKey.key.verify(hash,sig))

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ExtSignTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ExtSignTest.scala
@@ -1,0 +1,15 @@
+package org.bitcoins.core.crypto
+
+import org.bitcoins.testkit.core.gen.CryptoGenerators
+import org.bitcoins.testkit.util.BitcoinSUnitTest
+
+class ExtSignTest extends BitcoinSUnitTest {
+
+  it must "be able to sign something that extends ExtSignKey" in {
+    forAll(CryptoGenerators.extPrivateKey, CryptoGenerators.sha256Digest) {
+      case (extPrivKey, hash) =>
+        val sig = extPrivKey.sign(hash.bytes)
+        assert(extPrivKey.publicKey.verify(hash,sig))
+    }
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/SignTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/SignTest.scala
@@ -29,8 +29,6 @@ class SignTest extends BitcoinSUnitTest {
         val sigF = signTestImpl.signFunction(hash.bytes)
 
         sigF.map(sig => assert(pubKey.verify(hash.hex, sig)))
-
     }
   }
-
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.util._
 import scodec.bits.{ByteVector, HexStringSyntax}
 
 import scala.annotation.tailrec
+import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -208,6 +209,20 @@ sealed abstract class ExtPrivateKey extends ExtKey with ExtSign {
 
   def deriveChildPrivKey(idx: Long): Try[ExtPrivateKey] = {
     Try(UInt32(idx)).map(deriveChildPrivKey)
+  }
+
+  override def publicKey: ECPublicKey = key.publicKey
+
+  override def signFunction: ByteVector => Future[ECDigitalSignature] = {
+    key.signFunction
+  }
+
+  /** Signs the given bytes with the given [[BIP32Path path]] */
+  override def deriveAndSignFuture: (
+      ByteVector,
+      BIP32Path) => Future[ECDigitalSignature] = {
+    case (bytes, path) =>
+      deriveChildPrivKey(path).signFunction(bytes)
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -5,8 +5,7 @@ import org.bitcoins.core.hd.{BIP32Node, BIP32Path}
 import org.bitcoins.core.number.{UInt32, UInt8}
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.util._
-import scodec.bits.ByteVector
-import scodec.bits.HexStringSyntax
+import scodec.bits.{ByteVector, HexStringSyntax}
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
@@ -157,7 +156,7 @@ object ExtKey extends Factory[ExtKey] {
   }
 }
 
-sealed abstract class ExtPrivateKey extends ExtKey {
+sealed abstract class ExtPrivateKey extends ExtKey with ExtSign {
   import ExtKeyVersion._
 
   override protected type VersionType = ExtKeyPrivVersion

--- a/core/src/main/scala/org/bitcoins/core/crypto/Sign.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/Sign.scala
@@ -58,3 +58,12 @@ object Sign {
     }, publicKey)
   }
 }
+
+/** A signing interface for [[ExtKey]] */
+trait ExtSign extends Sign { this: ExtPrivateKey =>
+  override def publicKey: ECPublicKey = key.publicKey
+
+  override def signFunction: ByteVector => Future[ECDigitalSignature] = {
+    key.signFunction
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/crypto/Sign.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/Sign.scala
@@ -61,15 +61,12 @@ object Sign {
 }
 
 /** A signing interface for [[ExtKey]] */
-trait ExtSign extends Sign { this: ExtPrivateKey =>
-  override def publicKey: ECPublicKey = key.publicKey
+trait ExtSign extends Sign {
 
-  override def signFunction: ByteVector => Future[ECDigitalSignature] = {
-    key.signFunction
-  }
+  def deriveAndSignFuture: (ByteVector, BIP32Path) => Future[ECDigitalSignature]
 
-  /** Signs the given bytes with the given [[BIP32Path path]] */
+  /** First derives the child key that corresponds to [[BIP32Path path]] and then signs */
   def sign(bytes: ByteVector, path: BIP32Path): ECDigitalSignature = {
-    deriveChildPrivKey(path).sign(bytes)
+    Await.result(deriveAndSignFuture(bytes, path), 30.seconds)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/Sign.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/Sign.scala
@@ -69,7 +69,7 @@ trait ExtSign extends Sign { this: ExtPrivateKey =>
   }
 
   /** Signs the given bytes with the given [[BIP32Path path]] */
-  def sign(bytes: ByteVector, path: BIP32Path): Future[ECDigitalSignature] = {
-    deriveChildPrivKey(path).signFunction(bytes)
+  def sign(bytes: ByteVector, path: BIP32Path): ECDigitalSignature = {
+    deriveChildPrivKey(path).sign(bytes)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/Sign.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/Sign.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.crypto
 
+import org.bitcoins.core.hd.BIP32Path
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration.DurationInt
@@ -65,5 +66,10 @@ trait ExtSign extends Sign { this: ExtPrivateKey =>
 
   override def signFunction: ByteVector => Future[ECDigitalSignature] = {
     key.signFunction
+  }
+
+  /** Signs the given bytes with the given [[BIP32Path path]] */
+  def sign(bytes: ByteVector, path: BIP32Path): Future[ECDigitalSignature] = {
+    deriveChildPrivKey(path).signFunction(bytes)
   }
 }

--- a/docs/core/core-intro.md
+++ b/docs/core/core-intro.md
@@ -65,39 +65,6 @@ After providing this information, you can generate a validly signed bitcoin tran
 
 To see a complete example of this, see [our `TxBuilder` example](txbuilder.md)
 
-### The [`Sign` API](/api/org/bitcoins/core/crypto/Sign)
-
-This is the API we define to sign things with. It takes in an arbitrary byte vector and returns a `Future[ECDigitalSignature]`. The reason we incorporate `Future`s here is for extensibility of this API. We would like to provide implementations of this API for hardware devices, which need to be asynchrnous since they may require user input.
-
-From [`core/src/main/scala/org/bitcoins/core/crypto/Sign.scala`](/api/org/bitcoins/core/crypto/Sign):
-
-```scala mdoc
-import scodec.bits._
-import org.bitcoins.core.crypto._
-import scala.concurrent._
-import scala.concurrent.duration._
-
-trait Sign {
-  def signFunction: ByteVector => Future[ECDigitalSignature]
-
-  def signFuture(bytes: ByteVector): Future[ECDigitalSignature] =
-    signFunction(bytes)
-
-  def sign(bytes: ByteVector): ECDigitalSignature = {
-    Await.result(signFuture(bytes), 30.seconds)
-  }
-
-  def publicKey: ECPublicKey
-}
-
-```
-
-The `ByteVector` that is input to the `signFunction` should be the hash that is output from [`TransactionSignatureSerializer`](/api/org/bitcoins/core/crypto/TransactionSignatureSerializer)'s `hashForSignature` method. Our in-memory [`ECKey`](/api/org/bitcoins/core/crypto/ECKey) types implement the `Sign` API.
-
-If you wanted to implement a new `Sign` api for a hardware wallet, you can easily pass it into the `TxBuilder`/`Signer` classes to allow for you to use those devices to sign with Bitcoin-S.
-
-This API is currently used to sign ordinary transactions with our [`Signer`](/api/org/bitcoins/core/wallet/signer/Signer)s. The `Signer` subtypes (i.e. `P2PKHSigner`) implement the specific functionality needed to produce a valid digital signature for their corresponding script type.
-
 ### Verifying a transaction's script is valid (does not check if UTXO is valid)
 
 Transactions are run through the interpreter to check their validity. These are packaged up into an object called `ScriptProgram`, which contains the following:

--- a/docs/core/hd-keys.md
+++ b/docs/core/hd-keys.md
@@ -127,3 +127,7 @@ firstAccountAddress.value
 // HD path to generate an address at:
 val nextAddressPath: SegWitHDPath = firstAddressPath.next
 ```
+
+### Signing things with HD keys
+
+Please see [sign.md](sign.md) for information on how to sign things with HD keys.

--- a/docs/core/sign.md
+++ b/docs/core/sign.md
@@ -44,15 +44,32 @@ An [ExtKey](org/bitcoins/core/crypto/ExtKey.scala) is a data structure that can 
 You can sign with `ExtPrivateKey` the same way you could with a normal `ECPrivateKey`.
 
 ```scala mdoc
+[info] Starting scala interpreter...
+Welcome to Scala 2.13.1 (OpenJDK 64-Bit GraalVM CE 19.3.0, Java 1.8.0_232).
+Type in expressions for evaluation. Or try :help.
+
+scala> import org.bitcoins.core.hd._
+import org.bitcoins.core.hd._
+
 scala> import org.bitcoins.core.crypto._
 import org.bitcoins.core.crypto._
 
 scala> val extPrivKey = ExtPrivateKey(ExtKeyVersion.SegWitMainNetPriv)
-extPrivKey: org.bitcoins.core.crypto.ExtPrivateKey = zprvAWgYBBk7JR8Gm5KU7FQ6uiwgBXDSizdmcQnS68WW2quoFrZoCQpJV5jCXniZzuetnPafRUeJmZ6KbZFnWtchgYzEGv47c54Ss2AN8RpYv4C
+SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
+SLF4J: Defaulting to no-operation (NOP) logger implementation
+SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
+extPrivKey: org.bitcoins.core.crypto.ExtPrivateKey = zprvAWgYBBk7JR8GkbLHbSiLjaZ5MrxyErnQaeAMiiTK8BzfFE3r1ECF35GCKr3TSakAfshSGoqKGCz6Lcm567dExL3Hj9nyXm5GpQeq4WrLLhs
 
 scala> extPrivKey.sign(DoubleSha256Digest.empty.bytes)
-res2: org.bitcoins.core.crypto.ECDigitalSignature = ECDigitalSignature(3045022100f4bf38ef54a51dd110eadefe84ccffa4aabe3ccde387be09e20418f39a1ad29502202f6b3c7dd4aa83ce03014bce970ce7a1ebb2469f0cd4a820c1baa598ef3d106c)
+res0: org.bitcoins.core.crypto.ECDigitalSignature = ECDigitalSignature(304402203591cf49b08dae0c9830b0d0f955b329ec8bf033f91fb63b4e33bbaa92d55e3502206e7c498c0362ae1dadf3071eb45c23c77b347b062b1794d036bd63c3d73c13d7)
 
+scala> val path = BIP32Path(Vector(BIP32Node(0,false)))
+path: org.bitcoins.core.hd.BIP32Path = m/0
+
+scala> extPrivKey.sign(DoubleSha256Digest.empty.bytes,path)
+res4: org.bitcoins.core.crypto.ECDigitalSignature = ECDigitalSignature(304402203784368d19555227bdb9d96360d628f3fdea1e5ca189d125d534c1f0c891f5fb02203c5efd41366045d2f6ce69ccaed706924270cd4fa8bfbf76d29f7bbfecf27eb3)
 ```
 
-With `ExtSign`, you can use `ExtPrivateKey` to sign transactions inside of `TxBuilder` since `UTXOSpendingInfo` takes in `Sign` as a parameter.
+With `ExtSign`, you can use `ExtPrivateKey` to sign transactions inside of `TxBuilder` since `UTXOSpendingInfo` takes in `Sign` as a parameter. 
+
+You can also provide a `path` to use to derive a child `ExtPrivateKey`, and then sign with that child private key

--- a/docs/core/sign.md
+++ b/docs/core/sign.md
@@ -1,0 +1,58 @@
+---
+id: sign
+title: Sign api
+---
+
+### The [`Sign` API](org/bitcoins/core/crypto/Sign.scala)
+
+This is the API we define to sign things with. It takes in an arbitrary byte vector and returns a `Future[ECDigitalSignature]`. The reason we incorporate `Future`s here is for extensibility of this API. We would like to provide implementations of this API for hardware devices, which need to be asynchrnous since they may require user input.
+
+From [Sign.scala](../../core/src/main/scala/org/bitcoins/core/crypto/Sign.scala):
+
+```scala mdoc
+import scodec.bits._
+import org.bitcoins.core.crypto._
+import scala.concurrent._
+import scala.concurrent.duration._
+
+trait Sign {
+  def signFunction: ByteVector => Future[ECDigitalSignature]
+
+  def signFuture(bytes: ByteVector): Future[ECDigitalSignature] =
+    signFunction(bytes)
+
+  def sign(bytes: ByteVector): ECDigitalSignature = {
+    Await.result(signFuture(bytes), 30.seconds)
+  }
+
+  def publicKey: ECPublicKey
+}
+
+```
+
+The `ByteVector` that is input to the `signFunction` should be the hash that is output from [`TransactionSignatureSerializer`](/api/org/bitcoins/core/crypto/TransactionSignatureSerializer)'s `hashForSignature` method. Our in-memory [`ECKey`](/api/org/bitcoins/core/crypto/ECKey) types implement the `Sign` API.
+
+If you wanted to implement a new `Sign` api for a hardware wallet, you can easily pass it into the `TxBuilder`/`Signer` classes to allow for you to use those devices to sign with Bitcoin-S.
+
+This API is currently used to sign ordinary transactions with our [`Signer`](/api/org/bitcoins/core/wallet/signer/Signer)s. The `Signer` subtypes (i.e. `P2PKHSigner`) implement the specific functionality needed to produce a valid digital signature for their corresponding script type.
+
+
+### The [`ExtSign`](../../core/src/main/scala/org/bitcoins/core/crypto/Sign.scala) API.
+
+An [ExtKey](org/bitcoins/core/crypto/ExtKey.scala) is a data structure that can be used to generate more keys from a parent key. For more information look at [hd-keys.md](hd-keys.md)
+
+You can sign with `ExtPrivateKey` the same way you could with a normal `ECPrivateKey`.
+
+```scala mdoc
+scala> import org.bitcoins.core.crypto._
+import org.bitcoins.core.crypto._
+
+scala> val extPrivKey = ExtPrivateKey(ExtKeyVersion.SegWitMainNetPriv)
+extPrivKey: org.bitcoins.core.crypto.ExtPrivateKey = zprvAWgYBBk7JR8Gm5KU7FQ6uiwgBXDSizdmcQnS68WW2quoFrZoCQpJV5jCXniZzuetnPafRUeJmZ6KbZFnWtchgYzEGv47c54Ss2AN8RpYv4C
+
+scala> extPrivKey.sign(DoubleSha256Digest.empty.bytes)
+res2: org.bitcoins.core.crypto.ECDigitalSignature = ECDigitalSignature(3045022100f4bf38ef54a51dd110eadefe84ccffa4aabe3ccde387be09e20418f39a1ad29502202f6b3c7dd4aa83ce03014bce970ce7a1ebb2469f0cd4a820c1baa598ef3d106c)
+
+```
+
+With `ExtSign`, you can use `ExtPrivateKey` to sign transactions inside of `TxBuilder` since `UTXOSpendingInfo` takes in `Sign` as a parameter.

--- a/docs/core/sign.md
+++ b/docs/core/sign.md
@@ -43,31 +43,17 @@ An [ExtKey](org/bitcoins/core/crypto/ExtKey.scala) is a data structure that can 
 
 You can sign with `ExtPrivateKey` the same way you could with a normal `ECPrivateKey`.
 
-```scala mdoc
-[info] Starting scala interpreter...
-Welcome to Scala 2.13.1 (OpenJDK 64-Bit GraalVM CE 19.3.0, Java 1.8.0_232).
-Type in expressions for evaluation. Or try :help.
-
-scala> import org.bitcoins.core.hd._
+```scala mdoc:to-string
 import org.bitcoins.core.hd._
-
-scala> import org.bitcoins.core.crypto._
 import org.bitcoins.core.crypto._
 
-scala> val extPrivKey = ExtPrivateKey(ExtKeyVersion.SegWitMainNetPriv)
-SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
-SLF4J: Defaulting to no-operation (NOP) logger implementation
-SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
-extPrivKey: org.bitcoins.core.crypto.ExtPrivateKey = zprvAWgYBBk7JR8GkbLHbSiLjaZ5MrxyErnQaeAMiiTK8BzfFE3r1ECF35GCKr3TSakAfshSGoqKGCz6Lcm567dExL3Hj9nyXm5GpQeq4WrLLhs
+val extPrivKey = ExtPrivateKey(ExtKeyVersion.SegWitMainNetPriv)
 
-scala> extPrivKey.sign(DoubleSha256Digest.empty.bytes)
-res0: org.bitcoins.core.crypto.ECDigitalSignature = ECDigitalSignature(304402203591cf49b08dae0c9830b0d0f955b329ec8bf033f91fb63b4e33bbaa92d55e3502206e7c498c0362ae1dadf3071eb45c23c77b347b062b1794d036bd63c3d73c13d7)
+extPrivKey.sign(DoubleSha256Digest.empty.bytes)
 
-scala> val path = BIP32Path(Vector(BIP32Node(0,false)))
-path: org.bitcoins.core.hd.BIP32Path = m/0
+val path = BIP32Path(Vector(BIP32Node(0,false)))
 
-scala> extPrivKey.sign(DoubleSha256Digest.empty.bytes,path)
-res4: org.bitcoins.core.crypto.ECDigitalSignature = ECDigitalSignature(304402203784368d19555227bdb9d96360d628f3fdea1e5ca189d125d534c1f0c891f5fb02203c5efd41366045d2f6ce69ccaed706924270cd4fa8bfbf76d29f7bbfecf27eb3)
+extPrivKey.sign(DoubleSha256Digest.empty.bytes,path)
 ```
 
 With `ExtSign`, you can use `ExtPrivateKey` to sign transactions inside of `TxBuilder` since `UTXOSpendingInfo` takes in `Sign` as a parameter. 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -5,6 +5,7 @@
       "core/core-intro",
       "core/addresses",
       "core/hd-keys",
+      "core/sign",
       "core/txbuilder"
     ],
     "RPC clients": [


### PR DESCRIPTION
This PR creates `ExtSign` which is a version of `Sign` that is meant to work with `ExtKey`. Now you shouldn't have to access the private/public key yourself when using `ExtKey`. You can now just pass a `ExtKey` into `TxBuilder`. 

One note: It seems that sign is painfully slow. 

```
sbt:bitcoin-s-core-test> testOnly *ExtSignTest*
[info] ExtSignTest:
[info] - must be able to sign something that extends ExtSignKey
[info] ScalaTest
[info] Run completed in 24 seconds, 909 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 27 s, completed Dec 17, 2019 9:18:26 AM
```

I'm not sure why it takes 24 seconds to sign 20 times in the property based test. My first guess is slow generators, but i don't have time to look into it for now.