### PR TITLE
P2PKWithTimeoutSPK

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -210,8 +210,8 @@ class TransactionTest extends BitcoinSUnitTest {
                                            flags = testCase.flags)
               }
             case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-                _: MultiSignatureScriptPubKey | _: CLTVScriptPubKey |
-                _: CSVScriptPubKey | _: CLTVScriptPubKey |
+                _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+                _: CLTVScriptPubKey | _: CSVScriptPubKey | _: CLTVScriptPubKey |
                 _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
                 _: WitnessCommitment | EmptyScriptPubKey) =>
               val output = TransactionOutput(amount, x)
@@ -292,6 +292,7 @@ class TransactionTest extends BitcoinSUnitTest {
                                                flags = testCase.flags)
                   }
                 case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
+                    _: P2PKWithTimeoutScriptPubKey |
                     _: MultiSignatureScriptPubKey | _: CLTVScriptPubKey |
                     _: CSVScriptPubKey | _: CLTVScriptPubKey |
                     _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -79,8 +79,8 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
                                          flags = flags)
               t
             case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-                _: MultiSignatureScriptPubKey | _: CLTVScriptPubKey |
-                _: CSVScriptPubKey | _: CLTVScriptPubKey |
+                _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+                _: CLTVScriptPubKey | _: CSVScriptPubKey | _: CLTVScriptPubKey |
                 _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
                 _: WitnessCommitment | EmptyScriptPubKey) =>
               val output = TransactionOutput(amount, x)

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -525,8 +525,8 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
                                      Policy.standardFlags)
           case _: UnassignedWitnessScriptPubKey => ???
           case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-              _: MultiSignatureScriptPubKey | _: WitnessCommitment |
-              _: CSVScriptPubKey | _: CLTVScriptPubKey |
+              _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+              _: WitnessCommitment | _: CSVScriptPubKey | _: CLTVScriptPubKey |
               _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
               EmptyScriptPubKey) =>
             val o = TransactionOutput(CurrencyUnits.zero, x)

--- a/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
@@ -104,8 +104,8 @@ sealed abstract class WitnessTxSigComponentP2SH extends WitnessTxSigComponent {
     scriptSignature.redeemScript match {
       case w: WitnessScriptPubKey => Success(w)
       case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-          _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey |
-          _: CSVScriptPubKey | _: CLTVScriptPubKey |
+          _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+          _: P2SHScriptPubKey | _: CSVScriptPubKey | _: CLTVScriptPubKey |
           _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
           _: WitnessCommitment | EmptyScriptPubKey) =>
         Failure(new IllegalArgumentException(
@@ -179,9 +179,10 @@ object WitnessTxSigComponent {
       case _: P2SHScriptPubKey =>
         WitnessTxSigComponentP2SH(transaction, inputIndex, output, flags)
       case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-          _: MultiSignatureScriptPubKey | _: LockTimeScriptPubKey |
-          _: ConditionalScriptPubKey | _: WitnessCommitment |
-          _: NonStandardScriptPubKey | EmptyScriptPubKey) =>
+          _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+          _: LockTimeScriptPubKey | _: ConditionalScriptPubKey |
+          _: WitnessCommitment | _: NonStandardScriptPubKey |
+          EmptyScriptPubKey) =>
         throw new IllegalArgumentException(
           s"Cannot create a WitnessTxSigComponent out of $x")
     }
@@ -206,10 +207,10 @@ object WitnessTxSigComponentRaw {
       case _: WitnessScriptPubKey =>
         WitnessTxSigComponentRawImpl(transaction, inputIndex, output, flags)
       case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-          _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey |
-          _: LockTimeScriptPubKey | _: ConditionalScriptPubKey |
-          _: NonStandardScriptPubKey | _: WitnessCommitment |
-          EmptyScriptPubKey) =>
+          _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+          _: P2SHScriptPubKey | _: LockTimeScriptPubKey |
+          _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
+          _: WitnessCommitment | EmptyScriptPubKey) =>
         throw new IllegalArgumentException(
           s"Cannot create a WitnessTxSigComponentRaw with a spk of $x")
     }
@@ -235,9 +236,10 @@ object WitnessTxSigComponentP2SH {
       case _: P2SHScriptPubKey =>
         WitnessTxSigComponentP2SHImpl(transaction, inputIndex, output, flags)
       case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-          _: MultiSignatureScriptPubKey | _: LockTimeScriptPubKey |
-          _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
-          _: WitnessCommitment | _: WitnessScriptPubKey | EmptyScriptPubKey) =>
+          _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+          _: LockTimeScriptPubKey | _: ConditionalScriptPubKey |
+          _: NonStandardScriptPubKey | _: WitnessCommitment |
+          _: WitnessScriptPubKey | EmptyScriptPubKey) =>
         throw new IllegalArgumentException(
           s"Cannot create a WitnessTxSigComponentP2SH with a spk of $x")
     }

--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -187,19 +187,20 @@ object Bech32Address extends AddressFactory[Bech32Address] {
 
   override def fromScriptPubKey(
       spk: ScriptPubKey,
-      np: NetworkParameters): Try[Bech32Address] = spk match {
-    case witSPK: WitnessScriptPubKey =>
-      Bech32Address.fromScriptPubKey(witSPK, np)
-    case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-        _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey |
-        _: LockTimeScriptPubKey | _: WitnessScriptPubKey |
-        _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
-        _: WitnessCommitment | _: UnassignedWitnessScriptPubKey |
-        EmptyScriptPubKey) =>
-      Failure(
-        new IllegalArgumentException(
-          "Cannot create a address for the scriptPubKey: " + x))
-  }
+      np: NetworkParameters): Try[Bech32Address] =
+    spk match {
+      case witSPK: WitnessScriptPubKey =>
+        Bech32Address.fromScriptPubKey(witSPK, np)
+      case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
+          _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+          _: P2SHScriptPubKey | _: LockTimeScriptPubKey |
+          _: WitnessScriptPubKey | _: ConditionalScriptPubKey |
+          _: NonStandardScriptPubKey | _: WitnessCommitment |
+          _: UnassignedWitnessScriptPubKey | EmptyScriptPubKey) =>
+        Failure(
+          new IllegalArgumentException(
+            "Cannot create a address for the scriptPubKey: " + x))
+    }
 
 }
 
@@ -258,17 +259,19 @@ object P2PKHAddress extends AddressFactory[P2PKHAddress] {
 
   override def fromScriptPubKey(
       spk: ScriptPubKey,
-      np: NetworkParameters): Try[P2PKHAddress] = spk match {
-    case p2pkh: P2PKHScriptPubKey => Success(P2PKHAddress(p2pkh, np))
-    case x @ (_: P2PKScriptPubKey | _: MultiSignatureScriptPubKey |
-        _: P2SHScriptPubKey | _: LockTimeScriptPubKey |
-        _: ConditionalScriptPubKey | _: WitnessScriptPubKey |
-        _: NonStandardScriptPubKey | _: WitnessCommitment |
-        _: UnassignedWitnessScriptPubKey | EmptyScriptPubKey) =>
-      Failure(
-        new IllegalArgumentException(
-          "Cannot create a address for the scriptPubKey: " + x))
-  }
+      np: NetworkParameters): Try[P2PKHAddress] =
+    spk match {
+      case p2pkh: P2PKHScriptPubKey => Success(P2PKHAddress(p2pkh, np))
+      case x @ (_: P2PKScriptPubKey | _: P2PKWithTimeoutScriptPubKey |
+          _: MultiSignatureScriptPubKey | _: P2SHScriptPubKey |
+          _: LockTimeScriptPubKey | _: ConditionalScriptPubKey |
+          _: WitnessScriptPubKey | _: NonStandardScriptPubKey |
+          _: WitnessCommitment | _: UnassignedWitnessScriptPubKey |
+          EmptyScriptPubKey) =>
+        Failure(
+          new IllegalArgumentException(
+            "Cannot create a address for the scriptPubKey: " + x))
+    }
 }
 
 object P2SHAddress extends AddressFactory[P2SHAddress] {
@@ -296,7 +299,8 @@ object P2SHAddress extends AddressFactory[P2SHAddress] {
 
   def apply(
       hash: Sha256Hash160Digest,
-      network: NetworkParameters): P2SHAddress = P2SHAddressImpl(hash, network)
+      network: NetworkParameters): P2SHAddress =
+    P2SHAddressImpl(hash, network)
 
   override def fromString(address: String): Try[P2SHAddress] = {
     val decodeCheckP2SH: Try[ByteVector] = Base58.decodeCheck(address)
@@ -329,17 +333,19 @@ object P2SHAddress extends AddressFactory[P2SHAddress] {
 
   override def fromScriptPubKey(
       spk: ScriptPubKey,
-      np: NetworkParameters): Try[P2SHAddress] = spk match {
-    case p2sh: P2SHScriptPubKey => Success(P2SHAddress(p2sh, np))
-    case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-        _: MultiSignatureScriptPubKey | _: LockTimeScriptPubKey |
-        _: ConditionalScriptPubKey | _: WitnessScriptPubKey |
-        _: NonStandardScriptPubKey | _: WitnessCommitment |
-        _: UnassignedWitnessScriptPubKey | EmptyScriptPubKey) =>
-      Failure(
-        new IllegalArgumentException(
-          "Cannot create a address for the scriptPubKey: " + x))
-  }
+      np: NetworkParameters): Try[P2SHAddress] =
+    spk match {
+      case p2sh: P2SHScriptPubKey => Success(P2SHAddress(p2sh, np))
+      case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
+          _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+          _: LockTimeScriptPubKey | _: ConditionalScriptPubKey |
+          _: WitnessScriptPubKey | _: NonStandardScriptPubKey |
+          _: WitnessCommitment | _: UnassignedWitnessScriptPubKey |
+          EmptyScriptPubKey) =>
+        Failure(
+          new IllegalArgumentException(
+            "Cannot create a address for the scriptPubKey: " + x))
+    }
 }
 
 object BitcoinAddress extends AddressFactory[BitcoinAddress] {
@@ -358,18 +364,20 @@ object BitcoinAddress extends AddressFactory[BitcoinAddress] {
 
   override def fromScriptPubKey(
       spk: ScriptPubKey,
-      np: NetworkParameters): Try[BitcoinAddress] = spk match {
-    case p2pkh: P2PKHScriptPubKey    => Success(P2PKHAddress(p2pkh, np))
-    case p2sh: P2SHScriptPubKey      => Success(P2SHAddress(p2sh, np))
-    case witSPK: WitnessScriptPubKey => Success(Bech32Address(witSPK, np))
-    case x @ (_: P2PKScriptPubKey | _: MultiSignatureScriptPubKey |
-        _: LockTimeScriptPubKey | _: ConditionalScriptPubKey |
-        _: NonStandardScriptPubKey | _: WitnessCommitment |
-        _: UnassignedWitnessScriptPubKey | EmptyScriptPubKey) =>
-      Failure(
-        new IllegalArgumentException(
-          "Cannot create a address for the scriptPubKey: " + x))
-  }
+      np: NetworkParameters): Try[BitcoinAddress] =
+    spk match {
+      case p2pkh: P2PKHScriptPubKey    => Success(P2PKHAddress(p2pkh, np))
+      case p2sh: P2SHScriptPubKey      => Success(P2SHAddress(p2sh, np))
+      case witSPK: WitnessScriptPubKey => Success(Bech32Address(witSPK, np))
+      case x @ (_: P2PKScriptPubKey | _: P2PKWithTimeoutScriptPubKey |
+          _: MultiSignatureScriptPubKey | _: LockTimeScriptPubKey |
+          _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
+          _: WitnessCommitment | _: UnassignedWitnessScriptPubKey |
+          EmptyScriptPubKey) =>
+        Failure(
+          new IllegalArgumentException(
+            "Cannot create a address for the scriptPubKey: " + x))
+    }
 
 }
 
@@ -392,9 +400,10 @@ object Address extends AddressFactory[Address] {
   }
   override def fromScriptPubKey(
       spk: ScriptPubKey,
-      network: NetworkParameters): Try[Address] = network match {
-    case _: BitcoinNetwork => BitcoinAddress.fromScriptPubKey(spk, network)
-  }
+      network: NetworkParameters): Try[Address] =
+    network match {
+      case _: BitcoinNetwork => BitcoinAddress.fromScriptPubKey(spk, network)
+    }
 
   def apply(
       spk: ScriptPubKey,

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -912,14 +912,14 @@ object P2PKWithTimeoutScriptPubKey
       .calculatePushOp(timeoutPubKey.bytes)
       .toVector ++ Vector(ScriptConstant(timeoutPubKey.bytes))
 
-    P2PKWithTimeoutScriptPubKeyImpl {
+    P2PKWithTimeoutScriptPubKeyImpl(
       Vector(Vector(OP_IF),
              pubKeyAsm,
              Vector(OP_ELSE),
              timeoutAsm,
              timeoutPubKeyAsm,
              Vector(OP_ENDIF, OP_CHECKSIG)).flatten
-    }
+    )
   }
 
   def isP2PKWithTimeoutScriptPubKey(asm: Seq[ScriptToken]): Boolean = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -866,6 +866,15 @@ object NonStandardNotIfConditionalScriptPubKey
   }
 }
 
+/** The type for ScriptPubKeys of the form:
+  * OP_IF
+  *   <Public Key>
+  * OP_ELSE
+  *   <Timeout> OP_CHECKLOCKTIMEVERIFY OP_DROP
+  *   <Timeout Public Key>
+  * OP_ENDIF
+  * OP_CHECKSIG
+  */
 sealed trait P2PKWithTimeoutScriptPubKey extends RawScriptPubKey {
 
   lazy val pubKey: ECPublicKey =

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -866,6 +866,70 @@ object NonStandardNotIfConditionalScriptPubKey
   }
 }
 
+sealed trait P2PKWithTimeoutScriptPubKey extends RawScriptPubKey {
+
+  val pubKey: ECPublicKey =
+    ECPublicKey.fromBytes(asm(2).bytes)
+
+  val lockTime: ScriptNumber = ScriptNumber.fromBytes(asm(5).bytes)
+
+  val timeoutPubKey: ECPublicKey =
+    ECPublicKey.fromBytes(asm(9).bytes)
+}
+
+object P2PKWithTimeoutScriptPubKey
+    extends ScriptFactory[P2PKWithTimeoutScriptPubKey] {
+  private case class P2PKWithTimeoutScriptPubKeyImpl(asm: Vector[ScriptToken])
+      extends P2PKWithTimeoutScriptPubKey
+
+  override def fromAsm(asm: Seq[ScriptToken]): P2PKWithTimeoutScriptPubKey = {
+    buildScript(
+      asm = asm.toVector,
+      constructor = P2PKWithTimeoutScriptPubKeyImpl.apply,
+      invariant = isP2PKWithTimeoutScriptPubKey,
+      errorMsg = s"Given asm was not a P2PKWithTimeoutScriptPubKey, got $asm"
+    )
+  }
+
+  def apply(
+      pubKey: ECPublicKey,
+      lockTime: ScriptNumber,
+      timeoutPubKey: ECPublicKey): P2PKWithTimeoutScriptPubKey = {
+    val timeoutAsm = CLTVScriptPubKey(lockTime, EmptyScriptPubKey).asm.toVector
+    val pubKeyAsm = BitcoinScriptUtil
+      .calculatePushOp(pubKey.bytes)
+      .toVector ++ Vector(ScriptConstant(pubKey.bytes))
+    val timeoutPubKeyAsm = BitcoinScriptUtil
+      .calculatePushOp(timeoutPubKey.bytes)
+      .toVector ++ Vector(ScriptConstant(timeoutPubKey.bytes))
+
+    P2PKWithTimeoutScriptPubKeyImpl {
+      Vector(Vector(OP_IF),
+             pubKeyAsm,
+             Vector(OP_ELSE),
+             timeoutAsm,
+             timeoutPubKeyAsm,
+             Vector(OP_ENDIF, OP_CHECKSIG)).flatten
+    }
+  }
+
+  def isP2PKWithTimeoutScriptPubKey(asm: Seq[ScriptToken]): Boolean = {
+    if (asm.length == 12) {
+      val pubKey = ECPublicKey.fromBytes(asm(2).bytes)
+      val lockTimeTry = Try(ScriptNumber.fromBytes(asm(5).bytes))
+      val timeoutPubKey = ECPublicKey.fromBytes(asm(9).bytes)
+
+      lockTimeTry match {
+        case Success(lockTime) =>
+          asm == P2PKWithTimeoutScriptPubKey(pubKey, lockTime, timeoutPubKey).asm
+        case Failure(_) => false
+      }
+    } else {
+      false
+    }
+  }
+}
+
 sealed trait NonStandardScriptPubKey extends RawScriptPubKey
 
 object NonStandardScriptPubKey extends ScriptFactory[NonStandardScriptPubKey] {
@@ -896,6 +960,8 @@ object RawScriptPubKey extends ScriptFactory[RawScriptPubKey] {
 
   def fromAsm(asm: Seq[ScriptToken]): RawScriptPubKey = asm match {
     case Nil => EmptyScriptPubKey
+    case _ if P2PKWithTimeoutScriptPubKey.isP2PKWithTimeoutScriptPubKey(asm) =>
+      P2PKWithTimeoutScriptPubKey.fromAsm(asm)
     case _
         if MultiSignatureWithTimeoutScriptPubKey
           .isMultiSignatureWithTimeoutScriptPubKey(asm) =>

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -868,12 +868,12 @@ object NonStandardNotIfConditionalScriptPubKey
 
 sealed trait P2PKWithTimeoutScriptPubKey extends RawScriptPubKey {
 
-  val pubKey: ECPublicKey =
+  lazy val pubKey: ECPublicKey =
     ECPublicKey.fromBytes(asm(2).bytes)
 
-  val lockTime: ScriptNumber = ScriptNumber.fromBytes(asm(5).bytes)
+  lazy val lockTime: ScriptNumber = ScriptNumber.fromBytes(asm(5).bytes)
 
-  val timeoutPubKey: ECPublicKey =
+  lazy val timeoutPubKey: ECPublicKey =
     ECPublicKey.fromBytes(asm(9).bytes)
 }
 

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -88,6 +88,7 @@ sealed abstract class ScriptInterpreter extends BitcoinSLogger {
                 if (p2shEnabled) executeP2shScript(scriptSigExecutedProgram)
                 else scriptPubKeyExecutedProgram
               case _: P2PKHScriptPubKey | _: P2PKScriptPubKey |
+                  _: P2PKWithTimeoutScriptPubKey |
                   _: MultiSignatureScriptPubKey | _: CSVScriptPubKey |
                   _: CLTVScriptPubKey | _: ConditionalScriptPubKey |
                   _: NonStandardScriptPubKey | _: WitnessCommitment |
@@ -292,11 +293,11 @@ sealed abstract class ScriptInterpreter extends BitcoinSLogger {
               run(scriptPubKeyExecutedProgram, p2wsh)
             }
           case s @ (_: P2SHScriptPubKey | _: P2PKHScriptPubKey |
-              _: P2PKScriptPubKey | _: MultiSignatureScriptPubKey |
-              _: CLTVScriptPubKey | _: CSVScriptPubKey |
-              _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
-              _: WitnessCommitment | _: UnassignedWitnessScriptPubKey |
-              EmptyScriptPubKey) =>
+              _: P2PKWithTimeoutScriptPubKey | _: P2PKScriptPubKey |
+              _: MultiSignatureScriptPubKey | _: CLTVScriptPubKey |
+              _: CSVScriptPubKey | _: ConditionalScriptPubKey |
+              _: NonStandardScriptPubKey | _: WitnessCommitment |
+              _: UnassignedWitnessScriptPubKey | EmptyScriptPubKey) =>
             run(scriptPubKeyExecutedProgram, s)
         }
       } else {

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -451,9 +451,10 @@ trait BitcoinScriptUtil extends BitcoinSLogger {
             script
         }
       case _: P2PKHScriptPubKey | _: P2PKScriptPubKey |
-          _: MultiSignatureScriptPubKey | _: ConditionalScriptPubKey |
-          _: NonStandardScriptPubKey | _: CLTVScriptPubKey |
-          _: CSVScriptPubKey | _: WitnessCommitment | EmptyScriptPubKey =>
+          _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+          _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
+          _: CLTVScriptPubKey | _: CSVScriptPubKey | _: WitnessCommitment |
+          EmptyScriptPubKey =>
         script
     }
 
@@ -561,6 +562,8 @@ trait BitcoinScriptUtil extends BitcoinSLogger {
   def isOnlyCompressedPubKey(spk: ScriptPubKey): Boolean = {
     spk match {
       case p2pk: P2PKScriptPubKey => p2pk.publicKey.isCompressed
+      case p2pkWithTimeout: P2PKWithTimeoutScriptPubKey =>
+        p2pkWithTimeout.pubKey.isCompressed && p2pkWithTimeout.timeoutPubKey.isCompressed
       case m: MultiSignatureScriptPubKey =>
         !m.publicKeys.exists(k => !k.isCompressed)
       case l: LockTimeScriptPubKey =>

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -333,7 +333,7 @@ sealed abstract class P2PKWithTimeoutSigner
                             isDummySignature)
 
     val scriptSigF = signatureF.map { signature =>
-      P2PKWithTimeoutScriptSignature(spendingInfoToSatisfy.beforeTimeout,
+      P2PKWithTimeoutScriptSignature(spendingInfoToSatisfy.isBeforeTimeout,
                                      signature)
     }
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -16,6 +16,7 @@ import org.bitcoins.core.wallet.utxo.{
   MultiSignatureSpendingInfo,
   P2PKHSpendingInfo,
   P2PKSpendingInfo,
+  P2PKWithTimeoutSpendingInfo,
   P2SHSpendingInfo,
   P2WPKHV0SpendingInfo,
   P2WSHV0SpendingInfo,
@@ -192,6 +193,11 @@ object BitcoinSigner {
         P2PKSigner.sign(spendingInfo, unsignedTx, isDummySignature, p2pk)
       case p2pkh: P2PKHSpendingInfo =>
         P2PKHSigner.sign(spendingInfo, unsignedTx, isDummySignature, p2pkh)
+      case p2pKWithTimeout: P2PKWithTimeoutSpendingInfo =>
+        P2PKWithTimeoutSigner.sign(spendingInfo,
+                                   unsignedTx,
+                                   isDummySignature,
+                                   p2pKWithTimeout)
       case multiSig: MultiSignatureSpendingInfo =>
         MultiSigSigner.sign(spendingInfo,
                             unsignedTx,
@@ -307,6 +313,38 @@ sealed abstract class P2PKHSigner extends BitcoinSigner[P2PKHSpendingInfo] {
 }
 
 object P2PKHSigner extends P2PKHSigner
+
+sealed abstract class P2PKWithTimeoutSigner
+    extends BitcoinSigner[P2PKWithTimeoutSpendingInfo] {
+  override def sign(
+      spendingInfo: UTXOSpendingInfo,
+      unsignedTx: Transaction,
+      isDummySignature: Boolean,
+      spendingInfoToSatisfy: P2PKWithTimeoutSpendingInfo)(
+      implicit ec: ExecutionContext): Future[TxSigComponent] = {
+    val (signers, output, inputIndex, hashType) =
+      relevantInfo(spendingInfo, unsignedTx)
+
+    val sign = signers.head.signFunction
+
+    val signatureF = doSign(sigComponent(spendingInfo, unsignedTx),
+                            sign,
+                            hashType,
+                            isDummySignature)
+
+    val scriptSigF = signatureF.map { signature =>
+      P2PKWithTimeoutScriptSignature(spendingInfoToSatisfy.beforeTimeout,
+                                     signature)
+    }
+
+    updateScriptSigInSigComponent(unsignedTx,
+                                  inputIndex.toInt,
+                                  output,
+                                  scriptSigF)
+  }
+}
+
+object P2PKWithTimeoutSigner extends P2PKWithTimeoutSigner
 
 sealed abstract class MultiSigSigner
     extends BitcoinSigner[MultiSignatureSpendingInfo] {

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
@@ -11,6 +11,7 @@ import org.bitcoins.core.protocol.script.{
   NonStandardScriptPubKey,
   P2PKHScriptPubKey,
   P2PKScriptPubKey,
+  P2PKWithTimeoutScriptPubKey,
   P2SHScriptPubKey,
   P2WPKHWitnessSPKV0,
   P2WPKHWitnessV0,
@@ -72,14 +73,22 @@ sealed abstract class UTXOSpendingInfo {
   * then you would construct a ConditionalSpendingInfo using nonNestedTrue as your
   * ConditionalPath. Otherwise if you wanted to use P2PK2 you would use nonNestedFalse.
   */
-sealed trait ConditionalPath
+sealed trait ConditionalPath {
+  def head: Option[Boolean]
+}
 
 object ConditionalPath {
-  case object NoConditionsLeft extends ConditionalPath
+  case object NoConditionsLeft extends ConditionalPath {
+    override def head: Option[Boolean] = None
+  }
   case class ConditionTrue(nextCondition: ConditionalPath)
-      extends ConditionalPath
+      extends ConditionalPath {
+    override def head: Option[Boolean] = Some(true)
+  }
   case class ConditionFalse(nextCondition: ConditionalPath)
-      extends ConditionalPath
+      extends ConditionalPath {
+    override def head: Option[Boolean] = Some(false)
+  }
 
   val nonNestedTrue: ConditionalPath = ConditionTrue(NoConditionsLeft)
   val nonNestedFalse: ConditionalPath = ConditionFalse(NoConditionsLeft)
@@ -178,6 +187,19 @@ object BitcoinUTXOSpendingInfo {
         P2PKSpendingInfo(outPoint, output.value, p2pk, signers.head, hashType)
       case p2pkh: P2PKHScriptPubKey =>
         P2PKHSpendingInfo(outPoint, output.value, p2pkh, signers.head, hashType)
+      case p2pkWithTimeout: P2PKWithTimeoutScriptPubKey =>
+        conditionalPath.head match {
+          case None =>
+            throw new IllegalArgumentException(
+              "ConditionalPath must be specified for P2PKWithTimeout")
+          case Some(beforeTimeout) =>
+            P2PKWithTimeoutSpendingInfo(outPoint,
+                                        output.value,
+                                        p2pkWithTimeout,
+                                        signers.head,
+                                        hashType,
+                                        beforeTimeout)
+        }
       case multisig: MultiSignatureScriptPubKey =>
         MultiSignatureSpendingInfo(outPoint,
                                    output.value,
@@ -272,6 +294,19 @@ object RawScriptUTXOSpendingInfo {
         P2PKSpendingInfo(outPoint, amount, p2pk, signers.head, hashType)
       case p2pkh: P2PKHScriptPubKey =>
         P2PKHSpendingInfo(outPoint, amount, p2pkh, signers.head, hashType)
+      case p2pkWithTimeout: P2PKWithTimeoutScriptPubKey =>
+        conditionalPath.head match {
+          case None =>
+            throw new IllegalArgumentException(
+              "ConditionalPath must be specified for P2PKWithTimeout")
+          case Some(beforeTimeout) =>
+            P2PKWithTimeoutSpendingInfo(outPoint,
+                                        amount,
+                                        p2pkWithTimeout,
+                                        signers.head,
+                                        hashType,
+                                        beforeTimeout)
+        }
       case multisig: MultiSignatureScriptPubKey =>
         MultiSignatureSpendingInfo(outPoint,
                                    amount,
@@ -345,6 +380,28 @@ case class P2PKHSpendingInfo(
 
   override def conditionalPath: ConditionalPath =
     ConditionalPath.NoConditionsLeft
+}
+
+case class P2PKWithTimeoutSpendingInfo(
+    outPoint: TransactionOutPoint,
+    amount: CurrencyUnit,
+    scriptPubKey: P2PKWithTimeoutScriptPubKey,
+    signer: Sign,
+    hashType: HashType,
+    beforeTimeout: Boolean)
+    extends RawScriptUTXOSpendingInfo {
+  require(
+    scriptPubKey.pubKey == signer.publicKey || scriptPubKey.timeoutPubKey == signer.publicKey,
+    "Signer pubkey must match ScriptPubKey")
+
+  override val signers: Vector[Sign] = Vector(signer)
+
+  override def conditionalPath: ConditionalPath =
+    if (beforeTimeout) {
+      ConditionalPath.nonNestedTrue
+    } else {
+      ConditionalPath.nonNestedFalse
+    }
 }
 
 case class MultiSignatureSpendingInfo(

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CreditingTxGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CreditingTxGen.scala
@@ -86,22 +86,47 @@ sealed abstract class CreditingTxGen {
       }
   }
 
-  def output: Gen[BitcoinUTXOSpendingInfo] =
-    Gen.oneOf(
-      p2pkOutput,
-      p2pkhOutput,
-      /*p2pkWithTimeoutOutput,*/
-      multiSigOutput,
-      p2shOutput,
-      csvOutput, /*cltvOutput,*/
-      multiSignatureWithTimeoutOutput,
-      conditionalOutput,
-      p2wpkhOutput,
-      p2wshOutput
-    )
+  private val nonCltvOutputGens = Vector(
+    p2pkOutput,
+    p2pkhOutput,
+    multiSigOutput,
+    p2shOutput,
+    csvOutput,
+    multiSignatureWithTimeoutOutput,
+    conditionalOutput,
+    p2wpkhOutput,
+    p2wshOutput
+  )
 
+  private val cltvOutputGens = Vector(p2pkWithTimeoutOutput, cltvOutput)
+
+  def output: Gen[BitcoinUTXOSpendingInfo] =
+    Gen.oneOf(nonCltvOutputGens.head,
+              nonCltvOutputGens.tail.head,
+              nonCltvOutputGens.drop(2): _*)
+
+  /** Either a list of non-CLTV outputs or a single CLTV output, with proportional probability */
   def outputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
-    Gen.choose(min, 5).flatMap(n => Gen.listOfN(n, output))
+    val cltvGen = Gen
+      .oneOf(cltvOutput, p2pkWithTimeoutOutput)
+      .map { output =>
+        Vector(output)
+      }
+    val nonCltvGen = Gen.choose(min, 5).flatMap(n => Gen.listOfN(n, output))
+
+    val cltvSize = cltvOutputGens.length
+    val nonCltvSize = nonCltvOutputGens.length
+    val totalSize = cltvSize + nonCltvSize
+
+    cltvGen.flatMap { cltv =>
+      nonCltvGen.map { nonCltvs =>
+        if (Math.random() < cltvSize.toDouble / totalSize) {
+          cltv
+        } else {
+          nonCltvs
+        }
+      }
+    }
   }
 
   /** Generates a crediting tx with a p2pk spk at the returned index */

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CreditingTxGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CreditingTxGen.scala
@@ -29,12 +29,15 @@ sealed abstract class CreditingTxGen {
 
   /** Generator for non-script hash based output */
   def nonSHOutput: Gen[BitcoinUTXOSpendingInfo] = {
-    Gen.oneOf(p2pkOutput,
-              p2pkhOutput,
-              multiSigOutput, /*cltvOutput,*/ csvOutput,
-              multiSignatureWithTimeoutOutput,
-              conditionalOutput,
-              p2wpkhOutput)
+    Gen.oneOf(
+      p2pkOutput,
+      p2pkhOutput,
+      /*p2pkWithTimeoutOutput,*/
+      multiSigOutput, /*cltvOutput,*/ csvOutput,
+      multiSignatureWithTimeoutOutput,
+      conditionalOutput,
+      p2wpkhOutput
+    )
   }
 
   def nonSHOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
@@ -48,6 +51,7 @@ sealed abstract class CreditingTxGen {
     //note, cannot put a p2wpkh here
     Gen.oneOf(p2pkOutput,
               p2pkhOutput,
+              /*p2pkWithTimeoutOutput,*/
               multiSigOutput, /*cltvOutput,*/ csvOutput,
               multiSignatureWithTimeoutOutput,
               conditionalOutput)
@@ -56,13 +60,16 @@ sealed abstract class CreditingTxGen {
   /** Only for use in constructing P2SH outputs */
   private def nonP2SHOutput: Gen[BitcoinUTXOSpendingInfo] = {
     Gen
-      .oneOf(p2pkOutput,
-             p2pkhOutput,
-             multiSigOutput, /*cltvOutput,*/ csvOutput,
-             multiSignatureWithTimeoutOutput,
-             conditionalOutput,
-             p2wpkhOutput,
-             p2wshOutput)
+      .oneOf(
+        p2pkOutput,
+        p2pkhOutput,
+        /*p2pkWithTimeoutOutput,*/
+        multiSigOutput, /*cltvOutput,*/ csvOutput,
+        multiSignatureWithTimeoutOutput,
+        conditionalOutput,
+        p2wpkhOutput,
+        p2wshOutput
+      )
       .suchThat(output =>
         !ScriptGenerators.redeemScriptTooBig(output.scriptPubKey))
       .suchThat {
@@ -80,15 +87,18 @@ sealed abstract class CreditingTxGen {
   }
 
   def output: Gen[BitcoinUTXOSpendingInfo] =
-    Gen.oneOf(p2pkOutput,
-              p2pkhOutput,
-              multiSigOutput,
-              p2shOutput,
-              csvOutput, /*cltvOutput,*/
-              multiSignatureWithTimeoutOutput,
-              conditionalOutput,
-              p2wpkhOutput,
-              p2wshOutput)
+    Gen.oneOf(
+      p2pkOutput,
+      p2pkhOutput,
+      /*p2pkWithTimeoutOutput,*/
+      multiSigOutput,
+      p2shOutput,
+      csvOutput, /*cltvOutput,*/
+      multiSignatureWithTimeoutOutput,
+      conditionalOutput,
+      p2wpkhOutput,
+      p2wshOutput
+    )
 
   def outputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
     Gen.choose(min, 5).flatMap(n => Gen.listOfN(n, output))
@@ -103,6 +113,16 @@ sealed abstract class CreditingTxGen {
   /** Generates multiple crediting txs with p2pk spks at the returned index */
   def p2pkOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, p2pkOutput))
+  }
+
+  def p2pkWithTimeoutOutput: Gen[BitcoinUTXOSpendingInfo] = {
+    ScriptGenerators.p2pkWithTimeoutScriptPubKey.flatMap { p2pkWithTimeout =>
+      build(p2pkWithTimeout._1, Seq(p2pkWithTimeout._2.head), None, None)
+    }
+  }
+
+  def p2pkWithTimeoutOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
+    Gen.choose(min, max).flatMap(n => Gen.listOfN(n, p2pkWithTimeoutOutput))
   }
 
   /**
@@ -298,6 +318,7 @@ sealed abstract class CreditingTxGen {
       case conditional: ConditionalScriptPubKey =>
         ConditionalPath.ConditionTrue(
           computeAllTrueConditionalPath(conditional.trueSPK, None, None))
+      case _: P2PKWithTimeoutScriptPubKey => ConditionalPath.nonNestedTrue
       case lockTimeScriptPubKey: LockTimeScriptPubKey =>
         computeAllTrueConditionalPath(lockTimeScriptPubKey.nestedScriptPubKey,
                                       None,

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/NumberGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/NumberGenerator.scala
@@ -87,6 +87,7 @@ trait NumberGenerator {
   def scriptNumbers: Gen[ScriptNumber] =
     Gen.choose(Int64.min.toLong, Int64.max.toLong).map(ScriptNumber(_))
 
+  /** The policy bounds for nTimeLock fields (see TxBuilder) */
   def timeLockScriptNumbers: Gen[ScriptNumber] =
     Gen.choose(1L, UInt32.max.toLong - 1L).map(ScriptNumber(_))
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/NumberGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/NumberGenerator.scala
@@ -87,6 +87,9 @@ trait NumberGenerator {
   def scriptNumbers: Gen[ScriptNumber] =
     Gen.choose(Int64.min.toLong, Int64.max.toLong).map(ScriptNumber(_))
 
+  def timeLockScriptNumbers: Gen[ScriptNumber] =
+    Gen.choose(1L, UInt32.max.toLong - 1L).map(ScriptNumber(_))
+
   def positiveScriptNumbers: Gen[ScriptNumber] =
     Gen.choose(0L, Int64.max.toLong).map(ScriptNumber(_))
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
@@ -13,11 +13,17 @@ import org.bitcoins.core.script.control.{ConditionalOperation, OP_IF, OP_NOTIF}
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.core.wallet.signer.{MultiSigSigner, P2PKHSigner, P2PKSigner}
+import org.bitcoins.core.wallet.signer.{
+  MultiSigSigner,
+  P2PKHSigner,
+  P2PKSigner,
+  P2PKWithTimeoutSigner
+}
 import org.bitcoins.core.wallet.utxo.{
   MultiSignatureSpendingInfo,
   P2PKHSpendingInfo,
-  P2PKSpendingInfo
+  P2PKSpendingInfo,
+  P2PKWithTimeoutSpendingInfo
 }
 import org.scalacheck.Gen
 
@@ -51,6 +57,14 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       signature = privKey.sign(hash)
     } yield P2PKHScriptSignature(signature, privKey.publicKey)
 
+  def p2pkWithTimeoutScriptSignature: Gen[ConditionalScriptSignature] =
+    for {
+      privKey <- CryptoGenerators.privateKey
+      hash <- CryptoGenerators.doubleSha256Digest
+      signature = privKey.sign(hash)
+      beforeTimeout <- NumberGenerator.bool
+    } yield P2PKWithTimeoutScriptSignature(beforeTimeout, signature)
+
   def multiSignatureScriptSignature: Gen[MultiSignatureScriptSignature] = {
     val signatures: Gen[Seq[ECDigitalSignature]] = for {
       numKeys <- Gen.choose(1, Consensus.maxPublicKeysPerMultiSig)
@@ -67,6 +81,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       .oneOf(
         packageToSequenceOfPrivateKeys(signedP2PKHScriptSignature),
         packageToSequenceOfPrivateKeys(signedP2PKScriptSignature),
+        packageToSequenceOfPrivateKeys(signedP2PKWithTimeoutScriptSignature),
         signedMultiSignatureScriptSignature,
         signedCLTVScriptSignature,
         signedCSVScriptSignature
@@ -131,6 +146,19 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       pubKey = privKey.publicKey
       p2pkh = P2PKHScriptPubKey(pubKey)
     } yield (p2pkh, privKey)
+
+  def p2pkWithTimeoutScriptPubKey: Gen[
+    (P2PKWithTimeoutScriptPubKey, Seq[ECPrivateKey])] =
+    for {
+      privKey <- CryptoGenerators.privateKey
+      timeoutPrivKey <- CryptoGenerators.privateKey
+      lockTime <- NumberGenerator.scriptNumbers
+    } yield {
+      (P2PKWithTimeoutScriptPubKey(privKey.publicKey,
+                                   lockTime,
+                                   timeoutPrivKey.publicKey),
+       Vector(privKey, timeoutPrivKey))
+    }
 
   def cltvScriptPubKey: Gen[(CLTVScriptPubKey, Seq[ECPrivateKey])] = {
     cltvScriptPubKey(defaultMaxDepth)
@@ -347,6 +375,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     Gen.oneOf(
       p2pkScriptPubKey.map(privKeyToSeq(_)),
       p2pkhScriptPubKey.map(privKeyToSeq(_)),
+      p2pkWithTimeoutScriptPubKey,
       cltvScriptPubKey(defaultMaxDepth).suchThat(
         !_._1.nestedScriptPubKey.isInstanceOf[CSVScriptPubKey]),
       csvScriptPubKey(defaultMaxDepth).suchThat(
@@ -384,6 +413,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     Gen.oneOf(
       p2pkScriptPubKey.map(privKeyToSeq(_)),
       p2pkhScriptPubKey.map(privKeyToSeq(_)),
+      p2pkWithTimeoutScriptPubKey,
       multiSigScriptPubKey,
       emptyScriptPubKey,
       cltvScriptPubKey(defaultMaxDepth),
@@ -402,6 +432,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     Gen.oneOf(
       p2pkScriptPubKey.map(privKeyToSeq),
       p2pkhScriptPubKey.map(privKeyToSeq),
+      p2pkWithTimeoutScriptPubKey,
       multiSigScriptPubKey,
       emptyScriptPubKey,
       lockTimeScriptPubKey(defaultMaxDepth),
@@ -437,6 +468,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     Gen.oneOf(
       p2pkScriptPubKey.map(privKeyToSeq),
       p2pkhScriptPubKey.map(privKeyToSeq),
+      p2pkWithTimeoutScriptPubKey,
       multiSigScriptPubKey,
       emptyScriptPubKey,
       nonConditionalLockTimeScriptPubKey
@@ -452,6 +484,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     Gen.oneOf(
       p2pkScriptPubKey.map(privKeyToSeq),
       p2pkhScriptPubKey.map(privKeyToSeq),
+      p2pkWithTimeoutScriptPubKey,
       multiSigScriptPubKey,
       emptyScriptPubKey,
       lockTimeScriptPubKey(maxDepth),
@@ -465,6 +498,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     Gen.oneOf(
       p2pkScriptSignature,
       p2pkhScriptSignature,
+      p2pkWithTimeoutScriptSignature,
       multiSignatureScriptSignature,
       emptyScriptSignature,
       p2shScriptSignature,
@@ -482,9 +516,10 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     */
   private def pickCorrespondingScriptSignature(
       scriptPubKey: ScriptPubKey): Gen[ScriptSignature] = scriptPubKey match {
-    case _: P2PKScriptPubKey           => p2pkScriptSignature
-    case _: P2PKHScriptPubKey          => p2pkhScriptSignature
-    case _: MultiSignatureScriptPubKey => multiSignatureScriptSignature
+    case _: P2PKScriptPubKey            => p2pkScriptSignature
+    case _: P2PKHScriptPubKey           => p2pkhScriptSignature
+    case _: P2PKWithTimeoutScriptPubKey => p2pkWithTimeoutScriptSignature
+    case _: MultiSignatureScriptPubKey  => multiSignatureScriptSignature
     case conditional: ConditionalScriptPubKey =>
       pickCorrespondingScriptSignature(conditional.trueSPK)
         .map(ConditionalScriptSignature(_, true))
@@ -568,6 +603,36 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
         .asInstanceOf[P2PKHScriptSignature]
     } yield (signedScriptSig, scriptPubKey, privateKey)
 
+  def signedP2PKWithTimeoutScriptSignature: Gen[
+    (ConditionalScriptSignature, P2PKWithTimeoutScriptPubKey, ECPrivateKey)] =
+    for {
+      (spk, privKeys) <- p2pkWithTimeoutScriptPubKey
+      hashType <- CryptoGenerators.hashType
+    } yield {
+      val privKey = privKeys.head
+      val emptyScriptSig = P2PKWithTimeoutScriptSignature(beforeTimeout = true,
+                                                          EmptyDigitalSignature)
+      val (creditingTx, outputIndex) =
+        TransactionGenerators.buildCreditingTransaction(spk)
+      val (spendingTx, inputIndex) = TransactionGenerators
+        .buildSpendingTransaction(creditingTx, emptyScriptSig, outputIndex)
+      val spendingInfo = P2PKWithTimeoutSpendingInfo(
+        TransactionOutPoint(creditingTx.txIdBE, inputIndex),
+        creditingTx.outputs(outputIndex.toInt).value,
+        spk,
+        privKey,
+        hashType,
+        beforeTimeout = true)
+      val txSigComponentF = P2PKWithTimeoutSigner.sign(spendingInfo,
+                                                       spendingTx,
+                                                       isDummySignature = false)
+      val txSigComponent = Await.result(txSigComponentF, timeout)
+      val signedScriptSig =
+        txSigComponent.scriptSignature.asInstanceOf[ConditionalScriptSignature]
+
+      (signedScriptSig, spk, privKey)
+    }
+
   /**
     * Generates a signed
     * `MultiSignatureScriptSignature` that spends the
@@ -616,6 +681,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     val signed = Gen.oneOf(
       packageToSequenceOfPrivateKeys(signedP2PKHScriptSignature),
       packageToSequenceOfPrivateKeys(signedP2PKScriptSignature),
+      packageToSequenceOfPrivateKeys(signedP2PKWithTimeoutScriptSignature),
       signedMultiSignatureScriptSignature,
       signedCLTVScriptSignature,
       signedCSVScriptSignature,
@@ -688,7 +754,9 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       case _: LockTimeScriptPubKey =>
         throw new IllegalArgumentException(
           "This shouldn't happen since we are using nonLocktimeRawScriptPubKey")
-      case _: P2PKHScriptPubKey | _: P2PKScriptPubKey => 1
+      case _: P2PKHScriptPubKey | _: P2PKScriptPubKey |
+          _: P2PKWithTimeoutScriptPubKey =>
+        1
       case EmptyScriptPubKey | _: WitnessCommitment |
           _: NonStandardScriptPubKey =>
         0
@@ -747,7 +815,8 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       case _: UnassignedWitnessScriptPubKey | _: WitnessScriptPubKeyV0 =>
         throw new IllegalArgumentException(
           "Cannot created a witness scriptPubKey for a CSVScriptSig since we do not have a witness")
-      case _: P2SHScriptPubKey | _: CLTVScriptPubKey | _: CSVScriptPubKey |
+      case _: P2SHScriptPubKey | _: CLTVScriptPubKey |
+          _: P2PKWithTimeoutScriptPubKey | _: CSVScriptPubKey |
           _: NonStandardScriptPubKey | _: WitnessCommitment =>
         throw new IllegalArgumentException(
           "We only " +
@@ -800,7 +869,8 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       case _: UnassignedWitnessScriptPubKey | _: WitnessScriptPubKeyV0 =>
         throw new IllegalArgumentException(
           "Cannot created a witness scriptPubKey for a CSVScriptSig since we do not have a witness")
-      case _: P2SHScriptPubKey | _: CLTVScriptPubKey | _: CSVScriptPubKey |
+      case _: P2SHScriptPubKey | _: CLTVScriptPubKey |
+          _: P2PKWithTimeoutScriptPubKey | _: CSVScriptPubKey |
           _: NonStandardScriptPubKey | _: WitnessCommitment =>
         throw new IllegalArgumentException(
           "We only " +
@@ -944,6 +1014,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     Gen.oneOf(
       packageToSequenceOfPrivateKeys(signedP2PKHScriptSignature),
       packageToSequenceOfPrivateKeys(signedP2PKScriptSignature),
+      packageToSequenceOfPrivateKeys(signedP2PKWithTimeoutScriptSignature),
       signedMultiSignatureScriptSignature,
       signedCLTVScriptSignature,
       signedCSVScriptSignature,
@@ -994,7 +1065,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       case _: WitnessScriptPubKeyV0 | _: UnassignedWitnessScriptPubKey =>
         //bare segwit always has an empty script sig, see BIP141
         CSVScriptSignature(EmptyScriptSignature)
-      case _: LockTimeScriptPubKey =>
+      case _: LockTimeScriptPubKey | _: P2PKWithTimeoutScriptPubKey =>
         throw new IllegalArgumentException(
           "Cannot have a nested locktimeScriptPubKey inside a lockTimeScriptPubKey")
       case x @ (_: NonStandardScriptPubKey | _: P2SHScriptPubKey |

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
@@ -152,7 +152,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
     for {
       privKey <- CryptoGenerators.privateKey
       timeoutPrivKey <- CryptoGenerators.privateKey
-      lockTime <- NumberGenerator.scriptNumbers
+      lockTime <- NumberGenerator.timeLockScriptNumbers
     } yield {
       (P2PKWithTimeoutScriptPubKey(privKey.publicKey,
                                    lockTime,
@@ -167,7 +167,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   def cltvScriptPubKey(
       maxDepth: Int): Gen[(CLTVScriptPubKey, Seq[ECPrivateKey])] =
     for {
-      num <- NumberGenerator.scriptNumbers
+      num <- NumberGenerator.timeLockScriptNumbers
       (cltv, privKeys, num) <- cltvScriptPubKey(num, maxDepth)
     } yield (cltv, privKeys)
 
@@ -184,7 +184,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   def nonConditionalCltvScriptPubKey: Gen[
     (CLTVScriptPubKey, Seq[ECPrivateKey])] = {
     for {
-      num <- NumberGenerator.scriptNumbers
+      num <- NumberGenerator.timeLockScriptNumbers
       (cltv, privKeys, num) <- nonConditionalCltvScriptPubKey(num)
     } yield (cltv, privKeys)
   }
@@ -216,7 +216,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       maxDepth: Int): Gen[(CSVScriptPubKey, Seq[ECPrivateKey])] =
     for {
       (scriptPubKey, privKeys) <- nonLocktimeRawScriptPubKey(maxDepth - 1)
-      num <- NumberGenerator.scriptNumbers
+      num <- NumberGenerator.timeLockScriptNumbers
       csv = CSVScriptPubKey(num, scriptPubKey)
     } yield (csv, privKeys)
 
@@ -233,7 +233,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
   def nonConditionalCsvScriptPubKey: Gen[(CSVScriptPubKey, Seq[ECPrivateKey])] = {
     for {
       (scriptPubKey, privKeys) <- nonConditionalNonLocktimeRawScriptPubKey
-      num <- NumberGenerator.scriptNumbers
+      num <- NumberGenerator.timeLockScriptNumbers
       csv = CSVScriptPubKey(num, scriptPubKey)
     } yield (csv, privKeys)
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
@@ -622,7 +622,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
         spk,
         privKey,
         hashType,
-        beforeTimeout = true)
+        isBeforeTimeout = true)
       val txSigComponentF = P2PKWithTimeoutSigner.sign(spendingInfo,
                                                        spendingTx,
                                                        isDummySignature = false)


### PR DESCRIPTION
Introduces a new SPK type used by [DLCs](https://github.com/bitcoin-s/dlcspecs/blob/master/Transactions.md#CetOutputs)

The new SPK is of the following form:
```
OP_IF
    BytesToPushOntoStackImpl(33)
    ScriptConstantImpl(ByteVector(33 bytes, pubKeyBytes))
OP_ELSE
    BytesToPushOntoStackImpl(4)
    ScriptConstantImpl(ByteVector(4 bytes, timeLockBytes))
    OP_CHECKLOCKTIMEVERIFY
    OP_DROP

    BytesToPushOntoStackImpl(33)
    ScriptConstantImpl(ByteVector(33 bytes, timeoutPubKeyBytes))
OP_ENDIF

OP_CHECKSIG
```