### PR TITLE
Remove standalone node ci matrix and add it to the chain ci matrix to…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: scala
 env:
   matrix:
     - TEST_COMMAND="bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls"
-    - TEST_COMMAND="chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls"
+    - TEST_COMMAND="chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls"
     - TEST_COMMAND="eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls"
     - TEST_COMMAND="walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls"
-    - TEST_COMMAND="nodeTest/test node/coverageReport node/coverageAggregate node/coveralls"
     - TEST_COMMAND="coreTest/test core/coverageReport core/coverageAggregate core/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls"
 
 os: linux


### PR DESCRIPTION
… hopefully speed up CI time

This should allow us to use a hot JVM with pre-compiled code to run tests rather than having to redundantly do all of the compiling and JVM warmup procedures in another environment. 

In general, I don't think we've a local optima for CI build time. Putting everything into one build makes things slower, but putting everything in separate builds also makes things slower. We should gradually tinker with this to try and find what works best. 