### PR TITLE
Implement abililty to use BIP39 password. This means this password ne…

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -101,7 +101,7 @@ object Main extends App {
       val locked = LockedWallet(nodeApi, chainQueryApi)
 
       // TODO change me when we implement proper password handling
-      locked.unlock(BIP39KeyManager.badPassphrase,bip39PasswordOpt) match {
+      locked.unlock(BIP39KeyManager.badPassphrase, bip39PasswordOpt) match {
         case Right(wallet) =>
           Future.successful(wallet)
         case Left(kmError) =>

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -123,7 +123,8 @@ object Main extends App {
       logger.info(s"Creating new wallet")
       val unInitializedWallet = Wallet(keyManager, nodeApi, chainQueryApi)
 
-      Wallet.initialize(wallet = unInitializedWallet)
+      Wallet.initialize(wallet = unInitializedWallet,
+                        bip39PasswordOpt = bip39PasswordOpt)
     }
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -38,13 +38,13 @@ object Main extends App {
   val peerSocket =
     parseInetSocketAddress(nodeConf.peers.head, nodeConf.network.port)
   val peer = Peer.fromSocket(peerSocket)
-
+  val bip39PasswordOpt = None //todo need to prompt user for this
   val startFut = for {
     _ <- conf.initialize()
 
     uninitializedNode <- createNode
     chainApi <- uninitializedNode.chainApiFromDb()
-    wallet <- createWallet(uninitializedNode, chainApi)
+    wallet <- createWallet(uninitializedNode, chainApi, bip39PasswordOpt)
     node <- initializeNode(uninitializedNode, wallet)
 
     _ <- node.start()
@@ -94,13 +94,14 @@ object Main extends App {
 
   private def createWallet(
       nodeApi: Node,
-      chainQueryApi: ChainQueryApi): Future[UnlockedWalletApi] = {
+      chainQueryApi: ChainQueryApi,
+      bip39PasswordOpt: Option[String]): Future[UnlockedWalletApi] = {
     if (hasWallet()) {
       logger.info(s"Using pre-existing wallet")
       val locked = LockedWallet(nodeApi, chainQueryApi)
 
       // TODO change me when we implement proper password handling
-      locked.unlock(BIP39KeyManager.badPassphrase) match {
+      locked.unlock(BIP39KeyManager.badPassphrase,bip39PasswordOpt) match {
         case Right(wallet) =>
           Future.successful(wallet)
         case Left(kmError) =>
@@ -108,8 +109,10 @@ object Main extends App {
       }
     } else {
       logger.info(s"Initializing key manager")
+      val bip39PasswordOpt = None
       val keyManagerE: Either[KeyManagerInitializeError, BIP39KeyManager] =
-        BIP39KeyManager.initialize(walletConf.kmParams)
+        BIP39KeyManager.initialize(kmParams = walletConf.kmParams,
+                                   bip39PasswordOpt = bip39PasswordOpt)
 
       val keyManager = keyManagerE match {
         case Right(keyManager) => keyManager

--- a/docs/applications/wallet.md
+++ b/docs/applications/wallet.md
@@ -111,7 +111,10 @@ val syncF: Future[ChainApi] = configF.flatMap { _ =>
 
 //initialize our key manager, where we store our keys
 import org.bitcoins.keymanager.bip39._
-val keyManager = BIP39KeyManager.initialize(walletConfig.kmParams).getOrElse {
+//you can add a password here if you want
+//val bip39PasswordOpt = Some("my-password-here")
+val bip39PasswordOpt = None
+val keyManager = BIP39KeyManager.initialize(walletConfig.kmParams, bip39PasswordOpt).getOrElse {
   throw new RuntimeException(s"Failed to initalize key manager")
 }
 
@@ -135,7 +138,7 @@ val wallet = Wallet(keyManager, new NodeApi {
     override def getFiltersBetweenHeights(startHeight: Int, endHeight: Int): Future[Vector[FilterResponse]] = Future.successful(Vector.empty)
   })
 val walletF: Future[LockedWalletApi] = configF.flatMap { _ =>
-    Wallet.initialize(wallet)
+  Wallet.initialize(wallet,bip39PasswordOpt)
 }
 
 // when this future completes, ww have sent a transaction

--- a/docs/key-manager/key-manager.md
+++ b/docs/key-manager/key-manager.md
@@ -78,7 +78,7 @@ val network = RegTest
 
 val kmParams = KeyManagerParams(seedPath, purpose, network)
 
-val km = BIP39KeyManager.initializeWithMnemonic(mnemonic, kmParams)
+val km = BIP39KeyManager.initializeWithMnemonic(mnemonic, None, kmParams)
 
 val rootXPub = km.right.get.getRootXPub
 

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerTest.scala
@@ -38,7 +38,8 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
     val kmParams = buildParams()
 
     val keyManager = withInitializedKeyManager(kmParams = kmParams,
-      entropy = mnemonic.toEntropy)
+      entropy = mnemonic.toEntropy,
+      bip39PasswordOpt = None)
 
 
     keyManager.deriveXPub(hdAccount).get.toString must be ("xpub6D36zpm3tLPy3dBCpiScEpmmgsivFBcHxX5oXmPBW982BmLiEkjBEDdswxFUoeXpp272QuSpNKZ3f2TdEMkAHyCz1M7P3gFkYJJVEsM66SE")
@@ -50,7 +51,10 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
 
     val directXpub = direct.getRootXPub
 
-    val api = BIP39KeyManager.initializeWithEntropy(mnemonic.toEntropy, kmParams).right.get
+    val api = BIP39KeyManager.initializeWithEntropy(
+      mnemonic.toEntropy,
+      KeyManagerTestUtil.bip39PasswordOpt,
+      kmParams).right.get
 
     val apiXpub = api.getRootXPub
 
@@ -60,6 +64,43 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
     //we should be able to derive the same child xpub
     assert(api.deriveXPub(hdAccount) == direct.deriveXPub(hdAccount))
   }
+
+  it must "initialize a key manager with a bip39 password to the same xpub if we call constructor directly or use CreateKeyManagerApi" in {
+    val kmParams = buildParams()
+    val bip39Pw = KeyManagerTestUtil.bip39Password
+    val direct = BIP39KeyManager(mnemonic, kmParams,bip39Pw)
+
+    val directXpub = direct.getRootXPub
+
+    val api = BIP39KeyManager.initializeWithEntropy(
+      mnemonic.toEntropy,
+      Some(bip39Pw),
+      kmParams).right.get
+
+    val apiXpub = api.getRootXPub
+
+    assert(apiXpub == directXpub, s"We don't have initialization symmetry between our constructors!")
+
+
+    //we should be able to derive the same child xpub
+    assert(api.deriveXPub(hdAccount) == direct.deriveXPub(hdAccount))
+  }
+
+  it must "NOT initialize a key manager to the same xpub if one has a password and one does not" in {
+    val kmParams = buildParams()
+    val bip39Pw = KeyManagerTestUtil.bip39Password
+
+    val withPassword = BIP39KeyManager(mnemonic, kmParams,bip39Pw)
+    val withPasswordXpub = withPassword.getRootXPub
+
+    val noPassword = BIP39KeyManager(mnemonic, kmParams)
+
+    val noPwXpub = noPassword.getRootXPub
+
+    assert(withPasswordXpub != noPwXpub, s"A key manager with a BIP39 passwrod should not generate the same xpub as a key manager without a password!")
+
+  }
+
 
   it must "return a mnemonic not found if we have not initialized the key manager" in {
     val kmParams = buildParams()
@@ -80,7 +121,10 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
     val badEntropy = BitVector.empty
 
 
-    val init = BIP39KeyManager.initializeWithEntropy(badEntropy, buildParams())
+    val init = BIP39KeyManager.initializeWithEntropy(
+      entropy = badEntropy,
+      bip39PasswordOpt = KeyManagerTestUtil.bip39PasswordOpt,
+      kmParams = buildParams())
 
     assert(init == Left(InitializeKeyManagerError.BadEntropy))
   }

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerTest.scala
@@ -52,9 +52,9 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
     val directXpub = direct.getRootXPub
 
     val api = BIP39KeyManager.initializeWithEntropy(
-      mnemonic.toEntropy,
-      KeyManagerTestUtil.bip39PasswordOpt,
-      kmParams).right.get
+      entropy = mnemonic.toEntropy,
+      bip39PasswordOpt = None,
+      kmParams = kmParams).right.get
 
     val apiXpub = api.getRootXPub
 

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerTest.scala
@@ -47,7 +47,7 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
 
   it must "initialize a key manager to the same xpub if we call constructor directly or use CreateKeyManagerApi" in {
     val kmParams = buildParams()
-    val direct = BIP39KeyManager(mnemonic, kmParams)
+    val direct = BIP39KeyManager(mnemonic, kmParams, None)
 
     val directXpub = direct.getRootXPub
 
@@ -68,7 +68,7 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
   it must "initialize a key manager with a bip39 password to the same xpub if we call constructor directly or use CreateKeyManagerApi" in {
     val kmParams = buildParams()
     val bip39Pw = KeyManagerTestUtil.bip39Password
-    val direct = BIP39KeyManager(mnemonic, kmParams,bip39Pw)
+    val direct = BIP39KeyManager(mnemonic, kmParams,Some(bip39Pw))
 
     val directXpub = direct.getRootXPub
 
@@ -90,10 +90,10 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
     val kmParams = buildParams()
     val bip39Pw = KeyManagerTestUtil.bip39Password
 
-    val withPassword = BIP39KeyManager(mnemonic, kmParams,bip39Pw)
+    val withPassword = BIP39KeyManager(mnemonic, kmParams, Some(bip39Pw))
     val withPasswordXpub = withPassword.getRootXPub
 
-    val noPassword = BIP39KeyManager(mnemonic, kmParams)
+    val noPassword = BIP39KeyManager(mnemonic, kmParams, None)
 
     val noPwXpub = noPassword.getRootXPub
 
@@ -104,7 +104,9 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
 
   it must "return a mnemonic not found if we have not initialized the key manager" in {
     val kmParams = buildParams()
-    val kmE = BIP39KeyManager.fromParams(kmParams, BIP39KeyManager.badPassphrase)
+    val kmE = BIP39KeyManager.fromParams(kmParams = kmParams,
+      password = BIP39KeyManager.badPassphrase,
+      bip39PasswordOpt = None)
 
     assert(kmE == Left(ReadMnemonicError.NotFoundError))
   }

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManagerTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManagerTest.scala
@@ -6,9 +6,15 @@ import org.bitcoins.keymanager.{KeyManagerTestUtil, KeyManagerUnitTest, KeyManag
 class BIP39LockedKeyManagerTest extends KeyManagerUnitTest {
 
   it must "be able to read a locked mnemonic from disk" in {
-    val km = withInitializedKeyManager()
+    val bip39PwOpt = KeyManagerTestUtil.bip39PasswordOpt
+    val km = withInitializedKeyManager(bip39PasswordOpt = bip39PwOpt)
 
-    val unlockedKm = BIP39LockedKeyManager.unlock(KeyManagerTestUtil.badPassphrase, km.kmParams) match {
+    val unlockedE = BIP39LockedKeyManager.unlock(
+      KeyManagerTestUtil.badPassphrase,
+      bip39PasswordOpt = bip39PwOpt,
+      km.kmParams)
+
+    val unlockedKm =  unlockedE match {
       case Right(km) => km
       case Left(err) => fail(s"Failed to unlock key manager ${err}")
     }
@@ -20,7 +26,11 @@ class BIP39LockedKeyManagerTest extends KeyManagerUnitTest {
   it must "fail to read bad json in the seed file" in {
     val km = withInitializedKeyManager()
     val badPassword = AesPassword.fromString("other bad password").get
-    BIP39LockedKeyManager.unlock(passphrase = badPassword, kmParams = km.kmParams) match {
+    val unlockedE = BIP39LockedKeyManager.unlock(passphrase = badPassword,
+      bip39PasswordOpt = None,
+      kmParams = km.kmParams)
+
+    unlockedE match {
       case Left(KeyManagerUnlockError.BadPassword) => succeed
       case result @ (Left(_) | Right(_)) =>
         fail(s"Expected to fail test with ${KeyManagerUnlockError.BadPassword} got ${result}")
@@ -34,7 +44,9 @@ class BIP39LockedKeyManagerTest extends KeyManagerUnitTest {
 
     val badPath = km.kmParams.copy(seedPath = badSeedPath)
     val badPassword = AesPassword.fromString("other bad password").get
-    BIP39LockedKeyManager.unlock(badPassword, badPath) match {
+    val unlockedE = BIP39LockedKeyManager.unlock(badPassword, None, badPath)
+
+    unlockedE match {
       case Left(KeyManagerUnlockError.MnemonicNotFound) => succeed
       case result @ (Left(_) | Right(_)) =>
         fail(s"Expected to fail test with ${KeyManagerUnlockError.MnemonicNotFound} got ${result}")

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/KeyManagerCreateApi.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/KeyManagerCreateApi.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.keymanager
 
 import org.bitcoins.core.crypto.MnemonicCode
+import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import scodec.bits.BitVector
 
 /**
@@ -16,21 +17,29 @@ import scodec.bits.BitVector
   *                           can write it down. They should also be prompted
   *                           to confirm at least parts of the code.
   */
-trait KeyManagerCreateApi[T <: KeyManager] {
+trait BIP39KeyManagerCreateApi {
 
   /**
     * $initialize
     */
   final def initialize(
-      kmParams: KeyManagerParams): Either[KeyManagerInitializeError, T] =
-    initializeWithEntropy(entropy = MnemonicCode.getEntropy256Bits, kmParams)
+      kmParams: KeyManagerParams,
+      bip39PasswordOpt: Option[String]): Either[
+    KeyManagerInitializeError,
+    BIP39KeyManager] =
+    initializeWithEntropy(entropy = MnemonicCode.getEntropy256Bits,
+                          bip39PasswordOpt = bip39PasswordOpt,
+                          kmParams = kmParams)
 
   /**
     * $initializeWithEnt
     */
   def initializeWithEntropy(
       entropy: BitVector,
-      kmParams: KeyManagerParams): Either[KeyManagerInitializeError, T]
+      bip39PasswordOpt: Option[String],
+      kmParams: KeyManagerParams): Either[
+    KeyManagerInitializeError,
+    BIP39KeyManager]
 
   /**
     * Helper method to initialize a [[KeyManagerCreate$ KeyManager]] with a [[MnemonicCode MnemonicCode]]
@@ -41,8 +50,13 @@ trait KeyManagerCreateApi[T <: KeyManager] {
     */
   final def initializeWithMnemonic(
       mnemonicCode: MnemonicCode,
-      kmParams: KeyManagerParams): Either[KeyManagerInitializeError, T] = {
+      bip39PasswordOpt: Option[String],
+      kmParams: KeyManagerParams): Either[
+    KeyManagerInitializeError,
+    BIP39KeyManager] = {
     val entropy = mnemonicCode.toEntropy
-    initializeWithEntropy(entropy = entropy, kmParams)
+    initializeWithEntropy(entropy = entropy,
+                          bip39PasswordOpt = bip39PasswordOpt,
+                          kmParams = kmParams)
   }
 }

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -22,11 +22,12 @@ import scala.util.{Failure, Success, Try}
   */
 case class BIP39KeyManager(
     private val mnemonic: MnemonicCode,
-    kmParams: KeyManagerParams)
+    kmParams: KeyManagerParams,
+    private val bip39Password: String = BIP39Seed.EMPTY_PASSWORD)
     extends KeyManager {
 
-  private val seed = BIP39Seed.fromMnemonic(mnemonic = mnemonic,
-                                            password = BIP39Seed.EMPTY_PASSWORD)
+  private val seed =
+    BIP39Seed.fromMnemonic(mnemonic = mnemonic, password = bip39Password)
 
   private val privVersion: ExtKeyPrivVersion =
     HDUtil.getXprivVersion(kmParams.purpose, kmParams.network)
@@ -53,14 +54,13 @@ case class BIP39KeyManager(
   }
 }
 
-object BIP39KeyManager
-    extends KeyManagerCreateApi[BIP39KeyManager]
-    with BitcoinSLogger {
+object BIP39KeyManager extends BIP39KeyManagerCreateApi with BitcoinSLogger {
   val badPassphrase = AesPassword.fromString("changeMe").get
 
   /** Initializes the mnemonic seed and saves it to file */
   override def initializeWithEntropy(
       entropy: BitVector,
+      bip39PasswordOpt: Option[String],
       kmParams: KeyManagerParams): Either[
     KeyManagerInitializeError,
     BIP39KeyManager] = {
@@ -99,10 +99,22 @@ object BIP39KeyManager
           logger.info(s"Saved encrypted wallet mnemonic to $mnemonicPath")
         }
 
-      } yield BIP39KeyManager(mnemonic = mnemonic, kmParams = kmParams)
+      } yield {
+        bip39PasswordOpt match {
+          case Some(pw) =>
+            BIP39KeyManager(mnemonic = mnemonic,
+                            kmParams = kmParams,
+                            bip39Password = pw)
+          case None => BIP39KeyManager(mnemonic = mnemonic, kmParams = kmParams)
+        }
+
+      }
 
     //verify we can unlock it for a sanity check
-    val unlocked = BIP39LockedKeyManager.unlock(badPassphrase, kmParams)
+    val unlocked = BIP39LockedKeyManager.unlock(passphrase = badPassphrase,
+                                                bip39PasswordOpt =
+                                                  bip39PasswordOpt,
+                                                kmParams = kmParams)
 
     val biasedFinalE: CompatEither[KeyManagerInitializeError, BIP39KeyManager] =
       for {

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
@@ -28,12 +28,7 @@ object BIP39LockedKeyManager extends BitcoinSLogger {
       WalletStorage.decryptMnemonicFromDisk(kmParams.seedPath, passphrase)
     resultE match {
       case Right(mnemonicCode) =>
-        bip39PasswordOpt match {
-          case Some(pw) =>
-            Right(new BIP39KeyManager(mnemonicCode, kmParams, pw))
-          case None =>
-            Right(new BIP39KeyManager(mnemonicCode, kmParams))
-        }
+        Right(BIP39KeyManager(mnemonicCode, kmParams, bip39PasswordOpt))
 
       case Left(result) =>
         result match {

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
@@ -17,7 +17,10 @@ object BIP39LockedKeyManager extends BitcoinSLogger {
     * @param kmParams parameters needed to create the key manager
     *
     * */
-  def unlock(passphrase: AesPassword, kmParams: KeyManagerParams): Either[
+  def unlock(
+      passphrase: AesPassword,
+      bip39PasswordOpt: Option[String],
+      kmParams: KeyManagerParams): Either[
     KeyManagerUnlockError,
     BIP39KeyManager] = {
     logger.debug(s"Trying to unlock wallet with seedPath=${kmParams.seedPath}")
@@ -25,7 +28,13 @@ object BIP39LockedKeyManager extends BitcoinSLogger {
       WalletStorage.decryptMnemonicFromDisk(kmParams.seedPath, passphrase)
     resultE match {
       case Right(mnemonicCode) =>
-        Right(new BIP39KeyManager(mnemonicCode, kmParams))
+        bip39PasswordOpt match {
+          case Some(pw) =>
+            Right(new BIP39KeyManager(mnemonicCode, kmParams, pw))
+          case None =>
+            Right(new BIP39KeyManager(mnemonicCode, kmParams))
+        }
+
       case Left(result) =>
         result match {
           case DecryptionError =>

--- a/testkit/src/main/scala/org/bitcoins/keymanager/KeyManagerTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/keymanager/KeyManagerTestUtil.scala
@@ -2,9 +2,13 @@ package org.bitcoins.keymanager
 
 import java.nio.file.Path
 
+import org.bitcoins.core.config.Networks
 import org.bitcoins.core.crypto.AesPassword
+import org.bitcoins.core.hd.HDPurposes
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.core.gen.CryptoGenerators
+import org.scalacheck.Gen
 
 object KeyManagerTestUtil {
 
@@ -13,6 +17,25 @@ object KeyManagerTestUtil {
     BitcoinSTestAppConfig
       .tmpDir()
       .resolve(WalletStorage.ENCRYPTED_SEED_FILE_NAME)
+  }
+
+  def createKeyManagerParams(): KeyManagerParams = {
+    val seedPath = KeyManagerTestUtil.tmpSeedPath
+    KeyManagerParams(seedPath = seedPath,
+                     purpose = Gen.oneOf(HDPurposes.all).sample.get,
+                     network = Gen.oneOf(Networks.knownNetworks).sample.get)
+  }
+
+  def bip39PasswordOpt: Option[String] = {
+    if (scala.util.Random.nextBoolean()) {
+      Some(bip39Password)
+    } else {
+      None
+    }
+  }
+
+  def bip39Password: String = {
+    CryptoGenerators.bip39Password.sample.get
   }
 
   val badPassphrase: AesPassword = BIP39KeyManager.badPassphrase

--- a/testkit/src/main/scala/org/bitcoins/keymanager/KeyManagerUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/keymanager/KeyManagerUnitTest.scala
@@ -1,27 +1,19 @@
 package org.bitcoins.keymanager
 
-import org.bitcoins.core.config.Networks
 import org.bitcoins.core.crypto.MnemonicCode
-import org.bitcoins.core.hd.HDPurposes
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.testkit.util.BitcoinSUnitTest
-import org.scalacheck.Gen
 import scodec.bits.BitVector
 
 trait KeyManagerUnitTest extends BitcoinSUnitTest {
 
-  def createKeyManagerParams(): KeyManagerParams = {
-    val seedPath = KeyManagerTestUtil.tmpSeedPath
-    KeyManagerParams(seedPath = seedPath,
-                     purpose = Gen.oneOf(HDPurposes.all).sample.get,
-                     network = Gen.oneOf(Networks.knownNetworks).sample.get)
-  }
-
   def withInitializedKeyManager(
-      kmParams: KeyManagerParams = createKeyManagerParams(),
-      entropy: BitVector = MnemonicCode.getEntropy256Bits): BIP39KeyManager = {
+      kmParams: KeyManagerParams = KeyManagerTestUtil.createKeyManagerParams(),
+      entropy: BitVector = MnemonicCode.getEntropy256Bits,
+      bip39PasswordOpt: Option[String] = KeyManagerTestUtil.bip39PasswordOpt): BIP39KeyManager = {
     val kmResult = BIP39KeyManager.initializeWithEntropy(
       entropy = entropy,
+      bip39PasswordOpt = bip39PasswordOpt,
       kmParams = kmParams
     )
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CryptoGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CryptoGenerators.scala
@@ -99,6 +99,13 @@ sealed abstract class CryptoGenerators {
       code <- mnemonicCode
     } yield BIP39Seed.fromMnemonic(code)
 
+  /** Generates a password that can be used with bip39
+    * @see https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#From_mnemonic_to_seed
+    */
+  def bip39Password: Gen[String] = {
+    Gen.asciiStr
+  }
+
   /**
     * Generates a valid BIP39 seed from
     * an mnemonic with a random password
@@ -106,7 +113,7 @@ sealed abstract class CryptoGenerators {
   def bip39SeedWithPassword: Gen[BIP39Seed] =
     for {
       code <- mnemonicCode
-      pass <- Gen.alphaStr
+      pass <- bip39Password
     } yield BIP39Seed.fromMnemonic(code, pass)
 
   def privateKey: Gen[ECPrivateKey] = Gen.delay(ECPrivateKey())

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -228,7 +228,6 @@ object BitcoinSWalletTest extends WalletLogger {
       Future.successful(Vector.empty)
   }
 
-
   case class WalletWithBitcoind(
       wallet: UnlockedWalletApi,
       bitcoind: BitcoindRpcClient)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -10,6 +10,7 @@ import org.bitcoins.core.gcs.BlockFilter
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.db.AppConfig
+import org.bitcoins.keymanager.KeyManagerTestUtil
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.server.BitcoinSAppConfig
@@ -221,13 +222,16 @@ object BitcoinSWalletTest extends WalletLogger {
       Future.successful(Vector.empty)
   }
 
+
   case class WalletWithBitcoind(
       wallet: UnlockedWalletApi,
       bitcoind: BitcoindRpcClient)
 
   private def createNewKeyManager()(
       implicit config: BitcoinSAppConfig): BIP39KeyManager = {
-    val keyManagerE = BIP39KeyManager.initialize(config.walletConf.kmParams)
+    val keyManagerE = BIP39KeyManager.initialize(
+      kmParams = config.walletConf.kmParams,
+      bip39PasswordOpt = KeyManagerTestUtil.bip39PasswordOpt)
     keyManagerE match {
       case Right(keyManager) => keyManager
       case Left(err) =>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.wallet
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.bitcoins.core.api.ChainQueryApi
+import org.bitcoins.rpc.serializers.JsonSerializers._
 import org.bitcoins.core.crypto.{ExtPublicKey, MnemonicCode}
 import org.bitcoins.core.hd._
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -11,6 +11,7 @@ import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.fixtures.EmptyFixture
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{MockChainQueryApi, MockNodeApi}
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.models.{AccountDb, AddressDb}
 import org.scalatest.compatible.Assertion
@@ -141,7 +142,7 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
     kmE match {
       case Left(err) => Future.failed(new RuntimeException(s"Failed to initialize km with err=${err}"))
       case Right(km) =>
-        val wallet = Wallet(km, NodeApi.NoOp, ChainQueryApi.NoOp)(config, ec)
+        val wallet = Wallet(km, MockNodeApi, MockChainQueryApi)(config, ec)
         val walletF = Wallet.initialize(wallet = wallet,
           bip39PasswordOpt = bip39PasswordOpt)(config,ec)
         walletF

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -153,8 +153,8 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
   private def getWallet(config: WalletAppConfig)(
       implicit ec: ExecutionContext): Future[Wallet] = {
     val kmE =
-      BIP39KeyManager.initializeWithEntropy(mnemonic.toEntropy, config.kmParams)
-    kmE match {
+      BIP39KeyManager.initializeWithEntropy(mnemonic.toEntropy, None, config.kmParams)
+   kmE match {
       case Left(err) =>
         Future.failed(
           new RuntimeException(s"Failed to initialize km with err=${err}"))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -1,33 +1,16 @@
 package org.bitcoins.wallet
 
+import com.typesafe.config.{Config, ConfigFactory}
+import org.bitcoins.core.api.ChainQueryApi
 import org.bitcoins.core.crypto.{ExtPublicKey, MnemonicCode}
-
-import play.api.libs.json.JsValue
-import play.api.libs.json.Json
-import org.bitcoins.core.hd.HDCoinType
-import org.bitcoins.core.hd.HDPurpose
-import org.bitcoins.core.hd.HDPath
+import org.bitcoins.core.hd._
 import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.rpc.serializers.JsonSerializers._
-import play.api.libs.json.Reads
-import play.api.libs.json.JsResult
-import play.api.libs.json.JsError
-import play.api.libs.json.JsSuccess
-import org.bitcoins.core.hd.HDChainType
-import org.bitcoins.core.hd.HDPurposes
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.keymanager.KeyManagerParams
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.fixtures.EmptyFixture
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
-  MockChainQueryApi,
-  MockNodeApi
-}
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.models.{AccountDb, AddressDb}
 import org.scalatest.compatible.Assertion
@@ -150,17 +133,17 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
     ConfigFactory.parseString(confStr)
   }
 
-  private def getWallet(config: WalletAppConfig)(
-      implicit ec: ExecutionContext): Future[Wallet] = {
-    val kmE =
-      BIP39KeyManager.initializeWithEntropy(mnemonic.toEntropy, None, config.kmParams)
-   kmE match {
-      case Left(err) =>
-        Future.failed(
-          new RuntimeException(s"Failed to initialize km with err=${err}"))
+  private def getWallet(config: WalletAppConfig)(implicit ec: ExecutionContext): Future[Wallet] = {
+    val bip39PasswordOpt = None
+    val kmE = BIP39KeyManager.initializeWithEntropy(entropy = mnemonic.toEntropy,
+      bip39PasswordOpt = bip39PasswordOpt,
+      kmParams = config.kmParams)
+    kmE match {
+      case Left(err) => Future.failed(new RuntimeException(s"Failed to initialize km with err=${err}"))
       case Right(km) =>
-        val wallet = Wallet(km, MockNodeApi, MockChainQueryApi)(config, ec)
-        val walletF = Wallet.initialize(wallet)(config, ec)
+        val wallet = Wallet(km, NodeApi.NoOp, ChainQueryApi.NoOp)(config, ec)
+        val walletF = Wallet.initialize(wallet = wallet,
+          bip39PasswordOpt = bip39PasswordOpt)(config,ec)
         walletF
     }
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -146,7 +146,8 @@ class WalletUnitTest extends BitcoinSWalletTest {
   it should "fail to unlock the wallet with a bad password" in {
     wallet: UnlockedWalletApi =>
       val badpassphrase = AesPassword.fromNonEmptyString("bad")
-      val errorType = wallet.unlock(badpassphrase) match {
+
+      val errorType = wallet.unlock(badpassphrase, None) match {
         case Right(_)  => fail("Unlocked wallet with bad password!")
         case Left(err) => err
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -181,7 +181,7 @@ object Wallet extends WalletLogger {
       }
   }
 
-  def initialize(wallet: Wallet)(
+  def initialize(wallet: Wallet, bip39PasswordOpt: Option[String])(
       implicit walletAppConfig: WalletAppConfig,
       ec: ExecutionContext): Future[Wallet] = {
     // We want to make sure all level 0 accounts are created,
@@ -194,8 +194,11 @@ object Wallet extends WalletLogger {
         //we need to create key manager params for each purpose
         //and then initialize a key manager to derive the correct xpub
         val kmParams = wallet.keyManager.kmParams.copy(purpose = purpose)
-        val kmE =
-          BIP39KeyManager.fromParams(kmParams, BIP39KeyManager.badPassphrase)
+        val kmE = {
+          BIP39KeyManager.fromParams(kmParams = kmParams,
+                                     password = BIP39KeyManager.badPassphrase,
+                                     bip39PasswordOpt = bip39PasswordOpt)
+        }
         kmE match {
           case Right(km) => createRootAccount(wallet = wallet, keyManager = km)
           case Left(err) =>

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -184,13 +184,15 @@ trait LockedWalletApi extends WalletApi {
     * Unlocks the wallet with the provided passphrase,
     * making it possible to send transactions.
     */
-  def unlock(passphrase: AesPassword): Either[
+  def unlock(passphrase: AesPassword, bip39PasswordOpt: Option[String]): Either[
     KeyManagerUnlockError,
     UnlockedWalletApi] = {
     val kmParams = walletConfig.kmParams
 
     val unlockedKeyManagerE =
-      BIP39LockedKeyManager.unlock(passphrase, kmParams)
+      BIP39LockedKeyManager.unlock(passphrase = passphrase,
+                                   bip39PasswordOpt = bip39PasswordOpt,
+                                   kmParams = kmParams)
     unlockedKeyManagerE match {
       case Right(km) =>
         val w = Wallet(keyManager = km,


### PR DESCRIPTION
…eds to be password through our various projects to be able to correctly generate the key that controls the wallet. This also renames 'CreateKeyManagerApi' -> 'BIP39CreateKeymanagerApi' as the bip39 password is needed when creating the KeyManager

This partially addresses #972 . However there are still problems where we are requiring two passwords in certain places -- one to encrypt the mnemonic on disk and one to properly generate the root `xpriv` key. This needs to be thought out more, and it won't be done on this PR.