### PR TITLE
WIP: Multi-Party TxBuilder

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -94,8 +94,8 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
       hashType = HashType.sigHashAll,
       conditionalPath = ConditionalPath.NoConditionsLeft
     )
-    val feeUnit = SatoshisPerVirtualByte(Satoshis(-1))
     assertThrows[IllegalArgumentException] {
+      val feeUnit = SatoshisPerVirtualByte(Satoshis(-1))
       val _ = BitcoinTxBuilder(destinations = destinations,
                                utxos = Vector(utxo),
                                feeRate = feeUnit,

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -83,8 +83,6 @@ sealed abstract class TxBuilder {
     * should pay for this transaction */
   def feeRate: FeeUnit
 
-  require(feeRate.toLong > 0L, "Specified fee was too low")
-
   /**
     * This is where all the money that is NOT sent to destination outputs is spent too.
     * If we don't specify a change output, a large miner fee may be paid as more than likely

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -12,6 +12,8 @@ sealed abstract class FeeUnit {
   def *(tx: Transaction): CurrencyUnit = calc(tx)
   def calc(tx: Transaction): CurrencyUnit = Satoshis(tx.vsize * toLong)
   def toLong: Long = currencyUnit.satoshis.toLong
+
+  require(toLong > 0L, "Fee must be positive")
 }
 
 /**

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -33,16 +33,15 @@ sealed abstract class Wallet extends LockedWallet with UnlockedWalletApi {
     LockedWallet(nodeApi, chainQueryApi)
   }
 
-  override def sendToAddress(
-      address: BitcoinAddress,
-      amount: CurrencyUnit,
-      feeRate: FeeUnit,
-      fromAccount: AccountDb): Future[Transaction] = {
+  override def sendToAddress(address: BitcoinAddress,
+                             amount: CurrencyUnit,
+                             feeRate: FeeUnit,
+                             fromAccount: AccountDb): Future[Transaction] = {
     logger.info(s"Sending $amount to $address at feerate $feeRate")
     for {
       change <- getNewChangeAddress(fromAccount)
       walletUtxos <- listUtxos()
-      txBuilder <- {
+      txBuilder = {
         val destinations = Vector(
           TransactionOutput(amount, address.scriptPubKey))
 
@@ -150,12 +149,10 @@ object Wallet extends WalletLogger {
       override val ec: ExecutionContext
   ) extends Wallet
 
-  def apply(
-      keyManager: BIP39KeyManager,
-      nodeApi: NodeApi,
-      chainQueryApi: ChainQueryApi)(
-      implicit config: WalletAppConfig,
-      ec: ExecutionContext): Wallet = {
+  def apply(keyManager: BIP39KeyManager,
+            nodeApi: NodeApi,
+            chainQueryApi: ChainQueryApi)(implicit config: WalletAppConfig,
+                                          ec: ExecutionContext): Wallet = {
     WalletImpl(keyManager, nodeApi, chainQueryApi)
   }
 
@@ -181,9 +178,8 @@ object Wallet extends WalletLogger {
       }
   }
 
-  def initialize(wallet: Wallet)(
-      implicit walletAppConfig: WalletAppConfig,
-      ec: ExecutionContext): Future[Wallet] = {
+  def initialize(wallet: Wallet)(implicit walletAppConfig: WalletAppConfig,
+                                 ec: ExecutionContext): Future[Wallet] = {
     // We want to make sure all level 0 accounts are created,
     // so the user can change the default account kind later
     // and still have their wallet work

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -33,10 +33,11 @@ sealed abstract class Wallet extends LockedWallet with UnlockedWalletApi {
     LockedWallet(nodeApi, chainQueryApi)
   }
 
-  override def sendToAddress(address: BitcoinAddress,
-                             amount: CurrencyUnit,
-                             feeRate: FeeUnit,
-                             fromAccount: AccountDb): Future[Transaction] = {
+  override def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb): Future[Transaction] = {
     logger.info(s"Sending $amount to $address at feerate $feeRate")
     for {
       change <- getNewChangeAddress(fromAccount)
@@ -149,10 +150,12 @@ object Wallet extends WalletLogger {
       override val ec: ExecutionContext
   ) extends Wallet
 
-  def apply(keyManager: BIP39KeyManager,
-            nodeApi: NodeApi,
-            chainQueryApi: ChainQueryApi)(implicit config: WalletAppConfig,
-                                          ec: ExecutionContext): Wallet = {
+  def apply(
+      keyManager: BIP39KeyManager,
+      nodeApi: NodeApi,
+      chainQueryApi: ChainQueryApi)(
+      implicit config: WalletAppConfig,
+      ec: ExecutionContext): Wallet = {
     WalletImpl(keyManager, nodeApi, chainQueryApi)
   }
 
@@ -178,8 +181,9 @@ object Wallet extends WalletLogger {
       }
   }
 
-  def initialize(wallet: Wallet)(implicit walletAppConfig: WalletAppConfig,
-                                 ec: ExecutionContext): Future[Wallet] = {
+  def initialize(wallet: Wallet)(
+      implicit walletAppConfig: WalletAppConfig,
+      ec: ExecutionContext): Future[Wallet] = {
     // We want to make sure all level 0 accounts are created,
     // so the user can change the default account kind later
     // and still have their wallet work


### PR DESCRIPTION
Built on top of #995 

Attempts to allow for constructing txs where you are only one of many parties involved.

This is done by introducing a new `BitcoinUTXOSpendingInfo` which bypasses signing.

TODO:
- [ ] Tests
- [ ] Segwit Support