### PR TITLE
Add more expressive txo states for the wallet

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/TxoStateTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/TxoStateTest.scala
@@ -9,11 +9,11 @@ class TxoStateTest extends BitcoinSUnitTest {
   it must "read from string" in {
     TxoState.fromString("doesnotexist").get must be (TxoState.DoesNotExist)
 
-    TxoState.fromString("PendingReceived").get must be (TxoState.PendingReceived)
+    TxoState.fromString("PendingReceived").get must be (TxoState.UnconfirmedReceived)
 
     TxoState.fromString("ConfirmedReceived").get must be (TxoState.ConfirmedReceived)
 
-    TxoState.fromString("PendingSpent").get must be (TxoState.PendingSpent)
+    TxoState.fromString("PendingSpent").get must be (TxoState.UnconfirmedSpent)
 
     TxoState.fromString("ConfirmedSpent").get must be (TxoState.ConfirmedSpent)
   }

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/TxoStateTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/TxoStateTest.scala
@@ -1,0 +1,20 @@
+package org.bitcoins.core.wallet.utxo
+
+import org.bitcoins.testkit.util.BitcoinSUnitTest
+
+class TxoStateTest extends BitcoinSUnitTest {
+
+  behavior of "TxoState"
+
+  it must "read from string" in {
+    TxoState.fromString("doesnotexist").get must be (TxoState.DoesNotExist)
+
+    TxoState.fromString("PendingReceived").get must be (TxoState.PendingReceived)
+
+    TxoState.fromString("ConfirmedReceived").get must be (TxoState.ConfirmedReceived)
+
+    TxoState.fromString("PendingSpent").get must be (TxoState.PendingSpent)
+
+    TxoState.fromString("ConfirmedSpent").get must be (TxoState.ConfirmedSpent)
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/TxoStateTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/TxoStateTest.scala
@@ -9,11 +9,11 @@ class TxoStateTest extends BitcoinSUnitTest {
   it must "read from string" in {
     TxoState.fromString("doesnotexist").get must be (TxoState.DoesNotExist)
 
-    TxoState.fromString("PendingReceived").get must be (TxoState.UnconfirmedReceived)
+    TxoState.fromString("PendingConfirmationsReceived").get must be (TxoState.PendingConfirmationsReceived)
 
     TxoState.fromString("ConfirmedReceived").get must be (TxoState.ConfirmedReceived)
 
-    TxoState.fromString("PendingSpent").get must be (TxoState.UnconfirmedSpent)
+    TxoState.fromString("PendingConfirmationsSpent").get must be (TxoState.PendingConfirmationsSpent)
 
     TxoState.fromString("ConfirmedSpent").get must be (TxoState.ConfirmedSpent)
   }

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -322,6 +322,11 @@ sealed abstract class NumberUtil extends BitcoinSLogger {
       (nWord > UInt32(0xffff) && nSize > 32)
     )
   }
+
+  /** Generates a random positive integer */
+  def posInt: Int = {
+    Math.abs(scala.util.Random.nextInt())
+  }
 }
 
 object NumberUtil extends NumberUtil

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -325,7 +325,7 @@ sealed abstract class NumberUtil extends BitcoinSLogger {
 
   /** Generates a random positive integer */
   def posInt: Int = {
-    Math.abs(scala.util.Random.nextInt())
+    scala.util.Random.between(0, Int.MaxValue)
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -325,7 +325,7 @@ sealed abstract class NumberUtil extends BitcoinSLogger {
 
   /** Generates a random positive integer */
   def posInt: Int = {
-    scala.util.Random.between(0, Int.MaxValue)
+    Math.abs(scala.util.Random.nextInt())
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
@@ -13,21 +13,21 @@ object TxoState {
   final case object DoesNotExist extends TxoState
 
   /** Means we have received funds to this utxo, but they are not confirmed */
-  final case object UnconfirmedReceived extends ReceivedState
+  final case object PendingConfirmationsReceived extends ReceivedState
 
   /** Means we have received funds and they are fully confirmed for this utxo */
   final case object ConfirmedReceived extends ReceivedState
 
   /** Means we have spent this utxo, but it is not fully confirmed */
-  final case object UnconfirmedSpent extends SpentState
+  final case object PendingConfirmationsSpent extends SpentState
 
   /** Means we have spent this utxo, and it is fully confirmed */
   final case object ConfirmedSpent extends SpentState
 
   val all: Vector[TxoState] = Vector(DoesNotExist,
-                                     UnconfirmedReceived,
+                                     PendingConfirmationsReceived,
                                      ConfirmedReceived,
-                                     UnconfirmedSpent,
+                                     PendingConfirmationsSpent,
                                      ConfirmedSpent)
 
   def fromString(str: String): Option[TxoState] = {

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
@@ -1,0 +1,36 @@
+package org.bitcoins.core.wallet.utxo
+
+/** Represents the various states a transaction output can be in */
+sealed abstract class TxoState
+
+sealed abstract class ReceivedState extends TxoState
+
+sealed abstract class SpentState extends TxoState
+
+object TxoState {
+
+  /** Means that no funds have been sent to this utxo EVER */
+  final case object DoesNotExist extends TxoState
+
+  /** Means we have received funds to this utxo, but they are not confirmed */
+  final case object PendingReceived extends ReceivedState
+
+  /** Means we have received funds and they are fully confirmed for this utxo */
+  final case object ConfirmedReceived extends ReceivedState
+
+  /** Means we have spent this utxo, but it is not fully confirmed */
+  final case object PendingSpent extends SpentState
+
+  /** Means we have spent this utxo, and it is fully confirmed */
+  final case object ConfirmedSpent extends SpentState
+
+  val all: Vector[TxoState] = Vector(DoesNotExist,
+                                     PendingReceived,
+                                     ConfirmedReceived,
+                                     PendingSpent,
+                                     ConfirmedSpent)
+
+  def fromString(str: String): Option[TxoState] = {
+    all.find(state => str.toLowerCase() == state.toString.toLowerCase)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
@@ -13,21 +13,21 @@ object TxoState {
   final case object DoesNotExist extends TxoState
 
   /** Means we have received funds to this utxo, but they are not confirmed */
-  final case object PendingReceived extends ReceivedState
+  final case object UnconfirmedReceived extends ReceivedState
 
   /** Means we have received funds and they are fully confirmed for this utxo */
   final case object ConfirmedReceived extends ReceivedState
 
   /** Means we have spent this utxo, but it is not fully confirmed */
-  final case object PendingSpent extends SpentState
+  final case object UnconfirmedSpent extends SpentState
 
   /** Means we have spent this utxo, and it is fully confirmed */
   final case object ConfirmedSpent extends SpentState
 
   val all: Vector[TxoState] = Vector(DoesNotExist,
-                                     PendingReceived,
+                                     UnconfirmedReceived,
                                      ConfirmedReceived,
-                                     PendingSpent,
+                                     UnconfirmedSpent,
                                      ConfirmedSpent)
 
   def fromString(str: String): Option[TxoState] = {

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -14,6 +14,7 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.script.ScriptType
 import org.bitcoins.core.serializers.script.RawScriptWitnessParser
+import org.bitcoins.core.wallet.utxo.TxoState
 import scodec.bits.ByteVector
 import slick.jdbc.GetResult
 import slick.jdbc.SQLiteProfile.api._
@@ -160,6 +161,11 @@ abstract class DbCommonsColumnMappers {
   implicit val filterTypeMapper: BaseColumnType[FilterType] =
     MappedColumnType
       .base[FilterType, Short](FilterType.getCode, FilterType.byCode)
+
+  implicit val txoStateMapper: BaseColumnType[TxoState] = {
+    MappedColumnType
+      .base[TxoState, String](_.toString, TxoState.fromString(_).get)
+  }
 }
 
 object DbCommonsColumnMappers extends DbCommonsColumnMappers

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -19,7 +19,8 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
-import org.bitcoins.core.util.CryptoUtil
+import org.bitcoins.core.util.{CryptoUtil, NumberUtil}
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.{CryptoGenerators, NumberGenerator}
 import org.bitcoins.testkit.fixtures.WalletDAOs
@@ -79,7 +80,10 @@ object WalletTestUtil {
   private def randomBlockHash =
     CryptoGenerators.doubleSha256Digest.sampleSome.flip
 
-  private def randomSpent: Boolean = math.random > 0.5
+  private def randomState: TxoState = {
+    val idx = NumberUtil.posInt % TxoState.all.length
+    TxoState.all(idx)
+  }
 
   def sampleSegwitUTXO(spk: ScriptPubKey): SegwitV0SpendingInfo = {
     val outpoint = TransactionOutPoint(randomTXID, randomVout)
@@ -88,7 +92,7 @@ object WalletTestUtil {
     val scriptWitness = randomScriptWitness
     val privkeyPath = WalletTestUtil.sampleSegwitPath
     SegwitV0SpendingInfo(
-      spent = randomSpent,
+      state = randomState,
       txid = randomTXID,
       outPoint = outpoint,
       output = output,
@@ -104,7 +108,7 @@ object WalletTestUtil {
     val output =
       TransactionOutput(1.bitcoin, spk)
     val privKeyPath = WalletTestUtil.sampleLegacyPath
-    LegacySpendingInfo(spent = randomSpent,
+    LegacySpendingInfo(state = randomState,
                        txid = randomTXID,
                        outPoint = outpoint,
                        output = output,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
@@ -4,12 +4,9 @@ import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerByte}
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.testkit.Implicits._
-import org.bitcoins.testkit.core.gen.{
-  CryptoGenerators,
-  TransactionGenerators,
-  WitnessGenerators
-}
+import org.bitcoins.testkit.core.gen.{CryptoGenerators, TransactionGenerators, WitnessGenerators}
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 import org.bitcoins.wallet.models.{SegwitV0SpendingInfo, SpendingInfoDb}
 import org.scalatest.FutureOutcome
@@ -32,7 +29,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
 
     val utxo1 = SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
-      spent = false,
+      state = TxoState.DoesNotExist,
       id = Some(1),
       outPoint = TransactionGenerators.outPoint.sampleSome,
       output = TransactionOutput(10.sats, ScriptPubKey.empty),
@@ -42,7 +39,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
     )
     val utxo2 = SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
-      spent = false,
+      state = TxoState.DoesNotExist,
       id = Some(2),
       outPoint = TransactionGenerators.outPoint.sampleSome,
       output = TransactionOutput(90.sats, ScriptPubKey.empty),
@@ -52,7 +49,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
     )
     val utxo3 = SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
-      spent = false,
+      state = TxoState.DoesNotExist,
       id = Some(3),
       outPoint = TransactionGenerators.outPoint.sampleSome,
       output = TransactionOutput(20.sats, ScriptPubKey.empty),

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
@@ -81,10 +81,10 @@ class SpendingInfoDAOTest extends BitcoinSWalletTest with WalletDAOFixture {
     val WalletDAOs(_, _, spendingInfoDAO) = daos
     for {
       utxo <- WalletTestUtil.insertSegWitUTXO(daos)
-      updated <- spendingInfoDAO.update(utxo.copy(state = TxoState.PendingReceived))
+      updated <- spendingInfoDAO.update(utxo.copy(state = TxoState.UnconfirmedReceived))
       unspent <- spendingInfoDAO.findAllUnspent()
       updated <- spendingInfoDAO.updateTxoState(outputs = unspent.map(_.output),
-        state = TxoState.PendingSpent)
+        state = TxoState.UnconfirmedSpent)
       unspentPostUpdate <- spendingInfoDAO.findAllUnspent()
     } yield {
       assert(unspent.nonEmpty)
@@ -97,7 +97,7 @@ class SpendingInfoDAOTest extends BitcoinSWalletTest with WalletDAOFixture {
     val WalletDAOs(_, _, spendingInfoDAO) = daos
     for {
       utxo <- WalletTestUtil.insertLegacyUTXO(daos)
-      state = utxo.copy(state = TxoState.PendingReceived)
+      state = utxo.copy(state = TxoState.UnconfirmedReceived)
       updated <- spendingInfoDAO.update(state)
       unspent <- spendingInfoDAO.findAllUnspent()
     } yield {
@@ -112,7 +112,7 @@ class SpendingInfoDAOTest extends BitcoinSWalletTest with WalletDAOFixture {
     val WalletDAOs(_, _, spendingInfoDAO) = daos
     for {
       utxo <- WalletTestUtil.insertLegacyUTXO(daos)
-      state = utxo.copy(state = TxoState.PendingSpent)
+      state = utxo.copy(state = TxoState.UnconfirmedSpent)
       updated <- spendingInfoDAO.update(state)
       unspent <- spendingInfoDAO.findAllUnspent()
     } yield assert(unspent.isEmpty)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
@@ -1,18 +1,12 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.core.currency._
-import org.bitcoins.core.protocol.transaction.{TransactionOutPoint, TransactionOutput}
-import org.bitcoins.testkit.fixtures.WalletDAOFixture
-import org.bitcoins.wallet.Wallet
-import org.bitcoins.testkit.wallet.WalletTestUtil
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.testkit.fixtures.WalletDAOs
-import org.bitcoins.testkit.core.gen.TransactionGenerators
-import org.bitcoins.core.protocol.transaction.TransactionInput
 import org.bitcoins.core.protocol.script.ScriptSignature
-import org.bitcoins.core.protocol.transaction.BaseTransaction
+import org.bitcoins.core.protocol.transaction.{BaseTransaction, TransactionInput}
 import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.testkit.Implicits._
+import org.bitcoins.testkit.core.gen.TransactionGenerators
+import org.bitcoins.testkit.fixtures.{WalletDAOFixture, WalletDAOs}
+import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 
 class SpendingInfoDAOTest extends BitcoinSWalletTest with WalletDAOFixture {
   behavior of "SpendingInfoDAO"
@@ -81,10 +75,10 @@ class SpendingInfoDAOTest extends BitcoinSWalletTest with WalletDAOFixture {
     val WalletDAOs(_, _, spendingInfoDAO) = daos
     for {
       utxo <- WalletTestUtil.insertSegWitUTXO(daos)
-      updated <- spendingInfoDAO.update(utxo.copy(state = TxoState.UnconfirmedReceived))
+      updated <- spendingInfoDAO.update(utxo.copy(state = TxoState.PendingConfirmationsReceived))
       unspent <- spendingInfoDAO.findAllUnspent()
       updated <- spendingInfoDAO.updateTxoState(outputs = unspent.map(_.output),
-        state = TxoState.UnconfirmedSpent)
+        state = TxoState.PendingConfirmationsSpent)
       unspentPostUpdate <- spendingInfoDAO.findAllUnspent()
     } yield {
       assert(unspent.nonEmpty)
@@ -97,7 +91,7 @@ class SpendingInfoDAOTest extends BitcoinSWalletTest with WalletDAOFixture {
     val WalletDAOs(_, _, spendingInfoDAO) = daos
     for {
       utxo <- WalletTestUtil.insertLegacyUTXO(daos)
-      state = utxo.copy(state = TxoState.UnconfirmedReceived)
+      state = utxo.copy(state = TxoState.PendingConfirmationsReceived)
       updated <- spendingInfoDAO.update(state)
       unspent <- spendingInfoDAO.findAllUnspent()
     } yield {
@@ -112,7 +106,7 @@ class SpendingInfoDAOTest extends BitcoinSWalletTest with WalletDAOFixture {
     val WalletDAOs(_, _, spendingInfoDAO) = daos
     for {
       utxo <- WalletTestUtil.insertLegacyUTXO(daos)
-      state = utxo.copy(state = TxoState.UnconfirmedSpent)
+      state = utxo.copy(state = TxoState.PendingConfirmationsSpent)
       updated <- spendingInfoDAO.update(state)
       unspent <- spendingInfoDAO.findAllUnspent()
     } yield assert(unspent.isEmpty)

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -42,11 +42,11 @@ abstract class LockedWallet
           .map {
             case txo: SpendingInfoDb =>
               txo.state match {
-                case TxoState.UnconfirmedReceived |
+                case TxoState.PendingConfirmationsReceived |
                     TxoState.ConfirmedReceived =>
                   txo.output.value
-                case TxoState.UnconfirmedSpent | TxoState.ConfirmedSpent |
-                    TxoState.DoesNotExist =>
+                case TxoState.PendingConfirmationsSpent |
+                    TxoState.ConfirmedSpent | TxoState.DoesNotExist =>
                   CurrencyUnits.zero
               }
           }

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -42,10 +42,11 @@ abstract class LockedWallet
           .map {
             case txo: SpendingInfoDb =>
               txo.state match {
-                case TxoState.UnconfirmedReceived | TxoState.ConfirmedReceived =>
+                case TxoState.UnconfirmedReceived |
+                    TxoState.ConfirmedReceived =>
                   txo.output.value
                 case TxoState.UnconfirmedSpent | TxoState.ConfirmedSpent |
-                     TxoState.DoesNotExist =>
+                    TxoState.DoesNotExist =>
                   CurrencyUnits.zero
               }
           }

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -42,10 +42,10 @@ abstract class LockedWallet
           .map {
             case txo: SpendingInfoDb =>
               txo.state match {
-                case TxoState.PendingReceived | TxoState.ConfirmedReceived =>
+                case TxoState.UnconfirmedReceived | TxoState.ConfirmedReceived =>
                   txo.output.value
-                case TxoState.PendingSpent | TxoState.ConfirmedSpent |
-                    TxoState.DoesNotExist =>
+                case TxoState.UnconfirmedSpent | TxoState.ConfirmedSpent |
+                     TxoState.DoesNotExist =>
                   CurrencyUnits.zero
               }
           }

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -5,6 +5,7 @@ import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.transaction.TransactionOutPoint
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.wallet.api._
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.internal._
@@ -37,9 +38,16 @@ abstract class LockedWallet
     for (utxos <- spendingInfoDAO.findAll())
       yield {
         val filtered = utxos
-          .collect {
-            case (txo) if !txo.spent && predicate(txo) =>
-              txo.output.value
+          .filter(predicate)
+          .map {
+            case txo: SpendingInfoDb =>
+              txo.state match {
+                case TxoState.PendingReceived | TxoState.ConfirmedReceived =>
+                  txo.output.value
+                case TxoState.PendingSpent | TxoState.ConfirmedSpent |
+                    TxoState.DoesNotExist =>
+                  CurrencyUnits.zero
+              }
           }
 
         filtered.fold(0.sats)(_ + _)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -203,7 +203,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
         )
         updatedF.map(Some(_))
       case TxoState.ConfirmedSpent | TxoState.UnconfirmedSpent |
-           TxoState.DoesNotExist =>
+          TxoState.DoesNotExist =>
         FutureUtil.none
     }
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -192,8 +192,8 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
   private val markAsPendingSpent: SpendingInfoDb => Future[
     Option[SpendingInfoDb]] = { out: SpendingInfoDb =>
     out.state match {
-      case TxoState.ConfirmedReceived | TxoState.PendingReceived =>
-        val updated = out.copyWithState(state = TxoState.PendingSpent)
+      case TxoState.ConfirmedReceived | TxoState.UnconfirmedReceived =>
+        val updated = out.copyWithState(state = TxoState.UnconfirmedSpent)
         val updatedF =
           spendingInfoDAO.update(updated)
         updatedF.foreach(
@@ -202,8 +202,8 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
               s"Marked utxo=${updated.toHumanReadableString} as state=${updated.state}")
         )
         updatedF.map(Some(_))
-      case TxoState.ConfirmedSpent | TxoState.PendingSpent |
-          TxoState.DoesNotExist =>
+      case TxoState.ConfirmedSpent | TxoState.UnconfirmedSpent |
+           TxoState.DoesNotExist =>
         FutureUtil.none
     }
   }
@@ -345,7 +345,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
                       // TODO is this correct?
                       //we probably need to incorporate what
                       //what our wallet's desired confirmation number is
-                      state = TxoState.PendingReceived,
+                      state = TxoState.UnconfirmedReceived,
                       blockHash = blockHashOpt
                     ))
               }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -5,6 +5,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutput}
 import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.wallet._
 import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoSuccess}
 import org.bitcoins.wallet.models._
@@ -160,7 +161,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
             outputsBeingSpent <- spendingInfoDAO.findOutputsBeingSpent(
               transaction)
             processed <- FutureUtil.sequentially(outputsBeingSpent)(
-              markAsSpentIfUnspent)
+              markAsPendingSpent)
           } yield processed.flatten.toVector
 
         }
@@ -188,19 +189,22 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
   /** If the given UTXO is marked as unspent, updates
     * its spending status. Otherwise returns `None`.
     */
-  private val markAsSpentIfUnspent: SpendingInfoDb => Future[
-    Option[SpendingInfoDb]] = { out =>
-    if (out.spent) {
-      FutureUtil.none
-    } else {
-      val updatedF =
-        spendingInfoDAO.update(out.copyWithSpent(spent = true))
-      updatedF.foreach(
-        updated =>
-          logger.debug(
-            s"Marked utxo=${updated.toHumanReadableString} as spent=${updated.spent}")
-      )
-      updatedF.map(Some(_))
+  private val markAsPendingSpent: SpendingInfoDb => Future[
+    Option[SpendingInfoDb]] = { out: SpendingInfoDb =>
+    out.state match {
+      case TxoState.ConfirmedReceived | TxoState.PendingReceived =>
+        val updated = out.copyWithState(state = TxoState.PendingSpent)
+        val updatedF =
+          spendingInfoDAO.update(updated)
+        updatedF.foreach(
+          updated =>
+            logger.debug(
+              s"Marked utxo=${updated.toHumanReadableString} as state=${updated.state}")
+        )
+        updatedF.map(Some(_))
+      case TxoState.ConfirmedSpent | TxoState.PendingSpent |
+          TxoState.DoesNotExist =>
+        FutureUtil.none
     }
   }
 
@@ -212,15 +216,19 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
   private def processUtxo(
       transaction: Transaction,
       index: Int,
-      spent: Boolean,
-      blockHash: Option[DoubleSha256DigestBE]): Future[SpendingInfoDb] =
-    addUtxo(transaction, UInt32(index), spent = spent, blockHash = blockHash)
-      .flatMap {
-        case AddUtxoSuccess(utxo) => Future.successful(utxo)
-        case err: AddUtxoError =>
-          logger.error(s"Could not add UTXO", err)
-          Future.failed(err)
-      }
+      state: TxoState,
+      blockHash: Option[DoubleSha256DigestBE]): Future[SpendingInfoDb] = {
+    val addUtxoF = addUtxo(transaction = transaction,
+                           vout = UInt32(index),
+                           state = state,
+                           blockHash = blockHash)
+    addUtxoF.flatMap {
+      case AddUtxoSuccess(utxo) => Future.successful(utxo)
+      case err: AddUtxoError =>
+        logger.error(s"Could not add UTXO", err)
+        Future.failed(err)
+    }
+  }
 
   private case class OutputWithIndex(output: TransactionOutput, index: Int)
 
@@ -331,11 +339,15 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
               .sequence {
                 xs.map(
                   out =>
-                    processUtxo(transaction,
-                                out.index,
-                                // TODO is this correct?
-                                spent = false,
-                                blockHash = blockHashOpt))
+                    processUtxo(
+                      transaction,
+                      out.index,
+                      // TODO is this correct?
+                      //we probably need to incorporate what
+                      //what our wallet's desired confirmation number is
+                      state = TxoState.PendingReceived,
+                      blockHash = blockHashOpt
+                    ))
               }
 
           addUTXOsFut

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -11,7 +11,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.util.EitherUtil
-import org.bitcoins.core.wallet.utxo.{ReceivedState, TxoState}
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoResult, AddUtxoSuccess}
 import org.bitcoins.wallet.models._
 import org.bitcoins.wallet.{LockedWallet, WalletLogger}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -11,6 +11,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.util.EitherUtil
+import org.bitcoins.core.wallet.utxo.{ReceivedState, TxoState}
 import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoResult, AddUtxoSuccess}
 import org.bitcoins.wallet.models._
 import org.bitcoins.wallet.{LockedWallet, WalletLogger}
@@ -49,7 +50,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
   /** Constructs a DB level representation of the given UTXO, and persist it to disk */
   private def writeUtxo(
       txid: DoubleSha256DigestBE,
-      spent: Boolean,
+      state: TxoState,
       output: TransactionOutput,
       outPoint: TransactionOutPoint,
       addressDb: AddressDb,
@@ -58,7 +59,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     val utxo: SpendingInfoDb = addressDb match {
       case segwitAddr: SegWitAddressDb =>
         SegwitV0SpendingInfo(
-          spent = spent,
+          state = state,
           txid = txid,
           outPoint = outPoint,
           output = output,
@@ -67,7 +68,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
           blockHash = blockHash
         )
       case LegacyAddressDb(path, _, _, _, _) =>
-        LegacySpendingInfo(spent = spent,
+        LegacySpendingInfo(state = state,
                            txid = txid,
                            outPoint = outPoint,
                            output = output,
@@ -88,13 +89,12 @@ private[wallet] trait UtxoHandling extends WalletLogger {
   }
 
   /**
-    * Adds the provided UTXO to the wallet, making it
-    * available for spending.
+    * Adds the provided UTXO to the wallet
     */
   protected def addUtxo(
       transaction: Transaction,
       vout: UInt32,
-      spent: Boolean,
+      state: TxoState,
       blockHash: Option[DoubleSha256DigestBE]): Future[AddUtxoResult] = {
     import AddUtxoError._
 
@@ -128,11 +128,11 @@ private[wallet] trait UtxoHandling extends WalletLogger {
         val biasedE: CompatEither[AddUtxoError, Future[SpendingInfoDb]] = for {
           addressDb <- addressDbE
         } yield writeUtxo(txid = transaction.txIdBE,
-                          spent = spent,
-                          output,
-                          outPoint,
-                          addressDb,
-                          blockHash)
+                          state = state,
+                          output = output,
+                          outPoint = outPoint,
+                          addressDb = addressDb,
+                          blockHash = blockHash)
 
         EitherUtil.liftRightBiasedFutureE(biasedE)
       } map {

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -102,10 +102,10 @@ case class SpendingInfoDAO()(
   }
 
   private val receivedStates: Vector[TxoState] =
-    Vector(TxoState.PendingReceived, TxoState.ConfirmedReceived)
+    Vector(TxoState.UnconfirmedReceived, TxoState.ConfirmedReceived)
 
   /** Enumerates all unspent TX outputs in the wallet with the state
-    * [[TxoState.PendingReceived]] or [[TxoState.ConfirmedReceived]] */
+    * [[TxoState.UnconfirmedReceived]] or [[TxoState.ConfirmedReceived]] */
   def findAllUnspent(): Future[Vector[SpendingInfoDb]] = {
     val query = table.filter(_.state.inSet(receivedStates))
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -101,8 +101,8 @@ case class SpendingInfoDAO()(
     database.runVec(filtered.result)
   }
 
-  private val receivedStates: Vector[TxoState] =
-    Vector(TxoState.UnconfirmedReceived, TxoState.ConfirmedReceived)
+  private val receivedStates: Set[TxoState] =
+    Set(TxoState.UnconfirmedReceived, TxoState.ConfirmedReceived)
 
   /** Enumerates all unspent TX outputs in the wallet with the state
     * [[TxoState.UnconfirmedReceived]] or [[TxoState.ConfirmedReceived]] */

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -7,6 +7,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.db.CRUDAutoInc
 import org.bitcoins.wallet.config._
 import slick.jdbc.SQLiteProfile.api._
@@ -59,25 +60,26 @@ case class SpendingInfoDAO()(
     database.runVec(query.result)
   }
 
-  /** Marks the given outputs as spent. Assumes that all the
-    * given outputs are ours, throwing if numbers aren't
-    * confirming that.
+  /** Updates the [[org.bitcoins.core.wallet.utxo.TxoState TxoState]] of all of the given
+    * outputs in our database to be the state
     */
-  def markAsSpent(
-      outputs: Seq[TransactionOutput]): Future[Vector[SpendingInfoDb]] = {
+  def updateTxoState(
+      outputs: Seq[TransactionOutput],
+      state: TxoState): Future[Vector[SpendingInfoDb]] = {
     val spks = outputs.map(_.scriptPubKey)
     val filtered = table.filter(_.scriptPubKey.inSet(spks))
 
     for {
       utxos <- database.run(filtered.result)
-      _ = assert(
+      _ = require(
         utxos.length == outputs.length,
         s"Was given ${outputs.length} outputs, found ${utxos.length} in DB")
-      updated <- updateAll(utxos.map(_.copyWithSpent(spent = true)).toVector)
+      newStates = utxos.map(_.copyWithState(state = state)).toVector
+      updated <- updateAll(newStates)
     } yield {
-      assert(utxos.length == updated.length,
-             "Updated a different number of UTXOs than what we found!")
-      logger.debug(s"Marked ${updated.length} UTXO(s) as spent")
+      require(utxos.length == updated.length,
+              "Updated a different number of UTXOs than what we found!")
+      logger.debug(s"Updated ${updated.length} UTXO(s) to state=${state}")
       updated
 
     }
@@ -99,9 +101,13 @@ case class SpendingInfoDAO()(
     database.runVec(filtered.result)
   }
 
-  /** Enumerates all unspent TX outputs in the wallet */
+  private val receivedStates: Vector[TxoState] =
+    Vector(TxoState.PendingReceived, TxoState.ConfirmedReceived)
+
+  /** Enumerates all unspent TX outputs in the wallet with the state
+    * [[TxoState.PendingReceived]] or [[TxoState.ConfirmedReceived]] */
   def findAllUnspent(): Future[Vector[SpendingInfoDb]] = {
-    val query = table.filter(!_.spent)
+    val query = table.filter(_.state.inSet(receivedStates))
 
     database.run(query.result).map(_.toVector)
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -102,10 +102,10 @@ case class SpendingInfoDAO()(
   }
 
   private val receivedStates: Set[TxoState] =
-    Set(TxoState.UnconfirmedReceived, TxoState.ConfirmedReceived)
+    Set(TxoState.PendingConfirmationsReceived, TxoState.ConfirmedReceived)
 
   /** Enumerates all unspent TX outputs in the wallet with the state
-    * [[TxoState.UnconfirmedReceived]] or [[TxoState.ConfirmedReceived]] */
+    * [[TxoState.PendingConfirmationsReceived]] or [[TxoState.ConfirmedReceived]] */
   def findAllUnspent(): Future[Vector[SpendingInfoDb]] = {
     val query = table.filter(_.state.inSet(receivedStates))
 


### PR DESCRIPTION
This adds more states for a txo in our wallet. Previously we just had a flag that was called `spent`. As you can guess, `spent` just indicated if the utxo has been spent or not. There are many more states that a wallet txo can be in: 

1. DoesNotExist
2. UnconfirmedReceived
3. ConfirmedReceived
4. UnconfirmedSpent
5. ConfirmedSpent

There are still parts of the wallet that need clarification on when a txo can transition from `Unconfirmed` -> `Confirmed`, but that will have to be done in a separate PR.

NOTE: 

This breaks the existing wallet schema, specifically `SpendingInfoTable`.