### PR TITLE
2020 1 04 fund raw tx

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
@@ -9,7 +9,8 @@ import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.result.ScriptOk
-import org.bitcoins.core.util.{BitcoinSLogger, TransactionTestUtil}
+import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.testkit.util.TransactionTestUtil
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, MustMatchers}
 import scodec.bits.ByteVector

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/AddressFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/AddressFactoryTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol
 
-import org.bitcoins.core.util.{Base58, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.util.Base58
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 3/30/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/CompactSizeUIntTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/CompactSizeUIntTest.scala
@@ -2,8 +2,8 @@ package org.bitcoins.core.protocol
 
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.script.ScriptSignature
-import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.util.BitcoinSUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/CLTVScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/CLTVScriptPubKeyTest.scala
@@ -2,17 +2,11 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECPrivateKey
 import org.bitcoins.core.script.bitwise.OP_EQUALVERIFY
-import org.bitcoins.core.script.constant.{
-  BytesToPushOntoStack,
-  ScriptConstant,
-  ScriptNumber,
-  ScriptToken
-}
+import org.bitcoins.core.script.constant.{BytesToPushOntoStack, ScriptConstant, ScriptNumber, ScriptToken}
 import org.bitcoins.core.script.crypto.{OP_CHECKSIG, OP_HASH160}
 import org.bitcoins.core.script.locktime.OP_CHECKLOCKTIMEVERIFY
 import org.bitcoins.core.script.stack.{OP_DROP, OP_DUP}
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by tom on 9/21/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/CSVScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/CSVScriptPubKeyTest.scala
@@ -2,17 +2,11 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECPrivateKey
 import org.bitcoins.core.script.bitwise.OP_EQUALVERIFY
-import org.bitcoins.core.script.constant.{
-  BytesToPushOntoStack,
-  ScriptConstant,
-  ScriptNumber,
-  ScriptToken
-}
+import org.bitcoins.core.script.constant.{BytesToPushOntoStack, ScriptConstant, ScriptNumber, ScriptToken}
 import org.bitcoins.core.script.crypto.{OP_CHECKSIG, OP_HASH160}
 import org.bitcoins.core.script.locktime.OP_CHECKSEQUENCEVERIFY
 import org.bitcoins.core.script.stack.{OP_DROP, OP_DUP}
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by tom on 9/21/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/MultiSignatureScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/MultiSignatureScriptPubKeyTest.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECPublicKey
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 3/8/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/MultiSignatureScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/MultiSignatureScriptSignatureTest.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.core.protocol.script
 
-import org.bitcoins.core.util.TransactionTestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TransactionTestUtil}
 
 /**
   * Created by chris on 3/8/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKHScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKHScriptSignatureTest.scala
@@ -2,8 +2,7 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECDigitalSignature
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKScriptPubKeyTest.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECPublicKey
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 4/1/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2PKScriptSignatureTest.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECDigitalSignature
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 3/16/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2SHScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/P2SHScriptSignatureTest.scala
@@ -1,12 +1,9 @@
 package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto.ECPublicKey
-import org.bitcoins.core.script.constant.{
-  BytesToPushOntoStack,
-  OP_0,
-  ScriptConstant
-}
-import org.bitcoins.core.util.{BitcoinSLogger, TestUtil}
+import org.bitcoins.core.script.constant.{BytesToPushOntoStack, OP_0, ScriptConstant}
+import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.testkit.util.TestUtil
 import org.scalatest.{FlatSpec, MustMatchers}
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyFactoryTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol.script
 
-import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.util.BitcoinSUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 3/2/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
@@ -6,8 +6,8 @@ import org.bitcoins.core.script.bitwise.OP_EQUALVERIFY
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.crypto.{OP_CHECKSIG, OP_HASH160}
 import org.bitcoins.core.script.stack.OP_DUP
-import org.bitcoins.core.util.{CryptoUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.util.CryptoUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 1/14/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureFactoryTest.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.core.protocol.script
 
 import org.bitcoins.core.crypto._
-import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.util.BitcoinSUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureTest.scala
@@ -5,15 +5,11 @@ import org.bitcoins.core.currency.CurrencyUnits
 import org.bitcoins.core.number.Int32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script.testprotocol.SignatureHashTestCase
-import org.bitcoins.core.protocol.transaction.{
-  BaseTransaction,
-  Transaction,
-  TransactionOutput,
-  WitnessTransaction
-}
+import org.bitcoins.core.protocol.transaction.{BaseTransaction, Transaction, TransactionOutput, WitnessTransaction}
 import org.bitcoins.core.script.crypto.{HashType, SIGHASH_ALL}
 import org.bitcoins.core.serializers.script.RawScriptSignatureParser
-import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, TestUtil}
+import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
+import org.bitcoins.testkit.util.TestUtil
 import org.scalatest.{FlatSpec, MustMatchers}
 import scodec.bits.ByteVector
 import spray.json._

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionInputTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionInputTest.scala
@@ -1,11 +1,7 @@
 package org.bitcoins.core.protocol.transaction
 
-import org.bitcoins.core.protocol.script.{
-  EmptyScriptSignature,
-  P2PKScriptSignature
-}
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.protocol.script.{EmptyScriptSignature, P2PKScriptSignature}
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 3/30/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionOutPointTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionOutPointTest.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.core.protocol.transaction
 
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 3/30/16.

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -11,12 +11,12 @@ import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.result.ScriptOk
 import org.bitcoins.core.serializers.transaction.RawBaseTransactionParser
 import org.bitcoins.core.util.CryptoUtil
-import spray.json._
-import scodec.bits._
-
-import scala.io.Source
 import org.bitcoins.testkit.core.gen.TransactionGenerators
 import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
+import scodec.bits._
+import spray.json._
+
+import scala.io.Source
 
 class TransactionTest extends BitcoinSUnitTest {
   behavior of "Transaction"

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -1,10 +1,6 @@
 package org.bitcoins.core.protocol.transaction
 
-import org.bitcoins.core.crypto.{
-  BaseTxSigComponent,
-  WitnessTxSigComponentP2SH,
-  WitnessTxSigComponentRaw
-}
+import org.bitcoins.core.crypto.{BaseTxSigComponent, WitnessTxSigComponentP2SH, WitnessTxSigComponentRaw}
 import org.bitcoins.core.currency.CurrencyUnits
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script._
@@ -14,13 +10,13 @@ import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.result.ScriptOk
 import org.bitcoins.core.serializers.transaction.RawBaseTransactionParser
-import org.bitcoins.core.util.{CryptoUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.util.CryptoUtil
 import spray.json._
 import scodec.bits._
 
 import scala.io.Source
 import org.bitcoins.testkit.core.gen.TransactionGenerators
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 class TransactionTest extends BitcoinSUnitTest {
   behavior of "Transaction"

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
@@ -6,8 +6,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.script.constant.{OP_0, OP_1}
 import org.bitcoins.core.script.flag.ScriptFlagFactory
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 3/31/16.

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramTest.scala
@@ -1,8 +1,7 @@
 package org.bitcoins.core.script
 
 import org.bitcoins.core.script.constant._
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 2/6/16.

--- a/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
@@ -3,12 +3,9 @@ package org.bitcoins.core.script.arithmetic
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.flag.ScriptFlag
 import org.bitcoins.core.script.result._
-import org.bitcoins.core.script.{
-  ExecutedScriptProgram,
-  ExecutionInProgressScriptProgram
-}
-import org.bitcoins.core.util.{ScriptProgramTestUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.script.{ExecutedScriptProgram, ExecutionInProgressScriptProgram}
+import org.bitcoins.core.util.ScriptProgramTestUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 import scala.util.Try
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/bitwise/BitwiseInterpreterTest.scala
@@ -3,8 +3,7 @@ package org.bitcoins.core.script.bitwise
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.result.ScriptErrorInvalidStackOperation
 import org.bitcoins.core.script.ExecutedScriptProgram
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 1/6/16.

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
@@ -3,12 +3,9 @@ package org.bitcoins.core.script.constant
 import org.bitcoins.core.script.bitwise.OP_EQUAL
 import org.bitcoins.core.script.crypto.OP_CHECKMULTISIGVERIFY
 import org.bitcoins.core.script.flag.{ScriptFlag, ScriptVerifyMinimalData}
-import org.bitcoins.core.script.result.{
-  ScriptErrorBadOpCode,
-  ScriptErrorMinimalData
-}
-import org.bitcoins.core.util.{ScriptProgramTestUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.script.result.{ScriptErrorBadOpCode, ScriptErrorMinimalData}
+import org.bitcoins.core.util.ScriptProgramTestUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/script/control/ControlOperationsInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/control/ControlOperationsInterpreterTest.scala
@@ -1,20 +1,14 @@
 package org.bitcoins.core.script.control
 
-import org.bitcoins.core.script.{
-  ExecutedScriptProgram,
-  ExecutionInProgressScriptProgram,
-  StartedScriptProgram
-}
+import org.bitcoins.core.script.{ExecutedScriptProgram, ExecutionInProgressScriptProgram, StartedScriptProgram}
 import org.bitcoins.core.script.arithmetic.OP_ADD
 import org.bitcoins.core.script.bitwise.OP_EQUAL
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.reserved.{OP_RESERVED, OP_VER}
-import org.bitcoins.core.script.result.{
-  ScriptErrorInvalidStackOperation,
-  ScriptErrorOpReturn
-}
+import org.bitcoins.core.script.result.{ScriptErrorInvalidStackOperation, ScriptErrorOpReturn}
 import org.bitcoins.core.serializers.script.ScriptParser
 import org.bitcoins.core.util._
+import org.bitcoins.testkit.util.TestUtil
 import org.scalatest.{FlatSpec, MustMatchers}
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoInterpreterTest.scala
@@ -7,13 +7,10 @@ import org.bitcoins.core.protocol.script.ScriptSignature
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script._
 import org.bitcoins.core.script.constant._
-import org.bitcoins.core.script.flag.{
-  ScriptFlagFactory,
-  ScriptVerifyDerSig,
-  ScriptVerifyNullDummy
-}
+import org.bitcoins.core.script.flag.{ScriptFlagFactory, ScriptVerifyDerSig, ScriptVerifyNullDummy}
 import org.bitcoins.core.script.result._
-import org.bitcoins.core.util.{BitcoinSLogger, ScriptProgramTestUtil, TestUtil}
+import org.bitcoins.core.util.{BitcoinSLogger, ScriptProgramTestUtil}
+import org.bitcoins.testkit.util.TestUtil
 import org.scalatest.{FlatSpec, MustMatchers}
 
 import scala.util.Try

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -1,24 +1,14 @@
 package org.bitcoins.core.script.interpreter
 
-import org.bitcoins.core.crypto.{
-  BaseTxSigComponent,
-  WitnessTxSigComponentP2SH,
-  WitnessTxSigComponentRaw
-}
+import org.bitcoins.core.crypto.{BaseTxSigComponent, WitnessTxSigComponentP2SH, WitnessTxSigComponentRaw}
 import org.bitcoins.core.currency.CurrencyUnits
 import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction.{
-  TransactionOutput,
-  WitnessTransaction
-}
+import org.bitcoins.core.protocol.transaction.{TransactionOutput, WitnessTransaction}
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.flag.ScriptFlagFactory
 import org.bitcoins.core.script.interpreter.testprotocol.CoreTestCase
 import org.bitcoins.core.script.interpreter.testprotocol.CoreTestCaseProtocol._
-import org.bitcoins.core.util._
-import org.bitcoins.testkit.util.BitcoinSUnitTest
-import org.bitcoins.testkit.util.BitcoinSUnitTest
-import org.slf4j.LoggerFactory
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TransactionTestUtil}
 import spray.json._
 
 import scala.io.Source

--- a/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
@@ -6,12 +6,9 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.{OP_0, ScriptNumber}
 import org.bitcoins.core.script.result._
-import org.bitcoins.core.script.{
-  ExecutedScriptProgram,
-  PreExecutionScriptProgram
-}
-import org.bitcoins.core.util.{ScriptProgramTestUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.script.{ExecutedScriptProgram, PreExecutionScriptProgram}
+import org.bitcoins.core.util.ScriptProgramTestUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 3/30/16.

--- a/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/splice/SpliceInterpreterTest.scala
@@ -3,8 +3,7 @@ package org.bitcoins.core.script.splice
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.result.ScriptErrorInvalidStackOperation
 import org.bitcoins.core.script.ExecutedScriptProgram
-import org.bitcoins.core.util.TestUtil
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 2/4/16.

--- a/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
@@ -3,8 +3,8 @@ package org.bitcoins.core.script.stack
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.result._
 import org.bitcoins.core.script.ExecutedScriptProgram
-import org.bitcoins.core.util.{BitcoinSUtil, ScriptProgramTestUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.util.{BitcoinSUtil, ScriptProgramTestUtil}
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 /**
   * Created by chris on 1/6/16.

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParserTest.scala
@@ -5,8 +5,8 @@ import org.bitcoins.core.script.bitwise.OP_EQUALVERIFY
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.crypto.{OP_CHECKSIG, OP_HASH160}
 import org.bitcoins.core.script.stack.OP_DUP
-import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.util.BitcoinSUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParserTest.scala
@@ -2,8 +2,8 @@ package org.bitcoins.core.serializers.script
 
 import org.bitcoins.core.protocol.script.{EmptyScriptSignature, ScriptSignature}
 import org.bitcoins.core.script.constant._
-import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.util.BitcoinSUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/script/ScriptParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/script/ScriptParserTest.scala
@@ -4,17 +4,13 @@ import org.bitcoins.core.script.arithmetic.OP_1ADD
 import org.bitcoins.core.script.bitwise.{OP_EQUAL, OP_EQUALVERIFY}
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.control.{OP_ELSE, OP_ENDIF, OP_IF, OP_NOTIF}
-import org.bitcoins.core.script.crypto.{
-  OP_CHECKMULTISIG,
-  OP_CHECKSIG,
-  OP_HASH160
-}
+import org.bitcoins.core.script.crypto.{OP_CHECKMULTISIG, OP_CHECKSIG, OP_HASH160}
 import org.bitcoins.core.script.locktime.OP_CHECKLOCKTIMEVERIFY
 import org.bitcoins.core.script.reserved.OP_NOP
 import org.bitcoins.core.script.splice.OP_SIZE
 import org.bitcoins.core.script.stack.{OP_DROP, OP_DUP, OP_PICK, OP_SWAP}
-import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.util.BitcoinSUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawBaseTransactionParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawBaseTransactionParserTest.scala
@@ -1,12 +1,9 @@
 package org.bitcoins.core.serializers.transaction
 
 import org.bitcoins.core.number.{Int32, UInt32}
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionConstants
-}
-import org.bitcoins.core.util.{BitcoinSUtil, TestUtil}
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.protocol.transaction.{Transaction, TransactionConstants}
+import org.bitcoins.core.util.BitcoinSUtil
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
 
 /**

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawTransactionInputParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/transaction/RawTransactionInputParserTest.scala
@@ -1,11 +1,9 @@
 package org.bitcoins.core.serializers.transaction
 
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.transaction.{
-  TransactionConstants,
-  TransactionInput
-}
-import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil, TestUtil}
+import org.bitcoins.core.protocol.transaction.{TransactionConstants, TransactionInput}
+import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
+import org.bitcoins.testkit.util.TestUtil
 import org.scalatest.{FlatSpec, MustMatchers}
 import scodec.bits.ByteVector
 

--- a/core-test/src/test/scala/org/bitcoins/core/util/BitcoinScriptUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BitcoinScriptUtilTest.scala
@@ -10,7 +10,7 @@ import org.bitcoins.core.script.locktime.OP_CHECKLOCKTIMEVERIFY
 import org.bitcoins.core.script.reserved.{OP_NOP, OP_RESERVED}
 import org.bitcoins.core.script.result.ScriptErrorWitnessPubKeyType
 import org.bitcoins.testkit.core.gen.ScriptGenerators
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -56,4 +56,5 @@ case class SatoshisPerVirtualByte(currencyUnit: CurrencyUnit)
 
 object SatoshisPerVirtualByte {
   val zero: SatoshisPerVirtualByte = SatoshisPerVirtualByte(CurrencyUnits.zero)
+  val one: SatoshisPerVirtualByte = SatoshisPerVirtualByte(Satoshis.one)
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.wallet.fee
 
-import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits, Satoshis}
 import org.bitcoins.core.protocol.transaction.Transaction
 
 /**
@@ -53,3 +53,7 @@ case class SatoshisPerKiloByte(currencyUnit: CurrencyUnit)
   */
 case class SatoshisPerVirtualByte(currencyUnit: CurrencyUnit)
     extends BitcoinFeeUnit
+
+object SatoshisPerVirtualByte {
+  val zero: SatoshisPerVirtualByte = SatoshisPerVirtualByte(CurrencyUnits.zero)
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/TestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/TestUtil.scala
@@ -1,16 +1,22 @@
-package org.bitcoins.core.util
+package org.bitcoins.testkit.util
 
 import org.bitcoins.core.crypto.BaseTxSigComponent
 import org.bitcoins.core.currency.CurrencyUnits
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.core.protocol.script._
+import org.bitcoins.core.protocol.script.{
+  EmptyScriptPubKey,
+  P2SHScriptSignature,
+  ScriptPubKey,
+  ScriptSignature
+}
 import org.bitcoins.core.protocol.transaction.{
   Transaction,
   TransactionInput,
   TransactionOutput
 }
+import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.bitwise.{OP_EQUAL, OP_EQUALVERIFY}
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.crypto.{
@@ -19,7 +25,6 @@ import org.bitcoins.core.script.crypto.{
   OP_HASH160
 }
 import org.bitcoins.core.script.stack.OP_DUP
-import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.serializers.script.RawScriptPubKeyParser
 import org.bitcoins.core.serializers.transaction.RawTransactionInputParser
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/TransactionTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/TransactionTestUtil.scala
@@ -1,10 +1,11 @@
-package org.bitcoins.core.util
+package org.bitcoins.testkit.util
 
 import org.bitcoins.core.crypto.{ECPrivateKey, ECPublicKey}
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.util.BitcoinSLogger
 
 /**
   * Created by chris on 2/12/16.
@@ -239,6 +240,14 @@ trait TransactionTestUtil extends BitcoinSLogger {
                     Seq(EmptyTransactionInput),
                     Nil,
                     EmptyTransaction.lockTime)
+
+  /** Builds a dummy transaction that sends money to the given output */
+  def buildTransactionTo(output: TransactionOutput): Transaction = {
+    BaseTransaction(version = Int32.one,
+                    inputs = Vector(EmptyTransactionInput),
+                    outputs = Vector(output),
+                    lockTime = TransactionConstants.lockTime)
+  }
 }
 
 object TransactionTestUtil extends TransactionTestUtil

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.BlockFilter
 import org.bitcoins.core.protocol.BlockStamp
+import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.db.AppConfig
 import org.bitcoins.keymanager.KeyManagerTestUtil
@@ -17,8 +18,8 @@ import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.server.BitcoinSAppConfig._
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
-import org.bitcoins.testkit.util.FileUtil
-import org.bitcoins.wallet.api.UnlockedWalletApi
+import org.bitcoins.testkit.util.{FileUtil, TransactionTestUtil}
+import org.bitcoins.wallet.api.{LockedWalletApi, UnlockedWalletApi}
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.db.WalletDbManagement
 import org.bitcoins.wallet.{Wallet, WalletLogger}
@@ -125,6 +126,15 @@ trait BitcoinSWalletTest extends BitcoinSFixture with WalletLogger {
                                 chainQueryApi = chainQueryApi),
         destroy = destroyWallet
       )
+  }
+
+  def withFundedWallet(test: OneArgAsyncTest): FutureOutcome = {
+    makeDependentFixture(
+      build = () => createFundedWallet(nodeApi, chainQueryApi),
+      destroy = { funded: FundedWallet =>
+        destroyWallet(funded.wallet)
+      }
+    )(test)
   }
 
   /** Fixture for an initialized wallet which produce legacy addresses */
@@ -293,6 +303,22 @@ object BitcoinSWalletTest extends WalletLogger {
       chainQueryApi = chainQueryApi)(config, ec)() // get the standard config
   }
 
+  /** This wallet should have a total of 5 bitcoin in it
+    * spread across 3 utxos that have values 1, 2, 3 bitcoins */
+  case class FundedWallet(wallet: LockedWalletApi)
+
+  /** This creates a wallet that is funded that is not paired to a bitcoind instance. */
+  def createFundedWallet(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)(
+      implicit config: BitcoinSAppConfig,
+      system: ActorSystem): Future[FundedWallet] = {
+
+    import system.dispatcher
+    for {
+      wallet <- createDefaultWallet(nodeApi, chainQueryApi)
+      funded <- fundWallet(wallet)
+    } yield funded
+  }
+
   /** Pairs the given wallet with a bitcoind instance that has money in the bitcoind wallet */
   def createWalletWithBitcoind(
       wallet: UnlockedWalletApi
@@ -347,6 +373,41 @@ object BitcoinSWalletTest extends WalletLogger {
     } yield funded
   }
 
+  /** Funds a bitcoin-s wallet with 3 utxos with 1, 2 and 3 bitcoin in the utxos */
+  def fundWallet(wallet: UnlockedWalletApi)(
+      implicit ec: ExecutionContext): Future[FundedWallet] = {
+    //get three addresses
+    val addressesF = Future.sequence(Vector.fill(3)(wallet.getNewAddress()))
+
+    //construct three txs that send money to these addresses
+    //these are "fictional" transactions in the sense that the
+    //outpoints do not exist on a blockchain anywhere
+    val amounts = Vector(1.bitcoin, 2.bitcoin, 3.bitcoin)
+    val expectedAmt = amounts.fold(CurrencyUnits.zero)(_ + _)
+    val txsF = for {
+      addresses <- addressesF
+    } yield {
+      addresses.zip(amounts).map {
+        case (addr, amt) =>
+          val output =
+            TransactionOutput(value = amt, scriptPubKey = addr.scriptPubKey)
+          TransactionTestUtil.buildTransactionTo(output)
+      }
+    }
+
+    val fundedWalletF =
+      txsF.flatMap(txs => wallet.processTransactions(txs, None))
+
+    //sanity check to make sure we have money
+    for {
+      fundedWallet <- fundedWalletF
+      balance <- fundedWallet.getBalance()
+      _ = require(
+        balance == 5.bitcoin,
+        s"Funding wallet fixture failed ot fund the wallet, got balance=${balance} expected=${expectedAmt}")
+    } yield FundedWallet(fundedWallet)
+  }
+
   /** Funds the given wallet with money from the given bitcoind */
   def fundWalletWithBitcoind(pair: WalletWithBitcoind)(
       implicit ec: ExecutionContext): Future[WalletWithBitcoind] = {
@@ -378,10 +439,14 @@ object BitcoinSWalletTest extends WalletLogger {
 
   def destroyWallet(wallet: UnlockedWalletApi)(
       implicit ec: ExecutionContext): Future[Unit] = {
+    destroyWallet(wallet.lock())
+  }
+
+  def destroyWallet(wallet: LockedWalletApi)(
+      implicit ec: ExecutionContext): Future[Unit] = {
     val destroyWalletF = WalletDbManagement
       .dropAll()(config = wallet.walletConfig, ec = ec)
       .map(_ => ())
-
     destroyWalletF
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -405,9 +405,8 @@ object BitcoinSWalletTest extends WalletLogger {
     }
 
     val fundedWalletF =
-      txsF.flatMap(txs => wallet.processTransactions(
-        transactions = txs,
-        blockHash = None))
+      txsF.flatMap(txs =>
+        wallet.processTransactions(transactions = txs, blockHash = None))
 
     //sanity check to make sure we have money
     for {

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -22,7 +22,7 @@ import org.bitcoins.testkit.util.{FileUtil, TransactionTestUtil}
 import org.bitcoins.wallet.api.{LockedWalletApi, UnlockedWalletApi}
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.db.WalletDbManagement
-import org.bitcoins.wallet.{Wallet, WalletLogger}
+import org.bitcoins.wallet.{LockedWallet, Wallet, WalletLogger}
 import org.scalatest._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -305,7 +305,7 @@ object BitcoinSWalletTest extends WalletLogger {
 
   /** This wallet should have a total of 6 bitcoin in it
     * spread across 3 utxos that have values 1, 2, 3 bitcoins */
-  case class FundedWallet(wallet: LockedWalletApi)
+  case class FundedWallet(wallet: LockedWallet)
 
   /** This creates a wallet that is funded that is not paired to a bitcoind instance. */
   def createFundedWallet(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)(
@@ -375,8 +375,7 @@ object BitcoinSWalletTest extends WalletLogger {
 
   /** Funds a bitcoin-s wallet with 3 utxos with 1, 2 and 3 bitcoin in the utxos */
   def fundWallet(wallet: UnlockedWalletApi)(
-      implicit ec: ExecutionContext,
-      config: WalletAppConfig): Future[FundedWallet] = {
+      implicit ec: ExecutionContext): Future[FundedWallet] = {
     //get three addresses
     val addressesF = Future.sequence(Vector.fill(3) {
       //this Thread.sleep is needed because of
@@ -412,7 +411,7 @@ object BitcoinSWalletTest extends WalletLogger {
       _ = require(
         balance == 6.bitcoin,
         s"Funding wallet fixture failed ot fund the wallet, got balance=${balance} expected=${expectedAmt}")
-    } yield FundedWallet(fundedWallet)
+    } yield FundedWallet(fundedWallet.asInstanceOf[LockedWallet])
   }
 
   /** Funds the given wallet with money from the given bitcoind */

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -128,6 +128,9 @@ trait BitcoinSWalletTest extends BitcoinSFixture with WalletLogger {
       )
   }
 
+  /** Creates a wallet that is funded with some bitcoin, this wallet is NOT
+    * peered with a bitcoind so the funds in the wallet are not tied to an
+    * underlying blockchain */
   def withFundedWallet(test: OneArgAsyncTest): FutureOutcome = {
     makeDependentFixture(
       build = () => createFundedWallet(nodeApi, chainQueryApi),
@@ -402,7 +405,9 @@ object BitcoinSWalletTest extends WalletLogger {
     }
 
     val fundedWalletF =
-      txsF.flatMap(txs => wallet.processTransactions(txs, None))
+      txsF.flatMap(txs => wallet.processTransactions(
+        transactions = txs,
+        blockHash = None))
 
     //sanity check to make sure we have money
     for {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -8,7 +8,7 @@ import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest.FundedWallet
 import org.scalatest.FutureOutcome
 
-class FundTransactionTest extends BitcoinSWalletTest {
+class FundTransactionHandlingTest extends BitcoinSWalletTest {
 
   override type FixtureParam = FundedWallet
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
@@ -98,5 +98,10 @@ class FundTransactionTest extends BitcoinSWalletTest {
     recoverToSucceededIf[RuntimeException] {
       fundedTxF
     }
+  }
+
+  it must "fund from a specific account" ignore { _: FundedWallet =>
+    assert(false)
+
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionTest.scala
@@ -1,12 +1,11 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.core.currency.{Bitcoins, CurrencyUnits}
+import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
-import org.bitcoins.testkit.util.{TestUtil, TransactionTestUtil}
-import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
+import org.bitcoins.testkit.util.TestUtil
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest.FundedWallet
-import org.bitcoins.wallet.api.UnlockedWalletApi
 import org.scalatest.FutureOutcome
 
 class FundTransactionTest extends BitcoinSWalletTest {
@@ -17,22 +16,87 @@ class FundTransactionTest extends BitcoinSWalletTest {
   }
 
   val destination = TransactionOutput(Bitcoins(0.5),TestUtil.p2pkhScriptPubKey)
-  val feeRate = SatoshisPerVirtualByte.zero
+  val feeRate = SatoshisPerVirtualByte.one
 
   it must "fund a simple raw transaction that requires one utxo" in { fundedWallet : FundedWallet =>
 
     val wallet = fundedWallet.wallet
-    wallet.fundRawTransaction(Vector(destination),
-      feeRate,
-      fromAccount = ???)
-    fail()
+    val fundedTxF = wallet.fundRawTransaction(
+      destinations = Vector(destination),
+      feeRate = feeRate)
+    for {
+      fundedTx <- fundedTxF
+    } yield {
+      assert(fundedTx.inputs.length == 1, s"We should only need one input to fund this tx")
+      assert(fundedTx.outputs.contains(destination))
+      assert(fundedTx.outputs.length == 2, s"We must have a single destination output and a change output")
+    }
   }
 
-  it must "fail to fund a raw transaction" in { fundedWallet: FundedWallet =>
+  it must "fund a transaction that requires all utxos in our wallet" in { fundedWallet: FundedWallet =>
+    val amt = Bitcoins(5.5)
+    val newDestination = destination.copy(value = amt)
     val wallet = fundedWallet.wallet
-    wallet.fundRawTransaction(Vector(destination),
-      feeRate,
-      fromAccount = ???)
-    fail()
+    val fundedTxF = wallet.fundRawTransaction(
+      destinations = Vector(newDestination),
+      feeRate = feeRate)
+    for {
+      fundedTx <- fundedTxF
+    } yield {
+      assert(fundedTx.inputs.length == 3, s"We should need 3 inputs to fund this tx")
+      assert(fundedTx.outputs.contains(newDestination))
+      assert(fundedTx.outputs.length == 2, s"We must have a 2 destination output and a change output")
+    }
+  }
+
+  it must "not care about the number of destinations" in { fundedWallet: FundedWallet =>
+    val destinations = Vector.fill(5)(destination)
+
+    val wallet = fundedWallet.wallet
+    val fundedTxF = wallet.fundRawTransaction(
+      destinations = destinations,
+      feeRate = feeRate)
+    for {
+      fundedTx <- fundedTxF
+    } yield {
+      assert(fundedTx.inputs.length == 1, s"We should only need one input to fund this tx")
+
+      destinations.foreach(d =>
+        assert(fundedTx.outputs.contains(d))
+      )
+      assert(fundedTx.outputs.length == 6, s"We must have a 6 destination output and a change output")
+    }
+
+  }
+
+  it must "fail to fund a raw transaction if we don't have enough money in our wallet" in { fundedWallet: FundedWallet =>
+    //our wallet should only have 6 bitcoin in it
+    val tooMuchMoney = Bitcoins(10)
+    val tooBigOutput = destination.copy(value = tooMuchMoney)
+    val wallet = fundedWallet.wallet
+    val fundedTxF = wallet.fundRawTransaction(
+      destinations = Vector(tooBigOutput),
+      feeRate = feeRate)
+
+    recoverToSucceededIf[RuntimeException] {
+      fundedTxF
+    }
+  }
+
+  it must "fail to fund a raw transaction if we have the _exact_ amount of money in the wallet because of the fee" in {fundedWallet: FundedWallet =>
+    //our wallet should only have 6 bitcoin in it
+    val tooMuchMoney = Bitcoins(6)
+    val tooBigOutput = destination.copy(value = tooMuchMoney)
+    val wallet = fundedWallet.wallet
+
+    //6 bitcoin destination + 1 sat/vbyte fee means we should
+    //not have enough money for this
+    val fundedTxF = wallet.fundRawTransaction(
+      destinations = Vector(tooBigOutput),
+      feeRate = feeRate)
+
+    recoverToSucceededIf[RuntimeException] {
+      fundedTxF
+    }
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionTest.scala
@@ -1,0 +1,38 @@
+package org.bitcoins.wallet
+
+import org.bitcoins.core.currency.{Bitcoins, CurrencyUnits}
+import org.bitcoins.core.protocol.transaction.TransactionOutput
+import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.testkit.util.{TestUtil, TransactionTestUtil}
+import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest.FundedWallet
+import org.bitcoins.wallet.api.UnlockedWalletApi
+import org.scalatest.FutureOutcome
+
+class FundTransactionTest extends BitcoinSWalletTest {
+
+  override type FixtureParam = FundedWallet
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    withFundedWallet(test)
+  }
+
+  val destination = TransactionOutput(Bitcoins(0.5),TestUtil.p2pkhScriptPubKey)
+  val feeRate = SatoshisPerVirtualByte.zero
+
+  it must "fund a simple raw transaction that requires one utxo" in { fundedWallet : FundedWallet =>
+
+    val wallet = fundedWallet.wallet
+    wallet.fundRawTransaction(Vector(destination),
+      feeRate,
+      fromAccount = ???)
+    fail()
+  }
+
+  it must "fail to fund a raw transaction" in { fundedWallet: FundedWallet =>
+    val wallet = fundedWallet.wallet
+    wallet.fundRawTransaction(Vector(destination),
+      feeRate,
+      fromAccount = ???)
+    fail()
+  }
+}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -173,5 +173,4 @@ class WalletUnitTest extends BitcoinSWalletTest {
                                      blockHeight = 1)) == matched)
     }
   }
-
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -5,7 +5,11 @@ import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
 import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency._
-import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint, TransactionOutput}
+import org.bitcoins.core.protocol.transaction.{
+  Transaction,
+  TransactionOutPoint,
+  TransactionOutput
+}
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.TxoState

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -2,10 +2,15 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.api.{ChainQueryApi, NodeApi}
 import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
+import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency._
-import org.bitcoins.core.protocol.transaction.TransactionOutPoint
+import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint, TransactionOutput}
+import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
+import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.TxoState
+import org.bitcoins.keymanager.KeyManager
+import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.wallet.api._
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.internal._
@@ -53,6 +58,106 @@ abstract class LockedWallet
 
         filtered.fold(0.sats)(_ + _)
       }
+  }
+
+  override def fundRawTransaction(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb): Future[Transaction] = {
+    val txBuilderF =
+      fundRawTransactionInternal(destinations = destinations,
+                                 feeRate = feeRate,
+                                 fromAccount = fromAccount,
+                                 keyManagerOpt = None)
+    txBuilderF.flatMap(_.unsignedTx)
+  }
+
+  /** This returns a [[BitcoinTxBuilder]] that can be used to generate a unsigned transaction with [[BitcoinTxBuilder.unsignedTx unsignedTx]]
+    * which can be used with signing, or you can just directly call [[BitcoinTxBuilder.sign sign]] to sign the transaction with this instance
+    * of [[BitcoinTxBuilder]]
+    *
+    * If you pass in a [[KeyManager]], the [[org.bitcoins.core.wallet.utxo.UTXOSpendingInfo.signers signers]]
+    * will be populated with really signers that can be used to produce valid [[org.bitcoins.core.crypto.ECDigitalSignature signatures]]
+    *
+    * If you do not pass in a key manager, the transaction will contain [[org.bitcoins.core.protocol.script.EmptyScriptSignature EmptyScriptSignature]]
+    * */
+  private[wallet] def fundRawTransactionInternal(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      keyManagerOpt: Option[BIP39KeyManager]): Future[BitcoinTxBuilder] = {
+    val utxosF = listUtxos()
+    val changeAddrF = getNewChangeAddress(fromAccount)
+    val selectedUtxosF = for {
+      walletUtxos <- utxosF
+      change <- changeAddrF
+      //currently just grab the biggest utxos
+      selectedUtxos = CoinSelector
+        .accumulateLargest(walletUtxos, destinations, feeRate)
+    } yield selectedUtxos
+
+    val addrInfosWithUtxoF: Future[Vector[(SpendingInfoDb, AddressInfo)]] =
+      for {
+        selectedUtxos <- selectedUtxosF
+        addrInfoOptF = selectedUtxos.map { utxo =>
+          val addrInfoOptF = getAddressInfo(utxo)
+          //.get should be safe here because of foreign key at the database level
+          addrInfoOptF.map(addrInfoOpt => (utxo, addrInfoOpt.get))
+        }
+        vec <- Future.sequence(addrInfoOptF)
+      } yield vec
+
+    val txBuilderF = for {
+      addrInfosWithUtxo <- addrInfosWithUtxoF
+      change <- changeAddrF
+      utxoSpendingInfos = {
+        addrInfosWithUtxo.map {
+          case (utxo, addrInfo) =>
+            keyManagerOpt match {
+              case Some(km) =>
+                utxo.toUTXOSpendingInfo(account = fromAccount,
+                                        keyManager = km,
+                                        networkParameters = networkParameters)
+              case None =>
+                utxo.toUTXOSpendingInfo(account = fromAccount,
+                                        sign = Sign.dummySign(addrInfo.pubkey),
+                                        networkParameters = networkParameters)
+            }
+
+        }
+      }
+      txBuilder <- {
+
+        logger.info({
+          val utxosStr = utxoSpendingInfos
+            .map { utxo =>
+              import utxo.outPoint
+              s"${outPoint.txId.hex}:${outPoint.vout.toInt}"
+            }
+            .mkString(", ")
+          s"Spending UTXOs: $utxosStr"
+        })
+
+        utxoSpendingInfos.zipWithIndex.foreach {
+          case (utxo, index) =>
+            logger.info(s"UTXO $index details: ${utxo.output}")
+        }
+
+        networkParameters match {
+          case b: BitcoinNetwork =>
+            BitcoinTxBuilder(destinations = destinations,
+                             utxos = utxoSpendingInfos,
+                             feeRate = feeRate,
+                             changeSPK = change.scriptPubKey,
+                             network = b)
+        }
+
+      }
+    } yield {
+      txBuilder
+    }
+
+    txBuilderF
   }
 
   override def getConfirmedBalance(): Future[CurrencyUnit] = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -9,7 +9,6 @@ import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint,
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.TxoState
-import org.bitcoins.keymanager.KeyManager
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.wallet.api._
 import org.bitcoins.wallet.config.WalletAppConfig

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -2,18 +2,10 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.api.{ChainQueryApi, NodeApi}
 import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
-import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency._
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionOutPoint,
-  TransactionOutput
-}
-import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.protocol.transaction.TransactionOutPoint
 import org.bitcoins.core.wallet.utxo.TxoState
-import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.wallet.api._
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.internal._
@@ -26,6 +18,7 @@ abstract class LockedWallet
     with UtxoHandling
     with AddressHandling
     with AccountHandling
+    with FundTransactionHandling
     with TransactionProcessing
     with RescanHandling {
 
@@ -61,106 +54,6 @@ abstract class LockedWallet
 
         filtered.fold(0.sats)(_ + _)
       }
-  }
-
-  override def fundRawTransaction(
-      destinations: Vector[TransactionOutput],
-      feeRate: FeeUnit,
-      fromAccount: AccountDb): Future[Transaction] = {
-    val txBuilderF =
-      fundRawTransactionInternal(destinations = destinations,
-                                 feeRate = feeRate,
-                                 fromAccount = fromAccount,
-                                 keyManagerOpt = None)
-    txBuilderF.flatMap(_.unsignedTx)
-  }
-
-  /** This returns a [[BitcoinTxBuilder]] that can be used to generate a unsigned transaction with [[BitcoinTxBuilder.unsignedTx unsignedTx]]
-    * which can be used with signing, or you can just directly call [[BitcoinTxBuilder.sign sign]] to sign the transaction with this instance
-    * of [[BitcoinTxBuilder]]
-    *
-    * If you pass in a [[KeyManager]], the [[org.bitcoins.core.wallet.utxo.UTXOSpendingInfo.signers signers]]
-    * will be populated with really signers that can be used to produce valid [[org.bitcoins.core.crypto.ECDigitalSignature signatures]]
-    *
-    * If you do not pass in a key manager, the transaction will contain [[org.bitcoins.core.protocol.script.EmptyScriptSignature EmptyScriptSignature]]
-    * */
-  private[wallet] def fundRawTransactionInternal(
-      destinations: Vector[TransactionOutput],
-      feeRate: FeeUnit,
-      fromAccount: AccountDb,
-      keyManagerOpt: Option[BIP39KeyManager]): Future[BitcoinTxBuilder] = {
-    val utxosF = listUtxos()
-    val changeAddrF = getNewChangeAddress(fromAccount)
-    val selectedUtxosF = for {
-      walletUtxos <- utxosF
-      change <- changeAddrF
-      //currently just grab the biggest utxos
-      selectedUtxos = CoinSelector
-        .accumulateLargest(walletUtxos, destinations, feeRate)
-    } yield selectedUtxos
-
-    val addrInfosWithUtxoF: Future[Vector[(SpendingInfoDb, AddressInfo)]] =
-      for {
-        selectedUtxos <- selectedUtxosF
-        addrInfoOptF = selectedUtxos.map { utxo =>
-          val addrInfoOptF = getAddressInfo(utxo)
-          //.get should be safe here because of foreign key at the database level
-          addrInfoOptF.map(addrInfoOpt => (utxo, addrInfoOpt.get))
-        }
-        vec <- Future.sequence(addrInfoOptF)
-      } yield vec
-
-    val txBuilderF = for {
-      addrInfosWithUtxo <- addrInfosWithUtxoF
-      change <- changeAddrF
-      utxoSpendingInfos = {
-        addrInfosWithUtxo.map {
-          case (utxo, addrInfo) =>
-            keyManagerOpt match {
-              case Some(km) =>
-                utxo.toUTXOSpendingInfo(account = fromAccount,
-                                        keyManager = km,
-                                        networkParameters = networkParameters)
-              case None =>
-                utxo.toUTXOSpendingInfo(account = fromAccount,
-                                        sign = Sign.dummySign(addrInfo.pubkey),
-                                        networkParameters = networkParameters)
-            }
-
-        }
-      }
-      txBuilder <- {
-
-        logger.info({
-          val utxosStr = utxoSpendingInfos
-            .map { utxo =>
-              import utxo.outPoint
-              s"${outPoint.txId.hex}:${outPoint.vout.toInt}"
-            }
-            .mkString(", ")
-          s"Spending UTXOs: $utxosStr"
-        })
-
-        utxoSpendingInfos.zipWithIndex.foreach {
-          case (utxo, index) =>
-            logger.info(s"UTXO $index details: ${utxo.output}")
-        }
-
-        networkParameters match {
-          case b: BitcoinNetwork =>
-            BitcoinTxBuilder(destinations = destinations,
-                             utxos = utxoSpendingInfos,
-                             feeRate = feeRate,
-                             changeSPK = change.scriptPubKey,
-                             network = b)
-        }
-
-      }
-    } yield {
-      txBuilder
-    }
-
-    txBuilderF
   }
 
   override def getConfirmedBalance(): Future[CurrencyUnit] = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -73,6 +73,15 @@ trait LockedWalletApi extends WalletApi {
       transaction: Transaction,
       blockHash: Option[DoubleSha256DigestBE]): Future[LockedWalletApi]
 
+  def processTransactions(
+      transactions: Vector[Transaction],
+      blockHash: Option[DoubleSha256DigestBE]): Future[LockedWalletApi] = {
+    transactions.foldLeft(Future.successful(this)) {
+      case (wallet, tx) =>
+        wallet.flatMap(_.processTransaction(tx, blockHash))
+    }
+  }
+
   /**
     * Processes the give block, updating our DB state if it's relevant to us.
     * @param block The block we're processing

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -50,25 +50,6 @@ sealed trait WalletApi {
   */
 trait LockedWalletApi extends WalletApi {
 
-  def fundRawTransaction(
-      destinations: Vector[TransactionOutput],
-      feeRate: FeeUnit): Future[Transaction] = {
-    for {
-      account <- getDefaultAccount()
-      funded <- fundRawTransaction(destinations = destinations,
-                                   feeRate = feeRate,
-                                   fromAccount = account)
-    } yield funded
-  }
-
-  /** Creates a raw UNSIGNED transaction that sends money to the given destination with the desired fee rate and a changeSPk
-    * attached to the unsigned transaction.
-    * */
-  def fundRawTransaction(
-      destinations: Vector[TransactionOutput],
-      feeRate: FeeUnit,
-      fromAccount: AccountDb): Future[Transaction]
-
   /**
     * Retrieves a bloom filter that that can be sent to a P2P network node
     * to get information about our transactions, pubkeys and scripts.

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -50,6 +50,17 @@ sealed trait WalletApi {
   */
 trait LockedWalletApi extends WalletApi {
 
+  def fundRawTransaction(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      funded <- fundRawTransaction(destinations = destinations,
+                                   feeRate = feeRate,
+                                   fromAccount = account)
+    } yield funded
+  }
+
   /** Creates a raw UNSIGNED transaction that sends money to the given destination with the desired fee rate and a changeSPk
     * attached to the unsigned transaction.
     * */

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -1,0 +1,127 @@
+package org.bitcoins.wallet.internal
+
+import org.bitcoins.core.config.BitcoinNetwork
+import org.bitcoins.core.crypto.Sign
+import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutput}
+import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
+import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.keymanager.bip39.BIP39KeyManager
+import org.bitcoins.wallet.WalletLogger
+import org.bitcoins.wallet.api.{AddressInfo, CoinSelector, LockedWalletApi}
+import org.bitcoins.wallet.models.{AccountDb, SpendingInfoDb}
+
+import scala.concurrent.Future
+
+trait FundTransactionHandling extends WalletLogger { self: LockedWalletApi =>
+
+  def fundRawTransaction(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      funded <- fundRawTransaction(destinations = destinations,
+                                   feeRate = feeRate,
+                                   fromAccount = account)
+    } yield funded
+  }
+
+  def fundRawTransaction(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb): Future[Transaction] = {
+    val txBuilderF =
+      fundRawTransactionInternal(destinations = destinations,
+                                 feeRate = feeRate,
+                                 fromAccount = fromAccount,
+                                 keyManagerOpt = None)
+    txBuilderF.flatMap(_.unsignedTx)
+  }
+
+  /** This returns a [[BitcoinTxBuilder]] that can be used to generate a unsigned transaction with [[BitcoinTxBuilder.unsignedTx unsignedTx]]
+    * which can be used with signing, or you can just directly call [[BitcoinTxBuilder.sign sign]] to sign the transaction with this instance
+    * of [[BitcoinTxBuilder]]
+    *
+    * If you pass in a [[org.bitcoins.keymanager.KeyManager]], the [[org.bitcoins.core.wallet.utxo.UTXOSpendingInfo.signers signers]]
+    * will be populated with really signers that can be used to produce valid [[org.bitcoins.core.crypto.ECDigitalSignature signatures]]
+    *
+    * If you do not pass in a key manager, the transaction will contain [[org.bitcoins.core.protocol.script.EmptyScriptSignature EmptyScriptSignature]]
+    * */
+  private[wallet] def fundRawTransactionInternal(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      keyManagerOpt: Option[BIP39KeyManager]): Future[BitcoinTxBuilder] = {
+    val utxosF = listUtxos()
+    val changeAddrF = getNewChangeAddress(fromAccount)
+    val selectedUtxosF = for {
+      walletUtxos <- utxosF
+      change <- changeAddrF
+      //currently just grab the biggest utxos
+      selectedUtxos = CoinSelector
+        .accumulateLargest(walletUtxos, destinations, feeRate)
+    } yield selectedUtxos
+
+    val addrInfosWithUtxoF: Future[Vector[(SpendingInfoDb, AddressInfo)]] =
+      for {
+        selectedUtxos <- selectedUtxosF
+        addrInfoOptF = selectedUtxos.map { utxo =>
+          val addrInfoOptF = getAddressInfo(utxo)
+          //.get should be safe here because of foreign key at the database level
+          addrInfoOptF.map(addrInfoOpt => (utxo, addrInfoOpt.get))
+        }
+        vec <- Future.sequence(addrInfoOptF)
+      } yield vec
+
+    val txBuilderF = for {
+      addrInfosWithUtxo <- addrInfosWithUtxoF
+      change <- changeAddrF
+      utxoSpendingInfos = {
+        addrInfosWithUtxo.map {
+          case (utxo, addrInfo) =>
+            keyManagerOpt match {
+              case Some(km) =>
+                utxo.toUTXOSpendingInfo(account = fromAccount,
+                                        keyManager = km,
+                                        networkParameters = networkParameters)
+              case None =>
+                utxo.toUTXOSpendingInfo(account = fromAccount,
+                                        sign = Sign.dummySign(addrInfo.pubkey),
+                                        networkParameters = networkParameters)
+            }
+
+        }
+      }
+      txBuilder <- {
+
+        logger.info({
+          val utxosStr = utxoSpendingInfos
+            .map { utxo =>
+              import utxo.outPoint
+              s"${outPoint.txId.hex}:${outPoint.vout.toInt}"
+            }
+            .mkString(", ")
+          s"Spending UTXOs: $utxosStr"
+        })
+
+        utxoSpendingInfos.zipWithIndex.foreach {
+          case (utxo, index) =>
+            logger.info(s"UTXO $index details: ${utxo.output}")
+        }
+
+        networkParameters match {
+          case b: BitcoinNetwork =>
+            BitcoinTxBuilder(destinations = destinations,
+                             utxos = utxoSpendingInfos,
+                             feeRate = feeRate,
+                             changeSPK = change.scriptPubKey,
+                             network = b)
+        }
+
+      }
+    } yield {
+      txBuilder
+    }
+
+    txBuilderF
+  }
+}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -42,9 +42,11 @@ trait FundTransactionHandling extends WalletLogger { self: LockedWalletApi =>
     * of [[BitcoinTxBuilder]]
     *
     * If you pass in a [[org.bitcoins.keymanager.KeyManager]], the [[org.bitcoins.core.wallet.utxo.UTXOSpendingInfo.signers signers]]
-    * will be populated with really signers that can be used to produce valid [[org.bitcoins.core.crypto.ECDigitalSignature signatures]]
+    * will be populated with valid signers that can be used to produce valid [[org.bitcoins.core.crypto.ECDigitalSignature signatures]]
     *
-    * If you do not pass in a key manager, the transaction will contain [[org.bitcoins.core.protocol.script.EmptyScriptSignature EmptyScriptSignature]]
+    * If you do not pass in a key manager, the transaction built by [[BitcoinTxBuilder txbuilder]] will contain [[org.bitcoins.core.protocol.script.EmptyScriptSignature EmptyScriptSignature]]
+    *
+    * Currently utxos are funded with [[CoinSelector.accumulateLargest() accumulateLargest]] coin seleciton algorithm
     * */
   private[wallet] def fundRawTransactionInternal(
       destinations: Vector[TransactionOutput],

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTable.scala
@@ -135,9 +135,9 @@ class AddressTable(tag: Tag) extends Table[AddressDb](tag, "addresses") {
 
   def purpose: Rep[HDPurpose] = column("hd_purpose")
 
-  def accountIndex: Rep[Int] = column("account_index")
-
   def accountCoin: Rep[HDCoinType] = column("hd_coin")
+
+  def accountIndex: Rep[Int] = column("account_index")
 
   def accountChainType: Rep[HDChainType] = column("hd_chain_type")
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoTable.scala
@@ -133,10 +133,20 @@ sealed trait SpendingInfoDb extends DbRowAutoInc[SpendingInfoDb] {
   def toUTXOSpendingInfo(
       account: AccountDb,
       keyManager: BIP39KeyManager,
-      network: NetworkParameters): BitcoinUTXOSpendingInfo = {
+      networkParameters: NetworkParameters): BitcoinUTXOSpendingInfo = {
 
     val sign: Sign = keyManager.toSign(privKeyPath = privKeyPath)
 
+    toUTXOSpendingInfo(account = account,
+                       sign = sign,
+                       networkParameters = networkParameters)
+  }
+
+  def toUTXOSpendingInfo(
+      account: AccountDb,
+      sign: Sign,
+      networkParameters: NetworkParameters
+  ): BitcoinUTXOSpendingInfo = {
     BitcoinUTXOSpendingInfo(
       outPoint,
       output,


### PR DESCRIPTION
This implements the ability to set of outputs from the bitcoin-s wallet without providing signatures for the utxos used to fund the tx. Essentially this decouples the funding and signing process inside of the wallet. 

Addresses #896 