### PR TITLE
Single Signing

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -21,7 +21,7 @@ import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{
-  BitcoinUTXOSpendingInfo,
+  BitcoinUTXOSpendingInfoFull,
   ConditionalPath,
   LockTimeSpendingInfoFull,
   UTXOSpendingInfo
@@ -57,10 +57,10 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
                                       outputs = Seq(creditingOutput),
                                       lockTime = tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(
+    val utxo = BitcoinUTXOSpendingInfoFull(
       outPoint = outPoint,
       output = creditingOutput,
-      signers = Seq(privKey),
+      signers = Vector(privKey),
       redeemScriptOpt = None,
       scriptWitnessOpt = None,
       hashType = HashType.sigHashAll,
@@ -68,14 +68,14 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     )
 
     val listF =
-      BitcoinTxBuilder(destinations = Seq.empty,
+      BitcoinTxBuilder(destinations = Vector.empty,
                        utxos = List(utxo),
                        feeRate = SatoshisPerByte(1.sat),
                        changeSPK = EmptyScriptPubKey,
                        network = RegTest)
 
     val vecF =
-      BitcoinTxBuilder(destinations = Seq.empty,
+      BitcoinTxBuilder(destinations = Vector.empty,
                        utxos = List(utxo),
                        feeRate = SatoshisPerByte(1.sat),
                        changeSPK = EmptyScriptPubKey,
@@ -92,16 +92,16 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
 
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, spk)
     val destinations =
-      Seq(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
+      Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(version = tc.validLockVersion,
                                       inputs = Nil,
-                                      outputs = Seq(creditingOutput),
+                                      outputs = Vector(creditingOutput),
                                       lockTime = tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(
+    val utxo = BitcoinUTXOSpendingInfoFull(
       outPoint = outPoint,
       output = creditingOutput,
-      signers = Seq(privKey),
+      signers = Vector(privKey),
       redeemScriptOpt = None,
       scriptWitnessOpt = None,
       hashType = HashType.sigHashAll,
@@ -123,16 +123,16 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
   it must "fail to build a transaction when we pass in a negative fee rate" in {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, spk)
     val destinations =
-      Seq(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
+      Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(version = tc.validLockVersion,
                                       inputs = Nil,
-                                      outputs = Seq(creditingOutput),
+                                      outputs = Vector(creditingOutput),
                                       lockTime = tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(
+    val utxo = BitcoinUTXOSpendingInfoFull(
       outPoint = outPoint,
       output = creditingOutput,
-      signers = Seq(privKey),
+      signers = Vector(privKey),
       redeemScriptOpt = None,
       scriptWitnessOpt = None,
       hashType = HashType.sigHashAll,
@@ -153,20 +153,20 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
   it must "fail a transaction when the user invariants fail" in {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, spk)
     val destinations =
-      Seq(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
+      Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion,
                                       Nil,
-                                      Seq(creditingOutput),
+                                      Vector(creditingOutput),
                                       tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(outPoint,
-                                       creditingOutput,
-                                       Seq(privKey),
-                                       None,
-                                       None,
-                                       HashType.sigHashAll,
-                                       conditionalPath =
-                                         ConditionalPath.NoConditionsLeft)
+    val utxo = BitcoinUTXOSpendingInfoFull(outPoint,
+                                           creditingOutput,
+                                           Vector(privKey),
+                                           None,
+                                           None,
+                                           HashType.sigHashAll,
+                                           conditionalPath =
+                                             ConditionalPath.NoConditionsLeft)
     val utxoMap: UTXOMap = Map(outPoint -> utxo)
     val feeUnit = SatoshisPerVirtualByte(currencyUnit = Satoshis(1))
     val txBuilder = BitcoinTxBuilder(destinations = destinations,
@@ -175,7 +175,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
                                      changeSPK = EmptyScriptPubKey,
                                      network = TestNet3)
     //trivially false
-    val f = (_: Seq[BitcoinUTXOSpendingInfo], _: Transaction) => false
+    val f = (_: Seq[BitcoinUTXOSpendingInfoFull], _: Transaction) => false
     val resultFuture = txBuilder.flatMap(_.sign(f))
     recoverToSucceededIf[IllegalArgumentException] {
       resultFuture
@@ -186,29 +186,29 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     val creditingOutput =
       TransactionOutput(value = CurrencyUnits.zero, scriptPubKey = spk)
     val destinations = {
-      Seq(
+      Vector(
         TransactionOutput(value = Satoshis.one,
                           scriptPubKey = EmptyScriptPubKey))
     }
     val creditingTx = BaseTransaction(version = tc.validLockVersion,
                                       inputs = Nil,
-                                      outputs = Seq(creditingOutput),
+                                      outputs = Vector(creditingOutput),
                                       lockTime = tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(
+    val utxo = BitcoinUTXOSpendingInfoFull(
       outPoint = outPoint,
       output = creditingOutput,
-      signers = Seq(privKey),
+      signers = Vector(privKey),
       redeemScriptOpt = None,
       scriptWitnessOpt = None,
       hashType = HashType.sigHashAll,
       conditionalPath = ConditionalPath.NoConditionsLeft
     )
     val utxoMap: UTXOMap = Map(outPoint -> utxo)
-    val utxoSpendingInfo = BitcoinUTXOSpendingInfo(
+    val utxoSpendingInfo = BitcoinUTXOSpendingInfoFull(
       outPoint = outPoint,
       output = creditingOutput,
-      signers = Seq(privKey),
+      signers = Vector(privKey),
       redeemScriptOpt = None,
       scriptWitnessOpt = None,
       hashType = HashType.sigHashAll,
@@ -222,7 +222,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
                                         changeSPK = EmptyScriptPubKey,
                                         network = TestNet3)
     val txBuilderTuple = BitcoinTxBuilder(destinations = destinations,
-                                          utxos = Seq(utxoSpendingInfo),
+                                          utxos = Vector(utxoSpendingInfo),
                                           feeRate = feeUnit,
                                           changeSPK = EmptyScriptPubKey,
                                           network = TestNet3)
@@ -239,14 +239,14 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
     val creditingTx = BaseTransaction(version = tc.validLockVersion,
                                       inputs = Nil,
-                                      outputs = Seq(creditingOutput),
+                                      outputs = Vector(creditingOutput),
                                       lockTime = tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
     assertThrows[IllegalArgumentException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint = outPoint,
         output = creditingOutput,
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         redeemScriptOpt = Some(EmptyScriptPubKey),
         scriptWitnessOpt = None,
         hashType = HashType.sigHashAll,
@@ -260,14 +260,14 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wsh)
     val creditingTx = BaseTransaction(tc.validLockVersion,
                                       Nil,
-                                      Seq(creditingOutput),
+                                      Vector(creditingOutput),
                                       tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
     assertThrows[IllegalArgumentException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint,
         creditingOutput,
-        Seq(privKey),
+        Vector(privKey),
         None,
         Some(P2WSHWitnessV0(EmptyScriptPubKey)),
         HashType.sigHashAll,
@@ -280,16 +280,16 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     val p2pkh = P2PKHScriptPubKey(privKey.publicKey)
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2pkh)
     val destinations =
-      Seq(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
+      Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(tc.validLockVersion,
                                       Nil,
-                                      Seq(creditingOutput),
+                                      Vector(creditingOutput),
                                       tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(
+    val utxo = BitcoinUTXOSpendingInfoFull(
       outPoint,
       creditingOutput,
-      Seq(privKey),
+      Vector(privKey),
       None,
       Some(P2WSHWitnessV0(EmptyScriptPubKey)),
       HashType.sigHashAll,
@@ -314,17 +314,17 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     val pubKey2 = ECPrivateKey().publicKey
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2pkh)
     val destinations =
-      Seq(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
+      Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(version = tc.validLockVersion,
                                       inputs = Nil,
-                                      outputs = Seq(creditingOutput),
+                                      outputs = Vector(creditingOutput),
                                       lockTime = tc.lockTime)
     val outPoint =
       TransactionOutPoint(txId = creditingTx.txId, vout = UInt32.zero)
-    val utxo = BitcoinUTXOSpendingInfo(
+    val utxo = BitcoinUTXOSpendingInfoFull(
       outPoint = outPoint,
       output = creditingOutput,
-      signers = Seq(privKey),
+      signers = Vector(privKey),
       redeemScriptOpt = None,
       scriptWitnessOpt = Some(P2WSHWitnessV0(EmptyScriptPubKey)),
       hashType = HashType.sigHashAll,
@@ -350,15 +350,15 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
       TransactionOutput(value = CurrencyUnits.zero, scriptPubKey = p2wpkh)
     val creditingTx = BaseTransaction(version = tc.validLockVersion,
                                       inputs = Nil,
-                                      outputs = Seq(creditingOutput),
+                                      outputs = Vector(creditingOutput),
                                       lockTime = tc.lockTime)
     val outPoint =
       TransactionOutPoint(txId = creditingTx.txId, vout = UInt32.zero)
     assertThrows[IllegalArgumentException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint = outPoint,
         output = creditingOutput,
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         redeemScriptOpt = None,
         scriptWitnessOpt = Some(P2WSHWitnessV0(EmptyScriptPubKey)),
         hashType = HashType.sigHashAll,
@@ -372,14 +372,14 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wpkh)
     val creditingTx = BaseTransaction(tc.validLockVersion,
                                       Nil,
-                                      Seq(creditingOutput),
+                                      Vector(creditingOutput),
                                       tc.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
     assertThrows[IllegalArgumentException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint,
         creditingOutput,
-        Seq(privKey),
+        Vector(privKey),
         None,
         Some(P2WSHWitnessV0(EmptyScriptPubKey)),
         HashType.sigHashAll,
@@ -504,57 +504,60 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     )
   }
 
-  def verifyScript(tx: Transaction, utxos: Seq[UTXOSpendingInfo]): Boolean = {
-    val programs: Seq[PreExecutionScriptProgram] = tx.inputs.zipWithIndex.map {
-      case (input: TransactionInput, idx: Int) =>
-        val outpoint = input.previousOutput
+  def verifyScript(tx: Transaction,
+                   utxos: Vector[UTXOSpendingInfo]): Boolean = {
+    val programs: Vector[PreExecutionScriptProgram] =
+      tx.inputs.zipWithIndex.toVector.map {
+        case (input: TransactionInput, idx: Int) =>
+          val outpoint = input.previousOutput
 
-        val creditingTx = utxos.find(u => u.outPoint.txId == outpoint.txId).get
+          val creditingTx =
+            utxos.find(u => u.outPoint.txId == outpoint.txId).get
 
-        val output = creditingTx.output
+          val output = creditingTx.output
 
-        val spk = output.scriptPubKey
+          val spk = output.scriptPubKey
 
-        val amount = output.value
+          val amount = output.value
 
-        val txSigComponent = spk match {
-          case witSPK: WitnessScriptPubKeyV0 =>
-            val o = TransactionOutput(amount, witSPK)
-            WitnessTxSigComponentRaw(tx.asInstanceOf[WitnessTransaction],
+          val txSigComponent = spk match {
+            case witSPK: WitnessScriptPubKeyV0 =>
+              val o = TransactionOutput(amount, witSPK)
+              WitnessTxSigComponentRaw(tx.asInstanceOf[WitnessTransaction],
+                                       UInt32(idx),
+                                       o,
+                                       Policy.standardFlags)
+            case _: UnassignedWitnessScriptPubKey => ???
+            case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
+                _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
+                _: WitnessCommitment | _: CSVScriptPubKey |
+                _: CLTVScriptPubKey | _: ConditionalScriptPubKey |
+                _: NonStandardScriptPubKey | EmptyScriptPubKey) =>
+              val o = TransactionOutput(CurrencyUnits.zero, x)
+              BaseTxSigComponent(tx, UInt32(idx), o, Policy.standardFlags)
+
+            case p2sh: P2SHScriptPubKey =>
+              val p2shScriptSig =
+                tx.inputs(idx).scriptSignature.asInstanceOf[P2SHScriptSignature]
+              p2shScriptSig.redeemScript match {
+
+                case _: WitnessScriptPubKey =>
+                  WitnessTxSigComponentP2SH(
+                    transaction = tx.asInstanceOf[WitnessTransaction],
+                    inputIndex = UInt32(idx),
+                    output = output,
+                    flags = Policy.standardFlags)
+
+                case _ =>
+                  BaseTxSigComponent(tx,
                                      UInt32(idx),
-                                     o,
+                                     output,
                                      Policy.standardFlags)
-          case _: UnassignedWitnessScriptPubKey => ???
-          case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
-              _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
-              _: WitnessCommitment | _: CSVScriptPubKey | _: CLTVScriptPubKey |
-              _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
-              EmptyScriptPubKey) =>
-            val o = TransactionOutput(CurrencyUnits.zero, x)
-            BaseTxSigComponent(tx, UInt32(idx), o, Policy.standardFlags)
+              }
+          }
 
-          case p2sh: P2SHScriptPubKey =>
-            val p2shScriptSig =
-              tx.inputs(idx).scriptSignature.asInstanceOf[P2SHScriptSignature]
-            p2shScriptSig.redeemScript match {
-
-              case _: WitnessScriptPubKey =>
-                WitnessTxSigComponentP2SH(transaction =
-                                            tx.asInstanceOf[WitnessTransaction],
-                                          inputIndex = UInt32(idx),
-                                          output = output,
-                                          flags = Policy.standardFlags)
-
-              case _ =>
-                BaseTxSigComponent(tx,
-                                   UInt32(idx),
-                                   output,
-                                   Policy.standardFlags)
-            }
-        }
-
-        PreExecutionScriptProgram(txSigComponent)
-    }
+          PreExecutionScriptProgram(txSigComponent)
+      }
     ScriptInterpreter.runAllVerify(programs)
   }
 
@@ -586,7 +589,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
         val txF = builder.flatMap(_.sign)
 
         txF.map { tx =>
-          assert(verifyScript(tx, creditingTxsInfo))
+          assert(verifyScript(tx, creditingTxsInfo.toVector))
         }
     }
   }
@@ -605,7 +608,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
         val txF = builder.flatMap(_.sign)
 
         txF.map { tx =>
-          assert(verifyScript(tx, creditingTxsInfo))
+          assert(verifyScript(tx, creditingTxsInfo.toVector))
         }
     }
   }

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -561,7 +561,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     ScriptInterpreter.runAllVerify(programs)
   }
 
-  private def outputGen(outputs: Gen[Seq[BitcoinUTXOSpendingInfo]]) = {
+  private def outputGen(outputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]]) = {
     outputs
       .flatMap { creditingTxsInfo =>
         val creditingOutputs = creditingTxsInfo.map(c => c.output)

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -23,7 +23,7 @@ import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{
   BitcoinUTXOSpendingInfo,
   ConditionalPath,
-  LockTimeSpendingInfo,
+  LockTimeSpendingInfoFull,
   UTXOSpendingInfo
 }
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
@@ -397,7 +397,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
       CLTVScriptPubKey(ScriptNumber(lockTime),
                        P2PKScriptPubKey(fundingPrivKey.publicKey))
 
-    val cltvSpendingInfo = LockTimeSpendingInfo(
+    val cltvSpendingInfo = LockTimeSpendingInfoFull(
       TransactionOutPoint(DoubleSha256DigestBE.empty, UInt32.zero),
       Bitcoins.one,
       cltvSPK,
@@ -431,7 +431,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
       CLTVScriptPubKey(ScriptNumber(lockTime),
                        P2PKScriptPubKey(fundingPrivKey.publicKey))
 
-    val cltvSpendingInfo = LockTimeSpendingInfo(
+    val cltvSpendingInfo = LockTimeSpendingInfoFull(
       TransactionOutPoint(DoubleSha256DigestBE.empty, UInt32.zero),
       Bitcoins.one,
       cltvSPK,
@@ -470,7 +470,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
       CLTVScriptPubKey(ScriptNumber(lockTime2),
                        P2PKScriptPubKey(fundingPrivKey2.publicKey))
 
-    val cltvSpendingInfo1 = LockTimeSpendingInfo(
+    val cltvSpendingInfo1 = LockTimeSpendingInfoFull(
       TransactionOutPoint(DoubleSha256DigestBE.empty, UInt32.zero),
       Bitcoins.one,
       cltvSPK1,
@@ -479,7 +479,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
       ConditionalPath.NoConditionsLeft
     )
 
-    val cltvSpendingInfo2 = LockTimeSpendingInfo(
+    val cltvSpendingInfo2 = LockTimeSpendingInfoFull(
       TransactionOutPoint(DoubleSha256DigestBE.empty, UInt32.one),
       Bitcoins.one,
       cltvSPK2,

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.wallet.signer
 import org.bitcoins.core.protocol.script.WitnessScriptPubKey
 import org.bitcoins.core.wallet.utxo.{
   P2WPKHV0SpendingInfo,
-  P2WSHV0SpendingInfo,
+  P2WSHV0SpendingInfoFull,
   UnassignedSegwitNativeUTXOSpendingInfo
 }
 import org.bitcoins.testkit.core.gen.{
@@ -59,7 +59,7 @@ class SignerTest extends BitcoinSAsyncTest {
     val dumbSpendingInfo = GenUtil.sample(CreditingTxGen.output)
     val p2wsh = GenUtil
       .sample(CreditingTxGen.p2wshOutput)
-      .asInstanceOf[P2WSHV0SpendingInfo]
+      .asInstanceOf[P2WSHV0SpendingInfoFull]
     val tx = GenUtil.sample(TransactionGenerators.baseTransaction)
     recoverToSucceededIf[IllegalArgumentException] {
       P2WSHSigner.sign(dumbSpendingInfo, tx, isDummySignature = false, p2wsh)

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -6,11 +6,9 @@ import org.bitcoins.core.protocol.script.{
   EmptyScriptWitness,
   P2WPKHWitnessV0,
   P2WSHWitnessV0,
-  ScriptSignature,
   WitnessScriptPubKey
 }
 import org.bitcoins.core.protocol.transaction.WitnessTransaction
-import org.bitcoins.core.serializers.script.ScriptParser
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
@@ -42,7 +42,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
-      P2SHNoNestSpendingInfo(
+      P2SHNoNestSpendingInfoFull(
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2sh,
@@ -63,7 +63,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
-      P2SHNestedSegwitV0UTXOSpendingInfo(
+      P2SHNestedSegwitV0UTXOSpendingInfoFull(
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2sh,
@@ -90,7 +90,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
-      P2SHNestedSegwitV0UTXOSpendingInfo(
+      P2SHNestedSegwitV0UTXOSpendingInfoFull(
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2sh,
@@ -112,7 +112,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
-      P2SHNestedSegwitV0UTXOSpendingInfo(
+      P2SHNestedSegwitV0UTXOSpendingInfoFull(
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2sh,
@@ -134,7 +134,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
-      P2SHNestedSegwitV0UTXOSpendingInfo(
+      P2SHNestedSegwitV0UTXOSpendingInfoFull(
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2sh,

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfoTest.scala
@@ -46,7 +46,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2sh,
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScript = randomRawSPK,
         conditionalPath = ConditionalPath.NoConditionsLeft
@@ -67,7 +67,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2sh,
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScript = randomWitnessSPK,
         scriptWitness = P2WPKHWitnessV0(pubKey),
@@ -85,7 +85,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val creditingTx = BaseTransaction(version =
                                         TransactionConstants.validLockVersion,
                                       inputs = Nil,
-                                      outputs = Seq(creditingOutput),
+                                      outputs = Vector(creditingOutput),
                                       lockTime = TransactionConstants.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
@@ -94,7 +94,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2sh,
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScript = P2WPKHWitnessSPKV0(pubKey),
         scriptWitness = P2WPKHWitnessV0(ECPrivateKey.freshPrivateKey.publicKey),
@@ -116,7 +116,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2sh,
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScript = randomWitnessSPK,
         scriptWitness = P2WSHWitnessV0(P2PKScriptPubKey(pubKey)),
@@ -138,7 +138,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2sh,
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScript = P2WSHWitnessSPKV0(P2PKScriptPubKey(pubKey)),
         scriptWitness = P2WSHWitnessV0(randomRawSPK),
@@ -157,11 +157,11 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
-      SegwitV0NativeUTXOSpendingInfo(
+      SegwitV0NativeUTXOSpendingInfoFull(
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2wpkh,
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         scriptWitness = P2WPKHWitnessV0(ECPrivateKey.freshPrivateKey.publicKey),
         conditionalPath = ConditionalPath.NoConditionsLeft
@@ -179,11 +179,11 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
-      SegwitV0NativeUTXOSpendingInfo(
+      SegwitV0NativeUTXOSpendingInfoFull(
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = p2wsh,
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         scriptWitness = P2WSHWitnessV0(randomRawSPK),
         conditionalPath = ConditionalPath.NoConditionsLeft
@@ -209,10 +209,10 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint = outPoint,
         output = TransactionOutput(CurrencyUnits.zero, p2sh),
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScriptOpt = None,
         scriptWitnessOpt = None,
@@ -230,15 +230,15 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val creditingTx = BaseTransaction(version =
                                         TransactionConstants.validLockVersion,
                                       inputs = Nil,
-                                      outputs = Seq(creditingOutput),
+                                      outputs = Vector(creditingOutput),
                                       lockTime = TransactionConstants.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint = outPoint,
         output = TransactionOutput(CurrencyUnits.zero, p2sh),
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScriptOpt = Some(P2WPKHWitnessSPKV0(pubKey)),
         scriptWitnessOpt = None,
@@ -256,15 +256,15 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val creditingTx = BaseTransaction(version =
                                         TransactionConstants.validLockVersion,
                                       inputs = Nil,
-                                      outputs = Seq(creditingOutput),
+                                      outputs = Vector(creditingOutput),
                                       lockTime = TransactionConstants.lockTime)
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[UnsupportedOperationException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint = outPoint,
         output = TransactionOutput(CurrencyUnits.zero, p2sh),
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScriptOpt = Some(P2WPKHWitnessSPKV0(pubKey)),
         scriptWitnessOpt = Some(EmptyScriptWitness),
@@ -284,10 +284,10 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[UnsupportedOperationException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint = outPoint,
         output = TransactionOutput(CurrencyUnits.zero, p2sh),
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScriptOpt = Some(unassingedWitnessSPK),
         scriptWitnessOpt = None,
@@ -306,10 +306,10 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[UnsupportedOperationException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint = outPoint,
         output = TransactionOutput(CurrencyUnits.zero, p2wpkh),
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScriptOpt = None,
         scriptWitnessOpt = Some(EmptyScriptWitness),
@@ -328,10 +328,10 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[IllegalArgumentException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint = outPoint,
         output = TransactionOutput(CurrencyUnits.zero, p2wpkh),
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScriptOpt = None,
         scriptWitnessOpt = None,
@@ -340,7 +340,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     }
   }
 
-  it should "successfully return UnassingedSegwitNativeUTXOSpendingInfo" in {
+  it should "successfully return UnassingedSegwitNativeUTXOSpendingInfoFull" in {
     val unassingedWitnessSPK = UnassignedWitnessScriptPubKey.fromAsm(
       P2WPKHWitnessSPKV0(ECPublicKey.freshPublicKey).asm)
 
@@ -353,10 +353,10 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     val spendingInfo =
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint = outPoint,
         output = TransactionOutput(CurrencyUnits.zero, unassingedWitnessSPK),
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         redeemScriptOpt = None,
         scriptWitnessOpt = None,
@@ -368,7 +368,7 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
         outPoint = outPoint,
         amount = CurrencyUnits.zero,
         scriptPubKey = unassingedWitnessSPK,
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         hashType = HashType.sigHashAll,
         scriptWitness = EmptyScriptWitness,
         conditionalPath = ConditionalPath.NoConditionsLeft
@@ -386,10 +386,10 @@ class UTXOSpendingInfoTest extends BitcoinSAsyncTest {
     val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
     assertThrows[UnsupportedOperationException] {
-      BitcoinUTXOSpendingInfo(
+      BitcoinUTXOSpendingInfoFull(
         outPoint = outPoint,
         output = TransactionOutput(CurrencyUnits.zero, spk),
-        signers = Seq(privKey),
+        signers = Vector(privKey),
         redeemScriptOpt = None,
         scriptWitnessOpt = None,
         hashType = HashType.sigHashAll,

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -91,6 +91,17 @@ sealed abstract class P2WSHWitnessV0 extends ScriptWitnessV0 {
     val cmpct = CompactSizeUInt.calc(stack.head)
     RawScriptPubKey.fromBytes(cmpct.bytes ++ stack.head)
   }
+
+  lazy val signatures: Vector[ECDigitalSignature] = {
+    // ECDigital signatures are between 71 and 73 bytes long
+    // with a exponential decay on the probability of smaller sigs
+    // [[https://en.bitcoin.it/wiki/Elliptic_Curve_Digital_Signature_Algorithm]]
+    val relevantStack = stack.toVector.tail.filter(bytes =>
+      bytes.length >= 67 && bytes.length <= 73)
+
+    relevantStack.map(ECDigitalSignature.fromBytes)
+  }
+
   override def toString =
     s"P2WSHWitnessV0(${stack.map(BitcoinSUtil.encodeHex(_)).toString})"
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -20,7 +20,7 @@ import org.bitcoins.core.util.BitcoinSLogger
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.signer._
 import org.bitcoins.core.wallet.utxo.{
-  BitcoinUTXOSpendingInfo,
+  BitcoinUTXOSpendingInfoFull,
   ConditionalSpendingInfoFull,
   EmptySpendingInfo,
   LockTimeSpendingInfoFull,
@@ -28,10 +28,10 @@ import org.bitcoins.core.wallet.utxo.{
   P2PKHSpendingInfo,
   P2PKSpendingInfo,
   P2PKWithTimeoutSpendingInfo,
-  P2SHSpendingInfo,
+  P2SHSpendingInfoFull,
   P2WPKHV0SpendingInfo,
   P2WSHV0SpendingInfoFull,
-  UTXOSpendingInfo,
+  UTXOSpendingInfoFull,
   UnassignedSegwitNativeUTXOSpendingInfo
 }
 
@@ -85,7 +85,7 @@ sealed abstract class TxBuilder {
     */
   def utxoMap: TxBuilder.UTXOMap
 
-  def utxos: Seq[UTXOSpendingInfo] = utxoMap.values.toSeq
+  def utxos: Seq[UTXOSpendingInfoFull] = utxoMap.values.toSeq
 
   /** This represents the rate, in [[org.bitcoins.core.wallet.fee.FeeUnit FeeUnit]], we
     * should pay for this transaction */
@@ -140,8 +140,9 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
   override def utxoMap: BitcoinTxBuilder.UTXOMap
 
   override def sign(implicit ec: ExecutionContext): Future[Transaction] = {
-    val f: (Seq[BitcoinUTXOSpendingInfo], Transaction) => Boolean = { (_, _) =>
-      true
+    val f: (Seq[BitcoinUTXOSpendingInfoFull], Transaction) => Boolean = {
+      (_, _) =>
+        true
     }
     sign(f)
   }
@@ -212,7 +213,8 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     * @param invariants - invariants that should hold true when we are done signing the transaction
     * @return the signed transaction, or a [[TxBuilderError]] indicating what went wrong when signing the tx
     */
-  def sign(invariants: (Seq[BitcoinUTXOSpendingInfo], Transaction) => Boolean)(
+  def sign(
+      invariants: (Seq[BitcoinUTXOSpendingInfoFull], Transaction) => Boolean)(
       implicit ec: ExecutionContext): Future[Transaction] = {
     val utxos = utxoMap.values.toList
     val signedTxWithFee = unsignedTx.flatMap { utx: Transaction =>
@@ -237,7 +239,7 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
   }
 
   private def loop(
-      remaining: List[BitcoinUTXOSpendingInfo],
+      remaining: List[BitcoinUTXOSpendingInfoFull],
       txInProgress: Transaction,
       dummySignatures: Boolean)(
       implicit ec: ExecutionContext): Future[Transaction] = remaining match {
@@ -254,7 +256,7 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     * @return either the transaction with the signed input added, or a [[TxBuilderError]]
     */
   private def signAndAddInput(
-      utxo: BitcoinUTXOSpendingInfo,
+      utxo: BitcoinUTXOSpendingInfoFull,
       unsignedTx: Transaction,
       dummySignatures: Boolean)(
       implicit ec: ExecutionContext): Future[Transaction] = {
@@ -266,7 +268,7 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
       utxo match {
         case _: UnassignedSegwitNativeUTXOSpendingInfo =>
           Future.fromTry(TxBuilderError.NoSigner)
-        case _: BitcoinUTXOSpendingInfo =>
+        case _: BitcoinUTXOSpendingInfoFull =>
           BitcoinSigner
             .sign(utxo, unsignedTx, dummySignatures)
             .map(_.transaction)
@@ -303,7 +305,8 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     * locktime set to the same value (or higher) than the output it is spending.
     * See BIP65 for more info
     */
-  private def calcLockTime(utxos: Seq[BitcoinUTXOSpendingInfo]): Try[UInt32] = {
+  private def calcLockTime(
+      utxos: Seq[BitcoinUTXOSpendingInfoFull]): Try[UInt32] = {
     def computeNextLockTime(
         currentLockTimeOpt: Option[UInt32],
         locktime: Long): Try[UInt32] = {
@@ -335,7 +338,7 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
 
     @tailrec
     def loop(
-        remaining: Seq[BitcoinUTXOSpendingInfo],
+        remaining: Seq[BitcoinUTXOSpendingInfoFull],
         currentLockTimeOpt: Option[UInt32]): Try[UInt32] =
       remaining match {
         case Nil =>
@@ -370,7 +373,7 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
                   case _: Failure[UInt32] => result
                 }
               }
-            case p2sh: P2SHSpendingInfo =>
+            case p2sh: P2SHSpendingInfoFull =>
               loop(p2sh.nestedSpendingInfo +: newRemaining, currentLockTimeOpt)
             case p2wsh: P2WSHV0SpendingInfoFull =>
               loop(p2wsh.nestedSpendingInfo +: newRemaining, currentLockTimeOpt)
@@ -396,11 +399,11 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
     * See BIP68/112 and BIP65 for more info
     */
   private def calcSequenceForInputs(
-      utxos: Seq[UTXOSpendingInfo],
+      utxos: Seq[UTXOSpendingInfoFull],
       isRBFEnabled: Boolean): Seq[TransactionInput] = {
     @tailrec
     def loop(
-        remaining: Seq[UTXOSpendingInfo],
+        remaining: Seq[UTXOSpendingInfoFull],
         accum: Seq[TransactionInput]): Seq[TransactionInput] =
       remaining match {
         case Nil => accum.reverse
@@ -431,7 +434,7 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
                                              UInt32.zero)
                 loop(newRemaining, input +: accum)
               }
-            case p2sh: P2SHSpendingInfo =>
+            case p2sh: P2SHSpendingInfoFull =>
               loop(p2sh.nestedSpendingInfo +: newRemaining, accum)
             case p2wsh: P2WSHV0SpendingInfoFull =>
               loop(p2wsh.nestedSpendingInfo +: newRemaining, accum)
@@ -462,7 +465,7 @@ sealed abstract class BitcoinTxBuilder extends TxBuilder {
       inputIndex: UInt32,
       p2wpkh: P2WPKHWitnessSPKV0,
       output: TransactionOutput,
-      utxo: UTXOSpendingInfo,
+      utxo: UTXOSpendingInfoFull,
       hashType: HashType,
       dummySignatures: Boolean): Future[Transaction] = {
     //special rule for p2sh(p2wpkh)
@@ -520,7 +523,7 @@ object TxBuilder {
 
   /** This contains all the information needed to create a valid
     * [[org.bitcoins.core.protocol.transaction.TransactionInput TransactionInput]] that spends this utxo */
-  type UTXOMap = Map[TransactionOutPoint, UTXOSpendingInfo]
+  type UTXOMap = Map[TransactionOutPoint, UTXOSpendingInfoFull]
   private val logger = BitcoinSLogger.logger
 
   /** Runs various sanity checks on the final version of the signed transaction from TxBuilder */
@@ -639,7 +642,7 @@ object TxBuilder {
 }
 
 object BitcoinTxBuilder {
-  type UTXOMap = Map[TransactionOutPoint, BitcoinUTXOSpendingInfo]
+  type UTXOMap = Map[TransactionOutPoint, BitcoinUTXOSpendingInfoFull]
 
   private case class BitcoinTxBuilderImpl(
       destinations: Seq[TransactionOutput],
@@ -675,16 +678,16 @@ object BitcoinTxBuilder {
 
   def apply(
       destinations: Seq[TransactionOutput],
-      utxos: Seq[BitcoinUTXOSpendingInfo],
+      utxos: Seq[BitcoinUTXOSpendingInfoFull],
       feeRate: FeeUnit,
       changeSPK: ScriptPubKey,
       network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
     @tailrec
-    def loop(utxos: Seq[UTXOSpendingInfo], accum: UTXOMap): UTXOMap =
+    def loop(utxos: Seq[UTXOSpendingInfoFull], accum: UTXOMap): UTXOMap =
       utxos match {
         case Nil => accum
         case h +: t =>
-          val u = BitcoinUTXOSpendingInfo(
+          val u = BitcoinUTXOSpendingInfoFull(
             outPoint = h.outPoint,
             output = h.output,
             signers = h.signers,

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -185,24 +185,24 @@ object BitcoinSigner {
                                    p2pKWithTimeout)
       case p2sh: P2SHSpendingInfo =>
         P2SHSigner.sign(spendingInfo, unsignedTx, isDummySignature, p2sh)
-      case multiSig: MultiSignatureSpendingInfo =>
+      case multiSig: MultiSignatureSpendingInfoFull =>
         MultiSigSigner.sign(spendingInfo,
                             unsignedTx,
                             isDummySignature,
                             multiSig)
-      case lockTime: LockTimeSpendingInfo =>
+      case lockTime: LockTimeSpendingInfoFull =>
         LockTimeSigner.sign(spendingInfo,
                             unsignedTx,
                             isDummySignature,
                             lockTime)
-      case conditional: ConditionalSpendingInfo =>
+      case conditional: ConditionalSpendingInfoFull =>
         ConditionalSigner.sign(spendingInfo,
                                unsignedTx,
                                isDummySignature,
                                conditional)
       case p2wpkh: P2WPKHV0SpendingInfo =>
         P2WPKHSigner.sign(spendingInfo, unsignedTx, isDummySignature, p2wpkh)
-      case pw2sh: P2WSHV0SpendingInfo =>
+      case pw2sh: P2WSHV0SpendingInfoFull =>
         P2WSHSigner.sign(spendingInfo, unsignedTx, isDummySignature, pw2sh)
       case _: UnassignedSegwitNativeUTXOSpendingInfo =>
         throw new UnsupportedOperationException("Unsupported Segwit version")
@@ -331,13 +331,13 @@ sealed abstract class P2PKWithTimeoutSigner
 object P2PKWithTimeoutSigner extends P2PKWithTimeoutSigner
 
 sealed abstract class MultiSigSigner
-    extends BitcoinSigner[MultiSignatureSpendingInfo] {
+    extends BitcoinSigner[MultiSignatureSpendingInfoFull] {
 
   override def sign(
       spendingInfo: UTXOSpendingInfo,
       unsignedTx: Transaction,
       isDummySignature: Boolean,
-      spendingInfoToSatisfy: MultiSignatureSpendingInfo)(
+      spendingInfoToSatisfy: MultiSignatureSpendingInfoFull)(
       implicit ec: ExecutionContext): Future[TxSigComponent] = {
     val (signersWithPubKeys, output, inputIndex, hashType) =
       relevantInfo(spendingInfo, unsignedTx)
@@ -504,13 +504,14 @@ sealed abstract class P2WPKHSigner extends BitcoinSigner[P2WPKHV0SpendingInfo] {
 }
 object P2WPKHSigner extends P2WPKHSigner
 
-sealed abstract class P2WSHSigner extends BitcoinSigner[P2WSHV0SpendingInfo] {
+sealed abstract class P2WSHSigner
+    extends BitcoinSigner[P2WSHV0SpendingInfoFull] {
 
   override def sign(
       spendingInfo: UTXOSpendingInfo,
       unsignedTx: Transaction,
       isDummySignature: Boolean,
-      spendingInfoToSatisfy: P2WSHV0SpendingInfo)(
+      spendingInfoToSatisfy: P2WSHV0SpendingInfoFull)(
       implicit ec: ExecutionContext): Future[TxSigComponent] = {
     if (spendingInfoToSatisfy != spendingInfo) {
       Future.fromTry(TxBuilderError.WrongSigner)
@@ -546,13 +547,13 @@ sealed abstract class P2WSHSigner extends BitcoinSigner[P2WSHV0SpendingInfo] {
 object P2WSHSigner extends P2WSHSigner
 
 sealed abstract class LockTimeSigner
-    extends BitcoinSigner[LockTimeSpendingInfo] {
+    extends BitcoinSigner[LockTimeSpendingInfoFull] {
 
   override def sign(
       spendingInfo: UTXOSpendingInfo,
       unsignedTx: Transaction,
       isDummySignature: Boolean,
-      spendingInfoToSatisfy: LockTimeSpendingInfo)(
+      spendingInfoToSatisfy: LockTimeSpendingInfoFull)(
       implicit ec: ExecutionContext): Future[TxSigComponent] = {
     BitcoinSigner.sign(spendingInfo,
                        unsignedTx,
@@ -566,13 +567,13 @@ object LockTimeSigner extends LockTimeSigner
   * spent and then adds an OP_TRUE or OP_FALSE
   */
 sealed abstract class ConditionalSigner
-    extends BitcoinSigner[ConditionalSpendingInfo] {
+    extends BitcoinSigner[ConditionalSpendingInfoFull] {
 
   override def sign(
       spendingInfo: UTXOSpendingInfo,
       unsignedTx: Transaction,
       isDummySignature: Boolean,
-      spendingInfoToSatisfy: ConditionalSpendingInfo)(
+      spendingInfoToSatisfy: ConditionalSpendingInfoFull)(
       implicit ec: ExecutionContext): Future[TxSigComponent] = {
     val (_, output, inputIndex, _) = relevantInfo(spendingInfo, unsignedTx)
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -3,6 +3,7 @@ package org.bitcoins.core.wallet.signer
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
+import org.bitcoins.core.protocol.script
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.crypto.HashType
@@ -596,7 +597,11 @@ sealed abstract class P2WPKHSigner
                              unsignedTx,
                              isDummySignature,
                              spendingInfoToSatisfy)
-        sig = sigComponent.scriptSignature.signatures.head
+        sig = sigComponent
+          .asInstanceOf[WitnessTxSigComponent]
+          .witness
+          .asInstanceOf[script.P2WPKHWitnessV0]
+          .signature
       } yield {
         (spendingInfoToSatisfy.signer.publicKey, sig)
       }

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -89,9 +89,17 @@ abstract private[signer] class SignerUtils {
   }
 }
 
+/** The class used to represent a single key's signing process for a
+  * specific [[org.bitcoins.core.protocol.script.ScriptPubKey]] type */
 sealed trait SingleSigner[-SpendingInfo <: UTXOSpendingInfoSingle]
     extends SignerUtils {
 
+  /**
+    * The method used to sign a bitcoin unspent transaction output with a single key
+    * @param spendingInfo The information required for creating the signature
+    * @param unsignedTx the external Transaction that needs an input signed
+    * @param isDummySignature generates a dummy signature if true, useful for fee estimation
+    */
   def signSingle(
       spendingInfo: SpendingInfo,
       unsignedTx: Transaction,
@@ -103,6 +111,13 @@ sealed trait SingleSigner[-SpendingInfo <: UTXOSpendingInfoSingle]
                spendingInfoToSatisfy = spendingInfo)
   }
 
+  /**
+    * The method used to sign, with a single key, a bitcoin unspent transaction output that is potentially nested
+    * @param spendingInfo The information required for creating the signature
+    * @param unsignedTx the external Transaction that needs an input signed
+    * @param isDummySignature generates a dummy signature if true, useful for fee estimation
+    * @param spendingInfoToSatisfy - specifies the UTXOSpendingInfoSingle whose ScriptPubKey needs an ECDigitalSignature to be generated
+    */
   def signSingle(
       spendingInfo: UTXOSpendingInfoSingle,
       unsignedTx: Transaction,
@@ -182,6 +197,9 @@ sealed abstract class Signer[-SpendingInfo <: UTXOSpendingInfo]
   }
 }
 
+/** Represents all signers (for single keys) for the bitcoin protocol,
+  * we could add another network later like litecoin
+  */
 sealed trait BitcoinSignerSingle[-SpendingInfo <: BitcoinUTXOSpendingInfoSingle]
     extends SingleSigner[SpendingInfo] {
   override def signSingle(
@@ -334,11 +352,13 @@ object BitcoinSigner {
   }
 }
 
+/** Represents a BitcoinSigner for which only a single signature is required */
 sealed abstract class SingleKeyBitcoinSigner[
     -SpendingInfo <: BitcoinUTXOSpendingInfo]
     extends BitcoinSigner[SpendingInfo]
     with BitcoinSignerSingle[SpendingInfo]
 
+/** Represents a SingleKeyBitcoinSigner which signs a RawScriptPubKey */
 sealed abstract class RawSingleKeyBitcoinSigner[
     -SpendingInfo <: RawScriptUTXOSpendingInfo]
     extends SingleKeyBitcoinSigner[SpendingInfo] {

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
@@ -214,7 +214,18 @@ object BitcoinUTXOSpendingInfoSingle {
 
 sealed trait BitcoinUTXOSpendingInfo
     extends UTXOSpendingInfo
-    with BitcoinUTXOSpendingInfoSingle
+    with BitcoinUTXOSpendingInfoSingle {
+
+  def toSingle(signerIndex: Int): BitcoinUTXOSpendingInfoSingle = {
+    BitcoinUTXOSpendingInfoSingle(outPoint,
+                                  output,
+                                  signers(signerIndex),
+                                  redeemScriptOpt,
+                                  scriptWitnessOpt,
+                                  hashType,
+                                  conditionalPath)
+  }
+}
 
 object BitcoinUTXOSpendingInfo {
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
@@ -79,6 +79,12 @@ sealed abstract class UTXOSpendingInfo extends UTXOSpendingInfoSingle {
     * where full signing and single key singing happen.
     */
   override def signer: Sign = signers.head
+
+  def toSingle(signerIndex: Int): UTXOSpendingInfoSingle
+
+  def toSingles: Vector[UTXOSpendingInfoSingle] = {
+    signers.indices.toVector.map(toSingle)
+  }
 }
 
 /** Represents the spending branch being taken in a ScriptPubKey's execution
@@ -216,7 +222,7 @@ sealed trait BitcoinUTXOSpendingInfo
     extends UTXOSpendingInfo
     with BitcoinUTXOSpendingInfoSingle {
 
-  def toSingle(signerIndex: Int): BitcoinUTXOSpendingInfoSingle = {
+  override def toSingle(signerIndex: Int): BitcoinUTXOSpendingInfoSingle = {
     BitcoinUTXOSpendingInfoSingle(outPoint,
                                   output,
                                   signers(signerIndex),
@@ -611,7 +617,7 @@ case class MultiSignatureSpendingInfoFull(
                                      hashType)
   }
 
-  def toSingles: Vector[MultiSignatureSpendingInfoSingle] = {
+  override def toSingles: Vector[MultiSignatureSpendingInfoSingle] = {
     signers.map { signer =>
       MultiSignatureSpendingInfoSingle(outPoint,
                                        amount,

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
@@ -600,6 +600,26 @@ case class MultiSignatureSpendingInfoFull(
 ) extends RawScriptUTXOSpendingInfo
     with MultiSignatureSpendingInfo {
   require(signers.length >= scriptPubKey.requiredSigs, "Not enough signers!")
+
+  val requiredSigs: Int = scriptPubKey.requiredSigs
+
+  override def toSingle(signerIndex: Int): MultiSignatureSpendingInfoSingle = {
+    MultiSignatureSpendingInfoSingle(outPoint,
+                                     amount,
+                                     scriptPubKey,
+                                     signers(signerIndex),
+                                     hashType)
+  }
+
+  def toSingles: Vector[MultiSignatureSpendingInfoSingle] = {
+    signers.map { signer =>
+      MultiSignatureSpendingInfoSingle(outPoint,
+                                       amount,
+                                       scriptPubKey,
+                                       signer,
+                                       hashType)
+    }
+  }
 }
 
 sealed trait ConditionalSpendingInfo extends RawScriptUTXOSpendingInfoSingle {

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXOSpendingInfo.scala
@@ -63,8 +63,10 @@ sealed abstract class UTXOSpendingInfoSingle {
 }
 
 /**
-  * Contains the information required to spend an unspent transaction output (UTXO)
+  * Contains the information required to fully sign an unspent transaction output (UTXO)
   * on a blockchain.
+  *
+  * If you want to partially sign a UTXO you will likely need to use UTXOSpendingInfoSingle.
   */
 sealed abstract class UTXOSpendingInfo extends UTXOSpendingInfoSingle {
 
@@ -366,6 +368,11 @@ object BitcoinUTXOSpendingInfo {
   }
 }
 
+/** This represents the information needed to be sign, with a single key, scripts like
+  * [[org.bitcoins.core.protocol.script.P2PKHScriptPubKey p2pkh]] or
+  * [[org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey multisig]] scripts.
+  * Basically this is for ScriptPubKeys where there is no nesting that requires a redeem script
+  */
 sealed trait RawScriptUTXOSpendingInfoSingle
     extends BitcoinUTXOSpendingInfoSingle {
   override def scriptPubKey: RawScriptPubKey
@@ -734,6 +741,9 @@ case class LockTimeSpendingInfoFull(
   override val requiredSigs: Int = nestedSpendingInfo.requiredSigs
 }
 
+/** This is the case where we are signing a
+  * [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 witness v0 script]]
+  */
 sealed trait SegwitV0NativeUTXOSpendingInfoSingle
     extends BitcoinUTXOSpendingInfoSingle {
   override def scriptPubKey: WitnessScriptPubKeyV0

--- a/docs/core/txbuilder.md
+++ b/docs/core/txbuilder.md
@@ -55,15 +55,15 @@ val destinations = {
     val destination1 = TransactionOutput(value = destinationAmount,
                                          scriptPubKey = destinationSPK)
 
-    List(destination1)
+    Vector(destination1)
 }
 
 // we have to fabricate a transaction that contains the
 // UTXO we are trying to spend. If this were a real blockchain
 // we would need to reference the UTXO set
 val creditingTx = BaseTransaction(version = Int32.one,
-                                  inputs = List.empty,
-                                  outputs = List(utxo),
+                                  inputs = Vector.empty,
+                                  outputs = Vector(utxo),
                                   lockTime = UInt32.zero)
 
 // this is the information we need from the crediting TX
@@ -72,19 +72,19 @@ val outPoint = TransactionOutPoint(creditingTx.txId, UInt32.zero)
 
 // this contains all the information we need to
 // validly sign the UTXO above
-val utxoSpendingInfo = BitcoinUTXOSpendingInfo(outPoint = outPoint,
-                                               output = utxo,
-                                               signers = List(privKey),
-                                               redeemScriptOpt = None,
-                                               scriptWitnessOpt = None,
-                                               hashType =
-                                                HashType.sigHashAll,
-                                               conditionalPath =
-                                                ConditionalPath.NoConditionsLeft)
+val utxoSpendingInfo = BitcoinUTXOSpendingInfoFull(outPoint = outPoint,
+                                                   output = utxo,
+                                                   signers = Vector(privKey),
+                                                   redeemScriptOpt = None,
+                                                   scriptWitnessOpt = None,
+                                                   hashType =
+                                                       HashType.sigHashAll,
+                                                   conditionalPath =
+                                                       ConditionalPath.NoConditionsLeft)
 
 // all of the UTXO spending information, since we are only
 //spending one UTXO, this is just one element
-val utxos: List[BitcoinUTXOSpendingInfo] = List(utxoSpendingInfo)
+val utxos: Vector[BitcoinUTXOSpendingInfoFull] = Vector(utxoSpendingInfo)
 
 // this is how much we are going to pay as a fee to the network
 // for this example, we are going to pay 1 satoshi per byte

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CreditingTxGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CreditingTxGen.scala
@@ -9,7 +9,7 @@ import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.wallet.utxo.{
   BitcoinUTXOSpendingInfo,
   ConditionalPath,
-  P2SHNestedSegwitV0UTXOSpendingInfo
+  P2SHNestedSegwitV0UTXOSpendingInfoFull
 }
 import org.scalacheck.Gen
 
@@ -73,14 +73,14 @@ sealed abstract class CreditingTxGen {
       .suchThat(output =>
         !ScriptGenerators.redeemScriptTooBig(output.scriptPubKey))
       .suchThat {
-        case P2SHNestedSegwitV0UTXOSpendingInfo(_,
-                                                _,
-                                                _,
-                                                _,
-                                                _,
-                                                _,
-                                                witness: P2WSHWitnessV0,
-                                                _) =>
+        case P2SHNestedSegwitV0UTXOSpendingInfoFull(_,
+                                                    _,
+                                                    _,
+                                                    _,
+                                                    _,
+                                                    _,
+                                                    witness: P2WSHWitnessV0,
+                                                    _) =>
           witness.stack.exists(_.length > ScriptInterpreter.MAX_PUSH_SIZE)
         case _ => true
       }

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CreditingTxGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CreditingTxGen.scala
@@ -7,7 +7,7 @@ import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.wallet.utxo.{
-  BitcoinUTXOSpendingInfo,
+  BitcoinUTXOSpendingInfoFull,
   ConditionalPath,
   P2SHNestedSegwitV0UTXOSpendingInfoFull
 }
@@ -28,7 +28,7 @@ sealed abstract class CreditingTxGen {
     }
 
   /** Generator for non-script hash based output */
-  def nonSHOutput: Gen[BitcoinUTXOSpendingInfo] = {
+  def nonSHOutput: Gen[BitcoinUTXOSpendingInfoFull] = {
     Gen.oneOf(
       p2pkOutput,
       p2pkhOutput,
@@ -40,14 +40,14 @@ sealed abstract class CreditingTxGen {
     )
   }
 
-  def nonSHOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
+  def nonSHOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] =
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, nonSHOutput))
 
-  def basicOutput: Gen[BitcoinUTXOSpendingInfo] = {
+  def basicOutput: Gen[BitcoinUTXOSpendingInfoFull] = {
     Gen.oneOf(p2pkOutput, p2pkhOutput, multiSigOutput)
   }
 
-  def nonP2WSHOutput: Gen[BitcoinUTXOSpendingInfo] = {
+  def nonP2WSHOutput: Gen[BitcoinUTXOSpendingInfoFull] = {
     //note, cannot put a p2wpkh here
     Gen.oneOf(p2pkOutput,
               p2pkhOutput,
@@ -58,7 +58,7 @@ sealed abstract class CreditingTxGen {
   }
 
   /** Only for use in constructing P2SH outputs */
-  private def nonP2SHOutput: Gen[BitcoinUTXOSpendingInfo] = {
+  private def nonP2SHOutput: Gen[BitcoinUTXOSpendingInfoFull] = {
     Gen
       .oneOf(
         p2pkOutput,
@@ -100,11 +100,11 @@ sealed abstract class CreditingTxGen {
 
   private val cltvOutputGens = Vector(p2pkWithTimeoutOutput, cltvOutput)
 
-  def output: Gen[BitcoinUTXOSpendingInfo] =
+  def output: Gen[BitcoinUTXOSpendingInfoFull] =
     Gen.oneOf(nonCltvOutputGens).flatMap(identity)
 
   /** Either a list of non-CLTV outputs or a single CLTV output, with proportional probability */
-  def outputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
+  def outputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] = {
     val cltvGen = Gen
       .oneOf(cltvOutput, p2pkWithTimeoutOutput)
       .map { output =>
@@ -119,23 +119,23 @@ sealed abstract class CreditingTxGen {
   }
 
   /** Generates a crediting tx with a p2pk spk at the returned index */
-  def p2pkOutput: Gen[BitcoinUTXOSpendingInfo] =
+  def p2pkOutput: Gen[BitcoinUTXOSpendingInfoFull] =
     ScriptGenerators.p2pkScriptPubKey.flatMap { p2pk =>
       build(p2pk._1, Seq(p2pk._2), None, None)
     }
 
   /** Generates multiple crediting txs with p2pk spks at the returned index */
-  def p2pkOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
+  def p2pkOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] = {
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, p2pkOutput))
   }
 
-  def p2pkWithTimeoutOutput: Gen[BitcoinUTXOSpendingInfo] = {
+  def p2pkWithTimeoutOutput: Gen[BitcoinUTXOSpendingInfoFull] = {
     ScriptGenerators.p2pkWithTimeoutScriptPubKey.flatMap { p2pkWithTimeout =>
       build(p2pkWithTimeout._1, Seq(p2pkWithTimeout._2.head), None, None)
     }
   }
 
-  def p2pkWithTimeoutOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
+  def p2pkWithTimeoutOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] = {
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, p2pkWithTimeoutOutput))
   }
 
@@ -143,39 +143,39 @@ sealed abstract class CreditingTxGen {
     * Generates a transaction that has a p2pkh output at the returned index. This
     * output can be spent by the returned ECPrivateKey
     */
-  def p2pkhOutput: Gen[BitcoinUTXOSpendingInfo] =
+  def p2pkhOutput: Gen[BitcoinUTXOSpendingInfoFull] =
     ScriptGenerators.p2pkhScriptPubKey.flatMap { p2pkh =>
       build(p2pkh._1, Seq(p2pkh._2), None, None)
     }
 
   /** Generates a sequence of p2pkh outputs at the returned index */
-  def p2pkhOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
+  def p2pkhOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] = {
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, p2pkhOutput))
   }
 
-  def multiSigOutput: Gen[BitcoinUTXOSpendingInfo] =
+  def multiSigOutput: Gen[BitcoinUTXOSpendingInfoFull] =
     ScriptGenerators.multiSigScriptPubKey.flatMap { multisig =>
       build(multisig._1, multisig._2, None, None)
     }
 
-  def multiSigOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
+  def multiSigOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] = {
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, multiSigOutput))
   }
 
-  def multiSignatureWithTimeoutOutput: Gen[BitcoinUTXOSpendingInfo] = {
+  def multiSignatureWithTimeoutOutput: Gen[BitcoinUTXOSpendingInfoFull] = {
     ScriptGenerators.multiSignatureWithTimeoutScriptPubKey.flatMap {
       case (conditional, keys) =>
         build(conditional, keys, None, None)
     }
   }
 
-  def multiSignatureWithTimeoutOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
+  def multiSignatureWithTimeoutOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] = {
     Gen
       .choose(min, max)
       .flatMap(n => Gen.listOfN(n, multiSignatureWithTimeoutOutput))
   }
 
-  def conditionalOutput: Gen[BitcoinUTXOSpendingInfo] = {
+  def conditionalOutput: Gen[BitcoinUTXOSpendingInfoFull] = {
     ScriptGenerators
       .nonLocktimeConditionalScriptPubKey(ScriptGenerators.defaultMaxDepth)
       .flatMap {
@@ -184,33 +184,34 @@ sealed abstract class CreditingTxGen {
       }
   }
 
-  def conditionalOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
+  def conditionalOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] = {
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, conditionalOutput))
   }
 
-  def p2shOutput: Gen[BitcoinUTXOSpendingInfo] = nonP2SHOutput.flatMap { o =>
-    CryptoGenerators.hashType.map { hashType =>
-      val oldOutput = o.output
-      val redeemScript = o.output.scriptPubKey
-      val p2sh = P2SHScriptPubKey(redeemScript)
-      val updatedOutput = TransactionOutput(oldOutput.value, p2sh)
-      BitcoinUTXOSpendingInfo(
-        TransactionOutPoint(o.outPoint.txId, o.outPoint.vout),
-        updatedOutput,
-        o.signers,
-        Some(redeemScript),
-        o.scriptWitnessOpt,
-        hashType,
-        computeAllTrueConditionalPath(redeemScript, None, o.scriptWitnessOpt)
-      )
-    }
+  def p2shOutput: Gen[BitcoinUTXOSpendingInfoFull] = nonP2SHOutput.flatMap {
+    o =>
+      CryptoGenerators.hashType.map { hashType =>
+        val oldOutput = o.output
+        val redeemScript = o.output.scriptPubKey
+        val p2sh = P2SHScriptPubKey(redeemScript)
+        val updatedOutput = TransactionOutput(oldOutput.value, p2sh)
+        BitcoinUTXOSpendingInfoFull(
+          TransactionOutPoint(o.outPoint.txId, o.outPoint.vout),
+          updatedOutput,
+          o.signers,
+          Some(redeemScript),
+          o.scriptWitnessOpt,
+          hashType,
+          computeAllTrueConditionalPath(redeemScript, None, o.scriptWitnessOpt)
+        )
+      }
   }
 
-  def p2shOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] = {
+  def p2shOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] = {
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, p2shOutput))
   }
 
-  def cltvOutput: Gen[BitcoinUTXOSpendingInfo] =
+  def cltvOutput: Gen[BitcoinUTXOSpendingInfoFull] =
     TransactionGenerators.spendableCLTVValues.flatMap {
       case (scriptNum, _) =>
         basicOutput.flatMap { o =>
@@ -218,7 +219,7 @@ sealed abstract class CreditingTxGen {
             val oldOutput = o.output
             val csvSPK = CLTVScriptPubKey(scriptNum, oldOutput.scriptPubKey)
             val updatedOutput = TransactionOutput(oldOutput.value, csvSPK)
-            BitcoinUTXOSpendingInfo(
+            BitcoinUTXOSpendingInfoFull(
               TransactionOutPoint(o.outPoint.txId, o.outPoint.vout),
               updatedOutput,
               o.signers,
@@ -231,10 +232,10 @@ sealed abstract class CreditingTxGen {
         }
     }
 
-  def cltvOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
+  def cltvOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] =
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, cltvOutput))
 
-  def csvOutput: Gen[BitcoinUTXOSpendingInfo] =
+  def csvOutput: Gen[BitcoinUTXOSpendingInfoFull] =
     TransactionGenerators.spendableCSVValues.flatMap {
       case (scriptNum, _) =>
         basicOutput.flatMap { o =>
@@ -242,7 +243,7 @@ sealed abstract class CreditingTxGen {
             val oldOutput = o.output
             val csvSPK = CSVScriptPubKey(scriptNum, oldOutput.scriptPubKey)
             val updatedOutput = TransactionOutput(oldOutput.value, csvSPK)
-            BitcoinUTXOSpendingInfo(
+            BitcoinUTXOSpendingInfoFull(
               TransactionOutPoint(o.outPoint.txId, o.outPoint.vout),
               updatedOutput,
               o.signers,
@@ -255,24 +256,24 @@ sealed abstract class CreditingTxGen {
         }
     }
 
-  def csvOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
+  def csvOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] =
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, csvOutput))
 
-  def p2wpkhOutput: Gen[BitcoinUTXOSpendingInfo] =
+  def p2wpkhOutput: Gen[BitcoinUTXOSpendingInfoFull] =
     ScriptGenerators.p2wpkhSPKV0.flatMap { witSPK =>
       val scriptWit = P2WPKHWitnessV0(witSPK._2.head.publicKey)
       build(witSPK._1, witSPK._2, None, Some(scriptWit))
     }
 
-  def p2wpkhOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
+  def p2wpkhOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] =
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, p2wpkhOutput))
 
-  def p2wshOutput: Gen[BitcoinUTXOSpendingInfo] =
+  def p2wshOutput: Gen[BitcoinUTXOSpendingInfoFull] =
     nonP2WSHOutput
       .suchThat(output =>
         !ScriptGenerators.redeemScriptTooBig(output.scriptPubKey))
       .flatMap {
-        case BitcoinUTXOSpendingInfo(_, txOutput, signer, _, _, _, _) =>
+        case BitcoinUTXOSpendingInfoFull(_, txOutput, signer, _, _, _, _) =>
           val spk = txOutput.scriptPubKey
           spk match {
             case rspk: RawScriptPubKey =>
@@ -285,18 +286,18 @@ sealed abstract class CreditingTxGen {
           }
       }
 
-  def p2wshOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
+  def p2wshOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] =
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, p2wshOutput))
 
   /** A nested output is a p2sh/p2wsh wrapped output */
-  def nestedOutput: Gen[BitcoinUTXOSpendingInfo] = {
+  def nestedOutput: Gen[BitcoinUTXOSpendingInfoFull] = {
     Gen.oneOf(p2wshOutput, p2shOutput)
   }
 
-  def nestedOutputs: Gen[Seq[BitcoinUTXOSpendingInfo]] =
+  def nestedOutputs: Gen[Seq[BitcoinUTXOSpendingInfoFull]] =
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, nestedOutput))
 
-  def random: Gen[BitcoinUTXOSpendingInfo] = nonEmptyOutputs.flatMap {
+  def random: Gen[BitcoinUTXOSpendingInfoFull] = nonEmptyOutputs.flatMap {
     outputs =>
       Gen.choose(0, outputs.size - 1).flatMap { outputIndex: Int =>
         ScriptGenerators.scriptPubKey.flatMap {
@@ -304,12 +305,12 @@ sealed abstract class CreditingTxGen {
             WitnessGenerators.scriptWitness.flatMap { wit: ScriptWitness =>
               CryptoGenerators.hashType.map { hashType: HashType =>
                 val tc = TransactionConstants
-                val signers: Seq[Sign] = keys
+                val signers: Vector[Sign] = keys.toVector
                 val creditingTx = BaseTransaction(tc.validLockVersion,
                                                   Nil,
                                                   outputs,
                                                   tc.lockTime)
-                BitcoinUTXOSpendingInfo(
+                BitcoinUTXOSpendingInfoFull(
                   TransactionOutPoint(creditingTx.txId,
                                       UInt32.apply(outputIndex)),
                   TransactionOutput(
@@ -327,7 +328,7 @@ sealed abstract class CreditingTxGen {
       }
   }
 
-  def randoms: Gen[Seq[BitcoinUTXOSpendingInfo]] =
+  def randoms: Gen[Seq[BitcoinUTXOSpendingInfoFull]] =
     Gen.choose(min, max).flatMap(n => Gen.listOfN(n, random))
 
   private def computeAllTrueConditionalPath(
@@ -371,7 +372,7 @@ sealed abstract class CreditingTxGen {
       spk: ScriptPubKey,
       signers: Seq[Sign],
       redeemScript: Option[ScriptPubKey],
-      scriptWitness: Option[ScriptWitness]): Gen[BitcoinUTXOSpendingInfo] =
+      scriptWitness: Option[ScriptWitness]): Gen[BitcoinUTXOSpendingInfoFull] =
     nonEmptyOutputs.flatMap { outputs =>
       CryptoGenerators.hashType.flatMap { hashType =>
         Gen.choose(0, outputs.size - 1).map { idx =>
@@ -379,10 +380,10 @@ sealed abstract class CreditingTxGen {
           val updated = outputs.updated(idx, TransactionOutput(old.value, spk))
           val tc = TransactionConstants
           val btx = BaseTransaction(tc.version, Nil, updated, tc.lockTime)
-          BitcoinUTXOSpendingInfo(
+          BitcoinUTXOSpendingInfoFull(
             TransactionOutPoint(btx.txId, UInt32.apply(idx)),
             TransactionOutput(old.value, spk),
-            signers,
+            signers.toVector,
             redeemScript,
             scriptWitness,
             hashType,

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
@@ -20,7 +20,7 @@ import org.bitcoins.core.wallet.signer.{
   P2PKWithTimeoutSigner
 }
 import org.bitcoins.core.wallet.utxo.{
-  MultiSignatureSpendingInfo,
+  MultiSignatureSpendingInfoFull,
   P2PKHSpendingInfo,
   P2PKSpendingInfo,
   P2PKWithTimeoutSpendingInfo
@@ -660,7 +660,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
         creditingTx,
         scriptSig,
         outputIndex)
-      spendingInfo = MultiSignatureSpendingInfo(
+      spendingInfo = MultiSignatureSpendingInfoFull(
         TransactionOutPoint(creditingTx.txIdBE, inputIndex),
         creditingTx.outputs(outputIndex.toInt).value,
         multiSigScriptPubKey,

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoTable.scala
@@ -11,7 +11,7 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.wallet.utxo.{
-  BitcoinUTXOSpendingInfo,
+  BitcoinUTXOSpendingInfoFull,
   ConditionalPath,
   TxoState
 }
@@ -133,7 +133,7 @@ sealed trait SpendingInfoDb extends DbRowAutoInc[SpendingInfoDb] {
   def toUTXOSpendingInfo(
       account: AccountDb,
       keyManager: BIP39KeyManager,
-      networkParameters: NetworkParameters): BitcoinUTXOSpendingInfo = {
+      networkParameters: NetworkParameters): BitcoinUTXOSpendingInfoFull = {
 
     val sign: Sign = keyManager.toSign(privKeyPath = privKeyPath)
 
@@ -146,11 +146,11 @@ sealed trait SpendingInfoDb extends DbRowAutoInc[SpendingInfoDb] {
       account: AccountDb,
       sign: Sign,
       networkParameters: NetworkParameters
-  ): BitcoinUTXOSpendingInfo = {
-    BitcoinUTXOSpendingInfo(
+  ): BitcoinUTXOSpendingInfoFull = {
+    BitcoinUTXOSpendingInfoFull(
       outPoint,
       output,
-      List(sign),
+      Vector(sign),
       redeemScriptOpt,
       scriptWitnessOpt,
       hashType,


### PR DESCRIPTION
Implements `UTXOSpendingInfoSingle` and `SingleSigner` which together allows for users to using single `Sign`ers to get `ECDigitalSignature`s on transactions, without requiring all `Sign`ers be present.

Adds a property-based test to ensure that `SingleSigner` and `Signer` don't diverge