### PR TITLE
PSBT Input Updater property based tests

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTTest.scala
@@ -197,6 +197,41 @@ class PSBTTest extends BitcoinSAsyncTest {
     assertThrows[IllegalArgumentException](psbt0.combinePSBT(psbt1))
   }
 
+  it must "correctly update PSBTs' inputs" in {
+    forAllAsync(PSBTGenerators.psbtToBeSigned)(_.flatMap {
+      case (fullPsbt, utxos) =>
+        val emptyPsbt = PSBT.fromUnsignedTx(fullPsbt.transaction)
+
+        val infoAndTxs = PSBTGenerators
+          .spendingInfoAndNonWitnessTxsFromSpendingInfos(fullPsbt.transaction,
+                                                         utxos.toVector)
+          .infoAndTxOpts
+        val updatedPSBT = infoAndTxs.zipWithIndex.foldLeft(emptyPsbt) {
+          case (psbt, ((utxo, txOpt), index)) =>
+            val partUpdatedPsbt = psbt
+              .addUTXOToInput(txOpt.get, index)
+              .addSigHashTypeToInput(utxo.hashType, index)
+
+            (utxo.redeemScriptOpt, utxo.scriptWitnessOpt) match {
+              case (Some(redeemScript), Some(scriptWitness)) =>
+                partUpdatedPsbt
+                  .addRedeemOrWitnessScriptToInput(redeemScript, index)
+                  .addScriptWitnessToInput(scriptWitness, index)
+              case (Some(redeemScript), None) =>
+                partUpdatedPsbt
+                  .addRedeemOrWitnessScriptToInput(redeemScript, index)
+              case (None, Some(scriptWitness)) =>
+                partUpdatedPsbt
+                  .addScriptWitnessToInput(scriptWitness, index)
+              case (None, None) =>
+                partUpdatedPsbt
+            }
+
+        }
+        assert(updatedPSBT == fullPsbt)
+    })
+  }
+
   it must "successfully extract a transaction from a finalized PSBT" in {
     val psbt = PSBT(
       "70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000000107da00473044022074018ad4180097b873323c0015720b3684cc8123891048e7dbcd9b55ad679c99022073d369b740e3eb53dcefa33823c8070514ca55a7dd9544f157c167913261118c01483045022100f61038b308dc1da865a34852746f015772934208c6d24454393cd99bdf2217770220056e675a675a6d0a02b85b14e5e29074d8a25a9b5760bea2816f661910a006ea01475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae0001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e8870107232200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b20289030108da0400473044022062eb7a556107a7c73f45ac4ab5a1dddf6f7075fb1275969a7f383efff784bcb202200c05dbb7470dbf2f08557dd356c7325c1ed30913e996cd3840945db12228da5f01473044022065f45ba5998b59a27ffe1a7bed016af1f1f90d54b3aa8f7450aa5f56a25103bd02207f724703ad1edb96680b284b56d4ffcb88f7fb759eabbe08aa30f29b851383d20147522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae00220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000")

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -282,14 +282,18 @@ case class PSBT(
   def addScriptWitnessToInput(
       scriptWitness: ScriptWitness,
       index: Int): PSBT = {
+    require(index >= 0,
+            s"index must be greater than or equal to 0, got: $index")
     require(
       index < inputMaps.size,
       s"index must be less than the number of input maps present in the psbt, $index >= ${inputMaps.size}")
     require(!inputMaps(index).isFinalized,
             s"Cannot update an InputPSBTMap that is finalized, index: $index")
+    require(
+      inputMaps(index).witnessScriptOpt.isEmpty,
+      s"Input map already contains a ScriptWitness: ${inputMaps(index).witnessScriptOpt.get}")
 
     val previousElements = inputMaps(index).elements
-      .filterNot(_.key.head == PSBTInputKeyId.WitnessScriptKeyId.byte)
 
     val newMap = scriptWitness match {
       case p2wpkh: P2WPKHWitnessV0 =>

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -306,7 +306,7 @@ case class PSBT(
         val newElement = InputPSBTRecord.WitnessScript(p2wsh.redeemScript)
         InputPSBTMap(previousElements :+ newElement)
           .compressMap(transaction.inputs(index))
-      case _: ScriptWitness =>
+      case EmptyScriptWitness =>
         throw new IllegalArgumentException(
           s"Invalid scriptWitness given, got: $scriptWitness")
     }

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
@@ -143,6 +143,10 @@ object GlobalPSBTMap extends PSBTMapFactory[GlobalPSBTRecord, GlobalPSBTMap] {
 
 case class InputPSBTMap(elements: Vector[InputPSBTRecord])
     extends PSBTMap[InputPSBTRecord] {
+  require(
+    this.witnessUTXOOpt.isEmpty || this.nonWitnessOrUnknownUTXOOpt.isEmpty,
+    "InputPSBTMap cannot have both a NonWitnessOrUnknownUTXO and a WitnessUTXO"
+  )
   import org.bitcoins.core.psbt.InputPSBTRecord._
   import org.bitcoins.core.psbt.PSBTInputKeyId._
 
@@ -584,10 +588,6 @@ case class InputPSBTMap(elements: Vector[InputPSBTRecord])
     * @return The compressed InputPSBTMap
     */
   def compressMap(txIn: TransactionInput): InputPSBTMap = {
-    require(
-      this.witnessUTXOOpt.isEmpty || this.nonWitnessOrUnknownUTXOOpt.isEmpty,
-      "Cannot compress if map does not have a NonWitnessOrUnknownUTXO or a WitnessUTXO"
-    )
     if (isFinalized) {
       this
     } else {

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
@@ -584,11 +584,13 @@ case class InputPSBTMap(elements: Vector[InputPSBTRecord])
     * @return The compressed InputPSBTMap
     */
   def compressMap(txIn: TransactionInput): InputPSBTMap = {
+    require(
+      this.witnessUTXOOpt.isEmpty || this.nonWitnessOrUnknownUTXOOpt.isEmpty,
+      "Cannot compress if map does not have a NonWitnessOrUnknownUTXO or a WitnessUTXO"
+    )
     if (isFinalized) {
       this
     } else {
-      require(
-        this.witnessUTXOOpt.isEmpty || this.nonWitnessOrUnknownUTXOOpt.isEmpty)
       val newElements = {
         if (nonWitnessOrUnknownUTXOOpt.isDefined) {
           val nonWitUtxo = nonWitnessOrUnknownUTXOOpt.get.transactionSpent


### PR DESCRIPTION
Needed to add `addScriptWitnessToInput` because there was no way to do native segwit