### PR TITLE
Try bumping the Thread.sleep() to get CI to pass on slow mac osx

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -384,7 +384,7 @@ object BitcoinSWalletTest extends WalletLogger {
       //this Thread.sleep is needed because of
       //https://github.com/bitcoin-s/bitcoin-s/issues/1009
       //once that is resolved we should be able to remove this
-      Thread.sleep(250)
+      Thread.sleep(500)
       wallet.getNewAddress()
     })
 


### PR DESCRIPTION
This attempts to address #1029 which i believe is happening because mac osx ci is very slow. We double the Thread.sleep() when generating addresses from 250 milliseconds to 500 milliseconds. This won't be a problem when we address #1009 