### PR TITLE
ECPubKey Addition

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.crypto
 
+import org.bitcoin.NativeSecp256k1
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits._
@@ -33,6 +34,19 @@ class ECPublicKeyTest extends BitcoinSUnitTest {
       val p = pubKey.toPoint
       val pub2 = ECPublicKey.fromPoint(p, pubKey.isCompressed)
       assert(pubKey == pub2)
+    }
+  }
+
+  it must "add keys correctly" in {
+    forAll(CryptoGenerators.publicKey, CryptoGenerators.privateKey) {
+      case (pubKey, privKey) =>
+        val sumKeyBytes = NativeSecp256k1.pubKeyTweakAdd(pubKey.bytes.toArray,
+                                                         privKey.bytes.toArray,
+                                                         true)
+        val sumKeyExpected = ECPublicKey.fromBytes(ByteVector(sumKeyBytes))
+        val sumKey = pubKey.add(privKey.publicKey)
+
+        assert(sumKey == sumKeyExpected)
     }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -347,6 +347,17 @@ sealed abstract class ECPublicKey extends BaseECKey {
   def toPoint: ECPoint = {
     CryptoParams.curve.getCurve.decodePoint(bytes.toArray)
   }
+
+  /** Adds this ECPublicKey to another as points and returns the resulting ECPublicKey.
+    *
+    * Note: if this ever becomes a bottleneck, secp256k1_ec_pubkey_combine should
+    * get wrapped in NativeSecp256k1 to speed things up.
+    */
+  def add(otherKey: ECPublicKey): ECPublicKey = {
+    val sumPoint = toPoint.add(otherKey.toPoint)
+
+    ECPublicKey.fromPoint(sumPoint)
+  }
 }
 
 object ECPublicKey extends Factory[ECPublicKey] {


### PR DESCRIPTION
Introduced `ECPublicKey.add` which does point addition on two public keys. Added a property-based test comparing results to those of `NativeSecp256k1.pubKeyTweakAdd`