### PR TITLE
PSBT unit tests by Ben

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTTest.scala
@@ -10,9 +10,19 @@ import org.bitcoins.core.protocol.script.{
   RawScriptPubKey,
   ScriptPubKey
 }
-import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.core.psbt.GlobalPSBTRecord.Version
+import org.bitcoins.core.protocol.transaction.{
+  BaseTransaction,
+  EmptyTransactionInput,
+  Transaction,
+  TransactionOutput
+}
+import org.bitcoins.core.psbt.GlobalPSBTRecord.{UnsignedTransaction, Version}
+import org.bitcoins.core.psbt.InputPSBTRecord.{
+  NonWitnessOrUnknownUTXO,
+  WitnessUTXO
+}
 import org.bitcoins.core.psbt.OutputPSBTRecord.{RedeemScript, WitnessScript}
+import org.bitcoins.core.psbt.PSBTGlobalKeyId.XPubKeyKeyId
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.wallet.utxo.{
   BitcoinUTXOSpendingInfoFull,
@@ -118,6 +128,26 @@ class PSBTTest extends BitcoinSAsyncTest {
     assert(psbtWithSigHash == nextExpected)
   }
 
+  it must "fail to create a InputPSBTMap with both a NonWitness and Witness UTXO" in {
+    val nonWitnessOrUnknownUTXO = NonWitnessOrUnknownUTXO(Transaction(
+      "02000000019dfc6628c26c5899fe1bd3dc338665bfd55d7ada10f6220973df2d386dec12760100000000ffffffff01f03dcd1d000000001600147b3a00bfdc14d27795c2b74901d09da6ef13357900000000"))
+    val witnessUTXO =
+      WitnessUTXO(TransactionOutput(Satoshis.one, ScriptPubKey.empty))
+
+    assertThrows[IllegalArgumentException](
+      InputPSBTMap(Vector(nonWitnessOrUnknownUTXO, witnessUTXO)))
+  }
+
+  it must "correctly filter a GlobalPSBTMap" in {
+    val psbt = PSBT(
+      "70736274ff01009d0100000002710ea76ab45c5cb6438e607e59cc037626981805ae9e0dfd9089012abb0be5350100000000ffffffff190994d6a8b3c8c82ccbcfb2fba4106aa06639b872a8d447465c0d42588d6d670000000000ffffffff0200e1f505000000001976a914b6bc2c0ee5655a843d79afedd0ccc3f7dd64340988ac605af405000000001600141188ef8e4ce0449eaac8fb141cbf5a1176e6a088000000004f010488b21e039e530cac800000003dbc8a5c9769f031b17e77fea1518603221a18fd18f2b9a54c6c8c1ac75cbc3502f230584b155d1c7f1cd45120a653c48d650b431b67c5b2c13f27d7142037c1691027569c503100008000000080000000800001011f00e1f5050000000016001433b982f91b28f160c920b4ab95e58ce50dda3a4a220203309680f33c7de38ea6a47cd4ecd66f1f5a49747c6ffb8808ed09039243e3ad5c47304402202d704ced830c56a909344bd742b6852dccd103e963bae92d38e75254d2bb424502202d86c437195df46c0ceda084f2a291c3da2d64070f76bf9b90b195e7ef28f77201220603309680f33c7de38ea6a47cd4ecd66f1f5a49747c6ffb8808ed09039243e3ad5c1827569c5031000080000000800000008000000000010000000001011f00e1f50500000000160014388fb944307eb77ef45197d0b0b245e079f011de220202c777161f73d0b7c72b9ee7bde650293d13f095bc7656ad1f525da5fd2e10b11047304402204cb1fb5f869c942e0e26100576125439179ae88dca8a9dc3ba08f7953988faa60220521f49ca791c27d70e273c9b14616985909361e25be274ea200d7e08827e514d01220602c777161f73d0b7c72b9ee7bde650293d13f095bc7656ad1f525da5fd2e10b1101827569c5031000080000000800000008000000000000000000000220202d20ca502ee289686d21815bd43a80637b0698e1fbcdbe4caed445f6c1a0a90ef1827569c50310000800000008000000080000000000400000000")
+
+    val records = psbt.globalMap.filterRecords(XPubKeyKeyId)
+    assert(!records.exists(_.key.head == XPubKeyKeyId.byte))
+    assert(
+      GlobalPSBTMap(records).bytes == hex"01009d0100000002710ea76ab45c5cb6438e607e59cc037626981805ae9e0dfd9089012abb0be5350100000000ffffffff190994d6a8b3c8c82ccbcfb2fba4106aa06639b872a8d447465c0d42588d6d670000000000ffffffff0200e1f505000000001976a914b6bc2c0ee5655a843d79afedd0ccc3f7dd64340988ac605af405000000001600141188ef8e4ce0449eaac8fb141cbf5a1176e6a0880000000000")
+  }
+
   it must "successfully combine two PSBTs" in {
     // PSBT with 2 inputs, and empty outputs
     val expected = PSBT.fromBytes(
@@ -187,6 +217,22 @@ class PSBTTest extends BitcoinSAsyncTest {
     assert(psbt1.combinePSBT(psbt2) == expected)
   }
 
+  it must "correctly combine two GlobalPSBTMap with differing versions" in {
+    val sharedTx = BaseTransaction(
+      "02000000019dfc6628c26c5899fe1bd3dc338665bfd55d7ada10f6220973df2d386dec12760100000000ffffffff01f03dcd1d000000001600147b3a00bfdc14d27795c2b74901d09da6ef13357900000000")
+    val unsignedTxRecord = UnsignedTransaction(sharedTx)
+
+    val version0 = Version(UInt32.zero)
+    val version1 = Version(UInt32.one)
+
+    val globalMap0 = GlobalPSBTMap(Vector(unsignedTxRecord, version0))
+    val globalMap1 = GlobalPSBTMap(Vector(unsignedTxRecord, version1))
+
+    val combined = globalMap0.combine(globalMap1)
+
+    assert(combined.version == version1)
+  }
+
   it must "fail to combine two PSBTs with differing global transactions" in {
     val psbt0 = PSBT.fromUnsignedTx(Transaction(
       "020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000"))
@@ -195,6 +241,8 @@ class PSBTTest extends BitcoinSAsyncTest {
       "02000000019dfc6628c26c5899fe1bd3dc338665bfd55d7ada10f6220973df2d386dec12760100000000ffffffff01f03dcd1d000000001600147b3a00bfdc14d27795c2b74901d09da6ef13357900000000"))
 
     assertThrows[IllegalArgumentException](psbt0.combinePSBT(psbt1))
+    assertThrows[IllegalArgumentException](
+      psbt0.globalMap.combine(psbt1.globalMap))
   }
 
   it must "correctly update PSBTs' inputs" in {
@@ -248,6 +296,21 @@ class PSBTTest extends BitcoinSAsyncTest {
     assert(tx == expected)
   }
 
+  it must "finalize an already finalized input" in {
+    val inputMap = InputPSBTMap(
+      "0x0100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000000107da00473044022074018ad4180097b873323c0015720b3684cc8123891048e7dbcd9b55ad679c99022073d369b740e3eb53dcefa33823c8070514ca55a7dd9544f157c167913261118c01483045022100f61038b308dc1da865a34852746f015772934208c6d24454393cd99bdf2217770220056e675a675a6d0a02b85b14e5e29074d8a25a9b5760bea2816f661910a006ea01475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae00")
+    val finalizedT = inputMap.finalize(EmptyTransactionInput)
+    assert(finalizedT.isSuccess)
+    assert(inputMap == finalizedT.get)
+  }
+
+  it must "fail to finalize an input with no UTXO" in {
+    val inputMap = InputPSBTMap(Vector.empty)
+    val finalizedT = inputMap.finalize(EmptyTransactionInput)
+
+    assert(finalizedT.isFailure)
+  }
+
   it must "fail to extract a transaction from a non-finalized PSBT" in {
     val psbt = PSBT(
       "70736274ff0100a00200000002ab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40000000000feffffffab0949a08c5af7c49b8212f417e2f15ab3f5c33dcf153821a8139f877a5b7be40100000000feffffff02603bea0b000000001976a914768a40bbd740cbe81d988e71de2a4d5c71396b1d88ac8e240000000000001976a9146f4620b553fa095e721b9ee0efe9fa039cca459788ac000000000001076a47304402204759661797c01b036b25928948686218347d89864b719e1f7fcf57d1e511658702205309eabf56aa4d8891ffd111fdf1336f3a29da866d7f8486d75546ceedaf93190121035cdc61fc7ba971c0b501a646a2a83b102cb43881217ca682dc86e2d73fa882920001012000e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787010416001485d13537f2e265405a34dbafa9e3dda01fb82308000000")
@@ -294,16 +357,6 @@ class PSBTTest extends BitcoinSAsyncTest {
         P2WSHWitnessV0(RawScriptPubKey.fromAsmHex(
           "5221029da12cdb5b235692b91536afefe5c91c3ab9473d8e43b533836ab456299c88712103372b34234ed7cf9c1fea5d05d441557927be9542b162eb02e1ab2ce80224c00b52ae"))))
     assert(spendingInfo.conditionalPath == ConditionalPath.NoConditionsLeft)
-  }
-
-  it must "fail to create a valid UTXOSpendingInfo given a bad index" in {
-
-    val psbt = PSBT(
-      "70736274ff01005202000000019dfc6628c26c5899fe1bd3dc338665bfd55d7ada10f6220973df2d386dec12760100000000ffffffff01f03dcd1d000000001600147b3a00bfdc14d27795c2b74901d09da6ef133579000000004f01043587cf02da3fd0088000000097048b1ad0445b1ec8275517727c87b4e4ebc18a203ffa0f94c01566bd38e9000351b743887ee1d40dc32a6043724f2d6459b3b5a4d73daec8fbae0472f3bc43e20cd90c6a4fae000080000000804f01043587cf02da3fd00880000001b90452427139cd78c2cff2444be353cd58605e3e513285e528b407fae3f6173503d30a5e97c8adbc557dac2ad9a7e39c1722ebac69e668b6f2667cc1d671c83cab0cd90c6a4fae000080010000800001012b0065cd1d000000002200202c5486126c4978079a814e13715d65f36459e4d6ccaded266d0508645bafa6320105475221029da12cdb5b235692b91536afefe5c91c3ab9473d8e43b533836ab456299c88712103372b34234ed7cf9c1fea5d05d441557927be9542b162eb02e1ab2ce80224c00b52ae2206029da12cdb5b235692b91536afefe5c91c3ab9473d8e43b533836ab456299c887110d90c6a4fae0000800000008000000000220603372b34234ed7cf9c1fea5d05d441557927be9542b162eb02e1ab2ce80224c00b10d90c6a4fae0000800100008000000000002202039eff1f547a1d5f92dfa2ba7af6ac971a4bd03ba4a734b03156a256b8ad3a1ef910ede45cc500000080000000800100008000")
-
-    assertThrows[IllegalArgumentException](psbt.getUTXOSpendingInfo(index = -1))
-    assertThrows[IllegalArgumentException](
-      psbt.getUTXOSpendingInfo(index = Int.MaxValue))
   }
 
   it must "fail to create a valid UTXOSpendingInfo from a PSBTInputMap with insufficient data" in {

--- a/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTTest.scala
@@ -4,12 +4,7 @@ import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.hd.BIP32Path
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.script.{
-  P2WSHWitnessSPKV0,
-  P2WSHWitnessV0,
-  RawScriptPubKey,
-  ScriptPubKey
-}
+import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction.{
   BaseTransaction,
   EmptyTransactionInput,
@@ -132,7 +127,7 @@ class PSBTTest extends BitcoinSAsyncTest {
     val nonWitnessOrUnknownUTXO = NonWitnessOrUnknownUTXO(Transaction(
       "02000000019dfc6628c26c5899fe1bd3dc338665bfd55d7ada10f6220973df2d386dec12760100000000ffffffff01f03dcd1d000000001600147b3a00bfdc14d27795c2b74901d09da6ef13357900000000"))
     val witnessUTXO =
-      WitnessUTXO(TransactionOutput(Satoshis.one, ScriptPubKey.empty))
+      WitnessUTXO(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
 
     assertThrows[IllegalArgumentException](
       InputPSBTMap(Vector(nonWitnessOrUnknownUTXO, witnessUTXO)))

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -132,15 +132,6 @@ case class PSBT(
                              isDummySignature = isDummySignature)
   }
 
-  def getUTXOSpendingInfo(
-      index: Int,
-      conditionalPath: ConditionalPath = ConditionalPath.NoConditionsLeft): UTXOSpendingInfoFull = {
-    require(index >= 0 && index < inputMaps.size,
-            s"Index must be within 0 and the number of inputs, got: $index")
-    inputMaps(index)
-      .toUTXOSpendingInfo(transaction.inputs(index), conditionalPath)
-  }
-
   /**
     * Takes the InputPSBTMap at the given index and returns a UTXOSpendingInfoFull
     * that can be used to sign the input

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
@@ -476,16 +476,6 @@ case class InputPSBTMap(elements: Vector[InputPSBTRecord])
     InputPSBTMap((this.elements ++ other.elements).distinct)
   }
 
-  def toUTXOSpendingInfo(
-      txIn: TransactionInput,
-      conditionalPath: ConditionalPath = ConditionalPath.NoConditionsLeft): UTXOSpendingInfoFull = {
-    val signersVec = getRecords(PartialSignatureKeyId)
-    val signers =
-      signersVec.map(sig => Sign.constant(sig.signature, sig.pubKey))
-
-    toUTXOSpendingInfoUsingSigners(txIn, signers, conditionalPath)
-  }
-
   /**
     * Takes the InputPSBTMap returns a UTXOSpendingInfoFull
     * that can be used to sign the input


### PR DESCRIPTION
Removed `toUTXOSpendingInfo`, `getUTXOSpendingInfo` and the test that only checked if we didn't give a negative index to those functions.

These functions weren't used and didn't have much use as they returned spend infos for already signed inputs

All tests pass locally