### PR TITLE
Bech32 weakness test vectors

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
@@ -205,4 +205,17 @@ class Bech32Test extends BitcoinSUnitTest {
       assert(u8s == u8sAgain)
     }
   }
+
+  // bech 32 Weakness test vectors
+  private val invalidBech32 = Vector(
+    "bc1qvfu057ptzatpxf30xc2yunuqad4dg54gkuvx04fuzch6gezltk2q63lcaqp",
+    "bc1ql6mqttdzpekxmdp9gaglvjtnfg4ydwzdtgcqxxru7f6m0eg9pckqnncp",
+    "bc1q6g6y8y62cgt7x3s2sdwax3nuur00uwcey570zqqp",
+    "bc1q3qwt6j7yr9nzhskdh36eh6ktesy93ggwjfs9p"
+  )
+  it must "fail to find the bech32 weakness" in {
+    val failsAll = invalidBech32.forall(invalid =>
+      Bech32.splitToHrpAndData(invalid).isSuccess)
+    assert(failsAll)
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
@@ -504,4 +504,11 @@ class LnInvoiceUnitTest extends BitcoinSUnitTest {
     invoice.lnTags.features must be(
       Some(LnTag.FeaturesTag(ByteVector.fromValidHex("0800"))))
   }
+
+  it must "ensure that the malleability of the checksum in bech32 strings cannot cause a signature to become valid" in {
+    val strWithError =
+      "lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srqqqqqp"
+
+    assert(LnInvoice.fromString(strWithError).isFailure)
+  }
 }


### PR DESCRIPTION
Closes #1053 

The LnInvoice parser already handled the weakness correctly, so I added tests to make sure we do in the future.