### PR TITLE
DLC Dust Outputs

### DIFF
--- a/dlc-test/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCClientIntegrationTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCClientIntegrationTest.scala
@@ -82,6 +82,7 @@ class BinaryOutcomeDLCClientIntegrationTest extends BitcoindRpcTest {
   val preCommittedR: ECPublicKey = preCommittedK.publicKey
   val localInput: CurrencyUnit = CurrencyUnits.oneBTC
   val remoteInput: CurrencyUnit = CurrencyUnits.oneBTC
+  val totalInput: CurrencyUnit = localInput + remoteInput
 
   val inputPrivKeyLocal: ECPrivateKey = ECPrivateKey.freshPrivateKey
   val inputPubKeyLocal: ECPublicKey = inputPrivKeyLocal.publicKey
@@ -212,8 +213,8 @@ class BinaryOutcomeDLCClientIntegrationTest extends BitcoindRpcTest {
         remoteFundingInputs = Vector(
           (TransactionOutPoint(fundingTx.txIdBE, remoteVout),
            fundingTx.outputs(remoteVout.toInt))),
-        winPayout = localInput + CurrencyUnits.oneMBTC,
-        losePayout = localInput - CurrencyUnits.oneMBTC,
+        winPayout = totalInput,
+        losePayout = CurrencyUnits.zero,
         timeouts = DLCTimeouts(penaltyTimeout = csvTimeout,
                                tomorrowInBlocks,
                                twoDaysInBlocks),
@@ -237,8 +238,8 @@ class BinaryOutcomeDLCClientIntegrationTest extends BitcoindRpcTest {
         remoteFundingInputs = Vector(
           (TransactionOutPoint(fundingTx.txIdBE, localVout),
            fundingTx.outputs(localVout.toInt))),
-        winPayout = remoteInput - CurrencyUnits.oneMBTC,
-        losePayout = remoteInput + CurrencyUnits.oneMBTC,
+        winPayout = CurrencyUnits.zero,
+        losePayout = totalInput,
         timeouts = DLCTimeouts(penaltyTimeout = csvTimeout,
                                tomorrowInBlocks,
                                twoDaysInBlocks),
@@ -257,18 +258,26 @@ class BinaryOutcomeDLCClientIntegrationTest extends BitcoindRpcTest {
   }
 
   def validateOutcome(outcome: DLCOutcome): Future[Assertion] = {
-    for {
-      client <- clientF
-      regtestLocalClosingTx <- client.getRawTransaction(
-        outcome.closingTx.txIdBE)
-    } yield {
-      assert(regtestLocalClosingTx.hex == outcome.closingTx)
-      assert(regtestLocalClosingTx.confirmations.isDefined)
-      assert(regtestLocalClosingTx.confirmations.get >= 6)
+    clientF.flatMap { client =>
+      outcome.closingTxOpt match {
+        case None =>
+          Future {
+            assert(noEmptySPKOutputs(outcome.fundingTx))
+            assert(noEmptySPKOutputs(outcome.cet))
+          }
+        case Some(closingTx) =>
+          val txResultF = client.getRawTransaction(closingTx.txIdBE)
 
-      assert(noEmptySPKOutputs(outcome.fundingTx))
-      assert(noEmptySPKOutputs(outcome.cet))
-      assert(noEmptySPKOutputs(outcome.closingTx))
+          txResultF.map { regtestLocalClosingTx =>
+            assert(regtestLocalClosingTx.hex == outcome.closingTxOpt.get)
+            assert(regtestLocalClosingTx.confirmations.isDefined)
+            assert(regtestLocalClosingTx.confirmations.get >= 6)
+
+            assert(noEmptySPKOutputs(outcome.fundingTx))
+            assert(noEmptySPKOutputs(outcome.cet))
+            assert(noEmptySPKOutputs(outcome.closingTxOpt.get))
+          }
+      }
     }
   }
 
@@ -470,10 +479,14 @@ class BinaryOutcomeDLCClientIntegrationTest extends BitcoindRpcTest {
       _ <- waitUntilBlock(
         unilateralDLC.timeouts.contractMaturity.toUInt32.toInt)
       _ <- publishTransaction(unilateralOutcome.cet)
-      _ <- publishTransaction(unilateralOutcome.closingTx)
+      _ <- unilateralOutcome.closingTxOpt
+        .map(publishTransaction)
+        .getOrElse(FutureUtil.unit)
       otherOutcome <- otherDLC.executeRemoteUnilateralDLC(otherSetup,
                                                           unilateralOutcome.cet)
-      _ <- publishTransaction(otherOutcome.closingTx)
+      _ <- otherOutcome.closingTxOpt
+        .map(publishTransaction)
+        .getOrElse(FutureUtil.unit)
       _ <- validateOutcome(unilateralOutcome)
       _ <- validateOutcome(otherOutcome)
     } yield {
@@ -496,8 +509,8 @@ class BinaryOutcomeDLCClientIntegrationTest extends BitcoindRpcTest {
       _ <- recoverToSucceededIf[BitcoindException](publishTransaction(cet))
       _ <- waitUntilBlock(timeout)
       _ <- publishTransaction(cet)
-      _ <- publishTransaction(offerOutcome.closingTx)
-      _ <- publishTransaction(acceptOutcome.closingTx)
+      _ <- publishTransaction(offerOutcome.closingTxOpt.get)
+      _ <- publishTransaction(acceptOutcome.closingTxOpt.get)
       _ <- validateOutcome(offerOutcome)
       _ <- validateOutcome(acceptOutcome)
     } yield {
@@ -552,15 +565,29 @@ class BinaryOutcomeDLCClientIntegrationTest extends BitcoindRpcTest {
         cetWronglyPublished)
       _ = assert(toRemoteOutcome.cet == cetWronglyPublished)
       _ = assert(justiceOutcome.cet == cetWronglyPublished)
-      _ <- publishTransaction(toRemoteOutcome.closingTx)
-      _ <- recoverToSucceededIf[BitcoindException](
-        publishTransaction(justiceOutcome.closingTx))
+      _ <- toRemoteOutcome.closingTxOpt
+        .map(publishTransaction)
+        .getOrElse(FutureUtil.unit)
+      _ <- justiceOutcome.closingTxOpt
+        .map { tx =>
+          recoverToSucceededIf[BitcoindException](
+            publishTransaction(tx)
+          )
+        }
+        .getOrElse(FutureUtil.unit)
       penaltyHeight = heightBeforePublish + punisherDLC.timeouts.penaltyTimeout + 1
       _ <- waitUntilBlock(penaltyHeight - 1)
-      _ <- recoverToSucceededIf[BitcoindException](
-        publishTransaction(justiceOutcome.closingTx))
+      _ <- justiceOutcome.closingTxOpt
+        .map { tx =>
+          recoverToSucceededIf[BitcoindException](
+            publishTransaction(tx)
+          )
+        }
+        .getOrElse(FutureUtil.unit)
       _ <- waitUntilBlock(penaltyHeight)
-      _ <- publishTransaction(justiceOutcome.closingTx)
+      _ <- justiceOutcome.closingTxOpt
+        .map(publishTransaction)
+        .getOrElse(FutureUtil.unit)
       _ <- validateOutcome(toRemoteOutcome)
       _ <- validateOutcome(justiceOutcome)
     } yield {

--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCOutcome.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCOutcome.scala
@@ -7,7 +7,7 @@ import org.bitcoins.core.wallet.utxo.BitcoinUTXOSpendingInfoFull
 case class DLCOutcome(
     fundingTx: Transaction,
     cet: Transaction,
-    closingTx: Transaction,
+    closingTxOpt: Option[Transaction],
     cetSpendingInfo: BitcoinUTXOSpendingInfoFull
 )
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCOutcome.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCOutcome.scala
@@ -3,12 +3,44 @@ package org.bitcoins.dlc
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.utxo.BitcoinUTXOSpendingInfoFull
 
-/** Contains all DLC transactions and the BitcoinUTXOSpendingInfos they use. */
-case class DLCOutcome(
-    fundingTx: Transaction,
-    cet: Transaction,
-    closingTxOpt: Option[Transaction],
-    cetSpendingInfo: BitcoinUTXOSpendingInfoFull
-)
+sealed trait DLCOutcome {
+  def fundingTx: Transaction
+}
 
-case class CooperativeDLCOutcome(fundingTx: Transaction, closingTx: Transaction)
+sealed trait UnilateralDLCOutcome extends DLCOutcome {
+  def cet: Transaction
+}
+
+/** Contains all DLC transactions and the BitcoinUTXOSpendingInfos they use. */
+case class UnilateralDLCOutcomeWithClosing(
+    override val fundingTx: Transaction,
+    override val cet: Transaction,
+    closingTx: Transaction,
+    cetSpendingInfo: BitcoinUTXOSpendingInfoFull
+) extends UnilateralDLCOutcome
+
+case class UnilateralDLCOutcomeWithDustClosing(
+    override val fundingTx: Transaction,
+    override val cet: Transaction)
+    extends UnilateralDLCOutcome
+
+sealed trait RefundDLCOutcome extends DLCOutcome {
+  def refundTx: Transaction
+}
+
+case class RefundDLCOutcomeWithClosing(
+    override val fundingTx: Transaction,
+    override val refundTx: Transaction,
+    closingTx: Transaction,
+    refundSpendingInfo: BitcoinUTXOSpendingInfoFull)
+    extends RefundDLCOutcome
+
+case class RefundDLCOutcomeWithDustClosing(
+    override val fundingTx: Transaction,
+    override val refundTx: Transaction)
+    extends RefundDLCOutcome
+
+case class CooperativeDLCOutcome(
+    override val fundingTx: Transaction,
+    closingTx: Transaction)
+    extends DLCOutcome

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
@@ -60,6 +60,7 @@ import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
+// TODO: Add test vectors to dlc_test.json where dust outputs are removed
 case class DLCTestVector(
     localPayouts: Map[String, CurrencyUnit],
     realOutcome: String,
@@ -81,8 +82,8 @@ case class DLCTestVector(
     remoteWinCet: Transaction,
     remoteLoseCet: Transaction,
     refundTx: Transaction,
-    localClosingTx: Transaction,
-    remoteClosingTx: Transaction
+    localClosingTxOpt: Option[Transaction],
+    remoteClosingTxOpt: Option[Transaction]
 ) {
   require(localPayouts.keySet.contains(realOutcome), "Outcome must be possible")
   require(localPayouts.size == 2, "Currently only Binary DLCs are supported")
@@ -271,8 +272,8 @@ object DLCTestVector {
         remoteWinCet = acceptSetup.cetWin,
         remoteLoseCet = acceptSetup.cetLose,
         refundTx = offerSetup.refundTx,
-        localClosingTx = unilateralOutcome.closingTx,
-        remoteClosingTx = toRemoteOutcome.closingTx
+        localClosingTxOpt = unilateralOutcome.closingTxOpt,
+        remoteClosingTxOpt = toRemoteOutcome.closingTxOpt
       )
     }
   }
@@ -307,8 +308,8 @@ case class SerializedDLCTestVector(
       remoteWinCet = outputs.remoteCets.head,
       remoteLoseCet = outputs.remoteCets.last,
       refundTx = outputs.refundTx,
-      localClosingTx = outputs.localClosingTx,
-      remoteClosingTx = outputs.remoteClosingTx
+      localClosingTxOpt = outputs.localClosingTx,
+      remoteClosingTxOpt = outputs.remoteClosingTx
     )
   }
 
@@ -355,8 +356,8 @@ object SerializedDLCTestVector {
       localCets = Vector(testVector.localWinCet, testVector.localLoseCet),
       remoteCets = Vector(testVector.remoteWinCet, testVector.remoteLoseCet),
       refundTx = testVector.refundTx,
-      localClosingTx = testVector.localClosingTx,
-      remoteClosingTx = testVector.remoteClosingTx
+      localClosingTx = testVector.localClosingTxOpt,
+      remoteClosingTx = testVector.remoteClosingTxOpt
     )
 
     SerializedDLCTestVector(inputs, outputs)
@@ -624,8 +625,8 @@ case class SerializedDLCOutputs(
     localCets: Vector[Transaction],
     remoteCets: Vector[Transaction],
     refundTx: Transaction,
-    localClosingTx: Transaction,
-    remoteClosingTx: Transaction) {
+    localClosingTx: Option[Transaction],
+    remoteClosingTx: Option[Transaction]) {
   require(localCets.length == 2,
           s"There must be two local CETs, got $localCets")
   require(remoteCets.length == 2,

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
@@ -44,7 +44,9 @@ import org.bitcoins.dlc.{
   BinaryOutcomeDLCClient,
   CETSignatures,
   DLCTimeouts,
-  FundingSignatures
+  FundingSignatures,
+  UnilateralDLCOutcomeWithClosing,
+  UnilateralDLCOutcomeWithDustClosing
 }
 import play.api.libs.json.{
   JsNumber,
@@ -251,6 +253,17 @@ object DLCTestVector {
         acceptSetup,
         unilateralOutcome.cet)
     } yield {
+      val localClosingTxOpt = unilateralOutcome match {
+        case UnilateralDLCOutcomeWithClosing(_, _, closingTx, _) =>
+          Some(closingTx)
+        case _: UnilateralDLCOutcomeWithDustClosing => None
+      }
+      val remoteClosingTxOpt = toRemoteOutcome match {
+        case UnilateralDLCOutcomeWithClosing(_, _, closingTx, _) =>
+          Some(closingTx)
+        case _: UnilateralDLCOutcomeWithDustClosing => None
+      }
+
       DLCTestVector(
         localPayouts = localPayouts,
         realOutcome = realOutcome,
@@ -272,8 +285,8 @@ object DLCTestVector {
         remoteWinCet = acceptSetup.cetWin,
         remoteLoseCet = acceptSetup.cetLose,
         refundTx = offerSetup.refundTx,
-        localClosingTxOpt = unilateralOutcome.closingTxOpt,
-        remoteClosingTxOpt = toRemoteOutcome.closingTxOpt
+        localClosingTxOpt = localClosingTxOpt,
+        remoteClosingTxOpt = remoteClosingTxOpt
       )
     }
   }


### PR DESCRIPTION
Added the logic to remove outputs with value below `Policy.dustThreshold`, finally enabling us to remove the weird over-collateralization in tests (where each party was putting in 1 BTC to gain or lose 1 mBTC).

Tests now have single output CETs as is expected from binary outcome DLCs.