### PR TITLE
Added server handling for empty account tables while a seed exists

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -84,10 +84,7 @@ object Main extends App {
   /** Checks if the user already has a wallet */
   private def hasWallet(): Future[Boolean] = {
     val walletDB = walletConf.dbPath resolve walletConf.dbName
-    val hdCoin = HDCoin(purpose = walletConf.kmParams.purpose,
-                        coinType =
-                          HDUtil.getCoinType(walletConf.kmParams.network))
-
+    val hdCoin = walletConf.defaultAccount.coin
     if (Files.exists(walletDB) && walletConf.seedExists()) {
       AccountDAO().read((hdCoin, 0)).map(_.isDefined)
     } else {

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -7,14 +7,17 @@ import akka.actor.ActorSystem
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.Core
 import org.bitcoins.core.api.ChainQueryApi
+import org.bitcoins.core.hd.HDCoin
 import org.bitcoins.keymanager.KeyManagerInitializeError
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
+import org.bitcoins.keymanager.util.HDUtil
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.DataMessageHandler
 import org.bitcoins.node.{NeutrinoNode, Node, NodeCallbacks, SpvNode}
 import org.bitcoins.wallet.api._
 import org.bitcoins.wallet.config.WalletAppConfig
+import org.bitcoins.wallet.models.AccountDAO
 import org.bitcoins.wallet.{LockedWallet, Wallet}
 
 import scala.concurrent.duration._
@@ -79,9 +82,17 @@ object Main extends App {
   }
 
   /** Checks if the user already has a wallet */
-  private def hasWallet(): Boolean = {
+  private def hasWallet(): Future[Boolean] = {
     val walletDB = walletConf.dbPath resolve walletConf.dbName
-    Files.exists(walletDB) && walletConf.seedExists()
+    val hdCoin = HDCoin(purpose = walletConf.kmParams.purpose,
+                        coinType =
+                          HDUtil.getCoinType(walletConf.kmParams.network))
+
+    if (Files.exists(walletDB) && walletConf.seedExists()) {
+      AccountDAO().read((hdCoin, 0)).map(_.isDefined)
+    } else {
+      Future.successful(false)
+    }
   }
 
   private def createNode: Future[Node] = {
@@ -99,35 +110,37 @@ object Main extends App {
       nodeApi: Node,
       chainQueryApi: ChainQueryApi,
       bip39PasswordOpt: Option[String]): Future[UnlockedWalletApi] = {
-    if (hasWallet()) {
-      logger.info(s"Using pre-existing wallet")
-      val locked = LockedWallet(nodeApi, chainQueryApi)
+    hasWallet().flatMap { walletExists =>
+      if (walletExists) {
+        logger.info(s"Using pre-existing wallet")
+        val locked = LockedWallet(nodeApi, chainQueryApi)
 
-      // TODO change me when we implement proper password handling
-      locked.unlock(BIP39KeyManager.badPassphrase, bip39PasswordOpt) match {
-        case Right(wallet) =>
-          Future.successful(wallet)
-        case Left(kmError) =>
-          error(kmError)
+        // TODO change me when we implement proper password handling
+        locked.unlock(BIP39KeyManager.badPassphrase, bip39PasswordOpt) match {
+          case Right(wallet) =>
+            Future.successful(wallet)
+          case Left(kmError) =>
+            error(kmError)
+        }
+      } else {
+        logger.info(s"Initializing key manager")
+        val bip39PasswordOpt = None
+        val keyManagerE: Either[KeyManagerInitializeError, BIP39KeyManager] =
+          BIP39KeyManager.initialize(kmParams = walletConf.kmParams,
+                                     bip39PasswordOpt = bip39PasswordOpt)
+
+        val keyManager = keyManagerE match {
+          case Right(keyManager) => keyManager
+          case Left(err) =>
+            error(err)
+        }
+
+        logger.info(s"Creating new wallet")
+        val unInitializedWallet = Wallet(keyManager, nodeApi, chainQueryApi)
+
+        Wallet.initialize(wallet = unInitializedWallet,
+                          bip39PasswordOpt = bip39PasswordOpt)
       }
-    } else {
-      logger.info(s"Initializing key manager")
-      val bip39PasswordOpt = None
-      val keyManagerE: Either[KeyManagerInitializeError, BIP39KeyManager] =
-        BIP39KeyManager.initialize(kmParams = walletConf.kmParams,
-                                   bip39PasswordOpt = bip39PasswordOpt)
-
-      val keyManager = keyManagerE match {
-        case Right(keyManager) => keyManager
-        case Left(err) =>
-          error(err)
-      }
-
-      logger.info(s"Creating new wallet")
-      val unInitializedWallet = Wallet(keyManager, nodeApi, chainQueryApi)
-
-      Wallet.initialize(wallet = unInitializedWallet,
-                        bip39PasswordOpt = bip39PasswordOpt)
     }
   }
 


### PR DESCRIPTION
Now the wallet is not considered initialized by the Server if the accounts table is empty.

And when a BIP39KeyManager is being initialized while a seed already exists, that seed is used rather than failing.