### PR TITLE
Create migration to drop confirmations column from txo_spending_info …

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -102,7 +102,8 @@ abstract class DbManagement extends DatabaseLogger {
     try {
       flyway.migrate()
     } catch {
-      case _: FlywayException =>
+      case err: FlywayException =>
+        logger(appConfig).warn(s"Failed to apply first round of migrations, attempting baseline and re-apply",err)
         //maybe we have an existing database, so attempt to baseline the existing
         //database and then apply migrations again
         flyway.baseline()

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -29,7 +29,7 @@ trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
 
     val outcomeF: Future[Outcome] = fixtureF.flatMap { fixture =>
       test(fixture.asInstanceOf[FixtureParam]).toFuture
-    }.recoverWith { err =>
+    }.recoverWith { case err =>
       FutureOutcome.failed(err).toFuture
     }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -27,13 +27,10 @@ trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
       destroy: T => Future[Any])(test: OneArgAsyncTest): FutureOutcome = {
     val fixtureF = build()
 
-    fixtureF.failed.foreach { err =>
-      println(s"Failed to build fixture with err=${err}")
-      throw err
-    }
-
     val outcomeF: Future[Outcome] = fixtureF.flatMap { fixture =>
       test(fixture.asInstanceOf[FixtureParam]).toFuture
+    }.recoverWith { err =>
+      FutureOutcome.failed(err).toFuture
     }
 
     val futOutcome: FutureOutcome = new FutureOutcome(outcomeF)

--- a/wallet/src/main/resources/walletdb/migration/V3__txo_spending_info_drop_confirmations.sql
+++ b/wallet/src/main/resources/walletdb/migration/V3__txo_spending_info_drop_confirmations.sql
@@ -1,0 +1,8 @@
+
+-- This block drops the "confirmations" column
+CREATE TEMPORARY TABLE "txo_spending_info_backup" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,"tx_outpoint" VARCHAR(254) NOT NULL, "script_pub_key" VARCHAR(254) NOT NULL,"value" INTEGER NOT NULL,"hd_privkey_path" VARCHAR(254) NOT NULL,"redeem_script" VARCHAR(254),"script_witness" VARCHAR(254),"confirmations" INTEGER,"txid" VARCHAR(254) NOT NULL,"block_hash" VARCHAR(254), "txo_state" VARCHAR(254) NOT NULL, constraint "fk_scriptPubKey" foreign key("script_pub_key") references "addresses"("script_pub_key"));
+INSERT INTO "txo_spending_info_backup" SELECT "id", "tx_outpoint", "script_pub_key", "value", "hd_privkey_path", "redeem_script", "script_witness", "confirmations", "txid","block_hash", "txo_state" FROM "txo_spending_info";
+DROP TABLE "txo_spending_info";
+CREATE TABLE "txo_spending_info" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,"tx_outpoint" VARCHAR(254) NOT NULL, "script_pub_key" VARCHAR(254) NOT NULL,"value" INTEGER NOT NULL,"hd_privkey_path" VARCHAR(254) NOT NULL,"redeem_script" VARCHAR(254),"script_witness" VARCHAR(254),"txid" VARCHAR(254) NOT NULL,"block_hash" VARCHAR(254), "txo_state" VARCHAR(254) NOT NULL, constraint "fk_scriptPubKey" foreign key("script_pub_key") references "addresses"("script_pub_key") on update NO ACTION on delete NO ACTION);
+INSERT INTO "txo_spending_info" SELECT "id", "tx_outpoint", "script_pub_key", "value", "hd_privkey_path", "redeem_script", "script_witness", "txid", "block_hash", "txo_state" FROM "txo_spending_info_backup";
+DROP TABLE "txo_spending_info_backup";


### PR DESCRIPTION
…table in the wallet database, also fix a long standing issue in BitcoinSFixture where failure cases in the testing suite were not being handled properly

Fixes #1076 

Maybe the more important thing this PR does is fix the problem we have with swallowing exceptions when the `BitcoinSFixture.makeDepedentFixture()` fails. If the `build` function failed, we would give a cryptic error message saying that the test suite failed rather than propagating the stack trace.