### PR TITLE
Add codehause dependecy as a work around for issue 1110, there is a i…

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -193,6 +193,9 @@ object Deps {
     else Compile.newMicroPickle,
     Compile.logback,
     Compile.scopt,
+    //we can remove this dependency when this is fixed
+    //https://github.com/oracle/graal/issues/1943
+    //see https://github.com/bitcoin-s/bitcoin-s/issues/1100
     Compile.codehaus
   )
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -53,6 +53,7 @@ object Deps {
     // CLI deps
     val scoptV = "4.0.0-RC2"
     val sttpV = "1.7.2"
+    val codehausV = "3.1.0"
   }
 
   object Compile {
@@ -69,7 +70,7 @@ object Deps {
     val typesafeConfig = "com.typesafe" % "config" % V.typesafeConfigV withSources () withJavadoc ()
 
     val logback = "ch.qos.logback" % "logback-classic" % V.logback withSources () withJavadoc ()
-
+    val codehaus = "org.codehaus.janino" % "janino" % V.codehausV
     //for loading secp256k1 natively
     val nativeLoader = "org.scijava" % "native-lib-loader" % V.nativeLoaderV withSources () withJavadoc ()
 
@@ -191,7 +192,8 @@ object Deps {
     if (scalaVersion.startsWith("2.11")) Compile.oldMicroPickle
     else Compile.newMicroPickle,
     Compile.logback,
-    Compile.scopt
+    Compile.scopt,
+    Compile.codehaus
   )
 
   def picklers(scalaVersion: String) = List(


### PR DESCRIPTION
…ssue in graalvm native image generator where images aren't being generated correctly. THis is related to the logback dependecy

See #1100 

As a workaround for the graalvm issue, we explictly include the `codehaus`. This should be able to be removed when the underlying oracle graavm issue is fixed. 