### PR TITLE
Move binaries to be stored inside of the HOME/.bitcoin-s/binaries ins…

### DIFF
--- a/bitcoind-rpc/bitcoind-rpc.sbt
+++ b/bitcoind-rpc/bitcoind-rpc.sbt
@@ -17,7 +17,8 @@ TaskKeys.downloadBitcoind := {
   val logger = streams.value.log
   import scala.sys.process._
 
-  val binaryDir = Paths.get("binaries", "bitcoind")
+  val binaryDir = CommonSettings.binariesPath.resolve("bitcoind")
+
 
   if (Files.notExists(binaryDir)) {
     logger.info(s"Creating directory for bitcoind binaries: $binaryDir")

--- a/eclair-rpc/eclair-rpc.sbt
+++ b/eclair-rpc/eclair-rpc.sbt
@@ -1,5 +1,7 @@
 import java.nio.file._
 
+import scala.util.Properties
+
 name := "bitcoin-s-eclair-rpc"
 
 libraryDependencies ++= Deps.eclairRpc
@@ -12,7 +14,7 @@ TaskKeys.downloadEclair := {
   val logger = streams.value.log
   import scala.sys.process._
 
-  val binaryDir = Paths.get("binaries", "eclair")
+  val binaryDir = CommonSettings.binariesPath.resolve("eclair")
 
   if (Files.notExists(binaryDir)) {
     logger.info(s"Creating directory for Eclair binaires: $binaryDir")

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -700,7 +700,7 @@ class EclairRpcClient(val instance: EclairInstance, binary: Option[File] = None)
         }
       case (None, Some(path)) =>
         val eclairV =
-          s"/eclair-node-${EclairRpcClient.version}-${EclairRpcClient.commit}.jar"
+          s"eclair-node-${EclairRpcClient.version}-${EclairRpcClient.commit}.jar"
         val fullPath = path + eclairV
 
         val jar = new File(fullPath)

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -1,4 +1,6 @@
 // these two imports are needed for sbt syntax to work
+import java.nio.file.Paths
+
 import sbt._
 import sbt.Keys._
 
@@ -116,4 +118,6 @@ object CommonSettings {
   ) ++ testSettings
 
   lazy val prodSettings: Seq[Setting[_]] = settings
+
+  lazy val binariesPath = Paths.get(Properties.userHome, ".bitcoin-s", "binaries")
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -26,6 +26,7 @@ import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstance}
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.async.TestAsyncUtil
 import org.bitcoins.testkit.rpc.{BitcoindRpcTestUtil, TestRpcUtil}
+import org.bitcoins.testkit.util.TestkitBinaries
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
@@ -47,7 +48,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
 
   /** Directory where sbt downloads Eclair binaries */
   private[bitcoins] val binaryDirectory =
-    BitcoindRpcTestUtil.baseBinaryDirectory.resolve("eclair")
+    TestkitBinaries.baseBinaryDirectory.resolve("eclair")
 
   /** Path to Jar downloaded by Eclair, if it exists */
   private[bitcoins] def binary(

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -53,7 +53,7 @@ import org.bitcoins.rpc.jsonmodels.{
   SignRawTransactionResult
 }
 import org.bitcoins.rpc.util.{AsyncUtil, RpcUtil}
-import org.bitcoins.testkit.util.FileUtil
+import org.bitcoins.testkit.util.{FileUtil, TestkitBinaries}
 import org.bitcoins.util.ListUtil
 
 import scala.annotation.tailrec
@@ -156,25 +156,9 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
 
   lazy val network: RegTest.type = RegTest
 
-  /** The base directory where binaries needed in tests
-    * are located. */
-  private[bitcoins] val baseBinaryDirectory = {
-    val cwd = Paths.get(Properties.userDir)
-    val pathsToGoBackFrom = List("eclair-rpc-test",
-                                 "bitcoind-rpc-test",
-                                 "node-test",
-                                 "wallet-test",
-                                 "chain-test")
-
-    val rootDir = if (pathsToGoBackFrom.exists(cwd.endsWith)) {
-      cwd.getParent()
-    } else cwd
-    rootDir.resolve("binaries")
-  }
-
   /** The directory that sbt downloads bitcoind binaries into */
   private[bitcoins] val binaryDirectory = {
-    baseBinaryDirectory.resolve("bitcoind")
+    TestkitBinaries.baseBinaryDirectory.resolve("bitcoind")
   }
 
   def newestBitcoindBinary: File = getBinary(BitcoindVersion.newest)

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/TestkitBinaries.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/TestkitBinaries.scala
@@ -1,0 +1,16 @@
+package org.bitcoins.testkit.util
+
+import java.nio.file.{Path, Paths}
+
+import scala.util.Properties
+
+object TestkitBinaries {
+
+  /** The base directory where binaries needed in tests
+    * are located. */
+  lazy val baseBinaryDirectory: Path = {
+    val home = Paths.get(Properties.userHome, ".bitcoin-s", "binaries")
+    home
+  }
+
+}


### PR DESCRIPTION
…tead of usrdir/binaries. This makes it so different projects that use bitcoin-s can re-use binaries instead of having to download them for every project

This addresses #1121 and #1109. 

Basically if you run `downloadBitcoind` and `downloadEclair` the binaries that are downloaded will be stored under `$HOME/.bitcoin-s/binaries` rather than the current working directory `${Properties.userDir}/binaries/`. 

This means after this PR first gets merged, you will have to re-download these binaries, or manually move the existing `binaries/` to `~/.bitcoin-s/`


