### PR TITLE
Fix async bug in chain fixtures setup phase

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -436,15 +436,13 @@ object ChainUnitTest extends ChainVerificationLogger {
       appConfig: ChainAppConfig): Future[(ChainHandler, BlockHeaderDb)] = {
     val tableSetupF = setupAllTables()
 
-    val chainHandlerF = makeChainHandler()
-
     val genesisHeaderF = tableSetupF.flatMap { _ =>
+      val chainHandlerF = makeChainHandler()
       for {
         chainHandler <- chainHandlerF
         genHeader <- chainHandler.blockHeaderDAO.create(genesisHeaderDb)
-        genFilterHeader <- chainHandler.filterHeaderDAO.create(
-          genesisFilterHeaderDb)
-        genFilter <- chainHandler.filterDAO.create(genesisFilterDb)
+        _ <- chainHandler.filterHeaderDAO.create(genesisFilterHeaderDb)
+        _ <- chainHandler.filterDAO.create(genesisFilterDb)
       } yield genHeader
     }
 


### PR DESCRIPTION
Address #916 

In our chain project fixtures we did not make sure that tables were fully created before trying to insert information into tables in futures. This causes race conditions on slow CI machines that are fixed now because we call 'makeChainHandler()' inside of the setupTableF flatMap