### PR TITLE
Bump 'downloadBitcoind' timeout

### DIFF
--- a/bitcoind-rpc/bitcoind-rpc.sbt
+++ b/bitcoind-rpc/bitcoind-rpc.sbt
@@ -81,6 +81,6 @@ TaskKeys.downloadBitcoind := {
     }
   }
 
-  //timeout if we cannot download in 120 seconds
-  Await.result(Future.sequence(downloads), 120.seconds)
+  //timeout if we cannot download in 5 minutes
+  Await.result(Future.sequence(downloads), 5.minutes)
 }


### PR DESCRIPTION
It seems that build are currently timing out with the 2 minute timeout we currently have: 

https://travis-ci.org/bitcoin-s/bitcoin-s/jobs/651937140#L298