### PR TITLE
Demo breakup 3

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -9,6 +9,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BlockStamp.BlockTime
 import org.bitcoins.core.protocol._
 import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import scodec.bits.ByteVector
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
@@ -127,6 +128,14 @@ object CliReaders {
 
       override def reads: String => SchnorrDigitalSignature =
         SchnorrDigitalSignature.fromHex
+    }
+
+  implicit val partialSigReads: Read[PartialSignature] =
+    new Read[PartialSignature] {
+      override def arity: Int = 1
+
+      override def reads: String => PartialSignature =
+        PartialSignature.fromHex
     }
 
   implicit val sha256DigestBEReads: Read[Sha256DigestBE] =

--- a/app/picklers/src/main/scala/org/bitcoins/picklers/Picklers.scala
+++ b/app/picklers/src/main/scala/org/bitcoins/picklers/Picklers.scala
@@ -5,6 +5,7 @@ import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
+import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.dlc.DLCMessage._
@@ -45,6 +46,9 @@ package object picklers {
   implicit val schnorrDigitalSignaturePickler: ReadWriter[
     SchnorrDigitalSignature] =
     readwriter[String].bimap(_.hex, SchnorrDigitalSignature.fromHex)
+
+  implicit val partialSignaturePickler: ReadWriter[PartialSignature] =
+    readwriter[String].bimap(_.hex, PartialSignature.fromHex)
 
   implicit val dlcOfferPickler: ReadWriter[DLCOffer] =
     readwriter[String]

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -6,6 +6,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BlockStamp.BlockHeight
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
+import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.dlc.DLCMessage._
@@ -265,6 +266,51 @@ object InitDLCMutualClose extends ServerJsonModels {
         Failure(
           new IllegalArgumentException(
             s"Bad number of arguments: ${other.length}. Expected: 3"))
+    }
+  }
+}
+
+case class AcceptDLCMutualClose(
+    eventId: Sha256DigestBE,
+    oracleSig: SchnorrDigitalSignature,
+    closeSig: PartialSignature)
+
+object AcceptDLCMutualClose extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[AcceptDLCMutualClose] = {
+    jsArr.arr.toList match {
+      case eventIdJs :: oracleSigJs :: closeSigJs :: Nil =>
+        Try {
+          val eventId = Sha256DigestBE(eventIdJs.str)
+          val oracleSig = jsToSchnorrDigitalSignature(oracleSigJs)
+          val closeSig = PartialSignature(closeSigJs.str)
+          AcceptDLCMutualClose(eventId, oracleSig, closeSig)
+        }
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 3"))
+    }
+  }
+}
+
+case class GetDLCFundingTx(eventId: Sha256DigestBE)
+
+object GetDLCFundingTx extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[GetDLCFundingTx] = {
+    jsArr.arr.toList match {
+      case eventIdJs :: Nil =>
+        Try {
+          val eventId = Sha256DigestBE(eventIdJs.str)
+          GetDLCFundingTx(eventId)
+        }
+      case Nil =>
+        Failure(new IllegalArgumentException("Missing eventId argument"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 1"))
     }
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -58,8 +58,7 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
         case Success(
-            CreateDLCOffer(collateral,
-                           oracleInfo,
+            CreateDLCOffer(oracleInfo,
                            contractInfo,
                            collateral,
                            feeRateOpt,

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCClientIntegrationTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCClientIntegrationTest.scala
@@ -416,7 +416,7 @@ class BinaryOutcomeDLCClientIntegrationTest extends BitcoindRpcTest {
           override def run(): Unit = {
             if (!mutualCloseTxP.isCompleted) {
               val fundingTxId = initDLC
-                .createUnsignedMutualClosePSBT(oracleSig, initSetup.fundingTx)
+                .createUnsignedMutualClosePSBT(oracleSig)
                 .transaction
                 .txIdBE
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCClient.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCClient.scala
@@ -733,7 +733,6 @@ case class BinaryOutcomeDLCClient(
 
   def createMutualCloseSig(
       eventId: Sha256DigestBE,
-      dlcSetup: SetupDLC,
       oracleSig: SchnorrDigitalSignature): Future[DLCMutualCloseSig] = {
 
     createMutualCloseTxSig(oracleSig).map { sig =>

--- a/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCClient.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCClient.scala
@@ -224,6 +224,12 @@ case class BinaryOutcomeDLCClient(
                     lockTime = txWithFee.lockTime)
   }
 
+  lazy val fundingTxId: DoubleSha256Digest =
+    createUnsignedFundingTransaction.txId
+
+  lazy val fundingOutput: TransactionOutput =
+    createUnsignedFundingTransaction.outputs.head
+
   def createFundingTransactionSigs(): Future[FundingSignatures] = {
     val fundingTx = createUnsignedFundingTransaction
 
@@ -280,9 +286,7 @@ case class BinaryOutcomeDLCClient(
     *
     * @param sig The oracle's signature for this contract
     */
-  def createUnsignedMutualClosePSBT(
-      sig: SchnorrDigitalSignature,
-      fundingTx: Transaction): PSBT = {
+  def createUnsignedMutualClosePSBT(sig: SchnorrDigitalSignature): PSBT = {
     val (toLocalPayout, toRemotePayout) =
       if (Schnorr.verify(messageWin, sig, oraclePubKey)) {
         (winPayout, remoteWinPayout)
@@ -303,10 +307,9 @@ case class BinaryOutcomeDLCClient(
     } else {
       Vector(toRemote, toLocal)
     }
-    val input = TransactionInput(
-      TransactionOutPoint(fundingTx.txId, UInt32.zero),
-      EmptyScriptSignature,
-      sequence)
+    val input = TransactionInput(TransactionOutPoint(fundingTxId, UInt32.zero),
+                                 EmptyScriptSignature,
+                                 sequence)
     val utx = BaseTransaction(TransactionConstants.validLockVersion,
                               Vector(input),
                               outputs.filter(_.value >= Policy.dustThreshold),
@@ -314,14 +317,14 @@ case class BinaryOutcomeDLCClient(
 
     PSBT
       .fromUnsignedTx(utx)
-      .addUTXOToInput(fundingTx, index = 0)
+      .addWitnessUTXOToInput(fundingOutput, index = 0)
       .addScriptWitnessToInput(P2WSHWitnessV0(fundingSPK), index = 0)
   }
 
   def createMutualCloseTxSig(
-      sig: SchnorrDigitalSignature,
-      fundingTx: Transaction): Future[PartialSignature] = {
-    val unsignedPSBT = createUnsignedMutualClosePSBT(sig, fundingTx)
+      sig: SchnorrDigitalSignature): Future[PartialSignature] = {
+    val unsignedPSBT =
+      createUnsignedMutualClosePSBT(sig)
 
     unsignedPSBT
       .sign(inputIndex = 0, fundingPrivKey)
@@ -330,9 +333,9 @@ case class BinaryOutcomeDLCClient(
 
   def createMutualCloseTx(
       sig: SchnorrDigitalSignature,
-      fundingSig: PartialSignature,
-      fundingTx: Transaction): Future[Transaction] = {
-    val unsignedPSBT = createUnsignedMutualClosePSBT(sig, fundingTx)
+      fundingSig: PartialSignature): Future[Transaction] = {
+    val unsignedPSBT =
+      createUnsignedMutualClosePSBT(sig)
 
     val signedPSBTF = unsignedPSBT
       .addSignature(fundingSig, inputIndex = 0)
@@ -371,10 +374,8 @@ case class BinaryOutcomeDLCClient(
 
     val outputs: Vector[TransactionOutput] = Vector(toLocal, toRemote)
 
-    val fundingTx = createUnsignedFundingTransaction
-    val fundingTxid = fundingTx.txId
     val fundingInput = TransactionInput(
-      TransactionOutPoint(fundingTxid, UInt32.zero),
+      TransactionOutPoint(fundingTxId, UInt32.zero),
       EmptyScriptSignature,
       sequence)
 
@@ -387,7 +388,7 @@ case class BinaryOutcomeDLCClient(
 
     val readyToSignPSBT = psbt
       .addSignature(remoteSig, inputIndex = 0)
-      .addUTXOToInput(fundingTx, index = 0)
+      .addWitnessUTXOToInput(fundingOutput, index = 0)
       .addScriptWitnessToInput(P2WSHWitnessV0(fundingSPK), index = 0)
 
     val signedPSBTF = readyToSignPSBT.sign(inputIndex = 0, fundingPrivKey)
@@ -436,9 +437,7 @@ case class BinaryOutcomeDLCClient(
 
     val outputs: Vector[TransactionOutput] = Vector(toLocal, toRemote)
 
-    val fundingTx = createUnsignedFundingTransaction
-    val fundingTxid = fundingTx.txIdBE
-    val fundingOutPoint = TransactionOutPoint(fundingTxid, UInt32.zero)
+    val fundingOutPoint = TransactionOutPoint(fundingTxId, UInt32.zero)
     val fundingInput =
       TransactionInput(fundingOutPoint, EmptyScriptSignature, sequence)
 
@@ -450,7 +449,7 @@ case class BinaryOutcomeDLCClient(
 
     val sigF = PSBT
       .fromUnsignedTx(unsignedTx)
-      .addUTXOToInput(fundingTx, index = 0)
+      .addWitnessUTXOToInput(fundingOutput, index = 0)
       .addScriptWitnessToInput(P2WSHWitnessV0(fundingSPK), index = 0)
       .sign(inputIndex = 0, fundingPrivKey)
       .flatMap(findSigInPSBT(_, fundingPrivKey.publicKey))
@@ -502,12 +501,11 @@ case class BinaryOutcomeDLCClient(
   }
 
   def createRefundSig(): Future[(Transaction, PartialSignature)] = {
-    val fundingTx = createUnsignedFundingTransaction
     val refundTx = createUnsignedRefundTx
 
     val sigF = PSBT
       .fromUnsignedTx(refundTx)
-      .addUTXOToInput(fundingTx, index = 0)
+      .addWitnessUTXOToInput(fundingOutput, index = 0)
       .addScriptWitnessToInput(P2WSHWitnessV0(fundingSPK), index = 0)
       .sign(inputIndex = 0, fundingPrivKey)
       .flatMap(findSigInPSBT(_, fundingPrivKey.publicKey))
@@ -525,7 +523,7 @@ case class BinaryOutcomeDLCClient(
 
     val signedPSBTF = psbt
       .addSignature(remoteSig, inputIndex = 0)
-      .addUTXOToInput(createUnsignedFundingTransaction, index = 0)
+      .addWitnessUTXOToInput(fundingOutput, index = 0)
       .addScriptWitnessToInput(P2WSHWitnessV0(fundingSPK), index = 0)
       .sign(inputIndex = 0, fundingPrivKey)
 
@@ -737,9 +735,8 @@ case class BinaryOutcomeDLCClient(
       eventId: Sha256DigestBE,
       dlcSetup: SetupDLC,
       oracleSig: SchnorrDigitalSignature): Future[DLCMutualCloseSig] = {
-    val fundingTx = dlcSetup.fundingTx
 
-    createMutualCloseTxSig(oracleSig, fundingTx).map { sig =>
+    createMutualCloseTxSig(oracleSig).map { sig =>
       DLCMutualCloseSig(eventId, oracleSig, sig)
     }
   }
@@ -761,7 +758,7 @@ case class BinaryOutcomeDLCClient(
     logger.info(s"Attempting Mutual Close for funding tx: ${fundingTx.txIdBE}")
 
     for {
-      fundingSig <- createMutualCloseTxSig(sig, fundingTx)
+      fundingSig <- createMutualCloseTxSig(sig)
       _ <- sendSigs(sig, fundingSig)
       mutualCloseTx <- getMutualCloseTx
     } yield {
@@ -782,7 +779,7 @@ case class BinaryOutcomeDLCClient(
 
     for {
       (sig, fundingSig) <- getSigs
-      mutualCloseTx <- createMutualCloseTx(sig, fundingSig, fundingTx)
+      mutualCloseTx <- createMutualCloseTx(sig, fundingSig)
     } yield {
       CooperativeDLCOutcome(fundingTx, mutualCloseTx)
     }

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -55,6 +55,7 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
     * This is the first step of the initiator
     */
   override def createDLCOffer(
+      collateral: CurrencyUnit,
       oracleInfo: OracleInfo,
       contractInfo: ContractInfo,
       collateral: Satoshis,

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -9,6 +9,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.protocol.{Bech32Address, BlockStamp}
+import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.utxo.BitcoinUTXOSpendingInfoSingle
@@ -55,7 +56,6 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
     * This is the first step of the initiator
     */
   override def createDLCOffer(
-      collateral: CurrencyUnit,
       oracleInfo: OracleInfo,
       contractInfo: ContractInfo,
       collateral: Satoshis,
@@ -441,4 +441,12 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
       sigMessage <- client.createMutualCloseSig(eventId, setup, oracleSig)
     } yield sigMessage
   }
+
+  override def acceptDLCMutualClose(
+      eventId: Sha256DigestBE,
+      oracleSig: SchnorrDigitalSignature,
+      closeSig: PartialSignature): Future[Transaction] = ???
+
+  override def getDLCFundingTx(eventId: Sha256DigestBE): Future[Transaction] =
+    ???
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -408,12 +408,11 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
       )
 
       val setupF = if (dlcDb.isInitiator) {
-        val fundingTxIdBE = client.createUnsignedFundingTransaction.txIdBE
-        val fundingTxF = ???
-
-        client.setupDLCOffer(Future.successful(dlcAccept.cetSigs),
-                             (_, _) => FutureUtil.unit,
-                             fundingTxF)
+        // TODO: Note that the funding tx in this setup is not signed
+        client.setupDLCOffer(
+          Future.successful(dlcAccept.cetSigs),
+          (_, _) => FutureUtil.unit,
+          Future.successful(client.createUnsignedFundingTransaction))
       } else {
         client.setupDLCAccept(
           _ => FutureUtil.unit,
@@ -436,9 +435,9 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
       dlcAcceptOpt <- dlcAcceptDAO.findByEventId(eventId)
       dlcAccept = dlcAcceptOpt.get
 
-      (client, setup) <- clientFromDb(dlcDb, dlcOffer, dlcAccept)
+      (client, _) <- clientFromDb(dlcDb, dlcOffer, dlcAccept)
 
-      sigMessage <- client.createMutualCloseSig(eventId, setup, oracleSig)
+      sigMessage <- client.createMutualCloseSig(eventId, oracleSig)
     } yield sigMessage
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -435,7 +435,6 @@ trait UnlockedWalletApi extends LockedWalletApi {
   def lock(): LockedWalletApi
 
   def createDLCOffer(
-      collateral: CurrencyUnit,
       oracleInfo: OracleInfo,
       contractInfo: ContractInfo,
       collateral: Satoshis,

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -14,6 +14,7 @@ import org.bitcoins.core.protocol.blockchain.{Block, ChainParams}
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
+import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.dlc.DLCMessage._
@@ -434,6 +435,7 @@ trait UnlockedWalletApi extends LockedWalletApi {
   def lock(): LockedWalletApi
 
   def createDLCOffer(
+      collateral: CurrencyUnit,
       oracleInfo: OracleInfo,
       contractInfo: ContractInfo,
       collateral: Satoshis,
@@ -450,6 +452,13 @@ trait UnlockedWalletApi extends LockedWalletApi {
   def initDLCMutualClose(
       eventId: Sha256DigestBE,
       oracleSig: SchnorrDigitalSignature): Future[DLCMutualCloseSig]
+
+  def acceptDLCMutualClose(
+      eventId: Sha256DigestBE,
+      oracleSig: SchnorrDigitalSignature,
+      closeSig: PartialSignature): Future[Transaction]
+
+  def getDLCFundingTx(eventId: Sha256DigestBE): Future[Transaction]
 
   /**
     *


### PR DESCRIPTION
The third leg of #1140 (built on top of #1147)

Adds `acceptmutualclose` and `getdlcfundingtx`

Removes `BinaryOutcomeDLCClient`'s reliance on the signed funding tx in order to compute outcomes