### PR TITLE
Demo breakup 4

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -16,6 +16,7 @@ import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.dlc.DLCMessage.{
   ContractInfo,
   DLCAccept,
+  DLCMutualCloseSig,
   DLCOffer,
   DLCSign,
   OracleInfo
@@ -171,4 +172,12 @@ object CliReaders {
       DLCSign.fromJson(ujson.read(str))
     }
   }
+
+  implicit val dlcMutualCloseSigReads: Read[DLCMutualCloseSig] =
+    new Read[DLCMutualCloseSig] {
+      override def arity: Int = 1
+
+      override def reads: String => DLCMutualCloseSig =
+        str => DLCMutualCloseSig.fromJson(ujson.read(str))
+    }
 }

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -8,7 +8,6 @@ import org.bitcoins.core.currency._
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.transaction.{EmptyTransaction, Transaction}
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
-import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.dlc.DLCMessage._
@@ -247,31 +246,16 @@ object ConsoleCli {
                 case other => other
               }))
         ),
-      cmd("acceptmutualclose")
+      cmd("acceptdlcmutualclose")
         .hidden()
-        .action((_, conf) =>
-          conf.copy(command = AcceptDLCMutualClose(null, null, null)))
+        .action((_, conf) => conf.copy(command = AcceptDLCMutualClose(null)))
         .text("Sign Mutual Close Tx for given oracle event")
         .children(
-          opt[Sha256DigestBE]("eventid").required
-            .action((eventId, conf) =>
+          opt[DLCMutualCloseSig]("closesig").required
+            .action((closeSig, conf) =>
               conf.copy(command = conf.command match {
                 case acceptClose: AcceptDLCMutualClose =>
-                  acceptClose.copy(eventId = eventId)
-                case other => other
-              })),
-          opt[SchnorrDigitalSignature]("oraclesig").required
-            .action((sig, conf) =>
-              conf.copy(command = conf.command match {
-                case acceptClose: AcceptDLCMutualClose =>
-                  acceptClose.copy(oracleSig = sig)
-                case other => other
-              })),
-          opt[PartialSignature]("closesig").required
-            .action((sig, conf) =>
-              conf.copy(command = conf.command match {
-                case acceptClose: AcceptDLCMutualClose =>
-                  acceptClose.copy(closeSig = sig)
+                  acceptClose.copy(mutualCloseSig = closeSig)
                 case other => other
               }))
         ),
@@ -363,47 +347,6 @@ object ConsoleCli {
               conf.copy(command = conf.command match {
                 case claimDLCPenaltyFunds: ClaimDLCPenaltyFunds =>
                   claimDLCPenaltyFunds.copy(forceCloseTx = tx)
-                case other => other
-              }))
-        ),
-      cmd("acceptmutualclose")
-        .hidden()
-        .action((_, conf) =>
-          conf.copy(command = AcceptDLCMutualClose(null, null, null)))
-        .text("Sign Mutual Close Tx for given oracle event")
-        .children(
-          opt[Sha256DigestBE]("eventid").required
-            .action((eventId, conf) =>
-              conf.copy(command = conf.command match {
-                case acceptClose: AcceptDLCMutualClose =>
-                  acceptClose.copy(eventId = eventId)
-                case other => other
-              })),
-          opt[SchnorrDigitalSignature]("oraclesig").required
-            .action((sig, conf) =>
-              conf.copy(command = conf.command match {
-                case acceptClose: AcceptDLCMutualClose =>
-                  acceptClose.copy(oracleSig = sig)
-                case other => other
-              })),
-          opt[PartialSignature]("closesig").required
-            .action((sig, conf) =>
-              conf.copy(command = conf.command match {
-                case acceptClose: AcceptDLCMutualClose =>
-                  acceptClose.copy(closeSig = sig)
-                case other => other
-              }))
-        ),
-      cmd("getdlcfundingtx")
-        .hidden()
-        .action((_, conf) => conf.copy(command = GetDLCFundingTx(null)))
-        .text("Returns the Funding Tx corresponding to the DLC with the given eventId")
-        .children(
-          opt[Sha256DigestBE]("eventid").required
-            .action((eventId, conf) =>
-              conf.copy(command = conf.command match {
-                case getDLCFundingTx: GetDLCFundingTx =>
-                  getDLCFundingTx.copy(eventId = eventId)
                 case other => other
               }))
         ),
@@ -579,10 +522,8 @@ object ConsoleCli {
         RequestParam(
           "initdlcmutualclose",
           Seq(up.writeJs(eventId), up.writeJs(oracleSig), up.writeJs(escaped)))
-      case AcceptDLCMutualClose(eventId, oracleSig, closeSig) =>
-        RequestParam(
-          "acceptdlcmutualclose",
-          Seq(up.writeJs(eventId), up.writeJs(oracleSig), up.writeJs(closeSig)))
+      case AcceptDLCMutualClose(mutualCloseSig) =>
+        RequestParam("acceptdlcmutualclose", Seq(up.writeJs(mutualCloseSig)))
       case GetDLCFundingTx(eventId) =>
         RequestParam("getdlcfundingtx", Seq(up.writeJs(eventId)))
       case ExecuteDLCForceClose(eventId, oracleSig) =>
@@ -745,10 +686,7 @@ object CliCommand {
       escaped: Boolean)
       extends CliCommand
 
-  case class AcceptDLCMutualClose(
-      eventId: Sha256DigestBE,
-      oracleSig: SchnorrDigitalSignature,
-      closeSig: PartialSignature)
+  case class AcceptDLCMutualClose(mutualCloseSig: DLCMutualCloseSig)
       extends CliCommand
 
   case class GetDLCFundingTx(eventId: Sha256DigestBE) extends CliCommand

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -272,6 +272,27 @@ object ConsoleCli {
                 case other => other
               }))
         ),
+      cmd("executedlcunilateralclose")
+        .hidden()
+        .action((_, conf) =>
+          conf.copy(command = ExecuteDLCUnilateralClose(null, null)))
+        .text("Executes a force close for the DLC with the given eventId")
+        .children(
+          opt[Sha256DigestBE]("eventid").required
+            .action((eventId, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCUnilateralClose: ExecuteDLCUnilateralClose =>
+                  executeDLCUnilateralClose.copy(eventId = eventId)
+                case other => other
+              })),
+          opt[SchnorrDigitalSignature]("oraclesig").required
+            .action((sig, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCUnilateralClose: ExecuteDLCUnilateralClose =>
+                  executeDLCUnilateralClose.copy(oracleSig = sig)
+                case other => other
+              }))
+        ),
       cmd("executedlcforceclose")
         .hidden()
         .action((_, conf) =>
@@ -524,6 +545,9 @@ object ConsoleCli {
           Seq(up.writeJs(eventId), up.writeJs(oracleSig), up.writeJs(escaped)))
       case AcceptDLCMutualClose(mutualCloseSig) =>
         RequestParam("acceptdlcmutualclose", Seq(up.writeJs(mutualCloseSig)))
+      case ExecuteDLCUnilateralClose(eventId, oracleSig) =>
+        RequestParam("executedlcunilateralclose",
+                     Seq(up.writeJs(eventId), up.writeJs(oracleSig)))
       case GetDLCFundingTx(eventId) =>
         RequestParam("getdlcfundingtx", Seq(up.writeJs(eventId)))
       case ExecuteDLCForceClose(eventId, oracleSig) =>
@@ -690,6 +714,11 @@ object CliCommand {
       extends CliCommand
 
   case class GetDLCFundingTx(eventId: Sha256DigestBE) extends CliCommand
+
+  case class ExecuteDLCUnilateralClose(
+      eventId: Sha256DigestBE,
+      oracleSig: SchnorrDigitalSignature)
+      extends CliCommand
 
   case class ExecuteDLCForceClose(
       eventId: Sha256DigestBE,

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -156,11 +156,11 @@ object ConsoleCli {
                   offer.copy(refundLT = refundLT)
                 case other => other
               })),
-          opt[Boolean]("escaped")
-            .action((escaped, conf) =>
+          opt[Unit]("escaped")
+            .action((_, conf) =>
               conf.copy(command = conf.command match {
                 case create: CreateDLCOffer =>
-                  create.copy(escaped = escaped)
+                  create.copy(escaped = true)
                 case other => other
               }))
         ),
@@ -177,11 +177,11 @@ object ConsoleCli {
                   accept.copy(offer = offer)
                 case other => other
               })),
-          opt[Boolean]("escaped")
-            .action((escaped, conf) =>
+          opt[Unit]("escaped")
+            .action((_, conf) =>
               conf.copy(command = conf.command match {
                 case accept: AcceptDLCOffer =>
-                  accept.copy(escaped = escaped)
+                  accept.copy(escaped = true)
                 case other => other
               }))
         ),
@@ -198,11 +198,11 @@ object ConsoleCli {
                   signDLC.copy(accept = accept)
                 case other => other
               })),
-          opt[Boolean]("escaped")
-            .action((escaped, conf) =>
+          opt[Unit]("escaped")
+            .action((_, conf) =>
               conf.copy(command = conf.command match {
                 case signDLC: SignDLC =>
-                  signDLC.copy(escaped = escaped)
+                  signDLC.copy(escaped = true)
                 case other => other
               }))
         ),
@@ -239,11 +239,130 @@ object ConsoleCli {
                   initClose.copy(oracleSig = sig)
                 case other => other
               })),
-          opt[Boolean]("escaped")
-            .action((escaped, conf) =>
+          opt[Unit]("escaped")
+            .action((_, conf) =>
               conf.copy(command = conf.command match {
                 case initClose: InitDLCMutualClose =>
-                  initClose.copy(escaped = escaped)
+                  initClose.copy(escaped = true)
+                case other => other
+              }))
+        ),
+      cmd("acceptmutualclose")
+        .hidden()
+        .action((_, conf) =>
+          conf.copy(command = AcceptDLCMutualClose(null, null, null)))
+        .text("Sign Mutual Close Tx for given oracle event")
+        .children(
+          opt[Sha256DigestBE]("eventid").required
+            .action((eventId, conf) =>
+              conf.copy(command = conf.command match {
+                case acceptClose: AcceptDLCMutualClose =>
+                  acceptClose.copy(eventId = eventId)
+                case other => other
+              })),
+          opt[SchnorrDigitalSignature]("oraclesig").required
+            .action((sig, conf) =>
+              conf.copy(command = conf.command match {
+                case acceptClose: AcceptDLCMutualClose =>
+                  acceptClose.copy(oracleSig = sig)
+                case other => other
+              })),
+          opt[PartialSignature]("closesig").required
+            .action((sig, conf) =>
+              conf.copy(command = conf.command match {
+                case acceptClose: AcceptDLCMutualClose =>
+                  acceptClose.copy(closeSig = sig)
+                case other => other
+              }))
+        ),
+      cmd("getdlcfundingtx")
+        .hidden()
+        .action((_, conf) => conf.copy(command = GetDLCFundingTx(null)))
+        .text("Returns the Funding Tx corresponding to the DLC with the given eventId")
+        .children(
+          opt[Sha256DigestBE]("eventid").required
+            .action((eventId, conf) =>
+              conf.copy(command = conf.command match {
+                case getDLCFundingTx: GetDLCFundingTx =>
+                  getDLCFundingTx.copy(eventId = eventId)
+                case other => other
+              }))
+        ),
+      cmd("executedlcforceclose")
+        .hidden()
+        .action((_, conf) =>
+          conf.copy(command = ExecuteDLCForceClose(null, null)))
+        .text("Executes a force close for the DLC with the given eventId")
+        .children(
+          opt[Sha256DigestBE]("eventid").required
+            .action((eventId, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCForceClose: ExecuteDLCForceClose =>
+                  executeDLCForceClose.copy(eventId = eventId)
+                case other => other
+              })),
+          opt[SchnorrDigitalSignature]("oraclesig").required
+            .action((sig, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCForceClose: ExecuteDLCForceClose =>
+                  executeDLCForceClose.copy(oracleSig = sig)
+                case other => other
+              }))
+        ),
+      cmd("claimdlcremotefunds")
+        .hidden()
+        .action((_, conf) =>
+          conf.copy(command = ClaimDLCRemoteFunds(null, EmptyTransaction)))
+        .text("Claims the remote funds for the corresponding DLC")
+        .children(
+          opt[Sha256DigestBE]("eventid").required
+            .action((eventId, conf) =>
+              conf.copy(command = conf.command match {
+                case claimDLCRemoteFunds: ClaimDLCRemoteFunds =>
+                  claimDLCRemoteFunds.copy(eventId = eventId)
+                case other => other
+              })),
+          opt[Transaction]("forceclosetx")
+            .required()
+            .action((tx, conf) =>
+              conf.copy(command = conf.command match {
+                case claimDLCRemoteFunds: ClaimDLCRemoteFunds =>
+                  claimDLCRemoteFunds.copy(forceCloseTx = tx)
+                case other => other
+              }))
+        ),
+      cmd("executedlcrefund")
+        .hidden()
+        .action((_, conf) => conf.copy(command = ExecuteDLCRefund(null)))
+        .text("Executes the Refund transaction for the given DLC")
+        .children(
+          opt[Sha256DigestBE]("eventid").required
+            .action((eventId, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCRefund: ExecuteDLCRefund =>
+                  executeDLCRefund.copy(eventId = eventId)
+                case other => other
+              }))
+        ),
+      cmd("claimdlcpenaltyfunds")
+        .hidden()
+        .action((_, conf) =>
+          conf.copy(command = ClaimDLCPenaltyFunds(null, EmptyTransaction)))
+        .text("Claims the penalty funds for the corresponding DLC")
+        .children(
+          opt[Sha256DigestBE]("eventid").required
+            .action((eventId, conf) =>
+              conf.copy(command = conf.command match {
+                case claimDLCPenaltyFunds: ClaimDLCPenaltyFunds =>
+                  claimDLCPenaltyFunds.copy(eventId = eventId)
+                case other => other
+              })),
+          opt[Transaction]("forceclosetx")
+            .required()
+            .action((tx, conf) =>
+              conf.copy(command = conf.command match {
+                case claimDLCPenaltyFunds: ClaimDLCPenaltyFunds =>
+                  claimDLCPenaltyFunds.copy(forceCloseTx = tx)
                 case other => other
               }))
         ),
@@ -466,6 +585,17 @@ object ConsoleCli {
           Seq(up.writeJs(eventId), up.writeJs(oracleSig), up.writeJs(closeSig)))
       case GetDLCFundingTx(eventId) =>
         RequestParam("getdlcfundingtx", Seq(up.writeJs(eventId)))
+      case ExecuteDLCForceClose(eventId, oracleSig) =>
+        RequestParam("executedlcforceclose",
+                     Seq(up.writeJs(eventId), up.writeJs(oracleSig)))
+      case ClaimDLCRemoteFunds(eventId, forceCloseTx) =>
+        RequestParam("claimdlcremotefunds",
+                     Seq(up.writeJs(eventId), up.writeJs(forceCloseTx)))
+      case ExecuteDLCRefund(eventId) =>
+        RequestParam("executedlcrefund", Seq(up.writeJs(eventId)))
+      case ClaimDLCPenaltyFunds(eventId, forceCloseTx) =>
+        RequestParam("claimdlcpenaltyfunds",
+                     Seq(up.writeJs(eventId), up.writeJs(forceCloseTx)))
       // Wallet
       case GetBalance =>
         RequestParam("getbalance")
@@ -622,6 +752,23 @@ object CliCommand {
       extends CliCommand
 
   case class GetDLCFundingTx(eventId: Sha256DigestBE) extends CliCommand
+
+  case class ExecuteDLCForceClose(
+      eventId: Sha256DigestBE,
+      oracleSig: SchnorrDigitalSignature)
+      extends CliCommand
+
+  case class ClaimDLCRemoteFunds(
+      eventId: Sha256DigestBE,
+      forceCloseTx: Transaction)
+      extends CliCommand
+
+  case class ExecuteDLCRefund(eventId: Sha256DigestBE) extends CliCommand
+
+  case class ClaimDLCPenaltyFunds(
+      eventId: Sha256DigestBE,
+      forceCloseTx: Transaction)
+      extends CliCommand
 
   // Wallet
   case class SendToAddress(destination: BitcoinAddress, amount: Bitcoins)

--- a/app/picklers/src/main/scala/org/bitcoins/picklers/Picklers.scala
+++ b/app/picklers/src/main/scala/org/bitcoins/picklers/Picklers.scala
@@ -62,6 +62,11 @@ package object picklers {
     readwriter[String]
       .bimap(_.toJsonStr, str => DLCSign.fromJson(ujson.read(str).obj))
 
+  implicit val dlcMutualCloseSigPickler: ReadWriter[DLCMutualCloseSig] =
+    readwriter[String].bimap(
+      _.toJsonStr,
+      str => DLCMutualCloseSig.fromJson(ujson.read(str).obj))
+
   implicit val blockStampPickler: ReadWriter[BlockStamp] =
     readwriter[String].bimap(_.mkString, BlockStamp.fromString(_).get)
 

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -277,7 +277,8 @@ object AcceptDLCMutualClose extends ServerJsonModels {
     jsArr.arr.toList match {
       case mutualCloseSig :: Nil =>
         Try {
-          AcceptDLCMutualClose(DLCMutualCloseSig.fromJson(mutualCloseSig))
+          AcceptDLCMutualClose(
+            DLCMutualCloseSig.fromJson(ujson.read(mutualCloseSig.str)))
         }
       case other =>
         Failure(

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -309,6 +309,33 @@ object GetDLCFundingTx extends ServerJsonModels {
   }
 }
 
+case class ExecuteDLCUnilateralClose(
+    eventId: Sha256DigestBE,
+    oracleSig: SchnorrDigitalSignature)
+
+object ExecuteDLCUnilateralClose extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[ExecuteDLCUnilateralClose] = {
+    jsArr.arr.toList match {
+      case eventIdJs :: oracleSigJs :: Nil =>
+        Try {
+          val eventId = Sha256DigestBE(eventIdJs.str)
+          val oracleSig = jsToSchnorrDigitalSignature(oracleSigJs)
+
+          ExecuteDLCUnilateralClose(eventId, oracleSig)
+        }
+      case Nil =>
+        Failure(
+          new IllegalArgumentException(
+            "Missing eventId and oracleSig arguments"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
+    }
+  }
+}
+
 case class ExecuteDLCForceClose(
     eventId: Sha256DigestBE,
     oracleSig: SchnorrDigitalSignature)

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -6,7 +6,6 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BlockStamp.BlockHeight
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
-import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.dlc.DLCMessage._
@@ -270,26 +269,20 @@ object InitDLCMutualClose extends ServerJsonModels {
   }
 }
 
-case class AcceptDLCMutualClose(
-    eventId: Sha256DigestBE,
-    oracleSig: SchnorrDigitalSignature,
-    closeSig: PartialSignature)
+case class AcceptDLCMutualClose(mutualCloseSig: DLCMutualCloseSig)
 
 object AcceptDLCMutualClose extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[AcceptDLCMutualClose] = {
     jsArr.arr.toList match {
-      case eventIdJs :: oracleSigJs :: closeSigJs :: Nil =>
+      case mutualCloseSig :: Nil =>
         Try {
-          val eventId = Sha256DigestBE(eventIdJs.str)
-          val oracleSig = jsToSchnorrDigitalSignature(oracleSigJs)
-          val closeSig = PartialSignature(closeSigJs.str)
-          AcceptDLCMutualClose(eventId, oracleSig, closeSig)
+          AcceptDLCMutualClose(DLCMutualCloseSig.fromJson(mutualCloseSig))
         }
       case other =>
         Failure(
           new IllegalArgumentException(
-            s"Bad number of arguments: ${other.length}. Expected: 3"))
+            s"Bad number of arguments: ${other.length}. Expected: 1"))
     }
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -315,6 +315,106 @@ object GetDLCFundingTx extends ServerJsonModels {
   }
 }
 
+case class ExecuteDLCForceClose(
+    eventId: Sha256DigestBE,
+    oracleSig: SchnorrDigitalSignature)
+
+object ExecuteDLCForceClose extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[ExecuteDLCForceClose] = {
+    jsArr.arr.toList match {
+      case eventIdJs :: oracleSigJs :: Nil =>
+        Try {
+          val eventId = Sha256DigestBE(eventIdJs.str)
+          val oracleSig = jsToSchnorrDigitalSignature(oracleSigJs)
+
+          ExecuteDLCForceClose(eventId, oracleSig)
+        }
+      case Nil =>
+        Failure(
+          new IllegalArgumentException(
+            "Missing eventId and oracleSig arguments"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
+    }
+  }
+}
+
+case class ClaimDLCRemoteFunds(
+    eventId: Sha256DigestBE,
+    forceCloseTx: Transaction)
+
+object ClaimDLCRemoteFunds extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[ClaimDLCRemoteFunds] = {
+    jsArr.arr.toList match {
+      case eventIdJs :: forceCloseTxJs :: Nil =>
+        Try {
+          val eventId = Sha256DigestBE(eventIdJs.str)
+          val forceCloseTx = jsToTx(forceCloseTxJs)
+          ClaimDLCRemoteFunds(eventId, forceCloseTx)
+        }
+      case Nil =>
+        Failure(
+          new IllegalArgumentException(
+            "Missing eventId and forceCloseTx arguments"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
+    }
+  }
+}
+
+case class ExecuteDLCRefund(eventId: Sha256DigestBE)
+
+object ExecuteDLCRefund extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[ExecuteDLCRefund] = {
+    jsArr.arr.toList match {
+      case eventIdJs :: Nil =>
+        Try {
+          val eventId = Sha256DigestBE(eventIdJs.str)
+          ExecuteDLCRefund(eventId)
+        }
+      case Nil =>
+        Failure(new IllegalArgumentException("Missing eventId argument"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 1"))
+    }
+  }
+}
+
+case class ClaimDLCPenaltyFunds(
+    eventId: Sha256DigestBE,
+    forceCloseTx: Transaction)
+
+object ClaimDLCPenaltyFunds extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[ClaimDLCPenaltyFunds] = {
+    jsArr.arr.toList match {
+      case eventIdJs :: forceCloseTxJs :: Nil =>
+        Try {
+          val eventId = Sha256DigestBE(eventIdJs.str)
+          val forceCloseTx = jsToTx(forceCloseTxJs)
+          ClaimDLCPenaltyFunds(eventId, forceCloseTx)
+        }
+      case Nil =>
+        Failure(
+          new IllegalArgumentException(
+            "Missing eventId and forceCloseTx arguments"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
+    }
+  }
+}
+
 case class SendToAddress(address: BitcoinAddress, amount: Bitcoins)
 
 object SendToAddress extends ServerJsonModels {

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -151,6 +151,54 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           }
       }
 
+    case ServerCommand("executedlcforceclose", arr) =>
+      ExecuteDLCForceClose.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(ExecuteDLCForceClose(eventId, oracleSig)) =>
+          complete {
+            wallet.executeDLCForceClose(eventId, oracleSig).map { tx =>
+              Server.httpSuccess(tx.hex)
+            }
+          }
+      }
+
+    case ServerCommand("claimdlcremotefunds", arr) =>
+      ClaimDLCRemoteFunds.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(ClaimDLCRemoteFunds(eventId, tx)) =>
+          complete {
+            wallet.claimDLCRemoteFunds(eventId, tx).map { tx =>
+              Server.httpSuccess(tx.hex)
+            }
+          }
+      }
+
+    case ServerCommand("executedlcrefund", arr) =>
+      ExecuteDLCRefund.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(ExecuteDLCRefund(eventId)) =>
+          complete {
+            wallet.executeDLCRefund(eventId).map { tx =>
+              Server.httpSuccess(tx.hex)
+            }
+          }
+      }
+
+    case ServerCommand("claimdlcpenaltyfunds", arr) =>
+      ClaimDLCPenaltyFunds.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(ClaimDLCPenaltyFunds(eventId, tx)) =>
+          complete {
+            wallet.claimDLCPenaltyFunds(eventId, tx).map { tx =>
+              Server.httpSuccess(tx.hex)
+            }
+          }
+      }
+
     case ServerCommand("sendtoaddress", arr) =>
       // TODO create custom directive for this?
       SendToAddress.fromJsArr(arr) match {

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -130,11 +130,10 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
       AcceptDLCMutualClose.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
-        case Success(AcceptDLCMutualClose(eventId, oracleSig, closeSig)) =>
+        case Success(AcceptDLCMutualClose(mutualCloseSig)) =>
           complete {
-            wallet.acceptDLCMutualClose(eventId, oracleSig, closeSig).map {
-              tx =>
-                Server.httpSuccess(tx.hex)
+            wallet.acceptDLCMutualClose(mutualCloseSig).map { tx =>
+              Server.httpSuccess(tx.hex)
             }
           }
       }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -150,6 +150,23 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           }
       }
 
+    case ServerCommand("executedlcunilateralclose", arr) =>
+      ExecuteDLCUnilateralClose.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(ExecuteDLCUnilateralClose(eventId, oracleSig)) =>
+          complete {
+            wallet.executeDLCUnilateralClose(eventId, oracleSig).map { txs =>
+              txs._2 match {
+                case Some(closingTx) =>
+                  Server.httpSuccess(s"${txs._1.hex} \n ${closingTx.hex}")
+                case None =>
+                  Server.httpSuccess(txs._1.hex)
+              }
+            }
+          }
+      }
+
     case ServerCommand("executedlcforceclose", arr) =>
       ExecuteDLCForceClose.fromJsArr(arr) match {
         case Failure(exception) =>

--- a/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCClient.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/BinaryOutcomeDLCClient.scala
@@ -868,6 +868,11 @@ case class BinaryOutcomeDLCClient(
     }
   }
 
+  def executeUnilateralDLC(
+      dlcSetup: SetupDLC,
+      oracleSig: SchnorrDigitalSignature): Future[UnilateralDLCOutcome] =
+    executeUnilateralDLC(dlcSetup, Future.successful(oracleSig))
+
   /** Constructs the closing transaction on the to_remote output of a counter-party's unilateral CET broadcast
     * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#closing-transaction-unilateral]]
     */

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -448,4 +448,19 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
 
   override def getDLCFundingTx(eventId: Sha256DigestBE): Future[Transaction] =
     ???
+
+  override def executeDLCForceClose(
+      eventId: Sha256DigestBE,
+      oracleSig: SchnorrDigitalSignature): Future[Transaction] = ???
+
+  override def claimDLCRemoteFunds(
+      eventId: Sha256DigestBE,
+      forceCloseTx: Transaction): Future[Transaction] = ???
+
+  override def executeDLCRefund(eventId: Sha256DigestBE): Future[Transaction] =
+    ???
+
+  override def claimDLCPenaltyFunds(
+      eventId: Sha256DigestBE,
+      forceCloseTx: Transaction): Future[Transaction] = ???
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -481,9 +481,9 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
         case closing: UnilateralDLCOutcomeWithClosing =>
           BitcoinSigner
             .sign(closing.cetSpendingInfo,
-                  closing.cet,
+                  closing.closingTx,
                   isDummySignature = false)
-            .map(signed => (signed.transaction, Some(closing.closingTx)))
+            .map(signed => (outcome.cet, Some(signed.transaction)))
         case _: UnilateralDLCOutcomeWithDustClosing =>
           Future.successful((outcome.cet, None))
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -14,7 +14,6 @@ import org.bitcoins.core.protocol.blockchain.{Block, ChainParams}
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
-import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.dlc.DLCMessage._
@@ -453,9 +452,7 @@ trait UnlockedWalletApi extends LockedWalletApi {
       oracleSig: SchnorrDigitalSignature): Future[DLCMutualCloseSig]
 
   def acceptDLCMutualClose(
-      eventId: Sha256DigestBE,
-      oracleSig: SchnorrDigitalSignature,
-      closeSig: PartialSignature): Future[Transaction]
+      mutualCloseSig: DLCMutualCloseSig): Future[Transaction]
 
   def getDLCFundingTx(eventId: Sha256DigestBE): Future[Transaction]
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -456,6 +456,11 @@ trait UnlockedWalletApi extends LockedWalletApi {
 
   def getDLCFundingTx(eventId: Sha256DigestBE): Future[Transaction]
 
+  def executeDLCUnilateralClose(
+      eventId: Sha256DigestBE,
+      oracleSig: SchnorrDigitalSignature): Future[
+    (Transaction, Option[Transaction])]
+
   def executeDLCForceClose(
       eventId: Sha256DigestBE,
       oracleSig: SchnorrDigitalSignature): Future[Transaction]

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -459,6 +459,20 @@ trait UnlockedWalletApi extends LockedWalletApi {
 
   def getDLCFundingTx(eventId: Sha256DigestBE): Future[Transaction]
 
+  def executeDLCForceClose(
+      eventId: Sha256DigestBE,
+      oracleSig: SchnorrDigitalSignature): Future[Transaction]
+
+  def claimDLCRemoteFunds(
+      eventId: Sha256DigestBE,
+      forceCloseTx: Transaction): Future[Transaction]
+
+  def executeDLCRefund(eventId: Sha256DigestBE): Future[Transaction]
+
+  def claimDLCPenaltyFunds(
+      eventId: Sha256DigestBE,
+      forceCloseTx: Transaction): Future[Transaction]
+
   /**
     *
     * Sends money from the specified account


### PR DESCRIPTION
The fourth leg of #1140 (built on top of #1148)

Adds `--escaped` flag options to `DLCMessage`s returned

Refactor `acceptdlcmutualclose` to take in a `DLCMutualCloseSig`

Adds `executedlcunilateralclose`, `executedlcforceclose`, `claimdlcremotefunds`, `executedlcrefund`, `claimdlcpenaltyfunds`

Save oracle sig in db