### PR TITLE
Demo breakup 5

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -276,7 +276,7 @@ object ConsoleCli {
         .hidden()
         .action((_, conf) =>
           conf.copy(command = ExecuteDLCUnilateralClose(null, null)))
-        .text("Executes a force close for the DLC with the given eventId")
+        .text("Executes a unilateral close for the DLC with the given eventId")
         .children(
           opt[Sha256DigestBE]("eventid").required
             .action((eventId, conf) =>
@@ -290,6 +290,28 @@ object ConsoleCli {
               conf.copy(command = conf.command match {
                 case executeDLCUnilateralClose: ExecuteDLCUnilateralClose =>
                   executeDLCUnilateralClose.copy(oracleSig = sig)
+                case other => other
+              }))
+        ),
+      cmd("executedlcremoteunilateralclose")
+        .hidden()
+        .action((_, conf) =>
+          conf.copy(
+            command = ExecuteDLCRemoteUnilateralClose(null, EmptyTransaction)))
+        .text("Executes a unilateral close for the DLC with the given eventId")
+        .children(
+          opt[Sha256DigestBE]("eventid").required
+            .action((eventId, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCRemoteUnilateralClose: ExecuteDLCRemoteUnilateralClose =>
+                  executeDLCRemoteUnilateralClose.copy(eventId = eventId)
+                case other => other
+              })),
+          opt[Transaction]("cet").required
+            .action((cet, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCRemoteUnilateralClose: ExecuteDLCRemoteUnilateralClose =>
+                  executeDLCRemoteUnilateralClose.copy(cet = cet)
                 case other => other
               }))
         ),
@@ -548,6 +570,9 @@ object ConsoleCli {
       case ExecuteDLCUnilateralClose(eventId, oracleSig) =>
         RequestParam("executedlcunilateralclose",
                      Seq(up.writeJs(eventId), up.writeJs(oracleSig)))
+      case ExecuteDLCRemoteUnilateralClose(eventId, cet) =>
+        RequestParam("executedlcremoteunilateralclose",
+                     Seq(up.writeJs(eventId), up.writeJs(cet)))
       case GetDLCFundingTx(eventId) =>
         RequestParam("getdlcfundingtx", Seq(up.writeJs(eventId)))
       case ExecuteDLCForceClose(eventId, oracleSig) =>
@@ -718,6 +743,11 @@ object CliCommand {
   case class ExecuteDLCUnilateralClose(
       eventId: Sha256DigestBE,
       oracleSig: SchnorrDigitalSignature)
+      extends CliCommand
+
+  case class ExecuteDLCRemoteUnilateralClose(
+      eventId: Sha256DigestBE,
+      cet: Transaction)
       extends CliCommand
 
   case class ExecuteDLCForceClose(

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -49,6 +49,18 @@ object ConsoleCli {
         .hidden()
         .action((_, conf) => conf.copy(command = GetBestBlockHash))
         .text(s"Get the best block hash"),
+      cmd("decoderawtransaction")
+        .hidden()
+        .action((_, conf) =>
+          conf.copy(command = DecodeRawTransaction(EmptyTransaction)))
+        .text(s"Decode the given raw hex transaction")
+        .children(opt[Transaction]("tx")
+          .required()
+          .action((tx, conf) =>
+            conf.copy(command = conf.command match {
+              case decode: DecodeRawTransaction => decode.copy(transaction = tx)
+              case other                        => other
+            }))),
       cmd("rescan")
         .hidden()
         .action(
@@ -623,6 +635,9 @@ object ConsoleCli {
       case ConvertToPSBT(tx) =>
         RequestParam("converttopsbt", Seq(up.writeJs(tx)))
 
+      case DecodeRawTransaction(tx) =>
+        RequestParam("decoderawtransaction", Seq(up.writeJs(tx)))
+
       case NoCommand => ???
     }
 
@@ -781,6 +796,7 @@ object CliCommand {
   case object GetBlockCount extends CliCommand
   case object GetFilterCount extends CliCommand
   case object GetFilterHeaderCount extends CliCommand
+  case class DecodeRawTransaction(transaction: Transaction) extends CliCommand
   case class Rescan(
       addressBatchSize: Option[Int],
       startBlock: Option[BlockStamp],

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -319,7 +319,7 @@ object ConsoleCli {
                   executeDLCRemoteUnilateralClose.copy(eventId = eventId)
                 case other => other
               })),
-          opt[Transaction]("cet").required
+          opt[Transaction]("forceCloseTx").required
             .action((cet, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCRemoteUnilateralClose: ExecuteDLCRemoteUnilateralClose =>

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -80,6 +80,24 @@ object ConvertToPSBT extends ServerJsonModels {
   }
 }
 
+case class DecodeRawTransaction(tx: Transaction)
+
+object DecodeRawTransaction extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[DecodeRawTransaction] = {
+    jsArr.arr.toList match {
+      case tx :: Nil =>
+        Try {
+          DecodeRawTransaction(Transaction.fromHex(tx.str))
+        }
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 1"))
+    }
+  }
+}
+
 case class Rescan(
     batchSize: Option[Int],
     startBlock: Option[BlockStamp],

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -336,6 +336,32 @@ object ExecuteDLCUnilateralClose extends ServerJsonModels {
   }
 }
 
+case class ExecuteDLCRemoteUnilateralClose(
+    eventId: Sha256DigestBE,
+    cet: Transaction)
+
+object ExecuteDLCRemoteUnilateralClose extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[ExecuteDLCRemoteUnilateralClose] = {
+    jsArr.arr.toList match {
+      case eventIdJs :: cetJs :: Nil =>
+        Try {
+          val eventId = Sha256DigestBE(eventIdJs.str)
+          val cet = jsToTx(cetJs)
+
+          ExecuteDLCRemoteUnilateralClose(eventId, cet)
+        }
+      case Nil =>
+        Failure(
+          new IllegalArgumentException("Missing eventId and cet arguments"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
+    }
+  }
+}
+
 case class ExecuteDLCForceClose(
     eventId: Sha256DigestBE,
     oracleSig: SchnorrDigitalSignature)

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -33,7 +33,8 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
       dlcMessage: DLCMessage,
       escaped: Boolean): HttpEntity.Strict = {
     val str = dlcMessage.toJsonStr
-    val sendString = if (escaped) escape(str) else str
+    val sendString =
+      if (escaped) escape(str) else ujson.read(str).render(indent = 2)
     Server.httpSuccess(sendString)
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -167,6 +167,22 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           }
       }
 
+    case ServerCommand("executedlcremoteunilateralclose", arr) =>
+      ExecuteDLCRemoteUnilateralClose.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(ExecuteDLCRemoteUnilateralClose(eventId, cet)) =>
+          complete {
+            wallet.executeRemoteUnilateralDLC(eventId, cet).map {
+              case Some(closingTx) =>
+                Server.httpSuccess(closingTx.hex)
+              case None =>
+                Server.httpSuccess(
+                  "Recieved would have only been dust, they have been used as fees")
+            }
+          }
+      }
+
     case ServerCommand("executedlcforceclose", arr) =>
       ExecuteDLCForceClose.fromJsArr(arr) match {
         case Failure(exception) =>

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -179,7 +179,7 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
                 Server.httpSuccess(closingTx.hex)
               case None =>
                 Server.httpSuccess(
-                  "Recieved would have only been dust, they have been used as fees")
+                  "Received would have only been dust, they have been used as fees")
             }
           }
       }
@@ -212,7 +212,7 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
                 Server.httpSuccess(closingTx.hex)
               case None =>
                 Server.httpSuccess(
-                  "Recieved would have only been dust, they have been used as fees")
+                  "Received would have only been dust, they have been used as fees")
             }
           }
       }
@@ -245,7 +245,7 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
                 Server.httpSuccess(closingTx.hex)
               case None =>
                 Server.httpSuccess(
-                  "Recieved would have only been dust, they have been used as fees")
+                  "Received would have only been dust, they have been used as fees")
             }
           }
       }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -213,8 +213,13 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           reject(ValidationRejection("failure", Some(exception)))
         case Success(ExecuteDLCRefund(eventId)) =>
           complete {
-            wallet.executeDLCRefund(eventId).map { tx =>
-              Server.httpSuccess(tx.hex)
+            wallet.executeDLCRefund(eventId).map { txs =>
+              txs._2 match {
+                case Some(closingTx) =>
+                  Server.httpSuccess(s"${txs._1.hex} \n ${closingTx.hex}")
+                case None =>
+                  Server.httpSuccess(txs._1.hex)
+              }
             }
           }
       }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -274,5 +274,15 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           }
       }
 
+    case ServerCommand("decoderawtransaction", arr) =>
+      DecodeRawTransaction.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(DecodeRawTransaction(tx)) =>
+          complete {
+            val jsonStr = wallet.decodeRawTransaction(tx)
+            Server.httpSuccess(jsonStr)
+          }
+      }
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -189,8 +189,13 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           reject(ValidationRejection("failure", Some(exception)))
         case Success(ExecuteDLCForceClose(eventId, oracleSig)) =>
           complete {
-            wallet.executeDLCForceClose(eventId, oracleSig).map { tx =>
-              Server.httpSuccess(tx.hex)
+            wallet.executeDLCForceClose(eventId, oracleSig).map { txs =>
+              txs._2 match {
+                case Some(closingTx) =>
+                  Server.httpSuccess(s"${txs._1.hex} \n ${closingTx.hex}")
+                case None =>
+                  Server.httpSuccess(txs._1.hex)
+              }
             }
           }
       }
@@ -201,8 +206,12 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           reject(ValidationRejection("failure", Some(exception)))
         case Success(ClaimDLCRemoteFunds(eventId, tx)) =>
           complete {
-            wallet.claimDLCRemoteFunds(eventId, tx).map { tx =>
-              Server.httpSuccess(tx.hex)
+            wallet.claimDLCRemoteFunds(eventId, tx).map {
+              case Some(closingTx) =>
+                Server.httpSuccess(closingTx.hex)
+              case None =>
+                Server.httpSuccess(
+                  "Recieved would have only been dust, they have been used as fees")
             }
           }
       }
@@ -230,8 +239,12 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           reject(ValidationRejection("failure", Some(exception)))
         case Success(ClaimDLCPenaltyFunds(eventId, tx)) =>
           complete {
-            wallet.claimDLCPenaltyFunds(eventId, tx).map { tx =>
-              Server.httpSuccess(tx.hex)
+            wallet.claimDLCPenaltyFunds(eventId, tx).map {
+              case Some(closingTx) =>
+                Server.httpSuccess(closingTx.hex)
+              case None =>
+                Server.httpSuccess(
+                  "Recieved would have only been dust, they have been used as fees")
             }
           }
       }

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -379,7 +379,7 @@ object AppConfig extends BitcoinSLogger {
     * should probably mimic what Bitcoin Core does
     */
   private[bitcoins] val DEFAULT_BITCOIN_S_DATADIR: Path =
-    Paths.get(Properties.userHome, ".bitcoin-s")
+    Paths.get(Properties.userHome, ".bitcoin-s2")
 
   /**
     * Matches the default data directory location

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -379,7 +379,7 @@ object AppConfig extends BitcoinSLogger {
     * should probably mimic what Bitcoin Core does
     */
   private[bitcoins] val DEFAULT_BITCOIN_S_DATADIR: Path =
-    Paths.get(Properties.userHome, ".bitcoin-s2")
+    Paths.get(Properties.userHome, ".bitcoin-s")
 
   /**
     * Matches the default data directory location

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCClientIntegrationTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCClientIntegrationTest.scala
@@ -516,7 +516,7 @@ class BinaryOutcomeDLCClientIntegrationTest extends BitcoindRpcTest {
       otherOutcome <- otherDLC.executeRemoteUnilateralDLC(
         otherSetup,
         unilateralOutcome.cet,
-        ECPrivateKey.freshPrivateKey)
+        P2WPKHWitnessSPKV0(ECPublicKey.freshPublicKey))
       _ <- {
         otherOutcome match {
           case UnilateralDLCOutcomeWithClosing(_, _, closingTx, _) =>
@@ -624,7 +624,7 @@ class BinaryOutcomeDLCClientIntegrationTest extends BitcoindRpcTest {
       toRemoteOutcome <- punisherDLC.executeRemoteUnilateralDLC(
         punisherSetup,
         cetWronglyPublished,
-        ECPrivateKey.freshPrivateKey)
+        P2WPKHWitnessSPKV0(ECPublicKey.freshPublicKey))
       _ = assert(toRemoteOutcome.cet == cetWronglyPublished)
       _ = assert(justiceOutcome.cet == cetWronglyPublished)
       _ <- {

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCClientTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/BinaryOutcomeDLCClientTest.scala
@@ -400,7 +400,7 @@ class BinaryOutcomeDLCClientTest extends BitcoinSAsyncTest {
           otherOutcome <- otherDLC.executeRemoteUnilateralDLC(
             otherSetup,
             unilateralOutcome.cet,
-            ECPrivateKey.freshPrivateKey)
+            P2WPKHWitnessSPKV0(ECPublicKey.freshPublicKey))
         } yield {
           validateOutcome(unilateralOutcome)
           validateOutcome(otherOutcome)
@@ -448,7 +448,7 @@ class BinaryOutcomeDLCClientTest extends BitcoinSAsyncTest {
           toRemoteOutcome <- punisherDLC.executeRemoteUnilateralDLC(
             punisherSetup,
             timedOutCET,
-            ECPrivateKey.freshPrivateKey)
+            P2WPKHWitnessSPKV0(ECPublicKey.freshPublicKey))
         } yield {
           validateOutcome(justiceOutcome)
           validateOutcome(toRemoteOutcome)

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
@@ -260,7 +260,7 @@ object DLCTestVector {
       toRemoteOutcome <- acceptDLC.executeRemoteUnilateralDLC(
         acceptSetup,
         unilateralOutcome.cet,
-        acceptDLC.finalPrivKey)
+        P2WPKHWitnessSPKV0(acceptDLC.finalPrivKey.publicKey))
     } yield {
       val localClosingTxOpt = unilateralOutcome match {
         case UnilateralDLCOutcomeWithClosing(_, _, closingTx, _) =>

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -540,11 +540,14 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
 
   override def executeDLCForceClose(
       eventId: Sha256DigestBE,
-      oracleSig: SchnorrDigitalSignature): Future[Transaction] = ???
+      oracleSig: SchnorrDigitalSignature): Future[
+    (Transaction, Option[Transaction])] =
+    executeDLCUnilateralClose(eventId, oracleSig)
 
   override def claimDLCRemoteFunds(
       eventId: Sha256DigestBE,
-      forceCloseTx: Transaction): Future[Transaction] = ???
+      forceCloseTx: Transaction): Future[Option[Transaction]] =
+    executeRemoteUnilateralDLC(eventId, forceCloseTx)
 
   override def executeDLCRefund(
       eventId: Sha256DigestBE): Future[(Transaction, Option[Transaction])] = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -546,8 +546,26 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
       eventId: Sha256DigestBE,
       forceCloseTx: Transaction): Future[Transaction] = ???
 
-  override def executeDLCRefund(eventId: Sha256DigestBE): Future[Transaction] =
-    ???
+  override def executeDLCRefund(
+      eventId: Sha256DigestBE): Future[(Transaction, Option[Transaction])] = {
+    for {
+      (dlcDb, dlcOffer, dlcAccept) <- getAllDLCData(eventId)
+
+      (client, setup) <- clientFromDb(dlcDb, dlcOffer, dlcAccept)
+
+      outcome <- client.executeRefundDLC(setup)
+      txs <- outcome match {
+        case closing: RefundDLCOutcomeWithClosing =>
+          BitcoinSigner
+            .sign(closing.refundSpendingInfo,
+                  closing.closingTx,
+                  isDummySignature = false)
+            .map(signed => (outcome.refundTx, Some(signed.transaction)))
+        case _: RefundDLCOutcomeWithDustClosing =>
+          Future.successful((outcome.refundTx, None))
+      }
+    } yield txs
+  }
 
   override def claimDLCPenaltyFunds(
       eventId: Sha256DigestBE,

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/SerializedTransaction.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/SerializedTransaction.scala
@@ -1,0 +1,177 @@
+package org.bitcoins.wallet.api
+
+import org.bitcoins.core.crypto.{
+  DoubleSha256DigestBE,
+  ECDigitalSignature,
+  ECPublicKey
+}
+import org.bitcoins.core.number.{Int32, UInt32}
+import org.bitcoins.core.protocol.script.{
+  EmptyScriptWitness,
+  P2WPKHWitnessV0,
+  P2WSHWitnessV0,
+  ScriptPubKey
+}
+import org.bitcoins.core.protocol.transaction.{
+  BaseTransaction,
+  Transaction,
+  WitnessTransaction
+}
+import org.bitcoins.core.script.constant.{
+  ScriptConstant,
+  ScriptNumberOperation,
+  ScriptToken
+}
+import play.api.libs.json.{JsNumber, JsString, Json, Writes}
+import scodec.bits.ByteVector
+
+case class SerializedTransaction(
+    txid: DoubleSha256DigestBE,
+    wtxid: Option[DoubleSha256DigestBE],
+    version: Int32,
+    size: Long,
+    vsize: Long,
+    weight: Long,
+    locktime: UInt32,
+    vin: Vector[SerializedTransactionInput],
+    vout: Vector[SerializedTransactionOutput])
+
+case class SerializedTransactionInput(
+    txid: DoubleSha256DigestBE,
+    hex: String,
+    vout: UInt32,
+    scriptSig: Vector[ScriptToken],
+    txinwitness: Option[SerializedTransactionWitness],
+    sequence: UInt32
+)
+
+case class SerializedTransactionWitness(
+    hex: String,
+    scriptType: Option[String],
+    script: Option[Vector[ScriptToken]],
+    pubKey: Option[ECPublicKey],
+    signature: Option[ECDigitalSignature],
+    stack: Option[Vector[ByteVector]])
+
+case class SerializedTransactionOutput(
+    value: BigDecimal,
+    n: UInt32,
+    scriptPubKey: ScriptPubKey,
+    hex: String
+)
+
+object SerializedTransaction {
+
+  def decodeRawTransaction(tx: Transaction): String = {
+    def tokenToString(token: ScriptToken): String = {
+      token match {
+        case numOp: ScriptNumberOperation => numOp.toString
+        case constOp: ScriptConstant      => constOp.bytes.toString
+        case otherOp                      => otherOp.toString
+      }
+    }
+
+    implicit val byteVectorWrites: Writes[ByteVector] =
+      Writes[ByteVector](bytes => JsString(bytes.toHex))
+    implicit val ecDigitalSignatureWrites: Writes[ECDigitalSignature] =
+      Writes[ECDigitalSignature](sig => JsString(sig.hex))
+    implicit val ecPublicKeyWrites: Writes[ECPublicKey] =
+      Writes[ECPublicKey](pubKey => JsString(pubKey.hex))
+    implicit val scriptTokenWrites: Writes[ScriptToken] =
+      Writes[ScriptToken](token => JsString(tokenToString(token)))
+    implicit val doubleSha256DigestBEWrites: Writes[DoubleSha256DigestBE] =
+      Writes[DoubleSha256DigestBE](hash => JsString(hash.hex))
+    implicit val uInt32Writes: Writes[UInt32] =
+      Writes[UInt32](num => JsNumber(num.toLong))
+    implicit val int32Writes: Writes[Int32] =
+      Writes[Int32](num => JsNumber(num.toLong))
+    implicit val scriptPubKeyWrites: Writes[ScriptPubKey] =
+      Writes[ScriptPubKey](spk => Json.toJson(spk.asm))
+
+    implicit val serializedTransactionWitnessWrites: Writes[
+      SerializedTransactionWitness] = Json.writes[SerializedTransactionWitness]
+    implicit val serializedTransactionInputWrites: Writes[
+      SerializedTransactionInput] = Json.writes[SerializedTransactionInput]
+    implicit val serializedTransactionOutputWrites: Writes[
+      SerializedTransactionOutput] = Json.writes[SerializedTransactionOutput]
+    implicit val serializedTransactionWrites: Writes[SerializedTransaction] =
+      Json.writes[SerializedTransaction]
+
+    val inputs = tx.inputs.toVector.zipWithIndex.map {
+      case (input, index) =>
+        val witnessOpt = tx match {
+          case _: BaseTransaction => None
+          case wtx: WitnessTransaction =>
+            wtx.witness.witnesses(index) match {
+              case EmptyScriptWitness => None
+              case p2wpkh: P2WPKHWitnessV0 =>
+                Some(
+                  SerializedTransactionWitness(p2wpkh.hex,
+                                               Some("P2WPKH"),
+                                               None,
+                                               Some(p2wpkh.pubKey),
+                                               Some(p2wpkh.signature),
+                                               None))
+              case p2wsh: P2WSHWitnessV0 =>
+                Some(
+                  SerializedTransactionWitness(
+                    p2wsh.hex,
+                    Some("P2WSH"),
+                    Some(p2wsh.redeemScript.asm.toVector),
+                    None,
+                    None,
+                    Some(p2wsh.stack.toVector.tail)))
+            }
+        }
+
+        SerializedTransactionInput(input.previousOutput.txIdBE,
+                                   input.hex,
+                                   input.previousOutput.vout,
+                                   input.scriptSignature.asm.toVector,
+                                   witnessOpt,
+                                   input.sequence)
+    }
+
+    val outputs = tx.outputs.toVector.zipWithIndex.map {
+      case (output, index) =>
+        SerializedTransactionOutput(output.value.toBigDecimal,
+                                    UInt32(index),
+                                    output.scriptPubKey,
+                                    output.hex)
+    }
+
+    val wtxidOpt = tx match {
+      case _: BaseTransaction      => None
+      case wtx: WitnessTransaction => Some(wtx.wTxIdBE)
+    }
+
+    val serializedTx = SerializedTransaction(tx.txIdBE,
+                                             wtxidOpt,
+                                             tx.version,
+                                             tx.size,
+                                             tx.vsize,
+                                             tx.weight,
+                                             tx.lockTime,
+                                             inputs,
+                                             outputs)
+
+    val json = Json.toJson(serializedTx)
+    val strWithEscaped = Json.prettyPrint(json)
+
+    var escaped: Boolean = false
+
+    strWithEscaped
+      .map {
+        case '\\' =>
+          escaped = true
+          '\\'
+        case 'n' if escaped =>
+          escaped = false
+          '\n'
+        case char =>
+          escaped = false
+          char
+      }
+      .filterNot(_ == '\\')
+  }
+}

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -592,11 +592,12 @@ trait UnlockedWalletApi extends LockedWalletApi {
 
   def executeDLCForceClose(
       eventId: Sha256DigestBE,
-      oracleSig: SchnorrDigitalSignature): Future[Transaction]
+      oracleSig: SchnorrDigitalSignature): Future[
+    (Transaction, Option[Transaction])]
 
   def claimDLCRemoteFunds(
       eventId: Sha256DigestBE,
-      forceCloseTx: Transaction): Future[Transaction]
+      forceCloseTx: Transaction): Future[Option[Transaction]]
 
   def executeDLCRefund(
       eventId: Sha256DigestBE): Future[(Transaction, Option[Transaction])]

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -8,26 +8,12 @@ import org.bitcoins.core.crypto.{DoubleSha256DigestBE, _}
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.gcs.{GolombFilter, SimpleFilterMatcher}
 import org.bitcoins.core.hd.{AddressType, HDAccount, HDPurpose}
-import org.bitcoins.core.number.{Int32, UInt32}
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.blockchain.{Block, ChainParams}
-import org.bitcoins.core.protocol.script.{
-  EmptyScriptWitness,
-  P2WPKHWitnessV0,
-  P2WSHWitnessV0,
-  ScriptPubKey
-}
-import org.bitcoins.core.protocol.transaction.{
-  BaseTransaction,
-  Transaction,
-  WitnessTransaction
-}
+import org.bitcoins.core.protocol.script.ScriptPubKey
+import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
-import org.bitcoins.core.script.constant.{
-  ScriptConstant,
-  ScriptNumberOperation,
-  ScriptToken
-}
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.dlc.DLCMessage._
@@ -42,7 +28,6 @@ import org.bitcoins.wallet.models.{
   ExecutedDLCDb,
   SpendingInfoDb
 }
-import play.api.libs.json.{JsNumber, JsString, Json, Writes}
 
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
@@ -67,115 +52,8 @@ sealed trait WalletApi {
 
   def networkParameters: NetworkParameters = walletConfig.network
 
-  case class SerializedTransactionInput(
-      txid: DoubleSha256DigestBE,
-      vout: UInt32,
-      scriptSig: String,
-      txinwitness: String,
-      sequence: UInt32
-  )
-
-  case class SerializedTransactionOutput(
-      value: BigDecimal,
-      n: UInt32,
-      scriptPubKey: ScriptPubKey
-  )
-
-  case class SerializedTransaction(
-      txid: DoubleSha256DigestBE,
-      version: Int32,
-      size: Long,
-      vsize: Long,
-      weight: Long,
-      locktime: UInt32,
-      vin: Vector[SerializedTransactionInput],
-      vout: Vector[SerializedTransactionOutput])
-
-  def decodeRawTransaction(tx: Transaction): String = {
-    def asmToString(asm: Vector[ScriptToken]): String = {
-      (if (asm.isEmpty) "" else "\n") ++ asm
-        .map {
-          case numOp: ScriptNumberOperation => numOp.toString
-          case constOp: ScriptConstant      => constOp.bytes.toString
-          case otherOp                      => otherOp.toString
-        }
-        .mkString("\n")
-    }
-
-    implicit val doubleSha256DigestBEWrites: Writes[DoubleSha256DigestBE] =
-      Writes[DoubleSha256DigestBE](hash => JsString(hash.hex))
-    implicit val uInt32Writes: Writes[UInt32] =
-      Writes[UInt32](num => JsNumber(num.toLong))
-    implicit val int32Writes: Writes[Int32] =
-      Writes[Int32](num => JsNumber(num.toLong))
-    implicit val scriptPubKeyWrites: Writes[ScriptPubKey] =
-      Writes[ScriptPubKey](spk => JsString(asmToString(spk.asm.toVector)))
-
-    implicit val serializedTransactionInputWrites: Writes[
-      SerializedTransactionInput] = Json.writes[SerializedTransactionInput]
-    implicit val serializedTransactionOutputWrites: Writes[
-      SerializedTransactionOutput] = Json.writes[SerializedTransactionOutput]
-    implicit val serializedTransactionWrites: Writes[SerializedTransaction] =
-      Json.writes[SerializedTransaction]
-
-    val inputs = tx.inputs.toVector.zipWithIndex.map {
-      case (input, index) =>
-        val witnessStr = tx match {
-          case _: BaseTransaction => ""
-          case wtx: WitnessTransaction =>
-            wtx.witness.witnesses(index) match {
-              case EmptyScriptWitness => ""
-              case p2wpkh: P2WPKHWitnessV0 =>
-                s"p2wpkh of pubkey ${p2wpkh.pubKey} with signature ${p2wpkh.signature}"
-              case p2wsh: P2WSHWitnessV0 =>
-                s"p2wsh of ${asmToString(p2wsh.redeemScript.asm.toVector)} with stack ${Json
-                  .toJson(p2wsh.stack.tail.map(_.toHex))}"
-            }
-        }
-
-        SerializedTransactionInput(
-          input.previousOutput.txIdBE,
-          input.previousOutput.vout,
-          asmToString(input.scriptSignature.asm.toVector),
-          witnessStr,
-          input.sequence)
-    }
-
-    val outputs = tx.outputs.toVector.zipWithIndex.map {
-      case (output, index) =>
-        SerializedTransactionOutput(output.value.toBigDecimal,
-                                    UInt32(index),
-                                    output.scriptPubKey)
-    }
-
-    val serializedTx = SerializedTransaction(tx.txIdBE,
-                                             tx.version,
-                                             tx.size,
-                                             tx.vsize,
-                                             tx.weight,
-                                             tx.lockTime,
-                                             inputs,
-                                             outputs)
-
-    val json = Json.toJson(serializedTx)
-    val strWithEscaped = Json.prettyPrint(json)
-
-    var escaped: Boolean = false
-
-    strWithEscaped
-      .map {
-        case '\\' =>
-          escaped = true
-          '\\'
-        case 'n' if escaped =>
-          escaped = false
-          '\n'
-        case char =>
-          escaped = false
-          char
-      }
-      .filterNot(_ == '\\')
-  }
+  def decodeRawTransaction(tx: Transaction): String =
+    SerializedTransaction.decodeRawTransaction(tx)
 }
 
 /**

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -604,7 +604,7 @@ trait UnlockedWalletApi extends LockedWalletApi {
 
   def claimDLCPenaltyFunds(
       eventId: Sha256DigestBE,
-      forceCloseTx: Transaction): Future[Transaction]
+      forceCloseTx: Transaction): Future[Option[Transaction]]
 
   /**
     *

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -598,7 +598,8 @@ trait UnlockedWalletApi extends LockedWalletApi {
       eventId: Sha256DigestBE,
       forceCloseTx: Transaction): Future[Transaction]
 
-  def executeDLCRefund(eventId: Sha256DigestBE): Future[Transaction]
+  def executeDLCRefund(
+      eventId: Sha256DigestBE): Future[(Transaction, Option[Transaction])]
 
   def claimDLCPenaltyFunds(
       eventId: Sha256DigestBE,

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -461,6 +461,10 @@ trait UnlockedWalletApi extends LockedWalletApi {
       oracleSig: SchnorrDigitalSignature): Future[
     (Transaction, Option[Transaction])]
 
+  def executeRemoteUnilateralDLC(
+      eventId: Sha256DigestBE,
+      cet: Transaction): Future[Option[Transaction]]
+
   def executeDLCForceClose(
       eventId: Sha256DigestBE,
       oracleSig: SchnorrDigitalSignature): Future[Transaction]


### PR DESCRIPTION
The fifth leg of #1140 (built on top of #1149)

Adds `decoderawtransaction`, `executedlcremoteunilateralclose`

Changes `BinaryOutcomeDLCClient.constructClosingTx` to sweep to a `ScriptPubKey` rather than a single `ECPrivateKey`