### PR TITLE
2020 02 21 datadir configurable

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.server
 
 import java.net.InetSocketAddress
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, Paths}
 
 import akka.actor.ActorSystem
 import org.bitcoins.chain.config.ChainAppConfig
@@ -24,12 +24,16 @@ import scala.concurrent.{Await, Future}
 
 object Main extends App {
   implicit val conf = {
-    val path: Path = if (args.isEmpty) {
-      AppConfig.DEFAULT_BITCOIN_S_DATADIR
-    } else {
-      Paths.get(args(0))
+    val dataDirIndexOpt = args.zipWithIndex
+      .find(_._1.toLowerCase == "--datadir")
+
+    val datadirPath = dataDirIndexOpt match {
+      case None => AppConfig.DEFAULT_BITCOIN_S_DATADIR
+      case Some((_, dataDirIndex)) =>
+        val str = args(dataDirIndex + 1)
+        Paths.get(str)
     }
-    BitcoinSAppConfig(path)
+    BitcoinSAppConfig(datadirPath)
   }
 
   private val logger = HttpLoggerImpl(conf.nodeConf).getLogger

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -1,12 +1,13 @@
 package org.bitcoins.server
 
 import java.net.InetSocketAddress
-import java.nio.file.Files
+import java.nio.file.{Files, Path, Paths}
 
 import akka.actor.ActorSystem
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.Core
 import org.bitcoins.core.api.ChainQueryApi
+import org.bitcoins.db.AppConfig
 import org.bitcoins.keymanager.KeyManagerInitializeError
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.node.config.NodeAppConfig
@@ -22,7 +23,14 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 object Main extends App {
-  implicit val conf = BitcoinSAppConfig.fromDefaultDatadir()
+  implicit val conf = {
+    val path: Path = if (args.isEmpty) {
+      AppConfig.DEFAULT_BITCOIN_S_DATADIR
+    } else {
+      Paths.get(args(0))
+    }
+    BitcoinSAppConfig(path)
+  }
 
   private val logger = HttpLoggerImpl(conf.nodeConf).getLogger
 

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -34,7 +34,7 @@ $ ./app/server/target/universal/stage/bin/bitcoin-s-server
 If you would like to pass in a custom datadir for your server, you can do
 
 ```bash
-./app/server/target/universal/stage/bin/bitcoin-s-server -- /path/to/datadir/
+./app/server/target/universal/stage/bin/bitcoin-s-server --datadir /path/to/datadir/
 ```
 For more information on configuring the server please see our [configuration](configuration.md) document
 

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -31,6 +31,11 @@ This will produce a script to execute bitcoin-s which you can start with
 $ ./app/server/target/universal/stage/bin/bitcoin-s-server
 ```
 
+If you would like to pass in a custom datadir for your server, you can do
+
+```bash
+./app/server/target/universal/stage/bin/bitcoin-s-server -- /path/to/datadir/
+```
 For more information on configuring the server please see our [configuration](configuration.md) document
 
 For more information on how to use our built in `cli` to interact with the server please see [cli.md](cli.md)


### PR DESCRIPTION
This makes it so we can pass in a datadir that is configurable.

This is done with the [sbt-native-packager](https://www.scala-sbt.org/sbt-native-packager/archetypes/java_app/index.html#start-script-options) tool. You can read the docs to see how it works. 

You can now pass in a datadir to our server with 

```
 ./app/server/target/universal/stage/bin/bitcoin-s-server --datadir /path/to/datadir
```

you can also omit it, and the datadir defaults to `$HOME/.bitcoin-s/`

- [x] Test with old scala versions (`2.11.x` and `2.12.x`)
- [x] figure out if we can use named parameters (see below)

~I would like to make it so we don't just pass it into the `args: Array[String]` in `App`, as this means the ordering is important. It would be much nicer to have something like `--datadir /path/to/datadir/` than what I have now. @benthecarman do you have any idea of how to accomplish this?~