### PR TITLE
Made ContractInfo compatible with both scala 2.12 and 2.13

### DIFF
--- a/core/src/main/scala-2.11/org/bitcoins/core/util/MapWrapper.scala
+++ b/core/src/main/scala-2.11/org/bitcoins/core/util/MapWrapper.scala
@@ -1,0 +1,11 @@
+package org.bitcoins.core.util
+
+trait MapWrapper[K, +T] extends Map[K, T] {
+  protected def wrapped: Map[K, T]
+  override def +[B1 >: T](kv: (K, B1)): Map[K, B1] = wrapped.+(kv)
+  override def get(key: K): Option[T] = wrapped.get(key)
+  override def iterator: Iterator[(K, T)] = wrapped.iterator
+  override def updated[V1 >: T](key: K, value: V1): Map[K, V1] =
+    wrapped.updated(key, value)
+  override def -(key: K): Map[K, T] = wrapped.-(key)
+}

--- a/core/src/main/scala-2.12/org/bitcoins/core/util/MapWrapper.scala
+++ b/core/src/main/scala-2.12/org/bitcoins/core/util/MapWrapper.scala
@@ -1,0 +1,11 @@
+package org.bitcoins.core.util
+
+trait MapWrapper[K, +T] extends Map[K, T] {
+  protected def wrapped: Map[K, T]
+  override def +[B1 >: T](kv: (K, B1)): Map[K, B1] = wrapped.+(kv)
+  override def get(key: K): Option[T] = wrapped.get(key)
+  override def iterator: Iterator[(K, T)] = wrapped.iterator
+  override def updated[V1 >: T](key: K, value: V1): Map[K, V1] =
+    wrapped.updated(key, value)
+  override def -(key: K): Map[K, T] = wrapped.-(key)
+}

--- a/core/src/main/scala-2.13/org/bitcoins/core/util/MapWrapper.scala
+++ b/core/src/main/scala-2.13/org/bitcoins/core/util/MapWrapper.scala
@@ -1,12 +1,5 @@
 package org.bitcoins.core.util
 
-trait SeqWrapper[+T] extends IndexedSeq[T] {
-  protected def wrapped: IndexedSeq[T]
-  override def iterator: Iterator[T] = wrapped.iterator
-  override def length: Int = wrapped.length
-  override def apply(idx: Int): T = wrapped(idx)
-}
-
 trait MapWrapper[K, +T] extends Map[K, T] {
   protected def wrapped: Map[K, T]
   override def +[B1 >: T](kv: (K, B1)): Map[K, B1] = wrapped.+(kv)
@@ -14,4 +7,5 @@ trait MapWrapper[K, +T] extends Map[K, T] {
   override def iterator: Iterator[(K, T)] = wrapped.iterator
   override def updated[V1 >: T](key: K, value: V1): Map[K, V1] =
     wrapped.updated(key, value)
+  override def removed(key: K): Map[K, T] = wrapped.removed(key)
 }

--- a/core/src/main/scala/org/bitcoins/core/util/SeqWrapper.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/SeqWrapper.scala
@@ -1,0 +1,8 @@
+package org.bitcoins.core.util
+
+trait SeqWrapper[+T] extends IndexedSeq[T] {
+  protected def wrapped: IndexedSeq[T]
+  override def iterator: Iterator[T] = wrapped.iterator
+  override def length: Int = wrapped.length
+  override def apply(idx: Int): T = wrapped(idx)
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCMessage.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCMessage.scala
@@ -77,8 +77,12 @@ object DLCMessage {
       with MapWrapper[Sha256DigestBE, Satoshis] {
     override def wrapped: Map[Sha256DigestBE, Satoshis] = outcomeValueMap
 
-    override def removed(key: Sha256DigestBE): ContractInfo = {
-      ContractInfo(outcomeValueMap.removed(key))
+    def removed(key: Sha256DigestBE): ContractInfo = {
+      ContractInfo(outcomeValueMap - key)
+    }
+
+    def -(key: Sha256DigestBE): ContractInfo = {
+      ContractInfo(outcomeValueMap - key)
     }
 
     override def bytes: ByteVector = {

--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCMessage.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCMessage.scala
@@ -77,14 +77,6 @@ object DLCMessage {
       with MapWrapper[Sha256DigestBE, Satoshis] {
     override def wrapped: Map[Sha256DigestBE, Satoshis] = outcomeValueMap
 
-    def removed(key: Sha256DigestBE): ContractInfo = {
-      ContractInfo(outcomeValueMap - key)
-    }
-
-    def -(key: Sha256DigestBE): ContractInfo = {
-      ContractInfo(outcomeValueMap - key)
-    }
-
     override def bytes: ByteVector = {
       outcomeValueMap.foldLeft(ByteVector.empty) {
         case (vec, (digest, sats)) => vec ++ digest.bytes ++ sats.bytes


### PR DESCRIPTION
The `Map` interface was changed between these versions (`-` was replaced by `removed`)