### PR TITLE
TxoState Life Cycle Tests

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -30,7 +30,7 @@ import org.bitcoins.testkit.node.fixture.{
 }
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.wallet.api.UnlockedWalletApi
+import org.bitcoins.wallet.Wallet
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.duration._
@@ -168,17 +168,17 @@ object NodeUnitTest extends P2PLogger {
     * 4. a spv node that is connected to the bitcoin instance -- but not started!  */
   trait NodeFundedWalletBitcoind {
     def node: Node
-    def wallet: UnlockedWalletApi
+    def wallet: Wallet
     def bitcoindRpc: BitcoindRpcClient
   }
   case class SpvNodeFundedWalletBitcoind(
       node: SpvNode,
-      wallet: UnlockedWalletApi,
+      wallet: Wallet,
       bitcoindRpc: BitcoindRpcClient)
       extends NodeFundedWalletBitcoind
   case class NeutrinoNodeFundedWalletBitcoind(
       node: NeutrinoNode,
-      wallet: UnlockedWalletApi,
+      wallet: Wallet,
       bitcoindRpc: BitcoindRpcClient)
       extends NodeFundedWalletBitcoind
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -174,7 +174,7 @@ trait BitcoinSWalletTest extends BitcoinSFixture with WalletLogger {
       builder = { () =>
         createDefaultWallet(nodeApi, chainQueryApi)
       },
-      dependentBuilder = { (wallet: UnlockedWalletApi) =>
+      dependentBuilder = { (wallet: Wallet) =>
         createWalletWithBitcoind(wallet)
       },
       wrap = (_: UnlockedWalletApi, walletWithBitcoind: WalletWithBitcoind) =>
@@ -191,7 +191,7 @@ trait BitcoinSWalletTest extends BitcoinSFixture with WalletLogger {
         builder = { () =>
           createDefaultWallet(nodeApi, chainQueryApi)
         },
-        dependentBuilder = { (wallet: UnlockedWalletApi) =>
+        dependentBuilder = { (wallet: Wallet) =>
           createWalletWithBitcoind(wallet)
         },
         processResult = (_: UnlockedWalletApi, pair: WalletWithBitcoind) =>
@@ -251,9 +251,7 @@ object BitcoinSWalletTest extends WalletLogger {
       Future.successful(Vector.empty)
   }
 
-  case class WalletWithBitcoind(
-      wallet: UnlockedWalletApi,
-      bitcoind: BitcoindRpcClient)
+  case class WalletWithBitcoind(wallet: Wallet, bitcoind: BitcoindRpcClient)
 
   private def createNewKeyManager(
       bip39PasswordOpt: Option[String] = KeyManagerTestUtil.bip39PasswordOpt)(
@@ -330,7 +328,7 @@ object BitcoinSWalletTest extends WalletLogger {
 
   /** Pairs the given wallet with a bitcoind instance that has money in the bitcoind wallet */
   def createWalletWithBitcoind(
-      wallet: UnlockedWalletApi
+      wallet: Wallet
   )(implicit system: ActorSystem): Future[WalletWithBitcoind] = {
     val bitcoindF = BitcoinSFixture.createBitcoindWithFunds()
     bitcoindF.map(WalletWithBitcoind(wallet, _))(system.dispatcher)
@@ -338,7 +336,7 @@ object BitcoinSWalletTest extends WalletLogger {
 
   /** Pairs the given wallet with a bitcoind instance that has money in the bitcoind wallet */
   def createWalletWithBitcoind(
-      wallet: UnlockedWalletApi,
+      wallet: Wallet,
       versionOpt: Option[BitcoindVersion]
   )(implicit system: ActorSystem): Future[WalletWithBitcoind] = {
     import system.dispatcher
@@ -347,7 +345,7 @@ object BitcoinSWalletTest extends WalletLogger {
   }
 
   def createWalletWithBitcoind(
-      wallet: UnlockedWalletApi,
+      wallet: Wallet,
       bitcoindRpcClient: BitcoindRpcClient
   ): Future[WalletWithBitcoind] = {
     Future.successful(WalletWithBitcoind(wallet, bitcoindRpcClient))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -1,0 +1,73 @@
+package org.bitcoins.wallet
+
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.script.EmptyScriptPubKey
+import org.bitcoins.core.protocol.transaction.TransactionOutput
+import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.utxo.TxoState
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest.WalletWithBitcoind
+import org.scalatest.FutureOutcome
+
+class UTXOLifeCycleTest extends BitcoinSWalletTest {
+
+  behavior of "Wallet Txo States"
+
+  override type FixtureParam = WalletWithBitcoind
+
+  val testAddr: BitcoinAddress =
+    BitcoinAddress.fromString("n4MN27Lk7Yh3pwfjCiAbRXtRVjs4Uk67fG").get
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    withFundedWalletAndBitcoind(test)
+  }
+
+  it should "track a utxo state change to pending spent" in { param =>
+    val WalletWithBitcoind(wallet, _) = param
+
+    for {
+      tx <- wallet.sendToAddress(testAddr,
+                                 Satoshis(3000),
+                                 SatoshisPerVirtualByte(Satoshis(3)))
+
+      updatedCoins <- wallet.spendingInfoDAO.findOutputsBeingSpent(tx)
+    } yield {
+      assert(updatedCoins.forall(_.state == TxoState.PendingConfirmationsSpent))
+    }
+  }
+
+  it should "track a utxo state change to pending recieved" in { param =>
+    val WalletWithBitcoind(wallet, bitcoind) = param
+
+    for {
+      addr <- wallet.getNewAddress()
+
+      txId <- bitcoind.sendToAddress(addr, Satoshis(3000))
+      tx <- bitcoind.getRawTransactionRaw(txId)
+      _ <- wallet.processOurTransaction(tx, None)
+
+      updatedCoin <- wallet.spendingInfoDAO.findByScriptPubKey(
+        addr.scriptPubKey)
+    } yield {
+      assert(
+        updatedCoin.forall(_.state == TxoState.PendingConfirmationsReceived))
+    }
+  }
+
+  it should "track a utxo state change to reserved" in { param =>
+    val WalletWithBitcoind(wallet, _) = param
+
+    val dummyOutput = TransactionOutput(Satoshis(3000), EmptyScriptPubKey)
+
+    for {
+      tx <- wallet.fundRawTransaction(Vector(dummyOutput),
+                                      SatoshisPerVirtualByte.one,
+                                      markAsReserved = true)
+
+      updatedCoins <- wallet.spendingInfoDAO.findOutputsBeingSpent(tx)
+    } yield {
+      assert(updatedCoins.forall(_.state == TxoState.Reserved))
+    }
+  }
+}


### PR DESCRIPTION
Closes #1160 

I needed to change `NodeFundedWalletBitcoind` to use a `Wallet` instead of `UnlockedWalletApi` so I could query the internal databases for the tests