### PR TITLE
Make eclair tests use bitcoind v19 rather than bitcoind v17

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -89,7 +89,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
       port: Int = RpcUtil.randomPort,
       rpcPort: Int = RpcUtil.randomPort,
       zmqPort: Int = RpcUtil.randomPort): BitcoindInstance = {
-    BitcoindRpcTestUtil.v17Instance(port = port,
+    BitcoindRpcTestUtil.v19Instance(port = port,
                                     rpcPort = rpcPort,
                                     zmqPort = zmqPort)
   }


### PR DESCRIPTION
All of our eclair testing was using bitcoind `v17` because of this rather than `v19`.