### PR TITLE
Track addresses that correspond to dlc pub keys

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -42,6 +42,7 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
               oracleSigOpt = None
             )
           }
+          _ <- writeDLCKeysToAddressDb(account, nextIndex)
           writtenDLC <- dlcDAO.create(dlc)
         } yield writtenDLC
     }
@@ -57,6 +58,18 @@ abstract class DLCWallet extends LockedWallet with UnlockedWalletApi {
         Future.failed(
           new NoSuchElementException(
             s"No DLC found with that eventId ${eventId.hex}"))
+    }
+  }
+
+  private def writeDLCKeysToAddressDb(
+      account: AccountDb,
+      index: Int): Future[Vector[AddressDb]] = {
+    for {
+      zero <- getAddress(account, HDChainType.External, index)
+      one <- getAddress(account, HDChainType.External, index + 1)
+      two <- getAddress(account, HDChainType.External, index + 2)
+    } yield {
+      Vector(zero, one, two)
     }
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -184,6 +184,63 @@ private[wallet] trait AddressHandling extends WalletLogger {
     addrF
   }
 
+  def getAddress(
+      account: AccountDb,
+      chainType: HDChainType,
+      addressIndex: Int): Future[AddressDb] = {
+
+    val coinType = account.hdAccount.coin.coinType
+    val accountIndex = account.hdAccount.index
+
+    val path = account.hdAccount.purpose match {
+      case HDPurposes.Legacy =>
+        LegacyHDPath(coinType, accountIndex, chainType, addressIndex)
+      case HDPurposes.NestedSegWit =>
+        NestedSegWitHDPath(coinType, accountIndex, chainType, addressIndex)
+      case HDPurposes.SegWit =>
+        SegWitHDPath(coinType, accountIndex, chainType, addressIndex)
+    }
+
+    val pathDiff =
+      account.hdAccount.diff(path) match {
+        case Some(value) => value
+        case None =>
+          throw new IllegalArgumentException(
+            s"Could not diff ${account.hdAccount} and $path")
+      }
+
+    val pubkey = account.xpub.deriveChildPubKey(pathDiff) match {
+      case Failure(exception) => throw exception
+      case Success(value)     => value.key
+    }
+
+    val addressDb = account.hdAccount.purpose match {
+      case HDPurposes.SegWit =>
+        AddressDbHelper.getSegwitAddress(
+          pubkey,
+          SegWitHDPath(coinType, accountIndex, chainType, addressIndex),
+          networkParameters)
+      case HDPurposes.NestedSegWit =>
+        AddressDbHelper.getNestedSegwitAddress(
+          pubkey,
+          NestedSegWitHDPath(coinType, accountIndex, chainType, addressIndex),
+          networkParameters)
+      case HDPurposes.Legacy =>
+        AddressDbHelper.getLegacyAddress(
+          pubkey,
+          LegacyHDPath(coinType, accountIndex, chainType, addressIndex),
+          networkParameters)
+    }
+
+    logger.debug(s"Writing $addressDb to DB")
+
+    addressDAO.upsert(addressDb).map { written =>
+      logger.debug(
+        s"Got $chainType address ${written.address} at key path ${written.path} with pubkey ${written.ecPublicKey}")
+      written
+    }
+  }
+
   def findAccount(account: HDAccount): Future[Option[AccountDb]] = {
     accountDAO.findByAccount(account)
   }


### PR DESCRIPTION
Closes #1188

Allows for spending after a DLC.

Fixes a bug caused the accepter to not be using the keys they saved in their database