### PR TITLE
Bouncy Castle Fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,13 @@ matrix:
         - TEST_COMMAND="test:compile"
       scala:
         - 2.11.12
+    - os: linux
+      name: "Secp256k1 Disabled Core Test"
+      env:
+        - DISABLE_SECP256K1="true"
+        - TEST_COMMAND="coreTest/test"
+      scala:
+        - 2.13.1
     - os: osx
       name: "macOS bitcoind and eclair tests"
       env:

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/BouncyCastleSecp256k1Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/BouncyCastleSecp256k1Test.scala
@@ -1,0 +1,83 @@
+package org.bitcoins.core.crypto
+
+import org.bitcoin.{NativeSecp256k1, Secp256k1Context}
+import org.bitcoins.testkit.core.gen.{CryptoGenerators, NumberGenerator}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.scalacheck.Gen
+import org.scalatest.{Outcome, Succeeded}
+import scodec.bits.ByteVector
+
+class BouncyCastleSecp256k1Test extends BitcoinSUnitTest {
+
+  behavior of "CryptoLibraries"
+
+  override def withFixture(test: NoArgTest): Outcome = {
+    if (Secp256k1Context.isEnabled) {
+      super.withFixture(test)
+    } else {
+      logger.warn(s"Test ${test.name} skipped as Secp256k1 is not available.")
+      Succeeded
+    }
+  }
+
+  it must "add keys the same" in {
+    forAll(CryptoGenerators.publicKey, CryptoGenerators.privateKey) {
+      case (pubKey, privKey) =>
+        val sumKeyBytes =
+          NativeSecp256k1.pubKeyTweakAdd(pubKey.bytes.toArray,
+                                         privKey.bytes.toArray,
+                                         true)
+        val sumKeyExpected = ECPublicKey.fromBytes(ByteVector(sumKeyBytes))
+        val sumKey = pubKey.add(privKey.publicKey) // This uses Bouncy Castle
+
+        assert(sumKey == sumKeyExpected)
+    }
+  }
+
+  it must "validate keys the same" in {
+    val keyOrGarbageGen = Gen.oneOf(CryptoGenerators.publicKey.map(_.bytes),
+                                    NumberGenerator.bytevector(33))
+    forAll(keyOrGarbageGen) { bytes =>
+      assert(
+        ECPublicKey.isFullyValidWithBouncyCastle(bytes) ==
+          ECPublicKey.isFullyValidWithSecp(bytes)
+      )
+    }
+  }
+
+  it must "decompress keys the same" in {
+    forAll(CryptoGenerators.publicKey) { pubKey =>
+      assert(pubKey.decompressedWithBouncyCastle == pubKey.decompressedWithSecp)
+    }
+  }
+
+  it must "compute public keys the same" in {
+    forAll(CryptoGenerators.privateKey) { privKey =>
+      assert(privKey.publicKeyWithBouncyCastle == privKey.publicKeyWithSecp)
+    }
+  }
+
+  it must "compute signatures the same" in {
+    forAll(CryptoGenerators.privateKey, NumberGenerator.bytevector(32)) {
+      case (privKey, bytes) =>
+        assert(
+          privKey.signWithBouncyCastle(bytes) == privKey.signWithSecp(bytes))
+    }
+  }
+
+  it must "verify signatures the same" in {
+    forAll(CryptoGenerators.privateKey,
+           NumberGenerator.bytevector(32),
+           CryptoGenerators.digitalSignature) {
+      case (privKey, bytes, badSig) =>
+        val sig = privKey.sign(bytes)
+        val pubKey = privKey.publicKey
+        assert(
+          pubKey.verifyWithBouncyCastle(bytes, sig) == pubKey
+            .verifyWithSecp(bytes, sig))
+        assert(
+          pubKey.verifyWithBouncyCastle(bytes, badSig) == pubKey
+            .verifyWithSecp(bytes, badSig))
+    }
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.crypto
 
-import org.bitcoin.NativeSecp256k1
+import org.bitcoin.{NativeSecp256k1, Secp256k1Context}
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits._
@@ -38,15 +38,20 @@ class ECPublicKeyTest extends BitcoinSUnitTest {
   }
 
   it must "add keys correctly" in {
-    forAll(CryptoGenerators.publicKey, CryptoGenerators.privateKey) {
-      case (pubKey, privKey) =>
-        val sumKeyBytes = NativeSecp256k1.pubKeyTweakAdd(pubKey.bytes.toArray,
-                                                         privKey.bytes.toArray,
-                                                         true)
-        val sumKeyExpected = ECPublicKey.fromBytes(ByteVector(sumKeyBytes))
-        val sumKey = pubKey.add(privKey.publicKey)
+    if (Secp256k1Context.isEnabled) {
+      forAll(CryptoGenerators.publicKey, CryptoGenerators.privateKey) {
+        case (pubKey, privKey) =>
+          val sumKeyBytes =
+            NativeSecp256k1.pubKeyTweakAdd(pubKey.bytes.toArray,
+                                           privKey.bytes.toArray,
+                                           true)
+          val sumKeyExpected = ECPublicKey.fromBytes(ByteVector(sumKeyBytes))
+          val sumKey = pubKey.add(privKey.publicKey)
 
-        assert(sumKey == sumKeyExpected)
+          assert(sumKey == sumKeyExpected)
+      }
+    } else {
+      succeed
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
@@ -5,6 +5,8 @@ import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits._
 
+import scala.concurrent.ExecutionContext
+
 class ECPublicKeyTest extends BitcoinSUnitTest {
 
   it must "be able to decompress keys" in {
@@ -37,22 +39,20 @@ class ECPublicKeyTest extends BitcoinSUnitTest {
     }
   }
 
-  it must "add keys correctly" in {
-    if (Secp256k1Context.isEnabled) {
-      forAll(CryptoGenerators.publicKey, CryptoGenerators.privateKey) {
-        case (pubKey, privKey) =>
-          val sumKeyBytes =
-            NativeSecp256k1.pubKeyTweakAdd(pubKey.bytes.toArray,
-                                           privKey.bytes.toArray,
-                                           true)
-          val sumKeyExpected = ECPublicKey.fromBytes(ByteVector(sumKeyBytes))
-          val sumKey = pubKey.add(privKey.publicKey)
+  it must "decompress keys correctly" in {
+    forAll(CryptoGenerators.privateKey) { privKey =>
+      val pubKey = privKey.publicKey
 
-          assert(sumKey == sumKeyExpected)
-      }
-    } else {
-      // No other implementation to compare to
-      succeed
+      assert(privKey.isCompressed)
+      assert(pubKey.isCompressed)
+
+      val decompressedPrivKey =
+        ECPrivateKey(privKey.bytes, isCompressed = false)(
+          ExecutionContext.global)
+      val decompressedPubKey = pubKey.decompressed
+
+      assert(decompressedPrivKey.publicKey == decompressedPubKey)
+      assert(pubKey.bytes.tail == decompressedPubKey.bytes.splitAt(33)._1.tail)
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ECPublicKeyTest.scala
@@ -51,6 +51,7 @@ class ECPublicKeyTest extends BitcoinSUnitTest {
           assert(sumKey == sumKeyExpected)
       }
     } else {
+      // No other implementation to compare to
       succeed
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/crypto/BouncyCastleUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/BouncyCastleUtil.scala
@@ -20,12 +20,15 @@ object BouncyCastleUtil {
   private val G: ECPoint = CryptoParams.curve.getG
   private val N: BigInteger = CryptoParams.curve.getN
 
-  private def number(bytes: ByteVector): BigInteger = {
+  private def getBigInteger(bytes: ByteVector): BigInteger = {
     new BigInteger(1, bytes.toArray)
   }
 
   def addNumbers(num1: ByteVector, num2: ByteVector): BigInteger = {
-    number(num1).add(number(num2)).mod(N)
+    val bigInteger1 = getBigInteger(num1)
+    val bigInteger2 = getBigInteger(num2)
+
+    bigInteger1.add(bigInteger2).mod(N)
   }
 
   def decodePoint(bytes: ByteVector): ECPoint = {
@@ -50,7 +53,7 @@ object BouncyCastleUtil {
   }
 
   def computePublicKey(privateKey: ECPrivateKey): ECPublicKey = {
-    val priv = number(privateKey.bytes)
+    val priv = getBigInteger(privateKey.bytes)
     val point = G.multiply(priv)
     val pubBytes = ByteVector(point.getEncoded(privateKey.isCompressed))
     require(
@@ -66,7 +69,8 @@ object BouncyCastleUtil {
     val signer: ECDSASigner = new ECDSASigner(
       new HMacDSAKCalculator(new SHA256Digest()))
     val privKey: ECPrivateKeyParameters =
-      new ECPrivateKeyParameters(number(privateKey.bytes), CryptoParams.curve)
+      new ECPrivateKeyParameters(getBigInteger(privateKey.bytes),
+                                 CryptoParams.curve)
     signer.init(true, privKey)
     val components: Array[BigInteger] =
       signer.generateSignature(dataToSign.toArray)

--- a/core/src/main/scala/org/bitcoins/core/crypto/BouncyCastleUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/BouncyCastleUtil.scala
@@ -1,0 +1,110 @@
+package org.bitcoins.core.crypto
+
+import java.math.BigInteger
+
+import org.bitcoins.core.util.BitcoinSUtil
+import org.bouncycastle.crypto.digests.SHA256Digest
+import org.bouncycastle.crypto.params.{
+  ECPrivateKeyParameters,
+  ECPublicKeyParameters
+}
+import org.bouncycastle.crypto.signers.{ECDSASigner, HMacDSAKCalculator}
+import org.bouncycastle.math.ec.{ECCurve, ECPoint}
+import scodec.bits.ByteVector
+
+import scala.util.Try
+
+object BouncyCastleUtil {
+
+  private val curve: ECCurve = CryptoParams.curve.getCurve
+  private val G: ECPoint = CryptoParams.curve.getG
+  private val N: BigInteger = CryptoParams.curve.getN
+
+  private def number(bytes: ByteVector): BigInteger = {
+    new BigInteger(1, bytes.toArray)
+  }
+
+  def addNumbers(num1: ByteVector, num2: ByteVector): BigInteger = {
+    number(num1).add(number(num2)).mod(N)
+  }
+
+  def decodePoint(bytes: ByteVector): ECPoint = {
+    curve.decodePoint(bytes.toArray)
+  }
+
+  def validatePublicKey(bytes: ByteVector): Boolean = {
+    Try(decodePoint(bytes))
+      .map(_.getCurve == curve)
+      .getOrElse(false)
+  }
+
+  def decompressPublicKey(publicKey: ECPublicKey): ECPublicKey = {
+    if (publicKey.isCompressed) {
+      val point = decodePoint(publicKey.bytes)
+      val decompressedBytes =
+        ByteVector.fromHex("04").get ++
+          ByteVector(point.getXCoord.getEncoded) ++
+          ByteVector(point.getYCoord.getEncoded)
+      ECPublicKey(decompressedBytes)
+    } else publicKey
+  }
+
+  def computePublicKey(privateKey: ECPrivateKey): ECPublicKey = {
+    val priv = number(privateKey.bytes)
+    val point = G.multiply(priv)
+    val pubBytes = ByteVector(point.getEncoded(privateKey.isCompressed))
+    require(
+      ECPublicKey.isFullyValid(pubBytes),
+      s"Bouncy Castle failed to generate a valid public key, got: ${BitcoinSUtil
+        .encodeHex(pubBytes)}")
+    ECPublicKey(pubBytes)
+  }
+
+  def sign(
+      dataToSign: ByteVector,
+      privateKey: ECPrivateKey): ECDigitalSignature = {
+    val signer: ECDSASigner = new ECDSASigner(
+      new HMacDSAKCalculator(new SHA256Digest()))
+    val privKey: ECPrivateKeyParameters =
+      new ECPrivateKeyParameters(number(privateKey.bytes), CryptoParams.curve)
+    signer.init(true, privKey)
+    val components: Array[BigInteger] =
+      signer.generateSignature(dataToSign.toArray)
+    val (r, s) = (components(0), components(1))
+    val signature = ECDigitalSignature(r, s)
+    //make sure the signature follows BIP62's low-s value
+    //https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Low_S_values_in_signatures
+    //bitcoinj implementation
+    //https://github.com/bitcoinj/bitcoinj/blob/1e66b9a8e38d9ad425507bf5f34d64c5d3d23bb8/core/src/main/java/org/bitcoinj/core/ECKey.java#L551
+    val signatureLowS = DERSignatureUtil.lowS(signature)
+    require(
+      signatureLowS.isDEREncoded,
+      "We must create DER encoded signatures when signing a piece of data, got: " + signatureLowS)
+    signatureLowS
+  }
+
+  def verifyDigitalSignature(
+      data: ByteVector,
+      publicKey: ECPublicKey,
+      signature: ECDigitalSignature): Boolean = {
+    val resultTry = Try {
+      val publicKeyParams =
+        new ECPublicKeyParameters(decodePoint(publicKey.bytes),
+                                  CryptoParams.curve)
+
+      val signer = new ECDSASigner
+      signer.init(false, publicKeyParams)
+      signature match {
+        case EmptyDigitalSignature =>
+          signer.verifySignature(data.toArray,
+                                 java.math.BigInteger.valueOf(0),
+                                 java.math.BigInteger.valueOf(0))
+        case _: ECDigitalSignature =>
+          val rBigInteger: BigInteger = new BigInteger(signature.r.toString())
+          val sBigInteger: BigInteger = new BigInteger(signature.s.toString())
+          signer.verifySignature(data.toArray, rBigInteger, sBigInteger)
+      }
+    }
+    resultTry.getOrElse(false)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -372,6 +372,10 @@ sealed abstract class ECPublicKey extends BaseECKey {
     * get wrapped in NativeSecp256k1 to speed things up.
     */
   def add(otherKey: ECPublicKey): ECPublicKey = {
+    addWithBouncyCastle(otherKey)
+  }
+
+  def addWithBouncyCastle(otherKey: ECPublicKey): ECPublicKey = {
     val sumPoint = toPoint.add(otherKey.toPoint)
 
     ECPublicKey.fromPoint(sumPoint)

--- a/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -8,14 +8,11 @@ import org.bitcoins.core.config.{NetworkParameters, Networks}
 import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.util.{BitcoinSUtil, _}
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
-import org.bouncycastle.crypto.digests.SHA256Digest
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator
 import org.bouncycastle.crypto.params.{
   ECKeyGenerationParameters,
-  ECPrivateKeyParameters,
-  ECPublicKeyParameters
+  ECPrivateKeyParameters
 }
-import org.bouncycastle.crypto.signers.{ECDSASigner, HMacDSAKCalculator}
 import org.bouncycastle.math.ec.ECPoint
 import scodec.bits.ByteVector
 
@@ -49,14 +46,26 @@ sealed abstract class ECPrivateKey
     * @return the digital signature
     */
   override def sign(dataToSign: ByteVector): ECDigitalSignature = {
+    sign(dataToSign, Secp256k1Context.isEnabled)
+  }
+
+  def sign(dataToSign: ByteVector, useSecp: Boolean): ECDigitalSignature = {
     require(dataToSign.length == 32 && bytes.length <= 32)
-    if (Secp256k1Context.isEnabled) {
-      val signature =
-        NativeSecp256k1.sign(dataToSign.toArray, bytes.toArray)
-      ECDigitalSignature(ByteVector(signature))
+    if (useSecp) {
+      signWithSecp(dataToSign)
     } else {
       signWithBouncyCastle(dataToSign)
     }
+  }
+
+  def signWithSecp(dataToSign: ByteVector): ECDigitalSignature = {
+    val signature =
+      NativeSecp256k1.sign(dataToSign.toArray, bytes.toArray)
+    ECDigitalSignature(ByteVector(signature))
+  }
+
+  def signWithBouncyCastle(dataToSign: ByteVector): ECDigitalSignature = {
+    BouncyCastleUtil.sign(dataToSign, this)
   }
 
   def sign(hash: HashDigest): ECDigitalSignature = sign(hash.bytes)
@@ -65,53 +74,33 @@ sealed abstract class ECPrivateKey
       implicit ec: ExecutionContext): Future[ECDigitalSignature] =
     Future(sign(hash))
 
-  def signWithBouncyCastle(dataToSign: ByteVector): ECDigitalSignature = {
-    val signer: ECDSASigner = new ECDSASigner(
-      new HMacDSAKCalculator(new SHA256Digest()))
-    val privKey: ECPrivateKeyParameters = new ECPrivateKeyParameters(
-      new BigInteger(1, bytes.toArray),
-      CryptoParams.curve)
-    signer.init(true, privKey)
-    val components: Array[BigInteger] =
-      signer.generateSignature(dataToSign.toArray)
-    val (r, s) = (components(0), components(1))
-    val signature = ECDigitalSignature(r, s)
-    //make sure the signature follows BIP62's low-s value
-    //https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Low_S_values_in_signatures
-    //bitcoinj implementation
-    //https://github.com/bitcoinj/bitcoinj/blob/1e66b9a8e38d9ad425507bf5f34d64c5d3d23bb8/core/src/main/java/org/bitcoinj/core/ECKey.java#L551
-    val signatureLowS = DERSignatureUtil.lowS(signature)
-    require(
-      signatureLowS.isDEREncoded,
-      "We must create DER encoded signatures when signing a piece of data, got: " + signatureLowS)
-    signatureLowS
-  }
-
   /** Signifies if the this private key corresponds to a compressed public key */
   def isCompressed: Boolean
 
+  override def publicKey: ECPublicKey = publicKey(Secp256k1Context.isEnabled)
+
   /** Derives the public for a the private key */
-  def publicKey: ECPublicKey = {
-    if (Secp256k1Context.isEnabled) {
-      val pubKeyBytes: Array[Byte] =
-        NativeSecp256k1.computePubkey(bytes.toArray, isCompressed)
-      val pubBytes = ByteVector(pubKeyBytes)
-      require(
-        ECPublicKey.isFullyValid(pubBytes),
-        s"secp256k1 failed to generate a valid public key, got: ${BitcoinSUtil
-          .encodeHex(pubBytes)}")
-      ECPublicKey(pubBytes)
+  def publicKey(useSecp: Boolean): ECPublicKey = {
+    if (useSecp) {
+      publicKeyWithSecp
     } else {
-      val priv = new BigInteger(1, bytes.toArray)
-      val point =
-        CryptoParams.curve.getG.multiply(priv)
-      val pubBytes = ByteVector(point.getEncoded(isCompressed))
-      require(
-        ECPublicKey.isFullyValid(pubBytes),
-        s"Bouncy Castle failed to generate a valid public key, got: ${BitcoinSUtil
-          .encodeHex(pubBytes)}")
-      ECPublicKey(pubBytes)
+      publicKeyWithBouncyCastle
     }
+  }
+
+  def publicKeyWithSecp: ECPublicKey = {
+    val pubKeyBytes: Array[Byte] =
+      NativeSecp256k1.computePubkey(bytes.toArray, isCompressed)
+    val pubBytes = ByteVector(pubKeyBytes)
+    require(
+      ECPublicKey.isFullyValid(pubBytes),
+      s"secp256k1 failed to generate a valid public key, got: ${BitcoinSUtil
+        .encodeHex(pubBytes)}")
+    ECPublicKey(pubBytes)
+  }
+
+  def publicKeyWithBouncyCastle: ECPublicKey = {
+    BouncyCastleUtil.computePublicKey(this)
   }
 
   /**
@@ -296,11 +285,27 @@ sealed abstract class ECPublicKey extends BaseECKey {
     * [[org.bitcoins.core.crypto.ECPrivateKey ECPrivateKey]]'s corresponding
     * [[org.bitcoins.core.crypto.ECPublicKey ECPublicKey]]. */
   def verify(data: ByteVector, signature: ECDigitalSignature): Boolean = {
-    val result = if (Secp256k1Context.isEnabled) {
+    verify(data, signature, Secp256k1Context.isEnabled)
+  }
+
+  def verify(
+      data: ByteVector,
+      signature: ECDigitalSignature,
+      useSecp: Boolean): Boolean = {
+    if (useSecp) {
+      verifyWithSecp(data, signature)
+    } else {
+      verifyWithBouncyCastle(data, signature)
+    }
+  }
+
+  def verifyWithSecp(
+      data: ByteVector,
+      signature: ECDigitalSignature): Boolean = {
+    val result =
       NativeSecp256k1.verify(data.toArray,
                              signature.bytes.toArray,
                              bytes.toArray)
-    } else false
 
     if (!result) {
       //if signature verification fails with libsecp256k1 we need to use our old
@@ -309,8 +314,14 @@ sealed abstract class ECPublicKey extends BaseECKey {
       //bitcoin core implements this functionality here:
       //https://github.com/bitcoin/bitcoin/blob/master/src/pubkey.cpp#L16-L165
       //TODO: Implement functionality in Bitcoin Core linked above
-      oldVerify(data, signature)
+      verifyWithBouncyCastle(data, signature)
     } else result
+  }
+
+  def verifyWithBouncyCastle(
+      data: ByteVector,
+      signature: ECDigitalSignature): Boolean = {
+    BouncyCastleUtil.verifyDigitalSignature(data, this, signature)
   }
 
   def verify(hex: String, signature: ECDigitalSignature): Boolean =
@@ -318,56 +329,32 @@ sealed abstract class ECPublicKey extends BaseECKey {
 
   override def toString = "ECPublicKey(" + hex + ")"
 
-  private def oldVerify(
-      data: ByteVector,
-      signature: ECDigitalSignature): Boolean = {
-
-    /** The elliptic curve used by bitcoin. */
-    def curve = CryptoParams.curve
-
-    /** This represents this public key in the bouncy castle library */
-    def publicKeyParams =
-      new ECPublicKeyParameters(curve.getCurve.decodePoint(bytes.toArray),
-                                curve)
-
-    val resultTry = Try {
-      val signer = new ECDSASigner
-      signer.init(false, publicKeyParams)
-      signature match {
-        case EmptyDigitalSignature =>
-          signer.verifySignature(data.toArray,
-                                 java.math.BigInteger.valueOf(0),
-                                 java.math.BigInteger.valueOf(0))
-        case _: ECDigitalSignature =>
-          val rBigInteger: BigInteger = new BigInteger(signature.r.toString())
-          val sBigInteger: BigInteger = new BigInteger(signature.s.toString())
-          signer.verifySignature(data.toArray, rBigInteger, sBigInteger)
-      }
-    }
-    resultTry.getOrElse(false)
-  }
-
   /** Checks if the [[org.bitcoins.core.crypto.ECPublicKey ECPublicKey]] is compressed */
   def isCompressed: Boolean = bytes.size == 33
 
   /** Checks if the [[org.bitcoins.core.crypto.ECPublicKey ECPublicKey]] is valid according to secp256k1 */
-  def isFullyValid = ECPublicKey.isFullyValid(bytes)
+  def isFullyValid: Boolean = ECPublicKey.isFullyValid(bytes)
 
   /** Returns the decompressed version of this [[org.bitcoins.core.crypto.ECPublicKey ECPublicKey]] */
-  def decompressed: ECPublicKey = {
+  def decompressed: ECPublicKey = decompressed(Secp256k1Context.isEnabled)
+
+  def decompressed(useSecp: Boolean): ECPublicKey = {
+    if (useSecp) {
+      decompressedWithSecp
+    } else {
+      decompressedWithBouncyCastle
+    }
+  }
+
+  def decompressedWithSecp: ECPublicKey = {
     if (isCompressed) {
-      if (Secp256k1Context.isEnabled) {
-        val decompressed = NativeSecp256k1.decompress(bytes.toArray)
-        ECPublicKey.fromBytes(ByteVector(decompressed))
-      } else {
-        val point = CryptoParams.curve.getCurve.decodePoint(bytes.toArray)
-        val decompressedBytes =
-          ByteVector.fromHex("04").get ++
-            ByteVector(point.getXCoord.getEncoded) ++
-            ByteVector(point.getYCoord.getEncoded)
-        ECPublicKey(decompressedBytes)
-      }
+      val decompressed = NativeSecp256k1.decompress(bytes.toArray)
+      ECPublicKey.fromBytes(ByteVector(decompressed))
     } else this
+  }
+
+  def decompressedWithBouncyCastle: ECPublicKey = {
+    BouncyCastleUtil.decompressPublicKey(this)
   }
 
   /** Decodes a [[org.bitcoins.core.crypto.ECPublicKey ECPublicKey]] in bitcoin-s
@@ -376,7 +363,7 @@ sealed abstract class ECPublicKey extends BaseECKey {
     * @return
     */
   def toPoint: ECPoint = {
-    CryptoParams.curve.getCurve.decodePoint(bytes.toArray)
+    BouncyCastleUtil.decodePoint(bytes)
   }
 
   /** Adds this ECPublicKey to another as points and returns the resulting ECPublicKey.
@@ -420,14 +407,24 @@ object ECPublicKey extends Factory[ECPublicKey] {
     * [[https://github.com/bitcoin/bitcoin/blob/27765b6403cece54320374b37afb01a0cfe571c3/src/pubkey.cpp#L207-L212]]
     */
   def isFullyValid(bytes: ByteVector): Boolean = {
-    if (Secp256k1Context.isEnabled) {
-      Try(NativeSecp256k1.isValidPubKey(bytes.toArray))
-        .getOrElse(false) && isValid(bytes)
+    isFullyValid(bytes, Secp256k1Context.isEnabled)
+  }
+
+  def isFullyValid(bytes: ByteVector, useSecp: Boolean): Boolean = {
+    if (useSecp) {
+      isFullyValidWithSecp(bytes)
     } else {
-      Try(CryptoParams.curve.getCurve.decodePoint(bytes.toArray))
-        .map(_.getCurve == CryptoParams.curve.getCurve)
-        .getOrElse(false) && isValid(bytes)
+      isFullyValidWithBouncyCastle(bytes)
     }
+  }
+
+  def isFullyValidWithSecp(bytes: ByteVector): Boolean = {
+    Try(NativeSecp256k1.isValidPubKey(bytes.toArray))
+      .getOrElse(false) && isValid(bytes)
+  }
+
+  def isFullyValidWithBouncyCastle(bytes: ByteVector): Boolean = {
+    BouncyCastleUtil.validatePublicKey(bytes) && isValid(bytes)
   }
 
   /**

--- a/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ECKey.scala
@@ -102,10 +102,10 @@ sealed abstract class ECPrivateKey
           .encodeHex(pubBytes)}")
       ECPublicKey(pubBytes)
     } else {
-      val priv = new BigInteger(bytes.toArray)
+      val priv = new BigInteger(1, bytes.toArray)
       val point =
         CryptoParams.curve.getG.multiply(priv)
-      val pubBytes = ByteVector(point.getEncoded(true))
+      val pubBytes = ByteVector(point.getEncoded(isCompressed))
       require(
         ECPublicKey.isFullyValid(pubBytes),
         s"Bouncy Castle failed to generate a valid public key, got: ${BitcoinSUtil
@@ -145,7 +145,7 @@ object ECPrivateKey extends Factory[ECPrivateKey] {
               s"Invalid key according to secp256k1, hex: ${bytes.toHex}")
     } else {
       require(CryptoParams.curve.getCurve
-                .isValidFieldElement(new BigInteger(bytes.toArray)),
+                .isValidFieldElement(new BigInteger(1, bytes.toArray)),
               s"Invalid key according to Bouncy Castle, hex: ${bytes.toHex}")
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -1,6 +1,8 @@
 package org.bitcoins.core.crypto
 
-import org.bitcoin.NativeSecp256k1
+import java.math.BigInteger
+
+import org.bitcoin.{NativeSecp256k1, Secp256k1Context}
 import org.bitcoins.core.hd.{BIP32Node, BIP32Path}
 import org.bitcoins.core.number.{UInt32, UInt8}
 import org.bitcoins.core.protocol.NetworkElement
@@ -200,7 +202,15 @@ sealed abstract class ExtPrivateKey
     val (il, ir) = hmac.splitAt(32)
     //should be ECGroup addition
     //parse256(IL) + kpar (mod n)
-    val tweak = NativeSecp256k1.privKeyTweakAdd(il.toArray, key.bytes.toArray)
+    val tweak = if (Secp256k1Context.isEnabled) {
+      NativeSecp256k1.privKeyTweakAdd(il.toArray, key.bytes.toArray)
+    } else {
+      val sum =
+        new BigInteger(1, key.bytes.toArray)
+          .add(new BigInteger(1, il.toArray))
+          .mod(CryptoParams.curve.getN)
+      sum.toByteArray
+    }
     val childKey = ECPrivateKey(ByteVector(tweak))
     val fp = CryptoUtil.sha256Hash160(key.publicKey.bytes).bytes.take(4)
     ExtPrivateKey(version, depth + UInt8.one, fp, idx, ChainCode(ir), childKey)
@@ -353,10 +363,15 @@ sealed abstract class ExtPublicKey extends ExtKey {
       val hmac = CryptoUtil.hmac512(chainCode.bytes, data)
       val (il, ir) = hmac.splitAt(32)
       val priv = ECPrivateKey(il)
-      val tweaked = NativeSecp256k1.pubKeyTweakAdd(key.bytes.toArray,
-                                                   hmac.toArray,
-                                                   priv.isCompressed)
-      val childPubKey = ECPublicKey(ByteVector(tweaked))
+      val childPubKey = if (Secp256k1Context.isEnabled) {
+        val tweaked = NativeSecp256k1.pubKeyTweakAdd(key.bytes.toArray,
+                                                     il.toArray,
+                                                     priv.isCompressed)
+        ECPublicKey(ByteVector(tweaked))
+      } else {
+        val tweak = ECPrivateKey.fromBytes(il).publicKey
+        key.add(tweak)
+      }
 
       //we do not handle this case since it is impossible
       //In case parse256(IL) ≥ n or Ki is the point at infinity, the resulting key is invalid,

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -1,7 +1,5 @@
 package org.bitcoins.core.crypto
 
-import java.math.BigInteger
-
 import org.bitcoin.{NativeSecp256k1, Secp256k1Context}
 import org.bitcoins.core.hd.{BIP32Node, BIP32Path}
 import org.bitcoins.core.number.{UInt32, UInt8}

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -205,10 +205,7 @@ sealed abstract class ExtPrivateKey
     val tweak = if (Secp256k1Context.isEnabled) {
       NativeSecp256k1.privKeyTweakAdd(il.toArray, key.bytes.toArray)
     } else {
-      val sum =
-        new BigInteger(1, key.bytes.toArray)
-          .add(new BigInteger(1, il.toArray))
-          .mod(CryptoParams.curve.getN)
+      val sum = BouncyCastleUtil.addNumbers(key.bytes, il)
       sum.toByteArray
     }
     val childKey = ECPrivateKey(ByteVector(tweak))

--- a/secp256k1jni/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/secp256k1jni/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -18,6 +18,8 @@ package org.bitcoin;
 
 import org.scijava.nativelib.NativeLoader;
 
+import java.util.Properties;
+
 /**
  * This class holds the context reference used in native methods 
  * to handle ECDSA operations.
@@ -46,7 +48,12 @@ public class Secp256k1Context {
   }
 
   public static boolean isEnabled() {
-     return enabled;
+      String secpDisabled = System.getenv("DISABLE_SECP256K1");
+      if (secpDisabled != null && secpDisabled.equals("true")) {
+          return false;
+      } else {
+          return enabled;
+      }
   }
 
   public static long getContext() {

--- a/secp256k1jni/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/secp256k1jni/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -18,8 +18,6 @@ package org.bitcoin;
 
 import org.scijava.nativelib.NativeLoader;
 
-import java.util.Properties;
-
 /**
  * This class holds the context reference used in native methods 
  * to handle ECDSA operations.
@@ -49,7 +47,9 @@ public class Secp256k1Context {
 
   public static boolean isEnabled() {
       String secpDisabled = System.getenv("DISABLE_SECP256K1");
-      if (secpDisabled != null && secpDisabled.equals("true")) {
+      if (secpDisabled != null &&
+              (secpDisabled.toLowerCase().equals("true") ||
+                      secpDisabled.equals("1"))) {
           return false;
       } else {
           return enabled;

--- a/secp256k1jni/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/secp256k1jni/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -45,6 +45,11 @@ public class Secp256k1Context {
       context = contextRef;
   }
 
+  /**
+   * Detects whether or not the libsecp256k1 binaries were successfully
+   * loaded in static initialization above. Useful in enabling a fallback
+   * to Bouncy Castle implementations in the case of having no libsecp present.
+   */
   public static boolean isEnabled() {
       String secpDisabled = System.getenv("DISABLE_SECP256K1");
       if (secpDisabled != null &&


### PR DESCRIPTION
When `Secp256k1Context.isEnabled` is `false` we now use `bouncycastle` as a fallback.