### PR TITLE
Allow FeeUnit to represent decimals

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -50,7 +50,7 @@ object CliReaders {
       val arity: Int = 1
 
       val reads: String => SatoshisPerVirtualByte = str =>
-        SatoshisPerVirtualByte(Satoshis(BigInt(str)))
+        SatoshisPerVirtualByte(BigDecimal(str).toDouble)
     }
 
   implicit val blockStampReads: Read[BlockStamp] =

--- a/app/picklers/src/main/scala/org/bitcoins/picklers/Picklers.scala
+++ b/app/picklers/src/main/scala/org/bitcoins/picklers/Picklers.scala
@@ -1,8 +1,8 @@
 package org.bitcoins
 
-import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
-import org.bitcoins.core.currency.{Bitcoins, Satoshis}
+import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import upickle.default._
@@ -30,6 +30,5 @@ package object picklers {
 
   implicit val satoshisPerVirtualBytePickler: ReadWriter[
     SatoshisPerVirtualByte] =
-    readwriter[Long].bimap(_.currencyUnit.satoshis.toLong,
-                           l => SatoshisPerVirtualByte(Satoshis(l)))
+    readwriter[Double].bimap(_.sats, SatoshisPerVirtualByte(_))
 }

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -20,7 +20,7 @@ import org.bitcoins.core.protocol.BlockStamp.{
 import org.bitcoins.core.protocol.transaction.{EmptyTransaction, Transaction}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.fee.FeeRate
 import org.bitcoins.node.Node
 import org.bitcoins.wallet.MockUnlockedWalletApi
 import org.scalamock.scalatest.MockFactory
@@ -239,7 +239,7 @@ class RoutesSpec
       // positive cases
 
       (mockWalletApi
-        .sendToAddress(_: BitcoinAddress, _: CurrencyUnit, _: FeeUnit))
+        .sendToAddress(_: BitcoinAddress, _: CurrencyUnit, _: FeeRate))
         .expects(testAddress, Bitcoins(100), *)
         .returning(Future.successful(EmptyTransaction))
 

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.server
 
-import org.bitcoins.core.currency.{Bitcoins, Satoshis}
+import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.protocol.BlockStamp.BlockHeight
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
@@ -165,7 +165,7 @@ object SendToAddress extends ServerJsonModels {
           val bitcoins = Bitcoins(bitcoinsJs.num)
           val satoshisPerVirtualByte =
             nullToOpt(satsPerVBytesJs).map(satsPerVBytes =>
-              SatoshisPerVirtualByte(Satoshis(satsPerVBytes.num.toLong)))
+              SatoshisPerVirtualByte(satsPerVBytes.num.toLong))
           SendToAddress(address, bitcoins, satoshisPerVirtualByte)
         }
       case Nil =>

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -55,7 +55,7 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           complete {
             // TODO dynamic fees based off mempool and recent blocks
             val feeRate =
-              satoshisPerVirtualByteOpt.getOrElse(SatoshisPerByte(100.satoshis))
+              satoshisPerVirtualByteOpt.getOrElse(SatoshisPerByte(100))
             wallet.sendToAddress(address, bitcoins, feeRate).map { tx =>
               node.broadcastTransaction(tx)
               Server.httpSuccess(tx.txIdBE)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -8,15 +8,15 @@ import org.bitcoins.core.crypto.{
   ECPrivateKey,
   ECPublicKey
 }
-import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit, Satoshis}
-import org.bitcoins.core.number.{Int64, UInt32}
+import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit}
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script.ScriptSignature
 import org.bitcoins.core.protocol.transaction.{
   TransactionInput,
   TransactionOutPoint
 }
 import org.bitcoins.core.protocol.{BitcoinAddress, P2PKHAddress}
-import org.bitcoins.core.wallet.fee.SatoshisPerByte
+import org.bitcoins.core.wallet.fee.BitcoinsPerKiloByte
 import org.bitcoins.rpc.client.common.RpcOpts.AddressType
 import org.bitcoins.rpc.client.common.{
   BitcoindRpcClient,
@@ -487,7 +487,7 @@ class WalletRpcTest extends BitcoindRpcTest {
       info <- client.getWalletInfo
     } yield {
       assert(success)
-      assert(info.paytxfee == SatoshisPerByte(1000))
+      assert(info.paytxfee == BitcoinsPerKiloByte(0.01))
     }
   }
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -487,7 +487,7 @@ class WalletRpcTest extends BitcoindRpcTest {
       info <- client.getWalletInfo
     } yield {
       assert(success)
-      assert(info.paytxfee == SatoshisPerByte(Satoshis(1000)))
+      assert(info.paytxfee == SatoshisPerByte(1000))
     }
   }
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
@@ -4,7 +4,7 @@ import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.core.wallet.fee.BitcoinFeeUnit
+import org.bitcoins.core.wallet.fee.BitcoinFeeRate
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.gcs.GolombFilter
 
@@ -200,10 +200,10 @@ case class GetMemPoolResultPostV19(
 }
 
 case class FeeInfo(
-    base: BitcoinFeeUnit,
-    modified: BitcoinFeeUnit,
-    ancestor: BitcoinFeeUnit,
-    descendant: BitcoinFeeUnit
+    base: BitcoinFeeRate,
+    modified: BitcoinFeeRate,
+    ancestor: BitcoinFeeRate,
+    descendant: BitcoinFeeRate
 )
 
 sealed trait GetMemPoolEntryResult extends BlockchainResult {
@@ -214,10 +214,10 @@ sealed trait GetMemPoolEntryResult extends BlockchainResult {
   def height: Int
   def descendantcount: Int
   def descendantsize: Int
-  def descendantfees: BitcoinFeeUnit
+  def descendantfees: BitcoinFeeRate
   def ancestorcount: Int
   def ancestorsize: Int
-  def ancestorfees: BitcoinFeeUnit
+  def ancestorfees: BitcoinFeeRate
   def wtxid: DoubleSha256DigestBE
   def fees: FeeInfo
   def depends: Option[Vector[DoubleSha256DigestBE]]
@@ -231,10 +231,10 @@ case class GetMemPoolEntryResultPreV19(
     height: Int,
     descendantcount: Int,
     descendantsize: Int,
-    descendantfees: BitcoinFeeUnit,
+    descendantfees: BitcoinFeeRate,
     ancestorcount: Int,
     ancestorsize: Int,
-    ancestorfees: BitcoinFeeUnit,
+    ancestorfees: BitcoinFeeRate,
     wtxid: DoubleSha256DigestBE,
     fees: FeeInfo,
     depends: Option[Vector[DoubleSha256DigestBE]])
@@ -249,10 +249,10 @@ case class GetMemPoolEntryResultPostV19(
     height: Int,
     descendantcount: Int,
     descendantsize: Int,
-    descendantfees: BitcoinFeeUnit,
+    descendantfees: BitcoinFeeRate,
     ancestorcount: Int,
     ancestorsize: Int,
-    ancestorfees: BitcoinFeeUnit,
+    ancestorfees: BitcoinFeeRate,
     wtxid: DoubleSha256DigestBE,
     fees: FeeInfo,
     depends: Option[Vector[DoubleSha256DigestBE]])
@@ -265,7 +265,7 @@ case class GetMemPoolInfoResult(
     bytes: Int,
     usage: Int,
     maxmempool: Int,
-    mempoolminfee: BitcoinFeeUnit,
+    mempoolminfee: BitcoinFeeRate,
     minrelaytxfee: Bitcoins)
     extends BlockchainResult
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/BlockchainResult.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.rpc.jsonmodels
 
+import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.crypto.DoubleSha256DigestBE
 import org.bitcoins.core.currency.Bitcoins
+import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.core.wallet.fee.BitcoinFeeRate
-import org.bitcoins.core.config.NetworkParameters
-import org.bitcoins.core.gcs.GolombFilter
+import org.bitcoins.core.wallet.fee.BitcoinsPerKiloByte
 
 sealed abstract class BlockchainResult
 
@@ -200,10 +200,10 @@ case class GetMemPoolResultPostV19(
 }
 
 case class FeeInfo(
-    base: BitcoinFeeRate,
-    modified: BitcoinFeeRate,
-    ancestor: BitcoinFeeRate,
-    descendant: BitcoinFeeRate
+    base: BitcoinsPerKiloByte,
+    modified: BitcoinsPerKiloByte,
+    ancestor: BitcoinsPerKiloByte,
+    descendant: BitcoinsPerKiloByte
 )
 
 sealed trait GetMemPoolEntryResult extends BlockchainResult {
@@ -214,10 +214,10 @@ sealed trait GetMemPoolEntryResult extends BlockchainResult {
   def height: Int
   def descendantcount: Int
   def descendantsize: Int
-  def descendantfees: BitcoinFeeRate
+  def descendantfees: BitcoinsPerKiloByte
   def ancestorcount: Int
   def ancestorsize: Int
-  def ancestorfees: BitcoinFeeRate
+  def ancestorfees: BitcoinsPerKiloByte
   def wtxid: DoubleSha256DigestBE
   def fees: FeeInfo
   def depends: Option[Vector[DoubleSha256DigestBE]]
@@ -231,10 +231,10 @@ case class GetMemPoolEntryResultPreV19(
     height: Int,
     descendantcount: Int,
     descendantsize: Int,
-    descendantfees: BitcoinFeeRate,
+    descendantfees: BitcoinsPerKiloByte,
     ancestorcount: Int,
     ancestorsize: Int,
-    ancestorfees: BitcoinFeeRate,
+    ancestorfees: BitcoinsPerKiloByte,
     wtxid: DoubleSha256DigestBE,
     fees: FeeInfo,
     depends: Option[Vector[DoubleSha256DigestBE]])
@@ -249,10 +249,10 @@ case class GetMemPoolEntryResultPostV19(
     height: Int,
     descendantcount: Int,
     descendantsize: Int,
-    descendantfees: BitcoinFeeRate,
+    descendantfees: BitcoinsPerKiloByte,
     ancestorcount: Int,
     ancestorsize: Int,
-    ancestorfees: BitcoinFeeRate,
+    ancestorfees: BitcoinsPerKiloByte,
     wtxid: DoubleSha256DigestBE,
     fees: FeeInfo,
     depends: Option[Vector[DoubleSha256DigestBE]])
@@ -265,7 +265,7 @@ case class GetMemPoolInfoResult(
     bytes: Int,
     usage: Int,
     maxmempool: Int,
-    mempoolminfee: BitcoinFeeRate,
+    mempoolminfee: BitcoinsPerKiloByte,
     minrelaytxfee: Bitcoins)
     extends BlockchainResult
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/OtherResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/OtherResult.scala
@@ -13,7 +13,7 @@ import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.SeqWrapper
-import org.bitcoins.core.wallet.fee.BitcoinFeeRate
+import org.bitcoins.core.wallet.fee.BitcoinsPerKiloByte
 import play.api.libs.json.JsObject
 
 sealed abstract class OtherResult
@@ -149,7 +149,7 @@ case class ValidateAddressResultImpl(
     extends ValidateAddressResult
 
 case class EstimateSmartFeeResult(
-    feerate: Option[BitcoinFeeRate],
+    feerate: Option[BitcoinsPerKiloByte],
     errors: Option[Vector[String]],
     blocks: Int)
     extends OtherResult

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/OtherResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/OtherResult.scala
@@ -13,7 +13,7 @@ import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.SeqWrapper
-import org.bitcoins.core.wallet.fee.BitcoinFeeUnit
+import org.bitcoins.core.wallet.fee.BitcoinFeeRate
 import play.api.libs.json.JsObject
 
 sealed abstract class OtherResult
@@ -149,7 +149,7 @@ case class ValidateAddressResultImpl(
     extends ValidateAddressResult
 
 case class EstimateSmartFeeResult(
-    feerate: Option[BitcoinFeeUnit],
+    feerate: Option[BitcoinFeeRate],
     errors: Option[Vector[String]],
     blocks: Int)
     extends OtherResult

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/WalletResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/WalletResult.scala
@@ -16,7 +16,7 @@ import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.script.{ScriptPubKey, WitnessVersion}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.script.ScriptType
-import org.bitcoins.core.wallet.fee.BitcoinFeeUnit
+import org.bitcoins.core.wallet.fee.BitcoinFeeRate
 import org.bitcoins.rpc.client.common.RpcOpts.LabelPurpose
 
 sealed abstract class WalletResult
@@ -85,7 +85,7 @@ case class GetWalletInfoResult(
     keypoololdest: UInt32,
     keypoolsize: Int,
     keypoolsize_hd_internal: Int,
-    paytxfee: BitcoinFeeUnit,
+    paytxfee: BitcoinFeeRate,
     hdmasterkeyid: Option[Sha256Hash160Digest],
     unlocked_until: Option[Int])
     extends WalletResult

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/WalletResult.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/jsonmodels/WalletResult.scala
@@ -16,7 +16,7 @@ import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.script.{ScriptPubKey, WitnessVersion}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.script.ScriptType
-import org.bitcoins.core.wallet.fee.BitcoinFeeRate
+import org.bitcoins.core.wallet.fee.BitcoinsPerKiloByte
 import org.bitcoins.rpc.client.common.RpcOpts.LabelPurpose
 
 sealed abstract class WalletResult
@@ -85,7 +85,7 @@ case class GetWalletInfoResult(
     keypoololdest: UInt32,
     keypoolsize: Int,
     keypoolsize_hd_internal: Int,
-    paytxfee: BitcoinFeeRate,
+    paytxfee: BitcoinsPerKiloByte,
     hdmasterkeyid: Option[Sha256Hash160Digest],
     unlocked_until: Option[Int])
     extends WalletResult

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
@@ -532,7 +532,7 @@ object JsonReaders {
   implicit object BitcoinFeeUnitReads extends Reads[BitcoinFeeRate] {
     override def reads(json: JsValue): JsResult[BitcoinFeeRate] =
       SerializerUtil.processJsNumber[BitcoinFeeRate](num =>
-        SatoshisPerByte((num * 100000).toDouble))(json)
+        SatoshisPerByte(num * 100000.0))(json)
   }
 
   implicit object FileReads extends Reads[File] {

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
@@ -532,7 +532,7 @@ object JsonReaders {
   implicit object BitcoinFeeUnitReads extends Reads[BitcoinFeeUnit] {
     override def reads(json: JsValue): JsResult[BitcoinFeeUnit] =
       SerializerUtil.processJsNumber[BitcoinFeeUnit](num =>
-        SatoshisPerByte(Satoshis((num * 100000).toBigInt)))(json)
+        SatoshisPerByte((num * 100000).toDouble))(json)
   }
 
   implicit object FileReads extends Reads[File] {

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
@@ -25,7 +25,7 @@ import org.bitcoins.core.protocol.{
 }
 import org.bitcoins.core.script.ScriptType
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.wallet.fee.{BitcoinFeeRate, SatoshisPerByte}
+import org.bitcoins.core.wallet.fee.BitcoinsPerKiloByte
 import org.bitcoins.rpc.client.common.RpcOpts.LabelPurpose
 import org.bitcoins.rpc.jsonmodels._
 import org.bitcoins.rpc.serializers.JsonSerializers._
@@ -529,10 +529,10 @@ object JsonReaders {
   }
 
   // Currently takes in BTC/kB
-  implicit object BitcoinFeeUnitReads extends Reads[BitcoinFeeRate] {
-    override def reads(json: JsValue): JsResult[BitcoinFeeRate] =
-      SerializerUtil.processJsNumber[BitcoinFeeRate](num =>
-        SatoshisPerByte(num * 100000.0))(json)
+  implicit object BitcoinsPerKiloByteReads extends Reads[BitcoinsPerKiloByte] {
+    override def reads(json: JsValue): JsResult[BitcoinsPerKiloByte] =
+      SerializerUtil.processJsNumber[BitcoinsPerKiloByte](num =>
+        BitcoinsPerKiloByte(num))(json)
   }
 
   implicit object FileReads extends Reads[File] {

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonReaders.scala
@@ -25,7 +25,7 @@ import org.bitcoins.core.protocol.{
 }
 import org.bitcoins.core.script.ScriptType
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.wallet.fee.{BitcoinFeeUnit, SatoshisPerByte}
+import org.bitcoins.core.wallet.fee.{BitcoinFeeRate, SatoshisPerByte}
 import org.bitcoins.rpc.client.common.RpcOpts.LabelPurpose
 import org.bitcoins.rpc.jsonmodels._
 import org.bitcoins.rpc.serializers.JsonSerializers._
@@ -529,9 +529,9 @@ object JsonReaders {
   }
 
   // Currently takes in BTC/kB
-  implicit object BitcoinFeeUnitReads extends Reads[BitcoinFeeUnit] {
-    override def reads(json: JsValue): JsResult[BitcoinFeeUnit] =
-      SerializerUtil.processJsNumber[BitcoinFeeUnit](num =>
+  implicit object BitcoinFeeUnitReads extends Reads[BitcoinFeeRate] {
+    override def reads(json: JsValue): JsResult[BitcoinFeeRate] =
+      SerializerUtil.processJsNumber[BitcoinFeeRate](num =>
         SatoshisPerByte((num * 100000).toDouble))(json)
   }
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
@@ -153,7 +153,7 @@ object JsonSerializers {
 
       def reads(json: JsValue): JsResult[SatoshisPerKiloByte] =
         SerializerUtil.processJsNumber(num =>
-          SatoshisPerKiloByte(Satoshis(num.toBigInt)))(json)
+          SatoshisPerKiloByte(num.toDouble))(json)
     }
 
   implicit val peerNetworkInfoReads: Reads[PeerNetworkInfo] =

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
@@ -2,6 +2,7 @@ package org.bitcoins.rpc.serializers
 
 import java.io.File
 import java.net.{InetAddress, URI}
+import java.time.LocalDateTime
 
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
@@ -21,12 +22,11 @@ import org.bitcoins.core.protocol.{
   P2SHAddress
 }
 import org.bitcoins.core.script.ScriptType
-import org.bitcoins.core.wallet.fee.{BitcoinFeeRate, SatoshisPerKiloByte}
+import org.bitcoins.core.wallet.fee.{BitcoinsPerKiloByte, SatoshisPerKiloByte}
 import org.bitcoins.rpc.client.common.RpcOpts.AddressType
 import org.bitcoins.rpc.jsonmodels._
 import org.bitcoins.rpc.serializers.JsonReaders._
 import org.bitcoins.rpc.serializers.JsonWriters._
-import java.time.LocalDateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
@@ -69,7 +69,8 @@ object JsonSerializers {
   implicit val transactionReads: Reads[Transaction] = TransactionReads
   implicit val transactionOutPointReads: Reads[TransactionOutPoint] =
     TransactionOutPointReads
-  implicit val bitcoinFeeUnitReads: Reads[BitcoinFeeRate] = BitcoinFeeUnitReads
+  implicit val bitcoinsPerKiloByteReads: Reads[BitcoinsPerKiloByte] =
+    BitcoinsPerKiloByteReads
   implicit val fileReads: Reads[File] = FileReads
   implicit val uRIReads: Reads[URI] = URIReads
   implicit val scriptSignatureReads: Reads[ScriptSignature] =

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
@@ -152,8 +152,7 @@ object JsonSerializers {
     new Reads[SatoshisPerKiloByte] {
 
       def reads(json: JsValue): JsResult[SatoshisPerKiloByte] =
-        SerializerUtil.processJsNumber(num =>
-          SatoshisPerKiloByte(num.toDouble))(json)
+        SerializerUtil.processJsNumber(num => SatoshisPerKiloByte(num))(json)
     }
 
   implicit val peerNetworkInfoReads: Reads[PeerNetworkInfo] =

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/serializers/JsonSerializers.scala
@@ -21,7 +21,7 @@ import org.bitcoins.core.protocol.{
   P2SHAddress
 }
 import org.bitcoins.core.script.ScriptType
-import org.bitcoins.core.wallet.fee.{BitcoinFeeUnit, SatoshisPerKiloByte}
+import org.bitcoins.core.wallet.fee.{BitcoinFeeRate, SatoshisPerKiloByte}
 import org.bitcoins.rpc.client.common.RpcOpts.AddressType
 import org.bitcoins.rpc.jsonmodels._
 import org.bitcoins.rpc.serializers.JsonReaders._
@@ -69,7 +69,7 @@ object JsonSerializers {
   implicit val transactionReads: Reads[Transaction] = TransactionReads
   implicit val transactionOutPointReads: Reads[TransactionOutPoint] =
     TransactionOutPointReads
-  implicit val bitcoinFeeUnitReads: Reads[BitcoinFeeUnit] = BitcoinFeeUnitReads
+  implicit val bitcoinFeeUnitReads: Reads[BitcoinFeeRate] = BitcoinFeeUnitReads
   implicit val fileReads: Reads[File] = FileReads
   implicit val uRIReads: Reads[URI] = URIReads
   implicit val scriptSignatureReads: Reads[ScriptSignature] =

--- a/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTTest.scala
@@ -170,7 +170,7 @@ class PSBTTest extends BitcoinSAsyncTest {
           creditingTxsInfo.foldLeft(0L)(_ + _.amount.satoshis.toLong)
         val spending = destinations.foldLeft(0L)(_ + _.value.satoshis.toLong)
         val maxFee = crediting - spending
-        val fee = GenUtil.sample(CurrencyUnitGenerator.feeUnit(maxFee))
+        val fee = GenUtil.sample(CurrencyUnitGenerator.feeRate(maxFee))
         for {
           (psbt, _) <- PSBTGenerators.psbtAndBuilderFromInputs(
             finalized = false,

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -60,14 +60,14 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     val listF =
       BitcoinTxBuilder(destinations = Vector.empty,
                        utxos = List(utxo),
-                       feeRate = SatoshisPerByte(1.sat),
+                       feeRate = SatoshisPerByte(1),
                        changeSPK = EmptyScriptPubKey,
                        network = RegTest)
 
     val vecF =
       BitcoinTxBuilder(destinations = Vector.empty,
                        utxos = List(utxo),
-                       feeRate = SatoshisPerByte(1.sat),
+                       feeRate = SatoshisPerByte(1),
                        changeSPK = EmptyScriptPubKey,
                        network = RegTest)
 
@@ -98,7 +98,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
       conditionalPath = ConditionalPath.NoConditionsLeft
     )
     val utxoMap: UTXOMap = Map(outPoint -> utxo)
-    val feeUnit = SatoshisPerVirtualByte(Satoshis.one)
+    val feeUnit = SatoshisPerVirtualByte.one
     val txBuilder = BitcoinTxBuilder(destinations = destinations,
                                      utxos = utxoMap,
                                      feeRate = feeUnit,
@@ -129,7 +129,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
       conditionalPath = ConditionalPath.NoConditionsLeft
     )
     val utxoMap: UTXOMap = Map(outPoint -> utxo)
-    val feeUnit = SatoshisPerVirtualByte(Satoshis(-1))
+    val feeUnit = SatoshisPerVirtualByte(-1)
     val txBuilder = BitcoinTxBuilder(destinations = destinations,
                                      utxos = utxoMap,
                                      feeRate = feeUnit,
@@ -158,7 +158,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
                                            conditionalPath =
                                              ConditionalPath.NoConditionsLeft)
     val utxoMap: UTXOMap = Map(outPoint -> utxo)
-    val feeUnit = SatoshisPerVirtualByte(currencyUnit = Satoshis(1))
+    val feeUnit = SatoshisPerVirtualByte.one
     val txBuilder = BitcoinTxBuilder(destinations = destinations,
                                      utxos = utxoMap,
                                      feeRate = feeUnit,
@@ -205,7 +205,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
       conditionalPath = ConditionalPath.NoConditionsLeft
     )
 
-    val feeUnit = SatoshisPerVirtualByte(Satoshis.one)
+    val feeUnit = SatoshisPerVirtualByte.one
     val txBuilderMap = BitcoinTxBuilder(destinations = destinations,
                                         utxos = utxoMap,
                                         feeRate = feeUnit,
@@ -287,7 +287,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     )
     val utxoMap: UTXOMap = Map(outPoint -> utxo)
 
-    val feeUnit = SatoshisPerVirtualByte(Satoshis.one)
+    val feeUnit = SatoshisPerVirtualByte.one
     val txBuilderWitness = BitcoinTxBuilder(destinations,
                                             utxoMap,
                                             feeUnit,
@@ -321,7 +321,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     )
     val utxoMap: UTXOMap = Map(outPoint -> utxo)
 
-    val feeUnit = SatoshisPerVirtualByte(Satoshis.one)
+    val feeUnit = SatoshisPerVirtualByte.one
     val txBuilderWitness = BitcoinTxBuilder(destinations = destinations,
                                             utxos = utxoMap,
                                             feeRate = feeUnit,
@@ -401,7 +401,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
           TransactionOutput(Bitcoins.one - CurrencyUnits.oneMBTC,
                             EmptyScriptPubKey)),
         Vector(cltvSpendingInfo),
-        SatoshisPerByte(Satoshis.one),
+        SatoshisPerByte(1),
         EmptyScriptPubKey,
         RegTest
       )
@@ -435,7 +435,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
           TransactionOutput(Bitcoins.one - CurrencyUnits.oneMBTC,
                             EmptyScriptPubKey)),
         Vector(cltvSpendingInfo),
-        SatoshisPerByte(Satoshis.one),
+        SatoshisPerByte(1),
         EmptyScriptPubKey,
         RegTest
       )
@@ -483,7 +483,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
           TransactionOutput(Bitcoins.one + Bitcoins.one - CurrencyUnits.oneMBTC,
                             EmptyScriptPubKey)),
         Vector(cltvSpendingInfo1, cltvSpendingInfo2),
-        SatoshisPerByte(Satoshis.one),
+        SatoshisPerByte(1),
         EmptyScriptPubKey,
         RegTest
       )
@@ -556,7 +556,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
                 ScriptGenerators.scriptPubKey,
                 ChainParamsGenerator.bitcoinNetworkParams) {
       case ((creditingTxsInfo, destinations), changeSPK, network) =>
-        val fee = SatoshisPerVirtualByte(Satoshis(1000))
+        val fee = SatoshisPerVirtualByte(1000)
         val builder = BitcoinTxBuilder(destinations,
                                        creditingTxsInfo,
                                        fee,
@@ -575,7 +575,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
                 ScriptGenerators.scriptPubKey,
                 ChainParamsGenerator.bitcoinNetworkParams) {
       case ((creditingTxsInfo, destinations), changeSPK, network) =>
-        val fee = SatoshisPerByte(Satoshis(1000))
+        val fee = SatoshisPerByte(1000)
         val builder = BitcoinTxBuilder(destinations,
                                        creditingTxsInfo,
                                        fee,

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/BitcoinTxBuilderTest.scala
@@ -60,14 +60,14 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
     val listF =
       BitcoinTxBuilder(destinations = Vector.empty,
                        utxos = List(utxo),
-                       feeRate = SatoshisPerByte(1),
+                       feeRate = SatoshisPerByte.one,
                        changeSPK = EmptyScriptPubKey,
                        network = RegTest)
 
     val vecF =
       BitcoinTxBuilder(destinations = Vector.empty,
                        utxos = List(utxo),
-                       feeRate = SatoshisPerByte(1),
+                       feeRate = SatoshisPerByte.one,
                        changeSPK = EmptyScriptPubKey,
                        network = RegTest)
 
@@ -401,7 +401,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
           TransactionOutput(Bitcoins.one - CurrencyUnits.oneMBTC,
                             EmptyScriptPubKey)),
         Vector(cltvSpendingInfo),
-        SatoshisPerByte(1),
+        SatoshisPerByte.one,
         EmptyScriptPubKey,
         RegTest
       )
@@ -435,7 +435,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
           TransactionOutput(Bitcoins.one - CurrencyUnits.oneMBTC,
                             EmptyScriptPubKey)),
         Vector(cltvSpendingInfo),
-        SatoshisPerByte(1),
+        SatoshisPerByte.one,
         EmptyScriptPubKey,
         RegTest
       )
@@ -483,7 +483,7 @@ class BitcoinTxBuilderTest extends BitcoinSAsyncTest {
           TransactionOutput(Bitcoins.one + Bitcoins.one - CurrencyUnits.oneMBTC,
                             EmptyScriptPubKey)),
         Vector(cltvSpendingInfo1, cltvSpendingInfo2),
-        SatoshisPerByte(1),
+        SatoshisPerByte.one,
         EmptyScriptPubKey,
         RegTest
       )

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/TxBuilderTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/TxBuilderTest.scala
@@ -10,7 +10,7 @@ class TxBuilderTest extends BitcoinSUnitTest {
   "TxBuilder" must "detect a bad fee on the tx" in {
     val estimatedFee = 1000.sats
     val actualFee = 1.sat
-    val feeRate = SatoshisPerVirtualByte(1.sat)
+    val feeRate = SatoshisPerVirtualByte.one
     TxBuilder
       .isValidFeeRange(estimatedFee, actualFee, feeRate)
       .isFailure must be(true)

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeRateTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeRateTest.scala
@@ -56,4 +56,26 @@ class FeeRateTest extends BitcoinSUnitTest {
 
     assert(satoshisPerByte.calc(wtx) != satoshisPerVByte.calc(wtx))
   }
+
+  it must "fail to calculate a fee greater than a the max value for SatoshisPerByte" in {
+    val feeRate = SatoshisPerByte(Satoshis.max.toDouble)
+
+    assertThrows[IllegalArgumentException](feeRate.calc(tx))
+  }
+
+  it must "fail to calculate a fee greater than a the max value for SatoshisPerVirtualByte" in {
+    val feeRate = SatoshisPerVirtualByte(Satoshis.max.toDouble)
+
+    assertThrows[IllegalArgumentException](feeRate.calc(tx))
+  }
+
+  it must "fail to calculate a fee greater than a the max value for SatoshisPerKiloByte" in {
+    val feeRate = SatoshisPerKiloByte(Satoshis.max.toDouble)
+
+    assertThrows[IllegalArgumentException](feeRate.calc(tx))
+  }
+
+  it must "fail to calculate a fee greater than a the max value for FlatSatoshis" in {
+    assertThrows[IllegalArgumentException](FlatSatoshis(Satoshis.max.toLong))
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeRateTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeRateTest.scala
@@ -25,6 +25,12 @@ class FeeRateTest extends BitcoinSUnitTest {
     assert(feeRate.calc(tx) == Satoshis(606))
   }
 
+  it must "calculate the correct fee with a BitcoinsPerKiloByte fee rate" in {
+    val feeRate = BitcoinsPerKiloByte(0.000037)
+
+    assert(feeRate.calc(tx) == Satoshis(503))
+  }
+
   it must "calculate the correct fee with a SatoshisPerKiloByte fee rate" in {
     val feeRate = SatoshisPerKiloByte(3700)
 
@@ -57,15 +63,49 @@ class FeeRateTest extends BitcoinSUnitTest {
     assert(satoshisPerByte.calc(wtx) != satoshisPerVByte.calc(wtx))
   }
 
+  it must "correctly convert SatoshisPerByte to SatoshisPerKiloByte" in {
+    val satoshisPerByte = SatoshisPerByte(3.7)
+
+    assert(satoshisPerByte.toSatPerKb == SatoshisPerKiloByte(3700))
+  }
+
+  it must "correctly convert SatoshisPerByte to BitcoinsPerKiloByte" in {
+    val satoshisPerByte = SatoshisPerByte(3.7)
+
+    assert(satoshisPerByte.toBTCPerKb == BitcoinsPerKiloByte(0.000037))
+  }
+
+  it must "correctly convert SatoshisPerKiloByte to SatoshisPerByte" in {
+    val satPerKb = SatoshisPerKiloByte(3700)
+
+    assert(satPerKb.toSatPerByte == SatoshisPerByte(3.7))
+  }
+
+  it must "correctly convert BitcoinsPerKiloByte to SatoshisPerByte" in {
+    val btcPerKb = BitcoinsPerKiloByte(0.000037)
+
+    assert(btcPerKb.toSatPerByte == SatoshisPerByte(3.7))
+  }
+
+  it must "correctly convert SatoshisPerKiloByte to BitcoinsPerKiloByte" in {
+    val satPerKb = SatoshisPerKiloByte(3700)
+    val btcPerKb = BitcoinsPerKiloByte(0.000037)
+
+    assert(satPerKb.toBTCPerKb == btcPerKb)
+    assert(btcPerKb.toSatPerKb == satPerKb)
+  }
+
   it must "correctly calculate the correct fee rate for a transaction" in {
     val inputAmount = Bitcoins(32.96382044)
     val satsPerByte = SatoshisPerByte.calc(tx, inputAmount)
     val satsPerVByte = SatoshisPerVirtualByte.calc(tx, inputAmount)
     val satsPerKByte = SatoshisPerKiloByte.calc(tx, inputAmount)
+    val btcPerKByte = BitcoinsPerKiloByte.calc(tx, inputAmount)
 
     assert(satsPerByte == SatoshisPerByte(8424.235294117647))
     assert(satsPerVByte == SatoshisPerVirtualByte(6985.951219512195))
     assert(satsPerKByte == SatoshisPerKiloByte(8.424235294117647))
+    assert(btcPerKByte == BitcoinsPerKiloByte(0.00000008424235294117647))
   }
 
   it must "fail to calculate a fee greater than a the max value for SatoshisPerByte" in {
@@ -82,6 +122,12 @@ class FeeRateTest extends BitcoinSUnitTest {
 
   it must "fail to calculate a fee greater than a the max value for SatoshisPerKiloByte" in {
     val feeRate = SatoshisPerKiloByte(Satoshis.max.toDouble)
+
+    assertThrows[IllegalArgumentException](feeRate.calc(tx))
+  }
+
+  it must "fail to calculate a fee greater than a the max value for BitcoinsPerKiloByte" in {
+    val feeRate = BitcoinsPerKiloByte(Satoshis.max.toDouble)
 
     assertThrows[IllegalArgumentException](feeRate.calc(tx))
   }

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeRateTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeRateTest.scala
@@ -1,0 +1,59 @@
+package org.bitcoins.core.wallet.fee
+
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.core.protocol.transaction.{
+  BaseTransaction,
+  Transaction,
+  WitnessTransaction
+}
+
+class FeeRateTest extends BitcoinSUnitTest {
+
+  val tx: Transaction = Transaction(
+    "02000000000101a2619b5d58b209439c937e563018efcf174063ca011e4f177a5b14e5ba76211c0100000017160014614e9b96cbc7477eda98f0936385ded6b636f74efeffffff024e3f57c4000000001600147cf00288c2c1b3c5cdf275db532a1c15c514bb2fae1112000000000016001440efb02597b9e9d9bc968f12cec3347e2e264c570247304402205768c2ac8178539fd44721e2a7541bedd6b55654f095143514624203c133f7e8022060d51f33fc2b5c1f51f26c7f703de21be6246dbb5fb7e1c6919aae6d442610c6012102b99a63f166ef53ca67a5c55ae969e80c33456e07189f8457e3438f000be42c19307d1900")
+
+  it must "calculate the correct fee with a SatoshisPerByte fee rate" in {
+    val feeRate = SatoshisPerByte(3.7)
+
+    assert(feeRate.calc(tx) == Satoshis(503))
+  }
+
+  it must "calculate the correct fee with a SatoshisPerVirtualByte fee rate" in {
+    val feeRate = SatoshisPerVirtualByte(3.7)
+
+    assert(feeRate.calc(tx) == Satoshis(606))
+  }
+
+  it must "calculate the correct fee with a SatoshisPerKiloByte fee rate" in {
+    val feeRate = SatoshisPerKiloByte(3700)
+
+    assert(feeRate.calc(tx) == Satoshis(503))
+  }
+
+  it must "calculate the correct fee with a FlatSatoshis fee rate" in {
+    val feeRate = FlatSatoshis(500)
+
+    assert(feeRate.calc(tx) == Satoshis(500))
+  }
+
+  it must "have symmetry for SatoshisPerByte and SatoshisPerVirtualByte with BaseTransactions" in {
+    val baseTx = BaseTransaction(
+      "020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000")
+
+    val satoshisPerByte = SatoshisPerByte(3.7)
+    val satoshisPerVByte = SatoshisPerVirtualByte(3.7)
+
+    assert(satoshisPerByte.calc(baseTx) == satoshisPerVByte.calc(baseTx))
+  }
+
+  it must "have NOT symmetry for SatoshisPerByte and SatoshisPerVirtualByte with WitnessTransactions" in {
+    val wtx = WitnessTransaction(
+      "02000000000101a2619b5d58b209439c937e563018efcf174063ca011e4f177a5b14e5ba76211c0100000017160014614e9b96cbc7477eda98f0936385ded6b636f74efeffffff024e3f57c4000000001600147cf00288c2c1b3c5cdf275db532a1c15c514bb2fae1112000000000016001440efb02597b9e9d9bc968f12cec3347e2e264c570247304402205768c2ac8178539fd44721e2a7541bedd6b55654f095143514624203c133f7e8022060d51f33fc2b5c1f51f26c7f703de21be6246dbb5fb7e1c6919aae6d442610c6012102b99a63f166ef53ca67a5c55ae969e80c33456e07189f8457e3438f000be42c19307d1900")
+
+    val satoshisPerByte = SatoshisPerByte(3.7)
+    val satoshisPerVByte = SatoshisPerVirtualByte(3.7)
+
+    assert(satoshisPerByte.calc(wtx) != satoshisPerVByte.calc(wtx))
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeRateTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeRateTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.wallet.fee
 
-import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 import org.bitcoins.core.protocol.transaction.{
   BaseTransaction,
@@ -55,6 +55,17 @@ class FeeRateTest extends BitcoinSUnitTest {
     val satoshisPerVByte = SatoshisPerVirtualByte(3.7)
 
     assert(satoshisPerByte.calc(wtx) != satoshisPerVByte.calc(wtx))
+  }
+
+  it must "correctly calculate the correct fee rate for a transaction" in {
+    val inputAmount = Bitcoins(32.96382044)
+    val satsPerByte = SatoshisPerByte.calc(tx, inputAmount)
+    val satsPerVByte = SatoshisPerVirtualByte.calc(tx, inputAmount)
+    val satsPerKByte = SatoshisPerKiloByte.calc(tx, inputAmount)
+
+    assert(satsPerByte == SatoshisPerByte(8424.235294117647))
+    assert(satsPerVByte == SatoshisPerVirtualByte(6985.951219512195))
+    assert(satsPerKByte == SatoshisPerKiloByte(8.424235294117647))
   }
 
   it must "fail to calculate a fee greater than a the max value for SatoshisPerByte" in {

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeUnitTest.scala
@@ -16,6 +16,10 @@ class FeeUnitTest extends BitcoinSUnitTest {
     assert(SatoshisPerKiloByte.one.units == FeeUnit.PerKiloByte)
   }
 
+  "BitcoinsPerKiloByte" must "have the correct FeeUnit" in {
+    assert(BitcoinsPerKiloByte.one.units == FeeUnit.PerKiloByte)
+  }
+
   "FlatSatoshis" must "have the correct FeeUnit" in {
     assert(FlatSatoshis(1000).units == FeeUnit.Flat)
   }

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeUnitTest.scala
@@ -1,0 +1,22 @@
+package org.bitcoins.core.wallet.fee
+
+import org.bitcoins.testkit.util.BitcoinSUnitTest
+
+class FeeUnitTest extends BitcoinSUnitTest {
+
+  "SatoshisPerByte" must "have the correct FeeUnit" in {
+    assert(SatoshisPerByte.one.units == FeeUnit.PerByte)
+  }
+
+  "SatoshisPerVirtualByte" must "have the correct FeeUnit" in {
+    assert(SatoshisPerVirtualByte.one.units == FeeUnit.PerVirtualByte)
+  }
+
+  "SatoshisPerKiloByte" must "have the correct FeeUnit" in {
+    assert(SatoshisPerKiloByte.one.units == FeeUnit.PerKiloByte)
+  }
+
+  "FlatSatoshis" must "have the correct FeeUnit" in {
+    assert(FlatSatoshis(1000).units == FeeUnit.Flat)
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -87,7 +87,7 @@ class SignerTest extends BitcoinSAsyncTest {
                 ScriptGenerators.scriptPubKey,
                 ChainParamsGenerator.bitcoinNetworkParams) {
       case ((creditingTxsInfos, destinations), changeSPK, network) =>
-        val fee = SatoshisPerVirtualByte(Satoshis(1000))
+        val fee = SatoshisPerVirtualByte(1000)
 
         for {
           builder <- BitcoinTxBuilder(destinations,

--- a/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -116,6 +116,8 @@ sealed abstract class Satoshis extends CurrencyUnit {
 
   def toLong: Long = underlying.toLong
 
+  def toDouble: Double = toLong.toDouble
+
   def ==(satoshis: Satoshis): Boolean = underlying == satoshis.underlying
 }
 

--- a/core/src/main/scala/org/bitcoins/core/currency/package.scala
+++ b/core/src/main/scala/org/bitcoins/core/currency/package.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.core
 
 import scala.math.Ordering
+import scala.util.{Failure, Success, Try}
 
 // We extend AnyVal to avoid runtime allocation of new
 // objects. See the Scala documentation on value classes
@@ -41,5 +42,42 @@ package object currency {
   implicit val currencyUnitOrdering: Ordering[CurrencyUnit] =
     new Ordering[CurrencyUnit] {
       override def compare(x: CurrencyUnit, y: CurrencyUnit): Int = x.compare(y)
+    }
+
+  implicit val currencyUnitNumeric: Numeric[CurrencyUnit] =
+    new Numeric[CurrencyUnit] {
+      override def plus(x: CurrencyUnit, y: CurrencyUnit): CurrencyUnit = x + y
+
+      override def minus(x: CurrencyUnit, y: CurrencyUnit): CurrencyUnit = x - y
+
+      override def times(x: CurrencyUnit, y: CurrencyUnit): CurrencyUnit = x * y
+
+      override def negate(x: CurrencyUnit): CurrencyUnit = -x
+
+      override def fromInt(x: Int): CurrencyUnit = Satoshis(x.toLong)
+
+      override def toInt(x: CurrencyUnit): Int = x.satoshis.toLong.toInt
+
+      override def toLong(x: CurrencyUnit): Long = x.satoshis.toLong
+
+      override def toFloat(x: CurrencyUnit): Float = x.satoshis.toBigInt.toFloat
+
+      override def toDouble(x: CurrencyUnit): Double =
+        x.satoshis.toBigInt.toDouble
+
+      override def compare(x: CurrencyUnit, y: CurrencyUnit): Int =
+        x.satoshis compare y.satoshis
+
+      // Cannot use the override modifier because this method was added in scala version 2.13
+      def parseString(str: String): Option[CurrencyUnit] = {
+        if (str.isEmpty) {
+          None
+        } else {
+          Try(str.toLong) match {
+            case Success(num) => Some(Satoshis(num))
+            case Failure(_)   => None
+          }
+        }
+      }
     }
 }

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawFeeFilterMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawFeeFilterMessageSerializer.scala
@@ -12,12 +12,13 @@ sealed abstract class RawFeeFilterMessageSerializer
   override def read(bytes: ByteVector): FeeFilterMessage = {
     val satBytes = bytes.take(8).reverse
     val sat = Satoshis(satBytes)
-    val satPerKb = SatoshisPerKiloByte(sat)
+    val satPerKb = SatoshisPerKiloByte(sat.toDouble)
     FeeFilterMessage(satPerKb)
   }
 
   override def write(feeFilterMessage: FeeFilterMessage): ByteVector = {
-    feeFilterMessage.feeRate.currencyUnit.satoshis.bytes.reverse
+    val sats = Satoshis(feeFilterMessage.feeRate.sats.toLong)
+    sats.bytes.reverse
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -17,7 +17,7 @@ import org.bitcoins.core.script.control.OP_RETURN
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.script.locktime.LockTimeInterpreter
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.fee.FeeRate
 import org.bitcoins.core.wallet.signer._
 import org.bitcoins.core.wallet.utxo.{
   BitcoinUTXOSpendingInfoFull,
@@ -87,9 +87,9 @@ sealed abstract class TxBuilder {
 
   def utxos: Seq[UTXOSpendingInfoFull] = utxoMap.values.toSeq
 
-  /** This represents the rate, in [[org.bitcoins.core.wallet.fee.FeeUnit FeeUnit]], we
+  /** This represents the rate, in [[org.bitcoins.core.wallet.fee.FeeRate FeeRate]], we
     * should pay for this transaction */
-  def feeRate: FeeUnit
+  def feeRate: FeeRate
 
   /**
     * This is where all the money that is NOT sent to destination outputs is spent too.
@@ -607,7 +607,7 @@ object TxBuilder {
   def isValidFeeRange(
       estimatedFee: CurrencyUnit,
       actualFee: CurrencyUnit,
-      feeRate: FeeUnit): Try[Unit] = {
+      feeRate: FeeRate): Try[Unit] = {
 
     //what the number '40' represents is the allowed variance -- in bytes -- between the size of the two
     //versions of signed tx. I believe the two signed version can vary in size because the digital
@@ -647,7 +647,7 @@ object BitcoinTxBuilder {
   private case class BitcoinTxBuilderImpl(
       destinations: Seq[TransactionOutput],
       utxoMap: UTXOMap,
-      feeRate: FeeUnit,
+      feeRate: FeeRate,
       changeSPK: ScriptPubKey,
       network: BitcoinNetwork)
       extends BitcoinTxBuilder
@@ -665,7 +665,7 @@ object BitcoinTxBuilder {
   def apply(
       destinations: Seq[TransactionOutput],
       utxos: BitcoinTxBuilder.UTXOMap,
-      feeRate: FeeUnit,
+      feeRate: FeeRate,
       changeSPK: ScriptPubKey,
       network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
     if (feeRate.baseAmount <= 0) {
@@ -679,7 +679,7 @@ object BitcoinTxBuilder {
   def apply(
       destinations: Seq[TransactionOutput],
       utxos: Seq[BitcoinUTXOSpendingInfoFull],
-      feeRate: FeeUnit,
+      feeRate: FeeRate,
       changeSPK: ScriptPubKey,
       network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
     @tailrec

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/TxBuilder.scala
@@ -622,9 +622,9 @@ object TxBuilder {
     //See this link for more info on variance in size on ECDigitalSignatures
     //https://en.bitcoin.it/wiki/Elliptic_Curve_Digital_Signature_Algorithm
 
-    val acceptableVariance = 40 * feeRate.toLong
-    val min = Satoshis(-acceptableVariance)
-    val max = Satoshis(acceptableVariance)
+    val acceptableVariance = 40 * feeRate.baseAmount
+    val min = Satoshis(-acceptableVariance.toLong)
+    val max = Satoshis(acceptableVariance.toLong)
     val difference = estimatedFee - actualFee
     if (difference <= min) {
       logger.error(
@@ -668,7 +668,7 @@ object BitcoinTxBuilder {
       feeRate: FeeUnit,
       changeSPK: ScriptPubKey,
       network: BitcoinNetwork): Future[BitcoinTxBuilder] = {
-    if (feeRate.toLong <= 0) {
+    if (feeRate.baseAmount <= 0) {
       Future.fromTry(TxBuilderError.LowFee)
     } else {
       Future.successful(

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.wallet.fee
 
+import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.protocol.transaction.Transaction
 
@@ -27,7 +28,7 @@ sealed abstract class BitcoinFeeRate extends FeeRate {
     val fee = tx.baseSize * baseAmount
 
     require(fee >= 0, "Fee cannot be negative")
-    require(fee < Satoshis.max.toDouble,
+    require(fee < Consensus.maxMoney.satoshis.toDouble,
             "Fee cannot be greater than the max value")
 
     Satoshis(fee.toLong)
@@ -83,8 +84,7 @@ case class SatoshisPerVirtualByte(sats: Double) extends BitcoinFeeRate {
   override def calc(tx: Transaction): CurrencyUnit = {
     val fee = tx.vsize * baseAmount
 
-    require(fee >= 0, "Fee cannot be negative")
-    require(fee < Satoshis.max.toDouble,
+    require(fee < Consensus.maxMoney.satoshis.toDouble,
             "Fee cannot be greater than the max value")
 
     Satoshis(fee.toLong)
@@ -105,6 +105,9 @@ object SatoshisPerVirtualByte {
 /** Represents how many satoshis to be paid for the transaction fee */
 case class FlatSatoshis(satoshis: Long) extends BitcoinFeeRate {
   override def sats: Double = satoshis.toDouble
+
+  require(satoshis <= Consensus.maxMoney.satoshis.toDouble,
+          "Fee cannot be greater than the max value")
 
   def currencyUnit: Satoshis = Satoshis(satoshis)
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
@@ -49,6 +49,13 @@ object SatoshisPerByte {
 
   def apply(sats: BigDecimal): SatoshisPerByte = SatoshisPerByte(sats.toDouble)
 
+  def calc(tx: Transaction, inputAmount: CurrencyUnit): SatoshisPerByte = {
+    val feePaid = inputAmount - tx.outputs.map(_.value).sum
+    val feeRate = feePaid.satoshis.toLong / tx.baseSize.toDouble
+
+    SatoshisPerByte(feeRate)
+  }
+
   val zero: SatoshisPerByte = SatoshisPerByte(0)
   val one: SatoshisPerByte = SatoshisPerByte(1)
 }
@@ -69,6 +76,13 @@ object SatoshisPerKiloByte {
 
   def apply(sats: BigDecimal): SatoshisPerKiloByte =
     SatoshisPerKiloByte(sats.toDouble)
+
+  def calc(tx: Transaction, inputAmount: CurrencyUnit): SatoshisPerKiloByte = {
+    val feePaid = inputAmount - tx.outputs.map(_.value).sum
+    val feeRate = feePaid.satoshis.toLong / tx.baseSize.toDouble
+
+    SatoshisPerKiloByte(feeRate * 0.001)
+  }
 
   val zero: SatoshisPerKiloByte = SatoshisPerKiloByte(0)
   val one: SatoshisPerKiloByte = SatoshisPerKiloByte(1)
@@ -97,6 +111,15 @@ object SatoshisPerVirtualByte {
 
   def apply(sats: BigDecimal): SatoshisPerVirtualByte =
     SatoshisPerVirtualByte(sats.toDouble)
+
+  def calc(
+      tx: Transaction,
+      inputAmount: CurrencyUnit): SatoshisPerVirtualByte = {
+    val feePaid = inputAmount - tx.outputs.map(_.value).sum
+    val feeRate = feePaid.satoshis.toLong / tx.vsize.toDouble
+
+    SatoshisPerVirtualByte(feeRate)
+  }
 
   val zero: SatoshisPerVirtualByte = SatoshisPerVirtualByte(0)
   val one: SatoshisPerVirtualByte = SatoshisPerVirtualByte(1)

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
@@ -13,7 +13,6 @@ sealed abstract class FeeRate {
   def units: FeeUnit
   def baseAmount: Double
 
-  require(baseAmount >= 0, "FeeRate cannot be negative")
 }
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
@@ -1,7 +1,12 @@
 package org.bitcoins.core.wallet.fee
 
 import org.bitcoins.core.consensus.Consensus
-import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.currency.{
+  Bitcoins,
+  CurrencyUnit,
+  CurrencyUnits,
+  Satoshis
+}
 import org.bitcoins.core.protocol.transaction.Transaction
 
 /**
@@ -82,6 +87,36 @@ object SatoshisPerKiloByte {
     val feeRate = feePaid.satoshis.toLong / tx.baseSize.toDouble
 
     SatoshisPerKiloByte(feeRate * 0.001)
+  }
+
+  val zero: SatoshisPerKiloByte = SatoshisPerKiloByte(0)
+  val one: SatoshisPerKiloByte = SatoshisPerKiloByte(1)
+}
+
+/** Represents how satoshis per kilobyte of the transaction fee */
+case class BitcoinsPerKiloByte(btc: Double) extends BitcoinFeeRate {
+
+  override def baseAmount: Double = sats * 0.001
+
+  override def sats: Double = btc * CurrencyUnits.btcToSatoshiScalar
+
+  def toSatPerByte: SatoshisPerByte = {
+    SatoshisPerByte(baseAmount)
+  }
+
+  override def units: FeeUnit = FeeUnit.PerKiloByte
+}
+
+object BitcoinsPerKiloByte {
+
+  def apply(sats: BigDecimal): BitcoinsPerKiloByte =
+    BitcoinsPerKiloByte(sats.toDouble)
+
+  def calc(tx: Transaction, inputAmount: CurrencyUnit): BitcoinsPerKiloByte = {
+    val feePaid = inputAmount - tx.outputs.map(_.value).sum
+    val feeRate = Bitcoins(feePaid.satoshis).toBigDecimal / tx.baseSize.toDouble
+
+    BitcoinsPerKiloByte(feeRate * 0.001)
   }
 
   val zero: SatoshisPerKiloByte = SatoshisPerKiloByte(0)

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
@@ -47,6 +47,10 @@ case class SatoshisPerByte(sats: Double) extends BitcoinFeeRate {
     SatoshisPerKiloByte(sats * 1000)
   }
 
+  def toBTCPerKb: BitcoinsPerKiloByte = {
+    BitcoinsPerKiloByte(sats * 1000 * CurrencyUnits.satoshisToBTCScalar)
+  }
+
   override def units: FeeUnit = FeeUnit.PerByte
 }
 
@@ -72,6 +76,10 @@ case class SatoshisPerKiloByte(sats: Double) extends BitcoinFeeRate {
 
   def toSatPerByte: SatoshisPerByte = {
     SatoshisPerByte(baseAmount)
+  }
+
+  def toBTCPerKb: BitcoinsPerKiloByte = {
+    BitcoinsPerKiloByte(sats * CurrencyUnits.satoshisToBTCScalar)
   }
 
   override def units: FeeUnit = FeeUnit.PerKiloByte
@@ -104,6 +112,10 @@ case class BitcoinsPerKiloByte(btc: Double) extends BitcoinFeeRate {
     SatoshisPerByte(baseAmount)
   }
 
+  def toSatPerKb: SatoshisPerKiloByte = {
+    SatoshisPerKiloByte(sats)
+  }
+
   override def units: FeeUnit = FeeUnit.PerKiloByte
 }
 
@@ -119,8 +131,8 @@ object BitcoinsPerKiloByte {
     BitcoinsPerKiloByte(feeRate * 0.001)
   }
 
-  val zero: SatoshisPerKiloByte = SatoshisPerKiloByte(0)
-  val one: SatoshisPerKiloByte = SatoshisPerKiloByte(1)
+  val zero: BitcoinsPerKiloByte = BitcoinsPerKiloByte(0)
+  val one: BitcoinsPerKiloByte = BitcoinsPerKiloByte(1)
 }
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
@@ -27,7 +27,7 @@ sealed abstract class BitcoinFeeRate extends FeeRate {
   def calc(tx: Transaction): CurrencyUnit = {
     val fee = tx.baseSize * baseAmount
 
-    require(fee < 0, "Fee cannot be negative")
+    require(fee >= 0, "Fee cannot be negative")
     require(fee < Satoshis.max.toDouble,
             "Fee cannot be greater than the max value")
 
@@ -84,7 +84,7 @@ case class SatoshisPerVirtualByte(sats: Double) extends BitcoinFeeRate {
   override def calc(tx: Transaction): CurrencyUnit = {
     val fee = tx.vsize * baseAmount
 
-    require(fee < 0, "Fee cannot be negative")
+    require(fee >= 0, "Fee cannot be negative")
     require(fee < Satoshis.max.toDouble,
             "Fee cannot be greater than the max value")
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeRate.scala
@@ -1,0 +1,87 @@
+package org.bitcoins.core.wallet.fee
+
+import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.protocol.transaction.Transaction
+
+/**
+  * This is meant to be an abstract type that represents different fee rates for
+  * blockchains
+  */
+sealed abstract class FeeRate {
+  def *(tx: Transaction): CurrencyUnit = calc(tx)
+  def calc(tx: Transaction): CurrencyUnit
+  def baseAmount: Double
+  def units: FeeUnit
+}
+
+/**
+  * Meant to represent the different fee unit types for the bitcoin protocol
+  * @see [[https://en.bitcoin.it/wiki/Weight_units]]
+  */
+sealed abstract class BitcoinFeeRate extends FeeRate {
+  def sats: Double
+  override def baseAmount: Double = sats
+
+  def calc(tx: Transaction): CurrencyUnit = {
+    Satoshis((tx.baseSize * baseAmount).toLong)
+  }
+}
+
+case class SatoshisPerByte(sats: Double) extends BitcoinFeeRate {
+
+  def toSatPerKb: SatoshisPerKiloByte = {
+    SatoshisPerKiloByte(sats * 1000)
+  }
+
+  override def units: FeeUnit = FeeUnit.PerByte
+}
+
+object SatoshisPerByte {
+  val zero: SatoshisPerByte = SatoshisPerByte(0)
+  val one: SatoshisPerByte = SatoshisPerByte(1)
+}
+
+case class SatoshisPerKiloByte(sats: Double) extends BitcoinFeeRate {
+
+  override def baseAmount: Double = sats * 0.001
+
+  def toSatPerByte: SatoshisPerByte = {
+    SatoshisPerByte(baseAmount)
+  }
+
+  override def units: FeeUnit = FeeUnit.PerKiloByte
+}
+
+object SatoshisPerKiloByte {
+  val zero: SatoshisPerKiloByte = SatoshisPerKiloByte(0)
+  val one: SatoshisPerKiloByte = SatoshisPerKiloByte(1)
+}
+
+/**
+  * A 'virtual byte' (also known as virtual size) is a new weight measurement that
+  * was created with segregated witness (BIP141). Now 1 'virtual byte'
+  * has the weight of 4 bytes in the [[org.bitcoins.core.protocol.transaction.TransactionWitness]]
+  * of a [[org.bitcoins.core.protocol.transaction.WitnessTransaction]]
+  */
+case class SatoshisPerVirtualByte(sats: Double) extends BitcoinFeeRate {
+  override def calc(tx: Transaction): CurrencyUnit = {
+    Satoshis((tx.vsize * baseAmount).toLong)
+  }
+
+  override def units: FeeUnit = FeeUnit.PerVirtualByte
+}
+
+object SatoshisPerVirtualByte {
+  val zero: SatoshisPerVirtualByte = SatoshisPerVirtualByte(0)
+  val one: SatoshisPerVirtualByte = SatoshisPerVirtualByte(1)
+}
+
+case class FlatSatoshis(satoshis: Long) extends BitcoinFeeRate {
+  override def sats: Double = satoshis.toDouble
+
+  override def calc(tx: Transaction): CurrencyUnit = {
+    Satoshis(satoshis)
+  }
+
+  override def units: FeeUnit = FeeUnit.Flat
+}

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -8,11 +8,15 @@ sealed abstract class FeeUnit
 
 object FeeUnit {
 
+  /** Represents how many units of currency per byte of the transaction fee */
   final case object PerByte extends FeeUnit
 
+  /** Represents how many units of currency per virtual byte of the transaction fee */
   final case object PerVirtualByte extends FeeUnit
 
+  /** Represents how many units of currency per kilobyte of the transaction fee */
   final case object PerKiloByte extends FeeUnit
 
+  /** Represents how many units of currency to be paid for the transaction fee */
   final case object Flat extends FeeUnit
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -1,58 +1,18 @@
 package org.bitcoins.core.wallet.fee
 
-import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
-import org.bitcoins.core.protocol.transaction.Transaction
-
 /**
-  * This is meant to be an abstract type that represents different fee unit measurements for
+  * This is meant to be an abstract type that represents different fee rates for
   * blockchains
   */
-sealed abstract class FeeUnit {
-  def *(tx: Transaction): CurrencyUnit = calc(tx)
-  def calc(tx: Transaction): CurrencyUnit
-  def baseAmount: Double
-}
+sealed abstract class FeeUnit
 
-/**
-  * Meant to represent the different fee unit types for the bitcoin protocol
-  * @see [[https://en.bitcoin.it/wiki/Weight_units]]
-  */
-sealed abstract class BitcoinFeeUnit extends FeeUnit {
-  def sats: Double
-  override def baseAmount: Double = sats
+object FeeUnit {
 
-  def calc(tx: Transaction): CurrencyUnit =
-    Satoshis((tx.baseSize * baseAmount).toLong)
-}
+  final case object PerByte extends FeeUnit
 
-case class SatoshisPerByte(sats: Double) extends BitcoinFeeUnit {
+  final case object PerVirtualByte extends FeeUnit
 
-  def toSatPerKb: SatoshisPerKiloByte = {
-    SatoshisPerKiloByte(sats * 1000)
-  }
-}
+  final case object PerKiloByte extends FeeUnit
 
-case class SatoshisPerKiloByte(sats: Double) extends BitcoinFeeUnit {
-
-  override def baseAmount: Double = sats * 0.001
-
-  def toSatPerByte: SatoshisPerByte = {
-    SatoshisPerByte(baseAmount)
-  }
-}
-
-/**
-  * A 'virtual byte' (also known as virtual size) is a new weight measurement that
-  * was created with segregated witness (BIP141). Now 1 'virtual byte'
-  * has the weight of 4 bytes in the [[org.bitcoins.core.protocol.transaction.TransactionWitness]]
-  * of a [[org.bitcoins.core.protocol.transaction.WitnessTransaction]]
-  */
-case class SatoshisPerVirtualByte(sats: Double) extends BitcoinFeeUnit {
-  override def calc(tx: Transaction): CurrencyUnit =
-    Satoshis((tx.vsize * baseAmount).toLong)
-}
-
-object SatoshisPerVirtualByte {
-  val zero: SatoshisPerVirtualByte = SatoshisPerVirtualByte(0)
-  val one: SatoshisPerVirtualByte = SatoshisPerVirtualByte(1)
+  final case object Flat extends FeeUnit
 }

--- a/docs/core/txbuilder.md
+++ b/docs/core/txbuilder.md
@@ -92,7 +92,7 @@ val utxos: Vector[BitcoinUTXOSpendingInfoFull] = Vector(utxoSpendingInfo)
 
 // this is how much we are going to pay as a fee to the network
 // for this example, we are going to pay 1 satoshi per byte
-val feeRate = SatoshisPerByte(1.satoshi)
+val feeRate = SatoshisPerByte(1)
 
 val changePrivKey = ECPrivateKey.freshPrivateKey
 val changeSPK = P2PKHScriptPubKey(pubKey = changePrivKey.publicKey)

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -224,7 +224,7 @@ class EclairRpcClient(val instance: EclairInstance, binary: Option[File] = None)
       "nodeId" -> nodeId.toString,
       "fundingSatoshis" -> fundingSatoshis) ++ Seq(
       pushMsat.map(x => "pushMsat" -> x.toBigDecimal.toString),
-      feerateSatPerByte.map(x => "feerateSatPerByte" -> x.toLong.toString),
+      feerateSatPerByte.map(x => "feerateSatPerByte" -> x.baseAmount.toString),
       channelFlags.map(x => "channelFlags" -> x.toString),
       openTimeout.map(x => "openTimeoutSeconds" -> x.toSeconds.toString)
     ).flatten

--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -52,7 +52,7 @@ class BroadcastTransactionTest extends NodeUnitTest {
       _ <- NodeTestUtil.awaitSync(node, rpc)
 
       tx <- wallet
-        .sendToAddress(address, 1.bitcoin, SatoshisPerByte(10.sats))
+        .sendToAddress(address, 1.bitcoin, SatoshisPerByte(10))
 
       bitcoindBalancePreBroadcast <- rpc.getBalance
       _ = node.broadcastTransaction(tx)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -46,7 +46,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
   }
 
   val TestAmount = 1.bitcoin
-  val FeeRate = SatoshisPerByte(10.sats)
+  val FeeRate = SatoshisPerByte(10)
   val TestFees = 2240.sats
 
   def callbacks: NodeCallbacks = {

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -132,9 +132,7 @@ class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
 
       addressFromBitcoind <- rpc.getNewAddress
       tx <- wallet
-        .sendToAddress(addressFromBitcoind,
-                       5.bitcoin,
-                       SatoshisPerByte(100.sats))
+        .sendToAddress(addressFromBitcoind, 5.bitcoin, SatoshisPerByte(100))
       _ = txFromWalletP.success(tx)
       updatedBloom <- spv.updateBloomFilter(tx).map(_.bloomFilter)
       _ = spv.broadcastTransaction(tx)

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
@@ -38,8 +38,8 @@ trait CurrencyUnitGenerator {
 
   /** Generates a FeeRate based on the maxFee allowed for a transaction */
   def feeRate(maxFee: Long): Gen[FeeRate] = {
-    Gen.choose(0L, maxFee / 10000L).map { n =>
-      SatoshisPerKiloByte(n.toDouble)
+    Gen.choose(0L, maxFee / 10000.0).map { n =>
+      SatoshisPerKiloByte(n)
     }
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
@@ -8,7 +8,7 @@ import org.bitcoins.core.currency.{
 }
 import org.bitcoins.core.protocol.ln.currency._
 import org.scalacheck.Gen
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.fee.FeeRate
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.core.wallet.fee.SatoshisPerKiloByte
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
@@ -33,11 +33,11 @@ trait CurrencyUnitGenerator {
     } yield SatoshisPerVirtualByte(curr.toDouble)
   }
 
-  def feeUnit: Gen[FeeUnit] =
+  def feeRate: Gen[FeeRate] =
     Gen.oneOf(satsPerByte, satsPerKiloByte, satsPerVirtualByte)
 
-  /** Generates a FeeUnit based on the maxFee allowed for a transaction */
-  def feeUnit(maxFee: Long): Gen[FeeUnit] = {
+  /** Generates a FeeRate based on the maxFee allowed for a transaction */
+  def feeRate(maxFee: Long): Gen[FeeRate] = {
     Gen.choose(0L, maxFee / 10000L).map { n =>
       SatoshisPerKiloByte(n.toDouble)
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
@@ -18,19 +18,19 @@ trait CurrencyUnitGenerator {
   def satsPerByte: Gen[SatoshisPerByte] = {
     for {
       curr <- positiveRealistic
-    } yield SatoshisPerByte(curr)
+    } yield SatoshisPerByte(curr.toDouble)
   }
 
   def satsPerKiloByte: Gen[SatoshisPerKiloByte] = {
     for {
       curr <- positiveRealistic
-    } yield SatoshisPerKiloByte(curr)
+    } yield SatoshisPerKiloByte(curr.toDouble)
   }
 
   def satsPerVirtualByte: Gen[SatoshisPerVirtualByte] = {
     for {
       curr <- positiveRealistic
-    } yield SatoshisPerVirtualByte(curr)
+    } yield SatoshisPerVirtualByte(curr.toDouble)
   }
 
   def feeUnit: Gen[FeeUnit] =
@@ -39,7 +39,7 @@ trait CurrencyUnitGenerator {
   /** Generates a FeeUnit based on the maxFee allowed for a transaction */
   def feeUnit(maxFee: Long): Gen[FeeUnit] = {
     Gen.choose(0L, maxFee / 10000L).map { n =>
-      SatoshisPerKiloByte(Satoshis(n))
+      SatoshisPerKiloByte(n.toDouble)
     }
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
@@ -59,7 +59,7 @@ trait CurrencyUnitGenerator {
     satoshis.suchThat(_ >= CurrencyUnits.zero)
 
   /**
-    * Generates a postiive satoshi value that is 'realistic'. This current 'realistic' range
+    * Generates a positive satoshi value that is 'realistic'. This current 'realistic' range
     * is from 0 to 1,000,000 bitcoin
     */
   def positiveRealistic: Gen[Satoshis] =

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/PSBTGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/PSBTGenerators.scala
@@ -14,7 +14,7 @@ import org.bitcoins.core.psbt.PSBT.SpendingInfoAndNonWitnessTxs
 import org.bitcoins.core.psbt.PSBTInputKeyId.PartialSignatureKeyId
 import org.bitcoins.core.psbt._
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.fee.FeeRate
 import org.bitcoins.core.wallet.utxo.{
   BitcoinUTXOSpendingInfoFull,
   UTXOSpendingInfoFull
@@ -193,7 +193,7 @@ object PSBTGenerators {
       destinations: Seq[TransactionOutput],
       changeSPK: ScriptPubKey,
       network: BitcoinNetwork,
-      fee: FeeUnit)(
+      fee: FeeRate)(
       implicit ec: ExecutionContext): Future[(PSBT, BitcoinTxBuilder)] = {
     val builderF =
       BitcoinTxBuilder(destinations, creditingTxsInfo, fee, changeSPK, network)
@@ -227,7 +227,7 @@ object PSBTGenerators {
         val spending = destinations.foldLeft(0L)(_ + _.value.satoshis.toLong)
         crediting - spending
       }
-      fee <- CurrencyUnitGenerator.feeUnit(maxFee)
+      fee <- CurrencyUnitGenerator.feeRate(maxFee)
     } yield {
       psbtAndBuilderFromInputs(finalized = finalized,
                                creditingTxsInfo = creditingTxsInfo,
@@ -256,7 +256,7 @@ object PSBTGenerators {
         val spending = destinations.foldLeft(0L)(_ + _.value.satoshis.toLong)
         crediting - spending
       }
-      fee <- CurrencyUnitGenerator.feeUnit(maxFee)
+      fee <- CurrencyUnitGenerator.feeRate(maxFee)
     } yield {
       val pAndB = psbtAndBuilderFromInputs(finalized = finalized,
                                            creditingTxsInfo = creditingTxsInfo,

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
@@ -16,9 +16,12 @@ import org.bitcoins.testkit.core.gen.{
 import org.scalacheck.Gen
 import scodec.bits.ByteVector
 import org.bitcoins.testkit.core.gen.CurrencyUnitGenerator
-import org.bitcoins.core.wallet.fee.SatoshisPerByte
-import org.bitcoins.core.wallet.fee.SatoshisPerKiloByte
-import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.fee.{
+  FlatSatoshis,
+  SatoshisPerByte,
+  SatoshisPerKiloByte,
+  SatoshisPerVirtualByte
+}
 
 object ControlMessageGenerator {
 
@@ -36,12 +39,12 @@ object ControlMessageGenerator {
 
   def feeFilterMessage: Gen[FeeFilterMessage] = {
     for {
-      fee <- CurrencyUnitGenerator.feeUnit.suchThat(
+      fee <- CurrencyUnitGenerator.feeRate.suchThat(
         !_.isInstanceOf[SatoshisPerVirtualByte])
     } yield fee match {
       case fee: SatoshisPerByte     => FeeFilterMessage(fee)
       case fee: SatoshisPerKiloByte => FeeFilterMessage(fee)
-      case SatoshisPerVirtualByte(_) =>
+      case SatoshisPerVirtualByte(_) | FlatSatoshis(_) =>
         throw new RuntimeException(s"We cannot end up here")
     }
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
@@ -3,25 +3,17 @@ package org.bitcoins.testkit.core.gen.p2p
 import java.net.{InetAddress, InetSocketAddress}
 
 import org.bitcoins.core.number.{UInt32, UInt64}
-import org.bitcoins.core.p2p.ProtocolVersion
+import org.bitcoins.core.p2p.{ProtocolVersion, _}
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.p2p._
-import org.bitcoins.core.p2p._
-import org.bitcoins.testkit.core.gen.{
-  BloomFilterGenerator,
-  CryptoGenerators,
-  NumberGenerator,
-  StringGenerators
-}
-import org.scalacheck.Gen
-import scodec.bits.ByteVector
-import org.bitcoins.testkit.core.gen.CurrencyUnitGenerator
 import org.bitcoins.core.wallet.fee.{
   FlatSatoshis,
   SatoshisPerByte,
   SatoshisPerKiloByte,
   SatoshisPerVirtualByte
 }
+import org.bitcoins.testkit.core.gen._
+import org.scalacheck.Gen
+import scodec.bits.ByteVector
 
 object ControlMessageGenerator {
 
@@ -40,7 +32,9 @@ object ControlMessageGenerator {
   def feeFilterMessage: Gen[FeeFilterMessage] = {
     for {
       fee <- CurrencyUnitGenerator.feeRate.suchThat(
-        !_.isInstanceOf[SatoshisPerVirtualByte])
+        rate =>
+          !rate.isInstanceOf[SatoshisPerVirtualByte] && !rate
+            .isInstanceOf[FlatSatoshis])
     } yield fee match {
       case fee: SatoshisPerByte     => FeeFilterMessage(fee)
       case fee: SatoshisPerKiloByte => FeeFilterMessage(fee)

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
@@ -6,6 +6,7 @@ import org.bitcoins.core.number.{UInt32, UInt64}
 import org.bitcoins.core.p2p.{ProtocolVersion, _}
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.wallet.fee.{
+  BitcoinsPerKiloByte,
   FlatSatoshis,
   SatoshisPerByte,
   SatoshisPerKiloByte,
@@ -38,7 +39,8 @@ object ControlMessageGenerator {
     } yield fee match {
       case fee: SatoshisPerByte     => FeeFilterMessage(fee)
       case fee: SatoshisPerKiloByte => FeeFilterMessage(fee)
-      case SatoshisPerVirtualByte(_) | FlatSatoshis(_) =>
+      case SatoshisPerVirtualByte(_) | FlatSatoshis(_) | BitcoinsPerKiloByte(
+            _) =>
         throw new RuntimeException(s"We cannot end up here")
     }
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -32,7 +32,7 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
     for {
       tx <- wallet.sendToAddress(testAddr,
                                  Satoshis(3000),
-                                 SatoshisPerVirtualByte(Satoshis(3)))
+                                 SatoshisPerVirtualByte(3))
 
       updatedCoins <- wallet.spendingInfoDAO.findOutputsBeingSpent(tx)
     } yield {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -19,7 +19,7 @@ class WalletIntegrationTest extends BitcoinSWalletTest {
 
   behavior of "Wallet - integration test"
 
-  val feeRate: SatoshisPerByte = SatoshisPerByte(1)
+  val feeRate: SatoshisPerByte = SatoshisPerByte.one
 
   /** Checks that the given vaues are the same-ish, save for fee-level deviations */
   private def isCloseEnough(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -19,7 +19,7 @@ class WalletIntegrationTest extends BitcoinSWalletTest {
 
   behavior of "Wallet - integration test"
 
-  val feeRate = SatoshisPerByte(Satoshis.one)
+  val feeRate: SatoshisPerByte = SatoshisPerByte(1)
 
   /** Checks that the given vaues are the same-ish, save for fee-level deviations */
   private def isCloseEnough(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
@@ -3,7 +3,7 @@ package org.bitcoins.wallet.api
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutput
-import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerByte}
+import org.bitcoins.core.wallet.fee.{FeeRate, SatoshisPerByte}
 import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.{
@@ -18,7 +18,7 @@ import org.scalatest.FutureOutcome
 class CoinSelectorTest extends BitcoinSWalletTest {
   case class CoinSelectionFixture(
       output: TransactionOutput,
-      feeRate: FeeUnit,
+      feeRate: FeeRate,
       utxo1: SpendingInfoDb,
       utxo2: SpendingInfoDb,
       utxo3: SpendingInfoDb) {
@@ -29,7 +29,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val output = TransactionOutput(99.sats, ScriptPubKey.empty)
-    val feeRate = SatoshisPerByte(0)
+    val feeRate = SatoshisPerByte.zero
 
     val utxo1 = SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
@@ -29,7 +29,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val output = TransactionOutput(99.sats, ScriptPubKey.empty)
-    val feeRate = SatoshisPerByte(CurrencyUnits.zero)
+    val feeRate = SatoshisPerByte(0)
 
     val utxo1 = SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.currency._
 import org.bitcoins.core.hd._
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction._
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.fee.FeeRate
 import org.bitcoins.keymanager.KeyManagerParams
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.keymanager.util.HDUtil
@@ -33,7 +33,7 @@ sealed abstract class Wallet extends LockedWallet with UnlockedWalletApi {
   override def sendToAddress(
       address: BitcoinAddress,
       amount: CurrencyUnit,
-      feeRate: FeeUnit,
+      feeRate: FeeRate,
       fromAccount: AccountDb): Future[Transaction] = {
     logger.info(s"Sending $amount to $address at feerate $feeRate")
     val destination = TransactionOutput(amount, address.scriptPubKey)

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
@@ -54,8 +54,8 @@ trait CoinSelector {
         valueSoFar: CurrencyUnit,
         bytesSoFar: Long,
         utxosLeft: Vector[SpendingInfoDb]): Vector[SpendingInfoDb] = {
-      val fee = feeRate.currencyUnit * bytesSoFar
-      if (valueSoFar > totalValue + fee) {
+      val fee = feeRate.baseAmount * bytesSoFar
+      if (valueSoFar.satoshis.toDouble > totalValue.satoshis.toDouble + fee) {
         alreadyAdded
       } else if (utxosLeft.isEmpty) {
         throw new RuntimeException(
@@ -63,8 +63,8 @@ trait CoinSelector {
       } else {
         val nextUtxo = utxosLeft.head
         val approxUtxoSize = CoinSelector.approximateUtxoSize(nextUtxo)
-        val nextUtxoFee = feeRate.currencyUnit * approxUtxoSize
-        if (nextUtxo.output.value < nextUtxoFee) {
+        val nextUtxoFee = feeRate.baseAmount * approxUtxoSize
+        if (nextUtxo.output.value.satoshis.toLong < nextUtxoFee) {
           addUtxos(alreadyAdded, valueSoFar, bytesSoFar, utxosLeft.tail)
         } else {
           val newAdded = alreadyAdded.:+(nextUtxo)

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
@@ -2,7 +2,7 @@ package org.bitcoins.wallet.api
 
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
 import org.bitcoins.core.protocol.transaction.TransactionOutput
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.fee.FeeRate
 import org.bitcoins.wallet.models.SpendingInfoDb
 
 import scala.annotation.tailrec
@@ -17,7 +17,7 @@ trait CoinSelector {
   def accumulateLargest(
       walletUtxos: Vector[SpendingInfoDb],
       outputs: Vector[TransactionOutput],
-      feeRate: FeeUnit): Vector[SpendingInfoDb] = {
+      feeRate: FeeRate): Vector[SpendingInfoDb] = {
     val sortedUtxos =
       walletUtxos.sortBy(_.output.value).reverse
 
@@ -33,7 +33,7 @@ trait CoinSelector {
   def accumulateSmallestViable(
       walletUtxos: Vector[SpendingInfoDb],
       outputs: Vector[TransactionOutput],
-      feeRate: FeeUnit): Vector[SpendingInfoDb] = {
+      feeRate: FeeRate): Vector[SpendingInfoDb] = {
     val sortedUtxos = walletUtxos.sortBy(_.output.value)
 
     accumulate(sortedUtxos, outputs, feeRate)
@@ -43,7 +43,7 @@ trait CoinSelector {
   def accumulate(
       walletUtxos: Vector[SpendingInfoDb],
       outputs: Vector[TransactionOutput],
-      feeRate: FeeUnit): Vector[SpendingInfoDb] = {
+      feeRate: FeeRate): Vector[SpendingInfoDb] = {
     val totalValue = outputs.foldLeft(CurrencyUnits.zero) {
       case (totVal, output) => totVal + output.value
     }

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -12,7 +12,7 @@ import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.fee.FeeRate
 import org.bitcoins.keymanager._
 import org.bitcoins.keymanager.bip39.{BIP39KeyManager, BIP39LockedKeyManager}
 import org.bitcoins.wallet.api.LockedWalletApi.BlockMatchingResponse
@@ -353,7 +353,7 @@ trait UnlockedWalletApi extends LockedWalletApi {
   def sendToAddress(
       address: BitcoinAddress,
       amount: CurrencyUnit,
-      feeRate: FeeUnit,
+      feeRate: FeeRate,
       fromAccount: AccountDb): Future[Transaction]
 
   /**
@@ -364,7 +364,7 @@ trait UnlockedWalletApi extends LockedWalletApi {
   def sendToAddress(
       address: BitcoinAddress,
       amount: CurrencyUnit,
-      feeRate: FeeUnit
+      feeRate: FeeRate
   ): Future[Transaction] = {
     for {
       account <- getDefaultAccount()

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -4,7 +4,7 @@ import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto.Sign
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutput}
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.fee.FeeRate
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.wallet.WalletLogger
 import org.bitcoins.wallet.api.{AddressInfo, CoinSelector, LockedWalletApi}
@@ -16,7 +16,7 @@ trait FundTransactionHandling extends WalletLogger { self: LockedWalletApi =>
 
   def fundRawTransaction(
       destinations: Vector[TransactionOutput],
-      feeRate: FeeUnit,
+      feeRate: FeeRate,
       markAsReserved: Boolean): Future[Transaction] = {
     for {
       account <- getDefaultAccount()
@@ -29,7 +29,7 @@ trait FundTransactionHandling extends WalletLogger { self: LockedWalletApi =>
 
   def fundRawTransaction(
       destinations: Vector[TransactionOutput],
-      feeRate: FeeUnit,
+      feeRate: FeeRate,
       fromAccount: AccountDb,
       markAsReserved: Boolean = false): Future[Transaction] = {
     val txBuilderF =
@@ -54,7 +54,7 @@ trait FundTransactionHandling extends WalletLogger { self: LockedWalletApi =>
     * */
   private[wallet] def fundRawTransactionInternal(
       destinations: Vector[TransactionOutput],
-      feeRate: FeeUnit,
+      feeRate: FeeRate,
       fromAccount: AccountDb,
       keyManagerOpt: Option[BIP39KeyManager],
       markAsReserved: Boolean = false): Future[BitcoinTxBuilder] = {


### PR DESCRIPTION
The main change is in `FeeUnit.scala` and `FeeRate.scala` the rest is fixing everything to be compatible.

The thinking is:

- remove `currencyUnit` because this cannot represent decimals
- add `baseAmount` this is the representation in satoshis
- fix `calc` so it correctly calculates the fee