### PR TITLE
Add disclaimers to the wallet/key-manager around API breaking changes…

### DIFF
--- a/docs/key-manager/key-manager.md
+++ b/docs/key-manager/key-manager.md
@@ -18,6 +18,18 @@ This means that ALL SIGNING should be done inside of the key-manager, and privat
 
 This makes it easier to reason about the security characteristics of our private keys, and a way to provide a uniform interface for alternative key storage systems (hsm, cloud based key storage, etc) to be plugged into the bitcoin-s library.
 
+### Disclaimer 
+
+Currently bip39 password is supported at the library level, but is not supported for end users using the server project. 
+[You can see that the bip39 password is hard coded to `None` here](https://github.com/bitcoin-s/bitcoin-s/blob/e387d075b0ff2e0a0fec15788fcb48e4ddc4d9d5/app/server/src/main/scala/org/bitcoins/server/Main.scala#L53).
+
+There is a password that is used to encrypt your mnemonic seed on disk, but that password is hard coded to a default value. 
+THIS MEANS THAT YOUR MNEMONIC SEED CAN TRIVIALLY BE STOLEN IF AN ATTACKER CAN ACCESS YOUR HARD DRIVE. 
+TAKE PROPER OPSEC PRECAUTIONS.
+
+Overall the key manager module should be considered insecure. For this release, it is more about setting up the module 
+as a logical distinction for further development in subsequent releases.
+
 #### Creating a key manager
 
 The first thing you need create a key manager is some entropy.

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -13,6 +13,10 @@ This wallet is currently only released as a library, and not as a binary.
 This is because it (nor the documentation) is not deemed production
 ready. Use at your own risk, and without too much money depending on it.
 
+### Disclaimer 
+The wallet api will changing significantly in the next release of bitcoin-s. EXPECT API BREAKING CHANGES and surprising
+behavior in the current wallet.
+
 ### How is the bitcoin-s wallet implemented
 
 The bitcoin-s wallet is a scalable way for individuals up to large bitcoin exchanges to safely and securely store their bitcoin in a scalable way.

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -14,8 +14,8 @@ This is because it (nor the documentation) is not deemed production
 ready. Use at your own risk, and without too much money depending on it.
 
 ### Disclaimer 
-The wallet api will changing significantly in the next release of bitcoin-s. EXPECT API BREAKING CHANGES and surprising
-behavior in the current wallet.
+The wallet api will changing significantly in the next release of bitcoin-s. EXPECT API BREAKING CHANGES and
+surprising behavior from the current wallet..
 
 ### How is the bitcoin-s wallet implemented
 


### PR DESCRIPTION
… and limitations of the current iteration of the wallet

We will be working on the wallet/key-manager project a lot for the next release of bitcoin-s, add disclaimers saying that the current projects structure will change. 