### PR TITLE
2020 03 15 chainhandler getnancestor

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -1,23 +1,25 @@
 package org.bitcoins.chain.blockchain
 
 import akka.actor.ActorSystem
-import org.bitcoins.chain.models.BlockHeaderDAO
+import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDb}
+import org.bitcoins.testkit.chain.fixture.ChainFixture
 import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainUnitTest}
 import org.scalatest.FutureOutcome
 
-class BlockchainTest extends ChainUnitTest {
+import scala.collection.mutable
 
-  override type FixtureParam = BlockHeaderDAO
+class BlockchainTest extends ChainUnitTest {
+  override type FixtureParam = ChainFixture
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withBlockHeaderDAO(test)
+    withChainFixture(test)
 
   implicit override val system: ActorSystem = ActorSystem("BlockchainTest")
 
   behavior of "Blockchain"
 
-  it must "connect a new header to the current tip of a blockchain" in {
-    bhDAO: BlockHeaderDAO =>
+  it must "connect a new header to the current tip of a blockchain" inFixtured {
+    case ChainFixture.Empty =>
       val blockchain = Blockchain.fromHeaders(
         headers = Vector(ChainUnitTest.genesisHeaderDb)
       )
@@ -35,5 +37,44 @@ class BlockchainTest extends ChainUnitTest {
         case fail @ (_: ConnectTipResult.Reorg | _: ConnectTipResult.BadTip) =>
           assert(false)
       }
+  }
+
+  it must "reconstruct a blockchain given a child header correctly" inFixtured {
+    case ChainFixture.Empty =>
+      val accum = new mutable.ArrayBuffer[BlockHeaderDb](5)
+      accum.+=(ChainUnitTest.genesisHeaderDb)
+      //generate 4 headers
+      0.until(4).foreach { _ =>
+        val newHeader = BlockHeaderHelper.buildNextHeader(accum.last)
+        accum.+=(newHeader)
+      }
+
+      //now given the last header, and the other headers we should reconstruct the blockchain
+      val headers = accum.dropRight(1).toVector
+      val tip = accum.last
+
+      val reconstructed = Blockchain.reconstructFromHeaders(childHeader = tip,
+                                                            ancestors = headers)
+
+      assert(reconstructed.length == 1)
+      val chain = reconstructed.head
+      assert(chain.toVector.length == 5)
+      assert(chain.tip == accum.last)
+      assert(chain.last == ChainUnitTest.genesisHeaderDb)
+      assert(chain.toVector == accum.reverse.toVector)
+  }
+
+  it must "fail to reconstruct a blockchain if we do not have validly connected headers" inFixtured {
+    case ChainFixture.Empty =>
+      val missingHeader =
+        BlockHeaderHelper.buildNextHeader(ChainUnitTest.genesisHeaderDb)
+
+      val thirdHeader = BlockHeaderHelper.buildNextHeader(missingHeader)
+
+      val reconstructed =
+        Blockchain.reconstructFromHeaders(thirdHeader,
+                                          Vector(ChainUnitTest.genesisHeaderDb))
+
+      assert(reconstructed.isEmpty)
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -234,19 +234,21 @@ private[blockchain] trait BaseBlockChainCompObject
     }
   }
 
-
   /** Walks backwards from the current header searching through ancestors if [[current.previousBlockHashBE]] is in [[ancestors]]
-   * This does not validate other things such as POW.
-   * */
+    * This does not validate other things such as POW.
+    * */
   @tailrec
-  final def connectWalkBackwards(current: BlockHeaderDb,
-                           accum: Vector[BlockHeader],
-                           ancestors: Vector[BlockHeaderDb])(implicit chainAppConfig: ChainAppConfig): Vector[BlockHeader] = {
+  final def connectWalkBackwards(
+      current: BlockHeaderDb,
+      accum: Vector[BlockHeader],
+      ancestors: Vector[BlockHeaderDb])(
+      implicit chainAppConfig: ChainAppConfig): Vector[BlockHeader] = {
     val prevHeaderOpt = ancestors.find(_.hashBE == current.previousBlockHashBE)
     prevHeaderOpt match {
-      case Some(h) => connectWalkBackwards(current = h,
-        accum = current.blockHeader +: accum,
-        ancestors = ancestors)
+      case Some(h) =>
+        connectWalkBackwards(current = h,
+                             accum = current.blockHeader +: accum,
+                             ancestors = ancestors)
       case None =>
         logger.debug(s"No prev found for $current hashBE=${current.hashBE}")
         current.blockHeader +: accum
@@ -254,14 +256,17 @@ private[blockchain] trait BaseBlockChainCompObject
   }
 
   /** Walks backwards from a child header reconstructing a blockchain
-   * This validates things like POW, difficulty change etc. 
-   * */
-  def reconstructFromHeaders(childHeader: BlockHeaderDb, ancestors: Vector[BlockHeaderDb])(implicit chainAppConfig: ChainAppConfig): Vector[Blockchain] = {
+    * This validates things like POW, difficulty change etc.
+    * */
+  def reconstructFromHeaders(
+      childHeader: BlockHeaderDb,
+      ancestors: Vector[BlockHeaderDb])(
+      implicit chainAppConfig: ChainAppConfig): Vector[Blockchain] = {
     //now all hashes are connected correctly forming a
     //valid blockchain in term of hashes connected to each other
     val orderedHeaders = connectWalkBackwards(current = childHeader,
-      accum = Vector.empty,
-      ancestors = ancestors)
+                                              accum = Vector.empty,
+                                              ancestors = ancestors)
 
     val initBlockchainOpt = orderedHeaders match {
       case Vector() | _ +: Vector() =>
@@ -278,12 +283,13 @@ private[blockchain] trait BaseBlockChainCompObject
 
     //now let's connect headers
     val blockchainUpdateOpt = initBlockchainOpt.map { initBlockchain =>
-      Blockchain.connectHeadersToChains(orderedHeaders.tail, Vector(initBlockchain))
+      Blockchain.connectHeadersToChains(orderedHeaders.tail,
+                                        Vector(initBlockchain))
     }
 
     blockchainUpdateOpt match {
       case Some(v) => v.map(_.blockchain)
-      case None => Vector.empty
+      case None    => Vector.empty
     }
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -234,4 +234,56 @@ private[blockchain] trait BaseBlockChainCompObject
     }
   }
 
+
+  /** Walks backwards from the current header searching through ancestors if [[current.previousBlockHashBE]] is in [[ancestors]]
+   * This does not validate other things such as POW.
+   * */
+  @tailrec
+  final def connectWalkBackwards(current: BlockHeaderDb,
+                           accum: Vector[BlockHeader],
+                           ancestors: Vector[BlockHeaderDb])(implicit chainAppConfig: ChainAppConfig): Vector[BlockHeader] = {
+    val prevHeaderOpt = ancestors.find(_.hashBE == current.previousBlockHashBE)
+    prevHeaderOpt match {
+      case Some(h) => connectWalkBackwards(current = h,
+        accum = current.blockHeader +: accum,
+        ancestors = ancestors)
+      case None =>
+        logger.debug(s"No prev found for $current hashBE=${current.hashBE}")
+        current.blockHeader +: accum
+    }
+  }
+
+  /** Walks backwards from a child header reconstructing a blockchain
+   * This validates things like POW, difficulty change etc. 
+   * */
+  def reconstructFromHeaders(childHeader: BlockHeaderDb, ancestors: Vector[BlockHeaderDb])(implicit chainAppConfig: ChainAppConfig): Vector[Blockchain] = {
+    //now all hashes are connected correctly forming a
+    //valid blockchain in term of hashes connected to each other
+    val orderedHeaders = connectWalkBackwards(current = childHeader,
+      accum = Vector.empty,
+      ancestors = ancestors)
+
+    val initBlockchainOpt = orderedHeaders match {
+      case Vector() | _ +: Vector() =>
+        //for the case of _ +: Vector() this means only our
+        //child header is in the chain, which means we
+        //weren't able to form a blockchain
+        None
+      case h +: _ =>
+        //find our first header as we need it's Db representation
+        //rather than just the raw header
+        val dbOpt = ancestors.find(_.hashBE == h.hashBE)
+        Some(Blockchain.fromHeaders(Vector(dbOpt.get)))
+    }
+
+    //now let's connect headers
+    val blockchainUpdateOpt = initBlockchainOpt.map { initBlockchain =>
+      Blockchain.connectHeadersToChains(orderedHeaders.tail, Vector(initBlockchain))
+    }
+
+    blockchainUpdateOpt match {
+      case Some(v) => v.map(_.blockchain)
+      case None => Vector.empty
+    }
+  }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -195,7 +195,7 @@ case class ChainHandler(
 
     val filterHeadersToCreateF: Future[Vector[CompactFilterHeaderDb]] = for {
       blockHeaders <- blockHeaderDAO
-        .getNAncestors(ancestorHash = stopHash, n = filterHeaders.size - 1)
+        .getNAncestors(childHash = stopHash, n = filterHeaders.size - 1)
         .map(_.sortBy(_.height))
     } yield {
       if (blockHeaders.size != filterHeaders.size) {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -195,7 +195,7 @@ case class ChainHandler(
 
     val filterHeadersToCreateF: Future[Vector[CompactFilterHeaderDb]] = for {
       blockHeaders <- blockHeaderDAO
-        .getNChildren(ancestorHash = stopHash, n = filterHeaders.size - 1)
+        .getNAncestors(ancestorHash = stopHash, n = filterHeaders.size - 1)
         .map(_.sortBy(_.height))
     } yield {
       if (blockHeaders.size != filterHeaders.size) {

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -160,18 +160,9 @@ case class BlockHeaderDAO()(
       }
     } yield {
       if (headerOpt.isDefined) {
-        val blockchains =
-          Blockchain.reconstructFromHeaders(headerOpt.get, headers)
-        require(
-          blockchains.length == 1 || blockchains.isEmpty,
-          s"Can only have one blockchain when walking backwards, got=${blockchains.length}")
-        blockchains.headOption match {
-          case Some(h) => h.toVector
-          case None    =>
-            //if we couldn't build a blockchain at all,
-            //form a trivial with the given childHash
-            Vector(headerOpt.get)
-        }
+        val connectedHeaders =
+          Blockchain.connectWalkBackwards(headerOpt.get, headers)
+        connectedHeaders.reverse
       } else {
         Vector.empty
       }

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -142,9 +142,10 @@ case class BlockHeaderDAO()(
   }
 
   /** Gets Block Headers of all children starting with the given block hash (inclusive), could be out of order */
-  def getNChildren(
+  def getNAncestors(
       ancestorHash: DoubleSha256DigestBE,
       n: Int): Future[Vector[BlockHeaderDb]] = {
+    logger.debug(s"Getting $n ancestors for blockhash=$ancestorHash")
     for {
       headerOpt <- findByHash(ancestorHash)
       res <- headerOpt match {

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -159,13 +159,11 @@ case class BlockHeaderDAO()(
           Future.successful(Vector.empty)
       }
     } yield {
-      if (headerOpt.isDefined) {
+      headerOpt.map { header =>
         val connectedHeaders =
-          Blockchain.connectWalkBackwards(headerOpt.get, headers)
+          Blockchain.connectWalkBackwards(header, headers)
         connectedHeaders.reverse
-      } else {
-        Vector.empty
-      }
+      }.getOrElse(Vector.empty)
     }
   }
 

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -142,8 +142,8 @@ case class BlockHeaderDAO()(
   }
 
   /** Gets ancestor block headers starting with the given block hash (inclusive)
-   * These headers are guaranteed to be in order and a valid chain.
-   * */
+    * These headers are guaranteed to be in order and a valid chain.
+    * */
   def getNAncestors(
       childHash: DoubleSha256DigestBE,
       n: Int): Future[Vector[BlockHeaderDb]] = {
@@ -160,11 +160,14 @@ case class BlockHeaderDAO()(
       }
     } yield {
       if (headerOpt.isDefined) {
-        val blockchains = Blockchain.reconstructFromHeaders(headerOpt.get, headers)
-        require(blockchains.length == 1 || blockchains.isEmpty, s"Can only have one blockchain when walking backwards, got=${blockchains.length}")
+        val blockchains =
+          Blockchain.reconstructFromHeaders(headerOpt.get, headers)
+        require(
+          blockchains.length == 1 || blockchains.isEmpty,
+          s"Can only have one blockchain when walking backwards, got=${blockchains.length}")
         blockchains.headOption match {
           case Some(h) => h.toVector
-          case None =>
+          case None    =>
             //if we couldn't build a blockchain at all,
             //form a trivial with the given childHash
             Vector(headerOpt.get)

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -49,7 +49,7 @@ sealed abstract class Pow {
                   case TestNetChainParams | MainNetChainParams =>
                     //if we can't find a non min diffulty block, let's just fail
                     throw new RuntimeException(
-                      s"Could not find non mindiffulty block in chain of size=${blockchain.length}! hash=${tip.hashBE.hex} height=${currentHeight}")
+                      s"Could not find non mindifficulty block in chain of size=${blockchain.length}! hash=${tip.hashBE.hex} height=${currentHeight}")
                 }
 
             }

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -42,7 +42,7 @@ sealed abstract class Pow {
 
             nonMinDiffF match {
               case Some(bh) => bh.nBits
-              case None     =>
+              case None =>
                 config.chain match {
                   case RegTestNetChainParams =>
                     RegTestNetChainParams.compressedPowLimit

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -49,7 +49,7 @@ sealed abstract class Pow {
                   case TestNetChainParams | MainNetChainParams =>
                     //if we can't find a non min diffulty block, let's just fail
                     throw new RuntimeException(
-                      s"Could not find non mindiffulty block in chain! hash=${tip.hashBE.hex} height=${currentHeight}")
+                      s"Could not find non mindiffulty block in chain of size=${blockchain.length}! hash=${tip.hashBE.hex} height=${currentHeight}")
                 }
 
             }

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.chain.pow
 
 import org.bitcoins.chain.blockchain.Blockchain
-import org.bitcoins.chain.models.{BlockHeaderDb}
-import org.bitcoins.core.number.UInt32
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.protocol.blockchain.{BlockHeader, ChainParams}
+import org.bitcoins.chain.models.BlockHeaderDb
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.blockchain._
 import org.bitcoins.core.util.NumberUtil
 
 /**
@@ -43,9 +43,15 @@ sealed abstract class Pow {
             nonMinDiffF match {
               case Some(bh) => bh.nBits
               case None     =>
-                //if we can't find a non min diffulty block, let's just fail
-                throw new RuntimeException(
-                  s"Could not find non mindiffulty block in chain! hash=${tip.hashBE.hex} height=${currentHeight}")
+                config.chain match {
+                  case RegTestNetChainParams =>
+                    RegTestNetChainParams.compressedPowLimit
+                  case TestNetChainParams | MainNetChainParams =>
+                    //if we can't find a non min diffulty block, let's just fail
+                    throw new RuntimeException(
+                      s"Could not find non mindiffulty block in chain! hash=${tip.hashBE.hex} height=${currentHeight}")
+                }
+
             }
           }
         } else {

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1046,6 +1046,17 @@ case class CompactFilterCheckPointMessage(
 
   def bytes: ByteVector =
     RawCompactFilterCheckpointMessageSerializer.write(this)
+
+  override def toString: String = {
+    val headersString = {
+      if (filterHeaders.isEmpty) {
+        "empty"
+      } else {
+        s"${filterHeaders.head}...${filterHeaders.last}"
+      }
+    }
+    s"CompactFilterCheckPointMessage(filterType=${filterType}, stopHash=${stopHash}, filterHeaders=${headersString})"
+  }
 }
 
 object CompactFilterCheckPointMessage

--- a/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
@@ -25,7 +25,7 @@ object BytesToPushOntoStack
     override val opCode = num
   }
 
-  override def operations: Seq[BytesToPushOntoStack] =
+  override val operations: Seq[BytesToPushOntoStack] =
     (for { i <- 0 to 75 } yield BytesToPushOntoStackImpl(i))
 
   def fromNumber(num: Long): BytesToPushOntoStack = {


### PR DESCRIPTION
This PR addresses #806 

Previously when fetching headers from the database, we would just select headers between a height range and then return the headers in this range from `BlockHeaderDAO.getNChildren()`. 

This doesn't work because we can have multiple block headers at the same height. This PR does two things: 

1. Renames `getNChildren()` -> `getNAncestors()` as that is what we are actually doing
2. Calls `Blockchain.connectWalkBackwards()` on the headers returned from `BlockHeaderDAO.getNAncestors()` to validate that we can actually form a blockchain with what is returned from the database.

closes #806 