### PR TITLE
Broadcast DLC transactions

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -263,7 +263,8 @@ object ConsoleCli {
         ),
       cmd("acceptdlcmutualclose")
         .hidden()
-        .action((_, conf) => conf.copy(command = AcceptDLCMutualClose(null)))
+        .action((_, conf) =>
+          conf.copy(command = AcceptDLCMutualClose(null, noBroadcast = false)))
         .text("Sign Mutual Close Tx for given oracle event")
         .children(
           opt[DLCMutualCloseSig]("closesig").required
@@ -272,11 +273,19 @@ object ConsoleCli {
                 case acceptClose: AcceptDLCMutualClose =>
                   acceptClose.copy(mutualCloseSig = closeSig)
                 case other => other
+              })),
+          opt[Unit]("noBroadcast").optional
+            .action((_, conf) =>
+              conf.copy(command = conf.command match {
+                case acceptClose: AcceptDLCMutualClose =>
+                  acceptClose.copy(noBroadcast = true)
+                case other => other
               }))
         ),
       cmd("getdlcfundingtx")
         .hidden()
-        .action((_, conf) => conf.copy(command = GetDLCFundingTx(null)))
+        .action((_, conf) =>
+          conf.copy(command = GetDLCFundingTx(null, noBroadcast = false)))
         .text("Returns the Funding Tx corresponding to the DLC with the given eventId")
         .children(
           opt[Sha256DigestBE]("eventid").required
@@ -285,12 +294,20 @@ object ConsoleCli {
                 case getDLCFundingTx: GetDLCFundingTx =>
                   getDLCFundingTx.copy(eventId = eventId)
                 case other => other
+              })),
+          opt[Unit]("noBroadcast").optional
+            .action((_, conf) =>
+              conf.copy(command = conf.command match {
+                case getDLCFundingTx: GetDLCFundingTx =>
+                  getDLCFundingTx.copy(noBroadcast = true)
+                case other => other
               }))
         ),
       cmd("executedlcunilateralclose")
         .hidden()
         .action((_, conf) =>
-          conf.copy(command = ExecuteDLCUnilateralClose(null, null)))
+          conf.copy(command =
+            ExecuteDLCUnilateralClose(null, null, noBroadcast = false)))
         .text("Executes a unilateral close for the DLC with the given eventId")
         .children(
           opt[Sha256DigestBE]("eventid").required
@@ -306,13 +323,23 @@ object ConsoleCli {
                 case executeDLCUnilateralClose: ExecuteDLCUnilateralClose =>
                   executeDLCUnilateralClose.copy(oracleSig = sig)
                 case other => other
+              })),
+          opt[Unit]("noBroadcast").optional
+            .action((_, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCUnilateralClose: ExecuteDLCUnilateralClose =>
+                  executeDLCUnilateralClose.copy(noBroadcast = true)
+                case other => other
               }))
         ),
       cmd("executedlcremoteunilateralclose")
         .hidden()
-        .action((_, conf) =>
-          conf.copy(
-            command = ExecuteDLCRemoteUnilateralClose(null, EmptyTransaction)))
+        .action(
+          (_, conf) =>
+            conf.copy(
+              command = ExecuteDLCRemoteUnilateralClose(null,
+                                                        EmptyTransaction,
+                                                        noBroadcast = false)))
         .text("Executes a unilateral close for the DLC with the given eventId")
         .children(
           opt[Sha256DigestBE]("eventid").required
@@ -328,12 +355,20 @@ object ConsoleCli {
                 case executeDLCRemoteUnilateralClose: ExecuteDLCRemoteUnilateralClose =>
                   executeDLCRemoteUnilateralClose.copy(cet = cet)
                 case other => other
+              })),
+          opt[Unit]("noBroadcast").optional
+            .action((_, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCRemoteUnilateralClose: ExecuteDLCRemoteUnilateralClose =>
+                  executeDLCRemoteUnilateralClose.copy(noBroadcast = true)
+                case other => other
               }))
         ),
       cmd("executedlcforceclose")
         .hidden()
         .action((_, conf) =>
-          conf.copy(command = ExecuteDLCForceClose(null, null)))
+          conf.copy(
+            command = ExecuteDLCForceClose(null, null, noBroadcast = false)))
         .text("Executes a force close for the DLC with the given eventId")
         .children(
           opt[Sha256DigestBE]("eventid").required
@@ -349,12 +384,20 @@ object ConsoleCli {
                 case executeDLCForceClose: ExecuteDLCForceClose =>
                   executeDLCForceClose.copy(oracleSig = sig)
                 case other => other
+              })),
+          opt[Unit]("noBroadcast").optional
+            .action((_, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCForceClose: ExecuteDLCForceClose =>
+                  executeDLCForceClose.copy(noBroadcast = true)
+                case other => other
               }))
         ),
       cmd("claimdlcremotefunds")
         .hidden()
         .action((_, conf) =>
-          conf.copy(command = ClaimDLCRemoteFunds(null, EmptyTransaction)))
+          conf.copy(command =
+            ClaimDLCRemoteFunds(null, EmptyTransaction, noBroadcast = false)))
         .text("Claims the remote funds for the corresponding DLC")
         .children(
           opt[Sha256DigestBE]("eventid").required
@@ -371,11 +414,20 @@ object ConsoleCli {
                 case claimDLCRemoteFunds: ClaimDLCRemoteFunds =>
                   claimDLCRemoteFunds.copy(forceCloseTx = tx)
                 case other => other
+              })),
+          opt[Unit]("noBroadcast")
+            .optional()
+            .action((_, conf) =>
+              conf.copy(command = conf.command match {
+                case claimDLCRemoteFunds: ClaimDLCRemoteFunds =>
+                  claimDLCRemoteFunds.copy(noBroadcast = true)
+                case other => other
               }))
         ),
       cmd("executedlcrefund")
         .hidden()
-        .action((_, conf) => conf.copy(command = ExecuteDLCRefund(null)))
+        .action((_, conf) =>
+          conf.copy(command = ExecuteDLCRefund(null, noBroadcast = false)))
         .text("Executes the Refund transaction for the given DLC")
         .children(
           opt[Sha256DigestBE]("eventid").required
@@ -384,12 +436,20 @@ object ConsoleCli {
                 case executeDLCRefund: ExecuteDLCRefund =>
                   executeDLCRefund.copy(eventId = eventId)
                 case other => other
+              })),
+          opt[Unit]("noBroadcast").optional
+            .action((_, conf) =>
+              conf.copy(command = conf.command match {
+                case executeDLCRefund: ExecuteDLCRefund =>
+                  executeDLCRefund.copy(noBroadcast = true)
+                case other => other
               }))
         ),
       cmd("claimdlcpenaltyfunds")
         .hidden()
         .action((_, conf) =>
-          conf.copy(command = ClaimDLCPenaltyFunds(null, EmptyTransaction)))
+          conf.copy(command =
+            ClaimDLCPenaltyFunds(null, EmptyTransaction, noBroadcast = false)))
         .text("Claims the penalty funds for the corresponding DLC")
         .children(
           opt[Sha256DigestBE]("eventid").required
@@ -405,6 +465,14 @@ object ConsoleCli {
               conf.copy(command = conf.command match {
                 case claimDLCPenaltyFunds: ClaimDLCPenaltyFunds =>
                   claimDLCPenaltyFunds.copy(forceCloseTx = tx)
+                case other => other
+              })),
+          opt[Unit]("noBroadcast")
+            .optional()
+            .action((_, conf) =>
+              conf.copy(command = conf.command match {
+                case claimDLCPenaltyFunds: ClaimDLCPenaltyFunds =>
+                  claimDLCPenaltyFunds.copy(noBroadcast = true)
                 case other => other
               }))
         ),
@@ -602,27 +670,39 @@ object ConsoleCli {
         RequestParam(
           "initdlcmutualclose",
           Seq(up.writeJs(eventId), up.writeJs(oracleSig), up.writeJs(escaped)))
-      case AcceptDLCMutualClose(mutualCloseSig) =>
-        RequestParam("acceptdlcmutualclose", Seq(up.writeJs(mutualCloseSig)))
-      case ExecuteDLCUnilateralClose(eventId, oracleSig) =>
+      case AcceptDLCMutualClose(mutualCloseSig, noBroadcast) =>
+        RequestParam("acceptdlcmutualclose",
+                     Seq(up.writeJs(mutualCloseSig), up.writeJs(noBroadcast)))
+      case ExecuteDLCUnilateralClose(eventId, oracleSig, noBroadcast) =>
         RequestParam("executedlcunilateralclose",
-                     Seq(up.writeJs(eventId), up.writeJs(oracleSig)))
-      case ExecuteDLCRemoteUnilateralClose(eventId, cet) =>
-        RequestParam("executedlcremoteunilateralclose",
-                     Seq(up.writeJs(eventId), up.writeJs(cet)))
-      case GetDLCFundingTx(eventId) =>
-        RequestParam("getdlcfundingtx", Seq(up.writeJs(eventId)))
-      case ExecuteDLCForceClose(eventId, oracleSig) =>
+                     Seq(up.writeJs(eventId),
+                         up.writeJs(oracleSig),
+                         up.writeJs(noBroadcast)))
+      case ExecuteDLCRemoteUnilateralClose(eventId, cet, noBroadcast) =>
+        RequestParam(
+          "executedlcremoteunilateralclose",
+          Seq(up.writeJs(eventId), up.writeJs(cet), up.writeJs(noBroadcast)))
+      case GetDLCFundingTx(eventId, noBroadcast) =>
+        RequestParam("getdlcfundingtx",
+                     Seq(up.writeJs(eventId), up.writeJs(noBroadcast)))
+      case ExecuteDLCForceClose(eventId, oracleSig, noBroadcast) =>
         RequestParam("executedlcforceclose",
-                     Seq(up.writeJs(eventId), up.writeJs(oracleSig)))
-      case ClaimDLCRemoteFunds(eventId, forceCloseTx) =>
+                     Seq(up.writeJs(eventId),
+                         up.writeJs(oracleSig),
+                         up.writeJs(noBroadcast)))
+      case ClaimDLCRemoteFunds(eventId, forceCloseTx, noBroadcast) =>
         RequestParam("claimdlcremotefunds",
-                     Seq(up.writeJs(eventId), up.writeJs(forceCloseTx)))
-      case ExecuteDLCRefund(eventId) =>
-        RequestParam("executedlcrefund", Seq(up.writeJs(eventId)))
-      case ClaimDLCPenaltyFunds(eventId, forceCloseTx) =>
+                     Seq(up.writeJs(eventId),
+                         up.writeJs(forceCloseTx),
+                         up.writeJs(noBroadcast)))
+      case ExecuteDLCRefund(eventId, noBroadcast) =>
+        RequestParam("executedlcrefund",
+                     Seq(up.writeJs(eventId), up.writeJs(noBroadcast)))
+      case ClaimDLCPenaltyFunds(eventId, forceCloseTx, noBroadcast) =>
         RequestParam("claimdlcpenaltyfunds",
-                     Seq(up.writeJs(eventId), up.writeJs(forceCloseTx)))
+                     Seq(up.writeJs(eventId),
+                         up.writeJs(forceCloseTx),
+                         up.writeJs(noBroadcast)))
       // Wallet
       case GetBalance(isSats) =>
         RequestParam("getbalance", Seq(up.writeJs(isSats)))
@@ -778,36 +858,45 @@ object CliCommand {
       escaped: Boolean)
       extends CliCommand
 
-  case class AcceptDLCMutualClose(mutualCloseSig: DLCMutualCloseSig)
+  case class AcceptDLCMutualClose(
+      mutualCloseSig: DLCMutualCloseSig,
+      noBroadcast: Boolean)
       extends CliCommand
 
-  case class GetDLCFundingTx(eventId: Sha256DigestBE) extends CliCommand
+  case class GetDLCFundingTx(eventId: Sha256DigestBE, noBroadcast: Boolean)
+      extends CliCommand
 
   case class ExecuteDLCUnilateralClose(
       eventId: Sha256DigestBE,
-      oracleSig: SchnorrDigitalSignature)
+      oracleSig: SchnorrDigitalSignature,
+      noBroadcast: Boolean)
       extends CliCommand
 
   case class ExecuteDLCRemoteUnilateralClose(
       eventId: Sha256DigestBE,
-      cet: Transaction)
+      cet: Transaction,
+      noBroadcast: Boolean)
       extends CliCommand
 
   case class ExecuteDLCForceClose(
       eventId: Sha256DigestBE,
-      oracleSig: SchnorrDigitalSignature)
+      oracleSig: SchnorrDigitalSignature,
+      noBroadcast: Boolean)
       extends CliCommand
 
   case class ClaimDLCRemoteFunds(
       eventId: Sha256DigestBE,
-      forceCloseTx: Transaction)
+      forceCloseTx: Transaction,
+      noBroadcast: Boolean)
       extends CliCommand
 
-  case class ExecuteDLCRefund(eventId: Sha256DigestBE) extends CliCommand
+  case class ExecuteDLCRefund(eventId: Sha256DigestBE, noBroadcast: Boolean)
+      extends CliCommand
 
   case class ClaimDLCPenaltyFunds(
       eventId: Sha256DigestBE,
-      forceCloseTx: Transaction)
+      forceCloseTx: Transaction,
+      noBroadcast: Boolean)
       extends CliCommand
 
   // Wallet

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -284,8 +284,7 @@ object ConsoleCli {
         ),
       cmd("getdlcfundingtx")
         .hidden()
-        .action((_, conf) =>
-          conf.copy(command = GetDLCFundingTx(null, noBroadcast = false)))
+        .action((_, conf) => conf.copy(command = GetDLCFundingTx(null)))
         .text("Returns the Funding Tx corresponding to the DLC with the given eventId")
         .children(
           opt[Sha256DigestBE]("eventid").required
@@ -294,12 +293,18 @@ object ConsoleCli {
                 case getDLCFundingTx: GetDLCFundingTx =>
                   getDLCFundingTx.copy(eventId = eventId)
                 case other => other
-              })),
-          opt[Unit]("noBroadcast").optional
-            .action((_, conf) =>
+              }))
+        ),
+      cmd("broadcastdlcfundingtx")
+        .hidden()
+        .action((_, conf) => conf.copy(command = BroadcastDLCFundingTx(null)))
+        .text("Broadcasts the funding Tx corresponding to the DLC with the given eventId")
+        .children(
+          opt[Sha256DigestBE]("eventid").required
+            .action((eventId, conf) =>
               conf.copy(command = conf.command match {
-                case getDLCFundingTx: GetDLCFundingTx =>
-                  getDLCFundingTx.copy(noBroadcast = true)
+                case broadcastDLCFundingTx: BroadcastDLCFundingTx =>
+                  broadcastDLCFundingTx.copy(eventId = eventId)
                 case other => other
               }))
         ),
@@ -691,9 +696,10 @@ object ConsoleCli {
         RequestParam(
           "executedlcremoteunilateralclose",
           Seq(up.writeJs(eventId), up.writeJs(cet), up.writeJs(noBroadcast)))
-      case GetDLCFundingTx(eventId, noBroadcast) =>
-        RequestParam("getdlcfundingtx",
-                     Seq(up.writeJs(eventId), up.writeJs(noBroadcast)))
+      case GetDLCFundingTx(eventId) =>
+        RequestParam("getdlcfundingtx", Seq(up.writeJs(eventId)))
+      case BroadcastDLCFundingTx(eventId) =>
+        RequestParam("broadcastdlcfundingtx", Seq(up.writeJs(eventId)))
       case ExecuteDLCForceClose(eventId, oracleSig, noBroadcast) =>
         RequestParam("executedlcforceclose",
                      Seq(up.writeJs(eventId),
@@ -880,9 +886,9 @@ object CliCommand {
     def noBroadcast: Boolean
   }
 
-  case class GetDLCFundingTx(eventId: Sha256DigestBE, noBroadcast: Boolean)
-      extends CliCommand
-      with Broadcastable
+  case class GetDLCFundingTx(eventId: Sha256DigestBE) extends CliCommand
+
+  case class BroadcastDLCFundingTx(eventId: Sha256DigestBE) extends CliCommand
 
   case class ExecuteDLCUnilateralClose(
       eventId: Sha256DigestBE,

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
@@ -49,7 +49,8 @@ class WalletGUIModel() {
             ConsoleCli.exec(
               SendToAddress(BitcoinAddress(address).get,
                             Bitcoins(BigDecimal(amount)),
-                            satoshisPerVirtualByte = None)) match {
+                            satoshisPerVirtualByte = None,
+                            noBroadcast = false)) match {
               case Success(txid) =>
                 GlobalData.log.value =
                   s"Sent $amount to $address in tx: $txid\n\n${GlobalData.log()}"

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -411,6 +411,41 @@ class RoutesSpec
       }
     }
 
+    "get dlc funding tx" in {
+      (mockWalletApi
+        .getDLCFundingTx(_: Sha256DigestBE))
+        .expects(eventId)
+        .returning(Future.successful(EmptyTransaction))
+
+      val route = walletRoutes.handleCommand(
+        ServerCommand("getdlcfundingtx", Arr(Str(eventId.hex))))
+
+      Post() ~> route ~> check {
+        contentType shouldEqual `application/json`
+        responseAs[String] shouldEqual s"""{"result":"${EmptyTransaction.hex}","error":null}"""
+      }
+    }
+
+    "broadcast dlc funding tx" in {
+      (mockWalletApi
+        .getDLCFundingTx(_: Sha256DigestBE))
+        .expects(eventId)
+        .returning(Future.successful(EmptyTransaction))
+
+      (mockNode.broadcastTransaction _)
+        .expects(EmptyTransaction)
+        .returning(FutureUtil.unit)
+        .anyNumberOfTimes()
+
+      val route = walletRoutes.handleCommand(
+        ServerCommand("broadcastdlcfundingtx", Arr(Str(eventId.hex))))
+
+      Post() ~> route ~> check {
+        contentType shouldEqual `application/json`
+        responseAs[String] shouldEqual s"""{"result":"${EmptyTransaction.txIdBE.hex}","error":null}"""
+      }
+    }
+
     "send to an address" in {
       // positive cases
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -426,7 +426,7 @@ class RoutesSpec
 
       val route = walletRoutes.handleCommand(
         ServerCommand("sendtoaddress",
-                      Arr(Str(testAddressStr), Num(100), Num(4))))
+                      Arr(Str(testAddressStr), Num(100), Num(4), Bool(false))))
 
       Post() ~> route ~> check {
         contentType shouldEqual `application/json`
@@ -436,7 +436,7 @@ class RoutesSpec
       // negative cases
 
       val route1 = walletRoutes.handleCommand(
-        ServerCommand("sendtoaddress", Arr(Null, Null, Null)))
+        ServerCommand("sendtoaddress", Arr(Null, Null, Null, Bool(false))))
 
       Post() ~> route1 ~> check {
         rejection shouldEqual ValidationRejection(
@@ -445,7 +445,7 @@ class RoutesSpec
       }
 
       val route2 = walletRoutes.handleCommand(
-        ServerCommand("sendtoaddress", Arr("Null", Null, Null)))
+        ServerCommand("sendtoaddress", Arr("Null", Null, Null, Bool(false))))
 
       Post() ~> route2 ~> check {
         rejection shouldEqual ValidationRejection(
@@ -454,7 +454,8 @@ class RoutesSpec
       }
 
       val route3 = walletRoutes.handleCommand(
-        ServerCommand("sendtoaddress", Arr(Str(testAddressStr), Null, Null)))
+        ServerCommand("sendtoaddress",
+                      Arr(Str(testAddressStr), Null, Null, Bool(false))))
 
       Post() ~> route3 ~> check {
         rejection shouldEqual ValidationRejection(
@@ -464,7 +465,7 @@ class RoutesSpec
 
       val route4 = walletRoutes.handleCommand(
         ServerCommand("sendtoaddress",
-                      Arr(Str(testAddressStr), Str("abc"), Null)))
+                      Arr(Str(testAddressStr), Str("abc"), Null, Bool(false))))
 
       Post() ~> route4 ~> check {
         rejection shouldEqual ValidationRejection(

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -200,7 +200,7 @@ object SendToAddress extends ServerJsonModels {
       case other =>
         Failure(
           new IllegalArgumentException(
-            s"Bad number of arguments: ${other.length}. Expected: 3"))
+            s"Bad number of arguments: ${other.length}. Expected: 4"))
     }
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -359,17 +359,37 @@ object AcceptDLCMutualClose extends ServerJsonModels {
   }
 }
 
-case class GetDLCFundingTx(eventId: Sha256DigestBE, noBroadcast: Boolean)
+case class GetDLCFundingTx(eventId: Sha256DigestBE)
 
 object GetDLCFundingTx extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[GetDLCFundingTx] = {
     jsArr.arr.toList match {
-      case eventIdJs :: noBroadcastJs :: Nil =>
+      case eventIdJs :: Nil =>
         Try {
           val eventId = Sha256DigestBE(eventIdJs.str)
-          val noBroadcast = noBroadcastJs.bool
-          GetDLCFundingTx(eventId, noBroadcast)
+          GetDLCFundingTx(eventId)
+        }
+      case Nil =>
+        Failure(new IllegalArgumentException("Missing eventId argument"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 1"))
+    }
+  }
+}
+
+case class BroadcastDLCFundingTx(eventId: Sha256DigestBE)
+
+object BroadcastDLCFundingTx extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[BroadcastDLCFundingTx] = {
+    jsArr.arr.toList match {
+      case eventIdJs :: Nil =>
+        Try {
+          val eventId = Sha256DigestBE(eventIdJs.str)
+          BroadcastDLCFundingTx(eventId)
         }
       case Nil =>
         Failure(new IllegalArgumentException("Missing eventId argument"))
@@ -405,7 +425,7 @@ object ExecuteDLCUnilateralClose extends ServerJsonModels {
       case other =>
         Failure(
           new IllegalArgumentException(
-            s"Bad number of arguments: ${other.length}. Expected: 2"))
+            s"Bad number of arguments: ${other.length}. Expected: 3"))
     }
   }
 }
@@ -433,7 +453,7 @@ object ExecuteDLCRemoteUnilateralClose extends ServerJsonModels {
       case other =>
         Failure(
           new IllegalArgumentException(
-            s"Bad number of arguments: ${other.length}. Expected: 2"))
+            s"Bad number of arguments: ${other.length}. Expected: 3"))
     }
   }
 }
@@ -462,7 +482,7 @@ object ExecuteDLCForceClose extends ServerJsonModels {
       case other =>
         Failure(
           new IllegalArgumentException(
-            s"Bad number of arguments: ${other.length}. Expected: 2"))
+            s"Bad number of arguments: ${other.length}. Expected: 3"))
     }
   }
 }
@@ -491,7 +511,7 @@ object ClaimDLCRemoteFunds extends ServerJsonModels {
       case other =>
         Failure(
           new IllegalArgumentException(
-            s"Bad number of arguments: ${other.length}. Expected: 2"))
+            s"Bad number of arguments: ${other.length}. Expected: 3"))
     }
   }
 }
@@ -514,7 +534,7 @@ object ExecuteDLCRefund extends ServerJsonModels {
       case other =>
         Failure(
           new IllegalArgumentException(
-            s"Bad number of arguments: ${other.length}. Expected: 1"))
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
     }
   }
 }
@@ -543,7 +563,7 @@ object ClaimDLCPenaltyFunds extends ServerJsonModels {
       case other =>
         Failure(
           new IllegalArgumentException(
-            s"Bad number of arguments: ${other.length}. Expected: 2"))
+            s"Bad number of arguments: ${other.length}. Expected: 3"))
     }
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -333,35 +333,40 @@ object InitDLCMutualClose extends ServerJsonModels {
   }
 }
 
-case class AcceptDLCMutualClose(mutualCloseSig: DLCMutualCloseSig)
+case class AcceptDLCMutualClose(
+    mutualCloseSig: DLCMutualCloseSig,
+    noBroadcast: Boolean)
 
 object AcceptDLCMutualClose extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[AcceptDLCMutualClose] = {
     jsArr.arr.toList match {
-      case mutualCloseSig :: Nil =>
+      case mutualCloseSigJs :: noBroadcastJs :: Nil =>
         Try {
-          AcceptDLCMutualClose(
-            DLCMutualCloseSig.fromJson(ujson.read(mutualCloseSig.str)))
+          val mutualCloseSig =
+            DLCMutualCloseSig.fromJson(ujson.read(mutualCloseSigJs.str))
+          val noBroadcast = noBroadcastJs.bool
+          AcceptDLCMutualClose(mutualCloseSig, noBroadcast)
         }
       case other =>
         Failure(
           new IllegalArgumentException(
-            s"Bad number of arguments: ${other.length}. Expected: 1"))
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
     }
   }
 }
 
-case class GetDLCFundingTx(eventId: Sha256DigestBE)
+case class GetDLCFundingTx(eventId: Sha256DigestBE, noBroadcast: Boolean)
 
 object GetDLCFundingTx extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[GetDLCFundingTx] = {
     jsArr.arr.toList match {
-      case eventIdJs :: Nil =>
+      case eventIdJs :: noBroadcastJs :: Nil =>
         Try {
           val eventId = Sha256DigestBE(eventIdJs.str)
-          GetDLCFundingTx(eventId)
+          val noBroadcast = noBroadcastJs.bool
+          GetDLCFundingTx(eventId, noBroadcast)
         }
       case Nil =>
         Failure(new IllegalArgumentException("Missing eventId argument"))
@@ -375,18 +380,20 @@ object GetDLCFundingTx extends ServerJsonModels {
 
 case class ExecuteDLCUnilateralClose(
     eventId: Sha256DigestBE,
-    oracleSig: SchnorrDigitalSignature)
+    oracleSig: SchnorrDigitalSignature,
+    noBroadcast: Boolean)
 
 object ExecuteDLCUnilateralClose extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[ExecuteDLCUnilateralClose] = {
     jsArr.arr.toList match {
-      case eventIdJs :: oracleSigJs :: Nil =>
+      case eventIdJs :: oracleSigJs :: noBroadcastJs :: Nil =>
         Try {
           val eventId = Sha256DigestBE(eventIdJs.str)
           val oracleSig = jsToSchnorrDigitalSignature(oracleSigJs)
+          val noBroadcast = noBroadcastJs.bool
 
-          ExecuteDLCUnilateralClose(eventId, oracleSig)
+          ExecuteDLCUnilateralClose(eventId, oracleSig, noBroadcast)
         }
       case Nil =>
         Failure(
@@ -402,18 +409,20 @@ object ExecuteDLCUnilateralClose extends ServerJsonModels {
 
 case class ExecuteDLCRemoteUnilateralClose(
     eventId: Sha256DigestBE,
-    cet: Transaction)
+    cet: Transaction,
+    noBroadcast: Boolean)
 
 object ExecuteDLCRemoteUnilateralClose extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[ExecuteDLCRemoteUnilateralClose] = {
     jsArr.arr.toList match {
-      case eventIdJs :: cetJs :: Nil =>
+      case eventIdJs :: cetJs :: noBroadcastJs :: Nil =>
         Try {
           val eventId = Sha256DigestBE(eventIdJs.str)
           val cet = jsToTx(cetJs)
+          val noBroadcast = noBroadcastJs.bool
 
-          ExecuteDLCRemoteUnilateralClose(eventId, cet)
+          ExecuteDLCRemoteUnilateralClose(eventId, cet, noBroadcast)
         }
       case Nil =>
         Failure(
@@ -428,18 +437,20 @@ object ExecuteDLCRemoteUnilateralClose extends ServerJsonModels {
 
 case class ExecuteDLCForceClose(
     eventId: Sha256DigestBE,
-    oracleSig: SchnorrDigitalSignature)
+    oracleSig: SchnorrDigitalSignature,
+    noBroadcast: Boolean)
 
 object ExecuteDLCForceClose extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[ExecuteDLCForceClose] = {
     jsArr.arr.toList match {
-      case eventIdJs :: oracleSigJs :: Nil =>
+      case eventIdJs :: oracleSigJs :: noBroadcastJs :: Nil =>
         Try {
           val eventId = Sha256DigestBE(eventIdJs.str)
           val oracleSig = jsToSchnorrDigitalSignature(oracleSigJs)
+          val noBroadcast = noBroadcastJs.bool
 
-          ExecuteDLCForceClose(eventId, oracleSig)
+          ExecuteDLCForceClose(eventId, oracleSig, noBroadcast)
         }
       case Nil =>
         Failure(
@@ -455,17 +466,20 @@ object ExecuteDLCForceClose extends ServerJsonModels {
 
 case class ClaimDLCRemoteFunds(
     eventId: Sha256DigestBE,
-    forceCloseTx: Transaction)
+    forceCloseTx: Transaction,
+    noBroadcast: Boolean)
 
 object ClaimDLCRemoteFunds extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[ClaimDLCRemoteFunds] = {
     jsArr.arr.toList match {
-      case eventIdJs :: forceCloseTxJs :: Nil =>
+      case eventIdJs :: forceCloseTxJs :: noBroadcastJs :: Nil =>
         Try {
           val eventId = Sha256DigestBE(eventIdJs.str)
           val forceCloseTx = jsToTx(forceCloseTxJs)
-          ClaimDLCRemoteFunds(eventId, forceCloseTx)
+          val noBroadcast = noBroadcastJs.bool
+
+          ClaimDLCRemoteFunds(eventId, forceCloseTx, noBroadcast)
         }
       case Nil =>
         Failure(
@@ -479,16 +493,18 @@ object ClaimDLCRemoteFunds extends ServerJsonModels {
   }
 }
 
-case class ExecuteDLCRefund(eventId: Sha256DigestBE)
+case class ExecuteDLCRefund(eventId: Sha256DigestBE, noBroadcast: Boolean)
 
 object ExecuteDLCRefund extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[ExecuteDLCRefund] = {
     jsArr.arr.toList match {
-      case eventIdJs :: Nil =>
+      case eventIdJs :: noBroadcastJs :: Nil =>
         Try {
           val eventId = Sha256DigestBE(eventIdJs.str)
-          ExecuteDLCRefund(eventId)
+          val noBroadcast = noBroadcastJs.bool
+
+          ExecuteDLCRefund(eventId, noBroadcast)
         }
       case Nil =>
         Failure(new IllegalArgumentException("Missing eventId argument"))
@@ -502,17 +518,20 @@ object ExecuteDLCRefund extends ServerJsonModels {
 
 case class ClaimDLCPenaltyFunds(
     eventId: Sha256DigestBE,
-    forceCloseTx: Transaction)
+    forceCloseTx: Transaction,
+    noBroadcast: Boolean)
 
 object ClaimDLCPenaltyFunds extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[ClaimDLCPenaltyFunds] = {
     jsArr.arr.toList match {
-      case eventIdJs :: forceCloseTxJs :: Nil =>
+      case eventIdJs :: forceCloseTxJs :: noBroadcastJs :: Nil =>
         Try {
           val eventId = Sha256DigestBE(eventIdJs.str)
           val forceCloseTx = jsToTx(forceCloseTxJs)
-          ClaimDLCPenaltyFunds(eventId, forceCloseTx)
+          val noBroadcast = noBroadcastJs.bool
+
+          ClaimDLCPenaltyFunds(eventId, forceCloseTx, noBroadcast)
         }
       case Nil =>
         Failure(

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -172,7 +172,8 @@ object Rescan extends ServerJsonModels {
 case class SendToAddress(
     address: BitcoinAddress,
     amount: Bitcoins,
-    satoshisPerVirtualByte: Option[SatoshisPerVirtualByte])
+    satoshisPerVirtualByte: Option[SatoshisPerVirtualByte],
+    noBroadcast: Boolean)
 
 object SendToAddress extends ServerJsonModels {
 
@@ -180,14 +181,16 @@ object SendToAddress extends ServerJsonModels {
   // custom akka-http directive?
   def fromJsArr(jsArr: ujson.Arr): Try[SendToAddress] = {
     jsArr.arr.toList match {
-      case addrJs :: bitcoinsJs :: satsPerVBytesJs :: Nil =>
+      case addrJs :: bitcoinsJs :: satsPerVBytesJs :: noBroadcastJs :: Nil =>
         Try {
           val address = jsToBitcoinAddress(addrJs)
           val bitcoins = Bitcoins(bitcoinsJs.num)
           val satoshisPerVirtualByte =
             nullToOpt(satsPerVBytesJs).map(satsPerVBytes =>
               SatoshisPerVirtualByte(Satoshis(satsPerVBytes.num.toLong)))
-          SendToAddress(address, bitcoins, satoshisPerVirtualByte)
+          val noBroadcast = noBroadcastJs.bool
+
+          SendToAddress(address, bitcoins, satoshisPerVirtualByte, noBroadcast)
         }
       case Nil =>
         Failure(

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.ActorMaterializer
 import org.bitcoins.core.currency._
+import org.bitcoins.core.protocol.NetworkElement
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.dlc.DLCMessage
@@ -41,12 +42,11 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
 
   private def handleBroadcastable(
       tx: Transaction,
-      noBroadcast: Boolean): String = {
+      noBroadcast: Boolean): Future[NetworkElement] = {
     if (noBroadcast) {
-      tx.hex
+      Future.successful(tx)
     } else {
-      node.broadcastTransaction(tx)
-      tx.txIdBE.hex
+      node.broadcastTransaction(tx).map(_ => tx.txIdBE)
     }
   }
 
@@ -155,9 +155,10 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           reject(ValidationRejection("failure", Some(exception)))
         case Success(AcceptDLCMutualClose(mutualCloseSig, noBroadcast)) =>
           complete {
-            wallet.acceptDLCMutualClose(mutualCloseSig).map { tx =>
-              val retStr = handleBroadcastable(tx, noBroadcast)
-              Server.httpSuccess(retStr)
+            wallet.acceptDLCMutualClose(mutualCloseSig).flatMap { tx =>
+              handleBroadcastable(tx, noBroadcast).map { retStr =>
+                Server.httpSuccess(retStr.hex)
+              }
             }
           }
       }
@@ -168,9 +169,10 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           reject(ValidationRejection("failure", Some(exception)))
         case Success(GetDLCFundingTx(eventId, noBroadcast)) =>
           complete {
-            wallet.getDLCFundingTx(eventId).map { tx =>
-              val retStr = handleBroadcastable(tx, noBroadcast)
-              Server.httpSuccess(retStr)
+            wallet.getDLCFundingTx(eventId).flatMap { tx =>
+              handleBroadcastable(tx, noBroadcast).map { retStr =>
+                Server.httpSuccess(retStr.hex)
+              }
             }
           }
       }
@@ -182,17 +184,20 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
         case Success(
             ExecuteDLCUnilateralClose(eventId, oracleSig, noBroadcast)) =>
           complete {
-            wallet.executeDLCUnilateralClose(eventId, oracleSig).map { txs =>
-              txs._2 match {
-                case Some(closingTx) =>
-                  val retStr = handleBroadcastable(txs._1, noBroadcast)
-                  val closingRetStr =
-                    handleBroadcastable(closingTx, noBroadcast)
-                  Server.httpSuccess(s"$retStr\n$closingRetStr")
-                case None =>
-                  val retStr = handleBroadcastable(txs._1, noBroadcast)
-                  Server.httpSuccess(retStr)
-              }
+            wallet.executeDLCUnilateralClose(eventId, oracleSig).flatMap {
+              txs =>
+                txs._2 match {
+                  case Some(closingTx) =>
+                    for {
+                      retStr <- handleBroadcastable(txs._1, noBroadcast)
+                      closingRetStr <- handleBroadcastable(closingTx,
+                                                           noBroadcast)
+                    } yield Server.httpSuccess(s"$retStr\n$closingRetStr")
+                  case None =>
+                    handleBroadcastable(txs._1, noBroadcast).map { retStr =>
+                      Server.httpSuccess(retStr.hex)
+                    }
+                }
             }
           }
       }
@@ -204,13 +209,16 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
         case Success(
             ExecuteDLCRemoteUnilateralClose(eventId, cet, noBroadcast)) =>
           complete {
-            wallet.executeRemoteUnilateralDLC(eventId, cet).map {
+            wallet.executeRemoteUnilateralDLC(eventId, cet).flatMap {
               case Some(closingTx) =>
-                val retStr = handleBroadcastable(closingTx, noBroadcast)
-                Server.httpSuccess(retStr)
+                handleBroadcastable(closingTx, noBroadcast).map { retStr =>
+                  Server.httpSuccess(retStr.hex)
+                }
               case None =>
-                Server.httpSuccess(
-                  "Received would have only been dust, they have been used as fees")
+                Future.successful(
+                  Server.httpSuccess(
+                    "Received would have only been dust, they have been used as fees")
+                )
             }
           }
       }
@@ -224,13 +232,14 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
             wallet.executeDLCForceClose(eventId, oracleSig).map { txs =>
               txs._2 match {
                 case Some(closingTx) =>
-                  val retStr = handleBroadcastable(txs._1, noBroadcast)
-                  val closingRetStr =
-                    handleBroadcastable(closingTx, noBroadcast)
-                  Server.httpSuccess(s"$retStr\n$closingRetStr")
+                  for {
+                    retStr <- handleBroadcastable(txs._1, noBroadcast)
+                    closingRetStr <- handleBroadcastable(closingTx, noBroadcast)
+                  } yield Server.httpSuccess(s"$retStr\n$closingRetStr")
                 case None =>
-                  val retStr = handleBroadcastable(txs._1, noBroadcast)
-                  Server.httpSuccess(retStr)
+                  handleBroadcastable(txs._1, noBroadcast).map { retStr =>
+                    Server.httpSuccess(retStr.hex)
+                  }
               }
             }
           }
@@ -242,13 +251,16 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           reject(ValidationRejection("failure", Some(exception)))
         case Success(ClaimDLCRemoteFunds(eventId, tx, noBroadcast)) =>
           complete {
-            wallet.claimDLCRemoteFunds(eventId, tx).map {
+            wallet.claimDLCRemoteFunds(eventId, tx).flatMap {
               case Some(closingTx) =>
-                val retStr = handleBroadcastable(closingTx, noBroadcast)
-                Server.httpSuccess(retStr)
+                handleBroadcastable(closingTx, noBroadcast).map { retStr =>
+                  Server.httpSuccess(retStr.hex)
+                }
               case None =>
-                Server.httpSuccess(
-                  "Received would have only been dust, they have been used as fees")
+                Future.successful(
+                  Server.httpSuccess(
+                    "Received would have only been dust, they have been used as fees")
+                )
             }
           }
       }
@@ -262,13 +274,14 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
             wallet.executeDLCRefund(eventId).map { txs =>
               txs._2 match {
                 case Some(closingTx) =>
-                  val retStr = handleBroadcastable(txs._1, noBroadcast)
-                  val closingRetStr =
-                    handleBroadcastable(closingTx, noBroadcast)
-                  Server.httpSuccess(s"$retStr\n$closingRetStr")
+                  for {
+                    retStr <- handleBroadcastable(txs._1, noBroadcast)
+                    closingRetStr <- handleBroadcastable(closingTx, noBroadcast)
+                  } yield Server.httpSuccess(s"$retStr\n$closingRetStr")
                 case None =>
-                  val retStr = handleBroadcastable(txs._1, noBroadcast)
-                  Server.httpSuccess(retStr)
+                  handleBroadcastable(txs._1, noBroadcast).map { retStr =>
+                    Server.httpSuccess(retStr.hex)
+                  }
               }
             }
           }
@@ -280,13 +293,16 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
           reject(ValidationRejection("failure", Some(exception)))
         case Success(ClaimDLCPenaltyFunds(eventId, tx, noBroadcast)) =>
           complete {
-            wallet.claimDLCPenaltyFunds(eventId, tx).map {
+            wallet.claimDLCPenaltyFunds(eventId, tx).flatMap {
               case Some(closingTx) =>
-                val retStr = handleBroadcastable(closingTx, noBroadcast)
-                Server.httpSuccess(retStr)
+                handleBroadcastable(closingTx, noBroadcast).map { retStr =>
+                  Server.httpSuccess(retStr.hex)
+                }
               case None =>
-                Server.httpSuccess(
-                  "Received would have only been dust, they have been used as fees")
+                Future.successful(
+                  Server.httpSuccess(
+                    "Received would have only been dust, they have been used as fees")
+                )
             }
           }
       }
@@ -306,8 +322,9 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
             val feeRate =
               satoshisPerVirtualByteOpt.getOrElse(SatoshisPerByte(100.satoshis))
             wallet.sendToAddress(address, bitcoins, feeRate).map { tx =>
-              val retStr = handleBroadcastable(tx, noBroadcast)
-              Server.httpSuccess(retStr)
+              handleBroadcastable(tx, noBroadcast).map { retStr =>
+                Server.httpSuccess(retStr.hex)
+              }
             }
           }
       }


### PR DESCRIPTION
DLC functions now broadcast the transactions by default, you have the option to do `--noBroadcast` to get the raw transaction.

I made it so you need to `getdlcfundingtx` for the tx broadcast rather than having `adddlcsigs` do it, curious on thoughts about which option is desirable.