### PR TITLE
Replace all usages of List inside of ScriptParser with Vector

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/serializers/script/ScriptParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/script/ScriptParserTest.scala
@@ -220,7 +220,7 @@ class ScriptParserTest extends BitcoinSUnitTest {
     val rawScriptSig =
       "4730440220048e15422cf62349dc586ffb8c749d40280781edd5064ff27a5910ff5cf225a802206a82685dbc2cf195d158c29309939d5a3cd41a889db6f766f3809fff35722305012103dcfc9882c1b3ae4e03fb6cac08bdb39e284e81d70c7aa8b27612457b2774509b"
 
-    val expectedAsm = List(
+    val expectedAsm = Vector(
       BytesToPushOntoStack(71),
       ScriptConstant(
         "30440220048e15422cf62349dc586ffb8c749d40280781edd5064ff27a5910ff5cf" +
@@ -230,7 +230,7 @@ class ScriptParserTest extends BitcoinSUnitTest {
         "03dcfc9882c1b3ae4e03fb6cac08bdb39e284e81d70c7aa8b27612457b2774509b")
     )
 
-    val scriptTokens: List[ScriptToken] = ScriptParser.fromHex(rawScriptSig)
+    val scriptTokens: Vector[ScriptToken] = ScriptParser.fromHex(rawScriptSig)
 
     scriptTokens must be(expectedAsm)
   }

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -590,8 +590,8 @@ trait BitcoinScriptUtil extends BitcoinSLogger {
     val scriptPubKeyBytes =
       bytes.slice(compactSizeUInt.byteSize.toInt,
                   len + compactSizeUInt.byteSize.toInt)
-    val script: List[ScriptToken] = ScriptParser.fromBytes(scriptPubKeyBytes)
-    f(script.toVector)
+    val script: Vector[ScriptToken] = ScriptParser.fromBytes(scriptPubKeyBytes)
+    f(script)
   }
 }
 


### PR DESCRIPTION
This makes `ScriptParser` use a `Vector` for parsing rather than a `List`. The reason I am replacing this is because `List` does not have safe random access (`O(n)`). 

Scaladoc on List: 

```
  *  ==Performance==
  *  '''Time:''' `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
  *  This includes the index-based lookup of elements, `length`, `append` and `reverse`.
```

We should use Vector pretty much everywhere unless there is a _very_ good reason not to.

