### PR TITLE
Reduce default num threads used for slick being a thread pool of 20 to 5

### DIFF
--- a/db-commons/src/main/resources/db.conf
+++ b/db-commons/src/main/resources/db.conf
@@ -3,9 +3,12 @@ common = {
   profile = "slick.jdbc.SQLiteProfile$"
 
   db {
+    //for information on parameters available here see
+    //https://scala-slick.org/doc/3.3.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database
     path = ${bitcoin-s.datadir}/${bitcoin-s.network}/
     driver = org.sqlite.JDBC
 
+    numThreads = 5 # default num threads is 20, which is way too much
     # as long as we're on SQLite there's no point
     # in doing connection pooling
     connectionPool = disabled


### PR DESCRIPTION
When looking at #1278 it appears that one problem we might be having is _to_ many threads in our database thread pools. While I doubt this is the _acutal_ problem, it seems seem logical to reduce the _large_ amount of threads that slick allocates by default to it's thread pool, which is 20!. 

See:

https://scala-slick.org/doc/3.3.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database

Says that the default number of threads allocated by slick is 20. That is way too much for our use case, even when i'm syncing filter headers it appears that 5 threads in the chain database is more than enough. 

![Screenshot from 2020-03-29 20-25-39](https://user-images.githubusercontent.com/3514957/77867118-7c0a4800-71fb-11ea-86ed-5ac8274179e8.png)
