### PR TITLE
Fetch addresses and utxos async in LockedWalletApi.processCompactFilt…

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -81,9 +81,11 @@ trait LockedWalletApi extends WalletApi with WalletLogger {
   def processCompactFilter(
       blockHash: DoubleSha256Digest,
       blockFilter: GolombFilter): Future[LockedWalletApi] = {
+    val utxosF = listUtxos()
+    val addressesF = listAddresses()
     for {
-      utxos <- listUtxos()
-      addresses <- listAddresses()
+      utxos <- utxosF
+      addresses <- addressesF
       scriptPubKeys = utxos.flatMap(_.redeemScriptOpt).toSet ++ addresses
         .map(_.scriptPubKey)
         .toSet


### PR DESCRIPTION
…er()

Picking some low hanging fruit on #1282 

Basically fetch utxos/addresses simultaneously, but this does not cache the across calls of `LockedWalletApi.processCompactFilter()`. 