### PR TITLE
Network specific filterHeaderBatchSize

### DIFF
--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -48,6 +48,13 @@ bitcoin-s {
     chain {
         neutrino {
             filter-header-batch-size = 2000
+            filter-header-batch-size.regtest = 10
+            # You can set a network specific filter-header-batch-size
+            # by adding a trailing `.networkId` (main, test, regtest)
+            # It is recommended to keep the main and test batch size high
+            # to keep the sync time fast, however, for regtest it should be small
+            # so it does not exceed the chain size.
+
             filter-batch-size = 100
         }
     }

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -83,7 +83,7 @@ case class ChainAppConfig(
       config.getInt(
         s"$moduleName.neutrino.filter-header-batch-size.${chain.network.chainParams.networkId}")
     } catch {
-      case _: ConfigException.Missing =>
+      case _: ConfigException.Missing | _: ConfigException.WrongType =>
         config.getInt(s"$moduleName.neutrino.filter-header-batch-size")
     }
   }

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -2,7 +2,7 @@ package org.bitcoins.chain.config
 
 import java.nio.file.Path
 
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigException}
 import org.bitcoins.chain.db.ChainDbManagement
 import org.bitcoins.chain.models.{BlockHeaderDAO, BlockHeaderDbHelper}
 import org.bitcoins.core.util.FutureUtil
@@ -77,8 +77,16 @@ case class ChainAppConfig(
     }
   }
 
-  lazy val filterHeaderBatchSize: Int =
-    config.getInt(s"${moduleName}.neutrino.filter-header-batch-size")
+  lazy val filterHeaderBatchSize: Int = {
+    // try by network, if that fails, try general
+    try {
+      config.getInt(
+        s"$moduleName.neutrino.filter-header-batch-size.${chain.network.chainParams.networkId}")
+    } catch {
+      case _: ConfigException.Missing =>
+        config.getInt(s"$moduleName.neutrino.filter-header-batch-size")
+    }
+  }
 
   lazy val filterBatchSize: Int =
     config.getInt(s"${moduleName}.neutrino.filter-batch-size")

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -120,6 +120,13 @@ bitcoin-s {
     chain {
         neutrino {
             filter-header-batch-size = 2000
+            filter-header-batch-size.regtest = 10
+            # You can set a network specific filter-header-batch-size
+            # by adding a trailing `.networkId` (main, test, regtest)
+            # It is recommended to keep the main and test batch size high
+            # to keep the sync time fast, however, for regtest it should be small
+            # so it does not exceed the chain size.
+
             filter-batch-size = 100
         }
     }

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -49,6 +49,13 @@ bitcoin-s {
     chain {
         neutrino {
             filter-header-batch-size = 2000
+            filter-header-batch-size.regtest = 10
+            # You can set a network specific filter-header-batch-size
+            # by adding a trailing `.networkId` (main, test, regtest)
+            # It is recommended to keep the main and test batch size high
+            # to keep the sync time fast, however, for regtest it should be small
+            # so it does not exceed the chain size.
+
             filter-batch-size = 100
         }
     }


### PR DESCRIPTION
Fixes #1246

Gives the ability to set a filterHeaderBatchSize for each network, this way for regtest you can set it to something much smaller and still keep the same config for other networks.