### PR TITLE
Add CLI commands for current wallet apis

### DIFF
--- a/app/picklers/src/main/scala/org/bitcoins/picklers/Picklers.scala
+++ b/app/picklers/src/main/scala/org/bitcoins/picklers/Picklers.scala
@@ -1,5 +1,6 @@
 package org.bitcoins
 
+import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.protocol.transaction.Transaction
@@ -32,4 +33,7 @@ package object picklers {
     SatoshisPerVirtualByte] =
     readwriter[Long].bimap(_.currencyUnit.satoshis.toLong,
                            l => SatoshisPerVirtualByte(Satoshis(l)))
+
+  implicit val extPubKeyPickler: ReadWriter[ExtPublicKey] =
+    readwriter[String].bimap(_.toString, ExtPublicKey.fromString(_).get)
 }

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -30,6 +30,44 @@ object GetBalance extends ServerJsonModels {
   }
 }
 
+case class GetConfirmedBalance(isSats: Boolean)
+
+object GetConfirmedBalance extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[GetConfirmedBalance] = {
+    require(jsArr.arr.size == 1,
+            s"Bad number of arguments: ${jsArr.arr.size}. Expected: 1")
+
+    Try(GetConfirmedBalance(jsArr.arr.head.bool))
+  }
+}
+
+case class GetUnconfirmedBalance(isSats: Boolean)
+
+object GetUnconfirmedBalance extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[GetUnconfirmedBalance] = {
+    require(jsArr.arr.size == 1,
+            s"Bad number of arguments: ${jsArr.arr.size}. Expected: 1")
+
+    Try(GetUnconfirmedBalance(jsArr.arr.head.bool))
+  }
+}
+
+case class GetAddressInfo(address: BitcoinAddress)
+
+object GetAddressInfo extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[GetAddressInfo] = {
+    require(jsArr.arr.size == 1,
+            s"Bad number of arguments: ${jsArr.arr.size}. Expected: 1")
+
+    val address = jsToBitcoinAddress(jsArr.arr.head)
+
+    Try(GetAddressInfo(address))
+  }
+}
+
 case class CombinePSBTs(psbts: Seq[PSBT])
 
 object CombinePSBTs extends ServerJsonModels {

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -20,6 +20,14 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
   implicit val materializer = ActorMaterializer()
 
   def handleCommand: PartialFunction[ServerCommand, StandardRoute] = {
+
+    case ServerCommand("isempty", _) =>
+      complete {
+        wallet.isEmpty().map { empty =>
+          Server.httpSuccess(empty)
+        }
+      }
+
     case ServerCommand("getbalance", arr) =>
       GetBalance.fromJsArr(arr) match {
         case Failure(exception) =>
@@ -27,6 +35,42 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
         case Success(GetBalance(isSats)) =>
           complete {
             wallet.getBalance().map { balance =>
+              Server.httpSuccess(
+                if (isSats) {
+                  balance.satoshis.toString
+                } else {
+                  Bitcoins(balance.satoshis).toString
+                }
+              )
+            }
+          }
+      }
+
+    case ServerCommand("getconfirmedbalance", arr) =>
+      GetBalance.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(GetBalance(isSats)) =>
+          complete {
+            wallet.getConfirmedBalance().map { balance =>
+              Server.httpSuccess(
+                if (isSats) {
+                  balance.satoshis.toString
+                } else {
+                  Bitcoins(balance.satoshis).toString
+                }
+              )
+            }
+          }
+      }
+
+    case ServerCommand("getunconfirmedbalance", arr) =>
+      GetBalance.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(GetBalance(isSats)) =>
+          complete {
+            wallet.getUnconfirmedBalance().map { balance =>
               Server.httpSuccess(
                 if (isSats) {
                   balance.satoshis.toString
@@ -88,6 +132,42 @@ case class WalletRoutes(wallet: UnlockedWalletApi, node: Node)(
             } yield msg
             res.map(msg => Server.httpSuccess(msg))
           }
+      }
+
+    case ServerCommand("getutxos", _) =>
+      complete {
+        wallet.listUtxos().map { utxos =>
+          val retStr = utxos.foldLeft("")((accum, spendInfo) =>
+            accum + s"${spendInfo.outPoint.hex} ${spendInfo.output.value}\n")
+          Server.httpSuccess(retStr)
+        }
+      }
+
+    case ServerCommand("getaddresses", _) =>
+      complete {
+        wallet.listAddresses().map { addressDbs =>
+          val addresses = addressDbs.map(_.address)
+          Server.httpSuccess(addresses)
+        }
+      }
+
+    case ServerCommand("getaccounts", _) =>
+      complete {
+        wallet.listAccounts().map { accounts =>
+          val xpubs = accounts.map(_.xpub)
+          Server.httpSuccess(xpubs)
+        }
+      }
+
+    case ServerCommand("createnewaccount", _) =>
+      complete {
+        for {
+          newWallet <- wallet.createNewAccount(wallet.keyManager.kmParams)
+          accounts <- newWallet.listAccounts()
+        } yield {
+          val xpubs = accounts.map(_.xpub)
+          Server.httpSuccess(xpubs)
+        }
       }
 
   }


### PR DESCRIPTION
Related to #1284 

Adds

- separate calls for confirmed and unconfirmed balance
- getUTXOs
- getAddresses
- getAccounts
- isEmpty
- getAddressInfo
- getNewAccount
