### PR TITLE
2020 04 02 get new address queue

### DIFF
--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -70,6 +70,13 @@ bitcoin-s {
         discoveryBatchSize = 100
 
         requiredConfirmations = 6
+        # How big the address queue size is before we throw an exception
+        # because of an overflow
+        addressQueueSize = 10
+
+        # How long we attempt to generate an address for
+        # before we timeout
+        addressQueueTimeout = 5 seconds
     }
 }
 

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -142,7 +142,16 @@ bitcoin-s {
         discoveryBatchSize = 100
 
         requiredConfirmations = 6
-    }
+
+        # How big the address queue size is before we throw an exception
+        # because of an overflow
+        addressQueueSize = 10
+
+        # How long we attempt to generate an address for
+        # before we timeout
+        addressQueueTimeout = 5 seconds
+
+   }
 }
 
 

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -71,6 +71,14 @@ bitcoin-s {
         discoveryBatchSize = 100
 
         requiredConfirmations = 6
+
+        # How big the address queue size is before we throw an exception
+        # because of an overflow
+        addressQueueSize = 10
+
+        # How long we attempt to generate an address for
+        # before we timeout
+        addressQueueTimeout = 5 seconds
     }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -20,7 +20,7 @@ trait FundWalletUtil {
       amts: Vector[CurrencyUnit],
       account: HDAccount,
       wallet: Wallet)(implicit ec: ExecutionContext): Future[Wallet] = {
-    
+
     val addressesF: Future[Vector[BitcoinAddress]] = Future.sequence {
       Vector.fill(3)(wallet.getNewAddress(account))
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -20,19 +20,9 @@ trait FundWalletUtil {
       amts: Vector[CurrencyUnit],
       account: HDAccount,
       wallet: Wallet)(implicit ec: ExecutionContext): Future[Wallet] = {
-
-    val init = Future.successful(Vector.empty[BitcoinAddress])
-    val addressesF: Future[Vector[BitcoinAddress]] = 0.until(3).foldLeft(init) {
-      case (accumF, _) =>
-        //this Thread.sleep is needed because of
-        //https://github.com/bitcoin-s/bitcoin-s/issues/1009
-        //once that is resolved we should be able to remove this
-        for {
-          accum <- accumF
-          address <- wallet.getNewAddress(account)
-        } yield {
-          accum.:+(address)
-        }
+    
+    val addressesF: Future[Vector[BitcoinAddress]] = Future.sequence {
+      Vector.fill(3)(wallet.getNewAddress(account))
     }
 
     //construct three txs that send money to these addresses

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -79,7 +79,9 @@ class AddressHandlingTest extends BitcoinSWalletTest {
 
       for {
         addresses <- addressesF
-      } yield assert(addresses.distinct.length == addresses.length,
+      } yield {
+        assert(addresses.size == 10)
+        assert(addresses.distinct.length == addresses.length,
                      s"We receive an identical address!")
 
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -6,6 +6,8 @@ import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 import org.scalatest.FutureOutcome
 
+import scala.concurrent.Future
+
 class AddressHandlingTest extends BitcoinSWalletTest {
   type FixtureParam = FundedWallet
 
@@ -68,4 +70,16 @@ class AddressHandlingTest extends BitcoinSWalletTest {
         assert(address2 != address3, "Must generate a new address")
       }
   }
+
+  it must "be safe to call getNewAddress multiple times in a row" in { wallet: Wallet =>
+    val addressesF = Future.sequence {
+      Vector.fill(3)(wallet.getNewAddress())
+    }
+
+    for {
+      addresses <- addressesF
+    } yield assert(addresses.distinct.length == addresses)
+
+  }
+
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -73,12 +73,12 @@ class AddressHandlingTest extends BitcoinSWalletTest {
 
   it must "be safe to call getNewAddress multiple times in a row" in { wallet: Wallet =>
     val addressesF = Future.sequence {
-      Vector.fill(3)(wallet.getNewAddress())
+      Vector.fill(10)(wallet.getNewAddress())
     }
 
     for {
       addresses <- addressesF
-    } yield assert(addresses.distinct.length == addresses)
+    } yield assert(addresses.distinct.length == addresses.length,s"We receive an identical address!")
 
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -83,7 +83,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
       } yield {
         assert(addresses.size == 10)
         assert(addresses.distinct.length == addresses.length,
-          s"We receive an identical address!")
+               s"We receive an identical address!")
 
       }
   }
@@ -99,7 +99,8 @@ class AddressHandlingTest extends BitcoinSWalletTest {
       //when the thread gets killed while processing things in the queue
       //we want to make sure everything                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              is done processing before we assert
       //we failed
-      val allCompletedF = AsyncUtil.retryUntilSatisfied(generatedF.forall(_.isCompleted))
+      val allCompletedF =
+        AsyncUtil.retryUntilSatisfied(generatedF.forall(_.isCompleted))
       val addressesF = allCompletedF.flatMap { _ =>
         Future.sequence {
           generatedF

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -73,7 +73,8 @@ class AddressHandlingTest extends BitcoinSWalletTest {
   }
 
   it must "be safe to call getNewAddress multiple times in a row" in {
-    wallet: Wallet =>
+    fundedWallet: FundedWallet =>
+      val wallet = fundedWallet.wallet
       val addressesF = Future.sequence {
         Vector.fill(10)(wallet.getNewAddress())
       }
@@ -89,7 +90,8 @@ class AddressHandlingTest extends BitcoinSWalletTest {
   }
 
   it must "fail with an illegal state exception if the queue is full" in {
-    wallet: Wallet =>
+    fundedWallet: FundedWallet =>
+      val wallet = fundedWallet.wallet
       //attempt to generate 20 addresses simultaneously
       //this should overwhelm our buffer size of 10
       val numAddress = 20

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.wallet
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
+import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 import org.scalatest.FutureOutcome
 
@@ -82,8 +83,32 @@ class AddressHandlingTest extends BitcoinSWalletTest {
       } yield {
         assert(addresses.size == 10)
         assert(addresses.distinct.length == addresses.length,
-                     s"We receive an identical address!")
+          s"We receive an identical address!")
 
+      }
+  }
+
+  it must "fail with an illegal state exception if the queue is full" in {
+    wallet: Wallet =>
+      //attempt to generate 20 addresses simultaneously
+      //this should overwhelm our buffer size of 10
+      val numAddress = 20
+      val generatedF = Vector.fill(numAddress)(wallet.getNewAddress())
+
+      //some hacking here so we don't get an ugly stack trace
+      //when the thread gets killed while processing things in the queue
+      //we want to make sure everything                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              is done processing before we assert
+      //we failed
+      val allCompletedF = AsyncUtil.retryUntilSatisfied(generatedF.forall(_.isCompleted))
+      val addressesF = allCompletedF.flatMap { _ =>
+        Future.sequence {
+          generatedF
+        }
+      }
+
+      recoverToSucceededIf[IllegalStateException] {
+        addressesF
+      }
   }
 
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -71,14 +71,16 @@ class AddressHandlingTest extends BitcoinSWalletTest {
       }
   }
 
-  it must "be safe to call getNewAddress multiple times in a row" in { wallet: Wallet =>
-    val addressesF = Future.sequence {
-      Vector.fill(10)(wallet.getNewAddress())
-    }
+  it must "be safe to call getNewAddress multiple times in a row" in {
+    wallet: Wallet =>
+      val addressesF = Future.sequence {
+        Vector.fill(10)(wallet.getNewAddress())
+      }
 
-    for {
-      addresses <- addressesF
-    } yield assert(addresses.distinct.length == addresses.length,s"We receive an identical address!")
+      for {
+        addresses <- addressesF
+      } yield assert(addresses.distinct.length == addresses.length,
+                     s"We receive an identical address!")
 
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -30,7 +30,7 @@ import scala.util.{Failure, Success}
   *
   * @see [[https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki BIP44]]
   */
-sealed trait  WalletApi {
+sealed trait WalletApi {
 
   implicit val walletConfig: WalletAppConfig
   implicit val ec: ExecutionContext

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -30,7 +30,7 @@ import scala.util.{Failure, Success}
   *
   * @see [[https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki BIP44]]
   */
-sealed trait WalletApi {
+sealed trait  WalletApi {
 
   implicit val walletConfig: WalletAppConfig
   implicit val ec: ExecutionContext

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.wallet.config
 
 import java.nio.file.{Files, Path}
+import java.util.concurrent.TimeUnit
 
 import com.typesafe.config.Config
 import org.bitcoins.core.hd._
@@ -9,6 +10,7 @@ import org.bitcoins.db.AppConfig
 import org.bitcoins.keymanager.{KeyManagerParams, WalletStorage}
 import org.bitcoins.wallet.db.WalletDbManagement
 
+import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
 /** Configuration for the Bitcoin-S wallet
@@ -98,6 +100,26 @@ case class WalletAppConfig(
   def kmParams: KeyManagerParams =
     KeyManagerParams(seedPath, defaultAccountKind, network)
 
+  /** How much elements we can have in [[org.bitcoins.wallet.internal.AddressHandling.addressRequestQueue]]
+   * before we throw an exception */
+  def addressQueueSize: Int = {
+    if (config.hasPath("wallet.addressQueueSize")) {
+      config.getInt("wallet.addressQueueSize")
+    } else {
+      100
+    }
+  }
+
+  /** How long we wait while generating an address in [[org.bitcoins.wallet.internal.AddressHandling.addressRequestQueue]]
+   * before we timeout */
+  def addressQueueTimeout: scala.concurrent.duration.Duration = {
+    if (config.hasPath("wallet.addressQueueTimeout")) {
+      val javaDuration = config.getDuration("wallet.addressQueueTimeout")
+      new FiniteDuration(javaDuration.toNanos, TimeUnit.NANOSECONDS)
+    } else {
+      5.second
+    }
+  }
 }
 
 object WalletAppConfig {

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -10,7 +10,7 @@ import org.bitcoins.db.AppConfig
 import org.bitcoins.keymanager.{KeyManagerParams, WalletStorage}
 import org.bitcoins.wallet.db.WalletDbManagement
 
-import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
 /** Configuration for the Bitcoin-S wallet

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -101,7 +101,7 @@ case class WalletAppConfig(
     KeyManagerParams(seedPath, defaultAccountKind, network)
 
   /** How much elements we can have in [[org.bitcoins.wallet.internal.AddressHandling.addressRequestQueue]]
-   * before we throw an exception */
+    * before we throw an exception */
   def addressQueueSize: Int = {
     if (config.hasPath("wallet.addressQueueSize")) {
       config.getInt("wallet.addressQueueSize")
@@ -111,7 +111,7 @@ case class WalletAppConfig(
   }
 
   /** How long we wait while generating an address in [[org.bitcoins.wallet.internal.AddressHandling.addressRequestQueue]]
-   * before we timeout */
+    * before we timeout */
   def addressQueueTimeout: scala.concurrent.duration.Duration = {
     if (config.hasPath("wallet.addressQueueTimeout")) {
       val javaDuration = config.getDuration("wallet.addressQueueTimeout")

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -59,7 +59,7 @@ trait FundTransactionHandling extends WalletLogger { self: LockedWalletApi =>
       keyManagerOpt: Option[BIP39KeyManager],
       markAsReserved: Boolean = false): Future[BitcoinTxBuilder] = {
     val utxosF = listUtxos(fromAccount.hdAccount)
-    val changeAddrF = getNewChangeAddress(fromAccount)
+
     val selectedUtxosF = for {
       walletUtxos <- utxosF
       //currently just grab the biggest utxos
@@ -82,7 +82,7 @@ trait FundTransactionHandling extends WalletLogger { self: LockedWalletApi =>
 
     val txBuilderF = for {
       addrInfosWithUtxo <- addrInfosWithUtxoF
-      change <- changeAddrF
+      change <- getNewChangeAddress(fromAccount)
       utxoSpendingInfos = {
         addrInfosWithUtxo.map {
           case (utxo, addrInfo) =>


### PR DESCRIPTION
Closes #1009

Creates a background thread that process requests to `getNewAddress()` so that we can now call it multiple times and not have a race condition to the database. 

Two things still need to be addresses

- [x] A async safe buffer that stores the requests and be can be updated in async safe way.
- [x] There are new stack trace errors showing up in test logs, probably because the tale is being destroyed in tests before the `addressRequestQueue` is being drained.