### PR TITLE
P2WSH Signer fix + tests

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -196,6 +196,24 @@ case class PSBT(
 
   }
 
+  def addWitnessUTXOToInput(output: TransactionOutput, index: Int): PSBT = {
+    require(WitnessScriptPubKey.isWitnessScriptPubKey(output.scriptPubKey.asm),
+            s"Given output was not a Witness UTXO: $output")
+    require(
+      index < inputMaps.size,
+      s"index must be less than the number of input maps present in the psbt, $index >= ${inputMaps.size}")
+
+    val inputMap = inputMaps(index)
+    require(!inputMap.isFinalized,
+            s"Cannot update an InputPSBTMap that is finalized, index: $index")
+
+    val elements = inputMap.filterRecords(WitnessUTXOKeyId) :+ WitnessUTXO(
+      output)
+    val newInputMaps = inputMaps.updated(index, InputPSBTMap(elements))
+
+    PSBT(globalMap, newInputMaps, outputMaps)
+  }
+
   /**
     * Adds script to the indexed InputPSBTMap to either the RedeemScript
     * or WitnessScript field depending on the script and available information in the PSBT
@@ -487,6 +505,30 @@ case class PSBT(
     )
 
     val newElements = inputMaps(inputIndex).elements :+ partialSignature
+
+    val newInputMaps =
+      inputMaps.updated(inputIndex, InputPSBTMap(newElements))
+
+    PSBT(globalMap, newInputMaps, outputMaps)
+  }
+
+  def addSignatures(
+      partialSignatures: Vector[PartialSignature],
+      inputIndex: Int): PSBT = {
+    require(
+      inputIndex < inputMaps.size,
+      s"index must be less than the number of input maps present in the psbt, $inputIndex >= ${inputMaps.size}")
+    require(
+      !inputMaps(inputIndex).isFinalized,
+      s"Cannot update an InputPSBTMap that is finalized, index: $inputIndex")
+    val intersect = inputMaps(inputIndex).partialSignatures
+      .map(_.pubKey)
+      .intersect(partialSignatures.map(_.pubKey))
+    require(
+      intersect.isEmpty,
+      s"Input has already been signed by one or more of the associated public keys given ${intersect}"
+    )
+    val newElements = inputMaps(inputIndex).elements ++ partialSignatures
 
     val newInputMaps =
       inputMaps.updated(inputIndex, InputPSBTMap(newElements))

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -60,21 +60,14 @@ sealed abstract class SignerUtils {
 
     spendingInfo.output.scriptPubKey match {
       case _: WitnessScriptPubKey =>
-        val wtx = unsignedTx match {
-          case btx: BaseTransaction =>
-            val transactionWitnessOpt =
-              spendingInfo.scriptWitnessOpt.map(scriptWit =>
-                TransactionWitness(Vector(scriptWit)))
-            val transactionWitness =
-              transactionWitnessOpt.getOrElse(
-                EmptyWitness.fromInputs(btx.inputs))
-
-            WitnessTransaction(btx.version,
-                               btx.inputs,
-                               btx.outputs,
-                               btx.lockTime,
-                               transactionWitness)
-          case wtx: WitnessTransaction => wtx
+        val wtx = {
+          val noWitnessWtx = WitnessTransaction.toWitnessTx(unsignedTx)
+          spendingInfo.scriptWitnessOpt match {
+            case None =>
+              noWitnessWtx
+            case Some(scriptWitness) =>
+              noWitnessWtx.updateWitness(index.toInt, scriptWitness)
+          }
         }
 
         WitnessTxSigComponent(wtx, index, spendingInfo.output, flags)
@@ -800,7 +793,10 @@ sealed abstract class P2WSHSignerSingle
       isDummySignature: Boolean,
       spendingInfoToSatisfy: P2WSHV0SpendingInfoSingle)(
       implicit ec: ExecutionContext): Future[PartialSignature] = {
-    val wtx = WitnessTransaction.toWitnessTx(unsignedTx)
+    val inputIndex = inputIndex(spendingInfo, unsignedTx)
+    val wtx = WitnessTransaction
+      .toWitnessTx(unsignedTx)
+      .updateWitness(inputIndex, spendingInfoToSatisfy.scriptWitness)
 
     BitcoinSignerSingle.signSingle(spendingInfo,
                                    wtx,
@@ -825,7 +821,9 @@ sealed abstract class P2WSHSigner
     } else {
       val (_, output, inputIndex, _) = relevantInfo(spendingInfo, unsignedTx)
 
-      val wtx = WitnessTransaction.toWitnessTx(unsignedTx)
+      val wtx = WitnessTransaction
+        .toWitnessTx(unsignedTx)
+        .updateWitness(inputIndex.toInt, spendingInfoToSatisfy.scriptWitness)
 
       val signedSigComponentF = BitcoinSigner.sign(
         spendingInfo,

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -793,10 +793,10 @@ sealed abstract class P2WSHSignerSingle
       isDummySignature: Boolean,
       spendingInfoToSatisfy: P2WSHV0SpendingInfoSingle)(
       implicit ec: ExecutionContext): Future[PartialSignature] = {
-    val inputIndex = inputIndex(spendingInfo, unsignedTx)
+    val idx = inputIndex(spendingInfo, unsignedTx)
     val wtx = WitnessTransaction
       .toWitnessTx(unsignedTx)
-      .updateWitness(inputIndex, spendingInfoToSatisfy.scriptWitness)
+      .updateWitness(idx.toInt, spendingInfoToSatisfy.scriptWitness)
 
     BitcoinSignerSingle.signSingle(spendingInfo,
                                    wtx,


### PR DESCRIPTION
What the problem was when signing we would get the redeem script for p2wsh out of the wtx witness data, however, sometimes we would remove the witness data or not have the witness data when we needed it, so now we add the correct witness data from the spending info when we have it.