### PR TITLE
Address/UTXO Tagging

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/wallet/MockUnlockedWalletApi.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/wallet/MockUnlockedWalletApi.scala
@@ -3,7 +3,7 @@ package org.bitcoins.wallet
 import org.bitcoins.core.hd.AddressType
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.wallet.api.UnlockedWalletApi
-import org.bitcoins.wallet.models.AccountDb
+import org.bitcoins.wallet.models.{AccountDb, AddressTagDAO}
 
 import scala.concurrent.Future
 
@@ -23,5 +23,8 @@ abstract class MockUnlockedWalletApi extends UnlockedWalletApi {
 
   private def stub[T] =
     Future.failed[T](new RuntimeException("Not implemented"))
+
+  override private[wallet] val addressTagDAOs: Vector[AddressTagDAO[_, _, _]] =
+    Vector.empty
 
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/AddressTag.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/AddressTag.scala
@@ -1,0 +1,14 @@
+package org.bitcoins.core.wallet.utxo
+
+trait AddressTag {
+  val typeName: String
+}
+
+trait AddressTagFactory[TagType <: AddressTag] {
+
+  val all: Vector[TagType]
+
+  def fromString(str: String): Option[TagType] = {
+    all.find(tag => str.toLowerCase() == tag.toString.toLowerCase)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/StorageLocationTag.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/StorageLocationTag.scala
@@ -1,0 +1,20 @@
+package org.bitcoins.core.wallet.utxo
+
+sealed abstract class StorageLocationTag extends AddressTag {
+  val typeName: String = "StorageLocationTag"
+}
+
+object StorageLocationTag extends AddressTagFactory[StorageLocationTag] {
+
+  /** Keys stored on a computer connected to the internet */
+  final case object HotStorage extends StorageLocationTag
+
+  /** Keys stored on a hardware wallet or other offline device */
+  final case object ColdStorage extends StorageLocationTag
+
+  /** Keys stored on a hardware wallet or other offline device locked in a safe in a distant location */
+  final case object DeepColdStorage extends StorageLocationTag
+
+  val all: Vector[StorageLocationTag] =
+    Vector(HotStorage, ColdStorage, DeepColdStorage)
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -329,7 +329,8 @@ object BitcoinSWalletTest extends WalletLogger {
 
       walletConfig.initialize().flatMap { _ =>
         val wallet =
-          Wallet(keyManager, nodeApi, chainQueryApi)(walletConfig, ec)
+          Wallet(keyManager, nodeApi, chainQueryApi, Vector.empty)(walletConfig,
+                                                                   ec)
         Wallet.initialize(wallet, bip39PasswordOpt)
       }
     }
@@ -388,11 +389,11 @@ object BitcoinSWalletTest extends WalletLogger {
 
       //create the wallet with the appropriate callbacks now that
       //we have them
-      walletWithCallback = Wallet(keyManager = wallet.keyManager,
-                                  nodeApi = apiCallback.nodeApi,
-                                  chainQueryApi = apiCallback.chainQueryApi)(
-        wallet.walletConfig,
-        wallet.ec)
+      walletWithCallback = Wallet(
+        keyManager = wallet.keyManager,
+        nodeApi = apiCallback.nodeApi,
+        chainQueryApi = apiCallback.chainQueryApi,
+        addressTagDAOs = Vector.empty)(wallet.walletConfig, wallet.ec)
       //complete the walletCallbackP so we can handle the callbacks when they are
       //called without hanging forever.
       _ = walletCallbackP.success(walletWithCallback)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -149,7 +149,8 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
         Future.failed(
           new RuntimeException(s"Failed to initialize km with err=${err}"))
       case Right(km) =>
-        val wallet = Wallet(km, MockNodeApi, MockChainQueryApi)(config, ec)
+        val wallet =
+          Wallet(km, MockNodeApi, MockChainQueryApi, Vector.empty)(config, ec)
         val walletF =
           Wallet.initialize(wallet = wallet,
                             bip39PasswordOpt = bip39PasswordOpt)(config, ec)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -52,7 +52,8 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
                                         feeRate = SatoshisPerByte(Satoshis(3)),
                                         inputAmount = Satoshis(4000),
                                         sentAmount = Satoshis(3000),
-                                        blockHashOpt = None)
+                                        blockHashOpt = None,
+                                        Vector.empty)
 
       updatedCoin <- wallet.spendingInfoDAO.findByScriptPubKey(
         addr.scriptPubKey)

--- a/wallet/src/main/resources/walletdb/migration/V5_wallet_example_addr_tag.sql
+++ b/wallet/src/main/resources/walletdb/migration/V5_wallet_example_addr_tag.sql
@@ -1,0 +1,1 @@
+CREATE TABLE "storage_location_tags" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,"address" VARCHAR(254) NOT NULL UNIQUE,"tag" VARCHAR(254) NOT NULL,constraint "fk_address" foreign key("address") references "addresses"("address") on update NO ACTION on delete NO ACTION);

--- a/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/LockedWallet.scala
@@ -32,6 +32,8 @@ abstract class LockedWallet
   private[wallet] val outgoingTxDAO: OutgoingTransactionDAO =
     OutgoingTransactionDAO()
 
+  private[wallet] val addressTagDAOs: Vector[AddressTagDAO[_, _, _]]
+
   override def isEmpty(): Future[Boolean] =
     for {
       addressCount <- addressDAO.count()
@@ -167,14 +169,18 @@ abstract class LockedWallet
 object LockedWallet {
   private case class LockedWalletImpl(
       override val nodeApi: NodeApi,
-      override val chainQueryApi: ChainQueryApi)(
+      override val chainQueryApi: ChainQueryApi,
+      override val addressTagDAOs: Vector[AddressTagDAO[_, _, _]])(
       implicit val ec: ExecutionContext,
       val walletConfig: WalletAppConfig)
-      extends LockedWallet {}
+      extends LockedWallet
 
-  def apply(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)(
+  def apply(
+      nodeApi: NodeApi,
+      chainQueryApi: ChainQueryApi,
+      addressTagDAO: Vector[AddressTagDAO[_, _, _]])(
       implicit ec: ExecutionContext,
       config: WalletAppConfig): LockedWallet =
-    LockedWalletImpl(nodeApi, chainQueryApi)
+    LockedWalletImpl(nodeApi, chainQueryApi, addressTagDAO)
 
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagDAO.scala
@@ -1,0 +1,71 @@
+package org.bitcoins.wallet.models
+
+import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.wallet.utxo.AddressTag
+import org.bitcoins.db.{CRUD, SlickUtil}
+import org.bitcoins.wallet.config._
+import slick.jdbc.SQLiteProfile.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+abstract class AddressTagDAO[
+    AddressTagType <: AddressTag,
+    DbEntryType <: AddressTagDb[AddressTagType],
+    DbTable <: AddressTagTable[AddressTagType, DbEntryType]](
+    implicit val ec: ExecutionContext,
+    val appConfig: WalletAppConfig)
+    extends CRUD[DbEntryType, BitcoinAddress] {
+  import org.bitcoins.db.DbCommonsColumnMappers._
+
+  val typeName: String
+
+  override val table: TableQuery[DbTable]
+  val spendingInfoTable: TableQuery[SpendingInfoTable]
+
+  def create(address: BitcoinAddress, tag: AddressTag): Future[DbEntryType]
+
+  override def createAll(ts: Vector[DbEntryType]): Future[Vector[DbEntryType]] =
+    SlickUtil.createAllNoAutoInc(ts, database, table)
+
+  override protected def findByPrimaryKeys(
+      addresses: Vector[BitcoinAddress]): Query[Table[_], DbEntryType, Seq] =
+    table.filter(_.address.inSet(addresses))
+
+  override def findByPrimaryKey(
+      address: BitcoinAddress): Query[Table[_], DbEntryType, Seq] = {
+    table.filter(_.address === address)
+  }
+
+  override def findAll(
+      txs: Vector[DbEntryType]): Query[Table[_], DbEntryType, Seq] =
+    findByPrimaryKeys(txs.map(_.address))
+
+  def findByTag(tag: AddressTagType): Future[Vector[DbEntryType]] = {
+//    val q = table.filter(_.tag === tag) // fixme
+    val q = table
+
+    database.run(q.result).map(_.toVector).map(_.filter(_.tag == tag)) // fixme
+  }
+
+  def findTx(
+      txIdBE: DoubleSha256DigestBE,
+      network: NetworkParameters): Future[DbEntryType] = {
+    val infoQuery = spendingInfoTable.filter(_.txid === txIdBE)
+    val spendingInfosF = database.runVec(infoQuery.result)
+
+    spendingInfosF.flatMap { spendingInfos =>
+      val firstSpk = spendingInfos.head.output.scriptPubKey
+      val address = BitcoinAddress.fromScriptPubKey(firstSpk, network).get
+
+      val query = findByPrimaryKey(address)
+      database.runVec(query.result).map(_.head)
+    }
+  }
+
+  def findTx(
+      txId: DoubleSha256Digest,
+      network: NetworkParameters): Future[DbEntryType] =
+    findTx(txId.flip, network)
+}

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagTable.scala
@@ -1,0 +1,47 @@
+package org.bitcoins.wallet.models
+
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.wallet.utxo.AddressTag
+import slick.jdbc.SQLiteProfile.api._
+import slick.lifted.{PrimaryKey, ProvenShape}
+
+abstract class AddressTagDb[AddressTagType <: AddressTag] {
+  def address: BitcoinAddress
+
+  def tag: AddressTagType
+}
+
+abstract class AddressTagTable[
+    AddressTagType <: AddressTag,
+    AddressTagDbType <: AddressTagDb[AddressTagType]](t: Tag, tableName: String)
+    extends Table[AddressTagDbType](t, tableName) {
+
+  import org.bitcoins.db.DbCommonsColumnMappers._
+
+  implicit val mapper: BaseColumnType[AddressTagType]
+
+  def address: Rep[BitcoinAddress] = column[BitcoinAddress]("address", O.Unique)
+
+  def tag: Rep[AddressTagType] = column[AddressTagType]("tag")(mapper)
+
+  type AddressTagTuple = (BitcoinAddress, AddressTagType)
+
+  val fromTuple: AddressTagTuple => AddressTagDbType
+
+  val toTuple: AddressTagDbType => Option[AddressTagTuple] =
+    AddressTag => Some((AddressTag.address, AddressTag.tag))
+
+  def * : ProvenShape[AddressTagDbType]
+
+  /** All Addresss must have a OutPoint in the wallet*/
+  def fk_address = {
+    val addressTable = TableQuery[AddressTable]
+    foreignKey("fk_address",
+               sourceColumns = address,
+               targetTableQuery = addressTable)(_.address)
+  }
+
+  def primaryKey: PrimaryKey =
+    primaryKey("pk_address", sourceColumns = address)
+
+}

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/StorageLocationTagDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/StorageLocationTagDAO.scala
@@ -1,0 +1,37 @@
+package org.bitcoins.wallet.models
+
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.wallet.utxo.{AddressTag, StorageLocationTag}
+import org.bitcoins.wallet.config.WalletAppConfig
+import slick.lifted.TableQuery
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class StorageLocationTagDAO()(
+    implicit override val ec: ExecutionContext,
+    override val appConfig: WalletAppConfig)
+    extends AddressTagDAO[
+      StorageLocationTag,
+      StorageLocationTagDb,
+      StorageLocationTagTable] {
+  override val typeName: String = "StorageLocationTag"
+  override val table: TableQuery[StorageLocationTagTable] =
+    TableQuery[StorageLocationTagTable]
+  override val spendingInfoTable: TableQuery[SpendingInfoTable] =
+    TableQuery[SpendingInfoTable]
+
+  def create(
+      address: BitcoinAddress,
+      tag: StorageLocationTag): Future[StorageLocationTagDb] = {
+    val db = StorageLocationTagDb(address, tag)
+    create(db)
+  }
+
+  override def create(
+      address: BitcoinAddress,
+      tag: AddressTag): Future[StorageLocationTagDb] = {
+    assert(tag.typeName == "StorageLocationTag")
+    val db = StorageLocationTagDb(address, tag.asInstanceOf[StorageLocationTag])
+    create(db)
+  }
+}

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/StorageLocationTagTable.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/StorageLocationTagTable.scala
@@ -1,0 +1,31 @@
+package org.bitcoins.wallet.models
+
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.wallet.utxo.StorageLocationTag
+import slick.jdbc.SQLiteProfile.api._
+import slick.lifted.ProvenShape
+
+case class StorageLocationTagDb(
+    address: BitcoinAddress,
+    tag: StorageLocationTag)
+    extends AddressTagDb[StorageLocationTag] {}
+
+class StorageLocationTagTable(t: Tag)
+    extends AddressTagTable[StorageLocationTag, StorageLocationTagDb](
+      t,
+      tableName = "storage_location_tags") {
+  import org.bitcoins.db.DbCommonsColumnMappers._
+
+  implicit override val mapper: BaseColumnType[StorageLocationTag] =
+    MappedColumnType
+      .base[StorageLocationTag, String](_.toString,
+                                        StorageLocationTag.fromString(_).get)
+
+  override val fromTuple: (
+      (BitcoinAddress, StorageLocationTag)) => StorageLocationTagDb = {
+    case (address, tag) => StorageLocationTagDb(address, tag)
+  }
+
+  override def * : ProvenShape[StorageLocationTagDb] =
+    (address, tag) <> (fromTuple, toTuple)
+}


### PR DESCRIPTION
First commit: The grunt of the work, this adds the ability to pass in an AddressTagDAO that will be used for tagging an address and subsequent utxos. Adds an argument to `sendToAddress` that is `newTags: Vector[AddressTag]` that will replace the current tags of the spent utxos to the new tags for the subsequent change utxo. Also adds an argument to `getNewAddress` that will tag the new address with the passed in `AddressTag`s.

Second commit: An example use case using this, creates a `StoreLocationTag` that specifies if a utxo is stored in a hot key, cold key, or deep cold key. To use it when calling `getNewAddress` they would now call it as `getNewAdress(..., tags =  Vector(HotStorage))` and `sendToAddress(..., newTags = Vector(ColdStorage))`
