### PR TITLE
Simplify `SingleSigner`

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -159,11 +159,13 @@ case class BlockHeaderDAO()(
           Future.successful(Vector.empty)
       }
     } yield {
-      headerOpt.map { header =>
-        val connectedHeaders =
-          Blockchain.connectWalkBackwards(header, headers)
-        connectedHeaders.reverse
-      }.getOrElse(Vector.empty)
+      headerOpt
+        .map { header =>
+          val connectedHeaders =
+            Blockchain.connectWalkBackwards(header, headers)
+          connectedHeaders.reverse
+        }
+        .getOrElse(Vector.empty)
     }
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -136,9 +136,9 @@ class SignerTest extends BitcoinSAsyncTest {
             val sigVecFs = singleInfosVec.map { singleInfos =>
               val sigFs = singleInfos.map { singleInfo =>
                 val keyAndSigF =
-                  BitcoinSignerSingle.signSingle(singleInfo,
-                                                 unsignedTx,
-                                                 isDummySignature = false)
+                  BitcoinSigner.signSingle(singleInfo,
+                                           unsignedTx,
+                                           isDummySignature = false)
 
                 keyAndSigF.map(_.signature)
               }
@@ -273,9 +273,9 @@ class SignerTest extends BitcoinSAsyncTest {
                                      unsignedTx.outputs,
                                      unsignedTx.lockTime,
                                      EmptyWitness.fromInputs(unsignedTx.inputs))
-                BitcoinSignerSingle.signSingle(singleInfo,
-                                               wtx,
-                                               isDummySignature = false)
+                BitcoinSigner.signSingle(singleInfo,
+                                         wtx,
+                                         isDummySignature = false)
 
               }
 

--- a/core/src/main/scala/org/bitcoins/core/hd/HDCoinType.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDCoinType.scala
@@ -38,7 +38,7 @@ object HDCoinType {
 
   def fromNetwork(np: NetworkParameters): HDCoinType = {
     np match {
-      case MainNet => Bitcoin
+      case MainNet            => Bitcoin
       case TestNet3 | RegTest => Testnet
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -13,7 +13,7 @@ import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.result.ScriptOk
 import org.bitcoins.core.util.Factory
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
-import org.bitcoins.core.wallet.signer.BitcoinSignerSingle
+import org.bitcoins.core.wallet.signer.BitcoinSigner
 import org.bitcoins.core.wallet.utxo._
 import scodec.bits._
 
@@ -125,11 +125,11 @@ case class PSBT(
       conditionalPath: ConditionalPath = ConditionalPath.NoConditionsLeft,
       isDummySignature: Boolean = false)(
       implicit ec: ExecutionContext): Future[PSBT] = {
-    BitcoinSignerSingle.sign(psbt = this,
-                             inputIndex = inputIndex,
-                             signer = signer,
-                             conditionalPath = conditionalPath,
-                             isDummySignature = isDummySignature)
+    BitcoinSigner.sign(psbt = this,
+                       inputIndex = inputIndex,
+                       signer = signer,
+                       conditionalPath = conditionalPath,
+                       isDummySignature = isDummySignature)
   }
 
   /**

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
@@ -14,7 +14,7 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.util.{CryptoUtil, Factory, SeqWrapper}
-import org.bitcoins.core.wallet.signer.{BitcoinSigner, BitcoinSignerSingle}
+import org.bitcoins.core.wallet.signer.BitcoinSigner
 import org.bitcoins.core.wallet.utxo._
 import scodec.bits.ByteVector
 
@@ -670,9 +670,9 @@ object InputPSBTMap extends PSBTMapFactory[InputPSBTRecord, InputPSBTMap] {
       nonWitnessTxOpt: Option[Transaction])(
       implicit ec: ExecutionContext): Future[InputPSBTMap] = {
     val sigsF = spendingInfo.toSingles.map { spendingInfoSingle =>
-      BitcoinSignerSingle.signSingle(spendingInfoSingle,
-                                     unsignedTx,
-                                     isDummySignature = false)
+      BitcoinSigner.signSingle(spendingInfoSingle,
+                               unsignedTx,
+                               isDummySignature = false)
     }
 
     val sigFs = Future.sequence(sigsF)

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -144,7 +144,9 @@ sealed abstract class ScriptParser extends Factory[Vector[ScriptToken]] {
     */
   private def parse(bytes: ByteVector): Vector[ScriptToken] = {
     @tailrec
-    def loop(bytes: ByteVector, accum: Vector[ScriptToken]): Vector[ScriptToken] = {
+    def loop(
+        bytes: ByteVector,
+        accum: Vector[ScriptToken]): Vector[ScriptToken] = {
       //logger.debug("Byte to be parsed: " + bytes.headOption)
       if (bytes.nonEmpty) {
         val op = ScriptOperation.fromByte(bytes.head)

--- a/docs/core/psbts.md
+++ b/docs/core/psbts.md
@@ -23,7 +23,7 @@ import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.{BaseTransaction, Transaction}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.wallet.signer.BitcoinSignerSingle
+import org.bitcoins.core.wallet.signer.BitcoinSigner
 import org.bitcoins.core.wallet.utxo.{
   BitcoinUTXOSpendingInfoSingle,
   ConditionalPath
@@ -111,7 +111,7 @@ val psbtFirstSigF =
       .flatMap(_.sign(inputIndex = 0, signer = privKey1))
 
 // Alternatively, you can use produce a signature with a BitcoinUTXOSpendingInfoSingle
-// using the BitcoinSingleSigner will return a PartialSignature that can be added to a PSBT
+// using the BitcoinSigner will return a PartialSignature that can be added to a PSBT
 
 // First we need to declare out spendingInfoSingle
 val outPoint = unsignedTransaction.inputs.head.previousOutput
@@ -128,7 +128,7 @@ val spendingInfoSingle = BitcoinUTXOSpendingInfoSingle(
   )
 
 // Then we can sign the transaction
-val signatureF = BitcoinSignerSingle.signSingle(
+val signatureF = BitcoinSigner.signSingle(
     spendingInfo = spendingInfoSingle,
     unsignedTx = unsignedTransaction,
     isDummySignature = false)

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -51,7 +51,8 @@ case class WalletAppConfig(
 
   lazy val defaultAccount: HDAccount = {
     val purpose = defaultAccountKind
-    HDAccount(coin = HDCoin(purpose, HDCoinType.fromNetwork(network)), index = 0)
+    HDAccount(coin = HDCoin(purpose, HDCoinType.fromNetwork(network)),
+              index = 0)
   }
 
   lazy val bloomFalsePositiveRate: Double =


### PR DESCRIPTION
Removed `SingleSigner` abstraction and replaced with a simple `signSingle` method in `SignerUtils`

Fixes #1305