### PR TITLE
Require that addresses are the correct network when sending

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/WalletRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/WalletRpc.scala
@@ -76,7 +76,8 @@ trait WalletRpc { self: Client =>
     val params =
       List(JsString(accountOrLabel)) ++ addressType.map(Json.toJson(_)).toList
 
-    bitcoindCall[BitcoinAddress]("getnewaddress", params)
+    bitcoindCall[BitcoinAddress]("getnewaddress", params).map(addr =>
+      BitcoinAddress.fromScriptPubKey(addr.scriptPubKey, instance.network).get)
   }
 
   def getNewAddress: Future[BitcoinAddress] =

--- a/core/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
+++ b/core/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
@@ -42,6 +42,11 @@ sealed abstract class NetworkParameters {
     */
   def magicBytes: ByteVector
 
+  def isSameNetworkBytes(other: NetworkParameters): Boolean = {
+    p2pkhNetworkByte == other.p2pkhNetworkByte &&
+    p2shNetworkByte == other.p2shNetworkByte
+  }
+
 }
 
 sealed abstract class BitcoinNetwork extends NetworkParameters {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -20,7 +20,9 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
   override type FixtureParam = WalletWithBitcoind
 
   val testAddr: BitcoinAddress =
-    BitcoinAddress.fromString("n4MN27Lk7Yh3pwfjCiAbRXtRVjs4Uk67fG").get
+    BitcoinAddress
+      .fromString("bcrt1qlhctylgvdsvaanv539rg7hyn0sjkdm23y70kgq")
+      .get
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     withFundedWalletAndBitcoind(test)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -22,7 +22,8 @@ class WalletSendingTest extends BitcoinSWalletTest {
   it should "correctly send to an address" in { fundedWallet =>
     val wallet = fundedWallet.wallet
 
-    val testAddress = BitcoinAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa").get
+    val testAddress =
+      BitcoinAddress("bcrt1qlhctylgvdsvaanv539rg7hyn0sjkdm23y70kgq").get
     val amountToSend: Bitcoins = Bitcoins(0.5)
 
     for {
@@ -35,10 +36,10 @@ class WalletSendingTest extends BitcoinSWalletTest {
   }
 
   val addresses = Vector(
-    BitcoinAddress("tb1q6cmkvmyachk0jhljv7r0ey04a580cj3wnkvhff").get,
-    BitcoinAddress("n43ybT6wR9NZP2im4VPBZK14hmr7Kt79mx").get,
-    BitcoinAddress("2N16oE62ZjAPup985dFBQYAuy5zpDraH7Hk").get,
-    BitcoinAddress("2N3jP8HLLA3ihGGi3T7AaLUapVXu8LkGDqm").get
+    BitcoinAddress("bcrt1qlhctylgvdsvaanv539rg7hyn0sjkdm23y70kgq").get,
+    BitcoinAddress("bcrt1qf4rju7adz5hpuymkfwvg5s94mydc8llk94v74w").get,
+    BitcoinAddress("bcrt1q9h9wkz6ad49szfl035wh3qdacuslkp6j9pfp4j").get,
+    BitcoinAddress("bcrt1q9scvqvyf3ssed8zqnfgk5zttnneatg2aszu5q9").get
   )
 
   val amounts = Vector(
@@ -105,6 +106,38 @@ class WalletSendingTest extends BitcoinSWalletTest {
       tx <- wallet.sendToOutputs(expectedOutputs, feeRate, reserveUtxos = false)
     } yield {
       assert(expectedOutputs.diff(tx.outputs).isEmpty)
+    }
+  }
+
+  it should "fail to send to a different network address" in { fundedWallet =>
+    val wallet = fundedWallet.wallet
+
+    val sendToAddressesF =
+      wallet.sendToAddress(
+        BitcoinAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa").get,
+        Satoshis(1000),
+        feeRate)
+
+    recoverToSucceededIf[IllegalArgumentException] {
+      sendToAddressesF
+    }
+  }
+
+  it should "fail to send to different network addresses" in { fundedWallet =>
+    val wallet = fundedWallet.wallet
+
+    val addrs = Vector(
+      BitcoinAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa").get,
+      BitcoinAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa").get,
+      BitcoinAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa").get,
+      BitcoinAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa").get
+    )
+
+    val sendToAddressesF =
+      wallet.sendToAddresses(addrs, amounts, feeRate, reserveUtxos = false)
+
+    recoverToSucceededIf[IllegalArgumentException] {
+      sendToAddressesF
     }
   }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -37,7 +37,7 @@ sealed abstract class Wallet extends LockedWallet with UnlockedWalletApi {
       feeRate: FeeUnit,
       fromAccount: AccountDb): Future[Transaction] = {
     require(
-      address.networkParameters.p2pkhNetworkByte == networkParameters.p2pkhNetworkByte,
+      address.networkParameters.isSameNetworkBytes(networkParameters),
       s"Cannot send to address on other network, got ${address.networkParameters}"
     )
     logger.info(s"Sending $amount to $address at feerate $feeRate")
@@ -78,7 +78,7 @@ sealed abstract class Wallet extends LockedWallet with UnlockedWalletApi {
             "Must have an amount for every address")
     require(
       addresses.forall(
-        _.networkParameters.p2pkhNetworkByte == networkParameters.p2pkhNetworkByte),
+        _.networkParameters.isSameNetworkBytes(networkParameters)),
       s"Cannot send to address on other network, got ${addresses.map(_.networkParameters)}"
     )
     val destinations = addresses.zip(amounts).map {

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.wallet
 
 import org.bitcoins.core.api.{ChainQueryApi, NodeApi}
+import org.bitcoins.core.config.MainNet
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency._
 import org.bitcoins.core.hd._
@@ -35,6 +36,9 @@ sealed abstract class Wallet extends LockedWallet with UnlockedWalletApi {
       amount: CurrencyUnit,
       feeRate: FeeUnit,
       fromAccount: AccountDb): Future[Transaction] = {
+    require(
+      address.networkParameters == networkParameters,
+      s"Cannot send to address on other network, got ${address.networkParameters}")
     logger.info(s"Sending $amount to $address at feerate $feeRate")
     val destination = TransactionOutput(amount, address.scriptPubKey)
     for {
@@ -71,6 +75,9 @@ sealed abstract class Wallet extends LockedWallet with UnlockedWalletApi {
       reserveUtxos: Boolean): Future[Transaction] = {
     require(amounts.size == addresses.size,
             "Must have an amount for every address")
+    require(
+      addresses.forall(_.networkParameters == networkParameters),
+      s"Cannot send to address on other network, got ${addresses.map(_.networkParameters)}")
     val destinations = addresses.zip(amounts).map {
       case (address, amount) =>
         logger.info(s"Sending $amount to $address at feerate $feeRate")

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -37,8 +37,9 @@ sealed abstract class Wallet extends LockedWallet with UnlockedWalletApi {
       feeRate: FeeUnit,
       fromAccount: AccountDb): Future[Transaction] = {
     require(
-      address.networkParameters == networkParameters,
-      s"Cannot send to address on other network, got ${address.networkParameters}")
+      address.networkParameters.p2pkhNetworkByte == networkParameters.p2pkhNetworkByte,
+      s"Cannot send to address on other network, got ${address.networkParameters}"
+    )
     logger.info(s"Sending $amount to $address at feerate $feeRate")
     val destination = TransactionOutput(amount, address.scriptPubKey)
     for {
@@ -76,8 +77,10 @@ sealed abstract class Wallet extends LockedWallet with UnlockedWalletApi {
     require(amounts.size == addresses.size,
             "Must have an amount for every address")
     require(
-      addresses.forall(_.networkParameters == networkParameters),
-      s"Cannot send to address on other network, got ${addresses.map(_.networkParameters)}")
+      addresses.forall(
+        _.networkParameters.p2pkhNetworkByte == networkParameters.p2pkhNetworkByte),
+      s"Cannot send to address on other network, got ${addresses.map(_.networkParameters)}"
+    )
     val destinations = addresses.zip(amounts).map {
       case (address, amount) =>
         logger.info(s"Sending $amount to $address at feerate $feeRate")


### PR DESCRIPTION
I needed to add a small change to the bitcoind rpc so it has the correct network parameters because regtest addresses also parse as testnet addresses