### PR TITLE
Verify Signatures given to DLCWallet

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -82,6 +82,22 @@ case class PSBT(
     PSBT(global, inputs, outputs)
   }
 
+  def finalizeInput(index: Int): Try[PSBT] = {
+    require(index >= 0 && index < inputMaps.size,
+            s"Index must be within 0 and the number of inputs, got: $index")
+    val inputMap = inputMaps(index)
+    if (inputMap.isFinalized) {
+      Success(this)
+    } else {
+      inputMap.finalize(transaction.inputs(index)).map { finalizedInputMap =>
+        val newInputMaps =
+          inputMaps.updated(index, finalizedInputMap)
+
+        PSBT(globalMap, newInputMaps, outputMaps)
+      }
+    }
+  }
+
   /** Finalizes this PSBT if possible, returns a Failure otherwise
     * @see [[https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#input-finalizer]]
     */
@@ -522,6 +538,51 @@ case class PSBT(
       inputMaps.updated(inputIndex, InputPSBTMap(newElements))
 
     PSBT(globalMap, newInputMaps, outputMaps)
+  }
+
+  def verifyFinalizedInput(index: Int): Boolean = {
+    val inputMap = inputMaps(index)
+    require(inputMap.isFinalized, "Input must be finalized to verify")
+
+    val wUtxoOpt = inputMap.witnessUTXOOpt
+    val utxoOpt = inputMap.nonWitnessOrUnknownUTXOOpt
+
+    val newInput = {
+      val input = transaction.inputs(index)
+      val scriptSigOpt = inputMap.finalizedScriptSigOpt
+      val scriptSig =
+        scriptSigOpt.map(_.scriptSig).getOrElse(EmptyScriptSignature)
+      TransactionInput(input.previousOutput, scriptSig, input.sequence)
+    }
+
+    val tx = transaction.updateInput(index, newInput)
+
+    wUtxoOpt match {
+      case Some(wUtxo) =>
+        inputMap.finalizedScriptWitnessOpt match {
+          case Some(scriptWit) =>
+            val wtx = {
+              val wtx = WitnessTransaction.toWitnessTx(transaction)
+              wtx.updateWitness(index, scriptWit.scriptWitness)
+            }
+            val output = wUtxo.witnessUTXO
+
+            ScriptInterpreter.verifyInputScript(wtx, index, output)
+          case None =>
+            false
+        }
+      case None =>
+        utxoOpt match {
+          case Some(utxo) =>
+            val input = tx.inputs(index)
+            val output =
+              utxo.transactionSpent.outputs(input.previousOutput.vout.toInt)
+
+            ScriptInterpreter.verifyInputScript(tx, index, output)
+          case None =>
+            false
+        }
+    }
   }
 
   /**

--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCClient.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCClient.scala
@@ -31,6 +31,7 @@ import org.bitcoins.commons.jsonmodels.dlc.{
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 /** This case class allows for the construction and execution of
   * Discreet Log Contracts between two parties.
@@ -238,6 +239,38 @@ case class DLCClient(
     sigsMapF.map(FundingSignatures.apply)
   }
 
+  def verifyRemoteFundingSigs(remoteSigs: FundingSignatures): Boolean = {
+    val remoteTweak = if (isInitiator) {
+      fundingUtxos.length
+    } else {
+      0
+    }
+
+    val psbt = PSBT.fromUnsignedTx(createUnsignedFundingTransaction)
+
+    remoteSigs.zipWithIndex
+      .foldLeft(true) {
+        case (ret, ((outPoint, sigs), index)) =>
+          if (ret) {
+            require(psbt.transaction.inputs(index).previousOutput == outPoint,
+                    "Adding signature for incorrect input")
+
+            val idx = index + remoteTweak
+
+            // TODO: add funding witness and redeem scripts
+            psbt
+              .addWitnessUTXOToInput(remoteFundingInputs(index).output, idx)
+              .addSignatures(sigs, idx)
+              .finalizeInput(idx) match {
+              case Success(finalized) =>
+                finalized.verifyFinalizedInput(idx)
+              case Failure(_) =>
+                false
+            }
+          } else false
+      }
+  }
+
   def createFundingTransaction(
       remoteSigs: FundingSignatures): Future[Transaction] = {
     val (localTweak, remoteTweak) = if (isInitiator) {
@@ -251,6 +284,8 @@ case class DLCClient(
         case (psbt, ((outPoint, sigs), index)) =>
           require(psbt.transaction.inputs(index).previousOutput == outPoint,
                   "Adding signature for incorrect input")
+
+          // TODO: add funding witness and redeem scripts
           psbt
             .addWitnessUTXOToInput(remoteFundingInputs(index).output,
                                    index + remoteTweak)
@@ -342,20 +377,44 @@ case class DLCClient(
     }
   }
 
-  /** Constructs CET given sig*G, the funding tx's UTXOSpendingInfo and payouts */
-  def createCET(
-      msg: Sha256DigestBE,
-      remoteSig: PartialSignature): (Future[Transaction], P2WSHWitnessV0) = {
+  def verifyCETSig(outcome: Sha256DigestBE, sig: PartialSignature): Boolean = {
+    val cet = createUnsignedCET(outcome)
+    val fundingTx = createUnsignedFundingTransaction
+
+    val sigComponent = WitnessTxSigComponentRaw(transaction = cet,
+                                                inputIndex = UInt32.zero,
+                                                output = fundingTx.outputs.head,
+                                                flags = Policy.standardFlags)
+
+    TransactionSignatureChecker
+      .checkSignature(
+        sigComponent,
+        sigComponent.output.scriptPubKey.asm.toVector,
+        sig.pubKey,
+        sig.signature,
+        Policy.standardFlags
+      )
+      .isValid
+  }
+
+  private def getCETToLocalSPK(
+      msg: Sha256DigestBE): P2PKWithTimeoutScriptPubKey = {
     val tweak = CryptoUtil.sha256(cetToLocalPrivKey.publicKey.bytes).flip
+
     val tweakPubKey = ECPrivateKey.fromBytes(tweak.bytes).publicKey
 
     val pubKey = sigPubKeys(msg).add(fundingPubKey).add(tweakPubKey)
 
-    val toLocalSPK = P2PKWithTimeoutScriptPubKey(
+    P2PKWithTimeoutScriptPubKey(
       pubKey = pubKey,
       lockTime = ScriptNumber(timeouts.penaltyTimeout.toLong),
       timeoutPubKey = cetToLocalRemotePubKey
     )
+  }
+
+  /** Constructs an unsigned CET given sig*G, the funding tx's UTXOSpendingInfo and payouts */
+  def createUnsignedCET(msg: Sha256DigestBE): WitnessTransaction = {
+    val toLocalSPK = getCETToLocalSPK(msg)
 
     val toLocal: TransactionOutput =
       TransactionOutput(outcomes(msg) + toLocalClosingFee,
@@ -370,12 +429,22 @@ case class DLCClient(
       EmptyScriptSignature,
       timeLockSequence)
 
-    val psbt = PSBT.fromUnsignedTx(
-      BaseTransaction(TransactionConstants.validLockVersion,
-                      Vector(fundingInput),
-                      outputs.filter(_.value >= Policy.dustThreshold),
-                      timeouts.contractMaturity.toUInt32)
+    WitnessTransaction(
+      TransactionConstants.validLockVersion,
+      Vector(fundingInput),
+      outputs.filter(_.value >= Policy.dustThreshold),
+      timeouts.contractMaturity.toUInt32,
+      TransactionWitness(Vector(P2WSHWitnessV0(fundingSPK)))
     )
+  }
+
+  /** Constructs a signed CET given sig*G, the funding tx's UTXOSpendingInfo and payouts */
+  def createCET(
+      msg: Sha256DigestBE,
+      remoteSig: PartialSignature): (Future[Transaction], P2WSHWitnessV0) = {
+    val unsignedTx = createUnsignedCET(msg)
+
+    val psbt = PSBT.fromUnsignedTx(unsignedTx)
 
     val readyToSignPSBT = psbt
       .addSignature(remoteSig, inputIndex = 0)
@@ -388,6 +457,8 @@ case class DLCClient(
       val txT = signedPSBT.finalizePSBT.flatMap(_.extractTransactionAndValidate)
       Future.fromTry(txT)
     }
+
+    val toLocalSPK = getCETToLocalSPK(msg)
 
     (signedCETF, P2WSHWitnessV0(toLocalSPK))
   }
@@ -448,7 +519,27 @@ case class DLCClient(
     sigF.map((unsignedTx, P2WSHWitnessV0(toLocalSPK), _))
   }
 
-  lazy val createUnsignedRefundTx: Transaction = {
+  def verifyRefundSig(sig: PartialSignature): Boolean = {
+    val refundTx = createUnsignedRefundTx
+    val fundingTx = createUnsignedFundingTransaction
+
+    val sigComponent = WitnessTxSigComponentRaw(transaction = refundTx,
+                                                inputIndex = UInt32.zero,
+                                                output = fundingTx.outputs.head,
+                                                flags = Policy.standardFlags)
+
+    TransactionSignatureChecker
+      .checkSignature(
+        sigComponent,
+        sigComponent.output.scriptPubKey.asm.toVector,
+        sig.pubKey,
+        sig.signature,
+        Policy.standardFlags
+      )
+      .isValid
+  }
+
+  lazy val createUnsignedRefundTx: WitnessTransaction = {
     val fundingTx = createUnsignedFundingTransaction
     val fundingTxid = fundingTx.txId
     val fundingInput = TransactionInput(
@@ -483,12 +574,22 @@ case class DLCClient(
 
     val outputs = Vector(toInitiatorOutput, toOtherOutput)
 
+    val witness = TransactionWitness(Vector(P2WSHWitnessV0(fundingSPK)))
+
     val refundTxNoFee = BaseTransaction(TransactionConstants.validLockVersion,
                                         Vector(fundingInput),
                                         outputs,
                                         timeouts.contractTimeout.toUInt32)
 
-    subtractFeeFromOutputs(refundTxNoFee, feeRate, outputs.map(_.scriptPubKey))
+    val refundTxWithFee = subtractFeeFromOutputs(refundTxNoFee,
+                                                 feeRate,
+                                                 outputs.map(_.scriptPubKey))
+
+    WitnessTransaction(refundTxWithFee.version,
+                       refundTxWithFee.inputs,
+                       refundTxWithFee.outputs,
+                       refundTxWithFee.lockTime,
+                       witness)
   }
 
   def createRefundSig(): Future[(Transaction, PartialSignature)] = {
@@ -1178,7 +1279,7 @@ object DLCClient {
 
   /** Subtracts the estimated fee by removing from each output with a specified spk evenly */
   def subtractFeeFromOutputs(
-      tx: BaseTransaction,
+      tx: Transaction,
       feeRate: FeeUnit,
       spks: Vector[ScriptPubKey]): BaseTransaction = {
     // tx has empty script sigs and we need to account for witness data in fees

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
@@ -40,8 +40,12 @@ trait BitcoinSDualWalletTest extends BitcoinSWalletTest {
             Some(segwitWalletConf))(config2, system)
         } yield (walletA, walletB),
       destroy = { fundedWallets: (FundedWallet, FundedWallet) =>
-        destroyWallet(fundedWallets._1.wallet)
-        destroyWallet(fundedWallets._2.wallet)
+        val destroy1 = destroyWallet(fundedWallets._1.wallet)
+        val destroy2 = destroyWallet(fundedWallets._2.wallet)
+        for {
+          _ <- destroy1
+          _ <- destroy2
+        } yield ()
       }
     )(test)
   }
@@ -62,8 +66,12 @@ trait BitcoinSDualWalletTest extends BitcoinSWalletTest {
                                                                      walletB)
         } yield (dlcWalletA, dlcWalletB),
       destroy = { dlcWallets: (InitializedDLCWallet, InitializedDLCWallet) =>
-        destroyWallet(dlcWallets._1.wallet)
-        destroyWallet(dlcWallets._2.wallet)
+        val destroy1 = destroyWallet(dlcWallets._1.wallet)
+        val destroy2 = destroyWallet(dlcWallets._2.wallet)
+        for {
+          _ <- destroy1
+          _ <- destroy2
+        } yield ()
       }
     )(test)
   }


### PR DESCRIPTION
I needed to rework some of the `DLCClient` parts so I can get the unsigned versions of the transactions. Also, a bug wound found in the `TransactionSignatureChecker`, that will be added to master along with tests. Another thing that was added was a verify input function for PSBTs, this was only used for the funding inputs because we should have all the necessary data to be able to create a valid input there, however, for the CETs we would have to produce signatures of our own so we only verify the other party's signature instead of the whole input.