### PR TITLE
Batch processing compact filters

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -156,11 +156,10 @@ object Main extends App {
     lazy val onTx: OnTxReceived = { tx =>
       wallet.processTransaction(tx, blockHash = None).map(_ => ())
     }
-    lazy val onCompactFilter: OnCompactFiltersReceived = {
-      (blockHash, blockFilter) =>
-        wallet
-          .processCompactFilter(blockHash.head, blockFilter.head)
-          .map(_ => ())
+    lazy val onCompactFilters: OnCompactFiltersReceived = { blockFilters =>
+      wallet
+        .processCompactFilters(blockFilters = blockFilters)
+        .map(_ => ())
     }
     lazy val onBlock: OnBlockReceived = { block =>
       wallet.processBlock(block).map(_ => ())
@@ -179,7 +178,7 @@ object Main extends App {
     } else if (nodeConf.isNeutrinoEnabled) {
       Future.successful(
         NodeCallbacks(onBlockReceived = Seq(onBlock),
-                      onCompactFilterReceived = Seq(onCompactFilter),
+                      onCompactFiltersReceived = Seq(onCompactFilters),
                       onBlockHeadersReceived = Seq(onHeaders)))
     } else {
       Future.failed(new RuntimeException("Unexpected node type"))

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -156,9 +156,11 @@ object Main extends App {
     lazy val onTx: OnTxReceived = { tx =>
       wallet.processTransaction(tx, blockHash = None).map(_ => ())
     }
-    lazy val onCompactFilter: OnCompactFilterReceived = {
+    lazy val onCompactFilter: OnCompactFiltersReceived = {
       (blockHash, blockFilter) =>
-        wallet.processCompactFilter(blockHash, blockFilter).map(_ => ())
+        wallet
+          .processCompactFilter(blockHash.head, blockFilter.head)
+          .map(_ => ())
     }
     lazy val onBlock: OnBlockReceived = { block =>
       wallet.processBlock(block).map(_ => ())

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -3,7 +3,7 @@ package org.bitcoins.node
 import org.bitcoins.core.currency._
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.node.networking.peer.DataMessageHandler
-import org.bitcoins.node.networking.peer.DataMessageHandler.OnCompactFilterReceived
+import org.bitcoins.node.networking.peer.DataMessageHandler.OnCompactFiltersReceived
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.server.BitcoinSAppConfig
@@ -56,11 +56,12 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
         _ <- wallet.processBlock(block)
       } yield ()
     }
-    val onCompactFilter: OnCompactFilterReceived = { (blockHash, blockFilter) =>
-      for {
-        wallet <- walletF
-        _ <- wallet.processCompactFilter(blockHash, blockFilter)
-      } yield ()
+    val onCompactFilter: OnCompactFiltersReceived = {
+      (blockHashes, blockFilters) =>
+        for {
+          wallet <- walletF
+          _ <- wallet.processCompactFilters(blockHashes, blockFilters)
+        } yield ()
     }
 
     NodeCallbacks(

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -56,17 +56,16 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
         _ <- wallet.processBlock(block)
       } yield ()
     }
-    val onCompactFilter: OnCompactFiltersReceived = {
-      (blockHashes, blockFilters) =>
-        for {
-          wallet <- walletF
-          _ <- wallet.processCompactFilters(blockHashes, blockFilters)
-        } yield ()
+    val onCompactFilter: OnCompactFiltersReceived = { blockFilters =>
+      for {
+        wallet <- walletF
+        _ <- wallet.processCompactFilters(blockFilters)
+      } yield ()
     }
 
     NodeCallbacks(
       onBlockReceived = Seq(onBlock),
-      onCompactFilterReceived = Seq(onCompactFilter)
+      onCompactFiltersReceived = Seq(onCompactFilter)
     )
   }
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -96,7 +96,7 @@ case class DataMessageHandler(
               if (!syncing) {
                 logger.info(s"We are synced")
               }
-              (currentFilterBatch.appended(filter), syncing)
+              (currentFilterBatch :+ filter, syncing)
             }
           }
           newChainApi <- chainApi.processFilter(filter)

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -104,14 +104,13 @@ trait LockedWalletApi extends WalletApi with WalletLogger {
       scriptPubKeys = utxos.flatMap(_.redeemScriptOpt).toSet ++ addresses
         .map(_.scriptPubKey)
         .toSet
-      processFs = blockFilters.map {
+      _ <- FutureUtil.sequentially(blockFilters) {
         case (blockHash, blockFilter) =>
           val matcher = SimpleFilterMatcher(blockFilter)
           if (matcher.matchesAny(scriptPubKeys.toVector.map(_.asmBytes))) {
             nodeApi.downloadBlocks(Vector(blockHash))
           } else FutureUtil.unit
       }
-      _ <- Future.sequence(processFs)
     } yield {
       this
     }


### PR DESCRIPTION
Fixes #1282 

The change here is to process filters in batches when we are syncing. Specifically, we process the filters after we have accumulated `chainConfig.filterBatchSize` filters. This also required changing `OnCompactFilterReceived` to `OnCompactFiltersReceived`.