### PR TITLE
 Ignore immature coinbase outputs when funding a transaction 

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/consensus/Consensus.scala
+++ b/core/src/main/scala/org/bitcoins/core/consensus/Consensus.scala
@@ -7,6 +7,8 @@ import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
   */
 sealed abstract class Consensus {
 
+  def coinbaseMaturity: Long = 100
+
   def maxBlockSize: Long = 1000000
 
   def weightScalar: Long = 4

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutPoint.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutPoint.scala
@@ -24,7 +24,7 @@ case class TransactionOutPoint(txId: DoubleSha256Digest, vout: UInt32)
   def ==(outPoint: TransactionOutPoint): Boolean =
     txId == outPoint.txId && vout == outPoint.vout
 
-  def !==(outPoint: TransactionOutPoint): Boolean =
+  def !=(outPoint: TransactionOutPoint): Boolean =
     !(this == outPoint)
 }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutPoint.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutPoint.scala
@@ -20,6 +20,12 @@ case class TransactionOutPoint(txId: DoubleSha256Digest, vout: UInt32)
 
   override def toString: String =
     s"TransactionOutPoint(${txIdBE.hex}:${vout.toBigInt})"
+
+  def ==(outPoint: TransactionOutPoint): Boolean =
+    txId == outPoint.txId && vout == outPoint.vout
+
+  def !==(outPoint: TransactionOutPoint): Boolean =
+    !(this == outPoint)
 }
 
 /**

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -2,7 +2,11 @@ package org.bitcoins.wallet.internal
 
 import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto.Sign
-import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutput}
+import org.bitcoins.core.protocol.transaction.{
+  EmptyTransactionOutPoint,
+  Transaction,
+  TransactionOutput
+}
 import org.bitcoins.core.wallet.builder.BitcoinTxBuilder
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
@@ -58,7 +62,24 @@ trait FundTransactionHandling extends WalletLogger { self: LockedWalletApi =>
       fromAccount: AccountDb,
       keyManagerOpt: Option[BIP39KeyManager],
       markAsReserved: Boolean = false): Future[BitcoinTxBuilder] = {
-    val utxosF = listUtxos(fromAccount.hdAccount)
+    val utxosF = for {
+      utxos <- listUtxos(fromAccount.hdAccount)
+
+      // Need to remove immature coinbase inputs
+      coinbaseUtxos = utxos.filter(_.outPoint == EmptyTransactionOutPoint)
+      confFs = coinbaseUtxos.map(
+        utxo =>
+          chainQueryApi
+            .getNumberOfConfirmations(utxo.blockHash.get)
+            .map((utxo, _)))
+      confs <- Future.sequence(confFs)
+      immatureCoinbases = confs
+        .filter {
+          case (_, confsOpt) =>
+            confsOpt.isDefined && confsOpt.get > 100
+        }
+        .map(_._1)
+    } yield utxos.diff(immatureCoinbases)
 
     val selectedUtxosF = for {
       walletUtxos <- utxosF

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.wallet.internal
 
 import org.bitcoins.core.config.BitcoinNetwork
+import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.crypto.Sign
 import org.bitcoins.core.protocol.transaction.{
   EmptyTransactionOutPoint,
@@ -76,7 +77,7 @@ trait FundTransactionHandling extends WalletLogger { self: LockedWalletApi =>
       immatureCoinbases = confs
         .filter {
           case (_, confsOpt) =>
-            confsOpt.isDefined && confsOpt.get > 100
+            confsOpt.isDefined && confsOpt.get > Consensus.coinbaseMaturity
         }
         .map(_._1)
     } yield utxos.diff(immatureCoinbases)


### PR DESCRIPTION
Built on #1364 so I could change `FundTransactionHandlingTest` to `fundWalletWithBitcoind` without needing to rewrite the tests.

Fixes #1357 

