### PR TITLE
Re-enable NeutrinoNodeWithWalletTest for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ matrix:
     - os: osx
       name: "macOS wallet and node tests"
       env:
+        - CI="1"
         - TEST_COMMAND="walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls"
       scala:
         - 2.13.1

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
@@ -94,11 +94,13 @@ trait BitcoinSUtil {
     h.foldLeft(ByteVector.empty)(_ ++ _.bytes)
   }
 
-  lazy val isLinux: Boolean = scala.util.Properties.isLinux
+  private val osName = System.getProperty("os.name")
 
-  lazy val isMac: Boolean = scala.util.Properties.isMac
+  lazy val isLinux: Boolean = osName.startsWith("Linux")
 
-  lazy val isWindows: Boolean = scala.util.Properties.isWin
+  lazy val isMac: Boolean = osName.startsWith("Mac")
+
+  lazy val isWindows: Boolean = osName.startsWith("Windows")
 
   lazy val isCI: Boolean = {
     val prop = System.getProperty("TEST_COMMAND")

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
@@ -95,11 +95,13 @@ trait BitcoinSUtil {
     h.foldLeft(ByteVector.empty)(_ ++ _.bytes)
   }
 
-  lazy val isLinux: Boolean = Properties.isLinux
+  private val osName = System.getProperty("os.name")
 
-  lazy val isMac: Boolean = Properties.isMac
+  lazy val isLinux: Boolean = osName.startsWith("Linux")
 
-  lazy val isWindows: Boolean = Properties.isWin
+  lazy val isMac: Boolean = osName.startsWith("Mac")
+
+  lazy val isWindows: Boolean = osName.startsWith("Windows")
 
   lazy val isCI: Boolean = Properties.envOrNone("CI").contains("1")
 }

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
@@ -94,6 +94,11 @@ trait BitcoinSUtil {
     h.foldLeft(ByteVector.empty)(_ ++ _.bytes)
   }
 
+  lazy val isLinux: Boolean = scala.util.Properties.isLinux
+
+  lazy val isMac: Boolean = scala.util.Properties.isMac
+
+  lazy val isWindows: Boolean = scala.util.Properties.isWin
 }
 
 object BitcoinSUtil extends BitcoinSUtil

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
@@ -4,6 +4,7 @@ import org.bitcoins.core.protocol.NetworkElement
 import scodec.bits.{BitVector, ByteVector}
 
 import scala.math.BigInt
+import scala.util.Properties
 
 /**
   * Created by chris on 2/26/16.
@@ -94,18 +95,13 @@ trait BitcoinSUtil {
     h.foldLeft(ByteVector.empty)(_ ++ _.bytes)
   }
 
-  private val osName = System.getProperty("os.name")
+  lazy val isLinux: Boolean = Properties.isLinux
 
-  lazy val isLinux: Boolean = osName.startsWith("Linux")
+  lazy val isMac: Boolean = Properties.isMac
 
-  lazy val isMac: Boolean = osName.startsWith("Mac")
+  lazy val isWindows: Boolean = Properties.isWin
 
-  lazy val isWindows: Boolean = osName.startsWith("Windows")
-
-  lazy val isCI: Boolean = {
-    val prop = System.getProperty("TEST_COMMAND")
-    prop != null && prop.nonEmpty
-  }
+  lazy val isCI: Boolean = Properties.envOrNone("CI").contains("1")
 }
 
 object BitcoinSUtil extends BitcoinSUtil

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinSUtil.scala
@@ -99,6 +99,11 @@ trait BitcoinSUtil {
   lazy val isMac: Boolean = scala.util.Properties.isMac
 
   lazy val isWindows: Boolean = scala.util.Properties.isWin
+
+  lazy val isCI: Boolean = {
+    val prop = System.getProperty("TEST_COMMAND")
+    prop != null && prop.nonEmpty
+  }
 }
 
 object BitcoinSUtil extends BitcoinSUtil

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.node
 
 import org.bitcoins.core.currency._
+import org.bitcoins.core.util.BitcoinSUtil
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.node.networking.peer.DataMessageHandler
 import org.bitcoins.node.networking.peer.DataMessageHandler.OnCompactFiltersReceived
@@ -26,12 +27,17 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    if (isLinux) {
+    // We need to disable the test on non-linux CI runs
+    // because we do not have a mac binary of the BIP 157
+    // compatible version of bitcoin core
+    val prop = System.getProperty("TEST_COMMAND")
+    val isCI = prop != null && prop.nonEmpty
+    if (isCI && !BitcoinSUtil.isLinux) {
+      FutureOutcome.succeeded
+    } else {
       withNeutrinoNodeFundedWalletBitcoind(test,
                                            callbacks,
                                            Some(BitcoindVersion.Experimental))
-    } else {
-      FutureOutcome.succeeded
     }
   }
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -30,9 +30,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
     // We need to disable the test on non-linux CI runs
     // because we do not have a mac binary of the BIP 157
     // compatible version of bitcoin core
-    val prop = System.getProperty("TEST_COMMAND")
-    val isCI = prop != null && prop.nonEmpty
-    if (isCI && !BitcoinSUtil.isLinux) {
+    if (BitcoinSUtil.isCI && !BitcoinSUtil.isLinux) {
       FutureOutcome.succeeded
     } else {
       withNeutrinoNodeFundedWalletBitcoind(test,

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -26,7 +26,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    if (isLinux || isWindows) {
+    if (isLinux) {
       withNeutrinoNodeFundedWalletBitcoind(test,
                                            callbacks,
                                            Some(BitcoindVersion.Experimental))

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -100,8 +100,8 @@ case class DataMessageHandler(
           }
           newChainApi <- chainApi.processFilter(filter)
           // If we are not syncing or our filter batch is full, process the filters
-          _ <- if (!syncing || batchSizeFull) {
-            val blockFilters = currentFilterBatch.map { filter =>
+          _ <- if (!newSyncing || batchSizeFull) {
+            val blockFilters = newBatch.map { filter =>
               (filter.blockHash,
                BlockFilter.fromBytes(filter.filterBytes, filter.blockHash))
             }

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -29,7 +29,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionInput,
   TransactionOutPoint
 }
-import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.core.util.{BitcoinSLogger, BitcoinSUtil}
 import org.bitcoins.rpc.BitcoindException
 import org.bitcoins.rpc.client.common.BitcoindVersion.{
   Unknown,
@@ -982,8 +982,7 @@ object BitcoindRpcTestUtil extends BitcoindRpcTestUtil {
     * Used for long running async tasks
     */
   private val DEFAULT_LONG_DURATION = {
-    val isCI = Properties.envOrNone("CI").contains("1")
-    if (Properties.isMac && isCI) 10.seconds
+    if (BitcoinSUtil.isMac && BitcoinSUtil.isCI) 10.seconds
     else 3.seconds
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
@@ -50,6 +50,15 @@ trait BaseAsyncTest
 
   override lazy val timeLimit: Span = 5.minutes
 
+  lazy val isLinux: Boolean =
+    System.getProperty("os.name").startsWith("Linux")
+
+  lazy val isMac: Boolean =
+    System.getProperty("os.name").startsWith("Mac")
+
+  lazy val isWindows: Boolean =
+    System.getProperty("os.name").startsWith("Windows")
+
   /** This def ensures that shrinks are disabled for all calls to forAll.
     *
     * If you want to enable shrinking for a specific test, introduce an

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
@@ -50,15 +50,6 @@ trait BaseAsyncTest
 
   override lazy val timeLimit: Span = 5.minutes
 
-  lazy val isLinux: Boolean =
-    System.getProperty("os.name").startsWith("Linux")
-
-  lazy val isMac: Boolean =
-    System.getProperty("os.name").startsWith("Mac")
-
-  lazy val isWindows: Boolean =
-    System.getProperty("os.name").startsWith("Windows")
-
   /** This def ensures that shrinks are disabled for all calls to forAll.
     *
     * If you want to enable shrinking for a specific test, introduce an

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -245,7 +245,17 @@ trait BitcoinSWalletTest extends BitcoinSFixture with WalletLogger {
 
 object BitcoinSWalletTest extends WalletLogger {
 
-  lazy val initialFunds = 25.bitcoins
+  val defaultAcctAmts = Vector(1.bitcoin, 2.bitcoin, 3.bitcoin)
+
+  val expectedDefaultAmt: CurrencyUnit =
+    defaultAcctAmts.fold(CurrencyUnits.zero)(_ + _)
+
+  val account1Amt = Vector(Bitcoins(0.2), Bitcoins(0.3), Bitcoins(0.5))
+
+  val expectedAccount1Amt: CurrencyUnit =
+    account1Amt.fold(CurrencyUnits.zero)(_ + _)
+
+  lazy val initialFunds: CurrencyUnit = expectedDefaultAmt + expectedAccount1Amt
 
   object MockNodeApi extends NodeApi {
 
@@ -496,11 +506,6 @@ object BitcoinSWalletTest extends WalletLogger {
   def fundWalletWithBitcoind[T <: WalletWithBitcoind](pair: T)(
       implicit ec: ExecutionContext): Future[T] = {
     val (wallet, bitcoind) = (pair.wallet, pair.bitcoind)
-
-    val defaultAcctAmts = Vector(1.bitcoin, 2.bitcoin, 3.bitcoin)
-    val expectedDefaultAmt = defaultAcctAmts.fold(CurrencyUnits.zero)(_ + _)
-    val account1Amt = Vector(Bitcoins(0.2), Bitcoins(0.3), Bitcoins(0.5))
-    val expectedAccount1Amt = account1Amt.fold(CurrencyUnits.zero)(_ + _)
 
     val defaultAccount = wallet.walletConfig.defaultAccount
     val fundedDefaultAccountWalletF =

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -3,7 +3,7 @@ package org.bitcoins.testkit.wallet
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import org.bitcoins.core.api.{ChainQueryApi, NodeApi}
-import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit, CurrencyUnits, _}
+import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.TransactionOutput
@@ -76,14 +76,9 @@ trait FundWalletUtil {
   def fundWallet(wallet: Wallet)(
       implicit ec: ExecutionContext): Future[FundedWallet] = {
 
-    val defaultAcctAmts = Vector(1.bitcoin, 2.bitcoin, 3.bitcoin)
-    val expectedDefaultAmt = defaultAcctAmts.fold(CurrencyUnits.zero)(_ + _)
-    val account1Amt = Vector(Bitcoins(0.2), Bitcoins(0.3), Bitcoins(0.5))
-    val expectedAccount1Amt = account1Amt.fold(CurrencyUnits.zero)(_ + _)
-
     val defaultAccount = wallet.walletConfig.defaultAccount
     val fundedDefaultAccountWalletF = FundWalletUtil.fundAccountForWallet(
-      amts = defaultAcctAmts,
+      amts = BitcoinSWalletTest.defaultAcctAmts,
       account = defaultAccount,
       wallet = wallet
     )
@@ -92,7 +87,7 @@ trait FundWalletUtil {
     val fundedAccount1WalletF = for {
       fundedDefaultAcct <- fundedDefaultAccountWalletF
       fundedAcct1 <- FundWalletUtil.fundAccountForWallet(
-        amts = account1Amt,
+        amts = BitcoinSWalletTest.account1Amt,
         account = hdAccount1,
         fundedDefaultAcct
       )
@@ -103,14 +98,15 @@ trait FundWalletUtil {
       fundedWallet <- fundedAccount1WalletF
       balance <- fundedWallet.getBalance(defaultAccount)
       _ = require(
-        balance == expectedDefaultAmt,
-        s"Funding wallet fixture failed to fund the wallet, got balance=${balance} expected=${expectedDefaultAmt}")
+        balance == BitcoinSWalletTest.expectedDefaultAmt,
+        s"Funding wallet fixture failed to fund the wallet, got balance=${balance} expected=${BitcoinSWalletTest.expectedDefaultAmt}"
+      )
 
       account1Balance <- fundedWallet.getBalance(hdAccount1)
       _ = require(
-        account1Balance == expectedAccount1Amt,
+        account1Balance == BitcoinSWalletTest.expectedAccount1Amt,
         s"Funding wallet fixture failed to fund account 1, " +
-          s"got balance=${hdAccount1} expected=${expectedAccount1Amt}"
+          s"got balance=${hdAccount1} expected=${BitcoinSWalletTest.expectedAccount1Amt}"
       )
 
     } yield FundedWallet(fundedWallet)


### PR DESCRIPTION
Test will be disabled for mac and windows because we do not have a bitcoin core binaries that have neutrino enabled