### PR TITLE
Fix isMinimalPush to not look for OP_1Negate when pushing 0x4f(79)

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/util/BitcoinScriptUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BitcoinScriptUtilTest.scala
@@ -183,6 +183,20 @@ class BitcoinScriptUtilTest extends BitcoinSUnitTest {
       false)
   }
 
+  it must "determine that a script is not minimal push when pushing 4f (-1)" in {
+    BitcoinScriptUtil.isMinimalPush(BytesToPushOntoStack(1),
+                                    ScriptConstant("81")) must be(false)
+  }
+
+  it must "determine that a script is minimal push when pushing 4f (79)" in {
+    BitcoinScriptUtil.isMinimalPush(BytesToPushOntoStack(1),
+                                    ScriptConstant("4f")) must be(true)
+  }
+
+  it must "determine that a script is minimal push when pushing OP_1NEGATE (-1)" in {
+    BitcoinScriptUtil.isMinimalPush(OP_1NEGATE, OP_1NEGATE) must be(true)
+  }
+
   it must "determine that a script is push only if it only contains pushing an empty script constant" in {
     BitcoinScriptUtil.isMinimalPush(OP_0, ScriptConstant("")) must be(true)
   }

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -215,9 +215,7 @@ trait BitcoinScriptUtil extends BitcoinSLogger {
         false
       case token: ScriptToken =>
         token.bytes.size match {
-          case size if (size == 0) => pushOp == OP_0
-          case size if (size == 1 && token.bytes.head == OP_1NEGATE.opCode) =>
-            pushOp == OP_1NEGATE
+          case size if (size == 0)     => pushOp == OP_0
           case size if (size <= 75)    => token.bytes.size == pushOp.toLong
           case size if (size <= 255)   => pushOp == OP_PUSHDATA1
           case size if (size <= 65535) => pushOp == OP_PUSHDATA2


### PR DESCRIPTION
`isMinimalPush` was incorrectly expecting `OP_1NEGATE` when we were pushing 0x4f (79 in decimal) onto the stack to be valid. This was caused because we were checking `OP_1NEGATE`'s `opcode` not its actual `underlying` value.

Was able to delete this entire case
```
case size if (size == 1 && token.bytes.head == OP_1NEGATE.opCode) =>
            pushOp == OP_1NEGATE
```
because it should be captured by
```
case scriptNumOp: ScriptNumberOperation =>
        scriptNumOp == pushOp
```