### PR TITLE
Create KeyManagerTestUtil.bip39PasswordNonEmpty for test case that re…

### DIFF
--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerTest.scala
@@ -103,7 +103,7 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
 
   it must "NOT initialize a key manager to the same xpub if one has a password and one does not" in {
     val kmParams = buildParams()
-    val bip39Pw = KeyManagerTestUtil.bip39Password
+    val bip39Pw = KeyManagerTestUtil.bip39PasswordNonEmpty
 
     val withPassword = BIP39KeyManager(mnemonic, kmParams, Some(bip39Pw))
     val withPasswordXpub = withPassword.getRootXPub

--- a/testkit/src/main/scala/org/bitcoins/testkit/keymanager/KeyManagerTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/keymanager/KeyManagerTestUtil.scala
@@ -11,6 +11,8 @@ import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.scalacheck.Gen
 
+import scala.annotation.tailrec
+
 object KeyManagerTestUtil {
 
   /** A temporary file that can be used as a seed path for testing */
@@ -37,6 +39,13 @@ object KeyManagerTestUtil {
 
   def bip39Password: String = {
     CryptoGenerators.bip39Password.sample.get
+  }
+
+  @tailrec
+  final def bip39PasswordNonEmpty: String = {
+    val attempt = bip39Password
+    if (attempt.isEmpty) bip39PasswordNonEmpty
+    else attempt
   }
 
   val badPassphrase: AesPassword = BIP39KeyManager.badPassphrase


### PR DESCRIPTION
…quires non empty password

Closes #1216 

The test case requires a non empty password, but `KeyManagerTestUtil.bip39Password` can return a empty string.


