### PR TITLE
Re-add SchnorrNonce.freshNonce(), for DLC doc. Add mdoc:to-string to …

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/crypto/SchnorrNonce.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/SchnorrNonce.scala
@@ -88,8 +88,4 @@ object SchnorrNonce extends Factory[SchnorrNonce] {
   def apply(xCoor: FieldElement): SchnorrNonce = {
     SchnorrNonce(xCoor.bytes)
   }
-
-  def freshNonce(): SchnorrNonce = {
-    ECPrivateKey.freshPrivateKey.schnorrNonce
-  }
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/SchnorrNonce.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/SchnorrNonce.scala
@@ -90,7 +90,6 @@ object SchnorrNonce extends Factory[SchnorrNonce] {
   }
 
   def freshNonce(): SchnorrNonce = {
-    val xcordBytes = ECPrivateKey.freshPrivateKey.publicKey.bytes.tail
-    fromBytes(xcordBytes)
+    ECPrivateKey.freshPrivateKey.schnorrNonce
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/SchnorrNonce.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/SchnorrNonce.scala
@@ -88,4 +88,9 @@ object SchnorrNonce extends Factory[SchnorrNonce] {
   def apply(xCoor: FieldElement): SchnorrNonce = {
     SchnorrNonce(xCoor.bytes)
   }
+
+  def freshNonce(): SchnorrNonce = {
+    val xcordBytes = ECPrivateKey.freshPrivateKey.publicKey.bytes.tail
+    fromBytes(xcordBytes)
+  }
 }

--- a/docs/wallet/dlc.md
+++ b/docs/wallet/dlc.md
@@ -49,7 +49,6 @@ f8758d7f03a65b67b90f62301a3554849bde6d00d50e965eb123398de9fd6ea7af05f01f1ca852cf
 Note: if you wish to setup your own oracle for testing, you can do so by pasting the following into the `sbt core/console`:
 
 ```scala mdoc:to-string
-import org.bitcoin._
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.util.CryptoUtil
 import scodec.bits.ByteVector

--- a/docs/wallet/dlc.md
+++ b/docs/wallet/dlc.md
@@ -57,15 +57,15 @@ import org.bitcoins.core.currency._
 
 val privKey = ECPrivateKey.freshPrivateKey
 val pubKey = privKey.publicKey
-val nonce = SchnorrNonce.freshNonce
-val rValue = nonce.publicKey
+val kValue = ECPrivateKey.freshPrivateKey
+val rValue = kValue.schnorrNonce
 val winHash = CryptoUtil.sha256(ByteVector("WIN".getBytes)).flip
 val loseHash = CryptoUtil.sha256(ByteVector("LOSE".getBytes)).flip
 
 (pubKey.bytes ++ rValue.bytes).toHex
 (winHash.bytes ++ Satoshis(100000).bytes ++ loseHash.bytes ++ Satoshis.zero.bytes).toHex
-NativeSecp256k1.schnorrSignWithNonce(winHash.bytes.toArray, privKey.bytes.toArray, nonce.bytes.toArray)
-NativeSecp256k1.schnorrSignWithNonce(loseHash.bytes.toArray, privKey.bytes.toArray, nonce.bytes.toArray)
+privKey.schnorrSignWithNonce(winHash.bytes, kValue)
+privKey.schnorrSignWithNonce(loseHash.bytes, kValue)
 ```
 
 Where you can replace the messages `WIN` and `LOSE` to have the oracle sign any two messages, and replace `Satoshis(100000)` and `Satoshis.zero` to change the outcomes.

--- a/docs/wallet/dlc.md
+++ b/docs/wallet/dlc.md
@@ -48,7 +48,8 @@ f8758d7f03a65b67b90f62301a3554849bde6d00d50e965eb123398de9fd6ea7af05f01f1ca852cf
 
 Note: if you wish to setup your own oracle for testing, you can do so by pasting the following into the `sbt core/console`:
 
-```scala
+```scala mdoc:to-string
+import org.bitcoin._
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.util.CryptoUtil
 import scodec.bits.ByteVector
@@ -63,8 +64,8 @@ val loseHash = CryptoUtil.sha256(ByteVector("LOSE".getBytes)).flip
 
 (pubKey.bytes ++ rValue.bytes).toHex
 (winHash.bytes ++ Satoshis(100000).bytes ++ loseHash.bytes ++ Satoshis.zero.bytes).toHex
-Schnorr.signWithNonce(winHash.bytes, privKey, nonce).hex
-Schnorr.signWithNonce(loseHash.bytes, privKey, nonce).hex
+NativeSecp256k1.schnorrSignWithNonce(winHash.bytes.toArray, privKey.bytes.toArray, nonce.bytes.toArray)
+NativeSecp256k1.schnorrSignWithNonce(loseHash.bytes.toArray, privKey.bytes.toArray, nonce.bytes.toArray)
 ```
 
 Where you can replace the messages `WIN` and `LOSE` to have the oracle sign any two messages, and replace `Satoshis(100000)` and `Satoshis.zero` to change the outcomes.


### PR DESCRIPTION
…dlc doc to make sure the doc is compiled so we have failures on CI if the API changes