### PR TITLE
Attempt to add a bit of delay on expecting rescan to fail so we dont'…

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/NodeRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/NodeRpcTest.scala
@@ -6,6 +6,7 @@ import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoindRpcTest
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 import org.bitcoins.rpc.BitcoindException.MiscError
 
 class NodeRpcTest extends BitcoindRpcTest {
@@ -22,9 +23,10 @@ class NodeRpcTest extends BitcoindRpcTest {
         .flatMap { _ =>
           val rescanFailedF =
             recoverToSucceededIf[MiscError](client.rescanBlockChain())
-          client.abortRescan().flatMap { _ =>
-            rescanFailedF
+          system.scheduler.scheduleOnce(100.millis) {
+            client.abortRescan()
           }
+          rescanFailedF
         }
     }
   }


### PR DESCRIPTION
… have as much of a async issue

Closes #761 

The problem here is we need to start a rescan and abort it right away. The Future returned by `rescanBlockChain` isn't completed until the rescan is finished, so we can't add a callback on this future. 

My PR adds a slight delay of 100 milliseconds before attempting to abort the rescan to ensure it is started on slow CI machines.
