### PR TITLE
Create logger config for other libraries to configure bitcoin-s logging

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/HttpLogger.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/HttpLogger.scala
@@ -1,11 +1,12 @@
 package org.bitcoins.server
 
-import org.bitcoins.db.{AppConfig, AppLoggers, MarkedLogger}
+import org.bitcoins.db.{AppLoggers, LoggerConfig, MarkedLogger}
 
 /** Exposes access to the HTTP RPC server logger */
 private[bitcoins] trait HttpLogger {
   private var _logger: MarkedLogger = _
-  protected[bitcoins] def logger(implicit config: AppConfig) = {
+  protected[bitcoins] def logger(
+      implicit config: LoggerConfig): MarkedLogger = {
     if (_logger == null) {
       _logger = HttpLoggerImpl(config).getLogger
     }
@@ -13,7 +14,7 @@ private[bitcoins] trait HttpLogger {
   }
 }
 
-private[server] case class HttpLoggerImpl(override val conf: AppConfig)
+private[server] case class HttpLoggerImpl(override val conf: LoggerConfig)
     extends AppLoggers {
 
   /**

--- a/chain/src/main/scala/org/bitcoins/chain/ChainVerificationLogger.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/ChainVerificationLogger.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.chain
 
-import org.bitcoins.db.{AppLoggers, MarkedLogger}
-import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.db.{AppLoggers, LoggerConfig, MarkedLogger}
 
 /** Exposes access to the chain verification logger */
 private[bitcoins] trait ChainVerificationLogger {
   private var _logger: MarkedLogger = _
-  protected[bitcoins] def logger(implicit config: ChainAppConfig) = {
+  protected[bitcoins] def logger(
+      implicit config: LoggerConfig): MarkedLogger = {
     if (_logger == null) {
       _logger = ChainVerificationLoggerImpl(config).getLogger
     }
@@ -15,7 +15,7 @@ private[bitcoins] trait ChainVerificationLogger {
 }
 
 private[chain] case class ChainVerificationLoggerImpl(
-    override val conf: ChainAppConfig)
+    override val conf: LoggerConfig)
     extends AppLoggers {
 
   /**

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -29,7 +29,7 @@ import ch.qos.logback.classic.Level
   * @see [[https://github.com/bitcoin-s/bitcoin-s-core/blob/master/doc/configuration.md `configuration.md`]]
   *      for more information.
   */
-abstract class AppConfig {
+abstract class AppConfig extends LoggerConfig {
 
   private val logger = BitcoinSLogger.logger
 
@@ -240,6 +240,8 @@ abstract class AppConfig {
     baseDatadir.resolve(lastDirname)
   }
 
+  override val logFile: Path = datadir.resolve("bitcoin-s.log")
+
   private def stringToLogLevel(str: String): Option[Level] =
     str.toLowerCase() match {
       case "trace"   => Some(Level.TRACE)
@@ -279,25 +281,25 @@ abstract class AppConfig {
     }
 
   /** The logging level for our P2P logger */
-  lazy val p2pLogLevel: Level = levelOrDefault("logging.p2p")
+  override lazy val p2pLogLevel: Level = levelOrDefault("logging.p2p")
 
   /** The logging level for our chain verification logger */
-  lazy val verificationLogLevel: Level =
+  override lazy val verificationLogLevel: Level =
     levelOrDefault("logging.chain-verification")
 
   /** The logging level for our key handling logger */
-  lazy val keyHandlingLogLevel: Level =
+  override lazy val keyHandlingLogLevel: Level =
     levelOrDefault("logging.key-handling")
 
   /** Logging level for wallet */
-  lazy val walletLogLeveL: Level =
+  override lazy val walletLogLevel: Level =
     levelOrDefault("logging.wallet")
 
   /** Logging level for HTTP RPC server */
-  lazy val httpLogLevel: Level = levelOrDefault("logging.http")
+  override lazy val httpLogLevel: Level = levelOrDefault("logging.http")
 
   /** Logging level for database interactions */
-  lazy val databaseLogLevel: Level = levelOrDefault("logging.database")
+  override lazy val databaseLogLevel: Level = levelOrDefault("logging.database")
 
 }
 

--- a/db-commons/src/main/scala/org/bitcoins/db/AppLoggers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppLoggers.scala
@@ -1,17 +1,14 @@
 package org.bitcoins.db
 
 import ch.qos.logback.classic
-import org.slf4j.{LoggerFactory, MDC}
-import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder
-import ch.qos.logback.core.rolling.RollingFileAppender
-import ch.qos.logback.core.rolling.TimeBasedRollingPolicy
-import ch.qos.logback.core.encoder.Encoder
-import ch.qos.logback.core.FileAppender
-import ch.qos.logback.core.ConsoleAppender
 import ch.qos.logback.classic.joran.JoranConfigurator
-import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.{ConsoleAppender, FileAppender}
+import ch.qos.logback.core.encoder.Encoder
+import ch.qos.logback.core.rolling.{RollingFileAppender, TimeBasedRollingPolicy}
+import org.slf4j.{LoggerFactory, MDC}
 
 /** Provides logging functionality for Bitcoin-S
   * app modules (i.e. the modules that are capable
@@ -28,7 +25,7 @@ private[bitcoins] trait AppLoggers {
     case object Database extends LoggerKind
   }
 
-  def conf: AppConfig
+  def conf: LoggerConfig
 
   private val context = {
     val context = LoggerFactory.getILoggerFactory match {
@@ -87,15 +84,7 @@ private[bitcoins] trait AppLoggers {
 
     logFileAppender.setRollingPolicy(logFilePolicy)
 
-    val baseDir = conf.baseDatadir
-    val lastDirname = conf.network match {
-      case MainNet  => "mainnet"
-      case TestNet3 => "testnet3"
-      case RegTest  => "regtest"
-    }
-    val logFile = baseDir.resolve(lastDirname).resolve(s"bitcoin-s.log")
-
-    logFileAppender.setFile(logFile.toString)
+    logFileAppender.setFile(conf.logFile.toString)
     logFileAppender.start()
 
     logFileAppender.asInstanceOf[FileAppender[ILoggingEvent]]
@@ -120,7 +109,7 @@ private[bitcoins] trait AppLoggers {
         ("chain-verification", conf.verificationLogLevel)
       case KeyHandling => ("KEY-HANDLING", conf.keyHandlingLogLevel)
       case P2P         => ("P2P", conf.p2pLogLevel)
-      case Wallet      => ("WALLET", conf.walletLogLeveL)
+      case Wallet      => ("WALLET", conf.walletLogLevel)
       case Http        => ("HTTP", conf.httpLogLevel)
       case Database    => ("DATABASE", conf.databaseLogLevel)
     }

--- a/db-commons/src/main/scala/org/bitcoins/db/DatabaseLogger.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DatabaseLogger.scala
@@ -3,7 +3,8 @@ package org.bitcoins.db
 /** Exposes access to the database interaction logger */
 private[bitcoins] trait DatabaseLogger {
   private var _logger: MarkedLogger = _
-  protected[bitcoins] def logger(implicit config: AppConfig) = {
+  protected[bitcoins] def logger(
+      implicit config: LoggerConfig): MarkedLogger = {
     if (_logger == null) {
       _logger = DatabaseLoggerImpl(config).getLogger
     }
@@ -11,7 +12,7 @@ private[bitcoins] trait DatabaseLogger {
   }
 }
 
-private[db] case class DatabaseLoggerImpl(override val conf: AppConfig)
+private[db] case class DatabaseLoggerImpl(override val conf: LoggerConfig)
     extends AppLoggers {
 
   /**

--- a/db-commons/src/main/scala/org/bitcoins/db/LoggerConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/LoggerConfig.scala
@@ -1,0 +1,29 @@
+package org.bitcoins.db
+
+import java.nio.file.Path
+
+import ch.qos.logback.classic.Level
+
+abstract class LoggerConfig {
+
+  /** Where logs are written to */
+  def logFile: Path
+
+  /** The logging level for P2P logger */
+  def p2pLogLevel: Level
+
+  /** The logging level for chain verification logger */
+  def verificationLogLevel: Level
+
+  /** The logging level for key handling logger */
+  def keyHandlingLogLevel: Level
+
+  /** Logging level for wallet */
+  def walletLogLevel: Level
+
+  /** Logging level for HTTP RPC server */
+  def httpLogLevel: Level
+
+  /** Logging level for database logger */
+  def databaseLogLevel: Level
+}

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -12,6 +12,7 @@ import org.bitcoins.core.api.{ChainQueryApi, NodeApi}
 import org.bitcoins.core.p2p.{NetworkPayload, TypeIdentifier}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
+import org.bitcoins.db.MarkedLogger
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.{
   BroadcastAbleTransaction,
@@ -53,6 +54,11 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     callbacks.atomicUpdate(newCallbacks)(_ + _)
     this
   }
+
+  // Need to overwrite logger because nodeAppConfig and chainAppConfig are both
+  // instances of LoggerConfig
+  protected def logger(implicit config: NodeAppConfig): MarkedLogger =
+    super.logger(config)
 
   lazy val txDAO = BroadcastAbleTransactionDAO()
 

--- a/node/src/main/scala/org/bitcoins/node/P2PLogger.scala
+++ b/node/src/main/scala/org/bitcoins/node/P2PLogger.scala
@@ -1,12 +1,11 @@
 package org.bitcoins.node
 
-import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.db.{AppLoggers, MarkedLogger}
+import org.bitcoins.db.{AppLoggers, LoggerConfig, MarkedLogger}
 
 /** Exposes access to the P2P submodule logger */
 private[bitcoins] trait P2PLogger {
   private var _logger: MarkedLogger = _
-  protected def logger(implicit config: NodeAppConfig) = {
+  protected def logger(implicit config: LoggerConfig): MarkedLogger = {
     if (_logger == null) {
       _logger = P2PLoggerImpl(config).getLogger
     }
@@ -14,7 +13,7 @@ private[bitcoins] trait P2PLogger {
   }
 }
 
-private[node] case class P2PLoggerImpl(override val conf: NodeAppConfig)
+private[node] case class P2PLoggerImpl(override val conf: LoggerConfig)
     extends AppLoggers {
 
   /**

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader, MerkleBlock}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
+import org.bitcoins.db.MarkedLogger
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.BroadcastAbleTransactionDAO
 import org.bitcoins.node.{NodeCallbacks, P2PLogger}
@@ -30,6 +31,11 @@ case class DataMessageHandler(
     appConfig: NodeAppConfig,
     chainConfig: ChainAppConfig)
     extends P2PLogger {
+
+  // Need to overwrite logger because nodeAppConfig and chainAppConfig are both
+  // instances of LoggerConfig
+  protected def logger(implicit config: NodeAppConfig): MarkedLogger =
+    super.logger(config)
 
   private val txDAO = BroadcastAbleTransactionDAO()
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -10,6 +10,7 @@ import org.bitcoins.chain.models.{
   CompactFilterHeaderDAO
 }
 import org.bitcoins.core.p2p.{NetworkMessage, _}
+import org.bitcoins.db.MarkedLogger
 import org.bitcoins.node.{NodeCallbacks, P2PLogger}
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
@@ -41,6 +42,11 @@ class PeerMessageReceiver(
     chainAppConfig: ChainAppConfig)
     extends P2PLogger {
   import ref.dispatcher
+
+  // Need to overwrite logger because nodeAppConfig and chainAppConfig are both
+  // instances of LoggerConfig
+  protected def logger(implicit config: NodeAppConfig): MarkedLogger =
+    super.logger(config)
 
   /** This method is called when we have received
     * a [[akka.io.Tcp.Connected]] message from our peer

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -226,7 +226,8 @@ object NodeUnitTest extends P2PLogger {
       nodeConnectedWithBitcoind: NodeConnectedWithBitcoind)(
       implicit system: ActorSystem,
       appConfig: BitcoinSAppConfig): Future[Unit] = {
-    logger.debug(s"Beggining tear down of node connected with bitcoind")
+    logger(appConfig.nodeConf)
+      .debug(s"Beggining tear down of node connected with bitcoind")
     import system.dispatcher
     val node = nodeConnectedWithBitcoind.node
     val bitcoind = nodeConnectedWithBitcoind.bitcoind
@@ -234,7 +235,8 @@ object NodeUnitTest extends P2PLogger {
       _ <- destroyNode(node)
       _ <- ChainUnitTest.destroyBitcoind(bitcoind)
     } yield {
-      logger.debug(s"Done with teardown of node connected with bitcoind!")
+      logger(appConfig.nodeConf)
+        .debug(s"Done with teardown of node connected with bitcoind!")
       ()
     }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletLogger.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletLogger.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.wallet.config.WalletAppConfig
-import org.bitcoins.db.{AppLoggers, MarkedLogger}
+import org.bitcoins.db.{AppLoggers, LoggerConfig, MarkedLogger}
 
 /** Exposes acccess to the wallet logger */
 private[bitcoins] trait WalletLogger {
   private var _logger: MarkedLogger = _
-  protected[bitcoins] def logger(implicit config: WalletAppConfig) = {
+  protected[bitcoins] def logger(
+      implicit config: LoggerConfig): MarkedLogger = {
     if (_logger == null) {
       _logger = WalletLoggerImpl(config).getLogger
     }
@@ -14,7 +14,7 @@ private[bitcoins] trait WalletLogger {
   }
 }
 
-private[wallet] case class WalletLoggerImpl(override val conf: WalletAppConfig)
+private[wallet] case class WalletLoggerImpl(override val conf: LoggerConfig)
     extends AppLoggers {
 
   /**


### PR DESCRIPTION
Closes #699

This makes it so the Loggers no longer require an `AppConfig`, they now require a `LoggerConfig`. This allows it so people using an bitcoin-s as a library do not need an entire `AppConfig` set and can instead pass in a `LoggerConfig` that they create themselves.