### PR TITLE
Implement KeyManagerLogger

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -418,7 +418,7 @@ lazy val docs = project
 lazy val keyManager = project
   .in(file("key-manager"))
   .settings(CommonSettings.prodSettings: _*)
-  .dependsOn(core)
+  .dependsOn(core, dbCommons)
 
 lazy val keyManagerTest = project
   .in(file("key-manager-test"))

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/KeyManagerLogger.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/KeyManagerLogger.scala
@@ -1,0 +1,26 @@
+package org.bitcoins.keymanager
+
+import org.bitcoins.db.{AppLoggers, LoggerConfig}
+import org.slf4j.Logger
+
+/** Exposes access to the key manager logger */
+private[bitcoins] trait KeyManagerLogger {
+  private var _logger: Logger = _
+  protected[bitcoins] def logger(implicit config: LoggerConfig): Logger = {
+    if (_logger == null) {
+      _logger = KeyManagerLoggerImpl(config).getLogger
+    }
+    _logger
+  }
+}
+
+private[keymanager] case class KeyManagerLoggerImpl(
+    override val conf: LoggerConfig)
+    extends AppLoggers {
+
+  /**
+    * @return the generic Key Manager logger (i.e. everything related to secret keys)
+    */
+  def getLogger: Logger =
+    getLoggerImpl(LoggerKind.KeyHandling)
+}

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -27,7 +27,8 @@ case class BIP39KeyManager(
     kmParams: KeyManagerParams,
     private val bip39PasswordOpt: Option[String],
     creationTime: Instant)
-    extends KeyManager {
+    extends KeyManager
+    with KeyManagerLogger {
   private val seed = bip39PasswordOpt match {
     case Some(pw) =>
       BIP39Seed.fromMnemonic(mnemonic = mnemonic, password = pw)


### PR DESCRIPTION
Built on top of #1465 so CI passes.

Previously, we had defined the `KeyHandling` `LoggerKind` but never used it. Now the `KeyManager` should use the correct logger.