### PR TITLE
Add rpcport configuration options in both bitcoin-s.conf and as a com…

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.gui
 
 import org.bitcoins.cli.CliCommand.{GetBalance, GetNewAddress, SendToAddress}
-import org.bitcoins.cli.ConsoleCli
+import org.bitcoins.cli.{Config, ConsoleCli}
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.gui.dialog.{GetNewAddressDialog, SendDialog}
@@ -28,7 +28,7 @@ class WalletGUIModel() {
     taskRunner.run(
       caption = "Get New Address",
       op = {
-        ConsoleCli.exec(GetNewAddress) match {
+        ConsoleCli.exec(GetNewAddress,Config.empty) match {
           case Success(commandReturn) => address.value = commandReturn
           case Failure(err)           => throw err
         }
@@ -49,7 +49,8 @@ class WalletGUIModel() {
             ConsoleCli.exec(
               SendToAddress(BitcoinAddress(address).get,
                             Bitcoins(BigDecimal(amount)),
-                            satoshisPerVirtualByte = None)) match {
+                            satoshisPerVirtualByte = None),
+              Config.empty) match {
               case Success(txid) =>
                 GlobalData.log.value =
                   s"Sent $amount to $address in tx: $txid\n\n${GlobalData.log()}"
@@ -64,7 +65,7 @@ class WalletGUIModel() {
   }
 
   private def updateBalance(): Unit = {
-    ConsoleCli.exec(GetBalance(isSats = false)) match {
+    ConsoleCli.exec(GetBalance(isSats = false), Config.empty) match {
       case Success(commandReturn) =>
         GlobalData.currentBalance.value = commandReturn.split(' ').head.toDouble
       case Failure(err) =>

--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -78,6 +78,11 @@ bitcoin-s {
         # before we timeout
         addressQueueTimeout = 5 seconds
     }
+
+    server {
+        # The port we bind our rpc server on
+        rpcport = 9999
+    }
 }
 
 akka {

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -44,6 +44,18 @@ case class BitcoinSAppConfig(
     // be equal
     nodeConf.config
   }
+
+  def serverConf: Config = {
+    config.getConfig("server")
+  }
+
+  def rpcPortOpt: Option[Int] = {
+    if(serverConf.hasPath("rpcport")) {
+      Some(serverConf.getInt("rpcport"))
+    } else {
+      None
+    }
+  }
 }
 
 /**

--- a/app/server/src/main/scala/org/bitcoins/server/Server.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Server.scala
@@ -7,13 +7,14 @@ import akka.stream.ActorMaterializer
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
-
 import de.heikoseeberger.akkahttpupickle.UpickleSupport._
 import akka.http.scaladsl.server.directives.DebuggingDirectives
 import akka.event.Logging
 import org.bitcoins.db.AppConfig
 
-case class Server(conf: AppConfig, handlers: Seq[ServerRoute])(
+import scala.concurrent.Future
+
+case class Server(conf: AppConfig, handlers: Seq[ServerRoute], rpcport: Int = 9999)(
     implicit system: ActorSystem)
     extends HttpLogger {
   implicit private val config: AppConfig = conf
@@ -76,9 +77,9 @@ case class Server(conf: AppConfig, handlers: Seq[ServerRoute])(
       }
     }
 
-  def start() = {
+  def start(): Future[Http.ServerBinding] = {
     val httpFut =
-      Http().bindAndHandle(route, "localhost", 9999)
+      Http().bindAndHandle(route, "localhost", rpcport)
     httpFut.foreach { http =>
       logger.info(s"Started Bitcoin-S HTTP server at ${http.localAddress}")
     }

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -36,6 +36,13 @@ If you would like to pass in a custom datadir for your server, you can do
 ```bash
 ./app/server/target/universal/stage/bin/bitcoin-s-server --datadir /path/to/datadir/
 ```
+
+You can also pass in a custom `rpcport` to bind to
+
+```bash
+./app/server/target/universal/stage/bin/bitcoin-s-server --rpcport 12345
+```
+
 For more information on configuring the server please see our [configuration](../config/configuration.md) document
 
 For more information on how to use our built in `cli` to interact with the server please see [cli.md](cli.md)

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -153,6 +153,11 @@ bitcoin-s {
         addressQueueTimeout = 5 seconds
 
    }
+
+    server {
+        # The port we bind our rpc server on
+        rpcport = 9999
+    }
 }
 
 

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -80,6 +80,11 @@ bitcoin-s {
         # before we timeout
         addressQueueTimeout = 5 seconds
     }
+
+    server {
+        # The port we bind our rpc server on
+        rpcport = 9999
+    }
 }
 
 


### PR DESCRIPTION
…mand line parameter

You can now set `rpcport` with the command line like `--rpcport 12345` or in the `bitcoin-s.conf` file with `bitcoin-s.server.rpcport=12345`

The rpc command line option takes precedent over the `bitcoin-s.conf` if they are both used.

You can also use the `--rpcport` option on the `bitcoin-s-cli`. Unfortunately there is a limitation. You need to pass in the arg _after_ the command you are going to run: `bitcoin-s-cli getblockcount --rpcport=12345`. 

This format will NOT work:

```
bitcoin-s-cli --rpcport=12345 getblockcount
```