### PR TITLE
End to End DLC with SbClient

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/sbclient/Asset.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/sbclient/Asset.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.sbclient
+package org.bitcoins.commons.jsonmodels.sbclient
 
 sealed abstract class Asset {
   def toLowerString: String = this.toString.toLowerCase

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/sbclient/Exchange.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/sbclient/Exchange.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.sbclient
+package org.bitcoins.commons.jsonmodels.sbclient
 
 sealed trait Exchange {
 
@@ -93,6 +93,16 @@ object Exchange {
     override def toString: String = "kraken"
     override def toLongString: String = "krakenfut"
     override def pairs: Vector[TradingPair] = KrakenFutTradingPair.all
+  }
+
+  def fromString(exchange: String): Option[Exchange] = {
+    SpotExchange
+      .fromString(exchange) match {
+      case Some(spot) =>
+        Some(spot)
+      case None =>
+        FuturesExchange.fromString(exchange)
+    }
   }
 }
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/sbclient/TradingPair.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/sbclient/TradingPair.scala
@@ -1,7 +1,7 @@
-package org.bitcoins.sbclient
+package org.bitcoins.commons.jsonmodels.sbclient
 
-import org.bitcoins.sbclient.Asset._
-import org.bitcoins.sbclient.TradingPair.UnsupportedTradingPair
+import org.bitcoins.commons.jsonmodels.sbclient.Asset._
+import org.bitcoins.commons.jsonmodels.sbclient.TradingPair.UnsupportedTradingPair
 
 sealed abstract class TradingPair(left: Asset, right: Asset)
     extends Serializable {

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -2,6 +2,7 @@ package org.bitcoins.commons.serializers
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.commons.jsonmodels.sbclient.{Exchange, TradingPair}
 import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.number.UInt32
@@ -88,4 +89,10 @@ object Picklers {
 
   implicit val coinSelectionAlgoPickler: ReadWriter[CoinSelectionAlgo] =
     readwriter[String].bimap(_.toString, CoinSelectionAlgo.fromString(_).get)
+
+  implicit val exchangePickler: ReadWriter[Exchange] =
+    readwriter[String].bimap(_.toLongString, Exchange.fromString(_).get)
+
+  implicit val tradingPairPickler: ReadWriter[TradingPair] =
+    readwriter[String].bimap(_.toString, TradingPair.fromString)
 }

--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -4,6 +4,7 @@ import java.time.{ZoneId, ZonedDateTime}
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.commons.jsonmodels.sbclient.{Exchange, TradingPair}
 import org.bitcoins.core.config.{NetworkParameters, Networks}
 import org.bitcoins.core.currency._
 import org.bitcoins.core.number.UInt32
@@ -191,4 +192,16 @@ object CliReaders {
       override def reads: String => DLCMutualCloseSig =
         str => DLCMutualCloseSig.fromJson(ujson.read(str))
     }
+
+  implicit val exchangeReads: Read[Exchange] = new Read[Exchange] {
+    override def arity: Int = 1
+
+    override def reads: String => Exchange = Exchange.fromString(_).get
+  }
+
+  implicit val tradingPairReads: Read[TradingPair] = new Read[TradingPair] {
+    override def arity: Int = 1
+
+    override def reads: String => TradingPair = TradingPair.fromString
+  }
 }

--- a/app/dlc-suredbits-client-test/src/test/scala/org/bitcoins/sbclient/MockServer.scala
+++ b/app/dlc-suredbits-client-test/src/test/scala/org/bitcoins/sbclient/MockServer.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import org.bitcoins.commons.jsonmodels.sbclient.{Exchange, TradingPair}
 import org.bitcoins.core.protocol.ln.currency.{LnCurrencyUnit, MilliSatoshis}
 import org.bitcoins.core.protocol.ln.{LnInvoice, PaymentPreimage}
 import org.bitcoins.crypto._

--- a/app/dlc-suredbits-client-test/src/test/scala/org/bitcoins/sbclient/SbClientTest.scala
+++ b/app/dlc-suredbits-client-test/src/test/scala/org/bitcoins/sbclient/SbClientTest.scala
@@ -5,6 +5,7 @@ import org.bitcoins.commons.jsonmodels.eclair.{
   OutgoingPaymentStatus
 }
 import org.bitcoins.crypto.{CryptoUtil, ECPrivateKey}
+import org.bitcoins.commons.jsonmodels.sbclient.{Exchange, TradingPair}
 import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
 import org.bitcoins.testkit.eclair.MockEclairClient
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
@@ -110,8 +111,8 @@ class SbClientTest extends BitcoinSAsyncTest {
   it should "successfully request and receive a public key" in {
     forAllAsync(exchangeAndPairGen) {
       case (exchange, pair) =>
-        SbClient
-          .getPublicKey(exchange, pair, server.endpoint)
+        SbClient(server.mockEclair, server.endpoint)
+          .getPublicKey(exchange, pair)
           .map { response =>
             val hash = CryptoUtil.sha256(
               ByteVector(

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
@@ -3,6 +3,7 @@ package org.bitcoins.gui
 import javafx.event.{ActionEvent, EventHandler}
 import javafx.scene.image.Image
 import org.bitcoins.gui.dlc.DLCPane
+import org.bitcoins.gui.sbclient.SbClientPane
 import org.bitcoins.gui.settings.SettingsPane
 import scalafx.application.{JFXApp, Platform}
 import scalafx.beans.property.StringProperty
@@ -55,7 +56,7 @@ object WalletGUI extends JFXApp {
       s"\n\n${(0 until 60).map(_ => "-").mkString("")}\n\n") + GlobalData.log
   }
 
-  private val model = new WalletGUIModel()
+  val model = new WalletGUIModel()
 
   private val getNewAddressButton = new Button {
     text = "Get New Address"
@@ -71,10 +72,17 @@ object WalletGUI extends JFXApp {
     }
   }
 
+  private val updateBalanceButton = new Button {
+    text = "Update Balance"
+    onAction = new EventHandler[ActionEvent] {
+      override def handle(event: ActionEvent): Unit = model.updateBalance()
+    }
+  }
+
   private val buttonBar = new HBox {
-    children = Seq(getNewAddressButton, sendButton)
+    children = Seq(updateBalanceButton, getNewAddressButton, sendButton)
     alignment = Pos.Center
-    spacing <== width / 2
+    spacing <== width / children.size
   }
 
   private val borderPane = new BorderPane {
@@ -84,6 +92,8 @@ object WalletGUI extends JFXApp {
   }
 
   private val dlcPane = new DLCPane(glassPane)
+
+  private val sbClientPane = new SbClientPane(glassPane)
 
   private val settingsPane = new SettingsPane
 
@@ -99,12 +109,17 @@ object WalletGUI extends JFXApp {
       content = dlcPane.borderPane
     }
 
+    val sbClientTab: Tab = new Tab {
+      text = "Sb Client"
+      content = sbClientPane.borderPane
+    }
+
     val settingsTab: Tab = new Tab {
       text = "Settings"
       content = settingsPane.view
     }
 
-    tabs = Seq(walletTab, dlcTab, settingsTab)
+    tabs = Seq(walletTab, dlcTab, sbClientTab, settingsTab)
 
     tabClosingPolicy = TabClosingPolicy.Unavailable
   }

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
@@ -64,7 +64,7 @@ class WalletGUIModel() {
     updateBalance()
   }
 
-  private def updateBalance(): Unit = {
+  def updateBalance(): Unit = {
     ConsoleCli.exec(GetBalance(isSats = false), Config.empty) match {
       case Success(commandReturn) =>
         GlobalData.currentBalance.value = commandReturn.split(' ').head.toDouble

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -26,8 +26,7 @@ class DLCPane(glassPane: VBox) {
     prefHeight = 700
     prefWidth = 400
     editable = false
-    text =
-      "Click on Init Demo Oracle to generate example oracle and contract information"
+    text = "Click Create Contract Info button to get started"
     wrapText = true
   }
 
@@ -39,7 +38,7 @@ class DLCPane(glassPane: VBox) {
     new DLCPaneModel(resultArea, demoOracleArea, numOutcomesTF)
 
   private val demoOracleButton = new Button {
-    text = "Init Demo Oracle"
+    text = "Create Contract Info"
     onAction = new EventHandler[ActionEvent] {
       override def handle(event: ActionEvent): Unit = model.onInitOracle()
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialog.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand
+import org.bitcoins.gui.GlobalData
 import org.bitcoins.gui.dlc.GlobalDLCData
 import scalafx.Includes._
 import scalafx.application.Platform
@@ -47,6 +48,7 @@ abstract class DLCDialog[T <: CliCommand](
     }
 
     dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
 
     dialog.dialogPane().content = new GridPane {
       hgap = 10

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/GetFundingDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/GetFundingDLCDialog.scala
@@ -1,19 +1,19 @@
 package org.bitcoins.gui.dlc.dialog
 
-import org.bitcoins.cli.CliCommand.GetDLCFundingTx
+import org.bitcoins.cli.CliCommand.BroadcastDLCFundingTx
 import org.bitcoins.crypto.Sha256DigestBE
 import scalafx.scene.control.TextField
 
 object GetFundingDLCDialog
-    extends DLCDialog[GetDLCFundingTx](
+    extends DLCDialog[BroadcastDLCFundingTx](
       "DLC Funding Transaction",
       "Enter DLC event ID",
       Vector(DLCDialog.dlcEventIdStr -> new TextField())) {
   import DLCDialog._
 
   override def constructFromInput(
-      inputs: Map[String, String]): GetDLCFundingTx = {
+      inputs: Map[String, String]): BroadcastDLCFundingTx = {
     val eventId = Sha256DigestBE(inputs(dlcEventIdStr))
-    GetDLCFundingTx(eventId)
+    BroadcastDLCFundingTx(eventId)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitOracleDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitOracleDialog.scala
@@ -3,6 +3,7 @@ package org.bitcoins.gui.dlc.dialog
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.ContractInfo
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.crypto.CryptoUtil
+import org.bitcoins.gui.GlobalData
 import scalafx.Includes._
 import scalafx.application.Platform
 import scalafx.geometry.Insets
@@ -18,7 +19,7 @@ object InitOracleDialog {
       numOutcomes: Int): Option[(Vector[String], ContractInfo)] = {
     val dialog = new Dialog[Option[(Vector[String], ContractInfo)]]() {
       initOwner(parentWindow)
-      title = "Initialize Demo Oracle"
+      title = "Create Contract Info"
       headerText = "Enter contract outcomes and their outcome values"
     }
 
@@ -30,6 +31,7 @@ object InitOracleDialog {
          }))
 
     dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
 
     dialog.dialogPane().content = new GridPane {
       hgap = 10

--- a/app/gui/src/main/scala/org/bitcoins/gui/sbclient/SbClientPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/sbclient/SbClientPane.scala
@@ -1,0 +1,85 @@
+package org.bitcoins.gui.sbclient
+
+import javafx.event.{ActionEvent, EventHandler}
+import org.bitcoins.gui.{GlobalData, TaskRunner}
+import scalafx.geometry.{Insets, Pos}
+import scalafx.scene.control.{Button, Label, TextArea}
+import scalafx.scene.layout.{BorderPane, HBox, VBox}
+
+class SbClientPane(glassPane: VBox) {
+
+  private val statusLabel = new Label {
+    maxWidth = Double.MaxValue
+    padding = Insets(0, 10, 10, 10)
+    text <== GlobalData.statusText
+  }
+
+  private val resultArea = new TextArea {
+    editable = false
+    text = ""
+    wrapText = true
+  }
+
+  private val model = new SbClientPaneModel(resultArea)
+
+  private val openSbChannelButton = new Button {
+    text = "Open Channel to Suredbits"
+    onAction = new EventHandler[ActionEvent] {
+      override def handle(event: ActionEvent): Unit = model.onOpenSbChannel()
+    }
+  }
+
+  private val getPubKeyButton = new Button {
+    text = "Get Public Key"
+    onAction = new EventHandler[ActionEvent] {
+      override def handle(event: ActionEvent): Unit = model.onPublicKey()
+    }
+  }
+
+  private val getRValueButton = new Button {
+    text = "Get R Value"
+    onAction = new EventHandler[ActionEvent] {
+      override def handle(event: ActionEvent): Unit = model.onRValue()
+    }
+  }
+
+  private val getOracleInfoButton = new Button {
+    text = "Get Oracle Info"
+    onAction = new EventHandler[ActionEvent] {
+      override def handle(event: ActionEvent): Unit = model.onOracleInfo()
+    }
+  }
+
+  private val getLastSignatureButton = new Button {
+    text = "Get Last Signature"
+    onAction = new EventHandler[ActionEvent] {
+      override def handle(event: ActionEvent): Unit = model.onLastSig()
+    }
+  }
+
+  private val execButtonBar = new HBox {
+    children = Seq(openSbChannelButton,
+                   getPubKeyButton,
+                   getRValueButton,
+                   getOracleInfoButton,
+                   getLastSignatureButton)
+    alignment = Pos.Center
+    spacing <== width / 20
+  }
+
+  private val textAreaHBox = new HBox {
+    children = Seq(resultArea)
+    spacing = 10
+  }
+
+  val borderPane: BorderPane = new BorderPane {
+    top = execButtonBar
+    center = textAreaHBox
+    bottom = statusLabel
+  }
+
+  resultArea.prefWidth <== borderPane.width
+
+  private val taskRunner = new TaskRunner(borderPane, glassPane)
+  model.taskRunner = taskRunner
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/sbclient/SbClientPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/sbclient/SbClientPaneModel.scala
@@ -1,0 +1,102 @@
+package org.bitcoins.gui.sbclient
+
+import org.bitcoins.cli.CliCommand._
+import org.bitcoins.cli.{Config, ConsoleCli}
+import org.bitcoins.commons.jsonmodels.sbclient.{Exchange, TradingPair}
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.gui.TaskRunner
+import org.bitcoins.gui.dlc.GlobalDLCData
+import org.bitcoins.gui.sbclient.dialog.{
+  OpenChannelDialog,
+  SbClientInvoiceDialog
+}
+import scalafx.beans.property.ObjectProperty
+import scalafx.scene.control.TextArea
+import scalafx.stage.Window
+
+import scala.util.{Failure, Success}
+
+class SbClientPaneModel(resultArea: TextArea) {
+  var taskRunner: TaskRunner = _
+
+  // Sadly, it is a Java "pattern" to pass null into
+  // constructors to signal that you want some default
+  val parentWindow: ObjectProperty[Window] =
+    ObjectProperty[Window](null.asInstanceOf[Window])
+
+  val oracleSigCaption = "Last Oracle Signature"
+  val oracleInfoCaption = "Oracle Info"
+
+  private def execCommand(
+      caption: String,
+      toCliCommand: (Exchange, TradingPair) => PriceDataApiCall): Unit = {
+    val result =
+      SbClientInvoiceDialog.showAndWait(caption, parentWindow.value)
+
+    result match {
+      case Some((exchangeStr, tradingPairStr)) =>
+        val exchange = Exchange.fromString(exchangeStr).get
+        val tradingPair = TradingPair.fromString(tradingPairStr)
+
+        taskRunner.run(
+          caption = s"$caption for $tradingPairStr on $exchangeStr",
+          op = {
+
+            val command = toCliCommand(exchange, tradingPair)
+            ConsoleCli.exec(command, Config.empty) match {
+              case Success(commandReturn) =>
+                if (caption == oracleSigCaption) {
+                  GlobalDLCData.lastOracleSig = commandReturn
+                } else if (caption == oracleInfoCaption) {
+                  GlobalDLCData.lastOracleInfo = commandReturn
+                }
+                resultArea.text = commandReturn
+              case Failure(err) =>
+                resultArea.text = s"Error executing command:\n${err.getMessage}"
+            }
+          }
+        )
+      case None => ()
+    }
+  }
+
+  def onOpenSbChannel(): Unit = {
+    val result =
+      OpenChannelDialog.showAndWait(parentWindow.value)
+
+    result match {
+      case Some(amount) =>
+        val sats = Satoshis(amount.toLong)
+
+        taskRunner.run(
+          caption = s"Opening channel for $sats",
+          op = {
+            ConsoleCli.exec(OpenSbChannel(sats), Config.empty) match {
+              case Success(commandReturn) =>
+                resultArea.text = commandReturn
+              case Failure(err) =>
+                resultArea.text = s"Error executing command:\n${err.getMessage}"
+                err.printStackTrace()
+            }
+          }
+        )
+      case None => ()
+    }
+  }
+
+  def onPublicKey(): Unit = {
+    execCommand("Public Key", GetSbPubKey.apply)
+  }
+
+  def onRValue(): Unit = {
+    execCommand("R Value", GetSbRValue.apply)
+  }
+
+  def onOracleInfo(): Unit = {
+    execCommand(oracleInfoCaption, GetSbOracleInfo.apply)
+  }
+
+  def onLastSig(): Unit = {
+    execCommand(oracleSigCaption, GetSbLastSig.apply)
+  }
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/sbclient/dialog/OpenChannelDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/sbclient/dialog/OpenChannelDialog.scala
@@ -1,0 +1,58 @@
+package org.bitcoins.gui.sbclient.dialog
+
+import org.bitcoins.gui.GlobalData
+import scalafx.Includes._
+import scalafx.application.Platform
+import scalafx.geometry.Insets
+import scalafx.scene.control.{ButtonType, Dialog, Label, TextField}
+import scalafx.scene.layout.GridPane
+import scalafx.stage.Window
+
+object OpenChannelDialog {
+
+  def showAndWait(parentWindow: Window): Option[String] = {
+    val dialog = new Dialog[Option[String]]() {
+      initOwner(parentWindow)
+      title = "Open Channel"
+    }
+
+    dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+
+    val amountTF = new TextField()
+
+    dialog.dialogPane().content = new GridPane {
+      hgap = 10
+      vgap = 10
+      padding = Insets(20, 100, 10, 10)
+
+      var nextRow: Int = 0
+      def addRow(label: String, textField: TextField): Unit = {
+        add(new Label(label), 0, nextRow)
+        add(textField, 1, nextRow)
+        nextRow += 1
+      }
+
+      addRow("Amount (in sats)", amountTF)
+    }
+
+    // Enable/Disable OK button depending on whether all data was entered.
+    val okButton = dialog.dialogPane().lookupButton(ButtonType.OK)
+    // Simple validation that sufficient data was entered
+    okButton.disable <== amountTF.text.isEmpty
+
+    Platform.runLater(amountTF.requestFocus())
+
+    // When the OK button is clicked, convert the result to a T.
+    dialog.resultConverter = dialogButton =>
+      if (dialogButton == ButtonType.OK) {
+        Some(amountTF.text())
+      } else None
+
+    dialog.showAndWait() match {
+      case Some(Some(amount: String)) =>
+        Some(amount)
+      case Some(_) | None => None
+    }
+  }
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/sbclient/dialog/SbClientInvoiceDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/sbclient/dialog/SbClientInvoiceDialog.scala
@@ -1,0 +1,62 @@
+package org.bitcoins.gui.sbclient.dialog
+
+import org.bitcoins.gui.GlobalData
+import scalafx.Includes._
+import scalafx.application.Platform
+import scalafx.geometry.Insets
+import scalafx.scene.control.{ButtonType, Dialog, Label, TextField}
+import scalafx.scene.layout.GridPane
+import scalafx.stage.Window
+
+object SbClientInvoiceDialog {
+
+  def showAndWait(
+      titleStr: String,
+      parentWindow: Window): Option[(String, String)] = {
+    val dialog = new Dialog[Option[(String, String)]]() {
+      initOwner(parentWindow)
+      title = titleStr
+    }
+
+    dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+
+    val exchangeTF = new TextField()
+    val tradingPairTF = new TextField()
+
+    dialog.dialogPane().content = new GridPane {
+      hgap = 10
+      vgap = 10
+      padding = Insets(20, 100, 10, 10)
+
+      var nextRow: Int = 0
+      def addRow(label: String, textField: TextField): Unit = {
+        add(new Label(label), 0, nextRow)
+        add(textField, 1, nextRow)
+        nextRow += 1
+      }
+
+      addRow("Exchange", exchangeTF)
+      addRow("Trading Pair", tradingPairTF)
+    }
+
+    // Enable/Disable OK button depending on whether all data was entered.
+    val okButton = dialog.dialogPane().lookupButton(ButtonType.OK)
+    // Simple validation that sufficient data was entered
+    okButton.disable <== exchangeTF.text.isEmpty || tradingPairTF.text.isEmpty
+
+    Platform.runLater(exchangeTF.requestFocus())
+
+    // When the OK button is clicked, convert the result to a T.
+    dialog.resultConverter = dialogButton =>
+      if (dialogButton == ButtonType.OK) {
+        Some((exchangeTF.text(), tradingPairTF.text()))
+      } else None
+
+    dialog.showAndWait() match {
+      case Some(Some((exchange: String, tradingPair: String))) =>
+        Some((exchange, tradingPair))
+      case Some(_) | None => None
+    }
+  }
+}

--- a/app/server/src/main/scala/org/bitcoins/server/EclairBitcoindPair.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/EclairBitcoindPair.scala
@@ -1,0 +1,88 @@
+package org.bitcoins.server
+
+import java.nio.file.{Path, Paths}
+
+import org.bitcoins.core.util.{BitcoinSLogger, StartStop}
+import org.bitcoins.eclair.rpc.client.EclairRpcClient
+import org.bitcoins.eclair.rpc.config.EclairInstance
+import org.bitcoins.node.config.EclairAppConfig
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.client.common.BitcoindVersion._
+import org.bitcoins.rpc.config.BitcoindInstance
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Properties
+
+case class EclairBitcoindPair(
+    eclair: EclairRpcClient,
+    bitcoind: BitcoindRpcClient)(implicit ec: ExecutionContext)
+    extends StartStop[EclairBitcoindPair]
+    with BitcoinSLogger {
+
+  require(
+    eclair.instance.network == bitcoind.instance.network,
+    s"Eclair and bitcoind must be on the same network, Eclair: ${eclair.instance.network} bitcoind: ${bitcoind.instance.network}"
+  )
+
+  require(eclair.instance.zmqConfig.isDefined, "Eclair must have a zmq config")
+  require(
+    eclair.instance.bitcoindAuthCredentials.get == bitcoind.instance.authCredentials,
+    "Eclair's bitcoind authCredentials must match bitcoind's")
+  require(
+    eclair.instance.bitcoindRpcUri.get == bitcoind.instance.rpcUri,
+    s"Eclair's bitcoind rpc uri must match bitcoind's, ${eclair.instance.bitcoindRpcUri.get} != ${bitcoind.instance.rpcUri}"
+  )
+
+  require(
+    eclair.instance.zmqConfig.get.rawBlock == bitcoind.instance.zmqConfig.rawBlock,
+    s"Eclair's bitcoind zmq raw block must match bitcoind's, ${eclair.instance.zmqConfig.get.rawBlock} != ${bitcoind.instance.zmqConfig.rawBlock}"
+  )
+  require(
+    eclair.instance.zmqConfig.get.rawTx == bitcoind.instance.zmqConfig.rawTx,
+    s"Eclair's bitcoind zmq raw tx must match bitcoind's, ${eclair.instance.zmqConfig.get.rawTx} != ${bitcoind.instance.zmqConfig.rawTx}"
+  )
+
+  override def start(): Future[EclairBitcoindPair] = {
+    logger.info("Starting bitcoind")
+    val startBitcoindF = bitcoind.start()
+    for {
+      startedBitcoind <- startBitcoindF
+
+      _ = logger.info("Starting eclair")
+      _ <- eclair.start()
+    } yield EclairBitcoindPair(eclair, startedBitcoind)
+  }
+
+  override def stop(): Future[EclairBitcoindPair] = {
+    for {
+      stoppedEclair <- eclair.stop()
+      stoppedBitcoind <- bitcoind.stop()
+    } yield EclairBitcoindPair(stoppedEclair, stoppedBitcoind)
+  }
+}
+
+object EclairBitcoindPair {
+
+  def fromConfig(eclairConf: EclairAppConfig)(implicit
+      ec: ExecutionContext): EclairBitcoindPair = {
+    require(eclairConf.enabled, "Eclair is not enabled")
+    val bitcoindLocation =
+      getBitcoindBinary(binaryDirectory, eclairConf.bitcoindVersion)
+    val bitcoindInstance = BitcoindInstance.fromDatadir(
+      eclairConf.bitcoindDataDir.toFile,
+      bitcoindLocation)
+    val bitcoind = BitcoindRpcClient(bitcoindInstance)
+
+    val eclairInstance =
+      EclairInstance.fromDatadir(eclairConf.eclairDataDir.toFile, None)
+
+    val eclair = EclairRpcClient(
+      eclairInstance,
+      EclairRpcClient.getEclairBinary(binaryDirectory.resolve("eclair")))
+
+    EclairBitcoindPair(eclair, bitcoind)
+  }
+
+  private[bitcoins] val binaryDirectory: Path =
+    Paths.get(Properties.userHome, ".bitcoin-s", "binaries")
+}

--- a/app/server/src/main/scala/org/bitcoins/server/EclairRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/EclairRoutes.scala
@@ -1,0 +1,122 @@
+package org.bitcoins.server
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.OracleInfo
+import org.bitcoins.core.config.{MainNet, NetworkParameters, TestNet3}
+import org.bitcoins.core.protocol.ln.node.NodeId
+import org.bitcoins.eclair.rpc.api.EclairApi
+import org.bitcoins.eclair.rpc.network.NodeUri
+import org.bitcoins.node.config.EclairAppConfig
+import org.bitcoins.sbclient.SbClient
+
+import scala.util.{Failure, Success}
+
+case class EclairRoutes(eclairApi: EclairApi)(implicit
+    system: ActorSystem,
+    eclairAppConfig: EclairAppConfig)
+    extends ServerRoute {
+  import system.dispatcher
+
+  lazy val sbClient: SbClient =
+    SbClient(eclairApi, eclairAppConfig.suredbitsEndpoint)
+
+  lazy val (sbNodeId, sbNodeURI): (NodeId, NodeUri) =
+    eclairApi.network.network match {
+      case MainNet =>
+        val uri = NodeUri
+          .fromStringNoPort(
+            "038bdb5538a4e415c42f8fb09750729752c1a1800d321f4bb056a9f582569fbf8e@ln.suredbits.com")
+          .get
+        (uri.nodeId, uri)
+      case TestNet3 =>
+        val uri = NodeUri
+          .fromStringNoPort(
+            "0338f57e4e20abf4d5c86b71b59e995ce4378e373b021a7b6f41dabb42d3aad069@ln.test.suredbits.com")
+          .get
+        (uri.nodeId, uri)
+      case _: NetworkParameters =>
+        throw new IllegalStateException(
+          "Need to be on mainnet or testnet to open a channel")
+    }
+
+  def handleCommand: PartialFunction[ServerCommand, StandardRoute] = {
+
+    // Eclair Calls
+    // TODO: fund lightning channel, get balances, create invoice, etc
+
+    case ServerCommand("opensbchannel", arr) =>
+      OpenSbChannel.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(OpenSbChannel(sats)) =>
+          complete {
+            // requires bitcoind wallet is unlocked
+            for {
+              _ <- eclairApi.connect(sbNodeURI)
+              channelId <-
+                eclairApi.open(sbNodeId, sats, None, None, None, None)
+            } yield Server.httpSuccess(channelId.hex)
+          }
+      }
+
+    // SbClient Calls
+
+    case ServerCommand("getsbpubkey", arr) =>
+      GetSbPubKey.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(GetSbPubKey(exchange, tradingPair)) =>
+          complete {
+            sbClient.getPublicKey(exchange, tradingPair).map { pubkey =>
+              Server.httpSuccess(pubkey.hex)
+            }
+          }
+      }
+
+    case ServerCommand("getsbrvalue", arr) =>
+      GetSbRValue.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(GetSbRValue(exchange, tradingPair)) =>
+          complete {
+            sbClient.requestRValueAndPay(exchange, tradingPair, eclairApi).map {
+              rValue =>
+                Server.httpSuccess(rValue.hex)
+            }
+          }
+      }
+
+    case ServerCommand("getsboracleinfo", arr) =>
+      GetSbOracleInfo.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(GetSbOracleInfo(exchange, tradingPair)) =>
+          complete {
+            for {
+              pubKey <- sbClient.getPublicKey(exchange, tradingPair)
+              rValue <-
+                sbClient.requestRValueAndPay(exchange, tradingPair, eclairApi)
+            } yield {
+              val oracleInfo = OracleInfo(pubKey, rValue.schnorrNonce)
+              Server.httpSuccess(oracleInfo.hex)
+            }
+          }
+      }
+
+    case ServerCommand("getsblastsig", arr) =>
+      GetSbLastSig.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(GetSbLastSig(exchange, tradingPair)) =>
+          complete {
+            sbClient
+              .requestLastSigAndPay(exchange, tradingPair, eclairApi)
+              .map { sig =>
+                Server.httpSuccess(sig.hex)
+              }
+          }
+      }
+  }
+}

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -17,7 +17,7 @@ import org.bitcoins.core.util.{BitcoinSLogger, FutureUtil, NetworkUtil}
 import org.bitcoins.db.AppConfig
 import org.bitcoins.feeprovider.BitcoinerLiveFeeRateProvider
 import org.bitcoins.node._
-import org.bitcoins.node.config.NodeAppConfig
+import org.bitcoins.node.config.{EclairAppConfig, NodeAppConfig}
 import org.bitcoins.node.models.Peer
 import org.bitcoins.wallet.Wallet
 import org.bitcoins.wallet.config.WalletAppConfig
@@ -62,6 +62,7 @@ object Main extends App with BitcoinSLogger {
     require(nodeConf.isNeutrinoEnabled != nodeConf.isSPVEnabled,
             "Either Neutrino or SPV mode should be enabled")
     implicit val chainConf: ChainAppConfig = conf.chainConf
+    implicit val eclairConf: EclairAppConfig = conf.eclairConf
 
     if (nodeConf.peers.isEmpty) {
       throw new IllegalArgumentException(
@@ -73,6 +74,24 @@ object Main extends App with BitcoinSLogger {
                                          nodeConf.network.port)
     val peer = Peer.fromSocket(peerSocket)
     val bip39PasswordOpt = None //todo need to prompt user for this
+
+    val eclairAndBitcoindOpt = if (eclairConf.enabled) {
+      val eclairAndBitcoind = EclairBitcoindPair.fromConfig(eclairConf)
+      require(eclairAndBitcoind.eclair.instance.network == nodeConf.network,
+              "Eclair must be on the same network as us")
+      require(eclairAndBitcoind.bitcoind.instance.network == nodeConf.network,
+              "bitcoind must be on the same network as us")
+      require(
+        eclairAndBitcoind.bitcoind.instance.uri.getHost == peerSocket.getHostString,
+        s"${eclairAndBitcoind.bitcoind.instance.uri.getHost} != ${peerSocket.getHostString}"
+      )
+      require(
+        eclairAndBitcoind.bitcoind.instance.uri.getPort == peerSocket.getPort,
+        s"${eclairAndBitcoind.bitcoind.instance.uri.getPort} != ${peerSocket.getPort}")
+      Some(eclairAndBitcoind)
+    } else {
+      None
+    }
 
     //initialize the config, run migrations
     val configInitializedF = conf.initialize()
@@ -118,7 +137,9 @@ object Main extends App with BitcoinSLogger {
       wallet <- configuredWalletF
       _ <- node.start()
       _ <- wallet.start()
-      binding <- startHttpServer(node, wallet, rpcPortOpt)
+      _ <- eclairAndBitcoindOpt.map(_.start()).getOrElse(FutureUtil.unit)
+
+      binding <- startHttpServer(node, wallet, eclairAndBitcoindOpt, rpcPortOpt)
       _ = {
         if (nodeConf.isSPVEnabled) {
           logger.info(s"Starting SPV node sync")
@@ -137,6 +158,9 @@ object Main extends App with BitcoinSLogger {
         logger.error(s"Exiting process")
 
         wallet.stop()
+
+        eclairAndBitcoindOpt.foreach(
+          _.stop().foreach(_ => logger.info("Stopped eclair and bitcoind")))
 
         node
           .stop()
@@ -238,32 +262,36 @@ object Main extends App with BitcoinSLogger {
   private def startHttpServer(
       node: Node,
       wallet: Wallet,
+      eclairAndBitcoindOpt: Option[EclairBitcoindPair],
       rpcPortOpt: Option[Int])(implicit
       system: ActorSystem,
       conf: BitcoinSAppConfig): Future[Http.ServerBinding] = {
     import system.dispatcher
     implicit val nodeConf: NodeAppConfig = conf.nodeConf
+    implicit val eclairConf: EclairAppConfig = conf.eclairConf
     for {
       syncedChainApi <- node.chainApiFromDb()
       walletRoutes = WalletRoutes(wallet, node)
       nodeRoutes = NodeRoutes(node)
       chainRoutes = ChainRoutes(syncedChainApi)
       coreRoutes = CoreRoutes(Core)
+      standardRoutes = Seq(walletRoutes, nodeRoutes, chainRoutes, coreRoutes)
+      routes = standardRoutes ++ (eclairAndBitcoindOpt match {
+        case Some(eclairAndBitcoind) =>
+          Seq(EclairRoutes(eclairAndBitcoind.eclair))
+        case None =>
+          Seq.empty
+      })
       server = {
         rpcPortOpt match {
           case Some(rpcport) =>
-            Server(nodeConf,
-                   Seq(walletRoutes, nodeRoutes, chainRoutes, coreRoutes),
-                   rpcport = rpcport)
+            Server(nodeConf, routes, rpcport = rpcport)
           case None =>
             conf.rpcPortOpt match {
               case Some(rpcport) =>
-                Server(nodeConf,
-                       Seq(walletRoutes, nodeRoutes, chainRoutes, coreRoutes),
-                       rpcport)
+                Server(nodeConf, routes, rpcport)
               case None =>
-                Server(nodeConf,
-                       Seq(walletRoutes, nodeRoutes, chainRoutes, coreRoutes))
+                Server(nodeConf, routes)
             }
         }
       }

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -2,6 +2,7 @@ package org.bitcoins.server
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.commons.jsonmodels.sbclient.{Exchange, TradingPair}
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BlockStamp.BlockHeight
@@ -744,6 +745,129 @@ object OpReturnCommit extends ServerJsonModels {
     }
   }
 
+}
+
+// SbClient
+
+case class OpenSbChannel(amount: Satoshis)
+
+object OpenSbChannel extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[OpenSbChannel] = {
+    require(jsArr.arr.size == 1,
+            s"Bad number of arguments: ${jsArr.arr.size}. Expected: 1")
+
+    Try(OpenSbChannel(jsToSatoshis(jsArr.arr.head)))
+  }
+}
+
+trait PriceDataApiCall {
+  def exchange: Exchange
+  def tradingPair: TradingPair
+}
+
+case class GetSbPubKey(exchange: Exchange, tradingPair: TradingPair)
+    extends PriceDataApiCall
+
+object GetSbPubKey extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[GetSbPubKey] = {
+    jsArr.arr.toList match {
+      case exchangeJs :: tradingPairJs :: Nil =>
+        Try {
+          val exchange = Exchange.fromString(exchangeJs.str).get
+          val tradingPair = TradingPair.fromString(tradingPairJs.str)
+
+          GetSbPubKey(exchange, tradingPair)
+        }
+      case Nil =>
+        Failure(
+          new IllegalArgumentException(
+            "Missing exchange and tradingPair arguments"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
+    }
+  }
+}
+
+case class GetSbRValue(exchange: Exchange, tradingPair: TradingPair)
+    extends PriceDataApiCall
+
+object GetSbRValue extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[GetSbRValue] = {
+    jsArr.arr.toList match {
+      case exchangeJs :: tradingPairJs :: Nil =>
+        Try {
+          val exchange = Exchange.fromString(exchangeJs.str).get
+          val tradingPair = TradingPair.fromString(tradingPairJs.str)
+
+          GetSbRValue(exchange, tradingPair)
+        }
+      case Nil =>
+        Failure(
+          new IllegalArgumentException(
+            "Missing exchange and tradingPair arguments"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
+    }
+  }
+}
+
+case class GetSbOracleInfo(exchange: Exchange, tradingPair: TradingPair)
+    extends PriceDataApiCall
+
+object GetSbOracleInfo extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[GetSbOracleInfo] = {
+    jsArr.arr.toList match {
+      case exchangeJs :: tradingPairJs :: Nil =>
+        Try {
+          val exchange = Exchange.fromString(exchangeJs.str).get
+          val tradingPair = TradingPair.fromString(tradingPairJs.str)
+
+          GetSbOracleInfo(exchange, tradingPair)
+        }
+      case Nil =>
+        Failure(
+          new IllegalArgumentException(
+            "Missing exchange and tradingPair arguments"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
+    }
+  }
+}
+
+case class GetSbLastSig(exchange: Exchange, tradingPair: TradingPair)
+    extends PriceDataApiCall
+
+object GetSbLastSig extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[GetSbLastSig] = {
+    jsArr.arr.toList match {
+      case exchangeJs :: tradingPairJs :: Nil =>
+        Try {
+          val exchange = Exchange.fromString(exchangeJs.str).get
+          val tradingPair = TradingPair.fromString(tradingPairJs.str)
+
+          GetSbLastSig(exchange, tradingPair)
+        }
+      case Nil =>
+        Failure(
+          new IllegalArgumentException(
+            "Missing exchange and tradingPair arguments"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
+    }
+  }
 }
 
 trait ServerJsonModels {

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -292,7 +292,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi, node: Node)(implicit
                   for {
                     retStr <- handleBroadcastable(txs._1, noBroadcast)
                     closingRetStr <- handleBroadcastable(closingTx, noBroadcast)
-                  } yield Server.httpSuccess(s"$retStr\n$closingRetStr")
+                  } yield Server.httpSuccess(
+                    s"${retStr.hex}\n${closingRetStr.hex}")
                 case None =>
                   handleBroadcastable(txs._1, noBroadcast).map { retStr =>
                     Server.httpSuccess(retStr.hex)
@@ -334,7 +335,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi, node: Node)(implicit
                   for {
                     retStr <- handleBroadcastable(txs._1, noBroadcast)
                     closingRetStr <- handleBroadcastable(closingTx, noBroadcast)
-                  } yield Server.httpSuccess(s"$retStr\n$closingRetStr")
+                  } yield Server.httpSuccess(
+                    s"${retStr.hex}\n${closingRetStr.hex}")
                 case None =>
                   handleBroadcastable(txs._1, noBroadcast).map { retStr =>
                     Server.httpSuccess(retStr.hex)

--- a/build.sbt
+++ b/build.sbt
@@ -251,6 +251,8 @@ lazy val appServer = project
     chain,
     wallet,
     bitcoindRpc,
+    eclairRpc,
+    dlcSuredbitsClient,
     feeProvider,
     dlc
   )

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -404,7 +404,9 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
       eclair <- {
         val server = EclairRpcTestUtil.eclairInstance(bitcoind)
         val eclair =
-          new EclairRpcClient(server, EclairRpcTestUtil.binary(None, None))
+          new EclairRpcClient(
+            server,
+            EclairRpcClient.getEclairBinary(EclairRpcTestUtil.binaryDirectory))
         eclair.start().map(_ => eclair)
       }
       _ <- TestAsyncUtil.retryUntilSatisfiedF(conditionF =
@@ -534,7 +536,9 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
 
     val badClientF =
       badInstanceF.map(
-        new EclairRpcClient(_, EclairRpcTestUtil.binary(None, None)))
+        new EclairRpcClient(
+          _,
+          EclairRpcClient.getEclairBinary(EclairRpcTestUtil.binaryDirectory)))
 
     badClientF.flatMap { badClient =>
       recoverToSucceededIf[RuntimeException](badClient.getInfo)

--- a/node/src/main/scala/org/bitcoins/node/config/EclairAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/EclairAppConfig.scala
@@ -1,0 +1,93 @@
+package org.bitcoins.node.config
+
+import java.nio.file.{Files, Path, Paths}
+
+import com.typesafe.config.Config
+import org.bitcoins.core.util.{BitcoinSLogger, FutureUtil}
+import org.bitcoins.db._
+import org.bitcoins.rpc.client.common.BitcoindVersion
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Configuration for the Bitcoin-S wallet
+  * @param directory The data directory of the wallet
+  * @param conf Optional sequence of configuration overrides
+  */
+case class EclairAppConfig(
+    private val directory: Path,
+    override val useLogbackConf: Boolean,
+    private val conf: Config*)
+    extends AppConfig
+    with BitcoinSLogger {
+  override protected[bitcoins] def configOverrides: List[Config] = conf.toList
+  override protected[bitcoins] def moduleName: String = "eclair"
+  override protected[bitcoins] type ConfigType = EclairAppConfig
+
+  override protected[bitcoins] def newConfigOfType(
+      configs: Seq[Config]): EclairAppConfig =
+    EclairAppConfig(directory, useLogbackConf, configs: _*)
+
+  protected[bitcoins] def baseDatadir: Path = directory
+
+  lazy val enabled: Boolean = config.getBoolean(s"$moduleName.enabled")
+
+  lazy val eclairDataDir: Path =
+    Paths.get(config.getString(s"$moduleName.datadir"))
+
+  lazy val bitcoindDataDir: Path =
+    Paths.get(config.getString(s"$moduleName.bitcoind.datadir"))
+
+  lazy val bitcoindVersion: BitcoindVersion = {
+    val versionStr = config.getString(s"$moduleName.bitcoind.version")
+    val versionOpt = BitcoindVersion.fromString(versionStr)
+    versionOpt match {
+      case None =>
+        throw new RuntimeException(
+          s"$versionStr is not a valid bitcoind version")
+      case Some(version) =>
+        version
+    }
+  }
+
+  lazy val suredbitsEndpoint: String = config.getStringOrElse(
+    "sbclient.endpoint",
+    "https://test.api.suredbits.com/dlc/v0")
+
+  override def initialize()(implicit ec: ExecutionContext): Future[Unit] = {
+    logger.debug(s"Initializing eclair setup")
+
+    if (Files.notExists(datadir)) {
+      Files.createDirectories(datadir)
+    }
+
+    if (Files.notExists(eclairDataDir)) {
+      throw new RuntimeException(
+        s"Cannot find eclair data dir at ${eclairDataDir.toString}")
+    }
+
+    if (Files.notExists(bitcoindDataDir)) {
+      throw new RuntimeException(
+        s"Cannot find bitcoind data dir at ${bitcoindDataDir.toString}")
+    }
+
+    logger.debug(s"Initializing eclair with bitcoind version $bitcoindVersion")
+
+    FutureUtil.unit
+  }
+
+  /** Starts the associated application */
+  override def start(): Future[Unit] = FutureUtil.unit
+}
+
+object EclairAppConfig {
+
+  /** Constructs a eclair configuration from the default Bitcoin-S
+    * data directory and given list of configuration overrides.
+    */
+  def fromDefaultDatadir(
+      useLogbackConf: Boolean,
+      confs: Config*): EclairAppConfig =
+    EclairAppConfig(AppConfig.DEFAULT_BITCOIN_S_DATADIR,
+                    useLogbackConf,
+                    confs: _*)
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -2,7 +2,6 @@ package org.bitcoins.testkit.eclair.rpc
 
 import java.io.{File, PrintWriter}
 import java.net.URI
-import java.nio.file.Files
 
 import akka.actor.ActorSystem
 import com.typesafe.config.{Config, ConfigFactory}
@@ -60,21 +59,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
       eclairVersionOpt: Option[String],
       eclairCommitOpt: Option[String]): Option[File] = {
     val path = binaryDirectory
-      .resolve(eclairVersionOpt.getOrElse(EclairRpcClient.version))
-      .resolve(
-        s"eclair-node-${EclairRpcClient.version}-${eclairCommitOpt.getOrElse(EclairRpcClient.commit)}")
-      .resolve("bin")
-      .resolve(
-        if (sys.props("os.name").toLowerCase.contains("windows"))
-          "eclair-node.bat"
-        else
-          "eclair-node.sh")
-
-    if (Files.exists(path)) {
-      Some(path.toFile)
-    } else {
-      None
-    }
+    EclairRpcClient.getEclairBinary(path, eclairVersionOpt, eclairCommitOpt)
   }
 
   def randomDirName: String =


### PR DESCRIPTION
Starts up bitcoind, eclair, and bitcoin-s server enforcing they have compatible configs. As well as adds rpc commands for sb client.

This should not be merged in it's current state. It currently will always require that elcair and bitcoind be started with every bitcon-s server. This should be a config option or separate type of server.