### PR TITLE
2020 05 11 bech32 addr tostring

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/AddressTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/AddressTest.scala
@@ -27,6 +27,7 @@ class AddressTest extends BitcoinSUnitTest {
   }
 
   it must "serialize a bech32 address correctly" in {
-    TestUtil.bech32Address.toString must be ("bcrt1qq6w6pu6zq90az9krn53zlkvgyzkyeglzukyepf")
+    TestUtil.bech32Address.toString must be(
+      "bcrt1qq6w6pu6zq90az9krn53zlkvgyzkyeglzukyepf")
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/AddressTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/AddressTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol
 
 import org.bitcoins.testkit.core.gen.AddressGenerator
-import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.bitcoins.testkit.util.{BitcoinSUnitTest, TestUtil}
 
 import scala.util.{Failure, Success}
 
@@ -24,5 +24,9 @@ class AddressTest extends BitcoinSUnitTest {
         case Failure(exception) => fail(exception.getMessage)
       }
     }
+  }
+
+  it must "serialize a bech32 address correctly" in {
+    TestUtil.bech32Address.toString must be ("bcrt1qq6w6pu6zq90az9krn53zlkvgyzkyeglzukyepf")
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -113,7 +113,7 @@ sealed abstract class Bech32Address extends BitcoinAddress {
     Bech32.hrpExpand(hrp)
   }
 
-  override def toString: String = "Bech32Address(" + value + ")"
+  override def toString: String = value
 
 }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -112,9 +112,6 @@ sealed abstract class Bech32Address extends BitcoinAddress {
   def expandHrp: Vector[UInt5] = {
     Bech32.hrpExpand(hrp)
   }
-
-  override def toString: String = value
-
 }
 
 object Bech32Address extends AddressFactory[Bech32Address] {

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/TestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/TestUtil.scala
@@ -4,26 +4,13 @@ import org.bitcoins.core.crypto.BaseTxSigComponent
 import org.bitcoins.core.currency.CurrencyUnits
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
-import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.core.protocol.script.{
-  EmptyScriptPubKey,
-  P2SHScriptSignature,
-  ScriptPubKey,
-  ScriptSignature
-}
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionInput,
-  TransactionOutput
-}
+import org.bitcoins.core.protocol.{Bech32Address, BitcoinAddress}
+import org.bitcoins.core.protocol.script.{EmptyScriptPubKey, P2SHScriptSignature, ScriptPubKey, ScriptSignature}
+import org.bitcoins.core.protocol.transaction.{Transaction, TransactionInput, TransactionOutput}
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.bitwise.{OP_EQUAL, OP_EQUALVERIFY}
 import org.bitcoins.core.script.constant._
-import org.bitcoins.core.script.crypto.{
-  OP_CHECKMULTISIG,
-  OP_CHECKSIG,
-  OP_HASH160
-}
+import org.bitcoins.core.script.crypto.{OP_CHECKMULTISIG, OP_CHECKSIG, OP_HASH160}
 import org.bitcoins.core.script.stack.OP_DUP
 import org.bitcoins.core.serializers.script.RawScriptPubKeyParser
 import org.bitcoins.core.serializers.transaction.RawTransactionInputParser
@@ -35,6 +22,7 @@ object TestUtil {
 
   def testBitcoinAddress = BitcoinAddress("n3p1ct69ao3qxWvEvzLhLtWG2zJGTjN3EV")
   def testP2SHAddress = BitcoinAddress("2MzYbQdkSVp5wVyMRp6A5PHPuQNHpiaTbCj")
+  val bech32Address: Bech32Address = Bech32Address.fromString("bcrt1qq6w6pu6zq90az9krn53zlkvgyzkyeglzukyepf").get
   def bitcoinAddress = BitcoinAddress("1C4kYhyLftmkn48YarSoLupxHfYFo8kp64")
   def multiSigAddress = BitcoinAddress("342ftSRCvFHfCeFFBuz4xwbeqnDw6BGUey")
 


### PR DESCRIPTION
Make `Bech32Address.toString` give us `bcrt1qq6w6pu6zq90az9krn53zlkvgyzkyeglzukyepf` rather than `Bech32Address(bcrt1qq6w6pu6zq90az9krn53zlkvgyzkyeglzukyepf)`