### PR TITLE
2020 05 17 optimizations

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.protocol.blockchain
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.bitcoins.testkit.util.BitcoinSUnitTest
 import org.slf4j.LoggerFactory
 
 import scala.io.Source
@@ -8,8 +8,7 @@ import scala.io.Source
 /**
   * Created by chris on 7/15/16.
   */
-class BlockTest extends FlatSpec with MustMatchers {
-  private val logger = LoggerFactory.getLogger(this.getClass)
+class BlockTest extends BitcoinSUnitTest {
 
   def timeBlockParsing[R](block: => R): Long = {
     val t0 = System.currentTimeMillis()

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockTest.scala
@@ -33,8 +33,14 @@ class BlockTest extends FlatSpec with MustMatchers {
     val fileName =
       "/00000000000000000008513c860373da0484f065983aeb063ebf81c172e81d48.txt"
     val lines = Source.fromURL(getClass.getResource(fileName)).mkString
-    val time = timeBlockParsing(Block.fromHex(lines))
-    assert(time <= 15000)
+    var counter = 0
+    while (counter < 250) {
+      val time = timeBlockParsing(Block.fromHex(lines))
+      assert(time <= 15000)
+      counter += 1
+    }
+
+    succeed
   }
 
   it must "parse a large block 000000000000000000050f70113ab1932c195442cb49bcc4ee4d7f426c8a3295" in {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockTest.scala
@@ -33,14 +33,8 @@ class BlockTest extends FlatSpec with MustMatchers {
     val fileName =
       "/00000000000000000008513c860373da0484f065983aeb063ebf81c172e81d48.txt"
     val lines = Source.fromURL(getClass.getResource(fileName)).mkString
-    var counter = 0
-    while (counter < 250) {
-      val time = timeBlockParsing(Block.fromHex(lines))
-      assert(time <= 15000)
-      counter += 1
-    }
-
-    succeed
+    val time = timeBlockParsing(Block.fromHex(lines))
+    assert(time <= 15000)
   }
 
   it must "parse a large block 000000000000000000050f70113ab1932c195442cb49bcc4ee4d7f426c8a3295" in {

--- a/core/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala
@@ -15,14 +15,14 @@ sealed abstract class CompactSizeUInt extends NetworkElement {
   /** The number parsed from VarInt. */
   def num: UInt64
 
-  override def hex = byteSize match {
-    case 1 => BytesUtil.flipEndianness(num.hex.slice(14, 16))
-    case 3 => "fd" + BytesUtil.flipEndianness(num.hex.slice(12, 16))
-    case 5 => "fe" + BytesUtil.flipEndianness(num.hex.slice(8, 16))
-    case _ => "ff" + BytesUtil.flipEndianness(num.hex)
+  override def bytes: ByteVector = {
+    byteSize match {
+      case 1 => num.bytes.takeRight(1)
+      case 3 => 0xfd.toByte +: num.bytes.takeRight(2).reverse
+      case 5 => 0xfe.toByte +: num.bytes.takeRight(4).reverse
+      case _ => 0xff.toByte +: num.bytes.reverse
+    }
   }
-
-  def bytes: ByteVector = BytesUtil.decodeHex(hex)
 
   def toLong: Long = num.toLong
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1094,16 +1094,12 @@ object WitnessScriptPubKey {
 
     //we can also have a LockTimeScriptPubKey with a nested 0 public key multisig script, need to check that as well
     val bytes = BytesUtil.toByteVector(asm)
-    lazy val isMultiSig =
-      MultiSignatureScriptPubKey.isMultiSignatureScriptPubKey(asm)
-    lazy val isLockTimeSPK = {
-      LockTimeScriptPubKey.isValidLockTimeScriptPubKey(asm)
-    }
 
     val firstOp = asm.headOption
     if (bytes.size < 4 || bytes.size > 42) false
     else if (!validWitVersions.contains(firstOp.getOrElse(OP_1NEGATE))) false
-    else if (isMultiSig || isLockTimeSPK) false
+    else if (MultiSignatureScriptPubKey.isMultiSignatureScriptPubKey(asm)) false
+    else if (LockTimeScriptPubKey.isValidLockTimeScriptPubKey(asm)) false
     else if (asm(1).toLong + 2 == bytes.size) true
     else false
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -125,7 +125,7 @@ object P2PKHScriptSignature extends ScriptFactory[P2PKHScriptSignature] {
              _: ScriptConstant,
              _: BytesToPushOntoStack,
              z: ScriptConstant) =>
-      if (ECPublicKey.isFullyValid(z.bytes)) true
+      if ((z.bytes.length == 33 || z.bytes.length == 65) && ECPublicKey.isFullyValid(z.bytes)) true
       else !P2SHScriptSignature.isRedeemScript(z)
     case _ => false
   }

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
@@ -53,16 +53,9 @@ trait ScriptOperationFactory[T <: ScriptOperation] extends BitcoinSLogger {
 
   /** Finds a [[org.bitcoins.core.script.ScriptOperation ScriptOperation]] from a given [[scala.Byte Byte]]. */
   @inline final def fromByte(byte: Byte): T = {
-    var idx = 0
-    while (idx < operations.length) {
-      val op = operations(idx)
-      if (op.toByte == byte) {
-        return op
-      } else {
-        idx += 1
-      }
-    }
-    sys.error(s"Could not find opcode for byte=${byte}")
+    ScriptOperation.map.get(byte).getOrElse {
+      sys.error(s"Could not find opcode for byte=${byte}")
+    }.asInstanceOf[T]
   }
 
   def fromBytes(bytes: ByteVector): Option[T] = {
@@ -81,6 +74,9 @@ trait ScriptOperationFactory[T <: ScriptOperation] extends BitcoinSLogger {
 
 object ScriptOperation extends ScriptOperationFactory[ScriptOperation] {
 
+  lazy val map: Map[Byte,ScriptOperation] = {
+    operations.map(o => (o.toByte,o)).toMap
+  }
   /** This contains duplicate operations
    * There is an optimization here by moving popular opcodes
    * to the front of the vector so when we iterate through it,

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
@@ -86,7 +86,7 @@ object ScriptOperation extends ScriptOperationFactory[ScriptOperation] {
    * to the front of the vector so when we iterate through it,
    * we are more likely to find the op code we are looking for
    * sooner */
-  override val operations: Vector[ScriptOperation] = {
+  final override val operations: Vector[ScriptOperation] = {
     Vector(OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG) ++ //p2pkh
     Vector(BytesToPushOntoStack.push20Bytes, BytesToPushOntoStack.push33Bytes,
       BytesToPushOntoStack.push32Bytes) ++ //popular push op codes

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
@@ -72,7 +72,7 @@ trait ScriptOperationFactory[T <: ScriptOperation] extends BitcoinSLogger {
 
 object ScriptOperation extends ScriptOperationFactory[ScriptOperation] {
 
-  val operations: Seq[ScriptOperation] = {
+  override val operations: Seq[ScriptOperation] = {
     ScriptNumberOperation.operations ++
       Seq(OP_FALSE, OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4, OP_TRUE) ++
       StackOperation.operations ++

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
@@ -52,7 +52,7 @@ trait ScriptOperationFactory[T <: ScriptOperation] extends BitcoinSLogger {
   }
 
   /** Finds a [[org.bitcoins.core.script.ScriptOperation ScriptOperation]] from a given [[scala.Byte Byte]]. */
-  @inline def fromByte(byte: Byte): T = {
+  @inline final def fromByte(byte: Byte): T = {
     var idx = 0
     while (idx < operations.length) {
       val op = operations(idx)

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
@@ -21,7 +21,7 @@ import scodec.bits.ByteVector
 trait ScriptOperationFactory[T <: ScriptOperation] extends BitcoinSLogger {
 
   /** All of the [[org.bitcoins.core.script.ScriptOperation ScriptOperation]]s for a particular `T`. */
-  def operations: Seq[T]
+  def operations: Vector[T]
 
   /**
     * Finds a [[org.bitcoins.core.script.ScriptOperation ScriptOperation]] from a given string
@@ -52,8 +52,17 @@ trait ScriptOperationFactory[T <: ScriptOperation] extends BitcoinSLogger {
   }
 
   /** Finds a [[org.bitcoins.core.script.ScriptOperation ScriptOperation]] from a given [[scala.Byte Byte]]. */
-  def fromByte(byte: Byte): T = {
-    operations.find(_.toByte == byte).get
+  @inline def fromByte(byte: Byte): T = {
+    var idx = 0
+    while (idx < operations.length) {
+      val op = operations(idx)
+      if (op.toByte == byte) {
+        return op
+      } else {
+        idx += 1
+      }
+    }
+    sys.error(s"Could not find opcode for byte=${byte}")
   }
 
   def fromBytes(bytes: ByteVector): Option[T] = {
@@ -72,9 +81,9 @@ trait ScriptOperationFactory[T <: ScriptOperation] extends BitcoinSLogger {
 
 object ScriptOperation extends ScriptOperationFactory[ScriptOperation] {
 
-  override val operations: Seq[ScriptOperation] = {
+  override val operations: Vector[ScriptOperation] = {
     ScriptNumberOperation.operations ++
-      Seq(OP_FALSE, OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4, OP_TRUE) ++
+      Vector(OP_FALSE, OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4, OP_TRUE) ++
       StackOperation.operations ++
       LocktimeOperation.operations ++
       CryptoOperation.operations ++

--- a/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticOperations.scala
@@ -144,7 +144,7 @@ case object OP_RSHIFT extends ArithmeticOperation {
 }
 
 object ArithmeticOperation extends ScriptOperationFactory[ArithmeticOperation] {
-  override val operations = Seq(
+  override val operations = Vector(
     OP_0NOTEQUAL,
     OP_1ADD,
     OP_1SUB,

--- a/core/src/main/scala/org/bitcoins/core/script/bitwise/BitwiseOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/bitwise/BitwiseOperations.scala
@@ -39,6 +39,6 @@ case object OP_XOR extends BitwiseOperation {
 }
 
 object BitwiseOperation extends ScriptOperationFactory[BitwiseOperation] {
-  override def operations =
+  override val operations =
     Seq(OP_EQUAL, OP_EQUALVERIFY, OP_INVERT, OP_AND, OP_OR, OP_XOR)
 }

--- a/core/src/main/scala/org/bitcoins/core/script/bitwise/BitwiseOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/bitwise/BitwiseOperations.scala
@@ -40,5 +40,5 @@ case object OP_XOR extends BitwiseOperation {
 
 object BitwiseOperation extends ScriptOperationFactory[BitwiseOperation] {
   override val operations =
-    Seq(OP_EQUAL, OP_EQUALVERIFY, OP_INVERT, OP_AND, OP_OR, OP_XOR)
+    Vector(OP_EQUAL, OP_EQUALVERIFY, OP_INVERT, OP_AND, OP_OR, OP_XOR)
 }

--- a/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
@@ -43,7 +43,7 @@ object BytesToPushOntoStack
         case Some(bytesToPushOntoStack) => bytesToPushOntoStack
         case None =>
           throw new IllegalArgumentException(
-            "We cannot have a BytesToPushOntoStack for greater than 75 bytes")
+            s"We cannot have a BytesToPushOntoStack for greater than 75 bytes, got=$num")
       }
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
@@ -25,8 +25,9 @@ object BytesToPushOntoStack
     override val opCode = num
   }
 
-  override val operations: Seq[BytesToPushOntoStack] =
-    (for { i <- 0 to 75 } yield BytesToPushOntoStackImpl(i))
+  override val operations: Vector[BytesToPushOntoStack] = {
+    (for { i <- 0 to 75 } yield BytesToPushOntoStackImpl(i)).toVector
+  }
 
   def fromNumber(num: Long): BytesToPushOntoStack = {
     if (num > 75)

--- a/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
@@ -17,6 +17,10 @@ object BytesToPushOntoStack
     */
   lazy val zero: BytesToPushOntoStack = apply(0)
 
+  lazy val push33Bytes = operations(33)
+  lazy val push32Bytes = operations(32)
+  lazy val push20Bytes = operations(20)
+
   private case class BytesToPushOntoStackImpl(num: Int)
       extends BytesToPushOntoStack {
     /*  //see the 'Constants; section in https://en.bitcoin.it/wiki/Script

--- a/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
@@ -33,7 +33,7 @@ trait ScriptOperation extends ScriptToken {
 
   override def bytes: ByteVector = ByteVector.fromByte(toByte)
 
-  def toByte: Byte = opCode.toByte
+  lazy val toByte: Byte = opCode.toByte
 }
 
 /** A constant in the Script language for instance as String or a number. */
@@ -357,7 +357,7 @@ object ScriptNumberOperation
   def fromNumber(underlying: Long): Option[ScriptNumberOperation] =
     operations.find(_.underlying == underlying)
 
-  val operations = Seq(OP_0,
+  override val operations = Seq(OP_0,
                        OP_1,
                        OP_1NEGATE,
                        OP_2,

--- a/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
@@ -31,7 +31,7 @@ sealed trait ScriptToken extends NetworkElement {
 trait ScriptOperation extends ScriptToken {
   def opCode: Int
 
-  override def bytes: ByteVector = ByteVector.fromByte(toByte)
+  override lazy val bytes: ByteVector = ByteVector.fromByte(toByte)
 
   lazy val toByte: Byte = opCode.toByte
 }
@@ -221,7 +221,7 @@ case object OP_FALSE extends ScriptNumberOperation {
 
   override val underlying = OP_0.underlying
 
-  override val bytes = OP_0.bytes
+  override lazy val bytes = OP_0.bytes
 }
 
 /** The number 1 is pushed onto the stack. */

--- a/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
@@ -357,7 +357,7 @@ object ScriptNumberOperation
   def fromNumber(underlying: Long): Option[ScriptNumberOperation] =
     operations.find(_.underlying == underlying)
 
-  override val operations = Seq(OP_0,
+  override val operations = Vector(OP_0,
                        OP_1,
                        OP_1NEGATE,
                        OP_2,

--- a/core/src/main/scala/org/bitcoins/core/script/control/ControlOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/control/ControlOperations.scala
@@ -56,5 +56,5 @@ case object OP_RETURN extends ControlOperations {
 
 object ControlOperations extends ScriptOperationFactory[ControlOperations] {
   override val operations =
-    Seq(OP_ELSE, OP_ENDIF, OP_IF, OP_NOTIF, OP_RETURN, OP_VERIFY)
+    Vector(OP_ELSE, OP_ENDIF, OP_IF, OP_NOTIF, OP_RETURN, OP_VERIFY)
 }

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoOperations.scala
@@ -81,7 +81,7 @@ case object OP_CHECKMULTISIGVERIFY extends CryptoSignatureEvaluation {
 }
 
 object CryptoOperation extends ScriptOperationFactory[CryptoOperation] {
-  override def operations =
+  override val operations =
     Seq(OP_CHECKMULTISIG,
         OP_CHECKMULTISIGVERIFY,
         OP_CHECKSIG,

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoOperations.scala
@@ -82,7 +82,7 @@ case object OP_CHECKMULTISIGVERIFY extends CryptoSignatureEvaluation {
 
 object CryptoOperation extends ScriptOperationFactory[CryptoOperation] {
   override val operations =
-    Seq(OP_CHECKMULTISIG,
+    Vector(OP_CHECKMULTISIG,
         OP_CHECKMULTISIGVERIFY,
         OP_CHECKSIG,
         OP_CHECKSIGVERIFY,

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoSignatureEvaluationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoSignatureEvaluationFactory.scala
@@ -9,7 +9,7 @@ trait CryptoSignatureEvaluationFactory
     extends ScriptOperationFactory[CryptoSignatureEvaluation] {
 
   /** The current [[CryptoSignatureEvaluation]] operations. */
-  def operations =
+  override val operations =
     Seq(OP_CHECKMULTISIG,
         OP_CHECKMULTISIGVERIFY,
         OP_CHECKSIG,

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoSignatureEvaluationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoSignatureEvaluationFactory.scala
@@ -10,7 +10,7 @@ trait CryptoSignatureEvaluationFactory
 
   /** The current [[CryptoSignatureEvaluation]] operations. */
   override val operations =
-    Seq(OP_CHECKMULTISIG,
+    Vector(OP_CHECKMULTISIG,
         OP_CHECKMULTISIGVERIFY,
         OP_CHECKSIG,
         OP_CHECKSIGVERIFY)

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LocktimeOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LocktimeOperations.scala
@@ -39,5 +39,5 @@ case object OP_CHECKSEQUENCEVERIFY extends LocktimeOperation {
 }
 
 object LocktimeOperation extends ScriptOperationFactory[LocktimeOperation] {
-  override def operations = Seq(OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY)
+  override val operations = Seq(OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY)
 }

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LocktimeOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LocktimeOperations.scala
@@ -39,5 +39,5 @@ case object OP_CHECKSEQUENCEVERIFY extends LocktimeOperation {
 }
 
 object LocktimeOperation extends ScriptOperationFactory[LocktimeOperation] {
-  override val operations = Seq(OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY)
+  override val operations = Vector(OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY)
 }

--- a/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala
@@ -97,7 +97,7 @@ object ReservedOperation extends ScriptOperationFactory[ReservedOperation] {
   lazy val undefinedOpCodes = for { i <- 0xba to 0xff } yield UndefinedOP_NOP(i)
 
   override val operations =
-    Seq(OP_RESERVED,
+    Vector(OP_RESERVED,
         OP_VER,
         OP_VERIF,
         OP_VERNOTIF,

--- a/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala
@@ -96,7 +96,7 @@ case class UndefinedOP_NOP(opCode: Int) extends ReservedOperation
 object ReservedOperation extends ScriptOperationFactory[ReservedOperation] {
   lazy val undefinedOpCodes = for { i <- 0xba to 0xff } yield UndefinedOP_NOP(i)
 
-  def operations =
+  override val operations =
     Seq(OP_RESERVED,
         OP_VER,
         OP_VERIF,

--- a/core/src/main/scala/org/bitcoins/core/script/splice/SpliceOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/splice/SpliceOperations.scala
@@ -29,5 +29,5 @@ case object OP_SIZE extends SpliceOperation {
 }
 
 object SpliceOperation extends ScriptOperationFactory[SpliceOperation] {
-  def operations = Seq(OP_CAT, OP_LEFT, OP_RIGHT, OP_SIZE, OP_SUBSTR)
+  override val operations = Seq(OP_CAT, OP_LEFT, OP_RIGHT, OP_SIZE, OP_SUBSTR)
 }

--- a/core/src/main/scala/org/bitcoins/core/script/splice/SpliceOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/splice/SpliceOperations.scala
@@ -29,5 +29,5 @@ case object OP_SIZE extends SpliceOperation {
 }
 
 object SpliceOperation extends ScriptOperationFactory[SpliceOperation] {
-  override val operations = Seq(OP_CAT, OP_LEFT, OP_RIGHT, OP_SIZE, OP_SUBSTR)
+  override val operations = Vector(OP_CAT, OP_LEFT, OP_RIGHT, OP_SIZE, OP_SUBSTR)
 }

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackOperations.scala
@@ -144,13 +144,13 @@ case object OP_2SWAP extends StackOperation {
 object StackOperation extends ScriptOperationFactory[StackOperation] {
   override val operations =
     Vector(
+      OP_DUP,
       OP_TOALTSTACK,
       OP_FROMALTSTACK,
       OP_IFDUP,
       OP_DEPTH,
       OP_DEPTH,
       OP_DROP,
-      OP_DUP,
       OP_NIP,
       OP_OVER,
       OP_ROLL,

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackOperations.scala
@@ -143,7 +143,7 @@ case object OP_2SWAP extends StackOperation {
 
 object StackOperation extends ScriptOperationFactory[StackOperation] {
   override val operations =
-    Seq(
+    Vector(
       OP_TOALTSTACK,
       OP_FROMALTSTACK,
       OP_IFDUP,

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackOperations.scala
@@ -142,7 +142,7 @@ case object OP_2SWAP extends StackOperation {
 }
 
 object StackOperation extends ScriptOperationFactory[StackOperation] {
-  override def operations =
+  override val operations =
     Seq(
       OP_TOALTSTACK,
       OP_FROMALTSTACK,

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
@@ -16,7 +16,6 @@ import scodec.bits.ByteVector
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
 
 /**
   * Created by chris on 2/16/16.
@@ -320,8 +319,12 @@ object ECPublicKey extends Factory[ECPublicKey] {
   }
 
   def isFullyValidWithSecp(bytes: ByteVector): Boolean = {
-    Try(NativeSecp256k1.isValidPubKey(bytes.toArray))
-      .getOrElse(false) && isValid(bytes)
+    try {
+      NativeSecp256k1.isValidPubKey(bytes.toArray) && isValid(bytes)
+    } catch {
+      case scala.util.control.NonFatal(_) =>
+        false
+    }
   }
 
   def isFullyValidWithBouncyCastle(bytes: ByteVector): Boolean = {


### PR DESCRIPTION
Optimize `ScriptOperations` which was using `def` for pre-defined script opts, and use `Vector[]` as the collection that contains script operations rather than `Seq`. `Seq` can sometimes be implemented as a `List` which has some O(n) behavior