### PR TITLE
Implemented (lax) signature parsing in Bitcoin-S

### DIFF
--- a/crypto-test/src/test/scala/org/bitcoins/crypto/DERSignatureUtilTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/DERSignatureUtilTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.crypto
 
 import org.bitcoins.core.util.NumberUtil
 import org.bitcoins.testkit.util.BitcoinSUnitTest
+import scodec.bits.ByteVector
 
 /**
   * Created by chris on 3/23/16.
@@ -94,5 +95,65 @@ class DERSignatureUtilTest extends BitcoinSUnitTest {
     val highS = ECDigitalSignature(
       "304502203e4516da7253cf068effec6b95c41221c0cf3a8e6ccb8cbf1725b562e9afde2c022100ab1e3da73d67e32045a20e0b999e049978ea8d6ee5480d485fcf2ce0d03b2ef001".toLowerCase)
     DERSignatureUtil.isLowS(highS) must be(false)
+  }
+
+  it must "parse lax DER signatures" in {
+    // Copied from https://github.com/rust-bitcoin/rust-secp256k1/blob/a1842125a77cadaa8ac7d6ca794ddb1f4852c593/src/lib.rs#L940-L956 except for the first one
+    // which is from script_tests.json and the second one which is from tx_valid.json
+    val signatures = Vector(
+      "304402200060558477337b9022e70534f1fea71a318caf836812465a2509931c5e7c4987022078ec32bd50ac9e03a349ba953dfd9fe1c8d2dd8bdb1d38ddca844d3d5c78c11801",
+      "30440220ffda47bfc776bcd269da4832626ac332adfca6dd835e8ecd83cd1ebe7d709b0e022049cffa1cdc102a0b56e0e04913606c70af702a1149dc3b305ab9439288fee09001",
+      "304402204c2dd8a9b6f8d425fcd8ee9a20ac73b619906a6367eac6cb93e70375225ec0160220356878eff111ff3663d7e6bf08947f94443845e0dcc54961664d922f7660b80c",
+      "304402202ea9d51c7173b1d96d331bd41b3d1b4e78e66148e64ed5992abd6ca66290321c0220628c47517e049b3e41509e9d71e480a0cdc766f8cdec265ef0017711c1b5336f",
+      "3045022100bf8e050c85ffa1c313108ad8c482c4849027937916374617af3f2e9a881861c9022023f65814222cab09d5ec41032ce9c72ca96a5676020736614de7b78a4e55325a",
+      "3046022100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45",
+      "3046022100eaa5f90483eb20224616775891397d47efa64c68b969db1dacb1c30acdfc50aa022100cf9903bbefb1c8000cf482b0aeeb5af19287af20bd794de11d82716f9bae3db1",
+      "3045022047d512bc85842ac463ca3b669b62666ab8672ee60725b6c06759e476cebdc6c102210083805e93bd941770109bcc797784a71db9e48913f702c56e60b1c3e2ff379a60",
+      "3044022023ee4e95151b2fbbb08a72f35babe02830d14d54bd7ed1320e4751751d1baa4802206235245254f58fd1be6ff19ca291817da76da65c2f6d81d654b5185dd86b8acf"
+    ).map(ByteVector.fromValidHex(_))
+
+    signatures.foreach { sig =>
+      DERSignatureUtil.parseDERLax(sig) match {
+        case None => fail(s"Failed to parse $sig")
+        case Some((r, s)) =>
+          if (r == BigInt(0) || s == BigInt(0)) {
+            fail(s"Failed to parse $sig")
+          } else {
+            succeed
+          }
+      }
+    }
+  }
+
+  it must "fail to parse garbage signatures" in {
+    val signatures = Vector(
+      ("4402204c2dd8a9b6f8d425fcd8ee9a20ac73b619906a6367eac6cb93e70375225ec0160220356878eff111ff3663d7e6bf08947f94443845e0dcc54961664d922f7660b80c",
+       "no leading byte"),
+      ("204402202ea9d51c7173b1d96d331bd41b3d1b4e78e66148e64ed5992abd6ca66290321c0220628c47517e049b3e41509e9d71e480a0cdc766f8cdec265ef0017711c1b5336f",
+       "bad leading byte"),
+      ("30477022100bf8e050c85ffa1c313108ad8c482c4849027937916374617af3f2e9a881861c9022023f65814222cab09d5ec41032ce9c72ca96a5676020736614de7b78a4e55325a",
+       "long length byte"),
+      ("30462100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45",
+       "no r integer tag"),
+      ("3046022100eaa5f90483eb20224616775891397d47efa64c68b969db1dacb1c30acdfc50aa2100cf9903bbefb1c8000cf482b0aeeb5af19287af20bd794de11d82716f9bae3db1",
+       "no s integer tag"),
+      ("3045022847d512bc85842ac463ca3b669b62666ab8672ee60725b6c06759e476cebdc6c102210083805e93bd941770109bcc797784a71db9e48913f702c56e60b1c3e2ff379a60",
+       "long r length"),
+      ("3044022023ee4e95151b2fbbb08a72f35babe02830d14d54bd7ed1320e4751751d1baa4802286235245254f58fd1be6ff19ca291817da76da65c2f6d81d654b5185dd86b8acf",
+       "long s length")
+    ).map { case (sig, msg) => (ByteVector.fromValidHex(sig), msg) }
+
+    signatures.foreach {
+      case (sig, msg) =>
+        DERSignatureUtil.parseDERLax(sig) match {
+          case None => succeed
+          case Some((r, s)) =>
+            if (r == BigInt(0) || s == BigInt(0)) {
+              succeed
+            } else {
+              fail(s"Successfully parsed bad signature $sig : $msg")
+            }
+        }
+    }
   }
 }

--- a/crypto/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
@@ -103,9 +103,8 @@ object BouncyCastleUtil {
                                  java.math.BigInteger.valueOf(0),
                                  java.math.BigInteger.valueOf(0))
         case _: ECDigitalSignature =>
-          val rBigInteger: BigInteger = new BigInteger(signature.r.toString())
-          val sBigInteger: BigInteger = new BigInteger(signature.s.toString())
-          signer.verifySignature(data.toArray, rBigInteger, sBigInteger)
+          val (r, s) = signature.decodeSignature
+          signer.verifySignature(data.toArray, r.bigInteger, s.bigInteger)
       }
     }
     resultTry.getOrElse(false)

--- a/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
@@ -60,7 +60,7 @@ sealed abstract class DERSignatureUtil {
     * throws an exception if the given sequence of bytes is not a DER encoded signature
     */
   def decodeSignature(bytes: ByteVector): (BigInt, BigInt) = {
-    DERSignatureUtil.parseDERLax(bytes) match {
+    DERSignatureUtil.parseDERLax2(bytes) match {
       case Some((r, s)) => (r, s)
       case None         => (0, 0)
     }
@@ -345,6 +345,124 @@ sealed abstract class DERSignatureUtil {
     val s = BigInt(1, tmpSig.takeRight(32))
 
     Some((r, s))
+  }
+
+  /** 0x30 | total length | 0x02 | R length | [R] \ 0x02 | S length | [S] */
+  def parseDERLax2(input: ByteVector): Option[(BigInt, BigInt)] = {
+    // Check zero'th byte exists and is 0x30
+    // Check first byte exists and process as length byte
+    // Check next byte exists and is 0x02
+    // Check next byte exists and process as R length byte
+    // Mark position where R starts
+    // Check next byte exists and is 0x02
+    // Check next byte exists and process as S length byte
+    // Mark position where S starts
+    // Erase leading zeroes in R and S (adjusting length and position accordingly)
+    // If either length > 32, then overflow and return (0, 0)
+    // Pad R and S (on the left) to 32 bytes each, return (R, S)
+
+    val iterator = input.toIterable.iterator.buffered
+
+    for {
+      head <- iterator.nextOption()
+      _ <- Option.when(head == 0x30.toByte)(())
+
+      totalLengthByteUnProcessed <- iterator.nextOption()
+      _ <- {
+        if ((totalLengthByteUnProcessed & 0x80) != 0) {
+          val processedTotalLengthByte = totalLengthByteUnProcessed - 0x80
+          (0 until processedTotalLengthByte)
+            .foldLeft(Option(0.toByte)) {
+              case (bOpt, _) =>
+                bOpt.flatMap(_ => iterator.nextOption())
+            }
+        } else {
+          Some(())
+        }
+      }
+
+      rTag <- iterator.nextOption()
+      _ <- Option.when(rTag == 0x02.toByte)(())
+
+      rLengthByteUnProcessed <- iterator.nextOption()
+      rLength <- {
+        if ((rLengthByteUnProcessed & 0x80) != 0) {
+          var lenByte = rLengthByteUnProcessed - 0x80
+
+          while (lenByte > 0 && iterator.headOption.contains(0.toByte)) {
+            iterator.next()
+            lenByte -= 1
+          }
+          val rLenInit = if (lenByte >= 4) None else Some(0)
+          (0 until lenByte).foldLeft(rLenInit) {
+            case (rLenOpt, _) =>
+              rLenOpt.flatMap { rLenSoFar =>
+                iterator.nextOption().map { nextByte =>
+                  (rLenSoFar << 8) + nextByte
+                }
+              }
+          }
+        } else {
+          Some(rLengthByteUnProcessed.toInt)
+        }
+      }
+
+      rBytes <- (0 until rLength).foldLeft(Option(ByteVector.empty)) {
+        case (rOpt, _) =>
+          rOpt.flatMap { rSoFar =>
+            iterator.nextOption().map(rSoFar.:+)
+          }
+      }
+
+      sTag <- iterator.nextOption()
+      _ <- Option.when(sTag == 0x02.toByte)(())
+
+      sLengthByteUnProcessed <- iterator.nextOption()
+      sLength <- {
+        if ((sLengthByteUnProcessed & 0x80) != 0) {
+          var lenByte = sLengthByteUnProcessed - 0x80
+
+          while (lenByte > 0 && iterator.headOption.contains(0.toByte)) {
+            iterator.next()
+            lenByte -= 1
+          }
+          val sLenInit = if (lenByte >= 4) None else Some(0)
+          (0 until lenByte).foldLeft(sLenInit) {
+            case (sLenOpt, _) =>
+              sLenOpt.flatMap { sLenSoFar =>
+                iterator.nextOption().map { nextByte =>
+                  (sLenSoFar << 8) + nextByte
+                }
+              }
+          }
+        } else {
+          Some(sLengthByteUnProcessed.toInt)
+        }
+      }
+
+      sBytes <- (0 until sLength).foldLeft(Option(ByteVector.empty)) {
+        case (sOpt, _) =>
+          sOpt.flatMap { sSoFar =>
+            iterator.nextOption().map(sSoFar.:+)
+          }
+      }
+
+      r <- {
+        val rBytesWithoutLeadingZero = rBytes.dropWhile(_ == 0.toByte)
+        Option.when(rBytesWithoutLeadingZero.length <= 32) {
+          BigInt(1, rBytesWithoutLeadingZero.toArray)
+        }
+      }
+
+      s <- {
+        val sBytesWithoutLeadingZero = sBytes.dropWhile(_ == 0.toByte)
+        Option.when(sBytesWithoutLeadingZero.length <= 32) {
+          BigInt(1, sBytesWithoutLeadingZero.toArray)
+        }
+      }
+    } yield {
+      (r, s)
+    }
   }
 }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
@@ -259,7 +259,7 @@ sealed abstract class DERSignatureUtil {
           if ((lengthByteUnProcessed & 0x80) != 0) {
             var lenByte = lengthByteUnProcessed - 0x80
 
-            while (lenByte > 0 && iterator.headOption.contains(0.toByte)) {
+            while (lenByte > 0 && iterator.hasNext && iterator.head == 0.toByte) {
               iterator.next()
               lenByte -= 1
             }

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
@@ -34,7 +34,8 @@ sealed abstract class ECDigitalSignature {
     * throws an exception if the given sequence of bytes is not a DER encoded signature
     * @return the (r,s) values for the elliptic curve digital signature
     */
-  def decodeSignature: (BigInt, BigInt) = DERSignatureUtil.decodeSignature(this)
+  lazy val decodeSignature: (BigInt, BigInt) =
+    DERSignatureUtil.decodeSignature(this)
 
   /** Represents the r value found in a elliptic curve digital signature */
   def r: BigInt = {

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
@@ -209,7 +209,6 @@ sealed abstract class ECPublicKey extends BaseECKey {
       //transactions can have weird non strict der encoded digital signatures
       //bitcoin core implements this functionality here:
       //https://github.com/bitcoin/bitcoin/blob/master/src/pubkey.cpp#L16-L165
-      //TODO: Implement functionality in Bitcoin Core linked above
       verifyWithBouncyCastle(data, signature)
     } else result
   }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -3,7 +3,7 @@ import sbt._
 object Deps {
 
   object V {
-    val bouncyCastle = "1.55"
+    val bouncyCastle = "1.65"
     val logback = "1.2.3"
     val scalacheck = "1.14.3"
     val scalaTest = "3.1.2"


### PR DESCRIPTION
This allows us to finally update bouncy castle!

The current version is literally just me mimicking  (`var`s, `Array`s and all) the code here line for line: https://github.com/bitcoin/bitcoin/blob/master/src/pubkey.cpp#L16-L165

I will attempt to clean this up and scala-fy it tomorrow, though I've already attempted it once and tbh I don't fully understand the business with the first bit of length bytes (I know it has to do with leading zeroes appended to r and s values, but need to get a better grasp on this), which makes it quite hard to re-write.

That said, at the time I did not actually have a working integration and now that I do it should be easier to write a new function that (should do) does the same thing and compare.

I still haven't been able to access the Gemini fork and see what is going on over there but hopefully this can help on their end!

EDIT:
I have now implemented it in a clean and readable way that is still efficient using iterators!