### PR TITLE
Fix allowing BytesToPushOntoStack(0)

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
@@ -92,7 +92,7 @@ class TransactionSignatureCreatorTest
     val scriptPubKey = P2PKScriptPubKey(publicKey)
     val (creditingTx, outputIndex) =
       TransactionTestUtil.buildCreditingTransaction(scriptPubKey)
-    val scriptSig = P2PKScriptSignature(EmptyDigitalSignature)
+    val scriptSig = EmptyScriptSignature
     val (spendingTx, inputIndex) =
       TransactionTestUtil.buildSpendingTransaction(creditingTx,
                                                    scriptSig,
@@ -139,7 +139,7 @@ class TransactionSignatureCreatorTest
     val scriptPubKey = P2PKHScriptPubKey(publicKey)
     val (creditingTx, outputIndex) =
       TransactionTestUtil.buildCreditingTransaction(scriptPubKey)
-    val scriptSig = P2PKHScriptSignature(EmptyDigitalSignature, publicKey)
+    val scriptSig = EmptyScriptSignature
     val (spendingTx, inputIndex) =
       TransactionTestUtil.buildSpendingTransaction(creditingTx,
                                                    scriptSig,

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.core.protocol.transaction
 
-import org.bitcoins.testkit.core.gen.WitnessGenerators
 import org.bitcoins.core.protocol.script._
-import org.bitcoins.crypto.{ECPrivateKey, EmptyDigitalSignature}
-import org.scalacheck.Prop
+import org.bitcoins.crypto.{DummyECDigitalSignature, ECPrivateKey}
+import org.bitcoins.testkit.core.gen.WitnessGenerators
 import org.bitcoins.testkit.util.BitcoinSUnitTest
+import org.scalacheck.Prop
 
 /**
   * Created by chris on 11/28/16.
@@ -22,7 +22,7 @@ class TransactionWitnessSpec extends BitcoinSUnitTest {
   it must "be able to resize a witness to the given index" in {
     val empty = EmptyWitness.fromN(0)
     val pubKey = ECPrivateKey.freshPrivateKey.publicKey
-    val p2pkh = P2PKHScriptSignature(EmptyDigitalSignature, pubKey)
+    val p2pkh = P2PKHScriptSignature(DummyECDigitalSignature, pubKey)
     val scriptWit = P2WPKHWitnessV0.fromP2PKHScriptSig(p2pkh)
     val updated = empty.updated(2, scriptWit)
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ConstantInterpreterTest.scala
@@ -78,33 +78,6 @@ class ConstantInterpreterTest extends BitcoinSUnitTest {
     newProgram.stack must be(List(ScriptConstant("0100")))
   }
 
-  it must "push 0 bytes onto the stack which is OP_0" in {
-    val stack = List()
-    val script = List(OP_PUSHDATA1, BytesToPushOntoStack(0))
-    val program = TestUtil.testProgramExecutionInProgress
-      .updateStackAndScript(stack, script)
-      .removeFlags()
-    val newProgram = CI.opPushData1(program)
-    newProgram.stackTopIsFalse must be(true)
-    newProgram.stack must be(List(ScriptNumber.zero))
-
-    val stack1 = List()
-    val script1 = List(OP_PUSHDATA2, BytesToPushOntoStack(0))
-    val program1 = TestUtil.testProgramExecutionInProgress
-      .updateStackAndScript(stack1, script1)
-      .removeFlags()
-    val newProgram1 = CI.opPushData2(program1)
-    newProgram1.stack must be(List(ScriptNumber.zero))
-
-    val stack2 = List()
-    val script2 = List(OP_PUSHDATA4, BytesToPushOntoStack(0))
-    val program2 = TestUtil.testProgramExecutionInProgress
-      .updateStackAndScript(stack2, script2)
-      .removeFlags()
-    val newProgram2 = CI.opPushData4(program2)
-    newProgram2.stack must be(List(ScriptNumber.zero))
-  }
-
   it must "mark a program as invalid if we have do not have enough bytes to be pushed onto the stack by the push operation" in {
     val stack = List()
     val script = List(OP_PUSHDATA1, BytesToPushOntoStack(1))
@@ -119,19 +92,19 @@ class ConstantInterpreterTest extends BitcoinSUnitTest {
 
   it must "fail the require statement if the first op_code in the program's script doesn't match the OP_PUSHDATA we're looking for" in {
     val stack1 = List()
-    val script1 = List(OP_PUSHDATA1, BytesToPushOntoStack(0))
+    val script1 = List(OP_PUSHDATA1, BytesToPushOntoStack(1))
     val program1 = TestUtil.testProgramExecutionInProgress
       .updateStackAndScript(stack1, script1)
       .removeFlags()
 
     val stack2 = List()
-    val script2 = List(OP_PUSHDATA2, BytesToPushOntoStack(0))
+    val script2 = List(OP_PUSHDATA2, BytesToPushOntoStack(1))
     val program2 = TestUtil.testProgramExecutionInProgress
       .updateStackAndScript(stack2, script2)
       .removeFlags()
 
     val stack4 = List()
-    val script4 = List(OP_PUSHDATA4, BytesToPushOntoStack(0))
+    val script4 = List(OP_PUSHDATA4, BytesToPushOntoStack(1))
     val program4 = TestUtil.testProgramExecutionInProgress
       .updateStackAndScript(stack4, script4)
       .removeFlags()

--- a/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
@@ -20,6 +20,7 @@ object BytesToPushOntoStack
     /*  //see the 'Constants; section in https://en.bitcoin.it/wiki/Script
       require(num >= -1 && num <= 75, "A valid script number is between 1 and 75, the number passed in was: " + num)*/
     require(num >= 1, "BytesToPushOntoStackImpl cannot be less than 1")
+    require(num <= 75, "BytesToPushOntoStackImpl cannot be greater than 75")
     override val opCode = num
   }
 

--- a/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/BytesToPushOntoStack.scala
@@ -11,12 +11,6 @@ trait BytesToPushOntoStack extends ScriptOperation
 object BytesToPushOntoStack
     extends ScriptOperationFactory[BytesToPushOntoStack] {
 
-  /**
-    * Represents that zero bytes need to be pushed onto the stack
-    * this really means we need to push an empty byte vector on the stack
-    */
-  lazy val zero: BytesToPushOntoStack = apply(0)
-
   lazy val push33Bytes = operations(33)
   lazy val push32Bytes = operations(32)
   lazy val push20Bytes = operations(20)
@@ -25,12 +19,12 @@ object BytesToPushOntoStack
       extends BytesToPushOntoStack {
     /*  //see the 'Constants; section in https://en.bitcoin.it/wiki/Script
       require(num >= -1 && num <= 75, "A valid script number is between 1 and 75, the number passed in was: " + num)*/
-    require(num >= 0, "BytesToPushOntoStackImpl cannot be negative")
+    require(num >= 1, "BytesToPushOntoStackImpl cannot be less than 1")
     override val opCode = num
   }
 
   override val operations: Vector[BytesToPushOntoStack] = {
-    (for { i <- 0 to 75 } yield BytesToPushOntoStackImpl(i)).toVector
+    (for { i <- 1 to 75 } yield BytesToPushOntoStackImpl(i)).toVector
   }
 
   def fromNumber(num: Long): BytesToPushOntoStack = {

--- a/core/src/main/scala/org/bitcoins/core/script/constant/ConstantInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/ConstantInterpreter.scala
@@ -130,8 +130,7 @@ sealed abstract class ConstantInterpreter {
     }
 
     program.script(1) match {
-      case OP_0 | BytesToPushOntoStack.zero | ScriptNumber.zero |
-          ScriptNumber.negativeZero =>
+      case OP_0 | ScriptNumber.zero | ScriptNumber.negativeZero =>
         emptyPush()
       case token: ScriptConstant if token.bytes.toSeq.forall(_ == 0.toByte) =>
         emptyPush()

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -231,7 +231,9 @@ trait BitcoinScriptUtil extends BitcoinSLogger {
     //push ops following an OP_PUSHDATA operation are interpreted as unsigned numbers
     val scriptTokenSize = UInt32(scriptToken.bytes.size)
     val bytes = scriptTokenSize.bytes
-    if (scriptToken.isInstanceOf[ScriptNumberOperation]) Nil
+    if (scriptToken
+          .isInstanceOf[ScriptNumberOperation] || scriptToken.bytes.size <= 0)
+      Nil
     else if (scriptTokenSize <= UInt32(75))
       Seq(BytesToPushOntoStack(scriptToken.bytes.size))
     else if (scriptTokenSize <= UInt32(OP_PUSHDATA1.max)) {

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/ScriptGenerators.scala
@@ -575,10 +575,9 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       scriptPubKey = P2PKScriptPubKey(publicKey)
       (creditingTx, outputIndex) = TransactionGenerators
         .buildCreditingTransaction(scriptPubKey)
-      scriptSig = P2PKScriptSignature(EmptyDigitalSignature)
       (spendingTx, inputIndex) = TransactionGenerators.buildSpendingTransaction(
         creditingTx,
-        scriptSig,
+        EmptyScriptSignature,
         outputIndex)
       spendingInfo = ScriptSignatureParams(
         P2PKInputInfo(TransactionOutPoint(creditingTx.txIdBE, inputIndex),
@@ -634,8 +633,7 @@ sealed abstract class ScriptGenerators extends BitcoinSLogger {
       hashType <- CryptoGenerators.hashType
     } yield {
       val privKey = privKeys.head
-      val emptyScriptSig = P2PKWithTimeoutScriptSignature(beforeTimeout = true,
-                                                          EmptyDigitalSignature)
+      val emptyScriptSig = EmptyScriptSignature
       val (creditingTx, outputIndex) =
         TransactionGenerators.buildCreditingTransaction(spk)
       val (spendingTx, inputIndex) = TransactionGenerators


### PR DESCRIPTION
Fixes #1445 

As described in #1445, `BytesToPushOnStack(0)` should not be valid but we were pushing `OP_0` when this occurred. This fixes that problem. However, after fixing that it caused some of our tests to fail, namely anywhere that we were putting an `EmptyDigitalSignature` into a script signature. This was a problem because when we check if it is valid script sig, we check that it has the correct `BytesToPushOnStack`, however, now when pushing `BytesToPushOnStack(0)` we no longer add anything to the stack. Luckily, this was easily remedied by replacing these instances with an `EmptyScriptSignature`