### PR TITLE
Fix balance by account

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -128,7 +128,7 @@ abstract class Wallet
     } yield {
       allUnspent.filter { utxo =>
         HDAccount.isSameAccount(utxo.privKeyPath.path, account) &&
-        utxo.blockHash.isDefined
+        utxo.state == ConfirmedReceived
       }
     }
 
@@ -151,7 +151,7 @@ abstract class Wallet
     } yield {
       allUnspent.filter { utxo =>
         HDAccount.isSameAccount(utxo.privKeyPath.path, account) &&
-        utxo.blockHash.isEmpty
+        utxo.state == PendingConfirmationsReceived
       }
     }
 


### PR DESCRIPTION
Missed from #1178 

We should consider the utxo confirmed if it has reached the `ConfirmedReceived` state, not if it just has been included in a block