### PR TITLE
Create a simplified version of the WalletApi.unmarkUTXOsAsReserved() …

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -99,4 +99,21 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
         assert(unreservedUtxos.forall(_.state != TxoState.Reserved))
       }
   }
+
+  it should "track a utxo state change to reserved and then to unreserved using the transaction the utxo was included in" in {
+    param =>
+      val WalletWithBitcoindRpc(wallet, _) = param
+
+      val dummyOutput = TransactionOutput(Satoshis(3000), EmptyScriptPubKey)
+
+      for {
+        tx <- wallet.fundRawTransaction(Vector(dummyOutput),
+                                        SatoshisPerVirtualByte.one,
+                                        markAsReserved = true)
+        unreservedUtxos <- wallet.unmarkUTXOsAsReserved(tx)
+      } yield {
+        assert(unreservedUtxos.forall(_.state != TxoState.Reserved))
+      }
+  }
+
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -192,6 +192,9 @@ trait WalletApi extends WalletLogger {
   def unmarkUTXOsAsReserved(
       utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]]
 
+  /** Unmarks all utxos that are ours in this transactions indicating they are no longer reserved */
+  def unmarkUTXOsAsReserved(tx: Transaction): Future[Vector[SpendingInfoDb]]
+
   /** Checks if the wallet contains any data */
   def isEmpty(): Future[Boolean]
 


### PR DESCRIPTION
…that just takes in a tx and scans outpoints if they are in our wallet, also move the mark/unmark methods out of Wallet.scala and into UtxoHandling.scala

Builds off of #1458 

1. Adds `unmarkUTXOsAsReserved` that takes in a tx and then scans outpoints looking for ones that are in our wallet, and then un-reserves them. 
2. Moves the Utxo methods out of `Wallet.scala` and into `UtxoHandling.scala`