### PR TITLE
CryptoContext Refactor

### DIFF
--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoContext.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoContext.scala
@@ -1,0 +1,25 @@
+package org.bitcoins.crypto
+
+import org.bitcoin.Secp256k1Context
+
+sealed trait CryptoContext
+
+object CryptoContext {
+
+  case object LibSecp256k1 extends CryptoContext
+
+  case object BouncyCastle extends CryptoContext
+
+  def default: CryptoContext = {
+    val secpDisabled = System.getenv("DISABLE_SECP256K1")
+    if (secpDisabled != null && (secpDisabled.toLowerCase == "true" || secpDisabled == "1")) {
+      BouncyCastle
+    } else {
+      if (Secp256k1Context.isEnabled) {
+        LibSecp256k1
+      } else {
+        BouncyCastle
+      }
+    }
+  }
+}

--- a/docs/secp256k1/secp256k1.md
+++ b/docs/secp256k1/secp256k1.md
@@ -66,7 +66,7 @@ There are two reasons you wouldn't want to use libsecp256k1
 
 There are two ways you can circumvent libsecp256k1
 
-1. Set `DISABLE_SECP256K1=true` in your environment variables. This will force `Secp256k1Context.isEnabled()` to return false
+1. Set `DISABLE_SECP256K1=true` in your environment variables. This will force `CryptoContext.default` to return false which will make Bitcoin-S act like `Secp256k1Context.isEnabled()` has returned false.
 2. Call Bouncy castle methods in `ECKey`. 
 
 Here is an example of calling bouncy castle methods in `ECKey`

--- a/secp256k1jni/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/secp256k1jni/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -51,14 +51,7 @@ public class Secp256k1Context {
    * to Bouncy Castle implementations in the case of having no libsecp present.
    */
   public static boolean isEnabled() {
-      String secpDisabled = System.getenv("DISABLE_SECP256K1");
-      if (secpDisabled != null &&
-              (secpDisabled.toLowerCase().equals("true") ||
-                      secpDisabled.equals("1"))) {
-          return false;
-      } else {
-          return enabled;
-      }
+      return enabled;
   }
 
   public static long getContext() {


### PR DESCRIPTION
Moved logic to disable use of secp256k1 library into `crypto` project.

Should fix #1468