### PR TITLE
Drop 2.11 from inThisBuild.sbt and Deps.scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,6 @@ scala:
 # is going to look like
 matrix:
   include:
-    # this way of including jobs is not ideal... unfortunately it's not
-    # possible to nest env.matrix. could a better solution be to write
-    # a small script that generates a Travis config for us?
-    - os: linux
-      name: "Linux compile for 2.11"
-      env:
-        - TEST_COMMAND="test:compile"
-      scala:
-        - 2.11.12
     - os: linux
       name: "Secp256k1 Disabled Core Test"
       env:

--- a/inThisBuild.sbt
+++ b/inThisBuild.sbt
@@ -1,7 +1,6 @@
-val scala2_11 = "2.11.12"
 val scala2_12 = "2.12.11"
 val scala2_13 = "2.13.2"
 
 scalaVersion in ThisBuild := scala2_13
 
-crossScalaVersions in ThisBuild := List(scala2_13, scala2_12, scala2_11)
+crossScalaVersions in ThisBuild := List(scala2_13, scala2_12)

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -23,8 +23,6 @@ object Deps {
     val scalaFxV = "14-R19"
     val javaFxV = "14.0.1"
 
-    // async dropped Scala 2.11 in 0.10.0
-    val asyncOldScalaV = "0.9.7"
     val asyncNewScalaV = "0.10.0"
 
     val flywayV = "6.4.2"
@@ -34,10 +32,6 @@ object Deps {
     val sqliteV = "3.31.1"
     val scalameterV = "0.17"
     val scalamockV = "4.4.0"
-
-    // Wallet/node/chain server deps
-    val oldMicroPickleV = "0.7.4"
-    val oldMicroJsonV = oldMicroPickleV
 
     val newMicroPickleV = "0.8.0"
     val newMicroJsonV = newMicroPickleV
@@ -107,14 +101,8 @@ object Deps {
     val postgres = "org.postgresql" % "postgresql" % V.postgresV
     val flyway = "org.flywaydb" % "flyway-core" % V.flywayV
 
-    // zero dep JSON library. Have to use different versiont to juggle
-    // Scala 2.11/12/13
-    val oldMicroJson = "com.lihaoyi" %% "ujson" % V.oldMicroJsonV
     val newMicroJson = "com.lihaoyi" %% "ujson" % V.newMicroJsonV
 
-    // serializing to and from JSON Have to use different versiont to juggle
-    // Scala 2.11/12/13
-    val oldMicroPickle = "com.lihaoyi" %% "upickle" % V.oldMicroPickleV
     val newMicroPickle = "com.lihaoyi" %% "upickle" % V.newMicroPickleV
 
     // get access to reflection data at compile-time
@@ -132,7 +120,6 @@ object Deps {
   }
 
   object Test {
-    val oldAsync = "org.scala-lang.modules" %% "scala-async" % V.asyncOldScalaV % "test" withSources () withJavadoc ()
     val newAsync = "org.scala-lang.modules" %% "scala-async" % V.asyncNewScalaV % "test" withSources () withJavadoc ()
     val junitInterface = "com.novocode" % "junit-interface" % V.junitV % "test" withSources () withJavadoc ()
     val logback = Compile.logback % "test"
@@ -154,8 +141,7 @@ object Deps {
   val chainTest = List()
 
   def appCommons(scalaVersion: String) = List(
-    if (scalaVersion.startsWith("2.11")) Compile.oldMicroPickle
-    else Compile.newMicroPickle,
+    Compile.newMicroPickle,
     Compile.playJson,
     Compile.slf4j
   )
@@ -208,7 +194,7 @@ object Deps {
     Test.logback,
     Test.scalaTest,
     Test.scalacheck,
-    if (scalaVersion.startsWith("2.11")) Test.oldAsync else Test.newAsync
+    Test.newAsync
   )
 
   val bench = List(
@@ -228,8 +214,7 @@ object Deps {
 
   def cli(scalaVersion: String) = List(
     Compile.sttp,
-    if (scalaVersion.startsWith("2.11")) Compile.oldMicroPickle
-    else Compile.newMicroPickle,
+    Compile.newMicroPickle,
     Compile.logback,
     Compile.scopt,
     //we can remove this dependency when this is fixed
@@ -241,8 +226,7 @@ object Deps {
   val gui = List(Compile.scalaFx) ++ Compile.javaFxDeps
 
   def server(scalaVersion: String) = List(
-    if (scalaVersion.startsWith("2.11")) Compile.oldMicroPickle
-    else Compile.newMicroPickle,
+    Compile.newMicroPickle,
     Compile.logback,
     Compile.akkaActor,
     Compile.akkaHttp
@@ -285,8 +269,7 @@ object Deps {
   )
 
   def keyManager(scalaVersion: String) = List(
-    if (scalaVersion.startsWith("2.11")) Compile.oldMicroJson
-    else Compile.newMicroJson
+    Compile.newMicroJson
   )
 
   val keyManagerTest = List(
@@ -295,8 +278,7 @@ object Deps {
   )
 
   def wallet(scalaVersion: String) = List(
-    if (scalaVersion.startsWith("2.11")) Compile.oldMicroJson
-    else Compile.newMicroJson,
+    Compile.newMicroJson,
     Compile.logback
   )
 


### PR DESCRIPTION
This PR drops support for Scala 2.11

This is needed because of other dependencies -- like akka in #1374 -- deciding to no longer support Scala 2.11. 

As a side effect for this PR, we are now dropping support for JDK 6 and JDK 7, as Scala 2.12.x only supports JDK 8+ 

https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html

This does not drop any source files that are 2.11 dependent, only the dependencies in the build. I will drop the source files in another PR.

