### PR TITLE
Add -Xfatal-warnings on Scala 2.13

### DIFF
--- a/bench/src/main/scala/org/bitcoins/bench/eclair/EclairBench.scala
+++ b/bench/src/main/scala/org/bitcoins/bench/eclair/EclairBench.scala
@@ -23,6 +23,7 @@ import scala.util.{Failure, Success}
   * and when the corresponding web socket event was received. It writes all results into [[OutputFileName]]
   * in CSV format.
   */
+@scala.annotation.nowarn
 object EclairBench extends App with EclairRpcTestUtil {
 
   import PaymentLog._
@@ -96,6 +97,7 @@ object EclairBench extends App with EclairRpcTestUtil {
         }
       })
     } yield paymentIds.flatten
+
 
   def runTests(network: EclairNetwork): Future[Vector[PaymentLogEntry]] = {
     println("Setting up the test network")

--- a/bitcoin-s-docs/docs.sbt
+++ b/bitcoin-s-docs/docs.sbt
@@ -43,3 +43,6 @@ Test / bloopGenerate := None
 Compile / bloopGenerate := None
 
 libraryDependencies ++= Deps.docs
+
+//https://stackoverflow.com/questions/26940253/in-sbt-how-do-you-override-scalacoptions-for-console-in-all-configurations
+scalacOptions in Compile ~= (_.filterNot(s => s == "-Xfatal-warnings"))

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -72,7 +72,7 @@ object CommonSettings {
     )
   }
 
-  private val scala2_13CompilerOpts = Seq("-Xlint:unused")
+  private val scala2_13CompilerOpts = Seq("-Xlint:unused","-Xfatal-warnings")
 
   private val nonScala2_13CompilerOpts = Seq(
     "-Xmax-classfile-name",

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -63,7 +63,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
     val path = binaryDirectory
       .resolve(eclairVersionOpt.getOrElse(EclairRpcClient.version))
       .resolve(
-        s"eclair-node-${EclairRpcClient.version}-${EclairRpcClient.commit}")
+        s"eclair-node-${EclairRpcClient.version}-${eclairCommitOpt.getOrElse(EclairRpcClient.commit)}")
       .resolve("bin")
       .resolve(
         if (sys.props("os.name").toLowerCase.contains("windows"))

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -820,7 +820,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
           val v17 = new BitcoindV17RpcClient(other.instance)
           v17.getAddressInfo(address).map(_.pubkey)
         } else {
-          other.validateAddress(address).map(_.pubkey)
+          other.getAddressInfo(address).map(_.pubkey)
         }
     }
   }


### PR DESCRIPTION
The Scala compiler option `-Xfatal-warnings` with throw errors on compile if there are warnings. This will prevent us from allowing dead code / bad imports into source.

You can see settings here: https://docs.scala-lang.org/overviews/compiler-options/index.html#Standard_Settings