### PR TITLE
Bump scodec to 1.14

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -15,7 +15,7 @@ object Deps {
     val akkav = "10.1.12"
     val akkaStreamv = "2.5.31"
     val playv = "2.7.4"
-    val scodecV = "1.1.12"
+    val scodecV = "1.1.14"
     val junitV = "0.11"
     val nativeLoaderV = "2.3.4"
     val typesafeConfigV = "1.4.0"

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSUnitTest.scala
@@ -41,7 +41,7 @@ abstract class BitcoinSUnitTest
     PropertyCheckConfiguration(
       minSuccessful = PosInt.from(executions).get,
       minSize = PosInt.from(executions).get,
-      workers = 2
+      workers = 1
     )
   }
 


### PR DESCRIPTION
Now that we have dropped support for 2.11 we can bump scodec

https://github.com/scodec/scodec-bits/releases