### PR TITLE
Skip publishing fee provider for now

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -317,7 +317,8 @@ lazy val feeProvider = project
   .settings(CommonSettings.prodSettings: _*)
   .settings(
     name := "bitcoin-s-fee-provider",
-    libraryDependencies ++= Deps.feeProvider
+    libraryDependencies ++= Deps.feeProvider,
+    publish / skip := true
   )
   .dependsOn(core, appCommons)
 


### PR DESCRIPTION
Builds are failing currently as we did not configure the fee provider project on sonatype yet in #1470 

https://travis-ci.org/github/bitcoin-s/bitcoin-s/jobs/692661898#L969