### PR TITLE
Reduce number of hashes used in GolombFilterTest to keep CI from timi…

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/gcs/GolombFilterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/gcs/GolombFilterTest.scala
@@ -54,7 +54,7 @@ class GolombFilterTest extends BitcoinSUnitTest {
     }
 
     val genRandHashes: Gen[Vector[UInt64]] =
-      Gen.listOfN(1000, NumberGenerator.uInt64).map(_.toVector)
+      Gen.listOfN(100, NumberGenerator.uInt64).map(_.toVector)
 
     forAll(genKey, genData, genRandHashes) {
       case (k, data, randHashes) =>


### PR DESCRIPTION
…ng out

This test case is timing out on CI at times (120 seconds). Reduce the number of hashes used in the generator from 1,000 -> 100 

![Screenshot from 2020-05-30 10-07-18](https://user-images.githubusercontent.com/3514957/83331725-7feb3280-a25d-11ea-96ca-c77246016e51.png)
