### PR TITLE
DLC Refactor/Rewrite

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCMessage.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCMessage.scala
@@ -308,6 +308,14 @@ object DLCMessage {
       eventId: Sha256DigestBE)
       extends DLCSetupMessage {
 
+    def withoutSigs: DLCAcceptWithoutSigs = {
+      DLCAcceptWithoutSigs(totalCollateral,
+                           pubKeys,
+                           fundingInputs,
+                           changeAddress,
+                           eventId)
+    }
+
     def toJson: Value = {
       val fundingInputsJson =
         fundingInputs.map(

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCMessage.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCMessage.scala
@@ -292,6 +292,13 @@ object DLCMessage {
     }
   }
 
+  case class DLCAcceptWithoutSigs(
+      totalCollateral: Satoshis,
+      pubKeys: DLCPublicKeys,
+      fundingInputs: Vector[OutputReference],
+      changeAddress: BitcoinAddress,
+      eventId: Sha256DigestBE)
+
   case class DLCAccept(
       totalCollateral: Satoshis,
       pubKeys: DLCPublicKeys,

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCSignatures.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCSignatures.scala
@@ -14,6 +14,17 @@ case class FundingSignatures(
   override protected def wrapped: Map[
     TransactionOutPoint,
     Vector[PartialSignature]] = sigs
+
+  def merge(other: FundingSignatures): FundingSignatures = {
+    val outPoints = sigs.keys ++ other.keys
+    val combinedSigs = outPoints.map { outPoint =>
+      val thisSigs = sigs.get(outPoint).toVector.flatten
+      val otherSigs = other.get(outPoint).toVector.flatten
+      outPoint -> (thisSigs ++ otherSigs)
+    }
+
+    FundingSignatures(combinedSigs.toMap)
+  }
 }
 
 case class CETSignatures(

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxBuilder.scala
@@ -181,3 +181,10 @@ case class RawTxBuilderWithFinalizer[F <: RawTxFinalizer](
     this
   }
 }
+
+object RawTxBuilderWithFinalizer {
+
+  def apply[F <: RawTxFinalizer](finalizer: F): RawTxBuilderWithFinalizer[F] = {
+    RawTxBuilderWithFinalizer(RawTxBuilder(), finalizer)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxBuilderResult.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxBuilderResult.scala
@@ -5,7 +5,9 @@ import org.bitcoins.core.protocol.transaction.{
   BaseTransaction,
   Transaction,
   TransactionInput,
-  TransactionOutput
+  TransactionOutput,
+  TransactionWitness,
+  WitnessTransaction
 }
 
 /** Raw Transaction to be finalized by a RawTxFinalizer */
@@ -17,6 +19,10 @@ case class RawTxBuilderResult(
 
   def toBaseTransaction: BaseTransaction = {
     BaseTransaction(version, inputs, outputs, lockTime)
+  }
+
+  def toWitnessTransaction(witness: TransactionWitness): WitnessTransaction = {
+    WitnessTransaction(version, inputs, outputs, lockTime, witness)
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxFinalizer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxFinalizer.scala
@@ -275,6 +275,10 @@ object StandardNonInteractiveFinalizer {
   }
 }
 
+/** Adds a future fee amount to the output with the given
+  * ScriptPubKey and subtracts that amount in equal portions
+  * from the specified change ScriptPubKeys.
+  */
 case class AddFutureFeeFinalizer(
     spk: ScriptPubKey,
     futureFee: CurrencyUnit,
@@ -318,6 +322,10 @@ case class AddFutureFeeFinalizer(
   }
 }
 
+/** Assumes the input transaction has had no fee considerations
+  * and subtracts the estimated fee in equal portions from the
+  * outputs with the specified ScriptPubKeys
+  */
 case class SubtractFeeFromOutputsFinalizer(
     inputInfos: Vector[InputInfo],
     feeRate: FeeUnit,
@@ -374,6 +382,10 @@ object SubtractFeeFromOutputsFinalizer {
   }
 }
 
+/** Assumes the input transaction has had no fee considerations
+  * and that all inputs are P2WPKH. Subtracts the estimated fee
+  * in equal portions from the outputs with the specified ScriptPubKeys
+  */
 case class P2WPKHSubtractFeesFromOutputsFinalizer(
     feeRate: FeeUnit,
     spks: Vector[ScriptPubKey])
@@ -394,7 +406,15 @@ case class P2WPKHSubtractFeesFromOutputsFinalizer(
   }
 }
 
-// Note: spendingVBytes may be 0
+/** Finalizes a dual-funded transaction given the InputInfos
+  * from both parties and the non-change output ScriptPubKey.
+  *
+  * This includes adding the future fee of spending transactions
+  * to the non-change output as well as subtracting relevant fees
+  * from the change outputs. This finalizer filters dust outputs.
+  *
+  * Note: spendingVBytes may be 0
+  */
 case class DualFundingTxFinalizer(
     spendingVBytes: Long,
     feeRate: FeeUnit,
@@ -421,6 +441,16 @@ case class DualFundingTxFinalizer(
   }
 }
 
+/** Finalizes a dual-funded transaction given the non-change output
+  * ScriptPubKey and under the assumption that all funding inputs
+  * from both parties are P2WPKH UTXOs.
+  *
+  * This includes adding the future fee of spending transactions
+  * to the non-change output as well as subtracting relevant fees
+  * from the change outputs. This finalizer filters dust outputs.
+  *
+  * Note: spendingVBytes may be 0
+  */
 case class P2WPKHDualFundingTxFinalizer(
     spendingVBytes: Long,
     feeRate: FeeUnit,

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxFinalizer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxFinalizer.scala
@@ -3,13 +3,14 @@ package org.bitcoins.core.wallet.builder
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.number.Int64
 import org.bitcoins.core.policy.Policy
-import org.bitcoins.core.protocol.script.ScriptPubKey
+import org.bitcoins.core.protocol.script.{P2WPKHWitnessV0, ScriptPubKey}
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.{InputInfo, InputSigningInfo}
+import org.bitcoins.crypto.{DummyECDigitalSignature, ECPublicKey}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
 /** This trait is responsible for converting RawTxBuilderResults into
   * finalized (unsigned) transactions. This process usually includes
@@ -274,32 +275,69 @@ object StandardNonInteractiveFinalizer {
   }
 }
 
-case class SubtractFeeFromOutputsFinalizer(
-    inputInfos: Vector[InputInfo],
-    feeRate: FeeUnit)
+case class AddFutureFeeFinalizer(
+    spk: ScriptPubKey,
+    futureFee: CurrencyUnit,
+    changeSPKs: Vector[ScriptPubKey])
     extends RawTxFinalizer {
   override def buildTx(txBuilderResult: RawTxBuilderResult)(
       implicit ec: ExecutionContext): Future[Transaction] = {
-    val RawTxBuilderResult(version, inputs, outputs, lockTime) = txBuilderResult
+    val changeOutputs = txBuilderResult.outputs.filter(output =>
+      changeSPKs.contains(output.scriptPubKey))
 
-    val witnesses = inputInfos.map(InputInfo.getScriptWitness)
-    val txWithPossibleWitness = TransactionWitness.fromWitOpt(witnesses) match {
-      case _: EmptyWitness =>
-        BaseTransaction(version, inputs, outputs, lockTime)
-      case wit: TransactionWitness =>
-        WitnessTransaction(version, inputs, outputs, lockTime, wit)
+    val outputT = txBuilderResult.outputs.zipWithIndex
+      .find(_._1.scriptPubKey == spk) match {
+      case Some((output, index)) =>
+        val newOutput = output.copy(value = output.value + futureFee)
+        Success((newOutput, index))
+      case None =>
+        Failure(new RuntimeException(
+          s"Did not find expected SPK $spk in ${txBuilderResult.outputs.map(_.scriptPubKey)}"))
     }
 
-    val dummyTxF = TxUtil.addDummySigs(txWithPossibleWitness, inputInfos)
+    val outputsT = outputT.map {
+      case (newOutput, index) =>
+        val subFromChange =
+          Satoshis(futureFee.satoshis.toLong / changeOutputs.length)
+        val outputsMinusChange = txBuilderResult.outputs.map { output =>
+          if (changeSPKs.contains(output.scriptPubKey)) {
+            output.copy(value = output.value - subFromChange)
+          } else {
+            output
+          }
+        }
+
+        outputsMinusChange.updated(index, newOutput)
+    }
+
+    val txT = outputsT.map { outputs =>
+      txBuilderResult.toBaseTransaction.copy(outputs = outputs)
+    }
+
+    Future.fromTry(txT)
+  }
+}
+
+case class SubtractFeeFromOutputsFinalizer(
+    inputInfos: Vector[InputInfo],
+    feeRate: FeeUnit,
+    spks: Vector[ScriptPubKey])
+    extends RawTxFinalizer {
+  override def buildTx(txBuilderResult: RawTxBuilderResult)(
+      implicit ec: ExecutionContext): Future[Transaction] = {
+    val dummyTxF =
+      TxUtil.addDummySigs(txBuilderResult.toBaseTransaction, inputInfos)
 
     val outputsAfterFeeF = dummyTxF.map { dummyTx =>
-      SubtractFeeFromOutputsFinalizer.subtractFees(dummyTx,
-                                                   feeRate,
-                                                   outputs.map(_.scriptPubKey))
+      SubtractFeeFromOutputsFinalizer.subtractFees(
+        dummyTx,
+        feeRate,
+        spks
+      )
     }
 
     outputsAfterFeeF.map { outputsAfterFee =>
-      BaseTransaction(version, inputs, outputsAfterFee, lockTime)
+      txBuilderResult.toBaseTransaction.copy(outputs = outputsAfterFee)
     }
   }
 }
@@ -312,12 +350,10 @@ object SubtractFeeFromOutputsFinalizer {
       spks: Vector[ScriptPubKey]): Vector[TransactionOutput] = {
     val fee = feeRate.calc(tx)
 
-    val outputs = tx.outputs.zipWithIndex.filter {
-      case (output, _) => spks.contains(output.scriptPubKey)
-    }
-    val unchangedOutputs = tx.outputs.zipWithIndex.filterNot {
-      case (output, _) => spks.contains(output.scriptPubKey)
-    }
+    val (outputs, unchangedOutputs) =
+      tx.outputs.zipWithIndex.toVector.partition {
+        case (output, _) => spks.contains(output.scriptPubKey)
+      }
 
     val feePerOutput = Satoshis(Int64(fee.satoshis.toLong / outputs.length))
     val feeRemainder = Satoshis(Int64(fee.satoshis.toLong % outputs.length))
@@ -334,6 +370,78 @@ object SubtractFeeFromOutputsFinalizer {
       .dropRight(1)
       .:+((newLastOutput, lastOutputIndex))
 
-    (newOutputs ++ unchangedOutputs).sortBy(_._2).map(_._1).toVector
+    (newOutputs ++ unchangedOutputs).sortBy(_._2).map(_._1)
+  }
+}
+
+case class P2WPKHSubtractFeesFromOutputsFinalizer(
+    feeRate: FeeUnit,
+    spks: Vector[ScriptPubKey])
+    extends RawTxFinalizer {
+  override def buildTx(txBuilderResult: RawTxBuilderResult)(
+      implicit ec: ExecutionContext): Future[Transaction] = {
+    val dummyTxWit = TransactionWitness(
+      Vector.fill(txBuilderResult.inputs.length)(
+        P2WPKHWitnessV0(ECPublicKey.freshPublicKey, DummyECDigitalSignature)))
+
+    val wtx = txBuilderResult.toWitnessTransaction(dummyTxWit)
+
+    val outputsAfterFee =
+      SubtractFeeFromOutputsFinalizer.subtractFees(wtx, feeRate, spks)
+
+    Future.successful(
+      txBuilderResult.toBaseTransaction.copy(outputs = outputsAfterFee))
+  }
+}
+
+// Note: spendingVBytes may be 0
+case class DualFundingTxFinalizer(
+    spendingVBytes: Long,
+    feeRate: FeeUnit,
+    fundingSPK: ScriptPubKey,
+    inputInfos: Vector[InputInfo])
+    extends RawTxFinalizer {
+  override def buildTx(txBuilderResult: RawTxBuilderResult)(
+      implicit ec: ExecutionContext): Future[Transaction] = {
+    val changeSPKs =
+      txBuilderResult.outputs.map(_.scriptPubKey).filterNot(_ == fundingSPK)
+
+    val addFutureFee = AddFutureFeeFinalizer(
+      fundingSPK,
+      Satoshis(feeRate.toLong * spendingVBytes),
+      changeSPKs)
+    val subtractFee =
+      SubtractFeeFromOutputsFinalizer(inputInfos, feeRate, changeSPKs)
+    val filterDust = FilterDustFinalizer
+
+    addFutureFee
+      .andThen(subtractFee)
+      .andThen(filterDust)
+      .buildTx(txBuilderResult)
+  }
+}
+
+case class P2WPKHDualFundingTxFinalizer(
+    spendingVBytes: Long,
+    feeRate: FeeUnit,
+    fundingSPK: ScriptPubKey)
+    extends RawTxFinalizer {
+  override def buildTx(txBuilderResult: RawTxBuilderResult)(
+      implicit ec: ExecutionContext): Future[Transaction] = {
+    val changeSPKs =
+      txBuilderResult.outputs.map(_.scriptPubKey).filterNot(_ == fundingSPK)
+
+    val addFutureFee = AddFutureFeeFinalizer(
+      fundingSPK,
+      Satoshis(feeRate.toLong * spendingVBytes),
+      changeSPKs)
+    val subtractFee =
+      P2WPKHSubtractFeesFromOutputsFinalizer(feeRate, changeSPKs)
+    val filterDust = FilterDustFinalizer
+
+    addFutureFee
+      .andThen(subtractFee)
+      .andThen(filterDust)
+      .buildTx(txBuilderResult)
   }
 }

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientIntegrationTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientIntegrationTest.scala
@@ -412,8 +412,7 @@ class DLCClientIntegrationTest extends BitcoindRpcTest {
           override def run(): Unit = {
             if (!mutualCloseTxP.isCompleted) {
               val fundingTxId = initDLC
-                .createUnsignedMutualClosePSBT(oracleSig)
-                .transaction
+                .createUnsignedMutualCloseTx(oracleSig)
                 .txIdBE
 
               clientF.foreach { client =>

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientIntegrationTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientIntegrationTest.scala
@@ -30,17 +30,7 @@ import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{P2WPKHV0InputInfo, ScriptSignatureParams}
 import org.bitcoins.crypto._
-import org.bitcoins.dlc.execution.{
-  CooperativeDLCOutcome,
-  DLCOutcome,
-  RefundDLCOutcome,
-  RefundDLCOutcomeWithClosing,
-  RefundDLCOutcomeWithDustClosing,
-  SetupDLC,
-  UnilateralDLCOutcome,
-  UnilateralDLCOutcomeWithClosing,
-  UnilateralDLCOutcomeWithDustClosing
-}
+import org.bitcoins.dlc.execution._
 import org.bitcoins.dlc.testgen.TestDLCClient
 import org.bitcoins.rpc.BitcoindException
 import org.bitcoins.testkit.dlc.DLCTestUtil

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientIntegrationTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientIntegrationTest.scala
@@ -323,8 +323,8 @@ class DLCClientIntegrationTest extends BitcoindRpcTest {
       override def run(): Unit = {
         if (!fundingTxP.isCompleted) {
           clientF.foreach { client =>
-            val fundingTxResultF = client.getRawTransaction(
-              dlcOffer.createUnsignedFundingTransaction.txIdBE)
+            val fundingTxResultF =
+              client.getRawTransaction(dlcOffer.fundingTxIdBE)
 
             fundingTxResultF.onComplete {
               case Success(fundingTxResult) =>

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
@@ -26,17 +26,7 @@ import org.bitcoins.core.wallet.builder.{
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{P2WPKHV0InputInfo, ScriptSignatureParams}
 import org.bitcoins.crypto._
-import org.bitcoins.dlc.execution.{
-  CooperativeDLCOutcome,
-  DLCOutcome,
-  RefundDLCOutcome,
-  RefundDLCOutcomeWithClosing,
-  RefundDLCOutcomeWithDustClosing,
-  SetupDLC,
-  UnilateralDLCOutcome,
-  UnilateralDLCOutcomeWithClosing,
-  UnilateralDLCOutcomeWithDustClosing
-}
+import org.bitcoins.dlc.execution._
 import org.bitcoins.dlc.testgen.TestDLCClient
 import org.bitcoins.testkit.core.gen.{ScriptGenerators, TransactionGenerators}
 import org.bitcoins.testkit.dlc.DLCTestUtil

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
@@ -471,9 +471,12 @@ class DLCClientTest extends BitcoinSAsyncTest {
   def runTests(
       exec: (Int, Int, Boolean) => Future[Assertion],
       local: Boolean): Future[Assertion] = {
-    val testFs = numOutcomesToTest.flatMap { numOutcomes =>
-      (0 until numOutcomes).map { outcomeIndex =>
-        exec(outcomeIndex, numOutcomes, local)
+    val testFs = numOutcomesToTest.map { numOutcomes =>
+      (0 until numOutcomes).foldLeft(Future.successful(succeed)) {
+        case (lastTestF, outcomeIndex) =>
+          lastTestF.flatMap { _ =>
+            exec(outcomeIndex, numOutcomes, local)
+          }
       }
     }
 

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
@@ -26,6 +26,18 @@ import org.bitcoins.core.wallet.builder.{
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{P2WPKHV0InputInfo, ScriptSignatureParams}
 import org.bitcoins.crypto._
+import org.bitcoins.dlc.execution.{
+  CooperativeDLCOutcome,
+  DLCOutcome,
+  RefundDLCOutcome,
+  RefundDLCOutcomeWithClosing,
+  RefundDLCOutcomeWithDustClosing,
+  SetupDLC,
+  UnilateralDLCOutcome,
+  UnilateralDLCOutcomeWithClosing,
+  UnilateralDLCOutcomeWithDustClosing
+}
+import org.bitcoins.dlc.testgen.TestDLCClient
 import org.bitcoins.testkit.core.gen.{ScriptGenerators, TransactionGenerators}
 import org.bitcoins.testkit.dlc.DLCTestUtil
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
@@ -198,15 +210,17 @@ class DLCClientTest extends BitcoinSAsyncTest {
 
   val feeRate: SatoshisPerVirtualByte = SatoshisPerVirtualByte(Satoshis.one)
 
-  def constructDLCClients(
-      numOutcomes: Int): (DLCClient, DLCClient, Vector[Sha256DigestBE]) = {
+  def constructDLCClients(numOutcomes: Int): (
+      TestDLCClient,
+      TestDLCClient,
+      Vector[Sha256DigestBE]) = {
     val outcomeHashes = DLCTestUtil.genOutcomes(numOutcomes)
 
     val (outcomes, remoteOutcomes) =
       DLCTestUtil.genContractInfos(outcomeHashes, totalInput)
 
     // Offer is local
-    val dlcOffer: DLCClient = DLCClient(
+    val dlcOffer: TestDLCClient = TestDLCClient(
       outcomes = outcomes,
       oraclePubKey = oraclePubKey,
       preCommittedR = preCommittedR,
@@ -228,7 +242,7 @@ class DLCClientTest extends BitcoinSAsyncTest {
     )
 
     // Accept is remote
-    val dlcAccept: DLCClient = DLCClient(
+    val dlcAccept: TestDLCClient = TestDLCClient(
       outcomes = remoteOutcomes,
       oraclePubKey = oraclePubKey,
       preCommittedR = preCommittedR,
@@ -294,8 +308,12 @@ class DLCClientTest extends BitcoinSAsyncTest {
     }
   }
 
-  def setupDLC(numOutcomes: Int): Future[
-    (SetupDLC, DLCClient, SetupDLC, DLCClient, Vector[Sha256DigestBE])] = {
+  def setupDLC(numOutcomes: Int): Future[(
+      SetupDLC,
+      TestDLCClient,
+      SetupDLC,
+      TestDLCClient,
+      Vector[Sha256DigestBE])] = {
     val (dlcOffer, dlcAccept, outcomeHashes) = constructDLCClients(numOutcomes)
 
     val offerSigReceiveP =

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/SetupDLCTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/SetupDLCTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.dlc
 import org.bitcoins.core.protocol.script.{P2PKHScriptPubKey, P2WSHWitnessV0}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPublicKey, Sha256DigestBE}
+import org.bitcoins.dlc.execution.{CETInfo, SetupDLC}
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import scodec.bits.ByteVector
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCClient.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCClient.scala
@@ -133,10 +133,13 @@ case class DLCClient(
     P2WSHWitnessV0(fundingSPK),
     ConditionalPath.NoCondition)
 
-  /** Returns the payouts for the signature as (toLocal, toRemote)  */
-  def getPayouts(
-      oracleSig: SchnorrDigitalSignature): (CurrencyUnit, CurrencyUnit) = {
-    dlcTxBuilder.getPayouts(oracleSig)
+  def getPayout(oracleSig: SchnorrDigitalSignature): CurrencyUnit = {
+    val (offerPayout, acceptPayout) = dlcTxBuilder.getPayouts(oracleSig)
+    if (isInitiator) {
+      offerPayout
+    } else {
+      acceptPayout
+    }
   }
 
   def createFundingTransactionSigs(): Future[FundingSignatures] = {

--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCClient.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCClient.scala
@@ -8,22 +8,17 @@ import org.bitcoins.commons.jsonmodels.dlc._
 import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency.CurrencyUnit
-import org.bitcoins.core.hd.BIP32Path
-import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
-import org.bitcoins.core.protocol.{Bech32Address, BitcoinAddress}
+import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.core.wallet.builder._
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto._
 import org.bitcoins.dlc.builder.DLCTxBuilder
 import org.bitcoins.dlc.execution.DLCExecutor
 import org.bitcoins.dlc.sign.DLCTxSigner
-import org.bitcoins.dlc.verify.DLCSignatureVerifier
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration.DurationInt
@@ -39,7 +34,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
   * @param nextAddressIndex The next unused address index for the provided extPrivKey
   * @param fundingUtxos This client's funding BitcoinUTXOSpendingInfo collection
   */
-case class DLCClient(
+case class DLCClient( // TODO: Move this to testgen package, rename to TestDLCClient, move DLCOutcome, SetupDLC to execution
     offer: DLCMessage.DLCOffer,
     accept: DLCMessage.DLCAcceptWithoutSigs,
     isInitiator: Boolean,
@@ -51,8 +46,6 @@ case class DLCClient(
 
   private val dlcTxBuilder = DLCTxBuilder(offer, accept)
 
-  private val dlcSigVerifier = DLCSignatureVerifier(dlcTxBuilder, isInitiator)
-
   private val dlcTxSigner = DLCTxSigner(dlcTxBuilder,
                                         isInitiator,
                                         extPrivKey,
@@ -60,12 +53,6 @@ case class DLCClient(
                                         fundingUtxos)
 
   private val dlcExecutor = DLCExecutor(dlcTxSigner)
-
-  private val remotePubKeys = if (isInitiator) {
-    accept.pubKeys
-  } else {
-    offer.pubKeys
-  }
 
   private val outcomes = if (isInitiator) {
     offer.contractInfo
@@ -75,111 +62,19 @@ case class DLCClient(
 
   val messages: Vector[Sha256DigestBE] = outcomes.keys.toVector
 
-  private val feeRate = offer.feeRate
-
   val timeouts: DLCTimeouts = offer.timeouts
 
-  val fundingPrivKey: ECPrivateKey =
-    extPrivKey
-      .deriveChildPrivKey(BIP32Path.fromString(s"m/0/$nextAddressIndex"))
-      .key
-
-  val cetToLocalPrivKey: ECPrivateKey =
-    extPrivKey
-      .deriveChildPrivKey(BIP32Path.fromString(s"m/0/${nextAddressIndex + 1}"))
-      .key
-
-  val finalPrivKey: ECPrivateKey =
-    extPrivKey
-      .deriveChildPrivKey(BIP32Path.fromString(s"m/0/${nextAddressIndex + 2}"))
-      .key
-
-  val fundingRemotePubKey: ECPublicKey = remotePubKeys.fundingKey
-
-  val cetToLocalRemotePubKey: ECPublicKey = remotePubKeys.toLocalCETKey
-
-  val finalRemoteScriptPubKey: ScriptPubKey =
-    remotePubKeys.finalAddress.scriptPubKey
-
-  val fundingPubKey: ECPublicKey = fundingPrivKey.publicKey
-
-  val fundingSPK: MultiSignatureScriptPubKey = {
-    val fundingKeys = if (isInitiator) {
-      Vector(fundingPubKey, fundingRemotePubKey)
-    } else {
-      Vector(fundingRemotePubKey, fundingPubKey)
-    }
-
-    MultiSignatureScriptPubKey(2, fundingKeys)
-  }
-
-  lazy val createUnsignedFundingTransaction: Transaction =
+  lazy val fundingTx: Transaction =
     Await.result(dlcTxBuilder.buildFundingTx, 5.seconds)
 
-  lazy val fundingTxId: DoubleSha256Digest =
-    createUnsignedFundingTransaction.txId
+  lazy val fundingTxIdBE: DoubleSha256DigestBE = fundingTx.txIdBE
 
-  lazy val fundingOutput: TransactionOutput =
-    createUnsignedFundingTransaction.outputs.head
-
-  lazy val fundingInputInfo: P2WSHV0InputInfo = P2WSHV0InputInfo(
-    TransactionOutPoint(fundingTxId, UInt32.zero),
-    fundingOutput.value,
-    P2WSHWitnessV0(fundingSPK),
-    ConditionalPath.NoCondition)
-
-  def getPayout(oracleSig: SchnorrDigitalSignature): CurrencyUnit = {
-    dlcTxSigner.getPayout(oracleSig)
-  }
-
-  def createFundingTransactionSigs(): Future[FundingSignatures] = {
-    dlcTxSigner.createFundingTxSigs()
-  }
-
-  def verifyRemoteFundingSigs(remoteSigs: FundingSignatures): Boolean = {
-    dlcSigVerifier.verifyRemoteFundingSigs(remoteSigs)
-  }
-
-  /** Creates a ready-to-sign PSBT for the Mutual Close tx
-    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#mutual-closing-transaction]]
-    *
-    * @param sig The oracle's signature for this contract
-    */
   def createUnsignedMutualCloseTx(sig: SchnorrDigitalSignature): Transaction = {
     val utxF = dlcTxBuilder.buildMutualCloseTx(sig)
 
     Await.result(utxF, 5.seconds)
   }
 
-  def createMutualCloseTx(
-      sig: SchnorrDigitalSignature,
-      fundingSig: PartialSignature): Future[Transaction] = {
-    dlcTxSigner.signMutualCloseTx(sig, fundingSig)
-  }
-
-  def verifyCETSig(outcome: Sha256DigestBE, sig: PartialSignature): Boolean = {
-    dlcSigVerifier.verifyCETSig(outcome, sig)
-  }
-
-  def verifyRefundSig(sig: PartialSignature): Boolean = {
-    dlcSigVerifier.verifyRefundSig(sig)
-  }
-
-  def createCETSigs: Future[CETSignatures] = {
-    dlcTxSigner.createCETSigs()
-  }
-
-  /** Executes DLC setup for the party responding to the initiator.
-    *
-    * This party is the first to send signatures but does not send funding
-    * tx signatures.
-    *
-    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Protocol.md#accept]]
-    *
-    * @param sendSigs The function by which this party sends their CET signatures to the initiator
-    * @param getSigs The future which becomes populated by the initiator's CET and funding signatures
-    *                (note that this will complete only after the receipt of this client's signatures)
-    */
   def setupDLCAccept(
       sendSigs: CETSignatures => Future[Unit],
       getSigs: Future[(CETSignatures, FundingSignatures)]): Future[SetupDLC] = {
@@ -189,200 +84,30 @@ case class DLCClient(
       remoteCetSigs <- dlcTxSigner.createCETSigs()
       _ <- sendSigs(remoteCetSigs)
       (cetSigs, fundingSigs) <- getSigs
-
-      localCetDataFs = cetSigs.outcomeSigs.map {
-        case (msg, sig) =>
-          for {
-            tx <- dlcTxSigner.signCET(msg, sig)
-            witness <- {
-              if (isInitiator) {
-                dlcTxBuilder.getOfferCETWitness(msg)
-              } else {
-                dlcTxBuilder.getAcceptCETWitness(msg)
-              }
-            }
-          } yield {
-            msg -> (tx, witness)
-          }
-      }
-      localCetData <- Future.sequence(localCetDataFs).map(_.toMap)
-
-      remoteCETDataFs = messages.map { msg =>
-        if (isInitiator) {
-          for {
-            utx <- dlcTxBuilder.buildAcceptCET(msg)
-            witness <- dlcTxBuilder.getAcceptCETWitness(msg)
-          } yield msg -> (utx, witness)
-        } else {
-          for {
-            utx <- dlcTxBuilder.buildOfferCET(msg)
-            witness <- dlcTxBuilder.getOfferCETWitness(msg)
-          } yield msg -> (utx, witness)
-        }
-      }
-      remoteCETData <- Future.sequence(remoteCETDataFs).map(_.toMap)
-
-      fundingTx <- dlcTxSigner.signFundingTx(fundingSigs)
-      refundTx <- dlcTxSigner.signRefundTx(cetSigs.refundSig)
+      setupDLC <- dlcExecutor.setupDLCAccept(cetSigs, fundingSigs)
     } yield {
-      val cetInfos = messages.map { msg =>
-        val (localCet, localWitness) = localCetData(msg)
-        val (remoteCet, remoteWitness) = remoteCETData(msg)
-        msg -> CETInfo(localCet, localWitness, remoteCet.txIdBE, remoteWitness)
-      }.toMap
-
-      SetupDLC(
-        fundingTx,
-        cetInfos,
-        refundTx
-      )
+      setupDLC
     }
   }
 
-  /** Executes DLC setup for the initiating party.
-    *
-    * This party is the first to send signatures but does not send funding
-    * tx signatures.
-    *
-    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Protocol.md#sign]]
-    *
-    * @param getSigs The future which becomes populated with the other party's CET signatures
-    * @param sendSigs The function by which this party sends their CET and funding signatures to the other party
-    */
   def setupDLCOffer(
       getSigs: Future[CETSignatures],
       sendSigs: (CETSignatures, FundingSignatures) => Future[Unit],
       getFundingTx: Future[Transaction]): Future[SetupDLC] = {
     require(isInitiator, "You should call setupDLCAccept")
 
-    getSigs.flatMap {
-      case CETSignatures(outcomeSigs, refundSig) =>
-        // Construct all CETs
-        val localCetDataFs = outcomeSigs.map {
-          case (msg, sig) =>
-            for {
-              tx <- dlcTxSigner.signCET(msg, sig)
-              witness <- {
-                if (isInitiator) {
-                  dlcTxBuilder.getOfferCETWitness(msg)
-                } else {
-                  dlcTxBuilder.getAcceptCETWitness(msg)
-                }
-              }
-            } yield {
-              msg -> (tx, witness)
-            }
-        }
-        val remoteCETDataFs = messages.map { msg =>
-          if (isInitiator) {
-            for {
-              utx <- dlcTxBuilder.buildAcceptCET(msg)
-              witness <- dlcTxBuilder.getAcceptCETWitness(msg)
-            } yield msg -> (utx, witness)
-          } else {
-            for {
-              utx <- dlcTxBuilder.buildOfferCET(msg)
-              witness <- dlcTxBuilder.getOfferCETWitness(msg)
-            } yield msg -> (utx, witness)
-          }
-        }
-
-        for {
-          localCetData <- Future.sequence(localCetDataFs).map(_.toMap)
-          remoteCetData <- Future.sequence(remoteCETDataFs).map(_.toMap)
-          refundTx <- dlcTxSigner.signRefundTx(refundSig)
-          cetSigs <- dlcTxSigner.createCETSigs()
-          localFundingSigs <- dlcTxSigner.createFundingTxSigs()
-          _ <- sendSigs(cetSigs, localFundingSigs)
-          fundingTx <- getFundingTx
-        } yield {
-          val cetInfos = messages.map { msg =>
-            val (localCet, localWitness) = localCetData(msg)
-            val (remoteCet, remoteWitness) = remoteCetData(msg)
-            msg -> CETInfo(localCet,
-                           localWitness,
-                           remoteCet.txIdBE,
-                           remoteWitness)
-          }.toMap
-
-          SetupDLC(
-            fundingTx,
-            cetInfos,
-            refundTx
-          )
-        }
+    for {
+      cetSigs <- getSigs
+      setupDLCWithoutFundingTxSigs <- dlcExecutor.setupDLCOffer(cetSigs)
+      cetSigs <- dlcTxSigner.createCETSigs()
+      localFundingSigs <- dlcTxSigner.createFundingTxSigs()
+      _ <- sendSigs(cetSigs, localFundingSigs)
+      fundingTx <- getFundingTx
+    } yield {
+      setupDLCWithoutFundingTxSigs.copy(fundingTx = fundingTx)
     }
   }
 
-  def constructClosingTx(
-      spendingInfo: ScriptSignatureParams[InputInfo],
-      msg: Sha256DigestBE,
-      spendsToLocal: Boolean,
-      sweepSPK: WitnessScriptPubKey = P2WPKHWitnessSPKV0(finalPrivKey.publicKey)): Future[
-    Option[Transaction]] = {
-    // If spendsToLocal, use payout as value, otherwise subtract fee
-    val spendingTxOptF = if (spendsToLocal) {
-      val payoutValue = outcomes(msg)
-
-      if (payoutValue < Policy.dustThreshold) {
-        Future.successful(None)
-      } else {
-        val inputs = InputUtil.calcSequenceForInputs(Vector(spendingInfo))
-        val lockTime = TxUtil.calcLockTime(Vector(spendingInfo)).get
-        val builder = RawTxBuilder().setLockTime(lockTime) ++= inputs += TransactionOutput(
-          payoutValue,
-          sweepSPK)
-
-        val finalizer = SanityCheckFinalizer(Vector(spendingInfo.inputInfo),
-                                             Vector(sweepSPK),
-                                             feeRate)
-          .andThen(AddWitnessDataFinalizer(Vector(spendingInfo.inputInfo)))
-
-        val utxF = finalizer.buildTx(builder.result())
-
-        val signedTxF = utxF.flatMap { utx =>
-          RawTxSigner.sign(utx, Vector(spendingInfo), feeRate)
-        }
-        signedTxF.map(Some(_))
-      }
-    } else {
-      val lockTime = TxUtil.calcLockTime(Vector(spendingInfo))
-      val inputs = InputUtil.calcSequenceForInputs(Vector(spendingInfo))
-
-      val builder = RawTxBuilder().setLockTime(lockTime.get) += TransactionOutput(
-        spendingInfo.output.value,
-        sweepSPK) ++= inputs
-
-      SubtractFeeFromOutputsFinalizer(Vector(spendingInfo.inputInfo),
-                                      feeRate,
-                                      Vector(sweepSPK))
-        .andThen(
-          SanityCheckFinalizer(Vector(spendingInfo.inputInfo),
-                               Vector(sweepSPK),
-                               feeRate))
-        .buildTx(builder.result())
-        .flatMap(utx => RawTxSigner.sign(utx, Vector(spendingInfo), feeRate))
-        .map(Some(_))
-    }
-
-    spendingTxOptF.foreach(txOpt =>
-      logger.info(s"Closing Tx: ${txOpt.map(_.hex)}"))
-
-    spendingTxOptF
-  }
-
-  def createMutualCloseSig(
-      oracleSig: SchnorrDigitalSignature): Future[DLCMutualCloseSig] = {
-    dlcTxSigner.createMutualCloseTxSig(oracleSig)
-  }
-
-  /** Initiates a Mutual Close by offering signatures to the counter-party
-    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#mutual-closing-transaction]]
-    *
-    * @param sig The oracle's signature on this contract's event
-    * @param sendSigs The function by which signatures are sent to the counter-party
-    * @param getMutualCloseTx The Future which becomes populated with the published Mutual Close tx
-    */
   def initiateMutualClose(
       dlcSetup: SetupDLC,
       sig: SchnorrDigitalSignature,
@@ -402,11 +127,6 @@ case class DLCClient(
     }
   }
 
-  /** Responds to initiation of a Mutual Close by constructing and publishing the Mutual Close tx
-    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#mutual-closing-transaction]]
-    *
-    * @param getSigs The Future which becomes populated with the initiating party's signatures
-    */
   def executeMutualClose(
       dlcSetup: SetupDLC,
       getSigs: Future[(SchnorrDigitalSignature, PartialSignature)]): Future[
@@ -421,11 +141,6 @@ case class DLCClient(
     }
   }
 
-  /** Constructs and executes on the unilateral spending branch of a DLC
-    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#closing-transaction-unilateral]]
-    *
-    * @return Each transaction published and its spending info
-    */
   def executeUnilateralDLC(
       dlcSetup: SetupDLC,
       oracleSigF: Future[SchnorrDigitalSignature]): Future[
@@ -435,15 +150,6 @@ case class DLCClient(
     }
   }
 
-  def executeUnilateralDLC(
-      dlcSetup: SetupDLC,
-      oracleSig: SchnorrDigitalSignature): Future[UnilateralDLCOutcome] = {
-    dlcExecutor.executeUnilateralDLC(dlcSetup, oracleSig)
-  }
-
-  /** Constructs the closing transaction on the to_remote output of a counter-party's unilateral CET broadcast
-    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#closing-transaction-unilateral]]
-    */
   def executeRemoteUnilateralDLC(
       dlcSetup: SetupDLC,
       publishedCET: Transaction,
@@ -451,23 +157,12 @@ case class DLCClient(
     dlcExecutor.executeRemoteUnilateralDLC(dlcSetup, publishedCET, sweepSPK)
   }
 
-  /** Constructs and executes on the justice spending branch of a DLC
-    * where a published CET has timed out.
-    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#closing-transaction-penalty]]
-    *
-    * @return Each transaction published and its spending info
-    */
   def executeJusticeDLC(
       dlcSetup: SetupDLC,
       timedOutCET: Transaction): Future[UnilateralDLCOutcome] = {
     dlcExecutor.executeJusticeDLC(dlcSetup, timedOutCET)
   }
 
-  /** Constructs and executes on the refund spending branch of a DLC
-    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#refund-transaction]]
-    *
-    * @return Each transaction published and its spending info
-    */
   def executeRefundDLC(dlcSetup: SetupDLC): Future[RefundDLCOutcome] = {
     dlcExecutor.executeRefundDLC(dlcSetup)
   }
@@ -608,53 +303,5 @@ object DLCClient {
       remoteChangeSPK = remoteChangeSPK,
       network = network
     )
-  }
-
-  def fromOffer(
-      offer: DLCMessage.DLCOffer,
-      extPrivKey: ExtPrivateKey,
-      nextAddressIndex: Int,
-      fundingUtxos: Vector[ScriptSignatureParams[InputInfo]],
-      totalCollateral: CurrencyUnit,
-      changeSPK: P2WPKHWitnessSPKV0,
-      network: BitcoinNetwork)(implicit ec: ExecutionContext): DLCClient = {
-    val accept = DLCMessage.DLCAcceptWithoutSigs(
-      totalCollateral.satoshis,
-      DLCPublicKeys.fromExtPrivKeyAndIndex(extPrivKey,
-                                           nextAddressIndex,
-                                           network),
-      fundingUtxos.map(_.outputReference),
-      Bech32Address(changeSPK, network),
-      offer.eventId
-    )
-
-    DLCClient(offer = offer,
-              accept = accept,
-              isInitiator = false,
-              extPrivKey = extPrivKey,
-              nextAddressIndex = nextAddressIndex,
-              fundingUtxos = fundingUtxos)
-  }
-
-  def fromOfferAndAccept(
-      offer: DLCMessage.DLCOffer,
-      accept: DLCMessage.DLCAccept,
-      extPrivKey: ExtPrivateKey,
-      nextAddressIndex: Int,
-      fundingUtxos: Vector[ScriptSignatureParams[InputInfo]])(
-      implicit ec: ExecutionContext): DLCClient = {
-    val acceptWithoutSigs = DLCMessage.DLCAcceptWithoutSigs(
-      accept.totalCollateral,
-      accept.pubKeys,
-      accept.fundingInputs,
-      accept.changeAddress,
-      accept.eventId)
-
-    DLCClient(offer = offer,
-              accept = acceptWithoutSigs,
-              isInitiator = true,
-              extPrivKey = extPrivKey,
-              nextAddressIndex = nextAddressIndex,
-              fundingUtxos = fundingUtxos)
   }
 }

--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCClient.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCClient.scala
@@ -129,12 +129,7 @@ case class DLCClient(
     ConditionalPath.NoCondition)
 
   def getPayout(oracleSig: SchnorrDigitalSignature): CurrencyUnit = {
-    val (offerPayout, acceptPayout) = dlcTxBuilder.getPayouts(oracleSig)
-    if (isInitiator) {
-      offerPayout
-    } else {
-      acceptPayout
-    }
+    dlcTxSigner.getPayout(oracleSig)
   }
 
   def createFundingTransactionSigs(): Future[FundingSignatures] = {

--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCTxBuilder.scala
@@ -1,0 +1,3 @@
+package org.bitcoins.dlc
+
+object DLCTxBuilder {}

--- a/dlc/src/main/scala/org/bitcoins/dlc/DLCTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/DLCTxBuilder.scala
@@ -1,3 +1,0 @@
-package org.bitcoins.dlc
-
-object DLCTxBuilder {}

--- a/dlc/src/main/scala/org/bitcoins/dlc/SetupDLC.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/SetupDLC.scala
@@ -36,3 +36,18 @@ case class CETInfo(
     witness: P2WSHWitnessV0,
     remoteTxid: DoubleSha256DigestBE,
     remoteWitness: P2WSHWitnessV0)
+
+object CETInfo {
+
+  def mapFromMaps(
+      localCetData: Map[Sha256DigestBE, (Transaction, P2WSHWitnessV0)],
+      remoteCetData: Map[Sha256DigestBE, (Transaction, P2WSHWitnessV0)]): Map[
+    Sha256DigestBE,
+    CETInfo] = {
+    localCetData.map {
+      case (msg, (localCet, localWitness)) =>
+        val (remoteCet, remoteWitness) = remoteCetData(msg)
+        msg -> CETInfo(localCet, localWitness, remoteCet.txIdBE, remoteWitness)
+    }
+  }
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCCETBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCCETBuilder.scala
@@ -2,7 +2,7 @@ package org.bitcoins.dlc.builder
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{ContractInfo, OracleInfo}
 import org.bitcoins.commons.jsonmodels.dlc.DLCTimeouts
-import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.ScriptNumber
@@ -54,11 +54,8 @@ case class DLCCETBuilder(
       fundingPubKey: ECPublicKey,
       toLocalCETKey: ECPublicKey,
       otherToLocalCETKey: ECPublicKey): P2PKWithTimeoutScriptPubKey = {
-    val tweak = CryptoUtil.sha256(toLocalCETKey.bytes).flip
-
-    val tweakPubKey = ECPrivateKey.fromBytes(tweak.bytes).publicKey
-
-    val pubKey = sigPubKeys(msg).add(fundingPubKey).add(tweakPubKey)
+    val pubKey =
+      DLCTxBuilder.tweakedPubKey(fundingPubKey, toLocalCETKey, sigPubKeys(msg))
 
     P2PKWithTimeoutScriptPubKey(
       pubKey = pubKey,

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCCETBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCCETBuilder.scala
@@ -1,0 +1,141 @@
+package org.bitcoins.dlc.builder
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{ContractInfo, OracleInfo}
+import org.bitcoins.commons.jsonmodels.dlc.DLCTimeouts
+import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.protocol.script._
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.script.constant.ScriptNumber
+import org.bitcoins.core.wallet.builder.{
+  AddWitnessDataFinalizer,
+  FilterDustFinalizer,
+  RawTxBuilder
+}
+import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.utxo.{ConditionalPath, P2WSHV0InputInfo}
+import org.bitcoins.crypto._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class DLCCETBuilder(
+    offerOutcomes: ContractInfo,
+    totalInput: CurrencyUnit,
+    offerFundingKey: ECPublicKey,
+    offerToLocalKey: ECPublicKey,
+    offerFinalSPK: ScriptPubKey,
+    acceptFundingKey: ECPublicKey,
+    acceptToLocalKey: ECPublicKey,
+    acceptFinalSPK: ScriptPubKey,
+    timeouts: DLCTimeouts,
+    feeRate: FeeUnit,
+    oracleInfo: OracleInfo,
+    fundingOutputRef: OutputReference) {
+  require(totalInput >= offerOutcomes.values.max,
+          "Total collateral must add up to max winnings")
+
+  val OracleInfo(oraclePubKey: SchnorrPublicKey, preCommittedR: SchnorrNonce) =
+    oracleInfo
+
+  val sigPubKeys: Map[Sha256DigestBE, ECPublicKey] = offerOutcomes.keys.map {
+    msg =>
+      msg -> oraclePubKey.computeSigPoint(msg.bytes, preCommittedR)
+  }.toMap
+
+  val acceptOutcomes: ContractInfo = ContractInfo(offerOutcomes.map {
+    case (hash, amt) => (hash, (totalInput - amt).satoshis)
+  })
+
+  private val fundingOutPoint = fundingOutputRef.outPoint
+
+  private val fundingInfo = P2WSHV0InputInfo(
+    outPoint = fundingOutPoint,
+    amount = fundingOutputRef.output.value,
+    scriptWitness = P2WSHWitnessV0(
+      MultiSignatureScriptPubKey(2, Vector(offerFundingKey, acceptFundingKey))),
+    conditionalPath = ConditionalPath.NoCondition
+  )
+
+  private def buildToLocalP2PK(
+      msg: Sha256DigestBE,
+      fundingPubKey: ECPublicKey,
+      toLocalCETKey: ECPublicKey,
+      otherToLocalCETKey: ECPublicKey): P2PKWithTimeoutScriptPubKey = {
+    val tweak = CryptoUtil.sha256(toLocalCETKey.bytes).flip
+
+    val tweakPubKey = ECPrivateKey.fromBytes(tweak.bytes).publicKey
+
+    val pubKey = sigPubKeys(msg).add(fundingPubKey).add(tweakPubKey)
+
+    P2PKWithTimeoutScriptPubKey(
+      pubKey = pubKey,
+      lockTime = ScriptNumber(timeouts.penaltyTimeout.toLong),
+      timeoutPubKey = otherToLocalCETKey
+    )
+  }
+
+  def buildOfferToLocalP2PK(
+      msg: Sha256DigestBE): P2PKWithTimeoutScriptPubKey = {
+    buildToLocalP2PK(msg, offerFundingKey, offerToLocalKey, acceptToLocalKey)
+  }
+
+  def buildAcceptToLocalP2PK(
+      msg: Sha256DigestBE): P2PKWithTimeoutScriptPubKey = {
+    buildToLocalP2PK(msg, acceptFundingKey, acceptToLocalKey, offerToLocalKey)
+  }
+
+  def buildCET(msg: Sha256DigestBE, isOffer: Boolean)(
+      implicit ec: ExecutionContext): Future[WitnessTransaction] = {
+    val builder = RawTxBuilder().setLockTime(timeouts.contractMaturity.toUInt32)
+
+    val toLocalSPK = if (isOffer) {
+      P2WSHWitnessSPKV0(buildOfferToLocalP2PK(msg))
+    } else {
+      P2WSHWitnessSPKV0(buildAcceptToLocalP2PK(msg))
+    }
+
+    val toLocalClosingFee = Satoshis(
+      feeRate.toLong * DLCTxBuilder.approxToLocalClosingVBytes)
+
+    val (toLocalValue, toRemoteValue) = if (isOffer) {
+      (offerOutcomes(msg), acceptOutcomes(msg))
+    } else {
+      (acceptOutcomes(msg), offerOutcomes(msg))
+    }
+
+    val toRemoteSPK = if (isOffer) {
+      acceptFinalSPK
+    } else {
+      offerFinalSPK
+    }
+
+    builder += TransactionOutput(toLocalValue + toLocalClosingFee, toLocalSPK)
+    builder += TransactionOutput(toRemoteValue, toRemoteSPK)
+
+    builder += TransactionInput(fundingOutPoint,
+                                EmptyScriptSignature,
+                                TransactionConstants.disableRBFSequence)
+
+    val finalizer =
+      FilterDustFinalizer.andThen(AddWitnessDataFinalizer(Vector(fundingInfo)))
+
+    val txF = finalizer.buildTx(builder.result())
+
+    txF.flatMap {
+      case _: NonWitnessTransaction =>
+        Future.failed(
+          new RuntimeException(
+            "Something went wrong with AddWitnessDataFinalizer"))
+      case wtx: WitnessTransaction => Future.successful(wtx)
+    }
+  }
+
+  def buildOfferCET(msg: Sha256DigestBE)(
+      implicit ec: ExecutionContext): Future[WitnessTransaction] = {
+    buildCET(msg, isOffer = true)
+  }
+
+  def buildAcceptCET(msg: Sha256DigestBE)(
+      implicit ec: ExecutionContext): Future[WitnessTransaction] = {
+    buildCET(msg, isOffer = false)
+  }
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCCETBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCCETBuilder.scala
@@ -19,7 +19,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class DLCCETBuilder(
     offerOutcomes: ContractInfo,
-    totalInput: CurrencyUnit,
+    acceptOutcomes: ContractInfo,
     offerFundingKey: ECPublicKey,
     offerToLocalKey: ECPublicKey,
     offerFinalSPK: ScriptPubKey,
@@ -30,8 +30,6 @@ case class DLCCETBuilder(
     feeRate: FeeUnit,
     oracleInfo: OracleInfo,
     fundingOutputRef: OutputReference) {
-  require(totalInput >= offerOutcomes.values.max,
-          "Total collateral must add up to max winnings")
 
   val OracleInfo(oraclePubKey: SchnorrPublicKey, preCommittedR: SchnorrNonce) =
     oracleInfo
@@ -40,10 +38,6 @@ case class DLCCETBuilder(
     msg =>
       msg -> oraclePubKey.computeSigPoint(msg.bytes, preCommittedR)
   }.toMap
-
-  val acceptOutcomes: ContractInfo = ContractInfo(offerOutcomes.map {
-    case (hash, amt) => (hash, (totalInput - amt).satoshis)
-  })
 
   private val fundingOutPoint = fundingOutputRef.outPoint
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCCETBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCCETBuilder.scala
@@ -17,6 +17,10 @@ import org.bitcoins.crypto._
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/** Responsible for constructing unsigned
+  * Contract Execution Transactions (CETs)
+  * and their ScriptPubKeys
+  */
 case class DLCCETBuilder(
     offerOutcomes: ContractInfo,
     acceptOutcomes: ContractInfo,
@@ -64,16 +68,25 @@ case class DLCCETBuilder(
     )
   }
 
+  /** Constructs the initiator's to_local ScriptPubKey (not
+    * yet wrapped in a P2WSH) for a given outcome hash
+    */
   def buildOfferToLocalP2PK(
       msg: Sha256DigestBE): P2PKWithTimeoutScriptPubKey = {
     buildToLocalP2PK(msg, offerFundingKey, offerToLocalKey, acceptToLocalKey)
   }
 
+  /** Constructs the non-initiator's to_local ScriptPubKey
+    * (not yet wrapped in a P2WSH) for a given outcome hash
+    */
   def buildAcceptToLocalP2PK(
       msg: Sha256DigestBE): P2PKWithTimeoutScriptPubKey = {
     buildToLocalP2PK(msg, acceptFundingKey, acceptToLocalKey, offerToLocalKey)
   }
 
+  /** Constructs a given parties Contract Execution Transaction
+    * (CET) for a given outcome hash
+    */
   def buildCET(msg: Sha256DigestBE, isOffer: Boolean)(
       implicit ec: ExecutionContext): Future[WitnessTransaction] = {
     val builder = RawTxBuilder().setLockTime(timeouts.contractMaturity.toUInt32)
@@ -120,11 +133,17 @@ case class DLCCETBuilder(
     }
   }
 
+  /** Constructs the initiator's unsigned Contract Execution
+    * Transaction (CET) for a given outcome hash
+    */
   def buildOfferCET(msg: Sha256DigestBE)(
       implicit ec: ExecutionContext): Future[WitnessTransaction] = {
     buildCET(msg, isOffer = true)
   }
 
+  /** Constructs the non-initiator's unsigned Contract Execution
+    * Transaction (CET) for a given outcome hash
+    */
   def buildAcceptCET(msg: Sha256DigestBE)(
       implicit ec: ExecutionContext): Future[WitnessTransaction] = {
     buildCET(msg, isOffer = false)

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCFundingTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCFundingTxBuilder.scala
@@ -1,0 +1,77 @@
+package org.bitcoins.dlc.builder
+
+import org.bitcoins.core.currency.CurrencyUnit
+import org.bitcoins.core.protocol.script.{
+  EmptyScriptSignature,
+  MultiSignatureScriptPubKey,
+  P2WSHWitnessSPKV0,
+  ScriptPubKey
+}
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.wallet.builder.{
+  P2WPKHDualFundingTxFinalizer,
+  RawTxBuilderWithFinalizer
+}
+import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.crypto.ECPublicKey
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class DLCFundingTxBuilder(
+    offerFundingKey: ECPublicKey,
+    acceptFundingKey: ECPublicKey,
+    feeRate: FeeUnit,
+    offerInput: CurrencyUnit,
+    acceptInput: CurrencyUnit,
+    offerFundingInputs: Vector[OutputReference],
+    acceptFundingInputs: Vector[OutputReference],
+    offerChangeSPK: ScriptPubKey,
+    acceptChangeSPK: ScriptPubKey) {
+  val totalInput: CurrencyUnit = offerInput + acceptInput
+
+  val offerTotalFunding: CurrencyUnit =
+    offerFundingInputs.map(_.output.value).sum
+
+  val acceptTotalFunding: CurrencyUnit =
+    acceptFundingInputs.map(_.output.value).sum
+
+  require(
+    offerTotalFunding >= offerInput,
+    "Offer funding inputs must add up to at least offer's total collateral")
+  require(
+    acceptTotalFunding >= acceptInput,
+    "Accept funding inputs must add up to at least accept's total collateral")
+
+  val fundingMultiSig: MultiSignatureScriptPubKey =
+    MultiSignatureScriptPubKey(2, Vector(offerFundingKey, acceptFundingKey))
+
+  val fundingSPK: P2WSHWitnessSPKV0 = P2WSHWitnessSPKV0(fundingMultiSig)
+
+  private val spendingFee = DLCTxBuilder.approxCETVBytes + DLCTxBuilder.approxToLocalClosingVBytes
+
+  val fundingTxFinalizer: P2WPKHDualFundingTxFinalizer =
+    P2WPKHDualFundingTxFinalizer(spendingFee, feeRate, fundingSPK)
+
+  def buildFundingTx()(implicit ec: ExecutionContext): Future[Transaction] = {
+    val builder = RawTxBuilderWithFinalizer(fundingTxFinalizer)
+
+    builder += TransactionOutput(totalInput, fundingSPK)
+    builder += TransactionOutput(offerTotalFunding - offerInput, offerChangeSPK)
+    builder += TransactionOutput(acceptTotalFunding - acceptInput,
+                                 acceptChangeSPK)
+
+    offerFundingInputs.foreach { ref =>
+      builder += TransactionInput(ref.outPoint,
+                                  EmptyScriptSignature,
+                                  TransactionConstants.sequence)
+    }
+
+    acceptFundingInputs.foreach { ref =>
+      builder += TransactionInput(ref.outPoint,
+                                  EmptyScriptSignature,
+                                  TransactionConstants.sequence)
+    }
+
+    builder.buildTx()
+  }
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCMutualCloseTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCMutualCloseTxBuilder.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.dlc.builder
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{ContractInfo, OracleInfo}
-import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.protocol.script.{EmptyScriptSignature, ScriptPubKey}
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.wallet.builder.{FilterDustFinalizer, RawTxBuilder}

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCMutualCloseTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCMutualCloseTxBuilder.scala
@@ -22,22 +22,12 @@ case class DLCMutualCloseTxBuilder(
     msg -> oraclePubKey.computeSigPoint(msg.bytes, preCommittedR)
   }.toMap
 
-  def getPayouts(
-      oracleSig: SchnorrDigitalSignature): (CurrencyUnit, CurrencyUnit) = {
-    sigPubKeys.find(_._2 == oracleSig.sig.getPublicKey) match {
-      case Some((hash, _)) =>
-        (offerOutcomes(hash), acceptOutcomes(hash))
-      case None =>
-        throw new IllegalArgumentException(
-          s"Signature does not correspond to a possible outcome! $oracleSig")
-    }
-  }
-
   def buildMutualCloseTx(sig: SchnorrDigitalSignature)(
       implicit ec: ExecutionContext): Future[Transaction] = {
     val builder = RawTxBuilder()
 
-    val (offerPayout, acceptPayout) = getPayouts(sig)
+    val (offerPayout, acceptPayout) =
+      DLCTxBuilder.getPayouts(sig, sigPubKeys, offerOutcomes, acceptOutcomes)
 
     builder += TransactionOutput(offerPayout, offerFinalSPK)
     builder += TransactionOutput(acceptPayout, acceptFinalSPK)

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCMutualCloseTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCMutualCloseTxBuilder.scala
@@ -1,0 +1,51 @@
+package org.bitcoins.dlc.builder
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{ContractInfo, OracleInfo}
+import org.bitcoins.core.currency.CurrencyUnit
+import org.bitcoins.core.protocol.script.{EmptyScriptSignature, ScriptPubKey}
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.wallet.builder.{FilterDustFinalizer, RawTxBuilder}
+import org.bitcoins.crypto.SchnorrDigitalSignature
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class DLCMutualCloseTxBuilder(
+    oracleInfo: OracleInfo,
+    offerFinalSPK: ScriptPubKey,
+    offerOutcomes: ContractInfo,
+    acceptFinalSPK: ScriptPubKey,
+    acceptOutcomes: ContractInfo,
+    fundingOutPoint: TransactionOutPoint) {
+  private val OracleInfo(oraclePubKey, preCommittedR) = oracleInfo
+
+  private val sigPubKeys = offerOutcomes.keys.map { msg =>
+    msg -> oraclePubKey.computeSigPoint(msg.bytes, preCommittedR)
+  }.toMap
+
+  def getPayouts(
+      oracleSig: SchnorrDigitalSignature): (CurrencyUnit, CurrencyUnit) = {
+    sigPubKeys.find(_._2 == oracleSig.sig.getPublicKey) match {
+      case Some((hash, _)) =>
+        (offerOutcomes(hash), acceptOutcomes(hash))
+      case None =>
+        throw new IllegalArgumentException(
+          s"Signature does not correspond to a possible outcome! $oracleSig")
+    }
+  }
+
+  def buildMutualCloseTx(sig: SchnorrDigitalSignature)(
+      implicit ec: ExecutionContext): Future[Transaction] = {
+    val builder = RawTxBuilder()
+
+    val (offerPayout, acceptPayout) = getPayouts(sig)
+
+    builder += TransactionOutput(offerPayout, offerFinalSPK)
+    builder += TransactionOutput(acceptPayout, acceptFinalSPK)
+
+    builder += TransactionInput(fundingOutPoint,
+                                EmptyScriptSignature,
+                                TransactionConstants.sequence)
+
+    FilterDustFinalizer.buildTx(builder.result())
+  }
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCMutualCloseTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCMutualCloseTxBuilder.scala
@@ -8,6 +8,7 @@ import org.bitcoins.crypto.SchnorrDigitalSignature
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/** Responsible for constructing unsigned DLC mutual close transactions */
 case class DLCMutualCloseTxBuilder(
     oracleInfo: OracleInfo,
     offerFinalSPK: ScriptPubKey,
@@ -21,6 +22,7 @@ case class DLCMutualCloseTxBuilder(
     msg -> oraclePubKey.computeSigPoint(msg.bytes, preCommittedR)
   }.toMap
 
+  /** Constructs an unsigned mutual close transaction given an oracle signature */
   def buildMutualCloseTx(sig: SchnorrDigitalSignature)(
       implicit ec: ExecutionContext): Future[Transaction] = {
     val builder = RawTxBuilder()

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCRefundTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCRefundTxBuilder.scala
@@ -20,6 +20,7 @@ import org.bitcoins.crypto.ECPublicKey
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/** Responsible for constructing the unsigned DLC refund transaction */
 case class DLCRefundTxBuilder(
     offerInput: CurrencyUnit,
     offerFundingKey: ECPublicKey,
@@ -40,6 +41,7 @@ case class DLCRefundTxBuilder(
     conditionalPath = ConditionalPath.NoCondition
   )
 
+  /** Constructs the unsigned DLC refund transaction */
   def buildRefundTx()(
       implicit ec: ExecutionContext): Future[WitnessTransaction] = {
     val builder = RawTxBuilder().setLockTime(timeouts.contractTimeout.toUInt32)

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCRefundTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCRefundTxBuilder.scala
@@ -1,0 +1,75 @@
+package org.bitcoins.dlc.builder
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCTimeouts
+import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.protocol.script.{
+  EmptyScriptSignature,
+  MultiSignatureScriptPubKey,
+  P2WSHWitnessV0,
+  ScriptPubKey
+}
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.wallet.builder.{
+  AddWitnessDataFinalizer,
+  P2WPKHSubtractFeesFromOutputsFinalizer,
+  RawTxBuilder
+}
+import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.utxo.{ConditionalPath, P2WSHV0InputInfo}
+import org.bitcoins.crypto.ECPublicKey
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class DLCRefundTxBuilder(
+    offerInput: CurrencyUnit,
+    offerFundingKey: ECPublicKey,
+    offerFinalSPK: ScriptPubKey,
+    acceptInput: CurrencyUnit,
+    acceptFundingKey: ECPublicKey,
+    acceptFinalSPK: ScriptPubKey,
+    fundingOutputRef: OutputReference,
+    timeouts: DLCTimeouts,
+    feeRate: FeeUnit) {
+  private val OutputReference(fundingOutPoint, fundingOutput) = fundingOutputRef
+  private val totalInput = offerInput + acceptInput
+  private val fundingInfo = P2WSHV0InputInfo(
+    outPoint = fundingOutPoint,
+    amount = fundingOutput.value,
+    scriptWitness = P2WSHWitnessV0(
+      MultiSignatureScriptPubKey(2, Vector(offerFundingKey, acceptFundingKey))),
+    conditionalPath = ConditionalPath.NoCondition
+  )
+
+  def buildRefundTx()(
+      implicit ec: ExecutionContext): Future[WitnessTransaction] = {
+    val builder = RawTxBuilder().setLockTime(timeouts.contractTimeout.toUInt32)
+
+    builder += TransactionInput(fundingOutPoint,
+                                EmptyScriptSignature,
+                                TransactionConstants.disableRBFSequence)
+
+    val offerValue = Satoshis(
+      (fundingOutput.value * offerInput).satoshis.toLong / totalInput.satoshis.toLong)
+    val acceptValue = Satoshis(
+      (fundingOutput.value * acceptInput).satoshis.toLong / totalInput.satoshis.toLong)
+
+    builder += TransactionOutput(offerValue, offerFinalSPK)
+    builder += TransactionOutput(acceptValue, acceptFinalSPK)
+
+    // TODO: Should be SubtractFeeFromOutputsFinalizer since we know fundingInputInfo
+    val finalizer = P2WPKHSubtractFeesFromOutputsFinalizer(
+      feeRate,
+      Vector(offerFinalSPK, acceptFinalSPK))
+      .andThen(AddWitnessDataFinalizer(Vector(fundingInfo)))
+
+    val txF = finalizer.buildTx(builder.result())
+
+    txF.flatMap {
+      case _: NonWitnessTransaction =>
+        Future.failed(
+          new RuntimeException(
+            "Something went wrong with AddWitnessDataFinalizer"))
+      case wtx: WitnessTransaction => Future.successful(wtx)
+    }
+  }
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCTxBuilder.scala
@@ -140,6 +140,16 @@ case class DLCTxBuilder(
     } yield cet
   }
 
+  def buildCET(
+      msg: Sha256DigestBE,
+      isInitiator: Boolean): Future[WitnessTransaction] = {
+    if (isInitiator) {
+      buildOfferCET(msg)
+    } else {
+      buildAcceptCET(msg)
+    }
+  }
+
   def getOfferCETWitness(msg: Sha256DigestBE): Future[P2WSHWitnessV0] = {
     cetBuilderF
       .map(_.buildOfferToLocalP2PK(msg))
@@ -150,6 +160,16 @@ case class DLCTxBuilder(
     cetBuilderF
       .map(_.buildAcceptToLocalP2PK(msg))
       .map(P2WSHWitnessV0(_))
+  }
+
+  def getCETWitness(
+      msg: Sha256DigestBE,
+      isInitiator: Boolean): Future[P2WSHWitnessV0] = {
+    if (isInitiator) {
+      getOfferCETWitness(msg)
+    } else {
+      getAcceptCETWitness(msg)
+    }
   }
 
   lazy val buildRefundTx: Future[WitnessTransaction] = {

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCTxBuilder.scala
@@ -1,0 +1,156 @@
+package org.bitcoins.dlc.builder
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.commons.jsonmodels.dlc.{DLCPublicKeys, DLCTimeouts}
+import org.bitcoins.core.config.BitcoinNetwork
+import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.{BitcoinAddress, BlockStampWithFuture}
+import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.crypto._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class DLCTxBuilder(
+    offer: DLCOffer,
+    accept: DLCAcceptWithoutSigs
+)(implicit ec: ExecutionContext) {
+
+  val DLCOffer(
+    outcomes: ContractInfo,
+    OracleInfo(oraclePubKey: SchnorrPublicKey, preCommittedR: SchnorrNonce),
+    DLCPublicKeys(offerFundingKey: ECPublicKey,
+                  offerToLocalCETKey: ECPublicKey,
+                  offerFinalAddress: BitcoinAddress),
+    offerTotalCollateral: Satoshis,
+    offerFundingInputs: Vector[OutputReference],
+    offerChangeAddress: BitcoinAddress,
+    feeRate: SatoshisPerVirtualByte,
+    DLCTimeouts(penaltyTimeout: UInt32,
+                contractMaturity: BlockStampWithFuture,
+                contractTimeout: BlockStampWithFuture)) = offer
+
+  val network: BitcoinNetwork = offerFinalAddress.networkParameters match {
+    case network: BitcoinNetwork => network
+  }
+
+  val DLCAcceptWithoutSigs(acceptTotalCollateral: Satoshis,
+                           DLCPublicKeys(acceptFundingKey: ECPublicKey,
+                                         acceptToLocalCETKey: ECPublicKey,
+                                         acceptFinalAddress: BitcoinAddress),
+                           acceptFundingInputs: Vector[OutputReference],
+                           acceptChangeAddress: BitcoinAddress,
+                           eventId: Sha256DigestBE) = accept
+
+  val totalInput: CurrencyUnit = offerTotalCollateral + acceptTotalCollateral
+
+  val offerTotalFunding: CurrencyUnit =
+    offerFundingInputs.map(_.output.value).sum
+
+  val acceptTotalFunding: CurrencyUnit =
+    acceptFundingInputs.map(_.output.value).sum
+
+  require(offer.eventId == eventId,
+          "Offer and accept (without sigs) must refer to same event")
+  require(acceptFinalAddress.networkParameters == network,
+          "Offer and accept (without sigs) must be on the same network")
+  require(offerChangeAddress.networkParameters == network,
+          "Offer change address must have same network as final address")
+  require(acceptChangeAddress.networkParameters == network,
+          "Accept change address must have same network as final address")
+  require(totalInput >= outcomes.values.max,
+          "Total collateral must add up to max winnings")
+  require(
+    offerTotalFunding >= offerTotalCollateral,
+    "Offer funding inputs must add up to at least offer's total collateral")
+  require(
+    acceptTotalFunding >= acceptTotalCollateral,
+    "Accept funding inputs must add up to at least accept's total collateral")
+
+  lazy val buildFundingTx: Future[Transaction] = {
+    DLCFundingTxBuilder(
+      offerFundingKey = offerFundingKey,
+      acceptFundingKey = acceptFundingKey,
+      feeRate = feeRate,
+      offerInput = offerTotalCollateral,
+      acceptInput = acceptTotalCollateral,
+      offerFundingInputs = offerFundingInputs,
+      acceptFundingInputs = acceptFundingInputs,
+      offerChangeSPK = offerChangeAddress.scriptPubKey,
+      acceptChangeSPK = acceptChangeAddress.scriptPubKey
+    ).buildFundingTx()
+  }
+
+  private lazy val cetBuilderF = {
+    for {
+      fundingTx <- buildFundingTx
+    } yield {
+      val fundingOutPoint = TransactionOutPoint(fundingTx.txId, UInt32.zero)
+      val fundingOutputRef =
+        OutputReference(fundingOutPoint, fundingTx.outputs.head)
+
+      DLCCETBuilder(
+        outcomes,
+        totalInput,
+        offerFundingKey,
+        offerToLocalCETKey,
+        offerFinalAddress.scriptPubKey,
+        acceptFundingKey,
+        acceptToLocalCETKey,
+        acceptFinalAddress.scriptPubKey,
+        offer.timeouts,
+        feeRate,
+        offer.oracleInfo,
+        fundingOutputRef
+      )
+    }
+  }
+
+  def buildOfferCET(msg: Sha256DigestBE): Future[WitnessTransaction] = {
+    for {
+      cetBuilder <- cetBuilderF
+      cet <- cetBuilder.buildOfferCET(msg)
+    } yield cet
+  }
+
+  def buildAcceptCET(msg: Sha256DigestBE): Future[WitnessTransaction] = {
+    for {
+      cetBuilder <- cetBuilderF
+      cet <- cetBuilder.buildAcceptCET(msg)
+    } yield cet
+  }
+
+  lazy val buildRefundTx: Future[WitnessTransaction] = {
+    val builderF = for {
+      fundingTx <- buildFundingTx
+    } yield {
+      val fundingOutPoint = TransactionOutPoint(fundingTx.txId, UInt32.zero)
+      val fundingOutputRef =
+        OutputReference(fundingOutPoint, fundingTx.outputs.head)
+
+      DLCRefundTxBuilder(
+        offerTotalCollateral,
+        offerFundingKey,
+        offerFinalAddress.scriptPubKey,
+        acceptTotalCollateral,
+        acceptFundingKey,
+        acceptFinalAddress.scriptPubKey,
+        fundingOutputRef,
+        offer.timeouts,
+        feeRate
+      )
+    }
+
+    builderF.flatMap(_.buildRefundTx())
+  }
+}
+
+object DLCTxBuilder {
+
+  /** Experimental approx. vbytes for a CET */
+  val approxCETVBytes = 190
+
+  /** Experimental approx. vbytes for a closing tx spending ToLocalOutput */
+  val approxToLocalClosingVBytes = 122
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCTxBuilder.scala
@@ -216,4 +216,15 @@ object DLCTxBuilder {
           s"Signature does not correspond to a possible outcome! $oracleSig")
     }
   }
+
+  def tweakedPubKey(
+      fundingPubKey: ECPublicKey,
+      toLocalCETKey: ECPublicKey,
+      sigPubKey: ECPublicKey): ECPublicKey = {
+    val tweak = CryptoUtil.sha256(toLocalCETKey.bytes).flip
+
+    val tweakPubKey = ECPrivateKey.fromBytes(tweak.bytes).publicKey
+
+    sigPubKey.add(fundingPubKey).add(tweakPubKey)
+  }
 }

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
@@ -1,0 +1,340 @@
+package org.bitcoins.dlc.execution
+
+import org.bitcoins.core.currency.CurrencyUnit
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.policy.Policy
+import org.bitcoins.core.protocol.script.{
+  P2WPKHWitnessSPKV0,
+  P2WSHWitnessSPKV0,
+  P2WSHWitnessV0,
+  ScriptPubKey,
+  WitnessScriptPubKey
+}
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.script.crypto.HashType
+import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.core.wallet.builder._
+import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.utxo.{
+  ConditionalPath,
+  InputInfo,
+  P2WPKHV0InputInfo,
+  P2WSHV0InputInfo,
+  ScriptSignatureParams
+}
+import org.bitcoins.crypto.{SchnorrDigitalSignature, Sha256DigestBE}
+import org.bitcoins.dlc.builder.DLCTxBuilder
+import org.bitcoins.dlc.sign.DLCTxSigner
+import org.bitcoins.dlc.{
+  RefundDLCOutcome,
+  RefundDLCOutcomeWithClosing,
+  RefundDLCOutcomeWithDustClosing,
+  SetupDLC,
+  UnilateralDLCOutcome,
+  UnilateralDLCOutcomeWithClosing,
+  UnilateralDLCOutcomeWithDustClosing
+}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class DLCExecutor(signer: DLCTxSigner) extends BitcoinSLogger {
+  implicit private val ec: ExecutionContext = signer.ec
+
+  val builder: DLCTxBuilder = signer.builder
+
+  val feeRate: SatoshisPerVirtualByte = builder.feeRate
+
+  val isInitiator: Boolean = signer.isInitiator
+
+  val messages: Vector[Sha256DigestBE] = builder.offerOutcomes.keys.toVector
+
+  def getPayout(sig: SchnorrDigitalSignature): CurrencyUnit = {
+    signer.getPayout(sig)
+  }
+
+  /** Constructs and executes on the unilateral spending branch of a DLC
+    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#closing-transaction-unilateral]]
+    *
+    * @return Each transaction published and its spending info
+    */
+  def executeUnilateralDLC(
+      dlcSetup: SetupDLC,
+      oracleSig: SchnorrDigitalSignature): Future[UnilateralDLCOutcome] = {
+    val SetupDLC(fundingTx, cetInfos, _) = dlcSetup
+
+    val msgOpt =
+      messages.find(msg => builder.oraclePubKey.verify(msg.bytes, oracleSig))
+    val (msg, cet, cetScriptWitness) = msgOpt match {
+      case Some(msg) =>
+        val cetInfo = cetInfos(msg)
+        (msg, cetInfo.tx, cetInfo.witness)
+      case None =>
+        throw new IllegalArgumentException(
+          s"Signature does not correspond to any possible outcome! $oracleSig")
+    }
+
+    val output = cet.outputs.head
+
+    output.scriptPubKey match {
+      case _: P2WSHWitnessSPKV0 =>
+        val localSpendingTxF =
+          constructUnilateralCETSpend(cet, cetScriptWitness, msg, oracleSig)
+
+        localSpendingTxF.map {
+          case Some((localSpendingTx, cetSpendingInfo)) =>
+            UnilateralDLCOutcomeWithClosing(
+              fundingTx = fundingTx,
+              cet = cet,
+              closingTx = localSpendingTx,
+              cetSpendingInfo = cetSpendingInfo
+            )
+          case None =>
+            UnilateralDLCOutcomeWithDustClosing(fundingTx = fundingTx,
+                                                cet = cet)
+        }
+      case _: ScriptPubKey =>
+        Future.successful(
+          UnilateralDLCOutcomeWithDustClosing(fundingTx = fundingTx, cet = cet)
+        )
+    }
+  }
+
+  /** Constructs the closing transaction on the to_remote output of a counter-party's unilateral CET broadcast
+    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#closing-transaction-unilateral]]
+    */
+  def executeRemoteUnilateralDLC(
+      dlcSetup: SetupDLC,
+      publishedCET: Transaction,
+      sweepSPK: WitnessScriptPubKey): Future[UnilateralDLCOutcome] = {
+    val output = publishedCET.outputs.last
+
+    output.scriptPubKey match {
+      case _: P2WSHWitnessSPKV0 =>
+        Future.successful(
+          UnilateralDLCOutcomeWithDustClosing(fundingTx = dlcSetup.fundingTx,
+                                              cet = publishedCET)
+        )
+      case _: ScriptPubKey =>
+        val msgOpt =
+          dlcSetup.cets.find(_._2.remoteTxid == publishedCET.txIdBE).map(_._1)
+
+        msgOpt match {
+          case Some(_) =>
+            val spendingInfo = ScriptSignatureParams(
+              inputInfo = P2WPKHV0InputInfo(
+                outPoint = TransactionOutPoint(publishedCET.txIdBE, UInt32.one),
+                amount = output.value,
+                pubKey = signer.finalPrivKey.publicKey),
+              signer = signer.finalPrivKey,
+              hashType = HashType.sigHashAll
+            )
+
+            val txF =
+              constructClosingTx(spendingInfo = spendingInfo,
+                                 sweepSPK = sweepSPK)
+
+            txF.map {
+              case Some(tx) =>
+                UnilateralDLCOutcomeWithClosing(
+                  fundingTx = dlcSetup.fundingTx,
+                  cet = publishedCET,
+                  closingTx = tx,
+                  cetSpendingInfo = spendingInfo
+                )
+              case None =>
+                UnilateralDLCOutcomeWithDustClosing(fundingTx =
+                                                      dlcSetup.fundingTx,
+                                                    cet = publishedCET)
+            }
+          case None =>
+            throw new IllegalArgumentException(
+              s"Published CET $publishedCET does not correspond to any known outcome")
+        }
+    }
+  }
+
+  /** Constructs and executes on the justice spending branch of a DLC
+    * where a published CET has timed out.
+    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#closing-transaction-penalty]]
+    *
+    * @return Each transaction published and its spending info
+    */
+  def executeJusticeDLC(
+      dlcSetup: SetupDLC,
+      timedOutCET: Transaction): Future[UnilateralDLCOutcome] = {
+    val justiceOutput = timedOutCET.outputs.head
+
+    val cetScriptWitness =
+      dlcSetup.cets.find(_._2.remoteTxid == timedOutCET.txIdBE) match {
+        case Some((_, cetInfo)) => cetInfo.remoteWitness
+        case None =>
+          throw new IllegalArgumentException(
+            s"Timed out CET $timedOutCET does not correspond to any known outcome")
+      }
+
+    val justiceSpendingInfo = ScriptSignatureParams(
+      inputInfo = P2WSHV0InputInfo(
+        outPoint = TransactionOutPoint(timedOutCET.txIdBE, UInt32.zero),
+        amount = justiceOutput.value,
+        scriptWitness = cetScriptWitness,
+        conditionalPath = ConditionalPath.nonNestedFalse
+      ),
+      signer = signer.cetToLocalPrivKey,
+      hashType = HashType.sigHashAll
+    )
+
+    justiceOutput.scriptPubKey match {
+      case _: P2WSHWitnessSPKV0 =>
+        val justiceSpendingTxF = constructClosingTx(justiceSpendingInfo)
+
+        justiceSpendingTxF.map {
+          case Some(justiceSpendingTx) =>
+            UnilateralDLCOutcomeWithClosing(
+              fundingTx = dlcSetup.fundingTx,
+              cet = timedOutCET,
+              closingTx = justiceSpendingTx,
+              cetSpendingInfo = justiceSpendingInfo
+            )
+          case None =>
+            UnilateralDLCOutcomeWithDustClosing(fundingTx = dlcSetup.fundingTx,
+                                                cet = timedOutCET)
+        }
+      case _: ScriptPubKey =>
+        Future.successful(
+          UnilateralDLCOutcomeWithDustClosing(fundingTx = dlcSetup.fundingTx,
+                                              cet = timedOutCET)
+        )
+    }
+  }
+
+  /** Constructs and executes on the refund spending branch of a DLC
+    * @see [[https://github.com/discreetlogcontracts/dlcspecs/blob/master/Transactions.md#refund-transaction]]
+    *
+    * @return Each transaction published and its spending info
+    */
+  def executeRefundDLC(dlcSetup: SetupDLC): Future[RefundDLCOutcome] = {
+    val SetupDLC(fundingTx, _, refundTx) =
+      dlcSetup
+
+    val (localOutput, vout) = if (isInitiator) {
+      (refundTx.outputs.head, UInt32.zero)
+    } else {
+      (refundTx.outputs.last, UInt32.one)
+    }
+
+    val localRefundSpendingInfo = ScriptSignatureParams(
+      inputInfo = P2WPKHV0InputInfo(
+        outPoint = TransactionOutPoint(refundTx.txIdBE, vout),
+        amount = localOutput.value,
+        pubKey = signer.finalPrivKey.publicKey
+      ),
+      signer = signer.finalPrivKey,
+      hashType = HashType.sigHashAll
+    )
+
+    val localSpendingTxF = constructClosingTx(localRefundSpendingInfo)
+
+    localSpendingTxF.map {
+      case Some(localSpendingTx) =>
+        RefundDLCOutcomeWithClosing(
+          fundingTx = fundingTx,
+          refundTx = refundTx,
+          closingTx = localSpendingTx,
+          refundSpendingInfo = localRefundSpendingInfo
+        )
+      case None =>
+        RefundDLCOutcomeWithDustClosing(fundingTx = fundingTx,
+                                        refundTx = refundTx)
+    }
+  }
+
+  private def constructClosingTx(
+      spendingInfo: ScriptSignatureParams[InputInfo],
+      sweepSPK: WitnessScriptPubKey = P2WPKHWitnessSPKV0(
+        signer.finalPrivKey.publicKey)): Future[Option[Transaction]] = {
+
+    val lockTime = TxUtil.calcLockTime(Vector(spendingInfo))
+    val inputs = InputUtil.calcSequenceForInputs(Vector(spendingInfo))
+
+    val builder = RawTxBuilder().setLockTime(lockTime.get) += TransactionOutput(
+      spendingInfo.output.value,
+      sweepSPK) ++= inputs
+
+    val finalizer = SubtractFeeFromOutputsFinalizer(
+      Vector(spendingInfo.inputInfo),
+      feeRate,
+      Vector(sweepSPK)
+    ).andThen(
+      SanityCheckFinalizer(
+        Vector(spendingInfo.inputInfo),
+        Vector(sweepSPK),
+        feeRate
+      )
+    )
+
+    val spendingTxOptF = finalizer
+      .buildTx(builder.result())
+      .flatMap(utx => RawTxSigner.sign(utx, Vector(spendingInfo), feeRate))
+      .map(Some(_))
+
+    spendingTxOptF.foreach(txOpt =>
+      logger.info(s"Closing Tx: ${txOpt.map(_.hex)}"))
+
+    spendingTxOptF
+  }
+
+  private def constructUnilateralCETSpend(
+      cet: Transaction,
+      cetScriptWitness: P2WSHWitnessV0,
+      msg: Sha256DigestBE,
+      oracleSig: SchnorrDigitalSignature): Future[
+    Option[(Transaction, ScriptSignatureParams[P2WSHV0InputInfo])]] = {
+    val payoutValue = if (isInitiator) {
+      builder.offerOutcomes(msg)
+    } else {
+      builder.acceptOutcomes(msg)
+    }
+
+    val inputInfo = P2WSHV0InputInfo(
+      outPoint = TransactionOutPoint(cet.txIdBE, UInt32.zero),
+      amount = cet.outputs.head.value,
+      scriptWitness = cetScriptWitness,
+      conditionalPath = ConditionalPath.nonNestedTrue
+    )
+
+    val privKey = DLCTxSigner.tweakedPrivKey(signer.fundingPrivKey,
+                                             signer.cetToLocalPrivKey,
+                                             oracleSig)
+
+    val spendingInfo = ScriptSignatureParams(
+      inputInfo = inputInfo,
+      signer = privKey,
+      hashType = HashType.sigHashAll
+    )
+
+    if (payoutValue < Policy.dustThreshold) {
+      Future.successful(None)
+    } else {
+      val inputs = InputUtil.calcSequenceForInputs(Vector(spendingInfo))
+      val lockTime = TxUtil.calcLockTime(Vector(spendingInfo)).get
+      val sweepSPK = P2WPKHWitnessSPKV0(signer.finalPrivKey.publicKey)
+      val builder = RawTxBuilder().setLockTime(lockTime) ++= inputs += TransactionOutput(
+        payoutValue,
+        sweepSPK)
+
+      val finalizer =
+        SanityCheckFinalizer(Vector(inputInfo), Vector(sweepSPK), feeRate)
+          .andThen(AddWitnessDataFinalizer(Vector(inputInfo)))
+
+      val utxF = finalizer.buildTx(builder.result())
+
+      val signedTxF = utxF.flatMap { utx =>
+        RawTxSigner.sign(utx, Vector(spendingInfo), feeRate)
+      }
+
+      signedTxF.foreach(tx => logger.info(s"Closing Tx: ${tx.hex}"))
+
+      signedTxF.map(signedTx => Some((signedTx, spendingInfo)))
+    }
+  }
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
@@ -29,6 +29,7 @@ import org.bitcoins.dlc.sign.DLCTxSigner
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/** Responsible for constructing SetupDLCs and DLCOutcomes */
 case class DLCExecutor(signer: DLCTxSigner) extends BitcoinSLogger {
   implicit private val ec: ExecutionContext = signer.ec
 
@@ -40,12 +41,19 @@ case class DLCExecutor(signer: DLCTxSigner) extends BitcoinSLogger {
 
   val messages: Vector[Sha256DigestBE] = builder.offerOutcomes.keys.toVector
 
+  /** Constructs the initiator's SetupDLC given the non-initiator's
+    * CETSignatures which should arrive in a DLC accept message
+    */
   def setupDLCOffer(cetSigs: CETSignatures): Future[SetupDLC] = {
     require(isInitiator, "You should call setupDLCAccept")
 
     setupDLC(cetSigs, None)
   }
 
+  /** Constructs the non-initiator's SetupDLC given the initiator's
+    * CETSignatures and FundingSignatures which should arrive in
+    * a DLC sign message
+    */
   def setupDLCAccept(
       cetSigs: CETSignatures,
       fundingSigs: FundingSignatures): Future[SetupDLC] = {
@@ -54,6 +62,9 @@ case class DLCExecutor(signer: DLCTxSigner) extends BitcoinSLogger {
     setupDLC(cetSigs, Some(fundingSigs))
   }
 
+  /** Constructs a SetupDLC given the necessary signature information
+    * from the counter-party.
+    */
   def setupDLC(
       cetSigs: CETSignatures,
       fundingSigsOpt: Option[FundingSignatures]): Future[SetupDLC] = {
@@ -102,6 +113,7 @@ case class DLCExecutor(signer: DLCTxSigner) extends BitcoinSLogger {
     }
   }
 
+  /** Return's this party's payout for a given oracle signature */
   def getPayout(sig: SchnorrDigitalSignature): CurrencyUnit = {
     signer.getPayout(sig)
   }

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
@@ -26,16 +26,6 @@ import org.bitcoins.core.wallet.utxo.{
 import org.bitcoins.crypto.{SchnorrDigitalSignature, Sha256DigestBE}
 import org.bitcoins.dlc.builder.DLCTxBuilder
 import org.bitcoins.dlc.sign.DLCTxSigner
-import org.bitcoins.dlc.{
-  CETInfo,
-  RefundDLCOutcome,
-  RefundDLCOutcomeWithClosing,
-  RefundDLCOutcomeWithDustClosing,
-  SetupDLC,
-  UnilateralDLCOutcome,
-  UnilateralDLCOutcomeWithClosing,
-  UnilateralDLCOutcomeWithDustClosing
-}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCOutcome.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCOutcome.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.dlc
+package org.bitcoins.dlc.execution
 
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.utxo.{InputInfo, ScriptSignatureParams}

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/SetupDLC.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/SetupDLC.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.dlc
+package org.bitcoins.dlc.execution
 
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script.P2WSHWitnessV0

--- a/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
@@ -115,7 +115,7 @@ case class DLCTxSigner(
             val sigF = BitcoinSigner.signSingle(utxoSingle,
                                                 fundingTx,
                                                 isDummySignature = false)
-            sigFs.addOne(sigF.map((utxo.outPoint, _)))
+            sigFs += sigF.map((utxo.outPoint, _))
           }
         }
       }

--- a/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
@@ -1,0 +1,277 @@
+package org.bitcoins.dlc.sign
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.DLCMutualCloseSig
+import org.bitcoins.commons.jsonmodels.dlc.{
+  CETSignatures,
+  DLCPublicKeys,
+  FundingSignatures
+}
+import org.bitcoins.core.crypto.ExtPrivateKey
+import org.bitcoins.core.hd.BIP32Path
+import org.bitcoins.core.protocol.script.{
+  MultiSignatureScriptPubKey,
+  P2WSHWitnessV0
+}
+import org.bitcoins.core.protocol.transaction.{
+  OutputReference,
+  Transaction,
+  TransactionOutPoint
+}
+import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
+import org.bitcoins.core.psbt.PSBT
+import org.bitcoins.core.wallet.signer.BitcoinSigner
+import org.bitcoins.core.wallet.utxo.{InputInfo, ScriptSignatureParams}
+import org.bitcoins.crypto.{
+  ECPrivateKey,
+  ECPublicKey,
+  SchnorrDigitalSignature,
+  Sha256DigestBE
+}
+import org.bitcoins.dlc.builder.DLCTxBuilder
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class DLCTxSigner(
+    builder: DLCTxBuilder,
+    isInitiator: Boolean,
+    extPrivKey: ExtPrivateKey,
+    nextAddressIndex: Int,
+    fundingUtxos: Vector[ScriptSignatureParams[InputInfo]])(
+    implicit ec: ExecutionContext) {
+  private val offer = builder.offer
+  private val accept = builder.accept
+
+  private val fundingSPK = MultiSignatureScriptPubKey(
+    2,
+    Vector(offer.pubKeys.fundingKey, accept.pubKeys.fundingKey)
+  )
+
+  val fundingPrivKey: ECPrivateKey =
+    extPrivKey
+      .deriveChildPrivKey(BIP32Path.fromString(s"m/0/$nextAddressIndex"))
+      .key
+
+  val cetToLocalPrivKey: ECPrivateKey =
+    extPrivKey
+      .deriveChildPrivKey(BIP32Path.fromString(s"m/0/${nextAddressIndex + 1}"))
+      .key
+
+  val finalPrivKey: ECPrivateKey =
+    extPrivKey
+      .deriveChildPrivKey(BIP32Path.fromString(s"m/0/${nextAddressIndex + 2}"))
+      .key
+
+  private val pubKeys = DLCPublicKeys.fromExtPrivKeyAndIndex(extPrivKey,
+                                                             nextAddressIndex,
+                                                             builder.network)
+
+  if (isInitiator) {
+    require(
+      pubKeys == offer.pubKeys,
+      "Given ExtPrivateKey and index does not match the public keys in offer")
+    require(fundingUtxos.map(_.outputReference) == offer.fundingInputs,
+            "Funding ScriptSignatureParams did not match offer funding inputs")
+  } else {
+    require(
+      pubKeys == accept.pubKeys,
+      "Given ExtPrivateKey and index does not match the public keys in accept")
+    require(fundingUtxos.map(_.outputReference) == accept.fundingInputs,
+            "Funding ScriptSignatureParams did not match accept funding inputs")
+  }
+
+  def createFundingTxSigs(): Future[FundingSignatures] = {
+    val sigFs =
+      Vector.newBuilder[Future[(TransactionOutPoint, PartialSignature)]]
+
+    for {
+      fundingTx <- builder.buildFundingTx
+
+      _ = {
+        fundingUtxos.foreach { utxo =>
+          utxo.toSingles.foreach { utxoSingle =>
+            val sigF = BitcoinSigner.signSingle(utxoSingle,
+                                                fundingTx,
+                                                isDummySignature = false)
+            sigFs.addOne(sigF.map((utxo.outPoint, _)))
+          }
+        }
+      }
+
+      sigs <- Future.sequence(sigFs.result())
+    } yield {
+      val sigsMap = sigs.groupBy(_._1).map {
+        case (outPoint, outPointAndSigs) =>
+          outPoint -> outPointAndSigs.map(_._2)
+      }
+
+      FundingSignatures(sigsMap)
+    }
+  }
+
+  def signFundingTx(remoteSigs: FundingSignatures): Future[Transaction] = {
+    val fundingInputs = offer.fundingInputs ++ accept.fundingInputs
+
+    val psbtF = for {
+      localSigs <- createFundingTxSigs()
+      allSigs = localSigs.merge(remoteSigs)
+      fundingTx <- builder.buildFundingTx
+    } yield {
+      fundingInputs.zipWithIndex.foldLeft(PSBT.fromUnsignedTx(fundingTx)) {
+        case (psbt, (OutputReference(outPoint, output), index)) =>
+          val sigs = allSigs(outPoint)
+
+          psbt
+            .addWitnessUTXOToInput(output, index)
+            .addSignatures(sigs, index)
+      }
+    }
+
+    psbtF.flatMap { psbt =>
+      val txT = psbt.finalizePSBT.flatMap(_.extractTransactionAndValidate)
+      Future.fromTry(txT)
+    }
+  }
+
+  private def findSigInPSBT(
+      psbt: PSBT,
+      pubKey: ECPublicKey): Future[PartialSignature] = {
+    val sigOpt = psbt.inputMaps.head.partialSignatures
+      .find(_.pubKey == pubKey)
+
+    sigOpt match {
+      case None =>
+        Future.failed(new RuntimeException("No signature found after signing"))
+      case Some(partialSig) => Future.successful(partialSig)
+    }
+  }
+
+  private def createPartiallySignedMutualCloseTx(
+      oracleSig: SchnorrDigitalSignature): Future[PSBT] = {
+    for {
+      fundingTx <- builder.buildFundingTx
+      utx <- builder.buildMutualCloseTx(oracleSig)
+      psbt = PSBT
+        .fromUnsignedTx(utx)
+        .addWitnessUTXOToInput(fundingTx.outputs.head, index = 0)
+        .addScriptWitnessToInput(P2WSHWitnessV0(fundingSPK), index = 0)
+      signedPSBT <- psbt.sign(inputIndex = 0, fundingPrivKey)
+    } yield {
+      signedPSBT
+    }
+  }
+
+  def createMutualCloseTxSig(
+      oracleSig: SchnorrDigitalSignature): Future[DLCMutualCloseSig] = {
+    for {
+      psbt <- createPartiallySignedMutualCloseTx(oracleSig)
+      sig <- findSigInPSBT(psbt, fundingPrivKey.publicKey)
+    } yield {
+      DLCMutualCloseSig(accept.eventId, oracleSig, sig)
+    }
+  }
+
+  def signMutualCloseTx(
+      oracleSig: SchnorrDigitalSignature,
+      remoteSig: PartialSignature): Future[Transaction] = {
+    createPartiallySignedMutualCloseTx(oracleSig).flatMap { psbt =>
+      val txT = psbt
+        .addSignature(remoteSig, inputIndex = 0)
+        .finalizePSBT
+        .flatMap(_.extractTransactionAndValidate)
+
+      Future.fromTry(txT)
+    }
+  }
+
+  private def createPartiallySignedCET(
+      msg: Sha256DigestBE,
+      isOffer: Boolean): Future[PSBT] = {
+    for {
+      fundingTx <- builder.buildFundingTx
+      utx <- {
+        if (isOffer) {
+          builder.buildOfferCET(msg)
+        } else {
+          builder.buildAcceptCET(msg)
+        }
+      }
+
+      psbt <- PSBT
+        .fromUnsignedTx(utx)
+        .addWitnessUTXOToInput(fundingTx.outputs.head, index = 0)
+        .addScriptWitnessToInput(P2WSHWitnessV0(fundingSPK), index = 0)
+        .sign(inputIndex = 0, fundingPrivKey)
+    } yield {
+      psbt
+    }
+  }
+
+  def createRemoteCETSig(msg: Sha256DigestBE): Future[PartialSignature] = {
+    for {
+      psbt <- createPartiallySignedCET(msg, !isInitiator)
+      signature <- findSigInPSBT(psbt, fundingPrivKey.publicKey)
+    } yield {
+      signature
+    }
+  }
+
+  def signCET(
+      msg: Sha256DigestBE,
+      remoteSig: PartialSignature): Future[Transaction] = {
+    for {
+      unsignedPsbt <- createPartiallySignedCET(msg, isInitiator)
+      psbt = unsignedPsbt.addSignature(remoteSig, inputIndex = 0)
+
+      cetT = psbt.finalizePSBT.flatMap(_.extractTransactionAndValidate)
+      cet <- Future.fromTry(cetT)
+    } yield {
+      cet
+    }
+  }
+
+  def createPartiallySignedRefundTx(): Future[PSBT] = {
+    for {
+      fundingTx <- builder.buildFundingTx
+      utx <- builder.buildRefundTx
+      psbt <- PSBT
+        .fromUnsignedTx(utx)
+        .addWitnessUTXOToInput(fundingTx.outputs.head, index = 0)
+        .addScriptWitnessToInput(P2WSHWitnessV0(fundingSPK), index = 0)
+        .sign(inputIndex = 0, fundingPrivKey)
+    } yield {
+      psbt
+    }
+  }
+
+  def createRefundSig(): Future[PartialSignature] = {
+    for {
+      psbt <- createPartiallySignedRefundTx()
+      signature <- findSigInPSBT(psbt, fundingPrivKey.publicKey)
+    } yield {
+      signature
+    }
+  }
+
+  def signRefundTx(remoteSig: PartialSignature): Future[Transaction] = {
+    for {
+      unsignedPSBT <- createPartiallySignedRefundTx()
+      psbt = unsignedPSBT.addSignature(remoteSig, inputIndex = 0)
+
+      refundTxT = psbt.finalizePSBT.flatMap(_.extractTransactionAndValidate)
+      refuntTx <- Future.fromTry(refundTxT)
+    } yield {
+      refuntTx
+    }
+  }
+
+  def createCETSigs(): Future[CETSignatures] = {
+    val cetSigFs = offer.contractInfo.keys.toVector.map { msg =>
+      createRemoteCETSig(msg).map(msg -> _)
+    }
+
+    for {
+      cetSigs <- Future.sequence(cetSigFs).map(_.toMap)
+      refundSig <- createRefundSig()
+    } yield CETSignatures(cetSigs, refundSig)
+  }
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
@@ -28,8 +28,7 @@ import org.bitcoins.core.wallet.utxo.{
   SegwitV0NativeInputInfo
 }
 import org.bitcoins.crypto._
-import org.bitcoins.dlc.{
-  DLCClient,
+import org.bitcoins.dlc.execution.{
   UnilateralDLCOutcomeWithClosing,
   UnilateralDLCOutcomeWithDustClosing
 }
@@ -153,7 +152,7 @@ object DLCTestVector {
       OutputReference(info.outPoint, info.output)
     }
 
-    val offerDLC = DLCClient(
+    val offerDLC = TestDLCClient(
       outcomeWin = possibleOutcomes.head,
       outcomeLose = possibleOutcomes.last,
       oraclePubKey = oracleKey.schnorrPublicKey,
@@ -177,7 +176,7 @@ object DLCTestVector {
       network = RegTest
     )
 
-    val acceptDLC = DLCClient(
+    val acceptDLC = TestDLCClient(
       outcomeWin = possibleOutcomes.head,
       outcomeLose = possibleOutcomes.last,
       oraclePubKey = oracleKey.schnorrPublicKey,

--- a/dlc/src/main/scala/org/bitcoins/dlc/verify/DLCSignatureVerifier.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/verify/DLCSignatureVerifier.scala
@@ -1,0 +1,97 @@
+package org.bitcoins.dlc.verify
+
+import org.bitcoins.commons.jsonmodels.dlc.FundingSignatures
+import org.bitcoins.core.crypto.{
+  TransactionSignatureChecker,
+  WitnessTxSigComponentRaw
+}
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.policy.Policy
+import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
+import org.bitcoins.core.psbt.PSBT
+import org.bitcoins.crypto.Sha256DigestBE
+import org.bitcoins.dlc.builder.DLCTxBuilder
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.util.{Failure, Success}
+
+case class DLCSignatureVerifier(builder: DLCTxBuilder, isInitiator: Boolean) {
+
+  private lazy val fundingTx = Await.result(builder.buildFundingTx, 5.seconds)
+
+  def verifyRemoteFundingSigs(remoteSigs: FundingSignatures): Boolean = {
+    val (remoteTweak, remoteFundingInputs) = if (isInitiator) {
+      (builder.offerFundingInputs.length, builder.acceptFundingInputs)
+    } else {
+      (0, builder.offerFundingInputs)
+    }
+
+    val psbt = PSBT.fromUnsignedTx(fundingTx)
+
+    remoteSigs.zipWithIndex
+      .foldLeft(true) {
+        case (ret, ((outPoint, sigs), index)) =>
+          if (ret) {
+            require(psbt.transaction.inputs(index).previousOutput == outPoint,
+                    "Adding signature for incorrect input")
+
+            val idx = index + remoteTweak
+
+            psbt
+              .addWitnessUTXOToInput(remoteFundingInputs(index).output, idx)
+              .addSignatures(sigs, idx)
+              .finalizeInput(idx) match {
+              case Success(finalized) =>
+                finalized.verifyFinalizedInput(idx)
+              case Failure(_) =>
+                false
+            }
+          } else false
+      }
+  }
+
+  def verifyCETSig(outcome: Sha256DigestBE, sig: PartialSignature): Boolean = {
+    val cetF = if (isInitiator) {
+      builder.buildOfferCET(outcome)
+    } else {
+      builder.buildAcceptCET(outcome)
+    }
+
+    val cet = Await.result(cetF, 5.seconds)
+
+    val sigComponent = WitnessTxSigComponentRaw(transaction = cet,
+                                                inputIndex = UInt32.zero,
+                                                output = fundingTx.outputs.head,
+                                                flags = Policy.standardFlags)
+
+    TransactionSignatureChecker
+      .checkSignature(
+        sigComponent,
+        sigComponent.output.scriptPubKey.asm.toVector,
+        sig.pubKey,
+        sig.signature,
+        Policy.standardFlags
+      )
+      .isValid
+  }
+
+  def verifyRefundSig(sig: PartialSignature): Boolean = {
+    val refundTx = Await.result(builder.buildRefundTx, 5.seconds)
+
+    val sigComponent = WitnessTxSigComponentRaw(transaction = refundTx,
+                                                inputIndex = UInt32.zero,
+                                                output = fundingTx.outputs.head,
+                                                flags = Policy.standardFlags)
+
+    TransactionSignatureChecker
+      .checkSignature(
+        sigComponent,
+        sigComponent.output.scriptPubKey.asm.toVector,
+        sig.pubKey,
+        sig.signature,
+        Policy.standardFlags
+      )
+      .isValid
+  }
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/verify/DLCSignatureVerifier.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/verify/DLCSignatureVerifier.scala
@@ -20,6 +20,7 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success}
 
+/** Responsible for verifying all DLC signatures */
 case class DLCSignatureVerifier(builder: DLCTxBuilder, isInitiator: Boolean) {
 
   private lazy val fundingTx = Await.result(builder.buildFundingTx, 5.seconds)
@@ -55,6 +56,7 @@ case class DLCSignatureVerifier(builder: DLCTxBuilder, isInitiator: Boolean) {
       }
   }
 
+  /** Verifies remote's CET signature for a given outcome hash */
   def verifyCETSig(outcome: Sha256DigestBE, sig: PartialSignature): Boolean = {
     val cetF = if (isInitiator) {
       builder.buildOfferCET(outcome)
@@ -80,6 +82,7 @@ case class DLCSignatureVerifier(builder: DLCTxBuilder, isInitiator: Boolean) {
       .isValid
   }
 
+  /** Verifies remote's refund signature */
   def verifyRefundSig(sig: PartialSignature): Boolean = {
     val refundTx = Await.result(builder.buildRefundTx, 5.seconds)
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/verify/DLCSignatureVerifier.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/verify/DLCSignatureVerifier.scala
@@ -1,5 +1,9 @@
 package org.bitcoins.dlc.verify
 
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{
+  DLCAcceptWithoutSigs,
+  DLCOffer
+}
 import org.bitcoins.commons.jsonmodels.dlc.FundingSignatures
 import org.bitcoins.core.crypto.{
   TransactionSignatureChecker,
@@ -12,7 +16,7 @@ import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.crypto.Sha256DigestBE
 import org.bitcoins.dlc.builder.DLCTxBuilder
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success}
 
@@ -93,5 +97,16 @@ case class DLCSignatureVerifier(builder: DLCTxBuilder, isInitiator: Boolean) {
         Policy.standardFlags
       )
       .isValid
+  }
+}
+
+object DLCSignatureVerifier {
+
+  def apply(
+      offer: DLCOffer,
+      accept: DLCAcceptWithoutSigs,
+      isInitiator: Boolean)(
+      implicit ec: ExecutionContext): DLCSignatureVerifier = {
+    DLCSignatureVerifier(DLCTxBuilder(offer, accept), isInitiator)
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.3.12

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -12,8 +12,14 @@ import org.bitcoins.core.protocol.{Bech32Address, BlockStamp}
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.utxo.{InputInfo, ScriptSignatureParams}
 import org.bitcoins.crypto._
-import org.bitcoins.dlc._
-import org.bitcoins.dlc.execution.DLCExecutor
+import org.bitcoins.dlc.execution.{
+  DLCExecutor,
+  RefundDLCOutcomeWithClosing,
+  RefundDLCOutcomeWithDustClosing,
+  SetupDLC,
+  UnilateralDLCOutcomeWithClosing,
+  UnilateralDLCOutcomeWithDustClosing
+}
 import org.bitcoins.dlc.sign.DLCTxSigner
 import org.bitcoins.dlc.verify.DLCSignatureVerifier
 import org.bitcoins.wallet.models._

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -349,8 +349,7 @@ abstract class DLCWallet extends Wallet {
         accept,
         keyManager.rootExtPrivKey.deriveChildPrivKey(dlc.account),
         dlc.keyIndex,
-        spendingInfos.map(_.toScriptSignatureParams),
-        offer.network
+        spendingInfos.map(_.toScriptSignatureParams)
       )
       cetSigs <- client.createCETSigs
       fundingSigs <- client.createFundingTransactionSigs()
@@ -372,7 +371,7 @@ abstract class DLCWallet extends Wallet {
                              fundingInputs,
                              outcomeSigs)
     } yield {
-      val correctNumberOfSigs = sign.cetSigs.outcomeSigs.size == client.outcomes.size
+      val correctNumberOfSigs = sign.cetSigs.outcomeSigs.size == client.messages.size
 
       correctNumberOfSigs && sign.cetSigs.outcomeSigs.foldLeft(true) {
         case (ret, (outcome, sig)) =>
@@ -611,7 +610,7 @@ abstract class DLCWallet extends Wallet {
         throw new UnsupportedOperationException(
           "Cannot execute a losing outcome")
 
-      sigMessage <- client.createMutualCloseSig(eventId, oracleSig)
+      sigMessage <- client.createMutualCloseSig(oracleSig)
     } yield sigMessage
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/DLCWallet.scala
@@ -12,14 +12,7 @@ import org.bitcoins.core.protocol.{Bech32Address, BlockStamp}
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.utxo.{InputInfo, ScriptSignatureParams}
 import org.bitcoins.crypto._
-import org.bitcoins.dlc.execution.{
-  DLCExecutor,
-  RefundDLCOutcomeWithClosing,
-  RefundDLCOutcomeWithDustClosing,
-  SetupDLC,
-  UnilateralDLCOutcomeWithClosing,
-  UnilateralDLCOutcomeWithDustClosing
-}
+import org.bitcoins.dlc.execution._
 import org.bitcoins.dlc.sign.DLCTxSigner
 import org.bitcoins.dlc.verify.DLCSignatureVerifier
 import org.bitcoins.wallet.models._
@@ -490,7 +483,7 @@ abstract class DLCWallet extends Wallet {
     val outPoints =
       fundingInputs.filter(_.isInitiator == dlcDb.isInitiator).map(_.outPoint)
 
-    listUtxos(outPoints).map(_.map(info => info.toUTXOInfo(keyManager)))
+    listUtxos(outPoints).map(_.map(_.toUTXOInfo(keyManager)))
   }
 
   private def verifierFromDb(

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/DLCAcceptDb.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/DLCAcceptDb.scala
@@ -1,6 +1,9 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.DLCAccept
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{
+  DLCAccept,
+  DLCAcceptWithoutSigs
+}
 import org.bitcoins.commons.jsonmodels.dlc.{CETSignatures, DLCPublicKeys}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -29,6 +32,18 @@ case class DLCAcceptDb(
               changeAddress,
               cetSigs,
               eventId)
+  }
+
+  def toDLCAcceptWithoutSigs(
+      fundingInputs: Vector[OutputReference]): DLCAcceptWithoutSigs = {
+    val pubKeys =
+      DLCPublicKeys(fundingKey, toLocalCETKey, finalAddress)
+
+    DLCAcceptWithoutSigs(totalCollateral.satoshis,
+                         pubKeys,
+                         fundingInputs,
+                         changeAddress,
+                         eventId)
   }
 }
 


### PR DESCRIPTION
Refactored the entirety of what was formerly `DLCClient` into nice modules and used these modules in `DLCWallet` (for the wallet) and `TestDLCClient` (for tests)

TODO: Scaladocs