### PR TITLE
Testkit wallet with bitcoind uses bitcoind as api

### DIFF
--- a/docs/wallet/wallet-rescan.md
+++ b/docs/wallet/wallet-rescan.md
@@ -17,6 +17,7 @@ To run this example you need to make sure you have access to a bitcoind binary. 
 
 ```scala mdoc:invisible
 import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.fixtures._
 import org.bitcoins.testkit.wallet._
 import org.bitcoins.server.BitcoinSAppConfig
 import akka.actor.ActorSystem
@@ -33,8 +34,9 @@ implicit val appConfig: BitcoinSAppConfig = BitcoinSTestAppConfig.getNeutrinoTes
 
 //ok now let's spin up a bitcoind and a bitcoin-s wallet with funds in it
 val walletWithBitcoindF = for {
-  w <- BitcoinSWalletTest.createWalletBitcoindNodeChainQueryApi()
-} yield w
+  bitcoind <- BitcoinSFixture.createBitcoindWithFunds()
+  walletWithBitcoind <- BitcoinSWalletTest.createWalletWithBitcoindCallbacks(bitcoind)
+} yield walletWithBitcoind
 
 val walletF = walletWithBitcoindF.map(_.wallet)
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -12,7 +12,6 @@ import org.bitcoins.core.util.{FutureUtil, TimeUtil}
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.db.AppConfig
-import org.bitcoins.feeprovider.ConstantFeeRateProvider
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
@@ -199,30 +198,45 @@ trait BitcoinSWalletTest extends BitcoinSFixture with WalletLogger {
   def withNewWalletAndBitcoind(test: OneArgAsyncTest): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind] = composeBuildersAndWrap(
       builder = { () =>
-        createDefaultWallet(nodeApi, chainQueryApi)
+        BitcoinSFixture.createBitcoindWithFunds()
       },
-      dependentBuilder = { (wallet: Wallet) =>
-        createWalletWithBitcoind(wallet)
+      dependentBuilder = { (bitcoind: BitcoindRpcClient) =>
+        createWalletWithBitcoind(bitcoind)
       },
-      wrap = (_: WalletApi, walletWithBitcoind: WalletWithBitcoind) =>
+      wrap = (_: BitcoindRpcClient, walletWithBitcoind: WalletWithBitcoind) =>
         walletWithBitcoind
     )
 
     makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
   }
 
+  def withNewWalletAndBitcoindV19(test: OneArgAsyncTest): FutureOutcome = {
+    val builder: () => Future[WalletWithBitcoind] = composeBuildersAndWrap(
+      builder = { () =>
+        BitcoinSFixture
+          .createBitcoindWithFunds(Some(BitcoindVersion.V19))
+          .map(_.asInstanceOf[BitcoindV19RpcClient])
+      },
+      dependentBuilder = { (bitcoind: BitcoindV19RpcClient) =>
+        createWalletWithBitcoindV19(bitcoind)
+      },
+      wrap =
+        (_: BitcoindV19RpcClient, walletWithBitcoind: WalletWithBitcoindV19) =>
+          walletWithBitcoind
+    )
+
+    makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
+  }
+
   def withFundedWalletAndBitcoind(test: OneArgAsyncTest): FutureOutcome = {
-    val builder: () => Future[WalletWithBitcoind] =
-      composeBuildersAndWrapFuture(
-        builder = { () =>
-          BitcoinSWalletTest.createWallet2Accounts(nodeApi, chainQueryApi)
-        },
-        dependentBuilder = { (wallet: Wallet) =>
-          createWalletWithBitcoind(wallet)
-        },
-        processResult = (_: WalletApi, pair: WalletWithBitcoind) =>
-          fundWalletWithBitcoind(pair)
-      )
+    val builder: () => Future[WalletWithBitcoind] = { () =>
+      for {
+        bitcoind <- BitcoinSFixture
+          .createBitcoindWithFunds(None)
+        wallet <- createWalletWithBitcoindCallbacks(bitcoind)
+        fundedWallet <- fundWalletWithBitcoind(wallet)
+      } yield fundedWallet
+    }
 
     makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
   }
@@ -230,9 +244,14 @@ trait BitcoinSWalletTest extends BitcoinSFixture with WalletLogger {
   def withFundedWalletAndBitcoindV19(test: OneArgAsyncTest): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoindV19] = { () =>
       for {
-        walletBitcoind <- createWalletBitcoindNodeChainQueryApi()
-        fundedWallet <- fundWalletWithBitcoind(walletBitcoind)
-      } yield fundedWallet
+        bitcoind <- BitcoinSFixture
+          .createBitcoindWithFunds(Some(BitcoindVersion.V19))
+          .map(_.asInstanceOf[BitcoindV19RpcClient])
+        wallet <- createWalletWithBitcoindCallbacks(bitcoind)
+        fundedWallet <- fundWalletWithBitcoind(wallet)
+      } yield {
+        WalletWithBitcoindV19(fundedWallet.wallet, bitcoind)
+      }
     }
 
     makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
@@ -402,50 +421,39 @@ object BitcoinSWalletTest extends WalletLogger {
 
   /** Creates a default wallet with bitcoind where the [[ChainQueryApi]] fed to the wallet
     * is implemented by bitcoind */
-  def createWalletBitcoindNodeChainQueryApi(extraConfig: Option[Config] = None)(
+  def createWalletWithBitcoindCallbacks(
+      bitcoind: BitcoindRpcClient,
+      extraConfig: Option[Config] = None)(
       implicit config: BitcoinSAppConfig,
-      system: ActorSystem): Future[WalletWithBitcoindV19] = {
+      system: ActorSystem): Future[WalletWithBitcoind] = {
     import system.dispatcher
-    val bitcoindF = BitcoinSFixture
-      .createBitcoindWithFunds(Some(BitcoindVersion.V19))
-      .map(_.asInstanceOf[BitcoindV19RpcClient])
-    val nodeChainQueryApiF =
-      bitcoindF.map(b => SyncUtil.getNodeChainQueryApi(b))
+    //we need to create a promise so we can inject the wallet with the callback
+    //after we have created it into SyncUtil.getNodeApiWalletCallback
+    //so we don't lose the internal state of the wallet
     val walletCallbackP = Promise[Wallet]()
-    val walletWithBitcoindV19F = for {
-      bitcoind <- bitcoindF
-      api <- nodeChainQueryApiF
-      wallet <- BitcoinSWalletTest.createWallet2Accounts(api.nodeApi,
-                                                         api.chainQueryApi,
+    val walletWithBitcoindF = for {
+      wallet <- BitcoinSWalletTest.createWallet2Accounts(bitcoind,
+                                                         bitcoind,
                                                          extraConfig)
-
-      //we need to create a promise so we can inject the wallet with the callback
-      //after we have created it into SyncUtil.getNodeChainQueryApiWalletCallback
-      //so we don't lose the internal state of the wallet
-
-      //now unfortunately we have to create _another_ wallet that has the correct callback
-      //setup for our wallet so we can receive block updates from bitcoind
-      apiCallback = SyncUtil.getNodeChainQueryApiWalletCallback(
-        bitcoindV19RpcClient = bitcoind,
-        walletF = walletCallbackP.future)
 
       //create the wallet with the appropriate callbacks now that
       //we have them
       walletWithCallback = Wallet(
         keyManager = wallet.keyManager,
-        nodeApi = apiCallback.nodeApi,
-        chainQueryApi = apiCallback.chainQueryApi,
-        feeRateApi = ConstantFeeRateProvider(SatoshisPerVirtualByte.one),
+        nodeApi =
+          SyncUtil.getNodeApiWalletCallback(bitcoind, walletCallbackP.future),
+        chainQueryApi = SyncUtil.getTestChainQueryApi(bitcoind),
+        feeRateApi = bitcoind,
         creationTime = wallet.keyManager.creationTime
       )(wallet.walletConfig, wallet.ec)
       //complete the walletCallbackP so we can handle the callbacks when they are
       //called without hanging forever.
       _ = walletCallbackP.success(walletWithCallback)
-    } yield WalletWithBitcoindV19(walletWithCallback, bitcoind)
+    } yield WalletWithBitcoindRpc(walletWithCallback, bitcoind)
 
-    walletWithBitcoindV19F.failed.foreach(err => walletCallbackP.failure(err))
+    walletWithBitcoindF.failed.foreach(err => walletCallbackP.failure(err))
 
-    walletWithBitcoindV19F
+    walletWithBitcoindF
   }
 
   def createWallet2Accounts(
@@ -486,6 +494,12 @@ object BitcoinSWalletTest extends WalletLogger {
     bitcoindF.map(WalletWithBitcoindRpc(wallet, _))
   }
 
+  def createWalletWithBitcoind(bitcoind: BitcoindRpcClient)(
+      implicit system: ActorSystem,
+      config: BitcoinSAppConfig): Future[WalletWithBitcoind] = {
+    createWalletWithBitcoindCallbacks(bitcoind, None)
+  }
+
   def createWalletWithBitcoindV19(wallet: Wallet)(
       implicit system: ActorSystem): Future[WalletWithBitcoindV19] = {
     import system.dispatcher
@@ -496,6 +510,16 @@ object BitcoinSWalletTest extends WalletLogger {
     } yield WalletWithBitcoindV19(
       created.wallet,
       created.bitcoind.asInstanceOf[BitcoindV19RpcClient])
+  }
+
+  def createWalletWithBitcoindV19(bitcoind: BitcoindV19RpcClient)(
+      implicit system: ActorSystem,
+      config: BitcoinSAppConfig): Future[WalletWithBitcoindV19] = {
+    import system.dispatcher
+    for {
+      created <- createWalletWithBitcoindCallbacks(bitcoind)
+
+    } yield WalletWithBitcoindV19(created.wallet, bitcoind)
   }
 
   def createWalletWithBitcoind(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -93,10 +93,10 @@ class WalletIntegrationTest extends BitcoinSWalletTest {
         .map(balance => assert(balance == valueFromBitcoind))
       _ <- wallet
         .getConfirmedBalance()
-        .map(confirmed => assert(confirmed == 0.bitcoin))
+        .map(confirmed => assert(confirmed == valueFromBitcoind))
       _ <- wallet
         .getUnconfirmedBalance()
-        .map(unconfirmed => assert(unconfirmed == valueFromBitcoind))
+        .map(unconfirmed => assert(unconfirmed == 0.satoshis))
 
       signedTx <- bitcoind.getNewAddress.flatMap {
         wallet.sendToAddress(_, valueToBitcoind, Some(feeRate))


### PR DESCRIPTION
Needed to fix `BitcoindV19RpcClient`'s `getFiltersBetweenHeights` to use batching so it doesn't overload akka with requests.

After this was able to verify that the neutrino coinbases issues do not exist, at least in tests.