### PR TITLE
Move slickDbConfig out of JdbcProfileComponent trait into AppConfig

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -30,7 +30,7 @@ case class ChainAppConfig(
     ChainAppConfig(directory, useLogbackConf, configs: _*)
   protected[bitcoins] def baseDatadir: Path = directory
 
-  override def appConfig: ChainAppConfig = this
+  override lazy val appConfig: ChainAppConfig = this
 
   /**
     * Checks whether or not the chain project is initialized by

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -5,17 +5,14 @@ import java.nio.file.{Files, Path, Paths}
 import ch.qos.logback.classic.Level
 import com.typesafe.config._
 import org.bitcoins.core.config.{MainNet, NetworkParameters, RegTest, TestNet3}
-import org.bitcoins.core.protocol.blockchain.{
-  ChainParams,
-  MainNetChainParams,
-  RegTestNetChainParams,
-  TestNetChainParams
-}
+import org.bitcoins.core.protocol.blockchain.{ChainParams, MainNetChainParams, RegTestNetChainParams, TestNetChainParams}
 import org.bitcoins.core.util.BitcoinSLogger
+import slick.basic.DatabaseConfig
+import slick.jdbc.JdbcProfile
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Properties
 import scala.util.matching.Regex
+import scala.util.{Failure, Properties, Success, Try}
 
 /**
   * Everything needed to configure functionality
@@ -300,6 +297,19 @@ abstract class AppConfig extends LoggerConfig {
   override val useLogbackConf: Boolean =
     config.getBooleanOrElse("logging.logback", default = false)
 
+  lazy val slickDbConfig: DatabaseConfig[JdbcProfile] = {
+    Try {
+      DatabaseConfig.forConfig[JdbcProfile](path = moduleName,
+        config = config)
+    } match {
+      case Success(value) =>
+        value
+      case Failure(exception) =>
+        logger.error(s"Error when loading database from config: $exception")
+        logger.error(s"Configuration: ${config.asReadableJson}")
+        throw exception
+    }
+  }
 }
 
 object AppConfig extends BitcoinSLogger {

--- a/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
@@ -6,8 +6,6 @@ import org.bitcoins.core.util.BitcoinSLogger
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 
-import scala.util.{Failure, Success, Try}
-
 trait JdbcProfileComponent[+ConfigType <: AppConfig] extends BitcoinSLogger {
 
   def appConfig: ConfigType
@@ -17,19 +15,7 @@ trait JdbcProfileComponent[+ConfigType <: AppConfig] extends BitcoinSLogger {
     * that require datbase connections
     */
   val dbConfig: DatabaseConfig[JdbcProfile] = {
-    val slickDbConfig = {
-      Try {
-        DatabaseConfig.forConfig[JdbcProfile](path = appConfig.moduleName,
-                                              config = appConfig.config)
-      } match {
-        case Success(value) =>
-          value
-        case Failure(exception) =>
-          logger.error(s"Error when loading database from config: $exception")
-          logger.error(s"Configuration: ${appConfig.config.asReadableJson}")
-          throw exception
-      }
-    }
+    val slickDbConfig = appConfig.slickDbConfig
 
     logger.debug(s"Resolved DB config: ${slickDbConfig.config.asReadableJson}")
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -125,6 +125,8 @@ case class WalletAppConfig(
       5.second
     }
   }
+
+
 }
 
 object WalletAppConfig extends AppConfigFactory[WalletAppConfig] {

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -125,8 +125,6 @@ case class WalletAppConfig(
       5.second
     }
   }
-
-
 }
 
 object WalletAppConfig extends AppConfigFactory[WalletAppConfig] {


### PR DESCRIPTION
closes #1507 

In #1355 we moved the database configuration into `JdbcProfileComponent`. This is a problem because the database thread pool gets re-created everytime a `JdbcProfileComponent` gets created on the jvm. This is a lot!

This PR moves the dbConfig into `AppConfig`, which should have just one every module we have. This means the thread pool gets created once rather than everytime a `JdbcProfileComponent` is created.