### PR TITLE
Add more descriptive log message in P2PClient when we get disconnectd

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -168,8 +168,7 @@ case class P2PClientActor(
 
       case closeCmd @ (Tcp.ConfirmedClosed | Tcp.Closed | Tcp.Aborted |
           Tcp.PeerClosed) =>
-        logger.debug(s"Closed command received: ${closeCmd}")
-
+        logger.info(s"We've been disconnected by $peer command=${closeCmd}")
         //tell our peer message handler we are disconnecting
         val newPeerMsgRecv = currentPeerMsgHandlerRecv.disconnect()
 


### PR DESCRIPTION
This is a mitigation tactic for #1513 

At least we have a higher level log message now for when we disconnected by bitcoind. 