### PR TITLE
Attempt to fix BitcoindV19RpcClientTest from losing connection

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v19/BitcoindV19RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v19/BitcoindV19RpcClientTest.scala
@@ -101,10 +101,11 @@ class BitcoindV19RpcClientTest extends BitcoindRpcTest {
 
     val psbt =
       "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA=="
-    val updatedF =
-      clientF.flatMap(client => client.utxoUpdatePsbt(psbt, Seq(descriptor)))
 
-    updatedF.map { result =>
+    for {
+      (client, _) <- clientPairF
+      result <- client.utxoUpdatePsbt(psbt, Seq(descriptor))
+    } yield {
       assert(result.contains(psbt))
     }
   }


### PR DESCRIPTION
In CI this would sometimes give
```
should check to see if the utxoUpdate input has been updated *** FAILED *** (10 milliseconds)
[info]   akka.stream.StreamTcpException: The connection closed with error: Connection reset
```
hopefully this fixes