### PR TITLE
2020 06 09 string factory

### DIFF
--- a/crypto/src/main/scala/org/bitcoins/crypto/StringFactory.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/StringFactory.scala
@@ -1,0 +1,20 @@
+package org.bitcoins.crypto
+
+import scala.util.Try
+
+/** A common factory trait that can be re-used to deserialize a string to a type t */
+trait StringFactory[T] {
+
+  /** Tries to parse a string to type t, throws an exception if fails */
+  def fromString(string: String): T
+
+  /** Treis to parse a string to type t, returns None if failure */
+  def fromStringOpt(string: String): Option[T] = {
+    fromStringT(string).toOption
+  }
+
+  /** Tries to parsea  string to type t, returns [[scala.util.Failure]] if the fails */
+  def fromStringT(string: String): Try[T] = {
+    Try(fromString(string))
+  }
+}


### PR DESCRIPTION
This adds a common StringFactory trait that can be used to deserialize a string to a type T. This is should be used for everything in our code base so we don't have a mismatch of how things are deserialized from a String.