### PR TITLE
Create safeRewind() helper method in secp256k1jni

### DIFF
--- a/secp256k1jni/src/main/java/org/bitcoin/NativeSecp256k1.java
+++ b/secp256k1jni/src/main/java/org/bitcoin/NativeSecp256k1.java
@@ -17,6 +17,7 @@
 
 package org.bitcoin;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -59,7 +60,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(data);
         byteBuff.put(signature);
         byteBuff.put(pub);
@@ -88,7 +90,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(data);
         byteBuff.put(seckey);
 
@@ -125,7 +128,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(seckey);
 
         r.lock();
@@ -153,7 +157,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(seckey);
 
         byte[][] retByteArray;
@@ -209,7 +214,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(seckey);
         byteBuff.put(tweak);
 
@@ -248,7 +254,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(seckey);
         byteBuff.put(tweak);
 
@@ -288,7 +295,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(pubkey);
         byteBuff.put(tweak);
 
@@ -328,7 +336,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(pubkey);
         byteBuff.put(tweak);
 
@@ -366,7 +375,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(pubkey);
 
         byte[][] retByteArray;
@@ -405,7 +415,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(pubkey);
 
         byte[][] retByteArray;
@@ -436,7 +447,8 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+
+        safeRewind(byteBuff);
         byteBuff.put(seckey);
         byteBuff.put(pubkey);
 
@@ -471,7 +483,7 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+        safeRewind(byteBuff);
         byteBuff.put(seed);
 
         w.lock();
@@ -480,6 +492,20 @@ public class NativeSecp256k1 {
         } finally {
           w.unlock();
         }
+    }
+
+
+    /**
+     * This helper method is needed to resolve issue 1524 on bitcoin-s
+     * This is because the API changed for ByteBuffer between jdks < 9 and jdk >= 9
+     * In the earlier versions of the jdk, a [[java.nio.Buffer]] is returned, but greather than jdk 8
+     * returns a [[ByteBuffer]]. This causes issues when compiling with jdk 11 but running with jdk 8
+     * as the APIs are incompatible.
+     * @see https://github.com/bitcoin-s/bitcoin-s/issues/1524
+     * @param byteBuff
+     */
+    private static void safeRewind(ByteBuffer byteBuff) {
+        ((Buffer) byteBuff).rewind();
     }
 
     private static native long secp256k1_ctx_clone(long context);


### PR DESCRIPTION
This closes #1524 

This fixes a breaking change in the `ByteBuffer` API between jdk 8 and jdk 9.

You can see that the [`ByteBuffer.rewind()`](https://docs.oracle.com/javase/8/docs/api/java/nio/Buffer.html#rewind--) API for jdk 8 returns a `java.nio.Buffer`. However [`ByteBuffer.rewind()`](https://docs.oracle.com/javase/9/docs/api/java/nio/ByteBuffer.html#rewind--) after java 8 return a `java.nio.ByteBuffer`. So then when we compile something on java11 where `ByteBuffer.rewind()` is available, and then run on java8, where `ByteBuffer.rewind()` does not exist we have problems.

This leads to a `NoSuchMethod` error when compiling with java 11, but running with java 8. The [`Buffer.rewind()`](https://docs.oracle.com/javase/9/docs/api/java/nio/Buffer.html#rewind--) API is the same for java8 and java9, so our solution is casting to `Buffer` which is suggested as an answer on other forums as well.