### PR TITLE
Optimize UpdateBloomFilterTest

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -5,7 +5,7 @@ import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.node.NodeUnitTest
-import org.bitcoins.testkit.node.NodeUnitTest.SpvNodeFundedWalletBitcoind
+import org.bitcoins.testkit.node.SpvNodeFundedWalletBitcoind
 import org.scalatest.{BeforeAndAfter, FutureOutcome}
 
 class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
@@ -17,14 +17,14 @@ class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withSpvNodeFundedWalletBitcoind(test, NodeCallbacks.empty)
+    withSpvNodeFundedWalletBitcoind(test, NodeCallbacks.empty, None)
   }
 
   private val junkAddress: BitcoinAddress =
     BitcoinAddress("2NFyxovf6MyxfHqtVjstGzs6HeLqv92Nq4U")
 
   it must "update the bloom filter with a TX" in { param =>
-    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc) = param
+    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc, _) = param
 
     for {
       _ <- wallet.getBloomFilter()
@@ -44,7 +44,7 @@ class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
   }
 
   it must "update the bloom filter with an address" in { param =>
-    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc) = param
+    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc, _) = param
 
     for {
       _ <- wallet.getBloomFilter()

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -1,25 +1,12 @@
 package org.bitcoins.node
 
-import akka.actor.Cancellable
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.core.protocol.blockchain.MerkleBlock
-import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.core.wallet.fee.SatoshisPerByte
-import org.bitcoins.node.networking.peer.DataMessageHandler
-import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
-import org.bitcoins.testkit.node.{
-  NodeTestUtil,
-  NodeUnitTest,
-  SpvNodeFundedWalletBitcoind
-}
-import org.scalatest.exceptions.TestFailedException
+import org.bitcoins.testkit.node.NodeUnitTest
+import org.bitcoins.testkit.node.NodeUnitTest.SpvNodeFundedWalletBitcoind
 import org.scalatest.{BeforeAndAfter, FutureOutcome}
-
-import scala.concurrent._
-import scala.concurrent.duration._
 
 class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
 
@@ -30,150 +17,42 @@ class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withSpvNodeFundedWalletBitcoind(test, callbacks, getBIP39PasswordOpt())
+    withSpvNodeFundedWalletBitcoind(test, NodeCallbacks.empty)
   }
 
-  val testTimeout = 30.seconds
-  private var assertionP: Promise[Boolean] = Promise()
-  after {
-    //reset assertion after a test runs, because we
-    //are doing mutation to work around our callback
-    //limitations, we can't currently modify callbacks
-    //after a SpvNode is constructed :-(
-    assertionP = Promise()
-  }
-
-  /** The address we expect to receive funds at */
-  private val addressFromWalletP: Promise[BitcoinAddress] = Promise()
-
-  // the TX we sent from our wallet to bitcoind,
-  // we expect to get notified once this is
-  // confirmed
-  private val txFromWalletP: Promise[Transaction] = Promise()
-
-  def addressCallback: OnTxReceived = { tx: Transaction =>
-    // we check if any of the addresses in the TX
-    // pays to our wallet address
-    for {
-      addressFromWallet <- addressFromWalletP.future
-      result = tx.outputs.exists(
-        _.scriptPubKey == addressFromWallet.scriptPubKey)
-    } yield {
-      if (result) {
-        assertionP.success(true)
-      }
-      ()
-    }
-  }
-
-  def txCallback: OnMerkleBlockReceived = {
-    (_: MerkleBlock, txs: Vector[Transaction]) =>
-      {
-        txFromWalletP.future
-          .map { tx =>
-            if (txs.contains(tx)) {
-              assertionP.success(true)
-            }
-            ()
-          }
-      }
-  }
-
-  def callbacks: NodeCallbacks = {
-    NodeCallbacks(onTxReceived = Vector(addressCallback),
-                  onMerkleBlockReceived = Vector(txCallback))
-  }
+  private val junkAddress: BitcoinAddress =
+    BitcoinAddress("2NFyxovf6MyxfHqtVjstGzs6HeLqv92Nq4U")
 
   it must "update the bloom filter with a TX" in { param =>
-    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc, _) = param
-
-    // we want to schedule a runnable that aborts
-    // the test after a timeout, but then
-    // we need to cancel that runnable once
-    // we get a result
-    var cancelable: Option[Cancellable] = None
+    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc) = param
 
     for {
-      firstBloom <- wallet.getBloomFilter()
-      addressFromBitcoind <- rpc.getNewAddress
-      tx <- wallet
-        .sendToAddress(addressFromBitcoind,
-                       5.bitcoin,
-                       Some(SatoshisPerByte(100.sats)))
-      _ = txFromWalletP.success(tx)
+      _ <- wallet.getBloomFilter()
+      tx <- wallet.sendToAddress(junkAddress, 5.bitcoin, None)
       updatedBloom <- spv.updateBloomFilter(tx).map(_.bloomFilter)
-      _ = spv.broadcastTransaction(tx)
-      _ <- spv.sync()
-      _ <- NodeTestUtil.awaitSync(spv, rpc)
       _ = assert(updatedBloom.contains(tx.txId))
-      _ = {
-        cancelable = Some {
-          system.scheduler.scheduleOnce(
-            testTimeout,
-            new Runnable {
-              override def run: Unit = {
-                if (!assertionP.isCompleted)
-                  assertionP.failure(new TestFailedException(
-                    s"Did not receive a merkle block message after $testTimeout!",
-                    failedCodeStackDepth = 0))
-              }
-            }
-          )
-        }
-      }
-      //make sure the tx is propagated to the node's mempool
-      _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-        rpc.getMemPoolEntryOpt(tx.txId).map(_.isDefined))
+      _ <- rpc.broadcastTransaction(tx)
+
       // this should confirm our TX
       // since we updated the bloom filter
-      // we should get notified about the block
-      _ <- rpc.getNewAddress.flatMap(rpc.generateToAddress(1, _))
+      hash <- rpc.generateToAddress(1, junkAddress).map(_.head)
 
-      result <- assertionP.future
-    } yield assert(result)
+      merkleBlock <- rpc.getTxOutProof(Vector(tx.txIdBE), hash)
+      txs <- rpc.verifyTxOutProof(merkleBlock)
 
+    } yield assert(txs.contains(tx.txIdBE))
   }
 
   it must "update the bloom filter with an address" in { param =>
-    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc, _) = param
-
-    // we want to schedule a runnable that aborts
-    // the test after a timeout, but then
-    // we need to cancel that runnable once
-    // we get a result
-    var cancelable: Option[Cancellable] = None
+    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc) = param
 
     for {
-      firstBloom <- wallet.getBloomFilter()
+      _ <- wallet.getBloomFilter()
 
-      // this has to be generated after our bloom filter
-      // is calculated
-      addressFromWallet <- wallet.getNewAddress()
-      _ = addressFromWalletP.success(addressFromWallet)
-      _ <- spv.updateBloomFilter(addressFromWallet)
-      _ <- spv.sync()
-      txid <- rpc.sendToAddress(addressFromWallet, 1.bitcoin)
-      _ <- NodeTestUtil.awaitSync(spv, rpc)
-
-      _ = {
-        cancelable = Some {
-          system.scheduler.scheduleOnce(
-            testTimeout,
-            new Runnable {
-              override def run: Unit = {
-                if (!assertionP.isCompleted)
-                  assertionP.failure(new TestFailedException(
-                    s"Did not receive a merkle block message after $testTimeout!",
-                    failedCodeStackDepth = 0))
-              }
-            }
-          )
-        }
-      }
-      //make sure the tx is propagated to the node's mempool
-      _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-        rpc.getMemPoolEntryOpt(txid).map(_.isDefined))
-      result <- assertionP.future
-    } yield assert(result)
+      address <- wallet.getNewAddress()
+      updatedBloom <- spv.updateBloomFilter(address).map(_.bloomFilter)
+      hash <- rpc.sendToAddress(address, 1.bitcoin)
+      tx <- rpc.getRawTransactionRaw(hash)
+    } yield assert(updatedBloom.isRelevant(tx))
   }
 }


### PR DESCRIPTION
Couple small optimizations, this at least makes it so we don't need to wait for the tx to be relayed from one node to another. Also slightly reduces on the number of calls needed.
