### PR TITLE
Change ChainApi.getBestFilterHeader() return type to Future[Option[Co…

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterDAOTest.scala
@@ -1,0 +1,19 @@
+package org.bitcoins.chain.models
+
+import org.bitcoins.testkit.chain.ChainDbUnitTest
+import org.scalatest.FutureOutcome
+
+class CompactFilterDAOTest extends ChainDbUnitTest {
+
+  override type FixtureParam = CompactFilterDAO
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+    withCompactFilterDAO(test)
+
+  behavior of "CompactFilterDAO"
+
+  it must "retrieve getBestFilter when there are no filters in the db" in { compactFilterDAO: CompactFilterDAO =>
+    compactFilterDAO.getBestFilter
+      .map(opt => assert(opt == None))
+  }
+}

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterDAOTest.scala
@@ -12,8 +12,9 @@ class CompactFilterDAOTest extends ChainDbUnitTest {
 
   behavior of "CompactFilterDAO"
 
-  it must "retrieve getBestFilter when there are no filters in the db" in { compactFilterDAO: CompactFilterDAO =>
-    compactFilterDAO.getBestFilter
-      .map(opt => assert(opt == None))
+  it must "retrieve getBestFilter when there are no filters in the db" in {
+    compactFilterDAO: CompactFilterDAO =>
+      compactFilterDAO.getBestFilter
+        .map(opt => assert(opt == None))
   }
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
@@ -12,9 +12,10 @@ class CompactFilterHeaderDAOTest extends ChainDbUnitTest {
 
   behavior of "CompactFilterHeaderDAO"
 
-  it must "get the best filter header with a table with zero rows in it" in { filterHeaderDAO =>
-    filterHeaderDAO.getBestFilterHeader.map { opt =>
-      assert(opt == None)
-    }
+  it must "get the best filter header with a table with zero rows in it" in {
+    filterHeaderDAO =>
+      filterHeaderDAO.getBestFilterHeader.map { opt =>
+        assert(opt == None)
+      }
   }
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
@@ -1,0 +1,20 @@
+package org.bitcoins.chain.models
+
+import org.bitcoins.testkit.chain.ChainDbUnitTest
+import org.scalatest.FutureOutcome
+
+class CompactFilterHeaderDAOTest extends ChainDbUnitTest {
+
+  override type FixtureParam = CompactFilterHeaderDAO
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+    withCompactFilterHeaderDAO(test)
+
+  behavior of "CompactFilterHeaderDAO"
+
+  it must "get the best filter header with a table with zero rows in it" in { filterHeaderDAO =>
+    filterHeaderDAO.getBestFilterHeader.map { opt =>
+      assert(opt == None)
+    }
+  }
+}

--- a/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
@@ -123,8 +123,9 @@ trait ChainApi extends ChainQueryApi {
   /** Finds the "best" filter header we have stored in our database
     * What this means in practice is the latest filter header we
     * have received from our peer.
+    * Returns none if we have no filters in the database
     * */
-  def getBestFilterHeader(): Future[CompactFilterHeaderDb]
+  def getBestFilterHeader(): Future[Option[CompactFilterHeaderDb]]
 
   /**
     * Looks up a compact filter header by its hash.

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -352,10 +352,15 @@ case class ChainHandler(
   /** @inheritdoc */
   override def getFilterHeaderCount: Future[Int] = {
     logger.debug(s"Querying for filter header count")
-    filterHeaderDAO.getBestFilter.map { filterHeader =>
-      val height = filterHeader.height
-      logger.debug(s"getFilterCount result: count=$height")
-      height
+    filterHeaderDAO.getBestFilterHeader.map { filterHeaderOpt =>
+      filterHeaderOpt match {
+        case Some(filterHeader) =>
+          val height = filterHeader.height
+          logger.debug(s"getFilterCount result: count=$height")
+          height
+        case None =>
+          0
+      }
     }
   }
 
@@ -365,8 +370,8 @@ case class ChainHandler(
     filterHeaderDAO.getAtHeight(height)
 
   /** @inheritdoc */
-  override def getBestFilterHeader(): Future[CompactFilterHeaderDb] = {
-    filterHeaderDAO.getBestFilter
+  override def getBestFilterHeader(): Future[Option[CompactFilterHeaderDb]] = {
+    filterHeaderDAO.getBestFilterHeader
   }
 
   /** @inheritdoc */
@@ -377,10 +382,14 @@ case class ChainHandler(
   /** @inheritdoc */
   override def getFilterCount: Future[Int] = {
     logger.debug(s"Querying for filter count")
-    filterDAO.getBestFilter.map { filter =>
-      val height = filter.height
-      logger.debug(s"getFilterCount result: count=$height")
-      height
+    filterDAO.getBestFilter.map { filterOpt =>
+      filterOpt match {
+        case Some(filter) =>
+          val height = filter.height
+          logger.debug(s"getFilterCount result: count=$height")
+          height
+        case None => 0
+      }
     }
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -155,6 +155,19 @@ trait ChainUnitTest
                 destroy = () => ChainUnitTest.destroyAllTables)(test)
   }
 
+  /** Creates a compact filter DAO with zero rows in it */
+  def withCompactFilterHeaderDAO(test: OneArgAsyncTest): FutureOutcome = {
+    makeFixture(build = () => ChainUnitTest.createFilterHeaderDAO(),
+      destroy = ChainUnitTest.destroyAllTables)(test)
+  }
+
+
+  /** Creates a compact filter DAO with zero rows in it */
+  def withCompactFilterDAO(test: OneArgAsyncTest): FutureOutcome = {
+    makeFixture(build = () => ChainUnitTest.createFilterDAO(),
+      destroy = ChainUnitTest.destroyAllTables)(test)
+  }
+
   def withPopulatedBlockHeaderDAO(test: OneArgAsyncTest): FutureOutcome = {
     makeFixture(build = () => ChainUnitTest.createPopulatedBlockHeaderDAO,
                 destroy = () => ChainUnitTest.destroyAllTables)(test)
@@ -313,6 +326,7 @@ object ChainUnitTest extends ChainVerificationLogger {
   def createFilterHeaderDAO()(
       implicit appConfig: ChainAppConfig,
       ec: ExecutionContext): Future[CompactFilterHeaderDAO] = {
+    appConfig.migrate()
     Future.successful(CompactFilterHeaderDAO())
   }
 
@@ -325,6 +339,7 @@ object ChainUnitTest extends ChainVerificationLogger {
   def createFilterDAO()(
       implicit appConfig: ChainAppConfig,
       ec: ExecutionContext): Future[CompactFilterDAO] = {
+    appConfig.migrate()
     Future.successful(CompactFilterDAO())
   }
 


### PR DESCRIPTION
…mpactFilterHeaderDb]] to resolve issue 1549

closes #1549 

We can have cases where we don't have filter headers or filters in the database -- for instance when we call `NeutrinoNode.start()`. So we need to indicate this in the return type. Unlike block headers -- where we should always have the genesis block -- we can have instances where there are zero filter headers or filters in the database. 