### PR TITLE
Make it so wallet fixtures take a bip39PasswordOpt as a paramter

### DIFF
--- a/docs/wallet/wallet-rescan.md
+++ b/docs/wallet/wallet-rescan.md
@@ -32,10 +32,11 @@ implicit val system: ActorSystem = ActorSystem(s"wallet-rescan-example")
 implicit val ec: ExecutionContext = system.dispatcher
 implicit val appConfig: BitcoinSAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig()
 
+val bip39PasswordOpt = None
 //ok now let's spin up a bitcoind and a bitcoin-s wallet with funds in it
 val walletWithBitcoindF = for {
   bitcoind <- BitcoinSFixture.createBitcoindWithFunds()
-  walletWithBitcoind <- BitcoinSWalletTest.createWalletWithBitcoindCallbacks(bitcoind)
+  walletWithBitcoind <- BitcoinSWalletTest.createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
 } yield walletWithBitcoind
 
 val walletF = walletWithBitcoindF.map(_.wallet)

--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -7,8 +7,11 @@ import org.bitcoins.rpc.BitcoindException
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.async.TestAsyncUtil
-import org.bitcoins.testkit.node.NodeUnitTest.SpvNodeFundedWalletBitcoind
-import org.bitcoins.testkit.node.{NodeTestUtil, NodeUnitTest}
+import org.bitcoins.testkit.node.{
+  NodeTestUtil,
+  NodeUnitTest,
+  SpvNodeFundedWalletBitcoind
+}
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future
@@ -23,7 +26,9 @@ class BroadcastTransactionTest extends NodeUnitTest {
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withSpvNodeFundedWalletBitcoind(test, NodeCallbacks.empty)
+    withSpvNodeFundedWalletBitcoind(test,
+                                    NodeCallbacks.empty,
+                                    getBIP39PasswordOpt())
 
   private val sendAmount = 1.bitcoin
 
@@ -31,7 +36,7 @@ class BroadcastTransactionTest extends NodeUnitTest {
     BitcoinAddress("2NFyxovf6MyxfHqtVjstGzs6HeLqv92Nq4U")
 
   it must "broadcast a transaction" in { param =>
-    val SpvNodeFundedWalletBitcoind(node, wallet, rpc) = param
+    val SpvNodeFundedWalletBitcoind(node, wallet, rpc, _) = param
 
     def hasSeenTx(transaction: Transaction): Future[Boolean] = {
       rpc

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -8,8 +8,11 @@ import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.fixtures.UsesExperimentalBitcoind
-import org.bitcoins.testkit.node.NodeUnitTest.NeutrinoNodeFundedWalletBitcoind
-import org.bitcoins.testkit.node.{NodeTestUtil, NodeUnitTest}
+import org.bitcoins.testkit.node.{
+  NeutrinoNodeFundedWalletBitcoind,
+  NodeTestUtil,
+  NodeUnitTest
+}
 import org.scalatest.{DoNotDiscover, FutureOutcome}
 
 import scala.concurrent.duration.DurationInt
@@ -27,6 +30,7 @@ class NeutrinoNodeTest extends NodeUnitTest {
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withNeutrinoNodeFundedWalletBitcoind(test,
                                          callbacks,
+                                         getBIP39PasswordOpt(),
                                          Some(BitcoindVersion.Experimental))
 
   private val testTimeout = 30.seconds

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -10,8 +10,11 @@ import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.fixtures.UsesExperimentalBitcoind
-import org.bitcoins.testkit.node.NodeUnitTest.NeutrinoNodeFundedWalletBitcoind
-import org.bitcoins.testkit.node.{NodeTestUtil, NodeUnitTest}
+import org.bitcoins.testkit.node.{
+  NeutrinoNodeFundedWalletBitcoind,
+  NodeTestUtil,
+  NodeUnitTest
+}
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.wallet.api.WalletApi
 import org.scalatest.FutureOutcome
@@ -33,9 +36,11 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
     if (EnvUtil.isCI && !EnvUtil.isLinux) {
       FutureOutcome.succeeded
     } else {
-      withNeutrinoNodeFundedWalletBitcoind(test,
-                                           callbacks,
-                                           Some(BitcoindVersion.Experimental))
+      withNeutrinoNodeFundedWalletBitcoind(
+        test = test,
+        callbacks = callbacks,
+        bip39PasswordOpt = getBIP39PasswordOpt(),
+        versionOpt = Some(BitcoindVersion.Experimental))
     }
   }
 
@@ -76,7 +81,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
 
   it must "receive information about received payments" taggedAs (UsesExperimentalBitcoind) in {
     param =>
-      val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind) = param
+      val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind, _) = param
 
       walletP.success(wallet)
 
@@ -147,7 +152,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
 
   it must "rescan and receive information about received payments" taggedAs (UsesExperimentalBitcoind) in {
     param =>
-      val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind) = param
+      val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind, _) = param
 
       walletP.success(wallet)
 

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
@@ -6,8 +6,11 @@ import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.node.networking.peer.DataMessageHandler
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
-import org.bitcoins.testkit.node.NodeUnitTest.SpvNodeFundedWalletBitcoind
-import org.bitcoins.testkit.node.{NodeTestUtil, NodeUnitTest}
+import org.bitcoins.testkit.node.{
+  NodeTestUtil,
+  NodeUnitTest,
+  SpvNodeFundedWalletBitcoind
+}
 import org.bitcoins.wallet.api.WalletApi
 import org.scalatest.FutureOutcome
 import org.scalatest.exceptions.TestFailedException
@@ -24,7 +27,7 @@ class SpvNodeWithWalletTest extends NodeUnitTest {
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withSpvNodeFundedWalletBitcoind(test, callbacks)
+    withSpvNodeFundedWalletBitcoind(test, callbacks, getBIP39PasswordOpt())
   }
 
   private val assertionP: Promise[Boolean] = Promise()
@@ -62,7 +65,7 @@ class SpvNodeWithWalletTest extends NodeUnitTest {
 
   it must "load a bloom filter and receive information about received payments" in {
     param =>
-      val SpvNodeFundedWalletBitcoind(spv, wallet, rpc) = param
+      val SpvNodeFundedWalletBitcoind(spv, wallet, rpc, _) = param
 
       walletP.success(wallet)
 

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -10,8 +10,11 @@ import org.bitcoins.node.networking.peer.DataMessageHandler
 import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
-import org.bitcoins.testkit.node.NodeUnitTest.SpvNodeFundedWalletBitcoind
-import org.bitcoins.testkit.node.{NodeTestUtil, NodeUnitTest}
+import org.bitcoins.testkit.node.{
+  NodeTestUtil,
+  NodeUnitTest,
+  SpvNodeFundedWalletBitcoind
+}
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.{BeforeAndAfter, FutureOutcome}
 
@@ -27,7 +30,7 @@ class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withSpvNodeFundedWalletBitcoind(test, callbacks)
+    withSpvNodeFundedWalletBitcoind(test, callbacks, getBIP39PasswordOpt())
   }
 
   val testTimeout = 30.seconds
@@ -80,7 +83,7 @@ class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
   }
 
   it must "update the bloom filter with a TX" in { param =>
-    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc) = param
+    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc, _) = param
 
     // we want to schedule a runnable that aborts
     // the test after a timeout, but then
@@ -130,7 +133,7 @@ class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
   }
 
   it must "update the bloom filter with an address" in { param =>
-    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc) = param
+    val SpvNodeFundedWalletBitcoind(spv, wallet, rpc, _) = param
 
     // we want to schedule a runnable that aborts
     // the test after a timeout, but then

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeFundedWalletBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeFundedWalletBitcoind.scala
@@ -1,0 +1,31 @@
+package org.bitcoins.testkit.node
+
+import org.bitcoins.node.{NeutrinoNode, Node, SpvNode}
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.wallet.Wallet
+
+/**
+ * Creates
+ * 1. a funded bitcoind wallet
+ * 2. a funded bitcoin-s wallet
+ * 3. a chain handler with the appropriate tables created
+ * 4. a spv node that is connected to the bitcoin instance -- but not started!  */
+trait NodeFundedWalletBitcoind {
+  def node: Node
+  def wallet: Wallet
+  def bitcoindRpc: BitcoindRpcClient
+  def bip39PasswordOpt: Option[String]
+}
+case class SpvNodeFundedWalletBitcoind(
+                                        node: SpvNode,
+                                        wallet: Wallet,
+                                        bitcoindRpc: BitcoindRpcClient,
+                                        bip39PasswordOpt: Option[String])
+  extends NodeFundedWalletBitcoind
+case class NeutrinoNodeFundedWalletBitcoind(
+                                             node: NeutrinoNode,
+                                             wallet: Wallet,
+                                             bitcoindRpc: BitcoindRpcClient,
+                                             bip39PasswordOpt: Option[String])
+  extends NodeFundedWalletBitcoind
+

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -128,15 +128,17 @@ object FundWalletUtil extends FundWalletUtil {
   def createFundedWallet(
       nodeApi: NodeApi,
       chainQueryApi: ChainQueryApi,
+      bip39PasswordOpt: Option[String],
       extraConfig: Option[Config] = None)(
       implicit config: BitcoinSAppConfig,
       system: ActorSystem): Future[FundedWallet] = {
 
     import system.dispatcher
     for {
-      wallet <- BitcoinSWalletTest.createWallet2Accounts(nodeApi,
-                                                         chainQueryApi,
-                                                         extraConfig)
+      wallet <- BitcoinSWalletTest.createWallet2Accounts(nodeApi = nodeApi,
+                                                         chainQueryApi = chainQueryApi,
+        bip39PasswordOpt = bip39PasswordOpt,
+                                                         extraConfig = extraConfig)
       funded <- FundWalletUtil.fundWallet(wallet)
     } yield funded
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletWithBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletWithBitcoind.scala
@@ -1,0 +1,17 @@
+package org.bitcoins.testkit.wallet
+
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.wallet.Wallet
+
+
+sealed trait WalletWithBitcoind {
+  def wallet: Wallet
+  def bitcoind: BitcoindRpcClient
+}
+case class WalletWithBitcoindRpc(wallet: Wallet, bitcoind: BitcoindRpcClient)
+  extends WalletWithBitcoind
+case class WalletWithBitcoindV19(
+                                  wallet: Wallet,
+                                  bitcoind: BitcoindV19RpcClient)
+  extends WalletWithBitcoind

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -14,7 +14,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
   type FixtureParam = FundedWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWallet(test)
+    withFundedWallet(test, getBIP39PasswordOpt())
   }
 
   behavior of "AddressHandling"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -5,15 +5,18 @@ import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.testkit.util.TestUtil
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest.WalletWithBitcoind
-import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
+import org.bitcoins.testkit.wallet.{
+  BitcoinSWalletTest,
+  WalletTestUtil,
+  WalletWithBitcoind
+}
 import org.scalatest.FutureOutcome
 
 class FundTransactionHandlingTest extends BitcoinSWalletTest {
 
   override type FixtureParam = WalletWithBitcoind
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWalletAndBitcoind(test)
+    withFundedWalletAndBitcoind(test, getBIP39PasswordOpt())
   }
 
   val destination = TransactionOutput(Bitcoins(0.5), TestUtil.p2pkhScriptPubKey)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -14,7 +14,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
   override type FixtureParam = WalletApi
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withNewWallet(test)
+    withNewWallet(test, getBIP39PasswordOpt())
   }
 
   behavior of "Wallet.processTransaction"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -5,8 +5,8 @@ import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
+import org.bitcoins.testkit.wallet.{
+  BitcoinSWalletTest,
   WalletWithBitcoind,
   WalletWithBitcoindV19
 }
@@ -20,7 +20,7 @@ class RescanHandlingTest extends BitcoinSWalletTest {
 
   override type FixtureParam = WalletWithBitcoind
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWalletAndBitcoindV19(test)
+    withFundedWalletAndBitcoindV19(test, getBIP39PasswordOpt())
   }
 
   behavior of "Wallet rescans"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -6,8 +6,8 @@ import org.bitcoins.core.protocol.script.EmptyScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.{SatoshisPerByte, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.utxo.TxoState
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
+import org.bitcoins.testkit.wallet.{
+  BitcoinSWalletTest,
   WalletWithBitcoind,
   WalletWithBitcoindRpc
 }
@@ -24,7 +24,7 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
       .fromString("bcrt1qlhctylgvdsvaanv539rg7hyn0sjkdm23y70kgq")
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWalletAndBitcoind(test)
+    withFundedWalletAndBitcoind(test, getBIP39PasswordOpt())
   }
 
   it should "track a utxo state change to pending spent" in { param =>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletBloomTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletBloomTest.scala
@@ -2,8 +2,8 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.testkit.Implicits._
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
+import org.bitcoins.testkit.wallet.{
+  BitcoinSWalletTest,
   WalletWithBitcoind,
   WalletWithBitcoindRpc
 }
@@ -15,7 +15,7 @@ class WalletBloomTest extends BitcoinSWalletTest {
   override type FixtureParam = WalletWithBitcoind
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withFundedWalletAndBitcoind(test)
+    withFundedWalletAndBitcoind(test, getBIP39PasswordOpt())
 
   it should "generate a bloom filter that matches the pubkeys in our wallet" in {
     param =>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -3,8 +3,8 @@ package org.bitcoins.wallet
 import org.bitcoins.core.currency._
 import org.bitcoins.core.hd.HDChainType
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
+import org.bitcoins.testkit.wallet.{
+  BitcoinSWalletTest,
   WalletWithBitcoind,
   WalletWithBitcoindRpc
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -21,7 +21,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
   override type FixtureParam = FundedWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withFundedWallet(test)
+    withFundedWallet(test, getBIP39PasswordOpt())
 
   behavior of "Wallet"
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -24,7 +24,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
   override type FixtureParam = WalletApi
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withNewWallet(test)
+    withNewWallet(test, getBIP39PasswordOpt())
 
   behavior of "Wallet - unit test"
 


### PR DESCRIPTION
Previously we would create a bip39 password internally inside of [`createDefaultWallet()`](https://github.com/bitcoin-s/bitcoin-s/compare/master...Christewart:2020-06-14-walletfixtures-bip39?expand=1#diff-0fb6ac004fe1e550b7c13258d7d0706cL408). The problem with this approach is the caller of the fixture has no idea what the password is, so it shouldn't be able to spend from the wallet.  

As far as I can tell, this hasn't mattered yet as the `BIP39KeyManager` seems to retain the password and doesn't ask for it to served by the wallet for spending from an address. We need to look into this further to understand why this is the case. 