### PR TITLE
Rescan when UTXOs don't have associated transactions

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -97,6 +97,7 @@ object Main extends App with BitcoinSLogger {
                                         chainApi,
                                         BitcoinerLiveFeeRateProvider(60),
                                         bip39PasswordOpt)
+      _ <- wallet.start()
     } yield wallet
 
     //add callbacks to our unitialized node

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -111,6 +111,7 @@ abstract class Wallet
     } yield {
       stopWalletThread()
     }
+    ()
   }
 
   override def broadcastTransaction(transaction: Transaction): Future[Unit] =

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -100,12 +100,17 @@ abstract class Wallet
     for {
       _ <- walletConfig.start()
       _ <- downloadMissingUtxos
-    } yield ()
+    } yield {
+      startWalletThread()
+    }
   }
 
   override def stop(): Unit = {
-    walletConfig.stop()
-    stopWalletThread()
+    for {
+      _ <- walletConfig.stop()
+    } yield {
+      stopWalletThread()
+    }
   }
 
   override def broadcastTransaction(transaction: Transaction): Future[Unit] =

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -13,7 +13,7 @@ import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.ScriptConstant
 import org.bitcoins.core.script.control.OP_RETURN
-import org.bitcoins.core.util.{BitcoinScriptUtil, Mutable}
+import org.bitcoins.core.util.{BitcoinScriptUtil, FutureUtil, Mutable}
 import org.bitcoins.core.wallet.builder.{
   RawTxBuilderWithFinalizer,
   RawTxSigner,
@@ -74,6 +74,26 @@ abstract class Wallet
     callbacks.atomicUpdate(newCallbacks)(_ + _)
     this
   }
+
+  private def utxosWithMissingTx: Future[Vector[SpendingInfoDb]] = {
+    for {
+      utxos <- spendingInfoDAO.findAllUnspent()
+      hasTxs <- FutureUtil.foldLeftAsync(Vector.empty[SpendingInfoDb], utxos) {
+        (accum, utxo) =>
+          // If we don't have tx in our transactionDAO, add it to the list
+          transactionDAO
+            .read(utxo.txid)
+            .map(txOpt => if (txOpt.isEmpty) accum :+ utxo else accum)
+      }
+    } yield hasTxs
+  }
+
+  for {
+    utxos <- utxosWithMissingTx
+    blockHashes = utxos.flatMap(_.blockHash.map(_.flip))
+    // Download the block the tx is from so we process the block and subsequent txs
+    _ <- nodeApi.downloadBlocks(blockHashes.distinct)
+  } yield ()
 
   override def stop(): Unit = {
     walletConfig.stop()

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -58,6 +58,8 @@ trait WalletApi extends WalletLogger {
   def broadcastTransaction(transaction: Transaction): Future[Unit] =
     nodeApi.broadcastTransaction(transaction)
 
+  def start(): Future[Unit]
+
   def stop(): Unit
 
   /**


### PR DESCRIPTION
Fixes #1558
Fixes #1275

Downloading the block should be sufficient here because we will process every tx in the block and any tx relevant to us should be added to our transaction database. 