### PR TITLE
Added compile scope scalafmtCheck to travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
     - stage: test
       name: Compile website and check formatting
       env:
-        - TEST_COMMAND="test:scalafmtCheck docs/mdoc"
+        - TEST_COMMAND="scalafmtCheck test:scalafmtCheck docs/mdoc"
       scala:
         - 2.13.2
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
@@ -8,9 +8,22 @@ import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.hd.BIP32Path
 import org.bitcoins.core.number.{Int32, UInt32, UInt64}
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader, MerkleBlock}
-import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptSignature, WitnessScriptPubKey}
-import org.bitcoins.core.protocol.transaction.{Transaction, TransactionInput, TransactionOutPoint}
-import org.bitcoins.core.protocol.{Address, BitcoinAddress, P2PKHAddress, P2SHAddress}
+import org.bitcoins.core.protocol.script.{
+  ScriptPubKey,
+  ScriptSignature,
+  WitnessScriptPubKey
+}
+import org.bitcoins.core.protocol.transaction.{
+  Transaction,
+  TransactionInput,
+  TransactionOutPoint
+}
+import org.bitcoins.core.protocol.{
+  Address,
+  BitcoinAddress,
+  P2PKHAddress,
+  P2SHAddress
+}
 import org.bitcoins.core.script.ScriptType
 import org.bitcoins.core.wallet.fee.{
   BitcoinFeeUnit,
@@ -184,7 +197,8 @@ object JsonSerializers {
   implicit val doubleSha256DigestWrites: Writes[DoubleSha256Digest] =
     DoubleSha256DigestWrites
   implicit val scriptPubKeyWrites: Writes[ScriptPubKey] = ScriptPubKeyWrites
-  implicit val witnessScriptPubKeyWrites: Writes[WitnessScriptPubKey] = WitnessScriptPubKeyWrites
+  implicit val witnessScriptPubKeyWrites: Writes[WitnessScriptPubKey] =
+    WitnessScriptPubKeyWrites
   implicit val transactionInputWrites: Writes[TransactionInput] =
     TransactionInputWrites
   implicit val uInt32Writes: Writes[UInt32] = UInt32Writes

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonWriters.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonWriters.scala
@@ -57,8 +57,10 @@ object JsonWriters {
       JsString(BytesUtil.encodeHex(o.asmBytes))
   }
 
-  implicit object WitnessScriptPubKeyWrites extends Writes[WitnessScriptPubKey] {
-    override def writes(o: WitnessScriptPubKey): JsValue = ScriptPubKeyWrites.writes(o)
+  implicit object WitnessScriptPubKeyWrites
+      extends Writes[WitnessScriptPubKey] {
+    override def writes(o: WitnessScriptPubKey): JsValue =
+      ScriptPubKeyWrites.writes(o)
   }
 
   implicit object TransactionInputWrites extends Writes[TransactionInput] {

--- a/bench/src/main/scala/org/bitcoins/bench/eclair/EclairBench.scala
+++ b/bench/src/main/scala/org/bitcoins/bench/eclair/EclairBench.scala
@@ -98,7 +98,6 @@ object EclairBench extends App with EclairRpcTestUtil {
       })
     } yield paymentIds.flatten
 
-
   def runTests(network: EclairNetwork): Future[Vector[PaymentLogEntry]] = {
     println("Setting up the test network")
     for {

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -17,7 +17,10 @@ import org.bitcoins.core.crypto.ECPrivateKeyUtil
 import org.bitcoins.core.util.{BitcoinSLogger, FutureUtil, StartStop}
 import org.bitcoins.crypto.ECPrivateKey
 import org.bitcoins.rpc.BitcoindException
-import org.bitcoins.rpc.config.BitcoindAuthCredentials.{CookieBased, PasswordBased}
+import org.bitcoins.rpc.config.BitcoindAuthCredentials.{
+  CookieBased,
+  PasswordBased
+}
 import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstance}
 import org.bitcoins.rpc.util.AsyncUtil
 import play.api.libs.json._

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/FilterSync.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/FilterSync.scala
@@ -43,12 +43,14 @@ abstract class FilterSync extends ChainVerificationLogger {
         oursOpt match {
           case Some(ours) =>
             syncFiltersToTip(chainApi = chainApi,
-              ourBestHeader = ourBestBlockHeader,
-              ourBestFilterHeader = ours,
-              getFilterFunc = getFilterFunc,
-              batchSize)
+                             ourBestHeader = ourBestBlockHeader,
+                             ourBestFilterHeader = ours,
+                             getFilterFunc = getFilterFunc,
+                             batchSize)
           case None =>
-            Future.failed(new RuntimeException(s"Cannot sync filters, we don't have any in the database"))
+            Future.failed(
+              new RuntimeException(
+                s"Cannot sync filters, we don't have any in the database"))
         }
       }
     } yield {
@@ -116,11 +118,12 @@ abstract class FilterSync extends ChainVerificationLogger {
                   bestFilterOpt match {
                     case Some(bestFilter) =>
                       fetchFiltersForHeaderGroup(api,
-                        missingHeaders,
-                        bestFilter,
-                        getFilterFunc)
+                                                 missingHeaders,
+                                                 bestFilter,
+                                                 getFilterFunc)
                     case None =>
-                      Future.failed(new RuntimeException(s"Cannot sync filter headers, we do not have any in the database"))
+                      Future.failed(new RuntimeException(
+                        s"Cannot sync filter headers, we do not have any in the database"))
                   }
 
                 }

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
@@ -127,13 +127,14 @@ case class CompactFilterDAO()(
 
   /** Gets the heaviest filter from the database */
   def getBestFilter: Future[Option[CompactFilterDb]] = {
-    val join = (table.join(blockHeaderTable))
+    val join = (table
+      .join(blockHeaderTable))
       .on(_.blockHash === _.hash)
     val query = join.groupBy(_._1).map {
       case (filter, headers) =>
         filter -> headers.map(_._2.chainWork).max
     }
-    val filtersWithWorkF: Future[Vector[(CompactFilterDb,Option[BigInt])]] = {
+    val filtersWithWorkF: Future[Vector[(CompactFilterDb, Option[BigInt])]] = {
       safeDatabase.runVec(query.result)
     }
 

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -123,16 +123,18 @@ case class CompactFilterHeaderDAO()(
       case (filter, headers) =>
         filter -> headers.map(_._2.chainWork).max
     }
-    val headersWithWorkF: Future[Vector[(CompactFilterHeaderDb,Option[BigInt])]] = {
+    val headersWithWorkF: Future[
+      Vector[(CompactFilterHeaderDb, Option[BigInt])]] = {
       safeDatabase.runVec(query.result)
     }
-    headersWithWorkF.map { headersWithWork: Vector[(CompactFilterHeaderDb,Option[BigInt])] =>
-      if (headersWithWork.isEmpty) {
-       None
-      } else {
-        val highestWork = headersWithWork.maxBy(_._2.getOrElse(BigInt(0)))._1
-        Some(highestWork)
-      }
+    headersWithWorkF.map {
+      headersWithWork: Vector[(CompactFilterHeaderDb, Option[BigInt])] =>
+        if (headersWithWork.isEmpty) {
+          None
+        } else {
+          val highestWork = headersWithWork.maxBy(_._2.getOrElse(BigInt(0)))._1
+          Some(highestWork)
+        }
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -161,7 +161,7 @@ sealed abstract class UInt64 extends UnsignedNumber[UInt64] {
       hex.slice(2, hex.length)
     } else {
       val needed = 16 - hex.length
-      CryptoBytesUtil.addPadding(needed,hex)
+      CryptoBytesUtil.addPadding(needed, hex)
     }
   }
 }
@@ -331,7 +331,6 @@ object UInt32
   lazy val min = zero
   lazy val max = UInt32(maxUnderlying)
 
-
   override def isInBound(num: A): Boolean =
     num <= maxUnderlying && num >= minUnderlying
 
@@ -490,7 +489,6 @@ object Int64
   }
 
   def apply(bigInt: BigInt): Int64 = Int64Impl(bigInt)
-
 
   private def checkCached(long: Long): Int64 = {
     if (long < 256 && long >= 0) cached(long.toInt)

--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -190,7 +190,7 @@ object Bech32Address extends AddressFactory[Bech32Address] {
 
     bech32T match {
       case Success(bech32) => bech32
-      case Failure(exn) => throw exn
+      case Failure(exn)    => throw exn
     }
   }
 
@@ -267,7 +267,7 @@ object P2PKHAddress extends AddressFactory[P2PKHAddress] {
 
     p2pkhT match {
       case Success(p2pkh) => p2pkh
-      case Failure(exn) => throw exn
+      case Failure(exn)   => throw exn
     }
   }
 
@@ -346,7 +346,7 @@ object P2SHAddress extends AddressFactory[P2SHAddress] {
 
     p2shT match {
       case Success(p2sh) => p2sh
-      case Failure(exn) => throw exn
+      case Failure(exn)  => throw exn
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/AddressFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/AddressFactory.scala
@@ -11,21 +11,23 @@ abstract class AddressFactory[T <: Address] extends StringFactory[T] {
   /** Same as fromString, but throws the exception */
   def fromStringExn(str: String): T = fromString(str)
 
-  def fromScriptPubKey(spk: ScriptPubKey, np: NetworkParameters): T= {
-    fromScriptPubKeyT(spk,np) match {
+  def fromScriptPubKey(spk: ScriptPubKey, np: NetworkParameters): T = {
+    fromScriptPubKeyT(spk, np) match {
       case Success(addr) => addr
-      case Failure(exn) => throw exn
+      case Failure(exn)  => throw exn
     }
   }
 
   /**
-   * Attempts to create a address from the given [[org.bitcoins.core.protocol.script.ScriptPubKey ScriptPubKey]]
-   * and [[org.bitcoins.core.config.NetworkParameters NetworkParameters]]
-   */
+    * Attempts to create a address from the given [[org.bitcoins.core.protocol.script.ScriptPubKey ScriptPubKey]]
+    * and [[org.bitcoins.core.config.NetworkParameters NetworkParameters]]
+    */
   def fromScriptPubKeyT(spk: ScriptPubKey, np: NetworkParameters): Try[T]
 
-  def fromScriptPubKeyOpt(spk: ScriptPubKey, np: NetworkParameters): Option[T] = {
-    fromScriptPubKeyT(spk,np).toOption
+  def fromScriptPubKeyOpt(
+      spk: ScriptPubKey,
+      np: NetworkParameters): Option[T] = {
+    fromScriptPubKeyT(spk, np).toOption
   }
 
   /** Checks if the given string is a valid address */

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnInvoice.scala
@@ -5,7 +5,12 @@ import org.bitcoins.core.protocol.ln.currency.{LnCurrencyUnit, PicoBitcoins}
 import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.core.protocol.ln.util.LnUtil
 import org.bitcoins.core.util._
-import org.bitcoins.crypto.{CryptoUtil, ECPrivateKey, Sha256Digest, StringFactory}
+import org.bitcoins.crypto.{
+  CryptoUtil,
+  ECPrivateKey,
+  Sha256Digest,
+  StringFactory
+}
 import scodec.bits.ByteVector
 
 import scala.util.{Failure, Success, Try}
@@ -183,7 +188,7 @@ object LnInvoice extends StringFactory[LnInvoice] with BitcoinSLogger {
     }
     if (sepIndexes.isEmpty) {
       throw new IllegalArgumentException(
-          "LnInvoice did not have the correct separator")
+        "LnInvoice did not have the correct separator")
     } else {
       val (_, sepIndex) = sepIndexes.last
 
@@ -213,7 +218,7 @@ object LnInvoice extends StringFactory[LnInvoice] with BitcoinSLogger {
         }
 
         invoiceT match {
-          case Success(i) => i
+          case Success(i)   => i
           case Failure(exn) => throw exn
         }
       }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -251,11 +251,11 @@ object MultiSignatureScriptPubKey
 
       (hasRequiredSignaturesTry, hasMaximumSignaturesTry) match {
         case (Success(hasRequiredSignatures), Success(hasMaximumSignatures)) =>
-
           val isStandardOps = asm.forall(
             op =>
               op.isInstanceOf[ScriptConstant] || op
-                .isInstanceOf[BytesToPushOntoStack] || op.isInstanceOf[ScriptNumber] || op == OP_CHECKMULTISIG ||
+                .isInstanceOf[BytesToPushOntoStack] || op
+                .isInstanceOf[ScriptNumber] || op == OP_CHECKMULTISIG ||
                 op == OP_CHECKMULTISIGVERIFY)
 
           val result = isNotEmpty && containsMultiSigOp && hasRequiredSignatures &&

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -20,6 +20,7 @@ import scala.util.Try
   * while under Policy only OP_TRUE is True.
   */
 sealed abstract class ScriptSignature extends Script {
+
   /**
     * The digital signatures contained inside of the script signature
     * p2pkh script signatures only have one sig
@@ -242,8 +243,8 @@ object P2SHScriptSignature extends ScriptFactory[P2SHScriptSignature] {
       case _: P2PKHScriptPubKey | _: MultiSignatureScriptPubKey |
           _: P2SHScriptPubKey | _: P2PKScriptPubKey |
           _: P2PKWithTimeoutScriptPubKey | _: ConditionalScriptPubKey |
-          _: CLTVScriptPubKey | _: CSVScriptPubKey |
-          _: WitnessScriptPubKeyV0 | _: UnassignedWitnessScriptPubKey =>
+          _: CLTVScriptPubKey | _: CSVScriptPubKey | _: WitnessScriptPubKeyV0 |
+          _: UnassignedWitnessScriptPubKey =>
         true
       case _: NonStandardScriptPubKey | _: WitnessCommitment => false
       case EmptyScriptPubKey                                 => false
@@ -253,7 +254,7 @@ object P2SHScriptSignature extends ScriptFactory[P2SHScriptSignature] {
   /** Parses a redeem script from the given script token */
   def parseRedeemScript(scriptToken: ScriptToken): ScriptPubKey = {
     val asm = ScriptParser.fromBytes(scriptToken.bytes)
-    val redeemScript:ScriptPubKey = ScriptPubKey.fromAsm(asm)
+    val redeemScript: ScriptPubKey = ScriptPubKey.fromAsm(asm)
     redeemScript
   }
 }
@@ -330,12 +331,13 @@ object MultiSignatureScriptSignature
         }
     }
 
-
   /** Iterates through the given given script tokens and return false if
     * one of the elements is NOT [[ScriptConstant]] or a push operation */
   private def isPushOpsOrScriptConstants(asm: Seq[ScriptToken]): Boolean = {
-    asm.forall(token => token.isInstanceOf[ScriptConstant] ||
-      StackPushOperationFactory.isPushOperation(token))
+    asm.forall(
+      token =>
+        token.isInstanceOf[ScriptConstant] ||
+          StackPushOperationFactory.isPushOperation(token))
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
@@ -56,7 +56,8 @@ sealed abstract class RawSerializerHelper {
   }
 
   /** Serializes a [[scala.Seq Seq]] of [[NetworkElement]] to a [[scodec.bits.ByteVector]] */
-  final def writeNetworkElements[T <: NetworkElement](ts: Seq[T]): ByteVector = {
+  final def writeNetworkElements[T <: NetworkElement](
+      ts: Seq[T]): ByteVector = {
     val f = { t: T =>
       t.bytes
     }

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
@@ -14,8 +14,7 @@ sealed abstract class RawScriptSignatureParser
   def read(bytes: ByteVector): ScriptSignature = {
     if (bytes.isEmpty) EmptyScriptSignature
     else {
-      BitcoinScriptUtil.parseScript(bytes = bytes,
-        f = ScriptSignature.fromAsm)
+      BitcoinScriptUtil.parseScript(bytes = bytes, f = ScriptSignature.fromAsm)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala
@@ -19,11 +19,11 @@ abstract class NetworkUtil {
   }
 
   /** Parses a string that looks like this to [[java.net.InetSocketAddress]]
-   * "neutrino.testnet3.suredbits.com:18333"
-   * */
+    * "neutrino.testnet3.suredbits.com:18333"
+    * */
   def parseInetSocketAddress(
-                              address: String,
-                              defaultPort: Int): InetSocketAddress = {
+      address: String,
+      defaultPort: Int): InetSocketAddress = {
     address.split(":") match {
       case Array(host)       => new InetSocketAddress(host, defaultPort)
       case Array(host, port) => new InetSocketAddress(host, parsePort(port))

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfigFactory.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfigFactory.scala
@@ -8,10 +8,15 @@ import scala.concurrent.ExecutionContext
 
 trait AppConfigFactory[C <: AppConfig] {
 
-  def fromDefaultDatadir(useLogbackConf: Boolean, confs: Vector[Config] = Vector.empty)(
-    implicit ec: ExecutionContext): C = {
-    fromDatadir(AppConfig.DEFAULT_BITCOIN_S_DATADIR,useLogbackConf,confs)
+  def fromDefaultDatadir(
+      useLogbackConf: Boolean,
+      confs: Vector[Config] = Vector.empty)(
+      implicit ec: ExecutionContext): C = {
+    fromDatadir(AppConfig.DEFAULT_BITCOIN_S_DATADIR, useLogbackConf, confs)
   }
 
-  def fromDatadir(datadir: Path, useLogbackConf: Boolean, confs: Vector[Config] = Vector.empty)(implicit ec: ExecutionContext): C
+  def fromDatadir(
+      datadir: Path,
+      useLogbackConf: Boolean,
+      confs: Vector[Config] = Vector.empty)(implicit ec: ExecutionContext): C
 }

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -401,7 +401,8 @@ class EclairRpcClient(val instance: EclairInstance, binary: Option[File] = None)
       }
     }
 
-    val cancellable = system.scheduler.scheduleAtFixedRate(interval, interval)(runnable)
+    val cancellable =
+      system.scheduler.scheduleAtFixedRate(interval, interval)(runnable)
 
     p.future.onComplete(_ => cancellable.cancel())
 
@@ -864,7 +865,8 @@ class EclairRpcClient(val instance: EclairInstance, binary: Option[File] = None)
       }
     }
 
-    val cancellable = system.scheduler.scheduleAtFixedRate(interval, interval)(runnable)
+    val cancellable =
+      system.scheduler.scheduleAtFixedRate(interval, interval)(runnable)
 
     val f = p.future
 

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -74,8 +74,10 @@ case class NodeAppConfig(
   }
 
   /** Creates either a neutrino node or a spv node based on the [[NodeAppConfig]] given */
-  def createNode(peer: Peer)(chainConf: ChainAppConfig, system: ActorSystem): Future[Node] = {
-    NodeAppConfig.createNode(peer)(this,chainConf,system)
+  def createNode(peer: Peer)(
+      chainConf: ChainAppConfig,
+      system: ActorSystem): Future[Node] = {
+    NodeAppConfig.createNode(peer)(this, chainConf, system)
   }
 }
 
@@ -84,14 +86,17 @@ object NodeAppConfig extends AppConfigFactory[NodeAppConfig] {
   /** Constructs a node configuration from the default Bitcoin-S
     * data directory and given list of configuration overrides.
     */
-  override def fromDatadir(datadir: Path, useLogbackConf: Boolean, confs: Vector[Config])(
-      implicit ec: ExecutionContext): NodeAppConfig =
-    NodeAppConfig(datadir,
-                  useLogbackConf,
-                  confs: _*)
+  override def fromDatadir(
+      datadir: Path,
+      useLogbackConf: Boolean,
+      confs: Vector[Config])(implicit ec: ExecutionContext): NodeAppConfig =
+    NodeAppConfig(datadir, useLogbackConf, confs: _*)
 
   /** Creates either a neutrino node or a spv node based on the [[NodeAppConfig]] given */
-  def createNode(peer: Peer)(implicit nodeConf: NodeAppConfig, chainConf: ChainAppConfig, system: ActorSystem): Future[Node] = {
+  def createNode(peer: Peer)(
+      implicit nodeConf: NodeAppConfig,
+      chainConf: ChainAppConfig,
+      system: ActorSystem): Future[Node] = {
     if (nodeConf.isSPVEnabled) {
       Future.successful(SpvNode(peer, nodeConf, chainConf, system))
     } else if (nodeConf.isNeutrinoEnabled) {

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -158,14 +158,13 @@ trait ChainUnitTest
   /** Creates a compact filter DAO with zero rows in it */
   def withCompactFilterHeaderDAO(test: OneArgAsyncTest): FutureOutcome = {
     makeFixture(build = () => ChainUnitTest.createFilterHeaderDAO(),
-      destroy = ChainUnitTest.destroyAllTables)(test)
+                destroy = ChainUnitTest.destroyAllTables)(test)
   }
-
 
   /** Creates a compact filter DAO with zero rows in it */
   def withCompactFilterDAO(test: OneArgAsyncTest): FutureOutcome = {
     makeFixture(build = () => ChainUnitTest.createFilterDAO(),
-      destroy = ChainUnitTest.destroyAllTables)(test)
+                destroy = ChainUnitTest.destroyAllTables)(test)
   }
 
   def withPopulatedBlockHeaderDAO(test: OneArgAsyncTest): FutureOutcome = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeFundedWalletBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeFundedWalletBitcoind.scala
@@ -5,11 +5,11 @@ import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.wallet.Wallet
 
 /**
- * Creates
- * 1. a funded bitcoind wallet
- * 2. a funded bitcoin-s wallet
- * 3. a chain handler with the appropriate tables created
- * 4. a spv node that is connected to the bitcoin instance -- but not started!  */
+  * Creates
+  * 1. a funded bitcoind wallet
+  * 2. a funded bitcoin-s wallet
+  * 3. a chain handler with the appropriate tables created
+  * 4. a spv node that is connected to the bitcoin instance -- but not started!  */
 trait NodeFundedWalletBitcoind {
   def node: Node
   def wallet: Wallet
@@ -17,15 +17,14 @@ trait NodeFundedWalletBitcoind {
   def bip39PasswordOpt: Option[String]
 }
 case class SpvNodeFundedWalletBitcoind(
-                                        node: SpvNode,
-                                        wallet: Wallet,
-                                        bitcoindRpc: BitcoindRpcClient,
-                                        bip39PasswordOpt: Option[String])
-  extends NodeFundedWalletBitcoind
+    node: SpvNode,
+    wallet: Wallet,
+    bitcoindRpc: BitcoindRpcClient,
+    bip39PasswordOpt: Option[String])
+    extends NodeFundedWalletBitcoind
 case class NeutrinoNodeFundedWalletBitcoind(
-                                             node: NeutrinoNode,
-                                             wallet: Wallet,
-                                             bitcoindRpc: BitcoindRpcClient,
-                                             bip39PasswordOpt: Option[String])
-  extends NodeFundedWalletBitcoind
-
+    node: NeutrinoNode,
+    wallet: Wallet,
+    bitcoindRpc: BitcoindRpcClient,
+    bip39PasswordOpt: Option[String])
+    extends NodeFundedWalletBitcoind

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -10,7 +10,12 @@ import org.bitcoins.db.AppConfig
 import org.bitcoins.node._
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
-import org.bitcoins.node.networking.peer.{PeerHandler, PeerMessageReceiver, PeerMessageReceiverState, PeerMessageSender}
+import org.bitcoins.node.networking.peer.{
+  PeerHandler,
+  PeerMessageReceiver,
+  PeerMessageReceiverState,
+  PeerMessageSender
+}
 import org.bitcoins.rpc.client.common.BitcoindVersion.V18
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.server.BitcoinSAppConfig
@@ -19,7 +24,11 @@ import org.bitcoins.testkit.EmbeddedPg
 import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
-import org.bitcoins.testkit.node.fixture.{NeutrinoNodeConnectedWithBitcoind, NodeConnectedWithBitcoind, SpvNodeConnectedWithBitcoind}
+import org.bitcoins.testkit.node.fixture.{
+  NeutrinoNodeConnectedWithBitcoind,
+  NodeConnectedWithBitcoind,
+  SpvNodeConnectedWithBitcoind
+}
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletWithBitcoindRpc}
 import org.scalatest.FutureOutcome
@@ -106,12 +115,15 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
       appConfig: BitcoinSAppConfig): FutureOutcome = {
 
     makeDependentFixture(
-      build = () =>
-        NodeUnitTest.createSpvNodeFundedWalletBitcoind(callbacks = callbacks,
-          bip39PasswordOpt = bip39PasswordOpt,
-          versionOpt = Option(V18))(
-          system, // Force V18 because Spv is disabled on versions after
-          appConfig),
+      build =
+        () =>
+          NodeUnitTest.createSpvNodeFundedWalletBitcoind(callbacks = callbacks,
+                                                         bip39PasswordOpt =
+                                                           bip39PasswordOpt,
+                                                         versionOpt =
+                                                           Option(V18))(
+            system, // Force V18 because Spv is disabled on versions after
+            appConfig),
       destroy = NodeUnitTest.destroyNodeFundedWalletBitcoind(
         _: NodeFundedWalletBitcoind)(system, appConfig)
     )(test)
@@ -128,9 +140,10 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
     makeDependentFixture(
       build = () =>
         NodeUnitTest
-          .createNeutrinoNodeFundedWalletBitcoind(callbacks, bip39PasswordOpt, versionOpt)(
-            system,
-            appConfig),
+          .createNeutrinoNodeFundedWalletBitcoind(
+            callbacks,
+            bip39PasswordOpt,
+            versionOpt)(system, appConfig),
       destroy = NodeUnitTest.destroyNodeFundedWalletBitcoind(
         _: NodeFundedWalletBitcoind)(system, appConfig)
     )(test)
@@ -157,7 +170,8 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
     ()
   }
 
-  def getBIP39PasswordOpt(): Option[String] = KeyManagerTestUtil.bip39PasswordOpt
+  def getBIP39PasswordOpt(): Option[String] =
+    KeyManagerTestUtil.bip39PasswordOpt
 }
 
 object NodeUnitTest extends P2PLogger {
@@ -235,15 +249,16 @@ object NodeUnitTest extends P2PLogger {
     for {
       bitcoind <- BitcoinSFixture.createBitcoindWithFunds(versionOpt)
       node <- createSpvNode(bitcoind, callbacks)
-      fundedWallet <- BitcoinSWalletTest.fundedWalletAndBitcoind(bitcoind,
-                                                                 node,
-                                                                 node,
+      fundedWallet <- BitcoinSWalletTest.fundedWalletAndBitcoind(
+        bitcoind,
+        node,
+        node,
         bip39PasswordOpt)
     } yield {
       SpvNodeFundedWalletBitcoind(node = node,
                                   wallet = fundedWallet.wallet,
                                   bitcoindRpc = fundedWallet.bitcoind,
-        bip39PasswordOpt)
+                                  bip39PasswordOpt)
     }
   }
 
@@ -259,15 +274,16 @@ object NodeUnitTest extends P2PLogger {
     for {
       bitcoind <- BitcoinSFixture.createBitcoindWithFunds(versionOpt)
       node <- createNeutrinoNode(bitcoind, callbacks)
-      fundedWallet <- BitcoinSWalletTest.fundedWalletAndBitcoind(bitcoindRpcClient = bitcoind,
-                                                                 nodeApi = node,
-                                                                 chainQueryApi = node,
+      fundedWallet <- BitcoinSWalletTest.fundedWalletAndBitcoind(
+        bitcoindRpcClient = bitcoind,
+        nodeApi = node,
+        chainQueryApi = node,
         bip39PasswordOpt = bip39PasswordOpt)
     } yield {
       NeutrinoNodeFundedWalletBitcoind(node = node,
                                        wallet = fundedWallet.wallet,
                                        bitcoindRpc = fundedWallet.bitcoind,
-        bip39PasswordOpt = bip39PasswordOpt)
+                                       bip39PasswordOpt = bip39PasswordOpt)
     }
   }
 
@@ -278,7 +294,7 @@ object NodeUnitTest extends P2PLogger {
     import system.dispatcher
     val walletWithBitcoind = {
       WalletWithBitcoindRpc(fundedWalletBitcoind.wallet,
-                                               fundedWalletBitcoind.bitcoindRpc)
+                            fundedWalletBitcoind.bitcoindRpc)
     }
 
     //these need to be done in order, as the spv node needs to be

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -157,21 +157,28 @@ trait BitcoinSWalletTest
   /** Creates a wallet that is funded with some bitcoin, this wallet is NOT
     * peered with a bitcoind so the funds in the wallet are not tied to an
     * underlying blockchain */
-  def withFundedWallet(test: OneArgAsyncTest, bip39PasswordOpt: Option[String]): FutureOutcome = {
+  def withFundedWallet(
+      test: OneArgAsyncTest,
+      bip39PasswordOpt: Option[String]): FutureOutcome = {
     makeDependentFixture(
-      build = () => FundWalletUtil.createFundedWallet(nodeApi, chainQueryApi, bip39PasswordOpt),
+      build = () =>
+        FundWalletUtil.createFundedWallet(nodeApi,
+                                          chainQueryApi,
+                                          bip39PasswordOpt),
       destroy = { funded: FundedWallet =>
         destroyWallet(funded.wallet)
       }
     )(test)
   }
 
-  def withFundedSegwitWallet(test: OneArgAsyncTest, bip39PasswordOpt: Option[String]): FutureOutcome = {
+  def withFundedSegwitWallet(
+      test: OneArgAsyncTest,
+      bip39PasswordOpt: Option[String]): FutureOutcome = {
     makeDependentFixture(
       build = () =>
         FundWalletUtil.createFundedWallet(nodeApi,
                                           chainQueryApi,
-          bip39PasswordOpt,
+                                          bip39PasswordOpt,
                                           Some(segwitWalletConf)),
       destroy = { funded: FundedWallet =>
         destroyWallet(funded.wallet)
@@ -189,12 +196,16 @@ trait BitcoinSWalletTest
     withNewConfiguredWallet(segwitWalletConf)(test)
   }
 
-  def withNewWallet(test: OneArgAsyncTest, bip39PasswordOpt: Option[String]): FutureOutcome =
+  def withNewWallet(
+      test: OneArgAsyncTest,
+      bip39PasswordOpt: Option[String]): FutureOutcome =
     makeDependentFixture(build = { () =>
       createDefaultWallet(nodeApi, chainQueryApi, bip39PasswordOpt)
     }, destroy = destroyWallet)(test)
 
-  def withNewWallet2Accounts(test: OneArgAsyncTest, bip39PasswordOpt: Option[String]): FutureOutcome = {
+  def withNewWallet2Accounts(
+      test: OneArgAsyncTest,
+      bip39PasswordOpt: Option[String]): FutureOutcome = {
     makeDependentFixture(build = { () =>
       createWallet2Accounts(nodeApi, chainQueryApi, bip39PasswordOpt)
     }, destroy = destroyWallet)(test)
@@ -215,7 +226,9 @@ trait BitcoinSWalletTest
     makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
   }
 
-  def withNewWalletAndBitcoindV19(test: OneArgAsyncTest, bip39PasswordOpt: Option[String]): FutureOutcome = {
+  def withNewWalletAndBitcoindV19(
+      test: OneArgAsyncTest,
+      bip39PasswordOpt: Option[String]): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind] = composeBuildersAndWrap(
       builder = { () =>
         BitcoinSFixture
@@ -233,13 +246,16 @@ trait BitcoinSWalletTest
     makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
   }
 
-  def withFundedWalletAndBitcoind(test: OneArgAsyncTest, bip39PasswordOpt: Option[String]): FutureOutcome = {
+  def withFundedWalletAndBitcoind(
+      test: OneArgAsyncTest,
+      bip39PasswordOpt: Option[String]): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind] = { () =>
       for {
         bitcoind <- BitcoinSFixture
           .createBitcoindWithFunds(None)
         wallet <- createWalletWithBitcoindCallbacks(bitcoind = bitcoind,
-          bip39PasswordOpt = bip39PasswordOpt)
+                                                    bip39PasswordOpt =
+                                                      bip39PasswordOpt)
         fundedWallet <- fundWalletWithBitcoind(wallet)
       } yield fundedWallet
     }
@@ -247,13 +263,15 @@ trait BitcoinSWalletTest
     makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
   }
 
-  def withFundedWalletAndBitcoindV19(test: OneArgAsyncTest, bip39PasswordOpt: Option[String]): FutureOutcome = {
+  def withFundedWalletAndBitcoindV19(
+      test: OneArgAsyncTest,
+      bip39PasswordOpt: Option[String]): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoindV19] = { () =>
       for {
         bitcoind <- BitcoinSFixture
           .createBitcoindWithFunds(Some(BitcoindVersion.V19))
           .map(_.asInstanceOf[BitcoindV19RpcClient])
-        wallet <- createWalletWithBitcoindCallbacks(bitcoind,bip39PasswordOpt)
+        wallet <- createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
         fundedWallet <- fundWalletWithBitcoind(wallet)
       } yield {
         WalletWithBitcoindV19(fundedWallet.wallet, bitcoind)
@@ -277,8 +295,8 @@ trait BitcoinSWalletTest
     makeDependentFixture(builder, destroy = destroy)(test)
   }
 
-
-  def getBIP39PasswordOpt(): Option[String] = KeyManagerTestUtil.bip39PasswordOpt
+  def getBIP39PasswordOpt(): Option[String] =
+    KeyManagerTestUtil.bip39PasswordOpt
 }
 
 object BitcoinSWalletTest extends WalletLogger {
@@ -362,7 +380,7 @@ object BitcoinSWalletTest extends WalletLogger {
     * example use this to override the default data directory, network
     * or account type.
     */
-  private def   createNewWallet(
+  private def createNewWallet(
       keyManager: BIP39KeyManager,
       bip39PasswordOpt: Option[String],
       extraConfig: Option[Config],
@@ -433,7 +451,8 @@ object BitcoinSWalletTest extends WalletLogger {
     val walletWithBitcoindF = for {
       wallet <- BitcoinSWalletTest.createWallet2Accounts(bitcoind,
                                                          bitcoind,
-                                                         bip39PasswordOpt = bip39PasswordOpt,
+                                                         bip39PasswordOpt =
+                                                           bip39PasswordOpt,
                                                          extraConfig)
       _ = wallet.stopWalletThread()
 
@@ -514,7 +533,9 @@ object BitcoinSWalletTest extends WalletLogger {
       created.bitcoind.asInstanceOf[BitcoindV19RpcClient])
   }
 
-  def createWalletWithBitcoindV19(bitcoind: BitcoindV19RpcClient, bip39PasswordOpt: Option[String])(
+  def createWalletWithBitcoindV19(
+      bitcoind: BitcoindV19RpcClient,
+      bip39PasswordOpt: Option[String])(
       implicit system: ActorSystem,
       config: BitcoinSAppConfig): Future[WalletWithBitcoindV19] = {
     import system.dispatcher
@@ -541,7 +562,9 @@ object BitcoinSWalletTest extends WalletLogger {
       system: ActorSystem): Future[WalletWithBitcoind] = {
     import system.dispatcher
     for {
-      wallet <- BitcoinSWalletTest.createWallet2Accounts(nodeApi, chainQueryApi, bip39PasswordOpt)
+      wallet <- BitcoinSWalletTest.createWallet2Accounts(nodeApi,
+                                                         chainQueryApi,
+                                                         bip39PasswordOpt)
       withBitcoind <- createWalletWithBitcoind(wallet, versionOpt)
       funded <- fundWalletWithBitcoind(withBitcoind)
     } yield funded

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -135,10 +135,11 @@ object FundWalletUtil extends FundWalletUtil {
 
     import system.dispatcher
     for {
-      wallet <- BitcoinSWalletTest.createWallet2Accounts(nodeApi = nodeApi,
-                                                         chainQueryApi = chainQueryApi,
+      wallet <- BitcoinSWalletTest.createWallet2Accounts(
+        nodeApi = nodeApi,
+        chainQueryApi = chainQueryApi,
         bip39PasswordOpt = bip39PasswordOpt,
-                                                         extraConfig = extraConfig)
+        extraConfig = extraConfig)
       funded <- FundWalletUtil.fundWallet(wallet)
     } yield funded
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletWithBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletWithBitcoind.scala
@@ -4,14 +4,11 @@ import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.wallet.Wallet
 
-
 sealed trait WalletWithBitcoind {
   def wallet: Wallet
   def bitcoind: BitcoindRpcClient
 }
 case class WalletWithBitcoindRpc(wallet: Wallet, bitcoind: BitcoindRpcClient)
-  extends WalletWithBitcoind
-case class WalletWithBitcoindV19(
-                                  wallet: Wallet,
-                                  bitcoind: BitcoindV19RpcClient)
-  extends WalletWithBitcoind
+    extends WalletWithBitcoind
+case class WalletWithBitcoindV19(wallet: Wallet, bitcoind: BitcoindV19RpcClient)
+    extends WalletWithBitcoind

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -5,8 +5,16 @@ import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.core.protocol.script.{P2WPKHWitnessSPKV0, P2WPKHWitnessV0, ScriptPubKey}
-import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint, TransactionOutput}
+import org.bitcoins.core.protocol.script.{
+  P2WPKHWitnessSPKV0,
+  P2WPKHWitnessV0,
+  ScriptPubKey
+}
+import org.bitcoins.core.protocol.transaction.{
+  Transaction,
+  TransactionOutPoint,
+  TransactionOutput
+}
 import org.bitcoins.core.util.{EitherUtil, FutureUtil}
 import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.crypto.DoubleSha256DigestBE
@@ -202,15 +210,14 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     }
   }
 
-
   override def markUTXOsAsReserved(
-                                    utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]] = {
+      utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]] = {
     val updated = utxos.map(_.copyWithState(TxoState.Reserved))
     spendingInfoDAO.updateAll(updated)
   }
 
   override def unmarkUTXOsAsReserved(
-                                      utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]] = {
+      utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]] = {
     val unreserved = utxos.filterNot(_.state == TxoState.Reserved)
     require(unreserved.isEmpty, s"Some utxos are not reserved, got $unreserved")
 
@@ -241,7 +248,8 @@ private[wallet] trait UtxoHandling extends WalletLogger {
   }
 
   /** @inheritdoc */
-  override def unmarkUTXOsAsReserved(tx: Transaction): Future[Vector[SpendingInfoDb]] = {
+  override def unmarkUTXOsAsReserved(
+      tx: Transaction): Future[Vector[SpendingInfoDb]] = {
     val utxosF = listUtxos()
     val utxosInTxF = for {
       utxos <- utxosF
@@ -254,7 +262,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
 
   /** @inheritdoc */
   override def updateUtxoPendingStates(
-                               blockHeader: BlockHeader): Future[Vector[SpendingInfoDb]] = {
+      blockHeader: BlockHeader): Future[Vector[SpendingInfoDb]] = {
     for {
       infos <- spendingInfoDAO.findAllPendingConfirmation
       updatedInfos <- updateUtxoConfirmedStates(infos, blockHeader.hashBE)


### PR DESCRIPTION
This was broken on #1023 where it was replaced with `test:scalafmtCheck` ... which only runs for test scope, both commands are needed