### PR TITLE
Bump spread for address info tests in BitcoindV17RpcClientTest

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -108,7 +108,7 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
     } yield assert(signed.complete)
   }
 
-  private val SpreadInSeconds = 30
+  private val SpreadInSeconds = 40
 
   it should "be able to get the address info for a given address" in {
     for {


### PR DESCRIPTION
We had some failing in ~35 seconds, this should help prevent CI failures

https://travis-ci.org/github/bitcoin-s/bitcoin-s/jobs/699439480#L732
