### PR TITLE
Temporary fix for update all on CRUDAutoInc Tables

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
@@ -24,6 +24,8 @@ abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](implicit
     safeDatabase.runVec(actions)
   }
 
+  // FIXME: This is a temporary fix for https://github.com/bitcoin-s/bitcoin-s/issues/1586
+  // This is an inefficient solution that does each update individually
   override def updateAll(ts: Vector[T]): Future[Vector[T]] = {
     FutureUtil.foldLeftAsync(Vector.empty[T], ts) { (accum, t) =>
       super.updateAll(Vector(t)).map(accum ++ _)

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
@@ -1,7 +1,8 @@
 package org.bitcoins.db
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
+import org.bitcoins.core.util.FutureUtil
+
+import scala.concurrent.{ExecutionContext, Future}
 
 abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](implicit
     ec: ExecutionContext,
@@ -21,6 +22,12 @@ abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](implicit
     }
     val actions = query.++=(ts)
     safeDatabase.runVec(actions)
+  }
+
+  override def updateAll(ts: Vector[T]): Future[Vector[T]] = {
+    FutureUtil.foldLeftAsync(Vector.empty[T], ts) { (accum, t) =>
+      super.updateAll(Vector(t)).map(accum ++ _)
+    }
   }
 
   override def findByPrimaryKeys(


### PR DESCRIPTION
Addresses #1586

This fixes that issue but not in a great way, what this does is does each update individually which is not optimal. I could not find a fix for this, possibly an issue with `update` in Jdbc because `upsert` works just fine. 