### PR TITLE
Only fail CallbackTest if promise is not completed 

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/api/CallbackTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/api/CallbackTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.core.api
 
-import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import org.scalatest.Assertion
 
@@ -21,14 +20,14 @@ class CallbackTest extends BitcoinSAsyncTest {
           promise.complete(fail("2nd callback did not start before timeout"))
         }
       }
-      FutureUtil.unit
+      promise.future.map(_ => ())
     }
 
     val f2: Callback[Unit] = _ => {
       if (!promise.isCompleted) {
         promise.complete(Success(succeed))
       }
-      FutureUtil.unit
+      promise.future.map(_ => ())
     }
 
     val handler =

--- a/core-test/src/test/scala/org/bitcoins/core/api/CallbackTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/api/CallbackTest.scala
@@ -17,13 +17,19 @@ class CallbackTest extends BitcoinSAsyncTest {
 
     val f1: Callback[Unit] = _ => {
       Thread.sleep(testTimeout.toMillis)
-      promise.complete(fail("2nd callback did not start before timeout"))
+      if (!promise.isCompleted) {
+        promise.complete(fail("2nd callback did not start before timeout"))
+      }
       FutureUtil.unit
     }
+
     val f2: Callback[Unit] = _ => {
-      promise.complete(Success(succeed))
+      if (!promise.isCompleted) {
+        promise.complete(Success(succeed))
+      }
       FutureUtil.unit
     }
+
     val handler =
       CallbackHandler[Unit, Callback[Unit]](name = "name", Vector(f1, f2))
 

--- a/core-test/src/test/scala/org/bitcoins/core/api/CallbackTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/api/CallbackTest.scala
@@ -16,9 +16,10 @@ class CallbackTest extends BitcoinSAsyncTest {
     val promise = Promise[Assertion]()
 
     val f1: Callback[Unit] = _ => {
-      Thread.sleep(testTimeout.toMillis)
-      if (!promise.isCompleted) {
-        promise.complete(fail("2nd callback did not start before timeout"))
+      system.scheduler.scheduleOnce(testTimeout) {
+        if (!promise.isCompleted) {
+          promise.complete(fail("2nd callback did not start before timeout"))
+        }
       }
       FutureUtil.unit
     }


### PR DESCRIPTION
Closes #1604

I think previously, the test would "pass" but then after the timeout expired the it would attempt to complete the promise and throw an error, causing the test to fail after the fact.