### PR TITLE
Override correct equals functions

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -43,10 +43,13 @@ case class PSBT(
   import org.bitcoins.core.psbt.InputPSBTRecord._
   import org.bitcoins.core.psbt.PSBTInputKeyId._
 
-  // Need to define these so when we compare the PSBTs
+  // Need to define this so when we compare the PSBTs
   // the map lexicographical ordering is enforced
-  def ==(p: PSBT): Boolean = this.bytes == p.bytes
-  def !=(p: PSBT): Boolean = !(this == p)
+  override def equals(other: Any): Boolean =
+    other match {
+      case p: PSBT => this.bytes == p.bytes
+      case _       => other.equals(this)
+    }
 
   private val inputBytes: ByteVector =
     inputMaps.foldLeft(ByteVector.empty)(_ ++ _.bytes)

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
@@ -10,8 +10,11 @@ sealed abstract class ECDigitalSignature {
   require(s.signum == 1 || s.signum == 0, s"s must not be negative, got $s")
   def hex: String = CryptoBytesUtil.encodeHex(bytes)
 
-  def ==(p: ECDigitalSignature): Boolean = this.bytes == p.bytes
-  def !=(p: ECDigitalSignature): Boolean = !(this == p)
+  override def equals(other: Any): Boolean =
+    other match {
+      case sig: ECDigitalSignature => bytes == sig.bytes
+      case _                       => other.equals(this)
+    }
 
   def bytes: ByteVector
 

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -38,17 +38,6 @@ case class BIP39KeyManager(
                              password = BIP39Seed.EMPTY_PASSWORD)
   }
 
-  def ==(km: KeyManager): Boolean =
-    km match {
-      case bip39Km: BIP39KeyManager =>
-        mnemonic == bip39Km.mnemonic &&
-          kmParams == bip39Km.kmParams &&
-          bip39PasswordOpt == bip39Km.bip39PasswordOpt &&
-          creationTime.getEpochSecond == bip39Km.creationTime.getEpochSecond
-      case _: KeyManager =>
-        km == this
-    }
-
   override def equals(other: Any): Boolean =
     other match {
       case bip39Km: BIP39KeyManager =>

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -49,6 +49,17 @@ case class BIP39KeyManager(
         km == this
     }
 
+  override def equals(other: Any): Boolean =
+    other match {
+      case bip39Km: BIP39KeyManager =>
+        mnemonic == bip39Km.mnemonic &&
+          kmParams == bip39Km.kmParams &&
+          bip39PasswordOpt == bip39Km.bip39PasswordOpt &&
+          creationTime.getEpochSecond == bip39Km.creationTime.getEpochSecond
+      case _ =>
+        other.equals(this)
+    }
+
   private val privVersion: ExtKeyPrivVersion =
     HDUtil.getXprivVersion(kmParams.purpose, kmParams.network)
 


### PR DESCRIPTION
TIL overriding `==` is incorrect and should instead override the `equals` function.