### PR TITLE
Fix length of BigIntMapper

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -74,7 +74,7 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
   implicit val bigIntMapper: BaseColumnType[BigInt] =
     MappedColumnType
       .base[BigInt, Array[Byte]](
-        bi => ByteVector(bi.toByteArray).padLeft(32).toArray,
+        bi => ByteVector(bi.toByteArray).padLeft(33).toArray,
         BigInt(1, _))
 
   implicit val bigIntPostgresMapper: BaseColumnType[BigInt] =

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -73,8 +73,9 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
 
   implicit val bigIntMapper: BaseColumnType[BigInt] =
     MappedColumnType
-      .base[BigInt, Array[Byte]](_.toByteArray.dropWhile(_ == 0x00),
-                                 BigInt(1, _))
+      .base[BigInt, Array[Byte]](
+        bi => ByteVector(bi.toByteArray).padLeft(32).toArray,
+        BigInt(1, _))
 
   implicit val bigIntPostgresMapper: BaseColumnType[BigInt] =
     MappedColumnType


### PR DESCRIPTION
Closes #1645 

For mainnet block 88443 it's chain work is encoded to `0xfffef2bf0566ab`
and for block 260000 is encoded to `0x01253721228459eac00c`, so sqlite sees 88443 as larger because it starts with 0xff even though block 260000's chain work is longer.

The solution here is to enforce that they are all 32 bytes long so sqlite can't confuse them and prioritize ones with shorter lengths. 