### PR TITLE
Fix CoinSelector for KiloX fee rates

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -61,6 +61,10 @@ sealed abstract class CurrencyUnit
     Satoshis(satoshis.underlying * c.satoshis.underlying)
   }
 
+  def /(c: CurrencyUnit): CurrencyUnit = {
+    Satoshis(satoshis.underlying / c.satoshis.underlying)
+  }
+
   def unary_- : CurrencyUnit = {
     Satoshis(-satoshis.underlying)
   }

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -12,9 +12,7 @@ sealed abstract class FeeUnit {
   final def *(cu: CurrencyUnit): CurrencyUnit = this * cu.satoshis.toLong
   final def *(int: Int): CurrencyUnit = this * int.toLong
 
-  final def *(long: Long): CurrencyUnit =
-    if (scaleFactor == 1) currencyUnit * long
-    else currencyUnit * long / Satoshis(scaleFactor)
+  final def *(long: Long): CurrencyUnit = Satoshis(toLong * long / scaleFactor)
   def *(tx: Transaction): CurrencyUnit = calc(tx)
 
   /** The coefficient the denominator in the unit is multiplied by,

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -9,10 +9,21 @@ import org.bitcoins.core.protocol.transaction.Transaction
   */
 sealed abstract class FeeUnit {
   def currencyUnit: CurrencyUnit
-  def *(cu: CurrencyUnit): CurrencyUnit = this * cu.satoshis.toLong
-  def *(int: Int): CurrencyUnit = this * int.toLong
+  final def *(cu: CurrencyUnit): CurrencyUnit = this * cu.satoshis.toLong
+  final def *(int: Int): CurrencyUnit = this * int.toLong
+
+  /** Should multiply currencyUnit by long along with a scale factor if necessary.
+    * This will be used when calculating the fee for a transaction.
+    *
+    * This should ONLY be overridden if the FeeUnit's denominator is NOT a multiple of 1.
+    *  ie sats/kilobyte
+    */
   def *(long: Long): CurrencyUnit = currencyUnit * long
   def *(tx: Transaction): CurrencyUnit = calc(tx)
+
+  /** Takes the given transaction returns a size that will be used for calculating the fee rate.
+    * This is generally the denominator in the unit, ie sats/byte
+    */
   def txSizeForCalc(tx: Transaction): Long
 
   /** Calculates the fee for the transaction using this fee rate, rounds down satoshis */

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
@@ -68,7 +68,7 @@ trait CoinSelector {
         valueSoFar: CurrencyUnit,
         bytesSoFar: Long,
         utxosLeft: Vector[SpendingInfoDb]): Vector[SpendingInfoDb] = {
-      val fee = feeRate.currencyUnit * bytesSoFar
+      val fee = feeRate * bytesSoFar
       if (valueSoFar > totalValue + fee) {
         alreadyAdded
       } else if (utxosLeft.isEmpty) {
@@ -77,7 +77,7 @@ trait CoinSelector {
       } else {
         val nextUtxo = utxosLeft.head
         val approxUtxoSize = CoinSelector.approximateUtxoSize(nextUtxo)
-        val nextUtxoFee = feeRate.currencyUnit * approxUtxoSize
+        val nextUtxoFee = feeRate * approxUtxoSize
         if (nextUtxo.output.value < nextUtxoFee) {
           addUtxos(alreadyAdded, valueSoFar, bytesSoFar, utxosLeft.tail)
         } else {


### PR DESCRIPTION
There was a bug in the `CoinSelector` when we are using a fee rate that is either `SatoshisPerKiloByte` or `SatoshisPerKW`. This was caused because at this line:

https://github.com/benthecarman/bitcoin-s/blob/2d8ad5b14e9767bd8c6c70ff95dafd49200e1197/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala#L59

we would multiply by `feeRate.currencyUnit`, this causes problems for anything where in our calculation we have to divide by X (in this case 1000) and overestimate the fee that each input is adding.

To fix this, I reworked the `FeeUnit` api to hopefully prevent this, now we take in a function that is what we use for the tx calc and a separate function for multiplying. This way the user will have to set a the scale factor in the multiply function and to correctly calculate the tx fee, so their `feeRate * Long` will be correct as well.
