### PR TITLE
Skip downloadBlocks if given an empty Vector

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -11,7 +11,7 @@ import org.bitcoins.chain.models.{
 import org.bitcoins.core.api.{ChainQueryApi, NodeApi}
 import org.bitcoins.core.p2p.{NetworkPayload, TypeIdentifier}
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.core.util.Mutable
+import org.bitcoins.core.util.{FutureUtil, Mutable}
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.{
@@ -229,11 +229,15 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     */
   override def downloadBlocks(
       blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = {
-    for {
-      peerMsgSender <- peerMsgSenderF
-      _ <- peerMsgSender.sendGetDataMessage(TypeIdentifier.MsgBlock,
-                                            blockHashes: _*)
-    } yield ()
+    if (blockHashes.isEmpty) {
+      FutureUtil.unit
+    } else {
+      for {
+        peerMsgSender <- peerMsgSenderF
+        _ <- peerMsgSender.sendGetDataMessage(TypeIdentifier.MsgBlock,
+                                              blockHashes: _*)
+      } yield ()
+    }
   }
 
   /** Gets the height of the given block */

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -95,7 +95,10 @@ abstract class Wallet
       utxos <- utxosWithMissingTx
       blockHashes = utxos.flatMap(_.blockHash.map(_.flip))
       // Download the block the tx is from so we process the block and subsequent txs
-      _ <- nodeApi.downloadBlocks(blockHashes.distinct)
+      _ <-
+        if (blockHashes.nonEmpty) {
+          nodeApi.downloadBlocks(blockHashes.distinct)
+        } else FutureUtil.unit
     } yield ()
 
   override def start(): Future[Unit] = {


### PR DESCRIPTION
This should help stop the problems in #1689 as well. If there are no blocks to download it will now not initialize the `peerMsgSenderF` and should also prevent the `peerMsgSenderF` from not having the callbacks.