### PR TITLE
Have Wallet initializers give a Wallet, rather than a WalletApi

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -19,6 +19,7 @@ import org.bitcoins.feeprovider.BitcoinerLiveFeeRateProvider
 import org.bitcoins.node._
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
+import org.bitcoins.wallet.Wallet
 import org.bitcoins.wallet.api._
 import org.bitcoins.wallet.config.WalletAppConfig
 
@@ -233,7 +234,7 @@ object Main extends App with BitcoinSLogger {
 
   private def startHttpServer(
       node: Node,
-      wallet: WalletApi,
+      wallet: Wallet,
       rpcPortOpt: Option[Int])(implicit
       system: ActorSystem,
       conf: BitcoinSAppConfig): Future[Http.ServerBinding] = {

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -6,12 +6,12 @@ import akka.http.scaladsl.server._
 import org.bitcoins.commons.serializers.Picklers._
 import org.bitcoins.core.currency._
 import org.bitcoins.node.Node
-import org.bitcoins.wallet.api.WalletApi
+import org.bitcoins.wallet.Wallet
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-case class WalletRoutes(wallet: WalletApi, node: Node)(implicit
+case class WalletRoutes(wallet: Wallet, node: Node)(implicit
     system: ActorSystem)
     extends ServerRoute {
   import system.dispatcher

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -162,7 +162,7 @@ case class WalletAppConfig(
       chainQueryApi: ChainQueryApi,
       feeRateApi: FeeRateApi,
       bip39PasswordOpt: Option[String])(implicit
-      ec: ExecutionContext): Future[WalletApi] = {
+      ec: ExecutionContext): Future[Wallet] = {
     WalletAppConfig.createWallet(nodeApi = nodeApi,
                                  chainQueryApi = chainQueryApi,
                                  feeRateApi = feeRateApi,
@@ -193,7 +193,7 @@ object WalletAppConfig
       feeRateApi: FeeRateApi,
       bip39PasswordOpt: Option[String])(implicit
       walletConf: WalletAppConfig,
-      ec: ExecutionContext): Future[WalletApi] = {
+      ec: ExecutionContext): Future[Wallet] = {
     walletConf.hasWallet().flatMap { walletExists =>
       if (walletExists) {
         logger.info(s"Using pre-existing wallet")


### PR DESCRIPTION
This will be required for #1284, so the `WalletRoutes` can take in a `Wallet` rather than a `WalletApi`. This is needed because with `WalletApi` being stripped down we will want to still have access to the functions calls in the wallet.