### PR TITLE
Create HDWalletApi

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/wallet/MockWalletApi.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/wallet/MockWalletApi.scala
@@ -2,7 +2,7 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.hd.AddressType
 import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.wallet.api.WalletApi
+import org.bitcoins.wallet.api.HDWalletApi
 import org.bitcoins.wallet.models.AccountDb
 
 import scala.concurrent.Future
@@ -11,7 +11,7 @@ import scala.concurrent.Future
   * ScalaMock cannot stub traits with protected methods,
   * so we need to stub them manually.
   */
-abstract class MockWalletApi extends WalletApi {
+abstract class MockWalletApi extends HDWalletApi {
 
   override protected[wallet] def getNewChangeAddress(
       account: AccountDb): Future[BitcoinAddress] = stub

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -89,10 +89,10 @@ object Main extends App with BitcoinSLogger {
       uninitializedNode <- uninitializedNodeF
       chainApi <- chainApiF
       _ = logger.info("Initialized chain api")
-      wallet <- walletConf.createWallet(uninitializedNode,
-                                        chainApi,
-                                        BitcoinerLiveFeeRateProvider(60),
-                                        bip39PasswordOpt)
+      wallet <- walletConf.createHDWallet(uninitializedNode,
+                                          chainApi,
+                                          BitcoinerLiveFeeRateProvider(60),
+                                          bip39PasswordOpt)
     } yield {
       logger.info(s"Done configuring wallet")
       wallet

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -233,7 +233,7 @@ object Main extends App with BitcoinSLogger {
 
   private def startHttpServer(
       node: Node,
-      wallet: WalletApi,
+      wallet: HDWalletApi,
       rpcPortOpt: Option[Int])(implicit
       system: ActorSystem,
       conf: BitcoinSAppConfig): Future[Http.ServerBinding] = {

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -6,12 +6,12 @@ import akka.http.scaladsl.server._
 import org.bitcoins.commons.serializers.Picklers._
 import org.bitcoins.core.currency._
 import org.bitcoins.node.Node
-import org.bitcoins.wallet.api.WalletApi
+import org.bitcoins.wallet.api.HDWalletApi
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-case class WalletRoutes(wallet: WalletApi, node: Node)(implicit
+case class WalletRoutes(wallet: HDWalletApi, node: Node)(implicit
     system: ActorSystem)
     extends ServerRoute {
   import system.dispatcher

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -92,7 +92,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
           confirmedBalance <- wallet.getConfirmedBalance()
           unconfirmedBalance <- wallet.getUnconfirmedBalance()
           addresses <- wallet.listAddresses()
-          utxos <- wallet.listUtxos()
+          utxos <- wallet.listUtxos(wallet.walletConfig.defaultAccount)
         } yield {
           (expectedConfirmedAmount == confirmedBalance) &&
           (expectedUnconfirmedAmount == unconfirmedBalance) &&
@@ -175,7 +175,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
 
       for {
         addresses <- wallet.listAddresses()
-        utxos <- wallet.listUtxos()
+        utxos <- wallet.listUtxos(wallet.walletConfig.defaultAccount)
         _ = assert(addresses.size == 6)
         _ = assert(utxos.size == 3)
 
@@ -189,14 +189,14 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
             .sendToAddress(address, TestAmount)
 
         addresses <- wallet.listAddresses()
-        utxos <- wallet.listUtxos()
+        utxos <- wallet.listUtxos(wallet.walletConfig.defaultAccount)
         _ = assert(addresses.size == 7)
         _ = assert(utxos.size == 3)
 
         _ <- wallet.clearAllUtxosAndAddresses()
 
         addresses <- wallet.listAddresses()
-        utxos <- wallet.listUtxos()
+        utxos <- wallet.listUtxos(wallet.walletConfig.defaultAccount)
         _ = assert(addresses.isEmpty)
         _ = assert(utxos.isEmpty)
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -92,7 +92,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
           confirmedBalance <- wallet.getConfirmedBalance()
           unconfirmedBalance <- wallet.getUnconfirmedBalance()
           addresses <- wallet.listAddresses()
-          utxos <- wallet.listUtxos(wallet.walletConfig.defaultAccount)
+          utxos <- wallet.listDefaultAccountUtxos()
         } yield {
           (expectedConfirmedAmount == confirmedBalance) &&
           (expectedUnconfirmedAmount == unconfirmedBalance) &&
@@ -175,7 +175,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
 
       for {
         addresses <- wallet.listAddresses()
-        utxos <- wallet.listUtxos(wallet.walletConfig.defaultAccount)
+        utxos <- wallet.listDefaultAccountUtxos()
         _ = assert(addresses.size == 6)
         _ = assert(utxos.size == 3)
 
@@ -189,14 +189,14 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
             .sendToAddress(address, TestAmount)
 
         addresses <- wallet.listAddresses()
-        utxos <- wallet.listUtxos(wallet.walletConfig.defaultAccount)
+        utxos <- wallet.listDefaultAccountUtxos()
         _ = assert(addresses.size == 7)
         _ = assert(utxos.size == 3)
 
         _ <- wallet.clearAllUtxosAndAddresses()
 
         addresses <- wallet.listAddresses()
-        utxos <- wallet.listUtxos(wallet.walletConfig.defaultAccount)
+        utxos <- wallet.listDefaultAccountUtxos()
         _ = assert(addresses.isEmpty)
         _ = assert(utxos.isEmpty)
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/LegacyWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/LegacyWalletTest.scala
@@ -3,17 +3,16 @@ package org.bitcoins.wallet
 import org.bitcoins.core.hd.{AddressType, HDPurposes}
 import org.bitcoins.core.protocol.{Bech32Address, P2PKHAddress, P2SHAddress}
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.wallet.api.WalletApi
 import org.scalatest.FutureOutcome
 
 class LegacyWalletTest extends BitcoinSWalletTest {
 
-  override type FixtureParam = WalletApi
+  override type FixtureParam = Wallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withLegacyWallet(test)
 
-  it should "generate legacy addresses" in { wallet: WalletApi =>
+  it should "generate legacy addresses" in { wallet: Wallet =>
     for {
       addr <- wallet.getNewAddress()
       account <- wallet.getDefaultAccount()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/SegwitWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/SegwitWalletTest.scala
@@ -3,18 +3,17 @@ package org.bitcoins.wallet
 import org.bitcoins.core.hd.{AddressType, HDPurposes}
 import org.bitcoins.core.protocol.{Bech32Address, P2PKHAddress, P2SHAddress}
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.wallet.api.WalletApi
 import org.scalatest.FutureOutcome
 
 class SegwitWalletTest extends BitcoinSWalletTest {
 
-  override type FixtureParam = WalletApi
+  override type FixtureParam = Wallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     withSegwitWallet(test)
   }
 
-  it should "generate segwit addresses" in { wallet: WalletApi =>
+  it should "generate segwit addresses" in { wallet =>
     for {
       addr <- wallet.getNewAddress()
       account <- wallet.getDefaultAccount()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -140,9 +140,9 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
 
       for {
         tx <- wallet.sendToOutputs(Vector(dummyOutput),
-                                   Some(SatoshisPerVirtualByte.one),
-                                   reserveUtxos = true)
+                                   Some(SatoshisPerVirtualByte.one))
         _ <- wallet.processTransaction(tx, None)
+        _ <- wallet.markUTXOsAsReserved(tx)
 
         allReserved <- wallet.listUtxos(TxoState.Reserved)
         _ = assert(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -3,16 +3,14 @@ package org.bitcoins.wallet
 import java.nio.file.Files
 
 import org.bitcoins.core.hd.HDChainType.{Change, External}
-import org.bitcoins.core.hd.{HDAccount, HDChainType, HDPurpose}
+import org.bitcoins.core.hd.{HDAccount, HDChainType}
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.AesPassword
 import org.bitcoins.keymanager.KeyManagerUnlockError.MnemonicNotFound
 import org.bitcoins.keymanager.{KeyManagerUnlockError, WalletStorage}
-import org.bitcoins.testkit.EmbeddedPg
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.wallet.api.WalletApi.BlockMatchingResponse
-import org.bitcoins.wallet.api.WalletApi
 import org.bitcoins.wallet.models.AddressDb
 import org.scalatest.FutureOutcome
 import org.scalatest.compatible.Assertion
@@ -30,7 +28,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
   behavior of "Wallet - unit test"
 
   it must "write the mnemonic seed to the root datadir -- NOT A NETWORK sub directory" in {
-    wallet: WalletApi =>
+    wallet: Wallet =>
       //since datadir has the path that relates it to a network ('mainnet'/'testnet'/'regtest')
       //we need to get the parent of that to find where the encrypted seed should be
       //this is where the bitcoin-s.conf should live too.
@@ -41,7 +39,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
   }
 
-  it should "create a new wallet" in { wallet: WalletApi =>
+  it should "create a new wallet" in { wallet: Wallet =>
     for {
       accounts <- wallet.listAccounts()
       addresses <- wallet.listAddresses()
@@ -51,7 +49,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
     }
   }
 
-  it should "generate addresses" in { wallet: WalletApi =>
+  it should "generate addresses" in { wallet: Wallet =>
     for {
       addr <- wallet.getNewAddress()
       otherAddr <- wallet.getNewAddress()
@@ -63,9 +61,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
     }
   }
 
-  it should "know what the last address index is" in { walletApi =>
-    val wallet = walletApi.asInstanceOf[Wallet]
-
+  it should "know what the last address index is" in { wallet =>
     def getMostRecent(
         hdAccount: HDAccount,
         chain: HDChainType): Future[AddressDb] = {
@@ -138,7 +134,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
   }
 
   it should "fail to unlock the wallet with a bad password" in {
-    wallet: WalletApi =>
+    wallet: Wallet =>
       val badpassphrase = AesPassword.fromNonEmptyString("bad")
 
       val errorType = wallet.unlock(badpassphrase, None) match {
@@ -152,7 +148,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
       }
   }
 
-  it should "match block filters" in { wallet: WalletApi =>
+  it should "match block filters" in { wallet: Wallet =>
     for {
       matched <- wallet.getMatchingBlocks(
         scripts = Vector(

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
@@ -430,7 +430,9 @@ trait HDWalletApi extends WalletApi {
 
   def listUnusedAddresses(account: HDAccount): Future[Vector[AddressDb]]
 
-  def clearUtxosAndAddresses(account: HDAccount): Future[WalletApi]
+  override def clearAllUtxosAndAddresses(): Future[HDWalletApi]
+
+  def clearUtxosAndAddresses(account: HDAccount): Future[HDWalletApi]
 
   /** Gets the address associated with the pubkey at
     * the resulting `BIP32Path` determined by the
@@ -503,7 +505,7 @@ trait HDWalletApi extends WalletApi {
     } yield ()
   }
 
-  def createNewAccount(keyManagerParams: KeyManagerParams): Future[Wallet]
+  def createNewAccount(keyManagerParams: KeyManagerParams): Future[HDWalletApi]
 
   /**
     * Tries to create a new account in this wallet. Fails if the
@@ -514,6 +516,6 @@ trait HDWalletApi extends WalletApi {
     */
   def createNewAccount(
       hdAccount: HDAccount,
-      keyManagerParams: KeyManagerParams): Future[Wallet]
+      keyManagerParams: KeyManagerParams): Future[HDWalletApi]
 
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
@@ -408,6 +408,9 @@ trait HDWalletApi extends WalletApi {
     } yield tx
   }
 
+  def listDefaultAccountUtxos(): Future[Vector[SpendingInfoDb]] =
+    listUtxos(walletConfig.defaultAccount)
+
   def listUtxos(account: HDAccount): Future[Vector[SpendingInfoDb]]
 
   def listUtxos(

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
@@ -12,7 +12,6 @@ import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
 import org.bitcoins.keymanager.KeyManagerParams
-import org.bitcoins.wallet.Wallet
 import org.bitcoins.wallet.models.{AccountDb, AddressDb, SpendingInfoDb}
 
 import scala.concurrent.Future

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
@@ -1,0 +1,516 @@
+package org.bitcoins.wallet.api
+
+import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
+import org.bitcoins.core.currency.CurrencyUnit
+import org.bitcoins.core.hd.{AddressType, HDAccount, HDChainType, HDPurpose}
+import org.bitcoins.core.protocol.transaction.{
+  Transaction,
+  TransactionOutPoint,
+  TransactionOutput
+}
+import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
+import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
+import org.bitcoins.keymanager.KeyManagerParams
+import org.bitcoins.wallet.Wallet
+import org.bitcoins.wallet.models.{AccountDb, AddressDb, SpendingInfoDb}
+
+import scala.concurrent.Future
+
+/**
+  * API for the wallet project.
+  *
+  * This wallet API is BIP44 compliant.
+  *
+  * @see [[https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki BIP44]]
+  */
+trait HDWalletApi extends WalletApi {
+
+  /** Gets the balance of the given account */
+  def getBalance(account: HDAccount): Future[CurrencyUnit] = {
+    val confirmedF = getConfirmedBalance(account)
+    val unconfirmedF = getUnconfirmedBalance(account)
+    for {
+      confirmed <- confirmedF
+      unconfirmed <- unconfirmedF
+    } yield {
+      confirmed + unconfirmed
+    }
+  }
+
+  def getConfirmedBalance(account: HDAccount): Future[CurrencyUnit]
+
+  def getUnconfirmedBalance(account: HDAccount): Future[CurrencyUnit]
+
+  /** Generates a new change address */
+  protected[wallet] def getNewChangeAddress(
+      account: AccountDb): Future[BitcoinAddress]
+
+  override def getNewChangeAddress(): Future[BitcoinAddress] = {
+    for {
+      account <- getDefaultAccount()
+      addr <- getNewChangeAddress(account)
+    } yield addr
+  }
+
+  /**
+    * Fetches the default account from the DB
+    * @return Future[AccountDb]
+    */
+  protected[wallet] def getDefaultAccount(): Future[AccountDb]
+
+  /** Fetches the default account for the given address/account kind
+    * @param addressType
+    */
+  protected[wallet] def getDefaultAccountForType(
+      addressType: AddressType): Future[AccountDb]
+
+  def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      algo: CoinSelectionAlgo,
+      fromAccount: AccountDb,
+      newTags: Vector[AddressTag]): Future[Transaction]
+
+  def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      algo: CoinSelectionAlgo,
+      fromAccount: AccountDb): Future[Transaction] =
+    sendWithAlgo(address, amount, feeRate, algo, fromAccount, Vector.empty)
+
+  def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit],
+      algo: CoinSelectionAlgo,
+      fromAccount: AccountDb): Future[Transaction] = {
+    for {
+      feeRate <- determineFeeRate(feeRateOpt)
+      tx <- sendWithAlgo(address, amount, feeRate, algo, fromAccount)
+    } yield tx
+  }
+
+  override def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit],
+      algo: CoinSelectionAlgo): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendWithAlgo(address, amount, feeRateOpt, algo, account)
+    } yield tx
+  }
+
+  override def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      algo: CoinSelectionAlgo): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendWithAlgo(address, amount, feeRate, algo, account)
+    } yield tx
+  }
+
+  def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      algo: CoinSelectionAlgo,
+      newTags: Vector[AddressTag]): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendWithAlgo(address, amount, feeRate, algo, account, newTags)
+    } yield tx
+  }
+
+  /**
+    * Sends money from the specified account
+    *
+    * todo: add error handling to signature
+    */
+  def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      newTags: Vector[AddressTag]): Future[Transaction]
+
+  def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb): Future[Transaction] =
+    sendFromOutPoints(outPoints,
+                      address,
+                      amount,
+                      feeRate,
+                      fromAccount,
+                      Vector.empty)
+
+  def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit],
+      fromAccount: AccountDb): Future[Transaction] = {
+    for {
+      feeRate <- determineFeeRate(feeRateOpt)
+      tx <- sendFromOutPoints(outPoints, address, amount, feeRate, fromAccount)
+    } yield tx
+  }
+
+  override def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit]
+  ): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendFromOutPoints(outPoints, address, amount, feeRateOpt, account)
+    } yield tx
+  }
+
+  override def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendFromOutPoints(outPoints, address, amount, feeRate, account)
+    } yield tx
+  }
+
+  def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      newTags: Vector[AddressTag]): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <-
+        sendFromOutPoints(outPoints, address, amount, feeRate, account, newTags)
+    } yield tx
+  }
+
+  /**
+    * Sends money from the specified account
+    *
+    * todo: add error handling to signature
+    */
+  def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      newTags: Vector[AddressTag]): Future[Transaction]
+
+  def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb): Future[Transaction] =
+    sendToAddress(address, amount, feeRate, fromAccount, Vector.empty)
+
+  def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit],
+      fromAccount: AccountDb): Future[Transaction] = {
+    for {
+      feeRate <- determineFeeRate(feeRateOpt)
+      tx <- sendToAddress(address, amount, feeRate, fromAccount)
+    } yield tx
+  }
+
+  override def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit]
+  ): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendToAddress(address, amount, feeRateOpt, account)
+    } yield tx
+  }
+
+  override def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendToAddress(address, amount, feeRate, account)
+    } yield tx
+  }
+
+  def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      newTags: Vector[AddressTag]): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendToAddress(address, amount, feeRate, account, newTags)
+    } yield tx
+  }
+
+  /**
+    * Sends money from the specified account
+    *
+    * todo: add error handling to signature
+    */
+  def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      newTags: Vector[AddressTag]): Future[Transaction]
+
+  def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb): Future[Transaction] =
+    sendToAddresses(addresses, amounts, feeRate, fromAccount, Vector.empty)
+
+  def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRateOpt: Option[FeeUnit],
+      fromAccount: AccountDb): Future[Transaction] = {
+    for {
+      feeRate <- determineFeeRate(feeRateOpt)
+      tx <- sendToAddresses(addresses, amounts, feeRate, fromAccount)
+    } yield tx
+  }
+
+  override def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRateOpt: Option[FeeUnit]
+  ): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendToAddresses(addresses, amounts, feeRateOpt, account)
+    } yield tx
+  }
+
+  override def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRate: FeeUnit): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendToAddresses(addresses, amounts, feeRate, account)
+    } yield tx
+  }
+
+  def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRate: FeeUnit,
+      newTags: Vector[AddressTag]): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendToAddresses(addresses, amounts, feeRate, account, newTags)
+    } yield tx
+  }
+
+  /**
+    * Sends money from the specified account
+    *
+    * todo: add error handling to signature
+    */
+  def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      newTags: Vector[AddressTag]): Future[Transaction]
+
+  def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb): Future[Transaction] =
+    sendToOutputs(outputs, feeRate, fromAccount, Vector.empty)
+
+  def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRateOpt: Option[FeeUnit],
+      fromAccount: AccountDb): Future[Transaction] = {
+    for {
+      feeRate <- determineFeeRate(feeRateOpt)
+      tx <- sendToOutputs(outputs, feeRate, fromAccount)
+    } yield tx
+  }
+
+  def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      newTags: Vector[AddressTag]): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendToOutputs(outputs, feeRate, account, newTags)
+    } yield tx
+  }
+
+  override def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRateOpt: Option[FeeUnit]
+  ): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendToOutputs(outputs, feeRateOpt, account)
+    } yield tx
+  }
+
+  override def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- sendToOutputs(outputs, feeRate, account)
+    } yield tx
+  }
+
+  def makeOpReturnCommitment(
+      message: String,
+      hashMessage: Boolean,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb): Future[Transaction]
+
+  def makeOpReturnCommitment(
+      message: String,
+      hashMessage: Boolean,
+      feeRateOpt: Option[FeeUnit],
+      fromAccount: AccountDb): Future[Transaction] = {
+    for {
+      feeRate <- determineFeeRate(feeRateOpt)
+      tx <- makeOpReturnCommitment(message, hashMessage, feeRate, fromAccount)
+    } yield tx
+  }
+
+  override def makeOpReturnCommitment(
+      message: String,
+      hashMessage: Boolean,
+      feeRate: FeeUnit): Future[Transaction] = {
+    for {
+      account <- getDefaultAccount()
+      tx <- makeOpReturnCommitment(message, hashMessage, feeRate, account)
+    } yield tx
+  }
+
+  def listUtxos(account: HDAccount): Future[Vector[SpendingInfoDb]]
+
+  def listUtxos(
+      hdAccount: HDAccount,
+      tag: AddressTag): Future[Vector[SpendingInfoDb]]
+
+  def listUtxos(
+      hdAccount: HDAccount,
+      state: TxoState): Future[Vector[SpendingInfoDb]]
+
+  def listAddresses(account: HDAccount): Future[Vector[AddressDb]]
+
+  def listSpentAddresses(account: HDAccount): Future[Vector[AddressDb]]
+
+  def listFundedAddresses(
+      account: HDAccount): Future[Vector[(AddressDb, CurrencyUnit)]]
+
+  def listUnusedAddresses(account: HDAccount): Future[Vector[AddressDb]]
+
+  def clearUtxosAndAddresses(account: HDAccount): Future[WalletApi]
+
+  /** Gets the address associated with the pubkey at
+    * the resulting `BIP32Path` determined by the
+    * default account and the given chainType and addressIndex
+    */
+  def getAddress(
+      chainType: HDChainType,
+      addressIndex: Int): Future[AddressDb] = {
+    for {
+      account <- getDefaultAccount()
+      address <- getAddress(account, chainType, addressIndex)
+    } yield address
+  }
+
+  /** Gets the address associated with the pubkey at
+    * the resulting `BIP32Path` determined the given
+    * account, chainType, and addressIndex
+    */
+  def getAddress(
+      account: AccountDb,
+      chainType: HDChainType,
+      addressIndex: Int): Future[AddressDb]
+
+  def listAccounts(): Future[Vector[AccountDb]]
+
+  /** Lists all wallet accounts with the given type
+    * @param purpose
+    * @return [[Future[Vector[AccountDb]]
+    */
+  def listAccounts(purpose: HDPurpose): Future[Vector[AccountDb]] =
+    listAccounts().map(_.filter(_.hdAccount.purpose == purpose))
+
+  def rescanNeutrinoWallet(
+      account: HDAccount,
+      startOpt: Option[BlockStamp],
+      endOpt: Option[BlockStamp],
+      addressBatchSize: Int,
+      useCreationTime: Boolean): Future[Unit]
+
+  override def rescanNeutrinoWallet(
+      startOpt: Option[BlockStamp],
+      endOpt: Option[BlockStamp],
+      addressBatchSize: Int,
+      useCreationTime: Boolean): Future[Unit] = {
+    for {
+      account <- getDefaultAccount()
+      _ <- rescanNeutrinoWallet(account.hdAccount,
+                                startOpt,
+                                endOpt,
+                                addressBatchSize,
+                                useCreationTime)
+    } yield ()
+  }
+
+  def fullRescanNeutrinoWallet(
+      account: HDAccount,
+      addressBatchSize: Int): Future[Unit] = {
+    rescanNeutrinoWallet(account = account,
+                         startOpt = None,
+                         endOpt = None,
+                         addressBatchSize = addressBatchSize,
+                         useCreationTime = false)
+  }
+
+  /** Helper method to rescan the ENTIRE blockchain. */
+  override def fullRescanNeutrinoWallet(addressBatchSize: Int): Future[Unit] = {
+    for {
+      account <- getDefaultAccount()
+      _ <- fullRescanNeutrinoWallet(account.hdAccount, addressBatchSize)
+    } yield ()
+  }
+
+  def createNewAccount(keyManagerParams: KeyManagerParams): Future[Wallet]
+
+  /**
+    * Tries to create a new account in this wallet. Fails if the
+    * most recent account has no transaction history, as per
+    * BIP44
+    *
+    * @see [[https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account BIP44 account section]]
+    */
+  def createNewAccount(
+      hdAccount: HDAccount,
+      keyManagerParams: KeyManagerParams): Future[Wallet]
+
+}

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -157,16 +157,17 @@ case class WalletAppConfig(
   }
 
   /** Creates a wallet based on this [[WalletAppConfig]] */
-  def createWallet(
+  def createHDWallet(
       nodeApi: NodeApi,
       chainQueryApi: ChainQueryApi,
       feeRateApi: FeeRateApi,
       bip39PasswordOpt: Option[String])(implicit
       ec: ExecutionContext): Future[HDWalletApi] = {
-    WalletAppConfig.createWallet(nodeApi = nodeApi,
-                                 chainQueryApi = chainQueryApi,
-                                 feeRateApi = feeRateApi,
-                                 bip39PasswordOpt = bip39PasswordOpt)(this, ec)
+    WalletAppConfig.createHDWallet(
+      nodeApi = nodeApi,
+      chainQueryApi = chainQueryApi,
+      feeRateApi = feeRateApi,
+      bip39PasswordOpt = bip39PasswordOpt)(this, ec)
   }
 
   /** Starts the associated application */
@@ -187,7 +188,7 @@ object WalletAppConfig
     WalletAppConfig(datadir, useLogbackConf, confs: _*)
 
   /** Creates a wallet based on the given [[WalletAppConfig]] */
-  def createWallet(
+  def createHDWallet(
       nodeApi: NodeApi,
       chainQueryApi: ChainQueryApi,
       feeRateApi: FeeRateApi,

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -14,7 +14,7 @@ import org.bitcoins.keymanager.{
   KeyManagerParams,
   WalletStorage
 }
-import org.bitcoins.wallet.api.WalletApi
+import org.bitcoins.wallet.api.HDWalletApi
 import org.bitcoins.wallet.db.WalletDbManagement
 import org.bitcoins.wallet.models.AccountDAO
 import org.bitcoins.wallet.{Wallet, WalletLogger}
@@ -162,7 +162,7 @@ case class WalletAppConfig(
       chainQueryApi: ChainQueryApi,
       feeRateApi: FeeRateApi,
       bip39PasswordOpt: Option[String])(implicit
-      ec: ExecutionContext): Future[WalletApi] = {
+      ec: ExecutionContext): Future[HDWalletApi] = {
     WalletAppConfig.createWallet(nodeApi = nodeApi,
                                  chainQueryApi = chainQueryApi,
                                  feeRateApi = feeRateApi,
@@ -193,7 +193,7 @@ object WalletAppConfig
       feeRateApi: FeeRateApi,
       bip39PasswordOpt: Option[String])(implicit
       walletConf: WalletAppConfig,
-      ec: ExecutionContext): Future[WalletApi] = {
+      ec: ExecutionContext): Future[HDWalletApi] = {
     walletConf.hasWallet().flatMap { walletExists =>
       if (walletExists) {
         logger.info(s"Using pre-existing wallet")


### PR DESCRIPTION
Part of #1284 

Separates the `WalletApi` into `HDWalletApi`. This new trait has any of the calls that had was associated with an account. This should allow us to delegate key manager types better.