### PR TITLE
Fix All Loggers!

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/HttpLogger.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/HttpLogger.scala
@@ -5,13 +5,9 @@ import org.slf4j.Logger
 
 /** Exposes access to the HTTP RPC server logger */
 private[bitcoins] trait HttpLogger {
-  private var _logger: Logger = _
 
   protected[bitcoins] def logger(implicit config: LoggerConfig): Logger = {
-    if (_logger == null) {
-      _logger = HttpLoggerImpl(config).getLogger
-    }
-    _logger
+    HttpLoggerImpl(config).getLogger
   }
 }
 

--- a/chain/src/main/scala/org/bitcoins/chain/ChainVerificationLogger.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/ChainVerificationLogger.scala
@@ -5,13 +5,9 @@ import org.slf4j.Logger
 
 /** Exposes access to the chain verification logger */
 private[bitcoins] trait ChainVerificationLogger {
-  private var _logger: Logger = _
 
   protected[bitcoins] def logger(implicit config: LoggerConfig): Logger = {
-    if (_logger == null) {
-      _logger = ChainVerificationLoggerImpl(config).getLogger
-    }
-    _logger
+    ChainVerificationLoggerImpl(config).getLogger
   }
 }
 

--- a/db-commons/src/main/scala/org/bitcoins/db/AppLoggers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppLoggers.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.db
 
+import java.util.concurrent.ConcurrentHashMap
+
 import ch.qos.logback.classic.{Logger, LoggerContext}
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.classic.joran.JoranConfigurator
@@ -27,7 +29,7 @@ private[bitcoins] trait AppLoggers {
 
   def conf: LoggerConfig
 
-  private val context: LoggerContext = {
+  private def context: LoggerContext = {
     val context = LoggerFactory.getILoggerFactory match {
       case ctx: LoggerContext => ctx
       case other              => sys.error(s"Expected LoggerContext, got: $other")
@@ -44,7 +46,7 @@ private[bitcoins] trait AppLoggers {
   }
 
   /** Responsible for formatting our logs */
-  private val encoder: Encoder[Nothing] = {
+  private def encoder: Encoder[Nothing] = {
     val encoder = new PatternLayoutEncoder()
     // same date format as Bitcoin Core
     encoder.setPattern(
@@ -55,13 +57,12 @@ private[bitcoins] trait AppLoggers {
   }
 
   /** Responsible for writing to stdout
-    *
-    * TODO: Use different appender than file?
     */
-  private lazy val consoleAppender: ConsoleAppender[ILoggingEvent] = {
+  private def newConsoleAppender(
+      logger: Logger): ConsoleAppender[ILoggingEvent] = {
     val appender = new ConsoleAppender()
     appender.setContext(context)
-    appender.setName("STDOUT")
+    appender.setName(s"STDOUT-${logger.hashCode}")
     appender.setEncoder(encoder)
     appender.start()
     appender.asInstanceOf[ConsoleAppender[ILoggingEvent]]
@@ -70,10 +71,10 @@ private[bitcoins] trait AppLoggers {
   /**
     * Responsible for writing to the log file
     */
-  private lazy val fileAppender: FileAppender[ILoggingEvent] = {
+  private def newFileAppender(logger: Logger): FileAppender[ILoggingEvent] = {
     val logFileAppender = new RollingFileAppender()
     logFileAppender.setContext(context)
-    logFileAppender.setName("FILE")
+    logFileAppender.setName(s"FILE-${logger.hashCode}")
     logFileAppender.setEncoder(encoder)
     logFileAppender.setAppend(true)
 
@@ -94,6 +95,9 @@ private[bitcoins] trait AppLoggers {
 
   /** Stitches together the encoder, appenders and sets the correct
     * logging level
+    *
+    * For some reason the LoggerContext where our loggers are cached does not
+    * keep appenders around, so they have to be attached _and_ started each time.
     */
   protected def getLoggerImpl(loggerKind: LoggerKind): Logger = {
     import LoggerKind._
@@ -112,8 +116,23 @@ private[bitcoins] trait AppLoggers {
     // This also will make any logger using the class name fall under the same logger
     val logger: Logger = context.getLogger(s"org.bitcoins.$name")
     logger.setAdditive(true)
-    logger.addAppender(fileAppender)
-    logger.addAppender(consoleAppender)
+    if (!AppLoggers.fileAppenders.containsKey(logger.hashCode)) {
+      val appender = newFileAppender(logger)
+      AppLoggers.fileAppenders.put(logger.hashCode, appender)
+    }
+    if (!AppLoggers.consoleAppenders.containsKey(logger.hashCode)) {
+      val appender = newConsoleAppender(logger)
+      AppLoggers.consoleAppenders.put(logger.hashCode, appender)
+    }
+    logger.addAppender(AppLoggers.fileAppenders.get(logger.hashCode))
+    logger.addAppender(AppLoggers.consoleAppenders.get(logger.hashCode))
+    val iter = logger.iteratorForAppenders()
+    while (iter.hasNext) {
+      val appender = iter.next()
+      if (!appender.isStarted) {
+        appender.start()
+      }
+    }
 
     // Set level from config if we aren't using the logback.conf
     if (!conf.useLogbackConf) {
@@ -122,4 +141,13 @@ private[bitcoins] trait AppLoggers {
 
     logger
   }
+}
+
+object AppLoggers {
+
+  val fileAppenders: ConcurrentHashMap[Int, FileAppender[ILoggingEvent]] =
+    new ConcurrentHashMap()
+
+  val consoleAppenders: ConcurrentHashMap[Int, ConsoleAppender[ILoggingEvent]] =
+    new ConcurrentHashMap()
 }

--- a/db-commons/src/main/scala/org/bitcoins/db/DatabaseLogger.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DatabaseLogger.scala
@@ -4,13 +4,9 @@ import org.slf4j.Logger
 
 /** Exposes access to the database interaction logger */
 private[bitcoins] trait DatabaseLogger {
-  private var _logger: Logger = _
 
   protected[bitcoins] def logger(implicit config: LoggerConfig): Logger = {
-    if (_logger == null) {
-      _logger = DatabaseLoggerImpl(config).getLogger
-    }
-    _logger
+    DatabaseLoggerImpl(config).getLogger
   }
 }
 

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/KeyManagerLogger.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/KeyManagerLogger.scala
@@ -5,13 +5,9 @@ import org.slf4j.Logger
 
 /** Exposes access to the key manager logger */
 private[bitcoins] trait KeyManagerLogger {
-  private var _logger: Logger = _
 
   protected[bitcoins] def logger(implicit config: LoggerConfig): Logger = {
-    if (_logger == null) {
-      _logger = KeyManagerLoggerImpl(config).getLogger
-    }
-    _logger
+    KeyManagerLoggerImpl(config).getLogger
   }
 }
 

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -23,7 +23,7 @@ case class NeutrinoNode(
 
   implicit override def nodeAppConfig: NodeAppConfig = nodeConfig
 
-  implicit override def chainAppConfig: ChainAppConfig = chainConfig
+  override def chainAppConfig: ChainAppConfig = chainConfig
 
   override val peer: Peer = nodePeer
 

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -25,7 +25,6 @@ import org.bitcoins.node.networking.peer.{
   PeerMessageSender
 }
 import org.bitcoins.rpc.util.AsyncUtil
-import org.slf4j.Logger
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
@@ -54,11 +53,6 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     callbacks.atomicUpdate(newCallbacks)(_ + _)
     this
   }
-
-  // Need to overwrite logger because nodeAppConfig and chainAppConfig are both
-  // instances of LoggerConfig
-  protected def logger(implicit config: NodeAppConfig): Logger =
-    super.logger(config)
 
   lazy val txDAO = BroadcastAbleTransactionDAO()
 

--- a/node/src/main/scala/org/bitcoins/node/P2PLogger.scala
+++ b/node/src/main/scala/org/bitcoins/node/P2PLogger.scala
@@ -1,17 +1,14 @@
 package org.bitcoins.node
 
 import org.bitcoins.db.{AppLoggers, LoggerConfig}
+import org.bitcoins.node.config.NodeAppConfig
 import org.slf4j.Logger
 
 /** Exposes access to the P2P submodule logger */
 private[bitcoins] trait P2PLogger {
-  private var _logger: Logger = _
 
-  protected def logger(implicit config: LoggerConfig): Logger = {
-    if (_logger == null) {
-      _logger = P2PLoggerImpl(config).getLogger
-    }
-    _logger
+  protected def logger(implicit config: NodeAppConfig): Logger = {
+    P2PLoggerImpl(config).getLogger
   }
 }
 

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -25,7 +25,7 @@ case class SpvNode(
 
   implicit override def nodeAppConfig: NodeAppConfig = nodeConfig
 
-  implicit override def chainAppConfig: ChainAppConfig = chainConfig
+  override def chainAppConfig: ChainAppConfig = chainConfig
 
   override val peer: Peer = nodePeer
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -9,7 +9,6 @@ import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.BroadcastAbleTransactionDAO
 import org.bitcoins.node.{NodeCallbacks, P2PLogger}
-import org.slf4j.Logger
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -29,11 +28,6 @@ case class DataMessageHandler(
     appConfig: NodeAppConfig,
     chainConfig: ChainAppConfig)
     extends P2PLogger {
-
-  // Need to overwrite logger because nodeAppConfig and chainAppConfig are both
-  // instances of LoggerConfig
-  protected def logger(implicit config: NodeAppConfig): Logger =
-    super.logger(config)
 
   private val txDAO = BroadcastAbleTransactionDAO()
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -20,7 +20,6 @@ import org.bitcoins.node.networking.peer.PeerMessageReceiverState.{
   Normal,
   Preconnection
 }
-import org.slf4j.Logger
 
 import scala.concurrent.Future
 
@@ -42,11 +41,6 @@ class PeerMessageReceiver(
     chainAppConfig: ChainAppConfig)
     extends P2PLogger {
   import ref.dispatcher
-
-  // Need to overwrite logger because nodeAppConfig and chainAppConfig are both
-  // instances of LoggerConfig
-  protected def logger(implicit config: NodeAppConfig): Logger =
-    super.logger(config)
 
   /** This method is called when we have received
     * a [[akka.io.Tcp.Connected]] message from our peer

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletLogger.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletLogger.scala
@@ -5,13 +5,9 @@ import org.slf4j.Logger
 
 /** Exposes acccess to the wallet logger */
 private[bitcoins] trait WalletLogger {
-  private var _logger: Logger = _
 
   protected[bitcoins] def logger(implicit config: LoggerConfig): Logger = {
-    if (_logger == null) {
-      _logger = WalletLoggerImpl(config).getLogger
-    }
-    _logger
+    WalletLoggerImpl(config).getLogger
   }
 }
 


### PR DESCRIPTION
 Fixes #1688 and more!

Fixed logging so that appenders are always started when a cached logger is retrieved, for some reason logger appenders get detached and I don't know why.

Previously what was happening is that loggers were cached per-object but appenders were stopped/detached the moment another object queried for a cached logger. The resulting behavior was that the first logs from an object/instance were seen and then once any other object did any logging the logs from the previous object would stop being added.