### PR TITLE
Add .transactionally to CRUD.updateAll(), CRUD.upsertAll(), CRUDAutoI…

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
@@ -89,7 +89,7 @@ abstract class CRUD[T, PrimaryKeyType](implicit
     val query = findAll(ts)
     val actions = ts.map(t => query.update(t))
     val affectedRows: Future[Vector[Int]] =
-      safeDatabase.run(DBIO.sequence(actions))
+      safeDatabase.run(DBIO.sequence(actions).transactionally)
     val updatedTs = findAll(ts)
     affectedRows.flatMap { _ =>
       safeDatabase.runVec(updatedTs.result)
@@ -125,7 +125,8 @@ abstract class CRUD[T, PrimaryKeyType](implicit
   /** Upserts all of the given ts in the database, then returns the upserted values */
   def upsertAll(ts: Vector[T]): Future[Vector[T]] = {
     val actions = ts.map(t => table.insertOrUpdate(t))
-    val result: Future[Vector[Int]] = safeDatabase.run(DBIO.sequence(actions))
+    val result: Future[Vector[Int]] =
+      safeDatabase.run(DBIO.sequence(actions).transactionally)
     val findQueryFuture = result.map(_ => findAll(ts).result)
     findQueryFuture.flatMap(safeDatabase.runVec(_))
   }

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
@@ -21,7 +21,7 @@ abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](implicit
       idAutoInc.into((t, id) => t.copyWithId(id = id))
     }
     val actions = query.++=(ts)
-    safeDatabase.runVec(actions)
+    safeDatabase.runVec(actions.transactionally)
   }
 
   // FIXME: This is a temporary fix for https://github.com/bitcoin-s/bitcoin-s/issues/1586


### PR DESCRIPTION
…nc.createAll()

This makes use of [`transactionally`](https://scala-slick.org/doc/3.3.1/api/index.html#slick.jdbc.JdbcActionComponent$JdbcActionExtensionMethods@transactionally:slick.dbio.DBIOAction[R,S,Ewithslick.dbio.Effect.Transactional]) when doing batch creates, upserts, and updates. 

Anecdotally when running #1697 with this patch this speeds up upserting 2016 block headers from ~20 seconds to ~5 seconds on my laptop.