### PR TITLE
Remove need to parse every header in a blockchain on instantiation

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -39,7 +39,7 @@ private[blockchain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
 
   val tip: BlockHeaderDb = headers.head
 
-  require(headers.size == 1 || headers(1).height == tip.height - 1)
+  require(headers.size <= 1 || headers(1).height == tip.height - 1)
 
   /** The height of the chain */
   val height: Int = tip.height

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -1,11 +1,10 @@
 package org.bitcoins.chain.blockchain
 
-import org.bitcoins.chain.models.BlockHeaderDb
-import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.ChainVerificationLogger
-import org.bitcoins.chain.validation.TipUpdateResult
-import org.bitcoins.chain.validation.TipValidation
+import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.chain.models.BlockHeaderDb
+import org.bitcoins.chain.validation.{TipUpdateResult, TipValidation}
+import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.util.SeqWrapper
 import org.bitcoins.crypto.DoubleSha256DigestBE
 
@@ -39,6 +38,8 @@ private[blockchain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
       headers: scala.collection.immutable.Seq[BlockHeaderDb]): Blockchain
 
   val tip: BlockHeaderDb = headers.head
+
+  require(headers.size == 1 || headers(1).height == tip.height - 1)
 
   /** The height of the chain */
   val height: Int = tip.height

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -38,7 +38,7 @@ private[blockchain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
   protected[blockchain] def compObjectfromHeaders(
       headers: scala.collection.immutable.Seq[BlockHeaderDb]): Blockchain
 
-  val tip: BlockHeaderDb = headers.maxBy(_.height)
+  val tip: BlockHeaderDb = headers.head
 
   /** The height of the chain */
   val height: Int = tip.height


### PR DESCRIPTION
Fixes #1699 

By using `maxBy` we were requiring us to parse every header everytime we made a new `Blockchain` to calculate the tip. 