### PR TITLE
Wallet API remove app config

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -449,9 +449,8 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     }
 
     "return a new address" in {
-      (mockWalletApi
-        .getNewAddress()(_: ExecutionContext))
-        .expects(executor)
+      (mockWalletApi.getNewAddress: () => Future[BitcoinAddress])
+        .expects()
         .returning(Future.successful(testAddress))
 
       val route =

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -17,13 +17,12 @@ import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.server.BitcoinSAppConfig._
-import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.bitcoins.testkit.chain.SyncUtil
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
 import org.bitcoins.testkit.util.FileUtil
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
-import org.bitcoins.wallet.api.WalletApi
+import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 import org.scalatest._
@@ -649,7 +648,7 @@ object BitcoinSWalletTest extends WalletLogger {
     } yield ()
   }
 
-  def destroyWallet(wallet: WalletApi): Future[Unit] = {
+  def destroyWallet(wallet: Wallet): Future[Unit] = {
     import wallet.walletConfig.ec
     for {
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -5,11 +5,13 @@ import java.time.Instant
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.core.api.{ChainQueryApi, FeeRateApi, NodeApi}
 import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
+import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.{GolombFilter, SimpleFilterMatcher}
 import org.bitcoins.core.hd.{HDAccount, HDCoin, HDPurposes}
 import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.blockchain.ChainParams
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.ScriptConstant
@@ -59,6 +61,14 @@ abstract class Wallet
     with RescanHandling {
 
   implicit val ec: ExecutionContext
+
+  implicit val walletConfig: WalletAppConfig
+
+  val chainParams: ChainParams = walletConfig.chain
+
+  val networkParameters: NetworkParameters = walletConfig.network
+
+  override val discoveryBatchSize: Int = walletConfig.discoveryBatchSize
 
   private[wallet] val addressDAO: AddressDAO = AddressDAO()
   private[wallet] val accountDAO: AccountDAO = AccountDAO()

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
@@ -436,8 +436,7 @@ trait HDWalletApi extends WalletApi {
     } yield tx
   }
 
-  def listDefaultAccountUtxos(): Future[Vector[SpendingInfoDb]] =
-    listUtxos(walletConfig.defaultAccount)
+  def listDefaultAccountUtxos(): Future[Vector[SpendingInfoDb]]
 
   def listUtxos(account: HDAccount): Future[Vector[SpendingInfoDb]]
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -241,6 +241,21 @@ private[wallet] trait AddressHandling extends WalletLogger {
   }
 
   /** @inheritdoc */
+  override def getNewAddress(): Future[BitcoinAddress] = {
+    for {
+      address <- getNewAddress(walletConfig.defaultAddressType)
+    } yield address
+  }
+
+  /** @inheritdoc */
+  override def getNewAddress(
+      tags: Vector[AddressTag]): Future[BitcoinAddress] = {
+    for {
+      address <- getNewAddress(walletConfig.defaultAddressType, tags)
+    } yield address
+  }
+
+  /** @inheritdoc */
   def getAddress(
       account: AccountDb,
       chainType: HDChainType,

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -121,7 +121,7 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
         addrInfoOptF = selectedUtxos.map { utxo =>
           // .gets should be safe here because of foreign key at the database level
           for {
-            addrInfo <- getAddressInfo(utxo).map(_.get)
+            addrInfo <- getAddressInfo(utxo, networkParameters).map(_.get)
             prevTx <-
               transactionDAO
                 .findByOutPoint(utxo.outPoint)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -35,6 +35,10 @@ private[wallet] trait UtxoHandling extends WalletLogger {
   self: Wallet =>
 
   /** @inheritdoc */
+  def listDefaultAccountUtxos(): Future[Vector[SpendingInfoDb]] =
+    listUtxos(walletConfig.defaultAccount)
+
+  /** @inheritdoc */
   override def listUtxos(): Future[Vector[SpendingInfoDb]] = {
     spendingInfoDAO.findAllUnspent()
   }


### PR DESCRIPTION
Part of #1284

removes the wallet app config from the api and moves it into our own wallet implementation