### PR TITLE
Optimize getBestFilter functions

### DIFF
--- a/chain/src/main/resources/postgresql/chain/migration/V3__chainwork_index.sql
+++ b/chain/src/main/resources/postgresql/chain/migration/V3__chainwork_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX block_headers_chain_work_index on block_headers (chain_work);

--- a/chain/src/main/resources/sqlite/chain/migration/V4__chain_work_to_varchar.sql
+++ b/chain/src/main/resources/sqlite/chain/migration/V4__chain_work_to_varchar.sql
@@ -1,0 +1,9 @@
+-- This block changes the chain work column from a VARBINARY to a VARCHAR
+CREATE TABLE "block_headers_temp" ("height" INTEGER NOT NULL,"hash" VARCHAR(254) PRIMARY KEY NOT NULL,"version" INTEGER NOT NULL,"previous_block_hash" VARCHAR(254) NOT NULL,"merkle_root_hash" VARCHAR(254) NOT NULL,"time" INTEGER NOT NULL,"n_bits" INTEGER NOT NULL,"nonce" INTEGER NOT NULL,"hex" VARCHAR(254) NOT NULL, "chain_work" VARCHAR(33) NOT NULL DEFAULT "0000000000000000000000000000000000000000000000000000000000000000");
+INSERT INTO "block_headers_temp" SELECT "height", "hash", "version", "previous_block_hash", "merkle_root_hash", "time", "n_bits", "nonce", "hex", hex("chain_work") FROM "block_headers";
+DROP TABLE "block_headers";
+CREATE TABLE "block_headers" ("height" INTEGER NOT NULL,"hash" VARCHAR(254) PRIMARY KEY NOT NULL,"version" INTEGER NOT NULL,"previous_block_hash" VARCHAR(254) NOT NULL,"merkle_root_hash" VARCHAR(254) NOT NULL,"time" INTEGER NOT NULL,"n_bits" INTEGER NOT NULL,"nonce" INTEGER NOT NULL,"hex" VARCHAR(254) NOT NULL, "chain_work" VARCHAR(33) NOT NULL DEFAULT "0000000000000000000000000000000000000000000000000000000000000000");
+INSERT INTO "block_headers" SELECT "height", "hash", "version", "previous_block_hash", "merkle_root_hash", "time", "n_bits", "nonce", "hex","chain_work"FROM "block_headers_temp";
+DROP TABLE "block_headers_temp";
+
+CREATE INDEX "block_headers_chain_work_index" on "block_headers" ("chain_work");

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -331,7 +331,8 @@ case class BlockHeaderDAO()(implicit
     val diffInterval = appConfig.chain.difficultyChangeInterval
     val height = Math.max(0, header.height - diffInterval)
     val headersF = getBetweenHeights(from = height, to = header.height)
-    headersF.map(headers => Blockchain.fromHeaders(headers.reverse))
+    headersF.map(headers =>
+      Blockchain.fromHeaders(headers.sortBy(_.height)(Ordering.Int.reverse)))
   }
 
   /** Retrieves a blockchain with the best tip being the given header */

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
@@ -138,16 +138,15 @@ case class CompactFilterDAO()(implicit
 
     val maxQuery = join.map(_._2.chainWork).max
 
+    val query = join.filter(_._2.chainWork === maxQuery).take(1).map(_._1)
+
+    println(query.result.statements.mkString(" "))
+
     for {
-      maxWorkOpt <- safeDatabase.run(maxQuery.result)
-      queryOpt = maxWorkOpt.map(maxWork =>
-        join.filter(_._2.chainWork === maxWork).take(1))
-      filterOpt <- queryOpt match {
-        case Some(query) =>
-          safeDatabase.run(query.result).map(_.headOption.map(_._1))
-        case None =>
-          Future.successful(None)
-      }
+      filterOpt <-
+        safeDatabase
+          .run(query.result)
+          .map(_.headOption)
     } yield filterOpt
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
@@ -140,8 +140,6 @@ case class CompactFilterDAO()(implicit
 
     val query = join.filter(_._2.chainWork === maxQuery).take(1).map(_._1)
 
-    println(query.result.statements.mkString(" "))
-
     for {
       filterOpt <-
         safeDatabase

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -129,17 +129,14 @@ case class CompactFilterHeaderDAO()(implicit
 
     val maxQuery = join.map(_._2.chainWork).max
 
+    val query = join.filter(_._2.chainWork === maxQuery).take(1).map(_._1)
+
     for {
-      maxWorkOpt <- safeDatabase.run(maxQuery.result)
-      queryOpt = maxWorkOpt.map(maxWork =>
-        join.filter(_._2.chainWork === maxWork).take(1))
-      filterHeaderOpt <- queryOpt match {
-        case Some(query) =>
-          safeDatabase.run(query.result).map(_.headOption.map(_._1))
-        case None =>
-          Future.successful(None)
-      }
-    } yield filterHeaderOpt
+      filterOpt <-
+        safeDatabase
+          .run(query.result)
+          .map(_.headOption)
+    } yield filterOpt
   }
 
 }

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -48,7 +48,7 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
                                         dbConfig(ProjectType.Chain))
     val chainDbManagement = createChainDbManagement(chainAppConfig)
     val result = chainDbManagement.migrate()
-    val expected = if (chainAppConfig.driverName == "postgresql") 2 else 3
+    val expected = if (chainAppConfig.driverName == "postgresql") 2 else 4
     assert(result == expected)
   }
 

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -48,7 +48,7 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
                                         dbConfig(ProjectType.Chain))
     val chainDbManagement = createChainDbManagement(chainAppConfig)
     val result = chainDbManagement.migrate()
-    val expected = if (chainAppConfig.driverName == "postgresql") 2 else 4
+    val expected = if (chainAppConfig.driverName == "postgresql") 3 else 4
     assert(result == expected)
   }
 

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -73,10 +73,17 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
 
   implicit val bigIntMapper: BaseColumnType[BigInt] =
     MappedColumnType
-      .base[BigInt, Array[Byte]](
-        bi => ByteVector(bi.toByteArray).padLeft(33).toArray,
-        { arr =>
-          val bytes = arr.dropWhile(_ == 0x00)
+      .base[BigInt, String](
+        { bigInt =>
+          val bytes = ByteVector(bigInt.toByteArray)
+          val padded = if (bytes.length <= 33) {
+            bytes.padLeft(33)
+          } else bytes
+
+          padded.toHex
+        },
+        { hex =>
+          val bytes = ByteVector.fromValidHex(hex).dropWhile(_ == 0x00).toArray
           BigInt(1, bytes)
         }
       )


### PR DESCRIPTION
Closes #1700 
Closes #1719 

Reduces the number of database reads needed from 2 -> 1. I think this is the most optimal sql query we can use to get the filter with the most work. 

This is the resulting sql query 
``` 
select s13."hash", s13."filter_type", s13."bytes", s13."height", s13."block_hash" from "cfilters" s13, "block_headers" s14 where (s14."chain_work" = (select max(s21."chain_work") from "cfilters" s20, "block_headers" s21 where s20."block_hash" = s21."hash")) and (s13."block_hash" = s14."hash") limit 1
```