### PR TITLE
Have wallet shuffle inputs and outputs

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -39,8 +39,8 @@ class WalletSendingTest extends BitcoinSWalletTest {
       tx <- wallet.sendToAddress(testAddress, amountToSend, feeRateOpt)
     } yield {
       assert(
-        tx.outputs.head == TransactionOutput(amountToSend,
-                                             testAddress.scriptPubKey))
+        tx.outputs.contains(
+          TransactionOutput(amountToSend, testAddress.scriptPubKey)))
     }
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -20,7 +20,7 @@ import org.bitcoins.core.util.{BitcoinScriptUtil, FutureUtil, Mutable}
 import org.bitcoins.core.wallet.builder.{
   RawTxBuilderWithFinalizer,
   RawTxSigner,
-  StandardNonInteractiveFinalizer
+  ShufflingNonInteractiveFinalizer
 }
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.TxoState.{
@@ -344,7 +344,7 @@ abstract class Wallet
     * finalizing and signing the transaction, then correctly processing and logging it
     */
   private def finishSend(
-      txBuilder: RawTxBuilderWithFinalizer[StandardNonInteractiveFinalizer],
+      txBuilder: RawTxBuilderWithFinalizer[ShufflingNonInteractiveFinalizer],
       utxoInfos: Vector[ScriptSignatureParams[InputInfo]],
       sentAmount: CurrencyUnit,
       feeRate: FeeUnit,
@@ -402,7 +402,7 @@ abstract class Wallet
       changeAddr <- getNewChangeAddress(fromAccount.hdAccount)
 
       output = TransactionOutput(amount, address.scriptPubKey)
-      txBuilder = StandardNonInteractiveFinalizer.txBuilderFrom(
+      txBuilder = ShufflingNonInteractiveFinalizer.txBuilderFrom(
         Vector(output),
         utxos,
         feeRate,

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.wallet.builder.{
   RawTxBuilder,
   RawTxBuilderWithFinalizer,
-  StandardNonInteractiveFinalizer
+  ShufflingNonInteractiveFinalizer
 }
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.{
@@ -74,7 +74,7 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
         CoinSelectionAlgo.AccumulateLargest,
       fromTagOpt: Option[AddressTag],
       markAsReserved: Boolean = false): Future[(
-      RawTxBuilderWithFinalizer[StandardNonInteractiveFinalizer],
+      RawTxBuilderWithFinalizer[ShufflingNonInteractiveFinalizer],
       Vector[ScriptSignatureParams[InputInfo]])] = {
     val utxosF = for {
       utxos <- fromTagOpt match {
@@ -170,7 +170,7 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
       val txBuilder =
         RawTxBuilder().setLockTime(lockTime) ++= destinations ++= inputs
 
-      val finalizer = StandardNonInteractiveFinalizer(
+      val finalizer = ShufflingNonInteractiveFinalizer(
         utxoSpendingInfos.map(_.inputInfo),
         feeRate,
         change.scriptPubKey)


### PR DESCRIPTION
Shuffle the wallet inputs and outputs to preserve privacy and reduce wallet fingerprinting.

Turns out [this comment](https://github.com/bitcoin-s/bitcoin-s/pull/1680#discussion_r458391361) was wrong, and we needed the iteration of the shuffler that had the sanity checks and witness data with the inputs and outputs in the shuffled order.