### PR TITLE
Fix Postgres types

### DIFF
--- a/chain/src/main/resources/postgresql/chain/migration/V4__chainge_filter_bytes_type.sql
+++ b/chain/src/main/resources/postgresql/chain/migration/V4__chainge_filter_bytes_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cfilters ALTER COLUMN bytes TYPE TEXT;

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -48,7 +48,7 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
                                         dbConfig(ProjectType.Chain))
     val chainDbManagement = createChainDbManagement(chainAppConfig)
     val result = chainDbManagement.migrate()
-    val expected = if (chainAppConfig.driverName == "postgresql") 3 else 4
+    val expected = if (chainAppConfig.driverName == "postgresql") 4 else 4
     assert(result == expected)
   }
 
@@ -58,7 +58,7 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
                                           dbConfig(ProjectType.Wallet))
     val walletDbManagement = createWalletDbManagement(walletAppConfig)
     val result = walletDbManagement.migrate()
-    val expected = if (walletAppConfig.driverName == "postgresql") 3 else 6
+    val expected = if (walletAppConfig.driverName == "postgresql") 4 else 6
     assert(result == expected)
   }
 

--- a/wallet/src/main/resources/postgresql/wallet/migration/V7__change_walletaddrestag_address_type.sql
+++ b/wallet/src/main/resources/postgresql/wallet/migration/V7__change_walletaddrestag_address_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE wallet_address_tags ALTER COLUMN address TYPE TEXT;


### PR DESCRIPTION
`VARCHAR(254)` is not enough to hold most of the compact filters.

Also the type of `wallet_address_tags.address` does not match the type of `addresses.address`.