### PR TITLE
ChainHandler: cache block and filter header counts

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -53,11 +53,15 @@ case class ChainHandler(
       case Some(count) => Future.successful(count)
       case None =>
         logger.debug(s"Querying for block count")
-        blockHeaderDAO.bestHeight.map { height =>
+        val res = blockHeaderDAO.bestHeight.map { height =>
           logger.debug(s"getBlockCount result: count=$height")
-          cacheBlockCount(Some(height))
           height
         }
+        res.foreach { count =>
+          cacheBlockCount(Some(count))
+        }
+        res.failed.foreach(_ => cacheBlockCount(None))
+        res
     }
   }
 


### PR DESCRIPTION
https://github.com/bitcoin-s/bitcoin-s/pull/1715 speeds up the sync process a lot, but filter sync is still too slow for Postgres.
The block count and the filter count don't change (or change once in 10 minutes) during the filter sync, so it makes sense to cache them.