### PR TITLE
Stop requesting merkle block messages while in neutrino mode

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -224,8 +224,11 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     } else {
       for {
         peerMsgSender <- peerMsgSenderF
-        _ <- peerMsgSender.sendGetDataMessage(TypeIdentifier.MsgBlock,
-                                              blockHashes: _*)
+        _ <-
+          if (nodeAppConfig.isSPVEnabled)
+            peerMsgSender.sendGetDataMessage(TypeIdentifier.MsgBlock,
+                                             blockHashes: _*)
+          else FutureUtil.unit
       } yield ()
     }
   }


### PR DESCRIPTION
Closes #1526

Found this while digging around in the `DataMessageHandler`