### PR TITLE
Improved block parsing time by approx. 33%

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -126,14 +126,14 @@ object P2PKHScriptSignature extends ScriptFactory[P2PKHScriptSignature] {
   def isP2PKHScriptSig(asm: Seq[ScriptToken]): Boolean =
     asm match {
       case Seq(_: BytesToPushOntoStack,
-               _: ScriptConstant,
+               maybeSig: ScriptConstant,
                _: BytesToPushOntoStack,
-               z: ScriptConstant) =>
+               maybeKey: ScriptConstant) =>
         if (
-          (z.bytes.length == 33 || z.bytes.length == 65) && ECPublicKey
-            .isFullyValid(z.bytes)
+          (maybeKey.bytes.length == 33 || maybeKey.bytes.length == 65) &&
+          (maybeSig.bytes.length > 68 && maybeSig.bytes.length < 73)
         ) true
-        else !P2SHScriptSignature.isRedeemScript(z)
+        else !P2SHScriptSignature.isRedeemScript(maybeKey)
       case _ => false
     }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -167,9 +167,9 @@ object ScriptWitness {
     //https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#restrictions-on-public-key-type
     val isPubKey = {
       stack.nonEmpty &&
-      ECPublicKey.isFullyValid(stack.head) &&
       (stack.head.size == 33
-      || stack.head.size == 65)
+      || stack.head.size == 65) &&
+      ECPublicKey.isFullyValid(stack.head)
     }
     if (stack.isEmpty) {
       EmptyScriptWitness


### PR DESCRIPTION
Every time we encounter a P2PKH script signature in a block we were triggering a key decompression to validate the key, which was not necessary in part because typing script is already an imperfect thing, and also because other validation that script signatures should go through fail and so there is no need to fail so early as it costs so much time.