### PR TITLE
CLI: Handle non-json responses

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1062,11 +1062,11 @@ object ConsoleCli {
         case Right(response) => response
       }
 
-      val js = ujson.read(rawBody)
       val jsObjT =
-        Try(js.obj).transform[mutable.LinkedHashMap[String, ujson.Value]](
-          Success(_),
-          _ => error(s"Response was not a JSON object! Got: $rawBody"))
+        Try(ujson.read(rawBody).obj)
+          .transform[mutable.LinkedHashMap[String, ujson.Value]](
+            Success(_),
+            _ => error(s"Response was not a JSON object! Got: $rawBody"))
 
       /** Gets the given key from jsObj if it exists
         * and is not null */


### PR DESCRIPTION
Closes #1733 

The error was thrown in `ujson.read(rawBody)` which wasn't wrrapped in the `Try` so we would just output whatever `ujson` was telling us instead of our nicely formatted message.