### PR TITLE
Send GetHeadersMessage using all of our cached headers to prevent reorgs from stalling node

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -40,7 +40,7 @@ private[blockchain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
   val tip: BlockHeaderDb = headers.head
 
   require(headers.size <= 1 || headers(1).height == tip.height - 1,
-          s"Headers must be in descending order, got $headers")
+          s"Headers must be in descending order, got ${headers.take(5)}")
 
   /** The height of the chain */
   val height: Int = tip.height

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -39,7 +39,8 @@ private[blockchain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
 
   val tip: BlockHeaderDb = headers.head
 
-  require(headers.size <= 1 || headers(1).height == tip.height - 1)
+  require(headers.size <= 1 || headers(1).height == tip.height - 1,
+          s"Headers must be in descending order, got $headers")
 
   /** The height of the chain */
   val height: Int = tip.height
@@ -118,7 +119,7 @@ private[blockchain] trait BaseBlockChainCompObject
           //found a header to connect to!
           val prevBlockHeader = blockchain.headers(prevHeaderIdx)
           logger.debug(
-            s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain of ${blockchain.length} headers")
+            s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain of ${blockchain.length} headers with tip ${blockchain.tip.hashBE.hex}")
           val chain = blockchain.fromValidHeader(prevBlockHeader)
           val tipResult =
             TipValidation.checkNewTip(newPotentialTip = header, chain)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -104,13 +104,16 @@ case class ChainHandler(
       }
 
       val headersToBeCreated = {
-        blockchainUpdates.flatMap(_.successfulHeaders).distinct
+        // During reorgs, we can be sent a header twice
+        blockchainUpdates
+          .flatMap(_.successfulHeaders)
+          .distinct
+          .filterNot(blockchains.flatMap(_.headers).contains)
       }
 
       val chains = blockchainUpdates.map(_.blockchain)
 
-      // During reorgs, we can be sent a header twice
-      val createdF = blockHeaderDAO.upsertAll(headersToBeCreated)
+      val createdF = blockHeaderDAO.createAll(headersToBeCreated)
 
       val newChainHandler = this.copy(blockchains = chains)
 
@@ -235,16 +238,11 @@ case class ChainHandler(
                 s"Unexpected previous header's height: ${prevHeader.height} != ${filterHeadersToCreate.head.height - 1}"
               )
             case None =>
-              if (
-                firstFilter.previousFilterHeaderBE == DoubleSha256DigestBE.empty && firstFilter.height == 0
-              ) {
-                //we are ok, according to BIP157 the previous the genesis filter's prev hash should
-                //be the empty hash
-                ()
-              } else {
-                sys.error(
-                  s"Previous filter header does not exist: $firstFilter")
-              }
+              // If the previous filter header doesn't exist it must be for the genesis block
+              require(
+                firstFilter.previousFilterHeaderBE == DoubleSha256DigestBE.empty && firstFilter.height == 0,
+                s"Previous filter header does not exist: $firstFilter"
+              )
           }
         } else FutureUtil.unit
       _ <- filterHeaderDAO.createAll(filterHeadersToCreate)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -109,7 +109,8 @@ case class ChainHandler(
 
       val chains = blockchainUpdates.map(_.blockchain)
 
-      val createdF = blockHeaderDAO.createAll(headersToBeCreated)
+      // During reorgs, we can be sent a header twice
+      val createdF = blockHeaderDAO.upsertAll(headersToBeCreated)
 
       val newChainHandler = this.copy(blockchains = chains)
 

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -59,7 +59,10 @@ case class NeutrinoNode(
       filterCount <- chainApi.getFilterCount
       peerMsgSender <- peerMsgSenderF
     } yield {
-      peerMsgSender.sendGetHeadersMessage(header.hashBE.flip)
+      // Get all of our cached headers in case of a reorg
+      val cachedHeaders =
+        chainApi.blockchains.flatMap(_.headers).map(_.hashBE.flip)
+      peerMsgSender.sendGetHeadersMessage(cachedHeaders)
 
       // If we have started syncing filters headers
       if (filterHeaderCount != 0) {

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -185,7 +185,10 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
       chainApi <- chainApiFromDb()
       header <- chainApi.getBestBlockHeader()
     } yield {
-      peerMsgSenderF.map(_.sendGetHeadersMessage(header.hashBE.flip))
+      // Get all of our cached headers in case of a reorg
+      val cachedHeaders =
+        chainApi.blockchains.flatMap(_.headers).map(_.hashBE.flip)
+      peerMsgSenderF.map(_.sendGetHeadersMessage(cachedHeaders))
       logger.info(
         s"Starting sync node, height=${header.height} hash=${header.hashBE}")
     }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -84,6 +84,14 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     sendMsg(headersMsg)
   }
 
+  def sendGetHeadersMessage(
+      hashes: Vector[DoubleSha256Digest]): Future[Unit] = {
+    // GetHeadersMessage has a max of 101 hashes
+    val headersMsg = GetHeadersMessage(hashes.distinct.take(101))
+    logger.trace(s"Sending getheaders=$headersMsg to peer=${client.peer}")
+    sendMsg(headersMsg)
+  }
+
   def sendHeadersMessage(): Future[Unit] = {
     val sendHeadersMsg = SendHeadersMessage
     sendMsg(sendHeadersMsg)


### PR DESCRIPTION
Fixes #1739 

There was a problem where if a node is stopped with it's chain tip being a one that is later reorged out it will not be able to continue syncing headers.

This happens because we request headers using a get headers message with hashes=`<current chain tip>` and stopHash=`<00000..0000>`. Since, our chain tip is reorged out we will receive the first 2000 block headers of the network.

Solution: Send more than just our tip in the `GetHeadersMessage` so other nodes can find our best tip in their best chain to send us headers.

Context: https://bitcoin.stackexchange.com/questions/98376/what-is-the-proper-way-to-handle-reorgs-when-fetching-headers