### PR TITLE
Drop older headers on chain update

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -139,7 +139,7 @@ private[blockchain] trait BaseBlockChainCompObject
                 ConnectTipResult.Reorg(success, newChain)
               } else {
                 val newChain = Blockchain(
-                  success.headerDb +: blockchain.headers)
+                  success.headerDb +: blockchain.headers.init)
                 //we just extended the latest tip
                 ConnectTipResult.ExtendChain(success, newChain)
               }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -138,8 +138,10 @@ private[blockchain] trait BaseBlockChainCompObject
                 //means we have a reorg, since we aren't connecting to latest tip
                 ConnectTipResult.Reorg(success, newChain)
               } else {
-                val newChain = Blockchain(
-                  success.headerDb +: blockchain.headers.init)
+                val olderChain = if (blockchain.size < 2016) {
+                  blockchain.headers
+                } else blockchain.headers.take(2015)
+                val newChain = Blockchain(success.headerDb +: olderChain)
                 //we just extended the latest tip
                 ConnectTipResult.ExtendChain(success, newChain)
               }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -115,8 +115,8 @@ case class ChainHandler(
 
       createdF.map { _ =>
         chains.foreach { c =>
-          logger.info(s"Processed headers from height=${c(
-            headers.length - 1).height} to ${c.height}. Best hash=${c.tip.hashBE.hex}")
+          logger.info(
+            s"Processed headers from height=${c.height - headers.length} to ${c.height}. Best hash=${c.tip.hashBE.hex}")
         }
         newChainHandler
       }


### PR DESCRIPTION
Fixes #1762 
Fixes #1714 

Should prevent memory explosions and make syncing faster