### PR TITLE
Use safeRewind for signWithEntropy

### DIFF
--- a/secp256k1jni/src/main/java/org/bitcoin/NativeSecp256k1.java
+++ b/secp256k1jni/src/main/java/org/bitcoin/NativeSecp256k1.java
@@ -136,7 +136,7 @@ public class NativeSecp256k1 {
             byteBuff.order(ByteOrder.nativeOrder());
             nativeECDSABuffer.set(byteBuff);
         }
-        byteBuff.rewind();
+        safeRewind(byteBuff);
         byteBuff.put(data);
         byteBuff.put(seckey);
         byteBuff.put(entropy);


### PR DESCRIPTION
This causes failures on some versions of java