### PR TITLE
Fix for Wallet confirmed states

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -182,7 +182,7 @@ object Main extends App with BitcoinSLogger {
       if (headers.isEmpty) {
         FutureUtil.unit
       } else {
-        wallet.updateUtxoPendingStates(headers.last).map(_ => ())
+        wallet.updateUtxoPendingStates().map(_ => ())
       }
     }
     if (nodeConf.isSPVEnabled) {

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -8,7 +8,6 @@ import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.AddressType
 import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.protocol.transaction.{
   Transaction,
   TransactionOutPoint,
@@ -71,8 +70,7 @@ trait WalletApi extends WalletLogger {
     * Takes in a block header and updates our TxoStates to the new chain tip
     * @param blockHeader Block header we are processing
     */
-  def updateUtxoPendingStates(
-      blockHeader: BlockHeader): Future[Vector[SpendingInfoDb]]
+  def updateUtxoPendingStates(): Future[Vector[SpendingInfoDb]]
 
   /** Gets the sum of all UTXOs in this wallet */
   def getBalance()(implicit ec: ExecutionContext): Future[CurrencyUnit] = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -313,7 +313,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
           }
 
           // Update Txo State
-          val updateF = updateUtxoConfirmedState(unreservedTxo, blockHash)
+          val updateF = updateUtxoConfirmedState(unreservedTxo)
 
           updateF.foreach(tx =>
             logger.debug(


### PR DESCRIPTION
Fixes #1780 
Fixes #1770 

There were 2 bugs here:

1) When we received a block, we would not try to process the header causing the callback to not be executed sometimes, as well as then not adding the header to the db

2) When the wallet tried to update the confirmed state of a txo it would check on the number of confirmations of the lastest block header (always 1), not the one that the transaction is associated with.