### PR TITLE
Use database to calculate number of confirmations

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -499,13 +499,29 @@ class ChainHandlerTest extends ChainDbUnitTest {
       }
   }
 
-  it must "return the number of confirmations" in {
+  it must "return the number of confirmations for the chain tip" in {
     chainHandler: ChainHandler =>
       for {
         bestBlockHashBE <- chainHandler.getBestBlockHash()
         confirmations <- chainHandler.getNumberOfConfirmations(bestBlockHashBE)
       } yield {
-        assert(confirmations == Some(1))
+        assert(confirmations.contains(1))
+      }
+  }
+
+  it must "return the number of confirmations" in {
+    chainHandler: ChainHandler =>
+      val headers = 0.until(20).foldLeft(Vector(genesis)) { (accum, _) =>
+        accum :+ BlockHeaderHelper.buildNextHeader(accum.last)
+      }
+
+      for {
+        _ <- chainHandler.blockHeaderDAO.createAll(headers.tail)
+
+        confirmations <-
+          chainHandler.getNumberOfConfirmations(headers(3).hashBE)
+      } yield {
+        assert(confirmations.contains(18))
       }
   }
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -448,11 +448,15 @@ case class ChainHandler(
           }
           ancestorChains <- Future.sequence(getNAncestorsFs)
         } yield {
-          ancestorChains.flatMap { chain =>
+          val confs = ancestorChains.flatMap { chain =>
             if (chain.last.hashBE == blockHash) {
               Some(chain.head.height - blockHeight + 1)
             } else None
-          }.maxOption
+          }
+
+          if (confs.nonEmpty) {
+            Some(confs.max)
+          } else None
         }
     }
   }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -441,11 +441,9 @@ case class ChainHandler(
     getBlockHeight(blockHash).flatMap {
       case None => FutureUtil.none
       case Some(blockHeight) =>
-        for {
-          tipHash <- getBestBlockHash()
-          tipHeightOpt <- getBlockHeight(tipHash)
-        } yield {
-          tipHeightOpt.map(tipHeight => tipHeight - blockHeight + 1)
+        blockHeaderDAO.chainTips.map { tips =>
+          val bestHeader = tips.maxBy(_.chainWork)
+          Some(bestHeader.height - blockHeight + 1)
         }
     }
   }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -232,13 +232,14 @@ case class DataMessageHandler(
       case msg: BlockMessage =>
         val block = msg.block
         logger.info(
-          s"Received block message with hash ${block.blockHeader.hash.flip}")
+          s"Received block message with hash ${block.blockHeader.hash.flip.hex}")
 
         val newApiF = {
           chainApi
             .getHeader(block.blockHeader.hashBE)
             .flatMap { headerOpt =>
               if (headerOpt.isEmpty) {
+                logger.debug("Processing block's header...")
                 for {
                   processedApi <- chainApi.processHeader(block.blockHeader)
                   _ <- callbacks.executeOnBlockHeadersReceivedCallbacks(

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -132,8 +132,12 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     }
 
     for {
-      toUpdate <- Future.sequence(toUpdateFs)
-      updated <- spendingInfoDAO.upsertAll(toUpdate.flatten.toVector)
+      toUpdate <- Future.sequence(toUpdateFs).map(_.flatten.toVector)
+      _ =
+        if (toUpdate.nonEmpty)
+          logger.info(s"${toUpdate.size} txos are now confirmed!")
+        else logger.info("No txos to be confirmed")
+      updated <- spendingInfoDAO.upsertAll(toUpdate)
     } yield updated
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -14,7 +14,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
-import org.bitcoins.core.util.EitherUtil
+import org.bitcoins.core.util.{EitherUtil, FutureUtil}
 import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoResult, AddUtxoSuccess}
@@ -94,45 +94,54 @@ private[wallet] trait UtxoHandling extends WalletLogger {
 
     val byBlock = spendingInfoDbs.groupBy(_.blockHash)
 
-    val toUpdateFs = byBlock.map {
-      case (Some(blockHash), txos) =>
-        chainQueryApi.getNumberOfConfirmations(blockHash).map {
-          case None =>
-            logger.warn(
-              s"Given txos exist in block (${blockHash.hex}) that we do not have! $txos")
-            Vector.empty
-          case Some(confs) =>
-            txos.map { txo =>
-              txo.state match {
-                case TxoState.PendingConfirmationsReceived =>
-                  if (confs >= walletConfig.requiredConfirmations) {
-                    txo.copyWithState(TxoState.ConfirmedReceived)
-                  } else {
+    def updateUtxosInBlock(
+        blockHashOpt: Option[DoubleSha256DigestBE],
+        txos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]] = {
+      blockHashOpt match {
+        case Some(blockHash) =>
+          chainQueryApi.getNumberOfConfirmations(blockHash).map {
+            case None =>
+              logger.warn(
+                s"Given txos exist in block (${blockHash.hex}) that we do not have! $txos")
+              Vector.empty
+            case Some(confs) =>
+              txos.map { txo =>
+                txo.state match {
+                  case TxoState.PendingConfirmationsReceived =>
+                    if (confs >= walletConfig.requiredConfirmations) {
+                      txo.copyWithState(TxoState.ConfirmedReceived)
+                    } else {
+                      txo
+                    }
+                  case TxoState.PendingConfirmationsSpent =>
+                    if (confs >= walletConfig.requiredConfirmations) {
+                      txo.copyWithState(TxoState.ConfirmedSpent)
+                    } else {
+                      txo
+                    }
+                  case TxoState.Reserved =>
+                    // We should keep the utxo as reserved so it is not used in
+                    // a future transaction that it should not be in
                     txo
-                  }
-                case TxoState.PendingConfirmationsSpent =>
-                  if (confs >= walletConfig.requiredConfirmations) {
-                    txo.copyWithState(TxoState.ConfirmedSpent)
-                  } else {
+                  case TxoState.DoesNotExist | TxoState.ConfirmedReceived |
+                      TxoState.ConfirmedSpent =>
                     txo
-                  }
-                case TxoState.Reserved =>
-                  // We should keep the utxo as reserved so it is not used in
-                  // a future transaction that it should not be in
-                  txo
-                case TxoState.DoesNotExist | TxoState.ConfirmedReceived |
-                    TxoState.ConfirmedSpent =>
-                  txo
+                }
               }
-            }
-        }
-      case (None, txos) =>
-        logger.debug(s"Currently have ${txos.size} transactions in the mempool")
-        Future.successful(Vector.empty)
+          }
+        case None =>
+          logger.debug(
+            s"Currently have ${txos.size} transactions in the mempool")
+          Future.successful(Vector.empty)
+      }
     }
 
     for {
-      toUpdate <- Future.sequence(toUpdateFs).map(_.flatten.toVector)
+      toUpdate <-
+        FutureUtil
+          .sequentially(byBlock.toVector)(item =>
+            updateUtxosInBlock(item._1, item._2))
+          .map(_.flatten.toVector)
       _ =
         if (toUpdate.nonEmpty)
           logger.info(s"${toUpdate.size} txos are now confirmed!")


### PR DESCRIPTION
Fixes #1780 

Context: https://github.com/bitcoin-s/bitcoin-s/issues/1780#issuecomment-670966280

This should not be an performance hit to anything too meaningful as `getNumberOfConfirmations` is only used for a few wallet functions