### PR TITLE
Address Tagging/Labeling Support from CLI

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.commons.serializers
 
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.number.UInt32
@@ -10,6 +10,7 @@ import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.utxo.AddressLabelTag
 import org.bitcoins.crypto.{SchnorrDigitalSignature, Sha256DigestBE}
 import upickle.default._
 
@@ -88,4 +89,7 @@ object Picklers {
 
   implicit val coinSelectionAlgoPickler: ReadWriter[CoinSelectionAlgo] =
     readwriter[String].bimap(_.toString, CoinSelectionAlgo.fromString(_).get)
+
+  implicit val addressLabelTagPickler: ReadWriter[AddressLabelTag] =
+    readwriter[String].bimap(_.name, AddressLabelTag)
 }

--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -2,8 +2,8 @@ package org.bitcoins.cli
 
 import java.time.{ZoneId, ZonedDateTime}
 
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.core.config.{NetworkParameters, Networks}
 import org.bitcoins.core.currency._
 import org.bitcoins.core.number.UInt32
@@ -13,6 +13,7 @@ import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.utxo.AddressLabelTag
 import org.bitcoins.crypto.{SchnorrDigitalSignature, Sha256DigestBE}
 import scopt._
 
@@ -145,6 +146,13 @@ object CliReaders {
 
       override def reads: String => PartialSignature =
         PartialSignature.fromHex
+    }
+
+  implicit val addressLabelTagReads: Read[AddressLabelTag] =
+    new Read[AddressLabelTag] {
+      val arity: Int = 1
+
+      val reads: String => AddressLabelTag = str => AddressLabelTag(str)
     }
 
   implicit val sha256DigestBEReads: Read[Sha256DigestBE] =

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
@@ -28,7 +28,7 @@ class WalletGUIModel() {
     taskRunner.run(
       caption = "Get New Address",
       op = {
-        ConsoleCli.exec(GetNewAddress, Config.empty) match {
+        ConsoleCli.exec(GetNewAddress(None), Config.empty) match {
           case Success(commandReturn) => address.value = commandReturn
           case Failure(err)           => throw err
         }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import org.bitcoins.commons.serializers.Picklers._
 import org.bitcoins.core.currency._
+import org.bitcoins.core.wallet.utxo.AddressLabelTagType
 import org.bitcoins.node.Node
 import org.bitcoins.wallet.api.AnyHDWalletApi
 
@@ -79,11 +80,75 @@ case class WalletRoutes(wallet: AnyHDWalletApi, node: Node)(implicit
           }
       }
 
-    case ServerCommand("getnewaddress", _) =>
-      complete {
-        wallet.getNewAddress().map { address =>
-          Server.httpSuccess(address)
-        }
+    case ServerCommand("getnewaddress", arr) =>
+      GetNewAddress.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(GetNewAddress(labelOpt)) =>
+          complete {
+            val labelVec = Vector(labelOpt).flatten
+            wallet.getNewAddress(labelVec).map { address =>
+              Server.httpSuccess(address)
+            }
+          }
+      }
+
+    case ServerCommand("labeladdress", arr) =>
+      LabelAddress.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(LabelAddress(address, label)) =>
+          complete {
+            wallet.tagAddress(address, label).map { tagDb =>
+              Server.httpSuccess(
+                s"Added label \'${tagDb.tagName.name}\' to ${tagDb.address.value}")
+            }
+          }
+      }
+
+    case ServerCommand("getaddresstags", arr) =>
+      GetAddressTags.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(GetAddressTags(address)) =>
+          complete {
+            wallet.getAddressTags(address).map { tagDbs =>
+              val retStr = tagDbs.map(_.tagName.name).mkString(", ")
+              Server.httpSuccess(retStr)
+            }
+          }
+      }
+
+    case ServerCommand("getaddresslabels", arr) =>
+      GetAddressLabels.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(GetAddressLabels(address)) =>
+          complete {
+            wallet.getAddressTags(address, AddressLabelTagType).map { tagDbs =>
+              val retStr = tagDbs.map(_.tagName.name).mkString(", ")
+              Server.httpSuccess(retStr)
+            }
+          }
+      }
+
+    case ServerCommand("dropaddresslabels", arr) =>
+      DropAddressLabels.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(DropAddressLabels(address)) =>
+          complete {
+            wallet.dropAddressTagType(address, AddressLabelTagType).map {
+              numDropped =>
+                if (numDropped <= 0) {
+                  Server.httpSuccess(s"Address had no labels")
+                } else if (numDropped == 1) {
+                  Server.httpSuccess(s"$numDropped label dropped")
+                } else {
+                  Server.httpSuccess(s"$numDropped labels dropped")
+                }
+            }
+          }
       }
 
     case ServerCommand("sendtoaddress", arr) =>

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/InternalAddressTag.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/InternalAddressTag.scala
@@ -153,6 +153,10 @@ object AddressLabelTagType extends InternalAddressTagType {
 
 case class AddressLabelTagName(name: String) extends InternalAddressTagName
 
+/** Used for generic address labeling, generally labels should be
+  * provided by the user so they keep track which parties are aware
+  * of which addresses
+  */
 case class AddressLabelTag(name: String) extends InternalAddressTag {
   override val tagType: AddressTagType = AddressLabelTagType
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/InternalAddressTag.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/InternalAddressTag.scala
@@ -63,7 +63,9 @@ object InternalAddressTagName {
 }
 
 object InternalAddressTagType {
-  val all: Seq[InternalAddressTagType] = Vector(StorageLocationTagType)
+
+  val all: Seq[InternalAddressTagType] =
+    Vector(StorageLocationTagType, AddressLabelTagType)
 
   def fromStringOpt(string: String): Option[InternalAddressTagType] =
     all.find(_.typeName.toLowerCase == string.toLowerCase)
@@ -78,8 +80,6 @@ object InternalAddressTag {
       tagName: AddressTagName,
       tagType: AddressTagType): InternalAddressTag = {
     tagType match {
-      case unknownType: UnknownAddressTagType =>
-        UnknownAddressTag(tagName, unknownType)
       case StorageLocationTagType =>
         tagName match {
           case StorageLocationTag.HotStorageName =>
@@ -91,6 +91,10 @@ object InternalAddressTag {
           case unknownName: UnknownAddressTagName =>
             UnknownAddressTag(unknownName, StorageLocationTagType)
         }
+      case AddressLabelTagType =>
+        AddressLabelTag(tagName.name)
+      case unknownType: UnknownAddressTagType =>
+        UnknownAddressTag(tagName, unknownType)
     }
   }
 }
@@ -141,4 +145,16 @@ object StorageLocationTag extends AddressTagFactory[StorageLocationTag] {
 
   override val all: Vector[StorageLocationTag] =
     Vector(HotStorage, ColdStorage, DeepColdStorage)
+}
+
+object AddressLabelTagType extends InternalAddressTagType {
+  override val typeName: String = "Label"
+}
+
+case class AddressLabelTagName(name: String) extends InternalAddressTagName
+
+case class AddressLabelTag(name: String) extends InternalAddressTag {
+  override val tagType: AddressTagType = AddressLabelTagType
+
+  override val tagName: AddressTagName = AddressLabelTagName(name)
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -15,11 +15,16 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
+import org.bitcoins.core.wallet.utxo.{AddressTag, AddressTagType, TxoState}
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.keymanager._
 import org.bitcoins.wallet.WalletLogger
-import org.bitcoins.wallet.models.{AddressDb, SpendingInfoDb, TransactionDb}
+import org.bitcoins.wallet.models.{
+  AddressDb,
+  AddressTagDb,
+  SpendingInfoDb,
+  TransactionDb
+}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -200,6 +205,27 @@ trait WalletApi extends WalletLogger {
         FutureUtil.none
     }
   }
+
+  /** Tags the address with the address tag, updates the tag if one of tag's TagType already exists */
+  def tagAddress(address: BitcoinAddress, tag: AddressTag): Future[AddressTagDb]
+
+  def getAddressTags(address: BitcoinAddress): Future[Vector[AddressTagDb]]
+
+  def getAddressTags(
+      address: BitcoinAddress,
+      tagType: AddressTagType): Future[Vector[AddressTagDb]]
+
+  def getAddressTags: Future[Vector[AddressTagDb]]
+
+  def getAddressTags(tagType: AddressTagType): Future[Vector[AddressTagDb]]
+
+  def dropAddressTag(addressTagDb: AddressTagDb): Future[Int]
+
+  def dropAddressTagType(addressTagType: AddressTagType): Future[Int]
+
+  def dropAddressTagType(
+      address: BitcoinAddress,
+      addressTagType: AddressTagType): Future[Int]
 
   /** Generates a new change address */
   protected[wallet] def getNewChangeAddress()(implicit

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -12,7 +12,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
-import org.bitcoins.core.wallet.utxo.AddressTag
+import org.bitcoins.core.wallet.utxo.{AddressTag, AddressTagType}
 import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.wallet._
 import org.bitcoins.wallet.api.AddressInfo
@@ -404,6 +404,46 @@ private[wallet] trait AddressHandling extends WalletLogger {
                     path = address.path)
       }
     }
+  }
+
+  override def tagAddress(
+      address: BitcoinAddress,
+      tag: AddressTag): Future[AddressTagDb] = {
+    val addressTagDb = AddressTagDb(address, tag)
+    addressTagDAO.upsert(addressTagDb)
+  }
+
+  def getAddressTags(address: BitcoinAddress): Future[Vector[AddressTagDb]] = {
+    addressTagDAO.findByAddress(address)
+  }
+
+  override def getAddressTags(
+      address: BitcoinAddress,
+      tagType: AddressTagType): Future[Vector[AddressTagDb]] = {
+    addressTagDAO.findByAddressAndTag(address, tagType)
+  }
+
+  def getAddressTags: Future[Vector[AddressTagDb]] = {
+    addressTagDAO.findAll()
+  }
+
+  def getAddressTags(tagType: AddressTagType): Future[Vector[AddressTagDb]] = {
+    addressTagDAO.findByTagType(tagType)
+  }
+
+  override def dropAddressTag(addressTagDb: AddressTagDb): Future[Int] = {
+    addressTagDAO.delete(addressTagDb)
+  }
+
+  override def dropAddressTagType(
+      addressTagType: AddressTagType): Future[Int] = {
+    addressTagDAO.dropByTagType(addressTagType)
+  }
+
+  override def dropAddressTagType(
+      address: BitcoinAddress,
+      addressTagType: AddressTagType): Future[Int] = {
+    addressTagDAO.dropByAddressAndTag(address, addressTagType)
   }
 
   private val threadStarted = new AtomicBoolean(false)


### PR DESCRIPTION
Closes #1784 

Adds a `AddressLabelTagType` for the user to label their address.

Adds an option to `getnewaddress` to generate an address with a label

Then adds the following new commands:

1) `labeladdress <address> <label>`: Add a label to the wallet address
2) `getaddresstags <address>`: Get all the tags associated with this address
3) `getaddresslabels <address>`: Get all the labels associated with this address
4) `dropaddresslabels <address>`: Drop all the labels associated with this address