### PR TITLE
Revert scalaTest to 3.2.0

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -6,7 +6,7 @@ object Deps {
     val bouncyCastle = "1.66"
     val logback = "1.2.3"
     val scalacheck = "1.14.3"
-    val scalaTest = "3.2.1"
+    val scalaTest = "3.2.0"
 
     val scalaTestPlus = "3.2.1.0" //super annoying... https://oss.sonatype.org/content/groups/public/org/scalatestplus/
     val slf4j = "1.7.30"


### PR DESCRIPTION
It seems scala test 3.2.1 is bugged it does not show the tests that are run

3.2.1:
![image](https://user-images.githubusercontent.com/15256660/89724245-1eb2ae80-d9c6-11ea-9e70-2bd38c7d18ce.png)

3.2.0:

![image](https://user-images.githubusercontent.com/15256660/89724255-3be77d00-d9c6-11ea-9054-00adeac4a0a5.png)
