### PR TITLE
Send correct version message on node start up

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/p2p/VersionMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/VersionMessageTest.scala
@@ -35,7 +35,8 @@ class VersionMessageTest extends BitcoinSUnitTest {
 
     versionMessage.nonce must be(UInt64.zero)
     versionMessage.startHeight must be(Int32.zero)
-    versionMessage.timestamp.toLong must be(Instant.now().toEpochMilli +- 1000)
+    versionMessage.timestamp.toLong must be(
+      Instant.now().getEpochSecond +- 1000)
   }
 
   it must "correctly deduce service flags" in {

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1257,14 +1257,25 @@ object VersionMessage extends Factory[VersionMessage] {
       network: NetworkParameters,
       receivingIpAddress: InetAddress,
       transmittingIpAddress: InetAddress): VersionMessage = {
+    VersionMessage(network,
+                   ProtocolVersion.userAgent,
+                   Int32.zero,
+                   receivingIpAddress,
+                   transmittingIpAddress)
+  }
+
+  def apply(
+      network: NetworkParameters,
+      userAgent: String,
+      startHeight: Int32,
+      receivingIpAddress: InetAddress,
+      transmittingIpAddress: InetAddress): VersionMessage = {
     val nonce = UInt64.zero
-    val userAgent = ProtocolVersion.userAgent
-    val startHeight = Int32.zero
     val relay = false
     VersionMessage(
       version = ProtocolVersion.default,
       services = ServiceIdentifier.NODE_NONE,
-      timestamp = Int64(java.time.Instant.now.toEpochMilli),
+      timestamp = Int64(java.time.Instant.now.getEpochSecond),
       addressReceiveServices = ServiceIdentifier.NODE_NONE,
       addressReceiveIpAddress = receivingIpAddress,
       addressReceivePort = network.port,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -10,7 +10,6 @@ import org.bitcoins.chain.models.{
   CompactFilterHeaderDAO
 }
 import org.bitcoins.core.p2p.{NetworkMessage, _}
-import org.bitcoins.node.{NodeCallbacks, P2PLogger}
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.P2PClient
@@ -20,6 +19,7 @@ import org.bitcoins.node.networking.peer.PeerMessageReceiverState.{
   Normal,
   Preconnection
 }
+import org.bitcoins.node.{NodeCallbacks, P2PLogger}
 
 import scala.concurrent.Future
 
@@ -60,7 +60,7 @@ class PeerMessageReceiver(
 
         val peerMsgSender = PeerMessageSender(client)
 
-        peerMsgSender.sendVersionMessage()
+        peerMsgSender.sendVersionMessage(dataMessageHandler.chainApi)
 
         val newRecv = toState(newState)
 


### PR DESCRIPTION
The `timestamp` field was incorrectly sending the current epoch in milliseconds instead of seconds. It also will now send a better user agent string, and the correct starting block height.

I am still not sure on how to send the synced headers and blocks message, it is not in the version message: https://developer.bitcoin.org/reference/p2p_networking.html#version

Before:
![image](https://user-images.githubusercontent.com/15256660/89752699-111b2880-da9b-11ea-92d7-cbde96f0640a.png)

After:
![image](https://user-images.githubusercontent.com/15256660/89752711-18423680-da9b-11ea-89d9-71b43814c52b.png)
