### PR TITLE
Create more of a project structure in org.bitcoins.core.api, move DbR…

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/CoreRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/CoreRoutes.scala
@@ -3,7 +3,7 @@ package org.bitcoins.server
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
-import org.bitcoins.core.api.CoreApi
+import org.bitcoins.core.api.core.CoreApi
 
 import scala.util.{Failure, Success}
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -3,7 +3,9 @@ package org.bitcoins.rpc.client.common
 import java.io.File
 
 import akka.actor.ActorSystem
-import org.bitcoins.core.api.{ChainQueryApi, FeeRateApi, NodeApi}
+import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.FutureUtil

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v16/BitcoindV16RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v16/BitcoindV16RpcClient.scala
@@ -7,7 +7,7 @@ import org.bitcoins.commons.jsonmodels.bitcoind.{
 }
 import org.bitcoins.commons.serializers.JsonSerializers._
 import org.bitcoins.commons.serializers.JsonWriters._
-import org.bitcoins.core.api.ChainQueryApi
+import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.crypto.ECPrivateKey

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v17/BitcoindV17RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v17/BitcoindV17RpcClient.scala
@@ -8,7 +8,7 @@ import org.bitcoins.commons.jsonmodels.bitcoind.{
 }
 import org.bitcoins.commons.serializers.JsonSerializers._
 import org.bitcoins.commons.serializers.JsonWriters._
-import org.bitcoins.core.api.ChainQueryApi
+import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.crypto.ECPrivateKey

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v18/BitcoindV18RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v18/BitcoindV18RpcClient.scala
@@ -7,7 +7,7 @@ import org.bitcoins.commons.jsonmodels.bitcoind.{
 }
 import org.bitcoins.commons.serializers.JsonSerializers._
 import org.bitcoins.commons.serializers.JsonWriters._
-import org.bitcoins.core.api.ChainQueryApi
+import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.crypto.ECPrivateKey

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
@@ -10,8 +10,8 @@ import org.bitcoins.commons.jsonmodels.bitcoind.{
 }
 import org.bitcoins.commons.serializers.JsonSerializers._
 import org.bitcoins.commons.serializers.JsonWriters._
-import org.bitcoins.core.api.ChainQueryApi
-import org.bitcoins.core.api.ChainQueryApi.FilterResponse
+import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
+import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.script.crypto.HashType

--- a/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/api/ChainApi.scala
@@ -5,7 +5,7 @@ import org.bitcoins.chain.models.{
   CompactFilterDb,
   CompactFilterHeaderDb
 }
-import org.bitcoins.core.api.ChainQueryApi
+import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.gcs.FilterHeader
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.BlockStamp

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -5,7 +5,7 @@ import org.bitcoins.chain.api.ChainApi
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models._
 import org.bitcoins.chain.pow.Pow
-import org.bitcoins.core.api.ChainQueryApi.FilterResponse
+import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.gcs.FilterHeader
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.p2p.CompactFilterMessage

--- a/core/src/main/scala/org/bitcoins/core/Core.scala
+++ b/core/src/main/scala/org/bitcoins/core/Core.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core
 
-import org.bitcoins.core.api.CoreApi
+import org.bitcoins.core.api.core.CoreApi
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.psbt.PSBT
 

--- a/core/src/main/scala/org/bitcoins/core/api/NodeChainQueryApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/NodeChainQueryApi.scala
@@ -1,3 +1,0 @@
-package org.bitcoins.core.api
-
-case class NodeChainQueryApi(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainQueryApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainQueryApi.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.core.api
+package org.bitcoins.core.api.chain
 
 import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.protocol.BlockStamp
@@ -10,8 +10,6 @@ import scala.concurrent.{ExecutionContext, Future}
   * This trait provides methods to query various types of blockchain data.
   */
 trait ChainQueryApi {
-
-  import org.bitcoins.core.api.ChainQueryApi._
 
   /** Gets the height of the given block */
   def getBlockHeight(blockHash: DoubleSha256DigestBE): Future[Option[Int]]
@@ -39,7 +37,7 @@ trait ChainQueryApi {
 
   def getFiltersBetweenHeights(
       startHeight: Int,
-      endHeight: Int): Future[Vector[FilterResponse]]
+      endHeight: Int): Future[Vector[ChainQueryApi.FilterResponse]]
 
   /** Gets the block height of the closest block to the given time */
   def epochSecondToBlockHeight(time: Long): Future[Int]

--- a/core/src/main/scala/org/bitcoins/core/api/core/CoreApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/core/CoreApi.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.core.api
+package org.bitcoins.core.api.core
 
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.psbt.PSBT

--- a/core/src/main/scala/org/bitcoins/core/api/db/DbRowAutoInc.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/db/DbRowAutoInc.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.db
+package org.bitcoins.core.api.db
 
 /** This is meant to be coupled with [[CRUDAutoInc]]
   * and [[TableAutoInc]] to allow for automatically incrementing an id

--- a/core/src/main/scala/org/bitcoins/core/api/feeprovider/FeeRateApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/feeprovider/FeeRateApi.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.core.api
+package org.bitcoins.core.api.feeprovider
 
 import org.bitcoins.core.wallet.fee.FeeUnit
 

--- a/core/src/main/scala/org/bitcoins/core/api/node/NodeApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/NodeApi.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.core.api
+package org.bitcoins.core.api.node
 
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.DoubleSha256Digest

--- a/core/src/main/scala/org/bitcoins/core/api/node/NodeChainQueryApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/NodeChainQueryApi.scala
@@ -1,0 +1,5 @@
+package org.bitcoins.core.api.node
+
+import org.bitcoins.core.api.chain.ChainQueryApi
+
+case class NodeChainQueryApi(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.db
 
+import org.bitcoins.core.api.db.DbRowAutoInc
+
 import scala.concurrent.{ExecutionContext, Future}
 
 abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](implicit

--- a/docs/wallet/chain-query-api.md
+++ b/docs/wallet/chain-query-api.md
@@ -6,7 +6,8 @@ title: Chain Query API
 ```scala mdoc:invisible
 import akka.actor.ActorSystem
 import org.bitcoins.core.api._
-import org.bitcoins.core.api.ChainQueryApi.FilterResponse
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.core.gcs.{FilterType, GolombFilter}
 import org.bitcoins.core.protocol.BlockStamp

--- a/docs/wallet/node-api.md
+++ b/docs/wallet/node-api.md
@@ -6,6 +6,7 @@ title: Node API
 ```scala mdoc:invisible
 import akka.actor.ActorSystem
 import org.bitcoins.core.api._
+import org.bitcoins.core.api.node._
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.Transaction

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -49,7 +49,9 @@ import org.bitcoins.chain.api.ChainApi
 import org.bitcoins.chain.models._
 
 import org.bitcoins.core.api._
-import ChainQueryApi._
+import chain._
+import chain.ChainQueryApi.FilterResponse
+import node._
 import org.bitcoins.crypto._
 import org.bitcoins.core.protocol._
 import org.bitcoins.core.protocol.transaction._

--- a/fee-provider-test/src/test/scala/org/bitcoins/feeprovider/FeeRateProviderTest.scala
+++ b/fee-provider-test/src/test/scala/org/bitcoins/feeprovider/FeeRateProviderTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.feeprovider
 
-import org.bitcoins.core.api.FeeRateApi
+import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.feeprovider.MempoolSpaceTarget._

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/ConstantFeeRateProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/ConstantFeeRateProvider.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.feeprovider
 
-import org.bitcoins.core.api.FeeRateApi
+import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.wallet.fee.FeeUnit
 
 import scala.concurrent.Future

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/HttpFeeRateProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/HttpFeeRateProvider.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{HttpRequest, Uri}
 import akka.util.ByteString
-import org.bitcoins.core.api.FeeRateApi
+import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.core.wallet.fee.FeeUnit
 

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -2,7 +2,7 @@ package org.bitcoins.node
 
 import akka.actor.ActorSystem
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.ChainQueryApi.FilterResponse
+import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -8,7 +8,8 @@ import org.bitcoins.chain.models.{
   CompactFilterDAO,
   CompactFilterHeaderDAO
 }
-import org.bitcoins.core.api.{ChainQueryApi, NodeApi}
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.p2p.{NetworkPayload, TypeIdentifier}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.FutureUtil

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -2,7 +2,7 @@ package org.bitcoins.node
 
 import akka.actor.ActorSystem
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.ChainQueryApi.FilterResponse
+import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.bloom.BloomFilter
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}

--- a/node/src/main/scala/org/bitcoins/node/models/Peer.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/Peer.scala
@@ -2,7 +2,7 @@ package org.bitcoins.node.models
 
 import java.net.InetSocketAddress
 
-import org.bitcoins.db.DbRowAutoInc
+import org.bitcoins.core.api.db.DbRowAutoInc
 import org.bitcoins.rpc.config.BitcoindInstance
 
 case class Peer(socket: InetSocketAddress, id: Option[Long] = None)

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
@@ -2,8 +2,10 @@ package org.bitcoins.testkit.chain
 
 import org.bitcoins.chain.blockchain.sync.FilterWithHeaderHash
 import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockFilterResult
-import org.bitcoins.core.api.ChainQueryApi.FilterResponse
-import org.bitcoins.core.api.{ChainQueryApi, NodeApi, NodeChainQueryApi}
+import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
+import org.bitcoins.core.api.node.{NodeApi, NodeChainQueryApi}
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.node
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.blockchain.BlockHeader
@@ -180,7 +182,7 @@ abstract class SyncUtil extends BitcoinSLogger {
       ec: ExecutionContext): NodeChainQueryApi = {
     val chainQuery = SyncUtil.getTestChainQueryApi(bitcoind)
     val nodeApi = SyncUtil.getNodeApi(bitcoind)
-    NodeChainQueryApi(nodeApi, chainQuery)
+    node.NodeChainQueryApi(nodeApi, chainQuery)
   }
 
   def getNodeChainQueryApiWalletCallback(
@@ -190,7 +192,7 @@ abstract class SyncUtil extends BitcoinSLogger {
     val chainQuery = SyncUtil.getTestChainQueryApi(bitcoind)
     val nodeApi =
       SyncUtil.getNodeApiWalletCallback(bitcoind, walletF)
-    NodeChainQueryApi(nodeApi, chainQuery)
+    node.NodeChainQueryApi(nodeApi, chainQuery)
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -10,7 +10,7 @@ import org.bitcoins.chain.models.{
   CompactFilterDb,
   CompactFilterHeaderDb
 }
-import org.bitcoins.core.api.ChainQueryApi
+import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.gcs.FilterHeader
 import org.bitcoins.core.p2p.CompactFilterMessage

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -2,8 +2,10 @@ package org.bitcoins.testkit.wallet
 
 import akka.actor.ActorSystem
 import com.typesafe.config.{Config, ConfigFactory}
-import org.bitcoins.core.api.ChainQueryApi.FilterResponse
-import org.bitcoins.core.api.{ChainQueryApi, FeeRateApi, NodeApi}
+import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
+import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.BlockFilter
 import org.bitcoins.core.protocol.BlockStamp

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -2,7 +2,8 @@ package org.bitcoins.testkit.wallet
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import org.bitcoins.core.api.{ChainQueryApi, NodeApi}
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.protocol.BitcoinAddress

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -3,7 +3,9 @@ package org.bitcoins.wallet
 import java.time.Instant
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
-import org.bitcoins.core.api.{ChainQueryApi, FeeRateApi, NodeApi}
+import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.crypto.ExtPublicKey

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -3,7 +3,9 @@ package org.bitcoins.wallet.api
 import java.time.Instant
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
-import org.bitcoins.core.api.{ChainQueryApi, FeeRateApi, NodeApi}
+import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.AddressType

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -4,7 +4,9 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.TimeUnit
 
 import com.typesafe.config.Config
-import org.bitcoins.core.api.{ChainQueryApi, FeeRateApi, NodeApi}
+import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.hd._
 import org.bitcoins.core.util.{FutureUtil, Mutable}
 import org.bitcoins.db.{AppConfig, AppConfigFactory, JdbcProfileComponent}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -2,7 +2,10 @@ package org.bitcoins.wallet.internal
 
 import java.util.concurrent.Executors
 
-import org.bitcoins.core.api.ChainQueryApi.{FilterResponse, InvalidBlockRange}
+import org.bitcoins.core.api.chain.ChainQueryApi.{
+  FilterResponse,
+  InvalidBlockRange
+}
 import org.bitcoins.core.gcs.SimpleFilterMatcher
 import org.bitcoins.core.hd.{HDAccount, HDChainType}
 import org.bitcoins.core.protocol.BlockStamp.BlockHeight

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDb.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDb.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet.models
 
+import org.bitcoins.core.api.db.DbRowAutoInc
 import org.bitcoins.core.hd.{
   HDPath,
   LegacyHDPath,
@@ -20,7 +21,6 @@ import org.bitcoins.core.wallet.utxo.{
   TxoState
 }
 import org.bitcoins.crypto.{DoubleSha256DigestBE, Sign}
-import org.bitcoins.db.DbRowAutoInc
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 
 /**


### PR DESCRIPTION
…owAutoInc into the core project

This is part of #1284 

This moves `DbRowAutoInc` into the core project which is required to move other database row representations in `WalletApi` or `ChainApi` etc. 

I also reworked the `org.bitcoins.core.api` directory structure to represent the modules we have. This is what it looks like now

> tree
.
├── Callback.scala
├── chain
│   └── ChainQueryApi.scala
├── core
│   └── CoreApi.scala
├── db
│   └── DbRowAutoInc.scala
├── feeprovider
│   └── FeeRateApi.scala
├── node
│   ├── NodeApi.scala
│   └── NodeChainQueryApi.scala
└── wallet
