### PR TITLE
Revert scalaTestPlus to 3.2.0.0

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -9,7 +9,7 @@ object Deps {
     val scalaTest = "3.2.0"
 
     val scalaTestPlus =
-      "3.2.1.0" //super annoying... https://oss.sonatype.org/content/groups/public/org/scalatestplus/
+      "3.2.0.0" //super annoying... https://oss.sonatype.org/content/groups/public/org/scalatestplus/
     val slf4j = "1.7.30"
     val spray = "1.3.5"
     val zeromq = "0.5.2"


### PR DESCRIPTION
To configure the logging in the test cases you should use the `level` config.

2 things here:

1) scalaTestPlus 3.2.1.0 was causing the test cases being ran not to output, reverting the update fixed this.

2) Modules that rely on an appconfig that did not have a reference.conf file were using some fallback config that we could not easily configure. This adds a reference.conf to each testing module so it can easily configured.