### PR TITLE
Output logger configuration on startup now

### DIFF
--- a/core-test/src/test/resources/logback-test.xml
+++ b/core-test/src/test/resources/logback-test.xml
@@ -1,9 +1,0 @@
-<configuration>
-    <include resource="common-logback.xml" />
-
-    <root level="OFF">
-        <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE"/>
-    </root>
-
-</configuration>

--- a/core/src/test/resources/common-logback.xml
+++ b/core/src/test/resources/common-logback.xml
@@ -1,6 +1,9 @@
 <included>
-    <!-- Stop output INFO at start -->
-    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+    <!-- http://logback.qos.ch/manual/configuration.html#dumpingStatusData
+         This prints status of the logging configuration on startup
+         If you want to silence this output replace 'OnConsoleStatusListener'
+         with 'NopStatusListener' -->
+    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
 
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">

--- a/testkit/src/main/resources/logback.xml
+++ b/testkit/src/main/resources/logback.xml
@@ -1,5 +1,8 @@
 <configuration>
-    <!-- Stop output INFO at start -->
+    <!-- http://logback.qos.ch/manual/configuration.html#dumpingStatusData
+         This prints status of the logging configuration on startup
+         If you want to silence this output replace 'OnConsoleStatusListener'
+         with 'NopStatusListener' -->
     <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
 
 

--- a/testkit/src/main/resources/logback.xml
+++ b/testkit/src/main/resources/logback.xml
@@ -1,9 +1,6 @@
-<included>
-    <!-- http://logback.qos.ch/manual/configuration.html#dumpingStatusData
-         This prints status of the logging configuration on startup
-         If you want to silence this output replace 'OnConsoleStatusListener'
-         with 'NopStatusListener' -->
-    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+<configuration>
+    <!-- Stop output INFO at start -->
+    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
 
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
@@ -97,11 +94,12 @@
     <!-- see what's returned by Slick -->
     <logger name="slick.jdbc.StatementInvoker.result" level="INFO"/>
 
-    <!-- Get rid of messages like this: 
-    Connection attempt failed. Backing off new connection 
+    <!-- Get rid of messages like this:
+    Connection attempt failed. Backing off new connection
     attempts for at least 800 milliseconds. -->
     <logger name="akka.http.impl.engine.client.PoolGateway" level="OFF"/>
 
     <!-- get rid of "Slf4jLogger started" messages -->
     <logger name="akka.event.slf4j.Slf4jLogger" level="OFF"/>
-</included>
+
+</configuration>


### PR DESCRIPTION
This now gives us output at the beginning of test runs showing logger configuration. In the wake of #1813 #1809 #1805 #1808 etc 

We put this here in #499 because it can be annoying to see this log output every time you run a test case, but since we are having a bunch of issues I think it's best to bring it back for now. You should see information like this on startup. For erference, i'm running this test case (random test case)

> coreTest/testOnly *BlockTest* -- -z "create a merkle block from a sequence of txids and a block"


>08:47:14,264 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback-test.xml] at [file:/home/suredbits/dev/bitcoin-s/core-test/target/scala-2.13/test-classes/logback-test.xml]
08:47:14,300 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - debug attribute not set
08:47:14,305 |-INFO in ch.qos.logback.core.joran.util.ConfigurationWatchListUtil@32d93859 - Adding [file:/home/suredbits/dev/bitcoin-s/core/target/scala-2.13/test-classes/common-logback.xml] to configuration watch list.
08:47:14,308 |-INFO in ch.qos.logback.core.joran.action.StatusListenerAction - Added status listener of type [ch.qos.logback.core.status.OnConsoleStatusListener]
08:47:14,309 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.FileAppender]
08:47:14,313 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [FILE]
08:47:14,318 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
08:47:14,341 |-INFO in ch.qos.logback.core.FileAppender[FILE] - File property is set to [logs/application.log]
08:47:14,342 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
08:47:14,343 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [STDOUT]
08:47:14,344 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
08:47:14,346 |-INFO in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to INFO
08:47:14,346 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [FILE] to Logger[ROOT]
08:47:14,347 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [STDOUT] to Logger[ROOT]
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.db.SafeDatabase] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.chain.config] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.node.config] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.wallet.config] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.chain.db] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.node.db] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.wallet.db] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.node.networking.peer.PeerMessageReceiver] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.node.networking.peer.PeerMessageSender] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.node.networking.peer.DataMessageHandler] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.node.networking.P2PClientActor] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.chain.blockchain.ChainHandler] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.chain.validation] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [slick.jdbc.JdbcBackend.benchmark] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [slick.jdbc.JdbcBackend.statement] to INFO
08:47:14,348 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [slick.compiler] to INFO
08:47:14,349 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [slick.jdbc.StatementInvoker.result] to INFO
08:47:14,349 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [akka.http.impl.engine.client.PoolGateway] to OFF
08:47:14,349 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [akka.event.slf4j.Slf4jLogger] to OFF
08:47:14,349 |-INFO in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to OFF
08:47:14,349 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [STDOUT] to Logger[ROOT]
08:47:14,349 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [FILE] to Logger[ROOT]
08:47:14,349 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - End of configuration.
08:47:14,350 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@6fde4168 - Registering current configuration as safe fallback point

You can see configuration options here: http://logback.qos.ch/manual/configuration.html#dumpingStatusData

Unfortunately this _still_ isn't working for our modules... probably because the logging configuration is broken somewhere along the way. 

> chainTest/testOnly *ChainHandlerTest* -- -z "process a new valid block header, and then be able to fetch that header"
[info] ChainHandlerTest:
[info] ChainHandler
08:52:26.249 INFO VersionPrinter - Flyway Community Edition 6.4.2 by Redgate
08:52:26.370 INFO DatabaseFactory - Database: jdbc:sqlite:/tmp/bitcoin-s-16144178708643713556/mainnet/chaindb.sqlite (SQLite 3.32)
08:52:26.423 INFO DbValidate - Successfully validated 5 migrations (execution time 00:00.035s)
08:52:26.425 INFO JdbcTableSchemaHistory - Creating Schema History table "main"."flyway_schema_history" ...
08:52:26.443 INFO DbMigrate - Current version of schema "main": << Empty Schema >>
08:52:26.450 INFO DbMigrate - Migrating schema "main" to version 1 - chain db baseline
08:52:26.472 INFO DbMigrate - Migrating schema "main" to version 2 - add block header chain work
08:52:26.481 INFO DbMigrate - Migrating schema "main" to version 3 - change chain work default
08:52:26.495 INFO DbMigrate - Migrating schema "main" to version 4 - chain work to varchar
08:52:26.503 INFO DbMigrate - Migrating schema "main" to version 5 - re add block header indexes
08:52:26.513 INFO DbMigrate - Successfully applied 5 migrations to schema "main" (execution time 00:00.070s)
2020-08-13T13:52:27 INFO [chain-verification] Processed headers from height=0 to 1. Best hash=5aa67677d562f706479c2f80ed25a8573f93d886f05228e416a3c626dd51e4cd
[info] ScalaTest
