### PR TITLE
Remove default false for useLogbackConf

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -22,9 +22,9 @@ import org.bitcoins.db.AppConfig
 case class BitcoinSAppConfig(
     private val directory: Path,
     private val confs: Config*)(implicit ec: ExecutionContext) {
-  val walletConf: WalletAppConfig = WalletAppConfig(directory, false, confs: _*)
-  val nodeConf: NodeAppConfig = NodeAppConfig(directory, false, confs: _*)
-  val chainConf: ChainAppConfig = ChainAppConfig(directory, false, confs: _*)
+  val walletConf: WalletAppConfig = WalletAppConfig(directory, confs: _*)
+  val nodeConf: NodeAppConfig = NodeAppConfig(directory, confs: _*)
+  val chainConf: ChainAppConfig = ChainAppConfig(directory, confs: _*)
 
   /** Initializes the wallet, node and chain projects */
   def initialize()(implicit ec: ExecutionContext): Future[Unit] = {

--- a/chain-test/src/test/scala/org/bitcoins/chain/config/ChainAppConfigTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/config/ChainAppConfigTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.FutureOutcome
 
 class ChainAppConfigTest extends ChainUnitTest {
   val tempDir = Files.createTempDirectory("bitcoin-s")
-  val config = ChainAppConfig(directory = tempDir, useLogbackConf = false)
+  val config = ChainAppConfig(directory = tempDir)
 
   //if we don't turn off logging here, isInitF a few lines down will
   //produce some nasty error logs since we are testing initialization
@@ -72,7 +72,7 @@ class ChainAppConfigTest extends ChainUnitTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig = ChainAppConfig(directory = tempDir, useLogbackConf = false)
+    val appConfig = ChainAppConfig(directory = tempDir)
 
     assert(appConfig.datadir == tempDir.resolve("testnet3"))
     assert(appConfig.network == TestNet3)

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -17,7 +17,6 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 case class ChainAppConfig(
     private val directory: Path,
-    override val useLogbackConf: Boolean,
     private val confs: Config*)(implicit override val ec: ExecutionContext)
     extends AppConfig
     with ChainDbManagement
@@ -29,7 +28,7 @@ case class ChainAppConfig(
 
   override protected[bitcoins] def newConfigOfType(
       configs: Seq[Config]): ChainAppConfig =
-    ChainAppConfig(directory, useLogbackConf, configs: _*)
+    ChainAppConfig(directory, configs: _*)
   protected[bitcoins] def baseDatadir: Path = directory
 
   override lazy val appConfig: ChainAppConfig = this
@@ -111,9 +110,7 @@ object ChainAppConfig extends AppConfigFactory[ChainAppConfig] {
   /** Constructs a chain verification configuration from the default Bitcoin-S
     * data directory and given list of configuration overrides.
     */
-  override def fromDatadir(
-      datadir: Path,
-      useLogbackConf: Boolean,
-      confs: Vector[Config])(implicit ec: ExecutionContext): ChainAppConfig =
-    ChainAppConfig(datadir, useLogbackConf, confs: _*)
+  override def fromDatadir(datadir: Path, confs: Vector[Config])(implicit
+      ec: ExecutionContext): ChainAppConfig =
+    ChainAppConfig(datadir, confs: _*)
 }

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -44,7 +44,6 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
 
   it must "run migrations for chain db" in {
     val chainAppConfig = ChainAppConfig(BitcoinSTestAppConfig.tmpDir(),
-                                        useLogbackConf = false,
                                         dbConfig(ProjectType.Chain))
     val chainDbManagement = createChainDbManagement(chainAppConfig)
     val result = chainDbManagement.migrate()
@@ -54,7 +53,6 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
 
   it must "run migrations for wallet db" in {
     val walletAppConfig = WalletAppConfig(BitcoinSTestAppConfig.tmpDir(),
-                                          useLogbackConf = false,
                                           dbConfig(ProjectType.Wallet))
     val walletDbManagement = createWalletDbManagement(walletAppConfig)
     val result = walletDbManagement.migrate()
@@ -64,9 +62,7 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
 
   it must "run migrations for node db" in {
     val nodeAppConfig =
-      NodeAppConfig(BitcoinSTestAppConfig.tmpDir(),
-                    useLogbackConf = false,
-                    dbConfig(ProjectType.Node))
+      NodeAppConfig(BitcoinSTestAppConfig.tmpDir(), dbConfig(ProjectType.Node))
     val nodeDbManagement = createNodeDbManagement(nodeAppConfig)
     val result = nodeDbManagement.migrate()
     assert(result == 2)

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfigFactory.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfigFactory.scala
@@ -8,15 +8,11 @@ import scala.concurrent.ExecutionContext
 
 trait AppConfigFactory[C <: AppConfig] {
 
-  def fromDefaultDatadir(
-      useLogbackConf: Boolean,
-      confs: Vector[Config] = Vector.empty)(implicit
+  def fromDefaultDatadir(confs: Vector[Config] = Vector.empty)(implicit
       ec: ExecutionContext): C = {
-    fromDatadir(AppConfig.DEFAULT_BITCOIN_S_DATADIR, useLogbackConf, confs)
+    fromDatadir(AppConfig.DEFAULT_BITCOIN_S_DATADIR, confs)
   }
 
-  def fromDatadir(
-      datadir: Path,
-      useLogbackConf: Boolean,
-      confs: Vector[Config] = Vector.empty)(implicit ec: ExecutionContext): C
+  def fromDatadir(datadir: Path, confs: Vector[Config] = Vector.empty)(implicit
+      ec: ExecutionContext): C
 }

--- a/docs/chain/chain.md
+++ b/docs/chain/chain.md
@@ -60,7 +60,7 @@ val config = ConfigFactory.parseString {
     |""".stripMargin
 }
 
-implicit val chainConfig = ChainAppConfig(datadir, false, config)
+implicit val chainConfig = ChainAppConfig(datadir, config)
 
 // Initialize the needed database tables if they don't exist:
 val chainProjectInitF = chainConfig.initialize()

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -28,16 +28,16 @@ import scala.util.Properties
 import scala.concurrent.ExecutionContext.Implicits.global
 
 // reads $HOME/.bitcoin-s/
-val defaultConfig = WalletAppConfig.fromDefaultDatadir(false)
+val defaultConfig = WalletAppConfig.fromDefaultDatadir()
 
 
 // reads a custom data directory
 val customDirectory = Paths.get(Properties.userHome, "custom-bitcoin-s-directory")
-val configFromCustomDatadir = WalletAppConfig(customDirectory, false)
+val configFromCustomDatadir = WalletAppConfig(customDirectory)
 
 // reads a custom data directory and overrides the network to be testnet3
 val customOverride = ConfigFactory.parseString("bitcoin-s.network = testnet3")
-val configFromCustomDirAndOverride = WalletAppConfig(customDirectory, false, customOverride)
+val configFromCustomDirAndOverride = WalletAppConfig(customDirectory, customOverride)
 ```
 
 You can pass as many `com.typesafe.config.Config`s as you'd like. If any

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -87,10 +87,10 @@ val config = ConfigFactory.parseString {
 val datadir = Files.createTempDirectory("bitcoin-s-wallet")
 
 
-implicit val walletConfig = WalletAppConfig(datadir, false, config)
+implicit val walletConfig = WalletAppConfig(datadir, config)
 
 // we also need to store chain state for syncing purposes
-implicit val chainConfig = ChainAppConfig(datadir, false, config)
+implicit val chainConfig = ChainAppConfig(datadir, config)
 
 // when this future completes, we have
 // created the necessary directories and

--- a/node-test/src/test/scala/org/bitcoins/node/NodeAppConfigTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeAppConfigTest.scala
@@ -14,7 +14,7 @@ class NodeAppConfigTest extends BitcoinSAsyncTest {
   val tempDir = Files.createTempDirectory("bitcoin-s")
 
   val config: NodeAppConfig =
-    NodeAppConfig(directory = tempDir, useLogbackConf = false)
+    NodeAppConfig(directory = tempDir)
 
   it must "be overridable" in {
     assert(config.network == RegTest)
@@ -53,7 +53,7 @@ class NodeAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig = NodeAppConfig(directory = tempDir, useLogbackConf = false)
+    val appConfig = NodeAppConfig(directory = tempDir)
 
     assert(appConfig.datadir == tempDir.resolve("testnet3"))
     assert(appConfig.network == TestNet3)

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -19,7 +19,6 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 case class NodeAppConfig(
     private val directory: Path,
-    override val useLogbackConf: Boolean,
     private val confs: Config*)(implicit override val ec: ExecutionContext)
     extends AppConfig
     with NodeDbManagement
@@ -30,7 +29,7 @@ case class NodeAppConfig(
 
   override protected[bitcoins] def newConfigOfType(
       configs: Seq[Config]): NodeAppConfig =
-    NodeAppConfig(directory, useLogbackConf, configs: _*)
+    NodeAppConfig(directory, configs: _*)
 
   protected[bitcoins] def baseDatadir: Path = directory
 
@@ -100,11 +99,9 @@ object NodeAppConfig extends AppConfigFactory[NodeAppConfig] {
   /** Constructs a node configuration from the default Bitcoin-S
     * data directory and given list of configuration overrides.
     */
-  override def fromDatadir(
-      datadir: Path,
-      useLogbackConf: Boolean,
-      confs: Vector[Config])(implicit ec: ExecutionContext): NodeAppConfig =
-    NodeAppConfig(datadir, useLogbackConf, confs: _*)
+  override def fromDatadir(datadir: Path, confs: Vector[Config])(implicit
+      ec: ExecutionContext): NodeAppConfig =
+    NodeAppConfig(datadir, confs: _*)
 
   /** Creates either a neutrino node or a spv node based on the [[NodeAppConfig]] given */
   def createNode(peer: Peer)(implicit

--- a/testkit/src/main/resources/logback-test.xml
+++ b/testkit/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -34,17 +34,17 @@
     <!-- ╚═══════════════════╝ -->
 
     <!-- inspect resolved DB connection -->
-    <logger name="org.bitcoins.db.SafeDatabase" level="INFO"/>
+    <logger name="org.bitcoins.db.SafeDatabase" level="WARN"/>
 
     <!-- inspect resolved config -->
-    <logger name="org.bitcoins.chain.config" level="INFO"/>
-    <logger name="org.bitcoins.node.config" level="INFO"/>
-    <logger name="org.bitcoins.wallet.config" level="INFO"/>
+    <logger name="org.bitcoins.chain.config" level="WARN"/>
+    <logger name="org.bitcoins.node.config" level="WARN"/>
+    <logger name="org.bitcoins.wallet.config" level="WARN"/>
 
     <!-- inspect table creation, etc -->
-    <logger name="org.bitcoins.chain.db" level="INFO" />
-    <logger name="org.bitcoins.node.db" level="INFO" />
-    <logger name="org.bitcoins.wallet.db" level="INFO" />
+    <logger name="org.bitcoins.chain.db" level="WARN" />
+    <logger name="org.bitcoins.node.db" level="WARN" />
+    <logger name="org.bitcoins.wallet.db" level="WARN" />
 
     <!-- ╔═════════════════╗ -->
     <!-- ║   Node module   ║ -->
@@ -68,10 +68,9 @@
 
     <!-- See queries received by chain handler, as well as result of  -->
     <!-- connecting new block headers to chain -->
-    <logger name="org.bitcoins.chain.blockchain.ChainHandler" level="INFO"/>
+    <logger name="org.bitcoins.chain.blockchain.ChainHandler" level="WARN"/>
 
-    <!-- Set to TRACE to inspect details of chain vaidation -->
-    <logger name="org.bitcoins.chain.validation" level="INFO"/>
+    <logger name="org.bitcoins.chain.validation" level="WARN"/>
 
     <!-- ╔═════════════════════╗ -->
     <!-- ║   Wallet module     ║ -->

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
@@ -19,7 +19,7 @@ class WalletAppConfigTest extends BitcoinSAsyncTest {
   val tempDir = Files.createTempDirectory("bitcoin-s")
 
   val config: WalletAppConfig =
-    WalletAppConfig(directory = tempDir, useLogbackConf = false)
+    WalletAppConfig(directory = tempDir)
 
   it must "resolve DB connections correctly " in {
     assert(config.dbPath.startsWith(Properties.tmpDir))
@@ -44,13 +44,12 @@ class WalletAppConfigTest extends BitcoinSAsyncTest {
                                                  |}
                                                  |""".stripMargin)
 
-    val throughConstuctor =
-      WalletAppConfig(tempDir, useLogbackConf = false, overrider)
+    val throughConstructor = WalletAppConfig(tempDir, overrider)
     val throughWithOverrides = config.withOverrides(overrider)
     assert(throughWithOverrides.network == MainNet)
-    assert(throughWithOverrides.network == throughConstuctor.network)
+    assert(throughWithOverrides.network == throughConstructor.network)
 
-    assert(throughWithOverrides.datadir == throughConstuctor.datadir)
+    assert(throughWithOverrides.datadir == throughConstructor.datadir)
 
   }
 
@@ -96,7 +95,7 @@ class WalletAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig = WalletAppConfig(directory = tempDir, useLogbackConf = false)
+    val appConfig = WalletAppConfig(directory = tempDir)
 
     assert(appConfig.datadir == tempDir.resolve("testnet3"))
     assert(appConfig.network == TestNet3)

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -29,7 +29,6 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 case class WalletAppConfig(
     private val directory: Path,
-    override val useLogbackConf: Boolean,
     private val conf: Config*)(implicit override val ec: ExecutionContext)
     extends AppConfig
     with WalletDbManagement
@@ -40,7 +39,7 @@ case class WalletAppConfig(
 
   override protected[bitcoins] def newConfigOfType(
       configs: Seq[Config]): WalletAppConfig =
-    WalletAppConfig(directory, useLogbackConf, configs: _*)
+    WalletAppConfig(directory, configs: _*)
 
   protected[bitcoins] def baseDatadir: Path = directory
 
@@ -190,11 +189,9 @@ object WalletAppConfig
   /** Constructs a wallet configuration from the default Bitcoin-S
     * data directory and given list of configuration overrides.
     */
-  override def fromDatadir(
-      datadir: Path,
-      useLogbackConf: Boolean,
-      confs: Vector[Config])(implicit ec: ExecutionContext): WalletAppConfig =
-    WalletAppConfig(datadir, useLogbackConf, confs: _*)
+  override def fromDatadir(datadir: Path, confs: Vector[Config])(implicit
+      ec: ExecutionContext): WalletAppConfig =
+    WalletAppConfig(datadir, confs: _*)
 
   /** Creates a wallet based on the given [[WalletAppConfig]] */
   def createHDWallet(


### PR DESCRIPTION
Fixes #1813 

In #1398 I had set it all of the `AppConfig`s to override the `useLogbackConf` option to `false`. The reasoning was so we can use our own settings, however, I'm not sure why I did that, the `logback` option should just cover that for us. This removes the defaulting to false and just has it read from the config file.