### PR TITLE
Require utxos aren't spent when sending from outpoints

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -385,6 +385,11 @@ abstract class Wallet
       diff = utxoDbs.map(_.outPoint).diff(outPoints)
       _ = require(diff.isEmpty,
                   s"Not all OutPoints belong to this wallet, diff $diff")
+      spentUtxos =
+        utxoDbs.filterNot(utxo => TxoState.receivedStates.contains(utxo.state))
+      _ = require(
+        spentUtxos.isEmpty,
+        s"Some out points given have already been spent, ${spentUtxos.map(_.outPoint)}")
 
       prevTxFs = utxoDbs.map(utxo =>
         transactionDAO.findByOutPoint(utxo.outPoint).map(_.get.transaction))


### PR DESCRIPTION
Found while testing cli stuff that we could make a tx with already spent inputs with `sendfromoutpoints`. This fixes that.