### PR TITLE
Remove unnecessary parallelization in Wallet

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -138,11 +138,9 @@ abstract class Wallet
   override def processCompactFilters(
       blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
     Wallet] = {
-    val utxosF = listUtxos()
-    val addressesF = listAddresses()
     for {
-      utxos <- utxosF
-      addresses <- addressesF
+      utxos <- listUtxos()
+      addresses <- listAddresses()
       scriptPubKeys =
         utxos.flatMap(_.redeemScriptOpt).toSet ++ addresses
           .map(_.scriptPubKey)
@@ -222,16 +220,15 @@ abstract class Wallet
       yield {
         val filtered = utxos
           .filter(predicate)
-          .map {
-            case txo: SpendingInfoDb =>
-              txo.state match {
-                case TxoState.PendingConfirmationsReceived |
-                    TxoState.ConfirmedReceived =>
-                  txo.output.value
-                case TxoState.Reserved | TxoState.PendingConfirmationsSpent |
-                    TxoState.ConfirmedSpent | TxoState.DoesNotExist =>
-                  CurrencyUnits.zero
-              }
+          .map { txo =>
+            txo.state match {
+              case TxoState.PendingConfirmationsReceived |
+                  TxoState.ConfirmedReceived =>
+                txo.output.value
+              case TxoState.Reserved | TxoState.PendingConfirmationsSpent |
+                  TxoState.ConfirmedSpent | TxoState.DoesNotExist =>
+                CurrencyUnits.zero
+            }
           }
 
         filtered.fold(0.sats)(_ + _)
@@ -239,24 +236,22 @@ abstract class Wallet
   }
 
   override def getConfirmedBalance(): Future[CurrencyUnit] = {
-    val confirmed = filterThenSum(_.state == ConfirmedReceived)
-    confirmed.foreach(balance =>
-      logger.trace(s"Confirmed balance=${balance.satoshis}"))
-    confirmed
+    filterThenSum(_.state == ConfirmedReceived).map { balance =>
+      logger.trace(s"Confirmed balance=${balance.satoshis}")
+      balance
+    }
   }
 
   override def getConfirmedBalance(account: HDAccount): Future[CurrencyUnit] = {
-    val allUnspentF = spendingInfoDAO.findAllUnspent()
-    val unspentInAccountF = for {
-      allUnspent <- allUnspentF
+    for {
+      allUnspent <- spendingInfoDAO.findAllUnspent()
     } yield {
-      allUnspent.filter { utxo =>
+      val confirmedUtxos = allUnspent.filter { utxo =>
         HDAccount.isSameAccount(utxo.privKeyPath.path, account) &&
         utxo.state == ConfirmedReceived
       }
+      confirmedUtxos.foldLeft(CurrencyUnits.zero)(_ + _.output.value)
     }
-
-    unspentInAccountF.map(_.foldLeft(CurrencyUnits.zero)(_ + _.output.value))
   }
 
   override def getConfirmedBalance(tag: AddressTag): Future[CurrencyUnit] = {
@@ -267,26 +262,23 @@ abstract class Wallet
   }
 
   override def getUnconfirmedBalance(): Future[CurrencyUnit] = {
-    val unconfirmed = filterThenSum(_.state == PendingConfirmationsReceived)
-    unconfirmed.foreach(balance =>
-      logger.trace(s"Unconfirmed balance=${balance.satoshis}"))
-    unconfirmed
-
+    filterThenSum(_.state == PendingConfirmationsReceived).map { balance =>
+      logger.trace(s"Unconfirmed balance=${balance.satoshis}")
+      balance
+    }
   }
 
   override def getUnconfirmedBalance(
       account: HDAccount): Future[CurrencyUnit] = {
-    val allUnspentF = spendingInfoDAO.findAllUnspent()
-    val unspentInAccountF = for {
-      allUnspent <- allUnspentF
+    for {
+      allUnspent <- spendingInfoDAO.findAllUnspent()
     } yield {
-      allUnspent.filter { utxo =>
+      val confirmedUtxos = allUnspent.filter { utxo =>
         HDAccount.isSameAccount(utxo.privKeyPath.path, account) &&
         utxo.state == PendingConfirmationsReceived
       }
+      confirmedUtxos.foldLeft(CurrencyUnits.zero)(_ + _.output.value)
     }
-
-    unspentInAccountF.map(_.foldLeft(CurrencyUnits.zero)(_ + _.output.value))
   }
 
   override def getUnconfirmedBalance(tag: AddressTag): Future[CurrencyUnit] = {
@@ -540,14 +532,15 @@ abstract class Wallet
     * @return
     */
   override def createNewAccount(kmParams: KeyManagerParams): Future[Wallet] = {
-    val lastAccountOptF = accountDAO
-      .findAll()
-      .map(_.filter(_.hdAccount.purpose == kmParams.purpose))
-      .map(_.sortBy(_.hdAccount.index))
-      // we want to the most recently created account,
-      // to know what the index of our new account
-      // should be.
-      .map(_.lastOption)
+    def lastAccountOptF =
+      accountDAO
+        .findAll()
+        .map(_.filter(_.hdAccount.purpose == kmParams.purpose))
+        .map(_.sortBy(_.hdAccount.index))
+        // we want to the most recently created account,
+        // to know what the index of our new account
+        // should be.
+        .map(_.lastOption)
 
     lastAccountOptF.flatMap {
       case Some(accountDb) =>
@@ -578,10 +571,10 @@ abstract class Wallet
       }
     }
     val newAccountDb = AccountDb(xpub, hdAccount)
-    val accountCreationF = accountDAO.create(newAccountDb)
-    accountCreationF.map(created =>
-      logger.debug(s"Created new account ${created.hdAccount}"))
-    accountCreationF.map(_ => this)
+    accountDAO.create(newAccountDb).map { created =>
+      logger.debug(s"Created new account ${created.hdAccount}")
+      this
+    }
   }
 }
 
@@ -622,7 +615,6 @@ object Wallet extends WalletLogger {
     // safe since we're deriving from a priv
     val xpub = keyManager.deriveXPub(account).get
     val accountDb = AccountDb(xpub, account)
-    val accountDAO = wallet.accountDAO
 
     //see if we already have this account in our database
     //Three possible cases:
@@ -630,8 +622,7 @@ object Wallet extends WalletLogger {
     //2. We already have this account in our database, so we do nothing
     //3. We have this account in our database, with a DIFFERENT xpub. This is bad. Fail with an exception
     //   this most likely means that we have a different key manager than we expected
-    val accountOptF = accountDAO.read(account.coin, account.index)
-    accountOptF.flatMap {
+    wallet.accountDAO.read(account.coin, account.index).flatMap {
       case Some(account) =>
         if (account.xpub != xpub) {
           val errorMsg =
@@ -660,32 +651,32 @@ object Wallet extends WalletLogger {
     // We want to make sure all level 0 accounts are created,
     // so the user can change the default account kind later
     // and still have their wallet work
-    val initConfigF = walletAppConfig.initialize()
-    val createAccountFutures = for {
-      _ <- initConfigF
-      accounts = HDPurposes.all.map { purpose =>
-        //we need to create key manager params for each purpose
-        //and then initialize a key manager to derive the correct xpub
-        val kmParams = wallet.keyManager.kmParams.copy(purpose = purpose)
-        val kmE = {
-          BIP39KeyManager.fromParams(kmParams = kmParams,
-                                     password = BIP39KeyManager.badPassphrase,
-                                     bip39PasswordOpt = bip39PasswordOpt)
-        }
-        kmE match {
-          case Right(km) => createRootAccount(wallet = wallet, keyManager = km)
-          case Left(err) =>
-            //probably means you haven't initialized the key manager via the
-            //'CreateKeyManagerApi'
-            Future.failed(
-              new RuntimeException(
+    def createAccountFutures =
+      for {
+        _ <- walletAppConfig.initialize()
+        accounts = HDPurposes.all.map { purpose =>
+          //we need to create key manager params for each purpose
+          //and then initialize a key manager to derive the correct xpub
+          val kmParams = wallet.keyManager.kmParams.copy(purpose = purpose)
+          val kmE = {
+            BIP39KeyManager.fromParams(kmParams = kmParams,
+                                       password = BIP39KeyManager.badPassphrase,
+                                       bip39PasswordOpt = bip39PasswordOpt)
+          }
+          kmE match {
+            case Right(km) =>
+              createRootAccount(wallet = wallet, keyManager = km)
+            case Left(err) =>
+              //probably means you haven't initialized the key manager via the
+              //'CreateKeyManagerApi'
+              Future.failed(new RuntimeException(
                 s"Failed to create keymanager with params=$kmParams err=$err"))
+          }
+
         }
+      } yield accounts
 
-      }
-    } yield accounts
-
-    val accountCreationF =
+    def accountCreationF =
       createAccountFutures.flatMap(accounts => FutureUtil.collect(accounts))
 
     accountCreationF.foreach { _ =>

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -676,19 +676,10 @@ object Wallet extends WalletLogger {
         }
       } yield accounts
 
-    def accountCreationF =
-      createAccountFutures.flatMap(accounts => FutureUtil.collect(accounts))
-
-    accountCreationF.foreach { _ =>
-      logger.debug(s"Created root level accounts for wallet")
+    createAccountFutures.flatMap(accounts => FutureUtil.collect(accounts)).map {
+      _ =>
+        logger.debug(s"Created root level accounts for wallet")
+        wallet
     }
-
-    accountCreationF.failed.foreach { err =>
-      err.printStackTrace()
-      logger.error(s"Failed to create root level accounts: $err")
-    }
-
-    accountCreationF.map(_ => wallet)
   }
-
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -212,18 +212,15 @@ private[wallet] trait RescanHandling extends WalletLogger {
     val threadPool =
       Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors() * 2)
 
-    def blocksF =
-      for {
-        blocks <- getMatchingBlocks(
-          scripts = scriptPubKeys,
-          startOpt = startOpt,
-          endOpt = endOpt)(ExecutionContext.fromExecutor(threadPool))
-      } yield {
-        blocks.sortBy(_.blockHeight).map(_.blockHash.flip)
-      }
-
-    blocksF.onComplete(_ => threadPool.shutdown())
-    blocksF
+    for {
+      blocks <- getMatchingBlocks(
+        scripts = scriptPubKeys,
+        startOpt = startOpt,
+        endOpt = endOpt)(ExecutionContext.fromExecutor(threadPool))
+    } yield {
+      threadPool.shutdown()
+      blocks.sortBy(_.blockHeight).map(_.blockHash.flip)
+    }
   }
 
   private def generateScriptPubKeys(

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -212,14 +212,15 @@ private[wallet] trait RescanHandling extends WalletLogger {
     val threadPool =
       Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors() * 2)
 
-    val blocksF = for {
-      blocks <- getMatchingBlocks(
-        scripts = scriptPubKeys,
-        startOpt = startOpt,
-        endOpt = endOpt)(ExecutionContext.fromExecutor(threadPool))
-    } yield {
-      blocks.sortBy(_.blockHeight).map(_.blockHash.flip)
-    }
+    def blocksF =
+      for {
+        blocks <- getMatchingBlocks(
+          scripts = scriptPubKeys,
+          startOpt = startOpt,
+          endOpt = endOpt)(ExecutionContext.fromExecutor(threadPool))
+      } yield {
+        blocks.sortBy(_.blockHeight).map(_.blockHash.flip)
+      }
 
     blocksF.onComplete(_ => threadPool.shutdown())
     blocksF

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -212,7 +212,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
     val threadPool =
       Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors() * 2)
 
-    for {
+    val blocksF = for {
       blocks <- getMatchingBlocks(
         scripts = scriptPubKeys,
         startOpt = startOpt,
@@ -221,6 +221,9 @@ private[wallet] trait RescanHandling extends WalletLogger {
       threadPool.shutdown()
       blocks.sortBy(_.blockHeight).map(_.blockHash.flip)
     }
+
+    blocksF.onComplete(_ => threadPool.shutdown())
+    blocksF
   }
 
   private def generateScriptPubKeys(

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -208,7 +208,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
 
         }
 
-        val aggregateFut =
+        def aggregateFut =
           for {
             incoming <- incomingTxoFut
             outgoing <- outgoingTxFut
@@ -233,8 +233,8 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
   /** If the given UTXO is marked as unspent, updates
     * its spending status. Otherwise returns `None`.
     */
-  private val markAsPendingSpent: SpendingInfoDb => Future[
-    Option[SpendingInfoDb]] = { out: SpendingInfoDb =>
+  private def markAsPendingSpent(
+      out: SpendingInfoDb): Future[Option[SpendingInfoDb]] = {
     out.state match {
       case TxoState.ConfirmedReceived | TxoState.PendingConfirmationsReceived =>
         val updated =
@@ -261,11 +261,10 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
       index: Int,
       state: TxoState,
       blockHash: Option[DoubleSha256DigestBE]): Future[SpendingInfoDb] = {
-    val addUtxoF = addUtxo(transaction = transaction,
-                           vout = UInt32(index),
-                           state = state,
-                           blockHash = blockHash)
-    addUtxoF.flatMap {
+    addUtxo(transaction = transaction,
+            vout = UInt32(index),
+            state = state,
+            blockHash = blockHash).flatMap {
       case AddUtxoSuccess(utxo) => Future.successful(utxo)
       case err: AddUtxoError =>
         logger.error(s"Could not add UTXO", err)
@@ -313,7 +312,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
           }
 
           // Update Txo State
-          val updateF = updateUtxoConfirmedState(unreservedTxo)
+          def updateF = updateUtxoConfirmedState(unreservedTxo)
 
           updateF.foreach(tx =>
             logger.debug(

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -241,19 +241,20 @@ private[wallet] trait UtxoHandling extends WalletLogger {
 
       // second check: do we have an address associated with the provided
       // output in our DB?
-      val addressDbEitherF: Future[CompatEither[AddUtxoError, AddressDb]] =
+      def addressDbEitherF: Future[CompatEither[AddUtxoError, AddressDb]] =
         findAddress(output.scriptPubKey)
 
       // insert the UTXO into the DB
       addressDbEitherF.flatMap { addressDbE =>
-        val biasedE: CompatEither[AddUtxoError, Future[SpendingInfoDb]] = for {
-          addressDb <- addressDbE
-        } yield writeUtxo(tx = transaction,
-                          state = state,
-                          output = output,
-                          outPoint = outPoint,
-                          addressDb = addressDb,
-                          blockHash = blockHash)
+        def biasedE: CompatEither[AddUtxoError, Future[SpendingInfoDb]] =
+          for {
+            addressDb <- addressDbE
+          } yield writeUtxo(tx = transaction,
+                            state = state,
+                            output = output,
+                            outPoint = outPoint,
+                            addressDb = addressDb,
+                            blockHash = blockHash)
 
         EitherUtil.liftRightBiasedFutureE(biasedE)
       } map {

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -358,8 +358,7 @@ case class SpendingInfoDAO()(implicit
 
   def findAllForAccount(
       hdAccount: HDAccount): Future[Vector[SpendingInfoDb]] = {
-    val allUtxosF = findAllSpendingInfos()
-    allUtxosF.map(filterUtxosByAccount(_, hdAccount))
+    findAllSpendingInfos().map(filterUtxosByAccount(_, hdAccount))
   }
 
   def findByTxoState(state: TxoState): Future[Vector[SpendingInfoDb]] = {


### PR DESCRIPTION
As @rorp discovered, we have lots of future that are parallelized in the wallet unnecessarily and can cause database errors due to SQLite only allowing a single database connection.

I went through the wallet and tried to fix every one I found.