### PR TITLE
Fix address tag issue where we weren't adding tags to an address, we …

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
@@ -128,10 +128,11 @@ abstract class CRUD[T, PrimaryKeyType](implicit
     * @return t - the record that has been inserted / updated
     */
   def upsert(t: T): Future[T] = {
-    upsertAll(Vector(t)).map { ts =>
+    upsertAll(Vector(t)).flatMap { ts =>
       ts.headOption match {
-        case Some(updated) => updated
-        case None          => throw UpsertFailedException("Upsert failed for: " + t)
+        case Some(updated) => Future.successful(updated)
+        case None =>
+          Future.failed(UpsertFailedException("Upsert failed for: " + t))
       }
     }
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -410,7 +410,8 @@ private[wallet] trait AddressHandling extends WalletLogger {
       address: BitcoinAddress,
       tag: AddressTag): Future[AddressTagDb] = {
     val addressTagDb = AddressTagDb(address, tag)
-    addressTagDAO.upsert(addressTagDb)
+    val f = addressTagDAO.create(addressTagDb)
+    f
   }
 
   def getAddressTags(address: BitcoinAddress): Future[Vector[AddressTagDb]] = {


### PR DESCRIPTION
fixes #1815 

Previously we would use `upsert()` for `AddressTagDAO.tagAddress()`. This effectively means we we cannot have more than one tag per address (we will overwrite existing tags with `upsert()`). This PR uses `create()` rather than `upsert()` now to get the unit test passing.