### PR TITLE
Fix get missing utxos

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -92,7 +92,7 @@ abstract class Wallet
 
   private def utxosWithMissingTx: Future[Vector[SpendingInfoDb]] = {
     for {
-      utxos <- spendingInfoDAO.findAllUnspent()
+      utxos <- spendingInfoDAO.findAll()
       hasTxs <- FutureUtil.foldLeftAsync(Vector.empty[SpendingInfoDb], utxos) {
         (accum, utxo) =>
           // If we don't have tx in our transactionDAO, add it to the list
@@ -110,6 +110,8 @@ abstract class Wallet
       // Download the block the tx is from so we process the block and subsequent txs
       _ <-
         if (blockHashes.nonEmpty) {
+          logger.info(
+            s"Missing relevant ${utxos.size} wallet transactions, fetching their blocks..")
           nodeApi.downloadBlocks(blockHashes.distinct)
         } else FutureUtil.unit
     } yield ()


### PR DESCRIPTION
On `wallet.start()` we would call `downloadMissingUtxos` to get the txs associated with out outputs. However, when we'd process these txs we would see we already have the utxo and not add the tx to our database becuase we only add it in `processNewIncomingTx`. This fixes that by changing `processExistingIncomingTxo` to try and add the tx to the database if we are processing it's block a second time.