### PR TITLE
Fix case of cli command sendwithalgo

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1079,7 +1079,7 @@ object ConsoleCli {
                          up.writeJs(bitcoins),
                          up.writeJs(feeRateOpt)))
       case SendWithAlgo(address, bitcoins, feeRateOpt, algo) =>
-        RequestParam("SendWithAlgo",
+        RequestParam("sendwithalgo",
                      Seq(up.writeJs(address),
                          up.writeJs(bitcoins),
                          up.writeJs(feeRateOpt),


### PR DESCRIPTION
Would cause `sendwithalgo` to always fail because this is case sensitive 