### PR TITLE
Don't wait for rescan completion to send message

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -250,9 +250,9 @@ case class WalletRoutes(wallet: AnyHDWalletApi, node: Node)(implicit
                       startOpt = startBlock,
                       endOpt = endBlock,
                       addressBatchSize =
-                        batchSize.getOrElse(wallet.discoveryBatchSize),
+                        batchSize.getOrElse(wallet.discoveryBatchSize()),
                       useCreationTime = !ignoreCreationTime)
-                    .map(_ => "scheduled")
+                  Future.successful("Rescan started.")
                 } else {
                   Future.successful(
                     "DANGER! The wallet is not empty, however the rescan " +


### PR DESCRIPTION
Previously, if you were rescanning a large amount of blocks the request would time out and you would get

```
$ bs-cli rescan --force
Got unexpected response: The server was not able to produce a timely response to your request.
Please try again in a short while!
```

This changes it to have the rescan run in the background and send you

```
$ bs-cli rescan --force
Rescan started.
```