### PR TITLE
Disable logging for tests

### DIFF
--- a/testkit/src/main/resources/logback-test.xml
+++ b/testkit/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="WARN">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -6,7 +6,7 @@ bitcoin-s {
         # Ignore bitcoin-s logging config and use a logback config
         logback = true
 
-        level = WARN # trace, debug, info, warn, error, off
+        level = OFF # trace, debug, info, warn, error, off
 
         # You can also tune specific module loggers.
         # They each take the same levels as above.


### PR DESCRIPTION
It seems that logging is slowing down CI and filling up the CI logs. This should return us to what we had previously.