### PR TITLE
Make database thread pool of size 1 to remove concerns of concurrent …

### DIFF
--- a/db-commons/src/main/resources/db.conf
+++ b/db-commons/src/main/resources/db.conf
@@ -10,7 +10,7 @@ common = {
     username = ""
     password = ""
 
-    numThreads = 5 # default num threads is 20, which is way too much
+    numThreads = 1 # default num threads is 20, which is way too much
     #maxConnections = 1
     # as long as we're on SQLite there's no point
     # in doing connection pooling

--- a/db-commons/src/main/resources/db.conf
+++ b/db-commons/src/main/resources/db.conf
@@ -10,7 +10,9 @@ common = {
     username = ""
     password = ""
 
-    numThreads = 1 # default num threads is 20, which is way too much
+    # this needs to be set to 1 for SQLITE as it does not support concurrent database operations
+    # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
+    numThreads = 1
     #maxConnections = 1
     # as long as we're on SQLite there's no point
     # in doing connection pooling


### PR DESCRIPTION
…access to the database

This uses the [`numThreads`](https://scala-slick.org/doc/3.3.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database) inside of scala slicks configuration to gurantee synchronous access to datatabase. This is -- in my opinion -- a superior alternative to #1823 as it actually fixes the `SQLITE_BUSY` problem by making it impossible to happen.

This allows for us to write Scala code and not worry about concurrent access to the sqlite database anymore, it also _preserves_ concurrent access to databases like postgres that support multiple connections to the database. 

You can see the single threads for `wallet.db-1` and `chain.db-1` 

![Screenshot from 2020-08-16 09-56-51](https://user-images.githubusercontent.com/3514957/90337250-d176a400-dfa6-11ea-96fd-12191a3fa65e.png)


In the future inside of `db.conf` we should really have different configurations for sqlite and postgres so that we can preserve safe concurrent accesses for the database in postgres. 

More generally, this is the only way to solve the `SQLITE_BUSY` problem. Since bitcoin-s is a library, there is no way to guarantee a caller of a method that accesses the database does not do it twice in a row, so the solution proposed in #1823 isn't really satisfactory IMO. 

```scala
//3rd party library 
val getbalance1 = wallet.getBalance()
val getbalance2 = wallet.getBalance()
```

With this PR, since the thread pool is of size 1, this two calls will have to be synchronized by the single thread that can access the database. 

This does not solve the problem hinted at by #1825 

>java.util.concurrent.RejectedExecutionException: Task slick.basic.BasicBackend$DatabaseDef$$anon$3@118ce568 rejected from slick.util.AsyncExecutor$$anon$1$$anon$2@31e3b8fb[Running, pool size = 5, active threads = 5, queued tasks = 1000, completed tasks = 2435]

With this PR, we can still overwhelm the queue. There is no way to solve as far as I can tell, you need to upgrade the performance of your database or switch to something like postgres that allows for concurrent accesses. This error can _also_ occur on postgres since at the end of the day you always hammer the database with arbitrary sql queries. You can adjust the [`queueSize`](https://scala-slick.org/doc/3.3.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database) configuration option to have a bigger queue if this is needed for your application

>queueSize (Int, optional, default: 1000): The size of the queue for database actions which cannot be executed immediately when all threads are busy. Beyond this limit new actions fail immediately. Set to 0 for no queue (direct hand-off) or to -1 for an unlimited queue size (not recommended).

