### PR TITLE
Create KeyManager Api & move SpendingInfoDb to core

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.bitcoins.chain.api.ChainApi
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.core.Core
+import org.bitcoins.core.api.wallet.db.{SegwitV0SpendingInfo, SpendingInfoDb}
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit, Satoshis}
@@ -29,8 +30,6 @@ import org.bitcoins.core.wallet.utxo.{
   AddressLabelTagType,
   AddressTag,
   AddressTagType,
-  SegwitV0SpendingInfo,
-  SpendingInfoDb,
   TxoState
 }
 import org.bitcoins.crypto.{

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -29,6 +29,8 @@ import org.bitcoins.core.wallet.utxo.{
   AddressLabelTagType,
   AddressTag,
   AddressTagType,
+  SegwitV0SpendingInfo,
+  SpendingInfoDb,
   TxoState
 }
 import org.bitcoins.crypto.{

--- a/core/src/main/scala/org/bitcoins/core/api/keymanager/KeyManagerApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/keymanager/KeyManagerApi.scala
@@ -1,0 +1,15 @@
+package org.bitcoins.core.api.keymanager
+
+import org.bitcoins.core.crypto.ExtPublicKey
+import org.bitcoins.core.hd.{HDAccount, HDPath}
+import org.bitcoins.crypto.Sign
+
+import scala.util.Try
+
+sealed trait KeyManagerApi
+
+trait BIP39KeyManagerApi extends KeyManagerApi {
+  def toSign(privKeyPath: HDPath): Sign
+  def deriveXPub(account: HDAccount): Try[ExtPublicKey]
+  def getRootXPub: ExtPublicKey
+}

--- a/core/src/main/scala/org/bitcoins/core/api/keymanager/KeyManagerApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/keymanager/KeyManagerApi.scala
@@ -6,7 +6,7 @@ import org.bitcoins.crypto.Sign
 
 import scala.util.Try
 
-sealed trait KeyManagerApi
+trait KeyManagerApi
 
 trait BIP39KeyManagerApi extends KeyManagerApi {
   def toSign(privKeyPath: HDPath): Sign

--- a/core/src/main/scala/org/bitcoins/core/api/keymanager/KeyManagerCreateApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/keymanager/KeyManagerCreateApi.scala
@@ -1,8 +1,13 @@
-package org.bitcoins.keymanager
+package org.bitcoins.core.api.keymanager
 
 import org.bitcoins.core.crypto.MnemonicCode
-import org.bitcoins.keymanager.bip39.BIP39KeyManager
+import org.bitcoins.core.wallet.keymanagement.{
+  KeyManagerInitializeError,
+  KeyManagerParams
+}
 import scodec.bits.BitVector
+
+trait KeyManagerCreateApi
 
 /**
   * @define initialize
@@ -17,16 +22,15 @@ import scodec.bits.BitVector
   *                           can write it down. They should also be prompted
   *                           to confirm at least parts of the code.
   */
-trait BIP39KeyManagerCreateApi {
+trait BIP39KeyManagerCreateApi[T <: BIP39KeyManagerApi]
+    extends KeyManagerCreateApi {
 
   /**
     * $initialize
     */
   final def initialize(
       kmParams: KeyManagerParams,
-      bip39PasswordOpt: Option[String]): Either[
-    KeyManagerInitializeError,
-    BIP39KeyManager] =
+      bip39PasswordOpt: Option[String]): Either[KeyManagerInitializeError, T] =
     initializeWithEntropy(entropy = MnemonicCode.getEntropy256Bits,
                           bip39PasswordOpt = bip39PasswordOpt,
                           kmParams = kmParams)
@@ -37,9 +41,7 @@ trait BIP39KeyManagerCreateApi {
   def initializeWithEntropy(
       entropy: BitVector,
       bip39PasswordOpt: Option[String],
-      kmParams: KeyManagerParams): Either[
-    KeyManagerInitializeError,
-    BIP39KeyManager]
+      kmParams: KeyManagerParams): Either[KeyManagerInitializeError, T]
 
   /**
     * Helper method to initialize a [[KeyManagerCreate$ KeyManager]] with a [[MnemonicCode MnemonicCode]]
@@ -51,9 +53,7 @@ trait BIP39KeyManagerCreateApi {
   final def initializeWithMnemonic(
       mnemonicCode: MnemonicCode,
       bip39PasswordOpt: Option[String],
-      kmParams: KeyManagerParams): Either[
-    KeyManagerInitializeError,
-    BIP39KeyManager] = {
+      kmParams: KeyManagerParams): Either[KeyManagerInitializeError, T] = {
     val entropy = mnemonicCode.toEntropy
     initializeWithEntropy(entropy = entropy,
                           bip39PasswordOpt = bip39PasswordOpt,

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.core.wallet.utxo
+package org.bitcoins.core.api.wallet.db
 
 import org.bitcoins.core.api.db.DbRowAutoInc
 import org.bitcoins.core.api.keymanager.BIP39KeyManagerApi
@@ -15,6 +15,12 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.script.crypto.HashType
+import org.bitcoins.core.wallet.utxo.{
+  ConditionalPath,
+  InputInfo,
+  ScriptSignatureParams,
+  TxoState
+}
 import org.bitcoins.crypto.{DoubleSha256DigestBE, Sign}
 
 /**

--- a/core/src/main/scala/org/bitcoins/core/wallet/keymanagement/KeyManagerInitializeError.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/keymanagement/KeyManagerInitializeError.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.keymanager
+package org.bitcoins.core.wallet.keymanagement
 
 sealed trait KeyManagerInitializeError extends Error
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/keymanagement/KeyManagerParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/keymanagement/KeyManagerParams.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.keymanager
+package org.bitcoins.core.wallet.keymanagement
 
 import java.nio.file.Path
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/keymanagement/KeyManagerUnlockError.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/keymanagement/KeyManagerUnlockError.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.keymanager
+package org.bitcoins.core.wallet.keymanagement
 
 sealed trait KeyManagerUnlockError extends Error
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/SpendingInfoDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/SpendingInfoDb.scala
@@ -1,6 +1,7 @@
-package org.bitcoins.wallet.models
+package org.bitcoins.core.wallet.utxo
 
 import org.bitcoins.core.api.db.DbRowAutoInc
+import org.bitcoins.core.api.keymanager.BIP39KeyManagerApi
 import org.bitcoins.core.hd.{
   HDPath,
   LegacyHDPath,
@@ -14,14 +15,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.wallet.utxo.{
-  ConditionalPath,
-  InputInfo,
-  ScriptSignatureParams,
-  TxoState
-}
 import org.bitcoins.crypto.{DoubleSha256DigestBE, Sign}
-import org.bitcoins.keymanager.bip39.BIP39KeyManager
 
 /**
   * DB representation of a native V0
@@ -175,7 +169,7 @@ sealed trait SpendingInfoDb extends DbRowAutoInc[SpendingInfoDb] {
     * a signable (and sensitive) real-world UTXO
     */
   def toUTXOInfo(
-      keyManager: BIP39KeyManager,
+      keyManager: BIP39KeyManagerApi,
       prevTransaction: Transaction): ScriptSignatureParams[InputInfo] = {
 
     val sign: Sign = keyManager.toSign(privKeyPath = privKeyPath)

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXORecord.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXORecord.scala
@@ -1,6 +1,12 @@
 package org.bitcoins.core.wallet.utxo
 
 import org.bitcoins.core.api.db.DbRowAutoInc
+import org.bitcoins.core.api.wallet.db.{
+  LegacySpendingInfo,
+  NestedSegwitV0SpendingInfo,
+  SegwitV0SpendingInfo,
+  SpendingInfoDb
+}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.{
   HDPath,

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXORecord.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/UTXORecord.scala
@@ -1,5 +1,6 @@
-package org.bitcoins.wallet.models
+package org.bitcoins.core.wallet.utxo
 
+import org.bitcoins.core.api.db.DbRowAutoInc
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.{
   HDPath,
@@ -16,9 +17,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
-import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.core.api.db.DbRowAutoInc
 
 case class UTXORecord(
     outpoint: TransactionOutPoint,
@@ -27,7 +26,7 @@ case class UTXORecord(
     scriptPubKeyId: Long, // output SPK
     value: CurrencyUnit, // output value
     path: HDPath,
-    redeemScript: Option[ScriptPubKey], // ReedemScript
+    redeemScript: Option[ScriptPubKey], // RedeemScript
     scriptWitness: Option[ScriptWitness],
     blockHash: Option[DoubleSha256DigestBE], // block hash
     id: Option[Long] = None

--- a/docs/key-manager/key-manager.md
+++ b/docs/key-manager/key-manager.md
@@ -76,6 +76,8 @@ import org.bitcoins.keymanager._
 
 import org.bitcoins.keymanager.bip39._
 
+import org.bitcoins.core.wallet.keymanagement._
+
 import java.nio.file._
 
 ```

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
@@ -6,12 +6,20 @@ import org.bitcoins.core.config.{MainNet, RegTest}
 import org.bitcoins.core.crypto.MnemonicCode
 import org.bitcoins.core.hd._
 import org.bitcoins.core.util.TimeUtil
+import org.bitcoins.core.wallet.keymanagement
+import org.bitcoins.core.wallet.keymanagement.{
+  InitializeKeyManagerError,
+  KeyManagerParams
+}
 import org.bitcoins.crypto.{AesPassword, DoubleSha256DigestBE}
 import org.bitcoins.keymanager._
-import org.bitcoins.testkit.keymanager.{KeyManagerTestUtil, KeyManagerUnitTest}
+import org.bitcoins.testkit.keymanager.{
+  KeyManagerApiUnitTest,
+  KeyManagerTestUtil
+}
 import scodec.bits.BitVector
 
-class BIP39KeyManagerTest extends KeyManagerUnitTest {
+class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
   val purpose = HDPurposes.Legacy
 
   //this is taken from 'trezor-addresses.json' which give us test cases that conform with trezor
@@ -200,7 +208,8 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
 
   it must "read an existing seed from disk if we call initialize and one already exists" in {
     val seedPath = KeyManagerTestUtil.tmpSeedPath
-    val kmParams = KeyManagerParams(seedPath, HDPurposes.SegWit, RegTest)
+    val kmParams =
+      keymanagement.KeyManagerParams(seedPath, HDPurposes.SegWit, RegTest)
     val entropy = MnemonicCode.getEntropy256Bits
     val passwordOpt = Some(KeyManagerTestUtil.bip39Password)
     val keyManager = withInitializedKeyManager(kmParams = kmParams,
@@ -225,8 +234,8 @@ class BIP39KeyManagerTest extends KeyManagerUnitTest {
   }
 
   private def buildParams(): KeyManagerParams = {
-    KeyManagerParams(seedPath = KeyManagerTestUtil.tmpSeedPath,
-                     purpose = purpose,
-                     network = MainNet)
+    keymanagement.KeyManagerParams(seedPath = KeyManagerTestUtil.tmpSeedPath,
+                                   purpose = purpose,
+                                   network = MainNet)
   }
 }

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManagerApiTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManagerApiTest.scala
@@ -1,10 +1,13 @@
 package org.bitcoins.keymanager.bip39
 
+import org.bitcoins.core.wallet.keymanagement.KeyManagerUnlockError
 import org.bitcoins.crypto.AesPassword
-import org.bitcoins.keymanager.KeyManagerUnlockError
-import org.bitcoins.testkit.keymanager.{KeyManagerTestUtil, KeyManagerUnitTest}
+import org.bitcoins.testkit.keymanager.{
+  KeyManagerApiUnitTest,
+  KeyManagerTestUtil
+}
 
-class BIP39LockedKeyManagerTest extends KeyManagerUnitTest {
+class BIP39LockedKeyManagerApiTest extends KeyManagerApiUnitTest {
 
   it must "be able to read a locked mnemonic from disk" in {
     val bip39PwOpt = KeyManagerTestUtil.bip39PasswordOpt

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/util/HdUtilTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/util/HdUtilTest.scala
@@ -16,9 +16,9 @@ import org.bitcoins.core.crypto.ExtKeyVersion.{
   SegWitTestNet3Pub
 }
 import org.bitcoins.core.hd.{HDCoinType, HDPurpose, HDPurposes}
-import org.bitcoins.testkit.keymanager.KeyManagerUnitTest
+import org.bitcoins.testkit.keymanager.KeyManagerApiUnitTest
 
-class HdUtilTest extends KeyManagerUnitTest {
+class HdUtilTest extends KeyManagerApiUnitTest {
 
   it must "get the correct version for a public key" in {
     assert(

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/KeyManager.scala
@@ -1,3 +1,0 @@
-package org.bitcoins.keymanager
-
-trait KeyManager

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -3,10 +3,21 @@ package org.bitcoins.keymanager.bip39
 import java.nio.file.Files
 import java.time.Instant
 
+import org.bitcoins.core.api.keymanager.{
+  BIP39KeyManagerApi,
+  BIP39KeyManagerCreateApi,
+  KeyManagerApi
+}
 import org.bitcoins.core.compat.{CompatEither, CompatLeft, CompatRight}
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.hd.{HDAccount, HDPath}
 import org.bitcoins.core.util.{BitcoinSLogger, TimeUtil}
+import org.bitcoins.core.wallet.keymanagement.KeyManagerUnlockError._
+import org.bitcoins.core.wallet.keymanagement.{
+  InitializeKeyManagerError,
+  KeyManagerInitializeError,
+  KeyManagerParams
+}
 import org.bitcoins.crypto.{AesPassword, Sign}
 import org.bitcoins.keymanager._
 import org.bitcoins.keymanager.util.HDUtil
@@ -27,7 +38,7 @@ case class BIP39KeyManager(
     kmParams: KeyManagerParams,
     private val bip39PasswordOpt: Option[String],
     creationTime: Instant)
-    extends KeyManager
+    extends BIP39KeyManagerApi
     with KeyManagerLogger {
 
   private val seed = bip39PasswordOpt match {
@@ -74,7 +85,9 @@ case class BIP39KeyManager(
   }
 }
 
-object BIP39KeyManager extends BIP39KeyManagerCreateApi with BitcoinSLogger {
+object BIP39KeyManager
+    extends BIP39KeyManagerCreateApi[BIP39KeyManager]
+    with BitcoinSLogger {
   val badPassphrase = AesPassword.fromString("changeMe").get
 
   /** Initializes the mnemonic seed and saves it to file */
@@ -89,7 +102,7 @@ object BIP39KeyManager extends BIP39KeyManagerCreateApi with BitcoinSLogger {
 
     val time = TimeUtil.now
 
-    val writtenToDiskE: CompatEither[KeyManagerInitializeError, KeyManager] =
+    val writtenToDiskE: CompatEither[KeyManagerInitializeError, KeyManagerApi] =
       if (Files.notExists(seedPath)) {
         logger.info(
           s"Seed path parent directory does not exist, creating ${seedPath.getParent}")
@@ -144,7 +157,7 @@ object BIP39KeyManager extends BIP39KeyManagerCreateApi with BitcoinSLogger {
           case Left(err) =>
             CompatLeft(
               InitializeKeyManagerError.FailedToReadWrittenSeed(
-                KeyManagerUnlockError.JsonParsingError(err.toString)))
+                JsonParsingError(err.toString)))
         }
       }
 

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.keymanager.bip39
 
 import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.core.wallet.keymanagement.{
+  KeyManagerParams,
+  KeyManagerUnlockError
+}
 import org.bitcoins.crypto.AesPassword
 import org.bitcoins.keymanager.ReadMnemonicError.{
   DecryptionError,

--- a/testkit/src/main/scala/org/bitcoins/testkit/keymanager/KeyManagerApiUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/keymanager/KeyManagerApiUnitTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.testkit.keymanager
 
 import org.bitcoins.core.crypto.MnemonicCode
-import org.bitcoins.keymanager.KeyManagerParams
+import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 import scodec.bits.BitVector
 
-trait KeyManagerUnitTest extends BitcoinSUnitTest {
+trait KeyManagerApiUnitTest extends BitcoinSUnitTest {
 
   def withInitializedKeyManager(
       kmParams: KeyManagerParams = KeyManagerTestUtil.createKeyManagerParams(),

--- a/testkit/src/main/scala/org/bitcoins/testkit/keymanager/KeyManagerTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/keymanager/KeyManagerTestUtil.scala
@@ -4,9 +4,10 @@ import java.nio.file.Path
 
 import org.bitcoins.core.config.Networks
 import org.bitcoins.core.hd.HDPurposes
+import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.crypto.AesPassword
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
-import org.bitcoins.keymanager.{KeyManagerParams, WalletStorage}
+import org.bitcoins.keymanager.WalletStorage
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.scalacheck.Gen

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.testkit.wallet
 
 import org.bitcoins.core.config.RegTest
-import org.bitcoins.core.crypto.{ExtPublicKey, _}
+import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency._
 import org.bitcoins.core.hd._
 import org.bitcoins.core.number.UInt32
@@ -18,7 +18,7 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.protocol.{Bech32Address, P2SHAddress}
 import org.bitcoins.core.util.NumberUtil
-import org.bitcoins.core.wallet.utxo.TxoState
+import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.{CryptoUtil, ECPublicKey}
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.{CryptoGenerators, NumberGenerator}

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -1,5 +1,12 @@
 package org.bitcoins.testkit.wallet
 
+import org.bitcoins.core.api.wallet.db
+import org.bitcoins.core.api.wallet.db.{
+  LegacySpendingInfo,
+  NestedSegwitV0SpendingInfo,
+  SegwitV0SpendingInfo,
+  SpendingInfoDb
+}
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency._
@@ -122,7 +129,7 @@ object WalletTestUtil {
       TransactionOutput(1.bitcoin, spk)
     val scriptWitness = randomScriptWitness
     val privkeyPath = WalletTestUtil.sampleSegwitPath
-    SegwitV0SpendingInfo(
+    db.SegwitV0SpendingInfo(
       state = randomState,
       txid = randomTXID,
       outPoint = outpoint,
@@ -139,12 +146,12 @@ object WalletTestUtil {
     val output =
       TransactionOutput(1.bitcoin, spk)
     val privKeyPath = WalletTestUtil.sampleLegacyPath
-    LegacySpendingInfo(state = randomState,
-                       txid = randomTXID,
-                       outPoint = outpoint,
-                       output = output,
-                       privKeyPath = privKeyPath,
-                       blockHash = Some(randomBlockHash))
+    db.LegacySpendingInfo(state = randomState,
+                          txid = randomTXID,
+                          outPoint = outpoint,
+                          output = output,
+                          privKeyPath = privKeyPath,
+                          blockHash = Some(randomBlockHash))
   }
 
   def sampleNestedSegwitUTXO(
@@ -155,7 +162,7 @@ object WalletTestUtil {
       TransactionOutput(1.bitcoin, P2SHScriptPubKey(wpkh))
     val scriptWitness = randomScriptWitness
     val privkeyPath = WalletTestUtil.sampleNestedSegwitPath
-    NestedSegwitV0SpendingInfo(
+    db.NestedSegwitV0SpendingInfo(
       state = randomState,
       txid = randomTXID,
       outPoint = outpoint,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -7,8 +7,8 @@ import org.bitcoins.core.hd._
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.util.{FutureUtil, TimeUtil}
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.feeprovider.ConstantFeeRateProvider
-import org.bitcoins.keymanager.KeyManagerParams
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.fixtures.EmptyFixture

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.wallet
 
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.{EmptyTransaction, Transaction}
-import org.bitcoins.core.wallet.utxo.SpendingInfoDb
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
 import org.scalatest.FutureOutcome

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
@@ -2,9 +2,9 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.{EmptyTransaction, Transaction}
+import org.bitcoins.core.wallet.utxo.SpendingInfoDb
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
-import org.bitcoins.wallet.models.SpendingInfoDb
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.{Future, Promise}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -6,9 +6,10 @@ import org.bitcoins.core.hd.HDChainType.{Change, External}
 import org.bitcoins.core.hd.{HDAccount, HDChainType}
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.wallet.keymanagement.KeyManagerUnlockError
+import org.bitcoins.core.wallet.keymanagement.KeyManagerUnlockError.MnemonicNotFound
 import org.bitcoins.crypto.AesPassword
-import org.bitcoins.keymanager.KeyManagerUnlockError.MnemonicNotFound
-import org.bitcoins.keymanager.{KeyManagerUnlockError, WalletStorage}
+import org.bitcoins.keymanager.WalletStorage
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.wallet.api.NeutrinoWalletApi.BlockMatchingResponse
 import org.bitcoins.wallet.models.AddressDb

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
@@ -4,7 +4,11 @@ import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerByte}
-import org.bitcoins.core.wallet.utxo.TxoState
+import org.bitcoins.core.wallet.utxo.{
+  SegwitV0SpendingInfo,
+  SpendingInfoDb,
+  TxoState
+}
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.{
   CryptoGenerators,
@@ -12,7 +16,6 @@ import org.bitcoins.testkit.core.gen.{
   WitnessGenerators
 }
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
-import org.bitcoins.wallet.models.{SegwitV0SpendingInfo, SpendingInfoDb}
 import org.scalatest.FutureOutcome
 
 class CoinSelectorTest extends BitcoinSWalletTest {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/api/CoinSelectorTest.scala
@@ -1,14 +1,12 @@
 package org.bitcoins.wallet.api
 
+import org.bitcoins.core.api.wallet.db
+import org.bitcoins.core.api.wallet.db.{SegwitV0SpendingInfo, SpendingInfoDb}
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerByte}
-import org.bitcoins.core.wallet.utxo.{
-  SegwitV0SpendingInfo,
-  SpendingInfoDb,
-  TxoState
-}
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.{
   CryptoGenerators,
@@ -45,7 +43,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
       scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
       blockHash = None
     )
-    val utxo2 = SegwitV0SpendingInfo(
+    val utxo2 = db.SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
       state = TxoState.DoesNotExist,
       id = Some(2),
@@ -55,7 +53,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
       scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
       blockHash = None
     )
-    val utxo3 = SegwitV0SpendingInfo(
+    val utxo3 = db.SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
       state = TxoState.DoesNotExist,
       id = Some(3),

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
@@ -5,7 +5,7 @@ import org.bitcoins.core.protocol.transaction.{
   BaseTransaction,
   TransactionInput
 }
-import org.bitcoins.core.wallet.utxo.TxoState
+import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.TransactionGenerators
 import org.bitcoins.testkit.fixtures.{WalletDAOFixture, WalletDAOs}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
@@ -1,5 +1,10 @@
 package org.bitcoins.wallet.models
 
+import org.bitcoins.core.api.wallet.db.{
+  LegacySpendingInfo,
+  NestedSegwitV0SpendingInfo,
+  SegwitV0SpendingInfo
+}
 import org.bitcoins.core.protocol.script.ScriptSignature
 import org.bitcoins.core.protocol.transaction.{
   BaseTransaction,

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -6,6 +6,7 @@ import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.crypto.ExtPublicKey

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -25,16 +25,15 @@ import org.bitcoins.core.wallet.builder.{
   ShufflingNonInteractiveFinalizer
 }
 import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.keymanagement.{
+  KeyManagerParams,
+  KeyManagerUnlockError
+}
 import org.bitcoins.core.wallet.utxo.TxoState.{
   ConfirmedReceived,
   PendingConfirmationsReceived
 }
-import org.bitcoins.core.wallet.utxo.{
-  AddressTag,
-  InputInfo,
-  ScriptSignatureParams,
-  TxoState
-}
+import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.{
   AesPassword,
   CryptoUtil,
@@ -43,11 +42,10 @@ import org.bitcoins.crypto.{
 }
 import org.bitcoins.keymanager.bip39.{BIP39KeyManager, BIP39LockedKeyManager}
 import org.bitcoins.keymanager.util.HDUtil
-import org.bitcoins.keymanager.{KeyManagerParams, KeyManagerUnlockError}
 import org.bitcoins.wallet.api._
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.internal._
-import org.bitcoins.wallet.models.{ScriptPubKeyDAO, SpendingInfoDb, _}
+import org.bitcoins.wallet.models._
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletCallbacks.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletCallbacks.scala
@@ -3,7 +3,7 @@ package org.bitcoins.wallet
 import org.bitcoins.core.api.{Callback, CallbackHandler}
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.wallet.models.SpendingInfoDb
+import org.bitcoins.core.wallet.utxo.SpendingInfoDb
 import org.slf4j.Logger
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletCallbacks.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletCallbacks.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.wallet
 
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.api.{Callback, CallbackHandler}
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.core.wallet.utxo.SpendingInfoDb
 import org.slf4j.Logger
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/AddUtxoResult.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/AddUtxoResult.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet.api
 
-import org.bitcoins.core.wallet.utxo.SpendingInfoDb
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 
 sealed trait AddUtxoResult
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/AddUtxoResult.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/AddUtxoResult.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet.api
 
-import org.bitcoins.wallet.models._
+import org.bitcoins.core.wallet.utxo.SpendingInfoDb
 
 sealed trait AddUtxoResult
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
@@ -5,7 +5,7 @@ import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo._
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.wallet.models.SpendingInfoDb
+import org.bitcoins.core.wallet.utxo.SpendingInfoDb
 
 import scala.annotation.tailrec
 import scala.util.Random

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/CoinSelector.scala
@@ -2,10 +2,10 @@ package org.bitcoins.wallet.api
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo._
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.core.wallet.utxo.SpendingInfoDb
 
 import scala.annotation.tailrec
 import scala.util.Random

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
@@ -10,10 +10,10 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
-import org.bitcoins.keymanager.KeyManagerParams
+import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
+import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
-import org.bitcoins.wallet.models.{AccountDb, AddressDb, SpendingInfoDb}
+import org.bitcoins.wallet.models.{AccountDb, AddressDb}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.wallet.api
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.{AddressType, HDAccount, HDChainType, HDPurpose}
 import org.bitcoins.core.protocol.BitcoinAddress

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -7,6 +7,7 @@ import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.keymanager.KeyManagerApi
 import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.AddressType

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -3,9 +3,10 @@ package org.bitcoins.wallet.api
 import java.time.Instant
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
-import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
+import org.bitcoins.core.api.keymanager.KeyManagerApi
+import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.AddressType
@@ -18,15 +19,13 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.core.wallet.utxo.{AddressTag, AddressTagType, TxoState}
+import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.keymanager._
 import org.bitcoins.wallet.WalletLogger
 import org.bitcoins.wallet.models.{
   AddressDb,
   AddressTagDb,
   ScriptPubKeyDb,
-  SpendingInfoDb,
   TransactionDb
 }
 
@@ -239,7 +238,7 @@ trait WalletApi extends WalletLogger {
   protected[wallet] def getNewChangeAddress()(implicit
       ec: ExecutionContext): Future[BitcoinAddress]
 
-  def keyManager: KeyManager
+  def keyManager: KeyManagerApi
 
   protected def determineFeeRate(feeRateOpt: Option[FeeUnit]): Future[FeeUnit] =
     feeRateOpt match {

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -9,13 +9,13 @@ import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.hd._
 import org.bitcoins.core.util.{FutureUtil, Mutable}
+import org.bitcoins.core.wallet.keymanagement.{
+  KeyManagerInitializeError,
+  KeyManagerParams
+}
 import org.bitcoins.db.{AppConfig, AppConfigFactory, JdbcProfileComponent}
 import org.bitcoins.keymanager.bip39.{BIP39KeyManager, BIP39LockedKeyManager}
-import org.bitcoins.keymanager.{
-  KeyManagerInitializeError,
-  KeyManagerParams,
-  WalletStorage
-}
+import org.bitcoins.keymanager.WalletStorage
 import org.bitcoins.wallet.db.WalletDbManagement
 import org.bitcoins.wallet.models.AccountDAO
 import org.bitcoins.wallet.{Wallet, WalletCallbacks, WalletLogger}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.wallet.internal
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.util.FutureUtil

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -10,15 +10,11 @@ import org.bitcoins.core.wallet.builder.{
   ShufflingNonInteractiveFinalizer
 }
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.core.wallet.utxo.{
-  AddressTag,
-  InputInfo,
-  ScriptSignatureParams
-}
+import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.Sign
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.wallet.api.{AddressInfo, CoinSelector}
-import org.bitcoins.wallet.models.{AccountDb, SpendingInfoDb}
+import org.bitcoins.wallet.models.AccountDb
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 
 import scala.concurrent.Future
@@ -58,7 +54,7 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
   /** This returns a [[RawTxBuilder]] that can be used to generate an unsigned transaction with [[RawTxBuilder.result()]]
     * which can be used with signing.
     *
-    * If you pass in a [[org.bitcoins.keymanager.KeyManager]], the [[org.bitcoins.core.wallet.utxo.ScriptSignatureParams.signers signers]]
+    * If you pass in a [[KeyManagerApi]], the [[org.bitcoins.core.wallet.utxo.ScriptSignatureParams.signers signers]]
     * will be populated with valid signers that can be used to produce valid [[org.bitcoins.crypto.ECDigitalSignature signatures]]
     *
     * If you do not pass in a key manager, the transaction built by [[RawTxBuilder txbuilder]] will contain [[org.bitcoins.core.protocol.script.EmptyScriptSignature EmptyScriptSignature]]

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -7,7 +7,7 @@ import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutput}
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
+import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.wallet._
 import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoSuccess}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet.internal
 
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -1,5 +1,11 @@
 package org.bitcoins.wallet.internal
 
+import org.bitcoins.core.api.wallet.db.{
+  LegacySpendingInfo,
+  NestedSegwitV0SpendingInfo,
+  SegwitV0SpendingInfo,
+  SpendingInfoDb
+}
 import org.bitcoins.core.compat._
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.number.UInt32

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -15,7 +15,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.util.{EitherUtil, FutureUtil}
-import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
+import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoResult, AddUtxoSuccess}
 import org.bitcoins.wallet.models._

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -2,6 +2,7 @@ package org.bitcoins.wallet.models
 
 import java.sql.SQLException
 
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd._
 import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptWitness}

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -11,7 +11,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
+import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.db.CRUDAutoInc
 import org.bitcoins.wallet.config._


### PR DESCRIPTION
Part of #1284 

Originally tried just moving `SpendingInfoDb` to `core`. However I discovered we needed the `KeyManager`. So I created `KeyManagerApi` and `BIP39KeyManagerApi` along with it.