### PR TITLE
Bring back strict compiler opts

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -7,7 +7,6 @@ import sbt.Keys._
 import scala.util.Properties
 
 object CommonSettings {
-
   private val isCI = {
     sys.props
       .get("CI")
@@ -39,16 +38,21 @@ object CommonSettings {
     apiURL := homepage.value.map(_.toString + "/api").map(url(_)),
     // scaladoc settings end
     ////
+
     scalacOptions in Compile := compilerOpts(scalaVersion.value),
     //remove annoying import unused things in the scala console
     //https://stackoverflow.com/questions/26940253/in-sbt-how-do-you-override-scalacoptions-for-console-in-all-configurations
     scalacOptions in (Compile, console) ~= (_ filterNot (s =>
-      s == "-Xfatal-warnings"
-      //for 2.13 -- they use different compiler opts
-    )),
+      s == "-Ywarn-unused-import"
+        || s =="-Ywarn-unused"
+        || s =="-Xfatal-warnings"
+        //for 2.13 -- they use different compiler opts
+        || s == "-Xlint:unused")),
+
     //we don't want -Xfatal-warnings for publishing with publish/publishLocal either
-    scalacOptions in (Compile, doc) ~= (_ filterNot (s =>
+    scalacOptions in (Compile,doc) ~= (_ filterNot (s =>
       s == "-Xfatal-warnings")),
+
     scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
     scalacOptions in Test := testCompilerOpts,
     Compile / compile / javacOptions ++= {
@@ -73,11 +77,13 @@ object CommonSettings {
     )
   }
 
-  private val scala2_13CompilerOpts = Seq("-Xfatal-warnings")
+  private val scala2_13CompilerOpts = Seq("-Xlint:unused","-Xfatal-warnings")
 
   private val nonScala2_13CompilerOpts = Seq(
     "-Xmax-classfile-name",
-    "128"
+    "128",
+    "-Ywarn-unused",
+    "-Ywarn-unused-import"
   )
 
   //https://docs.scala-lang.org/overviews/compiler-options/index.html
@@ -88,7 +94,12 @@ object CommonSettings {
       "-unchecked",
       "-feature",
       "-deprecation",
-      "-Ywarn-dead-code"
+      "-Ywarn-dead-code",
+      "-Ywarn-value-discard",
+      "-Ywarn-unused",
+      "-unchecked",
+      "-deprecation",
+      "-feature"
     ) ++ commonCompilerOpts ++ {
       if (scalaVersion.startsWith("2.13")) scala2_13CompilerOpts
       else nonScala2_13CompilerOpts
@@ -112,6 +123,5 @@ object CommonSettings {
 
   lazy val prodSettings: Seq[Setting[_]] = settings
 
-  lazy val binariesPath =
-    Paths.get(Properties.userHome, ".bitcoin-s", "binaries")
+  lazy val binariesPath = Paths.get(Properties.userHome, ".bitcoin-s", "binaries")
 }


### PR DESCRIPTION
Bring back compiler opts that were removed in #1798, not sure why @rorp got rid of these