### PR TITLE
Fix selecting Utxos twice in fundRawTransactionInternal

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -203,8 +203,10 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       for {
         fundedTx <- fundedTxF
         spendingInfos <- wallet.spendingInfoDAO.findOutputsBeingSpent(fundedTx)
+        reserved <- wallet.spendingInfoDAO.findByTxoState(TxoState.Reserved)
       } yield {
         assert(spendingInfos.exists(_.state == TxoState.Reserved))
+        assert(reserved.size == spendingInfos.size)
       }
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -160,6 +160,7 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
     } yield {
       assert(updatedCoins.forall(_.state == TxoState.Reserved))
       assert(updatedCoins.forall(reserved.contains))
+      assert(updatedCoins.size == reserved.size)
       assert(!oldTransactions.map(_.transaction).contains(tx))
       assert(!newTransactions.map(_.transaction).contains(tx))
     }
@@ -184,9 +185,11 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
         _ = assert(reservedUtxos.forall(allReserved.contains))
 
         unreservedUtxos <- wallet.unmarkUTXOsAsReserved(reservedUtxos.toVector)
+        newReserved <- wallet.listUtxos(TxoState.Reserved)
         newTransactions <- wallet.listTransactions()
       } yield {
         assert(unreservedUtxos.forall(_.state != TxoState.Reserved))
+        assert(newReserved.isEmpty)
         assert(!oldTransactions.map(_.transaction).contains(tx))
         assert(!newTransactions.map(_.transaction).contains(tx))
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -101,7 +101,7 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
             .map(_._1)
       } yield utxos.diff(immatureCoinbases)
 
-    def selectedUtxosF: Future[Vector[SpendingInfoDb]] =
+    val selectedUtxosF: Future[Vector[SpendingInfoDb]] =
       for {
         walletUtxos <- utxosF
         //currently just grab the biggest utxos


### PR DESCRIPTION
Fixes #1856

This was caused by my pr that reduced parallelization. The cause here is because `selectedUtxosF` was a `def`, this means when we do 

```
        selectedUtxos <- selectedUtxosF
        _ = selectedUtxosF.failed.foreach(err =>
          logger.error("Error selecting utxos to fund transaction ", err))
```

we are calling `selectedUtxosF` twice once to store to selectedUtxos and the second time to see if it failed. The second one would always fail if we are reserving utxos because then we wouldn't have enough to be able to fund the tx. The exceptions we're likely being eaten because the test would likely complete and before it could propagate.

I added to the test case that we are only reserving the the txos we get in the tx, this should let us detect the error in the future without having to get the failure on slower machines like CI.