### PR TITLE
Start calling appConfig.stop() in destruction fixture code

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -152,6 +152,7 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     logger.info(s"Stopping node")
     val disconnectF = for {
       _ <- nodeAppConfig.stop()
+      _ <- chainAppConfig.stop()
       p <- peerMsgSenderF
       disconnect <- p.disconnect()
     } yield disconnect

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -349,9 +349,10 @@ object NodeUnitTest extends P2PLogger {
   def destroyNode(node: Node)(implicit
       config: BitcoinSAppConfig,
       ec: ExecutionContext): Future[Unit] = {
-    node
-      .stop()
-      .flatMap(_ => ChainUnitTest.destroyAllTables())
+    for {
+      _ <- ChainUnitTest.destroyAllTables()
+      _ <- node.stop()
+    } yield ()
   }
 
   def destroyNodeConnectedWithBitcoind(
@@ -445,6 +446,7 @@ object NodeUnitTest extends P2PLogger {
     val destroyedF = for {
       _ <- destroyNode(fundedWalletBitcoind.node)
       _ <- BitcoinSWalletTest.destroyWalletWithBitcoind(walletWithBitcoind)
+      _ <- appConfig.walletConf.stop()
     } yield ()
 
     destroyedF

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -660,7 +660,8 @@ object BitcoinSWalletTest extends WalletLogger {
 
       _ <- wallet.walletConfig.dropTable("flyway_schema_history")
       _ <- wallet.walletConfig.dropAll()
-    } yield wallet.stop()
+      _ <- wallet.stop()
+    } yield ()
   }
 
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -117,22 +117,23 @@ abstract class Wallet
         } else FutureUtil.unit
     } yield ()
 
-  override def start(): Future[Unit] = {
+  override def start(): Future[WalletApi] = {
     for {
       _ <- walletConfig.start()
       _ <- downloadMissingUtxos
     } yield {
       startWalletThread()
+      this
     }
   }
 
-  override def stop(): Unit = {
+  override def stop(): Future[WalletApi] = {
     for {
       _ <- walletConfig.stop()
     } yield {
       stopWalletThread()
+      this
     }
-    ()
   }
 
   override def processCompactFilters(

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -117,7 +117,7 @@ abstract class Wallet
         } else FutureUtil.unit
     } yield ()
 
-  override def start(): Future[WalletApi] = {
+  override def start(): Future[Wallet] = {
     for {
       _ <- walletConfig.start()
       _ <- downloadMissingUtxos
@@ -127,7 +127,7 @@ abstract class Wallet
     }
   }
 
-  override def stop(): Future[WalletApi] = {
+  override def stop(): Future[Wallet] = {
     for {
       _ <- walletConfig.stop()
     } yield {

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -16,7 +16,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
-import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.util.{FutureUtil, StartStopAsync}
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.{AddressTag, AddressTagType, TxoState}
 import org.bitcoins.crypto.DoubleSha256DigestBE
@@ -40,7 +40,7 @@ import scala.util.{Failure, Success}
   *
   * @see [[https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki BIP44]]
   */
-trait WalletApi extends WalletLogger {
+trait WalletApi extends WalletLogger with StartStopAsync[WalletApi] {
 
   val nodeApi: NodeApi
   val chainQueryApi: ChainQueryApi
@@ -50,9 +50,9 @@ trait WalletApi extends WalletLogger {
   def broadcastTransaction(transaction: Transaction): Future[Unit] =
     nodeApi.broadcastTransaction(transaction)
 
-  def start(): Future[Unit]
+  def start(): Future[WalletApi]
 
-  def stop(): Unit
+  def stop(): Future[WalletApi]
 
   /**
     * Processes the given transaction, updating our DB state if it's relevant to us.


### PR DESCRIPTION
Basically after running tests, if you are watching visualvm, you will see there is a _ton_ of slick thread pools still running. I'm sure after running this for long periods of time this will cause our OS to stall or at least have sbt crash

This is just from looking at `nodeTest/test`

![Screenshot from 2020-08-21 10-27-12](https://user-images.githubusercontent.com/3514957/90912712-b047f600-e3a0-11ea-999d-b54826d85e21.png)

and after 

![Screenshot from 2020-08-21 11-21-23](https://user-images.githubusercontent.com/3514957/90912740-bc33b800-e3a0-11ea-95c2-07edebda579d.png)

You can see i still don't have them all cleaned up

