### PR TITLE
Simplify Transaction Broadcast

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -67,6 +67,10 @@ class BroadcastTransactionTest extends NodeUnitTest {
     def attemptBroadcast(tx: Transaction): Future[Unit] = {
       for {
         _ <- node.broadcastTransaction(tx)
+        txOpt <- node.txDAO.findByHash(tx.txId)
+        _ = assert(
+          txOpt.isDefined,
+          "Transaction was not added to BroadcastableTransaction database")
         _ <- TestAsyncUtil.awaitConditionF(() => hasSeenTx(tx),
                                            duration = 1.second,
                                            maxTries = 25)

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -207,13 +207,21 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
         logger.error(s"Error when writing broadcastable TX to DB", exception)
       case Success(written) =>
         logger.debug(
-          s"Wrote tx=${written.transaction.txIdBE} to broadcastable table")
+          s"Wrote tx=${written.transaction.txIdBE.hex} to broadcastable table")
     }
 
     for {
       _ <- addToDbF
       peerMsgSender <- peerMsgSenderF
-      _ = logger.info(s"Sending out txmessage for tx=${transaction.txIdBE}")
+
+      // Note: This is a privacy leak and should be fixed in the future. Ideally, we should
+      // be using an inventory message to broadcast the transaction to help hide the fact that
+      // this transaction belongs to us. However, currently it is okay for us to use a transaction
+      // message because a Bitcoin-S node currently doesn't have a mempool and only
+      // broadcasts/relays transactions from its own wallet.
+      // See https://developer.bitcoin.org/reference/p2p_networking.html#tx
+      _ =
+        logger.info(s"Sending out tx message for tx=${transaction.txIdBE.hex}")
       _ <- peerMsgSender.sendTransactionMessage(transaction)
     } yield ()
   }

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -213,8 +213,8 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     for {
       _ <- addToDbF
       peerMsgSender <- peerMsgSenderF
-      _ = logger.info(s"Sending out inv for tx=${transaction.txIdBE}")
-      _ <- peerMsgSender.sendInventoryMessage(transaction)
+      _ = logger.info(s"Sending out txmessage for tx=${transaction.txIdBE}")
+      _ <- peerMsgSender.sendTransactionMessage(transaction)
     } yield ()
   }
 


### PR DESCRIPTION
Using `sendInventoryMessage` will only send the txId and require the other peer to request it before they fully receive the transaction. This changes it to `sendTransactionMessage` and send the transaction initially.