### PR TITLE
2020 08 21 clean broadcast dao

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -125,7 +125,7 @@ object Main extends App with BitcoinSLogger {
     val bip39PasswordOpt = None //todo need to prompt user for this
 
     //initialize the config, run migrations
-    val configInitializedF = conf.initialize()
+    val configInitializedF = conf.start()
 
     //run chain work migration
     val chainApiF = configInitializedF.flatMap { _ =>

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
@@ -10,7 +10,8 @@ class BitcoindChainHandlerViaZmqTest extends ChainDbUnitTest {
 
   override type FixtureParam = BitcoindChainHandlerViaZmq
 
-  implicit override val system: ActorSystem = ActorSystem("ChainUnitTest")
+  implicit override val system: ActorSystem = ActorSystem(
+    "BitcoindChainHandlerViaZmqTest")
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBitcoindChainHandlerViaZmq(test)

--- a/node-test/src/test/scala/org/bitcoins/node/NodeAppConfigTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeAppConfigTest.scala
@@ -9,6 +9,8 @@ import org.bitcoins.core.config.MainNet
 import ch.qos.logback.classic.Level
 import java.nio.file.Files
 
+import scala.concurrent.Await
+
 class NodeAppConfigTest extends BitcoinSAsyncTest {
   val tempDir = Files.createTempDirectory("bitcoin-s")
 
@@ -25,6 +27,7 @@ class NodeAppConfigTest extends BitcoinSAsyncTest {
     val mainnetConf = ConfigFactory.parseString("bitcoin-s.network = mainnet")
     val mainnet: NodeAppConfig = withOther.withOverrides(mainnetConf)
     assert(mainnet.network == MainNet)
+    withOther.stop().map(_ => succeed)
   }
 
   it must "be overridable with multiple levels" in {
@@ -58,5 +61,10 @@ class NodeAppConfigTest extends BitcoinSAsyncTest {
     assert(appConfig.network == TestNet3)
     assert(appConfig.logLevel == Level.OFF)
     assert(appConfig.p2pLogLevel == Level.WARN)
+  }
+
+  override def afterAll(): Unit = {
+    Await.result(config.stop(), akkaTimeout.duration)
+    super.afterAll()
   }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/NodeAppConfigTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeAppConfigTest.scala
@@ -27,7 +27,12 @@ class NodeAppConfigTest extends BitcoinSAsyncTest {
     val mainnetConf = ConfigFactory.parseString("bitcoin-s.network = mainnet")
     val mainnet: NodeAppConfig = withOther.withOverrides(mainnetConf)
     assert(mainnet.network == MainNet)
-    withOther.stop().map(_ => succeed)
+    for {
+      _ <- withOther.stop()
+      _ <- mainnet.stop()
+    } yield {
+      succeed
+    }
   }
 
   it must "be overridable with multiple levels" in {

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -14,7 +14,7 @@ import org.bitcoins.node.networking.peer.PeerMessageReceiver
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.async.TestAsyncUtil
-import org.bitcoins.testkit.node.NodeTestUtil
+import org.bitcoins.testkit.node.{CachedAppConfig, NodeTestUtil}
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoindRpcTest
 import org.scalatest._
@@ -23,10 +23,7 @@ import scodec.bits._
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
-class P2PClientTest extends BitcoindRpcTest {
-
-  implicit private val config: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig()
+class P2PClientTest extends BitcoindRpcTest with CachedAppConfig {
 
   lazy val bitcoindRpcF =
     BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
@@ -123,11 +120,17 @@ class P2PClientTest extends BitcoindRpcTest {
 
   override def afterAll(): Unit = {
     implicit val chainConf = config.chainConf
-    for {
+    val shutdownConfigF = for {
       _ <- chainConf.dropTable("flyway_schema_history")
       _ <- chainConf.dropAll()
-    } yield ()
-    super.afterAll()
+    } yield {
+      super[CachedAppConfig].afterAll()
+    }
+
+    shutdownConfigF.onComplete { _ =>
+      super[BitcoindRpcTest].afterAll()
+    }
+
   }
 
   it must "establish a tcp connection with a bitcoin node" in {

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -14,7 +14,11 @@ import org.bitcoins.node.networking.peer.PeerMessageReceiver
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.async.TestAsyncUtil
-import org.bitcoins.testkit.node.{CachedAppConfig, NodeTestUtil}
+import org.bitcoins.testkit.node.{
+  CachedAppConfig,
+  CachedBitcoinSAppConfig,
+  NodeTestUtil
+}
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoindRpcTest
 import org.scalatest._
@@ -23,7 +27,7 @@ import scodec.bits._
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
-class P2PClientTest extends BitcoindRpcTest with CachedAppConfig {
+class P2PClientTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
 
   lazy val bitcoindRpcF =
     BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
@@ -124,7 +128,7 @@ class P2PClientTest extends BitcoindRpcTest with CachedAppConfig {
       _ <- chainConf.dropTable("flyway_schema_history")
       _ <- chainConf.dropAll()
     } yield {
-      super[CachedAppConfig].afterAll()
+      super[CachedBitcoinSAppConfig].afterAll()
     }
 
     shutdownConfigF.onComplete { _ =>

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/MerkleBuffersTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/MerkleBuffersTest.scala
@@ -9,14 +9,14 @@ import org.bitcoins.testkit.core.gen.{
   BlockchainElementsGenerator,
   TransactionGenerators
 }
-import org.bitcoins.testkit.node.CachedAppConfig
+import org.bitcoins.testkit.node.{CachedAppConfig, CachedBitcoinSAppConfig}
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import org.scalacheck.Gen
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
-class MerkleBuffersTest extends BitcoinSAsyncTest with CachedAppConfig {
+class MerkleBuffersTest extends BitcoinSAsyncTest with CachedBitcoinSAppConfig {
 
   behavior of "MerkleBuffers"
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/MerkleBuffersTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/MerkleBuffersTest.scala
@@ -5,22 +5,18 @@ import org.bitcoins.core.protocol.blockchain.{Block, MerkleBlock}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.node.{NodeCallbacks, OnMerkleBlockReceived}
-import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.core.gen.{
   BlockchainElementsGenerator,
   TransactionGenerators
 }
+import org.bitcoins.testkit.node.CachedAppConfig
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import org.scalacheck.Gen
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
-class MerkleBuffersTest extends BitcoinSAsyncTest {
-
-  implicit private val config: NodeAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig().nodeConf
+class MerkleBuffersTest extends BitcoinSAsyncTest with CachedAppConfig {
 
   behavior of "MerkleBuffers"
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -18,6 +18,7 @@ import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.testkit.chain.fixture._
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
+import org.bitcoins.testkit.node.CachedChainAppConfig
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.{chain, BitcoinSTestAppConfig}
 import org.bitcoins.zmq.ZMQSubscriber
@@ -31,7 +32,8 @@ import scala.concurrent.{ExecutionContext, Future}
 trait ChainUnitTest
     extends BitcoinSFixture
     with ChainFixtureHelper
-    with ChainVerificationLogger {
+    with ChainVerificationLogger
+    with CachedChainAppConfig {
 
   implicit lazy val appConfig: ChainAppConfig =
     BitcoinSTestAppConfig.getSpvTestConfig()
@@ -47,6 +49,11 @@ trait ChainUnitTest
 
   override def beforeAll(): Unit = {
     AppConfig.throwIfDefaultDatadir(appConfig)
+  }
+
+  override def afterAll(): Unit = {
+    super[CachedChainAppConfig].afterAll()
+    super[BitcoinSFixture].afterAll()
   }
 
   /**

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -1,0 +1,17 @@
+package org.bitcoins.testkit.node
+
+import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.util.BitcoinSAsyncTest
+
+import scala.concurrent.Await
+
+trait CachedAppConfig { _: BitcoinSAsyncTest =>
+
+  implicit protected lazy val config: BitcoinSAppConfig =
+    BitcoinSTestAppConfig.getSpvTestConfig()
+
+  override def afterAll(): Unit = {
+    Await.result(config.stop(), akkaTimeout.duration)
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -1,13 +1,30 @@
 package org.bitcoins.testkit.node
 
+import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.db.AppConfig
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
-import org.bitcoins.testkit.util.BitcoinSAsyncTest
+import org.bitcoins.testkit.util.{BaseAsyncTest}
 
 import scala.concurrent.Await
 
-trait CachedAppConfig { _: BitcoinSAsyncTest =>
+sealed trait CachedAppConfig { _: BaseAsyncTest =>
+
+  /** Unfortunately this can't be a 'val' because of NPE */
+  implicit protected def appConfig: AppConfig
+
+  override def afterAll(): Unit = {
+    Await.result(appConfig.stop(), akkaTimeout.duration)
+  }
+}
+
+trait CachedChainAppConfig extends CachedAppConfig { _: BaseAsyncTest =>
+
+  implicit protected def appConfig: ChainAppConfig
+}
+
+trait CachedBitcoinSAppConfig { _: BaseAsyncTest =>
 
   implicit protected lazy val config: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvTestConfig()

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.testkit.node
 
+import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
@@ -10,6 +11,10 @@ trait CachedAppConfig { _: BitcoinSAsyncTest =>
 
   implicit protected lazy val config: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvTestConfig()
+
+  implicit protected lazy val nodeConf: NodeAppConfig = {
+    config.nodeConf
+  }
 
   override def afterAll(): Unit = {
     Await.result(config.stop(), akkaTimeout.duration)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -2,7 +2,7 @@ package org.bitcoins.testkit.node
 
 import java.net.InetSocketAddress
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, Cancellable}
 import org.bitcoins.chain.api.ChainApi
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.{
@@ -287,9 +287,10 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
     )(test)
   }
 
-  /** Helper method to generate blocks every interval */
+  /** Helper method to generate blocks every interval
+    * @return a cancellable that will stop generating blocks */
   def genBlockInterval(bitcoind: BitcoindRpcClient)(implicit
-      system: ActorSystem): Unit = {
+      system: ActorSystem): Cancellable = {
 
     var counter = 0
     val desiredBlocks = 5
@@ -305,7 +306,6 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
     }
 
     system.scheduler.scheduleAtFixedRate(2.second, interval)(genBlock)
-    ()
   }
 
   def getBIP39PasswordOpt(): Option[String] =

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
@@ -43,7 +43,7 @@ trait BaseAsyncTest
     * Needed because the default execution context will become overloaded
     * if we do not specify a unique execution context for each suite
     */
-  implicit override lazy val executionContext: ExecutionContext =
+  implicit override def executionContext: ExecutionContext =
     system.dispatcher
 
   override lazy val timeLimit: Span = 5.minutes
@@ -56,7 +56,7 @@ trait BaseAsyncTest
     */
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny[T]
 
-  override def afterAll: Unit = {
+  override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
   }
 


### PR DESCRIPTION
Addresses parts of #1874 and #1871 

1. Extends `StartStopAsync` in BitcoinSAppConfig()
2. Adds `CachedAppConfig` trait 
3. Makes sure `P2PClientTest` cleans up after itself!