### PR TITLE
Move all remaining wallet db representations

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -9,7 +9,10 @@ import org.bitcoins.chain.api.ChainApi
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.core.Core
 import org.bitcoins.core.api.wallet.db.{
+  AccountDb,
+  AddressDb,
   AddressTagDb,
+  LegacyAddressDb,
   SegwitV0SpendingInfo,
   SpendingInfoDb
 }

--- a/app/server-test/src/test/scala/org/bitcoins/wallet/MockWalletApi.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/wallet/MockWalletApi.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.wallet
 
+import org.bitcoins.core.api.wallet.db.AccountDb
 import org.bitcoins.core.hd.AddressType
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.wallet.api.AnyHDWalletApi
-import org.bitcoins.wallet.models.AccountDb
 
 import scala.concurrent.Future
 

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/AccountDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/AccountDb.scala
@@ -1,13 +1,18 @@
-package org.bitcoins.wallet.models
+package org.bitcoins.core.api.wallet.db
 
-import org.bitcoins.core.crypto._
-import org.bitcoins.core.hd._
-import org.bitcoins.keymanager.util.HDUtil
+import org.bitcoins.core.crypto.{
+  ExtKeyPrivVersion,
+  ExtKeyPubVersion,
+  ExtPublicKey
+}
+import org.bitcoins.core.hd.HDAccount
+import org.bitcoins.core.util.HDUtil
 
 /** Represents the xpub at the account level, NOT the root xpub
   * that in conjunction with the path specified in hdAccount
   * can be used to generate the account level xpub
   * m / purpose' / coin_type' / account'
+  *
   * @see https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels
   */
 case class AccountDb(xpub: ExtPublicKey, hdAccount: HDAccount) {

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/AddressDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/AddressDb.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.wallet.models
+package org.bitcoins.core.api.wallet.db
 
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.hd._

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/AddressRecord.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/AddressRecord.scala
@@ -1,21 +1,13 @@
-package org.bitcoins.wallet.models
+package org.bitcoins.core.api.wallet.db
 
-import org.bitcoins.core.hd.{
-  HDChainType,
-  HDCoinType,
-  HDPurpose,
-  HDPurposes,
-  LegacyHDPath,
-  NestedSegWitHDPath,
-  SegWitHDPath
-}
+import org.bitcoins.core.hd._
+import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptWitness}
 import org.bitcoins.core.protocol.{
   Bech32Address,
   BitcoinAddress,
   P2PKHAddress,
   P2SHAddress
 }
-import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptWitness}
 import org.bitcoins.crypto.{ECPublicKey, Sha256Hash160Digest}
 
 case class AddressRecord(

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/IncomingTransactionDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/IncomingTransactionDb.scala
@@ -1,11 +1,11 @@
-package org.bitcoins.wallet.models
+package org.bitcoins.core.api.wallet.db
 
-import org.bitcoins.core.api.wallet.db.TxDB
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 
 /**
   * Represents a relevant transaction for the wallet that we should be keeping track of
+  *
   * @param txIdBE Transaction ID
   */
 case class IncomingTransactionDb(

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/OutgoingTransactionDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/OutgoingTransactionDb.scala
@@ -1,6 +1,5 @@
-package org.bitcoins.wallet.models
+package org.bitcoins.core.api.wallet.db
 
-import org.bitcoins.core.api.wallet.db.TxDB
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.wallet.fee.SatoshisPerByte

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/ScriptPubKeyDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/ScriptPubKeyDb.scala
@@ -1,7 +1,7 @@
-package org.bitcoins.wallet.models
+package org.bitcoins.core.api.wallet.db
 
-import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.api.db.DbRowAutoInc
+import org.bitcoins.core.protocol.script.ScriptPubKey
 
 case class ScriptPubKeyDb(scriptPubKey: ScriptPubKey, id: Option[Long] = None)
     extends DbRowAutoInc[ScriptPubKeyDb] {

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/UTXORecord.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/UTXORecord.scala
@@ -1,12 +1,6 @@
-package org.bitcoins.core.wallet.utxo
+package org.bitcoins.core.api.wallet.db
 
 import org.bitcoins.core.api.db.DbRowAutoInc
-import org.bitcoins.core.api.wallet.db.{
-  LegacySpendingInfo,
-  NestedSegwitV0SpendingInfo,
-  SegwitV0SpendingInfo,
-  SpendingInfoDb
-}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.{
   HDPath,
@@ -23,6 +17,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.crypto.DoubleSha256DigestBE
 
 case class UTXORecord(

--- a/core/src/main/scala/org/bitcoins/core/util/HDUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/HDUtil.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.keymanager.util
+package org.bitcoins.core.util
 
 import org.bitcoins.core.config.{MainNet, NetworkParameters, RegTest, TestNet3}
 import org.bitcoins.core.crypto.{ExtKeyPrivVersion, ExtKeyPubVersion}

--- a/docs/wallet/address-tagging.md
+++ b/docs/wallet/address-tagging.md
@@ -9,7 +9,7 @@ import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.wallet.fee._
 import org.bitcoins.core.currency._
-import org.bitcoins.wallet.models.AccountDb
+import org.bitcoins.core.api.wallet.db.AccountDb
 import org.bitcoins.wallet._
 
 val ExampleAddressTag = UnknownAddressTag("name", "tagType")

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/util/HdUtilTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/util/HdUtilTest.scala
@@ -16,6 +16,7 @@ import org.bitcoins.core.crypto.ExtKeyVersion.{
   SegWitTestNet3Pub
 }
 import org.bitcoins.core.hd.{HDCoinType, HDPurpose, HDPurposes}
+import org.bitcoins.core.util.HDUtil
 import org.bitcoins.testkit.keymanager.KeyManagerApiUnitTest
 
 class HdUtilTest extends KeyManagerApiUnitTest {

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -11,7 +11,7 @@ import org.bitcoins.core.api.keymanager.{
 import org.bitcoins.core.compat.{CompatEither, CompatLeft, CompatRight}
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.hd.{HDAccount, HDPath}
-import org.bitcoins.core.util.{BitcoinSLogger, TimeUtil}
+import org.bitcoins.core.util.{BitcoinSLogger, HDUtil, TimeUtil}
 import org.bitcoins.core.wallet.keymanagement.KeyManagerUnlockError._
 import org.bitcoins.core.wallet.keymanagement.{
   InitializeKeyManagerError,
@@ -20,7 +20,6 @@ import org.bitcoins.core.wallet.keymanagement.{
 }
 import org.bitcoins.crypto.{AesPassword, Sign}
 import org.bitcoins.keymanager._
-import org.bitcoins.keymanager.util.HDUtil
 import scodec.bits.BitVector
 
 import scala.util.{Failure, Success, Try}

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -26,7 +26,6 @@ import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.{CryptoGenerators, NumberGenerator}
 import org.bitcoins.testkit.fixtures.WalletDAOs
 import org.bitcoins.wallet.config.WalletAppConfig
-import org.bitcoins.wallet.models._
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/EncryptedMnemonicTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/EncryptedMnemonicTest.scala
@@ -3,9 +3,9 @@ package org.bitcoins.wallet
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.crypto.AesPassword
 import org.bitcoins.keymanager.{DecryptedMnemonic, EncryptedMnemonicHelper}
+import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.testkit.util.BitcoinSUnitTest
-import org.bitcoins.testkit.Implicits._
 
 import scala.util.{Failure, Success}
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.wallet
 
 import com.typesafe.config.{Config, ConfigFactory}
 import org.bitcoins.commons.serializers.JsonSerializers._
+import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.crypto.{ExtPublicKey, MnemonicCode}
 import org.bitcoins.core.hd._
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -18,7 +19,6 @@ import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
   MockNodeApi
 }
 import org.bitcoins.wallet.config.WalletAppConfig
-import org.bitcoins.wallet.models.{AccountDb, AddressDb}
 import org.scalatest.compatible.Assertion
 import play.api.libs.json._
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
@@ -1,16 +1,13 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.testkit.util.{BitcoinSAsyncTest}
-import org.bitcoins.core.config.TestNet3
-import com.typesafe.config.ConfigFactory
-import org.bitcoins.core.config.RegTest
-import org.bitcoins.core.config.MainNet
-import org.bitcoins.wallet.config.WalletAppConfig
-
-import org.bitcoins.core.hd.HDPurposes
 import java.nio.file.Files
 
 import ch.qos.logback.classic.Level
+import com.typesafe.config.ConfigFactory
+import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
+import org.bitcoins.core.hd.HDPurposes
+import org.bitcoins.testkit.util.BitcoinSAsyncTest
+import org.bitcoins.wallet.config.WalletAppConfig
 
 import scala.util.Properties
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.wallet
 
 import java.nio.file.Files
 
+import org.bitcoins.core.api.wallet.db.AddressDb
 import org.bitcoins.core.hd.HDChainType.{Change, External}
 import org.bitcoins.core.hd.{HDAccount, HDChainType}
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -12,7 +13,6 @@ import org.bitcoins.crypto.AesPassword
 import org.bitcoins.keymanager.WalletStorage
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.wallet.api.NeutrinoWalletApi.BlockMatchingResponse
-import org.bitcoins.wallet.models.AddressDb
 import org.scalatest.FutureOutcome
 import org.scalatest.compatible.Assertion
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/AccountDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/AccountDAOTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet.models
 
+import org.bitcoins.core.api.wallet.db.AccountDb
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.testkit.fixtures.WalletDAOFixture
@@ -15,8 +16,7 @@ class AccountDAOTest extends BitcoinSWalletTest with WalletDAOFixture {
 
         val xpub = CryptoGenerators.extPublicKey.sampleSome
 
-        val accountDb =
-          AccountDb(xpub, account)
+        val accountDb = AccountDb(xpub, account)
         accountDAO.create(accountDb)
       }
       found <-

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/AddressDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/AddressDAOTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.wallet.models
 
 import java.sql.SQLException
 
+import org.bitcoins.core.api.wallet.db.AddressRecord
 import org.bitcoins.testkit.fixtures.WalletDAOFixture
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/IncomingTransactionDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/IncomingTransactionDAOTest.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.core.api.wallet.db.{TransactionDb, TransactionDbHelper}
+import org.bitcoins.core.api.wallet.db.{
+  IncomingTransactionDb,
+  TransactionDb,
+  TransactionDbHelper
+}
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.testkit.fixtures.WalletDAOFixture
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/OutgoingTransactionDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/OutgoingTransactionDAOTest.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.core.api.wallet.db.{TransactionDb, TransactionDbHelper}
+import org.bitcoins.core.api.wallet.db.{
+  OutgoingTransactionDb,
+  TransactionDb,
+  TransactionDbHelper
+}
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.testkit.fixtures.WalletDAOFixture
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/ScriptPubKeyDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/ScriptPubKeyDAOTest.scala
@@ -2,29 +2,13 @@ package org.bitcoins.wallet.models
 
 import java.sql.SQLException
 
-import org.bitcoins.core.protocol.script.{
-  CLTVScriptPubKey,
-  CSVScriptPubKey,
-  EmptyScriptPubKey,
-  MultiSignatureScriptPubKey,
-  MultiSignatureWithTimeoutScriptPubKey,
-  NonStandardIfConditionalScriptPubKey,
-  NonStandardNotIfConditionalScriptPubKey,
-  NonStandardScriptPubKey,
-  P2PKHScriptPubKey,
-  P2PKScriptPubKey,
-  P2PKWithTimeoutScriptPubKey,
-  P2SHScriptPubKey,
-  P2WPKHWitnessSPKV0,
-  P2WSHWitnessSPKV0,
-  RawScriptPubKey,
-  WitnessCommitment
-}
+import org.bitcoins.core.api.wallet.db.ScriptPubKeyDb
+import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.script.constant.ScriptNumber
-import org.bitcoins.crypto.{DoubleSha256Digest, ECPublicKey}
-import org.bitcoins.testkit.fixtures.{WalletDAOFixture}
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.core.script.reserved._
+import org.bitcoins.crypto.{DoubleSha256Digest, ECPublicKey}
+import org.bitcoins.testkit.fixtures.WalletDAOFixture
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 
 class ScriptPubKeyDAOTest extends BitcoinSWalletTest with WalletDAOFixture {
   behavior of "ScriptPubKeyDAO"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/util/GetAddresses.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/util/GetAddresses.scala
@@ -2,6 +2,7 @@ package org.bitcoins.wallet.util
 
 import org.bitcoins.core.hd._
 import play.api.libs.json._
+
 import scala.sys.process._
 
 /** This program connects to a running Trezor, and gets

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -3,10 +3,10 @@ package org.bitcoins.wallet
 import java.time.Instant
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
-import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
-import org.bitcoins.core.api.wallet.db.SpendingInfoDb
+import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.wallet.db.{AccountDb, SpendingInfoDb}
 import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.crypto.ExtPublicKey
@@ -19,7 +19,7 @@ import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.ScriptConstant
 import org.bitcoins.core.script.control.OP_RETURN
-import org.bitcoins.core.util.{BitcoinScriptUtil, FutureUtil}
+import org.bitcoins.core.util.{BitcoinScriptUtil, FutureUtil, HDUtil}
 import org.bitcoins.core.wallet.builder.{
   RawTxBuilderWithFinalizer,
   RawTxSigner,
@@ -42,7 +42,6 @@ import org.bitcoins.crypto.{
   ECPublicKey
 }
 import org.bitcoins.keymanager.bip39.{BIP39KeyManager, BIP39LockedKeyManager}
-import org.bitcoins.keymanager.util.HDUtil
 import org.bitcoins.wallet.api._
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.internal._

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/AddressInfo.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/AddressInfo.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.wallet.api
 
-import org.bitcoins.core.hd.HDPath
 import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.hd.HDPath
 import org.bitcoins.crypto.ECPublicKey
 
 /**

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.wallet.api
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
-import org.bitcoins.core.api.wallet.db.SpendingInfoDb
+import org.bitcoins.core.api.wallet.db.{AccountDb, AddressDb, SpendingInfoDb}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.{AddressType, HDAccount, HDChainType, HDPurpose}
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -14,7 +14,6 @@ import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
-import org.bitcoins.wallet.models.{AccountDb, AddressDb}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -7,11 +7,7 @@ import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.keymanager.KeyManagerApi
 import org.bitcoins.core.api.node.NodeApi
-import org.bitcoins.core.api.wallet.db.{
-  AddressTagDb,
-  SpendingInfoDb,
-  TransactionDb
-}
+import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.AddressType
@@ -27,7 +23,6 @@ import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.{AddressTag, AddressTagType, TxoState}
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.wallet.WalletLogger
-import org.bitcoins.wallet.models.{AddressDb, ScriptPubKeyDb}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -4,9 +4,9 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.TimeUnit
 
 import com.typesafe.config.Config
-import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
+import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.hd._
 import org.bitcoins.core.util.{FutureUtil, Mutable}
 import org.bitcoins.core.wallet.keymanagement.{
@@ -14,8 +14,8 @@ import org.bitcoins.core.wallet.keymanagement.{
   KeyManagerParams
 }
 import org.bitcoins.db.{AppConfig, AppConfigFactory, JdbcProfileComponent}
-import org.bitcoins.keymanager.bip39.{BIP39KeyManager, BIP39LockedKeyManager}
 import org.bitcoins.keymanager.WalletStorage
+import org.bitcoins.keymanager.bip39.{BIP39KeyManager, BIP39LockedKeyManager}
 import org.bitcoins.wallet.db.WalletDbManagement
 import org.bitcoins.wallet.models.AccountDAO
 import org.bitcoins.wallet.{Wallet, WalletCallbacks, WalletLogger}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AccountHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AccountHandling.scala
@@ -1,17 +1,16 @@
 package org.bitcoins.wallet.internal
 
-import org.bitcoins.wallet.Wallet
-import scala.concurrent.Future
-import org.bitcoins.wallet.models.AccountDb
-import org.bitcoins.core.hd.HDCoinType
-import org.bitcoins.core.hd.HDCoin
-import org.bitcoins.core.protocol.blockchain.TestNetChainParams
-import org.bitcoins.core.protocol.blockchain.RegTestNetChainParams
-import org.bitcoins.core.protocol.blockchain.MainNetChainParams
-import org.bitcoins.core.hd.HDPurpose
+import org.bitcoins.core.api.wallet.db.AccountDb
 import org.bitcoins.core.hd.AddressType._
-import org.bitcoins.core.hd.AddressType
-import org.bitcoins.core.hd.HDPurposes
+import org.bitcoins.core.hd._
+import org.bitcoins.core.protocol.blockchain.{
+  MainNetChainParams,
+  RegTestNetChainParams,
+  TestNetChainParams
+}
+import org.bitcoins.wallet.Wallet
+
+import scala.concurrent.Future
 
 /**
   * Provides functionality related enumerating accounts. Account

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -2,7 +2,7 @@ package org.bitcoins.wallet.internal
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import org.bitcoins.core.api.wallet.db.AddressTagDb
+import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd._
 import org.bitcoins.core.number.UInt32
@@ -17,12 +17,6 @@ import org.bitcoins.core.wallet.utxo.{AddressTag, AddressTagType}
 import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.wallet._
 import org.bitcoins.wallet.api.AddressInfo
-import org.bitcoins.wallet.models.{
-  AccountDb,
-  AddressDb,
-  AddressDbHelper,
-  ScriptPubKeyDb
-}
 
 import scala.concurrent.{Await, Future, Promise, TimeoutException}
 import scala.util.{Failure, Success}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.wallet.internal
 
 import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
-import org.bitcoins.core.api.wallet.db.SpendingInfoDb
+import org.bitcoins.core.api.wallet.db.{AccountDb, SpendingInfoDb}
 import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.util.FutureUtil
@@ -15,7 +15,6 @@ import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.Sign
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.wallet.api.{AddressInfo, CoinSelector}
-import org.bitcoins.wallet.models.AccountDb
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 
 import scala.concurrent.Future

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -1,11 +1,6 @@
 package org.bitcoins.wallet.internal
 
-import org.bitcoins.core.api.wallet.db.{
-  AddressTagDb,
-  SpendingInfoDb,
-  TransactionDb,
-  TransactionDbHelper
-}
+import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -17,7 +12,6 @@ import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.wallet._
 import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoSuccess}
-import org.bitcoins.wallet.models._
 
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -1,11 +1,6 @@
 package org.bitcoins.wallet.internal
 
-import org.bitcoins.core.api.wallet.db.{
-  LegacySpendingInfo,
-  NestedSegwitV0SpendingInfo,
-  SegwitV0SpendingInfo,
-  SpendingInfoDb
-}
+import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.compat._
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.number.UInt32
@@ -24,7 +19,6 @@ import org.bitcoins.core.util.{EitherUtil, FutureUtil}
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoResult, AddUtxoSuccess}
-import org.bitcoins.wallet.models._
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 
 import scala.concurrent.Future

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet.models
 
+import org.bitcoins.core.api.wallet.db.AccountDb
 import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.hd._
 import org.bitcoins.db.{CRUD, SlickUtil}

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressDAO.scala
@@ -2,6 +2,11 @@ package org.bitcoins.wallet.models
 
 import java.sql.SQLException
 
+import org.bitcoins.core.api.wallet.db.{
+  AddressDb,
+  AddressRecord,
+  ScriptPubKeyDb
+}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.{HDAccount, HDChainType, HDCoinType, HDPurpose}
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -89,8 +94,8 @@ case class AddressDAO()(implicit
         case None =>
           (for {
             newSpkId <-
-              (spkTable returning spkTable.map(_.id)) += (ScriptPubKeyDb(
-                addressDb.scriptPubKey))
+              (spkTable returning spkTable.map(_.id)) += ScriptPubKeyDb(
+                addressDb.scriptPubKey)
           } yield table.insertOrUpdate(
             AddressRecord.fromAddressDb(addressDb, newSpkId))).flatten
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/IncomingTransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/IncomingTransactionDAO.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.core.api.wallet.db.TransactionDb
+import org.bitcoins.core.api.wallet.db.{IncomingTransactionDb, TransactionDb}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.wallet.config._

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/OutgoingTransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/OutgoingTransactionDAO.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.core.api.wallet.db.TransactionDb
+import org.bitcoins.core.api.wallet.db.{OutgoingTransactionDb, TransactionDb}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.crypto.DoubleSha256DigestBE

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/ScriptPubKeyDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/ScriptPubKeyDAO.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet.models
 
+import org.bitcoins.core.api.wallet.db.ScriptPubKeyDb
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.script.ScriptType
 import org.bitcoins.db.CRUDAutoInc

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -2,7 +2,7 @@ package org.bitcoins.wallet.models
 
 import java.sql.SQLException
 
-import org.bitcoins.core.api.wallet.db.SpendingInfoDb
+import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd._
 import org.bitcoins.core.protocol.script.{ScriptPubKey, ScriptWitness}
@@ -118,8 +118,8 @@ case class SpendingInfoDAO()(implicit
         case None =>
           (for {
             newSpkId <-
-              (spkTable returning spkTable.map(_.id)) += (ScriptPubKeyDb(
-                si.output.scriptPubKey))
+              (spkTable returning spkTable.map(_.id)) += ScriptPubKeyDb(
+                si.output.scriptPubKey)
           } yield {
             val utxo = UTXORecord.fromSpendingInfoDb(si, newSpkId)
             table.filter(_.id === utxo.id).update(utxo)
@@ -156,8 +156,8 @@ case class SpendingInfoDAO()(implicit
         case None =>
           (for {
             newSpkId <-
-              (spkTable returning spkTable.map(_.id)) += (ScriptPubKeyDb(
-                si.output.scriptPubKey))
+              (spkTable returning spkTable.map(_.id)) += ScriptPubKeyDb(
+                si.output.scriptPubKey)
           } yield table.insertOrUpdate(
             UTXORecord.fromSpendingInfoDb(si, newSpkId))).flatten
       }


### PR DESCRIPTION
Part of #1284 

Moves all the remaining wallet db representations to core. I also ran optimize imports on the `wallet` and `walletTest` projects to hopefully cut down on the number of rebase errors in the future.