### PR TITLE
Move WalletApi necessities to core

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.commons.serializers
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
+import org.bitcoins.core.api.wallet.CoinSelectionAlgo
 import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.number.UInt32

--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -3,7 +3,7 @@ package org.bitcoins.cli
 import java.time.{ZoneId, ZonedDateTime}
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
+import org.bitcoins.core.api.wallet.CoinSelectionAlgo
 import org.bitcoins.core.config.{NetworkParameters, Networks}
 import org.bitcoins.core.currency._
 import org.bitcoins.core.number.UInt32

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -2,9 +2,9 @@ package org.bitcoins.cli
 
 import org.bitcoins.cli.CliCommand._
 import org.bitcoins.cli.CliReaders._
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
 import org.bitcoins.commons.serializers.Picklers._
+import org.bitcoins.core.api.wallet.CoinSelectionAlgo
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.currency._
 import org.bitcoins.core.number.UInt32

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -6,8 +6,8 @@ import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.server.ValidationRejection
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.bitcoins.chain.api.ChainApi
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.core.Core
+import org.bitcoins.core.api.wallet.{AddressInfo, CoinSelectionAlgo}
 import org.bitcoins.core.api.wallet.db.{
   AccountDb,
   AddressDb,
@@ -40,8 +40,6 @@ import org.bitcoins.crypto.{
 }
 import org.bitcoins.node.Node
 import org.bitcoins.wallet.MockWalletApi
-import org.bitcoins.wallet.api.AddressInfo
-import org.bitcoins.wallet.models._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.wordspec.AnyWordSpec
 import scodec.bits.ByteVector

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.server
 
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
+import org.bitcoins.core.api.wallet.CoinSelectionAlgo
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.protocol.BlockStamp.BlockHeight
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}

--- a/core-test/src/test/scala/org/bitcoins/core/api/CoinSelectorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/api/CoinSelectorTest.scala
@@ -1,6 +1,6 @@
-package org.bitcoins.wallet.api
+package org.bitcoins.core.api
 
-import org.bitcoins.core.api.wallet.db
+import org.bitcoins.core.api.wallet.CoinSelector
 import org.bitcoins.core.api.wallet.db.{SegwitV0SpendingInfo, SpendingInfoDb}
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.script.ScriptPubKey
@@ -43,7 +43,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
       scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
       blockHash = None
     )
-    val utxo2 = db.SegwitV0SpendingInfo(
+    val utxo2 = SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
       state = TxoState.DoesNotExist,
       id = Some(2),
@@ -53,7 +53,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
       scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
       blockHash = None
     )
-    val utxo3 = db.SegwitV0SpendingInfo(
+    val utxo3 = SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
       state = TxoState.DoesNotExist,
       id = Some(3),

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/AddUtxoResult.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/AddUtxoResult.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.wallet.api
+package org.bitcoins.core.api.wallet
 
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/AddressInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/AddressInfo.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.wallet.api
+package org.bitcoins.core.api.wallet
 
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.hd.HDPath

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelectionAlgo.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelectionAlgo.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.commons.jsonmodels.wallet
+package org.bitcoins.core.api.wallet
 
 /** Represents the various ways the wallet can do coin selection */
 sealed abstract class CoinSelectionAlgo

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelector.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelector.scala
@@ -1,7 +1,6 @@
-package org.bitcoins.wallet.api
+package org.bitcoins.core.api.wallet
 
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo._
+import org.bitcoins.core.api.wallet.CoinSelectionAlgo._
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
 import org.bitcoins.core.protocol.transaction.TransactionOutput

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
+import org.bitcoins.core.api.wallet.{CoinSelectionAlgo, CoinSelector}
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.TransactionOutput
@@ -11,7 +11,6 @@ import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.crypto.CryptoUtil
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
-import org.bitcoins.wallet.api.CoinSelector
 import org.scalatest.{Assertion, FutureOutcome}
 import scodec.bits.ByteVector
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -2,10 +2,10 @@ package org.bitcoins.wallet
 
 import java.time.Instant
 
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.wallet.CoinSelectionAlgo
 import org.bitcoins.core.api.wallet.db.{AccountDb, SpendingInfoDb}
 import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
 import org.bitcoins.core.config.NetworkParameters

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/HDWalletApi.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet.api
 
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
+import org.bitcoins.core.api.wallet.CoinSelectionAlgo
 import org.bitcoins.core.api.wallet.db.{AccountDb, AddressDb, SpendingInfoDb}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.{AddressType, HDAccount, HDChainType, HDPurpose}

--- a/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/api/WalletApi.scala
@@ -2,11 +2,11 @@ package org.bitcoins.wallet.api
 
 import java.time.Instant
 
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.keymanager.KeyManagerApi
 import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.wallet.{AddressInfo, CoinSelectionAlgo}
 import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.currency.CurrencyUnit

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -2,6 +2,8 @@ package org.bitcoins.wallet.internal
 
 import java.util.concurrent.atomic.AtomicBoolean
 
+import org.bitcoins.core.api.wallet
+import org.bitcoins.core.api.wallet.AddressInfo
 import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd._
@@ -16,7 +18,6 @@ import org.bitcoins.core.protocol.transaction.{
 import org.bitcoins.core.wallet.utxo.{AddressTag, AddressTagType}
 import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.wallet._
-import org.bitcoins.wallet.api.AddressInfo
 
 import scala.concurrent.{Await, Future, Promise, TimeoutException}
 import scala.util.{Failure, Success}
@@ -394,9 +395,9 @@ private[wallet] trait AddressHandling extends WalletLogger {
       address: BitcoinAddress): Future[Option[AddressInfo]] = {
     addressDAO.findAddress(address).map { addressOpt =>
       addressOpt.map { address =>
-        AddressInfo(pubkey = address.ecPublicKey,
-                    network = address.address.networkParameters,
-                    path = address.path)
+        wallet.AddressInfo(pubkey = address.ecPublicKey,
+                           network = address.address.networkParameters,
+                           path = address.path)
       }
     }
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.wallet.internal
 
-import org.bitcoins.commons.jsonmodels.wallet.CoinSelectionAlgo
+import org.bitcoins.core.api.wallet.{
+  AddressInfo,
+  CoinSelectionAlgo,
+  CoinSelector
+}
 import org.bitcoins.core.api.wallet.db.{AccountDb, SpendingInfoDb}
 import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.protocol.transaction._
@@ -14,7 +18,6 @@ import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.Sign
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
-import org.bitcoins.wallet.api.{AddressInfo, CoinSelector}
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 
 import scala.concurrent.Future

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet.internal
 
+import org.bitcoins.core.api.wallet.{AddUtxoError, AddUtxoSuccess}
 import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.UInt32
@@ -11,7 +12,6 @@ import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.wallet._
-import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoSuccess}
 
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -1,6 +1,12 @@
 package org.bitcoins.wallet.internal
 
+import org.bitcoins.core.api.wallet.AddUtxoError._
 import org.bitcoins.core.api.wallet.db._
+import org.bitcoins.core.api.wallet.{
+  AddUtxoError,
+  AddUtxoResult,
+  AddUtxoSuccess
+}
 import org.bitcoins.core.compat._
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.number.UInt32
@@ -18,7 +24,6 @@ import org.bitcoins.core.protocol.transaction.{
 import org.bitcoins.core.util.{EitherUtil, FutureUtil}
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.wallet.api.{AddUtxoError, AddUtxoResult, AddUtxoSuccess}
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 
 import scala.concurrent.Future
@@ -217,7 +222,6 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       vout: UInt32,
       state: TxoState,
       blockHash: Option[DoubleSha256DigestBE]): Future[AddUtxoResult] = {
-    import AddUtxoError._
 
     logger.info(s"Adding UTXO to wallet: ${transaction.txId.hex}:${vout.toInt}")
 


### PR DESCRIPTION
Part of #1284 

This should be the final move needed before we can move the `WalletApi` to core.

This should wait on #1686 as there will be likely merge conflicts.

