### PR TITLE
DLC TLVs

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
@@ -5,9 +5,6 @@ import org.bitcoins.testkit.util.BitcoinSUnitTest
 
 class TLVTest extends BitcoinSUnitTest {
 
-  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    generatorDrivenConfigNewCode
-
   "TLV" must "have serizliation symmetry" in {
     forAll(TLVGen.tlv) { tlv =>
       assert(TLV(tlv.bytes) == tlv)
@@ -63,10 +60,24 @@ class TLVTest extends BitcoinSUnitTest {
     }
   }
 
+  "CETSignaturesV0TLV" must "have serialization symmetry" in {
+    forAll(TLVGen.cetSignaturesV0TLV) { cetSigs =>
+      assert(CETSignaturesV0TLV(cetSigs.bytes) == cetSigs)
+      assert(TLV(cetSigs.bytes) == cetSigs)
+    }
+  }
+
   "DLCOfferTLV" must "have serialization symmetry" in {
-    forAll(TLVGen.dLCOfferTLV) { offer =>
+    forAll(TLVGen.dlcOfferTLV) { offer =>
       assert(DLCOfferTLV(offer.bytes) == offer)
       assert(TLV(offer.bytes) == offer)
+    }
+  }
+
+  "DLCAcceptTLV" must "have serialization symmetry" in {
+    forAll(TLVGen.dlcAcceptTLV) { accept =>
+      assert(DLCAcceptTLV(accept.bytes) == accept)
+      assert(TLV(accept.bytes) == accept)
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
@@ -67,6 +67,13 @@ class TLVTest extends BitcoinSUnitTest {
     }
   }
 
+  "FundingSignaturesV0TLV" must "have serialization symmetry" in {
+    forAll(TLVGen.fundingSignaturesV0TLV) { fundingSigs =>
+      assert(FundingSignaturesV0TLV(fundingSigs.bytes) == fundingSigs)
+      assert(TLV(fundingSigs.bytes) == fundingSigs)
+    }
+  }
+
   "DLCOfferTLV" must "have serialization symmetry" in {
     forAll(TLVGen.dlcOfferTLV) { offer =>
       assert(DLCOfferTLV(offer.bytes) == offer)
@@ -78,6 +85,13 @@ class TLVTest extends BitcoinSUnitTest {
     forAll(TLVGen.dlcAcceptTLV) { accept =>
       assert(DLCAcceptTLV(accept.bytes) == accept)
       assert(TLV(accept.bytes) == accept)
+    }
+  }
+
+  "DLCSignTLV" must "have serialization symmetry" in {
+    forAll(TLVGen.dlcSignTLV) { sign =>
+      assert(DLCSignTLV(sign.bytes) == sign)
+      assert(TLV(sign.bytes) == sign)
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
@@ -41,4 +41,32 @@ class TLVTest extends BitcoinSUnitTest {
       assert(TLV(pong.bytes) == pong)
     }
   }
+
+  "ContractInfoV0TLV" must "have serialization symmetry" in {
+    forAll(TLVGen.contractInfoV0TLV) { contractInfo =>
+      assert(ContractInfoV0TLV(contractInfo.bytes) == contractInfo)
+      assert(TLV(contractInfo.bytes) == contractInfo)
+    }
+  }
+
+  "OracleInfoV0TLV" must "have serialization symmetry" in {
+    forAll(TLVGen.oracleInfoV0TLV) { oracleInfo =>
+      assert(OracleInfoV0TLV(oracleInfo.bytes) == oracleInfo)
+      assert(TLV(oracleInfo.bytes) == oracleInfo)
+    }
+  }
+
+  "FundingInputTempTLV" must "have serialization symmetry" in {
+    forAll(TLVGen.fundingInputTempTLV) { fundingInput =>
+      assert(FundingInputTempTLV(fundingInput.bytes) == fundingInput)
+      assert(TLV(fundingInput.bytes) == fundingInput)
+    }
+  }
+
+  "DLCOfferTLV" must "have serialization symmetry" in {
+    forAll(TLVGen.dLCOfferTLV) { offer =>
+      assert(DLCOfferTLV(offer.bytes) == offer)
+      assert(TLV(offer.bytes) == offer)
+    }
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -1,7 +1,13 @@
 package org.bitcoins.core.currency
 
 import org.bitcoins.core.consensus.Consensus
-import org.bitcoins.core.number.{BaseNumbers, BasicArithmetic, Bounded, Int64}
+import org.bitcoins.core.number.{
+  BaseNumbers,
+  BasicArithmetic,
+  Bounded,
+  Int64,
+  UInt64
+}
 import org.bitcoins.core.serializers.RawSatoshisSerializer
 import org.bitcoins.crypto.{Factory, NetworkElement}
 import scodec.bits.ByteVector
@@ -95,6 +101,12 @@ sealed abstract class Satoshis extends CurrencyUnit {
 
   def toLong: Long = underlying.toLong
 
+  def toUInt64: UInt64 = {
+    require(toLong >= 0, "Cannot cast negative value to UInt64")
+
+    UInt64(toLong)
+  }
+
   def ==(satoshis: Satoshis): Boolean = underlying == satoshis.underlying
 }
 
@@ -111,6 +123,7 @@ object Satoshis
   override def fromBytes(bytes: ByteVector): Satoshis =
     RawSatoshisSerializer.read(bytes)
   def apply(int64: Int64): Satoshis = SatoshisImpl(int64)
+  def apply(uint64: UInt64): Satoshis = SatoshisImpl(Int64(uint64.toLong))
   def apply(satoshis: Long): Satoshis = SatoshisImpl(Int64(satoshis))
   def apply(satoshis: BigInt): Satoshis = SatoshisImpl(Int64(satoshis))
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -1,9 +1,20 @@
 package org.bitcoins.core.protocol.tlv
 
-import org.bitcoins.core.number.UInt16
-import org.bitcoins.core.protocol.BigSizeUInt
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.number.{UInt16, UInt32, UInt64}
+import org.bitcoins.core.protocol.{BigSizeUInt, BlockTimeStamp}
+import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.tlv.TLV.DecodeTLVResult
-import org.bitcoins.crypto.{Factory, NetworkElement}
+import org.bitcoins.core.protocol.transaction.OutputReference
+import org.bitcoins.core.wallet.fee.SatoshisPerKW
+import org.bitcoins.crypto.{
+  ECPublicKey,
+  Factory,
+  NetworkElement,
+  SchnorrNonce,
+  SchnorrPublicKey,
+  Sha256DigestBE
+}
 import scodec.bits.ByteVector
 
 sealed trait TLV extends NetworkElement {
@@ -41,7 +52,13 @@ object TLV extends Factory[TLV] {
   }
 
   private val allFactories: Vector[TLVFactory[TLV]] =
-    Vector(ErrorTLV, PingTLV, PongTLV)
+    Vector(ErrorTLV,
+           PingTLV,
+           PongTLV,
+           ContractInfoV0TLV,
+           OracleInfoV0TLV,
+           FundingInputTempTLV,
+           DLCOfferTLV)
 
   val knownTypes: Vector[BigSizeUInt] = allFactories.map(_.tpe)
 
@@ -65,6 +82,35 @@ sealed trait TLVFactory[+T <: TLV] extends Factory[T] {
     require(tpe == this.tpe, s"Invalid type $tpe when expecting ${this.tpe}")
 
     fromTLVValue(value)
+  }
+
+  protected case class ValueIterator(value: ByteVector, var index: Int = 0) {
+
+    def current: ByteVector = {
+      value.drop(index)
+    }
+
+    def skip(numBytes: Long): Unit = {
+      index += numBytes.toInt
+      ()
+    }
+
+    def skip(bytes: NetworkElement): Unit = {
+      skip(bytes.byteSize)
+    }
+
+    def take(numBytes: Int): ByteVector = {
+      val bytes = current.take(numBytes)
+      skip(numBytes)
+      bytes
+    }
+
+    def takeBits(numBits: Int): ByteVector = {
+      require(numBits % 8 == 0,
+              s"Must take a round byte number of bits, got $numBits")
+
+      take(numBytes = numBits / 8)
+    }
   }
 }
 
@@ -144,5 +190,155 @@ object PongTLV extends TLVFactory[PongTLV] {
 
   def forIgnored(ignored: ByteVector): PongTLV = {
     new PongTLV(ignored)
+  }
+}
+
+sealed trait ContractInfoTLV extends TLV
+
+case class ContractInfoV0TLV(outcomes: Map[Sha256DigestBE, Satoshis])
+    extends ContractInfoTLV {
+  override val tpe: BigSizeUInt = ContractInfoV0TLV.tpe
+
+  override val value: ByteVector = {
+    outcomes.foldLeft(ByteVector.empty) {
+      case (bytes, (outcome, amt)) =>
+        bytes ++ outcome.bytes ++ UInt64(amt.toLong).bytes
+    }
+  }
+}
+
+object ContractInfoV0TLV extends TLVFactory[ContractInfoV0TLV] {
+  override val tpe: BigSizeUInt = BigSizeUInt(42768)
+
+  override def fromTLVValue(value: ByteVector): ContractInfoV0TLV = {
+    val iter = ValueIterator(value)
+
+    val builder = Map.newBuilder[Sha256DigestBE, Satoshis]
+
+    while (iter.index <= value.length - 40) {
+      val outcome = Sha256DigestBE(iter.take(32))
+      val amt = Satoshis(UInt64(iter.takeBits(64)).toLong)
+      builder.+=(outcome -> amt)
+    }
+
+    ContractInfoV0TLV(builder.result())
+  }
+}
+
+sealed trait OracleInfoTLV extends TLV
+
+case class OracleInfoV0TLV(pubKey: SchnorrPublicKey, rValue: SchnorrNonce)
+    extends OracleInfoTLV {
+  override def tpe: BigSizeUInt = OracleInfoV0TLV.tpe
+
+  override val value: ByteVector = {
+    pubKey.bytes ++ rValue.bytes
+  }
+}
+
+object OracleInfoV0TLV extends TLVFactory[OracleInfoV0TLV] {
+  override val tpe: BigSizeUInt = BigSizeUInt(42770)
+
+  override def fromTLVValue(value: ByteVector): OracleInfoV0TLV = {
+    val (pubKeyBytes, rBytes) = value.splitAt(32)
+    val pubKey = SchnorrPublicKey(pubKeyBytes)
+    val rValue = SchnorrNonce(rBytes)
+
+    OracleInfoV0TLV(pubKey, rValue)
+  }
+}
+
+sealed trait FundingInputTLV extends TLV
+
+case class FundingInputTempTLV(outputRef: OutputReference)
+    extends FundingInputTLV {
+  override val tpe: BigSizeUInt = FundingInputTempTLV.tpe
+
+  override val value: ByteVector = outputRef.bytes
+}
+
+object FundingInputTempTLV extends TLVFactory[FundingInputTempTLV] {
+  override val tpe: BigSizeUInt = BigSizeUInt(42772)
+
+  override def fromTLVValue(value: ByteVector): FundingInputTempTLV = {
+    FundingInputTempTLV(OutputReference(value))
+  }
+}
+
+case class DLCOfferTLV(
+    contractFlags: Byte,
+    chainHash: Sha256DigestBE,
+    contractInfo: ContractInfoTLV,
+    oracleInfo: OracleInfoTLV,
+    fundingPubKey: ECPublicKey,
+    payoutSPK: ScriptPubKey,
+    totalCollateralSatoshis: Satoshis,
+    fundingInputs: Vector[FundingInputTLV],
+    changeSPK: ScriptPubKey,
+    feeRatePerKW: SatoshisPerKW,
+    contractMaturityBound: BlockTimeStamp,
+    contractTimeout: BlockTimeStamp)
+    extends TLV {
+  override val tpe: BigSizeUInt = DLCOfferTLV.tpe
+
+  override val value: ByteVector = {
+    ByteVector(contractFlags) ++
+      chainHash.bytes ++
+      contractInfo.bytes ++
+      oracleInfo.bytes ++
+      fundingPubKey.bytes ++
+      payoutSPK.bytes ++
+      UInt64(totalCollateralSatoshis.toLong).bytes ++
+      UInt16(fundingInputs.length).bytes ++
+      fundingInputs.foldLeft(ByteVector.empty)(_ ++ _.bytes) ++
+      changeSPK.bytes ++
+      UInt64(feeRatePerKW.toLong).bytes ++
+      contractMaturityBound.toUInt32.bytes ++
+      contractTimeout.toUInt32.bytes
+  }
+}
+
+object DLCOfferTLV extends TLVFactory[DLCOfferTLV] {
+  override val tpe: BigSizeUInt = BigSizeUInt(42774)
+
+  override def fromTLVValue(value: ByteVector): DLCOfferTLV = {
+    val iter = ValueIterator(value)
+
+    val contractFlags = iter.take(1).head
+    val chainHash = Sha256DigestBE(iter.take(32))
+    val contractInfo = ContractInfoV0TLV.fromBytes(iter.current)
+    iter.skip(contractInfo)
+    val oracleInfo = OracleInfoV0TLV.fromBytes(iter.current)
+    iter.skip(oracleInfo)
+    val fundingPubKey = ECPublicKey(iter.take(33))
+    val payoutSPK = ScriptPubKey(iter.current)
+    iter.skip(payoutSPK)
+    val totalCollateralSatoshis = Satoshis(UInt64(iter.takeBits(64)).toLong)
+    val numFundingInputs = UInt16(iter.takeBits(16))
+    val fundingInputs = (0 until numFundingInputs.toInt).toVector.map { _ =>
+      val fundingInput = FundingInputTempTLV.fromBytes(iter.current)
+      iter.skip(fundingInput)
+      fundingInput
+    }
+    val changeSPK = ScriptPubKey(iter.current)
+    iter.skip(changeSPK)
+    val feeRatePerKW = SatoshisPerKW(Satoshis(UInt64(iter.takeBits(64)).toLong))
+    val contractMaturityBound = BlockTimeStamp(UInt32(iter.takeBits(32)))
+    val contractTimeout = BlockTimeStamp(UInt32(iter.takeBits(32)))
+
+    DLCOfferTLV(
+      contractFlags,
+      chainHash,
+      contractInfo,
+      oracleInfo,
+      fundingPubKey,
+      payoutSPK,
+      totalCollateralSatoshis,
+      fundingInputs,
+      changeSPK,
+      feeRatePerKW,
+      contractMaturityBound,
+      contractTimeout
+    )
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -336,6 +336,39 @@ sealed abstract class NumberUtil extends BitcoinSLogger {
   def posInt: Int = {
     Math.abs(scala.util.Random.nextInt())
   }
+
+  /** Returns a pseudorandom, uniformly distributed long value between 0
+    *  (inclusive) and the specified value (exclusive), drawn from this
+    *  random number generator's sequence.
+    *
+    *  Stolen from scala.util.Random.nextLong (in scala version 2.13)
+    */
+  def randomLong(bound: Long): Long = {
+    require(bound > 0, "bound must be positive")
+
+    /*
+     * Divide bound by two until small enough for nextInt. On each
+     * iteration (at most 31 of them but usually much less),
+     * randomly choose both whether to include high bit in result
+     * (offset) and whether to continue with the lower vs upper
+     * half (which makes a difference only if odd).
+     */
+
+    var offset = 0L
+    var _bound = bound
+
+    while (_bound >= Integer.MAX_VALUE) {
+      val bits = scala.util.Random.nextInt(2)
+      val halfn = _bound >>> 1
+      val nextn =
+        if ((bits & 2) == 0) halfn
+        else _bound - halfn
+      if ((bits & 1) == 0)
+        offset += _bound - nextn
+      _bound = nextn
+    }
+    offset + scala.util.Random.nextInt(_bound.toInt)
+  }
 }
 
 object NumberUtil extends NumberUtil

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
@@ -121,6 +121,16 @@ object ECDigitalSignature extends Factory[ECDigitalSignature] {
     }
   }
 
+  def fromFrontOfBytes(bytes: ByteVector): ECDigitalSignature = {
+    val sigWithExtra = fromBytes(bytes)
+    val sig = fromRS(sigWithExtra.r, sigWithExtra.s)
+
+    require(bytes.startsWith(sig.bytes),
+            s"Received weirdly encoded signature at beginning of $bytes")
+
+    sig
+  }
+
   def apply(r: BigInt, s: BigInt): ECDigitalSignature = fromRS(r, s)
 
   /**

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CryptoGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CryptoGenerators.scala
@@ -21,6 +21,7 @@ import org.bitcoins.crypto.{
   SchnorrNonce,
   SchnorrPublicKey,
   Sha256Digest,
+  Sha256DigestBE,
   Sha256Hash160Digest
 }
 import org.scalacheck.Gen
@@ -246,6 +247,10 @@ sealed abstract class CryptoGenerators {
       bytes <- NumberGenerator.bytevector
       digest = CryptoUtil.sha256(bytes)
     } yield digest
+
+  def sha256DigestBE: Gen[Sha256DigestBE] = {
+    sha256Digest.map(_.flip)
+  }
 
   /** Generates a random [[DoubleSha256Digest DoubleSha256Digest]] */
   def doubleSha256Digest: Gen[DoubleSha256Digest] =

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
@@ -1,11 +1,6 @@
 package org.bitcoins.testkit.core.gen
 
-import org.bitcoins.core.currency.{
-  Bitcoins,
-  CurrencyUnit,
-  CurrencyUnits,
-  Satoshis
-}
+import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit, Satoshis}
 import org.bitcoins.core.protocol.ln.currency._
 import org.scalacheck.Gen
 import org.bitcoins.core.wallet.fee.FeeUnit
@@ -56,7 +51,7 @@ trait CurrencyUnitGenerator {
   def currencyUnit: Gen[CurrencyUnit] = Gen.oneOf(satoshis, bitcoins)
 
   def positiveSatoshis: Gen[Satoshis] =
-    satoshis.suchThat(_ >= CurrencyUnits.zero)
+    Gen.choose(0, Long.MaxValue).map(Satoshis.apply)
 
   /**
     * Generates a postiive satoshi value that is 'realistic'. This current 'realistic' range

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/TLVGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/TLVGen.scala
@@ -77,6 +77,16 @@ trait TLVGen {
       .map(sigs => CETSignaturesV0TLV(sigs.toVector))
   }
 
+  def fundingSignaturesV0TLV: Gen[FundingSignaturesV0TLV] = {
+    for {
+      numInputs <- Gen.choose(1, 10)
+      outPoints <- Gen.listOfN(numInputs, TransactionGenerators.outPoint)
+      sigs <- Gen.listOfN(numInputs, CryptoGenerators.digitalSignature)
+    } yield {
+      FundingSignaturesV0TLV(outPoints.zip(sigs).toMap)
+    }
+  }
+
   def dlcOfferTLV: Gen[DLCOfferTLV] = {
     for {
       contractFlags <- NumberGenerator.byte
@@ -132,6 +142,17 @@ trait TLVGen {
     }
   }
 
+  def dlcSignTLV: Gen[DLCSignTLV] = {
+    for {
+      contractId <- CryptoGenerators.sha256DigestBE
+      cetSigs <- cetSignaturesV0TLV
+      refundSig <- CryptoGenerators.digitalSignature
+      fundingSigs <- fundingSignaturesV0TLV
+    } yield {
+      DLCSignTLV(contractId, cetSigs, refundSig, fundingSigs)
+    }
+  }
+
   def tlv: Gen[TLV] = {
     Gen.oneOf(
       unknownTLV,
@@ -142,8 +163,10 @@ trait TLVGen {
       oracleInfoV0TLV,
       fundingInputTempTLV,
       cetSignaturesV0TLV,
+      fundingSignaturesV0TLV,
       dlcOfferTLV,
-      dlcAcceptTLV
+      dlcAcceptTLV,
+      dlcSignTLV
     )
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/TransactionGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/TransactionGenerators.scala
@@ -150,6 +150,13 @@ object TransactionGenerators extends BitcoinSLogger {
   def smallInputsNonEmpty: Gen[Seq[TransactionInput]] =
     Gen.choose(1, 5).flatMap(i => Gen.listOfN(i, input))
 
+  def outputReference: Gen[OutputReference] = {
+    for {
+      outPoint <- outPoint
+      output <- output
+    } yield OutputReference(outPoint, output)
+  }
+
   /**
     * Generates an arbitrary [[org.bitcoins.core.protocol.transaction.Transaction Transaction]]
     * This transaction's [[org.bitcoins.core.protocol.transaction.TransactionInput TransactionInput]]s

--- a/testkit/src/main/scala/org/bitcoins/testkit/dlc/DLCTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/dlc/DLCTestUtil.scala
@@ -3,6 +3,7 @@ package org.bitcoins.testkit.dlc
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.ContractInfo
 import org.bitcoins.commons.jsonmodels.dlc.{CETSignatures, FundingSignatures}
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.util.NumberUtil
 import org.bitcoins.crypto.{CryptoUtil, Sha256DigestBE}
 import org.bitcoins.testkit.util.BytesUtil
 import scodec.bits.ByteVector
@@ -24,7 +25,7 @@ object DLCTestUtil {
       Vector(totalAmount.satoshis, Satoshis.zero)
     } else {
       (0 until size - 2).map { _ =>
-        Satoshis(scala.util.Random.nextLong(totalAmount.satoshis.toLong))
+        Satoshis(NumberUtil.randomLong(totalAmount.satoshis.toLong))
       }.toVector :+ totalAmount.satoshis :+ Satoshis.zero
     }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/dlc/DLCTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/dlc/DLCTestUtil.scala
@@ -24,7 +24,7 @@ object DLCTestUtil {
       Vector(totalAmount.satoshis, Satoshis.zero)
     } else {
       (0 until size - 2).map { _ =>
-        Satoshis(scala.util.Random.nextInt(totalAmount.satoshis.toLong.toInt))
+        Satoshis(scala.util.Random.nextLong(totalAmount.satoshis.toLong))
       }.toVector :+ totalAmount.satoshis :+ Satoshis.zero
     }
 


### PR DESCRIPTION
Introduces TLVs for `DLCOffer`, `DLCAccept`, and `DLCSign` as specified in https://github.com/discreetlogcontracts/dlcspecs/blob/cf7e49e6a852c99e076777fbb96142e626cac641/Protocol.md