### PR TITLE
Create ADT for NodeType instead of booleans

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -16,7 +16,7 @@ case class NeutrinoNode(
     actorSystem: ActorSystem)
     extends Node {
   require(
-    nodeConfig.isNeutrinoEnabled,
+    nodeConfig.nodeType == NodeType.NeutrinoNode,
     s"We need our Neutrino mode enabled to be able to construct a Neutrino node!")
 
   implicit override def system: ActorSystem = actorSystem

--- a/node/src/main/scala/org/bitcoins/node/NodeType.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeType.scala
@@ -1,0 +1,40 @@
+package org.bitcoins.node
+
+import org.bitcoins.crypto.StringFactory
+
+sealed abstract class NodeType {
+  def shortName: String
+}
+
+object NodeType extends StringFactory[NodeType] {
+
+  final case object FullNode extends NodeType {
+    override def shortName: String = "full"
+  }
+
+  final case object NeutrinoNode extends NodeType {
+    override def shortName: String = "neutrino"
+  }
+
+  final case object SpvNode extends NodeType {
+    override def shortName: String = "spv"
+  }
+
+  val all: Vector[NodeType] = Vector(FullNode, NeutrinoNode, SpvNode)
+
+  override def fromStringOpt(str: String): Option[NodeType] = {
+    all.find(state => str.toLowerCase() == state.toString.toLowerCase) match {
+      case Some(value) => Some(value)
+      case None =>
+        all.find(state => str.toLowerCase() == state.shortName.toLowerCase)
+    }
+  }
+
+  override def fromString(string: String): NodeType = {
+    fromStringOpt(string) match {
+      case Some(state) => state
+      case None =>
+        sys.error(s"Could not find a NodeType for string=$string")
+    }
+  }
+}

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -18,7 +18,7 @@ case class SpvNode(
     chainConfig: ChainAppConfig,
     actorSystem: ActorSystem)
     extends Node {
-  require(nodeConfig.isSPVEnabled,
+  require(nodeConfig.nodeType == NodeType.SpvNode,
           s"We need our SPV mode enabled to be able to construct a SPV node!")
 
   implicit override def system: ActorSystem = actorSystem

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -180,7 +180,7 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
       appConfig: BitcoinSAppConfig): FutureOutcome = {
     val nodeWithBitcoindBuilder: () => Future[SpvNodeConnectedWithBitcoind] = {
       () =>
-        require(appConfig.isSPVEnabled && !appConfig.isNeutrinoEnabled)
+        require(appConfig.nodeType == NodeType.SpvNode)
         for {
           bitcoind <- BitcoinSFixture.createBitcoind(versionOpt)
           node <- NodeUnitTest.createSpvNode(bitcoind, NodeCallbacks.empty)(
@@ -202,7 +202,7 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
       appConfig: BitcoinSAppConfig): FutureOutcome = {
     val nodeWithBitcoindBuilder: () => Future[
       SpvNodeConnectedWithBitcoindV19] = { () =>
-      require(appConfig.isSPVEnabled && !appConfig.isNeutrinoEnabled)
+      require(appConfig.nodeType == NodeType.SpvNode)
       for {
         bitcoind <-
           BitcoinSFixture
@@ -229,7 +229,7 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
       appConfig: BitcoinSAppConfig): FutureOutcome = {
     val nodeWithBitcoindBuilder: () => Future[
       NeutrinoNodeConnectedWithBitcoind] = { () =>
-      require(appConfig.isNeutrinoEnabled && !appConfig.isSPVEnabled)
+      require(appConfig.nodeType == NodeType.NeutrinoNode)
       for {
         bitcoind <- BitcoinSFixture.createBitcoind(versionOpt)
         node <- NodeUnitTest.createNeutrinoNode(bitcoind, NodeCallbacks.empty)(
@@ -389,7 +389,7 @@ object NodeUnitTest extends P2PLogger {
       system: ActorSystem,
       appConfig: BitcoinSAppConfig): Future[SpvNodeFundedWalletBitcoind] = {
     import system.dispatcher
-    require(appConfig.isSPVEnabled && !appConfig.isNeutrinoEnabled)
+    require(appConfig.nodeType == NodeType.SpvNode)
     for {
       bitcoind <- BitcoinSFixture.createBitcoindWithFunds(versionOpt)
       node <- createSpvNode(bitcoind, nodeCallbacks)
@@ -417,7 +417,7 @@ object NodeUnitTest extends P2PLogger {
       appConfig: BitcoinSAppConfig): Future[
     NeutrinoNodeFundedWalletBitcoind] = {
     import system.dispatcher
-    require(appConfig.isNeutrinoEnabled && !appConfig.isSPVEnabled)
+    require(appConfig.nodeType == NodeType.NeutrinoNode)
     for {
       bitcoind <- BitcoinSFixture.createBitcoindWithFunds(versionOpt)
       node <- createNeutrinoNode(bitcoind, nodeCallbacks)
@@ -492,8 +492,7 @@ object NodeUnitTest extends P2PLogger {
     nodeAppConfig.addCallbacks(callbacks)
 
     val checkConfigF = Future {
-      assert(nodeAppConfig.isSPVEnabled)
-      assert(!nodeAppConfig.isNeutrinoEnabled)
+      assert(nodeAppConfig.nodeType == NodeType.SpvNode)
     }
     val chainApiF = for {
       _ <- checkConfigF
@@ -527,8 +526,7 @@ object NodeUnitTest extends P2PLogger {
     nodeAppConfig.addCallbacks(callbacks)
 
     val checkConfigF = Future {
-      assert(!nodeAppConfig.isSPVEnabled)
-      assert(nodeAppConfig.isNeutrinoEnabled)
+      assert(nodeAppConfig.nodeType == NodeType.NeutrinoNode)
     }
     val chainApiF = for {
       _ <- checkConfigF


### PR DESCRIPTION
Changes it so we don't need to do `nodeConf.isNeutrinoEnabled` everywhere, we can instead have a nice ADT that encompasses all different modes we support.