### PR TITLE
dlc branch -> adaptor-dlc branch

### DIFF
--- a/docs/wallet/dlc.md
+++ b/docs/wallet/dlc.md
@@ -9,7 +9,7 @@ title: Executing A DLC with Bitcoin-S
 
 See the [setup document](../getting-setup).
 
-Make sure to follow [Step 4](../getting-setup#step-4-optional-discreet-log-contract-branch) to checkout the `dlc` feature branch.
+Make sure to follow [Step 4](../getting-setup#step-4-optional-discreet-log-contract-branch) to checkout the `adaptor-dlc` feature branch.
 
 ## Step 2: Agree On Contract Terms
 


### PR DESCRIPTION
Fix missed branch reference, we now use `adaptor-dlc`