### PR TITLE
Improve logging in DataMessageHandler

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1019,8 +1019,8 @@ case class CompactFilterHeadersMessage(
       }
     }
     s"CompactFilterHeadersMessage(filterType=${filterType}, " +
-      s"previousFilterHeader=${previousFilterHeader}, " +
-      s"stopHash=${stopHash} " +
+      s"previousFilterHeader=${previousFilterHeader.flip.hex}, " +
+      s"stopHash=${stopHash.flip.hex} " +
       s"filterHeaders=${hashesString})"
   }
 }
@@ -1079,10 +1079,10 @@ case class CompactFilterCheckPointMessage(
       if (filterHeaders.isEmpty) {
         "empty"
       } else {
-        s"${filterHeaders.head}...${filterHeaders.last}"
+        s"${filterHeaders.head.flip.hex}...${filterHeaders.last.flip.hex}"
       }
     }
-    s"CompactFilterCheckPointMessage(filterType=${filterType}, stopHash=${stopHash}, filterHeaders=${headersString})"
+    s"CompactFilterCheckPointMessage(filterType=${filterType}, stopHash=${stopHash.flip.hex}, filterHeaders=${headersString})"
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1009,6 +1009,20 @@ case class CompactFilterHeadersMessage(
       acc :+ acc.last.nextHeader(nextFilterHash)
     }
   }
+
+  override def toString: String = {
+    val hashesString = {
+      if (filterHashes.isEmpty) {
+        "empty"
+      } else {
+        s"${filterHashes.head}...${filterHashes.last}"
+      }
+    }
+    s"CompactFilterHeadersMessage(filterType=${filterType}, " +
+      s"previousFilterHeader=${previousFilterHeader}, " +
+      s"stopHash=${stopHash} " +
+      s"filterHeaders=${hashesString})"
+  }
 }
 
 object CompactFilterHeadersMessage

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1015,7 +1015,7 @@ case class CompactFilterHeadersMessage(
       if (filterHashes.isEmpty) {
         "empty"
       } else {
-        s"${filterHashes.head}...${filterHashes.last}"
+        s"${filterHashes.head.flip.hex}...${filterHashes.last.flip.hex}"
       }
     }
     s"CompactFilterHeadersMessage(filterType=${filterType}, " +

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -120,7 +120,8 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
       node <- {
         val isInitializedF = for {
           _ <- peerMsgSenderF.map(_.connect())
-          _ <- AsyncUtil.retryUntilSatisfiedF(() => isInitialized)
+          _ <- AsyncUtil.retryUntilSatisfiedF(() => isInitialized,
+                                              duration = 250.millis)
         } yield ()
 
         isInitializedF.failed.foreach(err =>

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -36,7 +36,7 @@ case class DataMessageHandler(
       payload: DataPayload,
       peerMsgSender: PeerMessageSender): Future[DataMessageHandler] = {
 
-    payload match {
+    val resultF = payload match {
       case checkpoint: CompactFilterCheckPointMessage =>
         logger.debug(
           s"Got ${checkpoint.filterHeaders.size} checkpoints ${checkpoint}")
@@ -284,6 +284,13 @@ case class DataMessageHandler(
       case invMsg: InventoryMessage =>
         handleInventoryMsg(invMsg = invMsg, peerMsgSender = peerMsgSender)
     }
+
+    resultF.failed.foreach {
+      case err =>
+        logger.error(s"Failed to handle data payload=${payload}", err)
+    }
+
+    resultF
   }
 
   private def sendNextGetCompactFilterHeadersCommand(


### PR DESCRIPTION
We now log failures in `DataMessageHandler`! 

This allows bumps the timeout for connecting to a node from 5 seconds to 12.5 seconds.

Finally it makes the `CompactFilterHeaderMessage` more readable by eliding the headers in the middle of the payload.
