### PR TITLE
Implement getBestFilterHeader based on a number of block headers that…

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -587,6 +587,20 @@ class ChainHandlerTest extends ChainDbUnitTest {
     }
   }
 
+  it must "get best filter header with zero blockchains in memory" in {
+    chainHandler: ChainHandler =>
+      val noChainsChainHandler = chainHandler.copy(blockchains = Vector.empty)
+
+      val filterHeaderF = noChainsChainHandler.getBestFilterHeader()
+
+      for {
+        filterHeaderOpt <- filterHeaderF
+      } yield {
+        assert(filterHeaderOpt.isDefined)
+        assert(filterHeaderOpt.get == ChainUnitTest.genesisFilterHeaderDb)
+      }
+  }
+
   final def processHeaders(
       processorF: Future[ChainApi],
       headers: Vector[BlockHeader],

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
@@ -120,7 +120,11 @@ class CompactFilterHeaderDAOTest extends ChainDbUnitTest {
       val filterHeaders =
         Vector(filterHeaderDbLightWork, filterHeaderDbHeavyWork)
 
-      val createdF = filterHeaderDAO.createAll(filterHeaders)
+      val createdF = for {
+        _ <- blockHeaderDbF
+        created <- filterHeaderDAO.createAll(filterHeaders)
+      } yield created
+
       for {
         _ <- createdF
         found <- filterHeaderDAO.getBestFilterHeader

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
@@ -1,6 +1,17 @@
 package org.bitcoins.chain.models
 
-import org.bitcoins.testkit.chain.ChainDbUnitTest
+import org.bitcoins.core.api.chain.db.{BlockHeaderDb, CompactFilterHeaderDb}
+import org.bitcoins.core.protocol.blockchain.BlockHeader
+import org.bitcoins.testkit.chain.{
+  BlockHeaderHelper,
+  ChainDbUnitTest,
+  ChainTestUtil,
+  ChainUnitTest
+}
+import org.bitcoins.testkit.core.gen.{
+  BlockchainElementsGenerator,
+  CryptoGenerators
+}
 import org.scalatest.FutureOutcome
 
 class CompactFilterHeaderDAOTest extends ChainDbUnitTest {
@@ -17,5 +28,117 @@ class CompactFilterHeaderDAOTest extends ChainDbUnitTest {
       filterHeaderDAO.getBestFilterHeader.map { opt =>
         assert(opt == None)
       }
+  }
+
+  it must "create and read a filter header from the database" in {
+    filterHeaderDAO =>
+      val blockHeaderDAO = BlockHeaderDAO()
+      val blockHeaderDb =
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
+      val blockHeaderDbF = blockHeaderDAO.create(blockHeaderDb)
+      val filterHeaderDb1F = for {
+        blockHeaderDb <- blockHeaderDbF
+      } yield {
+        randomFilterHeader(blockHeaderDb)
+      }
+
+      val createdF = filterHeaderDb1F.flatMap(filterHeaderDAO.create)
+
+      for {
+        headerDb <- createdF
+        original <- filterHeaderDb1F
+        fromDbOpt <- filterHeaderDAO.read(headerDb.hashBE)
+      } yield {
+        assert(fromDbOpt.isDefined)
+        assert(original == fromDbOpt.get)
+      }
+  }
+
+  it must "get the best filter header that has a block header associated with it" in {
+    filterHeaderDAO =>
+      val blockHeaderDAO = BlockHeaderDAO()
+      val blockHeaderDb = {
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
+      }
+      val blockHeaderDbF = blockHeaderDAO.create(blockHeaderDb)
+      val filterHeaderDb1F = for {
+        blockHeaderDb <- blockHeaderDbF
+      } yield {
+        randomFilterHeader(blockHeaderDb)
+      }
+
+      val createdF = filterHeaderDb1F.flatMap(filterHeaderDAO.create)
+      for {
+        blockHeader <- blockHeaderDbF
+        _ <- createdF
+        headers = Vector(blockHeader)
+        found <- filterHeaderDAO.getBestFilterHeaderForHeaders(headers)
+        empty <- filterHeaderDAO.getBestFilterHeaderForHeaders(Vector.empty)
+      } yield {
+        assert(found.nonEmpty)
+        assert(empty.isEmpty)
+      }
+  }
+
+  it must "fail to find a filter header if the block header is not in the db" in {
+    filterHeaderDAO =>
+      val blockHeaderDb = {
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
+      }
+      val headers = Vector(blockHeaderDb)
+
+      for {
+        resultOpt <- filterHeaderDAO.getBestFilterHeaderForHeaders(headers)
+      } yield {
+        assert(resultOpt.isEmpty)
+      }
+  }
+
+  it must "find the filter header with the heaviest work" in {
+    filterHeaderDAO =>
+      val blockHeaderDAO = BlockHeaderDAO()
+      val blockHeaderDbLightWork = {
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
+      }
+
+      val blockHeaderDbHeavyWork = {
+        blockHeaderDbLightWork.copy(
+          chainWork =
+            blockHeaderDbLightWork.chainWork + 1,
+          hashBE = CryptoGenerators.doubleSha256Digest.sample.get.flip)
+      }
+      val headers = Vector(blockHeaderDbLightWork, blockHeaderDbHeavyWork)
+      val blockHeaderDbF = blockHeaderDAO.createAll(headers)
+      val filterHeaderDbLightWork = {
+        randomFilterHeader(blockHeaderDbLightWork)
+      }
+
+      val filterHeaderDbHeavyWork = {
+        randomFilterHeader(blockHeaderDbHeavyWork)
+      }
+
+      val filterHeaders =
+        Vector(filterHeaderDbLightWork, filterHeaderDbHeavyWork)
+
+      val createdF = filterHeaderDAO.createAll(filterHeaders)
+      for {
+        _ <- createdF
+        found <- filterHeaderDAO.getBestFilterHeader
+      } yield {
+        assert(found.nonEmpty)
+        assert(found.get == filterHeaderDbHeavyWork)
+      }
+  }
+
+  private def randomFilterHeader(
+      blockHeader: BlockHeaderDb): CompactFilterHeaderDb = {
+    CompactFilterHeaderDb(
+      CryptoGenerators.doubleSha256Digest.sample.get.flip,
+      filterHashBE = CryptoGenerators.doubleSha256Digest.sample.get.flip,
+      previousFilterHeaderBE =
+        CryptoGenerators.doubleSha256Digest.sample.get.flip,
+      blockHashBE = blockHeader.hashBE,
+      blockHeader.height
+    )
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -88,6 +88,10 @@ private[blockchain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
 
     loop(0)
   }
+
+  override def toString: String = {
+    s"BaseBlockchain(tip=${tip},last=${last},length=${length})"
+  }
 }
 
 private[blockchain] trait BaseBlockChainCompObject

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -384,9 +384,13 @@ case class ChainHandler(
 
     for {
       filterHeaders <- filterHeadersOptF
-      maxHeightOpt = filterHeaders.flatten.maxByOption(_.height)
     } yield {
-      maxHeightOpt
+      val flattened = filterHeaders.flatten
+      if (flattened.isEmpty) None
+      else {
+        Some(flattened.maxBy(_.height))
+      }
+
     }
 
   }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -409,7 +409,7 @@ case class ChainHandler(
     Option[CompactFilterHeaderDb]] = {
     val bestFilterHeaderOptF = filterHeaderDAO.getBestFilterHeader
 
-    //get best blockchain we currently have
+    //get best blockchain around our latest filter header
     val blockchainF: Future[Blockchain] = {
       for {
         bestFilterHeaderOpt <- bestFilterHeaderOptF

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -129,20 +129,10 @@ case class CompactFilterHeaderDAO()(implicit
     * @see https://github.com/bitcoin-s/bitcoin-s/issues/1919#issuecomment-682041737
     */
   def getBestFilterHeader: Future[Option[CompactFilterHeaderDb]] = {
-    val join = table
-      .join(blockHeaderTable)
-      .on(_.blockHash === _.hash)
-
-    val maxQuery = join.map(_._2.chainWork).max
-
-    val query = join.filter(_._2.chainWork === maxQuery).take(1).map(_._1)
-
-    for {
-      filterOpt <-
-        safeDatabase
-          .run(query.result)
-          .map(_.headOption)
-    } yield filterOpt
+    val blockHeaderDAO = BlockHeaderDAO()
+    val blockchainsF = blockHeaderDAO.getBlockchains()
+    blockchainsF.flatMap(blockchains =>
+      getBestFilterHeaderForHeaders(blockchains.flatten))
   }
 
   /** This looks for best filter headers whose [[CompactFilterHeaderDb.blockHashBE]] are associated with the given

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -123,6 +123,11 @@ case class CompactFilterHeaderDAO()(implicit
     query
   }
 
+  /** Fetches the best filter header from the database _without_ context
+    * that it's actually in our best blockchain. For instance, this filter header could be
+    * reorged out for whatever reason.
+    * @see https://github.com/bitcoin-s/bitcoin-s/issues/1919#issuecomment-682041737
+    */
   def getBestFilterHeader: Future[Option[CompactFilterHeaderDb]] = {
     val join = table
       .join(blockHeaderTable)
@@ -140,6 +145,9 @@ case class CompactFilterHeaderDAO()(implicit
     } yield filterOpt
   }
 
+  /** This looks for best filter headers whose [[CompactFilterHeaderDb.blockHashBE]] are associated with the given
+    * [[BlockHeaderDb.hashBE]] given as a parameter.
+    */
   def getBestFilterHeaderForHeaders(
       headers: Vector[BlockHeaderDb]): Future[Option[CompactFilterHeaderDb]] = {
     val hashes = headers.map(_.hashBE)

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -155,14 +155,12 @@ case class CompactFilterHeaderDAO()(implicit
       .join(blockHeaderTable)
       .on(_.blockHash === _.hash)
 
-    val maxQuery = join.map(_._2.chainWork).max
-
     val query = join
       .filter {
         case (filterTable, _) =>
           filterTable.blockHash.inSet(hashes)
       }
-      .filter(_._2.chainWork === maxQuery)
+      .sortBy(_._2.chainWork.desc)
       .take(1)
       .map(_._1)
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -302,7 +302,7 @@ case class DataMessageHandler(
       stopHash = stopHash)
 
   private def sendFirstGetCompactFilterHeadersCommand(
-      peerMsgSender: PeerMessageSender): Future[Boolean] =
+      peerMsgSender: PeerMessageSender): Future[Boolean] = {
     for {
       filterHeaderCount <- chainApi.getFilterHeaderCount()
       highestFilterHeaderOpt <-
@@ -316,6 +316,7 @@ case class DataMessageHandler(
       res <- sendNextGetCompactFilterHeadersCommand(peerMsgSender,
                                                     highestFilterBlockHash)
     } yield res
+  }
 
   private def sendNextGetCompactFilterCommand(
       peerMsgSender: PeerMessageSender,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -304,13 +304,11 @@ case class DataMessageHandler(
   private def sendFirstGetCompactFilterHeadersCommand(
       peerMsgSender: PeerMessageSender): Future[Boolean] = {
     for {
-      filterHeaderCount <- chainApi.getFilterHeaderCount()
-      highestFilterHeaderOpt <-
+      bestFilterHeaderOpt <-
         chainApi
-          .getFilterHeadersAtHeight(filterHeaderCount)
-          .map(_.headOption)
+          .getBestFilterHeader()
       highestFilterBlockHash =
-        highestFilterHeaderOpt
+        bestFilterHeaderOpt
           .map(_.blockHashBE)
           .getOrElse(DoubleSha256DigestBE.empty)
       res <- sendNextGetCompactFilterHeadersCommand(peerMsgSender,

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -75,7 +75,7 @@ object CommonSettings {
     )
   }
 
-  private val scala2_13CompilerOpts = Seq("-Xlint:unused", "-Xfatal-warnings")
+  private val scala2_13CompilerOpts = Seq.empty //Seq("-Xlint:unused", "-Xfatal-warnings")
 
   private val nonScala2_13CompilerOpts = Seq(
     "-Xmax-classfile-name",

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -75,7 +75,7 @@ object CommonSettings {
     )
   }
 
-  private val scala2_13CompilerOpts = Seq.empty //Seq("-Xlint:unused", "-Xfatal-warnings")
+  private val scala2_13CompilerOpts = Seq("-Xlint:unused", "-Xfatal-warnings")
 
   private val nonScala2_13CompilerOpts = Seq(
     "-Xmax-classfile-name",


### PR DESCRIPTION
… can be passed in as a parameter. These headers can be used to indicate what your current best chain is

My proposals to fix #1919 

Basically, I created

```scala
def getBestFilterHeaderForHeaders(
      headers: Vector[BlockHeaderDb]): Future[Option[CompactFilterHeaderDb]]
```

This allows you to pass in `headers` that are part of your best chain, and we will join the filter header table and block header table looking for the filter header with the max chain work. 

I have not tested this out locally yet to see if this fixes my problem. 