### PR TITLE
Calculate correct TxoState when processing a transaction

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -123,7 +123,7 @@ class RescanHandlingTest extends BitcoinSWalletTest {
         //balance doesn't have to exactly equal, as there was money in the
         //wallet before hand.
         assert(balance >= amt)
-        assert(balance == unconfirmedBalance)
+        assert(amt == unconfirmedBalance)
         newTxWallet
       }
 
@@ -174,7 +174,7 @@ class RescanHandlingTest extends BitcoinSWalletTest {
         //balance doesn't have to exactly equal, as there was money in the
         //wallet before hand.
         assert(balance >= amt)
-        assert(balance == unconfirmedBalance)
+        assert(amt == unconfirmedBalance)
         newTxWallet
       }
 
@@ -234,7 +234,7 @@ class RescanHandlingTest extends BitcoinSWalletTest {
         //balance doesn't have to exactly equal, as there was money in the
         //wallet before hand.
         assert(balance >= amt)
-        assert(balance == unconfirmedBalance)
+        assert(amt == unconfirmedBalance)
         newTxWallet
       }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -143,8 +143,10 @@ class RescanHandlingTest extends BitcoinSWalletTest {
                                                 DEFAULT_ADDR_BATCH_SIZE,
                                               useCreationTime = false)
         balance <- newTxWallet.getBalance()
+        unconfirmedBalance <- newTxWallet.getUnconfirmedBalance()
       } yield {
         assert(balance == amt)
+        assert(unconfirmedBalance == Bitcoins(1))
       }
   }
 
@@ -246,8 +248,10 @@ class RescanHandlingTest extends BitcoinSWalletTest {
                                                 DEFAULT_ADDR_BATCH_SIZE,
                                               useCreationTime = true)
         balance <- newTxWallet.getBalance()
+        unconfirmedBalance <- newTxWallet.getUnconfirmedBalance()
       } yield {
         assert(balance == Bitcoins(7))
+        assert(unconfirmedBalance == Bitcoins(1))
       }
   }
 


### PR DESCRIPTION
Fixes #1928

Some of the `RescanHandlingTest`s were assuming that none of our utxos were confirmed, however, after this bug fix that assumption is wrong so I had to fix that.