### PR TITLE
Cache DoubleSha256Digest.hex

### DIFF
--- a/crypto/src/main/scala/org/bitcoins/crypto/HashDigest.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/HashDigest.scala
@@ -140,6 +140,8 @@ case class DoubleSha256DigestBE(bytes: ByteVector) extends HashDigest {
   def flip: DoubleSha256Digest =
     DoubleSha256Digest.fromBytes(bytes.reverse)
 
+  override lazy val hex: String = bytes.toHex
+
   override def toString = s"DoubleSha256BDigestBE($hex)"
 }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/HashDigest.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/HashDigest.scala
@@ -116,6 +116,8 @@ case class DoubleSha256Digest(bytes: ByteVector) extends HashDigest {
 
   lazy val flip: DoubleSha256DigestBE = DoubleSha256DigestBE(bytes.reverse)
 
+  override lazy val hex: String = bytes.toHex
+
   override def toString = s"DoubleSha256Digest($hex)"
 }
 


### PR DESCRIPTION
I'm syncing a testnet node and watching visualvm, apparently `DoubleSha256Digest.hex` is a host spot during IBD, let's just cache the hex representation to avoid this:

![Screenshot from 2020-08-28 15-12-53](https://user-images.githubusercontent.com/3514957/91612322-c62a5d80-e942-11ea-80b3-51a2b7b0ca6f.png)
