### PR TITLE
Fix maxBy() exception in the case of empty Blockchain in ChainHandler…

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
@@ -54,6 +54,29 @@ class CompactFilterHeaderDAOTest extends ChainDbUnitTest {
       }
   }
 
+  it must "find filters between height" in { filterHeaderDAO =>
+    val blockHeaderDAO = BlockHeaderDAO()
+    val blockHeaderDb =
+      BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
+    val blockHeaderDbF = blockHeaderDAO.create(blockHeaderDb)
+    val filterHeaderDb1F = for {
+      blockHeaderDb <- blockHeaderDbF
+    } yield {
+      randomFilterHeader(blockHeaderDb)
+    }
+
+    val createdF = filterHeaderDb1F.flatMap(filterHeaderDAO.create)
+
+    for {
+      headerDb <- createdF
+      fromDbVec <-
+        filterHeaderDAO.getBetweenHeights(headerDb.height, headerDb.height)
+    } yield {
+      assert(fromDbVec.length == 1)
+      assert(fromDbVec.head == headerDb)
+    }
+  }
+
   it must "get the best filter header that has a block header associated with it" in {
     filterHeaderDAO =>
       val blockHeaderDAO = BlockHeaderDAO()


### PR DESCRIPTION
….bestFilterHeaderSearch()

This was introduced in #1926 

The use of `maxBy()` is tricky in the Scala standard library, as it throws an exception if the `Vector` is empty. This PR adds a guard for the case that we are syncing a new node from scratch, we will have zero filter headers in the database. Previously we would fail with a `throw new UnsupportedOperationException("empty.maxBy")`

