### PR TITLE
Make sure both filter ehaders and filters are empty before sending fi…

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -125,7 +125,7 @@ sealed trait BlockHeader extends NetworkElement {
     * [[https://bitcoin.stackexchange.com/questions/2063/why-does-the-bitcoin-protocol-use-the-little-endian-notation]]
     * @return
     */
-  def hashBE: DoubleSha256DigestBE = hash.flip
+  lazy val hashBE: DoubleSha256DigestBE = hash.flip
 
   override def bytes: ByteVector = RawBlockHeaderSerializer.write(this)
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -215,8 +215,8 @@ case class DataMessageHandler(
                 // we probably need to sync filters
                 if (
                   appConfig.nodeType == NodeType.NeutrinoNode && (!syncing ||
-                  filterHeaderHeightOpt.isEmpty &&
-                  filterHeightOpt.isEmpty)
+                  (filterHeaderHeightOpt.isEmpty &&
+                  filterHeightOpt.isEmpty))
                 )
                   sendFirstGetCompactFilterHeadersCommand(peerMsgSender)
                 else

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -214,7 +214,9 @@ case class DataMessageHandler(
                 // so we also check if our cached filter heights have been set as well, if they haven't then
                 // we probably need to sync filters
                 if (
-                  appConfig.nodeType == NodeType.NeutrinoNode && (!syncing || filterHeaderHeightOpt.isEmpty || filterHeightOpt.isEmpty)
+                  appConfig.nodeType == NodeType.NeutrinoNode && (!syncing ||
+                  filterHeaderHeightOpt.isEmpty &&
+                  filterHeightOpt.isEmpty)
                 )
                   sendFirstGetCompactFilterHeadersCommand(peerMsgSender)
                 else


### PR DESCRIPTION
…rst filterheader sync message

This seems to fix #1933 

Now we only start syncing compact filter headers when both filters headers and filters are empty inside of `DataMessageHandler`. I'm not exactly sure why this fixes the problem though.

Also it caches `BlockHeader.hashBE` as a minor optimization.