### PR TITLE
Validate key manager matches account db on wallet startup

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -117,9 +117,34 @@ abstract class Wallet
         } else FutureUtil.unit
     } yield ()
 
+  private def checkRootAccount: Future[Unit] = {
+    val coinType = HDUtil.getCoinType(keyManager.kmParams.network)
+    val coin =
+      HDCoin(purpose = keyManager.kmParams.purpose, coinType = coinType)
+    val account = HDAccount(coin = coin, index = 0)
+    // safe since we're deriving from a priv
+    val xpub = keyManager.deriveXPub(account).get
+
+    accountDAO.read(account.coin, account.index).flatMap {
+      case Some(account) =>
+        if (account.xpub != xpub) {
+          val errorMsg =
+            s"Divergent xpubs for account=$account. Existing database xpub=${account.xpub}, key manager's xpub=$xpub. " +
+              s"It is possible we have a different key manager being used than expected, key manager=$keyManager"
+          Future.failed(new RuntimeException(errorMsg))
+        } else {
+          FutureUtil.unit
+        }
+      case None =>
+        val errorMsg = s"Missing root xpub for account $account in database"
+        Future.failed(new RuntimeException(errorMsg))
+    }
+  }
+
   override def start(): Future[Wallet] = {
     for {
       _ <- walletConfig.start()
+      _ <- checkRootAccount
       _ <- downloadMissingUtxos
     } yield {
       startWalletThread()


### PR DESCRIPTION
This should not allow the wallet to startup without having your account db and key manager match.