### PR TITLE
Throw errors that occurr in startup

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
@@ -1,0 +1,34 @@
+package org.bitcoins.server
+
+import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.util.BitcoinSAsyncTest
+
+import scala.concurrent.Future
+import scala.reflect.io.Directory
+
+class ServerRunTest extends BitcoinSAsyncTest {
+
+  // Note: on this test passing it will output a stack trace
+  // because runMain calls err.printStackTrace()
+  it must "throw errors" in {
+    val datadir = BitcoinSTestAppConfig.tmpDir()
+    val directory = new Directory(datadir.toFile)
+
+    val args =
+      Vector("--datadir", datadir.toAbsolutePath.toString)
+
+    // Use Exception because different errors can occur
+    recoverToSucceededIf[Exception] {
+      val runMainF = Main.runMain(args)
+      val deleteDirF = Future {
+        Thread.sleep(2000)
+        directory.deleteRecursively()
+        Thread.sleep(2000)
+      }
+      for {
+        _ <- runMainF
+        _ <- deleteDirF
+      } yield ()
+    }
+  }
+}

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -193,6 +193,8 @@ object Main extends App with BitcoinSLogger {
     }
     startFut.failed.foreach { err =>
       logger.error(s"Error on server startup!", err)
+      err.printStackTrace()
+      sys.exit(1)
     }
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -30,7 +30,7 @@ import scala.util.Properties
 
 object Main extends App with BitcoinSLogger {
 
-  private def runMain(): Unit = {
+  def runMain(args: Vector[String]): Future[Unit] = {
     val argsWithIndex = args.zipWithIndex
 
     val dataDirIndexOpt = {
@@ -188,18 +188,21 @@ object Main extends App with BitcoinSLogger {
             logger.info(s"Stopped ${nodeConf.nodeType.shortName} node"))
         system.terminate().foreach(_ => logger.info(s"Actor system terminated"))
       }
-
-      binding
+      ()
     }
     startFut.failed.foreach { err =>
       logger.error(s"Error on server startup!", err)
       err.printStackTrace()
-      sys.exit(1)
+      throw err
     }
+    startFut
   }
 
   //start everything!
-  runMain()
+  val run = runMain(args.toVector)
+
+  run.failed.foreach(_ => sys.exit(1))(
+    scala.concurrent.ExecutionContext.Implicits.global)
 
   private def createCallbacks(wallet: Wallet)(implicit
       nodeConf: NodeAppConfig,


### PR DESCRIPTION
Since `runMain()` returns `Unit` the application would just stall on an error. This ensures that we print the stack trace of the error and exit