### PR TITLE
Rename ChainApi.nextHeaderBatchRange -> ChainApi.nextBlockHeaderBatch…

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -466,7 +466,7 @@ class ChainHandlerTest extends ChainDbUnitTest {
         bestBlock <- chainHandler.getBestBlockHeader()
         bestBlockHashBE = bestBlock.hashBE
         rangeOpt <-
-          chainHandler.nextHeaderBatchRange(DoubleSha256DigestBE.empty, 1)
+          chainHandler.nextBlockHeaderBatchRange(DoubleSha256DigestBE.empty, 1)
       } yield {
         assert(rangeOpt.nonEmpty)
         assert(rangeOpt.get._1 == 0)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -135,7 +135,7 @@ case class ChainHandler(
   }
 
   /** @inheritdoc */
-  override def nextHeaderBatchRange(
+  override def nextBlockHeaderBatchRange(
       prevStopHash: DoubleSha256DigestBE,
       batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]] = {
     val startHeightF = if (prevStopHash == DoubleSha256DigestBE.empty) {

--- a/core/src/main/scala/org/bitcoins/core/api/chain/db/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/db/ChainApi.scala
@@ -67,7 +67,7 @@ trait ChainApi extends ChainQueryApi {
   /**
     * Generates a block range in form of (startHeight, stopHash) by the given stop hash.
     */
-  def nextHeaderBatchRange(
+  def nextBlockHeaderBatchRange(
       stopHash: DoubleSha256DigestBE,
       batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]]
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -215,7 +215,7 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
       ec: ExecutionContext): Future[Boolean] = {
     for {
       nextRangeOpt <-
-        chainApi.nextHeaderBatchRange(stopHash, filterHeaderBatchSize)
+        chainApi.nextBlockHeaderBatchRange(stopHash, filterHeaderBatchSize)
       res <- nextRangeOpt match {
         case Some((startHeight, stopHash)) =>
           logger.info(

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -104,7 +104,7 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
         stopHash: DoubleSha256DigestBE): Future[ChainApi] =
       Future.successful(this)
 
-    override def nextHeaderBatchRange(
+    override def nextBlockHeaderBatchRange(
         stopHash: DoubleSha256DigestBE,
         batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]] =
       Future.successful(None)


### PR DESCRIPTION
…rnage

What does `Header` mean? We have `FilterHeader`, `BlockHeader`, `HttpHeader`, etc. Let's be explicit in `ChainApi` for what we are referring to. 

