### PR TITLE
Optimize findClosestToTime

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
@@ -115,7 +115,8 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
       val createdF = blockHeaderDAO.create(blockHeader)
 
       val headerDbsF = createdF.flatMap(_ =>
-        blockHeaderDAO.findBeforeTime(UInt32(TimeUtil.currentEpochSecond)))
+        blockHeaderDAO.findClosestBeforeTime(
+          UInt32(TimeUtil.currentEpochSecond)))
 
       headerDbsF.map { headerDbOpt =>
         assert(headerDbOpt.isDefined)

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
@@ -115,10 +115,11 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
       val createdF = blockHeaderDAO.create(blockHeader)
 
       val headerDbsF = createdF.flatMap(_ =>
-        blockHeaderDAO.findAllBeforeTime(UInt32(TimeUtil.currentEpochSecond)))
+        blockHeaderDAO.findBeforeTime(UInt32(TimeUtil.currentEpochSecond)))
 
-      headerDbsF.map { headerDbs =>
-        assert(headerDbs.size == 2)
+      headerDbsF.map { headerDbOpt =>
+        assert(headerDbOpt.isDefined)
+        assert(headerDbOpt.get.hashBE == blockHeader.hashBE)
       }
   }
 

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -207,10 +207,14 @@ case class BlockHeaderDAO()(implicit
     table.filter(header => header.height >= from && header.height <= to).result
   }
 
-  def findAllBeforeTime(time: UInt32): Future[Vector[BlockHeaderDb]] = {
-    val query = table.filter(_.time < time)
+  def findBeforeTime(time: UInt32): Future[Option[BlockHeaderDb]] = {
+    val beforeTime = table.filter(_.time < time)
 
-    database.run(query.result).map(_.toVector)
+    val maxTime = beforeTime.map(_.time).max
+
+    val query = table.filter(_.time === maxTime)
+
+    safeDatabase.run(query.result).map(_.headOption)
   }
 
   def findClosestToTime(time: UInt32): Future[BlockHeaderDb] = {
@@ -223,7 +227,13 @@ case class BlockHeaderDAO()(implicit
 
     opt.flatMap {
       case None =>
-        findAllBeforeTime(time).map(_.maxBy(_.time))
+        findBeforeTime(time).flatMap {
+          case None =>
+            Future.failed(
+              new IllegalStateException("No block headers in database."))
+          case Some(header) =>
+            Future.successful(header)
+        }
       case Some(header) =>
         Future.successful(header)
     }

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -207,7 +207,7 @@ case class BlockHeaderDAO()(implicit
     table.filter(header => header.height >= from && header.height <= to).result
   }
 
-  def findBeforeTime(time: UInt32): Future[Option[BlockHeaderDb]] = {
+  def findClosestBeforeTime(time: UInt32): Future[Option[BlockHeaderDb]] = {
     val beforeTime = table.filter(_.time < time)
 
     val maxTime = beforeTime.map(_.time).max
@@ -227,10 +227,9 @@ case class BlockHeaderDAO()(implicit
 
     opt.flatMap {
       case None =>
-        findBeforeTime(time).flatMap {
+        findClosestBeforeTime(time).flatMap {
           case None =>
-            Future.failed(
-              new IllegalStateException("No block headers in database."))
+            Future.failed(new RuntimeException("No block headers in database."))
           case Some(header) =>
             Future.successful(header)
         }


### PR DESCRIPTION
Found this while looking through for places to use `_.maxByOption`. Here we are loading in every header before a given time, then doing the computation. Instead changed it to do that in the SQL query