### PR TITLE
 Rework ChainHandler.nextBlockHeadersBatchRange() to make sure the stopHash we return is in the best chain we have

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
@@ -2,7 +2,7 @@ package org.bitcoins.core.api.chain.db
 
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 
 case class BlockHeaderDb(
     height: Int,
@@ -27,6 +27,8 @@ case class BlockHeaderDb(
 
     blockHeader
   }
+
+  lazy val hash: DoubleSha256Digest = hashBE.flip
 }
 
 object BlockHeaderDbHelper {

--- a/core/src/main/scala/org/bitcoins/core/api/chain/db/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/db/ChainApi.scala
@@ -68,7 +68,7 @@ trait ChainApi extends ChainQueryApi {
     * Generates a block range in form of (startHeight, stopHash) by the given stop hash.
     */
   def nextBlockHeaderBatchRange(
-      stopHash: DoubleSha256DigestBE,
+      prevStopHash: DoubleSha256DigestBE,
       batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]]
 
   /**


### PR DESCRIPTION
Attempts to fix #1919 

Previously inside of `ChainHandler.nextBlockHeaderBatchRange` we wouldn't check that the `stopHash` we were returning is _actually_ part of our best blockchain. This fixes this problem. I'm wondering if this problem happens with `ChainHandler.nextFilterHeaderBatchRange()` we as well, but i haven't investigated. 

