### PR TITLE
Resolve issues with reorgs and syncing filters

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -315,14 +315,9 @@ class ChainHandlerTest extends ChainDbUnitTest {
         rangeOpt <-
           chainHandler.nextBlockHeaderBatchRange(DoubleSha256DigestBE.empty, 1)
       } yield {
-        println(s"Checking range=${rangeOpt}")
         assert(rangeOpt.nonEmpty)
-        println(s"Checking range2=${rangeOpt}")
         assert(rangeOpt.get._1 == 0)
-        println(s"Checking range3=${rangeOpt}")
         assert(rangeOpt.get._2 == genesisHeader.hash)
-        println(s"Checking range4=${rangeOpt}")
-        succeed
       }
 
       //let's process a block header, and then be able to fetch that header as the last stopHash
@@ -335,21 +330,18 @@ class ChainHandlerTest extends ChainDbUnitTest {
 
       val blockHeader = BlockHeaderHelper.buildNextHeader(blockHeaderDb)
       val chainApi2 = assert1F.flatMap { _ =>
-        println(s"assert1 done")
         chainHandler.processHeader(blockHeader.blockHeader)
-      }(scala.concurrent.ExecutionContext.Implicits.global)
+      }
 
       for {
         chainApi <- chainApi2
-        _ = println(s"assert2")
         rangeOpt <-
-          chainApi.nextBlockHeaderBatchRange(DoubleSha256DigestBE.empty, 2)
+          chainApi.nextBlockHeaderBatchRange(DoubleSha256DigestBE.empty, 1)
       } yield {
         assert(rangeOpt.nonEmpty)
         assert(rangeOpt.get._1 == 0)
         assert(rangeOpt.get._2 == blockHeader.hash)
       }
-
   }
 
   it must "generate the correct range of block filters if a header is reorged" in {
@@ -396,7 +388,7 @@ class ChainHandlerTest extends ChainDbUnitTest {
         assert(blockHeaderBatchOpt.isDefined)
         val Some((height, hash)) = blockHeaderBatchOpt
         assert(headerC.height == height)
-        assert(headerC.hash == hash)
+        assert(headerD.hash == hash)
       }
 
   }

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -310,14 +310,14 @@ class ChainHandlerTest extends ChainDbUnitTest {
   it must "generate a range for a block filter query" in {
     chainHandler: ChainHandler =>
       for {
-        bestBlock <- chainHandler.getBestBlockHeader()
-        bestBlockHashBE = bestBlock.hashBE
         rangeOpt <-
           chainHandler.nextBlockHeaderBatchRange(DoubleSha256DigestBE.empty, 1)
       } yield {
+        val genesisHash =
+          chainHandler.chainConfig.chain.genesisBlock.blockHeader.hash
         assert(rangeOpt.nonEmpty)
         assert(rangeOpt.get._1 == 0)
-        assert(rangeOpt.get._2 == bestBlockHashBE.flip)
+        assert(rangeOpt.get._2 == genesisHash)
       }
   }
 
@@ -334,6 +334,7 @@ class ChainHandlerTest extends ChainDbUnitTest {
       val assert1F = for {
         chainHandler <- chainHandlerF
         newHeaderB <- newHeaderBF
+        newHeaderC <- newHeaderCF
         blockHeaderBatchOpt <- chainHandler.nextBlockHeaderBatchRange(
           prevStopHash = ChainTestUtil.regTestGenesisHeaderDb.hashBE,
           batchSize = batchSize)

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -321,6 +321,54 @@ class ChainHandlerTest extends ChainDbUnitTest {
       }
   }
 
+  it must "generate the correct range of block filters if a header is reorged" in {
+    chainHandler: ChainHandler =>
+      val reorgFixtureF = buildChainHandlerCompetingHeaders(chainHandler)
+      val chainHandlerF = reorgFixtureF.map(_.chainApi)
+      val newHeaderBF = reorgFixtureF.map(_.headerDb1)
+      val newHeaderCF = reorgFixtureF.map(_.headerDb2)
+      val batchSize = 100
+
+      //two competing headers B,C built off of A
+      //so just pick the first headerB to be our next block header batch
+      val assert1F = for {
+        chainHandler <- chainHandlerF
+        newHeaderB <- newHeaderBF
+        blockHeaderBatchOpt <- chainHandler.nextBlockHeaderBatchRange(
+          prevStopHash = ChainTestUtil.regTestGenesisHeaderDb.hashBE,
+          batchSize = batchSize)
+        count <- chainHandler.getBlockCount()
+      } yield {
+        assert(count == 1)
+        assert(blockHeaderBatchOpt.isDefined)
+        val Some((height, hash)) = blockHeaderBatchOpt
+        assert(newHeaderB.hash == hash)
+        assert(newHeaderB.height == height)
+      }
+
+      //now let's build a new block header ontop of C and process it
+      //when we call chainHandler.nextBlockHeaderBatchRange it
+      //should be C's hash instead of B's hash
+      for {
+        _ <- assert1F
+        chainHandler <- chainHandlerF
+        headerC <- newHeaderCF
+        headerD = BlockHeaderHelper.buildNextHeader(headerC)
+        chainApiD <- chainHandler.processHeader(headerD.blockHeader)
+        blockHeaderBatchOpt <- chainApiD.nextBlockHeaderBatchRange(
+          prevStopHash = ChainTestUtil.regTestGenesisHeaderDb.hashBE,
+          batchSize = batchSize)
+        count <- chainApiD.getBlockCount()
+      } yield {
+        assert(count == 2)
+        assert(blockHeaderBatchOpt.isDefined)
+        val Some((height, hash)) = blockHeaderBatchOpt
+        assert(headerC.height == height)
+        assert(headerC.hash == hash)
+      }
+
+  }
+
   it must "generate a range for a block filter header query" in {
     chainHandler: ChainHandler =>
       for {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -265,7 +265,9 @@ case class ChainHandler(
   override def processFilterHeaders(
       filterHeaders: Vector[FilterHeader],
       stopHash: DoubleSha256DigestBE): Future[ChainApi] = {
-
+    filterHeaders.foreach { header =>
+      println(s"Processing filter header=$header")
+    }
     val filterHeadersToCreateF: Future[Vector[CompactFilterHeaderDb]] = for {
       blockHeaders <-
         blockHeaderDAO

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -174,6 +174,9 @@ case class ChainHandler(
     }
   }
 
+  /** Finds the next header in the chain. Uses chain work to break ties
+    * returning only the header in the chain with the most work
+    */
   private def findNextHeader(
       prevBlockHeader: BlockHeaderDb,
       batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]] = {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -186,9 +186,10 @@ case class ChainHandler(
     prevBlockHeaderOpt match {
       case None =>
         val hashHeightOpt = {
-          val chainsF = blockHeaderDAO.getBlockchainsBetweenHeights(from = 0,
-                                                                    to =
-                                                                      batchSize)
+          val chainsF = blockHeaderDAO.getBlockchainsBetweenHeights(
+            from = 0,
+            to =
+              batchSize - 1)
           for {
             chains <- chainsF
           } yield {
@@ -253,7 +254,6 @@ case class ChainHandler(
           .map(h => (startHeight, h.hash))
       }
     }
-
     hashHeightOpt
   }
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -150,27 +150,20 @@ case class ChainHandler(
   override def nextBlockHeaderBatchRange(
       prevStopHash: DoubleSha256DigestBE,
       batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]] = {
-    val prevBlockHeaderOptF: Future[Option[BlockHeaderDb]] = {
-      for {
-        prevStopHeaderOpt <- getHeader(prevStopHash)
-      } yield prevStopHeaderOpt
-    }
 
     for {
-      prevBlockHeaderOpt <- prevBlockHeaderOptF
-
+      prevBlockHeaderOpt <- getHeader(prevStopHash)
       headerOpt <- prevBlockHeaderOpt match {
         case Some(_) =>
           findNextHeader(prevBlockHeaderOpt, batchSize)
         case None =>
-          val result = if (prevStopHash == DoubleSha256DigestBE.empty) {
+          if (prevStopHash == DoubleSha256DigestBE.empty) {
             for {
               next <- findNextHeader(None, batchSize)
             } yield next
           } else {
             Future.successful(None)
           }
-          result
       }
     } yield {
       headerOpt

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -239,7 +239,7 @@ case class ChainHandler(
       blockchains: Vector[Blockchain]): Option[(Int, DoubleSha256Digest)] = {
     //ok, we need to select the header that is contained in the chain
     //with the most chain work
-    val targetHeight = startHeight + batchSize
+    val targetHeight = startHeight + batchSize - 1
     val mostWorkChainOpt = org.bitcoins.core
       .seqUtil(blockchains)
       .maxByOption(_.tip.chainWork)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/FilterSync.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/FilterSync.scala
@@ -86,11 +86,11 @@ abstract class FilterSync extends ChainVerificationLogger {
     }
     if (firstBlockHash == ourBestHeader.hashBE) {
       logger.info(
-        s"Our filters are synced with our peers filters, both at blockHash=${firstBlockHash}")
+        s"Our filters are synced with our peers filters, both at blockHash=${firstBlockHash.hex}")
       Future.successful(chainApi)
     } else {
       logger.info(
-        s"Beginning sync for filters from filterheader=${firstBlockHash} to blockheader=${ourBestHeader.hashBE}")
+        s"Beginning sync for filters from filterheader=${firstBlockHash.hex} to blockheader=${ourBestHeader.hashBE.hex}")
       //let's fetch all missing filter headers first
       val bestFilterBlockHeaderF =
         chainApi.getHeader(firstBlockHash)

--- a/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
@@ -2,7 +2,7 @@ package org.bitcoins.core.api.chain.db
 
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 
 case class BlockHeaderDb(
     height: Int,
@@ -27,6 +27,8 @@ case class BlockHeaderDb(
 
     blockHeader
   }
+
+  lazy val hash: DoubleSha256Digest = hashBE.flip
 }
 
 object BlockHeaderDbHelper {

--- a/core/src/main/scala/org/bitcoins/core/api/chain/db/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/db/ChainApi.scala
@@ -68,7 +68,7 @@ trait ChainApi extends ChainQueryApi {
     * Generates a block range in form of (startHeight, stopHash) by the given stop hash.
     */
   def nextBlockHeaderBatchRange(
-      stopHash: DoubleSha256DigestBE,
+      prevStopHash: DoubleSha256DigestBE,
       batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]]
 
   /**

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -128,6 +128,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
       for {
         _ <- node.sync()
         _ <- NodeTestUtil.awaitSync(node, bitcoind)
+        _ <- NodeTestUtil.awaitCompactFilterHeadersSync(node, bitcoind)
         _ <- NodeTestUtil.awaitCompactFiltersSync(node, bitcoind)
 
         // send
@@ -201,7 +202,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
       } yield assert(txs.exists(_.txIdBE == txSent.txIdBE))
   }
 
-  it must "rescan and receive information about received payments" taggedAs UsesExperimentalBitcoind in {
+  it must "rescan information about received payments" taggedAs UsesExperimentalBitcoind in {
     param =>
       val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind, _) = param
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -125,7 +125,9 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
         )
       }
 
+      val countF = node.chainApiFromDb().flatMap(_.getFilterHeaderCount)
       for {
+        count <- countF
         _ <- node.sync()
         _ <- NodeTestUtil.awaitSync(node, bitcoind)
         _ <- NodeTestUtil.awaitCompactFilterHeadersSync(node, bitcoind)

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -71,7 +71,7 @@ case class NeutrinoNode(
         peerMsgSender.sendNextGetCompactFilterHeadersCommand(
           chainApi = chainApi,
           filterHeaderBatchSize = chainConfig.filterHeaderBatchSize,
-          stopHash = header.hashBE)
+          prevStopHash = header.hashBE)
 
         // If we have started syncing filters
         if (filterCount != filterHeaderCount)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -334,7 +334,7 @@ case class DataMessageHandler(
             .map(_ => true)
         case None =>
           sys.error(
-            s"Could not find block header in database to sync filter headers from!")
+            s"Could not find block header in database to sync filter headers from! It's likely your database is corrupted")
       }
     } yield res
   }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -221,13 +221,6 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
       _ = stopHash.flip
       res <- nextRangeOpt match {
         case Some((startHeight, stopHash)) =>
-          println(s"startHeight=${startHeight} stopHash=${stopHash.flip}")
-          chainApi.getHeader(stopHash.flip).map { header =>
-            println(s"stophash.header=${header}")
-          }
-          chainApi.getFilterHeaderCount().map { count =>
-            println(s"filterHeader.count=${count}")
-          }
           logger.info(
             s"Requesting compact filter headers from=$startHeight to=${stopHash.flip}")
           sendGetCompactFilterHeadersMessage(startHeight, stopHash)

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -11,12 +11,14 @@ import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models._
 import org.bitcoins.chain.pow.Pow
 import org.bitcoins.core.api.chain.db._
+import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.db.AppConfig
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.testkit.chain.ChainUnitTest.createChainHandler
 import org.bitcoins.testkit.chain.fixture._
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.node.CachedChainAppConfig
@@ -177,6 +179,11 @@ trait ChainUnitTest
                 () => ChainUnitTest.destroyAllTables)(test)
   }
 
+  def withChainHandlerGenesisFilter(test: OneArgAsyncTest): FutureOutcome = {
+    makeFixture(() => createChainHandlerWithGenesisFilter(),
+                () => ChainUnitTest.destroyAllTables())(test)
+  }
+
   /** Creates and populates BlockHeaderTable with block headers 562375 to 571375 */
   def createPopulatedChainHandler(): Future[ChainHandler] = {
     for {
@@ -188,6 +195,17 @@ trait ChainUnitTest
                                                   filterHeaderDAO,
                                                 filterDAO = filterDAO)
     } yield chainHandler
+  }
+
+  def createChainHandlerWithGenesisFilter(): Future[ChainHandler] = {
+    for {
+      chainHandler <- createChainHandler()
+      filterHeaderChainApi <- chainHandler.processFilterHeader(
+        ChainUnitTest.genesisFilterHeaderDb.filterHeader,
+        ChainUnitTest.genesisHeaderDb.hashBE)
+      filterChainApi <-
+        filterHeaderChainApi.processFilter(ChainUnitTest.genesisFilterMessage)
+    } yield filterChainApi.asInstanceOf[ChainHandler]
   }
 
   def withPopulatedChainHandler(test: OneArgAsyncTest): FutureOutcome = {
@@ -388,6 +406,12 @@ object ChainUnitTest extends ChainVerificationLogger {
 
   val genesisFilterHeaderDb: CompactFilterHeaderDb =
     ChainTestUtil.regTestGenesisHeaderCompactFilterHeaderDb
+
+  val genesisFilterMessage: CompactFilterMessage = {
+    CompactFilterMessage(filterType = genesisFilterDb.filterType,
+                         blockHash = genesisFilterDb.blockHashBE.flip,
+                         filterBytes = genesisFilterDb.golombFilter.bytes)
+  }
 
   def createChainHandler()(implicit
       ec: ExecutionContext,
@@ -590,8 +614,8 @@ object ChainUnitTest extends ChainVerificationLogger {
       for {
         chainHandler <- chainHandlerF
         genHeader <- chainHandler.blockHeaderDAO.create(genesisHeaderDb)
-        _ <- chainHandler.filterHeaderDAO.create(genesisFilterHeaderDb)
-        _ <- chainHandler.filterDAO.create(genesisFilterDb)
+        //_ <- chainHandler.filterHeaderDAO.create(genesisFilterHeaderDb)
+        //_ <- chainHandler.filterDAO.create(genesisFilterDb)
       } yield genHeader
     }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -338,13 +338,16 @@ trait ChainUnitTest
   /** Builds two competing headers that are built from the same parent */
   private def buildCompetingHeaders(
       parent: BlockHeaderDb): (BlockHeader, BlockHeader) = {
-    val newHeaderB =
+    val newHeaderCandidate1 =
       BlockHeaderHelper.buildNextHeader(parent)
 
-    val newHeaderC =
+    val newHeaderCandidate2 =
       BlockHeaderHelper.buildNextHeader(parent)
-
-    (newHeaderB.blockHeader, newHeaderC.blockHeader)
+    if (newHeaderCandidate1.chainWork >= newHeaderCandidate2.chainWork) {
+      (newHeaderCandidate1.blockHeader, newHeaderCandidate2.blockHeader)
+    } else {
+      (newHeaderCandidate2.blockHeader, newHeaderCandidate1.blockHeader)
+    }
   }
 
   case class ReorgFixture(

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -614,8 +614,6 @@ object ChainUnitTest extends ChainVerificationLogger {
       for {
         chainHandler <- chainHandlerF
         genHeader <- chainHandler.blockHeaderDAO.create(genesisHeaderDb)
-        //_ <- chainHandler.filterHeaderDAO.create(genesisFilterHeaderDb)
-        //_ <- chainHandler.filterDAO.create(genesisFilterDb)
       } yield genHeader
     }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainFixture.scala
@@ -22,6 +22,12 @@ object ChainFixture {
   case class GenisisChainHandler(chainHandler: ChainHandler)
       extends ChainFixture
 
+  /** Genesis chain handler, but has both genesis [[org.bitcoins.core.api.chain.db.CompactFilterHeaderDb]] and
+    * [[org.bitcoins.core.api.chain.db.CompactFilterDb]] inserted into their respective tables
+    */
+  case class GenesisChainHandlerWithGenesisFilters(chainHandler: ChainHandler)
+      extends ChainFixture
+
   case class PopulatedChainHandler(chainHandler: ChainHandler)
       extends ChainFixture
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainFixtureHelper.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainFixtureHelper.scala
@@ -4,6 +4,7 @@ import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.chain.fixture.ChainFixture.{
   BitcoindZmqChainHandlerWithBlock,
   Empty,
+  GenesisChainHandlerWithGenesisFilters,
   GenisisBlockHeaderDAO,
   GenisisChainHandler,
   PopulatedBlockHeaderDAO,
@@ -19,6 +20,7 @@ trait ChainFixtureHelper { this: ChainUnitTest =>
       case ChainFixtureTag.Empty => Future.successful(ChainFixture.Empty)
       case ChainFixtureTag.GenisisBlockHeaderDAO =>
         ChainUnitTest.createBlockHeaderDAO().map(GenisisBlockHeaderDAO.apply)
+
       case ChainFixtureTag.PopulatedBlockHeaderDAO =>
         ChainUnitTest
           .createPopulatedBlockHeaderDAO()
@@ -28,6 +30,9 @@ trait ChainFixtureHelper { this: ChainUnitTest =>
       case ChainFixtureTag.PopulatedChainHandler =>
         createPopulatedChainHandler().map(
           ChainFixture.PopulatedChainHandler.apply)
+      case ChainFixtureTag.GenesisChainHandlerWithFilter =>
+        createChainHandlerWithGenesisFilter()
+          .map(ChainFixture.GenesisChainHandlerWithGenesisFilters(_))
       case ChainFixtureTag.BitcoindZmqChainHandlerWithBlock =>
         createBitcoindChainHandlerViaZmq().map(
           BitcoindZmqChainHandlerWithBlock.apply)
@@ -40,7 +45,9 @@ trait ChainFixtureHelper { this: ChainUnitTest =>
       case GenisisBlockHeaderDAO(_)   => ChainUnitTest.destroyAllTables()
       case PopulatedBlockHeaderDAO(_) => ChainUnitTest.destroyAllTables()
       case GenisisChainHandler(_)     => ChainUnitTest.destroyAllTables()
-      case PopulatedChainHandler(_)   => ChainUnitTest.destroyAllTables()
+      case GenesisChainHandlerWithGenesisFilters(_) =>
+        ChainUnitTest.destroyAllTables()
+      case PopulatedChainHandler(_) => ChainUnitTest.destroyAllTables()
       case BitcoindZmqChainHandlerWithBlock(bitcoindHandler) =>
         destroyBitcoindChainHandlerViaZmq(bitcoindHandler)
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainFixtureTag.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainFixtureTag.scala
@@ -21,6 +21,12 @@ object ChainFixtureTag {
 
   case object GenisisChainHandler extends ChainFixtureTag("GenisisChainHandler")
 
+  /** Creates the genesis block header and genesis [[org.bitcoins.core.api.chain.db.CompactFilterHeaderDb]]
+    * and [[org.bitcoins.core.api.chain.db.CompactFilterDb]]
+    */
+  case object GenesisChainHandlerWithFilter
+      extends ChainFixtureTag("GenesisChainHandlerWithFilter")
+
   case object PopulatedChainHandler
       extends ChainFixtureTag("PopulatedChainHandler")
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -125,7 +125,6 @@ abstract class NodeTestUtil extends P2PLogger {
       filterCount <- node.chainApiFromDb().flatMap(_.getFilterCount)
       blockCount <- rpcCountF
     } yield {
-      //println(s"filterCount=${filterCount} blockCount=${blockCount}")
       blockCount == filterCount
     }
   }
@@ -137,8 +136,6 @@ abstract class NodeTestUtil extends P2PLogger {
       filterHeaderCount <- node.chainApiFromDb().flatMap(_.getFilterHeaderCount)
       blockCount <- rpcCountF
     } yield {
-      /*      println(
-        s"blockCount=${blockCount} filterHeaderCount=${filterHeaderCount}")*/
       blockCount == filterHeaderCount
     }
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -125,6 +125,7 @@ abstract class NodeTestUtil extends P2PLogger {
       filterCount <- node.chainApiFromDb().flatMap(_.getFilterCount)
       blockCount <- rpcCountF
     } yield {
+      println(s"filterCount=${filterCount} blockCount=${blockCount}")
       blockCount == filterCount
     }
   }
@@ -136,6 +137,8 @@ abstract class NodeTestUtil extends P2PLogger {
       filterHeaderCount <- node.chainApiFromDb().flatMap(_.getFilterHeaderCount)
       blockCount <- rpcCountF
     } yield {
+      println(
+        s"blockCount=${blockCount} filterHeaderCount=${filterHeaderCount}")
       blockCount == filterHeaderCount
     }
   }
@@ -149,7 +152,9 @@ abstract class NodeTestUtil extends P2PLogger {
     for {
       count <- node.chainApiFromDb().flatMap(_.getBlockCount)
       rpcCount <- rpcCountF
-    } yield rpcCount == count
+    } yield {
+      rpcCount == count
+    }
   }
 
   /** Awaits sync between the given node and bitcoind client */

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -125,7 +125,7 @@ abstract class NodeTestUtil extends P2PLogger {
       filterCount <- node.chainApiFromDb().flatMap(_.getFilterCount)
       blockCount <- rpcCountF
     } yield {
-      println(s"filterCount=${filterCount} blockCount=${blockCount}")
+      //println(s"filterCount=${filterCount} blockCount=${blockCount}")
       blockCount == filterCount
     }
   }
@@ -137,8 +137,8 @@ abstract class NodeTestUtil extends P2PLogger {
       filterHeaderCount <- node.chainApiFromDb().flatMap(_.getFilterHeaderCount)
       blockCount <- rpcCountF
     } yield {
-      println(
-        s"blockCount=${blockCount} filterHeaderCount=${filterHeaderCount}")
+      /*      println(
+        s"blockCount=${blockCount} filterHeaderCount=${filterHeaderCount}")*/
       blockCount == filterHeaderCount
     }
   }


### PR DESCRIPTION
This pulls over test cases from #1962 

fixes #1965 

Basically it tests `ChainHandler.nextBlockHeaderRange()` in the case of reorgs. 

EDIT: 

So here is what is all done in this PR

1. Removes the insertion of the genesis filter header and the genesis filter in the test fixtures
2. Due to this, we create a new test fixture called `withChainHandlerGenesisFilter()` for uses where we want the gensis filter header and filter inserted
3. Makes all of our syncing code work with syncing the genesis filter header and filter from our data source
4. Adds unit tests to make sure filter header reorgs work.