### PR TITLE
Use randomized fee rates for wallet tests

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTTest.scala
@@ -181,7 +181,7 @@ class PSBTTest extends BitcoinSAsyncTest {
           creditingTxsInfo.foldLeft(0L)(_ + _.amount.satoshis.toLong)
         val spending = destinations.foldLeft(0L)(_ + _.value.satoshis.toLong)
         val maxFee = crediting - spending
-        val fee = GenUtil.sample(CurrencyUnitGenerator.feeUnit(maxFee))
+        val fee = GenUtil.sample(FeeUnitGen.feeUnit(maxFee))
         for {
           (psbt, _, _) <-
             PSBTGenerators.psbtAndBuilderFromInputs(finalized = false,

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/ShufflingNonInteractiveFinalizerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/ShufflingNonInteractiveFinalizerTest.scala
@@ -18,6 +18,7 @@ import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.{
   CreditingTxGen,
   CurrencyUnitGenerator,
+  FeeUnitGen,
   ScriptGenerators
 }
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
@@ -194,7 +195,7 @@ class ShufflingNonInteractiveFinalizerTest extends BitcoinSAsyncTest {
 
   it must "create a shuffled transaction with a ShufflingNonInteractiveFinalizer" in {
     forAllAsync(CreditingTxGen.inputsAndOutputs(),
-                CurrencyUnitGenerator.feeUnit(100),
+                FeeUnitGen.feeUnit(100),
                 ScriptGenerators.scriptPubKey) {
       case ((inputs, outputs), feeRate, (changeSpk, _)) =>
         val txsF =

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -42,6 +42,8 @@ trait WalletApi extends StartStopAsync[WalletApi] {
   def broadcastTransaction(transaction: Transaction): Future[Unit] =
     nodeApi.broadcastTransaction(transaction)
 
+  def getFeeRate: Future[FeeUnit] = feeRateApi.getFeeRate
+
   def start(): Future[WalletApi]
 
   def stop(): Future[WalletApi]

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/OutgoingTransactionDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/OutgoingTransactionDb.scala
@@ -39,14 +39,16 @@ object OutgoingTransactionDb {
       s"sentAmount ($sentAmount) cannot be greater than the amount the wallet input ($inputAmount)")
 
     val feePaid = inputAmount - totalOutput
-    val feeRate = feePaid.satoshis.toLong / tx.baseSize.toDouble
+
+    // Calculate fee rate in satoshis per byte
+    val feeRate = feePaid.satoshis.toLong / tx.byteSize.toDouble
     OutgoingTransactionDb(
       tx.txIdBE,
       inputAmount,
       sentAmount,
       feePaid,
       expectedFee,
-      SatoshisPerByte.fromLong(feeRate.toLong)
+      SatoshisPerByte.fromLong(Math.round(feeRate))
     )
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CurrencyUnitGenerator.scala
@@ -8,40 +8,8 @@ import org.bitcoins.core.currency.{
 }
 import org.bitcoins.core.protocol.ln.currency._
 import org.scalacheck.Gen
-import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.core.wallet.fee.SatoshisPerByte
-import org.bitcoins.core.wallet.fee.SatoshisPerKiloByte
-import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 
 trait CurrencyUnitGenerator {
-
-  def satsPerByte: Gen[SatoshisPerByte] = {
-    for {
-      curr <- positiveRealistic
-    } yield SatoshisPerByte(curr)
-  }
-
-  def satsPerKiloByte: Gen[SatoshisPerKiloByte] = {
-    for {
-      curr <- positiveRealistic
-    } yield SatoshisPerKiloByte(curr)
-  }
-
-  def satsPerVirtualByte: Gen[SatoshisPerVirtualByte] = {
-    for {
-      curr <- positiveRealistic
-    } yield SatoshisPerVirtualByte(curr)
-  }
-
-  def feeUnit: Gen[FeeUnit] =
-    Gen.oneOf(satsPerByte, satsPerKiloByte, satsPerVirtualByte)
-
-  /** Generates a FeeUnit based on the maxFee allowed for a transaction */
-  def feeUnit(maxFee: Long): Gen[FeeUnit] = {
-    Gen.choose(0L, maxFee / 10000L).map { n =>
-      SatoshisPerKiloByte(Satoshis(n))
-    }
-  }
 
   def satoshis: Gen[Satoshis] =
     for {

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/FeeUnitGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/FeeUnitGen.scala
@@ -8,31 +8,31 @@ abstract class FeeUnitGen {
 
   def satsPerByte: Gen[SatoshisPerByte] = {
     for {
-      curr <- fee
+      curr <- realisticFee
     } yield SatoshisPerByte(curr)
   }
 
   def satsPerKiloByte: Gen[SatoshisPerKiloByte] = {
     for {
-      curr <- fee
+      curr <- realisticFee
     } yield SatoshisPerKiloByte(curr * 1000)
   }
 
   def satsPerKiloWeight: Gen[SatoshisPerKW] = {
     for {
-      curr <- fee
+      curr <- realisticFee
     } yield SatoshisPerKW(curr * 1000)
   }
 
   def satsPerVirtualByte: Gen[SatoshisPerVirtualByte] = {
     for {
-      curr <- fee
+      curr <- realisticFee
     } yield SatoshisPerVirtualByte(curr)
   }
 
   /** Choose between different sets of Satoshi sizes so we get a better distribution */
-  private def fee: Gen[Satoshis] = {
-    Gen.oneOf(realisticFee, highFee, exorbitantFee)
+  private def realisticFee: Gen[Satoshis] = {
+    Gen.oneOf(lowFee, highFee, exorbitantFee)
   }
 
   /** Max fee between 101 - 100 sats. So we can have
@@ -40,7 +40,7 @@ abstract class FeeUnitGen {
     * 2. 100 sats/vbyte
     * 3. 100 sats/kb
     */
-  private def realisticFee: Gen[Satoshis] = {
+  private def lowFee: Gen[Satoshis] = {
     Gen
       .choose(0, 100)
       .map(Satoshis(_))

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/FeeUnitGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/FeeUnitGen.scala
@@ -1,0 +1,88 @@
+package org.bitcoins.testkit.core.gen
+
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.wallet.fee._
+import org.scalacheck.Gen
+
+abstract class FeeUnitGen {
+
+  def satsPerByte: Gen[SatoshisPerByte] = {
+    for {
+      curr <- fee
+    } yield SatoshisPerByte(curr)
+  }
+
+  def satsPerKiloByte: Gen[SatoshisPerKiloByte] = {
+    for {
+      curr <- fee
+    } yield SatoshisPerKiloByte(curr * 1000)
+  }
+
+  def satsPerKiloWeight: Gen[SatoshisPerKW] = {
+    for {
+      curr <- fee
+    } yield SatoshisPerKW(curr * 1000)
+  }
+
+  def satsPerVirtualByte: Gen[SatoshisPerVirtualByte] = {
+    for {
+      curr <- fee
+    } yield SatoshisPerVirtualByte(curr)
+  }
+
+  /** Choose between different sets of Satoshi sizes so we get a better distribution */
+  private def fee: Gen[Satoshis] = {
+    Gen.oneOf(realisticFee, highFee, exorbitantFee)
+  }
+
+  /** Max fee between 101 - 100 sats. So we can have
+    * 1. 100 sats/byte
+    * 2. 100 sats/vbyte
+    * 3. 100 sats/kb
+    */
+  private def realisticFee: Gen[Satoshis] = {
+    Gen
+      .choose(0, 100)
+      .map(Satoshis(_))
+  }
+
+  /** Max fee between 0 - 300 sats. So we can have
+    * 1. 300 sats/byte
+    * 2. 300 sats/vbyte
+    * 3. 300 sats/kb
+    */
+  private def highFee: Gen[Satoshis] = {
+    Gen
+      .choose(101, 300)
+      .map(Satoshis(_))
+  }
+
+  /** Max fee between 301 - 1,000 sats. So we can have
+    * 1. 1,000 sats/byte
+    * 2. 1,000 sats/vbyte
+    * 3. 1,000 sats/kb
+    *
+    * Anything higher can cause a bitcoind to reject the transaction
+    * for paying too high a fee
+    */
+  private def exorbitantFee: Gen[Satoshis] = {
+    Gen
+      .choose(301, 1000)
+      .map(Satoshis(_))
+  }
+
+  def feeUnit: Gen[FeeUnit] =
+    Gen.oneOf(satsPerByte,
+              satsPerKiloByte,
+              satsPerVirtualByte,
+              satsPerKiloWeight)
+
+  /** Generates a FeeUnit based on the maxFee allowed for a transaction */
+  def feeUnit(maxFee: Long): Gen[FeeUnit] = {
+    Gen.choose(0L, maxFee / 10000L).map { n =>
+      SatoshisPerKiloByte(Satoshis(n))
+    }
+  }
+}
+
+object FeeUnitGen extends FeeUnitGen

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/PSBTGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/PSBTGenerators.scala
@@ -226,7 +226,7 @@ object PSBTGenerators {
         val spending = destinations.foldLeft(0L)(_ + _.value.satoshis.toLong)
         crediting - spending
       }
-      fee <- CurrencyUnitGenerator.feeUnit(maxFee)
+      fee <- FeeUnitGen.feeUnit(maxFee)
     } yield {
       psbtAndBuilderFromInputs(finalized = finalized,
                                creditingTxsInfo = creditingTxsInfo,
@@ -253,7 +253,7 @@ object PSBTGenerators {
         val spending = destinations.foldLeft(0L)(_ + _.value.satoshis.toLong)
         crediting - spending
       }
-      fee <- CurrencyUnitGenerator.feeUnit(maxFee)
+      fee <- FeeUnitGen.feeUnit(maxFee)
     } yield {
       val pAndB = psbtAndBuilderFromInputs(finalized = finalized,
                                            creditingTxsInfo = creditingTxsInfo,

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
@@ -32,8 +32,8 @@ object ControlMessageGenerator {
 
   def feeFilterMessage: Gen[FeeFilterMessage] = {
     for {
-      fee <- CurrencyUnitGenerator.feeUnit.suchThat(
-        !_.isInstanceOf[SatoshisPerVirtualByte])
+      fee <-
+        FeeUnitGen.feeUnit.suchThat(!_.isInstanceOf[SatoshisPerVirtualByte])
     } yield fee match {
       case fee: SatoshisPerByte     => FeeFilterMessage(fee)
       case fee: SatoshisPerKiloByte => FeeFilterMessage(fee)

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
@@ -32,10 +32,7 @@ object ControlMessageGenerator {
 
   def feeFilterMessage: Gen[FeeFilterMessage] = {
     for {
-      fee <- FeeUnitGen.feeUnit.suchThat(feeRate =>
-        !feeRate
-          .isInstanceOf[SatoshisPerVirtualByte] && !feeRate
-          .isInstanceOf[SatoshisPerKW])
+      fee <- Gen.oneOf(FeeUnitGen.satsPerByte, FeeUnitGen.satsPerKiloByte)
     } yield fee match {
       case fee: SatoshisPerByte     => FeeFilterMessage(fee)
       case fee: SatoshisPerKiloByte => FeeFilterMessage(fee)

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/p2p/ControlMessageGenerator.scala
@@ -32,8 +32,10 @@ object ControlMessageGenerator {
 
   def feeFilterMessage: Gen[FeeFilterMessage] = {
     for {
-      fee <-
-        FeeUnitGen.feeUnit.suchThat(!_.isInstanceOf[SatoshisPerVirtualByte])
+      fee <- FeeUnitGen.feeUnit.suchThat(feeRate =>
+        !feeRate
+          .isInstanceOf[SatoshisPerVirtualByte] && !feeRate
+          .isInstanceOf[SatoshisPerKW])
     } yield fee match {
       case fee: SatoshisPerByte     => FeeFilterMessage(fee)
       case fee: SatoshisPerKiloByte => FeeFilterMessage(fee)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -10,8 +10,8 @@ import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.BlockFilter
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.core.util.{FutureUtil, TimeUtil}
-import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
+import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.wallet.fee._
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.db.AppConfig
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
@@ -19,7 +19,9 @@ import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.server.BitcoinSAppConfig._
+import org.bitcoins.testkit.Implicits.GeneratorOps
 import org.bitcoins.testkit.chain.SyncUtil
+import org.bitcoins.testkit.core.gen.FeeUnitGen
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
 import org.bitcoins.testkit.util.FileUtil
@@ -29,8 +31,8 @@ import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.{Wallet, WalletCallbacks, WalletLogger}
 import org.scalatest._
 
-import scala.concurrent.duration._
 import scala.concurrent._
+import scala.concurrent.duration._
 
 trait BitcoinSWalletTest
     extends BitcoinSFixture
@@ -375,14 +377,15 @@ object BitcoinSWalletTest extends WalletLogger {
     }
   }
 
-  private[testkit] class RandomFeeProvider extends FeeRateApi {
-    private val rnd = new scala.util.Random(TimeUtil.now.toEpochMilli)
-    private val start = 2
-    private val end = 100
+  private[bitcoins] class RandomFeeProvider extends FeeRateApi {
+    // Useful for tests
+    var lastFeeRate: Option[FeeUnit] = None
 
     def getFeeRate: Future[FeeUnit] = {
-      val satoshis = Satoshis(start + rnd.nextInt((end - start) + 1))
-      Future.successful(SatoshisPerVirtualByte(satoshis))
+      val feeRate = FeeUnitGen.feeUnit.sampleSome
+
+      lastFeeRate = Some(feeRate)
+      Future.successful(feeRate)
     }
   }
 
@@ -475,7 +478,7 @@ object BitcoinSWalletTest extends WalletLogger {
         nodeApi =
           SyncUtil.getNodeApiWalletCallback(bitcoind, walletCallbackP.future),
         chainQueryApi = SyncUtil.getTestChainQueryApi(bitcoind),
-        feeRateApi = bitcoind,
+        feeRateApi = new RandomFeeProvider,
         creationTime = wallet.keyManager.creationTime
       )(wallet.walletConfig, wallet.ec)
       //complete the walletCallbackP so we can handle the callbacks when they are

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -381,7 +381,7 @@ object BitcoinSWalletTest extends WalletLogger {
     // Useful for tests
     var lastFeeRate: Option[FeeUnit] = None
 
-    def getFeeRate: Future[FeeUnit] = {
+    override def getFeeRate: Future[FeeUnit] = {
       val feeRate = FeeUnitGen.feeUnit.sampleSome
 
       lastFeeRate = Some(feeRate)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -12,12 +12,7 @@ import org.bitcoins.core.protocol.blockchain.{
   RegTestNetChainParams
 }
 import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction.{
-  EmptyTransaction,
-  Transaction,
-  TransactionOutPoint,
-  TransactionOutput
-}
+import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.protocol.{Bech32Address, P2SHAddress}
 import org.bitcoins.core.util.NumberUtil
 import org.bitcoins.core.wallet.utxo._
@@ -85,7 +80,15 @@ object WalletTestUtil {
       second: CurrencyUnit,
       delta: CurrencyUnit = 300.sats): Boolean = {
     Math.abs(
-      first.satoshis.toLong - second.satoshis.toLong) < delta.satoshis.toLong
+      first.satoshis.toLong - second.satoshis.toLong) <= delta.satoshis.toLong
+  }
+
+  def isFeeRateCloseEnough(outgoingTx: OutgoingTransactionDb): Boolean = {
+    TxUtil
+      .isValidFeeRange(outgoingTx.expectedFee,
+                       outgoingTx.actualFee,
+                       outgoingTx.feeRate)
+      .isSuccess
   }
 
   val defaultHdAccount: HDAccount =

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -3,7 +3,6 @@ package org.bitcoins.wallet
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.protocol.script.EmptyScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutput
-import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.StorageLocationTag.HotStorage
 import org.bitcoins.core.wallet.utxo.{
   AddressLabelTag,
@@ -70,9 +69,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
         _ = assert(exists, s"Wallet must contain address after generating it")
         address2 <- wallet.getUnusedAddress
         _ = assert(address1 == address2, "Must generate same address")
-        _ <- wallet.sendToAddress(address1,
-                                  Satoshis(10000),
-                                  Some(SatoshisPerVirtualByte.one))
+        _ <- wallet.sendToAddress(address1, Satoshis(10000), None)
         address3 <- wallet.getUnusedAddress
       } yield {
         assert(address1 != address3, "Must generate a new address")
@@ -132,9 +129,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
         s"Wallet did not start with empty spent addresses, got $emptySpentAddresses")
 
       tempAddress <- wallet.getNewAddress()
-      tx <- wallet.sendToAddress(tempAddress,
-                                 Bitcoins(1),
-                                 Some(SatoshisPerVirtualByte(Satoshis(3))))
+      tx <- wallet.sendToAddress(tempAddress, Bitcoins(1), None)
       spentDbs <- wallet.spendingInfoDAO.findOutputsBeingSpent(tx)
       spentAddresses <- wallet.listSpentAddresses()
     } yield {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
@@ -4,7 +4,6 @@ import org.bitcoins.core.currency._
 import org.bitcoins.core.hd.HDChainType
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.builder.RawTxSigner
-import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.core.wallet.utxo.{InternalAddressTag, StorageLocationTag}
 import org.bitcoins.testkit.wallet.{
   BitcoinSWalletTest,
@@ -75,7 +74,7 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
           .map(unconfirmed => assert(unconfirmed == valueFromBitcoind))
 
       account <- wallet.getDefaultAccount()
-      feeRate <- wallet.feeRateApi.getFeeRate
+      feeRate <- wallet.getFeeRate
       (txBuilder, utxoInfos) <- bitcoind.getNewAddress.flatMap { addr =>
         val output = TransactionOutput(valueToBitcoind, addr.scriptPubKey)
         wallet

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -3,9 +3,11 @@ package org.bitcoins.wallet
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.builder.RawTxSigner
-import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.utxo.StorageLocationTag.HotStorage
 import org.bitcoins.core.wallet.utxo._
+import org.bitcoins.testkit.Implicits.GeneratorOps
+import org.bitcoins.testkit.core.gen.{CurrencyUnitGenerator, FeeUnitGen}
 import org.bitcoins.testkit.util.TestUtil
 import org.bitcoins.testkit.wallet.{
   BitcoinSWalletTest,
@@ -26,18 +28,17 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
 
   val destination: TransactionOutput =
     TransactionOutput(Bitcoins(0.5), TestUtil.p2pkhScriptPubKey)
-  val feeRate: SatoshisPerVirtualByte = SatoshisPerVirtualByte.one
 
   it must "fund a simple raw transaction that requires one utxo" in {
     fundedWallet: WalletWithBitcoind =>
       val wallet = fundedWallet.wallet
-      val fundedTxF = wallet.fundRawTransaction(destinations =
-                                                  Vector(destination),
-                                                feeRate = feeRate,
-                                                fromTagOpt = None,
-                                                markAsReserved = false)
       for {
-        fundedTx <- fundedTxF
+        feeRate <- wallet.feeRateApi.getFeeRate
+        fundedTx <- wallet.fundRawTransaction(destinations =
+                                                Vector(destination),
+                                              feeRate = feeRate,
+                                              fromTagOpt = None,
+                                              markAsReserved = false)
       } yield {
         assert(fundedTx.inputs.length == 1,
                s"We should only need one input to fund this tx")
@@ -52,13 +53,13 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       val amt = Bitcoins(5.5)
       val newDestination = destination.copy(value = amt)
       val wallet = fundedWallet.wallet
-      val fundedTxF = wallet.fundRawTransaction(destinations =
-                                                  Vector(newDestination),
-                                                feeRate = feeRate,
-                                                fromTagOpt = None,
-                                                markAsReserved = false)
       for {
-        fundedTx <- fundedTxF
+        feeRate <- wallet.feeRateApi.getFeeRate
+        fundedTx <- wallet.fundRawTransaction(destinations =
+                                                Vector(newDestination),
+                                              feeRate = feeRate,
+                                              fromTagOpt = None,
+                                              markAsReserved = false)
       } yield {
         assert(fundedTx.inputs.length == 3,
                s"We should need 3 inputs to fund this tx")
@@ -71,14 +72,14 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
   it must "not care about the number of destinations" in {
     fundedWallet: WalletWithBitcoind =>
       val destinations = Vector.fill(5)(destination)
-
       val wallet = fundedWallet.wallet
-      val fundedTxF = wallet.fundRawTransaction(destinations = destinations,
-                                                feeRate = feeRate,
-                                                fromTagOpt = None,
-                                                markAsReserved = false)
+
       for {
-        fundedTx <- fundedTxF
+        feeRate <- wallet.feeRateApi.getFeeRate
+        fundedTx <- wallet.fundRawTransaction(destinations = destinations,
+                                              feeRate = feeRate,
+                                              fromTagOpt = None,
+                                              markAsReserved = false)
       } yield {
         assert(fundedTx.inputs.length == 1,
                s"We should only need one input to fund this tx")
@@ -96,11 +97,15 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       val tooMuchMoney = Bitcoins(10)
       val tooBigOutput = destination.copy(value = tooMuchMoney)
       val wallet = fundedWallet.wallet
-      val fundedTxF = wallet.fundRawTransaction(destinations =
-                                                  Vector(tooBigOutput),
-                                                feeRate = feeRate,
-                                                fromTagOpt = None,
-                                                markAsReserved = false)
+
+      val fundedTxF = for {
+        feeRate <- wallet.feeRateApi.getFeeRate
+        fundedTx <- wallet.fundRawTransaction(destinations =
+                                                Vector(tooBigOutput),
+                                              feeRate = feeRate,
+                                              fromTagOpt = None,
+                                              markAsReserved = false)
+      } yield fundedTx
 
       recoverToSucceededIf[RuntimeException] {
         fundedTxF
@@ -114,13 +119,14 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       val tooBigOutput = destination.copy(value = tooMuchMoney)
       val wallet = fundedWallet.wallet
 
-      //6 bitcoin destination + 1 sat/vbyte fee means we should
-      //not have enough money for this
-      val fundedTxF = wallet.fundRawTransaction(destinations =
-                                                  Vector(tooBigOutput),
-                                                feeRate = feeRate,
-                                                fromTagOpt = None,
-                                                markAsReserved = false)
+      val fundedTxF = for {
+        feeRate <- wallet.feeRateApi.getFeeRate
+        fundedTx <- wallet.fundRawTransaction(destinations =
+                                                Vector(tooBigOutput),
+                                              feeRate = feeRate,
+                                              fromTagOpt = None,
+                                              markAsReserved = false)
+      } yield fundedTx
 
       recoverToSucceededIf[RuntimeException] {
         fundedTxF
@@ -132,12 +138,12 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       //we want to fund from account 1, not hte default account
       //account 1 has 1 btc in it
       val amt = Bitcoins(0.1)
-
       val newDestination = destination.copy(value = amt)
       val wallet = fundedWallet.wallet
       val account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
       val account1DbF = wallet.accountDAO.findByAccount(account1)
       for {
+        feeRate <- wallet.feeRateApi.getFeeRate
         account1DbOpt <- account1DbF
         fundedTx <- wallet.fundRawTransaction(Vector(newDestination),
                                               feeRate,
@@ -153,12 +159,12 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
     fundedWallet: WalletWithBitcoind =>
       //account 1 should only have 1 btc in it
       val amt = Bitcoins(1.1)
-
       val newDestination = destination.copy(value = amt)
       val wallet = fundedWallet.wallet
       val account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
       val account1DbF = wallet.accountDAO.findByAccount(account1)
       val fundedTxF = for {
+        feeRate <- wallet.feeRateApi.getFeeRate
         account1DbOpt <- account1DbF
         fundedTx <- wallet.fundRawTransaction(Vector(newDestination),
                                               feeRate,
@@ -174,8 +180,8 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
     fundedWallet: WalletWithBitcoind =>
       val wallet = fundedWallet.wallet
       val bitcoind = fundedWallet.bitcoind
-
       val fundedTxF = for {
+        feeRate <- wallet.feeRateApi.getFeeRate
         _ <- wallet.createNewAccount(wallet.keyManager.kmParams)
         accounts <- wallet.accountDAO.findAll()
         account2 = accounts.find(_.hdAccount.index == 2).get
@@ -201,13 +207,14 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
   it must "mark utxos as reserved after building a transaction" in {
     fundedWallet: WalletWithBitcoind =>
       val wallet = fundedWallet.wallet
-      val fundedTxF = wallet.fundRawTransaction(destinations =
-                                                  Vector(destination),
-                                                feeRate = feeRate,
-                                                fromTagOpt = None,
-                                                markAsReserved = true)
       for {
-        fundedTx <- fundedTxF
+        feeRate <- wallet.feeRateApi.getFeeRate
+        fundedTx <- wallet.fundRawTransaction(destinations =
+                                                Vector(destination),
+                                              feeRate = feeRate,
+                                              fromTagOpt = None,
+                                              markAsReserved = true)
+
         spendingInfos <- wallet.spendingInfoDAO.findOutputsBeingSpent(fundedTx)
         reserved <- wallet.spendingInfoDAO.findByTxoState(TxoState.Reserved)
       } yield {
@@ -221,7 +228,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       tag: AddressTag): Future[Assertion] = {
     for {
       account <- wallet.getDefaultAccount()
-
+      feeRate <- wallet.feeRateApi.getFeeRate
       taggedAddr <- wallet.getNewAddress(Vector(tag))
       _ <-
         wallet.sendToAddress(taggedAddr, destination.value * 2, Some(feeRate))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -33,7 +33,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
     fundedWallet: WalletWithBitcoind =>
       val wallet = fundedWallet.wallet
       for {
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         fundedTx <- wallet.fundRawTransaction(destinations =
                                                 Vector(destination),
                                               feeRate = feeRate,
@@ -54,7 +54,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       val newDestination = destination.copy(value = amt)
       val wallet = fundedWallet.wallet
       for {
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         fundedTx <- wallet.fundRawTransaction(destinations =
                                                 Vector(newDestination),
                                               feeRate = feeRate,
@@ -75,7 +75,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       val wallet = fundedWallet.wallet
 
       for {
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         fundedTx <- wallet.fundRawTransaction(destinations = destinations,
                                               feeRate = feeRate,
                                               fromTagOpt = None,
@@ -99,7 +99,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       val wallet = fundedWallet.wallet
 
       val fundedTxF = for {
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         fundedTx <- wallet.fundRawTransaction(destinations =
                                                 Vector(tooBigOutput),
                                               feeRate = feeRate,
@@ -120,7 +120,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       val wallet = fundedWallet.wallet
 
       val fundedTxF = for {
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         fundedTx <- wallet.fundRawTransaction(destinations =
                                                 Vector(tooBigOutput),
                                               feeRate = feeRate,
@@ -143,7 +143,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       val account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
       val account1DbF = wallet.accountDAO.findByAccount(account1)
       for {
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         account1DbOpt <- account1DbF
         fundedTx <- wallet.fundRawTransaction(Vector(newDestination),
                                               feeRate,
@@ -164,7 +164,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       val account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
       val account1DbF = wallet.accountDAO.findByAccount(account1)
       val fundedTxF = for {
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         account1DbOpt <- account1DbF
         fundedTx <- wallet.fundRawTransaction(Vector(newDestination),
                                               feeRate,
@@ -181,7 +181,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       val wallet = fundedWallet.wallet
       val bitcoind = fundedWallet.bitcoind
       val fundedTxF = for {
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         _ <- wallet.createNewAccount(wallet.keyManager.kmParams)
         accounts <- wallet.accountDAO.findAll()
         account2 = accounts.find(_.hdAccount.index == 2).get
@@ -208,7 +208,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
     fundedWallet: WalletWithBitcoind =>
       val wallet = fundedWallet.wallet
       for {
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         fundedTx <- wallet.fundRawTransaction(destinations =
                                                 Vector(destination),
                                               feeRate = feeRate,
@@ -228,7 +228,7 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
       tag: AddressTag): Future[Assertion] = {
     for {
       account <- wallet.getDefaultAccount()
-      feeRate <- wallet.feeRateApi.getFeeRate
+      feeRate <- wallet.getFeeRate
       taggedAddr <- wallet.getNewAddress(Vector(tag))
       _ <-
         wallet.sendToAddress(taggedAddr, destination.value * 2, Some(feeRate))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -306,8 +306,6 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
     testAccountType(HDPurposes.SegWit)
   }
 
-  // TODO: implement this when nested segwit addresses are implemented
-  // in the wallet
   it must "act the same way as Trezor for nested segwit accounts" in { _ =>
     testAccountType(HDPurposes.NestedSegWit)
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -145,7 +145,7 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
 
     for {
       oldTransactions <- wallet.listTransactions()
-      feeRate <- wallet.feeRateApi.getFeeRate
+      feeRate <- wallet.getFeeRate
       tx <- wallet.fundRawTransaction(Vector(dummyOutput),
                                       feeRate,
                                       fromTagOpt = None,
@@ -171,7 +171,7 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
 
       for {
         oldTransactions <- wallet.listTransactions()
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         tx <- wallet.fundRawTransaction(Vector(dummyOutput),
                                         feeRate,
                                         fromTagOpt = None,
@@ -201,7 +201,7 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
 
       for {
         oldTransactions <- wallet.listTransactions()
-        feeRate <- wallet.feeRateApi.getFeeRate
+        feeRate <- wallet.getFeeRate
         tx <- wallet.fundRawTransaction(Vector(dummyOutput),
                                         feeRate,
                                         fromTagOpt = None,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -34,9 +34,7 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
 
     for {
       oldTransactions <- wallet.listTransactions()
-      tx <- wallet.sendToAddress(testAddr,
-                                 Satoshis(3000),
-                                 Some(SatoshisPerByte(Satoshis(3))))
+      tx <- wallet.sendToAddress(testAddr, Satoshis(3000), None)
 
       updatedCoins <- wallet.spendingInfoDAO.findOutputsBeingSpent(tx)
       newTransactions <- wallet.listTransactions()
@@ -52,9 +50,7 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
 
     for {
       oldTransactions <- wallet.listTransactions()
-      tx <- wallet.sendToAddress(testAddr,
-                                 Satoshis(3000),
-                                 Some(SatoshisPerByte(Satoshis(3))))
+      tx <- wallet.sendToAddress(testAddr, Satoshis(3000), None)
 
       updatedCoins <- wallet.spendingInfoDAO.findOutputsBeingSpent(tx)
       newTransactions <- wallet.listTransactions()
@@ -149,8 +145,9 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
 
     for {
       oldTransactions <- wallet.listTransactions()
+      feeRate <- wallet.feeRateApi.getFeeRate
       tx <- wallet.fundRawTransaction(Vector(dummyOutput),
-                                      SatoshisPerVirtualByte.one,
+                                      feeRate,
                                       fromTagOpt = None,
                                       markAsReserved = true)
 
@@ -174,8 +171,9 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
 
       for {
         oldTransactions <- wallet.listTransactions()
+        feeRate <- wallet.feeRateApi.getFeeRate
         tx <- wallet.fundRawTransaction(Vector(dummyOutput),
-                                        SatoshisPerVirtualByte.one,
+                                        feeRate,
                                         fromTagOpt = None,
                                         markAsReserved = true)
 
@@ -203,8 +201,9 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
 
       for {
         oldTransactions <- wallet.listTransactions()
+        feeRate <- wallet.feeRateApi.getFeeRate
         tx <- wallet.fundRawTransaction(Vector(dummyOutput),
-                                        SatoshisPerVirtualByte.one,
+                                        feeRate,
                                         fromTagOpt = None,
                                         markAsReserved = true)
         allReserved <- wallet.listUtxos(TxoState.Reserved)
@@ -232,8 +231,7 @@ class UTXOLifeCycleTest extends BitcoinSWalletTest {
 
       for {
         oldTransactions <- wallet.listTransactions()
-        tx <- wallet.sendToOutputs(Vector(dummyOutput),
-                                   Some(SatoshisPerVirtualByte.one))
+        tx <- wallet.sendToOutputs(Vector(dummyOutput), None)
         _ <- wallet.processTransaction(tx, None)
         _ <- wallet.markUTXOsAsReserved(tx)
 


### PR DESCRIPTION
Fixes #1976 in master

Basically we should have test cases that have as input variable fees