### PR TITLE
Don't spend immature coinbases, fix tests

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.TransactionOutput
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.util.TransactionTestUtil
@@ -42,7 +43,8 @@ trait FundWalletUtil {
     }
 
     val fundedWalletF =
-      txsF.flatMap(txs => wallet.processTransactions(txs, None))
+      txsF.flatMap(txs =>
+        wallet.processTransactions(txs, Some(DoubleSha256DigestBE.empty)))
 
     fundedWalletF.map(_.asInstanceOf[Wallet])
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -181,7 +181,13 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
         account2 = accounts.find(_.hdAccount.index == 2).get
 
         addr <- wallet.getNewAddress(account2)
-        _ <- bitcoind.generateToAddress(1, addr)
+
+        hash <- bitcoind.generateToAddress(1, addr).map(_.head)
+        block <- bitcoind.getBlockRaw(hash)
+        _ <- wallet.processBlock(block)
+
+        utxos <- wallet.listUtxos(account2.hdAccount)
+        _ = assert(utxos.size == 1)
 
         fundedTx <-
           wallet.fundRawTransaction(Vector(destination), feeRate, account2)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
@@ -128,12 +128,12 @@ class WalletCallbackTest extends BitcoinSWalletTest {
 
       val callbacks = WalletCallbacks.onReservedUtxos(callback)
 
-      for {
-        utxos <- fundedWallet.wallet.listUtxos()
-        reserved <- fundedWallet.wallet.markUTXOsAsReserved(Vector(utxos.head))
-        _ = fundedWallet.wallet.walletConfig.addCallbacks(callbacks)
+      val wallet = fundedWallet.wallet
 
-        wallet = fundedWallet.wallet
+      for {
+        utxos <- wallet.listUtxos()
+        reserved <- wallet.markUTXOsAsReserved(Vector(utxos.head))
+        _ = fundedWallet.wallet.walletConfig.addCallbacks(callbacks)
 
         _ <- wallet.unmarkUTXOsAsReserved(reserved)
         result <- resultP.future

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -105,7 +105,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
           case None =>
             logger.warn(
               s"Given txos exist in block (${blockHash.hex}) that we do not have! $txos")
-            Vector.empty
+            txos
           case Some(confs) =>
             txos.map { txo =>
               txo.state match {
@@ -133,7 +133,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
         }
       case (None, txos) =>
         logger.debug(s"Currently have ${txos.size} transactions in the mempool")
-        Future.successful(Vector.empty)
+        Future.successful(txos)
     }
 
     for {
@@ -142,8 +142,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
         if (toUpdate.nonEmpty)
           logger.info(s"${toUpdate.size} txos are now confirmed!")
         else logger.info("No txos to be confirmed")
-      updated <-
-        spendingInfoDAO.upsertAllSpendingInfoDb(toUpdate.toVector.flatten)
+      updated <- spendingInfoDAO.upsertAllSpendingInfoDb(toUpdate.flatten)
     } yield updated
   }
 


### PR DESCRIPTION
Fixes #1975

Was orginially trying to indentify coinbase utxos with `utxos.filter(_.outPoint == EmptyTransactionOutPoint)` however, this would never happen because the `utxo.outPoint` would be the one we spend from, not the outpoint in the coinbase tx. Fixed by getting the wallet transaction and checking if it is a coinbase tx