### PR TITLE
Introduce 'FilterSyncMarker' to ChainApi, make it clearier what exact…

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -6,8 +6,8 @@ import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.server.ValidationRejection
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.bitcoins.core.Core
+import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.wallet.{AddressInfo, CoinSelectionAlgo}
-import org.bitcoins.core.api.chain.db.ChainApi
 import org.bitcoins.core.api.wallet.db.{
   AccountDb,
   AddressDb,

--- a/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import org.bitcoins.commons.serializers.Picklers._
-import org.bitcoins.core.api.chain.db.ChainApi
+import org.bitcoins.core.api.chain.ChainApi
 
 case class ChainRoutes(chain: ChainApi)(implicit system: ActorSystem)
     extends ServerRoute {

--- a/app/server/src/main/scala/org/bitcoins/server/Main.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Main.scala
@@ -14,7 +14,7 @@ import org.bitcoins.chain.models.{
   CompactFilterHeaderDAO
 }
 import org.bitcoins.core.Core
-import org.bitcoins.core.api.chain.db.ChainApi
+import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.config.{BitcoinNetworks, MainNet, RegTest, TestNet3}
 import org.bitcoins.core.util.{BitcoinSLogger, FutureUtil, NetworkUtil}
 import org.bitcoins.db._

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
@@ -2,7 +2,7 @@ package org.bitcoins.chain.blockchain.sync
 
 import akka.actor.ActorSystem
 import org.bitcoins.chain.blockchain.ChainHandler
-import org.bitcoins.core.api.chain.db.ChainApi
+import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.testkit.chain.fixture.BitcoindChainHandlerViaRpc
 import org.bitcoins.testkit.chain.{ChainDbUnitTest, SyncUtil}

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/FilterSyncTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/FilterSyncTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.chain.blockchain.sync
 
 import org.bitcoins.chain.blockchain.ChainHandler
-import org.bitcoins.core.api.chain.db.ChainApi
+import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.testkit.chain.fixture.BitcoindV19ChainHandler

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -4,6 +4,7 @@ import org.bitcoins.chain.ChainVerificationLogger
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models._
 import org.bitcoins.chain.pow.Pow
+import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
 import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.api.chain.db._
 import org.bitcoins.core.gcs.FilterHeader
@@ -12,11 +13,7 @@ import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.crypto.{
-  CryptoUtil,
-  DoubleSha256Digest,
-  DoubleSha256DigestBE
-}
+import org.bitcoins.crypto.{CryptoUtil, DoubleSha256DigestBE}
 
 import scala.annotation.tailrec
 import scala.concurrent._
@@ -149,8 +146,7 @@ case class ChainHandler(
   /** @inheritdoc */
   override def nextBlockHeaderBatchRange(
       prevStopHash: DoubleSha256DigestBE,
-      batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]] = {
-
+      batchSize: Int): Future[Option[FilterSyncMarker]] = {
     for {
       prevBlockHeaderOpt <- getHeader(prevStopHash)
       headerOpt <- prevBlockHeaderOpt match {
@@ -166,7 +162,8 @@ case class ChainHandler(
           }
       }
     } yield {
-      headerOpt
+      <<<<<<< HEAD
+        headerOpt
     }
   }
 
@@ -175,7 +172,7 @@ case class ChainHandler(
     */
   private def findNextHeader(
       prevBlockHeaderOpt: Option[BlockHeaderDb],
-      batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]] = {
+      batchSize: Int): Future[Option[FilterSyncMarker]] = {
 
     val chainsF = prevBlockHeaderOpt match {
       case None =>
@@ -240,7 +237,7 @@ case class ChainHandler(
   /** @inheritdoc */
   override def nextFilterHeaderBatchRange(
       prevStopHash: DoubleSha256DigestBE,
-      batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]] = {
+      batchSize: Int): Future[Option[FilterSyncMarker]] = {
     val startHeightF = if (prevStopHash == DoubleSha256DigestBE.empty) {
       Future.successful(0)
     } else {
@@ -265,7 +262,7 @@ case class ChainHandler(
       if (startHeight > stopHeight)
         None
       else
-        Some((startHeight, stopBlock.blockHashBE.flip))
+        Some(FilterSyncMarker(startHeight, stopBlock.blockHashBE.flip))
     }
   }
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -162,8 +162,7 @@ case class ChainHandler(
           }
       }
     } yield {
-      <<<<<<< HEAD
-        headerOpt
+      headerOpt
     }
   }
 
@@ -214,7 +213,7 @@ case class ChainHandler(
   private def getBestChainAtHeight(
       startHeight: Int,
       batchSize: Int,
-      blockchains: Vector[Blockchain]): Option[(Int, DoubleSha256Digest)] = {
+      blockchains: Vector[Blockchain]): Option[FilterSyncMarker] = {
     //ok, we need to select the header that is contained in the chain
     //with the most chain work
     val targetHeight = startHeight + batchSize - 1
@@ -224,11 +223,12 @@ case class ChainHandler(
     val hashHeightOpt = mostWorkChainOpt.flatMap { mostWorkChain =>
       val maxHeight = mostWorkChain.tip.height
       if (targetHeight >= maxHeight) {
-        Some((startHeight, mostWorkChain.tip.hash))
+        val marker = FilterSyncMarker(startHeight, mostWorkChain.tip.hash)
+        Some(marker)
       } else {
         mostWorkChain
           .find(_.height == targetHeight)
-          .map(h => (startHeight, h.hash))
+          .map(h => FilterSyncMarker(startHeight, h.hash))
       }
     }
     hashHeightOpt

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
@@ -3,7 +3,8 @@ package org.bitcoins.chain.blockchain.sync
 import org.bitcoins.chain.ChainVerificationLogger
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.chain.db.{BlockHeaderDb, ChainApi}
+import org.bitcoins.core.api.chain.ChainApi
+import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.crypto.DoubleSha256DigestBE
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/FilterSync.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/FilterSync.scala
@@ -2,11 +2,8 @@ package org.bitcoins.chain.blockchain.sync
 
 import org.bitcoins.chain.ChainVerificationLogger
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.chain.db.{
-  BlockHeaderDb,
-  ChainApi,
-  CompactFilterHeaderDb
-}
+import org.bitcoins.core.api.chain.ChainApi
+import org.bitcoins.core.api.chain.db.{BlockHeaderDb, CompactFilterHeaderDb}
 import org.bitcoins.core.gcs.{FilterHeader, GolombFilter}
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.BlockHeader

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -1,11 +1,15 @@
-package org.bitcoins.core.api.chain.db
+package org.bitcoins.core.api.chain
 
-import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.chain.db.{
+  BlockHeaderDb,
+  CompactFilterDb,
+  CompactFilterHeaderDb
+}
 import org.bitcoins.core.gcs.FilterHeader
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
+import org.bitcoins.crypto.DoubleSha256DigestBE
 
 import scala.concurrent.Future
 
@@ -69,14 +73,14 @@ trait ChainApi extends ChainQueryApi {
     */
   def nextBlockHeaderBatchRange(
       prevStopHash: DoubleSha256DigestBE,
-      batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]]
+      batchSize: Int): Future[Option[FilterSyncMarker]]
 
   /**
     * Generates a filter header range in form of (startHeight, stopHash) by the given stop hash.
     */
   def nextFilterHeaderBatchRange(
       stopHash: DoubleSha256DigestBE,
-      batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]]
+      batchSize: Int): Future[Option[FilterSyncMarker]]
 
   /**
     * Adds a compact filter into the filter database.

--- a/core/src/main/scala/org/bitcoins/core/api/chain/FilterSyncMarker.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/FilterSyncMarker.scala
@@ -2,4 +2,10 @@ package org.bitcoins.core.api.chain
 
 import org.bitcoins.crypto.DoubleSha256Digest
 
+/** This is a helper class for syncing block filters following the
+  * BIP157 protocol. This indicates the starting block height we are
+  * syncing filters at, and the last block hash we expect in the batch
+  * of filters sent back to us by our peer
+  * @see https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki#cfheaders
+  */
 case class FilterSyncMarker(startHeight: Int, stopBlockHash: DoubleSha256Digest)

--- a/core/src/main/scala/org/bitcoins/core/api/chain/FilterSyncMarker.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/FilterSyncMarker.scala
@@ -1,0 +1,5 @@
+package org.bitcoins.core.api.chain
+
+import org.bitcoins.crypto.DoubleSha256Digest
+
+case class FilterSyncMarker(startHeight: Int, stopBlockHash: DoubleSha256Digest)

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -45,7 +45,7 @@ on regtest.
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.blockchain.sync.ChainSync
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.chain.db.ChainApi
+import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.chain.models._
 
 import org.bitcoins.core.api._

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -2,7 +2,7 @@ package org.bitcoins.node.networking.peer
 
 import akka.Done
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.chain.db.ChainApi
+import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.gcs.BlockFilter
 import org.bitcoins.core.p2p._
 import org.bitcoins.crypto.DoubleSha256DigestBE

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -327,10 +327,9 @@ case class DataMessageHandler(
         prevStopHash = blockHash,
         batchSize = chainConfig.filterHeaderBatchSize)
       res <- hashHeightOpt match {
-        case Some((height, hash)) =>
+        case Some(filterSyncMarker) =>
           peerMsgSender
-            .sendGetCompactFilterHeadersMessage(startHeight = height,
-                                                stopHash = hash)
+            .sendGetCompactFilterHeadersMessage(filterSyncMarker)
             .map(_ => true)
         case None =>
           sys.error(

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -9,7 +9,7 @@ import org.bitcoins.chain.models.{
   CompactFilterDAO,
   CompactFilterHeaderDAO
 }
-import org.bitcoins.core.api.chain.db.ChainApi
+import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.p2p.{NetworkMessage, _}
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -10,6 +10,7 @@ import org.bitcoins.chain.blockchain.sync.ChainSync
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models._
 import org.bitcoins.chain.pow.Pow
+import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.chain.db._
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -4,10 +4,9 @@ import java.net.InetSocketAddress
 
 import akka.actor.{ActorSystem, Cancellable}
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.chain.{ChainApi, ChainQueryApi, FilterSyncMarker}
 import org.bitcoins.core.api.chain.db.{
   BlockHeaderDb,
-  ChainApi,
   CompactFilterDb,
   CompactFilterHeaderDb
 }
@@ -16,7 +15,7 @@ import org.bitcoins.core.gcs.FilterHeader
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
-import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.db.AppConfig
 import org.bitcoins.node._
 import org.bitcoins.node.config.NodeAppConfig
@@ -106,12 +105,12 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
 
     override def nextBlockHeaderBatchRange(
         stopHash: DoubleSha256DigestBE,
-        batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]] =
+        batchSize: Int): Future[Option[FilterSyncMarker]] =
       Future.successful(None)
 
     override def nextFilterHeaderBatchRange(
         stopHash: DoubleSha256DigestBE,
-        batchSize: Int): Future[Option[(Int, DoubleSha256Digest)]] =
+        batchSize: Int): Future[Option[FilterSyncMarker]] =
       Future.successful(None)
 
     override def processFilters(


### PR DESCRIPTION
…ly the (Int,DoubleSha256Digest) tuple is returned from ChainApi.nextBlockHeaderRange()

This creates `FilterSyncMarker` class and adds it to the `ChainApi`. 

This would have been _really_ nice to have in #1969 , it's easy for me to confuse raw `Int` and `DoubleSha256Digest` without named fields. Now we have nice fields to remind us what the int/hash stands for.

This also moves `ChainApi` out of the package `org.bitcoins.core.api.chain.db` to `org.bitcoins.core.api.chain`
