### PR TITLE
Rename parameter names from 'duration' -> 'interval' just like our Ac…

### DIFF
--- a/bench/src/main/scala/org/bitcoins/bench/eclair/EclairBench.scala
+++ b/bench/src/main/scala/org/bitcoins/bench/eclair/EclairBench.scala
@@ -113,13 +113,13 @@ object EclairBench extends App with EclairRpcTestUtil {
       _ <- sendPayments(network, PaymentAmount, PaymentCount)
       _ <- TestAsyncUtil.retryUntilSatisfied(
         condition = paymentLog.size() == NetworkSize * PaymentCount,
-        duration = 1.second,
+        interval = 1.second,
         maxTries = 100)
       _ <-
         TestAsyncUtil
           .retryUntilSatisfied(
             condition = EclairBenchUtil.paymentLogValues().forall(_.completed),
-            duration = 1.second,
+            interval = 1.second,
             maxTries = 100)
           .recover { case ex: Throwable => ex.printStackTrace() }
       _ = println("\nDone!")

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
@@ -40,7 +40,7 @@ class TestRpcUtilTest extends BitcoindRpcTest {
   it should "complete immediately if condition is true" in {
     AsyncUtil
       .retryUntilSatisfiedF(conditionF = () => Future.successful(true),
-                            duration = 0.millis)
+                            interval = 0.millis)
       .map { _ =>
         succeed
       }
@@ -50,7 +50,7 @@ class TestRpcUtilTest extends BitcoindRpcTest {
     recoverToSucceededIf[RpcRetryException] {
       AsyncUtil.retryUntilSatisfiedF(conditionF =
                                        () => Future.successful(false),
-                                     duration = 0.millis)
+                                     interval = 0.millis)
     }
   }
 
@@ -71,7 +71,7 @@ class TestRpcUtilTest extends BitcoindRpcTest {
   it should "timeout if condition is false" in {
     recoverToSucceededIf[RpcRetryException] {
       AsyncUtil
-        .awaitCondition(condition = () => false, duration = 0.millis)
+        .awaitCondition(condition = () => false, interval = 0.millis)
         .map(_ => succeed)
     }
   }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -142,7 +142,7 @@ trait Client extends BitcoinSLogger with StartStopAsync[BitcoindRpcClient] {
       for {
         _ <- awaitCookie(instance.authCredentials)
         _ <- AsyncUtil.retryUntilSatisfiedF(() => isStartedF,
-                                            duration = 1.seconds,
+                                            interval = 1.seconds,
                                             maxTries = 60)
       } yield this.asInstanceOf[BitcoindRpcClient]
     }

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -188,7 +188,7 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
     }
 
     AsyncUtil
-      .awaitConditionF(hasRoute, duration = 1.second, maxTries = 60)
+      .awaitConditionF(hasRoute, interval = 1.second, maxTries = 60)
       .map(_ => succeed)
   }
 
@@ -207,7 +207,7 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
     }
 
     AsyncUtil
-      .awaitConditionF(hasRoute, duration = 1.second, maxTries = 60)
+      .awaitConditionF(hasRoute, interval = 1.second, maxTries = 60)
       .map(_ => succeed)
   }
 
@@ -228,7 +228,7 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
           .awaitUntilIncomingPaymentStatus[IncomingPaymentStatus.Received](
             client4,
             invoice.lnTags.paymentHash.hash,
-            duration = 1.second)
+            interval = 1.second)
 
       _ <- EclairRpcTestUtil.awaitUntilPaymentSucceeded(client1,
                                                         paymentId,
@@ -417,13 +417,13 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
       }
       _ <- TestAsyncUtil.retryUntilSatisfiedF(conditionF =
                                                 () => eclair.isStarted(),
-                                              duration = 1.second,
+                                              interval = 1.second,
                                               maxTries = 60)
       _ = EclairRpcTestUtil.shutdown(eclair)
       _ <-
         TestAsyncUtil.retryUntilSatisfiedF(conditionF =
                                              () => eclair.isStarted().map(!_),
-                                           duration = 1.second,
+                                           interval = 1.second,
                                            maxTries = 60)
     } yield succeed
   }
@@ -1127,7 +1127,7 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
 
           AsyncUtil
             .retryUntilSatisfiedF((() => checkUpdates()),
-                                  duration = 1.second,
+                                  interval = 1.second,
                                   maxTries = 60)
             .transform(_ => succeed, ex => ex)
         }

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -778,7 +778,7 @@ class EclairRpcClient(
     val started: Future[EclairRpcClient] = {
       for {
         _ <- AsyncUtil.retryUntilSatisfiedF(() => isStarted,
-                                            duration = 1.seconds,
+                                            interval = 1.seconds,
                                             maxTries = 60)
       } yield this
     }

--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -72,7 +72,7 @@ class BroadcastTransactionTest extends NodeUnitTest {
           txOpt.isDefined,
           "Transaction was not added to BroadcastableTransaction database")
         _ <- TestAsyncUtil.awaitConditionF(() => hasSeenTx(tx),
-                                           duration = 1.second,
+                                           interval = 1.second,
                                            maxTries = 25)
       } yield ()
     }

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -131,7 +131,7 @@ class NeutrinoNodeTest extends NodeUnitTest {
                 .chainApiFromDb()
                 .flatMap(_.getBlockCount.map(_ == ExpectedCount))
             },
-            duration = 1000.millis)
+            interval = 1000.millis)
 
         def hasFilterHeadersF =
           RpcUtil.retryUntilSatisfiedF(
@@ -140,7 +140,7 @@ class NeutrinoNodeTest extends NodeUnitTest {
                 .chainApiFromDb()
                 .flatMap(_.getFilterHeaderCount.map(_ == ExpectedCount))
             },
-            duration = 1000.millis)
+            interval = 1000.millis)
 
         def hasFiltersF =
           RpcUtil.retryUntilSatisfiedF(
@@ -149,7 +149,7 @@ class NeutrinoNodeTest extends NodeUnitTest {
                 .chainApiFromDb()
                 .flatMap(_.getFilterCount.map(_ == ExpectedCount))
             },
-            duration = 1000.millis)
+            interval = 1000.millis)
 
         for {
           _ <- hasBlocksF

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
@@ -90,7 +90,7 @@ class SpvNodeTest extends NodeUnitTest {
         val has6BlocksF = RpcUtil.retryUntilSatisfiedF(
           conditionF =
             () => spvNode.chainApiFromDb().flatMap(_.getBlockCount.map(_ == 6)),
-          duration = 250.millis)
+          interval = 250.millis)
 
         has6BlocksF.map { _ =>
           val isCanceled = cancel.cancel()

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -183,7 +183,7 @@ class P2PClientTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
         _ = p2pClient.actor ! Tcp.Abort
         isDisconnected <-
           TestAsyncUtil.retryUntilSatisfiedF(p2pClient.isDisconnected,
-                                             duration = 1.seconds)
+                                             interval = 1.seconds)
       } yield isDisconnected
 
       isDisconnectedF.map { _ =>

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -36,7 +36,7 @@ class PeerMessageHandlerTest extends NodeUnitTest {
 
     val isConnectedF = TestAsyncUtil.retryUntilSatisfiedF(
       () => p2pClientF.flatMap(_.isConnected),
-      duration = 500.millis
+      interval = 500.millis
     )
 
     val isInitF = isConnectedF.flatMap { _ =>

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -125,7 +125,7 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
         val isInitializedF = for {
           _ <- peerMsgSenderF.map(_.connect())
           _ <- AsyncUtil.retryUntilSatisfiedF(() => isInitialized,
-                                              duration = 250.millis)
+                                              interval = 250.millis)
         } yield ()
 
         isInitializedF.failed.foreach(err =>

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -273,7 +273,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
     }
 
     TestAsyncUtil.retryUntilSatisfiedF(conditionF = () => isState(),
-                                       duration = 1.seconds)
+                                       interval = 1.seconds)
   }
 
   def awaitUntilPaymentSucceeded(
@@ -305,7 +305,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
   private def awaitUntilOutgoingPaymentStatus[T <: OutgoingPaymentStatus](
       client: EclairApi,
       paymentId: PaymentId,
-      duration: FiniteDuration,
+      interval: FiniteDuration,
       maxTries: Int,
       failFast: Boolean)(implicit
       system: ActorSystem,
@@ -341,14 +341,14 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
     }
 
     TestAsyncUtil.retryUntilSatisfiedF(conditionF = () => isInState(),
-                                       duration = duration,
+                                       interval = interval,
                                        maxTries = maxTries)
   }
 
   def awaitUntilIncomingPaymentStatus[T <: IncomingPaymentStatus](
       client: EclairApi,
       paymentHash: Sha256Digest,
-      duration: FiniteDuration = 1.second,
+      interval: FiniteDuration = 1.second,
       maxTries: Int = 60)(implicit
       system: ActorSystem,
       tag: ClassTag[T]): Future[Unit] = {
@@ -374,7 +374,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
     }
 
     TestAsyncUtil.retryUntilSatisfiedF(conditionF = () => isInState(),
-                                       duration = duration,
+                                       interval = interval,
                                        maxTries = maxTries)
   }
 
@@ -609,7 +609,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
     logger.debug(s"Awaiting connection between clients")
     val connected = TestRpcUtil.retryUntilSatisfiedF(conditionF =
                                                        () => isConnected(),
-                                                     duration = 1.second)
+                                                     interval = 1.second)
 
     connected.map(_ => logger.debug(s"Successfully connected two clients"))
 
@@ -751,7 +751,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
 
     TestAsyncUtil.retryUntilSatisfiedF(conditionF =
                                          () => clientInSync(eclair, bitcoind),
-                                       duration = 1.seconds)
+                                       interval = 1.seconds)
   }
 
   /** Shuts down an eclair daemon and the bitcoind daemon it is associated with

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -55,7 +55,6 @@ import scala.util._
 
 //noinspection AccessorLikeMethodIsEmptyParen
 trait BitcoindRpcTestUtil extends BitcoinSLogger {
-  import BitcoindRpcTestUtil.DEFAULT_LONG_DURATION
 
   type RpcClientAccum =
     mutable.Builder[BitcoindRpcClient, Vector[BitcoindRpcClient]]
@@ -344,7 +343,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
   def awaitConnection(
       from: BitcoindRpcClient,
       to: BitcoindRpcClient,
-      duration: FiniteDuration = 100.milliseconds,
+      interval: FiniteDuration = 100.milliseconds,
       maxTries: Int = 50)(implicit system: ActorSystem): Future[Unit] = {
     import system.dispatcher
 
@@ -357,7 +356,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     }
 
     AsyncUtil.retryUntilSatisfiedF(conditionF = isConnected,
-                                   duration = duration,
+                                   interval = interval,
                                    maxTries = maxTries)
   }
 
@@ -442,7 +441,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
   def awaitSynced(
       client1: BitcoindRpcClient,
       client2: BitcoindRpcClient,
-      duration: FiniteDuration = DEFAULT_LONG_DURATION,
+      interval: FiniteDuration = BitcoindRpcTestUtil.DEFAULT_LONG_INTERVAL,
       maxTries: Int = 50)(implicit system: ActorSystem): Future[Unit] = {
     implicit val ec: ExecutionContextExecutor = system.dispatcher
 
@@ -455,14 +454,14 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     }
 
     AsyncUtil.retryUntilSatisfiedF(conditionF = () => isSynced(),
-                                   duration = duration,
+                                   interval = interval,
                                    maxTries = maxTries)
   }
 
   def awaitSameBlockHeight(
       client1: BitcoindRpcClient,
       client2: BitcoindRpcClient,
-      duration: FiniteDuration = DEFAULT_LONG_DURATION,
+      interval: FiniteDuration = BitcoindRpcTestUtil.DEFAULT_LONG_INTERVAL,
       maxTries: Int = 50)(implicit system: ActorSystem): Future[Unit] = {
     import system.dispatcher
 
@@ -475,14 +474,14 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     }
 
     AsyncUtil.retryUntilSatisfiedF(conditionF = () => isSameBlockHeight(),
-                                   duration = duration,
+                                   interval = interval,
                                    maxTries = maxTries)
   }
 
   def awaitDisconnected(
       from: BitcoindRpcClient,
       to: BitcoindRpcClient,
-      duration: FiniteDuration = 100.milliseconds,
+      interval: FiniteDuration = 100.milliseconds,
       maxTries: Int = 50)(implicit system: ActorSystem): Future[Unit] = {
     import system.dispatcher
 
@@ -500,7 +499,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     }
 
     AsyncUtil.retryUntilSatisfiedF(conditionF = () => isDisconnected(),
-                                   duration = duration,
+                                   interval = interval,
                                    maxTries = maxTries)
   }
 
@@ -559,7 +558,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
       val futures = pairs.map {
         case (first, second) =>
           BitcoindRpcTestUtil
-            .awaitConnection(first, second, duration = 10.second)
+            .awaitConnection(first, second, interval = 10.second)
       }
       Future.sequence(futures)
     }
@@ -984,7 +983,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     val blocksGeneratedF = generatedF.flatMap { _ =>
       AsyncUtil.retryUntilSatisfiedF(
         () => areBlocksGenerated(),
-        duration = DEFAULT_LONG_DURATION
+        interval = BitcoindRpcTestUtil.DEFAULT_LONG_INTERVAL
       )
     }
 
@@ -999,7 +998,7 @@ object BitcoindRpcTestUtil extends BitcoindRpcTestUtil {
   /**
     * Used for long running async tasks
     */
-  private val DEFAULT_LONG_DURATION = {
+  private val DEFAULT_LONG_INTERVAL = {
     if (EnvUtil.isMac && EnvUtil.isCI) 10.seconds
     else 3.seconds
   }


### PR DESCRIPTION
…torSystem.schedule() names the parameter

Previously the parameter for `AsyncUtil.retryUntilSatisfiedF` had a parameter named `duration`. This was _very_ misleading. What this parameter really is a `interval` in between times to evaluate the predicate passed in as a parameter `conditionF` 

```scala
conditionF: () => Future[Boolean]
```

So `conditionF` gets called every `interval`. 

