### PR TITLE
Make BlockHeader, BlockHeaderDb have better toStrings

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
@@ -29,6 +29,11 @@ case class BlockHeaderDb(
   }
 
   lazy val hash: DoubleSha256Digest = hashBE.flip
+
+  override def toString: String = {
+    s"BlockHeaderDb(height=$height,hashBE=$hashBE,version=$version,prevBlockHashBE=${previousBlockHashBE}" +
+      s"merkleRootHashBE=$merkleRootHashBE,time=$time,nBits=$nBits,nonce=$nonce,chainWork=$chainWork)"
+  }
 }
 
 object BlockHeaderDbHelper {

--- a/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
@@ -31,8 +31,10 @@ case class BlockHeaderDb(
   lazy val hash: DoubleSha256Digest = hashBE.flip
 
   override def toString: String = {
-    s"BlockHeaderDb(height=$height,hashBE=$hashBE,version=$version,prevBlockHashBE=${previousBlockHashBE}" +
-      s"merkleRootHashBE=$merkleRootHashBE,time=$time,nBits=$nBits,nonce=$nonce,chainWork=$chainWork)"
+    s"BlockHeaderDb(height=$height,hashBE=${hashBE.hex},version=$version," +
+      s"prevBlockHashBE=${previousBlockHashBE.hex}" +
+      s"merkleRootHashBE=${merkleRootHashBE.hex}," +
+      s"time=$time,nBits=$nBits,nonce=$nonce,chainWork=$chainWork)"
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -130,8 +130,10 @@ sealed trait BlockHeader extends NetworkElement {
   override def bytes: ByteVector = RawBlockHeaderSerializer.write(this)
 
   override def toString: String = {
-    s"BlockHeader(hashBE=$hashBE,version=$version,prevBlockHashBE=${previousBlockHashBE}" +
-      s"merkleRootHashBE=$merkleRootHashBE,time=$time,nBits=$nBits,nonce=$nonce)"
+    s"BlockHeader(hashBE=${hashBE.hex},version=$version," +
+      s"prevBlockHashBE=${previousBlockHashBE.hex}," +
+      s"merkleRootHashBE=${merkleRootHashBE.hex}," +
+      s"time=$time,nBits=$nBits,nonce=$nonce)"
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -129,6 +129,10 @@ sealed trait BlockHeader extends NetworkElement {
 
   override def bytes: ByteVector = RawBlockHeaderSerializer.write(this)
 
+  override def toString: String = {
+    s"BlockHeader(hashBE=$hashBE,version=$version,prevBlockHashBE=${previousBlockHashBE}" +
+      s"merkleRootHashBE=$merkleRootHashBE,time=$time,nBits=$nBits,nonce=$nonce)"
+  }
 }
 
 /**


### PR DESCRIPTION
This gives us prefixes on hashes in the `BlockHeader` and `BlockHeaderDb` `toString` methods. 

Now you will see things like `BlockHeader(hashBE=1234...` rather than just `BlockHeader(1234...` which doesn't give you a clear indication which hash this is in the `toString()`. Is it the prev block hash, merkle root hash, block hash etc?

This removes that ambiguity when looking at logs.