### PR TITLE
2020 09 12 adaptor ecdsa dlc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -190,11 +190,11 @@ stages:
   - name: test
     if:
       commit_message !~ /(?i)^docs:/ AND NOT
-      ((branch = schnorr-dlc AND type = push) OR (tag IS present))
+      ((branch = adaptor-dlc AND type = push) OR (tag IS present))
     # don't run tests on merge builds, just publish library
     # and website
   - name: release
-    if: ((branch = schnorr-dlc AND type = push) OR (tag IS present)) AND NOT fork
+    if: ((branch = adaptor-dlc AND type = push) OR (tag IS present)) AND NOT fork
 
 script:
   # Modify PATH to include binaries we are about to download

--- a/inThisBuild.sbt
+++ b/inThisBuild.sbt
@@ -2,7 +2,7 @@ import scala.util.Properties
 
 version in ThisBuild ~= { version =>
   val withoutSuffix = version.dropRight(8)
-  withoutSuffix + "SCHNORR-DLC-SNAPSHOT"
+  withoutSuffix + "ADAPTOR-ECDSA-DLC-SNAPSHOT"
 }
 
 val scala2_12 = "2.12.12"


### PR DESCRIPTION
This enables publishing of artifacts on the `adaptor-dlc` branch, now artifacts will be published with the suffix of 

>  withoutSuffix + "ADAPTOR-ECDSA-DLC-SNAPSHOT"


