### PR TITLE
Handle the case where our block headers are synced already

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -392,6 +392,20 @@ class ChainHandlerTest extends ChainDbUnitTest {
 
   }
 
+  it must "return None for ChainHandler.nextBlockHeaderBatchRange if we are synced" in {
+    chainHandler: ChainHandler =>
+      val genesisHeader =
+        chainHandler.chainConfig.chain.genesisBlock.blockHeader
+      val assert1F = for {
+        rangeOpt <-
+          chainHandler.nextBlockHeaderBatchRange(genesisHeader.hashBE, 1)
+        count <- chainHandler.getBlockCount()
+      } yield {
+        assert(rangeOpt.isEmpty)
+      }
+      assert1F
+  }
+
   it must "generate a range for a block filter header query" in {
     chainHandler: ChainHandler =>
       for {


### PR DESCRIPTION
fixes #2020 (we should have NO MORE PROBLEMS IN 2020, I'VE FIXED THEM!)

The core issue was we weren't accounting for the case in `ChainHandler.nextBlockHeaderBatchRange()` where our `prevStopHash` was the best tip in our chain database. In this case, we should be done syncing filter headers. 

This PR adds a unit test for this case to make sure we are returning `None`. 