### PR TITLE
Add test to use llyod's info

### DIFF
--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -9,9 +9,14 @@ import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{
 }
 import org.bitcoins.commons.jsonmodels.dlc.{CETSignatures, DLCMessage}
 import org.bitcoins.core.currency.Satoshis
-import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
-import org.bitcoins.crypto.{CryptoUtil, FieldElement, SchnorrDigitalSignature}
+import org.bitcoins.crypto.{
+  CryptoUtil,
+  FieldElement,
+  SchnorrDigitalSignature,
+  SchnorrNonce,
+  SchnorrPublicKey
+}
 import org.bitcoins.testkit.wallet.DLCWalletUtil._
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
 import org.bitcoins.testkit.wallet.{BitcoinSDualWalletTest, DLCWalletUtil}
@@ -240,8 +245,14 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         10000).bytes ++ loseHash.bytes ++ Satoshis.zero.bytes ++ drawHash.bytes ++ Satoshis(
         5000).bytes)
 
-      val oracleInfo = OracleInfo(
-        "156c7d1c7922f0aa1168d9e21ac77ea88bbbe05e24e70a08bbe0519778f2e5daea3a68d8749b81682513b0479418d289d17e24d4820df2ce979f1a56a63ca525")
+      val oraclePubKey = SchnorrPublicKey(
+        "156c7d1c7922f0aa1168d9e21ac77ea88bbbe05e24e70a08bbe0519778f2e5da")
+      val oracleNonce = SchnorrNonce(
+        "ea3a68d8749b81682513b0479418d289d17e24d4820df2ce979f1a56a63ca525")
+      val attestation = FieldElement(
+        "de6000e2946e37af04f104db54066f560b88a353adc106c5b61bb52f34bc17af")
+
+      val oracleInfo = OracleInfo(oraclePubKey, oracleNonce)
 
       val offerData = DLCOffer(
         contractInfo,
@@ -254,11 +265,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         dummyTimeouts
       )
 
-      val oracleSig =
-        SchnorrDigitalSignature(
-          oracleInfo.rValue,
-          FieldElement(
-            "de6000e2946e37af04f104db54066f560b88a353adc106c5b61bb52f34bc17af"))
+      val oracleSig = SchnorrDigitalSignature(oracleNonce, attestation)
 
       val paramHash = DLCMessage.calcParamHash(offerData.oracleInfo,
                                                offerData.contractInfo,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -250,7 +250,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       val oracleNonce = SchnorrNonce(
         "ea3a68d8749b81682513b0479418d289d17e24d4820df2ce979f1a56a63ca525")
       val attestation = FieldElement(
-        "de6000e2946e37af04f104db54066f560b88a353adc106c5b61bb52f34bc17af")
+        "77a5aabd716936411bbe19219bd0b261fae8f0524367268feb264e0a3b215766")
 
       val oracleInfo = OracleInfo(oraclePubKey, oracleNonce)
 
@@ -340,7 +340,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
           (wallet: DLCWallet) => wallet.executeDLC(sign.contractId, oracleSig)
         result <- dlcExecutionTest(dlcA = walletA,
                                    dlcB = walletB,
-                                   asInitiator = false,
+                                   asInitiator = true,
                                    func = func,
                                    expectedOutputs = 1)
       } yield assert(result)

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -1,14 +1,22 @@
 package org.bitcoins.dlc.wallet
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{
+  ContractInfo,
   DLCAccept,
   DLCOffer,
-  DLCSign
+  DLCSign,
+  OracleInfo
 }
 import org.bitcoins.commons.jsonmodels.dlc.{CETSignatures, DLCMessage}
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.crypto.{CryptoUtil, FieldElement, SchnorrDigitalSignature}
+import org.bitcoins.testkit.wallet.DLCWalletUtil._
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
 import org.bitcoins.testkit.wallet.{BitcoinSDualWalletTest, DLCWalletUtil}
 import org.scalatest.{Assertion, FutureOutcome}
+import scodec.bits.ByteVector
 
 import scala.concurrent.Future
 
@@ -218,5 +226,116 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
           accept.copy(
             cetSigs = CETSignatures(accept.cetSigs.outcomeSigs,
                                     DLCWalletUtil.dummyPartialSig)))
+  }
+
+  it must "setup and execute with lloyd's example" in {
+    FundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
+      val walletA = FundedDLCWallets._1.wallet
+      val walletB = FundedDLCWallets._2.wallet
+
+      val winHash = CryptoUtil.sha256(ByteVector("Democrat_win".getBytes))
+      val loseHash = CryptoUtil.sha256(ByteVector("Republican_win".getBytes))
+      val drawHash = CryptoUtil.sha256(ByteVector("other".getBytes))
+      val contractInfo = ContractInfo(winHash.bytes ++ Satoshis(
+        10000).bytes ++ loseHash.bytes ++ Satoshis.zero.bytes ++ drawHash.bytes ++ Satoshis(
+        5000).bytes)
+
+      val oracleInfo = OracleInfo(
+        "156c7d1c7922f0aa1168d9e21ac77ea88bbbe05e24e70a08bbe0519778f2e5daea3a68d8749b81682513b0479418d289d17e24d4820df2ce979f1a56a63ca525")
+
+      val offerData = DLCOffer(
+        contractInfo,
+        oracleInfo,
+        dummyDLCKeys,
+        Satoshis(5000),
+        Vector(dummyOutputRefs.head),
+        dummyAddress,
+        SatoshisPerVirtualByte(Satoshis(3)),
+        dummyTimeouts
+      )
+
+      val oracleSig =
+        SchnorrDigitalSignature(
+          oracleInfo.rValue,
+          FieldElement(
+            "de6000e2946e37af04f104db54066f560b88a353adc106c5b61bb52f34bc17af"))
+
+      val paramHash = DLCMessage.calcParamHash(offerData.oracleInfo,
+                                               offerData.contractInfo,
+                                               offerData.timeouts)
+
+      for {
+        offer <- walletA.createDLCOffer(
+          offerData.oracleInfo,
+          offerData.contractInfo,
+          offerData.totalCollateral,
+          Some(offerData.feeRate),
+          offerData.timeouts.contractMaturity.toUInt32,
+          offerData.timeouts.contractTimeout.toUInt32
+        )
+        _ = {
+          assert(offer.oracleInfo == offerData.oracleInfo)
+          assert(offer.contractInfo == offerData.contractInfo)
+          assert(offer.totalCollateral == offerData.totalCollateral)
+          assert(offer.feeRate == offerData.feeRate)
+          assert(offer.timeouts == offerData.timeouts)
+          assert(offer.fundingInputs.nonEmpty)
+          assert(offer.changeAddress.value.nonEmpty)
+        }
+
+        accept <- walletB.acceptDLCOffer(offer)
+        _ = {
+          assert(accept.fundingInputs.nonEmpty)
+          assert(
+            accept.totalCollateral == offer.contractInfo.values.max - offer.totalCollateral)
+          assert(accept.changeAddress.value.nonEmpty)
+        }
+
+        sign <- walletA.signDLC(accept)
+        _ = {
+          assert(sign.fundingSigs.keys.size == offerData.fundingInputs.size)
+        }
+
+        dlcDb <- walletB.addDLCSigs(sign)
+        outcomeSigs <- walletB.dlcSigsDAO.findByParamHash(offer.paramHash)
+
+        refundSigsA <-
+          walletA.dlcRefundSigDAO
+            .findByParamHash(paramHash)
+            .map(_.map(_.refundSig))
+        refundSigsB <-
+          walletB.dlcRefundSigDAO
+            .findByParamHash(paramHash)
+            .map(_.map(_.refundSig))
+
+        walletAChange <- walletA.addressDAO.read(offer.changeAddress)
+        walletAFinal <- walletA.addressDAO.read(offer.pubKeys.payoutAddress)
+
+        walletBChange <- walletB.addressDAO.read(accept.changeAddress)
+        walletBFinal <- walletB.addressDAO.read(accept.pubKeys.payoutAddress)
+
+        _ = {
+          assert(dlcDb.contractIdOpt.get == sign.contractId)
+
+          assert(refundSigsA.size == 2)
+          assert(refundSigsA.forall(refundSigsB.contains))
+
+          assert(sign.cetSigs.outcomeSigs.forall(sig =>
+            outcomeSigs.exists(_.toTuple == sig)))
+          // Test that the Addresses are in the wallet's database
+          assert(walletAChange.isDefined)
+          assert(walletAFinal.isDefined)
+          assert(walletBChange.isDefined)
+          assert(walletBFinal.isDefined)
+        }
+
+        func =
+          (wallet: DLCWallet) => wallet.executeDLC(sign.contractId, oracleSig)
+        result <- dlcExecutionTest(dlcA = walletA,
+                                   dlcB = walletB,
+                                   asInitiator = false,
+                                   func = func,
+                                   expectedOutputs = 1)
+      } yield assert(result)
   }
 }


### PR DESCRIPTION
Moved some helper functions from the execution tests so we can setup and execute in other files.