### PR TITLE
2020 09 18 btchrp stringfactory

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
@@ -25,7 +25,7 @@ class Bech32Test extends BitcoinSUnitTest {
     val addrT = Address.fromStringT(addrStr)
     addrT match {
       case Success(addr: Bech32Address) => assert(addr.value == addrStr)
-      case Failure(err)                 => fail(err)
+      case _                            => fail()
     }
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32Test.scala
@@ -25,7 +25,7 @@ class Bech32Test extends BitcoinSUnitTest {
     val addrT = Address.fromStringT(addrStr)
     addrT match {
       case Success(addr: Bech32Address) => assert(addr.value == addrStr)
-      case _                            => fail()
+      case Failure(err)                 => fail(err)
     }
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/BtcHumanReadablePartTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/BtcHumanReadablePartTest.scala
@@ -9,9 +9,9 @@ class BtcHumanReadablePartTest extends BitcoinSUnitTest {
   import BtcHumanReadablePart._
 
   "HumanReadablePart" must "match the correct hrp with the correct string" in {
-    BtcHumanReadablePart("tb") must be(Success(tb))
-    BtcHumanReadablePart("bc") must be(Success(bc))
-    BtcHumanReadablePart("bcrt") must be(Success(bcrt))
+    BtcHumanReadablePart.fromStringT("tb") must be(Success(tb))
+    BtcHumanReadablePart.fromStringT("bc") must be(Success(bc))
+    BtcHumanReadablePart.fromStringT("bcrt") must be(Success(bcrt))
   }
 
   it must "match the correct hrp with the correct network" in {

--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -191,7 +191,7 @@ object Bech32Address extends AddressFactory[Bech32Address] {
   override def fromString(bech32: String): Bech32Address = {
     val bech32T = for {
       (hrp, data) <- Bech32.splitToHrpAndData(bech32)
-      btcHrp <- BtcHumanReadablePart(hrp)
+      btcHrp = BtcHumanReadablePart(hrp)
     } yield Bech32Address(btcHrp, data)
 
     bech32T match {

--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -112,7 +112,7 @@ sealed abstract class Bech32Address extends BitcoinAddress {
   }
 
   def expandHrp: Vector[UInt5] = {
-    Bech32.hrpExpand(hrp)
+    hrp.expand
   }
 }
 
@@ -151,7 +151,7 @@ object Bech32Address extends AddressFactory[Bech32Address] {
   def createChecksum(
       hrp: BtcHumanReadablePart,
       bytes: Vector[UInt5]): Vector[UInt5] = {
-    val values = Bech32.hrpExpand(hrp) ++ bytes
+    val values = hrp.expand ++ bytes
     Bech32.createChecksum(values)
   }
 
@@ -191,7 +191,7 @@ object Bech32Address extends AddressFactory[Bech32Address] {
   override def fromString(bech32: String): Bech32Address = {
     val bech32T = for {
       (hrp, data) <- Bech32.splitToHrpAndData(bech32)
-      btcHrp = BtcHumanReadablePart(hrp)
+      btcHrp = BtcHumanReadablePart.fromString(hrp)
     } yield Bech32Address(btcHrp, data)
 
     bech32T match {

--- a/core/src/main/scala/org/bitcoins/core/protocol/BtcHumanReadablePart.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/BtcHumanReadablePart.scala
@@ -38,7 +38,7 @@ object BtcHumanReadablePart extends StringFactory[BtcHumanReadablePart] {
     override def chars: String = "bcrt"
   }
 
-  def fromString(str: String): BtcHumanReadablePart =
+  override def fromString(str: String): BtcHumanReadablePart =
     str match {
       case "bc"   => bc
       case "tb"   => tb

--- a/core/src/main/scala/org/bitcoins/core/protocol/BtcHumanReadablePart.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/BtcHumanReadablePart.scala
@@ -2,8 +2,7 @@ package org.bitcoins.core.protocol
 
 import org.bitcoins.core.config._
 import org.bitcoins.core.util.Bech32HumanReadablePart
-
-import scala.util.{Failure, Success, Try}
+import org.bitcoins.crypto.StringFactory
 
 /**
   * Represents the HumanReadablePart of a Bech32 address
@@ -13,7 +12,7 @@ sealed abstract class BtcHumanReadablePart extends Bech32HumanReadablePart {
   def network: BitcoinNetwork
 }
 
-object BtcHumanReadablePart {
+object BtcHumanReadablePart extends StringFactory[BtcHumanReadablePart] {
 
   /** Represents the HumanReadablePart for a bitcoin mainnet bech32 address */
   case object bc extends BtcHumanReadablePart {
@@ -39,15 +38,14 @@ object BtcHumanReadablePart {
     override def chars: String = "bcrt"
   }
 
-  def apply(str: String): Try[BtcHumanReadablePart] =
+  def fromString(str: String): BtcHumanReadablePart =
     str match {
-      case "bc"   => Success(bc)
-      case "tb"   => Success(tb)
-      case "bcrt" => Success(bcrt) // Bitcoin Core specific
+      case "bc"   => bc
+      case "tb"   => tb
+      case "bcrt" => bcrt // Bitcoin Core specific
       case _ =>
-        Failure(
-          new IllegalArgumentException(
-            s"Could not construct BTC HRP from $str"))
+        throw new IllegalArgumentException(
+          s"Could not construct BTC HRP from $str")
     }
 
   def apply(network: NetworkParameters): BtcHumanReadablePart =
@@ -57,6 +55,6 @@ object BtcHumanReadablePart {
       case _: RegTest  => bcrt
     }
 
-  def apply(hrp: Bech32HumanReadablePart): Try[BtcHumanReadablePart] =
-    BtcHumanReadablePart(hrp.chars)
+  def apply(hrp: Bech32HumanReadablePart): BtcHumanReadablePart =
+    BtcHumanReadablePart.fromString(hrp.chars)
 }

--- a/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
@@ -108,8 +108,8 @@ sealed abstract class Bech32 {
 
     hrpT.flatMap { chars =>
       val str = chars.mkString
-      val lnT = LnHumanReadablePart(str)
-      val btcT = BtcHumanReadablePart(str)
+      val lnT = LnHumanReadablePart.fromStringT(str)
+      val btcT = BtcHumanReadablePart.fromStringT(str)
 
       lnT
         .orElse(btcT)

--- a/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
@@ -261,6 +261,18 @@ sealed abstract class Bech32 {
     }
   }
 
+  def splitToHrpAndData[T <: Bech32HumanReadablePart](
+      bech32: String,
+      factory: StringFactory[T]): Try[(T, Vector[UInt5])] = {
+
+    splitToHrpAndData(bech32).flatMap {
+      case (hrpString, data) =>
+        factory
+          .fromStringT(hrpString)
+          .map(hrp => (hrp, data))
+    }
+  }
+
   def verifyChecksum(hrp: Seq[UInt5], u5s: Seq[UInt5]): Boolean = {
     val data = hrp ++ u5s
     val checksum = Bech32.polyMod(data.toVector)

--- a/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
@@ -1,8 +1,6 @@
 package org.bitcoins.core.util
 
 import org.bitcoins.core.number.{UInt5, UInt8}
-import org.bitcoins.core.protocol.BtcHumanReadablePart
-import org.bitcoins.core.protocol.ln.LnHumanReadablePart
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
@@ -41,8 +39,8 @@ sealed abstract class Bech32 {
     * Expands the human readable part of a bech32 address as per
     * [[https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32 BIP173]]
     */
-  def hrpExpand(hrp: Bech32HumanReadablePart): Vector[UInt5] = {
-    val lowerchars = hrp.chars.toLowerCase
+  def hrpExpand(string: String): Vector[UInt5] = {
+    val lowerchars = string.toLowerCase
 
     val x: Vector[UInt5] = lowerchars.map { c =>
       UInt5(c >> 5)
@@ -75,7 +73,7 @@ sealed abstract class Bech32 {
     * [[https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32 BIP173]]
     * rules
     */
-  def checkHrpValidity(hrp: String): Try[Bech32HumanReadablePart] = {
+  def checkHrpValidity(hrp: String): Try[String] = {
     @tailrec
     def loop(
         remaining: List[Char],
@@ -106,15 +104,9 @@ sealed abstract class Bech32 {
     val hrpT =
       loop(hrp.toCharArray.toList, Nil, isLower = false, isUpper = false)
 
-    hrpT.flatMap { chars =>
+    hrpT.map { chars =>
       val str = chars.mkString
-      val lnT = LnHumanReadablePart.fromStringT(str)
-      val btcT = BtcHumanReadablePart.fromStringT(str)
-
-      lnT
-        .orElse(btcT)
-        .orElse(Failure(new IllegalArgumentException(
-          s"Could not construct valid LN or BTC HRP from $str ")))
+      str
     }
   }
 
@@ -210,8 +202,7 @@ sealed abstract class Bech32 {
     *      [[https://github.com/sipa/bech32/blob/master/ref/python/segwit_addr.py#L62 this function]]
     *      by Sipa
     */
-  def splitToHrpAndData(
-      bech32: String): Try[(Bech32HumanReadablePart, Vector[UInt5])] = {
+  def splitToHrpAndData(bech32: String): Try[(String, Vector[UInt5])] = {
     val sepIndexes = bech32.zipWithIndex.filter {
       case (sep, _) => sep == Bech32.separator
     }
@@ -245,25 +236,25 @@ sealed abstract class Bech32 {
         Failure(new IllegalArgumentException("Hrp/data too short"))
       } else {
         for {
-          hrp <- checkHrpValidity(hrpStr)
+          hrpString <- checkHrpValidity(hrpStr)
           dataWithCheck <- Bech32.checkDataValidity(dataStr)
+          hrpU5s = hrpExpand(hrpStr)
           dataNoCheck <- {
-            if (verifyChecksum(hrp, dataWithCheck)) {
+            if (verifyChecksum(hrpU5s, dataWithCheck)) {
               Success(dataWithCheck.take(dataWithCheck.size - 6))
             } else
               Failure(
                 new IllegalArgumentException(
                   s"Checksum was invalid on bech32 string $bech32"))
           }
-        } yield (hrp, dataNoCheck)
+        } yield (hrpString, dataNoCheck)
       }
     }
   }
 
-  def verifyChecksum(hrp: Bech32HumanReadablePart, u5s: Seq[UInt5]): Boolean = {
-    val expandedHrp = hrpExpand(hrp)
-    val data = expandedHrp ++ u5s
-    val checksum = Bech32.polyMod(data)
+  def verifyChecksum(hrp: Seq[UInt5], u5s: Seq[UInt5]): Boolean = {
+    val data = hrp ++ u5s
+    val checksum = Bech32.polyMod(data.toVector)
     checksum == 1
   }
 
@@ -302,5 +293,5 @@ abstract class Bech32HumanReadablePart {
   def chars: String
 
   /** Expands this HRP into a vector of UInt5s, in accordance with the Bech32 spec */
-  def expand: Vector[UInt5] = Bech32.hrpExpand(this)
+  def expand: Vector[UInt5] = Bech32.hrpExpand(chars)
 }

--- a/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/Bech32.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.core.util
 
 import org.bitcoins.core.number.{UInt5, UInt8}
+import org.bitcoins.crypto.StringFactory
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
@@ -108,6 +109,14 @@ sealed abstract class Bech32 {
       val str = chars.mkString
       str
     }
+  }
+
+  /** Checks the validity of the HRP against bech32 and the given [[StringFactory]] */
+  def checkHrpValidity[T <: Bech32HumanReadablePart](
+      hrp: String,
+      factory: StringFactory[T]): Try[T] = {
+    checkHrpValidity(hrp)
+      .flatMap(str => factory.fromStringT(str))
   }
 
   def isInHrpRange(char: Char): Boolean = char >= 33 && char <= 126


### PR DESCRIPTION
This PR does two things:

1. Makes `Bech32.checkHrpValidity()` return a string  rather than a `Bech32HumanReadablePart`
2. Makes `BtcHumanReadablePart` extend `StringFactory`

`1` is important because as we scale out to more `Bech32` applications (such as DLC) we don't want to have to modify the core code everytime. Now it's the responsibility of the caller of this code to place the returned `String` into the correct subclass of `Bech32HumanReadablePart`. 

I experienced this problem with working with a bech32 oracle address format.