### PR TITLE
DLCFundingSignatures now accepts P2WSH, P2SH(Segwit)

### DIFF
--- a/app-commons-test/src/test/scala/org/bitcoins/commons/dlc/DLCMessageTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/dlc/DLCMessageTest.scala
@@ -74,12 +74,6 @@ class DLCMessageTest extends BitcoinSAsyncTest {
         val accept = DLCAccept.fromTLV(acceptTLV, offer)
         val sign = DLCSign.fromTLV(signTLV, offer)
 
-        val pubKeys = signTLV.fundingSignatures match {
-          case FundingSignaturesV0TLV(witnesses) =>
-            witnesses.map(_.asInstanceOf[P2WPKHWitnessV0].pubKey)
-        }
-        assert(sign.fundingSigs.toVector.map(_._2.head.pubKey) == pubKeys)
-
         assert(offer.toTLV == offerTLV)
         assert(accept.toTLV == acceptTLV)
         assert(sign.toTLV == signTLV)

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCFundingInput.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/DLCFundingInput.scala
@@ -13,6 +13,13 @@ sealed trait DLCFundingInput {
   def maxWitnessLen: UInt16
   def redeemScriptOpt: Option[WitnessScriptPubKey]
 
+  def scriptSignature: ScriptSignature = {
+    redeemScriptOpt match {
+      case Some(redeemScript) => P2SHScriptSignature(redeemScript)
+      case None               => EmptyScriptSignature
+    }
+  }
+
   lazy val output: TransactionOutput = prevTx.outputs(prevTxVout.toInt)
 
   lazy val outPoint: TransactionOutPoint =

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -830,13 +830,13 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
         assert(responseAs[
-          String] == s"""{"result":"\\"{\\\\\\"cetSigs\\\\\\":{\\\\\\"outcomeSigs\\\\\\":[{\\\\\\"${winHash.hex}\\\\\\":\\\\\\"${dummyAdaptorSig.hex}\\\\\\"},{\\\\\\"${loseHash.hex}\\\\\\":\\\\\\"${dummyAdaptorSig.hex}\\\\\\"}],\\\\\\"refundSig\\\\\\":\\\\\\"${dummyPartialSig.hex}\\\\\\"},\\\\\\"fundingSigs\\\\\\":{\\\\\\"${EmptyTransactionOutPoint.hex}\\\\\\":[\\\\\\"${dummyPartialSig.hex}\\\\\\"]},\\\\\\"contractId\\\\\\":\\\\\\"${paramHash.hex}\\\\\\"}\\"","error":null}""")
+          String] == s"""{"result":"\\"{\\\\\\"cetSigs\\\\\\":{\\\\\\"outcomeSigs\\\\\\":[{\\\\\\"${winHash.hex}\\\\\\":\\\\\\"${dummyAdaptorSig.hex}\\\\\\"},{\\\\\\"${loseHash.hex}\\\\\\":\\\\\\"${dummyAdaptorSig.hex}\\\\\\"}],\\\\\\"refundSig\\\\\\":\\\\\\"${dummyPartialSig.hex}\\\\\\"},\\\\\\"fundingSigs\\\\\\":{\\\\\\"${EmptyTransactionOutPoint.hex}\\\\\\":\\\\\\"${dummyScriptWitness.hex}\\\\\\"},\\\\\\"contractId\\\\\\":\\\\\\"${paramHash.hex}\\\\\\"}\\"","error":null}""")
       }
     }
 
     "add dlc sigs" in {
       val sigsStr =
-        s"""{"cetSigs":{"outcomeSigs":[{"${winHash.hex}":"${dummyAdaptorSig.hex}"},{"${loseHash.hex}":"${dummyAdaptorSig.hex}"}],"refundSig":"${dummyPartialSig.hex}"},"fundingSigs":{"${EmptyTransactionOutPoint.hex}":["${dummyPartialSig.hex}"]},"contractId":"${contractId.toHex}"}"""
+        s"""{"cetSigs":{"outcomeSigs":[{"${winHash.hex}":"${dummyAdaptorSig.hex}"},{"${loseHash.hex}":"${dummyAdaptorSig.hex}"}],"refundSig":"${dummyPartialSig.hex}"},"fundingSigs":{"${EmptyTransactionOutPoint.hex}":"${dummyScriptWitness.hex}"},"contractId":"${contractId.toHex}"}"""
 
       (mockWalletApi
         .addDLCSigs(_: DLCSign))

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -36,7 +36,7 @@ import org.bitcoins.core.protocol.BlockStamp.{
   BlockTime,
   InvalidBlockStamp
 }
-import org.bitcoins.core.protocol.script.EmptyScriptWitness
+import org.bitcoins.core.protocol.script.{EmptyScriptWitness, P2WPKHWitnessV0}
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.protocol.{
   Bech32Address,
@@ -691,6 +691,10 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         "024c6eb53573aae186dbb1a93274cc00c795473d7cfe2cb69e7d185ee28a39b919"),
       DummyECDigitalSignature)
 
+    val dummyScriptWitness: P2WPKHWitnessV0 = {
+      P2WPKHWitnessV0(dummyPartialSig.pubKey, dummyPartialSig.signature)
+    }
+
     val dummyAdaptorSig = ECAdaptorSignature.dummy
 
     val dummyOracleSig = SchnorrDigitalSignature(
@@ -816,7 +820,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
             DLCSign(
               CETSignatures(dummyOutcomeSigs, dummyPartialSig),
               FundingSignatures(
-                Vector((EmptyTransactionOutPoint, Vector(dummyPartialSig)))),
+                Vector((EmptyTransactionOutPoint, dummyScriptWitness))),
               paramHash.bytes
             )))
 

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -355,6 +355,40 @@ case class PSBT(
     PSBT(globalMap, newInputMaps, outputMaps)
   }
 
+  def addFinalizedScriptWitnessToInput(
+      scriptSignature: ScriptSignature,
+      scriptWitness: ScriptWitness,
+      index: Int): PSBT = {
+    require(index >= 0,
+            s"index must be greater than or equal to 0, got: $index")
+    require(
+      index < inputMaps.size,
+      s"index must be less than the number of input maps present in the psbt, $index >= ${inputMaps.size}")
+    require(!inputMaps(index).isFinalized,
+            s"Cannot update an InputPSBTMap that is finalized, index: $index")
+
+    val prevInput = inputMaps(index)
+
+    require(
+      prevInput.elements.forall {
+        case _: NonWitnessOrUnknownUTXO | _: WitnessUTXO | _: Unknown => true
+        case _: InputPSBTRecord                                       => false
+      },
+      s"Input already contains fields: ${prevInput.elements}"
+    )
+
+    val utxos = Vector(prevInput.witnessUTXOOpt,
+                       prevInput.nonWitnessOrUnknownUTXOOpt).flatten
+    val unknowns = prevInput.filterRecords(UnknownKeyId)
+
+    val finalizedScripts = Vector(FinalizedScriptSig(scriptSignature),
+                                  FinalizedScriptWitness(scriptWitness))
+
+    val records = utxos ++ finalizedScripts ++ unknowns
+    val newInputMaps = inputMaps.updated(index, InputPSBTMap(records))
+    PSBT(globalMap, newInputMaps, outputMaps)
+  }
+
   /**
     * Adds script to the indexed OutputPSBTMap to either the RedeemScript
     * or WitnessScript field depending on the script and available information in the PSBT

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
@@ -546,7 +546,7 @@ case class InputPSBTMap(elements: Vector[InputPSBTRecord])
       tx.outputs(txIn.previousOutput.vout.toInt)
     } else {
       throw new UnsupportedOperationException(
-        "Not enough information in the InputPSBTMap to get a valid InputInfo")
+        s"Not enough information in the InputPSBTMap to get a valid InputInfo: $elements")
     }
 
     val redeemScriptOpt = finalizedScriptSigOpt match {

--- a/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
@@ -135,7 +135,7 @@ case class DLCTxSigner(
           val witness = allSigs(fundingInput.outPoint)
 
           psbt
-            //.addUTXOToInput(fundingInput.prevTx, index)
+            .addUTXOToInput(fundingInput.prevTx, index)
             .addFinalizedScriptWitnessToInput(fundingInput.scriptSignature,
                                               witness,
                                               index)

--- a/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
@@ -12,6 +12,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script.{
   MultiSignatureScriptPubKey,
   P2WPKHWitnessSPKV0,
+  P2WPKHWitnessV0,
   P2WSHWitnessV0
 }
 import org.bitcoins.core.protocol.transaction.{
@@ -29,6 +30,7 @@ import org.bitcoins.crypto._
 import org.bitcoins.dlc.builder.DLCTxBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
 
 /** Responsible for constructing all DLC signatures
   * and signed transactions
@@ -84,7 +86,7 @@ case class DLCTxSigner(
   /** Creates this party's FundingSignatures */
   def createFundingTxSigs(): Future[FundingSignatures] = {
     val sigFs =
-      Vector.newBuilder[Future[(TransactionOutPoint, PartialSignature)]]
+      Vector.newBuilder[Future[(TransactionOutPoint, P2WPKHWitnessV0)]]
 
     for {
       fundingTx <- builder.buildFundingTx
@@ -95,17 +97,15 @@ case class DLCTxSigner(
             val sigF = BitcoinSigner.signSingle(utxoSingle,
                                                 fundingTx,
                                                 isDummySignature = false)
-            sigFs += sigF.map((utxo.outPoint, _))
+            sigFs += sigF.map(sig =>
+              (utxo.outPoint, P2WPKHWitnessV0(sig.pubKey, sig.signature)))
           }
         }
       }
 
       sigs <- Future.sequence(sigFs.result())
     } yield {
-      val sigsMap = sigs.groupBy(_._1).map {
-        case (outPoint, outPointAndSigs) =>
-          outPoint -> outPointAndSigs.map(_._2)
-      }
+      val sigsMap = sigs.toMap
 
       val fundingInputs = if (isInitiator) {
         offer.fundingInputs
@@ -132,16 +132,24 @@ case class DLCTxSigner(
     } yield {
       fundingInputs.zipWithIndex.foldLeft(PSBT.fromUnsignedTx(fundingTx)) {
         case (psbt, (fundingInput, index)) =>
-          val sigs = allSigs(fundingInput.outPoint)
+          val witness = allSigs(fundingInput.outPoint)
 
           psbt
-            .addSignatures(sigs, index)
-            .addWitnessUTXOToInput(fundingInput.output, index)
+            //.addUTXOToInput(fundingInput.prevTx, index)
+            .addFinalizedScriptWitnessToInput(fundingInput.scriptSignature,
+                                              witness,
+                                              index)
       }
     }
 
     psbtF.flatMap { psbt =>
-      val txT = psbt.finalizePSBT.flatMap(_.extractTransactionAndValidate)
+      val finalizedT = if (psbt.isFinalized) {
+        Success(psbt)
+      } else {
+        psbt.finalizePSBT
+      }
+
+      val txT = finalizedT.flatMap(_.extractTransactionAndValidate)
       Future.fromTry(txT)
     }
   }

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTLVGen.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTLVGen.scala
@@ -122,6 +122,12 @@ object DLCTLVGen {
     PartialSignature(pubKey, ecdsaSig(sigHashByte))
   }
 
+  def p2wpkhWitnessV0(
+      pubKey: ECPublicKey = ECPublicKey.freshPublicKey,
+      sigHashByte: Boolean = true): P2WPKHWitnessV0 = {
+    P2WPKHWitnessV0(pubKey, ecdsaSig(sigHashByte))
+  }
+
   def cetSigs(
       outcomes: Vector[Sha256Digest] = DLCTestUtil.genOutcomes(3),
       fundingPubKey: ECPublicKey =
@@ -133,8 +139,7 @@ object DLCTLVGen {
   def fundingSigs(
       outPoints: Vector[TransactionOutPoint] = Vector(
         outputReference().outPoint)): FundingSignatures = {
-    FundingSignatures(
-      outPoints.map(outpoint => outpoint -> Vector(partialSig())))
+    FundingSignatures(outPoints.map(outpoint => outpoint -> p2wpkhWitnessV0()))
   }
 
   def dlcOffer(

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestUtil.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestUtil.scala
@@ -3,6 +3,12 @@ package org.bitcoins.dlc.testgen
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.ContractInfo
 import org.bitcoins.commons.jsonmodels.dlc.{CETSignatures, FundingSignatures}
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.protocol.script.{
+  EmptyScriptPubKey,
+  P2WPKHWitnessV0,
+  P2WSHWitnessV0,
+  ScriptWitnessV0
+}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.util.NumberUtil
 import org.bitcoins.crypto.{
@@ -71,11 +77,34 @@ object DLCTestUtil {
     ECAdaptorSignature(flipAtIndex(adaptorSignature.bytes, 40))
   }
 
+  def flipBit(witness: ScriptWitnessV0): ScriptWitnessV0 = {
+    witness match {
+      case p2wpkh: P2WPKHWitnessV0 =>
+        P2WPKHWitnessV0(p2wpkh.pubKey, flipBit(p2wpkh.signature))
+      case p2wsh: P2WSHWitnessV0 =>
+        val sigOpt = p2wsh.stack.zipWithIndex.find {
+          case (bytes, _) =>
+            bytes.length >= 67 && bytes.length <= 73
+        }
+
+        sigOpt match {
+          case Some((sig, index)) =>
+            P2WSHWitnessV0(
+              EmptyScriptPubKey,
+              p2wsh.stack.updated(index,
+                                  flipBit(ECDigitalSignature(sig)).bytes))
+          case None =>
+            P2WSHWitnessV0(
+              EmptyScriptPubKey,
+              p2wsh.stack.updated(0, flipAtIndex(p2wsh.stack.head, 0)))
+        }
+    }
+  }
+
   def flipBit(fundingSigs: FundingSignatures): FundingSignatures = {
-    val (firstOutPoint, sigs) = fundingSigs.head
-    val badSig = flipBit(sigs.head)
-    val badSigs = sigs.tail.+:(badSig)
-    FundingSignatures(fundingSigs.tail.toVector.+:(firstOutPoint -> badSigs))
+    val (firstOutPoint, witness) = fundingSigs.head
+    val badWitness = flipBit(witness)
+    FundingSignatures(fundingSigs.tail.toVector.+:(firstOutPoint -> badWitness))
   }
 
   def flipBit(cetSigs: CETSignatures): CETSignatures = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -124,8 +124,7 @@ trait DLCWalletUtil {
 
   lazy val dummyFundingSignatures: FundingSignatures = FundingSignatures(
     Vector(
-      (TransactionOutPoint(dummyBlockHash, UInt32.zero),
-       Vector(dummyPartialSig))))
+      (TransactionOutPoint(dummyBlockHash, UInt32.zero), dummyScriptWitness)))
 
   lazy val sampleDLCSign: DLCSign =
     DLCSign(dummyCETSigs, dummyFundingSignatures, ByteVector.empty)


### PR DESCRIPTION
Added support for counter-parties to use non-P2WPKH funding inputs.

Not in this PR because they come together in the next: tests using non-P2WPKH, correct fee computation