### PR TITLE
Fix HDPurpose Mapper for non standard values

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -184,9 +184,10 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
 
   implicit val hdPurposeMapper: BaseColumnType[HDPurpose] =
     MappedColumnType
-      .base[HDPurpose, Int](_.constant,
-                            HDPurposes.fromConstant(_).get
-      ) // hm rething .get
+      .base[HDPurpose, Int](
+        _.constant,
+        purpose =>
+          HDPurposes.fromConstant(purpose).getOrElse(HDPurpose(purpose)))
 
   implicit val bitcoinAddressMapper: BaseColumnType[BitcoinAddress] =
     MappedColumnType


### PR DESCRIPTION
Previously, we could only read purposes that are standard for bitcoin (44/49/84). This allows us to ready any value for the HD purpose.