### PR TITLE
Add ability to fully spend utxos

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
@@ -6,6 +6,7 @@ import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.script.crypto.HashType
+import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.util.BitcoinScriptUtil
 import org.bitcoins.core.wallet.fee.{SatoshisPerByte, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.utxo.{
@@ -14,7 +15,12 @@ import org.bitcoins.core.wallet.utxo.{
   LockTimeInputInfo,
   ScriptSignatureParams
 }
-import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPrivateKey}
+import org.bitcoins.crypto.{
+  DoubleSha256DigestBE,
+  DummyECDigitalSignature,
+  ECPrivateKey,
+  Sign
+}
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.{CreditingTxGen, ScriptGenerators}
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
@@ -299,6 +305,57 @@ class RawTxSignerTest extends BitcoinSAsyncTest {
 
         txF.map { tx =>
           assert(BitcoinScriptUtil.verifyScript(tx, creditingTxsInfo.toVector))
+        }
+    }
+  }
+
+  it should "dummy sign a mix of spks in a tx and then have fail verification" in {
+    forAllAsync(CreditingTxGen.inputsAndOutputs(),
+                ScriptGenerators.scriptPubKey) {
+      case ((creditingTxsInfo, destinations), (changeSPK, _)) =>
+        val fee = SatoshisPerVirtualByte(Satoshis(1000))
+
+        val dummySpendingInfos = creditingTxsInfo.map { spendingInfo =>
+          val inputInfo = spendingInfo.inputInfo
+          val mockSigners =
+            inputInfo.pubKeys.take(inputInfo.requiredSigs).map(Sign.dummySign)
+
+          inputInfo.toSpendingInfo(EmptyTransaction,
+                                   mockSigners,
+                                   HashType.sigHashAll)
+        }
+
+        val utxF =
+          StandardNonInteractiveFinalizer.txFrom(outputs = destinations,
+                                                 utxos = dummySpendingInfos,
+                                                 feeRate = fee,
+                                                 changeSPK = changeSPK)
+        val txF = utxF.flatMap(utx =>
+          RawTxSigner.sign(utx,
+                           dummySpendingInfos.toVector,
+                           RawTxSigner.emptyInvariant,
+                           dummySign = true))
+
+        // Can't use BitcoinScriptUtil.verifyScript because it will pass for things
+        // with EmptyScriptPubKeys or Multisig with 0 required sigs
+        txF.map {
+          case EmptyTransaction =>
+            succeed
+          case btx: BaseTransaction =>
+            assert(
+              btx.inputs.forall(_.scriptSignature.signatures.forall(
+                _ == DummyECDigitalSignature)))
+          case wtx: WitnessTransaction =>
+            assert(
+              wtx.witness.witnesses.forall {
+                case p2wsh: P2WSHWitnessV0 =>
+                  p2wsh.signatures.forall(_ == DummyECDigitalSignature)
+                case p2wpkh: P2WPKHWitnessV0 =>
+                  p2wpkh.signature == DummyECDigitalSignature
+                case EmptyScriptWitness =>
+                  true
+              }
+            )
         }
     }
   }

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
@@ -6,7 +6,6 @@ import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.script.crypto.HashType
-import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.util.BitcoinScriptUtil
 import org.bitcoins.core.wallet.fee.{SatoshisPerByte, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.utxo.{
@@ -17,8 +16,8 @@ import org.bitcoins.core.wallet.utxo.{
 }
 import org.bitcoins.crypto.{
   DoubleSha256DigestBE,
-  DummyECDigitalSignature,
   ECPrivateKey,
+  LowRDummyECDigitalSignature,
   Sign
 }
 import org.bitcoins.testkit.Implicits._
@@ -344,14 +343,14 @@ class RawTxSignerTest extends BitcoinSAsyncTest {
           case btx: BaseTransaction =>
             assert(
               btx.inputs.forall(_.scriptSignature.signatures.forall(
-                _ == DummyECDigitalSignature)))
+                _ == LowRDummyECDigitalSignature)))
           case wtx: WitnessTransaction =>
             assert(
               wtx.witness.witnesses.forall {
                 case p2wsh: P2WSHWitnessV0 =>
-                  p2wsh.signatures.forall(_ == DummyECDigitalSignature)
+                  p2wsh.signatures.forall(_ == LowRDummyECDigitalSignature)
                 case p2wpkh: P2WPKHWitnessV0 =>
-                  p2wpkh.signature == DummyECDigitalSignature
+                  p2wpkh.signature == LowRDummyECDigitalSignature
                 case EmptyScriptWitness =>
                   true
               }

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -261,6 +261,32 @@ trait WalletApi extends StartStopAsync[WalletApi] {
     } yield tx
   }
 
+  def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      feeRate: FeeUnit)(implicit ec: ExecutionContext): Future[Transaction]
+
+  def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      feeRateOpt: Option[FeeUnit]
+  )(implicit ec: ExecutionContext): Future[Transaction] = {
+    for {
+      feeRate <- determineFeeRate(feeRateOpt)
+      tx <- sendFromOutPoints(outPoints, address, feeRate)
+    } yield tx
+  }
+
+  def emptyWallet(address: BitcoinAddress, feeRateOpt: Option[FeeUnit])(implicit
+      ec: ExecutionContext): Future[Transaction] = {
+    for {
+      feeRate <- determineFeeRate(feeRateOpt)
+      utxos <- listUtxos()
+      outPoints = utxos.map(_.outPoint)
+      tx <- sendFromOutPoints(outPoints, address, feeRate)
+    } yield tx
+  }
+
   def sendWithAlgo(
       address: BitcoinAddress,
       amount: CurrencyUnit,

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -11,12 +11,7 @@ import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.script.flag.ScriptFlag
 import org.bitcoins.core.wallet.builder.TxBuilderError
 import org.bitcoins.core.wallet.utxo._
-import org.bitcoins.crypto.{
-  DummyECDigitalSignature,
-  ECDigitalSignature,
-  ECPublicKey,
-  Sign
-}
+import org.bitcoins.crypto._
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -45,7 +40,7 @@ sealed abstract class SignerUtils {
       isDummySignature: Boolean)(implicit
       ec: ExecutionContext): Future[ECDigitalSignature] = {
     if (isDummySignature) {
-      Future.successful(DummyECDigitalSignature)
+      Future.successful(LowRDummyECDigitalSignature)
     } else {
       TransactionSignatureCreator.createSig(unsignedTx,
                                             signingInfo,

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -60,7 +60,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
 
   val TestAmount = 1.bitcoin
   val FeeRate = SatoshisPerByte(10.sats)
-  val TestFees = 2240.sats
+  val TestFees: Satoshis = 2230.sats
 
   def nodeCallbacks: NodeCallbacks = {
     val onBlock: OnBlockReceived = { block =>
@@ -99,8 +99,9 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
           addresses <- wallet.listAddresses()
           utxos <- wallet.listDefaultAccountUtxos()
         } yield {
-          (expectedConfirmedAmount == confirmedBalance) &&
-          (expectedUnconfirmedAmount == unconfirmedBalance) &&
+          // +- fee rate because signatures could vary in size
+          (expectedConfirmedAmount === confirmedBalance +- FeeRate.currencyUnit) &&
+          (expectedUnconfirmedAmount === unconfirmedBalance +- FeeRate.currencyUnit) &&
           (expectedAddresses == addresses.size) &&
           (expectedUtxos == utxos.size)
         }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -13,9 +13,10 @@ import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.{GolombFilter, SimpleFilterMatcher}
 import org.bitcoins.core.hd.{HDAccount, HDCoin, HDPurpose, HDPurposes}
+import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.blockchain.ChainParams
-import org.bitcoins.core.protocol.script.ScriptPubKey
+import org.bitcoins.core.protocol.script.{EmptyScriptPubKey, ScriptPubKey}
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.ScriptConstant
 import org.bitcoins.core.script.control.OP_RETURN
@@ -25,7 +26,7 @@ import org.bitcoins.core.wallet.builder.{
   RawTxSigner,
   ShufflingNonInteractiveFinalizer
 }
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.fee._
 import org.bitcoins.core.wallet.keymanagement.{
   KeyManagerParams,
   KeyManagerUnlockError
@@ -387,6 +388,58 @@ abstract class Wallet
       }
       signed
     }
+  }
+
+  def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      feeRate: FeeUnit)(implicit ec: ExecutionContext): Future[Transaction] = {
+    require(
+      address.networkParameters.isSameNetworkBytes(networkParameters),
+      s"Cannot send to address on other network, got ${address.networkParameters}"
+    )
+    logger.info(s"Sending to $address at feerate $feeRate")
+    for {
+      utxoDbs <- spendingInfoDAO.findByOutPoints(outPoints)
+      diff = utxoDbs.map(_.outPoint).diff(outPoints)
+      _ = require(diff.isEmpty,
+                  s"Not all OutPoints belong to this wallet, diff $diff")
+      spentUtxos =
+        utxoDbs.filterNot(utxo => TxoState.receivedStates.contains(utxo.state))
+      _ = require(
+        spentUtxos.isEmpty,
+        s"Some out points given have already been spent, ${spentUtxos.map(_.outPoint)}")
+
+      prevTxFs = utxoDbs.map(utxo =>
+        transactionDAO.findByOutPoint(utxo.outPoint).map(_.get.transaction))
+      prevTxs <- FutureUtil.collect(prevTxFs)
+      utxos =
+        utxoDbs
+          .zip(prevTxs)
+          .map(info => info._1.toUTXOInfo(keyManager, info._2))
+
+      utxoAmount = utxoDbs.map(_.output.value).sum
+      dummyOutput = TransactionOutput(utxoAmount, address.scriptPubKey)
+
+      dummyTx <-
+        TxUtil.buildDummyTx(utxos.map(_.inputInfo), Vector(dummyOutput))
+
+      fee = feeRate * dummyTx
+      amount = utxoAmount - fee
+
+      _ = require(amount > Policy.dustThreshold,
+                  "Utxos are not large enough to send at this fee rate")
+
+      output = TransactionOutput(amount, address.scriptPubKey)
+      txBuilder = ShufflingNonInteractiveFinalizer.txBuilderFrom(
+        Vector(output),
+        utxos,
+        feeRate,
+        EmptyScriptPubKey // There will be no change
+      )
+
+      tx <- finishSend(txBuilder, utxos, amount, feeRate, Vector.empty)
+    } yield tx
   }
 
   override def sendFromOutPoints(


### PR DESCRIPTION
Built on top of #2062 

Closes #2051 

Needed to create `LowRDummyECDigitialSignature` so we can accurately predict tx/signature sizes when low r signing