### PR TITLE
Use SubtractFeeFromOutputsFinalizer when sending full utxos

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
@@ -308,7 +308,7 @@ class RawTxSignerTest extends BitcoinSAsyncTest {
     }
   }
 
-  it should "dummy sign a mix of spks in a tx and then have fail verification" in {
+  it should "dummy sign a mix of spks in a tx and fill it with dummy signatures" in {
     forAllAsync(CreditingTxGen.inputsAndOutputs(),
                 ScriptGenerators.scriptPubKey) {
       case ((creditingTxsInfo, destinations), (changeSPK, _)) =>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -9,7 +9,6 @@ import org.bitcoins.core.script.control.OP_RETURN
 import org.bitcoins.core.wallet.fee._
 import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.crypto.CryptoUtil
-import org.bitcoins.testkit.core.gen.{CurrencyUnitGenerator, FeeUnitGen}
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest.RandomFeeProvider
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet


### PR DESCRIPTION
Follow up from #2063 as @nkohen pointed out to me that I could instead use the `SubtractFeeFromOutputsFinalizer` instead of doing the calculation my self.

To do this however, I needed to fix the `AddWitnessDataFinalizer` to not care about the order of the input infos