### PR TITLE
Create ExtPrivateKeyHardened

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ExtKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ExtKeyTest.scala
@@ -1,9 +1,8 @@
 package org.bitcoins.core.crypto
 
-import ExtKeyVersion._
+import org.bitcoins.core.crypto.ExtKeyVersion._
 import org.bitcoins.core.hd.BIP32Path
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.crypto
 import org.bitcoins.testkit.core.gen.{
   CryptoGenerators,
   HDGenerators,
@@ -79,6 +78,21 @@ class ExtKeyTest extends BitcoinSUnitTest {
           case Success(_)   => fail
           case Failure(exc) => assert(exc.getMessage.contains("hardened"))
         }
+    }
+  }
+
+  it must "fail to derive a unhardened child key from a ExtPrivateKeyHardened" in {
+    forAll(CryptoGenerators.extPrivateKey, HDGenerators.hdAddress) {
+      (priv, path) =>
+        val hardened: ExtPrivateKeyHardened = priv.toHardened
+
+        assertThrows[IllegalArgumentException](hardened.deriveChildPrivKey(0))
+
+        assertThrows[IllegalArgumentException](
+          hardened.deriveChildPrivKey(UInt32.one))
+
+        assertThrows[IllegalArgumentException](
+          hardened.deriveChildPrivKey(path))
     }
   }
 


### PR DESCRIPTION
Conext: https://github.com/bitcoin-s/bitcoin-s/pull/2064#discussion_r496152949

The idea is to have an `ExtPrivateKey` that can only generate values from hardened paths. This should make things like deterministic nonce generation for DLC Oracles safer to use.