### PR TITLE
Allow any HDCoinType

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/hd/HDPathTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/hd/HDPathTest.scala
@@ -70,10 +70,12 @@ class HDPathTest extends BitcoinSUnitTest {
   behavior of "HDCoinType"
 
   it must "correctly represent Bitcoin and Testnet coins" in {
-    HDCoinType.fromInt(0) must be(HDCoinType.Bitcoin)
-    HDCoinType.fromInt(1) must be(HDCoinType.Testnet)
-    forAll(NumberGenerator.ints.suchThat(i => i != 1 && i != 0)) { i =>
-      assertThrows[IllegalArgumentException](HDCoinType.fromInt(i))
+    HDCoinType(0) must be(HDCoinType.Bitcoin)
+    HDCoinType(1) must be(HDCoinType.Testnet)
+    forAll(NumberGenerator.ints.suchThat(i =>
+      !HDCoinType.all.map(_.toInt).contains(i))) { i =>
+      HDCoinType(i).toInt must be(i)
+      HDCoinType.fromKnown(i) must be(None)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/hd/HDCoin.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDCoin.scala
@@ -13,7 +13,7 @@ object HDCoin {
   def fromPath(path: BIP32Path): Option[HDCoin] = {
     if (path.path.length == 2) {
       HDPurposes.fromNode(path.path.head).map { purpose =>
-        val coinType = HDCoinType.fromInt(path.path.last.index)
+        val coinType = HDCoinType(path.path.last.index)
 
         HDCoin(purpose, coinType)
       }

--- a/core/src/main/scala/org/bitcoins/core/hd/HDCoinType.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDCoinType.scala
@@ -10,9 +10,7 @@ import org.bitcoins.core.config._
   * [[https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki BIP49]]
   * coin type.
   */
-sealed trait HDCoinType {
-  def toInt: Int
-}
+case class HDCoinType(toInt: Int)
 
 /**
   * @see [[https://github.com/satoshilabs/slips/blob/master/slip-0044.md SLIP-0044]]
@@ -20,21 +18,12 @@ sealed trait HDCoinType {
   */
 object HDCoinType {
 
-  final case object Bitcoin extends HDCoinType {
-    override val toInt: Int = 0
-  }
+  final val Bitcoin = HDCoinType(0)
+  final val Testnet = HDCoinType(1)
 
-  final case object Testnet extends HDCoinType {
-    override val toInt: Int = 1
-  }
+  lazy val all: Vector[HDCoinType] = Vector(Bitcoin, Testnet)
 
-  def fromInt(int: Int): HDCoinType =
-    int match {
-      case Bitcoin.toInt => Bitcoin
-      case Testnet.toInt => Testnet
-      case _: Int =>
-        throw new IllegalArgumentException(s"$int is not valid coin type!")
-    }
+  def fromKnown(int: Int): Option[HDCoinType] = all.find(_.toInt == int)
 
   def fromNetwork(np: NetworkParameters): HDCoinType = {
     np match {
@@ -48,6 +37,6 @@ object HDCoinType {
     require(node.hardened,
             s"Cannot construct HDCoinType from un-hardened node: $node")
 
-    fromInt(node.index)
+    HDCoinType(node.index)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/hd/HDPathFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDPathFactory.scala
@@ -71,7 +71,7 @@ private[hd] trait HDPathFactory[PathType <: BIP32Path]
             "The address index child must not be hardened!")
 
     val chainType = HDChainType.fromInt(chainChild.index)
-    val coinType = HDCoinType.fromInt(coinChild.index)
+    val coinType = HDCoinType(coinChild.index)
 
     apply(coin = coinType,
           accountIndex = accountChild.index,

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -179,7 +179,7 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
   }
 
   implicit val hdCoinTypeMapper: BaseColumnType[HDCoinType] = {
-    MappedColumnType.base[HDCoinType, Int](_.toInt, HDCoinType.fromInt)
+    MappedColumnType.base[HDCoinType, Int](_.toInt, HDCoinType(_))
   }
 
   implicit val hdPathMappper: BaseColumnType[HDPath] =


### PR DESCRIPTION
Previously we could only represent a `HDCoinType` of 0 or 1, this changes it so we can represent any `HDCoinType`. This will be useful for things like [DLC Oracles](https://github.com/discreetlogcontracts/dlcspecs/issues/102) or if someone wants to use shitcoins >:(