### PR TITLE
Have scala-steward ignore scalafmt updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.ignore = [ { groupId = "org.scalameta", artifactId = "scalafmt-core" } ]


### PR DESCRIPTION
Closes #2138 
Closes #2198 

This should stop scala-steward from creating PRs to update the scalafmt version