### PR TITLE
Upgrade to scalac 2.13.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
       name: Compile Website
       env:
         - TEST_COMMAND="docs/mdoc"
-      scala: 2.13.2
+      scala: 2.13.3
 
     - stage: trivial
       os: linux
@@ -30,14 +30,14 @@ jobs:
       name: Compile website
       env:
         - TEST_COMMAND="docs/mdoc"
-      scala: 2.13.2
+      scala: 2.13.3
 
     - stage: test
-      name: Linux 2.13.2 bitcoind and eclair rpc tests
+      name: Linux 2.13.3 bitcoind and eclair rpc tests
       os: linux
       env:
         - TEST_COMMAND="bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls"
-      scala: 2.13.2
+      scala: 2.13.3
 
     - stage: test
       name: Linux 2.12.12 bitcoind and eclair rpc tests
@@ -47,11 +47,11 @@ jobs:
       scala: 2.12.12
 
     - stage: test
-      name: Linux 2.13.2 App, Chain, Node, and Core Tests
+      name: Linux 2.13.3 App, Chain, Node, and Core Tests
       os: linux
       env:
         - TEST_COMMAND="chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls cryptoTest/test crypto/coverageReport crypto/coverageAggregate crypto/coveralls coreTest/test core/coverageReport core/coverageAggregate core/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test"
-      scala: 2.13.2
+      scala: 2.13.3
 
     - stage: test
       name: Linux 2.12.12 App, Chain, Node, and Core Tests
@@ -61,17 +61,17 @@ jobs:
       scala: 2.12.12
       # In the future these should be removed as the tests will be broken up and put in other projects
     - stage: test
-      name: Linux 2.13.2 DLC Tests
+      name: Linux 2.13.3 DLC Tests
       os: linux
       env:
         - TEST_COMMAND="dlcOracleTest/test"
-      scala: 2.13.2
+      scala: 2.13.3
     - stage: test
-      name: Linux 2.13.2 KeyManager and Wallet tests
+      name: Linux 2.13.3 KeyManager and Wallet tests
       os: linux
       env:
         - TEST_COMMAND="keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls"
-      scala: 2.13.2
+      scala: 2.13.3
 
     - stage: test
       name: Linux 2.12.12 KeyManager and Wallet tests
@@ -86,7 +86,7 @@ jobs:
       env:
         - DISABLE_SECP256K1="true"
         - TEST_COMMAND="coreTest/test cryptoTest/test"
-      scala: 2.13.2
+      scala: 2.13.3
 
     - stage: test
       os: linux
@@ -94,14 +94,14 @@ jobs:
       env:
         - PG_ENABLED="1"
         - TEST_COMMAND="dbCommonsTest/test chainTest/test nodeTest/test walletTest/test"
-      scala: 2.13.2
+      scala: 2.13.3
 
     - stage: test
       os: osx
       name: "macOS bitcoind and eclair tests"
       env:
         - TEST_COMMAND="cryptoTest/test coreTest/test appCommonsTest/test bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls"
-      scala: 2.13.2
+      scala: 2.13.3
 
     # skip all test tagged as UsesExperimentalBitcoind
     # TODO remove this condition once we have a neutrino enabled bitcoind binary for OSX
@@ -110,13 +110,13 @@ jobs:
       name: "macOS wallet and node tests"
       env:
         - TEST_COMMAND="walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls"
-      scala: 2.13.2
+      scala: 2.13.3
     - stage: test
       os: osx
       name: "macOS dlc tests"
       env:
         - TEST_COMMAND="dlcOracleTest/test"
-      scala: 2.13.2
+      scala: 2.13.3
     # Release snapshots/versions of all libraries
     # run ci-release only if previous stages passed
     - stage: release

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -209,7 +209,8 @@ object ConsoleCli {
           conf.copy(command = AcceptDLCOffer(null, escaped = false)))
         .text("Accepts a DLC offer given from another party")
         .children(
-          opt[DLCOffer]("offer").required
+          opt[DLCOffer]("offer")
+            .required()
             .action((offer, conf) =>
               conf.copy(command = conf.command match {
                 case accept: AcceptDLCOffer =>
@@ -230,7 +231,8 @@ object ConsoleCli {
           conf.copy(command = SignDLC(null, escaped = false)))
         .text("Signs a DLC")
         .children(
-          opt[DLCAccept]("accept").required
+          opt[DLCAccept]("accept")
+            .required()
             .action((accept, conf) =>
               conf.copy(command = conf.command match {
                 case signDLC: SignDLC =>
@@ -250,7 +252,8 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = AddDLCSigs(null)))
         .text("Adds DLC Signatures into the database")
         .children(
-          opt[DLCSign]("sigs").required
+          opt[DLCSign]("sigs")
+            .required()
             .action((sigs, conf) =>
               conf.copy(command = conf.command match {
                 case addDLCSigs: AddDLCSigs =>
@@ -264,14 +267,16 @@ object ConsoleCli {
           conf.copy(command = InitDLCMutualClose(null, null, escaped = false)))
         .text("Sign Mutual Close Tx for given oracle event")
         .children(
-          opt[Sha256DigestBE]("eventid").required
+          opt[Sha256DigestBE]("eventid")
+            .required()
             .action((eventId, conf) =>
               conf.copy(command = conf.command match {
                 case initClose: InitDLCMutualClose =>
                   initClose.copy(eventId = eventId)
                 case other => other
               })),
-          opt[SchnorrDigitalSignature]("oraclesig").required
+          opt[SchnorrDigitalSignature]("oraclesig")
+            .required()
             .action((sig, conf) =>
               conf.copy(command = conf.command match {
                 case initClose: InitDLCMutualClose =>
@@ -292,14 +297,16 @@ object ConsoleCli {
           conf.copy(command = AcceptDLCMutualClose(null, noBroadcast = false)))
         .text("Sign Mutual Close Tx for given oracle event")
         .children(
-          opt[DLCMutualCloseSig]("closesig").required
+          opt[DLCMutualCloseSig]("closesig")
+            .required()
             .action((closeSig, conf) =>
               conf.copy(command = conf.command match {
                 case acceptClose: AcceptDLCMutualClose =>
                   acceptClose.copy(mutualCloseSig = closeSig)
                 case other => other
               })),
-          opt[Unit]("noBroadcast").optional
+          opt[Unit]("noBroadcast")
+            .optional()
             .action((_, conf) =>
               conf.copy(command = conf.command match {
                 case acceptClose: AcceptDLCMutualClose =>
@@ -312,7 +319,8 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = GetDLCFundingTx(null)))
         .text("Returns the Funding Tx corresponding to the DLC with the given eventId")
         .children(
-          opt[Sha256DigestBE]("eventid").required
+          opt[Sha256DigestBE]("eventid")
+            .required()
             .action((eventId, conf) =>
               conf.copy(command = conf.command match {
                 case getDLCFundingTx: GetDLCFundingTx =>
@@ -325,7 +333,8 @@ object ConsoleCli {
         .action((_, conf) => conf.copy(command = BroadcastDLCFundingTx(null)))
         .text("Broadcasts the funding Tx corresponding to the DLC with the given eventId")
         .children(
-          opt[Sha256DigestBE]("eventid").required
+          opt[Sha256DigestBE]("eventid")
+            .required()
             .action((eventId, conf) =>
               conf.copy(command = conf.command match {
                 case broadcastDLCFundingTx: BroadcastDLCFundingTx =>
@@ -340,21 +349,24 @@ object ConsoleCli {
             ExecuteDLCUnilateralClose(null, null, noBroadcast = false)))
         .text("Executes a unilateral close for the DLC with the given eventId")
         .children(
-          opt[Sha256DigestBE]("eventid").required
+          opt[Sha256DigestBE]("eventid")
+            .required()
             .action((eventId, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCUnilateralClose: ExecuteDLCUnilateralClose =>
                   executeDLCUnilateralClose.copy(eventId = eventId)
                 case other => other
               })),
-          opt[SchnorrDigitalSignature]("oraclesig").required
+          opt[SchnorrDigitalSignature]("oraclesig")
+            .required()
             .action((sig, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCUnilateralClose: ExecuteDLCUnilateralClose =>
                   executeDLCUnilateralClose.copy(oracleSig = sig)
                 case other => other
               })),
-          opt[Unit]("noBroadcast").optional
+          opt[Unit]("noBroadcast")
+            .optional()
             .action((_, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCUnilateralClose: ExecuteDLCUnilateralClose =>
@@ -371,21 +383,24 @@ object ConsoleCli {
                                                       noBroadcast = false)))
         .text("Executes a unilateral close for the DLC with the given eventId")
         .children(
-          opt[Sha256DigestBE]("eventid").required
+          opt[Sha256DigestBE]("eventid")
+            .required()
             .action((eventId, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCRemoteUnilateralClose: ExecuteDLCRemoteUnilateralClose =>
                   executeDLCRemoteUnilateralClose.copy(eventId = eventId)
                 case other => other
               })),
-          opt[Transaction]("forceCloseTx").required
+          opt[Transaction]("forceCloseTx")
+            .required()
             .action((cet, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCRemoteUnilateralClose: ExecuteDLCRemoteUnilateralClose =>
                   executeDLCRemoteUnilateralClose.copy(cet = cet)
                 case other => other
               })),
-          opt[Unit]("noBroadcast").optional
+          opt[Unit]("noBroadcast")
+            .optional()
             .action((_, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCRemoteUnilateralClose: ExecuteDLCRemoteUnilateralClose =>
@@ -400,21 +415,24 @@ object ConsoleCli {
             command = ExecuteDLCForceClose(null, null, noBroadcast = false)))
         .text("Executes a force close for the DLC with the given eventId")
         .children(
-          opt[Sha256DigestBE]("eventid").required
+          opt[Sha256DigestBE]("eventid")
+            .required()
             .action((eventId, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCForceClose: ExecuteDLCForceClose =>
                   executeDLCForceClose.copy(eventId = eventId)
                 case other => other
               })),
-          opt[SchnorrDigitalSignature]("oraclesig").required
+          opt[SchnorrDigitalSignature]("oraclesig")
+            .required()
             .action((sig, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCForceClose: ExecuteDLCForceClose =>
                   executeDLCForceClose.copy(oracleSig = sig)
                 case other => other
               })),
-          opt[Unit]("noBroadcast").optional
+          opt[Unit]("noBroadcast")
+            .optional()
             .action((_, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCForceClose: ExecuteDLCForceClose =>
@@ -429,7 +447,8 @@ object ConsoleCli {
             ClaimDLCRemoteFunds(null, EmptyTransaction, noBroadcast = false)))
         .text("Claims the remote funds for the corresponding DLC")
         .children(
-          opt[Sha256DigestBE]("eventid").required
+          opt[Sha256DigestBE]("eventid")
+            .required()
             .action((eventId, conf) =>
               conf.copy(command = conf.command match {
                 case claimDLCRemoteFunds: ClaimDLCRemoteFunds =>
@@ -459,14 +478,16 @@ object ConsoleCli {
           conf.copy(command = ExecuteDLCRefund(null, noBroadcast = false)))
         .text("Executes the Refund transaction for the given DLC")
         .children(
-          opt[Sha256DigestBE]("eventid").required
+          opt[Sha256DigestBE]("eventid")
+            .required()
             .action((eventId, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCRefund: ExecuteDLCRefund =>
                   executeDLCRefund.copy(eventId = eventId)
                 case other => other
               })),
-          opt[Unit]("noBroadcast").optional
+          opt[Unit]("noBroadcast")
+            .optional()
             .action((_, conf) =>
               conf.copy(command = conf.command match {
                 case executeDLCRefund: ExecuteDLCRefund =>
@@ -481,7 +502,8 @@ object ConsoleCli {
             ClaimDLCPenaltyFunds(null, EmptyTransaction, noBroadcast = false)))
         .text("Claims the penalty funds for the corresponding DLC")
         .children(
-          opt[Sha256DigestBE]("eventid").required
+          opt[Sha256DigestBE]("eventid")
+            .required()
             .action((eventId, conf) =>
               conf.copy(command = conf.command match {
                 case claimDLCPenaltyFunds: ClaimDLCPenaltyFunds =>
@@ -697,7 +719,8 @@ object ConsoleCli {
                   send.copy(satoshisPerVirtualByte = Some(feeRate))
                 case other => other
               })),
-          opt[Unit]("noBroadcast").optional
+          opt[Unit]("noBroadcast")
+            .optional()
             .action((_, conf) =>
               conf.copy(command = conf.command match {
                 case send: SendToAddress =>

--- a/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
@@ -13,7 +13,7 @@ case class ChainRoutes(chain: ChainApi)(implicit system: ActorSystem)
   def handleCommand: PartialFunction[ServerCommand, StandardRoute] = {
     case ServerCommand("getblockcount", _) =>
       complete {
-        chain.getBlockCount.map { count =>
+        chain.getBlockCount().map { count =>
           Server.httpSuccess(count)
         }
       }
@@ -31,7 +31,7 @@ case class ChainRoutes(chain: ChainApi)(implicit system: ActorSystem)
       }
     case ServerCommand("getbestblockhash", _) =>
       complete {
-        chain.getBestBlockHash.map { hash =>
+        chain.getBestBlockHash().map { hash =>
           Server.httpSuccess(hash)
         }
       }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -91,7 +91,7 @@ class BitcoindRpcClient(val instance: BitcoindInstance)(implicit
   }
 
   /** Gets the number of compact filters in the database */
-  override def getFilterCount: Future[Int] = ???
+  override def getFilterCount(): Future[Int] = ???
 
   /** Returns the block height of the given block stamp */
   override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] =

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v16/BitcoindV16RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v16/BitcoindV16RpcClient.scala
@@ -32,7 +32,7 @@ class BitcoindV16RpcClient(override val instance: BitcoindInstance)(implicit
 
   override def version: BitcoindVersion = BitcoindVersion.V16
 
-  override def getFilterCount: Future[Int] = filtersUnsupported
+  override def getFilterCount(): Future[Int] = filtersUnsupported
 
   override def getFiltersBetweenHeights(
       startHeight: Int,

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v17/BitcoindV17RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v17/BitcoindV17RpcClient.scala
@@ -39,7 +39,7 @@ class BitcoindV17RpcClient(override val instance: BitcoindInstance)(implicit
 
   override def version: BitcoindVersion = BitcoindVersion.V17
 
-  override def getFilterCount: Future[Int] = filtersUnsupported
+  override def getFilterCount(): Future[Int] = filtersUnsupported
 
   override def getFiltersBetweenHeights(
       startHeight: Int,

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v18/BitcoindV18RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v18/BitcoindV18RpcClient.scala
@@ -38,7 +38,7 @@ class BitcoindV18RpcClient(override val instance: BitcoindInstance)(implicit
 
   override lazy val version: BitcoindVersion = BitcoindVersion.V18
 
-  override def getFilterCount: Future[Int] = filtersUnsupported
+  override def getFilterCount(): Future[Int] = filtersUnsupported
 
   override def getFiltersBetweenHeights(
       startHeight: Int,

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
@@ -63,7 +63,7 @@ class BitcoindV19RpcClient(override val instance: BitcoindInstance)(implicit
                             batchSize = 25)
   }
 
-  override def getFilterCount: Future[Int] = getBlockCount
+  override def getFilterCount(): Future[Int] = getBlockCount
 
   override def getFilterHeaderCount(): Future[Int] = getBlockCount
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/BitcoindV20RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/BitcoindV20RpcClient.scala
@@ -61,7 +61,7 @@ class BitcoindV20RpcClient(override val instance: BitcoindInstance)(implicit
                             batchSize = 25)
   }
 
-  override def getFilterCount: Future[Int] = getBlockCount
+  override def getFilterCount(): Future[Int] = getBlockCount
 
   override def getFilterHeaderCount(): Future[Int] = getBlockCount
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/config/ChainAppConfigTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/config/ChainAppConfigTest.scala
@@ -78,7 +78,7 @@ class ChainAppConfigTest extends ChainUnitTest {
     assert(appConfig.network == TestNet3)
   }
 
-  override def afterAll: Unit = {
+  override def afterAll(): Unit = {
     FileUtil.deleteTmpDir(chainAppConfig.baseDatadir)
     val stopF = for {
       _ <- config.stop()

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -263,7 +263,7 @@ case class ChainHandler(
 
     for {
       startHeight <- startHeightF
-      filterHeaderCount <- getFilterHeaderCount
+      filterHeaderCount <- getFilterHeaderCount()
       stopHeight =
         if (startHeight - 1 + batchSize > filterHeaderCount)
           filterHeaderCount
@@ -454,7 +454,7 @@ case class ChainHandler(
     blockHeaderDAO.getAtHeight(height)
 
   /** @inheritdoc */
-  override def getFilterHeaderCount: Future[Int] = {
+  override def getFilterHeaderCount(): Future[Int] = {
     logger.debug(s"Querying for filter header count")
     filterHeaderDAO.getBestFilterHeader.map {
       case Some(filterHeader) =>
@@ -556,7 +556,7 @@ case class ChainHandler(
     filterHeaderDAO.findByBlockHash(blockHash)
 
   /** @inheritdoc */
-  override def getFilterCount: Future[Int] = {
+  override def getFilterCount(): Future[Int] = {
     logger.debug(s"Querying for filter count")
     filterDAO.getBestFilter.map {
       case Some(filter) =>

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
@@ -47,11 +47,8 @@ case class CompactFilterDAO()(implicit
     def hashIndex = index("cfilters_hash_index", hash)
 
     override def * = {
-      (hash,
-       filterType,
-       bytes,
-       height,
-       blockHash) <> (CompactFilterDb.tupled, CompactFilterDb.unapply)
+      (hash, filterType, bytes, height, blockHash).<>(CompactFilterDb.tupled,
+                                                      CompactFilterDb.unapply)
     }
   }
 

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -42,11 +42,9 @@ case class CompactFilterHeaderDAO()(implicit
     def blockHashIndex = index("cfheaders_block_hash_index", blockHash)
 
     override def * = {
-      (hash,
-       filterHash,
-       previousFilterHeader,
-       blockHash,
-       height) <> (CompactFilterHeaderDb.tupled, CompactFilterHeaderDb.unapply)
+      (hash, filterHash, previousFilterHeader, blockHash, height).<>(
+        CompactFilterHeaderDb.tupled,
+        CompactFilterHeaderDb.unapply)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainQueryApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainQueryApi.scala
@@ -30,7 +30,7 @@ trait ChainQueryApi {
       blockHashOpt: DoubleSha256DigestBE): Future[Option[Int]]
 
   /** Gets the number of compact filters in the database */
-  def getFilterCount: Future[Int]
+  def getFilterCount(): Future[Int]
 
   /** Returns the block height of the given block stamp */
   def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int]

--- a/core/src/main/scala/org/bitcoins/core/crypto/MnemonicCode.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/MnemonicCode.scala
@@ -277,7 +277,7 @@ object MnemonicCode {
     val resourceStream = getClass.getResourceAsStream(ENGLISH_WORDS_FILE)
     val source = Source.fromInputStream(resourceStream)
 
-    val lines = source.getLines
+    val lines = source.getLines()
     val linesVec = lines.toVector
     source.close()
     linesVec

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventDAO.scala
@@ -64,7 +64,7 @@ case class EventDAO()(implicit
        numOutcomes,
        signingVersion,
        maturationTime,
-       attestationOpt) <> (EventDb.tupled, EventDb.unapply)
+       attestationOpt).<>(EventDb.tupled, EventDb.unapply)
 
     def fk: ForeignKeyQuery[_, RValueDb] = {
       foreignKey("fk_nonce",

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAO.scala
@@ -58,9 +58,8 @@ case class EventOutcomeDAO()(implicit
     def hashedMessage: Rep[Sha256Digest] = column("hashed_message")
 
     def * : ProvenShape[EventOutcomeDb] =
-      (nonce,
-       message,
-       hashedMessage) <> (EventOutcomeDb.tupled, EventOutcomeDb.unapply)
+      (nonce, message, hashedMessage).<>(EventOutcomeDb.tupled,
+                                         EventOutcomeDb.unapply)
 
     def fk: ForeignKeyQuery[_, EventDb] = {
       foreignKey("fk_nonce",

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/RValueDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/RValueDAO.scala
@@ -66,6 +66,6 @@ case class RValueDAO()(implicit
        accountIndex,
        chainType,
        keyIndex,
-       commitmentSignature) <> (RValueDb.tupled, RValueDb.unapply)
+       commitmentSignature).<>(RValueDb.tupled, RValueDb.unapply)
   }
 }

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtilTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtilTest.scala
@@ -20,7 +20,7 @@ class EclairRpcTestUtilTest extends BitcoinSAsyncTest {
   private val clients =
     Vector.newBuilder[EclairRpcClient]
 
-  override def afterAll: Unit = {
+  override def afterAll(): Unit = {
     clients.result().foreach(EclairRpcTestUtil.shutdown)
     super.afterAll()
   }

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -777,7 +777,7 @@ class EclairRpcClient(
 
     val started: Future[EclairRpcClient] = {
       for {
-        _ <- AsyncUtil.retryUntilSatisfiedF(() => isStarted,
+        _ <- AsyncUtil.retryUntilSatisfiedF(() => isStarted(),
                                             interval = 1.seconds,
                                             maxTries = 60)
       } yield this
@@ -824,7 +824,7 @@ class EclairRpcClient(
     * @return
     */
   def isStopped: Future[Boolean] = {
-    isStarted.map(started => !started)
+    isStarted().map(started => !started)
   }
 
   /**

--- a/inThisBuild.sbt
+++ b/inThisBuild.sbt
@@ -1,7 +1,7 @@
 import scala.util.Properties
 
 val scala2_12 = "2.12.12"
-val scala2_13 = "2.13.2"
+val scala2_13 = "2.13.3"
 
 scalafmtOnCompile in ThisBuild := !Properties.envOrNone("CI").contains("true")
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -194,7 +194,7 @@ class PeerMessageHandlerTest extends NodeUnitTest {
           probe.expectMsg(Tcp.Closed)
         }*/
 
-  override def afterAll = {
+  override def afterAll(): Unit = {
     startedBitcoindF.flatMap(_.stop())
     super.afterAll
   }

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -57,8 +57,8 @@ case class NeutrinoNode(
     for {
       chainApi <- chainApiFromDb()
       header <- chainApi.getBestBlockHeader()
-      filterHeaderCount <- chainApi.getFilterHeaderCount
-      filterCount <- chainApi.getFilterCount
+      filterHeaderCount <- chainApi.getFilterHeaderCount()
+      filterCount <- chainApi.getFilterCount()
       peerMsgSender <- peerMsgSenderF
     } yield {
       // Get all of our cached headers in case of a reorg
@@ -87,8 +87,8 @@ case class NeutrinoNode(
   }
 
   /** Gets the number of compact filters in the database */
-  override def getFilterCount: Future[Int] =
-    chainApiFromDb().flatMap(_.getFilterCount)
+  override def getFilterCount(): Future[Int] =
+    chainApiFromDb().flatMap(_.getFilterCount())
 
   /** Returns the block height of the given block stamp */
   override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] =

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -101,16 +101,17 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
   }
 
   /** Checks if we have a tcp connection with our peer */
-  def isConnected: Future[Boolean] = peerMsgSenderF.flatMap(_.isConnected)
+  def isConnected: Future[Boolean] = peerMsgSenderF.flatMap(_.isConnected())
 
   /** Checks if we are fully initialized with our peer and have executed the handshake
     * This means we can now send arbitrary messages to our peer
     *
     * @return
     */
-  def isInitialized: Future[Boolean] = peerMsgSenderF.flatMap(_.isInitialized)
+  def isInitialized: Future[Boolean] = peerMsgSenderF.flatMap(_.isInitialized())
 
-  def isDisconnected: Future[Boolean] = peerMsgSenderF.flatMap(_.isDisconnected)
+  def isDisconnected: Future[Boolean] =
+    peerMsgSenderF.flatMap(_.isDisconnected())
 
   /** Starts our node */
   def start(): Future[Node] = {
@@ -120,7 +121,7 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     for {
       _ <- nodeAppConfig.start()
       // get chainApi so we don't need to call chainApiFromDb on every call
-      chainApi <- chainApiFromDb
+      chainApi <- chainApiFromDb()
       node <- {
         val isInitializedF = for {
           _ <- peerMsgSenderF.map(_.connect())
@@ -142,8 +143,8 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
       _ = logger.trace("Fetching node starting point")
       bestHash <- chainApi.getBestBlockHash()
       bestHeight <- chainApi.getBestHashBlockHeight()
-      filterCount <- chainApi.getFilterCount
-      filterHeaderCount <- chainApi.getFilterHeaderCount
+      filterCount <- chainApi.getFilterCount()
+      filterHeaderCount <- chainApi.getFilterHeaderCount()
     } yield {
       logger.info(
         s"Started node, best block hash ${bestHash.hex} at height $bestHeight, with $filterHeaderCount filter headers and $filterCount filters")

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -92,7 +92,7 @@ case class SpvNode(
   private val cfErrMsg = "Compact filters are not supported in SPV mode"
 
   /** Gets the number of compact filters in the database */
-  override def getFilterCount: Future[Int] =
+  override def getFilterCount(): Future[Int] =
     Future.failed(new RuntimeException(cfErrMsg))
 
   override def getFiltersBetweenHeights(

--- a/node/src/main/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAO.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAO.scala
@@ -74,6 +74,6 @@ final case class BroadcastAbleTransactionDAO()(implicit
     def bytes: Rep[ByteVector] = column("tx_bytes")
 
     def * : ProvenShape[BroadcastAbleTransaction] =
-      (txid, bytes) <> (fromTuple, toTuple)
+      (txid, bytes).<>(fromTuple, toTuple)
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -92,7 +92,7 @@ case class P2PClientActor(
           handleTcpMessage(message, Some(peer), unalignedBytes)
         context.become(awaitNetworkRequest(peer, newUnalignedBytes))
       case metaMsg: P2PClient.MetaMsg =>
-        sender ! handleMetaMsg(metaMsg)
+        sender() ! handleMetaMsg(metaMsg)
     }
 
   /** This context is responsible for initializing a tcp connection with a peer on the bitcoin p2p network */
@@ -115,7 +115,7 @@ case class P2PClientActor(
           s"Cannot send a message to our peer when we are not connected! payload=${payload} peer=${peer}")
 
       case metaMsg: P2PClient.MetaMsg =>
-        sender ! handleMetaMsg(metaMsg)
+        sender() ! handleMetaMsg(metaMsg)
     }
 
   /**
@@ -161,11 +161,11 @@ case class P2PClientActor(
         //this is what registers a actor to send all byte messages to that is
         //received from our peer. Since we are using 'self' that means
         //our bitcoin peer will send all messages to this actor.
-        sender ! Tcp.Register(self)
+        sender() ! Tcp.Register(self)
 
         currentPeerMsgHandlerRecv =
           currentPeerMsgHandlerRecv.connect(P2PClient(self, peer))
-        context.become(awaitNetworkRequest(sender, unalignedBytes))
+        context.become(awaitNetworkRequest(sender(), unalignedBytes))
         unalignedBytes
 
       case closeCmd @ (Tcp.ConfirmedClosed | Tcp.Closed | Tcp.Aborted |

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -198,7 +198,7 @@ case class DataMessageHandler(
 
               val lastHeader = headers.last
               val lastHash = lastHeader.hash
-              newApi.getBlockCount.map { count =>
+              newApi.getBlockCount().map { count =>
                 logger.trace(
                   s"Processed headers, most recent has height=$count and hash=$lastHash.")
               }

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -153,30 +153,30 @@ trait ChainUnitTest
     * genesis block
     */
   def withBlockHeaderDAO(test: OneArgAsyncTest): FutureOutcome = {
-    makeFixture(build = () => ChainUnitTest.createBlockHeaderDAO,
-                destroy = () => ChainUnitTest.destroyAllTables)(test)
+    makeFixture(build = () => ChainUnitTest.createBlockHeaderDAO(),
+                destroy = () => ChainUnitTest.destroyAllTables())(test)
   }
 
   /** Creates a compact filter DAO with zero rows in it */
   def withCompactFilterHeaderDAO(test: OneArgAsyncTest): FutureOutcome = {
     makeFixture(build = () => ChainUnitTest.createFilterHeaderDAO(),
-                destroy = ChainUnitTest.destroyAllTables)(test)
+                destroy = () => ChainUnitTest.destroyAllTables())(test)
   }
 
   /** Creates a compact filter DAO with zero rows in it */
   def withCompactFilterDAO(test: OneArgAsyncTest): FutureOutcome = {
     makeFixture(build = () => ChainUnitTest.createFilterDAO(),
-                destroy = ChainUnitTest.destroyAllTables)(test)
+                destroy = () => ChainUnitTest.destroyAllTables())(test)
   }
 
   def withPopulatedBlockHeaderDAO(test: OneArgAsyncTest): FutureOutcome = {
-    makeFixture(build = () => ChainUnitTest.createPopulatedBlockHeaderDAO,
-                destroy = () => ChainUnitTest.destroyAllTables)(test)
+    makeFixture(build = () => ChainUnitTest.createPopulatedBlockHeaderDAO(),
+                destroy = () => ChainUnitTest.destroyAllTables())(test)
   }
 
   def withChainHandler(test: OneArgAsyncTest): FutureOutcome = {
-    makeFixture(() => ChainUnitTest.createChainHandler,
-                () => ChainUnitTest.destroyAllTables)(test)
+    makeFixture(() => ChainUnitTest.createChainHandler(),
+                () => ChainUnitTest.destroyAllTables())(test)
   }
 
   def withChainHandlerGenesisFilter(test: OneArgAsyncTest): FutureOutcome = {
@@ -209,8 +209,8 @@ trait ChainUnitTest
   }
 
   def withPopulatedChainHandler(test: OneArgAsyncTest): FutureOutcome = {
-    makeFixture(() => createPopulatedChainHandler,
-                () => ChainUnitTest.destroyAllTables)(test)
+    makeFixture(() => createPopulatedChainHandler(),
+                () => ChainUnitTest.destroyAllTables())(test)
   }
 
   def createChainHandlerWithBitcoindZmq(
@@ -260,7 +260,7 @@ trait ChainUnitTest
       bitcoindChainHandler.chainHandler)
 
     ChainUnitTest.destroyBitcoindChainApiViaRpc(rpc).map { _ =>
-      bitcoindChainHandler.zmqSubscriber.stop
+      bitcoindChainHandler.zmqSubscriber.stop()
     }
   }
 
@@ -468,7 +468,7 @@ object ChainUnitTest extends ChainVerificationLogger {
 
     val source =
       scala.io.Source.fromURL(getClass.getResource("/block_headers.json"))
-    val arrStr = source.getLines.next
+    val arrStr = source.getLines().next()
     source.close()
 
     import org.bitcoins.commons.serializers.JsonReaders.BlockHeaderReads

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
@@ -106,6 +106,6 @@ case class TestDAO()(implicit
     def data: Rep[ByteVector] = column[ByteVector]("data")
 
     def * : ProvenShape[TestDb] =
-      (pk, data) <> (TestDb.tupled, TestDb.unapply)
+      (pk, data).<>(TestDb.tupled, TestDb.unapply)
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -156,7 +156,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
       cannonicalDatadir
     } else {
       //creates a random eclair datadir, but still assumes that a bitcoind instance is running right now
-      val datadir = randomEclairDatadir
+      val datadir = randomEclairDatadir()
       datadir.mkdirs()
       logger.trace(s"Creating temp eclair dir ${datadir.getAbsolutePath}")
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -111,7 +111,7 @@ abstract class NodeTestUtil extends P2PLogger {
     val hashF = rpc.getBestBlockHash
     for {
       chainApi <- node.chainApiFromDb()
-      bestHash <- chainApi.getBestBlockHash
+      bestHash <- chainApi.getBestBlockHash()
       hash <- hashF
     } yield {
       bestHash == hash
@@ -122,7 +122,7 @@ abstract class NodeTestUtil extends P2PLogger {
       implicit ec: ExecutionContext): Future[Boolean] = {
     val rpcCountF = rpc.getBlockCount
     for {
-      filterCount <- node.chainApiFromDb().flatMap(_.getFilterCount)
+      filterCount <- node.chainApiFromDb().flatMap(_.getFilterCount())
       blockCount <- rpcCountF
     } yield {
       blockCount == filterCount
@@ -133,7 +133,8 @@ abstract class NodeTestUtil extends P2PLogger {
       implicit ec: ExecutionContext): Future[Boolean] = {
     val rpcCountF = rpc.getBlockCount
     for {
-      filterHeaderCount <- node.chainApiFromDb().flatMap(_.getFilterHeaderCount)
+      filterHeaderCount <-
+        node.chainApiFromDb().flatMap(_.getFilterHeaderCount())
       blockCount <- rpcCountF
     } yield {
       blockCount == filterHeaderCount
@@ -147,7 +148,7 @@ abstract class NodeTestUtil extends P2PLogger {
       ec: ExecutionContext): Future[Boolean] = {
     val rpcCountF = rpc.getBlockCount
     for {
-      count <- node.chainApiFromDb().flatMap(_.getBlockCount)
+      count <- node.chainApiFromDb().flatMap(_.getBlockCount())
       rpcCount <- rpcCountF
     } yield {
       rpcCount == count
@@ -187,7 +188,7 @@ abstract class NodeTestUtil extends P2PLogger {
       system: ActorSystem): Future[Unit] = {
     import system.dispatcher
     def bestHashF: Future[DoubleSha256DigestBE] = {
-      node.chainApiFromDb().flatMap(_.getBestBlockHash)
+      node.chainApiFromDb().flatMap(_.getBestBlockHash())
     }
     TestAsyncUtil.retryUntilSatisfiedF(() => bestHashF.map(_ == hash))
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
@@ -42,7 +42,7 @@ abstract class BitcoindRpcTest extends BitcoinSAsyncTest {
     Vector[BitcoindRpcClient]] = Vector.newBuilder
 
   override def afterAll(): Unit = {
-    BitcoindRpcTestUtil.stopServers(clientAccum.result)
-    super.afterAll
+    BitcoindRpcTestUtil.stopServers(clientAccum.result())
+    super.afterAll()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -91,7 +91,7 @@ trait BitcoinSWalletTest extends BitcoinSFixture with EmbeddedPg {
         else FutureUtil.none
 
       /** Gets the number of compact filters in the database */
-      override def getFilterCount: Future[Int] = Future.successful(1)
+      override def getFilterCount(): Future[Int] = Future.successful(1)
 
       /** Returns the block height of the given block stamp */
       override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] =
@@ -350,7 +350,7 @@ object BitcoinSWalletTest extends WalletLogger {
     override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] =
       Future.successful(0)
 
-    override def getFilterCount: Future[Int] = Future.successful(0)
+    override def getFilterCount(): Future[Int] = Future.successful(0)
 
     override def getFiltersBetweenHeights(
         startHeight: Int,

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -211,7 +211,7 @@ private[wallet] trait AddressHandling extends WalletLogger {
       account: AccountDb,
       chainType: HDChainType
   ): Future[BitcoinAddress] = {
-    val p = Promise[AddressDb]
+    val p = Promise[AddressDb]()
     addressRequestQueue.add((account, chainType, p))
     for {
       addressDb <- p.future

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -99,7 +99,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
           chainQueryApi.getHeightByBlockStamp)
         _ = if (startHeight < 0)
           throw InvalidBlockRange(s"Start position cannot negative")
-        endHeight <- endOpt.fold(chainQueryApi.getFilterCount)(
+        endHeight <- endOpt.fold(chainQueryApi.getFilterCount())(
           chainQueryApi.getHeightByBlockStamp)
         _ = if (startHeight > endHeight)
           throw InvalidBlockRange(

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
@@ -84,7 +84,7 @@ case class AccountDAO()(implicit
          account.hdAccount.index))
 
     def * : ProvenShape[AccountDb] =
-      (purpose, xpub, coinType, index) <> (fromTuple, toTuple)
+      (purpose, xpub, coinType, index).<>(fromTuple, toTuple)
 
     def primaryKey: PrimaryKey =
       primaryKey("pk_account", sourceColumns = (purpose, coinType, index))

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressDAO.scala
@@ -342,7 +342,7 @@ case class AddressDAO()(implicit
        ecPublicKey,
        hashedPubKey,
        scriptPubKeyId,
-       scriptWitness) <> ((AddressRecord.apply _).tupled, AddressRecord.unapply)
+       scriptWitness).<>((AddressRecord.apply _).tupled, AddressRecord.unapply)
 
     def fk_scriptPubKeyId: ForeignKeyQuery[_, ScriptPubKeyDb] = {
       foreignKey("fk_spk",

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagDAO.scala
@@ -186,7 +186,7 @@ case class AddressTagDAO()(implicit
       addrTag => Some((addrTag.address, addrTag.tagName, addrTag.tagType))
 
     override def * : ProvenShape[AddressTagDb] =
-      (address, tagName, tagType) <> (fromTuple, toTuple)
+      (address, tagName, tagType).<>(fromTuple, toTuple)
 
     def primaryKey: PrimaryKey =
       primaryKey("pk_address_tags", sourceColumns = (address, tagType))

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/IncomingTransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/IncomingTransactionDAO.scala
@@ -46,7 +46,7 @@ case class IncomingTransactionDAO()(implicit
       IncomingTransactionTuple] = tx => Some((tx.txIdBE, tx.incomingAmount))
 
     def * : ProvenShape[IncomingTransactionDb] =
-      (txIdBE, incomingAmount) <> (fromTuple, toTuple)
+      (txIdBE, incomingAmount).<>(fromTuple, toTuple)
 
     def primaryKey: PrimaryKey =
       primaryKey("pk_in_tx", sourceColumns = txIdBE)

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/OutgoingTransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/OutgoingTransactionDAO.scala
@@ -74,12 +74,9 @@ case class OutgoingTransactionDAO()(implicit
          tx.feeRate))
 
     def * : ProvenShape[OutgoingTransactionDb] =
-      (txIdBE,
-       inputAmount,
-       sentAmount,
-       actualFee,
-       expectedFee,
-       feeRate) <> (fromTuple, toTuple)
+      (txIdBE, inputAmount, sentAmount, actualFee, expectedFee, feeRate).<>(
+        fromTuple,
+        toTuple)
 
     def primaryKey: PrimaryKey =
       primaryKey("pk_out_tx", sourceColumns = txIdBE)

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/ScriptPubKeyDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/ScriptPubKeyDAO.scala
@@ -67,7 +67,7 @@ case class ScriptPubKeyDAO()(implicit
     }
 
     override def * =
-      (id.?, scriptPubKey, scriptType) <> (fromTuple, toTuple)
+      (id.?, scriptPubKey, scriptType).<>(fromTuple, toTuple)
   }
 
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -516,6 +516,6 @@ case class SpendingInfoDAO()(implicit
        redeemScriptOpt,
        scriptWitnessOpt,
        blockHash,
-       id.?) <> ((UTXORecord.apply _).tupled, UTXORecord.unapply)
+       id.?).<>((UTXORecord.apply _).tupled, UTXORecord.unapply)
   }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/TransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/TransactionDAO.scala
@@ -120,7 +120,7 @@ case class TransactionDAO()(implicit
        totalOutput,
        numInputs,
        numOutputs,
-       locktime) <> (TransactionDb.tupled, TransactionDb.unapply)
+       locktime).<>(TransactionDb.tupled, TransactionDb.unapply)
 
     def primaryKey: PrimaryKey =
       primaryKey("pk_tx", sourceColumns = txIdBE)


### PR DESCRIPTION
fixes #1613 

Upgrade to scalac 2.13.3 

https://github.com/scala/scala/releases/tag/v2.13.3

Basically this forces us to get consistent with the usage of `()` with methods. This is why the diff is so big. They are beginning to slowly incorporate changes into releases that will need to be made to be compatible with Scala 3. 