### PR TITLE
Use Llyod's Oracle recommendations on commitment Signature

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/SigningVersion.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/dlc/SigningVersion.scala
@@ -4,17 +4,17 @@ import org.bitcoins.crypto.StringFactory
 
 sealed abstract class SigningVersion {
   def nonceTag: String
-  def commitmentTag: String
+  def announcementTag: String
   def outcomeTag: String
 }
 
 object SigningVersion extends StringFactory[SigningVersion] {
 
-  /** Initial signing version that was created with krystal bull, not a part of any spec */
+  /** Initial signing version that was created, not a part of any spec */
   final case object Mock extends SigningVersion {
     override def nonceTag: String = "DLCv0/Nonce"
 
-    override def commitmentTag: String = "DLCv0/Commitment"
+    override def announcementTag: String = "DLCv0/Announcement"
 
     override def outcomeTag: String = "DLCv0/Outcome"
   }

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -74,7 +74,8 @@ case class OracleRoutes(oracle: DLCOracle)(implicit system: ActorSystem)
                   "numOutcomes" -> Num(event.numOutcomes.toDouble),
                   "signingVersion" -> Str(event.signingVersion.toString),
                   "maturationTime" -> Str(event.maturationTime.toString),
-                  "commitmentSignature" -> Str(event.commitmentSignature.hex),
+                  "announcementSignature" -> Str(
+                    event.announcementSignature.hex),
                   "attestation" -> attestationJson,
                   "signature" -> signatureJson,
                   "outcomes" -> outcomesJson

--- a/dlc-oracle/src/main/resources/postgresql/oracle/migration/V1__dlc_oracle_baseline.sql
+++ b/dlc-oracle/src/main/resources/postgresql/oracle/migration/V1__dlc_oracle_baseline.sql
@@ -1,13 +1,13 @@
 CREATE TABLE r_values
 (
-    nonce                TEXT    NOT NULL,
-    event_name           TEXT    NOT NULL UNIQUE,
-    hd_purpose           INTEGER NOT NULL,
-    coin                 INTEGER NOT NULL,
-    account_index        INTEGER NOT NULL,
-    chain_type           INTEGER NOT NULL,
-    key_index            INTEGER NOT NULL UNIQUE,
-    commitment_signature TEXT    NOT NULL,
+    nonce                  TEXT    NOT NULL,
+    event_name             TEXT    NOT NULL UNIQUE,
+    hd_purpose             INTEGER NOT NULL,
+    coin                   INTEGER NOT NULL,
+    account_index          INTEGER NOT NULL,
+    chain_type             INTEGER NOT NULL,
+    key_index              INTEGER NOT NULL UNIQUE,
+    announcement_signature TEXT    NOT NULL,
     PRIMARY KEY (nonce)
 );
 

--- a/dlc-oracle/src/main/resources/sqlite/oracle/migration/V1__dlc_oracle_baseline.sql
+++ b/dlc-oracle/src/main/resources/sqlite/oracle/migration/V1__dlc_oracle_baseline.sql
@@ -1,13 +1,13 @@
 CREATE TABLE `r_values`
 (
-    `nonce`                VARCHAR(254) NOT NULL,
-    `event_name`           VARCHAR(254) NOT NULL UNIQUE,
-    `hd_purpose`           INTEGER      NOT NULL,
-    `coin`                 INTEGER      NOT NULL,
-    `account_index`        INTEGER      NOT NULL,
-    `chain_type`           INTEGER      NOT NULL,
-    `key_index`            INTEGER      NOT NULL UNIQUE,
-    `commitment_signature` VARCHAR(254) NOT NULL,
+    `nonce`                  VARCHAR(254) NOT NULL,
+    `event_name`             VARCHAR(254) NOT NULL UNIQUE,
+    `hd_purpose`             INTEGER      NOT NULL,
+    `coin`                   INTEGER      NOT NULL,
+    `account_index`          INTEGER      NOT NULL,
+    `chain_type`             INTEGER      NOT NULL,
+    `key_index`              INTEGER      NOT NULL UNIQUE,
+    `announcement_signature` VARCHAR(254) NOT NULL,
     PRIMARY KEY (`nonce`)
 );
 

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/Event.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/Event.scala
@@ -27,7 +27,7 @@ sealed trait Event {
   def maturationTime: Instant
 
   /** A signature by the oracle of the hash of nonce and event name */
-  def commitmentSignature: SchnorrDigitalSignature
+  def announcementSignature: SchnorrDigitalSignature
 
   /** The list of the possible outcomes */
   def outcomes: Vector[String]
@@ -39,7 +39,7 @@ case class PendingEvent(
     eventName: String,
     signingVersion: SigningVersion,
     maturationTime: Instant,
-    commitmentSignature: SchnorrDigitalSignature,
+    announcementSignature: SchnorrDigitalSignature,
     outcomes: Vector[String])
     extends Event
 
@@ -49,7 +49,7 @@ case class CompletedEvent(
     eventName: String,
     signingVersion: SigningVersion,
     maturationTime: Instant,
-    commitmentSignature: SchnorrDigitalSignature,
+    announcementSignature: SchnorrDigitalSignature,
     outcomes: Vector[String],
     attestation: FieldElement)
     extends Event {
@@ -73,7 +73,7 @@ object Event {
                        eventDb.eventName,
                        eventDb.signingVersion,
                        eventDb.maturationTime,
-                       rValDb.commitmentSignature,
+                       rValDb.announcementSignature,
                        outcomes,
                        sig)
       case None =>
@@ -82,7 +82,7 @@ object Event {
                      eventDb.eventName,
                      eventDb.signingVersion,
                      eventDb.maturationTime,
-                     rValDb.commitmentSignature,
+                     rValDb.announcementSignature,
                      outcomes)
     }
   }

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/RValueDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/RValueDAO.scala
@@ -55,8 +55,8 @@ case class RValueDAO()(implicit
 
     def keyIndex: Rep[Int] = column("key_index", O.Unique)
 
-    def commitmentSignature: Rep[SchnorrDigitalSignature] =
-      column("commitment_signature")
+    def announcementSignature: Rep[SchnorrDigitalSignature] =
+      column("announcement_signature")
 
     def * : ProvenShape[RValueDb] =
       (nonce,
@@ -66,6 +66,6 @@ case class RValueDAO()(implicit
        accountIndex,
        chainType,
        keyIndex,
-       commitmentSignature).<>(RValueDb.tupled, RValueDb.unapply)
+       announcementSignature).<>(RValueDb.tupled, RValueDb.unapply)
   }
 }

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/RValueDb.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/RValueDb.scala
@@ -11,7 +11,7 @@ case class RValueDb(
     accountIndex: Int,
     chainType: Int,
     keyIndex: Int,
-    commitmentSignature: SchnorrDigitalSignature) {
+    announcementSignature: SchnorrDigitalSignature) {
 
   val path: BIP32Path = BIP32Path.fromString(
     s"m/${purpose.constant}'/${accountCoin.toInt}'/$accountIndex'/$chainType'/$keyIndex'")
@@ -25,7 +25,7 @@ object RValueDbHelper {
       account: HDAccount,
       chainType: Int,
       keyIndex: Int,
-      commitmentSignature: SchnorrDigitalSignature): RValueDb = {
+      announcementSignature: SchnorrDigitalSignature): RValueDb = {
     RValueDb(nonce,
              eventName,
              account.purpose,
@@ -33,6 +33,6 @@ object RValueDbHelper {
              account.index,
              chainType,
              keyIndex,
-             commitmentSignature)
+             announcementSignature)
   }
 }


### PR DESCRIPTION
Llyod recommended to me to rename the `commitmentSignature` to `announcementSignature` which I think is better. Also to add the `maturityTime` to the announcement pre-image.