### PR TITLE
Increase DLC Oracle test coverage

### DIFF
--- a/app-commons-test/src/test/scala/org/bitcoins/commons/dlc/SigningVersionTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/dlc/SigningVersionTest.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.dlc.oracle
+package org.bitcoins.commons.dlc
 
 import org.bitcoins.commons.jsonmodels.dlc.SigningVersion
 import org.bitcoins.testkit.util.BitcoinSUnitTest

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -2,8 +2,14 @@ package org.bitcoins.dlc.oracle
 
 import java.sql.SQLException
 
+import org.bitcoins.commons.jsonmodels.dlc.SigningVersion
+import org.bitcoins.core.hd.{HDCoinType, HDPurpose}
+import org.bitcoins.core.protocol.Bech32Address
+import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.crypto._
+import org.bitcoins.dlc.oracle.storage._
+import org.bitcoins.testkit.core.gen.ChainParamsGenerator
 import org.bitcoins.testkit.fixtures.DLCOracleFixture
 
 class DLCOracleTest extends DLCOracleFixture {
@@ -13,7 +19,7 @@ class DLCOracleTest extends DLCOracleFixture {
   behavior of "DLCOracle"
 
   it must "correctly initialize" in { dlcOracle: DLCOracle =>
-    assert(dlcOracle.conf.seedExists())
+    assert(dlcOracle.conf.exists())
   }
 
   it must "start with no events" in { dlcOracle: DLCOracle =>
@@ -25,6 +31,15 @@ class DLCOracleTest extends DLCOracleFixture {
   it must "start with no pending events" in { dlcOracle: DLCOracle =>
     dlcOracle.listPendingEventDbs().map { events =>
       assert(events.isEmpty)
+    }
+  }
+
+  it must "calculate the correct staking address" in { dlcOracle: DLCOracle =>
+    forAllAsync(ChainParamsGenerator.bitcoinNetworkParams) { network =>
+      val expected =
+        Bech32Address(P2WPKHWitnessSPKV0(dlcOracle.publicKey.publicKey),
+                      network)
+      assert(dlcOracle.stakingAddress(network) == expected)
     }
   }
 
@@ -41,6 +56,36 @@ class DLCOracleTest extends DLCOracleFixture {
           pendingEvents.head.copy(maturationTime = testEventDb.maturationTime)
         assert(comparable == testEventDb)
       }
+  }
+
+  it must "create a new event and get its details" in { dlcOracle: DLCOracle =>
+    val time = TimeUtil.now
+    val eventName = "test"
+
+    for {
+      testEventDb <- dlcOracle.createNewEvent(eventName, time, testOutcomes)
+      eventOpt <- dlcOracle.getEvent(testEventDb.nonce)
+    } yield {
+      assert(eventOpt.isDefined)
+      val event = eventOpt.get
+
+      assert(event.isInstanceOf[PendingEvent])
+      assert(event.eventName == eventName)
+      assert(event.outcomes == testOutcomes)
+      assert(event.numOutcomes == testOutcomes.size)
+      assert(event.signingVersion == SigningVersion.latest)
+      assert(event.pubkey == dlcOracle.publicKey)
+      assert(event.nonce == testEventDb.nonce)
+      assert(event.maturationTime.getEpochSecond == time.getEpochSecond)
+    }
+  }
+
+  it must "not get an event that doesn't exit" in { dlcOracle: DLCOracle =>
+    val nonce = ECPublicKey.freshPublicKey.schnorrNonce
+    dlcOracle.getEvent(nonce).map {
+      case None    => succeed
+      case Some(_) => fail()
+    }
   }
 
   it must "create a new event with a valid commitment signature" in {
@@ -85,16 +130,41 @@ class DLCOracleTest extends DLCOracleFixture {
       signedEventDb <- dlcOracle.signEvent(eventDb.nonce, outcome)
       outcomeDbs <- dlcOracle.eventOutcomeDAO.findByNonce(eventDb.nonce)
       outcomeDb = outcomeDbs.find(_.message == outcome).get
-      signedEvent <- dlcOracle.eventDAO.read(eventDb.nonce)
+      eventOpt <- dlcOracle.getEvent(eventDb.nonce)
     } yield {
+      assert(eventOpt.isDefined)
+      val event = eventOpt.get
       val sig = signedEventDb.sigOpt.get
 
-      assert(signedEvent.isDefined)
-      assert(signedEvent.get.attestationOpt.contains(sig.sig))
-      assert(dlcOracle.publicKey.verify(outcomeDb.hashedMessage.bytes, sig))
-      assert(
-        SchnorrDigitalSignature(signedEvent.get.nonce,
-                                signedEvent.get.attestationOpt.get) == sig)
+      event match {
+        case completedEvent: CompletedEvent =>
+          assert(completedEvent.attestation == sig.sig)
+          assert(dlcOracle.publicKey.verify(outcomeDb.hashedMessage.bytes, sig))
+          assert(
+            SchnorrDigitalSignature(completedEvent.nonce,
+                                    completedEvent.attestation) == sig)
+        case _: PendingEvent =>
+          fail()
+      }
+    }
+  }
+
+  it must "correctly track pending events" in { dlcOracle: DLCOracle =>
+    val outcome = testOutcomes.head
+    for {
+      eventDb <- dlcOracle.createNewEvent("test", TimeUtil.now, testOutcomes)
+      beforePending <- dlcOracle.listPendingEventDbs()
+      beforeEvents <- dlcOracle.listEvents()
+      _ = assert(beforePending.size == 1)
+      _ = assert(beforeEvents.size == 1)
+      _ = assert(beforeEvents.head.isInstanceOf[PendingEvent])
+      _ <- dlcOracle.signEvent(eventDb.nonce, outcome)
+      afterPending <- dlcOracle.listPendingEventDbs()
+      afterEvents <- dlcOracle.listEvents()
+    } yield {
+      assert(afterPending.isEmpty)
+      assert(afterEvents.size == 1)
+      assert(afterEvents.head.isInstanceOf[CompletedEvent])
     }
   }
 
@@ -112,6 +182,47 @@ class DLCOracleTest extends DLCOracleFixture {
           eventDb <-
             dlcOracle.createNewEvent("test", TimeUtil.now, testOutcomes)
           _ <- dlcOracle.signEvent(eventDb.nonce, "not a real outcome")
+        } yield ()
+      }
+  }
+
+  it must "fail to sign an event with an outside nonce" in {
+    dlcOracle: DLCOracle =>
+      val ecKey = ECPublicKey.freshPublicKey
+      val publicKey = ecKey.schnorrPublicKey
+      val nonce = ecKey.schnorrNonce
+
+      val eventName = "dummy"
+      val sigVersion = SigningVersion.latest
+      val message = "dummy message"
+
+      val rValDb = RValueDb(nonce,
+                            eventName,
+                            HDPurpose(0),
+                            HDCoinType.Bitcoin,
+                            0,
+                            0,
+                            0,
+                            SchnorrDigitalSignature(nonce, FieldElement.one))
+
+      val eventDb =
+        EventDb(nonce, publicKey, eventName, 1, sigVersion, TimeUtil.now, None)
+
+      val outcomeDb =
+        EventOutcomeDb(nonce,
+                       message,
+                       CryptoUtil.taggedSha256(message, sigVersion.outcomeTag))
+
+      val setupF = for {
+        _ <- dlcOracle.rValueDAO.create(rValDb)
+        _ <- dlcOracle.eventDAO.create(eventDb)
+        _ <- dlcOracle.eventOutcomeDAO.create(outcomeDb)
+      } yield ()
+
+      recoverToSucceededIf[IllegalArgumentException] {
+        for {
+          _ <- setupF
+          _ <- dlcOracle.signEvent(nonce, message)
         } yield ()
       }
   }

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventDAOTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventDAOTest.scala
@@ -12,9 +12,6 @@ import org.bitcoins.testkit.fixtures.DLCOracleDAOFixture
 
 class EventDAOTest extends DLCOracleDAOFixture {
 
-  implicit override protected def config: DLCOracleAppConfig =
-    BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(pgUrl)
-
   behavior of "EventDAO"
 
   val ecKey: ECPublicKey = ECPublicKey.freshPublicKey

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventDAOTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventDAOTest.scala
@@ -1,0 +1,71 @@
+package org.bitcoins.dlc.oracle.storage
+
+import java.time.Instant
+
+import org.bitcoins.commons.jsonmodels.dlc.SigningVersion
+import org.bitcoins.core.hd.{HDCoinType, HDPurpose}
+import org.bitcoins.core.util.TimeUtil
+import org.bitcoins.crypto._
+import org.bitcoins.dlc.oracle.DLCOracleAppConfig
+import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.fixtures.DLCOracleDAOFixture
+
+class EventDAOTest extends DLCOracleDAOFixture {
+
+  implicit override protected def config: DLCOracleAppConfig =
+    BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(pgUrl)
+
+  behavior of "EventDAO"
+
+  val ecKey: ECPublicKey = ECPublicKey.freshPublicKey
+  val publicKey: SchnorrPublicKey = ecKey.schnorrPublicKey
+  val nonce: SchnorrNonce = ecKey.schnorrNonce
+
+  val eventName = "dummy"
+  val sigVersion: SigningVersion = SigningVersion.latest
+  val message = "dummy message"
+
+  val time: Instant = {
+    // Need to do this so it is comparable to the db representation
+    val now = TimeUtil.now.getEpochSecond
+    Instant.ofEpochSecond(now)
+  }
+
+  val dummyRValDb: RValueDb = RValueDb(
+    nonce,
+    eventName,
+    HDPurpose(0),
+    HDCoinType.Bitcoin,
+    0,
+    0,
+    0,
+    SchnorrDigitalSignature(nonce, FieldElement.one))
+
+  it must "create an EventDb and read it" in { daos =>
+    val rValDAO = daos.rValueDAO
+    val eventDAO = daos.eventDAO
+
+    val eventDb =
+      EventDb(nonce, publicKey, eventName, 1, sigVersion, time, None)
+
+    for {
+      _ <- rValDAO.create(dummyRValDb)
+      _ <- eventDAO.create(eventDb)
+      read <- eventDAO.read(nonce)
+    } yield assert(read.contains(eventDb))
+  }
+
+  it must "create an EventDb and find all" in { daos =>
+    val rValDAO = daos.rValueDAO
+    val eventDAO = daos.eventDAO
+
+    val eventDb =
+      EventDb(nonce, publicKey, eventName, 1, sigVersion, time, None)
+
+    for {
+      _ <- rValDAO.create(dummyRValDb)
+      _ <- eventDAO.create(eventDb)
+      all <- eventDAO.findAll()
+    } yield assert(all.contains(eventDb))
+  }
+}

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAOTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAOTest.scala
@@ -1,0 +1,102 @@
+package org.bitcoins.dlc.oracle.storage
+
+import java.time.Instant
+
+import org.bitcoins.commons.jsonmodels.dlc.SigningVersion
+import org.bitcoins.core.hd.{HDCoinType, HDPurpose}
+import org.bitcoins.core.util.TimeUtil
+import org.bitcoins.crypto._
+import org.bitcoins.dlc.oracle.DLCOracleAppConfig
+import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.fixtures.DLCOracleDAOFixture
+
+class EventOutcomeDAOTest extends DLCOracleDAOFixture {
+
+  implicit override protected def config: DLCOracleAppConfig =
+    BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(pgUrl)
+
+  behavior of "EventOutcomeDAO"
+
+  val ecKey: ECPublicKey = ECPublicKey.freshPublicKey
+  val publicKey: SchnorrPublicKey = ecKey.schnorrPublicKey
+  val nonce: SchnorrNonce = ecKey.schnorrNonce
+
+  val eventName = "dummy"
+  val sigVersion: SigningVersion = SigningVersion.latest
+  val message = "dummy message"
+
+  val hash: Sha256Digest =
+    CryptoUtil.taggedSha256(message, sigVersion.outcomeTag)
+
+  val time: Instant = {
+    // Need to do this so it is comparable to the db representation
+    val now = TimeUtil.now.getEpochSecond
+    Instant.ofEpochSecond(now)
+  }
+
+  val dummyRValDb: RValueDb = RValueDb(
+    nonce,
+    eventName,
+    HDPurpose(0),
+    HDCoinType.Bitcoin,
+    0,
+    0,
+    0,
+    SchnorrDigitalSignature(nonce, FieldElement.one))
+
+  val dummyEventDb: EventDb =
+    EventDb(nonce, publicKey, eventName, 1, sigVersion, time, None)
+
+  it must "create an EventOutcomeDb and read it" in { daos =>
+    val rValDAO = daos.rValueDAO
+    val eventDAO = daos.eventDAO
+    val outcomeDAO = daos.outcomeDAO
+
+    val outcomeDb = EventOutcomeDb(nonce, message, hash)
+
+    for {
+      _ <- rValDAO.create(dummyRValDb)
+      _ <- eventDAO.create(dummyEventDb)
+      _ <- outcomeDAO.create(outcomeDb)
+      read <- outcomeDAO.read((nonce, message))
+    } yield assert(read.contains(outcomeDb))
+  }
+
+  it must "create an EventOutcomeDb and find all" in { daos =>
+    val rValDAO = daos.rValueDAO
+    val eventDAO = daos.eventDAO
+    val outcomeDAO = daos.outcomeDAO
+
+    val outcomeDb = EventOutcomeDb(nonce, message, hash)
+
+    for {
+      _ <- rValDAO.create(dummyRValDb)
+      _ <- eventDAO.create(dummyEventDb)
+      _ <- outcomeDAO.create(outcomeDb)
+      all <- outcomeDAO.findAll()
+    } yield assert(all.contains(outcomeDb))
+  }
+
+  it must "create EventOutcomeDbs and find by nonce" in { daos =>
+    val rValDAO = daos.rValueDAO
+    val eventDAO = daos.eventDAO
+    val outcomeDAO = daos.outcomeDAO
+
+    val outcomeDb = EventOutcomeDb(nonce, message, hash)
+    val outcomeDb1 =
+      EventOutcomeDb(nonce,
+                     "message",
+                     CryptoUtil.taggedSha256("message", sigVersion.outcomeTag))
+
+    for {
+      _ <- rValDAO.create(dummyRValDb)
+      _ <- eventDAO.create(dummyEventDb)
+      _ <- outcomeDAO.createAll(Vector(outcomeDb, outcomeDb1))
+      all <- outcomeDAO.findByNonce(nonce)
+    } yield {
+      assert(all.size == 2)
+      assert(all.contains(outcomeDb))
+      assert(all.contains(outcomeDb1))
+    }
+  }
+}

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAOTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAOTest.scala
@@ -12,9 +12,6 @@ import org.bitcoins.testkit.fixtures.DLCOracleDAOFixture
 
 class EventOutcomeDAOTest extends DLCOracleDAOFixture {
 
-  implicit override protected def config: DLCOracleAppConfig =
-    BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(pgUrl)
-
   behavior of "EventOutcomeDAO"
 
   val ecKey: ECPublicKey = ECPublicKey.freshPublicKey

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/RValueDAOTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/RValueDAOTest.scala
@@ -1,0 +1,61 @@
+package org.bitcoins.dlc.oracle.storage
+
+import java.time.Instant
+
+import org.bitcoins.commons.jsonmodels.dlc.SigningVersion
+import org.bitcoins.core.hd.{HDCoinType, HDPurpose}
+import org.bitcoins.core.util.TimeUtil
+import org.bitcoins.crypto._
+import org.bitcoins.dlc.oracle.DLCOracleAppConfig
+import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.fixtures.DLCOracleDAOFixture
+
+class RValueDAOTest extends DLCOracleDAOFixture {
+
+  implicit override protected def config: DLCOracleAppConfig =
+    BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(pgUrl)
+
+  behavior of "RValueDAO"
+
+  val ecKey: ECPublicKey = ECPublicKey.freshPublicKey
+  val publicKey: SchnorrPublicKey = ecKey.schnorrPublicKey
+  val nonce: SchnorrNonce = ecKey.schnorrNonce
+
+  val eventName = "dummy"
+  val sigVersion: SigningVersion = SigningVersion.latest
+  val message = "dummy message"
+
+  val time: Instant = {
+    // Need to do this so it is comparable to the db representation
+    val now = TimeUtil.now.getEpochSecond
+    Instant.ofEpochSecond(now)
+  }
+
+  val rValDb: RValueDb = RValueDb(
+    nonce,
+    eventName,
+    HDPurpose(0),
+    HDCoinType.Bitcoin,
+    0,
+    0,
+    0,
+    SchnorrDigitalSignature(nonce, FieldElement.one))
+
+  it must "create an RValueDb and read it" in { daos =>
+    val rValDAO = daos.rValueDAO
+
+    for {
+      _ <- rValDAO.create(rValDb)
+      read <- rValDAO.read(nonce)
+    } yield assert(read.contains(rValDb))
+  }
+
+  it must "create an RValueDb and find all" in { daos =>
+    val rValDAO = daos.rValueDAO
+
+    for {
+      _ <- rValDAO.create(rValDb)
+      all <- rValDAO.findAll()
+    } yield assert(all.contains(rValDb))
+  }
+}

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/RValueDAOTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/RValueDAOTest.scala
@@ -12,9 +12,6 @@ import org.bitcoins.testkit.fixtures.DLCOracleDAOFixture
 
 class RValueDAOTest extends DLCOracleDAOFixture {
 
-  implicit override protected def config: DLCOracleAppConfig =
-    BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(pgUrl)
-
   behavior of "RValueDAO"
 
   val ecKey: ECPublicKey = ECPublicKey.freshPublicKey

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -50,7 +50,7 @@ case class DLCOracle(private val extPrivateKey: ExtPrivateKeyHardened)(implicit
   val publicKey: SchnorrPublicKey = signingKey.schnorrPublicKey
 
   def stakingAddress(network: BitcoinNetwork): Bech32Address =
-    Bech32Address(P2WPKHWitnessSPKV0(signingKey.publicKey), network)
+    Bech32Address(P2WPKHWitnessSPKV0(publicKey.publicKey), network)
 
   protected[bitcoins] val rValueDAO: RValueDAO = RValueDAO()
   protected[bitcoins] val eventDAO: EventDAO = EventDAO()

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracleAppConfig.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracleAppConfig.scala
@@ -78,7 +78,7 @@ case class DLCOracleAppConfig(
     lazy val hasDb = this.driver match {
       case PostgreSQL => true
       case SQLite =>
-        Files.exists(baseDatadir.resolve("oracle.sqlite"))
+        Files.exists(datadir.resolve("oracle.sqlite"))
     }
     seedExists() && hasDb
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -3,6 +3,7 @@ package org.bitcoins.testkit
 import java.nio.file._
 
 import com.typesafe.config._
+import org.bitcoins.dlc.oracle.DLCOracleAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.util.FileUtil
 
@@ -82,6 +83,14 @@ object BitcoinSTestAppConfig {
       tmpDir(),
       (overrideConf +: configWithEmbeddedDb(project = None,
                                             pgUrl) +: config): _*)
+  }
+
+  def getDLCOracleWithEmbeddedDbTestConfig(
+      pgUrl: () => Option[String],
+      config: Config*)(implicit ec: ExecutionContext): DLCOracleAppConfig = {
+    DLCOracleAppConfig(
+      tmpDir(),
+      configWithEmbeddedDb(project = None, pgUrl) +: config: _*)
   }
 
   sealed trait ProjectType

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleDAOFixture.scala
@@ -3,8 +3,8 @@ package org.bitcoins.testkit.fixtures
 import org.bitcoins.crypto.AesPassword
 import org.bitcoins.dlc.oracle.DLCOracleAppConfig
 import org.bitcoins.dlc.oracle.storage._
-import org.bitcoins.testkit.EmbeddedPg
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil.bip39PasswordOpt
+import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.scalatest._
 
 import scala.concurrent.Future
@@ -16,7 +16,8 @@ case class DLCOracleDAOs(
 
 trait DLCOracleDAOFixture extends BitcoinSFixture with EmbeddedPg {
 
-  implicit protected def config: DLCOracleAppConfig
+  implicit protected def config: DLCOracleAppConfig =
+    BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = DLCOracleDAOs
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleDAOFixture.scala
@@ -1,0 +1,43 @@
+package org.bitcoins.testkit.fixtures
+
+import org.bitcoins.crypto.AesPassword
+import org.bitcoins.dlc.oracle.DLCOracleAppConfig
+import org.bitcoins.dlc.oracle.storage._
+import org.bitcoins.testkit.EmbeddedPg
+import org.bitcoins.testkit.keymanager.KeyManagerTestUtil.bip39PasswordOpt
+import org.scalatest._
+
+import scala.concurrent.Future
+
+case class DLCOracleDAOs(
+    rValueDAO: RValueDAO,
+    eventDAO: EventDAO,
+    outcomeDAO: EventOutcomeDAO)
+
+trait DLCOracleDAOFixture extends BitcoinSFixture with EmbeddedPg {
+
+  implicit protected def config: DLCOracleAppConfig
+
+  override type FixtureParam = DLCOracleDAOs
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    makeFixture(
+      build = () => {
+        config
+          .initialize(AesPassword.fromString("Ben was here"), bip39PasswordOpt)
+          .map(oracle =>
+            DLCOracleDAOs(oracle.rValueDAO,
+                          oracle.eventDAO,
+                          oracle.eventOutcomeDAO))
+      },
+      destroy = () => destroyAppConfig(config)
+    )(test)
+  }
+
+  private def destroyAppConfig(conf: DLCOracleAppConfig): Future[Unit] = {
+    for {
+      _ <- conf.dropAll()
+      _ <- conf.stop()
+    } yield ()
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleFixture.scala
@@ -2,6 +2,7 @@ package org.bitcoins.testkit.fixtures
 
 import org.bitcoins.crypto.AesPassword
 import org.bitcoins.dlc.oracle.DLCOracle
+import org.bitcoins.testkit.keymanager.KeyManagerTestUtil.bip39PasswordOpt
 import org.bitcoins.testkit.util.FileUtil
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.scalatest._
@@ -16,7 +17,7 @@ trait DLCOracleFixture extends BitcoinSFixture with EmbeddedPg {
     val builder: () => Future[DLCOracle] = () => {
       val conf =
         BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(pgUrl)
-      conf.initialize(AesPassword.fromString("Ben was here"), None)
+      conf.initialize(AesPassword.fromString("Ben was here"), bip39PasswordOpt)
     }
 
     val destroy: DLCOracle => Future[Unit] = dlcOracle => {

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleFixture.scala
@@ -1,20 +1,21 @@
 package org.bitcoins.testkit.fixtures
 
 import org.bitcoins.crypto.AesPassword
-import org.bitcoins.dlc.oracle.{DLCOracle, DLCOracleAppConfig}
-import org.bitcoins.testkit.BitcoinSTestAppConfig.tmpDir
+import org.bitcoins.dlc.oracle.DLCOracle
 import org.bitcoins.testkit.util.FileUtil
+import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.scalatest._
 
 import scala.concurrent.Future
 
-trait DLCOracleFixture extends BitcoinSFixture {
+trait DLCOracleFixture extends BitcoinSFixture with EmbeddedPg {
 
   override type FixtureParam = DLCOracle
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val builder: () => Future[DLCOracle] = () => {
-      val conf = DLCOracleAppConfig(tmpDir())
+      val conf =
+        BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(pgUrl)
       conf.initialize(AesPassword.fromString("Ben was here"), None)
     }
 


### PR DESCRIPTION
Found a bug where if our public key was an odd value it would generate the wrong staking address due to the BIP 340 tie breaker