### PR TITLE
Disable logback meta logs

### DIFF
--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -1,4 +1,7 @@
 <configuration scan="true" scanPeriod="15 seconds" >
+
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%date{yyyy-MM-dd'T'HH:mm:ss,SSXXX, UTC}UTC %level [%logger{0}] %msg%n</pattern>

--- a/node-test/src/test/resources/logback-test.xml
+++ b/node-test/src/test/resources/logback-test.xml
@@ -1,6 +1,8 @@
 <configuration>
     <include resource="common-logback.xml" />
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <root level="OFF">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE"/>


### PR DESCRIPTION
This disables annoying meta logs about our logging config ie:

```
[info] 04:00:14,316 |-INFO in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to INFO
[info] 04:00:14,316 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [ASYNC] to Logger[ROOT]
[info] 04:00:14,316 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [FILE] to Logger[ROOT]
[info] 04:00:14,316 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.db.SafeDatabase] to WARN
[info] 04:00:14,316 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.chain.config] to WARN
[info] 04:00:14,316 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.bitcoins.node.config] to WARN
```