### PR TITLE
2020 10 08 issue 2147

### DIFF
--- a/db-commons-test/src/test/scala/org/bitcoins/db/AppConfigTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/AppConfigTest.scala
@@ -1,12 +1,7 @@
-package org.bitcoins.testkit.db
-
-import java.nio.file.{Path, Paths}
-import java.util.Properties
+package org.bitcoins.db
 
 import com.typesafe.config.ConfigFactory
 import org.bitcoins.core.config.TestNet3
-import org.bitcoins.db.AppConfig
-import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import org.bitcoins.wallet.config.WalletAppConfig

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -133,8 +133,6 @@ abstract class AppConfig extends StartStopAsync[Unit] with BitcoinSLogger {
     logger.debug(s"Resolved bitcoin-s config:")
     logger.debug(finalConfig.asReadableJson)
 
-    println(
-      s"property=${System.getProperty("bitcoin-s.wallet.requiredConfirmations")}")
     val resolved = {
       ConfigFactory
         .defaultOverrides(getClass.getClassLoader)

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -133,9 +133,11 @@ abstract class AppConfig extends StartStopAsync[Unit] with BitcoinSLogger {
     logger.debug(s"Resolved bitcoin-s config:")
     logger.debug(finalConfig.asReadableJson)
 
+    println(
+      s"property=${System.getProperty("bitcoin-s.wallet.requiredConfirmations")}")
     val resolved = {
       ConfigFactory
-        .defaultOverrides()
+        .defaultOverrides(getClass.getClassLoader)
         .withFallback(finalConfig)
         .resolve()
     }

--- a/testkit/src/test/scala/org/bitcoins/testkit/db/AppConfigTest.scala
+++ b/testkit/src/test/scala/org/bitcoins/testkit/db/AppConfigTest.scala
@@ -1,9 +1,16 @@
 package org.bitcoins.testkit.db
 
+import java.nio.file.{Path, Paths}
+import java.util.Properties
+
 import com.typesafe.config.ConfigFactory
 import org.bitcoins.core.config.TestNet3
+import org.bitcoins.db.AppConfig
+import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
+import org.bitcoins.wallet.config.WalletAppConfig
+import slick.jdbc.SQLiteProfile
 
 class AppConfigTest extends BitcoinSAsyncTest {
 
@@ -42,6 +49,41 @@ class AppConfigTest extends BitcoinSAsyncTest {
     val nodeConf = conf.nodeConf
     assert(chainConf.dbName != walletConf.dbName)
     assert(walletConf.dbName != nodeConf.dbName)
+  }
+
+  it must "fill in typesafe config variables correctly" in {
+    val datadir = BitcoinSTestAppConfig.tmpDir()
+    val walletAppConfig = WalletAppConfig(datadir)
+    for {
+      _ <- walletAppConfig.start()
+    } yield {
+      //this should get substituted as all default sqlite
+      //configuration is saved in the "bitcoin-s.sqlite" key
+      //if in the future we change our default database behavior
+      //this test case will need to change to check that the profile is correct
+      assert(walletAppConfig.dbConfig.profile.isInstanceOf[SQLiteProfile])
+    }
+  }
+
+  it should "override a configuration with a system property" in {
+    val datadir = BitcoinSTestAppConfig.tmpDir()
+    System.setProperty("bitcoin-s.wallet.requiredConfirmations", "1")
+
+    //need to invalidate the config cache to force typesafe config
+    //to freshly load all system properties
+    ConfigFactory.invalidateCaches()
+
+    val walletAppConfig = WalletAppConfig(datadir)
+    val assertF = for {
+      _ <- walletAppConfig.start()
+    } yield {
+      assert(walletAppConfig.requiredConfirmations == 1)
+    }
+    assertF.onComplete { _ =>
+      System.clearProperty("bitcoin-s.wallet.requiredConfirmations")
+      ConfigFactory.invalidateCaches()
+    }
+    assertF
   }
 
 }


### PR DESCRIPTION
This fixes #2147 

This adds two test cases: 

1. A test case to make sure the config gets resolved correctly by substituting variables in the config
2. That system properties override default configuration specification

