### PR TITLE
Add Wallet State Descriptors

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/wallet/WalletStateDescriptor.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/wallet/WalletStateDescriptor.scala
@@ -1,0 +1,73 @@
+package org.bitcoins.commons.jsonmodels.wallet
+
+import org.bitcoins.crypto.{DoubleSha256DigestBE, StringFactory}
+
+sealed abstract class WalletStateDescriptorType
+
+object WalletStateDescriptorType
+    extends StringFactory[WalletStateDescriptorType] {
+
+  final case object SyncHeight extends WalletStateDescriptorType
+
+  val all: Vector[WalletStateDescriptorType] = Vector(SyncHeight)
+
+  override def fromStringOpt(str: String): Option[WalletStateDescriptorType] = {
+    all.find(state => str.toLowerCase() == state.toString.toLowerCase)
+  }
+
+  override def fromString(string: String): WalletStateDescriptorType = {
+    fromStringOpt(string) match {
+      case Some(state) => state
+      case None =>
+        sys.error(
+          s"Could not find WalletStateDescriptorType for string=$string")
+    }
+  }
+}
+
+sealed abstract class WalletStateDescriptor {
+  def descriptorType: WalletStateDescriptorType
+}
+
+sealed trait WalletStateDescriptorFactory[T <: WalletStateDescriptor]
+    extends StringFactory[T] {
+  def tpe: WalletStateDescriptorType
+}
+
+object WalletStateDescriptor extends StringFactory[WalletStateDescriptor] {
+
+  val all: Vector[StringFactory[WalletStateDescriptor]] = Vector(
+    SyncHeightDescriptor)
+
+  override def fromString(string: String): WalletStateDescriptor = {
+    all.find(f => f.fromStringT(string).isSuccess) match {
+      case Some(factory) => factory.fromString(string)
+      case None =>
+        sys.error(s"Could not find WalletStateDescriptor for string=$string")
+    }
+  }
+}
+
+case class SyncHeightDescriptor(bestHash: DoubleSha256DigestBE, height: Int)
+    extends WalletStateDescriptor {
+
+  override val descriptorType: WalletStateDescriptorType =
+    WalletStateDescriptorType.SyncHeight
+  override val toString: String = s"${bestHash.hex} $height"
+}
+
+object SyncHeightDescriptor
+    extends WalletStateDescriptorFactory[SyncHeightDescriptor] {
+
+  override val tpe: WalletStateDescriptorType =
+    WalletStateDescriptorType.SyncHeight
+
+  override def fromString(string: String): SyncHeightDescriptor = {
+    val arr = string.split(' ').take(2)
+
+    val hash = DoubleSha256DigestBE(arr.head)
+    val height = arr.last.toInt
+
+    SyncHeightDescriptor(hash, height)
+  }
+}

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -141,7 +141,7 @@ class BitcoinSServerMain(override val args: Array[String])
           tmpWallet)
         _ = logger.info("Starting wallet")
         _ <- wallet.start()
-        _ <- BitcoindRpcBackendUtil.catchupWalletToBitcoind(bitcoind, wallet)
+        _ <- BitcoindRpcBackendUtil.syncWalletToBitcoind(bitcoind, wallet)
 
         blockCount <- bitcoind.getBlockCount
         // Create callbacks for processing new blocks

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -140,6 +140,8 @@ class BitcoinSServerMain(override val args: Array[String])
           bitcoind,
           tmpWallet)
         _ = logger.info("Starting wallet")
+        _ <- wallet.start()
+        _ <- BitcoindRpcBackendUtil.catchupWalletToBitcoind(bitcoind, wallet)
 
         blockCount <- bitcoind.getBlockCount
         // Create callbacks for processing new blocks
@@ -153,7 +155,6 @@ class BitcoinSServerMain(override val args: Array[String])
                                                              blockCount)
         }
 
-        _ <- wallet.start()
         binding <- startHttpServer(bitcoind, bitcoind, wallet, rpcPortOpt)
         _ = BitcoinSServer.startedFP.success(Future.successful(binding))
       } yield {

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -20,34 +20,63 @@ import scala.util.{Failure, Success}
 /** Useful utilities to use in the wallet project for syncing things against bitcoind */
 object BitcoindRpcBackendUtil extends BitcoinSLogger {
 
+  /** Has the wallet process all the blocks it has not seen up until bitcoind's chain tip */
   def catchupWalletToBitcoind(bitcoind: BitcoindRpcClient, wallet: Wallet)(
       implicit ec: ExecutionContext): Future[Unit] = {
+
+    def doSync(walletHeight: Int, bitcoindHeight: Int): Future[Unit] = {
+      if (walletHeight > bitcoindHeight) {
+        Future.failed(new RuntimeException(
+          s"Bitcoind and wallet are in incompatible states, " +
+            s"wallet height: $walletHeight, bitcoind height: $bitcoindHeight"))
+      } else {
+        val blockRange = walletHeight.to(bitcoindHeight).tail
+
+        logger.info(s"Syncing ${blockRange.size} blocks")
+
+        val func: Vector[Int] => Future[Unit] = { range =>
+          val hashFs =
+            range.map(bitcoind.getBlockHash(_).map(_.flip))
+          for {
+            hashes <- Future.sequence(hashFs)
+            _ <- wallet.nodeApi.downloadBlocks(hashes)
+          } yield ()
+        }
+
+        FutureUtil
+          .batchExecute(elements = blockRange.toVector,
+                        f = func,
+                        init = Vector.empty,
+                        batchSize = 25)
+          .map(_ => ())
+      }
+    }
+
     for {
       bitcoindHeight <- bitcoind.getBlockCount
       walletStateOpt <- wallet.getSyncHeight()
       _ <- walletStateOpt match {
-        case None => FutureUtil.unit // New wallet, nothing to sync
-        case Some(syncHeight) =>
-          if (syncHeight.height > bitcoindHeight) {
-            Future.failed(
-              new RuntimeException("Bitcoind is not caught up to wallet"))
-          } else {
-            val blockRange = syncHeight.height.to(bitcoindHeight).tail
-
-            val func: Vector[Int] => Future[Unit] = { range =>
-              val hashFs =
-                range.map(bitcoind.getBlockHash(_).map(_.flip))
-              for {
-                hashes <- Future.sequence(hashFs)
-                _ <- wallet.nodeApi.downloadBlocks(hashes)
-              } yield ()
+        case None =>
+          for {
+            utxos <- wallet.listUtxos()
+            lastConfirmedOpt = utxos.filter(_.blockHash.isDefined).lastOption
+            _ <- lastConfirmedOpt match {
+              case None => FutureUtil.unit
+              case Some(utxo) =>
+                for {
+                  heightOpt <- bitcoind.getBlockHeight(utxo.blockHash.get)
+                  _ <- heightOpt match {
+                    case Some(height) =>
+                      logger.info(
+                        s"Last utxo occurred at block $height, syncing from there")
+                      doSync(height, bitcoindHeight)
+                    case None => FutureUtil.unit
+                  }
+                } yield ()
             }
-
-            FutureUtil.batchExecute(elements = blockRange.toVector,
-                                    f = func,
-                                    init = Vector.empty,
-                                    batchSize = 25)
-          }
+          } yield ()
+        case Some(syncHeight) =>
+          doSync(syncHeight.height, bitcoindHeight)
       }
     } yield ()
   }

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -21,8 +21,8 @@ import scala.util.{Failure, Success}
 object BitcoindRpcBackendUtil extends BitcoinSLogger {
 
   /** Has the wallet process all the blocks it has not seen up until bitcoind's chain tip */
-  def catchupWalletToBitcoind(bitcoind: BitcoindRpcClient, wallet: Wallet)(
-      implicit ec: ExecutionContext): Future[Unit] = {
+  def syncWalletToBitcoind(bitcoind: BitcoindRpcClient, wallet: Wallet)(implicit
+      ec: ExecutionContext): Future[Unit] = {
 
     def doSync(walletHeight: Int, bitcoindHeight: Int): Future[Unit] = {
       if (walletHeight > bitcoindHeight) {

--- a/crypto/src/main/scala/org/bitcoins/crypto/StringFactory.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/StringFactory.scala
@@ -3,7 +3,7 @@ package org.bitcoins.crypto
 import scala.util.Try
 
 /** A common factory trait that can be re-used to deserialize a string to a type t */
-trait StringFactory[T] {
+trait StringFactory[+T] {
 
   /** Tries to parse a string to type t, throws an exception if fails */
   def fromString(string: String): T

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -74,13 +74,13 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
     val result = walletDbManagement.migrate()
     walletAppConfig.driver match {
       case SQLite =>
-        val expected = 8
+        val expected = 9
         assert(result == expected)
         val flywayInfo = walletDbManagement.info()
         assert(flywayInfo.applied().length == expected)
         assert(flywayInfo.pending().length == 0)
       case PostgreSQL =>
-        val expected = 6
+        val expected = 7
         assert(result == expected)
         val flywayInfo = walletDbManagement.info()
 

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -2,6 +2,10 @@ package org.bitcoins.db
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.ContractInfo
 import org.bitcoins.commons.jsonmodels.dlc.SigningVersion
+import org.bitcoins.commons.jsonmodels.wallet.{
+  WalletStateDescriptor,
+  WalletStateDescriptorType
+}
 import org.bitcoins.core.config.{BitcoinNetwork, BitcoinNetworks}
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
@@ -294,4 +298,16 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
       _.hex,
       SchnorrDigitalSignature.fromHex)
   }
+
+  implicit val walletStateDescriptorTypeMapper: BaseColumnType[
+    WalletStateDescriptorType] =
+    MappedColumnType.base[WalletStateDescriptorType, String](
+      _.toString,
+      WalletStateDescriptorType.fromString)
+
+  implicit val walletStateDescriptorMapper: BaseColumnType[
+    WalletStateDescriptor] =
+    MappedColumnType.base[WalletStateDescriptor, String](
+      _.toString,
+      WalletStateDescriptor.fromString)
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/WalletDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/WalletDAOFixture.scala
@@ -15,7 +15,8 @@ case class WalletDAOs(
     transactionDAO: TransactionDAO,
     incomingTxDAO: IncomingTransactionDAO,
     outgoingTxDAO: OutgoingTransactionDAO,
-    scriptPubKeyDAO: ScriptPubKeyDAO)
+    scriptPubKeyDAO: ScriptPubKeyDAO,
+    stateDescriptorDAO: WalletStateDescriptorDAO)
 
 trait WalletDAOFixture extends BitcoinSWalletTest {
 
@@ -28,6 +29,7 @@ trait WalletDAOFixture extends BitcoinSWalletTest {
     val incomingTx = IncomingTransactionDAO()
     val outgoingTx = OutgoingTransactionDAO()
     val scriptPubKey = ScriptPubKeyDAO()
+    val stateDescriptorDAO = WalletStateDescriptorDAO()
     WalletDAOs(account,
                address,
                tags,
@@ -35,7 +37,8 @@ trait WalletDAOFixture extends BitcoinSWalletTest {
                tx,
                incomingTx,
                outgoingTx,
-               scriptPubKey)
+               scriptPubKey,
+               stateDescriptorDAO)
   }
 
   final override type FixtureParam = WalletDAOs

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -1,0 +1,81 @@
+package org.bitcoins.wallet
+
+import org.bitcoins.commons.jsonmodels.wallet.SyncHeightDescriptor
+import org.bitcoins.core.currency._
+import org.bitcoins.db.AppConfig
+import org.bitcoins.server.{BitcoinSAppConfig, BitcoindRpcBackendUtil}
+import org.bitcoins.testkit.fixtures.BitcoinSFixture
+import org.bitcoins.testkit.util.BitcoinSAsyncTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
+import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
+import org.bitcoins.wallet.config.WalletAppConfig
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+class BitcoindBackendTest extends BitcoinSAsyncTest with EmbeddedPg {
+
+  /** Wallet config with data directory set to user temp directory */
+  implicit protected def config: BitcoinSAppConfig =
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+
+  implicit protected def walletAppConfig: WalletAppConfig = {
+    config.walletConf
+  }
+
+  override def beforeAll(): Unit = {
+    AppConfig.throwIfDefaultDatadir(config.walletConf)
+    super[EmbeddedPg].beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    Await.result(config.chainConf.stop(), 1.minute)
+    Await.result(config.nodeConf.stop(), 1.minute)
+    Await.result(config.walletConf.stop(), 1.minute)
+    super[EmbeddedPg].afterAll()
+  }
+
+  it must "correctly catch up to bitcoind" in {
+    val amountToSend = Bitcoins.one
+
+    for {
+      // Setup bitcoind
+      bitcoind <- BitcoinSFixture.createBitcoindWithFunds()
+      header <- bitcoind.getBestBlockHeader()
+
+      // Setup wallet
+      tmpWallet <-
+        BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind, None)
+      wallet =
+        BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(bitcoind,
+                                                                 tmpWallet)
+      // Assert wallet is empty
+      isEmpty <- wallet.isEmpty()
+      _ = assert(isEmpty)
+
+      // Send to wallet
+      addr <- wallet.getNewAddress()
+      _ <- bitcoind.sendToAddress(addr, amountToSend)
+      _ <- bitcoind.generateToAddress(6, addr)
+
+      // assert wallet hasn't seen it yet
+      firstBalance <- wallet.getBalance()
+      _ = assert(firstBalance == Satoshis.zero)
+
+      // Set sync height
+      _ <-
+        wallet.stateDescriptorDAO.updateSyncHeight(header.hashBE, header.height)
+
+      _ <- BitcoindRpcBackendUtil.catchupWalletToBitcoind(bitcoind, wallet)
+
+      balance <- wallet.getBalance()
+
+      height <- bitcoind.getBlockCount
+      bestHash <- bitcoind.getBestBlockHash
+      syncHeightOpt <- wallet.getSyncHeight()
+    } yield {
+      assert(balance == amountToSend)
+      assert(syncHeightOpt.contains(SyncHeightDescriptor(bestHash, height)))
+    }
+  }
+}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -66,7 +66,7 @@ class BitcoindBackendTest extends BitcoinSAsyncTest with EmbeddedPg {
       _ <-
         wallet.stateDescriptorDAO.updateSyncHeight(header.hashBE, header.height)
 
-      _ <- BitcoindRpcBackendUtil.catchupWalletToBitcoind(bitcoind, wallet)
+      _ <- BitcoindRpcBackendUtil.syncWalletToBitcoind(bitcoind, wallet)
 
       balance <- wallet.getBalance()
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
@@ -55,7 +55,8 @@ class SpendingInfoDAOTest extends BitcoinSWalletTest with WalletDAOFixture {
   }
 
   it must "be able to update multiple utxos" in { daos =>
-    val WalletDAOs(_, addressDAO, _, spendingInfoDAO, _, _, _, _) = daos
+    val addressDAO = daos.addressDAO
+    val spendingInfoDAO = daos.utxoDAO
 
     for {
       account <- daos.accountDAO.create(WalletTestUtil.firstAccountDb)

--- a/wallet/src/main/resources/postgresql/wallet/migration/V10__state_descriptor_table.sql
+++ b/wallet/src/main/resources/postgresql/wallet/migration/V10__state_descriptor_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE state_descriptors (
+    type TEXT PRIMARY KEY NOT NULL,
+    descriptor TEXT NOT NULL
+);

--- a/wallet/src/main/resources/sqlite/wallet/migration/V9__state_descriptor_table.sql
+++ b/wallet/src/main/resources/sqlite/wallet/migration/V9__state_descriptor_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE `state_descriptors` (
+    `type` VARCHAR(254) PRIMARY KEY NOT NULL,
+    `descriptor` VARCHAR(254) NOT NULL
+);

--- a/wallet/src/main/scala/org/bitcoins/wallet/db/WalletDbManagement.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/db/WalletDbManagement.scala
@@ -45,6 +45,10 @@ trait WalletDbManagement extends DbManagement {
     ScriptPubKeyDAO()(ec, appConfig).table
   }
 
+  private lazy val stateDescriptorTable: TableQuery[Table[_]] = {
+    WalletStateDescriptorDAO()(ec, appConfig).table
+  }
+
   // Ordering matters here, tables with a foreign key should be listed after
   // the table that key references
   override lazy val allTables: List[TableQuery[Table[_]]] = {
@@ -55,7 +59,8 @@ trait WalletDbManagement extends DbManagement {
          txTable,
          incomingTxTable,
          utxoTable,
-         outgoingTxTable)
+         outgoingTxTable,
+         stateDescriptorTable)
   }
 
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/WalletStateDescriptorDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/WalletStateDescriptorDAO.scala
@@ -1,0 +1,100 @@
+package org.bitcoins.wallet.models
+
+import org.bitcoins.commons.jsonmodels.wallet.WalletStateDescriptorType._
+import org.bitcoins.commons.jsonmodels.wallet.{
+  SyncHeightDescriptor,
+  WalletStateDescriptor,
+  WalletStateDescriptorType
+}
+import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.db.{CRUD, SlickUtil}
+import org.bitcoins.wallet.config.WalletAppConfig
+import slick.lifted.ProvenShape
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class WalletStateDescriptorDb(
+    tpe: WalletStateDescriptorType,
+    descriptor: WalletStateDescriptor) {
+  require(descriptor.descriptorType == tpe)
+}
+
+case class WalletStateDescriptorDAO()(implicit
+    val ec: ExecutionContext,
+    override val appConfig: WalletAppConfig)
+    extends CRUD[WalletStateDescriptorDb, WalletStateDescriptorType]
+    with SlickUtil[WalletStateDescriptorDb, WalletStateDescriptorType] {
+  import profile.api._
+  private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
+  import mappers._
+
+  override val table: profile.api.TableQuery[WalletStateDescriptorTable] =
+    TableQuery[WalletStateDescriptorTable]
+
+  override def createAll(ts: Vector[WalletStateDescriptorDb]): Future[
+    Vector[WalletStateDescriptorDb]] =
+    createAllNoAutoInc(ts, safeDatabase)
+
+  override def findByPrimaryKeys(ids: Vector[WalletStateDescriptorType]): Query[
+    WalletStateDescriptorTable,
+    WalletStateDescriptorDb,
+    Seq] = {
+    table.filter(_.tpe.inSet(ids))
+  }
+
+  override def findByPrimaryKey(id: WalletStateDescriptorType): Query[
+    Table[_],
+    WalletStateDescriptorDb,
+    Seq] = {
+    table.filter(_.tpe === id)
+  }
+
+  override def findAll(ts: Vector[WalletStateDescriptorDb]): Query[
+    Table[_],
+    WalletStateDescriptorDb,
+    Seq] =
+    findByPrimaryKeys(ts.map(_.tpe))
+
+  def getSyncHeightOpt(): Future[Option[SyncHeightDescriptor]] = {
+    read(SyncHeight).map {
+      case Some(db) =>
+        val desc = SyncHeightDescriptor.fromString(db.descriptor.toString)
+        Some(desc)
+      case None => None
+    }
+  }
+
+  def updateSyncHeight(
+      hash: DoubleSha256DigestBE,
+      height: Int): Future[WalletStateDescriptorDb] = {
+    getSyncHeightOpt().flatMap {
+      case Some(old) =>
+        if (old.height > height) {
+          Future.successful(WalletStateDescriptorDb(SyncHeight, old))
+        } else {
+          val descriptor = SyncHeightDescriptor(hash, height)
+          val newDb = WalletStateDescriptorDb(SyncHeight, descriptor)
+          update(newDb)
+        }
+      case None =>
+        val descriptor = SyncHeightDescriptor(hash, height)
+        val db = WalletStateDescriptorDb(SyncHeight, descriptor)
+        create(db)
+    }
+  }
+
+  class WalletStateDescriptorTable(t: Tag)
+      extends Table[WalletStateDescriptorDb](t,
+                                             schemaName,
+                                             "state_descriptors") {
+
+    def tpe: Rep[WalletStateDescriptorType] = column("type", O.PrimaryKey)
+
+    def descriptor: Rep[WalletStateDescriptor] = column("descriptor")
+
+    override def * : ProvenShape[WalletStateDescriptorDb] =
+      (tpe, descriptor).<>(WalletStateDescriptorDb.tupled,
+                           WalletStateDescriptorDb.unapply)
+
+  }
+}


### PR DESCRIPTION
This creates `WalletStateDescriptor`s. These are used to add any data about the state of the wallet to the db.

The first being `SyncHeight` which is just a block height and hash. This is used to keep track of what was the last block processed by the wallet.

This is useful for when we are using the bitcoind backend so we know which block we missed while offline so we can then process them.