### PR TITLE
Add -Xcheckinit compiler flag to tests to try and find uninitialized …

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -105,7 +105,9 @@ object CommonSettings {
       else nonScala2_13CompilerOpts
     }
 
-  val testCompilerOpts: Seq[String] = commonCompilerOpts
+  val testCompilerOpts: Seq[String] = commonCompilerOpts ++
+    //initialization checks: https://docs.scala-lang.org/tutorials/FAQ/initialization-order.html
+    Vector("-Xcheckinit")
 
   lazy val testSettings: Seq[Setting[_]] = Seq(
     //show full stack trace (-oF) of failed tests and duration of tests (-oD)


### PR DESCRIPTION
…vals

https://docs.scala-lang.org/tutorials/FAQ/initialization-order.html

I don't think this would have found the NPE fixed in #2160 as the documentation says this should only be run in test, but it can't hurt to add it

>-Xcheckinit: Add runtime check to field accessors.

>It is inadvisable to use this flag outside of testing. It adds significantly to the code size by putting a wrapper around all potentially uninitialized field accesses: the wrapper will throw an exception rather than allow a null (or 0/false in the case of primitive types) to silently appear. Note also that this adds a runtime check: it can only tell you anything about code paths which you exercise with it in place.