### PR TITLE
2020 10 12 issue 2164

### DIFF
--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.db.ChainDbManagement
 import org.bitcoins.db.DatabaseDriver._
+import org.bitcoins.dlc.oracle.DLCOracleAppConfig
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.db.NodeDbManagement
 import org.bitcoins.testkit.BitcoinSTestAppConfig.ProjectType
@@ -53,6 +54,9 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
       case PostgreSQL => 4
     }
     assert(result == expected)
+    val flywayInfo = chainDbManagement.info()
+    assert(flywayInfo.applied().length == expected)
+    assert(flywayInfo.pending().length == 0)
   }
 
   it must "run migrations for wallet db" in {
@@ -65,6 +69,9 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
       case PostgreSQL => 6
     }
     assert(result == expected)
+    val flywayInfo = walletDbManagement.info()
+    assert(flywayInfo.applied().length == expected)
+    assert(flywayInfo.pending().length == 0)
   }
 
   it must "run migrations for node db" in {
@@ -77,5 +84,8 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
       case PostgreSQL => 2
     }
     assert(result == expected)
+    val flywayInfo = nodeDbManagement.info()
+    assert(flywayInfo.applied().length == expected)
+    assert(flywayInfo.pending().length == 0)
   }
 }

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -49,14 +49,22 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
                                         dbConfig(ProjectType.Chain))
     val chainDbManagement = createChainDbManagement(chainAppConfig)
     val result = chainDbManagement.migrate()
-    val expected = chainAppConfig.driver match {
-      case SQLite     => 5
-      case PostgreSQL => 4
+    chainAppConfig.driver match {
+      case SQLite =>
+        val expected = 5
+        assert(result == expected)
+        val flywayInfo = chainDbManagement.info()
+        assert(flywayInfo.applied().length == expected)
+        assert(flywayInfo.pending().length == 0)
+      case PostgreSQL =>
+        val expected = 4
+        assert(result == expected)
+        val flywayInfo = chainDbManagement.info()
+        //+1 for << Flyway Schema Creation >>
+        assert(flywayInfo.applied().length == expected + 1)
+        assert(flywayInfo.pending().length == 0)
     }
-    assert(result == expected)
-    val flywayInfo = chainDbManagement.info()
-    assert(flywayInfo.applied().length == expected)
-    assert(flywayInfo.pending().length == 0)
+
   }
 
   it must "run migrations for wallet db" in {
@@ -64,14 +72,23 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
                                           dbConfig(ProjectType.Wallet))
     val walletDbManagement = createWalletDbManagement(walletAppConfig)
     val result = walletDbManagement.migrate()
-    val expected = walletAppConfig.driver match {
-      case SQLite     => 8
-      case PostgreSQL => 6
+    walletAppConfig.driver match {
+      case SQLite =>
+        val expected = 8
+        assert(result == expected)
+        val flywayInfo = walletDbManagement.info()
+        assert(flywayInfo.applied().length == expected)
+        assert(flywayInfo.pending().length == 0)
+      case PostgreSQL =>
+        val expected = 6
+        assert(result == expected)
+        val flywayInfo = walletDbManagement.info()
+
+        //+1 for << Flyway Schema Creation >>
+        assert(flywayInfo.applied().length == expected + 1)
+        assert(flywayInfo.pending().length == 0)
     }
-    assert(result == expected)
-    val flywayInfo = walletDbManagement.info()
-    assert(flywayInfo.applied().length == expected)
-    assert(flywayInfo.pending().length == 0)
+
   }
 
   it must "run migrations for node db" in {
@@ -79,13 +96,22 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
       NodeAppConfig(BitcoinSTestAppConfig.tmpDir(), dbConfig(ProjectType.Node))
     val nodeDbManagement = createNodeDbManagement(nodeAppConfig)
     val result = nodeDbManagement.migrate()
-    val expected = nodeAppConfig.driver match {
-      case SQLite     => 2
-      case PostgreSQL => 2
+    nodeAppConfig.driver match {
+      case SQLite =>
+        val expected = 2
+        assert(result == expected)
+        val flywayInfo = nodeDbManagement.info()
+        //+1 for << Flyway Schema Creation >>
+        assert(flywayInfo.applied().length == expected)
+        assert(flywayInfo.pending().length == 0)
+      case PostgreSQL =>
+        val expected = 2
+        assert(result == expected)
+        val flywayInfo = nodeDbManagement.info()
+
+        //+1 for << Flyway Schema Creation >>
+        assert(flywayInfo.applied().length == expected + 1)
+        assert(flywayInfo.pending().length == 0)
     }
-    assert(result == expected)
-    val flywayInfo = nodeDbManagement.info()
-    assert(flywayInfo.applied().length == expected)
-    assert(flywayInfo.pending().length == 0)
   }
 }


### PR DESCRIPTION
Fixes #2164 

This makes the flyway config accessible outside of `DbManagement.migrate()`. 

This PR also adds a new method, `DbManagement.info()` which is just a proxy for [`flyway.info()`](https://flywaydb.org/documentation/command/info)