### PR TITLE
Refactor db configuration to use the key 'user' rather than 'username…

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -11,7 +11,7 @@ bitcoin-s {
       //https://scala-slick.org/doc/3.3.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database
       path = ${bitcoin-s.datadir}/${bitcoin-s.network}/
       driver = org.sqlite.JDBC
-      username = ""
+      user = ""
       password = ""
 
       # this needs to be set to 1 for SQLITE as it does not support concurrent database operations

--- a/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
@@ -48,7 +48,7 @@ trait JdbcProfileComponent[+ConfigType <: AppConfig] extends BitcoinSLogger {
 
   lazy val driver: DatabaseDriver = DatabaseDriver.fromString(driverName)
 
-  lazy val username: String = dbConfig.config.getString("db.username")
+  lazy val username: String = dbConfig.config.getString("db.user")
 
   lazy val password: String = dbConfig.config.getString("db.password")
 

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -215,7 +215,7 @@ bitcoin-s {
         db {
             driver = org.postgresql.Driver
             url = "jdbc:postgresql://localhost:5432/database"
-            username = "user"
+            user = "user"
             password = "topsecret"
             numThreads = 5
         }
@@ -245,7 +245,7 @@ bitcoin-s {
         db {
             driver = org.postgresql.Driver
             url = "jdbc:postgresql://localhost:5432/chaindb"
-            username = "user"
+            user = "user"
             password = "topsecret"
         }
     }
@@ -254,7 +254,7 @@ bitcoin-s {
         db {
             driver = org.postgresql.Driver
             url = "jdbc:postgresql://localhost:5432/walletdb"
-            username = "user"
+            user = "user"
             password = "topsecret"
         }
     }

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -11,7 +11,7 @@ bitcoin-s {
             //https://scala-slick.org/doc/3.3.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database
             path = ${bitcoin-s.datadir}/${bitcoin-s.network}/
             driver = org.sqlite.JDBC
-            username = ""
+            user = ""
             password = ""
 
             # this needs to be set to 1 for SQLITE as it does not support concurrent database operations


### PR DESCRIPTION
…' inline with slick documentation

Fixes #2145 

Slick is very confusing in this respect, if you look at their documentation you will see they use `mydb.properties` as a configuration key. However when I actually try to use this it doesn't seem to work 

https://scala-slick.org/doc/3.3.2/database.html#examples

I'm also unable to find the ability to enable authentication in the [embedded-pg](https://github.com/opentable/otj-pg-embedded) dependency. So i don't think it will be possible to write a unit test for postgres authentication (#2146) 

I did run this locally, with authentication enabled on my local postgres server, and I failed to connect when I input the wrong password, and it worked when i input the correct password.