### PR TITLE
Exclude sbt keys that unused (are they really unused?)

### DIFF
--- a/inThisBuild.sbt
+++ b/inThisBuild.sbt
@@ -1,3 +1,5 @@
+import sbt.Keys.excludeLintKeys
+
 import scala.util.Properties
 
 val scala2_12 = "2.12.12"
@@ -8,3 +10,10 @@ scalafmtOnCompile in ThisBuild := !Properties.envOrNone("CI").contains("true")
 scalaVersion in ThisBuild := scala2_13
 
 crossScalaVersions in ThisBuild := List(scala2_13, scala2_12)
+
+//https://github.com/sbt/sbt/pull/5153
+excludeLintKeys in Global ++= Set(
+  com.typesafe.sbt.packager.Keys.maintainer,
+  Keys.mainClass,
+  com.typesafe.sbt.SbtGit.GitKeys.gitRemoteRepo
+)

--- a/inThisBuild.sbt
+++ b/inThisBuild.sbt
@@ -12,6 +12,7 @@ scalaVersion in ThisBuild := scala2_13
 crossScalaVersions in ThisBuild := List(scala2_13, scala2_12)
 
 //https://github.com/sbt/sbt/pull/5153
+//https://github.com/bitcoin-s/bitcoin-s/pull/2194
 excludeLintKeys in Global ++= Set(
   com.typesafe.sbt.packager.Keys.maintainer,
   Keys.mainClass,


### PR DESCRIPTION
When we merged in #2119 we get a bunch of errors when sbt is started up, they look like this: 

![Screenshot from 2020-10-15 08-54-21](https://user-images.githubusercontent.com/3514957/96139153-2b6ee980-0ec4-11eb-8ccf-aea07be49a58.png)

This PR fixes this, you can find documentation on how/why this was introduced in sbt 1.4.0 

https://github.com/sbt/sbt/pull/5153

you can find the release notes here for sbt 1.4.0 

https://github.com/sbt/sbt/releases/tag/v1.4.0

