### PR TITLE
DLCStatus Table in GUI

### DIFF
--- a/app/dlc-suredbits-client-test/src/test/scala/org/bitcoins/sbclient/SbClientTest.scala
+++ b/app/dlc-suredbits-client-test/src/test/scala/org/bitcoins/sbclient/SbClientTest.scala
@@ -29,9 +29,9 @@ class SbClientTest extends BitcoinSAsyncTest {
     val _ = Await.result(server.start(), 5.seconds)
   }
 
-  override def afterAll: Unit = {
+  override def afterAll(): Unit = {
     Await.result(server.stop(), 5.seconds)
-    super.afterAll
+    super.afterAll()
   }
 
   it should "successfully decrypt data from server" in {

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
@@ -133,7 +133,7 @@ object WalletGUI extends JFXApp {
     )
   }
 
-  private val walletScene = new Scene {
+  private val walletScene = new Scene(1000, 600) {
     root = rootView
     stylesheets = GlobalData.currentStyleSheets
   }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -1,7 +1,9 @@
 package org.bitcoins.gui.dlc
 
 import javafx.event.{ActionEvent, EventHandler}
+import org.bitcoins.commons.jsonmodels.dlc._
 import org.bitcoins.gui.{GlobalData, TaskRunner}
+import scalafx.beans.property._
 import scalafx.geometry.{Insets, Pos}
 import scalafx.scene.control._
 import scalafx.scene.layout._
@@ -15,16 +17,12 @@ class DLCPane(glassPane: VBox) {
   }
 
   private val resultArea = new TextArea {
-    prefHeight = 750
-    prefWidth = 800
     editable = false
     text = "Click on Offer or Accept to begin."
     wrapText = true
   }
 
   private val demoOracleArea = new TextArea {
-    prefHeight = 700
-    prefWidth = 400
     editable = false
     text =
       "Click on Init Demo Oracle to generate example oracle and contract information"
@@ -37,6 +35,8 @@ class DLCPane(glassPane: VBox) {
 
   private val model =
     new DLCPaneModel(resultArea, demoOracleArea, numOutcomesTF)
+
+  model.setUp()
 
   private val demoOracleButton = new Button {
     text = "Init Demo Oracle"
@@ -121,7 +121,6 @@ class DLCPane(glassPane: VBox) {
 
   private val buttonSpacer = new GridPane {
     hgap = 10
-    prefHeight = 50
     alignment = Pos.Center
 
     add(initButtonBar, 0, 0)
@@ -136,17 +135,145 @@ class DLCPane(glassPane: VBox) {
     spacing = 10
   }
 
+  private val tableView: TableView[DLCStatus] = {
+    val paramHashCol = new TableColumn[DLCStatus, String] {
+      text = "Temp Contract Id"
+      prefWidth = 150
+      cellValueFactory = { status =>
+        new StringProperty(status,
+                           "Temp Contract Id",
+                           status.value.tempContractId.hex)
+      }
+    }
+
+    val contractIdCol = new TableColumn[DLCStatus, String] {
+      text = "Contract Id"
+      prefWidth = 150
+      cellValueFactory = { status =>
+        val contractIdStr = status.value match {
+          case _: DLCStatus.Offered | _: DLCStatus.Accepted =>
+            ""
+          case signed: SignedDLCStatus =>
+            signed.contractId.toHex
+        }
+
+        new StringProperty(status, "Contract Id", contractIdStr)
+      }
+    }
+
+    val statusCol = new TableColumn[DLCStatus, String] {
+      text = "Status"
+      prefWidth = 150
+      cellValueFactory = { status =>
+        new StringProperty(status, "Status", status.value.statusString)
+      }
+    }
+
+    val initiatorCol = new TableColumn[DLCStatus, String] {
+      text = "Initiator"
+      prefWidth = 80
+      cellValueFactory = { status =>
+        val str = if (status.value.isInitiator) {
+          "Yes"
+        } else {
+          "No"
+        }
+        new StringProperty(status, "Initiator", str)
+      }
+    }
+
+    val collateralCol = new TableColumn[DLCStatus, String] {
+      text = "Collateral"
+      prefWidth = 110
+      cellValueFactory = { status =>
+        val num = if (status.value.isInitiator) {
+          status.value.offer.totalCollateral.toLong
+        } else {
+          status.value
+            .asInstanceOf[AcceptedDLCStatus]
+            .accept
+            .totalCollateral
+            .toLong
+        }
+        new StringProperty(status, "Collateral", num.toString)
+      }
+    }
+
+    val oracleCol = new TableColumn[DLCStatus, String] {
+      text = "Oracle"
+      prefWidth = 150
+      cellValueFactory = { status =>
+        new StringProperty(status,
+                           "Oracle",
+                           status.value.offer.oracleInfo.pubKey.hex)
+      }
+    }
+
+    val eventCol = new TableColumn[DLCStatus, String] {
+      text = "Event"
+      prefWidth = 150
+      cellValueFactory = { status =>
+        new StringProperty(status,
+                           "Event",
+                           status.value.offer.oracleInfo.rValue.hex)
+      }
+    }
+
+    val contractMaturityCol = new TableColumn[DLCStatus, String] {
+      text = "Contract Mat."
+      prefWidth = 110
+      cellValueFactory = { status =>
+        new StringProperty(
+          status,
+          "Contract Maturity",
+          status.value.offer.timeouts.contractMaturity.toUInt32.toLong.toString)
+      }
+    }
+
+    new TableView[DLCStatus](model.dlcs) {
+      columns ++= Seq(paramHashCol,
+                      contractIdCol,
+                      statusCol,
+                      initiatorCol,
+                      collateralCol,
+                      oracleCol,
+                      eventCol,
+                      contractMaturityCol)
+      margin = Insets(10, 0, 10, 0)
+
+      val infoItem: MenuItem = new MenuItem("View DLC") {
+        onAction = _ => {
+          val dlc = selectionModel.value.getSelectedItem
+          model.viewDLC(dlc)
+        }
+      }
+
+      contextMenu = new ContextMenu() {
+        items ++= Vector(infoItem)
+      }
+    }
+  }
+
+  private val textAreasAndTableViewVBox = new VBox {
+    children = Seq(textAreaHBox, tableView)
+    spacing = 10
+  }
+
   val borderPane: BorderPane = new BorderPane {
     top = buttonSpacer
-    center = textAreaHBox
+    center = textAreasAndTableViewVBox
     bottom = statusLabel
   }
 
   resultArea.prefWidth <== (borderPane.width * 2) / 3
   demoOracleVBox.prefWidth <== (borderPane.width / 3)
+  resultArea.prefHeight <== (borderPane.height * 2) / 3
+  demoOracleVBox.prefHeight <== (borderPane.height * 2) / 3
+  demoOracleArea.prefHeight <== demoOracleVBox.height * 0.9
 
   spaceRegion.prefWidth <== (borderPane.width - initButtonBar.width - acceptButtonBar.width - execButtonBar.width - 100) / 2
   spaceRegion2.prefWidth <== spaceRegion.prefWidth
+  tableView.prefHeight <== borderPane.height / 3
 
   private val taskRunner = new TaskRunner(buttonSpacer, glassPane)
   model.taskRunner = taskRunner

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -1,9 +1,7 @@
 package org.bitcoins.gui.dlc
 
 import javafx.event.{ActionEvent, EventHandler}
-import org.bitcoins.commons.jsonmodels.dlc._
 import org.bitcoins.gui.{GlobalData, TaskRunner}
-import scalafx.beans.property._
 import scalafx.geometry.{Insets, Pos}
 import scalafx.scene.control._
 import scalafx.scene.layout._
@@ -135,124 +133,7 @@ class DLCPane(glassPane: VBox) {
     spacing = 10
   }
 
-  private val tableView: TableView[DLCStatus] = {
-    val paramHashCol = new TableColumn[DLCStatus, String] {
-      text = "Temp Contract Id"
-      prefWidth = 150
-      cellValueFactory = { status =>
-        new StringProperty(status,
-                           "Temp Contract Id",
-                           status.value.tempContractId.hex)
-      }
-    }
-
-    val contractIdCol = new TableColumn[DLCStatus, String] {
-      text = "Contract Id"
-      prefWidth = 150
-      cellValueFactory = { status =>
-        val contractIdStr = status.value match {
-          case _: DLCStatus.Offered | _: DLCStatus.Accepted =>
-            ""
-          case signed: SignedDLCStatus =>
-            signed.contractId.toHex
-        }
-
-        new StringProperty(status, "Contract Id", contractIdStr)
-      }
-    }
-
-    val statusCol = new TableColumn[DLCStatus, String] {
-      text = "Status"
-      prefWidth = 150
-      cellValueFactory = { status =>
-        new StringProperty(status, "Status", status.value.statusString)
-      }
-    }
-
-    val initiatorCol = new TableColumn[DLCStatus, String] {
-      text = "Initiator"
-      prefWidth = 80
-      cellValueFactory = { status =>
-        val str = if (status.value.isInitiator) {
-          "Yes"
-        } else {
-          "No"
-        }
-        new StringProperty(status, "Initiator", str)
-      }
-    }
-
-    val collateralCol = new TableColumn[DLCStatus, String] {
-      text = "Collateral"
-      prefWidth = 110
-      cellValueFactory = { status =>
-        val num = if (status.value.isInitiator) {
-          status.value.offer.totalCollateral.toLong
-        } else {
-          status.value
-            .asInstanceOf[AcceptedDLCStatus]
-            .accept
-            .totalCollateral
-            .toLong
-        }
-        new StringProperty(status, "Collateral", num.toString)
-      }
-    }
-
-    val oracleCol = new TableColumn[DLCStatus, String] {
-      text = "Oracle"
-      prefWidth = 150
-      cellValueFactory = { status =>
-        new StringProperty(status,
-                           "Oracle",
-                           status.value.offer.oracleInfo.pubKey.hex)
-      }
-    }
-
-    val eventCol = new TableColumn[DLCStatus, String] {
-      text = "Event"
-      prefWidth = 150
-      cellValueFactory = { status =>
-        new StringProperty(status,
-                           "Event",
-                           status.value.offer.oracleInfo.rValue.hex)
-      }
-    }
-
-    val contractMaturityCol = new TableColumn[DLCStatus, String] {
-      text = "Contract Mat."
-      prefWidth = 110
-      cellValueFactory = { status =>
-        new StringProperty(
-          status,
-          "Contract Maturity",
-          status.value.offer.timeouts.contractMaturity.toUInt32.toLong.toString)
-      }
-    }
-
-    new TableView[DLCStatus](model.dlcs) {
-      columns ++= Seq(paramHashCol,
-                      contractIdCol,
-                      statusCol,
-                      initiatorCol,
-                      collateralCol,
-                      oracleCol,
-                      eventCol,
-                      contractMaturityCol)
-      margin = Insets(10, 0, 10, 0)
-
-      val infoItem: MenuItem = new MenuItem("View DLC") {
-        onAction = _ => {
-          val dlc = selectionModel.value.getSelectedItem
-          model.viewDLC(dlc)
-        }
-      }
-
-      contextMenu = new ContextMenu() {
-        items ++= Vector(infoItem)
-      }
-    }
-  }
+  private val tableView = new DLCTableView(model).tableView
 
   private val textAreasAndTableViewVBox = new VBox {
     children = Seq(textAreaHBox, tableView)

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -1,11 +1,14 @@
 package org.bitcoins.gui.dlc
 
-import org.bitcoins.cli.{CliCommand, ConsoleCli}
+import org.bitcoins.cli.CliCommand._
+import org.bitcoins.cli.{CliCommand, Config, ConsoleCli}
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.OracleInfo
-import org.bitcoins.crypto.ECPrivateKey
-import org.bitcoins.gui.{GlobalData, TaskRunner}
+import org.bitcoins.commons.jsonmodels.dlc.DLCStatus
+import org.bitcoins.crypto.{ECPrivateKey, Sha256DigestBE}
 import org.bitcoins.gui.dlc.dialog._
+import org.bitcoins.gui.{GlobalData, TaskRunner}
 import scalafx.beans.property.ObjectProperty
+import scalafx.collections.ObservableBuffer
 import scalafx.scene.control.{TextArea, TextField}
 import scalafx.stage.Window
 
@@ -21,6 +24,38 @@ class DLCPaneModel(
   // constructors to signal that you want some default
   val parentWindow: ObjectProperty[Window] =
     ObjectProperty[Window](null.asInstanceOf[Window])
+
+  val dlcs: ObservableBuffer[DLCStatus] = new ObservableBuffer[DLCStatus]()
+
+  def getDLCs: Vector[DLCStatus] = {
+    ConsoleCli.exec(GetDLCs, Config.empty) match {
+      case Failure(exception) => throw exception
+      case Success(dlcsStr) =>
+        ujson.read(dlcsStr).arr.map(DLCStatus.fromJson).toVector
+    }
+  }
+
+  def setUp(): Unit = {
+    dlcs.clear()
+    dlcs ++= getDLCs
+  }
+
+  def updateDLC(paramHash: Sha256DigestBE): Unit = {
+    ConsoleCli.exec(GetDLC(paramHash), Config.empty) match {
+      case Failure(exception) => throw exception
+      case Success(dlcStatus) =>
+        dlcs += DLCStatus.fromJson(ujson.read(dlcStatus))
+        dlcs.find(_.paramHash == paramHash).foreach(dlcs -= _)
+    }
+  }
+
+  def updateDLCs(): Unit = {
+    val newDLCs = getDLCs
+    val toAdd = newDLCs.diff(dlcs)
+    val toRemove = dlcs.diff(newDLCs)
+    dlcs ++= toAdd
+    dlcs --= toRemove
+  }
 
   def printDLCDialogResult[T <: CliCommand](
       caption: String,
@@ -38,6 +73,7 @@ class DLCPaneModel(
                 err.printStackTrace()
                 resultArea.text = s"Error executing command:\n${err.getMessage}"
             }
+            updateDLCs()
           }
         )
       case None => ()
@@ -111,5 +147,9 @@ class DLCPaneModel(
 
   def onRefund(): Unit = {
     printDLCDialogResult("ExecuteDLCRefund", RefundDLCDialog)
+  }
+
+  def viewDLC(status: DLCStatus): Unit = {
+    ViewDLCDialog.showAndWait(parentWindow.value, status)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -150,6 +150,9 @@ class DLCPaneModel(
   }
 
   def viewDLC(status: DLCStatus): Unit = {
-    ViewDLCDialog.showAndWait(parentWindow.value, status)
+    updateDLCs()
+    val updatedStatus = dlcs.find(_.tempContractId == status.tempContractId)
+    ViewDLCDialog.showAndWait(parentWindow.value,
+                              updatedStatus.getOrElse(status))
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
@@ -1,0 +1,134 @@
+package org.bitcoins.gui.dlc
+
+import org.bitcoins.commons.jsonmodels.dlc.DLCStatus.Offered
+import org.bitcoins.commons.jsonmodels.dlc.{
+  AcceptedDLCStatus,
+  DLCStatus,
+  SignedDLCStatus
+}
+import scalafx.beans.property.StringProperty
+import scalafx.geometry.Insets
+import scalafx.scene.control.{ContextMenu, MenuItem, TableColumn, TableView}
+
+class DLCTableView(model: DLCPaneModel) {
+
+  val tableView: TableView[DLCStatus] = {
+    val paramHashCol = new TableColumn[DLCStatus, String] {
+      text = "Temp Contract Id"
+      prefWidth = 150
+      cellValueFactory = { status =>
+        new StringProperty(status,
+                           "Temp Contract Id",
+                           status.value.tempContractId.hex)
+      }
+    }
+
+    val contractIdCol = new TableColumn[DLCStatus, String] {
+      text = "Contract Id"
+      prefWidth = 150
+      cellValueFactory = { status =>
+        val contractIdStr = status.value match {
+          case _: DLCStatus.Offered | _: DLCStatus.Accepted =>
+            ""
+          case signed: SignedDLCStatus =>
+            signed.contractId.toHex
+        }
+
+        new StringProperty(status, "Contract Id", contractIdStr)
+      }
+    }
+
+    val statusCol = new TableColumn[DLCStatus, String] {
+      text = "Status"
+      prefWidth = 150
+      cellValueFactory = { status =>
+        new StringProperty(status, "Status", status.value.statusString)
+      }
+    }
+
+    val initiatorCol = new TableColumn[DLCStatus, String] {
+      text = "Initiator"
+      prefWidth = 80
+      cellValueFactory = { status =>
+        val str = if (status.value.isInitiator) {
+          "Yes"
+        } else {
+          "No"
+        }
+        new StringProperty(status, "Initiator", str)
+      }
+    }
+
+    val collateralCol = new TableColumn[DLCStatus, String] {
+      text = "Collateral"
+      prefWidth = 110
+      cellValueFactory = { status =>
+        val num = if (status.value.isInitiator) {
+          status.value.offer.totalCollateral.toLong
+        } else {
+          status.value match {
+            case _: Offered => ""
+            case accepted: AcceptedDLCStatus =>
+              accepted.accept.totalCollateral.toLong
+          }
+        }
+        new StringProperty(status, "Collateral", num.toString)
+      }
+    }
+
+    val oracleCol = new TableColumn[DLCStatus, String] {
+      text = "Oracle"
+      prefWidth = 150
+      cellValueFactory = { status =>
+        new StringProperty(status,
+                           "Oracle",
+                           status.value.offer.oracleInfo.pubKey.hex)
+      }
+    }
+
+    val eventCol = new TableColumn[DLCStatus, String] {
+      text = "Event"
+      prefWidth = 150
+      cellValueFactory = { status =>
+        new StringProperty(status,
+                           "Event",
+                           status.value.offer.oracleInfo.rValue.hex)
+      }
+    }
+
+    val contractMaturityCol = new TableColumn[DLCStatus, String] {
+      text = "Contract Mat."
+      prefWidth = 110
+      cellValueFactory = { status =>
+        new StringProperty(
+          status,
+          "Contract Maturity",
+          status.value.offer.timeouts.contractMaturity.toUInt32.toLong.toString)
+      }
+    }
+
+    new TableView[DLCStatus](model.dlcs) {
+      columns ++= Seq(paramHashCol,
+                      contractIdCol,
+                      statusCol,
+                      initiatorCol,
+                      collateralCol,
+                      oracleCol,
+                      eventCol,
+                      contractMaturityCol)
+      margin = Insets(10, 0, 10, 0)
+
+      val infoItem: MenuItem = new MenuItem("View DLC") {
+        onAction = _ => {
+          val dlc = selectionModel.value.getSelectedItem
+          model.viewDLC(dlc)
+        }
+      }
+
+      contextMenu = new ContextMenu() {
+        items ++= Vector(infoItem)
+      }
+    }
+  }
+
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialog.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand
+import org.bitcoins.gui.GlobalData
 import org.bitcoins.gui.dlc.GlobalDLCData
 import scalafx.Includes._
 import scalafx.application.Platform
@@ -47,6 +48,7 @@ abstract class DLCDialog[T <: CliCommand](
     }
 
     dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
 
     dialog.dialogPane().content = new GridPane {
       hgap = 10

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/GetFundingDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/GetFundingDLCDialog.scala
@@ -1,19 +1,19 @@
 package org.bitcoins.gui.dlc.dialog
 
-import org.bitcoins.cli.CliCommand.GetDLCFundingTx
+import org.bitcoins.cli.CliCommand.BroadcastDLCFundingTx
 import org.bitcoins.crypto.Sha256Digest
 import scalafx.scene.control.TextField
 
 object GetFundingDLCDialog
-    extends DLCDialog[GetDLCFundingTx](
+    extends DLCDialog[BroadcastDLCFundingTx](
       "DLC Funding Transaction",
       "Enter DLC event ID",
       Vector(DLCDialog.dlcContractIdStr -> new TextField())) {
   import DLCDialog._
 
   override def constructFromInput(
-      inputs: Map[String, String]): GetDLCFundingTx = {
+      inputs: Map[String, String]): BroadcastDLCFundingTx = {
     val eventId = Sha256Digest(inputs(dlcContractIdStr))
-    GetDLCFundingTx(eventId)
+    BroadcastDLCFundingTx(eventId)
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitOracleDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitOracleDialog.scala
@@ -3,6 +3,7 @@ package org.bitcoins.gui.dlc.dialog
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.ContractInfo
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.crypto.CryptoUtil
+import org.bitcoins.gui.GlobalData
 import scalafx.Includes._
 import scalafx.application.Platform
 import scalafx.geometry.Insets
@@ -29,6 +30,7 @@ object InitOracleDialog {
          }))
 
     dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
 
     dialog.dialogPane().content = new GridPane {
       hgap = 10

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
@@ -1,0 +1,144 @@
+package org.bitcoins.gui.dlc.dialog
+
+import org.bitcoins.commons.jsonmodels.dlc._
+import org.bitcoins.gui.GlobalData
+import scalafx.Includes._
+import scalafx.geometry.Insets
+import scalafx.scene.control._
+import scalafx.scene.layout.GridPane
+import scalafx.stage.Window
+
+object ViewDLCDialog {
+
+  def showAndWait(parentWindow: Window, dlcStatus: DLCStatus): Unit = {
+    val dialog = new Dialog[Unit]() {
+      initOwner(parentWindow)
+      title = "View DLC"
+    }
+
+    dialog.dialogPane().buttonTypes = Seq(ButtonType.Close)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+
+    dialog.dialogPane().content = new GridPane() {
+      hgap = 10
+      vgap = 10
+      padding = Insets(20, 100, 10, 10)
+
+      add(new Label("Param Hash:"), 0, 0)
+      add(new TextField() {
+            text = dlcStatus.paramHash.hex
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 0)
+
+      add(new Label("Initiator:"), 0, 1)
+      add(new TextField() {
+            text = if (dlcStatus.isInitiator) "Yes" else "No"
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 1)
+
+      add(new Label("State:"), 0, 2)
+      add(new TextField() {
+            text = dlcStatus.statusString
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 2)
+
+      add(new Label("Temp Contract Id:"), 0, 3)
+      add(new TextField() {
+            text = dlcStatus.tempContractId.hex
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 3)
+
+      add(new Label("Contract Id:"), 0, 4)
+      add(new TextField() {
+            text = DLCStatus.getContractId(dlcStatus).map(_.toHex).getOrElse("")
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 4)
+
+      add(new Label("Fee Rate:"), 0, 5)
+      add(new TextField() {
+            text = s"${dlcStatus.offer.feeRate.toLong} sats/vbyte"
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 5)
+
+      add(new Label("Contract Maturity:"), 0, 6)
+      add(new TextField() {
+            text =
+              dlcStatus.offer.timeouts.contractMaturity.toUInt32.toLong.toString
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 6)
+
+      add(new Label("Contract Timeout:"), 0, 7)
+      add(new TextField() {
+            text =
+              dlcStatus.offer.timeouts.contractTimeout.toUInt32.toLong.toString
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 7)
+
+      add(new Label("Collateral:"), 0, 8)
+      add(
+        new TextField() {
+          val num: Long = if (dlcStatus.isInitiator) {
+            dlcStatus.offer.totalCollateral.toLong
+          } else {
+            dlcStatus
+              .asInstanceOf[AcceptedDLCStatus]
+              .accept
+              .totalCollateral
+              .toLong
+          }
+
+          text = num.toString
+          editable = false
+        },
+        columnIndex = 1,
+        rowIndex = 8
+      )
+
+      add(new Label("Funding TxId:"), 0, 9)
+      add(new TextField() {
+            text =
+              DLCStatus.getFundingTx(dlcStatus).map(_.txIdBE.hex).getOrElse("")
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 9)
+
+      add(new Label("Closing TxId:"), 0, 10)
+      add(new TextField() {
+            text =
+              DLCStatus.getClosingTx(dlcStatus).map(_.txIdBE.hex).getOrElse("")
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 10)
+
+      add(new Label("Oracle Signature:"), 0, 11)
+      add(new TextField() {
+            text =
+              DLCStatus.getOracleSignature(dlcStatus).map(_.hex).getOrElse("")
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = 11)
+
+    }
+
+    val _ = dialog.showAndWait()
+  }
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.gui.dlc.dialog
 
+import org.bitcoins.commons.jsonmodels.dlc.DLCStatus._
 import org.bitcoins.commons.jsonmodels.dlc._
 import org.bitcoins.gui.GlobalData
 import scalafx.Includes._
@@ -18,124 +19,146 @@ object ViewDLCDialog {
 
     dialog.dialogPane().buttonTypes = Seq(ButtonType.Close)
     dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+    dialog.resizable = true
 
     dialog.dialogPane().content = new GridPane() {
       hgap = 10
       vgap = 10
       padding = Insets(20, 100, 10, 10)
 
-      add(new Label("Param Hash:"), 0, 0)
+      private var row = 0
+      add(new Label("Param Hash:"), 0, row)
       add(new TextField() {
             text = dlcStatus.paramHash.hex
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 0)
+          rowIndex = row)
 
-      add(new Label("Initiator:"), 0, 1)
+      row += 1
+      add(new Label("Initiator:"), 0, row)
       add(new TextField() {
             text = if (dlcStatus.isInitiator) "Yes" else "No"
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 1)
+          rowIndex = row)
 
-      add(new Label("State:"), 0, 2)
+      row += 1
+      add(new Label("State:"), 0, row)
       add(new TextField() {
             text = dlcStatus.statusString
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 2)
+          rowIndex = row)
 
-      add(new Label("Temp Contract Id:"), 0, 3)
+      row += 1
+      add(new Label("Temp Contract Id:"), 0, row)
       add(new TextField() {
             text = dlcStatus.tempContractId.hex
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 3)
+          rowIndex = row)
 
-      add(new Label("Contract Id:"), 0, 4)
+      row += 1
+      add(new Label("Contract Id:"), 0, row)
       add(new TextField() {
             text = DLCStatus.getContractId(dlcStatus).map(_.toHex).getOrElse("")
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 4)
+          rowIndex = row)
 
-      add(new Label("Fee Rate:"), 0, 5)
+      row += 1
+      add(new Label("Oracle Info:"), 0, row)
+      add(new TextField() {
+            text = dlcStatus.offer.oracleInfo.hex
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = row)
+
+      row += 1
+      add(new Label("Fee Rate:"), 0, row)
       add(new TextField() {
             text = s"${dlcStatus.offer.feeRate.toLong} sats/vbyte"
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 5)
+          rowIndex = row)
 
-      add(new Label("Contract Maturity:"), 0, 6)
+      row += 1
+      add(new Label("Contract Maturity:"), 0, row)
       add(new TextField() {
             text =
               dlcStatus.offer.timeouts.contractMaturity.toUInt32.toLong.toString
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 6)
+          rowIndex = row)
 
-      add(new Label("Contract Timeout:"), 0, 7)
+      row += 1
+      add(new Label("Contract Timeout:"), 0, row)
       add(new TextField() {
             text =
               dlcStatus.offer.timeouts.contractTimeout.toUInt32.toLong.toString
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 7)
+          rowIndex = row)
 
-      add(new Label("Collateral:"), 0, 8)
+      row += 1
+      add(new Label("Collateral:"), 0, row)
       add(
         new TextField() {
           val num: Long = if (dlcStatus.isInitiator) {
             dlcStatus.offer.totalCollateral.toLong
           } else {
-            dlcStatus
-              .asInstanceOf[AcceptedDLCStatus]
-              .accept
-              .totalCollateral
-              .toLong
+            dlcStatus match {
+              case _: Offered => 0
+              case accepted: AcceptedDLCStatus =>
+                accepted.accept.totalCollateral.toLong
+            }
           }
 
           text = num.toString
           editable = false
         },
         columnIndex = 1,
-        rowIndex = 8
+        rowIndex = row
       )
 
-      add(new Label("Funding TxId:"), 0, 9)
+      row += 1
+      add(new Label("Funding TxId:"), 0, row)
       add(new TextField() {
             text =
               DLCStatus.getFundingTx(dlcStatus).map(_.txIdBE.hex).getOrElse("")
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 9)
+          rowIndex = row)
 
-      add(new Label("Closing TxId:"), 0, 10)
+      row += 1
+      add(new Label("Closing TxId:"), 0, row)
       add(new TextField() {
             text =
               DLCStatus.getClosingTx(dlcStatus).map(_.txIdBE.hex).getOrElse("")
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 10)
+          rowIndex = row)
 
-      add(new Label("Oracle Signature:"), 0, 11)
+      row += 1
+      add(new Label("Oracle Signature:"), 0, row)
       add(new TextField() {
             text =
               DLCStatus.getOracleSignature(dlcStatus).map(_.hex).getOrElse("")
             editable = false
           },
           columnIndex = 1,
-          rowIndex = 11)
+          rowIndex = row)
 
     }
 

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -13,7 +13,11 @@ import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.AddressLabelTag
-import org.bitcoins.crypto.{SchnorrDigitalSignature, SchnorrNonce}
+import org.bitcoins.crypto.{
+  SchnorrDigitalSignature,
+  SchnorrNonce,
+  Sha256DigestBE
+}
 import scodec.bits.ByteVector
 import ujson._
 import upickle.default._
@@ -392,6 +396,27 @@ object SendToAddress extends ServerJsonModels {
     }
   }
 
+}
+
+case class GetDLC(paramHash: Sha256DigestBE)
+
+object GetDLC extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[GetDLC] = {
+    jsArr.arr.toList match {
+      case paramHashJs :: Nil =>
+        Try {
+          val paramHash = Sha256DigestBE(paramHashJs.str)
+          GetDLC(paramHash)
+        }
+      case Nil =>
+        Failure(new IllegalArgumentException("Missing paramHash argument"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 1"))
+    }
+  }
 }
 
 case class CreateDLCOffer(

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -208,6 +208,27 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit system: ActorSystem)
           }
       }
 
+    case ServerCommand("getdlcs", _) =>
+      complete {
+        wallet.listDLCs().map { dlcs =>
+          Server.httpSuccess(dlcs.map(_.toJson))
+        }
+      }
+
+    case ServerCommand("getdlc", arr) =>
+      GetDLC.fromJsArr(arr) match {
+        case Failure(exception) =>
+          reject(ValidationRejection("failure", Some(exception)))
+        case Success(GetDLC(eventId)) =>
+          complete {
+            wallet.findDLC(eventId).map {
+              case None => Server.httpSuccess(ujson.Null)
+              case Some(dlc) =>
+                Server.httpSuccess(dlc.toJson)
+            }
+          }
+      }
+
     case ServerCommand("createdlcoffer", arr) =>
       CreateDLCOffer.fromJsArr(arr) match {
         case Failure(exception) =>

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
@@ -543,7 +543,7 @@ class DLCClientTest extends BitcoinSAsyncTest {
           val sign = DLCSign(offerCETSigs, offerFundingSigs, contractId)
 
           val offerRemoteClaimed =
-            DLCStatus.RemoteClaimed(paramHash.flip,
+            DLCStatus.RemoteClaimed(paramHash,
                                     isInitiator = true,
                                     offer,
                                     accept,
@@ -551,7 +551,7 @@ class DLCClientTest extends BitcoinSAsyncTest {
                                     offerOutcome.fundingTx,
                                     acceptOutcome.cet)
           val acceptRemoteClaimed =
-            DLCStatus.RemoteClaimed(paramHash.flip,
+            DLCStatus.RemoteClaimed(paramHash,
                                     isInitiator = false,
                                     offer,
                                     accept,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -2,6 +2,11 @@ package org.bitcoins.dlc.wallet
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.ContractInfo
 import org.bitcoins.commons.jsonmodels.dlc.DLCState
+import org.bitcoins.commons.jsonmodels.dlc.DLCStatus.{
+  Claimed,
+  Refunded,
+  RemoteClaimed
+}
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.crypto.{SchnorrDigitalSignature, Sha256Digest}
@@ -127,6 +132,18 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
       dlcDbAOpt <- wallets._1.wallet.dlcDAO.findByContractId(contractId)
       dlcDbBOpt <- wallets._2.wallet.dlcDAO.findByContractId(contractId)
 
+      paramHash = dlcDbAOpt.get.paramHash
+
+      statusAOpt <- wallets._1.wallet.findDLC(paramHash)
+      statusBOpt <- wallets._2.wallet.findDLC(paramHash)
+
+      _ = {
+        (statusAOpt, statusBOpt) match {
+          case (Some(statusA: Claimed), Some(statusB: RemoteClaimed)) =>
+            assert(statusA.oracleSig == statusB.oracleSig)
+          case (_, _) => fail()
+        }
+      }
     } yield {
       (dlcDbAOpt, dlcDbBOpt) match {
         case (Some(dlcA), Some(dlcB)) =>
@@ -154,6 +171,18 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
       dlcDbAOpt <- wallets._1.wallet.dlcDAO.findByContractId(contractId)
       dlcDbBOpt <- wallets._2.wallet.dlcDAO.findByContractId(contractId)
 
+      paramHash = dlcDbAOpt.get.paramHash
+
+      statusAOpt <- wallets._1.wallet.findDLC(paramHash)
+      statusBOpt <- wallets._2.wallet.findDLC(paramHash)
+
+      _ = {
+        (statusAOpt, statusBOpt) match {
+          case (Some(statusA: RemoteClaimed), Some(statusB: Claimed)) =>
+            assert(statusA.oracleSig == statusB.oracleSig)
+          case (_, _) => fail()
+        }
+      }
     } yield {
       (dlcDbAOpt, dlcDbBOpt) match {
         case (Some(dlcA), Some(dlcB)) =>
@@ -193,6 +222,18 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
       dlcDbAOpt <- wallets._1.wallet.dlcDAO.findByContractId(contractId)
       dlcDbBOpt <- wallets._2.wallet.dlcDAO.findByContractId(contractId)
 
+      paramHash = dlcDbAOpt.get.paramHash
+
+      statusAOpt <- wallets._1.wallet.findDLC(paramHash)
+      statusBOpt <- wallets._2.wallet.findDLC(paramHash)
+
+      _ = {
+        (statusAOpt, statusBOpt) match {
+          case (Some(statusA: Refunded), Some(statusB: Refunded)) =>
+            assert(statusA.refundTx == statusB.refundTx)
+          case (_, _) => fail()
+        }
+      }
     } yield {
       (dlcDbAOpt, dlcDbBOpt) match {
         case (Some(dlcA), Some(dlcB)) =>
@@ -218,6 +259,18 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
       dlcDbAOpt <- wallets._1.wallet.dlcDAO.findByContractId(contractId)
       dlcDbBOpt <- wallets._2.wallet.dlcDAO.findByContractId(contractId)
 
+      paramHash = dlcDbAOpt.get.paramHash
+
+      statusAOpt <- wallets._1.wallet.findDLC(paramHash)
+      statusBOpt <- wallets._2.wallet.findDLC(paramHash)
+
+      _ = {
+        (statusAOpt, statusBOpt) match {
+          case (Some(statusA: Refunded), Some(statusB: Refunded)) =>
+            assert(statusA.refundTx == statusB.refundTx)
+          case (_, _) => fail()
+        }
+      }
     } yield {
       (dlcDbAOpt, dlcDbBOpt) match {
         case (Some(dlcA), Some(dlcB)) =>

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1206,16 +1206,15 @@ abstract class DLCWallet extends Wallet with AnyDLCHDWalletApi {
 
               val offer = offerDb.toDLCOffer(fundingInputs)
               val acceptOpt = acceptDbOpt.map(
-                _.toDLCAccept(
-                  fundingInputs,
-                  sigDbs.filter(!_.isInitiator).map(_.toTuple).toMap,
-                  acceptRefundSigOpt.get))
+                _.toDLCAccept(fundingInputs,
+                              sigDbs.filter(!_.isInitiator).map(_.toTuple),
+                              acceptRefundSigOpt.get))
 
               val initSigs = sigDbs.filter(_.isInitiator)
 
               def getDLCSign: DLCSign = {
-                val cetSigs = CETSignatures(initSigs.map(_.toTuple).toMap,
-                                            offerRefundSigOpt.get)
+                val cetSigs =
+                  CETSignatures(initSigs.map(_.toTuple), offerRefundSigOpt.get)
 
                 val contractId = dlcDb.contractIdOpt.get
                 val fundingSigs =

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -3,6 +3,7 @@ package org.bitcoins.dlc.wallet
 import java.time.Instant
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.commons.jsonmodels.dlc.DLCState._
 import org.bitcoins.commons.jsonmodels.dlc._
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
@@ -1161,6 +1162,177 @@ abstract class DLCWallet extends Wallet with AnyDLCHDWalletApi {
     }
   }
 
+  override def listDLCs(): Future[Vector[DLCStatus]] = {
+    for {
+      ids <- dlcDAO.findAll().map(_.map(_.paramHash))
+      dlcFs = ids.map(findDLC)
+      dlcs <- Future.sequence(dlcFs)
+    } yield {
+      dlcs.collect {
+        case Some(dlc) => dlc
+      }
+    }
+  }
+
+  def findDLC(paramHash: Sha256DigestBE): Future[Option[DLCStatus]] = {
+    dlcDAO.read(paramHash).flatMap {
+      case None => FutureUtil.none
+      case Some(dlcDb) =>
+        for {
+          offerDbOpt <- dlcOfferDAO.findByParamHash(paramHash)
+          acceptDbOpt <- dlcAcceptDAO.findByParamHash(paramHash)
+          fundingInputDbs <- dlcInputsDAO.findByParamHash(paramHash)
+          txIds = fundingInputDbs.map(_.outPoint.txIdBE)
+          remotePrevTxs <- remoteTxDAO.findByTxIdBEs(txIds)
+          localPrevTxs <- transactionDAO.findByTxIdBEs(txIds)
+          refundSigDbs <- dlcRefundSigDAO.findByParamHash(paramHash)
+          sigDbs <- dlcSigsDAO.findByParamHash(paramHash)
+
+          res <- offerDbOpt match {
+            case None => FutureUtil.none
+            case Some(offerDb) =>
+              val prevTxs = (remotePrevTxs ++ localPrevTxs).map(_.transaction)
+              val txs = prevTxs.groupBy(_.txIdBE)
+
+              val isInit = dlcDb.isInitiator
+
+              val fundingInputs = fundingInputDbs.map(input =>
+                input.toFundingInput(txs(input.outPoint.txIdBE).head))
+
+              val offerRefundSigOpt =
+                refundSigDbs.find(_.isInitiator).map(_.refundSig)
+              val acceptRefundSigOpt =
+                refundSigDbs.find(!_.isInitiator).map(_.refundSig)
+
+              val offer = offerDb.toDLCOffer(fundingInputs)
+              val acceptOpt = acceptDbOpt.map(
+                _.toDLCAccept(
+                  fundingInputs,
+                  sigDbs.filter(!_.isInitiator).map(_.toTuple).toMap,
+                  acceptRefundSigOpt.get))
+
+              val initSigs = sigDbs.filter(_.isInitiator)
+
+              def getDLCSign: DLCSign = {
+                val cetSigs = CETSignatures(initSigs.map(_.toTuple).toMap,
+                                            offerRefundSigOpt.get)
+
+                val contractId = dlcDb.contractIdOpt.get
+                val fundingSigs =
+                  fundingInputDbs
+                    .filter(_.isInitiator)
+                    .map { input =>
+                      input.witnessScriptOpt match {
+                        case Some(witnessScript) =>
+                          witnessScript match {
+                            case EmptyScriptWitness =>
+                              throw new RuntimeException(
+                                "Script witness cannot be empty")
+                            case witness: ScriptWitnessV0 =>
+                              (input.outPoint, witness)
+                          }
+                        case None =>
+                          throw new RuntimeException("Must be segwit")
+                      }
+                    }
+
+                DLCSign(cetSigs, FundingSignatures(fundingSigs), contractId)
+              }
+
+              def getFundingTx: Future[Transaction] = {
+                transactionDAO
+                  .read(dlcDb.fundingTxIdOpt.get)
+                  .flatMap {
+                    case Some(txDb) => Future.successful(txDb.transaction)
+                    case None =>
+                      Future.failed(new RuntimeException(
+                        "Wallet does not have the funding transaction"))
+                  }
+              }
+
+              def getClosingTx: Future[Transaction] = {
+                transactionDAO
+                  .read(dlcDb.closingTxIdOpt.get)
+                  .flatMap {
+                    case Some(txDb) => Future.successful(txDb.transaction)
+                    case None =>
+                      Future.failed(new RuntimeException(
+                        "Wallet does not have the closing transaction"))
+                  }
+              }
+
+              val statusF = dlcDb.state match {
+                case Offered =>
+                  Future.successful(DLCStatus.Offered(paramHash, isInit, offer))
+                case Accepted =>
+                  Future.successful(
+                    DLCStatus
+                      .Accepted(paramHash, isInit, offer, acceptOpt.get))
+                case Signed =>
+                  Future.successful(
+                    DLCStatus
+                      .Signed(paramHash,
+                              isInit,
+                              offer,
+                              acceptOpt.get,
+                              getDLCSign))
+                case Broadcasted =>
+                  getFundingTx.map(tx =>
+                    DLCStatus.Broadcasted(paramHash,
+                                          isInit,
+                                          offer,
+                                          acceptOpt.get,
+                                          getDLCSign,
+                                          tx))
+                case Confirmed =>
+                  getFundingTx.map(tx =>
+                    DLCStatus.Confirmed(paramHash,
+                                        isInit,
+                                        offer,
+                                        acceptOpt.get,
+                                        getDLCSign,
+                                        tx))
+                case Claimed =>
+                  for {
+                    fundingTx <- getFundingTx
+                    closingTx <- getClosingTx
+                  } yield DLCStatus.Claimed(paramHash,
+                                            isInit,
+                                            offer,
+                                            acceptOpt.get,
+                                            getDLCSign,
+                                            fundingTx,
+                                            dlcDb.oracleSigOpt.get,
+                                            closingTx)
+                case RemoteClaimed =>
+                  for {
+                    fundingTx <- getFundingTx
+                    closingTx <- getClosingTx
+                  } yield DLCStatus.RemoteClaimed(paramHash,
+                                                  isInit,
+                                                  offer,
+                                                  acceptOpt.get,
+                                                  getDLCSign,
+                                                  fundingTx,
+                                                  closingTx)
+                case Refunded =>
+                  for {
+                    fundingTx <- getFundingTx
+                    closingTx <- getClosingTx
+                  } yield DLCStatus.Refunded(paramHash,
+                                             isInit,
+                                             offer,
+                                             acceptOpt.get,
+                                             getDLCSign,
+                                             fundingTx,
+                                             closingTx)
+              }
+
+              statusF.map(Some(_))
+          }
+        } yield res
+    }
+  }
 }
 
 object DLCWallet extends WalletLogger {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWalletApi.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWalletApi.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.dlc.wallet
 
 import org.bitcoins.commons.jsonmodels.dlc.DLCMessage._
+import org.bitcoins.commons.jsonmodels.dlc.DLCStatus
 import org.bitcoins.core.api.wallet.{
   HDWalletApi,
   NeutrinoWalletApi,
@@ -11,7 +12,7 @@ import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.crypto.SchnorrDigitalSignature
+import org.bitcoins.crypto.{SchnorrDigitalSignature, Sha256DigestBE}
 import org.bitcoins.dlc.wallet.models.DLCDb
 import scodec.bits.ByteVector
 
@@ -56,6 +57,9 @@ trait DLCWalletApi { self: WalletApi =>
   /** Creates the refund transaction for the given contractId, does not broadcast it */
   def executeDLCRefund(contractId: ByteVector): Future[Transaction]
 
+  def listDLCs(): Future[Vector[DLCStatus]]
+
+  def findDLC(paramHash: Sha256DigestBE): Future[Option[DLCStatus]]
 }
 
 /** An HDWallet that supports DLCs and both Neutrino and SPV methods of syncing */


### PR DESCRIPTION
Built on top of #2201 

Creates a table in the GUI of all the DLCs the wallet has or is participating in.

I haven't still have tested this out yet, but making the PR in case I can get some review in the mean time.

Closes #1500 
Closes #1520