### PR TITLE
Only Validate PSBT BIP143 vulnerability on signing

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
@@ -207,7 +207,9 @@ case class InputPSBTMap(elements: Vector[InputPSBTRecord])
       FinalizedScriptWitnessKeyId).nonEmpty
 
   def isBIP143Vulnerable: Boolean = {
-    if (!isFinalized && witnessUTXOOpt.isDefined) {
+    if (
+      !isFinalized && witnessUTXOOpt.isDefined && nonWitnessOrUnknownUTXOOpt.isEmpty
+    ) {
 
       val isNativeV0 = witnessUTXOOpt.get.witnessUTXO.scriptPubKey
         .isInstanceOf[WitnessScriptPubKeyV0]


### PR DESCRIPTION
This changes the PSBT to only validate if it is vulnerable to the BIP143 vulnerability when we are actually signing. This has caused some problems where we would constructing a PSBT a adding things in the wrong error can cause the requirement to fail even though it would otherwise be a safe PSBT.

This also makes it so we can parse any valid PSBT which should be nice for other libraries 