### PR TITLE
Fix overrides AppConfig.configOverrides with DLCOracleAppConfig, also…

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -53,7 +53,7 @@ abstract class AppConfig extends StartStopAsync[Unit] with BitcoinSLogger {
   /** List of user-provided configs that should
     * override defaults
     */
-  protected[bitcoins] def configOverrides: List[Config] = List.empty
+  protected[bitcoins] def configOverrides: List[Config]
 
   /**
     * This method returns a new `AppConfig`, where every

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracleAppConfig.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracleAppConfig.scala
@@ -17,12 +17,14 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class DLCOracleAppConfig(
     private val directory: Path,
-    private val conf: Config*)(implicit val ec: ExecutionContext)
+    private val confs: Config*)(implicit val ec: ExecutionContext)
     extends AppConfig
     with DbManagement
     with JdbcProfileComponent[DLCOracleAppConfig] {
 
   import profile.api._
+
+  override def configOverrides: List[Config] = confs.toList
 
   override def appConfig: DLCOracleAppConfig = this
 


### PR DESCRIPTION
… remove hardcoded value out of AppConfig.configOverrides so people have to implement it

fixes #2208 

It seems we weren't doing anything with the `private val confs: Config*` inside of DLCOracleAppConfig


