### PR TITLE
2020 10 31 Fix indeterminism with pairing dlc funding puts with funding transactions

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
@@ -1,6 +1,10 @@
 package org.bitcoins.core.protocol.tlv
 
-import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{DLCAccept, DLCOffer}
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{
+  DLCAccept,
+  DLCOffer,
+  DLCSign
+}
 import org.bitcoins.testkit.core.gen.TLVGen
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 
@@ -136,49 +140,5 @@ class TLVTest extends BitcoinSUnitTest {
       assert(DLCSignTLV(sign.bytes) == sign)
       assert(TLV(sign.bytes) == sign)
     }
-  }
-
-  it must "x" in {
-    val jsonString = s"""{
-                        |  "contractInfo": [
-                        |    {
-                        |      "sha256": "e8ef711baf2e0b8023125c021951d5fa3d5c963a7bacabb7894017fd8e903d02",
-                        |      "sats": 0
-                        |    },
-                        |    {
-                        |      "sha256": "7e5d428f799cac55b76828f90b32e216a84fabf76e9d27f3380a7bf7af14f452",
-                        |      "sats": 100000000
-                        |    },
-                        |    {
-                        |      "sha256": "d9298a10d1b0735837dc4bd85dac641b0f3cef27a47e5d53a54f2f3f5b2fcffa",
-                        |      "sats": 60000000
-                        |    }
-                        |  ],
-                        |  "oracleInfo": "57caa081b0a0e9e9413cf4fb72ddc2630d609bdf6a912b98c4cfd358a4ce149692ba989222e76cf0cb263fedd67587812110bde1dc1468bef63c8f6974692ea1",
-                        |  "pubKeys": {
-                        |    "fundingKey": "038cc19a94f9d90656173802a2cfcc4f87d43b11537a608175111f37136a2c2811",
-                        |    "payoutAddress": "bc1q6cj7a6aerxxm4wc3h8z0cm7s8rp2049nsluh3w"
-                        |  },
-                        |  "totalCollateral": 60000000,
-                        |  "fundingInputs": [
-                        |    {
-                        |      "prevTx": "02000000000101619d742014a3a867e7679e84b5fbf076e01c5f98446b71fc5b51ba19cf8301500100000000000000000298f708000000000016001470d0edeb2d54a194a6124e917f4be75b6d6e44607e41b7050000000016001452584eb56f12d421e5efc49ecddc5eb873958cc00247304402202a0ca561c1d8ab27adb1285452f8d3b1c65e4db9db0085e382adcf13e37e2eaa02206f78473ffd5f16518430411d4b49d403ea17ee1eb9c1b48d5a746111fa8c77440121032dbb453be8b548075ec467c77ed9a20375b4e671ac521f289fbcc132975472a400000000",
-                        |      "prevTxVout": 1,
-                        |      "sequence": 4294967295,
-                        |      "maxWitnessLength": 107
-                        |    }
-                        |  ],
-                        |  "changeAddress": "bc1qfwtf3538dku853wq5ga8pcx7haejdjd96mdwcu",
-                        |  "feeRate": 200,
-                        |  "timeouts": {
-                        |    "contractMaturity": 0,
-                        |    "contractTimeout": 667759
-                        |  }
-                        |}""".stripMargin
-
-    val jsonValue: ujson.Value = ujson.read(jsonString)
-    val acceptMsg = DLCOffer.fromJson(jsonValue)
-
-    println(s"offer=${acceptMsg.toTLV}")
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
@@ -1,10 +1,5 @@
 package org.bitcoins.core.protocol.tlv
 
-import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{
-  DLCAccept,
-  DLCOffer,
-  DLCSign
-}
 import org.bitcoins.testkit.core.gen.TLVGen
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.tlv
 
+import org.bitcoins.commons.jsonmodels.dlc.DLCMessage.{DLCAccept, DLCOffer}
 import org.bitcoins.testkit.core.gen.TLVGen
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 
@@ -135,5 +136,49 @@ class TLVTest extends BitcoinSUnitTest {
       assert(DLCSignTLV(sign.bytes) == sign)
       assert(TLV(sign.bytes) == sign)
     }
+  }
+
+  it must "x" in {
+    val jsonString = s"""{
+                        |  "contractInfo": [
+                        |    {
+                        |      "sha256": "e8ef711baf2e0b8023125c021951d5fa3d5c963a7bacabb7894017fd8e903d02",
+                        |      "sats": 0
+                        |    },
+                        |    {
+                        |      "sha256": "7e5d428f799cac55b76828f90b32e216a84fabf76e9d27f3380a7bf7af14f452",
+                        |      "sats": 100000000
+                        |    },
+                        |    {
+                        |      "sha256": "d9298a10d1b0735837dc4bd85dac641b0f3cef27a47e5d53a54f2f3f5b2fcffa",
+                        |      "sats": 60000000
+                        |    }
+                        |  ],
+                        |  "oracleInfo": "57caa081b0a0e9e9413cf4fb72ddc2630d609bdf6a912b98c4cfd358a4ce149692ba989222e76cf0cb263fedd67587812110bde1dc1468bef63c8f6974692ea1",
+                        |  "pubKeys": {
+                        |    "fundingKey": "038cc19a94f9d90656173802a2cfcc4f87d43b11537a608175111f37136a2c2811",
+                        |    "payoutAddress": "bc1q6cj7a6aerxxm4wc3h8z0cm7s8rp2049nsluh3w"
+                        |  },
+                        |  "totalCollateral": 60000000,
+                        |  "fundingInputs": [
+                        |    {
+                        |      "prevTx": "02000000000101619d742014a3a867e7679e84b5fbf076e01c5f98446b71fc5b51ba19cf8301500100000000000000000298f708000000000016001470d0edeb2d54a194a6124e917f4be75b6d6e44607e41b7050000000016001452584eb56f12d421e5efc49ecddc5eb873958cc00247304402202a0ca561c1d8ab27adb1285452f8d3b1c65e4db9db0085e382adcf13e37e2eaa02206f78473ffd5f16518430411d4b49d403ea17ee1eb9c1b48d5a746111fa8c77440121032dbb453be8b548075ec467c77ed9a20375b4e671ac521f289fbcc132975472a400000000",
+                        |      "prevTxVout": 1,
+                        |      "sequence": 4294967295,
+                        |      "maxWitnessLength": 107
+                        |    }
+                        |  ],
+                        |  "changeAddress": "bc1qfwtf3538dku853wq5ga8pcx7haejdjd96mdwcu",
+                        |  "feeRate": 200,
+                        |  "timeouts": {
+                        |    "contractMaturity": 0,
+                        |    "contractTimeout": 667759
+                        |  }
+                        |}""".stripMargin
+
+    val jsonValue: ujson.Value = ujson.read(jsonString)
+    val acceptMsg = DLCOffer.fromJson(jsonValue)
+
+    println(s"offer=${acceptMsg.toTLV}")
   }
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDb.scala
@@ -20,8 +20,10 @@ case class DLCFundingInputDb(
     OutputReference(outPoint, output)
 
   def toFundingInput(prevTx: Transaction): DLCFundingInput = {
-    require(prevTx.txId == outPoint.txId,
-            "Provided previous transaction didn't match database outpoint")
+    require(
+      prevTx.txId == outPoint.txId,
+      s"Provided previous transaction didn't match database outpoint outpoint=${outPoint.txIdBE.hex} prevTx.txId=${prevTx.txIdBE.hex}"
+    )
 
     DLCFundingInputP2WPKHV0(prevTx,
                             outPoint.vout,


### PR DESCRIPTION
Previously we were assuming that the ordering was correct for inputs and their funding transactions. We would just use `.zip()` on the two vectors pairing inputs with transactions. When it came time to `DLCFundingInput` it would fails this invariant 

https://github.com/bitcoin-s/bitcoin-s/blob/1d1efaf90a553d935e1657a7f9149dda916edf8e/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDb.scala#L23

since the outpoint and the funding transaction were not paired together correctly in some cases. 

Now we just match things up by txids and throw if there is an input that does not have a matching previous transaction.