### PR TITLE
Move newer functions to common rpc interface

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/WalletRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/WalletRpc.scala
@@ -1,6 +1,9 @@
 package org.bitcoins.rpc.client.common
 
-import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.AddressType
+import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.{
+  AddressType,
+  WalletFlag
+}
 import org.bitcoins.commons.jsonmodels.bitcoind._
 import org.bitcoins.commons.serializers.JsonSerializers._
 import org.bitcoins.commons.serializers.JsonWriters._
@@ -174,6 +177,37 @@ trait WalletRpc { self: Client =>
 
   def loadWallet(filePath: String): Future[LoadWalletResult] = {
     bitcoindCall[LoadWalletResult]("loadwallet", List(JsString(filePath)))
+  }
+
+  /**
+    * Change the state of the given wallet flag for a wallet.
+    */
+  def setWalletFlag(
+      flag: WalletFlag,
+      value: Boolean
+  ): Future[SetWalletFlagResult] = {
+
+    self.version match {
+      case V20 | V19 | Experimental | Unknown =>
+        bitcoindCall[SetWalletFlagResult](
+          "setwalletflag",
+          List(JsString(flag.toString), Json.toJson(value)))
+      case V16 | V17 | V18 =>
+        Future.failed(
+          new UnsupportedOperationException(
+            "setwalletflag is not available for versions before 0.19"))
+    }
+  }
+
+  def getBalances: Future[GetBalancesResult] = {
+    self.version match {
+      case V20 | V19 | Experimental | Unknown =>
+        bitcoindCall[GetBalancesResult]("getbalances")
+      case V16 | V17 | V18 =>
+        Future.failed(
+          new UnsupportedOperationException(
+            "getbalances is not available for versions before 0.19"))
+    }
   }
 
   // TODO: Should be BitcoinFeeUnit

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
@@ -1,11 +1,8 @@
 package org.bitcoins.rpc.client.v19
 
 import akka.actor.ActorSystem
-import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.WalletFlag
 import org.bitcoins.commons.jsonmodels.bitcoind.{
-  GetBalancesResult,
   RpcOpts,
-  SetWalletFlagResult,
   SignRawTransactionResult
 }
 import org.bitcoins.commons.serializers.JsonSerializers._
@@ -120,21 +117,6 @@ class BitcoindV19RpcClient(override val instance: BitcoindInstance)(implicit
                                                 Json.toJson(keys),
                                                 Json.toJson(utxoDeps),
                                                 Json.toJson(sigHash)))
-
-  /**
-    * Change the state of the given wallet flag for a wallet.
-    */
-  def setWalletFlag(
-      flag: WalletFlag,
-      value: Boolean
-  ): Future[SetWalletFlagResult] =
-    bitcoindCall[SetWalletFlagResult](
-      "setwalletflag",
-      List(JsString(flag.toString), Json.toJson(value)))
-
-  def getBalances: Future[GetBalancesResult] = {
-    bitcoindCall[GetBalancesResult]("getbalances")
-  }
 
 }
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/BitcoindV20RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/BitcoindV20RpcClient.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.rpc.client.v20
 
 import akka.actor.ActorSystem
-import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.WalletFlag
 import org.bitcoins.commons.jsonmodels.bitcoind._
 import org.bitcoins.commons.serializers.JsonSerializers._
 import org.bitcoins.commons.serializers.JsonWriters._
@@ -118,22 +117,6 @@ class BitcoindV20RpcClient(override val instance: BitcoindInstance)(implicit
                                                 Json.toJson(keys),
                                                 Json.toJson(utxoDeps),
                                                 Json.toJson(sigHash)))
-
-  /**
-    * Change the state of the given wallet flag for a wallet.
-    */
-  def setWalletFlag(
-      flag: WalletFlag,
-      value: Boolean
-  ): Future[SetWalletFlagResult] =
-    bitcoindCall[SetWalletFlagResult](
-      "setwalletflag",
-      List(JsString(flag.toString), Json.toJson(value)))
-
-  def getBalances: Future[GetBalancesResult] = {
-    bitcoindCall[GetBalancesResult]("getbalances")
-  }
-
 }
 
 object BitcoindV20RpcClient {


### PR DESCRIPTION
This is useful because instead of having to make a bitcoind v19 or v20 client, you can make a general bitcoind client and still be able to call the functions, they will just fail on an older version.