### PR TITLE
Add release notes directory similar to what bitcoin core does, docume…

### DIFF
--- a/release-notes/release-notes-2217.md
+++ b/release-notes/release-notes-2217.md
@@ -1,0 +1,9 @@
+### Configuration option changes required
+
+It is required that all wallets pre 2217 need to have the configuration 
+
+>bitcoin-s.wallet.aesPassword="changeMe"
+
+See https://github.com/bitcoin-s/bitcoin-s/issues/2245
+
+for the errors that are thrown when this isn't set.


### PR DESCRIPTION
…nt the breaking change in 2217

Takes ben's suggestion of copying what bitcoin core does for documenting things that need to be added to release notes

https://github.com/bitcoin/bitcoin/tree/master/doc/release-notes