### PR TITLE
Fix listEvents in DLCOracle

### DIFF
--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -71,6 +71,20 @@ class DLCOracleTest extends DLCOracleFixture {
       }
   }
 
+  it must "create the same event twice and list them" in {
+    dlcOracle: DLCOracle =>
+      val time = futureTime
+
+      for {
+        _ <- dlcOracle.createNewEvent("test", time, testDescriptor)
+        _ <- dlcOracle.createNewEvent("test2", time, testDescriptor)
+        events <- dlcOracle.listEvents()
+      } yield {
+        assert(events.size == 2)
+        assert(events.forall(_.eventDescriptorTLV == testDescriptor))
+      }
+  }
+
   it must "create an enum new event and get its details" in {
     dlcOracle: DLCOracle =>
       val time = futureTime

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -90,7 +90,7 @@ case class DLCOracle(private val extPrivateKey: ExtPrivateKeyHardened)(implicit
 
   def listEvents(): Future[Vector[OracleEvent]] = {
     eventDAO.findAll().map { eventDbs =>
-      val events = eventDbs.groupBy(_.eventDescriptorTLV)
+      val events = eventDbs.groupBy(_.announcementSignature)
       events.values.map(dbs => OracleEvent.fromEventDbs(dbs)).toVector
     }
   }

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.crypto.ExtKeyVersion.SegWitMainNetPriv
 import org.bitcoins.core.hd.HDPurpose
+import org.bitcoins.core.protocol.tlv.EventDescriptorTLV
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.crypto.AesPassword
@@ -61,10 +62,13 @@ case class DLCOracleAppConfig(
 
       if (migrationsApplied() == 2) {
         logger.debug(s"Doing V2 Migration")
+
+        val dummyMigrationTLV = EventDescriptorTLV("fdd806090001000564756d6d79")
+
         val eventDAO = EventDAO()(ec, appConfig)
         for {
-          // get all events
-          allEvents <- eventDAO.findAll()
+          // get all old events
+          allEvents <- eventDAO.findByEventDescriptor(dummyMigrationTLV)
           allOutcomes <- EventOutcomeDAO()(ec, appConfig).findAll()
 
           outcomesByNonce = allOutcomes.groupBy(_.nonce)

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventDAO.scala
@@ -46,6 +46,13 @@ case class EventDAO()(implicit
     findAll().map(_.filter(_.attestationOpt.isEmpty))
   }
 
+  def findByEventDescriptor(
+      descriptorTLV: EventDescriptorTLV): Future[Vector[EventDb]] = {
+    val query = table.filter(_.eventDescriptorTLV === descriptorTLV)
+
+    safeDatabase.runVec(query.result.transactionally)
+  }
+
   def findByOracleEventTLV(
       oracleEvent: OracleEventTLV): Future[Vector[EventDb]] = {
     val query = oracleEvent match {


### PR DESCRIPTION
Since event descriptors don't have the nonces anymore they aren't unique so grouping by descriptor is not enough. Announcement signatures should be unique between events because it is a signature of the event tlv which contains the nonces.

Also fixed the migration to only apply to old events