### PR TITLE
Add directive to configure timeout on the appServer

### DIFF
--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -210,6 +210,7 @@ akka {
         server {
             # The amount of time until a request times out on the server
             # If you have a large payload this may need to be bumped
+            # https://doc.akka.io/docs/akka-http/current/common/timeouts.html#request-timeout
             request-timeout = 10s
         }
     }

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -206,6 +206,12 @@ akka {
             # some requests potentially take a long time, like generate and prune
             idle-timeout = 5 minutes
         }
+
+        server {
+            # The amount of time until a request times out on the server
+            # If you have a large payload this may need to be bumped
+            request-timeout = 10s
+        }
     }
 
 


### PR DESCRIPTION
This adds a timeout for server directives. It keeps it to the current value 10 seconds for as I think that is a sane default for most cases. 

@benthecarman could you test this out with the workload you have by adjusting this setting and making sure it works?

https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/timeout-directives/withRequestTimeout.html#withrequesttimeout

https://doc.akka.io/docs/akka-http/current/common/timeouts.html#request-timeout