### PR TITLE
trivial: Add a sha256 hash field on all TLV

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -25,6 +25,8 @@ sealed trait TLV extends NetworkElement {
   override def bytes: ByteVector = {
     tpe.bytes ++ length.bytes ++ value
   }
+
+  def sha256: Sha256Digest = CryptoUtil.sha256(bytes)
 }
 
 sealed trait TLVParentFactory[T <: TLV] extends Factory[T] {


### PR DESCRIPTION
Useful for building unique identifiers for a TLV that are short