### PR TITLE
Add function to validate OracleAnnouncementV0TLV's signature

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -589,6 +589,8 @@ sealed trait OracleAnnouncementTLV extends TLV {
   def eventTLV: OracleEventTLV
   def announcementSignature: SchnorrDigitalSignature
   def publicKey: SchnorrPublicKey
+
+  def validateSignature: Boolean
 }
 
 case class OracleAnnouncementV0TLV(
@@ -600,6 +602,11 @@ case class OracleAnnouncementV0TLV(
 
   override val value: ByteVector =
     announcementSignature.bytes ++ publicKey.bytes ++ eventTLV.bytes
+
+  override def validateSignature: Boolean = {
+    publicKey.verify(CryptoUtil.sha256(eventTLV.bytes).bytes,
+                     announcementSignature)
+  }
 }
 
 object OracleAnnouncementV0TLV extends TLVFactory[OracleAnnouncementV0TLV] {

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -96,6 +96,7 @@ class DLCOracleTest extends DLCOracleFixture {
 
         eventOpt <- dlcOracle.findEvent(announcement.eventTLV)
       } yield {
+        assert(announcement.validateSignature)
         assert(eventOpt.isDefined)
         val event = eventOpt.get
 
@@ -151,6 +152,7 @@ class DLCOracleTest extends DLCOracleFixture {
 
         eventOpt <- dlcOracle.findEvent(announcement.eventTLV)
       } yield {
+        assert(announcement.validateSignature)
         assert(eventOpt.isDefined)
         val event = eventOpt.get
 
@@ -303,6 +305,8 @@ class DLCOracleTest extends DLCOracleFixture {
                                             unit = "units",
                                             precision = Int32.zero)
 
+      _ = assert(announcement.validateSignature)
+
       eventTLV = announcement.eventTLV
 
       event <- dlcOracle.signDigits(eventTLV, outcome)
@@ -371,6 +375,8 @@ class DLCOracleTest extends DLCOracleFixture {
                                               numDigits = 3,
                                               unit = "units",
                                               precision = Int32.zero)
+
+        _ = assert(announcement.validateSignature)
 
         eventTLV = announcement.eventTLV
 
@@ -441,6 +447,8 @@ class DLCOracleTest extends DLCOracleFixture {
                                               numDigits = 3,
                                               unit = "units",
                                               precision = Int32.zero)
+
+        _ = assert(announcement.validateSignature)
 
         eventTLV = announcement.eventTLV
 


### PR DESCRIPTION
Related to #2196 

Does not add an invariant but at least allows us to easily validate the signature.