### PR TITLE
Made CET Building and signing slightly more efficient

### DIFF
--- a/dlc-test/src/test/scala/org/bitcoins/dlc/SetupDLCTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/SetupDLCTest.scala
@@ -2,7 +2,7 @@ package org.bitcoins.dlc
 
 import org.bitcoins.core.protocol.dlc.{EnumOracleOutcome, EnumSingleOracleInfo}
 import org.bitcoins.core.protocol.tlv.EnumOutcome
-import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
 import org.bitcoins.crypto._
 import org.bitcoins.dlc.execution.{CETInfo, SetupDLC}
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
@@ -20,10 +20,10 @@ class SetupDLCTest extends BitcoinSAsyncTest {
     ECPrivateKey.freshPrivateKey.fieldElement
   )
 
-  val validFundingTx: Transaction = Transaction(
+  val validFundingTx: WitnessTransaction = WitnessTransaction(
     "02000000000102f6ec63ebf8589895147803ea2724f1cc9fbcc75077136c15af57210ab8b4342b0000000000ffffffffbfeda85fa8d2335694b3602f0e0918fa7e9d144051217330c8a0328b4d0caabd0000000000ffffffff03c8c2eb0b0000000022002060b1a927da5c8570b1280d6dd0306d6458edc1c4abb7cc3ce8f75d157e78825e1ee0f50500000000160014558979e57695d211a354b87369ae819ae720e2761ee0f50500000000160014dc93c91963fb7b42860f92caf11217ef6c28599702483045022100b9189d799cdc4845b273ff4a471fcaa36e2419609bc3e749d78668bb8c2cb1350220403cdcddf10d06b8cb36e2943d1c8d195cbc0b023d1cdaa29281dfa250a744a9012103f5413f7d813a4e1bff925fa8b1e6ce154b309d6df4433cc1c6ded5e04f4d2d6202473044022001d25acb7ad50c352604a36d20fa25426d98d9d917200b017c052954ddf97e43022005b6d6c70d029206851c5af7ac3013fda87d5536003b0eee1c29cac6903cfbbd0121039ef319718ac70f4a3e86fb4eab23adc1c41dda9109f6c700b9b06690ddb3138b00000000")
 
-  val validCET: Transaction = Transaction(
+  val validCET: WitnessTransaction = WitnessTransaction(
     "0200000000010112eb723473aa9ec2a91d82072b054feb4660389dc33ec407ff5836ff1ade73490000000000feffffff029014680300000000160014f161d1f494c1617a385f4480687b49826b5287ec70ad830800000000160014ea0f8ed8de8f6190bc67a2cf19f75bea97d0d582014752210258d139dc2f0507bd2b01794ff04530fd614a86dded69fd944da1942bcf748a7e2103eaf8df8e339381a19dfa5e37a4ce3c04ad3dc62f8d57774d92154e6d26ef06a452ae7c37265f"
   )
 
@@ -33,7 +33,7 @@ class SetupDLCTest extends BitcoinSAsyncTest {
     "0200000000010112eb723473aa9ec2a91d82072b054feb4660389dc33ec407ff5836ff1ade73490000000000feffffff02ace0f50500000000160014f161d1f494c1617a385f4480687b49826b5287ecabe0f50500000000160014ea0f8ed8de8f6190bc67a2cf19f75bea97d0d582040047304402206e204681682139ca91abca8a090c05d335c3077bcaa801d73ade4d30cf14befc0220114da42320f563f8df7ba29bfb26549b58b4dfc40d8af3a8e352b2da180fa9f001483045022100a9aa4a45d89d936762041cc2793700c3c6228326648a66228c4e265c9938337c0220024637e716c702176bde6029342ac42118a1af774ca6fb7a8225a31b15b1c839014752210258d139dc2f0507bd2b01794ff04530fd614a86dded69fd944da1942bcf748a7e2103eaf8df8e339381a19dfa5e37a4ce3c04ad3dc62f8d57774d92154e6d26ef06a452ae7d37265f")
 
   // These 2 can be the same, we only need them to have 1 input so we can do the correct checks
-  val invalidCET: Transaction = Transaction(
+  val invalidCET: WitnessTransaction = WitnessTransaction(
     "02000000000101bdaa2ea7eea92a88f357bd8af92003286c5acb9e9b51006d2394b47afa1c7a040000000000ffffffff018a831e000000000017a914b80e1c53b48628277bd2cb63d9d111c8fbcecdda870400483045022100ee40ca5537b5a9e9aeb04e659a8e7ec8c2d4a33dd8f8e620c98561a9e87f2db802200c1a9e35464412b0c4c28125e0279807b1b0df649a10dbfce41fa52722d71ede01483045022100cea1701d3b7fc9ca7f83cfed3fbd43853d243249a0ece0ec7fbefe51d3c526df02202fed76ce12e54793961ef3611cefcd684c40ba4b640bb3a01abee7c1dd0fab6a01475221031454ce0a0354aadf6bd13f4e27c1287d33534dd02e249d4455341d528b7ea7192103ab051b06e850b33196ddd80b43084883a29c854c0c5a924b273cbe4b1c3a228452ae00000000"
   )
 
@@ -51,9 +51,9 @@ class SetupDLCTest extends BitcoinSAsyncTest {
       refundTx: Transaction = validRefundTx): SetupDLC = {
     SetupDLC(
       fundingTx = fundingTx,
-      cets =
-        Map(EnumOracleOutcome(Vector(oracleInfo), EnumOutcome("WIN")) -> cet0,
-            EnumOracleOutcome(Vector(oracleInfo), EnumOutcome("LOSE")) -> cet1),
+      cets = Vector(
+        EnumOracleOutcome(Vector(oracleInfo), EnumOutcome("WIN")) -> cet0,
+        EnumOracleOutcome(Vector(oracleInfo), EnumOutcome("LOSE")) -> cet1),
       refundTx = refundTx
     )
   }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1370,7 +1370,7 @@ abstract class DLCWallet extends Wallet with AnyDLCHDWalletApi {
                   case None => throw new RuntimeException("")
                 }
               }
-          executor.setupDLCAccept(cetSigs, FundingSignatures(fundingSigs))
+          executor.setupDLCAccept(cetSigs, FundingSignatures(fundingSigs), None)
         }
 
         setupF.map((executor, _))

--- a/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCTxBuilder.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/builder/DLCTxBuilder.scala
@@ -109,7 +109,7 @@ case class DLCTxBuilder(offer: DLCOffer, accept: DLCAcceptWithoutSigs)(implicit
     buildFundingTx.map(_.txIdBE.bytes.xor(accept.tempContractId.bytes))
   }
 
-  private lazy val cetBuilderF = {
+  private[dlc] lazy val cetBuilderF = {
     for {
       fundingTx <- buildFundingTx
     } yield {
@@ -134,10 +134,14 @@ case class DLCTxBuilder(offer: DLCOffer, accept: DLCAcceptWithoutSigs)(implicit
     * for a given outcome hash
     */
   def buildCET(msg: OracleOutcome): Future[WitnessTransaction] = {
-    for {
-      cetBuilder <- cetBuilderF
-      cet <- cetBuilder.buildCET(msg)
-    } yield cet
+    cetBuilderF.map(_.buildCET(msg))
+  }
+
+  def buildCETs(
+      msgs: Vector[OracleOutcome]): Future[Vector[WitnessTransaction]] = {
+    cetBuilderF.map { cetBuilder =>
+      msgs.map(cetBuilder.buildCET)
+    }
   }
 
   /** Constructs the unsigned refund transaction */

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/SetupDLC.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/SetupDLC.scala
@@ -2,12 +2,16 @@ package org.bitcoins.dlc.execution
 
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.dlc.OracleOutcome
-import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
+import org.bitcoins.core.protocol.transaction.{
+  Transaction,
+  TransactionOutPoint,
+  WitnessTransaction
+}
 import org.bitcoins.crypto.ECAdaptorSignature
 
 case class SetupDLC(
     fundingTx: Transaction,
-    cets: Map[OracleOutcome, CETInfo],
+    cets: Vector[(OracleOutcome, CETInfo)],
     refundTx: Transaction) {
   cets.foreach { case (msg, cetInfo) =>
     require(
@@ -28,6 +32,15 @@ case class SetupDLC(
                                                                UInt32.zero),
     s"RefundTx is not spending the funding input, ${refundTx.inputs.head}"
   )
+
+  def getCETInfo(outcome: OracleOutcome): CETInfo = {
+    cets.find(_._1 == outcome) match {
+      case Some((_, info)) => info
+      case None =>
+        throw new IllegalArgumentException(
+          s"No CET found for the given outcome $outcome")
+    }
+  }
 }
 
-case class CETInfo(tx: Transaction, remoteSignature: ECAdaptorSignature)
+case class CETInfo(tx: WitnessTransaction, remoteSignature: ECAdaptorSignature)

--- a/testkit/src/main/scala/org/bitcoins/testkit/dlc/DLCTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/dlc/DLCTest.scala
@@ -14,7 +14,7 @@ import org.bitcoins.core.util.{FutureUtil, NumberUtil}
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto._
-import org.bitcoins.dlc.execution.SetupDLC
+import org.bitcoins.dlc.execution.{CETInfo, SetupDLC}
 import org.bitcoins.dlc.testgen.{DLCTestUtil, TestDLCClient}
 import org.scalatest.{Assertion, Assertions}
 
@@ -492,8 +492,8 @@ trait DLCTest {
     } yield {
       assert(acceptSetup.fundingTx == offerSetup.fundingTx)
       assert(acceptSetup.refundTx == offerSetup.refundTx)
-      acceptSetup.cets.foreach { case (msg, cetInfo) =>
-        assert(cetInfo.tx == offerSetup.cets(msg).tx)
+      acceptSetup.cets.foreach { case (outcome, CETInfo(cet, _)) =>
+        assert(cet == offerSetup.getCETInfo(outcome).tx)
       }
 
       (offerSetup, acceptSetup)


### PR DESCRIPTION
Got rid of some `Future`s and implicit `ExecutionContext`s as well as getting rid of some duplicated work by passing constructed unsigned CETs around.