### PR TITLE
Fix TLV parsing for non-standard strings

### DIFF
--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -128,7 +128,7 @@ case class OracleRoutes(oracle: DLCOracle)(implicit
               case Some(event: OracleEvent) =>
                 val outcomesJson = event.eventDescriptorTLV match {
                   case enum: EnumEventDescriptorV0TLV =>
-                    enum.outcomes.map(Str)
+                    enum.outcomes.map(outcome => Str(outcome.normStr))
                   case range: RangeEventDescriptorV0TLV =>
                     val outcomes: Vector[Long] = {
                       val startL = range.start.toLong

--- a/build.sbt
+++ b/build.sbt
@@ -501,9 +501,12 @@ lazy val walletTest = project
   .dependsOn(core % testAndCompile, testkit, wallet)
   .enablePlugins(FlywayPlugin)
 
+lazy val oracleDbSettings = dbFlywaySettings("oracle")
+
 lazy val dlcOracle = project
   .in(file("dlc-oracle"))
   .settings(CommonSettings.prodSettings: _*)
+  .settings(oracleDbSettings: _*)
   .settings(
     name := "bitcoin-s-dlc-oracle",
     libraryDependencies ++= Deps.dlcOracle

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -179,12 +179,8 @@ case class NormalizedString(private val str: String) {
 
 object NormalizedString {
 
-  def apply(str: String): NormalizedString = {
-    new NormalizedString(CryptoUtil.normalize(str))
-  }
-
   def apply(bytes: ByteVector): NormalizedString = {
-    apply(new String(bytes.toArray, StandardCharsets.UTF_8))
+    NormalizedString(new String(bytes.toArray, StandardCharsets.UTF_8))
   }
 
   import scala.language.implicitConversions

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -303,8 +303,9 @@ object EnumEventDescriptorV0TLV extends TLVFactory[EnumEventDescriptorV0TLV] {
 
     val result = builder.result()
 
-    require(count.toInt == result.size,
-            "Did not parse the expected number of outcomes")
+    require(
+      count.toInt == result.size,
+      s"Did not parse the expected number of outcomes, ${count.toInt} != ${result.size}")
 
     EnumEventDescriptorV0TLV(result)
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -27,6 +27,15 @@ sealed trait TLV extends NetworkElement {
   }
 
   def sha256: Sha256Digest = CryptoUtil.sha256(bytes)
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case tlv: TLV =>
+        tlv.bytes == this.bytes
+      case other =>
+        other.equals(this)
+    }
+  }
 }
 
 sealed trait TLVParentFactory[T <: TLV] extends Factory[T] {
@@ -262,7 +271,7 @@ case class EnumEventDescriptorV0TLV(outcomes: Vector[String])
 
     outcomes.foldLeft(starting) { (accum, outcome) =>
       val outcomeBytes = CryptoUtil.serializeForHash(outcome)
-      accum ++ UInt16(outcomeBytes.length).bytes ++ outcomeBytes
+      accum ++ BigSizeUInt(outcomeBytes.length).bytes ++ outcomeBytes
     }
   }
 
@@ -281,9 +290,7 @@ object EnumEventDescriptorV0TLV extends TLVFactory[EnumEventDescriptorV0TLV] {
     val builder = Vector.newBuilder[String]
 
     while (iter.index < value.length) {
-      val len = UInt16(iter.takeBits(16))
-      val outcomeBytes = iter.take(len.toInt)
-      val str = new String(outcomeBytes.toArray, StandardCharsets.UTF_8)
+      val str = iter.takeString()
       builder.+=(str)
     }
 
@@ -379,8 +386,8 @@ case class RangeEventDescriptorV0TLV(
   override val tpe: BigSizeUInt = RangeEventDescriptorV0TLV.tpe
 
   override val value: ByteVector = {
-    val unitSize = BigSizeUInt(unit.length)
     val unitBytes = CryptoUtil.serializeForHash(unit)
+    val unitSize = BigSizeUInt(unitBytes.size)
 
     start.bytes ++ count.bytes ++ step.bytes ++
       unitSize.bytes ++ unitBytes ++ precision.bytes
@@ -450,8 +457,8 @@ trait DigitDecompositionEventDescriptorV0TLV extends NumericEventDescriptorTLV {
       if (isSigned) ByteVector(TRUE_BYTE) else ByteVector(FALSE_BYTE)
 
     val numDigitBytes = numDigits.bytes
-    val unitSize = BigSizeUInt(unit.length)
     val unitBytes = CryptoUtil.serializeForHash(unit)
+    val unitSize = BigSizeUInt(unitBytes.size)
 
     base.bytes ++ isSignedByte ++ unitSize.bytes ++ unitBytes ++ precision.bytes ++ numDigitBytes
   }
@@ -534,7 +541,7 @@ case class OracleEventV0TLV(
     nonces: Vector[SchnorrNonce],
     eventMaturityEpoch: UInt32,
     eventDescriptor: EventDescriptorTLV,
-    eventURI: String
+    eventId: String
 ) extends OracleEventTLV {
 
   require(eventDescriptor.noncesNeeded == nonces.size,
@@ -543,11 +550,12 @@ case class OracleEventV0TLV(
   override def tpe: BigSizeUInt = OracleEventV0TLV.tpe
 
   override val value: ByteVector = {
-    val uriBytes = CryptoUtil.serializeForHash(eventURI)
+    val uriBytes = CryptoUtil.serializeForHash(eventId)
     val numNonces = UInt16(nonces.size)
     val noncesBytes = nonces.foldLeft(numNonces.bytes)(_ ++ _.bytes)
 
-    noncesBytes ++ eventMaturityEpoch.bytes ++ eventDescriptor.bytes ++ uriBytes
+    noncesBytes ++ eventMaturityEpoch.bytes ++ eventDescriptor.bytes ++ BigSizeUInt(
+      uriBytes.size).bytes ++ uriBytes
   }
 
   /** Gets the maturation of the event since epoch */
@@ -579,9 +587,9 @@ object OracleEventV0TLV extends TLVFactory[OracleEventV0TLV] {
     val eventMaturity = UInt32(iter.takeBits(32))
     val eventDescriptor = EventDescriptorTLV(iter.current)
     iter.skip(eventDescriptor.byteSize)
-    val eventURI = new String(iter.current.toArray, StandardCharsets.UTF_8)
+    val eventId = iter.takeString()
 
-    OracleEventV0TLV(nonces, eventMaturity, eventDescriptor, eventURI)
+    OracleEventV0TLV(nonces, eventMaturity, eventDescriptor, eventId)
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -466,7 +466,7 @@ trait DigitDecompositionEventDescriptorV0TLV extends NumericEventDescriptorTLV {
   private lazy val maxDigit: NormalizedString = (base.toInt - 1).toString
 
   override lazy val max: Vector[NormalizedString] = if (isSigned) {
-    "+" +: Vector.fill(numDigits.toInt)(maxDigit)
+    NormalizedString("+") +: Vector.fill(numDigits.toInt)(maxDigit)
   } else {
     Vector.fill(numDigits.toInt)(maxDigit)
   }
@@ -478,7 +478,7 @@ trait DigitDecompositionEventDescriptorV0TLV extends NumericEventDescriptorTLV {
   }
 
   override lazy val min: Vector[NormalizedString] = if (isSigned) {
-    "-" +: Vector.fill(numDigits.toInt)(maxDigit)
+    NormalizedString("-") +: Vector.fill(numDigits.toInt)(maxDigit)
   } else {
     Vector.fill(numDigits.toInt)("0")
   }

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -122,14 +122,14 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
     val result = oracleAppConfig.migrate()
     oracleAppConfig.driver match {
       case SQLite =>
-        val expected = 2
+        val expected = 3
         assert(result == expected)
         val flywayInfo = oracleAppConfig.info()
 
         assert(flywayInfo.applied().length == expected)
         assert(flywayInfo.pending().length == 0)
       case PostgreSQL =>
-        val expected = 2
+        val expected = 3
         assert(result == expected)
         val flywayInfo = oracleAppConfig.info()
 

--- a/dlc-oracle/src/main/resources/postgresql/oracle/migration/V3__fix_dumy_event_descriptor.sql
+++ b/dlc-oracle/src/main/resources/postgresql/oracle/migration/V3__fix_dumy_event_descriptor.sql
@@ -1,0 +1,4 @@
+-- Enforce UTF-8 encoding
+PRAGMA encoding="UTF-8";
+-- Fix dummy event descriptor to be a parsable one
+UPDATE events SET event_descriptor_tlv = 'fdd8060800010564756d6d79' WHERE event_descriptor_tlv = 'fdd806090001000564756d6d79';

--- a/dlc-oracle/src/main/resources/postgresql/oracle/migration/V3__fix_dumy_event_descriptor.sql
+++ b/dlc-oracle/src/main/resources/postgresql/oracle/migration/V3__fix_dumy_event_descriptor.sql
@@ -1,4 +1,2 @@
--- Enforce UTF-8 encoding
-PRAGMA encoding="UTF-8";
 -- Fix dummy event descriptor to be a parsable one
 UPDATE events SET event_descriptor_tlv = 'fdd8060800010564756d6d79' WHERE event_descriptor_tlv = 'fdd806090001000564756d6d79';

--- a/dlc-oracle/src/main/resources/sqlite/oracle/migration/V3__fix_dummy_event_descriptor.sql
+++ b/dlc-oracle/src/main/resources/sqlite/oracle/migration/V3__fix_dummy_event_descriptor.sql
@@ -1,0 +1,4 @@
+-- Enforce UTF-8 encoding
+PRAGMA encoding="UTF-8";
+-- Fix dummy event descriptor to be a parsable one
+UPDATE `events` SET `event_descriptor_tlv` = 'fdd8060800010564756d6d79' WHERE `event_descriptor_tlv` = 'fdd806090001000564756d6d79';

--- a/dlc-oracle/src/main/resources/sqlite/oracle/migration/V3__fix_dummy_event_descriptor.sql
+++ b/dlc-oracle/src/main/resources/sqlite/oracle/migration/V3__fix_dummy_event_descriptor.sql
@@ -1,4 +1,2 @@
--- Enforce UTF-8 encoding
-PRAGMA encoding="UTF-8";
 -- Fix dummy event descriptor to be a parsable one
 UPDATE `events` SET `event_descriptor_tlv` = 'fdd8060800010564756d6d79' WHERE `event_descriptor_tlv` = 'fdd806090001000564756d6d79';

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -1,7 +1,5 @@
 package org.bitcoins.dlc.oracle
 
-import java.time.Instant
-
 import org.bitcoins.commons.jsonmodels.dlc.SigningVersion
 import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto.ExtKeyVersion.SegWitMainNetPriv
@@ -18,6 +16,7 @@ import org.bitcoins.dlc.oracle.storage._
 import org.bitcoins.dlc.oracle.util.EventDbUtil
 import org.bitcoins.keymanager.{DecryptedMnemonic, WalletStorage}
 
+import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 
 case class DLCOracle(private val extPrivateKey: ExtPrivateKeyHardened)(implicit
@@ -273,7 +272,9 @@ case class DLCOracle(private val extPrivateKey: ExtPrivateKeyHardened)(implicit
               s"No event saved with nonce ${nonce.hex} $outcome"))
       }
 
-      eventOutcomeOpt <- eventOutcomeDAO.read((nonce, outcome.outcomeString))
+      hash = eventDb.signingVersion.calcOutcomeHash(eventDb.eventDescriptorTLV,
+                                                    outcome.outcomeString)
+      eventOutcomeOpt <- eventOutcomeDAO.find(nonce, hash)
       eventOutcomeDb <- eventOutcomeOpt match {
         case Some(value) => Future.successful(value)
         case None =>

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
@@ -62,10 +62,11 @@ case class DLCOracleAppConfig(
       }
       logger.info(s"Applied $numMigrations to the dlc oracle project")
 
-      if (migrationsApplied() == 2) {
-        logger.debug(s"Doing V2 Migration")
+      val migrations = migrationsApplied()
+      if (migrations == 2 || migrations == 3) { // For V2/V3 migrations
+        logger.debug(s"Doing V2/V3 Migration")
 
-        val dummyMigrationTLV = EventDescriptorTLV("fdd806090001000564756d6d79")
+        val dummyMigrationTLV = EventDescriptorTLV("fdd8060800010564756d6d79")
 
         val eventDAO = EventDAO()(ec, appConfig)
         for {

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAO.scala
@@ -49,6 +49,15 @@ case class EventOutcomeDAO()(implicit
     safeDatabase.runVec(query.result.transactionally)
   }
 
+  def find(
+      nonce: SchnorrNonce,
+      hash: ByteVector): Future[Option[EventOutcomeDb]] = {
+    val query =
+      table.filter(item => item.nonce === nonce && item.hashedMessage === hash)
+
+    safeDatabase.run(query.result.transactionally).map(_.headOption)
+  }
+
   class EventOutcomeTable(tag: Tag)
       extends Table[EventOutcomeDb](tag, schemaName, "event_outcomes") {
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/StringGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/StringGenerators.scala
@@ -2,6 +2,9 @@ package org.bitcoins.testkit.core.gen
 
 import org.scalacheck.Gen
 
+import java.nio.charset.StandardCharsets
+import scala.util.{Failure, Success, Try}
+
 /**
   * Created by chris on 6/20/16.
   */
@@ -55,6 +58,17 @@ trait StringGenerators {
       randomString <- genString(randomNum)
     } yield randomString
 
+  def genUTF8String: Gen[String] = {
+    for {
+      bytes <- NumberGenerator.bytes
+      str <- Try(new String(bytes.toArray, StandardCharsets.UTF_8)) match {
+        case Failure(_) =>
+          genUTF8String
+        case Success(value) =>
+          Gen.const(value)
+      }
+    } yield str
+  }
 }
 
 object StringGenerators extends StringGenerators

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/TLVGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/TLVGen.scala
@@ -44,7 +44,7 @@ trait TLVGen {
   def enumEventDescriptorV0TLV: Gen[EnumEventDescriptorV0TLV] = {
     for {
       numOutcomes <- Gen.choose(2, 10)
-      outcomes <- Gen.listOfN(numOutcomes, StringGenerators.genString)
+      outcomes <- Gen.listOfN(numOutcomes, StringGenerators.genUTF8String)
     } yield EnumEventDescriptorV0TLV(outcomes.toVector)
   }
 
@@ -53,7 +53,7 @@ trait TLVGen {
       start <- NumberGenerator.int32s
       count <- NumberGenerator.uInt32s
       step <- NumberGenerator.uInt16
-      unit <- StringGenerators.genString
+      unit <- StringGenerators.genUTF8String
       precision <- NumberGenerator.int32s
     } yield RangeEventDescriptorV0TLV(start, count, step, unit, precision)
   }
@@ -64,7 +64,7 @@ trait TLVGen {
       base <- NumberGenerator.uInt16
       isSigned <- NumberGenerator.bool
       numDigits <- Gen.choose(2, 20)
-      unit <- StringGenerators.genString
+      unit <- StringGenerators.genUTF8String
       precision <- NumberGenerator.int32s
     } yield DigitDecompositionEventDescriptorV0TLV(base,
                                                    isSigned,
@@ -81,7 +81,7 @@ trait TLVGen {
   def oracleEventV0TLV: Gen[OracleEventV0TLV] = {
     for {
       maturity <- NumberGenerator.uInt32s
-      uri <- StringGenerators.genString
+      uri <- StringGenerators.genUTF8String
       desc <- eventDescriptorTLV
       nonces <-
         Gen


### PR DESCRIPTION
Found by @rorp 

Fixes parsing UTF 8 strings with uncommon letters.

Needed to change the comparison between TLVs because it seems scala doesn't correctly compare complex UTF 8 strings, unless this is something to do with us not doing something with NFC normalization after parsing?