### PR TITLE
WIP: Multi-Oracle Support!

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/CETCalculatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/CETCalculatorTest.scala
@@ -2,8 +2,10 @@ package org.bitcoins.core.protocol.dlc
 
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.protocol.dlc.CETCalculator._
+import org.bitcoins.testkit.core.gen.NumberGenerator
 import org.bitcoins.testkit.util.BitcoinSUnitTest
 import org.scalacheck.Gen
+import org.scalatest.Assertion
 
 class CETCalculatorTest extends BitcoinSUnitTest {
 
@@ -308,5 +310,325 @@ class CETCalculatorTest extends BitcoinSUnitTest {
                                 min = 0,
                                 max = 110)
     assert(cetOutcomes == expected)
+  }
+
+  def computeCoveringCETsMinAndMax(
+      numDigits: Int,
+      cetDigits: Vector[Int],
+      maxErrorExp: Int,
+      minFailExp: Int): (
+      Vector[(Vector[Int], Vector[Int])],
+      Vector[(Vector[Int], Vector[Int])]) = {
+    val coveringCETsMax =
+      CETCalculator.computeCoveringCETsBinary(numDigits = numDigits,
+                                              cetDigits = cetDigits,
+                                              maxErrorExp = maxErrorExp,
+                                              minFailExp = minFailExp,
+                                              maximizeCoverage = true)
+    val coveringCETsMin =
+      CETCalculator.computeCoveringCETsBinary(numDigits = numDigits,
+                                              cetDigits = cetDigits,
+                                              maxErrorExp = maxErrorExp,
+                                              minFailExp = minFailExp,
+                                              maximizeCoverage = false)
+
+    (coveringCETsMax, coveringCETsMin)
+  }
+
+  it should "correctly cover small middle CETs" in {
+    // 2848 - 2879 (between 2048 + 128 and 4096 - 128)
+    val cet = Vector(0, 0, 1, 0, 1, 1, 0, 0, 1)
+
+    val (coveringCETsMax, coveringCETsMin) =
+      computeCoveringCETsMinAndMax(numDigits = 14,
+                                   cetDigits = cet,
+                                   maxErrorExp = 11,
+                                   minFailExp = 7)
+
+    assert(coveringCETsMax == Vector((cet, Vector(0, 0, 1))))
+    assert(coveringCETsMin == Vector((cet, Vector(0, 0, 1, 0, 1))))
+  }
+
+  it should "correctly cover small left CETs" in {
+    // 2096 - 2111 (between 2048 and 2048 + 128)
+    val cet = Vector(0, 1, 0, 0, 0, 0, 0, 1, 1)
+
+    val (coveringCETsMax, coveringCETsMin) =
+      computeCoveringCETsMinAndMax(numDigits = 13,
+                                   cetDigits = cet,
+                                   maxErrorExp = 11,
+                                   minFailExp = 7)
+
+    assert(
+      coveringCETsMax == Vector((cet, Vector(0, 0, 1)), (cet, Vector(0, 1))))
+    assert(
+      coveringCETsMin == Vector((cet, Vector(0, 0, 1, 1, 1, 1)),
+                                (cet, Vector(0, 1, 0, 0, 0))))
+  }
+
+  it should "correctly cover small right CETs" in {
+    // 4000 - 4015 (between 4096 - 128 and 4096)
+    val cet = Vector(0, 1, 1, 1, 1, 1, 0, 1, 0)
+
+    val (coveringCETsMax, coveringCETsMin) =
+      computeCoveringCETsMinAndMax(numDigits = 13,
+                                   cetDigits = cet,
+                                   maxErrorExp = 11,
+                                   minFailExp = 7)
+
+    assert(
+      coveringCETsMax == Vector((cet, Vector(0, 1)), (cet, Vector(1, 0, 0))))
+    assert(
+      coveringCETsMin == Vector((cet, Vector(0, 1, 1, 1, 1)),
+                                (cet, Vector(1, 0, 0, 0, 0, 0, 0))))
+  }
+
+  it should "correctly cover max-error sized CETs" in {
+    // 2048 - 4095
+    val cet = Vector(0, 1)
+
+    val (coveringCETsMax, coveringCETsMin) =
+      computeCoveringCETsMinAndMax(numDigits = 13,
+                                   cetDigits = cet,
+                                   maxErrorExp = 11,
+                                   minFailExp = 7)
+
+    assert(
+      coveringCETsMax == Vector((Vector(0, 1, 0), Vector(0, 0, 1)),
+                                (cet, cet),
+                                (Vector(0, 1, 1), Vector(1, 0, 0))))
+    assert(
+      coveringCETsMin == Vector(
+        (Vector(0, 1, 0, 0, 0, 0), Vector(0, 0, 1, 1, 1, 1)),
+        (cet, cet),
+        (Vector(0, 1, 1, 1, 1, 1), Vector(1, 0, 0, 0, 0, 0))))
+  }
+
+  it should "correctly cover large CETs" in {
+    // 4096 - 8192
+    val cet = Vector(0, 0, 1)
+
+    val (coveringCETsMax, coveringCETsMin) =
+      computeCoveringCETsMinAndMax(numDigits = 15,
+                                   cetDigits = cet,
+                                   maxErrorExp = 11,
+                                   minFailExp = 7)
+
+    assert(
+      coveringCETsMax == Vector((Vector(0, 0, 1, 0, 0), Vector(0, 0, 0, 1, 1)),
+                                (cet, cet),
+                                (Vector(0, 0, 1, 1, 1), Vector(0, 1, 0, 0, 0))))
+    assert(
+      coveringCETsMin == Vector(
+        (Vector(0, 0, 1, 0, 0, 0, 0, 0), Vector(0, 0, 0, 1, 1, 1, 1, 1)),
+        (cet, cet),
+        (Vector(0, 0, 1, 1, 1, 1, 1, 1), Vector(0, 1, 0, 0, 0, 0, 0, 0))))
+  }
+
+  it should "correctly cover small leftmost (0) CETs" in {
+    // 0 - 64 (between 0 and 0 + 128)
+    val cet = Vector(0, 0, 0, 0, 0, 0, 0)
+
+    val (coveringCETsMax, coveringCETsMin) =
+      computeCoveringCETsMinAndMax(numDigits = 13,
+                                   cetDigits = cet,
+                                   maxErrorExp = 11,
+                                   minFailExp = 7)
+
+    assert(coveringCETsMax == Vector((cet, Vector(0, 0))))
+    assert(coveringCETsMin == Vector((cet, Vector(0, 0, 0, 0, 0))))
+  }
+
+  it should "correctly cover small rightmost (maxValue) CETs" in {
+    // 8176 - 8191 (between 8192 - 128 and 8192)
+    val cet = Vector(1, 1, 1, 1, 1, 1, 1, 1)
+
+    val (coveringCETsMax, coveringCETsMin) =
+      computeCoveringCETsMinAndMax(numDigits = 13,
+                                   cetDigits = cet,
+                                   maxErrorExp = 11,
+                                   minFailExp = 7)
+
+    assert(coveringCETsMax == Vector((cet, Vector(1, 1))))
+    assert(coveringCETsMin == Vector((cet, Vector(1, 1, 1, 1, 1))))
+  }
+
+  it should "correctly cover large leftmost (0) CETs" in {
+    val cet = Vector(0, 0)
+
+    val (coveringCETsMax, coveringCETsMin) =
+      computeCoveringCETsMinAndMax(numDigits = 13,
+                                   cetDigits = cet,
+                                   maxErrorExp = 11,
+                                   minFailExp = 7)
+
+    assert(
+      coveringCETsMax == Vector((cet, cet), (Vector(0, 0, 1), Vector(0, 1, 0))))
+    assert(
+      coveringCETsMin == Vector(
+        (cet, cet),
+        (Vector(0, 0, 1, 1, 1, 1), Vector(0, 1, 0, 0, 0, 0))))
+  }
+
+  it should "correctly cover large rightmost (maxValue) CETs" in {
+    val cet = Vector(1, 1)
+
+    val (coveringCETsMax, coveringCETsMin) =
+      computeCoveringCETsMinAndMax(numDigits = 14,
+                                   cetDigits = cet,
+                                   maxErrorExp = 11,
+                                   minFailExp = 7)
+
+    assert(
+      coveringCETsMax == Vector((Vector(1, 1, 0, 0), Vector(1, 0, 1, 1)),
+                                (cet, cet)))
+    assert(
+      coveringCETsMin == Vector(
+        (Vector(1, 1, 0, 0, 0, 0, 0), Vector(1, 0, 1, 1, 1, 1, 1)),
+        (cet, cet)))
+  }
+
+  it should "correctly cover a CET with other CETs within bounds" in {
+    val gen = for {
+      numDigits <- Gen.choose(2, 30)
+      numDigitsUsed <- Gen.choose(1, numDigits)
+      cet <- Gen.listOfN(numDigitsUsed, NumberGenerator.bool).map {
+        _.toVector.map {
+          case false => 0
+          case true  => 1
+        }
+      }
+      maxError <- Gen.choose(1, numDigits - 1)
+      minFail <- Gen.choose(0, maxError - 1)
+    } yield {
+      (numDigits, cet, maxError, minFail)
+    }
+
+    forAll(gen) {
+      case (numDigits, cet, maxErrorExp, minFailExp) =>
+        val maxError = 1L << maxErrorExp
+        val minFail = 1L << minFailExp
+        val maxVal = (1L << numDigits) - 1
+
+        val (coveringCETsMax, coveringCETsMin) =
+          computeCoveringCETsMinAndMax(numDigits, cet, maxErrorExp, minFailExp)
+
+        assert(coveringCETsMin.length == coveringCETsMax.length)
+        assert(coveringCETsMin.map(_._1).zip(coveringCETsMax.map(_._1)).forall {
+          case (minD, maxD) => minD.startsWith(maxD)
+        })
+
+        val relevantPrimaryCETs = coveringCETsMax.map(_._1)
+
+        val (left, right) =
+          CETCalculator.computeCETIntervalBinary(cet, numDigits)
+
+        val primaryAndCoveringIntervalsMax = coveringCETsMax.map {
+          case (d1, d2) =>
+            val interval1 =
+              CETCalculator.computeCETIntervalBinary(d1, numDigits)
+            val interval2 =
+              CETCalculator.computeCETIntervalBinary(d2, numDigits)
+            (interval1, interval2)
+        }
+
+        val coveringIntervalsMin = coveringCETsMax.map {
+          case (_, d) => CETCalculator.computeCETIntervalBinary(d, numDigits)
+        }
+
+        primaryAndCoveringIntervalsMax.zip(coveringIntervalsMin).foreach {
+          case (((primaryLeft, primaryRight), (maxCoverLeft, maxCoverRight)),
+                (minCoverLeft, minCoverRight)) =>
+            assert(maxCoverLeft <= minCoverLeft)
+            assert(maxCoverRight >= minCoverRight)
+
+            if (primaryLeft == maxCoverLeft && primaryRight == maxCoverRight) {
+              assert(minCoverLeft == maxCoverLeft)
+              assert(minCoverRight == maxCoverRight)
+            }
+
+            def assertValidCover(
+                coverLeft: Long,
+                coverRight: Long,
+                maxCoverage: Boolean): Assertion = {
+              if (primaryLeft == coverLeft && primaryRight == coverRight) {
+                succeed
+              } else if (
+                primaryLeft >= coverLeft && primaryRight <= coverRight
+              ) {
+                if (maxCoverage) {
+                  assert(coverRight - coverLeft + 1 == maxError)
+                } else {
+                  val sideToBoundary =
+                    math.max(primaryRight % maxError,
+                             maxError - (primaryLeft % maxError))
+                  assert(coverRight - coverLeft + 1 <= 2 * sideToBoundary)
+                  assert(coverRight - coverLeft + 1 >= sideToBoundary)
+                }
+
+                assert(
+                  primaryLeft - coverLeft >= minFail || coverLeft == 0 || relevantPrimaryCETs.length == 2)
+                assert(primaryRight - coverLeft < maxError)
+                assert(
+                  coverRight - primaryRight >= minFail || coverRight == maxVal || relevantPrimaryCETs.length == 2)
+                assert(coverRight - primaryLeft < maxError)
+              } else {
+                val (mostInner, leastInner, mostOuter) =
+                  if (primaryLeft <= coverLeft) {
+                    (primaryLeft, primaryRight, coverRight)
+                  } else {
+                    (primaryRight, primaryLeft, coverLeft)
+                  }
+
+                def diff(x: Long, y: Long): Long = math.abs(x - y)
+
+                assert(diff(leastInner, mostOuter) >= minFail)
+                assert(diff(mostInner, mostOuter) < maxError)
+              }
+            }
+
+            assertValidCover(maxCoverLeft, maxCoverRight, maxCoverage = true)
+            assertValidCover(minCoverLeft, minCoverRight, maxCoverage = false)
+        }
+
+        val primaryInterval = primaryAndCoveringIntervalsMax
+          .map(_._1)
+          .reduce[(Long, Long)]({
+            case ((min, max), (start, end)) =>
+              (math.min(min, start), math.max(max, end))
+          })
+
+        assert(primaryInterval == (left, right))
+
+        val (maxCoverIntervalLeft, maxCoverIntervalRight) =
+          primaryAndCoveringIntervalsMax
+            .map(_._2)
+            .reduce[(Long, Long)]({
+              case ((min, max), (start, end)) =>
+                (math.min(min, start), math.max(max, end))
+            })
+        val (minCoverIntervalLeft, minCoverIntervalRight) = coveringIntervalsMin
+          .reduce[(Long, Long)]({
+            case ((min, max), (start, end)) =>
+              (math.min(min, start), math.max(max, end))
+          })
+
+        assert(maxCoverIntervalLeft <= minCoverIntervalLeft)
+        assert(maxCoverIntervalRight >= minCoverIntervalRight)
+
+        assert(
+          left - maxCoverIntervalLeft >= minFail || maxCoverIntervalLeft == 0)
+        assert(left - maxCoverIntervalLeft < maxError)
+        assert(
+          maxCoverIntervalRight - right >= minFail || maxCoverIntervalRight == maxVal)
+        assert(maxCoverIntervalRight - right < maxError)
+
+        assert(
+          left - minCoverIntervalLeft >= minFail || minCoverIntervalLeft == 0)
+        assert(left - minCoverIntervalLeft < maxError)
+        assert(
+          minCoverIntervalRight - right >= minFail || minCoverIntervalRight == maxVal)
+        assert(minCoverIntervalRight - right < maxError)
+    }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/CETCalculator.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/CETCalculator.scala
@@ -7,6 +7,7 @@ import org.bitcoins.core.protocol.tlv.{
   UnsignedNumericOutcome
 }
 import org.bitcoins.core.util.{Indexed, NumberUtil}
+import scodec.bits.BitVector
 
 import scala.annotation.tailrec
 
@@ -401,5 +402,282 @@ object CETCalculator {
     val max = Math.pow(base, numDigits).toLong - 1
 
     computeCETs(base, numDigits, function, totalCollateral, rounding, min, max)
+  }
+
+  /** Given binary digits corresponding to a CET, returns the CET's support bounds */
+  def computeCETIntervalBinary(
+      cet: Vector[Int],
+      numDigits: Int): (Long, Long) = {
+    val left = NumberUtil.fromDigits(cet, base = 2, numDigits)
+    val right = left + (1L << (numDigits - cet.length)) - 1
+
+    (left, right)
+  }
+
+  // TODO: Delete this when merging
+  def printToDecimal(
+      input: Vector[(Vector[Int], Vector[Int])],
+      numDigits: Int): Unit = {
+    input.foreach {
+      case (primaryCET, coveringCET) =>
+        val (primaryLeft, primaryRight) =
+          computeCETIntervalBinary(primaryCET, numDigits)
+        val (coveringLeft, coveringRight) =
+          computeCETIntervalBinary(coveringCET, numDigits)
+
+        println()
+        println(s"Primary Oracle in [$primaryLeft, $primaryRight]")
+        println(s"Covering Oracle in [$coveringLeft, $coveringRight]")
+    }
+  }
+
+  /** Given the right endpoint of a CET and the number of ignored digits,
+    * computes the binary digits for the CET.
+    */
+  def numToVec(num: Long, numDigits: Int, ignoredDigits: Int): Vector[Int] = {
+    BitVector
+      .fromLong(num, numDigits)
+      .toIndexedSeq
+      .toVector
+      .dropRight(ignoredDigits)
+      .map {
+        case false => 0
+        case true  => 1
+      }
+  }
+
+  /** Assumes that [start, end] is a Small Middle CET and returns the smallest
+    * single CET covering that interval satisfying error bounds.
+    */
+  private def minCoverMidCET(
+      start: Long,
+      end: Long,
+      minFail: Long,
+      numDigits: Int): Vector[Int] = {
+    val leftBound = start - minFail
+    val leftBoundDigits = NumberUtil.decompose(leftBound, base = 2, numDigits)
+    val rightBound = end + minFail
+    val rightBoundDigits = NumberUtil.decompose(rightBound, base = 2, numDigits)
+
+    // Shared prefix of start - minFail and end + minFail is the smallest CET.
+    // [start, end] being a small middle CET guarantees the shared prefix is
+    // at most of size maxError.
+    leftBoundDigits
+      .zip(rightBoundDigits)
+      .takeWhile { case (d1, d2) => d1 == d2 }
+      .map(_._1)
+  }
+
+  /** Assumes that [start, end] is a Small Left CET and returns the smallest
+    * single CET covering that interval, on the same multiple of maxError,
+    * satisfying error bounds.
+    */
+  private def minCoverLeftCET(
+      end: Long,
+      maxErrorExp: Int,
+      minFail: Long,
+      numDigits: Int): Vector[Int] = {
+    val rightBound = end + minFail
+    val rightBoundDigits = NumberUtil.decompose(rightBound, base = 2, numDigits)
+    val (prefix, halvingDigits) =
+      rightBoundDigits.splitAt(numDigits - maxErrorExp)
+
+    prefix ++ halvingDigits.takeWhile(_ == 0)
+  }
+
+  /** Assumes that [start, end] is a Small Right CET and returns the smallest
+    * single CET covering that interval, on the same multiple of maxError,
+    * satisfying error bounds.
+    */
+  private def minCoverRightCET(
+      start: Long,
+      maxErrorExp: Int,
+      minFail: Long,
+      numDigits: Int): Vector[Int] = {
+    val leftBound = start - minFail
+    val leftBoundDigits = NumberUtil.decompose(leftBound, base = 2, numDigits)
+    val (prefix, halvingDigits) =
+      leftBoundDigits.splitAt(numDigits - maxErrorExp)
+
+    prefix ++ halvingDigits.takeWhile(_ == 1)
+  }
+
+  /** Given the primary oracle's CET, computes the set of CETs needed
+    * for two oracles with an allowed difference (which is bounded).
+    *
+    * @param numDigits The number of binary digits signed by the oracles
+    * @param cetDigits Digits corresponding to a CET for the primary oracle
+    * @param maxErrorExp The exponent (of 2) representing the difference at which
+    *                    non-support (failure) is guaranteed
+    * @param minFailExp The exponent (of 2) representing the difference up to
+    *                   which support is guaranteed
+    */
+  def computeCoveringCETsBinary(
+      numDigits: Int,
+      cetDigits: Vector[Int],
+      maxErrorExp: Int,
+      minFailExp: Int,
+      maximizeCoverage: Boolean): Vector[(Vector[Int], Vector[Int])] = {
+    val maxNum = (1L << numDigits) - 1
+    val maxError = 1L << maxErrorExp
+    val halfMaxError = maxError >> 1
+    val minFail = 1L << minFailExp
+
+    val (start, end) = computeCETIntervalBinary(cetDigits, numDigits)
+
+    if (end - start + 1 < maxError) { // case: Small CET
+      // largest multiple of maxErrorExp < start
+      val leftErrorCET = (start >> maxErrorExp) << maxErrorExp
+      // smallest multiple minus one of maxErrorExp > end
+      val rightErrorCET = leftErrorCET + maxError - 1
+      // CET of width maxError covering [leftErrorCET, rightErrorCET]
+      val errorCET = numToVec(leftErrorCET, numDigits, maxErrorExp)
+      /* Picture of errorCET's interval on which [start, end] resides:
+       * __________________________________________________________________________
+       * |                  |                                  |                  |
+       * leftErrorCET   (leftErrorCET + minFail)     (rightErrorCET - minFail)  rightErrorCET
+       */
+
+      if (start >= leftErrorCET + minFail && end <= rightErrorCET - minFail) { // case: Middle CET
+        val coverCET = if (maximizeCoverage) {
+          errorCET
+        } else {
+          minCoverMidCET(start, end, minFail, numDigits)
+        }
+
+        Vector((cetDigits, coverCET))
+      } else if (start < leftErrorCET + minFail) { // case: Left CET
+        val coverCET = if (maximizeCoverage) {
+          errorCET
+        } else {
+          minCoverLeftCET(end, maxErrorExp, minFail, numDigits)
+        }
+
+        lazy val leftCET = if (maximizeCoverage) {
+          // CET of width halfMaxError covering [leftErrorCET - halfMaxError, leftErrorCET - 1]
+          numToVec(leftErrorCET - halfMaxError, numDigits, maxErrorExp - 1)
+        } else {
+          // CET of width minFail covering at most [leftErrorCET - minFail, leftErrorCET - 1]
+          minCoverRightCET(start, maxErrorExp, minFail, numDigits)
+        }
+
+        if (leftErrorCET == 0) { // special case: Leftmost CET
+          Vector((cetDigits, coverCET))
+        } else {
+          Vector((cetDigits, leftCET), (cetDigits, coverCET))
+        }
+      } else if (end > rightErrorCET - minFail) { // case: Right CET
+        val coverCET = if (maximizeCoverage) {
+          errorCET
+        } else {
+          minCoverRightCET(start, maxErrorExp, minFail, numDigits)
+        }
+
+        lazy val rightCET = if (maximizeCoverage) {
+          // CET of width halfMaxError covering [rightErrorCET + 1, rightErrorCET + halfMaxError]
+          numToVec(rightErrorCET + 1, numDigits, maxErrorExp - 1)
+        } else {
+          // CET of width minFail covering at most [rightErrorCET + 1, rightErrorCET + minFail]
+          minCoverLeftCET(end, maxErrorExp, minFail, numDigits)
+        }
+
+        if (rightErrorCET == maxNum) { // special case: Rightmost CET
+          Vector((cetDigits, coverCET))
+        } else {
+          Vector((cetDigits, coverCET), (cetDigits, rightCET))
+        }
+      } else {
+        throw new RuntimeException(
+          s"Unexpected case: $cetDigits, $numDigits, $maxErrorExp, $minFailExp")
+      }
+    } else { // case: Large CET
+      val builder = Vector.newBuilder[(Vector[Int], Vector[Int])]
+
+      /* zoom of left corner of [start, end]:
+       * _____________________________________________________
+       * |                         |                         |
+       * (start - halfMaxError)   start   (start + halfMaxError)
+       *
+       * Secondary oracle can be on left side if primary is on right.
+       */
+      if (start != 0) {
+        val leftInnerCET = if (maximizeCoverage) {
+          numToVec(start, numDigits, maxErrorExp - 1)
+        } else {
+          numToVec(start, numDigits, minFailExp)
+        }
+        val leftCET = if (maximizeCoverage) {
+          numToVec(start - halfMaxError, numDigits, maxErrorExp - 1)
+        } else {
+          numToVec(start - minFail, numDigits, minFailExp)
+        }
+
+        builder.+=((leftInnerCET, leftCET))
+      }
+
+      /* [start, end]:
+       * ____________________________________________________
+       * |                                                  |
+       * start                                            end
+       *
+       * If both oracles are in this range (corresponding to a fixed
+       * value payout) then this any difference can be ignored.
+       */
+      builder.+=((cetDigits, cetDigits))
+
+      /* zoom of right corner of [start, end]:
+       * _________________________________________________________
+       * |                           |                           |
+       * (end - halfMaxError + 1)   end   (end + halfMaxError - 1)
+       *
+       * Secondary oracle can be on right side if primary is on left.
+       */
+      if (end != maxNum) {
+        val rightInnerCET = if (maximizeCoverage) {
+          numToVec(end - halfMaxError + 1, numDigits, maxErrorExp - 1)
+        } else {
+          numToVec(end - minFail + 1, numDigits, minFailExp)
+        }
+        val rightCET = if (maximizeCoverage) {
+          numToVec(end + 1, numDigits, maxErrorExp - 1)
+        } else {
+          numToVec(end + 1, numDigits, minFailExp)
+        }
+
+        builder.+=((rightInnerCET, rightCET))
+      }
+
+      builder.result()
+    }
+  }
+
+  /** Given the primary oracle's CETs, computes the set of CETs needed
+    * for two oracles with an allowed difference (which is bounded).
+    *
+    * @param numDigits The number of binary digits signed by the oracles
+    * @param primaryCETs CETs corresponding to the primary oracle
+    * @param maxErrorExp The exponent (of 2) representing the difference at which
+    *                    non-support (failure) is guaranteed
+    * @param minFailExp The exponent (of 2) representing the difference up to
+    *                   which support is guaranteed
+    */
+  def computeSecondOracleCETsBinary(
+      numDigits: Int,
+      primaryCETs: Vector[(Vector[Int], Satoshis)],
+      maxErrorExp: Int,
+      minFailExp: Int,
+      maximizeCoverage: Boolean): Vector[
+    (Vector[Int], Vector[Int], Satoshis)] = {
+    require(minFailExp < maxErrorExp)
+
+    primaryCETs.flatMap {
+      case (cetDigits, payout) =>
+        computeCoveringCETsBinary(numDigits,
+                                  cetDigits,
+                                  maxErrorExp,
+                                  minFailExp,
+                                  maximizeCoverage)
+          .map { case (d1, d2) => (d1, d2, payout) }
+    }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/CETCalculator.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/CETCalculator.scala
@@ -431,7 +431,7 @@ object CETCalculator {
     }
   }
 
-  /** Given the right endpoint of a CET and the number of ignored digits,
+  /** Given the left endpoint of a CET and the number of ignored digits,
     * computes the binary digits for the CET.
     */
   def numToVec(num: Long, numDigits: Int, ignoredDigits: Int): Vector[Int] = {
@@ -557,7 +557,7 @@ object CETCalculator {
           // CET of width halfMaxError covering [leftErrorCET - halfMaxError, leftErrorCET - 1]
           numToVec(leftErrorCET - halfMaxError, numDigits, maxErrorExp - 1)
         } else {
-          // CET of width minFail covering at most [leftErrorCET - minFail, leftErrorCET - 1]
+          // CET of width minFail covering at least [start - minFail, leftErrorCET - 1]
           minCoverRightCET(start, maxErrorExp, minFail, numDigits)
         }
 
@@ -577,7 +577,7 @@ object CETCalculator {
           // CET of width halfMaxError covering [rightErrorCET + 1, rightErrorCET + halfMaxError]
           numToVec(rightErrorCET + 1, numDigits, maxErrorExp - 1)
         } else {
-          // CET of width minFail covering at most [rightErrorCET + 1, rightErrorCET + minFail]
+          // CET of width minFail covering at least [rightErrorCET + 1, end + minFail]
           minCoverLeftCET(end, maxErrorExp, minFail, numDigits)
         }
 


### PR DESCRIPTION
Implemented n-of-n oracle CET computation logic, manually tested in console and it works! (After I did some debugging of course, didn't magically get it right the first time this time)

TODO
* real tests
* simplification/refactor & documentation
* numeric version (as opposed to digit manipulation) to test against and for reference
* dual version which minimizes the number of non-required cases for the same number of CETs
* Logic for t-of-n => tCn t-of-ts
* Logic for having different variance parameters between oracles