### PR TITLE
Bump scalac setting in secp256k1jni.sbt to scala 2.12.12

### DIFF
--- a/secp256k1jni/secp256k1jni.sbt
+++ b/secp256k1jni/secp256k1jni.sbt
@@ -11,5 +11,5 @@ crossPaths := false // drop off Scala suffix from artifact names.
 //to avoid double publishing
 //https://www.scala-sbt.org/1.x/docs/Cross-Build.html
 crossScalaVersions := {
-  List("2.12.7")
+  List("2.12.12")
 }


### PR DESCRIPTION
This should get rid of the scala 2.12.7 scala warning logs when building the secp256k1jni module, now it uses the same scala 2.12.x version we have for the rest of projects