### PR TITLE
Have makeOpReturnCommitment use random UTXO selection

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -593,7 +593,19 @@ abstract class Wallet
 
     val output = TransactionOutput(0.satoshis, scriptPubKey)
 
-    sendToOutputs(Vector(output), feeRate, fromAccount)
+    for {
+      (txBuilder, utxoInfos) <- fundRawTransactionInternal(
+        destinations = Vector(output),
+        feeRate = feeRate,
+        fromAccount = fromAccount,
+        coinSelectionAlgo = CoinSelectionAlgo.RandomSelection,
+        fromTagOpt = None)
+      tx <- finishSend(txBuilder,
+                       utxoInfos,
+                       CurrencyUnits.zero,
+                       feeRate,
+                       Vector.empty)
+    } yield tx
   }
 
   override def sendToOutputs(


### PR DESCRIPTION
Previously `makeOpReturnCommitment` would use `AccumulateLargest` for coin selection. This was a privacy leak since `makeOpReturnCommitment` does not spend any funds(besides fees) and thus can use any utxo.

This fixes it to use a random utxo instead of always our largest.