### PR TITLE
Remove hard coded bitcoind version eclair was depending on and switch…

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -726,7 +726,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
         uri = new URI("http://localhost:18333"),
         rpcUri = auth.bitcoindRpcUri,
         authCredentials = auth.bitcoinAuthOpt.get,
-        binary = BitcoindRpcTestUtil.getBinary(BitcoindVersion.V17)
+        binary = BitcoindRpcTestUtil.getBinary(BitcoindVersion.newest)
       )
       BitcoindRpcClient.withActorSystem(bitcoindInstance)
     }


### PR DESCRIPTION
… to latest version of bitcoind

Basically we were always using `V17` of bitcoind