### PR TITLE
Don't allow fee unit gen to be 0

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/FeeUnitGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/FeeUnitGen.scala
@@ -79,7 +79,7 @@ abstract class FeeUnitGen {
 
   /** Generates a FeeUnit based on the maxFee allowed for a transaction */
   def feeUnit(maxFee: Long): Gen[FeeUnit] = {
-    Gen.choose(1L, maxFee / 10000L).map { n =>
+    Gen.choose(1L, maxFee).map { n =>
       SatoshisPerKiloByte(Satoshis(n))
     }
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/FeeUnitGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/FeeUnitGen.scala
@@ -42,7 +42,7 @@ abstract class FeeUnitGen {
     */
   private def lowFee: Gen[Satoshis] = {
     Gen
-      .choose(0, 100)
+      .choose(1, 100)
       .map(Satoshis(_))
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/FeeUnitGen.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/FeeUnitGen.scala
@@ -79,7 +79,7 @@ abstract class FeeUnitGen {
 
   /** Generates a FeeUnit based on the maxFee allowed for a transaction */
   def feeUnit(maxFee: Long): Gen[FeeUnit] = {
-    Gen.choose(0L, maxFee / 10000L).map { n =>
+    Gen.choose(1L, maxFee / 10000L).map { n =>
       SatoshisPerKiloByte(Satoshis(n))
     }
   }


### PR DESCRIPTION
We had a CI failure because we tried to broadcast a 0 fee transaction. Bitcoind will always reject these

https://github.com/bitcoin-s/bitcoin-s/runs/1531792984#step:5:840