### PR TITLE
Mask BIP39 password in the BIP39KeyManager

### DIFF
--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
@@ -44,6 +44,13 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
     assert(km != dummy)
   }
 
+  it must "not put the bip39 password in the toString" in {
+    val passpharse = "test-bip39-passpharse"
+    val km = withInitializedKeyManager(bip39PasswordOpt = Some(passpharse))
+    assert(!km.toString.contains(passpharse))
+    assert(km.toString.contains("Masked(bip39password)"))
+  }
+
   it must "initialize the key manager" in {
     val entropy = MnemonicCode.getEntropy256Bits
     val aesPasswordOpt = KeyManagerTestUtil.aesPasswordOpt

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -76,6 +76,19 @@ case class BIP39KeyManager(
   def getRootXPub: ExtPublicKey = {
     rootExtPrivKey.extPublicKey
   }
+
+  /** This is overriden because we do not have a type for bip39 passwords
+    * for which we can extend [[org.bitcoins.crypto.MaskedToString]]
+    */
+  override def toString: String = {
+    s"""
+       |BIP39KeyManager(
+       |    mnemonic=$mnemonic,
+       |    kmParams=$kmParams,
+       |    bip39PasswordOpt=${bip39PasswordOpt.map(_ =>
+      s"Masked(bip39password)")},
+       |    creationTime=$creationTime)""".stripMargin
+  }
 }
 
 object BIP39KeyManager


### PR DESCRIPTION
fixes #2344 

We might want to make a type for BIP39Password in the future, but for now I just override `BIP39KeyManager.toString`