### PR TITLE
Add ability to store ExtPrivateKey instead of Mnemonic

### DIFF
--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -366,7 +366,7 @@ object DLCOracle {
       case None           => decryptedMnemonic
     }
     if (!conf.seedExists()) {
-      WalletStorage.writeMnemonicToDisk(conf.kmConf.seedPath, toWrite)
+      WalletStorage.writeSeedToDisk(conf.kmConf.seedPath, toWrite)
     }
 
     val key =

--- a/docs/key-manager/key-manager.md
+++ b/docs/key-manager/key-manager.md
@@ -110,7 +110,7 @@ again after initializing it once. You can use the same `mnemonic` for different 
 val mainnetKmParams = KeyManagerParams(seedPath, HDPurposes.SegWit, MainNet)
 
 //we do not need to all `initializeWithMnemonic()` again as we have saved the seed to dis
-val mainnetKeyManager = BIP39KeyManager(mnemonic, mainnetKmParams, None, Instant.now)
+val mainnetKeyManager = BIP39KeyManager.fromMnemonic(mnemonic, mainnetKmParams, None, Instant.now)
 
 val mainnetXpub = mainnetKeyManager.getRootXPub
 

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
@@ -1,8 +1,6 @@
 package org.bitcoins.keymanager
 
 import com.typesafe.config.ConfigFactory
-
-import java.nio.file.{Files, Path}
 import org.bitcoins.core.crypto.BIP39Seed
 import org.bitcoins.core.crypto.ExtKeyVersion.SegWitMainNetPriv
 import org.bitcoins.core.util.TimeUtil
@@ -14,6 +12,8 @@ import org.bitcoins.testkit.core.gen.{CryptoGenerators, StringGenerators}
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.scalatest.{BeforeAndAfterEach, FutureOutcome}
+
+import java.nio.file.{Files, Path}
 
 class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
 
@@ -37,11 +37,19 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   def getAndWriteMnemonic(walletConf: WalletAppConfig): DecryptedMnemonic = {
     val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
     val decryptedMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now)
-    val encrypted =
-      EncryptedMnemonicHelper.encrypt(decryptedMnemonic, passphrase.get)
+    val encrypted = decryptedMnemonic.encrypt(passphrase.get)
     val seedPath = getSeedPath(walletConf)
-    WalletStorage.writeMnemonicToDisk(seedPath, encrypted)
+    WalletStorage.writeSeedToDisk(seedPath, encrypted)
     decryptedMnemonic
+  }
+
+  def getAndWriteXprv(walletConf: WalletAppConfig): DecryptedExtPrivKey = {
+    val xprv = CryptoGenerators.extPrivateKey.sampleSome
+    val decryptedExtPrivKey = DecryptedExtPrivKey(xprv, TimeUtil.now)
+    val encrypted = decryptedExtPrivKey.encrypt(passphrase.get)
+    val seedPath = getSeedPath(walletConf)
+    WalletStorage.writeSeedToDisk(seedPath, encrypted)
+    decryptedExtPrivKey
   }
 
   it must "write and read an encrypted mnemonic to disk" in {
@@ -54,14 +62,40 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       assert(walletConf.seedExists())
       val seedPath = getSeedPath(walletConf)
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, passphrase)
+        WalletStorage.decryptSeedFromDisk(seedPath, passphrase)
       read match {
-        case Right(readMnemonic) =>
+        case Right(readMnemonic: DecryptedMnemonic) =>
           assert(writtenMnemonic.mnemonicCode == readMnemonic.mnemonicCode)
           // Need to compare using getEpochSecond because when reading an epoch second
           // it will not include the milliseconds that writtenMnemonic will have
           assert(
             writtenMnemonic.creationTime.getEpochSecond == readMnemonic.creationTime.getEpochSecond)
+        case Right(xprv: DecryptedExtPrivKey) =>
+          fail(s"Parsed unexpected type of seed $xprv")
+        case Left(err) => fail(err.toString)
+      }
+  }
+
+  it must "write and read an encrypted seed to disk" in {
+    walletConf: WalletAppConfig =>
+      assert(!walletConf.seedExists())
+
+      val writtenXprv = getAndWriteXprv(walletConf)
+
+      // should have been written by now
+      assert(walletConf.seedExists())
+      val seedPath = getSeedPath(walletConf)
+      val read =
+        WalletStorage.decryptSeedFromDisk(seedPath, passphrase)
+      read match {
+        case Right(readXprv: DecryptedExtPrivKey) =>
+          assert(writtenXprv.xprv == readXprv.xprv)
+          // Need to compare using getEpochSecond because when reading an epoch second
+          // it will not include the milliseconds that writtenMnemonic will have
+          assert(
+            writtenXprv.creationTime.getEpochSecond == readXprv.creationTime.getEpochSecond)
+        case Right(readMnemonic: DecryptedMnemonic) =>
+          fail(s"Parsed unexpected type of seed $readMnemonic")
         case Left(err) => fail(err.toString)
       }
   }
@@ -72,19 +106,46 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
       val writtenMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now)
       val seedPath = getSeedPath(walletConf)
-      WalletStorage.writeMnemonicToDisk(seedPath, writtenMnemonic)
+      WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
 
       // should have been written by now
       assert(walletConf.seedExists())
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, None)
+        WalletStorage.decryptSeedFromDisk(seedPath, None)
       read match {
-        case Right(readMnemonic) =>
+        case Right(readMnemonic: DecryptedMnemonic) =>
           assert(writtenMnemonic.mnemonicCode == readMnemonic.mnemonicCode)
           // Need to compare using getEpochSecond because when reading an epoch second
           // it will not include the milliseconds that writtenMnemonic will have
           assert(
             writtenMnemonic.creationTime.getEpochSecond == readMnemonic.creationTime.getEpochSecond)
+        case Right(xprv: DecryptedExtPrivKey) =>
+          fail(s"Parsed unexpected type of seed $xprv")
+        case Left(err) => fail(err.toString)
+      }
+  }
+
+  it must "write and read an unencrypted xprv to disk" in {
+    walletConf: WalletAppConfig =>
+      assert(!walletConf.seedExists())
+      val xprv = CryptoGenerators.extPrivateKey.sampleSome
+      val writtenXprv = DecryptedExtPrivKey(xprv, TimeUtil.now)
+      val seedPath = getSeedPath(walletConf)
+      WalletStorage.writeSeedToDisk(seedPath, writtenXprv)
+
+      // should have been written by now
+      assert(walletConf.seedExists())
+      val read =
+        WalletStorage.decryptSeedFromDisk(seedPath, None)
+      read match {
+        case Right(readXprv: DecryptedExtPrivKey) =>
+          assert(writtenXprv.xprv == readXprv.xprv)
+          // Need to compare using getEpochSecond because when reading an epoch second
+          // it will not include the milliseconds that writtenMnemonic will have
+          assert(
+            writtenXprv.creationTime.getEpochSecond == readXprv.creationTime.getEpochSecond)
+        case Right(readMnemonic: DecryptedMnemonic) =>
+          fail(s"Parsed unexpected type of seed $readMnemonic")
         case Left(err) => fail(err.toString)
       }
   }
@@ -103,14 +164,16 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
                                       newPasswordOpt = badPassphrase)
 
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, badPassphrase)
+        WalletStorage.decryptSeedFromDisk(seedPath, badPassphrase)
       read match {
-        case Right(readMnemonic) =>
+        case Right(readMnemonic: DecryptedMnemonic) =>
           assert(writtenMnemonic.mnemonicCode == readMnemonic.mnemonicCode)
           // Need to compare using getEpochSecond because when reading an epoch second
           // it will not include the milliseconds that writtenMnemonic will have
           assert(
             writtenMnemonic.creationTime.getEpochSecond == readMnemonic.creationTime.getEpochSecond)
+        case Right(xprv: DecryptedExtPrivKey) =>
+          fail(s"Parsed unexpected type of seed $xprv")
         case Left(err) => fail(err.toString)
       }
   }
@@ -121,7 +184,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
       val writtenMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now)
       val seedPath = getSeedPath(walletConf)
-      WalletStorage.writeMnemonicToDisk(seedPath, writtenMnemonic)
+      WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
 
       assert(walletConf.seedExists())
 
@@ -130,14 +193,16 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
                                       newPasswordOpt = badPassphrase)
 
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, badPassphrase)
+        WalletStorage.decryptSeedFromDisk(seedPath, badPassphrase)
       read match {
-        case Right(readMnemonic) =>
+        case Right(readMnemonic: DecryptedMnemonic) =>
           assert(writtenMnemonic.mnemonicCode == readMnemonic.mnemonicCode)
           // Need to compare using getEpochSecond because when reading an epoch second
           // it will not include the milliseconds that writtenMnemonic will have
           assert(
             writtenMnemonic.creationTime.getEpochSecond == readMnemonic.creationTime.getEpochSecond)
+        case Right(xprv: DecryptedExtPrivKey) =>
+          fail(s"Parsed unexpected type of seed $xprv")
         case Left(err) => fail(err.toString)
       }
   }
@@ -156,14 +221,16 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
                                       newPasswordOpt = None)
 
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, None)
+        WalletStorage.decryptSeedFromDisk(seedPath, None)
       read match {
-        case Right(readMnemonic) =>
+        case Right(readMnemonic: DecryptedMnemonic) =>
           assert(writtenMnemonic.mnemonicCode == readMnemonic.mnemonicCode)
           // Need to compare using getEpochSecond because when reading an epoch second
           // it will not include the milliseconds that writtenMnemonic will have
           assert(
             writtenMnemonic.creationTime.getEpochSecond == readMnemonic.creationTime.getEpochSecond)
+        case Right(xprv: DecryptedExtPrivKey) =>
+          fail(s"Parsed unexpected type of seed $xprv")
         case Left(err) => fail(err.toString)
       }
   }
@@ -204,7 +271,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
       val writtenMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now)
       val seedPath = getSeedPath(walletConf)
-      WalletStorage.writeMnemonicToDisk(seedPath, writtenMnemonic)
+      WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
 
       assert(walletConf.seedExists())
 
@@ -229,9 +296,8 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       Files.write(seedPath, badJson.getBytes())
 
       val read =
-        WalletStorage.decryptMnemonicFromDisk(
-          seedPath,
-          Some(BIP39KeyManager.badPassphrase))
+        WalletStorage.decryptSeedFromDisk(seedPath,
+                                          Some(BIP39KeyManager.badPassphrase))
 
       read match {
         case Right(readMnemonic) =>
@@ -253,7 +319,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       Files.createDirectories(seedPath.getParent)
       Files.write(seedPath, badJson.getBytes())
 
-      val read = WalletStorage.decryptMnemonicFromDisk(seedPath, None)
+      val read = WalletStorage.decryptSeedFromDisk(seedPath, None)
 
       read match {
         case Right(readMnemonic) =>
@@ -279,7 +345,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       Files.write(seedPath, badJson.getBytes())
 
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, passphrase)
+        WalletStorage.decryptSeedFromDisk(seedPath, passphrase)
 
       read match {
         case Left(JsonParsingError(_))  => succeed
@@ -301,7 +367,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       Files.write(seedPath, badJson.getBytes())
 
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, None)
+        WalletStorage.decryptSeedFromDisk(seedPath, None)
 
       read match {
         case Left(JsonParsingError(_))  => succeed
@@ -313,7 +379,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
     walletConf =>
       val _ = getAndWriteMnemonic(walletConf)
       val seedPath = getSeedPath(walletConf)
-      val read = WalletStorage.decryptMnemonicFromDisk(seedPath, badPassphrase)
+      val read = WalletStorage.decryptSeedFromDisk(seedPath, badPassphrase)
 
       read match {
         case Right(_) =>
@@ -338,7 +404,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       Files.write(seedPath, badJson.getBytes())
 
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, passphrase)
+        WalletStorage.decryptSeedFromDisk(seedPath, passphrase)
 
       read match {
         case Left(JsonParsingError(_))  => succeed
@@ -359,7 +425,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       Files.write(seedPath, badJson.getBytes())
 
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, None)
+        WalletStorage.decryptSeedFromDisk(seedPath, None)
 
       read match {
         case Left(JsonParsingError(_))  => succeed
@@ -381,7 +447,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       Files.write(seedPath, badJson.getBytes())
 
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, passphrase)
+        WalletStorage.decryptSeedFromDisk(seedPath, passphrase)
 
       read match {
         case Left(JsonParsingError(_))  => succeed
@@ -401,7 +467,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       Files.createDirectories(seedPath.getParent)
       Files.write(seedPath, badJson.getBytes())
 
-      val read = WalletStorage.decryptMnemonicFromDisk(seedPath, None)
+      val read = WalletStorage.decryptSeedFromDisk(seedPath, None)
 
       read match {
         case Left(JsonParsingError(_))  => succeed
@@ -423,7 +489,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
     Files.write(seedPath, badJson.getBytes())
 
     val read =
-      WalletStorage.decryptMnemonicFromDisk(seedPath, passphrase)
+      WalletStorage.decryptSeedFromDisk(seedPath, passphrase)
 
     read match {
       case Left(JsonParsingError(_))  => succeed
@@ -436,7 +502,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       require(!walletConf.seedExists())
       val seedPath = getSeedPath(walletConf)
       val read =
-        WalletStorage.decryptMnemonicFromDisk(seedPath, None)
+        WalletStorage.decryptSeedFromDisk(seedPath, None)
 
       read match {
         case Left(NotFoundError)        => succeed
@@ -491,7 +557,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
       val writtenMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now)
       val seedPath = getSeedPath(walletConf)
-      WalletStorage.writeMnemonicToDisk(seedPath, writtenMnemonic)
+      WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
 
       val password = getBIP39PasswordOpt().getOrElse(BIP39Seed.EMPTY_PASSWORD)
       val keyVersion = SegWitMainNetPriv
@@ -539,7 +605,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
           s"bitcoin-s.wallet.walletName = $otherWalletName"))
 
       assert(!walletConfB.seedExists())
-      getAndWriteMnemonic(walletConfB)
+      getAndWriteXprv(walletConfB)
       assert(walletConfB.seedExists())
 
       val expectedParentDir =
@@ -550,9 +616,9 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       assert(walletConfA.seedPath != walletConfB.seedPath)
 
       val mnemonicAE =
-        WalletStorage.decryptMnemonicFromDisk(walletConfA.seedPath, passphrase)
+        WalletStorage.decryptSeedFromDisk(walletConfA.seedPath, passphrase)
       val mnemonicBE =
-        WalletStorage.decryptMnemonicFromDisk(walletConfB.seedPath, passphrase)
+        WalletStorage.decryptSeedFromDisk(walletConfB.seedPath, passphrase)
 
       (mnemonicAE, mnemonicBE) match {
         case (Left(_), Left(_)) | (Right(_), Left(_)) | (Left(_), Right(_)) =>

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
@@ -1,12 +1,10 @@
 package org.bitcoins.keymanager.bip39
 
-import java.nio.file.Files
-
 import org.bitcoins.core.api.keymanager.KeyManagerApi
 import org.bitcoins.core.config.{MainNet, RegTest}
-import org.bitcoins.core.crypto.MnemonicCode
+import org.bitcoins.core.crypto.{BIP39Seed, MnemonicCode}
 import org.bitcoins.core.hd._
-import org.bitcoins.core.util.TimeUtil
+import org.bitcoins.core.util.{HDUtil, TimeUtil}
 import org.bitcoins.core.wallet.keymanagement
 import org.bitcoins.core.wallet.keymanagement.KeyManagerUnlockError.JsonParsingError
 import org.bitcoins.core.wallet.keymanagement.{
@@ -21,6 +19,8 @@ import org.bitcoins.testkit.keymanager.{
   KeyManagerTestUtil
 }
 import scodec.bits.BitVector
+
+import java.nio.file.Files
 
 class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
   val purpose = HDPurposes.Legacy
@@ -44,13 +44,6 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
     assert(km != dummy)
   }
 
-  it must "not put the bip39 password in the toString" in {
-    val passpharse = "test-bip39-passpharse"
-    val km = withInitializedKeyManager(bip39PasswordOpt = Some(passpharse))
-    assert(!km.toString.contains(passpharse))
-    assert(km.toString.contains("Masked(bip39password)"))
-  }
-
   it must "initialize the key manager" in {
     val entropy = MnemonicCode.getEntropy256Bits
     val aesPasswordOpt = KeyManagerTestUtil.aesPasswordOpt
@@ -63,17 +56,18 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
            "KeyManager did not write the seed to disk!")
 
     val decryptedE =
-      WalletStorage.decryptMnemonicFromDisk(seedPath, aesPasswordOpt)
+      WalletStorage.decryptSeedFromDisk(seedPath, aesPasswordOpt)
 
-    val mnemonic = decryptedE match {
-      case Right(m) => m
+    decryptedE match {
+      case Right(mnemonic: DecryptedMnemonic) =>
+        assert(mnemonic.mnemonicCode.toEntropy == entropy,
+               s"We did not read the same entropy that we wrote!")
+      case Right(xprv: DecryptedExtPrivKey) =>
+        fail(s"Parsed unexpected type of seed $xprv")
       case Left(err) =>
         fail(
           s"Failed to read mnemonic that was written by key manager with err=$err")
     }
-
-    assert(mnemonic.mnemonicCode.toEntropy == entropy,
-           s"We did not read the same entropy that we wrote!")
   }
 
   it must "initialize the key manager with a specific mnemonic" in {
@@ -134,7 +128,7 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
     assert(api.deriveXPub(hdAccount) == direct.deriveXPub(hdAccount))
   }
 
-  it must "write a key manager to disk then initialize a key manager from a params" in {
+  it must "write a mnemonic key manager to disk then initialize a key manager from a params" in {
     val kmParams = buildParams()
     val bip39Pw = KeyManagerTestUtil.bip39Password
     val direct =
@@ -142,8 +136,39 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
 
     val decryptedMnemonic = DecryptedMnemonic(mnemonic, direct.creationTime)
     val password = AesPassword.fromNonEmptyString("password")
-    WalletStorage.writeMnemonicToDisk(kmParams.seedPath,
-                                      decryptedMnemonic.encrypt(password))
+    WalletStorage.writeSeedToDisk(kmParams.seedPath,
+                                  decryptedMnemonic.encrypt(password))
+
+    val directXpub = direct.getRootXPub
+    val api =
+      BIP39KeyManager
+        .fromParams(kmParams, Some(password), Some(bip39Pw))
+        .getOrElse(fail())
+
+    val apiXpub = api.getRootXPub
+
+    assert(apiXpub == directXpub,
+           s"We don't have initialization symmetry between our constructors!")
+
+    //we should be able to derive the same child xpub
+    assert(api.deriveXPub(hdAccount) == direct.deriveXPub(hdAccount))
+  }
+
+  it must "write a xprv key manager to disk then initialize a key manager from a params" in {
+    val kmParams = buildParams()
+    val bip39Pw = KeyManagerTestUtil.bip39Password
+
+    val direct =
+      BIP39KeyManager(mnemonic, kmParams, Some(bip39Pw), TimeUtil.now)
+    val seed = BIP39Seed.fromMnemonic(mnemonic, Some(bip39Pw))
+    val privVersion = HDUtil.getXprivVersion(kmParams.purpose, kmParams.network)
+    val rootExtPrivKey = seed.toExtPrivateKey(privVersion)
+
+    val decryptedXprv =
+      DecryptedExtPrivKey(rootExtPrivKey, direct.creationTime)
+    val password = AesPassword.fromNonEmptyString("password")
+    WalletStorage.writeSeedToDisk(kmParams.seedPath,
+                                  decryptedXprv.encrypt(password))
 
     val directXpub = direct.getRootXPub
     val api =

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
@@ -84,7 +84,8 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
 
   it must "initialize a key manager to the same xpub if we call constructor directly or use CreateKeyManagerApi" in {
     val kmParams = buildParams()
-    val direct = BIP39KeyManager(mnemonic, kmParams, None, TimeUtil.now)
+    val direct =
+      BIP39KeyManager.fromMnemonic(mnemonic, kmParams, None, TimeUtil.now)
 
     val directXpub = direct.getRootXPub
 
@@ -108,7 +109,10 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
     val kmParams = buildParams()
     val bip39Pw = KeyManagerTestUtil.bip39Password
     val direct =
-      BIP39KeyManager(mnemonic, kmParams, Some(bip39Pw), TimeUtil.now)
+      BIP39KeyManager.fromMnemonic(mnemonic,
+                                   kmParams,
+                                   Some(bip39Pw),
+                                   TimeUtil.now)
 
     val directXpub = direct.getRootXPub
 
@@ -132,7 +136,10 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
     val kmParams = buildParams()
     val bip39Pw = KeyManagerTestUtil.bip39Password
     val direct =
-      BIP39KeyManager(mnemonic, kmParams, Some(bip39Pw), TimeUtil.now)
+      BIP39KeyManager.fromMnemonic(mnemonic,
+                                   kmParams,
+                                   Some(bip39Pw),
+                                   TimeUtil.now)
 
     val decryptedMnemonic = DecryptedMnemonic(mnemonic, direct.creationTime)
     val password = AesPassword.fromNonEmptyString("password")
@@ -159,7 +166,10 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
     val bip39Pw = KeyManagerTestUtil.bip39Password
 
     val direct =
-      BIP39KeyManager(mnemonic, kmParams, Some(bip39Pw), TimeUtil.now)
+      BIP39KeyManager.fromMnemonic(mnemonic,
+                                   kmParams,
+                                   Some(bip39Pw),
+                                   TimeUtil.now)
     val seed = BIP39Seed.fromMnemonic(mnemonic, Some(bip39Pw))
     val privVersion = HDUtil.getXprivVersion(kmParams.purpose, kmParams.network)
     val rootExtPrivKey = seed.toExtPrivateKey(privVersion)
@@ -189,7 +199,10 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
     val kmParams = buildParams()
     val bip39Pw = KeyManagerTestUtil.bip39Password
     val direct =
-      BIP39KeyManager(mnemonic, kmParams, Some(bip39Pw), TimeUtil.now)
+      BIP39KeyManager.fromMnemonic(mnemonic,
+                                   kmParams,
+                                   Some(bip39Pw),
+                                   TimeUtil.now)
 
     val directXpub = direct.getRootXPub
 
@@ -215,11 +228,14 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
     val bip39Pw = KeyManagerTestUtil.bip39PasswordNonEmpty
 
     val withPassword =
-      BIP39KeyManager(mnemonic, kmParams, Some(bip39Pw), TimeUtil.now)
+      BIP39KeyManager.fromMnemonic(mnemonic,
+                                   kmParams,
+                                   Some(bip39Pw),
+                                   TimeUtil.now)
     val withPasswordXpub = withPassword.getRootXPub
 
     val noPassword =
-      BIP39KeyManager(mnemonic, kmParams, None, TimeUtil.now)
+      BIP39KeyManager.fromMnemonic(mnemonic, kmParams, None, TimeUtil.now)
 
     val noPwXpub = noPassword.getRootXPub
 

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
@@ -96,7 +96,7 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
     val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
     val mnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now)
     val seedPath = tempDir.resolve(WalletStorage.ENCRYPTED_SEED_FILE_NAME)
-    WalletStorage.writeMnemonicToDisk(seedPath, mnemonic)
+    WalletStorage.writeSeedToDisk(seedPath, mnemonic)
 
     config.start().map { _ =>
       assert(Files.exists(seedPath), "We should not delete the old seed!")

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/EncryptedMnemonic.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/EncryptedMnemonic.scala
@@ -27,25 +27,12 @@ sealed trait DecryptedSeedState extends SeedState {
 
 case class DecryptedMnemonic(mnemonicCode: MnemonicCode, creationTime: Instant)
     extends DecryptedSeedState {
-  override protected def strToEncrypt: String = mnemonicCode.words.mkString(" ")
+  override protected val strToEncrypt: String = mnemonicCode.words.mkString(" ")
 }
 
 case class DecryptedExtPrivKey(xprv: ExtPrivateKey, creationTime: Instant)
     extends DecryptedSeedState {
-
-  override def encrypt(aesPassword: AesPassword): EncryptedSeed = {
-    ByteVector.encodeUtf8(xprv.toStringSensitive) match {
-      case Left(err) => throw err
-      case Right(str) =>
-        val (key, salt) = aesPassword.toKey
-
-        val encrypted = AesCrypt.encrypt(str, key)
-
-        EncryptedSeed(encrypted, salt, creationTime)
-    }
-  }
-
-  override protected def strToEncrypt: String = xprv.toStringSensitive
+  override protected val strToEncrypt: String = xprv.toStringSensitive
 }
 
 case class EncryptedSeed(

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/EncryptedMnemonic.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/EncryptedMnemonic.scala
@@ -1,32 +1,60 @@
 package org.bitcoins.keymanager
 
-import java.time.Instant
-
 import org.bitcoins.core.compat.CompatEither
 import org.bitcoins.core.crypto._
 import org.bitcoins.crypto.{AesCrypt, AesEncryptedData, AesPassword, AesSalt}
 import scodec.bits.ByteVector
 
+import java.time.Instant
 import scala.util.{Failure, Success, Try}
 
-sealed trait MnemonicState {
+sealed trait SeedState {
   def creationTime: Instant
 }
 
-case class DecryptedMnemonic(mnemonicCode: MnemonicCode, creationTime: Instant)
-    extends MnemonicState {
+sealed trait DecryptedSeedState extends SeedState {
+  protected def strToEncrypt: String
 
-  def encrypt(password: AesPassword): EncryptedMnemonic =
-    EncryptedMnemonicHelper.encrypt(this, password)
+  def encrypt(password: AesPassword): EncryptedSeed = {
+    val Right(clearText) = ByteVector.encodeUtf8(strToEncrypt)
+    val (key, salt) = password.toKey
+
+    val encrypted = AesCrypt.encrypt(clearText, key)
+
+    EncryptedSeed(encrypted, salt, creationTime)
+  }
 }
 
-case class EncryptedMnemonic(
+case class DecryptedMnemonic(mnemonicCode: MnemonicCode, creationTime: Instant)
+    extends DecryptedSeedState {
+  override protected def strToEncrypt: String = mnemonicCode.words.mkString(" ")
+}
+
+case class DecryptedExtPrivKey(xprv: ExtPrivateKey, creationTime: Instant)
+    extends DecryptedSeedState {
+
+  override def encrypt(aesPassword: AesPassword): EncryptedSeed = {
+    ByteVector.encodeUtf8(xprv.toStringSensitive) match {
+      case Left(err) => throw err
+      case Right(str) =>
+        val (key, salt) = aesPassword.toKey
+
+        val encrypted = AesCrypt.encrypt(str, key)
+
+        EncryptedSeed(encrypted, salt, creationTime)
+    }
+  }
+
+  override protected def strToEncrypt: String = xprv.toStringSensitive
+}
+
+case class EncryptedSeed(
     value: AesEncryptedData,
     salt: AesSalt,
     creationTime: Instant)
-    extends MnemonicState {
+    extends SeedState {
 
-  def toMnemonic(password: AesPassword): Try[MnemonicCode] = {
+  private def decryptStr(password: AesPassword): Try[String] = {
     val key = password.toKey(salt)
     val either = AesCrypt.decrypt(value, key)
     CompatEither(either).toTry.flatMap { decrypted =>
@@ -35,28 +63,19 @@ case class EncryptedMnemonic(
           // when failing to decode this to a UTF-8 string
           // we assume it's because of a bad password
           Failure(ReadMnemonicError.DecryptionError)
-
-        case Right(wordsStr) =>
-          val wordsVec = wordsStr.split(" ").toVector
-          Success(MnemonicCode.fromWords(wordsVec))
+        case Right(str) => Success(str)
       }
     }
   }
-}
 
-object EncryptedMnemonicHelper {
+  def toMnemonic(password: AesPassword): Try[MnemonicCode] = {
+    decryptStr(password).map { wordsStr =>
+      val wordsVec = wordsStr.split(" ").toVector
+      MnemonicCode.fromWords(wordsVec)
+    }
+  }
 
-  def encrypt(
-      mnemonic: DecryptedMnemonic,
-      password: AesPassword): EncryptedMnemonic = {
-    val wordsStr = mnemonic.mnemonicCode.words.mkString(" ")
-    val Right(clearText) = ByteVector.encodeUtf8(wordsStr)
-
-    val (key, salt) = password.toKey
-
-    val encryted = AesCrypt
-      .encrypt(clearText, key)
-
-    EncryptedMnemonic(encryted, salt, mnemonic.creationTime)
+  def toExtPrivKey(password: AesPassword): Try[ExtPrivateKey] = {
+    decryptStr(password).map(ExtPrivateKey.fromString)
   }
 }

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/EncryptedMnemonic.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/EncryptedMnemonic.scala
@@ -25,12 +25,16 @@ sealed trait DecryptedSeedState extends SeedState {
   }
 }
 
-case class DecryptedMnemonic(mnemonicCode: MnemonicCode, creationTime: Instant)
+case class DecryptedMnemonic(
+    private[keymanager] val mnemonicCode: MnemonicCode,
+    creationTime: Instant)
     extends DecryptedSeedState {
   override protected val strToEncrypt: String = mnemonicCode.words.mkString(" ")
 }
 
-case class DecryptedExtPrivKey(xprv: ExtPrivateKey, creationTime: Instant)
+case class DecryptedExtPrivKey(
+    private[keymanager] val xprv: ExtPrivateKey,
+    creationTime: Instant)
     extends DecryptedSeedState {
   override protected val strToEncrypt: String = xprv.toStringSensitive
 }

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/WalletStorage.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/WalletStorage.scala
@@ -43,9 +43,7 @@ object WalletStorage extends KeyManagerLogger {
   /**
     * Writes the mnemonic to disk.
     * If we encounter a file in the place we're about
-    * to write to, we move it to a backup location
-    * with the current epoch timestamp as part of
-    * the file name.
+    * to write to, an error will be thrown.
     */
   def writeSeedToDisk(seedPath: Path, seed: SeedState): Path = {
     seed match {
@@ -61,9 +59,7 @@ object WalletStorage extends KeyManagerLogger {
   /**
     * Writes the encrypted mnemonic to disk.
     * If we encounter a file in the place we're about
-    * to write to, we move it to a backup location
-    * with the current epoch timestamp as part of
-    * the file name.
+    * to write to, an error will be thrown.
     */
   def writeSeedToDisk(seedPath: Path, seed: EncryptedSeed): Path = {
     val encrypted = seed.value
@@ -83,9 +79,7 @@ object WalletStorage extends KeyManagerLogger {
   /**
     * Writes the unencrypted mnemonic to disk.
     * If we encounter a file in the place we're about
-    * to write to, we move it to a backup location
-    * with the current epoch timestamp as part of
-    * the file name.
+    * to write to, an error will be thrown.
     */
   def writeSeedToDisk(seedPath: Path, mnemonic: DecryptedMnemonic): Path = {
     val mnemonicCode = mnemonic.mnemonicCode
@@ -104,9 +98,7 @@ object WalletStorage extends KeyManagerLogger {
   /**
     * Writes the unencrypted xprv to disk.
     * If we encounter a file in the place we're about
-    * to write to, we move it to a backup location
-    * with the current epoch timestamp as part of
-    * the file name.
+    * to write to, an error will be thrown.
     */
   def writeSeedToDisk(seedPath: Path, extKey: DecryptedExtPrivKey): Path = {
     val jsObject = {
@@ -120,6 +112,11 @@ object WalletStorage extends KeyManagerLogger {
     writeSeedJsonToDisk(seedPath, jsObject)
   }
 
+  /**
+    * Writes a seed's json output to disk.
+    * If we encounter a file in the place we're about
+    * to write to, an error will be thrown.
+    */
   private def writeSeedJsonToDisk(seedPath: Path, jsObject: Obj): Path = {
     logger.info(s"Writing seed to $seedPath")
 

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/WalletStorage.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/WalletStorage.scala
@@ -1,15 +1,14 @@
 package org.bitcoins.keymanager
 
+import org.bitcoins.core.compat._
+import org.bitcoins.core.crypto._
+import org.bitcoins.crypto._
+import scodec.bits.ByteVector
+import ujson._
+
 import java.nio.file.{Files, Path}
 import java.time.Instant
 import java.util.NoSuchElementException
-
-import org.bitcoins.core.compat._
-import org.bitcoins.core.crypto._
-import org.bitcoins.crypto.{AesEncryptedData, AesIV, AesPassword, AesSalt}
-import scodec.bits.ByteVector
-import ujson.{Obj, Value}
-
 import scala.util.{Failure, Success, Try}
 
 object WalletStorage extends KeyManagerLogger {
@@ -20,6 +19,9 @@ object WalletStorage extends KeyManagerLogger {
     "encrypted-bitcoin-s-seed.json"
 
   import org.bitcoins.core.compat.JavaConverters._
+
+  /** Epoch time of the mainnet Genesis Block */
+  val GENESIS_TIME = 1231006505L
 
   /** Start of bitcoin-s wallet project, Block 555,990 block time on 2018-12-28 */
   val FIRST_BITCOIN_S_WALLET_TIME = 1546042867L
@@ -35,6 +37,7 @@ object WalletStorage extends KeyManagerLogger {
     val SALT = "salt"
     val CREATION_TIME = "creationTime"
     val MNEMONIC_SEED = "mnemonicSeed"
+    val XPRV = "xprv"
   }
 
   /**
@@ -44,12 +47,14 @@ object WalletStorage extends KeyManagerLogger {
     * with the current epoch timestamp as part of
     * the file name.
     */
-  def writeMnemonicToDisk(seedPath: Path, mnemonic: MnemonicState): Path = {
-    mnemonic match {
+  def writeSeedToDisk(seedPath: Path, seed: SeedState): Path = {
+    seed match {
       case decryptedMnemonic: DecryptedMnemonic =>
-        writeMnemonicToDisk(seedPath, decryptedMnemonic)
-      case encryptedMnemonic: EncryptedMnemonic =>
-        writeMnemonicToDisk(seedPath, encryptedMnemonic)
+        writeSeedToDisk(seedPath, decryptedMnemonic)
+      case decryptedExtPrivKey: DecryptedExtPrivKey =>
+        writeSeedToDisk(seedPath, decryptedExtPrivKey)
+      case encrypted: EncryptedSeed =>
+        writeSeedToDisk(seedPath, encrypted)
     }
   }
 
@@ -60,20 +65,19 @@ object WalletStorage extends KeyManagerLogger {
     * with the current epoch timestamp as part of
     * the file name.
     */
-  def writeMnemonicToDisk(seedPath: Path, mnemonic: EncryptedMnemonic): Path = {
-    val encrypted = mnemonic.value
+  def writeSeedToDisk(seedPath: Path, seed: EncryptedSeed): Path = {
+    val encrypted = seed.value
     val jsObject = {
       import MnemonicJsonKeys._
       ujson.Obj(
         IV -> encrypted.iv.hex,
         CIPHER_TEXT -> encrypted.cipherText.toHex,
-        SALT -> mnemonic.salt.bytes.toHex,
-        CREATION_TIME -> ujson.Num(
-          mnemonic.creationTime.getEpochSecond.toDouble)
+        SALT -> seed.salt.bytes.toHex,
+        CREATION_TIME -> Num(seed.creationTime.getEpochSecond.toDouble)
       )
     }
 
-    writeMnemonicJsonToDisk(seedPath, jsObject)
+    writeSeedJsonToDisk(seedPath, jsObject)
   }
 
   /**
@@ -83,7 +87,7 @@ object WalletStorage extends KeyManagerLogger {
     * with the current epoch timestamp as part of
     * the file name.
     */
-  def writeMnemonicToDisk(seedPath: Path, mnemonic: DecryptedMnemonic): Path = {
+  def writeSeedToDisk(seedPath: Path, mnemonic: DecryptedMnemonic): Path = {
     val mnemonicCode = mnemonic.mnemonicCode
     val jsObject = {
       import MnemonicJsonKeys._
@@ -94,18 +98,37 @@ object WalletStorage extends KeyManagerLogger {
       )
     }
 
-    writeMnemonicJsonToDisk(seedPath, jsObject)
+    writeSeedJsonToDisk(seedPath, jsObject)
   }
 
-  private def writeMnemonicJsonToDisk(seedPath: Path, jsObject: Obj): Path = {
-    logger.info(s"Writing mnemonic to $seedPath")
+  /**
+    * Writes the unencrypted xprv to disk.
+    * If we encounter a file in the place we're about
+    * to write to, we move it to a backup location
+    * with the current epoch timestamp as part of
+    * the file name.
+    */
+  def writeSeedToDisk(seedPath: Path, extKey: DecryptedExtPrivKey): Path = {
+    val jsObject = {
+      import MnemonicJsonKeys._
+      ujson.Obj(
+        XPRV -> Str(extKey.xprv.toStringSensitive),
+        CREATION_TIME -> ujson.Num(extKey.creationTime.getEpochSecond.toDouble)
+      )
+    }
+
+    writeSeedJsonToDisk(seedPath, jsObject)
+  }
+
+  private def writeSeedJsonToDisk(seedPath: Path, jsObject: Obj): Path = {
+    logger.info(s"Writing seed to $seedPath")
 
     val writtenJs = ujson.write(jsObject)
 
     def writeJsToDisk(): Path = {
       Files.createDirectories(seedPath.getParent)
       val writtenPath = Files.write(seedPath, writtenJs.getBytes())
-      logger.trace(s"Wrote encrypted mnemonic to $seedPath")
+      logger.trace(s"Wrote encrypted seed to $seedPath")
 
       writtenPath
     }
@@ -116,7 +139,7 @@ object WalletStorage extends KeyManagerLogger {
     if (hasMnemonic) {
       logger.info(s"$seedPath already exists")
       throw new RuntimeException(
-        s"Attempting to overwrite an existing mnemonic seed, this is dangerous! path: $seedPath")
+        s"Attempting to overwrite an existing seed, this is dangerous! path: $seedPath")
     } else {
       logger.trace(s"$seedPath does not exist")
       writeJsToDisk()
@@ -135,33 +158,33 @@ object WalletStorage extends KeyManagerLogger {
     }
   }
 
+  private def readJsonFromDisk(
+      seedPath: Path): CompatEither[ReadMnemonicError, Value] = {
+    if (Files.isRegularFile(seedPath)) {
+      val rawJson = Files.readAllLines(seedPath).asScala.mkString("\n")
+      logger.debug(s"Read raw mnemonic from $seedPath")
+
+      Try(ujson.read(rawJson)) match {
+        case Failure(ujson.ParseException(clue, _, _, _)) =>
+          CompatLeft(ReadMnemonicError.JsonParsingError(clue))
+        case Failure(exception) => throw exception
+        case Success(value) =>
+          logger.debug(s"Parsed $seedPath into valid json")
+          CompatRight(value)
+      }
+    } else {
+      logger.error(s"Mnemonic not found at $seedPath")
+      CompatLeft(ReadMnemonicError.NotFoundError)
+    }
+  }
+
   /** Reads the raw encrypted mnemonic from disk,
     * performing no decryption
     */
   private def readEncryptedMnemonicFromDisk(
-      seedPath: Path): CompatEither[ReadMnemonicError, EncryptedMnemonic] = {
+      seedPath: Path): CompatEither[ReadMnemonicError, EncryptedSeed] = {
 
-    val jsonE: CompatEither[ReadMnemonicError, ujson.Value] = {
-      if (Files.isRegularFile(seedPath)) {
-        val rawJson = Files.readAllLines(seedPath).asScala.mkString("\n")
-        logger.debug(s"Read raw encrypted mnemonic from $seedPath")
-
-        Try {
-          ujson.read(rawJson)
-        } match {
-          case Failure(ujson.ParseException(clue, _, _, _)) =>
-            CompatLeft(ReadMnemonicError.JsonParsingError(clue))
-          case Failure(exception) => throw exception
-
-          case Success(value) =>
-            logger.debug(s"Parsed $seedPath into valid json")
-            CompatRight(value)
-        }
-      } else {
-        logger.error(s"Encrypted mnemonic not found at $seedPath")
-        CompatLeft(ReadMnemonicError.NotFoundError)
-      }
-    }
+    val jsonE = readJsonFromDisk(seedPath)
 
     import MnemonicJsonKeys._
     import ReadMnemonicError._
@@ -183,7 +206,7 @@ object WalletStorage extends KeyManagerLogger {
       }
     }
 
-    val encryptedEither: CompatEither[ReadMnemonicError, EncryptedMnemonic] =
+    val encryptedEither: CompatEither[ReadMnemonicError, EncryptedSeed] =
       readJsonTupleEither.flatMap {
         case (rawIv, rawCipherText, rawSalt, rawCreationTime) =>
           val encryptedOpt = for {
@@ -193,13 +216,13 @@ object WalletStorage extends KeyManagerLogger {
           } yield {
             logger.debug(
               s"Parsed contents of $seedPath into an EncryptedMnemonic")
-            EncryptedMnemonic(AesEncryptedData(cipherText, iv),
-                              salt,
-                              Instant.ofEpochSecond(rawCreationTime))
+            EncryptedSeed(AesEncryptedData(cipherText, iv),
+                          salt,
+                          Instant.ofEpochSecond(rawCreationTime))
           }
-          val toRight: Option[
-            CompatRight[ReadMnemonicError, EncryptedMnemonic]] = encryptedOpt
-            .map(CompatRight(_))
+          val toRight: Option[CompatRight[ReadMnemonicError, EncryptedSeed]] =
+            encryptedOpt
+              .map(CompatRight(_))
 
           toRight.getOrElse(
             CompatLeft(JsonParsingError("JSON contents was not hex strings")))
@@ -211,24 +234,7 @@ object WalletStorage extends KeyManagerLogger {
   private def readUnencryptedMnemonicFromDisk(
       seedPath: Path): CompatEither[ReadMnemonicError, DecryptedMnemonic] = {
 
-    val jsonE: CompatEither[ReadMnemonicError, ujson.Value] = {
-      if (Files.isRegularFile(seedPath)) {
-        val rawJson = Files.readAllLines(seedPath).asScala.mkString("\n")
-        logger.debug(s"Read raw mnemonic from $seedPath")
-
-        Try(ujson.read(rawJson)) match {
-          case Failure(ujson.ParseException(clue, _, _, _)) =>
-            CompatLeft(ReadMnemonicError.JsonParsingError(clue))
-          case Failure(exception) => throw exception
-          case Success(value) =>
-            logger.debug(s"Parsed $seedPath into valid json")
-            CompatRight(value)
-        }
-      } else {
-        logger.error(s"Mnemonic not found at $seedPath")
-        CompatLeft(ReadMnemonicError.NotFoundError)
-      }
-    }
+    val jsonE = readJsonFromDisk(seedPath)
 
     import MnemonicJsonKeys._
     import ReadMnemonicError._
@@ -267,25 +273,72 @@ object WalletStorage extends KeyManagerLogger {
     }
   }
 
+  /** Reads the raw unencrypted xprv from disk */
+  private def readUnencryptedSeedFromDisk(
+      seedPath: Path): CompatEither[ReadMnemonicError, DecryptedExtPrivKey] = {
+
+    val jsonE = readJsonFromDisk(seedPath)
+
+    import MnemonicJsonKeys._
+    import ReadMnemonicError._
+
+    val readJsonTupleEither: CompatEither[ReadMnemonicError, (String, Long)] =
+      jsonE.flatMap { json =>
+        logger.trace(s"Read mnemonic JSON: Masked(json)")
+        Try {
+          val creationTimeNum = parseCreationTime(json)
+          val xprvStr = json(XPRV).str
+          (xprvStr, creationTimeNum)
+        } match {
+          case Success(value) => CompatRight(value)
+          case Failure(exception) =>
+            CompatLeft(JsonParsingError(exception.getMessage))
+        }
+      }
+
+    readJsonTupleEither.flatMap {
+      case (str, rawCreationTime) =>
+        val decryptedExtPrivKeyT = ExtPrivateKey.fromStringT(str).map { xprv =>
+          logger.debug(s"Parsed contents of $seedPath into a DecryptedMnemonic")
+          DecryptedExtPrivKey(xprv, Instant.ofEpochSecond(rawCreationTime))
+        }
+
+        val toRight: Try[CompatRight[ReadMnemonicError, DecryptedExtPrivKey]] =
+          decryptedExtPrivKeyT
+            .map(CompatRight(_))
+
+        toRight.getOrElse(
+          CompatLeft(JsonParsingError("JSON contents was correctly formatted")))
+    }
+  }
+
   /**
     * Reads the wallet mnemonic from disk and tries to parse and
     * decrypt it
     */
-  def decryptMnemonicFromDisk(
+  def decryptSeedFromDisk(
       seedPath: Path,
       passphraseOpt: Option[AesPassword]): Either[
     ReadMnemonicError,
-    DecryptedMnemonic] = {
-    val decryptedEither: CompatEither[ReadMnemonicError, DecryptedMnemonic] =
+    DecryptedSeedState] = {
+    val decryptedEither: CompatEither[ReadMnemonicError, DecryptedSeedState] =
       passphraseOpt match {
         case Some(passphrase) =>
           val encryptedEither = readEncryptedMnemonicFromDisk(seedPath)
 
           encryptedEither.flatMap { encrypted =>
             encrypted.toMnemonic(passphrase) match {
-              case Failure(exc) =>
-                logger.error(s"Error when decrypting $encrypted: $exc")
-                CompatLeft(ReadMnemonicError.DecryptionError)
+              case Failure(_) =>
+                encrypted.toExtPrivKey(passphrase) match {
+                  case Failure(exc) =>
+                    logger.error(s"Error when decrypting $encrypted: $exc")
+                    CompatLeft(ReadMnemonicError.DecryptionError)
+                  case Success(xprv) =>
+                    logger.debug(s"Decrypted $encrypted successfully")
+                    val decryptedExtPrivKey =
+                      DecryptedExtPrivKey(xprv, encrypted.creationTime)
+                    CompatRight(decryptedExtPrivKey)
+                }
               case Success(mnemonic) =>
                 logger.debug(s"Decrypted $encrypted successfully")
                 val decryptedMnemonic =
@@ -294,7 +347,11 @@ object WalletStorage extends KeyManagerLogger {
             }
           }
         case None =>
-          readUnencryptedMnemonicFromDisk(seedPath)
+          readUnencryptedMnemonicFromDisk(seedPath) match {
+            case CompatLeft(_) =>
+              readUnencryptedSeedFromDisk(seedPath)
+            case CompatRight(mnemonic) => CompatRight(mnemonic)
+          }
       }
 
     decryptedEither match {
@@ -306,9 +363,9 @@ object WalletStorage extends KeyManagerLogger {
   def changeAesPassword(
       seedPath: Path,
       oldPasswordOpt: Option[AesPassword],
-      newPasswordOpt: Option[AesPassword]): MnemonicState = {
+      newPasswordOpt: Option[AesPassword]): SeedState = {
     logger.info("Changing encryption password for seed")
-    decryptMnemonicFromDisk(seedPath, oldPasswordOpt) match {
+    decryptSeedFromDisk(seedPath, oldPasswordOpt) match {
       case Left(err) => sys.error(err.toString)
       case Right(decrypted) =>
         val fileName = seedPath.getFileName.toString
@@ -323,7 +380,7 @@ object WalletStorage extends KeyManagerLogger {
             decrypted
         }
 
-        Try(writeMnemonicToDisk(seedPath, toWrite)) match {
+        Try(writeSeedToDisk(seedPath, toWrite)) match {
           case Failure(exception) =>
             logger.error(
               s"Failed to write new seed, backup of previous seed file can be found at $backup")
@@ -341,13 +398,18 @@ object WalletStorage extends KeyManagerLogger {
       privKeyVersion: ExtKeyPrivVersion,
       passphraseOpt: Option[AesPassword],
       bip39PasswordOpt: Option[String]): ExtPrivateKeyHardened = {
-    val mnemonicCode = decryptMnemonicFromDisk(seedPath, passphraseOpt) match {
+    val decryptedSeed = decryptSeedFromDisk(seedPath, passphraseOpt) match {
       case Left(error)     => sys.error(error.toString)
-      case Right(mnemonic) => mnemonic.mnemonicCode
+      case Right(mnemonic) => mnemonic
     }
-    val seed = BIP39Seed.fromMnemonic(mnemonicCode, bip39PasswordOpt)
 
-    seed.toExtPrivateKey(privKeyVersion).toHardened
+    decryptedSeed match {
+      case DecryptedMnemonic(mnemonicCode, _) =>
+        val seed = BIP39Seed.fromMnemonic(mnemonicCode, bip39PasswordOpt)
+        seed.toExtPrivateKey(privKeyVersion).toHardened
+      case DecryptedExtPrivKey(xprv, _) =>
+        xprv.toHardened
+    }
   }
 }
 

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -1,8 +1,5 @@
 package org.bitcoins.keymanager.bip39
 
-import java.nio.file.Files
-import java.time.Instant
-
 import org.bitcoins.core.api.keymanager.{
   BIP39KeyManagerApi,
   BIP39KeyManagerCreateApi,
@@ -22,41 +19,34 @@ import org.bitcoins.crypto.{AesPassword, Sign}
 import org.bitcoins.keymanager._
 import scodec.bits.BitVector
 
+import java.nio.file.Files
+import java.time.Instant
 import scala.util.{Failure, Success, Try}
 
 /**
   * This is a key manager implementation meant to represent an in memory
   * BIP39 key manager
   *
-  * @param mnemonic the mnemonic seed used for this wallet
+  * @param rootExtPrivKey the root seed used for this wallet
   * @param kmParams the parameters used to generate the right keychain
   * @see https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
   */
 case class BIP39KeyManager(
-    private val mnemonic: MnemonicCode,
+    private val rootExtPrivKey: ExtPrivateKey,
     kmParams: KeyManagerParams,
-    private val bip39PasswordOpt: Option[String],
     creationTime: Instant)
     extends BIP39KeyManagerApi
     with KeyManagerLogger {
 
-  private val seed = BIP39Seed.fromMnemonic(mnemonic, bip39PasswordOpt)
-
   override def equals(other: Any): Boolean =
     other match {
       case bip39Km: BIP39KeyManager =>
-        mnemonic == bip39Km.mnemonic &&
+        rootExtPrivKey == bip39Km.rootExtPrivKey &&
           kmParams == bip39Km.kmParams &&
-          bip39PasswordOpt == bip39Km.bip39PasswordOpt &&
           creationTime.getEpochSecond == bip39Km.creationTime.getEpochSecond
       case _ =>
         other.equals(this)
     }
-
-  private val privVersion: ExtKeyPrivVersion =
-    HDUtil.getXprivVersion(kmParams.purpose, kmParams.network)
-
-  private val rootExtPrivKey = seed.toExtPrivateKey(privVersion)
 
   /** Converts a non-sensitive DB representation of a UTXO into
     * a signable (and sensitive) real-world UTXO
@@ -76,24 +66,24 @@ case class BIP39KeyManager(
   def getRootXPub: ExtPublicKey = {
     rootExtPrivKey.extPublicKey
   }
-
-  /** This is overriden because we do not have a type for bip39 passwords
-    * for which we can extend [[org.bitcoins.crypto.MaskedToString]]
-    */
-  override def toString: String = {
-    s"""
-       |BIP39KeyManager(
-       |    mnemonic=$mnemonic,
-       |    kmParams=$kmParams,
-       |    bip39PasswordOpt=${bip39PasswordOpt.map(_ =>
-      s"Masked(bip39password)")},
-       |    creationTime=$creationTime)""".stripMargin
-  }
 }
 
 object BIP39KeyManager
     extends BIP39KeyManagerCreateApi[BIP39KeyManager]
     with BitcoinSLogger {
+
+  def apply(
+      mnemonic: MnemonicCode,
+      kmParams: KeyManagerParams,
+      bip39PasswordOpt: Option[String],
+      creationTime: Instant
+  ): BIP39KeyManager = {
+    val seed = BIP39Seed.fromMnemonic(mnemonic, bip39PasswordOpt)
+    val privVersion = HDUtil.getXprivVersion(kmParams.purpose, kmParams.network)
+    val rootExtPrivKey = seed.toExtPrivateKey(privVersion)
+    BIP39KeyManager(rootExtPrivKey, kmParams, creationTime)
+  }
+
   val badPassphrase: AesPassword = AesPassword.fromString("changeMe")
 
   /** Initializes the mnemonic seed and saves it to file */
@@ -128,12 +118,11 @@ object BIP39KeyManager
 
         val writableMnemonicE: CompatEither[
           KeyManagerInitializeError,
-          MnemonicState] =
+          SeedState] =
           mnemonicE.map { mnemonic =>
             val decryptedMnemonic = DecryptedMnemonic(mnemonic, time)
             aesPasswordOpt match {
-              case Some(aesPassword) =>
-                EncryptedMnemonicHelper.encrypt(decryptedMnemonic, aesPassword)
+              case Some(aesPassword) => decryptedMnemonic.encrypt(aesPassword)
               case None =>
                 decryptedMnemonic
             }
@@ -144,7 +133,7 @@ object BIP39KeyManager
           writable <- writableMnemonicE
         } yield {
           val mnemonicPath =
-            WalletStorage.writeMnemonicToDisk(seedPath, writable)
+            WalletStorage.writeSeedToDisk(seedPath, writable)
           logger.info(s"Saved wallet mnemonic to $mnemonicPath")
 
           BIP39KeyManager(mnemonic = mnemonic,
@@ -156,14 +145,17 @@ object BIP39KeyManager
         logger.info(
           s"Seed file already exists, attempting to initialize form existing seed file=$seedPath.")
 
-        WalletStorage.decryptMnemonicFromDisk(kmParams.seedPath,
-                                              aesPasswordOpt) match {
-          case Right(mnemonic) =>
+        WalletStorage.decryptSeedFromDisk(kmParams.seedPath,
+                                          aesPasswordOpt) match {
+          case Right(mnemonic: DecryptedMnemonic) =>
             CompatRight(
               BIP39KeyManager(mnemonic = mnemonic.mnemonicCode,
                               kmParams = kmParams,
                               bip39PasswordOpt = bip39PasswordOpt,
                               creationTime = mnemonic.creationTime))
+          case Right(xprv: DecryptedExtPrivKey) =>
+            val km = BIP39KeyManager(xprv.xprv, kmParams, xprv.creationTime)
+            CompatRight(km)
           case Left(err) =>
             CompatLeft(
               InitializeKeyManagerError.FailedToReadWrittenSeed(
@@ -213,15 +205,18 @@ object BIP39KeyManager
     ReadMnemonicError,
     BIP39KeyManager] = {
     val mnemonicCodeE =
-      WalletStorage.decryptMnemonicFromDisk(kmParams.seedPath, passwordOpt)
+      WalletStorage.decryptSeedFromDisk(kmParams.seedPath, passwordOpt)
 
     mnemonicCodeE match {
-      case Right(mnemonic) =>
+      case Right(mnemonic: DecryptedMnemonic) =>
         Right(
-          new BIP39KeyManager(mnemonic.mnemonicCode,
-                              kmParams,
-                              bip39PasswordOpt,
-                              mnemonic.creationTime))
+          BIP39KeyManager(mnemonic.mnemonicCode,
+                          kmParams,
+                          bip39PasswordOpt,
+                          mnemonic.creationTime))
+      case Right(xprv: DecryptedExtPrivKey) =>
+        val km = BIP39KeyManager(xprv.xprv, kmParams, xprv.creationTime)
+        Right(km)
       case Left(v) => Left(v)
     }
   }

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
@@ -28,14 +28,18 @@ object BIP39LockedKeyManager extends BitcoinSLogger {
     BIP39KeyManager] = {
     logger.debug(s"Trying to unlock wallet with seedPath=${kmParams.seedPath}")
     val resultE =
-      WalletStorage.decryptMnemonicFromDisk(kmParams.seedPath, passphraseOpt)
+      WalletStorage.decryptSeedFromDisk(kmParams.seedPath, passphraseOpt)
     resultE match {
-      case Right(mnemonic) =>
+      case Right(mnemonic: DecryptedMnemonic) =>
         Right(
           BIP39KeyManager(mnemonic.mnemonicCode,
                           kmParams,
                           bip39PasswordOpt,
                           mnemonic.creationTime))
+
+      case Right(xprv: DecryptedExtPrivKey) =>
+        val km = BIP39KeyManager(xprv.xprv, kmParams, xprv.creationTime)
+        Right(km)
 
       case Left(result) =>
         result match {

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
@@ -32,13 +32,13 @@ object BIP39LockedKeyManager extends BitcoinSLogger {
     resultE match {
       case Right(mnemonic: DecryptedMnemonic) =>
         Right(
-          BIP39KeyManager(mnemonic.mnemonicCode,
-                          kmParams,
-                          bip39PasswordOpt,
-                          mnemonic.creationTime))
+          BIP39KeyManager.fromMnemonic(mnemonic.mnemonicCode,
+                                       kmParams,
+                                       bip39PasswordOpt,
+                                       mnemonic.creationTime))
 
       case Right(xprv: DecryptedExtPrivKey) =>
-        val km = BIP39KeyManager(xprv.xprv, kmParams, xprv.creationTime)
+        val km = new BIP39KeyManager(xprv.xprv, kmParams, xprv.creationTime)
         Right(km)
 
       case Left(result) =>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/EncryptedMnemonicTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/EncryptedMnemonicTest.scala
@@ -2,7 +2,7 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.crypto.AesPassword
-import org.bitcoins.keymanager.{DecryptedMnemonic, EncryptedMnemonicHelper}
+import org.bitcoins.keymanager._
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.CryptoGenerators
 import org.bitcoins.testkit.util.BitcoinSUnitTest
@@ -18,19 +18,18 @@ class EncryptedMnemonicTest extends BitcoinSUnitTest {
 
     val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
     val mnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now)
-    val encrypted = EncryptedMnemonicHelper.encrypt(mnemonic, password)
+    val encrypted = mnemonic.encrypt(password)
 
     val decrypted = encrypted.toMnemonic(badPassword)
 
     assert(decrypted.isFailure)
-
   }
 
   it must "have encryption/decryption symmetry" in {
     forAll(CryptoGenerators.mnemonicCode, CryptoGenerators.aesPassword) {
       (mnemonicCode, password) =>
         val mnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now)
-        val encrypted = EncryptedMnemonicHelper.encrypt(mnemonic, password)
+        val encrypted = mnemonic.encrypt(password)
         val decrypted = encrypted.toMnemonic(password) match {
           case Success(clear) => clear
           case Failure(exc)   => fail(exc)


### PR DESCRIPTION
This is needed for #1420

This allows to read and write `ExtPrivateKey` as a seed.

To be able to use this I needed to change the `BIP39KeyManager` instead hold the root `ExtPrivateKey` instead of storing the mnemonic. This shouldn't change any functionality as we can are able to calculate the root key from the mnemonic