### PR TITLE
Rescan Improvements

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -159,13 +159,13 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
   it should "match block filters" in { wallet: Wallet =>
     for {
-      matched <- wallet.getMatchingBlocks(
+      height <- wallet.chainQueryApi.getFilterCount()
+      matched <- wallet.fetchFiltersInRange(
         scripts = Vector(
           // this is a random address which is included into the test block
           BitcoinAddress("n1RH2x3b3ah4TGQtgrmNAHfmad9wr8U2QY").scriptPubKey),
-        startOpt = None,
-        endOpt = None
-      )(system.dispatcher)
+        parallelismLevel = 1
+      )(heightRange = 0.to(height).toVector)
     } yield {
       assert(
         Vector(BlockMatchingResponse(blockHash = testBlockHash,

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -260,7 +260,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
     }
   }
 
-  private def fetchFiltersInRange(
+  private[wallet] def fetchFiltersInRange(
       scripts: Vector[ScriptPubKey],
       parallelismLevel: Int)(
       heightRange: Vector[Int]): Future[Vector[BlockMatchingResponse]] = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -111,6 +111,8 @@ private[wallet] trait RescanHandling extends WalletLogger {
           elements = range.toVector,
           f = fetchFiltersInRange(scripts, parallelismLevel),
           batchSize = batchSize)
+
+        _ <- downloadAndProcessBlocks(matched.map(_.blockHash.flip))
       } yield {
         logger.info(s"Matched ${matched.length} blocks on rescan")
         matched
@@ -128,10 +130,9 @@ private[wallet] trait RescanHandling extends WalletLogger {
       addressBatchSize: Int): Future[Unit] = {
     for {
       scriptPubKeys <- generateScriptPubKeys(account, addressBatchSize)
-      blocks <- matchBlocks(scriptPubKeys = scriptPubKeys,
-                            endOpt = endOpt,
-                            startOpt = startOpt)
-      _ <- downloadAndProcessBlocks(blocks)
+      _ <- matchBlocks(scriptPubKeys = scriptPubKeys,
+                       endOpt = endOpt,
+                       startOpt = startOpt)
       externalGap <- calcAddressGap(HDChainType.External, account)
       changeGap <- calcAddressGap(HDChainType.Change, account)
       res <-
@@ -249,7 +250,14 @@ private[wallet] trait RescanHandling extends WalletLogger {
                 address <- getNewChangeAddress(account)
               } yield prev :+ address
           }
-    } yield addresses.map(_.scriptPubKey) ++ changeAddresses.map(_.scriptPubKey)
+      spksDb <- scriptPubKeyDAO.findAll()
+    } yield {
+      val addrSpks =
+        addresses.map(_.scriptPubKey) ++ changeAddresses.map(_.scriptPubKey)
+      val otherSpks = spksDb.map(_.scriptPubKey)
+
+      (addrSpks ++ otherSpks).distinct
+    }
   }
 
   private def fetchFiltersInRange(


### PR DESCRIPTION
Previously, we would scan all filters and then afterwards download and process blocks. This would be bad because if we stopped the rescan in the middle it would have 0 effect, as well as could cause a rescan to fail because we do all the major network and computation functions all at once at the end. This makes it so we download a block once we find we need it.

This also fixes rescans so we use what is in our spk table