### PR TITLE
Fix BitGo fee provider parser

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/wallet/FeeRateApi.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/wallet/FeeRateApi.scala
@@ -19,7 +19,7 @@ case class BitGoResult(
     cpfpFeePerKb: SatoshisPerKiloByte,
     numBlocks: Int,
     confidence: Int,
-    multiplier: Int,
+    multiplier: Double,
     feeByBlockTarget: Map[Int, SatoshisPerKiloByte]
 ) extends FeeRateApiResult
 

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/BitGoFeeRateProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/BitGoFeeRateProvider.scala
@@ -10,7 +10,7 @@ import play.api.libs.json.{JsError, JsSuccess, Json}
 import scala.util.{Failure, Success, Try}
 
 /** Fetches fee rate from BitGo's API
-  * Documentation found here: https://www.bitgo.com/api/v2/#operation/v2.tx.getfeeestimate
+  * @see [[https://www.bitgo.com/api/v2/#operation/v2.tx.getfeeestimate]]
   */
 case class BitGoFeeRateProvider(blockTargetOpt: Option[Int])(implicit
     override val system: ActorSystem)
@@ -32,7 +32,7 @@ case class BitGoFeeRateProvider(blockTargetOpt: Option[Int])(implicit
       case JsError(error) =>
         Failure(
           new RuntimeException(
-            s"Unexpected error when parsing response: $error"))
+            s"Unexpected error when parsing response $str: $error"))
     }
   }
 


### PR DESCRIPTION
Was getting some CI failures because `multiplier` was unable to be parsed because it should have been a double.