### PR TITLE
Small DLC GUI touchups 

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -1,17 +1,10 @@
 package org.bitcoins.gui.dlc
 
-import java.io.File
-import java.nio.file.Files
-
 import javafx.event.{ActionEvent, EventHandler}
 import org.bitcoins.gui.{GlobalData, TaskRunner}
 import scalafx.geometry.{Insets, Pos}
 import scalafx.scene.control._
 import scalafx.scene.layout._
-import scalafx.stage.FileChooser
-import scalafx.stage.FileChooser.ExtensionFilter
-
-import scala.util.Properties
 
 class DLCPane(glassPane: VBox) {
 
@@ -28,25 +21,8 @@ class DLCPane(glassPane: VBox) {
   }
 
   private val exportButton = new Button("Export Result") {
-    alignmentInParent = Pos.BottomRight
-    onAction = _ => {
-      val txtFilter = new ExtensionFilter("Text Files", "*.txt")
-      val allExtensionFilter = new ExtensionFilter("All Files", "*")
-      val fileChooser = new FileChooser() {
-        extensionFilters.addAll(txtFilter, allExtensionFilter)
-        selectedExtensionFilter = txtFilter
-        initialDirectory = new File(Properties.userHome)
-      }
-
-      val selectedFile = fileChooser.showSaveDialog(null)
-
-      if (selectedFile != null) {
-        val bytes = resultTextArea.text.value.getBytes
-
-        Files.write(selectedFile.toPath, bytes)
-        ()
-      }
-    }
+    alignmentInParent = Pos.BottomLeft
+    onAction = _ => model.exportResult(resultTextArea.text.value)
   }
 
   private val resultArea = new BorderPane() {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -3,9 +3,9 @@ package org.bitcoins.gui.dlc
 import org.bitcoins.cli.CliCommand._
 import org.bitcoins.cli.{CliCommand, Config, ConsoleCli}
 import org.bitcoins.commons.serializers.Picklers._
-import org.bitcoins.core.protocol.dlc.DLCMessage._
 import org.bitcoins.core.config.MainNet
 import org.bitcoins.core.number.{Int32, UInt16, UInt32}
+import org.bitcoins.core.protocol.dlc.DLCMessage._
 import org.bitcoins.core.protocol.dlc.DLCStatus
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.protocol.transaction.Transaction
@@ -15,10 +15,13 @@ import org.bitcoins.gui.{GlobalData, TaskRunner}
 import scalafx.beans.property.ObjectProperty
 import scalafx.collections.ObservableBuffer
 import scalafx.scene.control.TextArea
-import scalafx.stage.Window
+import scalafx.stage.FileChooser.ExtensionFilter
+import scalafx.stage.{FileChooser, Window}
 import upickle.default._
 
-import scala.util.{Failure, Success, Try}
+import java.io.File
+import java.nio.file.Files
+import scala.util.{Failure, Properties, Success, Try}
 
 class DLCPaneModel(resultArea: TextArea, oracleInfoArea: TextArea) {
   var taskRunner: TaskRunner = _
@@ -263,5 +266,29 @@ class DLCPaneModel(resultArea: TextArea, oracleInfoArea: TextArea) {
     ViewDLCDialog.showAndWait(parentWindow.value,
                               updatedStatus.getOrElse(status),
                               this)
+  }
+
+  def exportResult(result: String): Unit = {
+    val txtFilter = new ExtensionFilter("Text Files", "*.txt")
+    val allExtensionFilter = new ExtensionFilter("All Files", "*")
+    val fileChooser = new FileChooser() {
+      extensionFilters.addAll(txtFilter, allExtensionFilter)
+      selectedExtensionFilter = txtFilter
+      initialDirectory = new File(Properties.userHome)
+    }
+
+    val selectedFile = fileChooser.showSaveDialog(null)
+
+    taskRunner.run(
+      "Export Result",
+      op = {
+        if (selectedFile != null) {
+          val bytes = result.getBytes
+
+          Files.write(selectedFile.toPath, bytes)
+          ()
+        }
+      }
+    )
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
@@ -58,10 +58,12 @@ class AcceptDLCDialog
           }
         } else {
           new Alert(AlertType.Confirmation) {
+            resizable = true
             initOwner(owner)
             title = "Confirm no Oracle Announcement"
             contentText =
               s"Are you sure you would like sign to accept this DLC Offer without verifying it has the correct oracle?"
+            dialogPane().getScene.getWindow.sizeToScene()
           }.showAndWait() match {
             case Some(ButtonType.OK) => ()
             case None | Some(_)      => throw new RuntimeException("Did not accept")

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AddSigsDLCDialog.scala
@@ -17,7 +17,8 @@ class AddSigsDLCDialog
                                                     Some(file)
                                                   DLCDialog.signFileChosenLabel.text =
                                                     file.toString
-                                                }
+                                                },
+                                              DLCDialog.fileChosenStr -> DLCDialog.signFileChosenLabel
                                             ),
                                             Vector(DLCDialog.dlcSigStr,
                                                    DLCDialog.dlcSignFileStr)) {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -16,7 +16,8 @@ class SignDLCDialog
                                                  Some(file)
                                                DLCDialog.acceptFileChosenLabel.text =
                                                  file.toString
-                                             }
+                                             },
+                                           DLCDialog.fileChosenStr -> DLCDialog.acceptFileChosenLabel
                                          ),
                                          Vector(DLCDialog.dlcAcceptStr,
                                                 DLCDialog.dlcAcceptFileStr)) {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
@@ -4,7 +4,7 @@ import org.bitcoins.core.protocol.dlc.DLCMessage.{
   MultiNonceContractInfo,
   SingleNonceContractInfo
 }
-import org.bitcoins.core.protocol.dlc.DLCStatus
+import org.bitcoins.core.protocol.dlc.{DLCPayoutCurve, DLCStatus}
 import org.bitcoins.gui.GlobalData
 import org.bitcoins.gui.dlc.{DLCPaneModel, DLCPlotUtil, GlobalDLCData}
 import scalafx.Includes._
@@ -193,9 +193,17 @@ object ViewDLCDialog {
                                     roundingIntervals) =>
           val previewGraphButton: Button = new Button("Preview Graph") {
             onAction = _ => {
+
+              val payoutCurve = if (status.isInitiator) {
+                outcomeValueFunc
+              } else {
+                DLCPayoutCurve(outcomeValueFunc.points.map { point =>
+                  point.copy(payout = totalCollateral.toLong - point.payout)
+                })
+              }
               DLCPlotUtil.plotCETsWithOriginalCurve(base,
                                                     numDigits,
-                                                    outcomeValueFunc,
+                                                    payoutCurve,
                                                     totalCollateral,
                                                     roundingIntervals)
               ()


### PR DESCRIPTION
Fixes:

- No text appears on the sign and add sigs dialog when you select a file the way it does for accept
- Warning message on confirmation when no announcement is given is not readable as it cuts off and can't be re-sized
- Adds status label at the bottom of the window said something after export result completes
- Display correct payout curve as recipient 