### PR TITLE
Remove autoScalaLibrary := false, this was not being used correctly a…

### DIFF
--- a/secp256k1jni/secp256k1jni.sbt
+++ b/secp256k1jni/secp256k1jni.sbt
@@ -3,8 +3,7 @@ name := "bitcoin-s-secp256k1jni"
 // TODO: we may want to override the version and publish separately
 // version := "0.0.1"
 
-autoScalaLibrary := false // exclude scala-library from dependencies
-
+//https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Scala-version+specific+source+directory
 crossPaths := false // drop off Scala suffix from artifact names.
 
 //sbt documents recommend setting scalaversion to a fixed value


### PR DESCRIPTION
…nd now is hindering builds on intellij

This fixes #2395 

the `autoScalaLibrary := false` setting was being used incorrectly. [From the documentation](https://www.scala-sbt.org/1.x/docs/Configuring-Scala.html#Configuring+the+scala-library+dependency) this is for _building_ the project and is not used at runtime which I originally thought. 

I confirmed this with the [`jdeps` tool](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/jdeps.html)

> jdeps bitcoin-s-secp256k1jni.jar
