### PR TITLE
2020 12 20 root dependson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,43 @@ lazy val `bitcoin-s` = project
     zmq,
     oracleServer
   )
+  .dependsOn(
+    secp256k1jni,
+    chain,
+    chainTest,
+    cli,
+    cliTest,
+    core,
+    coreTest,
+    crypto,
+    cryptoTest,
+    dbCommons,
+    dbCommonsTest,
+    feeProvider,
+    feeProviderTest,
+    dlcOracle,
+    dlcOracleTest,
+    bitcoindRpc,
+    bitcoindRpcTest,
+    bench,
+    eclairRpc,
+    eclairRpcTest,
+    bundle,
+    gui,
+    keyManager,
+    keyManagerTest,
+    node,
+    nodeTest,
+    wallet,
+    walletTest,
+    appServer,
+    appServerTest,
+    appCommons,
+    appCommonsTest,
+    testkit,
+    zmq,
+    oracleServer
+  )
   .settings(CommonSettings.settings: _*)
   // crossScalaVersions must be set to Nil on the aggregating project
   .settings(crossScalaVersions := Nil)

--- a/build.sbt
+++ b/build.sbt
@@ -120,8 +120,6 @@ lazy val `bitcoin-s` = project
     oracleServer
   )
   .settings(CommonSettings.settings: _*)
-  // crossScalaVersions must be set to Nil on the aggregating project
-  .settings(crossScalaVersions := Nil)
   // unidoc aggregates Scaladocs for all subprojects into one big doc
   .enablePlugins(ScalaUnidocPlugin)
   .settings(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
@@ -3,7 +3,6 @@ package org.bitcoins.wallet.models
 import org.bitcoins.core.api.wallet.db.{
   LegacySpendingInfo,
   NestedSegwitV0SpendingInfo,
-  ScriptPubKeyDb,
   SegwitV0SpendingInfo
 }
 import org.bitcoins.core.protocol.script.ScriptSignature


### PR DESCRIPTION
This fixes #2403 

and should be the last thing to fix #2330 

Basically it seems intellij does not honor the [`aggregate()`](https://www.scala-sbt.org/1.x/docs/Multi-Project.html#Aggregation) sbt command. What aggregate does is delegate a command (such as `compile`) to sub projects. This works fine when we use `sbt` directly, but it doesn't work with intellij for some reason.

To get around this, I made the top level `bitcoin-s` module `.dependsOn()` every sub project. This seems to allow us to build the top level module on intellij!