### PR TITLE
Implement rpcbind to allow for binding to a different interface

### DIFF
--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
@@ -22,13 +22,19 @@ class OracleServerMain(override val args: Array[String])
       routes = Seq(OracleRoutes(oracle))
       server = rpcPortOpt match {
         case Some(rpcport) =>
-          Server(conf, routes, rpcport = rpcport)
+          Server(conf = conf,
+                 handlers = routes,
+                 rpcbindOpt = rpcBindOpt,
+                 rpcport = rpcport)
         case None =>
           conf.rpcPortOpt match {
             case Some(rpcport) =>
-              Server(conf, routes, rpcport)
+              Server(conf = conf,
+                     handlers = routes,
+                     rpcbindOpt = rpcBindOpt,
+                     rpcport = rpcport)
             case None =>
-              Server(conf, routes)
+              Server(conf = conf, handlers = routes, rpcbindOpt = rpcBindOpt)
           }
       }
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSRunner.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSRunner.scala
@@ -26,6 +26,15 @@ trait BitcoinSRunner extends BitcoinSLogger {
 
   lazy val argsWithIndex: Vector[(String, Int)] = args.toVector.zipWithIndex
 
+  /** The ip address we are binding the server to */
+  lazy val rpcBindOpt: Option[String] = {
+    val rpcbindOpt = argsWithIndex.find(_._1.toLowerCase == "--rpcbind")
+    rpcbindOpt.map {
+      case (_, idx) =>
+        args(idx + 1)
+    }
+  }
+
   lazy val rpcPortOpt: Option[Int] = {
     val portOpt = argsWithIndex.find(_._1.toLowerCase == "--rpcport")
     portOpt.map {

--- a/app/server/src/main/scala/org/bitcoins/server/Server.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/Server.scala
@@ -16,6 +16,7 @@ import scala.concurrent.Future
 case class Server(
     conf: AppConfig,
     handlers: Seq[ServerRoute],
+    rpcbindOpt: Option[String],
     rpcport: Int = 9999)(implicit system: ActorSystem)
     extends HttpLogger {
 
@@ -78,7 +79,7 @@ case class Server(
 
   def start(): Future[Http.ServerBinding] = {
     val httpFut =
-      Http().bindAndHandle(route, "localhost", rpcport)
+      Http().bindAndHandle(route, rpcbindOpt.getOrElse("localhost"), rpcport)
     httpFut.foreach { http =>
       logger.info(s"Started Bitcoin-S HTTP server at ${http.localAddress}")
     }

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -108,6 +108,7 @@ bitcoin-s {
     server {
         # The port we bind our rpc server on
         rpcport = 9999
+        rpcbind = "127.0.0.1"
     }
 
   oracle = ${bitcoin-s.dbDefault}

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -51,6 +51,10 @@ There are a few command line options available that take precedence over configu
 
      `datadir` sets the data directory instead of using the default `$HOME/.bitcoin-s`
 
+- `--rpcbind <ip>`
+
+    `rpcbind` sets the interface the rpc server binds to instead of using the default `127.0.0.1`
+
 - `--rpcport <port>`
 
     `rpcport` sets the port the rpc server binds to instead of using the default `9999`
@@ -203,6 +207,9 @@ bitcoin-s {
     server {
         # The port we bind our rpc server on
         rpcport = 9999
+
+        # The ip address we bind our server too
+        rpcbind = "127.0.0.1"
     }
 }
 


### PR DESCRIPTION
This fixes #2407 

This adds the ability to bind to an arbitrary interface. This can be specified with the `--rpcbind` command line option for appserver or the `bitcoin-s.server.rpcbind`