### PR TITLE
Add extra checks for RBF transactions

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
@@ -24,6 +24,11 @@ import scala.util.{Failure, Success, Try}
 
 object TxUtil extends BitcoinSLogger {
 
+  def isRBFEnabled(transaction: Transaction): Boolean = {
+    transaction.inputs.exists(
+      _.sequence < TransactionConstants.disableRBFSequence)
+  }
+
   private def computeNextLockTime(
       currentLockTimeOpt: Option[UInt32],
       locktime: Long): Try[UInt32] = {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -374,6 +374,21 @@ class WalletSendingTest extends BitcoinSWalletTest {
     }
   }
 
+  it should "fail to CPFP a confirmed transaction" in { fundedWallet =>
+    val wallet = fundedWallet.wallet
+
+    val feeRate = FeeUnitGen.satsPerByte.sampleSome
+
+    for {
+      tx <- wallet.sendToAddress(testAddress, amountToSend, feeRate)
+      _ <- wallet.processTransaction(tx, Some(DoubleSha256DigestBE.empty))
+
+      res <- recoverToSucceededIf[IllegalArgumentException] {
+        wallet.bumpFeeCPFP(tx.txIdBE, feeRate)
+      }
+    } yield res
+  }
+
   it should "fail to CPFP a transaction we don't own" in { fundedWallet =>
     val wallet = fundedWallet.wallet
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -2,16 +2,22 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.api.wallet.{CoinSelectionAlgo, CoinSelector}
 import org.bitcoins.core.currency._
+import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.script.EmptyScriptSignature
 import org.bitcoins.core.protocol.transaction.{
+  BaseTransaction,
   EmptyTransaction,
+  TransactionConstants,
+  TransactionInput,
   TransactionOutput
 }
+import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.script.constant.{BytesToPushOntoStack, ScriptConstant}
 import org.bitcoins.core.script.control.OP_RETURN
 import org.bitcoins.core.wallet.fee._
 import org.bitcoins.core.wallet.utxo.TxoState
-import org.bitcoins.crypto.CryptoUtil
+import org.bitcoins.crypto.{CryptoUtil, DoubleSha256DigestBE}
 import org.bitcoins.testkit.Implicits.GeneratorOps
 import org.bitcoins.testkit.core.gen.FeeUnitGen
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
@@ -286,6 +292,50 @@ class WalletSendingTest extends BitcoinSWalletTest {
       assert(txDb1.actualFee < txDb2.actualFee)
       assert(firstBal - secondBal == txDb2.actualFee - txDb1.actualFee)
     }
+  }
+
+  it should "fail to RBF a confirmed transaction" in { fundedWallet =>
+    val wallet = fundedWallet.wallet
+
+    val feeRate = FeeUnitGen.satsPerByte.sampleSome
+    val newFeeRate = SatoshisPerByte(feeRate.currencyUnit + Satoshis.one)
+
+    for {
+      tx <- wallet.sendToAddress(testAddress, amountToSend, feeRate)
+      _ <- wallet.processTransaction(tx, Some(DoubleSha256DigestBE.empty))
+
+      res <- recoverToSucceededIf[IllegalArgumentException] {
+        wallet.bumpFeeRBF(tx.txIdBE, newFeeRate)
+      }
+    } yield res
+  }
+
+  it should "fail to RBF a non-signaling transaction" in { fundedWallet =>
+    val wallet = fundedWallet.wallet
+
+    for {
+      addr <- wallet.getNewAddress()
+      utxo <- wallet.listUtxos().map(_.head)
+
+      // Create tx not signaling RBF
+      input = TransactionInput(utxo.outPoint,
+                               EmptyScriptSignature,
+                               TransactionConstants.disableRBFSequence)
+      output =
+        TransactionOutput(utxo.output.value - Satoshis(500), addr.scriptPubKey)
+      tx =
+        BaseTransaction(Int32.two, Vector(input), Vector(output), UInt32.zero)
+      psbt = PSBT.fromUnsignedTx(tx)
+
+      // Have wallet sign and process transaction
+      signedPSBT <- wallet.signPSBT(psbt)
+      signedTx = signedPSBT.finalizePSBT.get.extractTransactionAndValidate.get
+      _ <- wallet.processTransaction(signedTx, None)
+
+      res <- recoverToSucceededIf[IllegalArgumentException] {
+        wallet.bumpFeeRBF(signedTx.txIdBE, SatoshisPerVirtualByte.fromLong(100))
+      }
+    } yield res
   }
 
   it should "correctly CPFP a transaction" in { fundedWallet =>


### PR DESCRIPTION
Added requirements that the original tx can't be confirmed or was not originally RBF.

Added tests to make sure this is functioning correctly.