### PR TITLE
Remove need for params in RPC request

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1611,7 +1611,10 @@ object ConsoleCli {
       params: Seq[ujson.Value.Value] = Nil) {
 
     lazy val toJsonMap: Map[String, ujson.Value] = {
-      Map("method" -> method, "params" -> params)
+      if (params.isEmpty)
+        Map("method" -> method)
+      else
+        Map("method" -> method, "params" -> params)
     }
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -22,7 +22,22 @@ import scala.util.{Failure, Try}
 case class ServerCommand(method: String, params: ujson.Arr)
 
 object ServerCommand {
-  implicit val rw: ReadWriter[ServerCommand] = macroRW
+
+  implicit val rw: ReadWriter[ServerCommand] =
+    readwriter[ujson.Value].bimap[ServerCommand](
+      cmd => {
+        if (cmd.params.arr.isEmpty)
+          Obj("method" -> Str(cmd.method))
+        else Obj("method" -> Str(cmd.method), "params" -> cmd.params)
+      },
+      json => {
+        val obj = json.obj
+        val method = obj("method").str
+        if (obj.contains("params"))
+          ServerCommand(method, obj("params").arr)
+        else ServerCommand(method, Arr())
+      }
+    )
 }
 
 case class GetNewAddress(labelOpt: Option[AddressLabelTag])


### PR DESCRIPTION
Fixes #2411 

Tested with a bunch of different CLI commands (with and without params) and tested with curl. All works!

Example curl request for testing:
```
curl --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getinfo"}' -H "Content-Type: application/json" http://127.0.0.1:9999
```
