### PR TITLE
Remove BlockHeader.getBlockchainsFrom(), rework type signature for Bl…

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
@@ -115,8 +115,7 @@ class BitcoinPowTest extends ChainDbUnitTest {
               Pow.getNetworkWorkRequired(nextTip.blockHeader, chain)
             assert(nextNBits == nextTip.nBits)
           case None =>
-            fail()
-
+            fail(s"Chain not found best on header at height=$height")
         }
       }
     }

--- a/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
@@ -104,14 +104,20 @@ class BitcoinPowTest extends ChainDbUnitTest {
     val nestedAssertions: Vector[Future[Assertion]] = {
       iterator.map { height =>
         val blockF = blockHeaderDAO.getAtHeight(height + 1).map(_.head)
-        val blockchainF =
+        val blockchainOptF: Future[Option[Blockchain]] =
           blockF.flatMap(b => blockHeaderDAO.getBlockchainFrom(b))
-        for {
-          blockchain <- blockchainF
-          nextTip = blockchain.head
-          chain = Blockchain.fromHeaders(blockchain.tail.toVector)
-          nextNBits = Pow.getNetworkWorkRequired(nextTip.blockHeader, chain)
-        } yield assert(nextNBits == nextTip.nBits)
+
+        blockchainOptF.map {
+          case Some(blockchain) =>
+            val chain = Blockchain.fromHeaders(blockchain.tail.toVector)
+            val nextTip = blockchain.tip
+            val nextNBits =
+              Pow.getNetworkWorkRequired(nextTip.blockHeader, chain)
+            assert(nextNBits == nextTip.nBits)
+          case None =>
+            fail()
+
+        }
       }
     }
     Future


### PR DESCRIPTION
…ockHeader.getBlockchainFrom() to return Future[Option[Blockchain]]

For some reason we had `getBlockchainsFrom(header)` and `getBlockchainFrom(header)`.

Conceptually these things are the same. If given a header, you can only walk backwards from a header. 

The PR also reworks the return type to be `Future[Option[Blockchain]]` rather than `Future[Vector[Blockchain]]`. As stated above, you can only obtain one blockchain when walking backwards from a given header. 

