### PR TITLE
User input passwords on new wallet startup

### DIFF
--- a/.github/workflows/Linux_2.13_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Node_Core_Tests.yml
@@ -1,4 +1,4 @@
-name: Linux 2.12 App, Chain, Node, and Core Tests
+name: Linux 2.13 App, Chain, Node, and Core Tests
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/build.sbt
+++ b/build.sbt
@@ -291,7 +291,7 @@ lazy val serverRoutes = project
   .settings(CommonSettings.prodSettings: _*)
   .settings(name := "bitcoin-s-server-routes")
   .settings(libraryDependencies ++= Deps.serverRoutes)
-  .dependsOn(appCommons, dbCommons)
+  .dependsOn(appCommons, dbCommons, keyManager)
 
 lazy val appServer = project
   .in(file("app/server"))


### PR DESCRIPTION
Closes #2220

Lets the user input a wallet password + bip 39 password when creating a new wallet. Works for completely new data dir as well as just setting up a new seed with the `bitcoin-s.wallet.walletName` config option.