### PR TITLE
2020 12 18 enable lint options

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitNumericContractDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/InitNumericContractDialog.scala
@@ -186,7 +186,7 @@ object InitNumericContractDialog {
             ) {
               val outcome = BigDecimal(outcomeTF.text.value.toDouble)
               val level = roundingLevelTF.text.value.toLong
-              Some(outcome, level)
+              Some((outcome, level))
             } else {
               None
             }

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -61,7 +61,8 @@ case class Server(
 
   val route: Route =
     // TODO implement better logging
-    DebuggingDirectives.logRequestResult("http-rpc-server", Logging.InfoLevel) {
+    DebuggingDirectives.logRequestResult(
+      ("http-rpc-server", Logging.InfoLevel)) {
       withErrorHandling {
         pathSingleSlash {
           post {

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -164,10 +164,17 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
         }
 
         val batchSize = 25
-        val batchedExecutedF = FutureUtil.batchExecute(elements = blockHashes,
-                                                       f = f,
-                                                       init = Vector.empty,
-                                                       batchSize = batchSize)
+        val batchedExecutedF = {
+          for {
+            wallet <- walletF
+            wallet <- FutureUtil.batchExecute[DoubleSha256Digest, Wallet](
+              elements = blockHashes,
+              f = f,
+              init = wallet,
+              batchSize = batchSize)
+          } yield wallet
+
+        }
 
         batchedExecutedF.map { _ =>
           logger.info(

--- a/build.sbt
+++ b/build.sbt
@@ -289,6 +289,7 @@ lazy val oracleServer = project
 lazy val serverRoutes = project
   .in(file("app/server-routes"))
   .settings(CommonSettings.prodSettings: _*)
+  .settings(name := "bitcoin-s-server-routes")
   .settings(libraryDependencies ++= Deps.serverRoutes)
   .dependsOn(appCommons, dbCommons)
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/testprotocol/CoreTestCaseProtocol.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/testprotocol/CoreTestCaseProtocol.scala
@@ -70,7 +70,7 @@ object CoreTestCaseProtocol extends DefaultJsonProtocol with BitcoinSLogger {
                            expectedResult,
                            "",
                            elements.toString,
-                           Some(witness, amount)))
+                           Some((witness, amount))))
       } else if (elements.size == 5) {
         val scriptPubKeyBytes: ByteVector = parseScriptPubKey(elements(1))
         val scriptPubKey = ScriptPubKey(scriptPubKeyBytes)
@@ -112,7 +112,7 @@ object CoreTestCaseProtocol extends DefaultJsonProtocol with BitcoinSLogger {
                            expectedResult,
                            comments,
                            elements.toString,
-                           Some(witness, amount)))
+                           Some((witness, amount))))
       } else None
     }
 

--- a/core/src/main/scala/org/bitcoins/core/hd/HDPath.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDPath.scala
@@ -4,7 +4,7 @@ import org.bitcoins.crypto.StringFactory
 
 import scala.util.{Failure, Success, Try}
 
-private[bitcoins] trait HDPath extends BIP32Path {
+trait HDPath extends BIP32Path {
 
   /**
     * This type is to give a cleaner return

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCMessage.scala
@@ -392,7 +392,7 @@ object DLCMessage {
         val offerPayout = offerContractInfo(msg)
         val acceptPayout = (totalCollateral - offerPayout).satoshis
 
-        builder.+=(msg -> (oracleInfo.sigPoint(msg), offerPayout, acceptPayout))
+        builder.+=((msg, (oracleInfo.sigPoint(msg), offerPayout, acceptPayout)))
       }
 
       builder.result()

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -172,7 +172,7 @@ object BaseTransaction extends Factory[BaseTransaction] {
 
   def unapply(tx: NonWitnessTransaction): Option[
     (Int32, Seq[TransactionInput], Seq[TransactionOutput], UInt32)] = {
-    Some(tx.version, tx.inputs, tx.outputs, tx.lockTime)
+    Some((tx.version, tx.inputs, tx.outputs, tx.lockTime))
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/util/Base58.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/Base58.scala
@@ -139,7 +139,10 @@ sealed abstract class Base58 {
       val decoded = decode(base58)
       val firstByte = decoded.head
       val compressedPubKey = List('K', 'L', 'c').contains(base58.head)
-      if (base58.contains(List('0', 'O', 'l', 'I'))) false
+      val hasInvalidChar: Boolean = {
+        Vector('0', 'O', 'l', 'I').exists(c => base58.contains(c))
+      }
+      if (hasInvalidChar) false
       else if (compressedPubKey) checkCompressedPubKeyValidity(base58)
       else if (isValidAddressPreFixByte(firstByte))
         base58.length >= 26 && base58.length <= 35

--- a/crypto/src/main/scala/org/bitcoins/crypto/AesCrypt.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/AesCrypt.scala
@@ -193,7 +193,7 @@ object AesKey {
     * and must be 16, 24 or 32 bytes long.
     */
   def fromBytes(bytes: ByteVector): Option[AesKey] = {
-    if (keylengths.contains(bytes.length)) {
+    if (keylengths.exists(k => k == bytes.length)) {
       Some(AesKey(bytes))
     } else {
       None

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -860,7 +860,7 @@ class EclairRpcClient(
                 .get()} for paymentId=${paymentId} for interval=${interval}"))
         } else {
           val resultsF = getSentInfo(paymentId)
-          resultsF.recover {
+          resultsF.failed.foreach {
             case e: Throwable =>
               logger.error(
                 s"Cannot check payment status for paymentId=${paymentId}",

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/HttpFeeRateProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/HttpFeeRateProvider.scala
@@ -49,7 +49,7 @@ abstract class CachedHttpFeeRateProvider extends HttpFeeRateProvider {
   private def updateFeeRate(): Future[FeeUnit] = {
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     super.getFeeRate.map { feeRate =>
-      cachedFeeRateOpt = Some(feeRate, TimeUtil.now)
+      cachedFeeRateOpt = Some((feeRate, TimeUtil.now))
       feeRate
     }
   }

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -56,7 +56,7 @@ class NeutrinoNodeTest extends NodeUnitTest {
   }
 
   def callbacks: NodeCallbacks = {
-    NodeCallbacks(onBlockReceived = Vector(blockCallback))
+    NodeCallbacks(onBlockReceived = Vector(blockCallback(_)))
   }
 
   behavior of "NeutrinoNode"

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -60,7 +60,7 @@ class DataMessageHandlerTest extends NodeUnitTest {
         _ <- dataMessageHandler.handleDataPayload(payload1, sender)
         _ <- dataMessageHandler.handleDataPayload(payload2, sender)
         result <- resultP.future
-      } yield assert(result == (merkleBlock, Vector(tx)))
+      } yield assert(result == ((merkleBlock, Vector(tx))))
   }
 
   it must "verify OnBlockReceived callbacks are executed" in {

--- a/node/src/main/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAO.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAO.scala
@@ -68,7 +68,7 @@ final case class BroadcastAbleTransactionDAO()(implicit
     }
 
     private val toTuple: BroadcastAbleTransaction => Option[Tuple] = tx =>
-      Some(tx.transaction.txId.flip, tx.transaction.bytes)
+      Some((tx.transaction.txId.flip, tx.transaction.bytes))
 
     def txid: Rep[DoubleSha256DigestBE] = column("txid", O.PrimaryKey)
     def bytes: Rep[ByteVector] = column("tx_bytes")

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -82,7 +82,9 @@ object CommonSettings {
       "-Xlint:unused",
       "-Xlint:adapted-args",
       "-Xlint:nullary-unit",
+      "-Xlint:inaccessible",
       "-Xlint:infer-any",
+      "-Xlint:missing-interpolator",
       "-Xlint:eta-sam"
     )
   }

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -41,10 +41,8 @@ object CommonSettings {
     apiURL := homepage.value.map(_.toString + "/api").map(url(_)),
     // scaladoc settings end
     ////
-    scalacOptions in Compile := compilerOpts(scalaVersion = scalaVersion.value,
-                                             isTestModule = false),
-    Test / scalacOptions := compilerOpts(scalaVersion = scalaVersion.value,
-                                         isTestModule = true),
+    scalacOptions in Compile := compilerOpts(scalaVersion = scalaVersion.value),
+    Test / scalacOptions := testCompilerOpts(scalaVersion = scalaVersion.value),
     //remove annoying import unused things in the scala console
     //https://stackoverflow.com/questions/26940253/in-sbt-how-do-you-override-scalacoptions-for-console-in-all-configurations
     scalacOptions in (Compile, console) ~= (_ filterNot (s =>
@@ -93,13 +91,6 @@ object CommonSettings {
     Seq("-Xfatal-warnings") ++ scala2_13CompilerLinting
   }
 
-  /** Compiler options for test code */
-  private val scala2_13TestCompilerOpts = {
-    Seq("-Xfatal-warnings",
-        //initialization checks: https://docs.scala-lang.org/tutorials/FAQ/initialization-order.html
-        "-Xcheckinit") ++ scala2_13CompilerLinting
-  }
-
   private val nonScala2_13CompilerOpts = Seq(
     "-Xmax-classfile-name",
     "128",
@@ -108,7 +99,7 @@ object CommonSettings {
   )
 
   //https://docs.scala-lang.org/overviews/compiler-options/index.html
-  def compilerOpts(scalaVersion: String, isTestModule: Boolean): Seq[String] = {
+  def compilerOpts(scalaVersion: String): Seq[String] = {
     Seq(
       "-unchecked",
       "-feature",
@@ -122,10 +113,8 @@ object CommonSettings {
       "-Ypatmat-exhaust-depth",
       "off"
     ) ++ commonCompilerOpts ++ {
-      if (scalaVersion.startsWith("2.13") && !isTestModule) {
+      if (scalaVersion.startsWith("2.13")) {
         scala2_13SourceCompilerOpts
-      } else if (scalaVersion.startsWith("2.13") && isTestModule) {
-        scala2_13TestCompilerOpts
       } else nonScala2_13CompilerOpts
     }
   }

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -95,7 +95,9 @@ object CommonSettings {
 
   /** Compiler options for test code */
   private val scala2_13TestCompilerOpts = {
-    Seq("-Xfatal-warnings") ++ scala2_13CompilerLinting
+    Seq("-Xfatal-warnings",
+        //initialization checks: https://docs.scala-lang.org/tutorials/FAQ/initialization-order.html
+        "-Xcheckinit") ++ scala2_13CompilerLinting
   }
 
   private val nonScala2_13CompilerOpts = Seq(

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -82,7 +82,8 @@ object CommonSettings {
       "-Xlint:unused",
       "-Xlint:adapted-args",
       "-Xlint:nullary-unit",
-      "-Xlint:infer-any"
+      "-Xlint:infer-any",
+      "-Xlint:eta-sam"
     )
   }
 

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -75,7 +75,11 @@ object CommonSettings {
     )
   }
 
-  private val scala2_13CompilerOpts = Seq("-Xlint:unused", "-Xfatal-warnings")
+  private val scala2_13CompilerOpts =
+    Seq("-Xlint:unused",
+        "-Xlint:adapted-args",
+        "-Xlint:nullary-unit",
+        "-Xfatal-warnings")
 
   private val nonScala2_13CompilerOpts = Seq(
     "-Xmax-classfile-name",
@@ -87,8 +91,6 @@ object CommonSettings {
   //https://docs.scala-lang.org/overviews/compiler-options/index.html
   def compilerOpts(scalaVersion: String): Seq[String] =
     Seq(
-      "-encoding",
-      "UTF-8",
       "-unchecked",
       "-feature",
       "-deprecation",

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
@@ -115,10 +115,18 @@ abstract class SyncUtil extends BitcoinSLogger {
         }
 
         val batchSize = 25
-        val batchedExecutedF = FutureUtil.batchExecute(elements = blockHashes,
-                                                       f = f,
-                                                       init = Vector.empty,
-                                                       batchSize = batchSize)
+        val batchedExecutedF = {
+          for {
+            wallet <- walletF
+            updatedWallet <-
+              FutureUtil.batchExecute[DoubleSha256Digest, Wallet](
+                elements = blockHashes,
+                f = f,
+                init = wallet,
+                batchSize = batchSize)
+          } yield updatedWallet
+
+        }
 
         batchedExecutedF.map { _ =>
           logger.info(

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CryptoGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/CryptoGenerators.scala
@@ -184,7 +184,7 @@ sealed abstract class CryptoGenerators {
     */
   def privateKeySeqWithRequiredSigs(num: Int): Gen[(Seq[ECPrivateKey], Int)] = {
     if (num <= 0) {
-      Gen.const(Nil, 0)
+      Gen.const((Nil, 0))
     } else {
       val privateKeys = privateKeySeq(num)
       for {

--- a/testkit/src/main/scala/org/bitcoins/testkit/core/gen/PSBTGenerators.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/core/gen/PSBTGenerators.scala
@@ -156,9 +156,7 @@ object PSBTGenerators {
           }
 
           Future.successful(
-            PSBT(psbt.globalMap, newInputsMaps, psbt.outputMaps),
-            infos,
-            fee)
+            (PSBT(psbt.globalMap, newInputsMaps, psbt.outputMaps), infos, fee))
       }
     }
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -77,7 +77,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
       port: Int = RpcUtil.randomPort,
       apiPort: Int = RpcUtil.randomPort): Config = {
     val configMap = {
-      Map(
+      Map[String, Any](
         "eclair.chain" -> "regtest",
         "eclair.spv" -> false,
         "eclair.server.public-ips.1" -> "127.0.0.1",

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -121,7 +121,7 @@ abstract class Wallet
     // safe since we're deriving from a priv
     val xpub = keyManager.deriveXPub(account).get
 
-    accountDAO.read(account.coin, account.index).flatMap {
+    accountDAO.read((account.coin, account.index)).flatMap {
       case Some(account) =>
         if (account.xpub != xpub) {
           val errorMsg =
@@ -918,7 +918,7 @@ object Wallet extends WalletLogger {
     //2. We already have this account in our database, so we do nothing
     //3. We have this account in our database, with a DIFFERENT xpub. This is bad. Fail with an exception
     //   this most likely means that we have a different key manager than we expected
-    wallet.accountDAO.read(account.coin, account.index).flatMap {
+    wallet.accountDAO.read((account.coin, account.index)).flatMap {
       case Some(account) =>
         if (account.xpub != xpub) {
           val errorMsg =

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/ScriptPubKeyDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/ScriptPubKeyDAO.scala
@@ -61,9 +61,10 @@ case class ScriptPubKeyDAO()(implicit
 
     private val toTuple: ScriptPubKeyDb => Option[ScriptPubKeyTuple] = {
       scriptPubKeyDb =>
-        Some(scriptPubKeyDb.id,
-             scriptPubKeyDb.scriptPubKey,
-             scriptPubKeyDb.scriptPubKey.scriptType)
+        Some(
+          (scriptPubKeyDb.id,
+           scriptPubKeyDb.scriptPubKey,
+           scriptPubKeyDb.scriptPubKey.scriptType))
     }
 
     override def * =


### PR DESCRIPTION
Adds more compiler options for linting

>    "-Xlint:unused",
      "-Xlint:adapted-args",
      "-Xlint:nullary-unit",
      "-Xlint:infer-any"

You can read more about the options here: https://docs.scala-lang.org/overviews/compiler-options/index.html