### PR TITLE
Recover errors in DataMessageHandler

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -12,6 +12,7 @@ import org.bitcoins.node.{NodeCallbacks, NodeType, P2PLogger}
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Try
+import scala.util.control.NonFatal
 
 /** This actor is meant to handle a [[org.bitcoins.core.p2p.DataPayload DataPayload]]
   * that a peer to sent to us on the p2p network, for instance, if we a receive a
@@ -297,12 +298,13 @@ case class DataMessageHandler(
         handleInventoryMsg(invMsg = invMsg, peerMsgSender = peerMsgSender)
     }
 
-    resultF.failed.foreach {
-      case err =>
-        logger.error(s"Failed to handle data payload=${payload}", err)
+    resultF.failed.foreach { err =>
+      logger.error(s"Failed to handle data payload=${payload}", err)
     }
 
-    resultF
+    resultF.recoverWith {
+      case NonFatal(_) => Future.successful(this)
+    }
   }
 
   private def sendNextGetCompactFilterHeadersCommand(


### PR DESCRIPTION
Discovered while reviewing #2436. Previously the node would stop working if any of the handlers would fail to process a message. This could mean that someone could send us data that could potentially stop the node. This fixes this problem by having the `DataMessageHandler` recover on errors.