### PR TITLE
Make KeyManager return better error messages

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -141,19 +141,9 @@ class WalletUnitTest extends BitcoinSWalletTest {
         case Left(err) => err
       }
       errorType match {
-        case KeyManagerUnlockError.MnemonicNotFound => fail(MnemonicNotFound)
-        case KeyManagerUnlockError.BadPassword      =>
-          // If wallet is unencrypted then we shouldn't get a bad password error
-          wallet.walletConfig.aesPasswordOpt match {
-            case Some(_) => succeed
-            case None    => fail()
-          }
-        case KeyManagerUnlockError.JsonParsingError(message) =>
-          // If wallet is encrypted then we shouldn't get a json parsing error
-          wallet.walletConfig.aesPasswordOpt match {
-            case Some(_) => fail(message)
-            case None    => succeed
-          }
+        case KeyManagerUnlockError.MnemonicNotFound          => fail(MnemonicNotFound)
+        case KeyManagerUnlockError.BadPassword               => succeed
+        case KeyManagerUnlockError.JsonParsingError(message) => fail(message)
       }
   }
 


### PR DESCRIPTION
Previously we would try to read the seed based on if we received a password or not, this would cause us to return a `JsonParsingError` when we would try to read an encrypted seed without a password or read an unencrypted seed with a password.

This flips this around so we see what kind of seed do we have and then parses & decrypts it. This makes it so we can return a `BadPasswordError` when the wallet gives a password when it shouldn't or vice versa.

Overall this should give better error messages when someone uses the wrong password for the key manager.