### PR TITLE
Version Number in logs & Cli Command

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -21,6 +21,7 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.psbt.PSBT
+import org.bitcoins.core.util.EnvUtil
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.AddressLabelTag
 import org.bitcoins.crypto.{
@@ -54,6 +55,9 @@ object ConsoleCli {
       opt[Int]("rpcport")
         .action((port, conf) => conf.copy(rpcPort = port))
         .text(s"The port to send our rpc request to on the server"),
+      opt[Unit]("version")
+        .action((_, conf) => conf.copy(command = GetVersion))
+        .hidden(),
       help('h', "help").text("Display this help message and exit"),
       note(sys.props("line.separator") + "Commands:"),
       note(sys.props("line.separator") + "===Blockchain ==="),
@@ -1604,6 +1608,10 @@ object ConsoleCli {
       case GetSignatures(tlv) =>
         RequestParam("getsignatures", Seq(up.writeJs(tlv)))
 
+      case GetVersion =>
+        // skip sending to server and just return version number of cli
+        return Success(EnvUtil.getVersion)
+
       case NoCommand => ???
     }
 
@@ -1707,6 +1715,10 @@ object CliCommand {
   trait Broadcastable {
     def noBroadcast: Boolean
   }
+
+  sealed trait ServerlessCliCommand extends CliCommand
+
+  case object GetVersion extends ServerlessCliCommand
 
   case object GetInfo extends CliCommand
 

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
@@ -3,7 +3,7 @@ package org.bitcoins.server.routes
 import akka.actor.ActorSystem
 import com.typesafe.config.{Config, ConfigFactory}
 import org.bitcoins.core.config._
-import org.bitcoins.core.util.BitcoinSLogger
+import org.bitcoins.core.util.{BitcoinSLogger, EnvUtil}
 import org.bitcoins.db.AppConfig
 import org.bitcoins.db.AppConfig.safePathToString
 
@@ -107,6 +107,8 @@ trait BitcoinSRunner extends BitcoinSLogger {
       }
       datadir.resolve(lastDirname)
     }
+
+    logger.info(s"version=${EnvUtil.getVersion}")
 
     // Properly set log location
     System.setProperty("bitcoins.log.location",

--- a/core/src/main/scala/org/bitcoins/core/util/EnvUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/EnvUtil.scala
@@ -12,4 +12,6 @@ object EnvUtil {
   lazy val isWindows: Boolean = osName.startsWith("Windows")
 
   lazy val isCI: Boolean = Properties.envOrNone("CI").contains("true")
+
+  def getVersion: String = getClass.getPackage.getImplementationVersion
 }


### PR DESCRIPTION
Closes #1755

Will log version on startup:

```
[info] 2021-01-04T21:34:21UTC INFO [BitcoinSServerMain] version=0.4.0+218-2454aecd-SNAPSHOT
```

Adds a cli command:

```
$ bs-cli --version
0.4.0+217-0cc85cc0+20210104-1529-SNAPSHOT
```

