### PR TITLE
Remove callbacks param from DataMessageHandler & PeerMessageReceiver

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -8,7 +8,6 @@ import org.bitcoins.core.p2p._
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.crypto.{CryptoUtil, DoubleSha256Digest}
-import org.bitcoins.node.NodeCallbacks
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.PeerMessageReceiver
 import org.bitcoins.testkit.async.TestAsyncUtil
@@ -172,7 +171,7 @@ class P2PClientTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
     val probe = TestProbe()
     val remote = peer.socket
     val peerMessageReceiverF =
-      PeerMessageReceiver.preConnection(peer, NodeCallbacks.empty, None)
+      PeerMessageReceiver.preConnection(peer, None)
 
     val clientActorF: Future[TestActorRef[P2PClientActor]] =
       peerMessageReceiverF.map { peerMsgRecv =>

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -35,11 +35,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
 
       val callback: OnMerkleBlockReceived = {
         (merkle: MerkleBlock, txs: Vector[Transaction]) =>
-          {
-            Future {
-              resultP.success((merkle, txs))
-              ()
-            }
+          Future {
+            resultP.success((merkle, txs))
+            ()
           }
       }
 
@@ -55,8 +53,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
         payload2 = TransactionMessage(tx)
 
         callbacks = NodeCallbacks.onMerkleBlockReceived(callback)
+        _ = nodeConfig.addCallbacks(callbacks)
 
-        dataMessageHandler = DataMessageHandler(genesisChainApi, callbacks)
+        dataMessageHandler = DataMessageHandler(genesisChainApi)
         _ <- dataMessageHandler.handleDataPayload(payload1, sender)
         _ <- dataMessageHandler.handleDataPayload(payload2, sender)
         result <- resultP.future
@@ -84,8 +83,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
         payload = BlockMessage(block)
 
         callbacks = NodeCallbacks.onBlockReceived(callback)
+        _ = nodeConfig.addCallbacks(callbacks)
 
-        dataMessageHandler = DataMessageHandler(genesisChainApi, callbacks)
+        dataMessageHandler = DataMessageHandler(genesisChainApi)
         _ <- dataMessageHandler.handleDataPayload(payload, sender)
         result <- resultP.future
       } yield assert(result == block)
@@ -113,8 +113,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
         payload = HeadersMessage(CompactSizeUInt.one, Vector(header))
 
         callbacks = NodeCallbacks.onBlockHeadersReceived(callback)
+        _ = nodeConfig.addCallbacks(callbacks)
 
-        dataMessageHandler = DataMessageHandler(genesisChainApi, callbacks)
+        dataMessageHandler = DataMessageHandler(genesisChainApi)
         _ <- dataMessageHandler.handleDataPayload(payload, sender)
         result <- resultP.future
       } yield assert(result == Vector(header))
@@ -128,11 +129,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
         Promise()
       val callback: OnCompactFiltersReceived = {
         (filters: Vector[(DoubleSha256Digest, GolombFilter)]) =>
-          {
-            Future {
-              resultP.success(filters)
-              ()
-            }
+          Future {
+            resultP.success(filters)
+            ()
           }
       }
       for {
@@ -145,8 +144,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
           CompactFilterMessage(FilterType.Basic, hash.flip, filter.filter.bytes)
 
         callbacks = NodeCallbacks.onCompactFilterReceived(callback)
+        _ = nodeConfig.addCallbacks(callbacks)
 
-        dataMessageHandler = DataMessageHandler(genesisChainApi, callbacks)
+        dataMessageHandler = DataMessageHandler(genesisChainApi)
         _ <- dataMessageHandler.handleDataPayload(payload, sender)
         result <- resultP.future
       } yield assert(result == Vector((hash.flip, filter.filter)))

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -76,7 +76,6 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
       val peerMsgRecv: PeerMessageReceiver =
         PeerMessageReceiver.newReceiver(chainApi = chainApi,
                                         peer = peer,
-                                        callbacks = nodeCallbacks,
                                         initialSyncDone = initialSyncDone)
       val p2p = P2PClient(context = system,
                           peer = peer,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -351,7 +351,6 @@ object NodeUnitTest extends P2PLogger {
       PeerMessageReceiver(state = PeerMessageReceiverState.fresh(),
                           chainApi = chainApi,
                           peer = peer,
-                          callbacks = NodeCallbacks.empty,
                           initialSyncDone = None)
     Future.successful(receiver)
   }
@@ -363,7 +362,7 @@ object NodeUnitTest extends P2PLogger {
     import system.dispatcher
     val chainApiF = ChainUnitTest.createChainHandler()
     val peerMsgReceiverF = chainApiF.flatMap { _ =>
-      PeerMessageReceiver.preConnection(peer, NodeCallbacks.empty, None)
+      PeerMessageReceiver.preConnection(peer, None)
     }
     //the problem here is the 'self', this needs to be an ordinary peer message handler
     //that can handle the handshake
@@ -490,7 +489,6 @@ object NodeUnitTest extends P2PLogger {
       PeerMessageReceiver(state = PeerMessageReceiverState.fresh(),
                           chainApi = chainApi,
                           peer = peer,
-                          callbacks = NodeCallbacks.empty,
                           initialSyncDone = None)
     Future.successful(receiver)
   }


### PR DESCRIPTION
Closes #2475

`PeerMessageReceiver` also had a `NodeCallbacks` param so that was removed as well.