### PR TITLE
Rename wallet.getSyncHeight() -> wallet.getSyncDescriptorOpt(). 

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -54,7 +54,7 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
 
     for {
       bitcoindHeight <- bitcoind.getBlockCount
-      walletStateOpt <- wallet.getSyncHeight()
+      walletStateOpt <- wallet.getSyncDescriptorOpt()
       _ <- walletStateOpt match {
         case None =>
           for {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -72,7 +72,7 @@ class BitcoindBackendTest extends BitcoinSAsyncTest with EmbeddedPg {
 
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
-      syncHeightOpt <- wallet.getSyncHeight()
+      syncHeightOpt <- wallet.getSyncDescriptorOpt()
     } yield {
       assert(balance == amountToSend)
       assert(syncHeightOpt.contains(SyncHeightDescriptor(bestHash, height)))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -35,7 +35,7 @@ class ProcessBlockTest extends BitcoinSWalletTest {
 
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
-      syncHeightOpt <- wallet.getSyncHeight()
+      syncHeightOpt <- wallet.getSyncDescriptorOpt()
     } yield {
       assert(utxos.size == 1)
       assert(utxos.head.output.scriptPubKey == addr.scriptPubKey)
@@ -63,7 +63,7 @@ class ProcessBlockTest extends BitcoinSWalletTest {
 
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
-      syncHeightOpt <- wallet.getSyncHeight()
+      syncHeightOpt <- wallet.getSyncDescriptorOpt()
     } yield {
       assert(utxos.size == 100)
       assert(balance == Bitcoins(50))
@@ -91,7 +91,7 @@ class ProcessBlockTest extends BitcoinSWalletTest {
 
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
-      syncHeightOpt <- wallet.getSyncHeight()
+      syncHeightOpt <- wallet.getSyncDescriptorOpt()
     } yield {
       assert(utxos.size == 100)
       assert(balance == Bitcoins(50))

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -157,8 +157,8 @@ abstract class Wallet
     }
   }
 
-  def getSyncHeight(): Future[Option[SyncHeightDescriptor]] = {
-    stateDescriptorDAO.getSyncHeightOpt()
+  def getSyncDescriptorOpt(): Future[Option[SyncHeightDescriptor]] = {
+    stateDescriptorDAO.getSyncDescriptorOpt()
   }
 
   override def processCompactFilters(

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/WalletStateDescriptorDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/WalletStateDescriptorDAO.scala
@@ -55,7 +55,7 @@ case class WalletStateDescriptorDAO()(implicit
     Seq] =
     findByPrimaryKeys(ts.map(_.tpe))
 
-  def getSyncHeightOpt(): Future[Option[SyncHeightDescriptor]] = {
+  def getSyncDescriptorOpt(): Future[Option[SyncHeightDescriptor]] = {
     read(SyncHeight).map {
       case Some(db) =>
         val desc = SyncHeightDescriptor.fromString(db.descriptor.toString)
@@ -67,7 +67,7 @@ case class WalletStateDescriptorDAO()(implicit
   def updateSyncHeight(
       hash: DoubleSha256DigestBE,
       height: Int): Future[WalletStateDescriptorDb] = {
-    getSyncHeightOpt().flatMap {
+    getSyncDescriptorOpt().flatMap {
       case Some(old) =>
         if (old.height > height) {
           Future.successful(WalletStateDescriptorDb(SyncHeight, old))


### PR DESCRIPTION
We don't just use height in the descriptor, the hash is just as valuable for connecting to chains

This is something that I thought while doing #2461