### PR TITLE
Add officially supported version of bitcoind by eclair, also add the …

### DIFF
--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -5,7 +5,6 @@ import java.net.InetSocketAddress
 import java.nio.file.NoSuchFileException
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.http.javadsl.model.headers.HttpCredentials
@@ -35,6 +34,7 @@ import org.bitcoins.crypto.{DoubleSha256DigestBE, Sha256Digest}
 import org.bitcoins.eclair.rpc.api._
 import org.bitcoins.eclair.rpc.config.EclairInstance
 import org.bitcoins.eclair.rpc.network.NodeUri
+import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.util.AsyncUtil
 import org.slf4j.LoggerFactory
 import play.api.libs.json._
@@ -973,4 +973,9 @@ object EclairRpcClient {
 
   /** The current version we support of Eclair */
   private[bitcoins] val version = "0.4.1"
+
+  /** The bitcoind version that eclair is officially tested & supported with by ACINQ
+    * @see https://github.com/ACINQ/eclair/releases/tag/v0.4
+    */
+  val bitcoindV: BitcoindVersion = BitcoindVersion.V19
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -62,13 +62,41 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
     BitcoindRpcTestUtil.startedBitcoindRpcClient(instance)
   }
 
+  /** Creates a bitcoind instance with the given parameters */
   def bitcoindInstance(
       port: Int = RpcUtil.randomPort,
       rpcPort: Int = RpcUtil.randomPort,
-      zmqPort: Int = RpcUtil.randomPort): BitcoindInstance = {
-    BitcoindRpcTestUtil.v19Instance(port = port,
-                                    rpcPort = rpcPort,
-                                    zmqPort = zmqPort)
+      zmqPort: Int = RpcUtil.randomPort,
+      bitcoindV: BitcoindVersion =
+        EclairRpcClient.bitcoindV): BitcoindInstance = {
+    bitcoindV match {
+      case BitcoindVersion.V20 =>
+        BitcoindRpcTestUtil.v20Instance(port = port,
+                                        rpcPort = rpcPort,
+                                        zmqPort = zmqPort)
+      case BitcoindVersion.V19 =>
+        BitcoindRpcTestUtil.v19Instance(port = port,
+                                        rpcPort = rpcPort,
+                                        zmqPort = zmqPort)
+      case BitcoindVersion.V18 =>
+        BitcoindRpcTestUtil.v18Instance(port = port,
+                                        rpcPort = rpcPort,
+                                        zmqPort = zmqPort)
+      case BitcoindVersion.V17 =>
+        BitcoindRpcTestUtil.v17Instance(port = port,
+                                        rpcPort = rpcPort,
+                                        zmqPort = zmqPort)
+      case BitcoindVersion.V16 =>
+        BitcoindRpcTestUtil.v16Instance(port = port,
+                                        rpcPort = rpcPort,
+                                        zmqPort = zmqPort)
+      case BitcoindVersion.Experimental =>
+        BitcoindRpcTestUtil.vExperimentalInstance(port = port,
+                                                  rpcPort = rpcPort,
+                                                  zmqPort = zmqPort)
+      case BitcoindVersion.Unknown =>
+        sys.error(s"Cannot start eclair with an unknown instance of bitcoind")
+    }
   }
 
   //cribbed from https://github.com/Christewart/eclair/blob/bad02e2c0e8bd039336998d318a861736edfa0ad/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala#L140-L153
@@ -676,7 +704,9 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
     EclairRpcTestUtil.awaitUntilChannelNormal(client1, chanId)
   }
 
-  def getBitcoindRpc(eclairRpcClient: EclairRpcClient)(implicit
+  def getBitcoindRpc(
+      eclairRpcClient: EclairRpcClient,
+      bitcoindVersion: BitcoindVersion = EclairRpcClient.bitcoindV)(implicit
       system: ActorSystem): BitcoindRpcClient = {
     val bitcoindRpc = {
       val instance = eclairRpcClient.instance
@@ -686,7 +716,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
         uri = new URI("http://localhost:18333"),
         rpcUri = auth.bitcoindRpcUri,
         authCredentials = auth.bitcoinAuthOpt.get,
-        binary = BitcoindRpcTestUtil.getBinary(BitcoindVersion.newest)
+        binary = BitcoindRpcTestUtil.getBinary(bitcoindVersion)
       )
       BitcoindRpcClient.withActorSystem(bitcoindInstance)
     }


### PR DESCRIPTION
…ability to specify which version of bitcoind you are using for EclairRpcTestUtil.getBitcoindRpc

This is needed on closed source side of things to play nice with CI, we don't want to always use `BitcoindVersion.latest` when trying to retrieve a bitcoind rpc client connected to eclair. 