### PR TITLE
Make allFactories lazy so we don't hit NPE exceptions

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -148,7 +148,7 @@ object TLV extends TLVParentFactory[TLV] {
 
   val typeName = "TLV"
 
-  val allFactories: Vector[TLVFactory[TLV]] = {
+  override lazy val allFactories: Vector[TLVFactory[TLV]] = {
     Vector(ErrorTLV,
            PingTLV,
            PongTLV,


### PR DESCRIPTION
We are getting a NPE exception on the oracle explorer on this `val` when the server is booted up, make it lazy for a workaround for now