### PR TITLE
Add new sbt-native-image plugin that helps generate a correct native …

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -18,13 +18,13 @@ jobs:
         include:
           - os: macOS-latest
             uploaded_filename: bitcoin-s-cli-x86_64-apple-darwin
-            local_path: cli/target/native-image/bitcoin-s-cli
+            local_path: app/cli/target/native-image/bitcoin-s-cli
           - os: ubuntu-latest
             uploaded_filename: bitcoin-s-cli-x86_64-pc-linux
-            local_path: cli/target/native-image/bitcoin-s-cli
+            local_path: app/cli/target/native-image/bitcoin-s-cli
           - os: windows-latest
             uploaded_filename: bitcoin-s-cli-x86_64-pc-win32.exe
-            local_path: cli\target\native-image\bitcoin-s-cli.exe
+            local_path: app\cli\target\native-image\bitcoin-s-cli.exe
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -1,0 +1,57 @@
+# Docs:
+# https://github.com/scalameta/sbt-native-image#generate-native-image-from-github-actions
+name: Native Image bitcoin-s-cli
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  release:
+    types: [published]
+jobs:
+  unix:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macOS-latest
+            uploaded_filename: bitcoin-s-cli-x86_64-apple-darwin
+            local_path: cli/target/native-image/bitcoin-s-cli
+          - os: ubuntu-latest
+            uploaded_filename: bitcoin-s-cli-x86_64-pc-linux
+            local_path: cli/target/native-image/bitcoin-s-cli
+          - os: windows-latest
+            uploaded_filename: bitcoin-s-cli-x86_64-pc-win32.exe
+            local_path: cli\target\native-image\bitcoin-s-cli.exe
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v10
+      - run: git fetch --tags || true
+      - run: sbt cli/nativeImage
+        shell: bash
+        if: ${{ matrix.os != 'windows-latest' }}
+      - run: echo $(pwd)
+        shell: bash
+      - name: sbt cliTest/test
+        shell: cmd
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: >-
+          "C:\Program Files (x86)\Microsoft Visual
+          Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && sbt
+          cli/nativeImage
+      - uses: actions/upload-artifact@master
+        with:
+          path: ${{ matrix.local_path }}
+          name: ${{ matrix.uploaded_filename }}
+      - name: Upload release
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ matrix.local_path }}
+          asset_name: ${{ matrix.uploaded_filename }}
+          asset_content_type: application/zip

--- a/app/cli/cli.sbt
+++ b/app/cli/cli.sbt
@@ -2,17 +2,4 @@ name := "bitcoin-s-cli"
 
 libraryDependencies ++= Deps.cli(scalaVersion.value)
 
-graalVMNativeImageOptions ++= Seq(
-  "-H:EnableURLProtocols=http",
-  "-H:+ReportExceptionStackTraces",
-  // builds a stand-alone image or reports a failure
-  "--no-fallback",
-  // without this, we get complaints about Function3
-  // I'm not sure why, though...
-  "--initialize-at-build-time=scala.Function3",
-  "--report-unsupported-elements-at-runtime",
-  "--verbose",
-  "--allow-incomplete-classpath"
-)
-
-enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin)
+enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin, NativeImagePlugin)

--- a/app/cli/cli.sbt
+++ b/app/cli/cli.sbt
@@ -10,4 +10,4 @@ nativeImageOptions ++= Seq(
   "--enable-https"
 )
 
-enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin, NativeImagePlugin)
+enablePlugins(JavaAppPackaging, NativeImagePlugin)

--- a/app/cli/cli.sbt
+++ b/app/cli/cli.sbt
@@ -2,4 +2,9 @@ name := "bitcoin-s-cli"
 
 libraryDependencies ++= Deps.cli(scalaVersion.value)
 
+nativeImageOptions ++= Seq(
+  "-H:+ReportExceptionStackTraces",
+  "--initialize-at-build-time"
+)
+
 enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin, NativeImagePlugin)

--- a/app/cli/cli.sbt
+++ b/app/cli/cli.sbt
@@ -5,7 +5,9 @@ libraryDependencies ++= Deps.cli(scalaVersion.value)
 nativeImageOptions ++= Seq(
   "-H:+ReportExceptionStackTraces",
   "--initialize-at-build-time",
-  "--no-fallback"
+  "--no-fallback",
+  "--enable-http",
+  "--enable-https"
 )
 
 enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin, NativeImagePlugin)

--- a/app/cli/cli.sbt
+++ b/app/cli/cli.sbt
@@ -4,7 +4,8 @@ libraryDependencies ++= Deps.cli(scalaVersion.value)
 
 nativeImageOptions ++= Seq(
   "-H:+ReportExceptionStackTraces",
-  "--initialize-at-build-time"
+  "--initialize-at-build-time",
+  "--no-fallback"
 )
 
 enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin, NativeImagePlugin)

--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -8,20 +8,8 @@ libraryDependencies ++= Deps.oracleServer
 
 mainClass := Some("org.bitcoins.oracle.server.OracleServerMain")
 
-graalVMNativeImageOptions ++= Seq(
-  "-H:EnableURLProtocols=http",
-  "-H:+ReportExceptionStackTraces",
-  // builds a stand-alone image or reports a failure
-  "--no-fallback",
-  // without this, we get complaints about Function3
-  // I'm not sure why, though...
-  "--initialize-at-build-time=scala.Function3",
-  "--report-unsupported-elements-at-runtime",
-  "--verbose"
-)
-
 packageSummary := "A DLC Oracle"
 
 packageDescription := "A basic DLC oracle that allows you to commit to events and sign them"
 
-enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin)
+enablePlugins(JavaAppPackaging)

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -8,21 +8,9 @@ libraryDependencies ++= Deps.server(scalaVersion.value)
 
 mainClass := Some("org.bitcoins.server.BitcoinSServerMain")
 
-graalVMNativeImageOptions ++= Seq(
-  "-H:EnableURLProtocols=http",
-  "-H:+ReportExceptionStackTraces",
-  // builds a stand-alone image or reports a failure
-  "--no-fallback",
-  // without this, we get complaints about Function3
-  // I'm not sure why, though...
-  "--initialize-at-build-time=scala.Function3",
-  "--report-unsupported-elements-at-runtime",
-  "--verbose"
-)
-
 packageSummary := "A Bitcoin neutrino node and wallet"
 
 packageDescription := "Runs a Bitcoin neutrino node and wallet, has functionality " +
   "for many different modes and configuration options, see more at https://bitcoin-s.org/docs/applications/server"
 
-enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin)
+enablePlugins(JavaAppPackaging)

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -11,7 +11,8 @@ mainClass := Some("org.bitcoins.server.BitcoinSServerMain")
 nativeImageOptions ++= Seq(
   "--enable-https",
   "--enable-http",
-  "--initialize-at-build-time"
+  "--initialize-at-build-time",
+  "--no-fallback"
 )
 
 packageSummary := "A Bitcoin neutrino node and wallet"

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -8,11 +8,16 @@ libraryDependencies ++= Deps.server(scalaVersion.value)
 
 mainClass := Some("org.bitcoins.server.BitcoinSServerMain")
 
-nativeImageOptions ++= Seq(
-  "--enable-https",
-  "--enable-http",
-  "--initialize-at-build-time",
-  "--no-fallback"
+graalVMNativeImageOptions ++= Seq(
+  "-H:EnableURLProtocols=http",
+  "-H:+ReportExceptionStackTraces",
+  // builds a stand-alone image or reports a failure
+  "--no-fallback",
+  // without this, we get complaints about Function3
+  // I'm not sure why, though...
+  "--initialize-at-build-time=scala.Function3",
+  "--report-unsupported-elements-at-runtime",
+  "--verbose"
 )
 
 packageSummary := "A Bitcoin neutrino node and wallet"
@@ -20,4 +25,4 @@ packageSummary := "A Bitcoin neutrino node and wallet"
 packageDescription := "Runs a Bitcoin neutrino node and wallet, has functionality " +
   "for many different modes and configuration options, see more at https://bitcoin-s.org/docs/applications/server"
 
-enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin, NativeImagePlugin)
+enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin)

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -8,16 +8,10 @@ libraryDependencies ++= Deps.server(scalaVersion.value)
 
 mainClass := Some("org.bitcoins.server.BitcoinSServerMain")
 
-graalVMNativeImageOptions ++= Seq(
-  "-H:EnableURLProtocols=http",
-  "-H:+ReportExceptionStackTraces",
-  // builds a stand-alone image or reports a failure
-  "--no-fallback",
-  // without this, we get complaints about Function3
-  // I'm not sure why, though...
-  "--initialize-at-build-time=scala.Function3",
-  "--report-unsupported-elements-at-runtime",
-  "--verbose"
+nativeImageOptions ++= Seq(
+  "--enable-https",
+  "--enable-http",
+  "--initialize-at-build-time"
 )
 
 packageSummary := "A Bitcoin neutrino node and wallet"
@@ -25,4 +19,4 @@ packageSummary := "A Bitcoin neutrino node and wallet"
 packageDescription := "Runs a Bitcoin neutrino node and wallet, has functionality " +
   "for many different modes and configuration options, see more at https://bitcoin-s.org/docs/applications/server"
 
-enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin)
+enablePlugins(JavaAppPackaging, GraalVMNativeImagePlugin, NativeImagePlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,3 +33,6 @@ addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % "6.4.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+
+//https://github.com/scalameta/sbt-native-image
+addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.2.2")


### PR DESCRIPTION
…image for the cli

This seems to work out of the box with our `cli` which is very exciting. This can be used when we ship binaries for the cli as per #2070 

https://github.com/scalameta/sbt-native-image

You can build the cli with 

`cli/nativeImage`

This will even download graalvm native image for you, before building the cli. So you just literally need to run the command. 

I did test this out, and it appears things are working _except_  `--version`

```scala
./bitcoin-s-cli getblockcount
1903161
./bitcoin-s-cli getnewaddress
myJf9nBETPST8jWDbTdpEK73RzwH5Rii8b
./bitcoin-s-cli --version
null
```
