### PR TITLE
2021 01 09 issue 2496

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
@@ -86,7 +86,7 @@ class ServerRunTest extends BitcoinSAsyncTest {
       // Cleanup
       directory.deleteRecursively()
 
-      val expectedDir = datadir
+      val expectedDir = datadir.resolve("regtest")
 
       // Check the log location was correctly set
       assert(

--- a/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
@@ -86,7 +86,7 @@ class ServerRunTest extends BitcoinSAsyncTest {
       // Cleanup
       directory.deleteRecursively()
 
-      val expectedDir = datadir.resolve("regtest")
+      val expectedDir = datadir
 
       // Check the log location was correctly set
       assert(

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -3,7 +3,6 @@ package org.bitcoins.server
 import akka.actor.ActorSystem
 import akka.dispatch.Dispatchers
 import akka.http.scaladsl.Http
-import grizzled.slf4j.Logging
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models._
@@ -26,8 +25,7 @@ import org.bitcoins.wallet.config.WalletAppConfig
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
 class BitcoinSServerMain(override val args: Array[String])
-    extends BitcoinSRunner
-    with Logging {
+    extends BitcoinSRunner {
 
   override val actorSystemName = "bitcoin-s-server"
 

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinSLogger.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinSLogger.scala
@@ -6,5 +6,3 @@ import grizzled.slf4j.Logging
   * Created by chris on 3/11/16.
   */
 trait BitcoinSLogger extends Logging
-
-object BitcoinSLogger extends BitcoinSLogger

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -122,8 +122,8 @@ abstract class AppConfig extends StartStopAsync[Unit] with BitcoinSLogger {
   protected lazy val config: Config = {
     val finalConfig = AppConfig.getBaseConfig(baseDatadir, configOverrides)
 
-    logger.debug(s"Resolved bitcoin-s config:")
-    logger.debug(finalConfig.asReadableJson)
+    logger.trace(s"Resolved bitcoin-s config:")
+    logger.trace(finalConfig.asReadableJson)
 
     val resolved = {
       ConfigFactory


### PR DESCRIPTION
fixes #2496 

There was/is a problem with our current logging setup. We set a JVM system property the indicate where we log to. This property is `bitcoin-s.log.location`. 

When then reference this property in our `logback.xml` file here 

https://github.com/bitcoin-s/bitcoin-s/blob/4785b5c7957ec505301485b886ae990a4f937c49/app/server/src/main/resources/logback.xml#L15

There is a problem though, if any logger is instantiated before the system property is set, we log to the directory that bitcoin-s was started in under a file called 

>bitcoins.log.location_IS_UNDEFINED/bitcoin-s.log

This is obviously not what we want. 

You can see logback documentation on this issue

>Given that "logback.configurationFile" is a Java system property, it may be set within your application as well. However, the system property must be set before any logger instance is created. 

This isn't the specific system property we are using, but i think the concept applies to all system properties

http://logback.qos.ch/manual/configuration.html

Unfortunately there seems to be a tradeoff in this PR, we can't retain network specific information for where to log. This PR logs in the root datadir (default `$HOME/.bitcoin-s/bitcoin-s.log`) and NOT `$HOME/.bitcoin-s/{mainnet,testnet3,regtest}/bitcoin-s.log`). 

I can't seem to figure out how to get the latter working.