### PR TITLE
2021 01 11 issue 2493

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/MainnetChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/MainnetChainHandlerTest.scala
@@ -23,7 +23,7 @@ class MainnetChainHandlerTest extends ChainDbUnitTest {
 
   override val defaultTag: ChainFixtureTag = ChainFixtureTag.GenisisChainHandler
 
-  implicit override lazy val appConfig: ChainAppConfig = mainnetAppConfig
+  implicit override lazy val cachedChainConf: ChainAppConfig = mainnetAppConfig
 
   val source: BufferedSource = FileUtil.getFileAsSource("block_headers.json")
   val arrStr: String = source.getLines().next()

--- a/chain-test/src/test/scala/org/bitcoins/chain/config/ChainAppConfigTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/config/ChainAppConfigTest.scala
@@ -17,7 +17,7 @@ class ChainAppConfigTest extends ChainUnitTest {
   //if we don't turn off logging here, isInitF a few lines down will
   //produce some nasty error logs since we are testing initialization
   //of the chain project
-  val chainAppConfig = appConfig.withOverrides(
+  val chainAppConfig = cachedChainConf.withOverrides(
     ConfigFactory.parseString("bitcoin-s.logging.level=OFF"))
 
   behavior of "ChainAppConfig"

--- a/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
@@ -24,7 +24,7 @@ class BitcoinPowTest extends ChainDbUnitTest {
   override type FixtureParam = ChainFixture
 
   // we're working with mainnet data
-  implicit override lazy val appConfig: ChainAppConfig = mainnetAppConfig
+  implicit override lazy val cachedChainConf: ChainAppConfig = mainnetAppConfig
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withChainFixture(test)

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -15,7 +15,7 @@ class TipValidationTest extends ChainDbUnitTest {
   override type FixtureParam = BlockHeaderDAO
 
   // we're working with mainnet data
-  implicit override lazy val appConfig: ChainAppConfig = mainnetAppConfig
+  implicit override lazy val cachedChainConf: ChainAppConfig = mainnetAppConfig
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBlockHeaderDAO(test)

--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -18,13 +18,13 @@ import scala.util.control.NonFatal
 class BroadcastTransactionTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def config: BitcoinSAppConfig =
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoindV19
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withSpvNodeConnectedToBitcoindV19(test)
+    withSpvNodeConnectedToBitcoindV19(test)(system, getFreshConfig)
 
   private val sendAmount = 1.bitcoin
 

--- a/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
@@ -4,19 +4,22 @@ import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.Implicits._
 import org.bitcoins.testkit.core.gen.TransactionGenerators
-import org.bitcoins.testkit.node.NodeUnitTest
+import org.bitcoins.testkit.node.{CachedBitcoinSAppConfig, NodeUnitTest}
 import org.scalatest.FutureOutcome
 
-class DisconnectedPeerTest extends NodeUnitTest {
+class DisconnectedPeerTest extends NodeUnitTest with CachedBitcoinSAppConfig {
+
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected val config: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
+  implicit override protected lazy val config: BitcoinSAppConfig =
+    getFreshConfig
 
   override type FixtureParam = SpvNode
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withDisconnectedSpvNode(test)
+    withDisconnectedSpvNode(test)(system, config)
 
   it must "fail to broadcast a transaction when disconnected" in { node =>
     val tx = TransactionGenerators.transaction.sampleSome

--- a/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
@@ -13,13 +13,13 @@ class DisconnectedPeerTest extends NodeUnitTest with CachedBitcoinSAppConfig {
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected lazy val config: BitcoinSAppConfig =
+  implicit override protected lazy val cachedConfig: BitcoinSAppConfig =
     getFreshConfig
 
   override type FixtureParam = SpvNode
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withDisconnectedSpvNode(test)(system, config)
+    withDisconnectedSpvNode(test)(system, cachedConfig)
 
   it must "fail to broadcast a transaction when disconnected" in { node =>
     val tx = TransactionGenerators.transaction.sampleSome

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -23,7 +23,7 @@ import scala.concurrent.{Future, Promise}
 class NeutrinoNodeTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def config: BitcoinSAppConfig =
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 class NeutrinoNodeWithWalletTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def config: BitcoinSAppConfig =
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
@@ -40,7 +40,7 @@ class NeutrinoNodeWithWalletTest extends NodeUnitTest {
         test = test,
         bip39PasswordOpt = getBIP39PasswordOpt(),
         versionOpt = Some(BitcoindVersion.Experimental)
-      )(system, config)
+      )(system, getFreshConfig)
     }
   }
 

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration.DurationInt
 class SpvNodeTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def config: BitcoinSAppConfig =
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoind

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Future
 class SpvNodeWithWalletTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def config: BitcoinSAppConfig =
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = SpvNodeFundedWalletBitcoind

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.{BeforeAndAfter, FutureOutcome}
 class UpdateBloomFilterTest extends NodeUnitTest with BeforeAndAfter {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def config: BitcoinSAppConfig =
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = SpvNodeFundedWalletBitcoind

--- a/node-test/src/test/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAOTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAOTest.scala
@@ -9,7 +9,7 @@ import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 class BroadcastAbleTransactionDAOTest extends NodeDAOFixture with EmbeddedPg {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def config: BitcoinSAppConfig =
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   behavior of "BroadcastAbleTransactionDAO"

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -122,13 +122,13 @@ class P2PClientTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
   behavior of "P2PClient"
 
   override def beforeAll(): Unit = {
-    implicit val chainConf = config.chainConf
+    implicit val chainConf = cachedConfig.chainConf
     chainConf.migrate()
     ()
   }
 
   override def afterAll(): Unit = {
-    implicit val chainConf = config.chainConf
+    implicit val chainConf = cachedConfig.chainConf
     val shutdownConfigF = for {
       _ <- chainConf.dropTable("flyway_schema_history")
       _ <- chainConf.dropAll()
@@ -165,8 +165,6 @@ class P2PClientTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
     * connection to the specified port
     */
   def connectAndDisconnect(peer: Peer): Future[Assertion] = {
-    implicit val chainConf = config.chainConf
-    implicit val nodeConf = config.nodeConf
 
     val probe = TestProbe()
     val remote = peer.socket

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -19,7 +19,7 @@ import scala.concurrent.{Future, Promise}
 class DataMessageHandlerTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def config: BitcoinSAppConfig =
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoindV19

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -25,7 +25,7 @@ class PeerMessageHandlerTest extends NodeUnitTest with CachedBitcoinSAppConfig {
   }
 
   implicit protected lazy val chainConfig: ChainAppConfig =
-    config.chainConf
+    cachedConfig.chainConf
 
   behavior of "PeerHandler"
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -1,11 +1,10 @@
 package org.bitcoins.node.networking.peer
 
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.async.TestAsyncUtil
-import org.bitcoins.testkit.node.NodeUnitTest
+import org.bitcoins.testkit.node.{CachedBitcoinSAppConfig, NodeUnitTest}
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.duration.DurationInt
@@ -13,10 +12,10 @@ import scala.concurrent.duration.DurationInt
 /**
   * Created by chris on 7/1/16.
   */
-class PeerMessageHandlerTest extends NodeUnitTest {
+class PeerMessageHandlerTest extends NodeUnitTest with CachedBitcoinSAppConfig {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def config: BitcoinSAppConfig =
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvTestConfig()
 
   override type FixtureParam = Unit
@@ -25,12 +24,8 @@ class PeerMessageHandlerTest extends NodeUnitTest {
     test(())
   }
 
-  private val cachedConfig = config
-
-  implicit private lazy val nodeAppConfig: NodeAppConfig = cachedConfig.nodeConf
-
   implicit protected lazy val chainConfig: ChainAppConfig =
-    cachedConfig.chainConf
+    config.chainConf
 
   behavior of "PeerHandler"
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainDbUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainDbUnitTest.scala
@@ -7,7 +7,7 @@ import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 
 trait ChainDbUnitTest extends ChainUnitTest with EmbeddedPg {
 
-  implicit override lazy val appConfig: ChainAppConfig = {
+  implicit override lazy val cachedChainConf: ChainAppConfig = {
     val memoryDb =
       BitcoinSTestAppConfig.configWithEmbeddedDb(Some(ProjectType.Chain), pgUrl)
     val chainConfig: ChainAppConfig =

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -41,9 +41,6 @@ trait ChainUnitTest
     with ChainFixtureHelper
     with CachedChainAppConfig {
 
-  implicit lazy val appConfig: ChainAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig()
-
   /**
     * Behaves exactly like the default conf, execpt
     * network is set to mainnet
@@ -54,7 +51,7 @@ trait ChainUnitTest
   }
 
   override def beforeAll(): Unit = {
-    AppConfig.throwIfDefaultDatadir(appConfig)
+    AppConfig.throwIfDefaultDatadir(cachedChainConf)
   }
 
   override def afterAll(): Unit = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/NodeDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/NodeDAOFixture.scala
@@ -21,11 +21,11 @@ trait NodeDAOFixture extends NodeUnitTest with CachedBitcoinSAppConfig {
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     makeFixture(build = () => {
-                  nodeConf
+                  cachedNodeConf
                     .start()
                     .map(_ => daos)
                 },
-                destroy = () => destroyAppConfig(nodeConf))(test)
+                destroy = () => destroyAppConfig(cachedNodeConf))(test)
   }
 
   private def destroyAppConfig(nodeConfig: NodeAppConfig): Future[Unit] = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/NodeDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/NodeDAOFixture.scala
@@ -2,7 +2,7 @@ package org.bitcoins.testkit.fixtures
 
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.BroadcastAbleTransactionDAO
-import org.bitcoins.testkit.node.NodeUnitTest
+import org.bitcoins.testkit.node.{CachedBitcoinSAppConfig, NodeUnitTest}
 import org.scalatest._
 
 import scala.concurrent.Future
@@ -10,9 +10,7 @@ import scala.concurrent.Future
 case class NodeDAOs(txDAO: BroadcastAbleTransactionDAO)
 
 /** Provides a fixture where all DAOs used by the node projects are provided */
-trait NodeDAOFixture extends NodeUnitTest {
-
-  implicit protected lazy val nodeConfig: NodeAppConfig = config.nodeConf
+trait NodeDAOFixture extends NodeUnitTest with CachedBitcoinSAppConfig {
 
   private lazy val daos = {
     val tx = BroadcastAbleTransactionDAO()
@@ -23,11 +21,11 @@ trait NodeDAOFixture extends NodeUnitTest {
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     makeFixture(build = () => {
-                  nodeConfig
+                  nodeConf
                     .start()
                     .map(_ => daos)
                 },
-                destroy = () => destroyAppConfig(nodeConfig))(test)
+                destroy = () => destroyAppConfig(nodeConf))(test)
   }
 
   private def destroyAppConfig(nodeConfig: NodeAppConfig): Future[Unit] = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -20,11 +20,6 @@ sealed trait CachedAppConfig { _: BaseAsyncTest =>
   }
 }
 
-trait CachedChainAppConfig extends CachedAppConfig { _: BaseAsyncTest =>
-
-  implicit protected def appConfig: ChainAppConfig
-}
-
 trait CachedBitcoinSAppConfig { _: BaseAsyncTest =>
 
   implicit protected lazy val cachedConfig: BitcoinSAppConfig =
@@ -45,4 +40,8 @@ trait CachedBitcoinSAppConfig { _: BaseAsyncTest =>
   override def afterAll(): Unit = {
     Await.result(cachedConfig.stop(), akkaTimeout.duration)
   }
+}
+
+trait CachedChainAppConfig extends CachedBitcoinSAppConfig { _: BaseAsyncTest =>
+
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -5,7 +5,8 @@ import org.bitcoins.db.AppConfig
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
-import org.bitcoins.testkit.util.{BaseAsyncTest}
+import org.bitcoins.testkit.util.BaseAsyncTest
+import org.bitcoins.wallet.config.WalletAppConfig
 
 import scala.concurrent.Await
 
@@ -26,14 +27,22 @@ trait CachedChainAppConfig extends CachedAppConfig { _: BaseAsyncTest =>
 
 trait CachedBitcoinSAppConfig { _: BaseAsyncTest =>
 
-  implicit protected lazy val config: BitcoinSAppConfig =
+  implicit protected lazy val cachedConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvTestConfig()
 
-  implicit protected lazy val nodeConf: NodeAppConfig = {
-    config.nodeConf
+  implicit protected lazy val cachedNodeConf: NodeAppConfig = {
+    cachedConfig.nodeConf
+  }
+
+  implicit protected lazy val cachedWalletConf: WalletAppConfig = {
+    cachedConfig.walletConf
+  }
+
+  implicit protected lazy val cachedChainConf: ChainAppConfig = {
+    cachedConfig.chainConf
   }
 
   override def afterAll(): Unit = {
-    Await.result(config.stop(), akkaTimeout.duration)
+    Await.result(cachedConfig.stop(), akkaTimeout.duration)
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -53,7 +53,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
 
   override def beforeAll(): Unit = {
-    AppConfig.throwIfDefaultDatadir(config.nodeConf)
+    AppConfig.throwIfDefaultDatadir(getFreshConfig.nodeConf)
     super[EmbeddedPg].beforeAll()
   }
 
@@ -62,9 +62,10 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
   }
 
   /** Wallet config with data directory set to user temp directory */
-  implicit protected def config: BitcoinSAppConfig
+  implicit protected def getFreshConfig: BitcoinSAppConfig
 
-  implicit override lazy val np: NetworkParameters = config.nodeConf.network
+  implicit override lazy val np: NetworkParameters =
+    getFreshConfig.nodeConf.network
 
   lazy val startedBitcoindF = BitcoindRpcTestUtil.startedBitcoindRpcClient()
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -45,22 +45,22 @@ trait BitcoinSWalletTest extends BitcoinSFixture with EmbeddedPg {
   import BitcoinSWalletTest._
 
   /** Wallet config with data directory set to user temp directory */
-  implicit protected def config: BitcoinSAppConfig =
+  implicit protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
-  implicit protected def walletAppConfig: WalletAppConfig = {
-    config.walletConf
+  implicit protected def getFreshWalletAppConfig: WalletAppConfig = {
+    getFreshConfig.walletConf
   }
 
   override def beforeAll(): Unit = {
-    AppConfig.throwIfDefaultDatadir(config.walletConf)
+    AppConfig.throwIfDefaultDatadir(getFreshConfig.walletConf)
     super[EmbeddedPg].beforeAll()
   }
 
   override def afterAll(): Unit = {
-    Await.result(config.chainConf.stop(), 1.minute)
-    Await.result(config.nodeConf.stop(), 1.minute)
-    Await.result(config.walletConf.stop(), 1.minute)
+    Await.result(getFreshConfig.chainConf.stop(), 1.minute)
+    Await.result(getFreshConfig.nodeConf.stop(), 1.minute)
+    Await.result(getFreshConfig.walletConf.stop(), 1.minute)
     super[EmbeddedPg].afterAll()
   }
 
@@ -152,7 +152,7 @@ trait BitcoinSWalletTest extends BitcoinSFixture with EmbeddedPg {
   /** Lets you customize the parameters for the created wallet */
   val withNewConfiguredWallet: Config => OneArgAsyncTest => FutureOutcome = {
     walletConfig =>
-      val newWalletConf = walletAppConfig.withOverrides(walletConfig)
+      val newWalletConf = getFreshWalletAppConfig.withOverrides(walletConfig)
       val km = createNewKeyManager()(newWalletConf)
       val bip39PasswordOpt = KeyManagerTestUtil.bip39PasswordOpt
       makeDependentFixture(
@@ -307,7 +307,7 @@ trait BitcoinSWalletTest extends BitcoinSFixture with EmbeddedPg {
 
   def withWalletConfig(test: OneArgAsyncTest): FutureOutcome = {
     val builder: () => Future[WalletAppConfig] = () => {
-      val baseConf = config.walletConf
+      val baseConf = getFreshConfig.walletConf
       val walletNameOpt = if (NumberGenerator.bool.sampleSome) {
         Some(StringGenerators.genNonEmptyString.sampleSome)
       } else None

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Future
 class RescanHandlingTest extends BitcoinSWalletTest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def config: BitcoinSAppConfig =
+  implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = WalletWithBitcoind


### PR DESCRIPTION
fixes #2493 

Previously we had a _method_ named `NodeUnitTest.config`. I think a lot of people thought this was a cached config file in the super trait `NodeUnitTest`. In reality it was a creating a _fresh_ `BitcoinSAppConfig` everytime it was called. This led to incorrect uses through out the `nodeTest` project. 