### PR TITLE
Fix native CI workflow for different branches

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -10,6 +10,7 @@ on:
     types: [published]
 jobs:
   unix:
+    if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -3,8 +3,8 @@
 name: Native Image bitcoin-s-cli
 on:
   push:
-    branches:
-      - master
+    branches: [master, main, adaptor-dlc]
+    tags: ["*"]
   pull_request:
   release:
     types: [published]


### PR DESCRIPTION
Previously it was always running the native ci workflow on documentation prs & would not be ran on the adaptor-dlc branch