### PR TITLE
Remove WalletSync.sync() -> WalletSync.syncFullBlocks()

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
@@ -168,13 +168,16 @@ abstract class SyncUtil extends BitcoinSLogger {
     node.NodeChainQueryApi(nodeApi, chainQuery)
   }
 
-  def syncWallet(wallet: Wallet, bitcoind: BitcoindRpcClient)(implicit
+  /** Syncs a wallet against bitcoind by retrieving full blocks and then calling
+    * [[Wallet.processBlock()]]
+    */
+  def syncWalletFullBlocks(wallet: Wallet, bitcoind: BitcoindRpcClient)(implicit
       ec: ExecutionContext): Future[Wallet] = {
-    WalletSync.sync(
+    WalletSync.syncFullBlocks(
       wallet = wallet,
       getBlockHeaderFunc = SyncUtil.getBlockHeaderFunc(bitcoind),
       getBestBlockHashFunc = SyncUtil.getBestBlockHashFunc(bitcoind),
-      getBlock = SyncUtil.getBlockFunc(bitcoind)
+      getBlockFunc = SyncUtil.getBlockFunc(bitcoind)
     )
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -274,8 +274,8 @@ trait BitcoinSWalletTest extends BitcoinSFixture with EmbeddedPg {
           bitcoind = bitcoind,
           bip39PasswordOpt = bip39PasswordOpt)
         fundedWallet <- fundWalletWithBitcoind(walletWithBitcoind)
-        _ <-
-          SyncUtil.syncWallet(wallet = fundedWallet.wallet, bitcoind = bitcoind)
+        _ <- SyncUtil.syncWalletFullBlocks(wallet = fundedWallet.wallet,
+                                           bitcoind = bitcoind)
         _ <- BitcoinSWalletTest.awaitWalletBalances(fundedWallet)
       } yield fundedWallet
     }
@@ -294,8 +294,8 @@ trait BitcoinSWalletTest extends BitcoinSFixture with EmbeddedPg {
             .map(_.asInstanceOf[BitcoindV19RpcClient])
         wallet <- createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
         fundedWallet <- fundWalletWithBitcoind(wallet)
-        _ <-
-          SyncUtil.syncWallet(wallet = fundedWallet.wallet, bitcoind = bitcoind)
+        _ <- SyncUtil.syncWalletFullBlocks(wallet = fundedWallet.wallet,
+                                           bitcoind = bitcoind)
         _ <- BitcoinSWalletTest.awaitWalletBalances(fundedWallet)
       } yield {
         WalletWithBitcoindV19(fundedWallet.wallet, bitcoind)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/sync/WalletSyncTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/sync/WalletSyncTest.scala
@@ -22,10 +22,10 @@ class WalletSyncTest extends BitcoinSWalletTest {
     val getBlockHeaderFunc = SyncUtil.getBlockHeaderFunc(bitcoind)
 
     val getBlockFunc = SyncUtil.getBlockFunc(bitcoind)
-    val syncedWalletF = WalletSync.sync(wallet,
-                                        getBlockHeaderFunc,
-                                        getBestBlockHashFunc,
-                                        getBlockFunc)
+    val syncedWalletF = WalletSync.syncFullBlocks(wallet,
+                                                  getBlockHeaderFunc,
+                                                  getBestBlockHashFunc,
+                                                  getBlockFunc)
 
     val bitcoindBestHeaderF = bitcoind.getBestBlockHeader()
     for {


### PR DESCRIPTION
As I was beginning to write #2486 i realized this method is named really poorly.

It is synchronizing blocks, and NOT using any neutrino stuff. I'm renaming this method with the hopes of preventing people from accidentally requesting blocks for the ENTIRE blockchain on live networks. 