### PR TITLE
Fix BitcoindV21RpcClient testkit errors

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -387,7 +387,6 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
       server.start().flatMap { res =>
         val createWalletF = for {
           _ <- res.createWallet("")
-          _ <- res.loadWallet("")
         } yield res
 
         createWalletF.recoverWith {


### PR DESCRIPTION
Fixes #2525

Looks like `createWallet` will load the wallet by default as well. The load wallet was causing the error logs.