### PR TITLE
2021 01 26 fix native image build

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -1207,7 +1207,7 @@ case class ContractInfoV0TLV(
 object ContractInfoV0TLV extends TLVFactory[ContractInfoV0TLV] {
   override val tpe: BigSizeUInt = BigSizeUInt(55342)
 
-  val dummy: ContractInfoV0TLV = {
+  lazy val dummy: ContractInfoV0TLV = {
     ContractInfoV0TLV(
       Satoshis.zero,
       ContractDescriptorV0TLV(Vector("dummy" -> Satoshis(10000))),


### PR DESCRIPTION
fixes #2558 

The problem is that `ContractInfoV0TLV.dummy` gets eagerly evaluated by the native image build tool. Since this makes calls to crypto code (`ECPrivateKey.freshPrivateKey()`) this gives the native image problems.

In the future with things like this we have two options 

1. Make it lazy
2. If it is a `dummy`, just hard code a private key. 

I opted for the former. 

This needs to go into adaptor-dlc and then be pulled down into #2543 