### PR TITLE
Optimize filter sync and fetching filter heights

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -169,7 +169,7 @@ class BitcoindRpcClient(val instance: BitcoindInstance)(implicit
         s"Bitcoind chainApi doesn't allow you fetch block header batch range"))
 
   override def nextFilterHeaderBatchRange(
-      stopHash: DoubleSha256DigestBE,
+      startHeight: Int,
       batchSize: Int): Future[Option[FilterSyncMarker]] =
     Future.failed(
       new UnsupportedOperationException(

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -426,8 +426,7 @@ class ChainHandlerTest extends ChainDbUnitTest {
       for {
         bestBlock <- chainHandler.getBestBlockHeader()
         bestBlockHashBE = bestBlock.hashBE
-        rangeOpt <-
-          chainHandler.nextFilterHeaderBatchRange(DoubleSha256DigestBE.empty, 1)
+        rangeOpt <- chainHandler.nextFilterHeaderBatchRange(0, 1)
       } yield {
         val marker = rangeOpt.get
         assert(rangeOpt.nonEmpty)

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -39,10 +39,10 @@ trait ChainApi extends ChainQueryApi {
     */
   def processHeaders(headers: Vector[BlockHeader]): Future[ChainApi]
 
-  /** Gets a [[org.bitcoins.chain.models.BlockHeaderDb]] from the chain's database */
+  /** Gets a [[org.bitcoins.core.api.chain.db.BlockHeaderDb]] from the chain's database */
   def getHeader(hash: DoubleSha256DigestBE): Future[Option[BlockHeaderDb]]
 
-  /** Gets all [[org.bitcoins.chain.models.BlockHeaderDb]]s at a given height */
+  /** Gets all [[org.bitcoins.core.api.chain.db.BlockHeaderDb]]s at a given height */
   def getHeadersAtHeight(height: Int): Future[Vector[BlockHeaderDb]]
 
   /** Gets the number of blocks in the database */
@@ -83,7 +83,7 @@ trait ChainApi extends ChainQueryApi {
     * Generates a filter header range in form of (startHeight, stopHash) by the given stop hash.
     */
   def nextFilterHeaderBatchRange(
-      prevStopHash: DoubleSha256DigestBE,
+      startHeight: Int,
       batchSize: Int): Future[Option[FilterSyncMarker]]
 
   /**

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -60,7 +60,7 @@ bitcoin-s {
       # to keep the sync time fast, however, for regtest it should be small
       # so it does not exceed the chain size.
 
-      filter-batch-size = 100
+      filter-batch-size = 1000
     }
     # this config key is read by Slick
     db {

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -168,7 +168,7 @@ bitcoin-s {
             # to keep the sync time fast, however, for regtest it should be small
             # so it does not exceed the chain size.
 
-            filter-batch-size = 100
+            filter-batch-size = 1000
         }
         
         hikari-logging = true

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -77,11 +77,11 @@ case class NeutrinoNode(
           prevStopHash = header.hashBE)
 
         // If we have started syncing filters
-        if (filterCount != filterHeaderCount)
+        if (filterCount != filterHeaderCount && filterCount != 0)
           peerMsgSender.sendNextGetCompactFilterCommand(
             chainApi = chainApi,
             filterBatchSize = chainConfig.filterBatchSize,
-            stopHash = header.hashBE)
+            startHeight = filterCount)
       }
 
       logger.info(

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -194,11 +194,10 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
   private[node] def sendNextGetCompactFilterCommand(
       chainApi: ChainApi,
       filterBatchSize: Int,
-      stopHash: DoubleSha256DigestBE)(implicit
-      ec: ExecutionContext): Future[Boolean] = {
+      startHeight: Int)(implicit ec: ExecutionContext): Future[Boolean] = {
     for {
       filterSyncMarkerOpt <-
-        chainApi.nextFilterHeaderBatchRange(stopHash, filterBatchSize)
+        chainApi.nextFilterHeaderBatchRange(startHeight, filterBatchSize)
       res <- filterSyncMarkerOpt match {
         case Some(filterSyncMarker) =>
           logger.info(s"Requesting compact filters from $filterSyncMarker")

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -76,7 +76,9 @@ bitcoin-s {
             # to keep the sync time fast, however, for regtest it should be small
             # so it does not exceed the chain size.
 
-            filter-batch-size = 100
+            # Set a small filter batch size in testkit so we test fetching
+            # multiple filter batches
+            filter-batch-size = 10
         }
         # this config key is read by Slick
         db {

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -108,7 +108,7 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
       Future.successful(None)
 
     override def nextFilterHeaderBatchRange(
-        stopHash: DoubleSha256DigestBE,
+        startHeight: Int,
         batchSize: Int): Future[Option[FilterSyncMarker]] =
       Future.successful(None)
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -153,7 +153,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       _ =
         if (toUpdate.nonEmpty)
           logger.info(s"${toUpdate.size} txos are now confirmed!")
-        else logger.info("No txos to be confirmed")
+        else logger.debug("No txos to be confirmed")
       updated <- spendingInfoDAO.upsertAllSpendingInfoDb(toUpdate.flatten)
     } yield updated
   }


### PR DESCRIPTION
Closes #2417
Closes #2504 

Removes some unneed db calls in filter syncing and should make fetching the filter height faster. Previously we would get all of the filter's data this changes it to just get the height.

Ran some IBD tests and was able to download all filters in under 15 minutes (from local node)