### PR TITLE
2021 01 27 conectionpool

### DIFF
--- a/app/oracle-server/src/main/resources/reference.conf
+++ b/app/oracle-server/src/main/resources/reference.conf
@@ -6,3 +6,10 @@ akka {
   http.server.parsing.max-content-length = 8m
   http.client.parsing.max-content-length = 8m
 }
+
+bitcoin-s {
+    oracle {
+        hikari-logging = true
+        hikari-logging-interval = 1 minute
+    }
+}

--- a/app/oracle-server/src/main/resources/reference.conf
+++ b/app/oracle-server/src/main/resources/reference.conf
@@ -1,3 +1,10 @@
+bitcoin-s {
+    oracle {
+        hikari-logging = true
+        hikari-logging-interval = 1 minute
+    }
+}
+
 akka {
 
   # Set these to the defaults instead of the
@@ -5,11 +12,4 @@ akka {
   http.server.request-timeout = 10s
   http.server.parsing.max-content-length = 8m
   http.client.parsing.max-content-length = 8m
-}
-
-bitcoin-s {
-    oracle {
-        hikari-logging = true
-        hikari-logging-interval = 1 minute
-    }
 }

--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -93,7 +93,7 @@
 
     <!-- Disable slick logging in server -->
     <logger name="slick" level="OFF"/>
-    <logger name="com.zaxxer" level="OFF"/>
+    <logger name="com.zaxxer" level="INFO"/>
 
     <!-- Get rid of messages like this:
     Connection attempt failed. Backing off new connection

--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -18,9 +18,4 @@ bitcoin-s {
         hikari-logging = true
         hikari-logging-interval = 1 minute
     }
-
-    oracle {
-        hikari-logging = true
-        hikari-logging-interval = 1 minute
-    }
 }

--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -1,8 +1,26 @@
 bitcoin-s {
     network = mainnet
 
+    chain {
+        hikari-logging = true
+        hikari-logging-interval = 1 minute
+    }
+
+    wallet {
+        hikari-logging = true
+        hikari-logging-interval = 1 minute
+    }
+
     node {
         mode = neutrino # neutrino, spv, bitcoind
         peers = ["neutrino.suredbits.com:8333"]
+
+        hikari-logging = true
+        hikari-logging-interval = 1 minute
+    }
+
+    oracle {
+        hikari-logging = true
+        hikari-logging-interval = 1 minute
     }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -91,7 +91,15 @@ case class ChainAppConfig(
           }
         }
       }
-      _ = startHikariLogger()
+      _ = {
+        if (isHikariLoggingEnabled) {
+          //.get is safe because hikari logging is enabled
+          startHikariLogger(hikariLoggingInterval.get)
+          ()
+        } else {
+          ()
+        }
+      }
     } yield {
       logger.info(s"Applied ${numMigrations} to chain project")
     }

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -91,10 +91,16 @@ case class ChainAppConfig(
           }
         }
       }
+      _ = startHikariLogger()
     } yield {
       logger.info(s"Applied ${numMigrations} to chain project")
     }
 
+  }
+
+  override def stop(): Future[Unit] = {
+    val _ = stopHikariLogger()
+    FutureUtil.unit
   }
 
   lazy val filterHeaderBatchSize: Int = {

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -91,17 +91,15 @@ case class ChainAppConfig(
           }
         }
       }
-      _ = {
-        if (isHikariLoggingEnabled) {
-          //.get is safe because hikari logging is enabled
-          startHikariLogger(hikariLoggingInterval.get)
-          ()
-        } else {
-          ()
-        }
-      }
     } yield {
+      if (isHikariLoggingEnabled) {
+        //.get is safe because hikari logging is enabled
+        startHikariLogger(hikariLoggingInterval.get)
+        ()
+      }
+
       logger.info(s"Applied ${numMigrations} to chain project")
+      ()
     }
 
   }

--- a/db-commons-test/src/test/scala/org/bitcoins/db/AppConfigTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/AppConfigTest.scala
@@ -97,7 +97,8 @@ class AppConfigTest extends BitcoinSAsyncTest {
     //to freshly load all system properties
     ConfigFactory.invalidateCaches()
 
-    val walletAppConfig = WalletAppConfig(datadir)
+    val walletAppConfig =
+      WalletAppConfig(datadir, BitcoinSTestAppConfig.genWalletNameConf)
     val assertF = for {
       _ <- walletAppConfig.start()
     } yield {

--- a/db-commons-test/src/test/scala/org/bitcoins/db/AppConfigTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/AppConfigTest.scala
@@ -98,7 +98,7 @@ class AppConfigTest extends BitcoinSAsyncTest {
     ConfigFactory.invalidateCaches()
 
     val walletAppConfig =
-      WalletAppConfig(datadir, BitcoinSTestAppConfig.genWalletNameConf)
+      WalletAppConfig(datadir)
     val assertF = for {
       _ <- walletAppConfig.start()
     } yield {

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -20,7 +20,8 @@ bitcoin-s {
       # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
       numThreads = 1
       queueSize=5000
-      connectionPool = disabled
+      connectionPool = "HikariCP"
+      registerMbeans = true
     }
     hikari-logging = false
     hikari-logging-interval = 1 minute

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -43,6 +43,9 @@ bitcoin-s {
     #   user = postgres
     #   password = ""
     # }
+
+    hikari-logging = true
+    hikari-logging-interval = 1 minute
   }
 
 
@@ -70,6 +73,8 @@ bitcoin-s {
     #   user = postgres
     #   password = ""
     # }
+    hikari-logging = true
+    hikari-logging-interval = 1 minute
   }
 
   wallet = ${bitcoin-s.dbDefault}
@@ -103,6 +108,9 @@ bitcoin-s {
     #   user = postgres
     #   password = ""
     # }
+
+    hikari-logging = true
+    hikari-logging-interval = 1 minute
   }
 
     server {
@@ -124,6 +132,9 @@ bitcoin-s {
     #   user = postgres
     #   password = ""
     # }
+
+    hikari-logging = true
+    hikari-logging-interval = 1 minute
   }
 
   test = ${bitcoin-s.dbDefault}

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -22,6 +22,8 @@ bitcoin-s {
       queueSize=5000
       connectionPool = disabled
     }
+    hikari-logging = false
+    hikari-logging-interval = 1 minute
   }
 
   node = ${bitcoin-s.dbDefault}
@@ -43,9 +45,6 @@ bitcoin-s {
     #   user = postgres
     #   password = ""
     # }
-
-    hikari-logging = true
-    hikari-logging-interval = 1 minute
   }
 
 
@@ -73,8 +72,6 @@ bitcoin-s {
     #   user = postgres
     #   password = ""
     # }
-    hikari-logging = true
-    hikari-logging-interval = 1 minute
   }
 
   wallet = ${bitcoin-s.dbDefault}
@@ -108,9 +105,6 @@ bitcoin-s {
     #   user = postgres
     #   password = ""
     # }
-
-    hikari-logging = true
-    hikari-logging-interval = 1 minute
   }
 
     server {
@@ -132,9 +126,6 @@ bitcoin-s {
     #   user = postgres
     #   password = ""
     # }
-
-    hikari-logging = true
-    hikari-logging-interval = 1 minute
   }
 
   test = ${bitcoin-s.dbDefault}

--- a/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala
@@ -107,7 +107,7 @@ abstract class AppConfig extends StartStopAsync[Unit] with BitcoinSLogger {
   /**
     * Name of the module. `chain`, `wallet`, `node` etc.
     */
-  protected[bitcoins] def moduleName: String
+  private[bitcoins] def moduleName: String
 
   /** Chain parameters for the blockchain we're on */
   lazy val chain: BitcoinChainParams = {

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -129,8 +129,8 @@ abstract class DbAppConfig extends AppConfig {
     hikariLoggingOpt match {
       case Some(bool) => bool
       case None       =>
-        //default hikari logging on
-        true
+        //default hikari logging off
+        false
     }
   }
 

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -7,7 +7,9 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 
 import java.nio.file.{Path, Paths}
+import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.{Failure, Success, Try}
 
 abstract class DbAppConfig extends AppConfig {
@@ -119,5 +121,36 @@ abstract class DbAppConfig extends AppConfig {
         logger.error(s"Configuration: ${usedConf.asReadableJson}")
         throw exception
     }
+  }
+
+  lazy val isHikariLoggingEnabled: Boolean = {
+    val hikariLoggingOpt =
+      config.getBooleanOpt(s"bitcoin-s.$moduleName.hikari-logging")
+    hikariLoggingOpt match {
+      case Some(bool) => bool
+      case None       =>
+        //default hikari logging on
+        true
+    }
+  }
+
+  /** Gets how often we should log hikari connection pool stats
+    * if None, this means [[isHikariLoggingEnabled]] is not enabled
+    */
+  lazy val hikariLoggingInterval: Option[Duration] = {
+    if (isHikariLoggingEnabled) {
+      val intervalOpt =
+        config.getDurationOpt(s"bitcoin-s.$moduleName.hikari-logging-interval")
+      val interval = intervalOpt match {
+        case Some(interval) => interval
+        case None           =>
+          //default to 1 minute if nothing is set
+          new FiniteDuration(1, TimeUnit.MINUTES)
+      }
+      Some(interval)
+    } else {
+      None
+    }
+
   }
 }

--- a/db-commons/src/main/scala/org/bitcoins/db/HikariLogging.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/HikariLogging.scala
@@ -1,0 +1,237 @@
+package org.bitcoins.db
+
+import com.codahale.metrics.{Histogram, MetricRegistry}
+import com.zaxxer.hikari.{HikariDataSource, HikariPoolMXBean}
+import org.bitcoins.core.util.{BitcoinSLogger, StartStop}
+import slick.jdbc.JdbcDataSource
+import slick.jdbc.hikaricp.HikariCPJdbcDataSource
+import slick.util.AsyncExecutorMXBean
+
+import java.lang.management.ManagementFactory
+import java.util.concurrent.{Executors, ScheduledFuture, TimeUnit}
+import javax.management.{JMX, ObjectName}
+import scala.concurrent.duration._
+
+case class HikariLogging(
+    hikariDataSource: HikariDataSource,
+    moduleName: String
+) extends BitcoinSLogger
+    with StartStop[HikariLogging] {
+
+  /** Logs thread activity */
+  private case class HikariActivityUpdate(
+      active: Int,
+      idle: Int,
+      waiting: Int,
+      total: Int,
+      maxThreads: Int,
+      activeThreads: Int,
+      maxQueueSize: Int,
+      queueSize: Int
+  ) {
+
+    override def toString: String = {
+      s"""
+         | "${moduleName}-activity-update" : { 
+         |  "active" : ${active},
+         |  "idle" : ${idle},
+         |  "waiting" : ${waiting},
+         |  "total" : ${total},
+         |  "maxThreads" : ${maxThreads},
+         |  "activeThreads" : ${activeThreads},
+         |  "maxQueueSize" : ${maxQueueSize},
+         |  "queueSize" : ${queueSize}
+         |}
+         |""".stripMargin.replaceAll("\\s", "")
+    }
+  }
+
+  /**
+    * From the docs:
+    * How long each connection is used before being returned to the pool. This is the "out of pool" or "in-use" time.
+    * @see https://github.com/brettwooldridge/HikariCP/wiki/Dropwizard-Metrics
+    */
+  private case class HikariPoolUsageUpdate(
+      `75thPercentile`: Double,
+      `95thPercentile`: Double,
+      `98thPercentile`: Double,
+      `99thPercentile`: Double,
+      `999thPercentile`: Double,
+      max: Double,
+      min: Double,
+      median: Double,
+      mean: Double
+  ) {
+
+    override def toString: String = {
+      s"""
+         |"${moduleName}-pool-usage" : { 
+         |  "max" : ${max},
+         |  "min" : ${min},
+         |  "median" : ${median},
+         |  "mean" : ${mean},
+         |  "75thPercentile" : ${`75thPercentile`},
+         |  "95thPercentile" : ${`95thPercentile`},
+         |  "98thPercentile" : ${`98thPercentile`},
+         |  "99thPercentile" : ${`99thPercentile`},
+         |  "999thPercentile" : ${`999thPercentile`}
+         |}
+         |""".stripMargin.replaceAll("\\s", "")
+    }
+  }
+
+  //this is needed to get the 'AsyncExecutor' bean below to register properly
+  //dbConfig.database.ioExecutionContext
+
+  private lazy val poolName = hikariDataSource.getPoolName
+  private lazy val mBeanServer = ManagementFactory.getPlatformMBeanServer
+
+  lazy val aeBeanName = new ObjectName(
+    s"slick:type=AsyncExecutor,name=$poolName")
+
+  lazy val poolBeanName = new ObjectName(
+    s"com.zaxxer.hikari:type=Pool ($poolName)")
+
+  lazy val poolConfigBeanName = new ObjectName(
+    s"com.zaxxer.hikari:type=PoolConfig ($poolName)"
+  )
+
+  /**
+    * MBean uses random string incantations for
+    * accessing attributes :-(
+    *
+    * @see [[https://github.com/brettwooldridge/HikariCP/wiki/MBean-(JMX)-Monitoring-and-Management#programmatic-access HikariCP docs]]
+    */
+  private lazy val objectName = new ObjectName(
+    s"com.zaxxer.hikari:type=Pool ($poolName)"
+  )
+
+  /**
+    * @see https://github.com/brettwooldridge/HikariCP/wiki/MBean-(JMX)-Monitoring-and-Management
+    */
+  private lazy val hikariMxBean =
+    JMX.newMXBeanProxy(mBeanServer, objectName, classOf[HikariPoolMXBean])
+
+  /**
+    * @see http://slick.lightbend.com/doc/3.3.0/config.html#monitoring
+    */
+  private lazy val slickMxBean =
+    JMX.newMXBeanProxy(mBeanServer, aeBeanName, classOf[AsyncExecutorMXBean])
+
+  // https://github.com/brettwooldridge/HikariCP/wiki/Dropwizard-Metrics#pool-namepoolusage
+  private lazy val poolUsageMetricName = s"$poolName.pool.Usage"
+
+  private lazy val metricRegistry: MetricRegistry = Option(
+    hikariDataSource.getMetricRegistry
+  ) match {
+    case Some(registry: MetricRegistry) =>
+      registry
+    case Some(other: AnyRef) =>
+      val msg = s"Could not load metric registry, got $other"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+    case None =>
+      val msg = "Could not load metric registry, got null!"
+      logger.error(msg)
+      throw new RuntimeException(msg)
+  }
+
+  private val logHikariStats: Runnable = () => {
+    import scala.jdk.CollectionConverters._
+
+    val usageHistogram: Histogram =
+      metricRegistry.getHistograms().asScala.get(poolUsageMetricName).get
+    val usageSnapshot = usageHistogram.getSnapshot()
+
+    val poolUsageUpdate = HikariPoolUsageUpdate(
+      `75thPercentile` = usageSnapshot.get75thPercentile(),
+      `95thPercentile` = usageSnapshot.get95thPercentile(),
+      `98thPercentile` = usageSnapshot.get98thPercentile(),
+      `99thPercentile` = usageSnapshot.get99thPercentile(),
+      `999thPercentile` = usageSnapshot.get999thPercentile(),
+      max = usageSnapshot.getMax().toDouble,
+      min = usageSnapshot.getMin().toDouble,
+      median = usageSnapshot.getMedian(),
+      mean = usageSnapshot.getMean()
+    )
+
+    val activityUpdate = HikariActivityUpdate(
+      active = hikariMxBean.getActiveConnections,
+      idle = hikariMxBean.getIdleConnections,
+      waiting = hikariMxBean.getThreadsAwaitingConnection,
+      total = hikariMxBean.getTotalConnections,
+      maxThreads = slickMxBean.getMaxThreads,
+      activeThreads = slickMxBean.getActiveThreads,
+      maxQueueSize = slickMxBean.getMaxQueueSize,
+      queueSize = slickMxBean.getQueueSize
+    )
+
+    logger.info(poolUsageUpdate)
+    logger.info(activityUpdate)
+  }
+
+  private val interval = 30.seconds
+
+  private[this] var started: Boolean = false
+  private[this] var cancelOpt: Option[ScheduledFuture[_]] = None
+
+  override def start(): HikariLogging = {
+    if (!started) {
+      val metricRegistry = new MetricRegistry
+
+      mBeanServer.getMBeanInfo(aeBeanName)
+      mBeanServer.getMBeanInfo(poolBeanName)
+      mBeanServer.getMBeanInfo(poolConfigBeanName)
+
+      hikariDataSource.setMetricRegistry(metricRegistry)
+      val future = HikariLogging.scheduler.scheduleAtFixedRate(
+        logHikariStats,
+        interval.toMillis,
+        interval.toMillis,
+        TimeUnit.MILLISECONDS)
+      cancelOpt = Some(future)
+      started = true
+      this
+    } else {
+      this
+    }
+  }
+
+  override def stop(): HikariLogging = {
+    cancelOpt match {
+      case Some(cancel) =>
+        if (!cancel.isCancelled) {
+          val _: Boolean = cancel.cancel(true)
+          this
+        } else {
+          cancelOpt = None
+          this
+        }
+      case None =>
+        this
+    }
+  }
+}
+
+object HikariLogging extends BitcoinSLogger {
+  private[db] val scheduler = Executors.newScheduledThreadPool(1)
+
+  /** Returns a started hikari logger if configuration is correct, else None */
+  def fromJdbcProfileComponent[T <: DbAppConfig](
+      jdbcProfileComponent: JdbcProfileComponent[T]): Option[HikariLogging] = {
+    val dataSource = jdbcProfileComponent.database.source
+    val moduleName = jdbcProfileComponent.appConfig.moduleName
+    dataSource match {
+      case hikariSource: HikariCPJdbcDataSource =>
+        val started = HikariLogging(hikariSource.ds, moduleName)
+          .start()
+        Some(started)
+      case _: JdbcDataSource =>
+        val err = {
+          s"JdbcProfile Component is not a Hikari source=${jdbcProfileComponent}"
+        }
+        logger.error(err)
+        None
+    }
+  }
+}

--- a/db-commons/src/main/scala/org/bitcoins/db/HikariLogging.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/HikariLogging.scala
@@ -137,10 +137,9 @@ case class HikariLogging(
   }
 
   private val logHikariStats: Runnable = () => {
-    import scala.jdk.CollectionConverters._
 
     val usageHistogram: Histogram =
-      metricRegistry.getHistograms().asScala.get(poolUsageMetricName).get
+      metricRegistry.getHistograms().get(poolUsageMetricName)
     val usageSnapshot = usageHistogram.getSnapshot()
 
     val poolUsageUpdate = HikariPoolUsageUpdate(

--- a/db-commons/src/main/scala/org/bitcoins/db/HikariLogging.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/HikariLogging.scala
@@ -230,7 +230,7 @@ object HikariLogging extends BitcoinSLogger {
         Some(started)
       case _: JdbcDataSource =>
         val err = {
-          s"JdbcProfile Component is not a Hikari source=${jdbcProfileComponent}"
+          s"JdbcProfile Component is not a Hikari source=${jdbcProfileComponent.dbConfig.profile}"
         }
         logger.error(err)
         None

--- a/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
@@ -50,7 +50,7 @@ trait JdbcProfileComponent[+ConfigType <: DbAppConfig] extends BitcoinSLogger {
             hikariLoggerOpt = Some(hikariLogger)
             hikariLogger
           case None =>
-            sys.error(s"Could not started hikari logging")
+            sys.error(s"Could not start hikari logging")
         }
     }
 

--- a/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
@@ -4,6 +4,8 @@ import org.bitcoins.core.util.BitcoinSLogger
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 
+import scala.concurrent.duration.Duration
+
 trait JdbcProfileComponent[+ConfigType <: DbAppConfig] extends BitcoinSLogger {
 
   def appConfig: ConfigType
@@ -32,8 +34,10 @@ trait JdbcProfileComponent[+ConfigType <: DbAppConfig] extends BitcoinSLogger {
 
   private[this] var hikariLoggerOpt: Option[HikariLogging] = None
 
-  /** Starts the background logger for hikari */
-  protected def startHikariLogger(): HikariLogging = {
+  /** Starts the background logger for hikari
+    * @param interval - how often hikari logs database connection pool information
+    */
+  protected def startHikariLogger(interval: Duration): HikariLogging = {
     hikariLoggerOpt match {
       case Some(hikarkiLogger) => hikarkiLogger
       case None                =>
@@ -41,7 +45,7 @@ trait JdbcProfileComponent[+ConfigType <: DbAppConfig] extends BitcoinSLogger {
         //dbConfig.database.ioExecutionContext
         val _ = database.ioExecutionContext
         //start a new one
-        HikariLogging.fromJdbcProfileComponent(this) match {
+        HikariLogging.fromJdbcProfileComponent(this, interval) match {
           case Some(hikariLogger) =>
             hikariLoggerOpt = Some(hikariLogger)
             hikariLogger

--- a/db-commons/src/main/scala/org/bitcoins/db/package.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/package.scala
@@ -2,6 +2,9 @@ package org.bitcoins
 
 import com.typesafe.config.{Config, ConfigRenderOptions}
 
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
 package object db {
 
   implicit class ConfigOps(private val config: Config) extends AnyVal {
@@ -50,6 +53,20 @@ package object db {
       } else {
         None
       }
+    }
+
+    def getBooleanOpt(key: String): Option[Boolean] = {
+      if (config.hasPath(key)) Some(config.getBoolean(key))
+      else None
+    }
+
+    def getDurationOpt(key: String): Option[Duration] = {
+      if (config.hasPath(key)) {
+        val javaDuration = config.getDuration(key)
+        val scalaDuration =
+          new FiniteDuration(javaDuration.toNanos, TimeUnit.NANOSECONDS)
+        Some(scalaDuration)
+      } else None
     }
   }
 }

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -280,20 +280,28 @@ bitcoin-s {
             user = "user"
             password = "topsecret"
             numThreads = 5
+            
+            # http://scala-slick.org/doc/3.3.3/database.html
+            connectionPool = "HikariCP"
+            registerMbeans = true
         }
     }
 
     chain.profile = ${bitcoin-s.common.profile}
     chain.db = ${bitcoin-s.common.db}
- 
+    chain.db.poolName = "chain-connection-pool"
+
     node.profile = ${bitcoin-s.common.profile}
     node.db = ${bitcoin-s.common.db}
+    node.db.poolName = "node-connection-pool"
     
     wallet.profile = ${bitcoin-s.common.profile}
     wallet.db = ${bitcoin-s.common.db}
+    wallet.db.poolName = "wallet-connection-pool"
 
     oracle.profile = ${bitcoin-s.common.profile}
     oracle.db = ${bitcoin-s.common.db}
+    oracle.db.poolName = "oracle-connection-pool"
 }
 ```
 

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -98,7 +98,31 @@ to ensure the entire module is initialized correctly.
 bitcoin-s {
     datadir = ${HOME}/.bitcoin-s
     network = regtest # regtest, testnet3, mainnet, signet
-
+    dbDefault = {
+      dataSourceClass = slick.jdbc.DatabaseUrlDataSource
+      profile = "slick.jdbc.SQLiteProfile$"
+  
+      db {
+        # for information on parameters available here see
+        # https://scala-slick.org/doc/3.3.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database
+        path = ${bitcoin-s.datadir}/${bitcoin-s.network}/
+        driver = org.sqlite.JDBC
+        user = ""
+        password = ""
+        host = localhost
+        port = 5432
+  
+        # this needs to be set to 1 for SQLITE as it does not support concurrent database operations
+        # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
+        numThreads = 1
+        queueSize=5000
+        connectionPool = "HikariCP"
+        registerMbeans = true
+      }
+      hikari-logging = false
+      hikari-logging-interval = 1 minute
+    }
+    
     bitcoind-rpc {
         # bitcoind rpc username
         rpcuser = user

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -128,6 +128,9 @@ bitcoin-s {
         # (e.g. "neutrino.testnet3.suredbits.com:18333")
         # Port number is optional, the default value is 8333 for mainnet,
         # 18333 for testnet and 18444 for regtest.
+        
+        hikari-logging = true
+        hikari-logging-interval = 1 minute
     }
 
     chain {
@@ -143,6 +146,9 @@ bitcoin-s {
 
             filter-batch-size = 100
         }
+        
+        hikari-logging = true
+        hikari-logging-interval = 1 minute
     }
 
     # settings for wallet module
@@ -171,6 +177,9 @@ bitcoin-s {
         # How long we attempt to generate an address for
         # before we timeout
         addressQueueTimeout = 5 seconds
+        
+        hikari-logging = true
+        hikari-logging-interval = 1 minute
    }
 
     keymanager {

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -53,7 +53,13 @@ case class NodeAppConfig(
     } yield {
       logger.debug(s"Initializing node setup")
       val numMigrations = migrate()
-      val _ = startHikariLogger()
+      val _ = if (isHikariLoggingEnabled) {
+        //.get is safe because hikari logging is enabled
+        startHikariLogger(hikariLoggingInterval.get)
+        ()
+      } else {
+        ()
+      }
       logger.info(s"Applied $numMigrations migrations fro the node project")
     }
   }

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -4,7 +4,7 @@ import akka.Done
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.util.Mutable
+import org.bitcoins.core.util.{FutureUtil, Mutable}
 import org.bitcoins.db.{AppConfigFactory, DbAppConfig, JdbcProfileComponent}
 import org.bitcoins.node._
 import org.bitcoins.node.db.NodeDbManagement
@@ -53,9 +53,14 @@ case class NodeAppConfig(
     } yield {
       logger.debug(s"Initializing node setup")
       val numMigrations = migrate()
-
+      val _ = startHikariLogger()
       logger.info(s"Applied $numMigrations migrations fro the node project")
     }
+  }
+
+  override def stop(): Future[Unit] = {
+    val _ = stopHikariLogger()
+    FutureUtil.unit
   }
 
   lazy val nodeType: NodeType =

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -4,6 +4,7 @@ object Deps {
 
   object V {
     val bouncyCastle = "1.68"
+    val dropwizardMetricsV = "3.1.0" //https://github.com/dropwizard/metrics
     val logback = "1.2.3"
     val grizzledSlf4j = "1.3.4"
     val scalacheck = "1.15.2"
@@ -179,6 +180,9 @@ object Deps {
 
     val pgEmbedded =
       "com.opentable.components" % "otj-pg-embedded" % V.pgEmbeddedV withSources () withJavadoc ()
+
+    val dropwizardMetrics =
+      "io.dropwizard.metrics" % "metrics-core" % V.dropwizardMetricsV withSources () withJavadoc ()
   }
 
   object Test {
@@ -293,6 +297,7 @@ object Deps {
   )
 
   val dbCommons = List(
+    Compile.dropwizardMetrics,
     Compile.flyway,
     Compile.slick,
     Compile.sourcecode,

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -4,7 +4,7 @@ object Deps {
 
   object V {
     val bouncyCastle = "1.68"
-    val dropwizardMetricsV = "3.1.0" //https://github.com/dropwizard/metrics
+    val dropwizardMetricsV = "4.1.0" //https://github.com/dropwizard/metrics
     val logback = "1.2.3"
     val grizzledSlf4j = "1.3.4"
     val scalacheck = "1.15.2"

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -1,5 +1,4 @@
 bitcoin-s {
-    datadir = ${HOME}/.bitcoin-s
     network = regtest # regtest, testnet3, mainnet, signet
 
     dbDefault = {

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -22,6 +22,10 @@ bitcoin-s {
             queueSize=5000
             connectionPool = disabled
         }
+
+        #turn hikari logging off for tests
+        hikari-logging = false
+        hikari-logging-interval = 0 seconds
     }
 
     oracle = ${bitcoin-s.dbDefault}

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -21,7 +21,7 @@ object BitcoinSTestAppConfig {
       Some(StringGenerators.genNonEmptyString.sampleSome)
     } else None
 
-    walletNameOpt match {
+    val walletNameConfig: Config = walletNameOpt match {
       case Some(walletName) =>
         ConfigFactory.parseString(
           s"bitcoin-s.wallet.walletName = $walletName"
@@ -29,6 +29,11 @@ object BitcoinSTestAppConfig {
 
       case None => ConfigFactory.empty()
     }
+
+    val boilerplateConfig = configWithEmbeddedDb(project =
+                                                   Some(ProjectType.Wallet),
+                                                 pgUrl = () => None)
+    walletNameConfig.withFallback(boilerplateConfig)
   }
 
   /**

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -21,7 +21,7 @@ object BitcoinSTestAppConfig {
       Some(StringGenerators.genNonEmptyString.sampleSome)
     } else None
 
-    val walletNameConfig: Config = walletNameOpt match {
+    walletNameOpt match {
       case Some(walletName) =>
         ConfigFactory.parseString(
           s"bitcoin-s.wallet.walletName = $walletName"
@@ -29,11 +29,6 @@ object BitcoinSTestAppConfig {
 
       case None => ConfigFactory.empty()
     }
-
-    val boilerplateConfig = configWithEmbeddedDb(project =
-                                                   Some(ProjectType.Wallet),
-                                                 pgUrl = () => None)
-    walletNameConfig.withFallback(boilerplateConfig)
   }
 
   /**

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -5,7 +5,7 @@ import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.hd._
-import org.bitcoins.core.util.Mutable
+import org.bitcoins.core.util.{FutureUtil, Mutable}
 import org.bitcoins.core.wallet.keymanagement.{
   KeyManagerInitializeError,
   KeyManagerParams
@@ -153,9 +153,14 @@ case class WalletAppConfig(
       val numMigrations = {
         migrate()
       }
-
+      val _ = startHikariLogger()
       logger.info(s"Applied $numMigrations to the wallet project")
     }
+  }
+
+  override def stop(): Future[Unit] = {
+    val _ = stopHikariLogger()
+    FutureUtil.unit
   }
 
   /** The path to our encrypted mnemonic seed */

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -153,13 +153,19 @@ case class WalletAppConfig(
       val numMigrations = {
         migrate()
       }
-      val _ = startHikariLogger()
+
+      if (isHikariLoggingEnabled) {
+        //.get is safe because hikari logging is enabled
+        startHikariLogger(hikariLoggingInterval.get)
+      }
       logger.info(s"Applied $numMigrations to the wallet project")
     }
   }
 
   override def stop(): Future[Unit] = {
-    val _ = stopHikariLogger()
+    if (isHikariLoggingEnabled) {
+      val _ = stopHikariLogger()
+    }
     FutureUtil.unit
   }
 


### PR DESCRIPTION
This PR adds new logs that give us information about our database's connection pools. I'm hoping it will be useful to get to the bottom of #2417 . 

This does require one new dependency, the [dropwizard core library](https://github.com/dropwizard/metrics/blob/release/4.1.x/metrics-core/pom.xml). It has [zero deps on it's own](https://github.com/dropwizard/metrics/blob/release/4.1.x/metrics-core/pom.xml) 
 
https://github.com/dropwizard/metrics

### Example logs

If you look carefully you will see things like `maxThreads`, `activeThreads`, how many elements rae in the database queue (`queueSize`). Basically it gives you holistic view of how the database connection pool is being used. 

>[info] 2021-01-28T00:05:20UTC INFO [HikariLogging] "node-pool-usage":{"max":0.0,"min":0.0,"median":0.0,"mean":0.0,"75thPercentile":0.0,"95thPercentile":0.0,"98thPercentile":0.0,"99thPercentile":0.0,"999thPercentile":0.0}
[info] 2021-01-28T00:05:20UTC INFO [HikariLogging] "node-activity-update":{"active":0,"idle":1,"waiting":0,"total":1,"maxThreads":1,"activeThreads":0,"maxQueueSize":5000,"queueSize":0}
[info] 2021-01-28T00:05:20UTC INFO [HikariLogging] "wallet-pool-usage":{"max":37.0,"min":1.0,"median":5.0,"mean":11.03414368257809,"75thPercentile":9.0,"95thPercentile":37.0,"98thPercentile":37.0,"99thPercentile":37.0,"999thPercentile":37.0}
[info] 2021-01-28T00:05:20UTC INFO [HikariLogging] "wallet-activity-update":{"active":0,"idle":1,"waiting":0,"total":1,"maxThreads":1,"activeThreads":0,"maxQueueSize":5000,"queueSize":0}
[info] 2021-01-28T00:05:20UTC INFO [HikariLogging] "chain-pool-usage":{"max":5448.0,"min":0.0,"median":0.0,"mean":5.978927673404428,"75thPercentile":0.0,"95thPercentile":0.0,"98thPercentile":0.0,"99thPercentile":1.0,"999thPercentile":5448.0}
[info] 2021-01-28T00:05:20UTC INFO [HikariLogging] "chain-activity-update":{"active":1,"idle":0,"waiting":0,"total":1,"maxThreads":1,"activeThreads":1,"maxQueueSize":5000,"queueSize":3}
