### PR TITLE
Add ContractOraclePair to enforce an invariant that contract descript…

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/ContractDescriptor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/ContractDescriptor.scala
@@ -12,6 +12,7 @@ import org.bitcoins.core.util.SeqWrapper
   * Payouts above totalCollateral may be subject to change
   * as totalCollateral does not exist in a ContractDescriptor,
   * which is reusable between DLCs.
+  * @see https://github.com/discreetlogcontracts/dlcspecs/blob/a8876ed28ed33d5f7d5104f01aa2a8d80d128460/Messaging.md#version-1-contract_descriptor
   */
 sealed trait ContractDescriptor extends TLVSerializable[ContractDescriptorTLV] {
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/ContractDescriptorOraclePair.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/ContractDescriptorOraclePair.scala
@@ -1,0 +1,51 @@
+package org.bitcoins.core.protocol.dlc
+
+sealed trait ContractOraclePair {
+  def contractDescriptor: ContractDescriptor
+  def oracleInfo: OracleInfo
+}
+
+object ContractOraclePair {
+
+  case class EnumPair(
+      contractDescriptor: EnumContractDescriptor,
+      oracleInfo: EnumOracleInfo)
+      extends ContractOraclePair
+
+  case class NumericPair(
+      contractDescriptor: NumericContractDescriptor,
+      oracleInfo: NumericOracleInfo)
+      extends ContractOraclePair
+
+  /** Returns a valid [[ContractOraclePair]] if the
+    * [[ContractDescriptor]] and [[OracleInfo]] are of the same type
+    */
+  def fromDescriptorOracleOpt(
+      descriptor: ContractDescriptor,
+      oracleInfo: OracleInfo): Option[ContractOraclePair] = {
+    (descriptor, oracleInfo) match {
+      case (e: EnumContractDescriptor, o: EnumOracleInfo) =>
+        Some(EnumPair(e, o))
+      case (n: NumericContractDescriptor, o: NumericOracleInfo) =>
+        Some(NumericPair(n, o))
+      case (_: EnumContractDescriptor, _: NumericOracleInfo) =>
+        None
+      case (_: NumericContractDescriptor, _: EnumOracleInfo) =>
+        None
+    }
+  }
+
+  /** Returns a valid [[ContractOraclePair]] if the
+    * [[ContractDescriptor]] and [[OracleInfo]] are of the same type
+    */
+  def fromDescriptorOracle(
+      descriptor: ContractDescriptor,
+      oracleInfo: OracleInfo): ContractOraclePair = {
+    fromDescriptorOracleOpt(descriptor, oracleInfo) match {
+      case Some(pair) => pair
+      case None =>
+        sys.error(
+          s"You passed in an incompatible contract/oracle pair, contract=$descriptor, oracle=${oracleInfo}")
+    }
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/ContractDescriptorOraclePair.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/ContractDescriptorOraclePair.scala
@@ -1,5 +1,10 @@
 package org.bitcoins.core.protocol.dlc
 
+/** A pair of [[ContractDescriptor]] and [[OracleInfo]]
+  * This type is meant to ensure consistentcy between various
+  * [[ContractDescriptor]] and [[OracleInfo]] so that you cannot
+  * have an incorrect pairing.
+  */
 sealed trait ContractOraclePair {
   def contractDescriptor: ContractDescriptor
   def oracleInfo: OracleInfo

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -22,9 +22,7 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
   type FixtureParam = (InitializedDLCWallet, InitializedDLCWallet)
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withDualDLCWallets(test,
-                       DLCWalletUtil.sampleContractDescriptor,
-                       DLCWalletUtil.sampleOracleInfo)
+    withDualDLCWallets(test, DLCWalletUtil.sampleContractOraclePair)
   }
 
   behavior of "DLCWallet"

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleEnumExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleEnumExecutionTest.scala
@@ -43,13 +43,16 @@ class DLCMultiOracleEnumExecutionTest extends BitcoinSDualWalletTest {
   val oracleInfo: EnumMultiOracleInfo =
     EnumMultiOracleInfo(threshold, announcements)
 
+  val contractOraclePair =
+    ContractOraclePair.EnumPair(contractDescriptor, oracleInfo)
+
   def sigsToTake: Int = {
     val vec = threshold.to(announcements.size).toVector
     Random.shuffle(vec).head
   }
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withDualDLCWallets(test, contractDescriptor, oracleInfo)
+    withDualDLCWallets(test, contractOraclePair)
   }
 
   val getSigs: (Vector[OracleAttestmentTLV], Vector[OracleAttestmentTLV]) = {

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
@@ -38,8 +38,11 @@ class DLCMultiOracleExactNumericExecutionTest extends BitcoinSDualWalletTest {
   val oracleInfo: NumericExactMultiOracleInfo =
     NumericExactMultiOracleInfo(threshold, announcements)
 
+  val contractOraclePair =
+    ContractOraclePair.NumericPair(contractDescriptor, oracleInfo)
+
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withDualDLCWallets(test, contractDescriptor, oracleInfo)
+    withDualDLCWallets(test, contractOraclePair)
   }
 
   def getSigs(contractInfo: ContractInfo): (

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
@@ -45,8 +45,11 @@ class DLCMultiOracleNumericExecutionTest
                            announcements = announcements,
                            params = params)
 
+  val contractOraclePair =
+    ContractOraclePair.NumericPair(contractDescriptor, oracleInfo)
+
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withDualDLCWallets(test, contractDescriptor, oracleInfo)
+    withDualDLCWallets(test, contractOraclePair)
   }
 
   def getSigs(contractInfo: ContractInfo): (

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCNumericExecutionTest.scala
@@ -13,9 +13,7 @@ class DLCNumericExecutionTest extends BitcoinSDualWalletTest {
   type FixtureParam = (InitializedDLCWallet, InitializedDLCWallet)
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withDualDLCWallets(test,
-                       DLCWalletUtil.multiNonceContractDescriptor,
-                       DLCWalletUtil.multiNonceOracleInfo)
+    withDualDLCWallets(test, DLCWalletUtil.multiNonceContractOraclePair)
   }
 
   behavior of "DLCWallet"

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTLVGen.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTLVGen.scala
@@ -48,14 +48,29 @@ object DLCTLVGen {
         events.map(EnumOutcome.apply)))
   }
 
+  def genEnumContractOraclePair(
+      oraclePrivKey: ECPrivateKey,
+      oracleRValue: SchnorrNonce,
+      outcomes: Vector[String],
+      totalInput: CurrencyUnit): ContractOraclePair.EnumPair = {
+    val contract = genContractDescriptor(outcomes, totalInput)
+
+    val oracleInfo = genOracleInfo(oraclePrivKey, oracleRValue, outcomes)
+    ContractOraclePair.EnumPair(contract, oracleInfo)
+  }
+
   def genContractInfo(
       oraclePrivKey: ECPrivateKey = ECPrivateKey.freshPrivateKey,
       oracleRValue: SchnorrNonce = ECPublicKey.freshPublicKey.schnorrNonce,
       outcomes: Vector[String] = DLCTestUtil.genOutcomes(3),
       totalInput: CurrencyUnit = defaultAmt * 2): ContractInfo = {
-    ContractInfo(totalInput.satoshis,
-                 genContractDescriptor(outcomes, totalInput),
-                 genOracleInfo(oraclePrivKey, oracleRValue, outcomes))
+    val pair = genEnumContractOraclePair(oraclePrivKey,
+                                         oracleRValue,
+                                         outcomes,
+                                         totalInput)
+
+    //this doesn't ever try numeric contracts?
+    ContractInfo(totalInput.satoshis, pair)
   }
 
   def contractInfoParsingTestVector(

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/TestDLCClient.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/TestDLCClient.scala
@@ -142,8 +142,11 @@ object TestDLCClient {
     )
 
     val remoteOutcomes: ContractInfo = {
-      outcomes.copy(contractDescriptor =
-        outcomes.contractDescriptor.flip((input + remoteInput).satoshis))
+      val descriptor =
+        outcomes.contractDescriptor.flip((input + remoteInput).satoshis)
+      val pair =
+        ContractOraclePair.fromDescriptorOracle(descriptor, outcomes.oracleInfo)
+      outcomes.copy(contractOraclePair = pair)
     }
 
     val changeAddress = BitcoinAddress.fromScriptPubKey(changeSPK, network)

--- a/testkit/src/main/scala/org/bitcoins/testkit/dlc/DLCTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/dlc/DLCTest.scala
@@ -369,8 +369,11 @@ trait DLCTest {
       }
     }
 
-    val offerInfo = ContractInfo(totalInput.satoshis, offerDesc, oracleInfo)
-    val acceptInfo = ContractInfo(totalInput.satoshis, acceptDesc, oracleInfo)
+    val numericPairOffer = ContractOraclePair.NumericPair(offerDesc, oracleInfo)
+    val numericPairAccept =
+      ContractOraclePair.NumericPair(acceptDesc, oracleInfo)
+    val offerInfo = ContractInfo(totalInput.satoshis, numericPairOffer)
+    val acceptInfo = ContractInfo(totalInput.satoshis, numericPairAccept)
     val outcomes =
       offerInfo.allOutcomes.map(_.asInstanceOf[NumericOracleOutcome].outcome)
 
@@ -598,10 +601,10 @@ trait DLCTest {
       contractInfo: ContractInfo,
       digits: Vector[Int],
       paramsOpt: Option[OracleParamsV0TLV]): NumericOracleOutcome = {
-    contractInfo.descriptorAndInfo match {
-      case Left(_) => Assertions.fail("Expected Numeric Contract")
-      case Right(
-            (_: NumericContractDescriptor, oracleInfo: NumericOracleInfo)) =>
+    contractInfo.contractOraclePair match {
+      case e: ContractOraclePair.EnumPair =>
+        Assertions.fail(s"Expected Numeric Contract, got enum=$e")
+      case ContractOraclePair.NumericPair(_, oracleInfo) =>
         lazy val possibleOutcomesOpt = paramsOpt.map { _ =>
           contractInfo.allOutcomes
             .map(
@@ -631,6 +634,7 @@ trait DLCTest {
         }
 
         NumericOracleOutcome(oraclesAndOutcomes)
+
     }
   }
 
@@ -641,10 +645,10 @@ trait DLCTest {
       outcomes: Vector[DLCOutcomeType],
       outcomeIndex: Long,
       paramsOpt: Option[OracleParamsV0TLV]): NumericOracleOutcome = {
-    dlcOffer.offer.contractInfo.descriptorAndInfo match {
-      case Left(_) => Assertions.fail("Expected Numeric Contract")
-      case Right(
-            (descriptor: NumericContractDescriptor, _: NumericOracleInfo)) =>
+    dlcOffer.offer.contractInfo.contractOraclePair match {
+      case e: ContractOraclePair.EnumPair =>
+        Assertions.fail(s"Expected Numeric Contract, got enum=$e")
+      case ContractOraclePair.NumericPair(descriptor, _) =>
         val digits =
           computeNumericOutcome(numDigits, descriptor, outcomes, outcomeIndex)
         genNumericOracleOutcome(chosenOracles,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
@@ -64,8 +64,7 @@ trait BitcoinSDualWalletTest extends BitcoinSWalletTest {
   /** Creates 2 funded segwit wallets that have a DLC initiated */
   def withDualDLCWallets(
       test: OneArgAsyncTest,
-      contractDescriptor: ContractDescriptor,
-      oracleInfo: OracleInfo): FutureOutcome = {
+      contractOraclePair: ContractOraclePair): FutureOutcome = {
     makeDependentFixture(
       build = () =>
         for {
@@ -80,8 +79,7 @@ trait BitcoinSDualWalletTest extends BitcoinSWalletTest {
             getBIP39PasswordOpt(),
             Some(segwitWalletConf))(config2, system)
 
-          contractInfo =
-            ContractInfo(Satoshis(10000), contractDescriptor, oracleInfo)
+          contractInfo = ContractInfo(Satoshis(10000), contractOraclePair)
 
           (dlcWalletA, dlcWalletB) <-
             DLCWalletUtil.initDLC(walletA, walletB, contractInfo)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -48,7 +48,7 @@ object DLCWalletUtil {
     EnumOutcome(winStr) -> Satoshis(10000),
     EnumOutcome(loseStr) -> Satoshis.zero)
 
-  lazy val sampleContractDescriptor: ContractDescriptor =
+  lazy val sampleContractDescriptor: EnumContractDescriptor =
     EnumContractDescriptor(sampleOutcomes)
 
   lazy val sampleOracleInfo: EnumSingleOracleInfo =
@@ -56,8 +56,11 @@ object DLCWalletUtil {
                                       rValue,
                                       sampleOutcomes.map(_._1))
 
+  lazy val sampleContractOraclePair =
+    ContractOraclePair.EnumPair(sampleContractDescriptor, sampleOracleInfo)
+
   lazy val sampleContractInfo: ContractInfo =
-    ContractInfo(Satoshis(10000), sampleContractDescriptor, sampleOracleInfo)
+    ContractInfo(Satoshis(10000), sampleContractOraclePair)
 
   lazy val sampleOracleWinSig: SchnorrDigitalSignature =
     oraclePrivKey.schnorrSignWithNonce(winHash.bytes, kValue)
@@ -75,10 +78,13 @@ object DLCWalletUtil {
       OracleAnnouncementV0TLV.dummyForKeys(oraclePrivKey,
                                            rValues.take(numDigits)))
 
+  lazy val multiNonceContractOraclePair = {
+    ContractOraclePair.NumericPair(multiNonceContractDescriptor,
+                                   multiNonceOracleInfo)
+  }
+
   lazy val multiNonceContractInfo: ContractInfo =
-    ContractInfo(Satoshis(10000),
-                 multiNonceContractDescriptor,
-                 multiNonceOracleInfo)
+    ContractInfo(Satoshis(10000), multiNonceContractOraclePair)
 
   lazy val dummyContractMaturity: BlockTimeStamp = BlockTimeStamp(1666335)
   lazy val dummyContractTimeout: BlockTimeStamp = BlockTimeStamp(1666337)


### PR DESCRIPTION
…ors and oracle infos are of the same type

This simply adds a new ADT called `ContractOraclePair` that makes sure that the contract descriptor and oracle info are of the same type.

I then propogated this throughout the rest of the codebase to try and get rid of some of the `Either` usage. 

It seems like this coule be expanded in the future to many subtypes of `EnumPair` and `NumericPair` (is it a single oracle info, multi oracle info?) but I decided to just do the simple thing to start. 