### PR TITLE
Add better Block.toString that doesn't blow up logs

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
@@ -51,11 +51,16 @@ sealed abstract class Block extends NetworkElement {
   */
 object Block extends Factory[Block] {
 
-  sealed private case class BlockImpl(
+  private case class BlockImpl(
       blockHeader: BlockHeader,
       txCount: CompactSizeUInt,
       transactions: Seq[Transaction])
-      extends Block
+      extends Block {
+
+    override def toString: String = {
+      s"Block(blockHeader=${blockHeader}, txCount=${txCount})"
+    }
+  }
 
   def apply(
       blockHeader: BlockHeader,

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
@@ -58,7 +58,7 @@ object Block extends Factory[Block] {
       extends Block {
 
     override def toString: String = {
-      s"Block(blockHeader=${blockHeader}, txCount=${txCount})"
+      s"Block(blockHeader=${blockHeader}, txCount=${txCount.toLong})"
     }
   }
 


### PR DESCRIPTION
When testing #2568 i ran into errors that ended up outputting a block to our logs. 

The current `Block.toString` logs _EVERY_ bitcoin transaction in the block which can be a ton of data. This adjustment just logs the header and the tx count. 