### PR TITLE
Add oracle configuration to example configuration.md

### DIFF
--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -244,6 +244,11 @@ bitcoin-s {
         # The ip address we bind our server too
         rpcbind = "127.0.0.1"
     }
+
+    oracle {
+        hikari-logging = true
+        hikari-logging-interval = 1 minute
+    }
 }
 
 


### PR DESCRIPTION
fixes #2579 

AFAICT these are the only oracle configuration settings we have so far? 