### PR TITLE
Rename PayoutCurveComponent -> PayoutCurveInterval, rename CETRange t…

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/CETCalculatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/CETCalculatorTest.scala
@@ -33,15 +33,15 @@ class CETCalculatorTest extends BitcoinSUnitTest {
       ))
 
     val expected = Vector(
-      RemotePayoutRange(0, 20),
+      ZeroPayoutRange(0, 20),
       VariablePayoutRange(21, 39),
-      LocalConstantPayoutRange(40, 50),
+      ConstantPayoutRange(40, 50),
       VariablePayoutRange(51, 69),
-      RemotePayoutRange(70, 70),
+      ZeroPayoutRange(70, 70),
       VariablePayoutRange(71, 79),
-      LocalConstantPayoutRange(80, 90),
+      ConstantPayoutRange(80, 90),
       VariablePayoutRange(91, 98),
-      StartTotal(99, 108),
+      MaxPayoutRange(99, 108),
       VariablePayoutRange(109, 110)
     )
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/CETCalculatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/CETCalculatorTest.scala
@@ -33,16 +33,16 @@ class CETCalculatorTest extends BitcoinSUnitTest {
       ))
 
     val expected = Vector(
-      StartZero(0, 20),
-      StartFunc(21, 39),
-      StartFuncConst(40, 50),
-      StartFunc(51, 69),
-      StartZero(70, 70),
-      StartFunc(71, 79),
-      StartFuncConst(80, 90),
-      StartFunc(91, 98),
+      RemotePayoutRange(0, 20),
+      VariablePayoutRange(21, 39),
+      LocalConstantPayoutRange(40, 50),
+      VariablePayoutRange(51, 69),
+      RemotePayoutRange(70, 70),
+      VariablePayoutRange(71, 79),
+      LocalConstantPayoutRange(80, 90),
+      VariablePayoutRange(91, 98),
       StartTotal(99, 108),
-      StartFunc(109, 110)
+      VariablePayoutRange(109, 110)
     )
 
     val ranges = CETCalculator.splitIntoRanges(0,

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/CETCalculator.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/CETCalculator.scala
@@ -53,7 +53,7 @@ object CETCalculator {
     */
   case class ZeroPayoutRange(indexFrom: Long, indexTo: Long) extends CETRange
 
-  /** This range contains payouts all >= totalCollateral */
+  /** This range contains payouts all == totalCollateral */
   case class MaxPayoutRange(indexFrom: Long, indexTo: Long) extends CETRange
 
   /** This range contains payouts that all vary at every step and cannot be compressed */

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCPayoutCurve.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCPayoutCurve.scala
@@ -30,10 +30,10 @@ case class DLCPayoutCurve(points: Vector[OutcomePayoutPoint]) {
     Indexed(points).filter(_.element.isEndpoint)
 
   /** This Vector contains the function pieces between the endpoints */
-  lazy val functionComponents: Vector[DLCPayoutCurveComponent] = {
+  lazy val functionComponents: Vector[DLCPayoutCurveInterval] = {
     endpoints.init.zip(endpoints.tail).map { // All pairs of adjacent endpoints
       case (Indexed(_, index), Indexed(_, nextIndex)) =>
-        DLCPayoutCurveComponent(points.slice(index, nextIndex + 1))
+        DLCPayoutCurveInterval(points.slice(index, nextIndex + 1))
     }
   }
 
@@ -42,7 +42,7 @@ case class DLCPayoutCurve(points: Vector[OutcomePayoutPoint]) {
   /** Returns the function component on which the given oracle outcome is
     * defined, along with its index
     */
-  def componentFor(outcome: Long): Indexed[DLCPayoutCurveComponent] = {
+  def componentFor(outcome: Long): Indexed[DLCPayoutCurveInterval] = {
     val endpointIndex = NumberUtil.search(outcomes, outcome)
     val Indexed(endpoint, _) = endpoints(endpointIndex)
 
@@ -162,7 +162,7 @@ object OutcomePayoutMidpoint {
 }
 
 /** A single piece of a larger piecewise function defined between left and right endpoints */
-sealed trait DLCPayoutCurveComponent {
+sealed trait DLCPayoutCurveInterval {
   def leftEndpoint: OutcomePayoutEndpoint
   def midpoints: Vector[OutcomePayoutMidpoint]
   def rightEndpoint: OutcomePayoutEndpoint
@@ -197,9 +197,9 @@ sealed trait DLCPayoutCurveComponent {
   }
 }
 
-object DLCPayoutCurveComponent {
+object DLCPayoutCurveInterval {
 
-  def apply(points: Vector[OutcomePayoutPoint]): DLCPayoutCurveComponent = {
+  def apply(points: Vector[OutcomePayoutPoint]): DLCPayoutCurveInterval = {
     require(points.head.isEndpoint && points.last.isEndpoint,
             s"First and last points must be endpoints, $points")
     require(points.tail.init.forall(!_.isEndpoint),
@@ -229,7 +229,7 @@ object DLCPayoutCurveComponent {
 case class OutcomePayoutConstant(
     leftEndpoint: OutcomePayoutEndpoint,
     rightEndpoint: OutcomePayoutEndpoint)
-    extends DLCPayoutCurveComponent {
+    extends DLCPayoutCurveInterval {
   require(leftEndpoint.payout == rightEndpoint.payout,
           "Constant function must have same values on endpoints")
 
@@ -243,7 +243,7 @@ case class OutcomePayoutConstant(
 case class OutcomePayoutLine(
     leftEndpoint: OutcomePayoutEndpoint,
     rightEndpoint: OutcomePayoutEndpoint)
-    extends DLCPayoutCurveComponent {
+    extends DLCPayoutCurveInterval {
   override lazy val midpoints: Vector[OutcomePayoutMidpoint] = Vector.empty
 
   lazy val slope: BigDecimal = {
@@ -265,7 +265,7 @@ case class OutcomePayoutQuadratic(
     leftEndpoint: OutcomePayoutEndpoint,
     midpoint: OutcomePayoutMidpoint,
     rightEndpoint: OutcomePayoutEndpoint)
-    extends DLCPayoutCurveComponent {
+    extends DLCPayoutCurveInterval {
   override lazy val midpoints: Vector[OutcomePayoutMidpoint] = Vector(midpoint)
 
   private lazy val (x01, x02, x12) =
@@ -298,7 +298,7 @@ case class OutcomePayoutCubic(
     leftMidpoint: OutcomePayoutMidpoint,
     rightMidpoint: OutcomePayoutMidpoint,
     rightEndpoint: OutcomePayoutEndpoint)
-    extends DLCPayoutCurveComponent {
+    extends DLCPayoutCurveInterval {
 
   override lazy val midpoints: Vector[OutcomePayoutMidpoint] =
     Vector(leftMidpoint, rightMidpoint)
@@ -340,7 +340,7 @@ case class OutcomePayoutCubic(
 
 /** A polynomial interpolating points and defining a piece of a larger payout curve */
 case class OutcomePayoutPolynomial(points: Vector[OutcomePayoutPoint])
-    extends DLCPayoutCurveComponent {
+    extends DLCPayoutCurveInterval {
   require(points.head.isEndpoint && points.last.isEndpoint,
           s"First and last points must be endpoints, $points")
   require(points.tail.init.forall(!_.isEndpoint),


### PR DESCRIPTION
Renames some data structures in the dlc protocol to be more descriptive, there is still one I would like to find a better name for -- `StartTotal`. I don't understand how this case is possible in the first place though. 
https://github.com/bitcoin-s/bitcoin-s/blob/ed86d8b336d0344bbdffd11aba4f8f73bfcc1a58/core/src/main/scala/org/bitcoins/core/protocol/dlc/CETCalculator.scala#L57


I don't understand how we can have more than our totalCollateral for payout in a DLC. 