### PR TITLE
Fix rescans with bitcoind backend

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
@@ -54,10 +54,9 @@ class BitcoindV19RpcClient(override val instance: BitcoindInstance)(implicit
       Future.sequence(filterFs)
     }
 
-    FutureUtil.batchExecute(elements = allHeights.toVector,
-                            f = f,
-                            init = Vector.empty,
-                            batchSize = 25)
+    FutureUtil.batchAndSyncExecute(elements = allHeights.toVector,
+                                   f = f,
+                                   batchSize = 25)
   }
 
   override def getFilterCount(): Future[Int] = getBlockCount

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/BitcoindV20RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/BitcoindV20RpcClient.scala
@@ -54,10 +54,9 @@ class BitcoindV20RpcClient(override val instance: BitcoindInstance)(implicit
       Future.sequence(filterFs)
     }
 
-    FutureUtil.batchExecute(elements = allHeights.toVector,
-                            f = f,
-                            init = Vector.empty,
-                            batchSize = 25)
+    FutureUtil.batchAndSyncExecute(elements = allHeights.toVector,
+                                   f = f,
+                                   batchSize = 25)
   }
 
   override def getFilterCount(): Future[Int] = getBlockCount

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v21/BitcoindV21RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v21/BitcoindV21RpcClient.scala
@@ -55,10 +55,9 @@ class BitcoindV21RpcClient(override val instance: BitcoindInstance)(implicit
       Future.sequence(filterFs)
     }
 
-    FutureUtil.batchExecute(elements = allHeights.toVector,
-                            f = f,
-                            init = Vector.empty,
-                            batchSize = 25)
+    FutureUtil.batchAndSyncExecute(elements = allHeights.toVector,
+                                   f = f,
+                                   batchSize = 25)
   }
 
   override def getFilterCount(): Future[Int] = getBlockCount


### PR DESCRIPTION
Previously, for `getFiltersBetweenHeights` it would not return all the filters requested because `batchExecute` does not guarantee that all of the results will be returned. This fixes that by switching it to use `batchAndSyncExecute`