### PR TITLE
Make contract info lazy so native image works

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -1233,7 +1233,7 @@ case class ContractInfoV0TLV(
 object ContractInfoV0TLV extends TLVFactory[ContractInfoV0TLV] {
   override val tpe: BigSizeUInt = BigSizeUInt(55342)
 
-  val dummy: ContractInfoV0TLV = {
+  lazy val dummy: ContractInfoV0TLV = {
     ContractInfoV0TLV(
       Satoshis.zero,
       ContractDescriptorV0TLV(Vector("dummy" -> Satoshis(10000))),


### PR DESCRIPTION
It seems this got lost in #2543 and was originally in #2561 , but seems to have got lost along the way. 