### PR TITLE
Reduce number of rows selected by best filter header/best filter query

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandlerCached.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandlerCached.scala
@@ -6,8 +6,8 @@ import org.bitcoins.chain.models.{
   CompactFilterDAO,
   CompactFilterHeaderDAO
 }
-import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, CompactFilterHeaderDb}
+import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.crypto.DoubleSha256DigestBE
 

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
@@ -166,10 +166,7 @@ case class CompactFilterDAO()(implicit
   }
 
   def getBestFilterHeight: Future[Int] = {
-    val start = System.currentTimeMillis()
     safeDatabase.run(bestFilterHeightQuery).map { filterHeightOpt =>
-      val now = System.currentTimeMillis()
-      logger.error(s"Took ${now - start}ms to execute getBestFilterHeight")
       filterHeightOpt.headOption.getOrElse(0)
     }
   }

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
@@ -149,20 +149,7 @@ case class CompactFilterDAO()(implicit
   }
 
   private val bestFilterHeightQuery = {
-    val join = table
-      .join(blockHeaderTable)
-      .on(_.blockHash === _.hash)
-      .sortBy(_._1.height.desc)
-      .take(appConfig.chain.difficultyChangeInterval)
-
-    val maxQuery = join.map(_._2.chainWork).max
-
-    join
-      .filter(_._2.chainWork === maxQuery)
-      .take(1)
-      .map(_._1.height)
-      .result
-      .transactionally
+    bestFilterQuery.map(_.headOption.map(_.height))
   }
 
   def getBestFilterHeight: Future[Int] = {

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
@@ -132,6 +132,10 @@ case class CompactFilterDAO()(implicit
     val join = table
       .join(blockHeaderTable)
       .on(_.blockHash === _.hash)
+      .sortBy(_._1.height.desc)
+      //just take the last 2016 headers, if we have a reorg larger than
+      //this we will not be able to retrieve that header
+      .take(appConfig.chain.difficultyChangeInterval)
 
     val maxQuery = join.map(_._2.chainWork).max
 

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -150,20 +150,7 @@ case class CompactFilterHeaderDAO()(implicit
   }
 
   private val bestFilterHeaderHeightQuery = {
-    val join = table
-      .join(blockHeaderTable)
-      .on(_.blockHash === _.hash)
-      .sortBy(_._1.height.desc)
-      .take(appConfig.chain.difficultyChangeInterval)
-
-    val maxQuery = join.map(_._2.chainWork).max
-
-    join
-      .filter(_._2.chainWork === maxQuery)
-      .take(1)
-      .map(_._1.height)
-      .result
-      .transactionally
+    bestFilterHeaderQuery.map(_.headOption.map(_.height))
   }
 
   def getBestFilterHeaderHeight: Future[Int] = {

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -124,6 +124,7 @@ case class CompactFilterHeaderDAO()(implicit
   private val bestFilterHeaderQuery = {
     val join = table
       .join(blockHeaderTable)
+      .on(_.blockHash === _.hash)
       //sort by height as an optimization
       .sortBy(_._1.height.desc)
       //just take the last 2016 headers, if we have a reorg larger than

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -125,7 +125,6 @@ case class CompactFilterHeaderDAO()(implicit
     val join = table
       .join(blockHeaderTable)
       .on(_.blockHash === _.hash)
-      //sort by height as an optimization
       .sortBy(_._1.height.desc)
       //just take the last 2016 headers, if we have a reorg larger than
       //this we will not be able to retrieve that header

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -167,11 +167,7 @@ case class CompactFilterHeaderDAO()(implicit
   }
 
   def getBestFilterHeaderHeight: Future[Int] = {
-    val start = System.currentTimeMillis()
     safeDatabase.run(bestFilterHeaderHeightQuery).map { filterHeaderHeightOpt =>
-      val now = System.currentTimeMillis()
-      logger.error(
-        s"Took ${now - start}ms to execute getBestFilterHeaderHeight")
       filterHeaderHeightOpt.headOption.getOrElse(0)
     }
   }


### PR DESCRIPTION
fixes #2616 and is related to past work in #2568 

Basically this reduces the number of rows selected in the filter header/filter queries to be the last difficulty Interval (2016 filters/filter headers)

With this change, it seems these queries run really fast now. 

>[info] 2021-02-03T12:39:48UTC ERROR [CompactFilterDAO] Took 18ms to execute getBestFilterHeight

>[info] 2021-02-03T12:39:44UTC ERROR [CompactFilterDAO] Took 15ms to execute getBestFilterHeight

>[info] 2021-02-03T12:39:41UTC ERROR [CompactFilterHeaderDAO] Took 9ms to execute getBestFilterHeaderHeight

when measuring this off of 865f1a6d460108325cc8a0a94621b205c13a5d8c (current master) these two queries would take roughly ~6 seconds and ~12 seconds on sqlite. 

>2021-02-02T22:59:11UTC ERROR [CompactFilterDAO] Took 6160ms to execute getBestFilterHeight
2021-02-02T22:59:17UTC ERROR [CompactFilterHeaderDAO] Took 12297ms to execute getBestFilterHeaderHeight

