### PR TITLE
Add number cache trait, use it in all number types (u8,u32,etc) and S…

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/script/constant/ScriptNumberUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/constant/ScriptNumberUtilTest.scala
@@ -174,7 +174,7 @@ class ScriptNumberUtilTest extends BitcoinSUnitTest {
 
   it must "serialize a positive number to the correct hex value" in {
     val hex = ScriptNumberUtil.longToHex(0L)
-    val expectedHex = "00"
+    val expectedHex = ""
     hex must be(expectedHex)
 
     val hex1 = ScriptNumberUtil.longToHex(1)

--- a/core/src/main/scala/org/bitcoins/core/number/NumberCache.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberCache.scala
@@ -1,0 +1,59 @@
+package org.bitcoins.core.number
+
+/** Helper trait to cache data types that represent numbers
+  * Examples are [[org.bitcoins.core.script.constant.ScriptNumber]]
+  * [[UInt32]] [[UInt64]] etc
+  */
+trait NumberCache[T] {
+  def fromNativeNumber(long: Long): T
+
+  /** The minimum number cached (inclusive) */
+  def minCached: Long = 0
+
+  /** The max number cached (inclusive) */
+  def maxCached: Long = 255
+
+  private lazy val cache: Vector[T] = {
+    minCached.to(maxCached).map(fromNativeNumber).toVector
+  }
+
+  /** Checks if the given number is cached
+    * if not, allocates a new object to represent the number
+    */
+  def checkCached(long: Long): T = {
+    if (long <= maxCached && long >= minCached) cache(long.toInt)
+    else {
+      fromNativeNumber(long)
+    }
+  }
+}
+
+/** Number cache, except for scala [[BigInt]] */
+trait NumberCacheBigInt[T] extends NumberCache[T] {
+
+  private val bigIntCache: Vector[T] = {
+    minCachedBigInt
+      .to(maxCachedBigInt)
+      .map(fromBigInt)
+      .toVector
+  }
+
+  def fromBigInt(bigInt: BigInt): T
+
+  /** The minimum number cached (inclusive) */
+  def minCachedBigInt: BigInt = BigInt(minCached)
+
+  /** The max number cached (inclusive) */
+  def maxCachedBigInt: BigInt = BigInt(maxCached)
+
+  /** Checks if the given number is cached
+    * if not, allocates a new object to represent the number
+    */
+  def checkCachedBigInt(bigInt: BigInt): T = {
+    if (bigInt <= maxCachedBigInt && bigInt >= minCachedBigInt)
+      bigIntCache(bigInt.toInt)
+    else {
+      fromBigInt(bigInt)
+    }
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
@@ -174,12 +174,11 @@ object ScriptNumber
       ScriptNumberImpl(ScriptNumberUtil.toLong(bytes))
 
     def apply(underlying: Long): ScriptNumber = {
-      ScriptNumberImpl(
-        underlying,
-        BytesUtil.decodeHex(ScriptNumberUtil.longToHex(underlying)))
+      ScriptNumberImpl(underlying,
+                       ScriptNumberUtil.longToByteVector(underlying))
     }
 
-    def apply(int64: Int64): ScriptNumber = ScriptNumberImpl(int64.toLong)
+    def apply(int64: Int64): ScriptNumber = checkCached(int64.toLong)
   }
 
 }

--- a/core/src/main/scala/org/bitcoins/core/script/constant/ScriptNumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/ScriptNumberUtil.scala
@@ -109,17 +109,20 @@ trait ScriptNumberUtil {
     * @return
     */
   def longToHex(long: Long): String = {
-    if (long == 0) {
-      ""
-    } else if (long > -1) {
+    longToByteVector(long).toHex
+  }
+
+  /** Converts a long number to the bytevec representation in Script */
+  def longToByteVector(long: Long): ByteVector = {
+    if (long == 0) ByteVector.empty
+    else if (long > -1) {
       val bytes = toByteVec(long)
-      BytesUtil.flipEndianness(BytesUtil.encodeHex(bytes))
+      bytes.reverse
     } else {
       val bytes = toByteVec(long.abs)
       //add sign bit
       val negativeNumberBytes = changeSignBitToNegative(bytes)
-      val hex = BytesUtil.encodeHex(negativeNumberBytes.reverse)
-      hex
+      negativeNumberBytes.reverse
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/script/constant/ScriptNumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/ScriptNumberUtil.scala
@@ -109,7 +109,9 @@ trait ScriptNumberUtil {
     * @return
     */
   def longToHex(long: Long): String = {
-    if (long > -1) {
+    if (long == 0) {
+      ""
+    } else if (long > -1) {
       val bytes = toByteVec(long)
       BytesUtil.flipEndianness(BytesUtil.encodeHex(bytes))
     } else {


### PR DESCRIPTION
…criptNumber

This was being done in our `UInt32`, `UInt8` etc before, but there wasn't a standard interface for caching numbers. 

This adds `NumberCache` and `NumberCacheBigInt` . Now these traits can be used by any number type where we nee caching.

I'm hoping this can be a foundation for beginning to improve performance throughout the serialization code base and get to the bottom of problems like #2596 