### PR TITLE
Don't publish website on adaptor-dlc branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
       - uses: olafurpg/setup-gpg@v3
-      - run: sbt ci-release docs/publishWebsite
+      - run: sbt ci-release #docs/publishWebsite
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
This would cause old versions of the docs to be published after merging a PR on the adaptor-dlc branch