### PR TITLE
Switch outcomeMap implementation to be parallel

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
@@ -108,4 +108,17 @@ object FutureUtil {
     val doneF = Future.sequence(execute)
     doneF
   }
+
+  /** Takes in a synchronous function f, and then executes that function on a set of elements in parallel */
+  def batchAndParallelExecuteSync[T, U](
+      elements: Vector[T],
+      f: Vector[T] => U,
+      batchSize: Int)(implicit ec: ExecutionContext): Future[Vector[U]] = {
+    val asyncF: Vector[T] => Future[U] = { case vec: Vector[T] =>
+      Future { f(vec) }
+    }
+    batchAndParallelExecute(elements = elements,
+                            f = asyncF,
+                            batchSize = batchSize)
+  }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.testkit.fixtures
 
 import akka.actor.ActorSystem
-import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
@@ -146,14 +145,8 @@ object BitcoinSFixture {
     import system.dispatcher
     for {
       bitcoind <- createBitcoind(versionOpt = versionOpt)
-      genesisAddress <- bitcoind.getNewAddress
-      addresses <- Future.sequence(0.until(5).map(_ => bitcoind.getNewAddress))
-
-      //fund a variety of addresses we so don't just have a single utxo funded
-      _ <- bitcoind.generateToAddress(blocks = 101, genesisAddress)
-      addrWithAmt = addresses.map(addr => (addr, Bitcoins.one)).toMap
-      _ <- bitcoind.sendMany(addrWithAmt)
-      _ <- bitcoind.generateToAddress(6, genesisAddress)
+      address <- bitcoind.getNewAddress
+      _ <- bitcoind.generateToAddress(blocks = 101, address)
     } yield bitcoind
   }
 


### PR DESCRIPTION
This makes the computation of `ContractInfo.outcomeMap` happen in parallel. 

The current implementation is run on the default scala execution context with an `Await.result()` at the end so I didn't have to start futurifying the return type of `ContractInfo.outcomeMap`. 

Some rough benchmarks show a 2x improvement in test suite time for `dlcTest/test`. It seems the test suite with the old `ContractInfo.outcomeMap` would run in ~3 minutes.
![Screenshot from 2021-02-07 15-10-02](https://user-images.githubusercontent.com/3514957/107159661-2ba16200-6957-11eb-88e4-d1289afef826.png)


The new implementation of `ContractInfo.outcomeMap` runs in ~1 min 45 seconds on my machine.

![Screenshot from 2021-02-07 15-05-51](https://user-images.githubusercontent.com/3514957/107159649-1af0ec00-6957-11eb-8c99-99810fed24e6.png)
  