### PR TITLE
Compute `sigPoint`s eagerly but asynchronously

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/OracleOutcome.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/OracleOutcome.scala
@@ -7,6 +7,9 @@ import org.bitcoins.core.protocol.tlv.{
 }
 import org.bitcoins.crypto.{ECPublicKey, SchnorrNonce}
 
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+
 /** OracleOutcomes are in one-to-one correspondence with Contract
   * Execution Transactions (CETs) and are defined by a set of oracles
   * needed to execute with a given CET, representing a certain outcome
@@ -39,8 +42,12 @@ case class EnumOracleOutcome(
     outcome: EnumOutcome)
     extends OracleOutcome {
 
-  override lazy val sigPoint: ECPublicKey = {
+  private val sigPointF = Future {
     oracles.map(_.sigPoint(outcome)).reduce(_.add(_))
+  }(ExecutionContext.global)
+
+  override lazy val sigPoint: ECPublicKey = {
+    Await.result(sigPointF, 10.seconds)
   }
 
   override lazy val aggregateNonce: SchnorrNonce = {
@@ -70,12 +77,16 @@ case class NumericOracleOutcome(oraclesAndOutcomes: Vector[
   def outcomes: Vector[UnsignedNumericOutcome] =
     oraclesAndOutcomes.map(_._2)
 
-  override lazy val sigPoint: ECPublicKey = {
+  private val sigPointF = Future {
     oraclesAndOutcomes
       .map { case (oracle, outcome) =>
         oracle.sigPoint(outcome)
       }
       .reduce(_.add(_))
+  }(ExecutionContext.global)
+
+  override lazy val sigPoint: ECPublicKey = {
+    Await.result(sigPointF, 10.seconds)
   }
 
   override lazy val aggregateNonce: SchnorrNonce = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/OracleOutcome.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/OracleOutcome.scala
@@ -86,7 +86,7 @@ case class NumericOracleOutcome(oraclesAndOutcomes: Vector[
   }(ExecutionContext.global)
 
   override lazy val sigPoint: ECPublicKey = {
-    Await.result(sigPointF, 10.seconds)
+    Await.result(sigPointF, 20.seconds)
   }
 
   override lazy val aggregateNonce: SchnorrNonce = {


### PR DESCRIPTION
This implements a simpler solution to the problem solved in #2635 because computing the `outcomeMap` in a `ContractInfo` isn't the issue, the bottleneck is solely computing the adaptor points (aka sigPoints) of each `OracleOutcome`.

As such, this solution simply has these `sigPoint`s evaluated eagerly but asynchronously with calls to `sigPoint` delegating to `Await.result` on the eager `Future` where it should be noted that `Await.result` does no blocking or anything else fancy in the case that the `Future` is completed (in which case it synchronously returns as if `fut.value.get.get` was called).

I ran this locally and got the exact same speedup that I got from running #2635 compared to the current `adaptor-dlc` branch.

I'm still open to either approach but figured I should open this for discussion.