### PR TITLE
Introduced distinct Sign and AsyncSign interfaces

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -578,7 +578,8 @@ class WalletRpcTest extends BitcoindFixturesCachedPairNewest {
         output = prevTx.outputs(outPoint.vout.toInt)
         privKey <- client.dumpPrivKey(
           BitcoinAddress.fromScriptPubKey(output.scriptPubKey, RegTest))
-        partialSig <- BitcoinSigner.signSingle(
+      } yield {
+        val partialSig = BitcoinSigner.signSingle(
           ECSignatureParams(
             P2WPKHV0InputInfo(outPoint, output.value, privKey.publicKey),
             prevTx,
@@ -586,7 +587,7 @@ class WalletRpcTest extends BitcoindFixturesCachedPairNewest {
             HashType.sigHashAll),
           transaction,
           isDummySignature = false)
-      } yield {
+
         signedTx match {
           case btx: NonWitnessTransaction =>
             assert(

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/ExtSignTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/ExtSignTest.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.core.crypto
 
 import org.bitcoins.testkitcore.gen.{CryptoGenerators, HDGenerators}
-import org.bitcoins.testkitcore.util.BitcoinSJvmTest
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 
-class ExtSignTest extends BitcoinSJvmTest {
+class ExtSignTest extends BitcoinSUnitTest {
 
   it must "be able to sign something that extends ExtSignKey" in {
     forAll(CryptoGenerators.extPrivateKey, CryptoGenerators.sha256Digest) {
@@ -14,15 +14,12 @@ class ExtSignTest extends BitcoinSJvmTest {
   }
 
   it must "be able to sign a specific path of a ext key" in {
-    forAllAsync(CryptoGenerators.extPrivateKey,
-                CryptoGenerators.sha256Digest,
-                HDGenerators.bip32Path) { case (extPrivKey, hash, path) =>
-      val sigF = extPrivKey.deriveAndSignFuture(hash.bytes, path)
+    forAll(CryptoGenerators.extPrivateKey,
+           CryptoGenerators.sha256Digest,
+           HDGenerators.bip32Path) { case (extPrivKey, hash, path) =>
+      val sig = extPrivKey.deriveAndSign(hash.bytes, path)
       val childPubKey = extPrivKey.deriveChildPubKey(path).get
-      sigF.map { sig =>
-        assert(childPubKey.key.verify(hash, sig))
-      }
-
+      assert(childPubKey.key.verify(hash, sig))
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
@@ -12,13 +12,13 @@ import org.bitcoins.core.wallet.builder.StandardNonInteractiveFinalizer
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.testkitcore.gen.{CreditingTxGen, ScriptGenerators}
-import org.bitcoins.testkitcore.util.BitcoinSJvmTest
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 
 import scala.util.Try
 
 /** Created by chris on 2/19/16.
   */
-class TransactionSignatureSerializerTest extends BitcoinSJvmTest {
+class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
 
   "TransactionSignatureSerializer" must "correctly serialize an input that is being checked where another input in the same tx is using SIGHASH_ANYONECANPAY" in {
     //this is from a test case inside of tx_valid.json
@@ -406,18 +406,17 @@ class TransactionSignatureSerializerTest extends BitcoinSJvmTest {
   }
 
   it should "have old and new serializeForSignature functions agree" in {
-    forAllAsync(CreditingTxGen.inputsAndOutputs(),
-                ScriptGenerators.scriptPubKey) {
+    forAll(CreditingTxGen.inputsAndOutputs(), ScriptGenerators.scriptPubKey) {
       case ((creditingTxsInfo, destinations), (changeSPK, _)) =>
         val fee = SatoshisPerVirtualByte(Satoshis(100))
 
-        val unsignedTxF = StandardNonInteractiveFinalizer
+        val spendingTx = StandardNonInteractiveFinalizer
           .txFrom(outputs = destinations,
                   utxos = creditingTxsInfo,
                   feeRate = fee,
                   changeSPK = changeSPK)
 
-        val correctScriptsF = unsignedTxF.map { spendingTx =>
+        val correctScripts =
           creditingTxsInfo.flatMap { signInfo =>
             signInfo.signers.map { _ =>
               val txSigComponent =
@@ -437,25 +436,23 @@ class TransactionSignatureSerializerTest extends BitcoinSJvmTest {
               oldBytes == newBytes
             }
           }
-        }
 
-        correctScriptsF.map(x => assert(x.forall(_ == true)))
+        assert(correctScripts.forall(_ == true))
     }
   }
 
   it should "have old and new hashForSignature functions agree" in {
-    forAllAsync(CreditingTxGen.inputsAndOutputs(),
-                ScriptGenerators.scriptPubKey) {
+    forAll(CreditingTxGen.inputsAndOutputs(), ScriptGenerators.scriptPubKey) {
       case ((creditingTxsInfo, destinations), (changeSPK, _)) =>
         val fee = SatoshisPerVirtualByte(Satoshis(100))
 
-        val unsignedTxF = StandardNonInteractiveFinalizer
+        val spendingTx = StandardNonInteractiveFinalizer
           .txFrom(outputs = destinations,
                   utxos = creditingTxsInfo,
                   feeRate = fee,
                   changeSPK = changeSPK)
 
-        val correctHashesF = unsignedTxF.map { spendingTx =>
+        val correctHashes =
           creditingTxsInfo.flatMap { signInfo =>
             signInfo.signers.map { _ =>
               val txSigComponent =
@@ -480,25 +477,23 @@ class TransactionSignatureSerializerTest extends BitcoinSJvmTest {
               oldHash == newHash
             }
           }
-        }
 
-        correctHashesF.map(x => assert(x.forall(_ == true)))
+        assert(correctHashes.forall(_ == true))
     }
   }
 
   it should "have old and new calculateScriptForSigning functions agree" in {
-    forAllAsync(CreditingTxGen.inputsAndOutputs(),
-                ScriptGenerators.scriptPubKey) {
+    forAll(CreditingTxGen.inputsAndOutputs(), ScriptGenerators.scriptPubKey) {
       case ((creditingTxsInfo, destinations), (changeSPK, _)) =>
         val fee = SatoshisPerVirtualByte(Satoshis(100))
 
-        val unsignedTxF = StandardNonInteractiveFinalizer
+        val spendingTx = StandardNonInteractiveFinalizer
           .txFrom(outputs = destinations,
                   utxos = creditingTxsInfo,
                   feeRate = fee,
                   changeSPK = changeSPK)
 
-        val correctScriptsF = unsignedTxF.map { spendingTx =>
+        val correctScripts =
           creditingTxsInfo.flatMap { signInfo =>
             signInfo.signers.map { _ =>
               val txSigComponent =
@@ -518,9 +513,8 @@ class TransactionSignatureSerializerTest extends BitcoinSJvmTest {
               oldScript == newScript
             }
           }
-        }
 
-        correctScriptsF.map(x => assert(x.forall(_ == true)))
+        assert(correctScripts.forall(_ == true))
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTSerializerTest.scala
@@ -13,13 +13,13 @@ import org.bitcoins.core.psbt.InputPSBTRecord.ProofOfReservesCommitment
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.testkitcore.gen.PSBTGenerators
-import org.bitcoins.testkitcore.util.BitcoinSJvmTest
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import scodec.bits._
 
 /** Test vectors are taken directly from the BIP 174 reference sheet
   * https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#test-vectors
   */
-class PSBTSerializerTest extends BitcoinSJvmTest {
+class PSBTSerializerTest extends BitcoinSUnitTest {
 
   val validPsbts: Vector[ByteVector] = Vector(
     // PSBT with one P2PKH input. Outputs are empty
@@ -243,18 +243,14 @@ class PSBTSerializerTest extends BitcoinSJvmTest {
   }
 
   it must "fail to serialize PSBTs with unknown version numbers" in {
-    forAllAsync(PSBTGenerators.psbtWithUnknownVersion) { psbtF =>
-      psbtF.map { psbt =>
-        assertThrows[IllegalArgumentException](PSBT(psbt.bytes))
-      }
+    forAll(PSBTGenerators.psbtWithUnknownVersion) { psbt =>
+      assertThrows[IllegalArgumentException](PSBT(psbt.bytes))
     }
   }
 
   it must "have serialization symmetry" in {
-    forAllAsync(PSBTGenerators.arbitraryPSBT) { psbtF =>
-      psbtF.map { psbt =>
-        assert(PSBT.fromBytes(psbt.bytes) == psbt)
-      }
+    forAll(PSBTGenerators.arbitraryPSBT) { psbt =>
+      assert(PSBT.fromBytes(psbt.bytes) == psbt)
     }
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/psbt/PSBTUnitTest.scala
@@ -16,13 +16,13 @@ import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.wallet.utxo.{ConditionalPath, InputInfo}
 import org.bitcoins.crypto._
-import org.bitcoins.testkitcore.util.BitcoinSJvmTest
-import org.bitcoins.testkitcore.util.TransactionTestUtil.{dummyPSBT, dummyTx}
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import org.bitcoins.testkitcore.util.TransactionTestUtil._
 import scodec.bits._
 
 import scala.util.{Failure, Success}
 
-class PSBTUnitTest extends BitcoinSJvmTest {
+class PSBTUnitTest extends BitcoinSUnitTest {
 
   behavior of "PSBT"
 
@@ -368,16 +368,14 @@ class PSBTUnitTest extends BitcoinSJvmTest {
         assert(missingSigs.forall(expectedPubKeyHashes.contains))
     }
 
-    for {
-      firstSig0 <- unsignedPsbt.sign(inputIndex = 0, signer = privKey0)
-      signedPsbt0 <- firstSig0.sign(inputIndex = 1, signer = privKey1)
+    val firstSig0 = unsignedPsbt.sign(inputIndex = 0, signer = privKey0)
+    val signedPsbt0 = firstSig0.sign(inputIndex = 1, signer = privKey1)
 
-      firstSig1 <- unsignedPsbt.sign(inputIndex = 0, signer = privKey2)
-      signedPsbt1 <- firstSig1.sign(inputIndex = 1, signer = privKey3)
-    } yield {
-      assert(signedPsbt0 == expectedPsbt0)
-      assert(signedPsbt1 == expectedPsbt1)
-    }
+    val firstSig1 = unsignedPsbt.sign(inputIndex = 0, signer = privKey2)
+    val signedPsbt1 = firstSig1.sign(inputIndex = 1, signer = privKey3)
+
+    assert(signedPsbt0 == expectedPsbt0)
+    assert(signedPsbt1 == expectedPsbt1)
   }
 
   it must "successfully change a NonWitnessUTXO to a WitnessUTXO when compressing" in {

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/StandardNonInteractiveFinalizerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/StandardNonInteractiveFinalizerTest.scala
@@ -15,9 +15,9 @@ import org.bitcoins.core.wallet.utxo.{
 import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPrivateKey, ECPublicKey}
 import org.bitcoins.testkitcore.Implicits._
 import org.bitcoins.testkitcore.gen.ScriptGenerators
-import org.bitcoins.testkitcore.util.BitcoinSJvmTest
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 
-class StandardNonInteractiveFinalizerTest extends BitcoinSJvmTest {
+class StandardNonInteractiveFinalizerTest extends BitcoinSUnitTest {
   behavior of "StandardNonInteractiveFinalizer"
 
   private val (spk, privKey) = ScriptGenerators.p2pkhScriptPubKey.sampleSome
@@ -115,7 +115,7 @@ class StandardNonInteractiveFinalizerTest extends BitcoinSJvmTest {
     val utxos = Vector(utxo)
     val feeUnit = SatoshisPerVirtualByte(Satoshis.one)
 
-    recoverToSucceededIf[IllegalArgumentException] {
+    assertThrows[IllegalArgumentException] {
       StandardNonInteractiveFinalizer.txFrom(outputs = destinations,
                                              utxos = utxos,
                                              feeRate = feeUnit,
@@ -149,7 +149,7 @@ class StandardNonInteractiveFinalizerTest extends BitcoinSJvmTest {
     val utxos = Vector(utxo)
     val feeUnit = SatoshisPerVirtualByte(Satoshis(-1))
 
-    recoverToSucceededIf[IllegalArgumentException] {
+    assertThrows[IllegalArgumentException] {
       StandardNonInteractiveFinalizer.txFrom(outputs = destinations,
                                              utxos = utxos,
                                              feeRate = feeUnit,
@@ -177,7 +177,7 @@ class StandardNonInteractiveFinalizerTest extends BitcoinSJvmTest {
         hashType = HashType.sigHashAll
       )
 
-    recoverToSucceededIf[UnsupportedOperationException] {
+    assertThrows[UnsupportedOperationException] {
       StandardNonInteractiveFinalizer.txFrom(
         Vector(TransactionOutput(Bitcoins.one, EmptyScriptPubKey)),
         Vector(spendingInfo),

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -7,7 +7,6 @@ import org.bitcoins.crypto._
 import scodec.bits.{ByteVector, HexStringSyntax}
 
 import scala.annotation.tailrec
-import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 /** Represents an extended key as defined by BIP32
@@ -225,21 +224,21 @@ sealed abstract class ExtPrivateKey
 
   override def publicKey: ECPublicKey = key.publicKey
 
-  override def signFunction: ByteVector => Future[ECDigitalSignature] = {
-    key.signFunction
+  override def sign(bytes: ByteVector): ECDigitalSignature = {
+    key.sign(bytes)
   }
 
-  override def signWithEntropyFunction: (
-      ByteVector,
-      ByteVector) => Future[ECDigitalSignature] = {
-    key.signWithEntropyFunction
+  override def signWithEntropy(
+      bytes: ByteVector,
+      entropy: ByteVector): ECDigitalSignature = {
+    key.signWithEntropy(bytes, entropy)
   }
 
   /** Signs the given bytes with the given [[BIP32Path path]] */
-  override def deriveAndSignFuture: (
-      ByteVector,
-      BIP32Path) => Future[ECDigitalSignature] = { case (bytes, path) =>
-    deriveChildPrivKey(path).signFunction(bytes)
+  override def deriveAndSign(
+      bytes: ByteVector,
+      path: BIP32Path): ECDigitalSignature = {
+    deriveChildPrivKey(path).sign(bytes)
   }
 
   override def toStringSensitive: String = {

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtSign.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtSign.scala
@@ -1,19 +1,38 @@
 package org.bitcoins.core.crypto
 
 import org.bitcoins.core.hd.BIP32Path
-import org.bitcoins.crypto.{ECDigitalSignature, Sign}
+import org.bitcoins.crypto.{AsyncSign, ECDigitalSignature, Sign}
 import scodec.bits.ByteVector
 
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Future
 
 /** A signing interface for [[ExtKey]] */
-trait ExtSign extends Sign {
+trait AsyncExtSign extends AsyncSign {
 
-  def deriveAndSignFuture: (ByteVector, BIP32Path) => Future[ECDigitalSignature]
+  def asyncDeriveAndSign(
+      bytes: ByteVector,
+      path: BIP32Path): Future[ECDigitalSignature]
+
+  /** First derives the child key that corresponds to [[BIP32Path path]] and then signs */
+  def asyncSign(
+      bytes: ByteVector,
+      path: BIP32Path): Future[ECDigitalSignature] = {
+    asyncDeriveAndSign(bytes, path)
+  }
+}
+
+trait ExtSign extends AsyncExtSign with Sign {
+
+  def deriveAndSign(bytes: ByteVector, path: BIP32Path): ECDigitalSignature
+
+  override def asyncDeriveAndSign(
+      bytes: ByteVector,
+      path: BIP32Path): Future[ECDigitalSignature] = {
+    Future.successful(deriveAndSign(bytes, path))
+  }
 
   /** First derives the child key that corresponds to [[BIP32Path path]] and then signs */
   def sign(bytes: ByteVector, path: BIP32Path): ECDigitalSignature = {
-    Await.result(deriveAndSignFuture(bytes, path), 30.seconds)
+    deriveAndSign(bytes, path)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/FinalizedTxWithSigningInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/FinalizedTxWithSigningInfo.scala
@@ -4,8 +4,6 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.{InputInfo, ScriptSignatureParams}
 
-import scala.concurrent.{ExecutionContext, Future}
-
 /** Contains a finalized tx (output from [[RawTxFinalizer.buildTx]]) and the
   * ScriptSignatureParams needed to sign that transaction.
   */
@@ -13,8 +11,7 @@ case class FinalizedTxWithSigningInfo(
     finalizedTx: Transaction,
     infos: Vector[ScriptSignatureParams[InputInfo]]) {
 
-  def sign(expectedFeeRate: FeeUnit)(implicit
-      ec: ExecutionContext): Future[Transaction] = {
+  def sign(expectedFeeRate: FeeUnit): Transaction = {
     RawTxSigner.sign(this, expectedFeeRate)
   }
 
@@ -22,8 +19,7 @@ case class FinalizedTxWithSigningInfo(
       expectedFeeRate: FeeUnit,
       invariants: (
           Vector[ScriptSignatureParams[InputInfo]],
-          Transaction) => Boolean)(implicit
-      ec: ExecutionContext): Future[Transaction] = {
+          Transaction) => Boolean): Transaction = {
     RawTxSigner.sign(this, expectedFeeRate, invariants)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxBuilder.scala
@@ -4,7 +4,6 @@ import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.transaction._
 
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future}
 
 /** The mutable transaction builder which collects:
   *   - Unsigned inputs (script signature will be ignored)
@@ -149,7 +148,7 @@ case class RawTxBuilderWithFinalizer[F <: RawTxFinalizer](
     finalizer: F) {
 
   /** Completes the builder and finalizes the result */
-  def buildTx()(implicit ec: ExecutionContext): Future[Transaction] = {
+  def buildTx(): Transaction = {
     finalizer.buildTx(builder.result())
   }
 

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/SignTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/SignTest.scala
@@ -2,7 +2,7 @@ package org.bitcoins.crypto
 
 import scodec.bits.ByteVector
 
-class SignTest extends BitcoinSCryptoAsyncTest {
+class SignTest extends BitcoinSCryptoTest {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     generatorDrivenConfigNewCode
@@ -30,12 +30,10 @@ class SignTest extends BitcoinSCryptoAsyncTest {
   }
 
   it must "sign arbitrary pieces of data correctly" in {
-    forAllAsync(CryptoGenerators.sha256Digest) { hash =>
-      val sigF = privKey.signFunction(hash.bytes)
+    forAll(CryptoGenerators.sha256Digest) { hash =>
+      val sig = privKey.sign(hash.bytes)
 
-      sigF.map { sig =>
-        assert(pubKey.verify(hash.bytes, sig))
-      }
+      assert(pubKey.verify(hash.bytes, sig))
     }
   }
 }

--- a/docs/core/txbuilder.md
+++ b/docs/core/txbuilder.md
@@ -106,7 +106,7 @@ val finalizer = StandardNonInteractiveFinalizer(
     changeSPK)
 
 // We can now finalize the tx builder result from earlier with this finalizer
-val unsignedTxF: Future[Transaction] = finalizer.buildTx(builderResult)
+val unsignedTx: Transaction = finalizer.buildTx(builderResult)
 
 // We now turn to signing the unsigned transaction
 // this contains all the information we need to
@@ -129,16 +129,12 @@ val utxoInfos: Vector[ScriptSignatureParams[InputInfo]] = Vector(utxoInfo)
 //   1: one input
 //   2: outputs (destination and change outputs)
 //   3: a fee rate of 1 satoshi/byte
-val signedTx: Transaction = {
-  val signedTxF = unsignedTxF.flatMap { unsignedTx =>
-    RawTxSigner.sign(
-        utx = unsignedTx,
-        utxoInfos = utxoInfos,
-        expectedFeeRate = feeRate
-    )
-  }
-  Await.result(signedTxF, 30.seconds)
-}
+val signedTx: Transaction =
+  RawTxSigner.sign(
+      utx = unsignedTx,
+      utxoInfos = utxoInfos,
+      expectedFeeRate = feeRate
+  )
 ```
 
 ```scala mdoc:to-string

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -29,8 +29,6 @@ import org.scalacheck.Gen
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 
 //TODO: Need to provide generators for [[NonStandardScriptSignature]] and [[NonStandardScriptPubKey]]
@@ -591,8 +589,9 @@ sealed abstract class ScriptGenerators {
         privateKey,
         hashType
       )
-      txSigComponentFuture = P2PKSigner.sign(spendingInfo, spendingTx, false)
-      txSigComponent = Await.result(txSigComponentFuture, timeout)
+      txSigComponent = P2PKSigner.sign(spendingInfo,
+                                       spendingTx,
+                                       isDummySignature = false)
       //add the signature to the scriptSig instead of having an empty scriptSig
       signedScriptSig =
         txSigComponent.scriptSignature
@@ -628,8 +627,9 @@ sealed abstract class ScriptGenerators {
         privateKey,
         hashType
       )
-      txSigComponentFuture = P2PKHSigner.sign(spendingInfo, unsignedTx, false)
-      txSigComponent = Await.result(txSigComponentFuture, timeout)
+      txSigComponent = P2PKHSigner.sign(spendingInfo,
+                                        unsignedTx,
+                                        isDummySignature = false)
       signedScriptSig =
         txSigComponent.scriptSignature
           .asInstanceOf[P2PKHScriptSignature]
@@ -658,10 +658,9 @@ sealed abstract class ScriptGenerators {
         privKey,
         hashType
       )
-      val txSigComponentF = P2PKWithTimeoutSigner.sign(spendingInfo,
-                                                       spendingTx,
-                                                       isDummySignature = false)
-      val txSigComponent = Await.result(txSigComponentF, timeout)
+      val txSigComponent = P2PKWithTimeoutSigner.sign(spendingInfo,
+                                                      spendingTx,
+                                                      isDummySignature = false)
       val signedScriptSig =
         txSigComponent.scriptSignature.asInstanceOf[ConditionalScriptSignature]
 
@@ -706,9 +705,8 @@ sealed abstract class ScriptGenerators {
         privateKeys.toVector,
         hashType
       )
-      txSigComponentFuture =
-        MultiSigSigner.sign(spendingInfo, spendingTx, false)
-      txSigComponent = Await.result(txSigComponentFuture, timeout)
+      txSigComponent =
+        MultiSigSigner.sign(spendingInfo, spendingTx, isDummySignature = false)
       signedScriptSig =
         txSigComponent.scriptSignature
           .asInstanceOf[MultiSignatureScriptSignature]

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
@@ -83,8 +83,8 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
                                       fromAccount = account,
                                       fromTagOpt = Some(exampleTag))
       }
-      utx <- txBuilder.buildTx()
-      signedTx <- RawTxSigner.sign(utx, utxoInfos, feeRate)
+      utx = txBuilder.buildTx()
+      signedTx = RawTxSigner.sign(utx, utxoInfos, feeRate)
       _ <- wallet.processTransaction(signedTx, None)
 
       utxos <- wallet.listUtxos()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -250,9 +250,10 @@ class FundTransactionHandlingTest
             fromTagOpt = Some(tag),
             markAsReserved = true
           )
-      utx <- txBuilder.buildTx()
-      tx <- RawTxSigner.sign(utx, utxoInfos, feeRate)
     } yield {
+      val utx = txBuilder.buildTx()
+      val tx = RawTxSigner.sign(utx, utxoInfos, feeRate)
+
       assert(tx.inputs.forall(input =>
         expectedUtxos.exists(_.outPoint == input.previousOutput)))
     }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -40,7 +40,7 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
                                fromAccount = fromAccount,
                                fromTagOpt = fromTagOpt,
                                markAsReserved = markAsReserved)
-      .flatMap(_._1.buildTx())
+      .map(_._1.buildTx())
   }
 
   /** This returns a [[RawTxBuilder]] that can be used to generate an unsigned transaction with [[RawTxBuilder.result()]]


### PR DESCRIPTION
Currently all code which uses signing does so through `ECPrivateKey` which has entirely synchronous signing. As such, the sign interface now also supports synchronous signing and asynchronous signers will instead extend the `AsyncSign` trait. This will mean that eventually, when AsyncSigners what to integrate, every method in `crypto` and `core` which handles a `Sign` will need a duplicate method that handles `AsyncSign`. This will lead to interfaces with different methods for sync and async signing functions so that sync signers won't have to get bogged down in futures and execution contexts. As of right now this PR does not implement these duplicate async functions.