### PR TITLE
Get basic docker image working with oracle server

### DIFF
--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -12,13 +12,15 @@ packageSummary := "A DLC Oracle"
 
 packageDescription := "A basic DLC oracle that allows you to commit to events and sign them"
 
-enablePlugins(JavaAppPackaging, DockerPlugin)
-
 //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
-dockerBaseImage := "openjdk"
+dockerBaseImage := "openjdk:16-jdk-buster"
 
 packageName in Docker := packageName.value
 
 version in Docker := version.value
 
 dockerExposedPorts ++= Seq(9998)
+
+dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-oracle-server",
+                        "--conf",
+                        "/opt/docker/docker-application.conf")

--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -12,4 +12,13 @@ packageSummary := "A DLC Oracle"
 
 packageDescription := "A basic DLC oracle that allows you to commit to events and sign them"
 
-enablePlugins(JavaAppPackaging)
+enablePlugins(JavaAppPackaging, DockerPlugin)
+
+//https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
+dockerBaseImage := "openjdk"
+
+packageName in Docker := packageName.value
+
+version in Docker := version.value
+
+dockerExposedPorts ++= Seq(9998)

--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -13,7 +13,7 @@ packageSummary := "A DLC Oracle"
 packageDescription := "A basic DLC oracle that allows you to commit to events and sign them"
 
 //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
-dockerBaseImage := "openjdk:16-jdk-buster"
+dockerBaseImage := "openjdk"
 
 packageName in Docker := packageName.value
 

--- a/app/oracle-server/src/main/resources/reference.conf
+++ b/app/oracle-server/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 bitcoin-s {
     oracle {
         rpcport = 9998
-        rpcbind = "0.0.0.0"
+        rpcbind = "127.0.0.1"
         hikari-logging = true
         hikari-logging-interval = 5 minute
     }

--- a/app/oracle-server/src/main/resources/reference.conf
+++ b/app/oracle-server/src/main/resources/reference.conf
@@ -1,8 +1,9 @@
 bitcoin-s {
     oracle {
         rpcport = 9998
+        rpcbind = "0.0.0.0"
         hikari-logging = true
-        hikari-logging-interval = 1 minute
+        hikari-logging-interval = 5 minute
     }
 }
 

--- a/app/oracle-server/src/universal/docker-application.conf
+++ b/app/oracle-server/src/universal/docker-application.conf
@@ -1,0 +1,5 @@
+# needed otherwise an exception is thrown
+bitcoin-s.network = regtest
+# need to bind to all interfaces so we can
+# have host machine forward requests to the docker container
+bitcoin-s.oracle.rpcbind="0.0.0.0"

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
@@ -19,7 +19,7 @@ trait BitcoinSRunner extends BitcoinSLogger {
 
   implicit lazy val system: ActorSystem = {
     val system = ActorSystem(actorSystemName, baseConfig)
-    system.log.info("Akka logger started")
+    system.log.info("Akka started")
     system
   }
   implicit lazy val ec: ExecutionContext = system.dispatcher

--- a/build.sbt
+++ b/build.sbt
@@ -203,8 +203,7 @@ lazy val secp256k1jni = project
     coverageEnabled := false
   )
 
-/**
-  * If you want sbt projects to depend on each other in
+/** If you want sbt projects to depend on each other in
   * slighly nonstandard ways, the way to do it is through
   * stringly typed syntax.
   *
@@ -281,10 +280,14 @@ lazy val appCommonsTest = project
 lazy val oracleServer = project
   .in(file("app/oracle-server"))
   .settings(CommonSettings.prodSettings: _*)
+  .settings(
+    Compile / unmanagedResourceDirectories += baseDirectory.value / "src" / "universal"
+  )
   .dependsOn(
     dlcOracle,
     serverRoutes
   )
+  .enablePlugins(JavaAppPackaging, DockerPlugin)
 
 lazy val serverRoutes = project
   .in(file("app/server-routes"))

--- a/docs/oracle/build-oracle-server.md
+++ b/docs/oracle/build-oracle-server.md
@@ -41,10 +41,12 @@ to download the secp256k1 submodule, this is so cryptographic functions like sig
 
 ## Step 3: Building the Oracle Server
 
+### Java Binary
+
 You can build the oracle server with the [sbt native packager](https://github.com/sbt/sbt-native-packager).
 The native packager offers [numerous ways to package the project](https://github.com/sbt/sbt-native-packager#examples).
 
-In this example we are going to use `stage` which will produce bash scripts we can easily execute. You can stage the server with the following command.
+In this example we are going to use `universal:stage` which will produce bash scripts we can easily execute. You can stage the server with the following command.
 
 ```bash
 sbt oracleServer/universal:stage
@@ -62,8 +64,48 @@ Alternatively you can run the server by just using:
 sbt oracleServer/run
 ```
 
+### Docker
+
+The oracle server also has docker support. You can build a docker image with the following commands
+
+```
+sbt "oracleServer/compile;oracleServer/docker:stage"
+```
+
+This will build a `Dockerfile` that is located in `app/oracle-server/target/docker/stage`
+
+You can publish to your local docker repository by using `docker:publishLocal` instead of `docker:stage`
+
+You can now build the docker image with
+
+```
+docker build app/oracle-server/target/docker/stage/ -t oracle-server
+```
+
+Finally, let's run the image! It's important that you correctly configure port forwarding with the docker container so
+you can interact with the running container with `bitcoin-s-cli` or `curl`. By default, our oracle
+server listens for requests on port `9998`.
+
+This means we need to forward requests on the host machine to the docker container correctly.
+
+This can be done with the following command
+```
+docker run -d -p 9998:9998 oracle-server:latest
+```
+
+Now you can send requests with `bitcoin-s-cli` or `curl`.
+Here is an example with `bitcoin-s-cli`
+```
+./bitcoin-s-cli getpublickey
+c9c9fe2772330b0d61a2efbfacabf5cab1137710a69f0e12f1eb3dbb74f7ea54
+```
+
+For more information on build configuration options with `sbt` please see the [sbt native packager docs](https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html#tasks)
+
+
 ## Step 4: Configuration
 
+### Java binary configuration
 If you would like to pass in a custom datadir for your server, you can do
 
 ```bash
@@ -85,3 +127,9 @@ You can also pass in a custom `rpcport` to bind to
 For more information on configuring the server please see our [configuration](../config/configuration.md) document.
 
 For more information on how to use our built in `cli` to interact with the server please see the [cli docs](../applications/cli.md).
+
+### Docker configuration
+
+Currently our docker configuration only allows for configuration at build time _not_ runtime.
+
+To the configuration file for the docker application is called [docker-application.conf](../../app/oracle-server/src/universal/docker-application.conf)


### PR DESCRIPTION
This is part of #2626 

This PR introduces configuration for building a docker image for the oracle server. 

## Building a docker image

You can build the docker image by doing the following inside of `sbt`. [Here](https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html#tasks) are the list of tasks you can use to build a docker image, we are going to use `stage

> oracleServer/compile;oracleServer/docker:stage

This builds a docker image and places it inside of the directory `app/oracle-server/target/docker/stage`

If you navigate to that directory, you can build the image by doing 

`docker build app/oracle-server/target/docker/stage/`

This will give you an image which you can see by doing 

![Screenshot from 2021-02-16 10-55-54](https://user-images.githubusercontent.com/3514957/108095514-946a9780-7045-11eb-9e35-e5d9757ae616.png)

## Running docker image

From the example above, you can see my docker image hash is `95b3d5989078`. We need this for running the image

Now we can start the image to create a running container with the [custom docker configuration](https://github.com/bitcoin-s/bitcoin-s/blob/7ad7a9fbf53f9d0534b009a50345a481ce2a7926/app/oracle-server/src/universal/docker-application.conf) following command

```
docker run -p 9998:9998 95b3d5989078
```
This should give you a log that looks like the following

![Screenshot from 2021-02-16 10-58-53](https://user-images.githubusercontent.com/3514957/108095952-09d66800-7046-11eb-8591-cd55a30415d0.png)

Once this is done, you should be able to send requests to the oracle server with `bitcoin-s-cli` 

> ./bitcoin-s-cli getpublickey
4a4d9bd3e5f66211024599a3c29a0f6a9a3c2b75a90b5e0860da7d8f13fbd33e

Here is a screenshot of the following interaction

![Screenshot from 2021-02-16 11-01-20](https://user-images.githubusercontent.com/3514957/108096252-646fc400-7046-11eb-9a1a-6b48f0874a38.png)


## Resources 

[Docker overview](https://docs.docker.com/get-started/overview/)
[Sbt native packager docker config](https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html#settings)