### PR TITLE
2021 02 15 appserver docker

### DIFF
--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -12,13 +12,6 @@ packageSummary := "A DLC Oracle"
 
 packageDescription := "A basic DLC oracle that allows you to commit to events and sign them"
 
-//https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
-dockerBaseImage := "openjdk"
-
-packageName in Docker := packageName.value
-
-version in Docker := version.value
-
 dockerExposedPorts ++= Seq(9998)
 
 dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-oracle-server",

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -13,4 +13,8 @@ packageSummary := "A Bitcoin neutrino node and wallet"
 packageDescription := "Runs a Bitcoin neutrino node and wallet, has functionality " +
   "for many different modes and configuration options, see more at https://bitcoin-s.org/docs/applications/server"
 
-enablePlugins(JavaAppPackaging)
+dockerExposedPorts ++= Seq(9999)
+
+dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-server",
+                        "--conf",
+                        "/opt/docker/docker-application.conf")

--- a/app/server/src/universal/docker-application.conf
+++ b/app/server/src/universal/docker-application.conf
@@ -1,0 +1,4 @@
+bitcoin-s.network = mainnet
+# need to bind to all interfaces so we can
+# have host machine forward requests to the docker container
+bitcoin-s.server.rpcbind="0.0.0.0"

--- a/build.sbt
+++ b/build.sbt
@@ -279,10 +279,8 @@ lazy val appCommonsTest = project
 
 lazy val oracleServer = project
   .in(file("app/oracle-server"))
-  .settings(CommonSettings.prodSettings: _*)
-  .settings(
-    Compile / unmanagedResourceDirectories += baseDirectory.value / "src" / "universal"
-  )
+  .settings(CommonSettings.appSettings: _*)
+  .settings(CommonSettings.dockerSettings: _*)
   .dependsOn(
     dlcOracle,
     serverRoutes
@@ -298,7 +296,8 @@ lazy val serverRoutes = project
 
 lazy val appServer = project
   .in(file("app/server"))
-  .settings(CommonSettings.prodSettings: _*)
+  .settings(CommonSettings.appSettings: _*)
+  .settings(CommonSettings.dockerSettings: _*)
   .dependsOn(
     serverRoutes,
     appCommons,
@@ -309,6 +308,7 @@ lazy val appServer = project
     feeProvider,
     zmq
   )
+  .enablePlugins(JavaAppPackaging, DockerPlugin)
 
 lazy val appServerTest = project
   .in(file("app/server-test"))

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -16,6 +16,7 @@ The server project provides a away to access information from these three projec
 
 ### Building the server
 
+#### Java binary
 You can build the server with the [sbt native packager](https://github.com/sbt/sbt-native-packager).
 The native packager offers [numerous ways to package the project](https://github.com/sbt/sbt-native-packager#examples).
 
@@ -30,6 +31,42 @@ This will produce a script to execute bitcoin-s which you can start with
 ```bash
 ./app/server/target/universal/stage/bin/bitcoin-s-server
 ```
+
+#### Docker
+
+The oracle server also has docker support. You can build a docker image with the following commands
+
+```
+sbt "appServer/compile;appServer/docker:stage"
+```
+
+This will build a `Dockerfile` that is located in `app/server/target/docker/stage`
+
+You can now build the docker image with
+
+```
+docker build app/server/target/docker/stage/ -t app-server
+```
+
+Finally, let's run the image! It's important that you correctly configure port forwarding with the docker container so
+you can interact with the running container with `bitcoin-s-cli` or `curl`. By default, our oracle
+server listens for requests on port `9999`.
+
+This means we need to forward requests on the host machine to the docker container correctly.
+
+This can be done with the following command
+```
+docker run -d -p 9999:9999 app-server:latest
+```
+
+Now you can send requests with `bitcoin-s-cli` or `curl`.
+Here is an example with `bitcoin-s-cli`
+```
+./bitcoin-s-cli getblockcount
+10000
+```
+
+For more information on build configuration options with `sbt` please see the [sbt native packager docs](https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html#tasks)
 
 ### Configuration
 

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -37,7 +37,7 @@ This will produce a script to execute bitcoin-s which you can start with
 The oracle server also has docker support. You can build a docker image with the following commands
 
 ```
-sbt "appServer/compile;appServer/docker:stage"
+sbt "appServer/docker:stage"
 ```
 
 This will build a `Dockerfile` that is located in `app/server/target/docker/stage`

--- a/docs/oracle/build-oracle-server.md
+++ b/docs/oracle/build-oracle-server.md
@@ -69,7 +69,7 @@ sbt oracleServer/run
 The oracle server also has docker support. You can build a docker image with the following commands
 
 ```
-sbt "oracleServer/compile;oracleServer/docker:stage"
+sbt "oracleServer/docker:stage"
 ```
 
 This will build a `Dockerfile` that is located in `app/oracle-server/target/docker/stage`

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -1,7 +1,10 @@
 // these two imports are needed for sbt syntax to work
-import java.nio.file.Paths
+import com.typesafe.sbt.SbtNativePackager.Docker
+import com.typesafe.sbt.SbtNativePackager.autoImport.packageName
 
+import java.nio.file.Paths
 import com.typesafe.sbt.packager.Keys.maintainer
+import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerBaseImage
 import sbt._
 import sbt.Keys._
 
@@ -49,7 +52,7 @@ object CommonSettings {
       s == "-Ywarn-unused-import"
         || s == "-Ywarn-unused"
         || s == "-Xfatal-warnings"
-      //for 2.13 -- they use different compiler opts
+        //for 2.13 -- they use different compiler opts
         || s == "-Xlint:unused")),
     //we don't want -Xfatal-warnings for publishing with publish/publishLocal either
     scalacOptions in (Compile, doc) ~= (_ filterNot (s =>
@@ -138,6 +141,20 @@ object CommonSettings {
   ) ++ settings
 
   lazy val prodSettings: Seq[Setting[_]] = settings
+
+  lazy val appSettings: Seq[Setting[_]] = prodSettings ++ Vector(
+    //gives us the 'universal' directory in build artifacts
+    Compile / unmanagedResourceDirectories += baseDirectory.value / "src" / "universal"
+  )
+
+  lazy val dockerSettings: Seq[Setting[_]] = {
+    Vector(
+      //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
+      dockerBaseImage := "openjdk",
+      packageName in Docker := packageName.value,
+      version in Docker := version.value
+    )
+  }
 
   lazy val binariesPath =
     Paths.get(Properties.userHome, ".bitcoin-s", "binaries")


### PR DESCRIPTION
This is built ontop of #2668 

This addresses part of #2626 

This adds instructions for building a docker image for `appServer`. You can see the instructions [here](https://github.com/Christewart/bitcoin-s-core/blob/e54cbffb9662ede4ebfdf4935ffaec071570c960/docs/applications/server.md#docker)