### PR TITLE
Add --depth 100 restriction when cloning bitcoin-s repo to speed up c…

### DIFF
--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -29,13 +29,13 @@ Simply follow the instructions in [this short blog](https://www.scala-lang.org/2
 Now, it is time to clone the [Bitcoin-S repository](https://github.com/bitcoin-s/bitcoin-s/) by running
 
 ```bashrc
-git clone --recursive git@github.com:bitcoin-s/bitcoin-s.git
+git clone --depth 100 --recursive git@github.com:bitcoin-s/bitcoin-s.git
 ```
 
 or alternatively, if you do not have ssh setup with github, you can run
 
 ```bashrc
-git clone --recursive https://github.com/bitcoin-s/bitcoin-s.git
+git clone --depth 100 --recursive https://github.com/bitcoin-s/bitcoin-s.git
 ```
 
 Next, you will want to execute the commands

--- a/docs/oracle/build-oracle-server.md
+++ b/docs/oracle/build-oracle-server.md
@@ -21,13 +21,13 @@ Simply follow the instructions in [this short blog](https://www.scala-lang.org/2
 Now, it is time to clone the [Bitcoin-S repository](https://github.com/bitcoin-s/bitcoin-s/) by running
 
 ```bashrc
-git clone --recursive git@github.com:bitcoin-s/bitcoin-s.git
+git clone --depth 100 --recursive git@github.com:bitcoin-s/bitcoin-s.git
 ```
 
 or alternatively, if you do not have ssh setup with github, you can run
 
 ```bashrc
-git clone --recursive https://github.com/bitcoin-s/bitcoin-s.git
+git clone --depth 100 --recursive https://github.com/bitcoin-s/bitcoin-s.git
 ```
 
 Next, you will want to execute the commands


### PR DESCRIPTION
…lone time


Before adding `--depth 100` 

```
 time git clone --recursive git@github.com:bitcoin-s/bitcoin-s.git            
Cloning into 'bitcoin-s'...
...
git clone --recursive git@github.com:bitcoin-s/bitcoin-s.git  
800.05s user 29.15s system 93% cpu 14:47.06 total
```
800 seconds!!

After adding `--depth 100` 

```
git clone --depth 100 --recursive git@github.com:bitcoin-s/bitcoin-s.git  
1.60s user 0.40s system 22% cpu 8.882 total
```
1 second
