### PR TITLE
Make sure dynver versions use '-' instead of '+'

### DIFF
--- a/inThisBuild.sbt
+++ b/inThisBuild.sbt
@@ -18,3 +18,8 @@ excludeLintKeys in Global ++= Set(
   Keys.mainClass,
   com.typesafe.sbt.SbtGit.GitKeys.gitRemoteRepo
 )
+
+//needed so that we can use our versions with docker
+//see: https://github.com/dwijnand/sbt-dynver#portable-version-strings
+//https://github.com/bitcoin-s/bitcoin-s/issues/2672
+dynverSeparator in ThisBuild := "-"


### PR DESCRIPTION
fixes #2672 

This will slightly change our versioning scheme from 

>0.5.0+27-5de4537f-20210218+1053-SNAPSHOT

to 

>0.5.0-27-5de4537f-20210218-1053-SNAPSHOT

(no `+`)