### PR TITLE
Add github workflow steps to publish to dockerhub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,11 +2,7 @@
 name: CI to Docker Hub
 on:
   pull_request:
-    branches: [ master, main, adaptor-dlc ]
-    tags: [ "*" ]
-  push:
-    branches: [master, main, adaptor-dlc]
-    tags: ["*"]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,7 @@
 # https://docs.docker.com/ci-cd/github-actions/
 name: CI to Docker Hub
 on:
+  pull_request:
   push:
     branches: [master, main, adaptor-dlc]
     tags: ["*"]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         run: sbt "oracleServer/docker:publish;appServer/docker:publish"
       - name: Image digest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@
 name: CI to Docker Hub
 on:
   push:
-    branches: [ main ]
+    branches: [master, main, adaptor-dlc]
     tags: ["*"]
 jobs:
   build:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@
 name: CI to Docker Hub
 on:
   pull_request:
+    branches: [ master, main, adaptor-dlc ]
+    tags: [ "*" ]
   push:
     branches: [master, main, adaptor-dlc]
     tags: ["*"]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Build and push
         run: sbt "oracleServer/docker:publish;appServer/docker:publish"
       - name: Image digest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,17 +4,12 @@ on:
   pull_request:
 
 jobs:
-  build:
+  login:
     runs-on: ubuntu-latest
     steps:
-      - name: Check Out Repo
-        uses: actions/checkout@v2
-      - name: Login to Docker Hub
+      -
+        name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      - name: Build and push
-        run: sbt "oracleServer/docker:publish;appServer/docker:publish"
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,9 +15,6 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
         run: sbt "oracleServer/docker:publish;appServer/docker:publish"
-
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,24 @@
+# https://docs.docker.com/ci-cd/github-actions/
+name: CI to Docker Hub
+on:
+  push:
+    branches: [ main ]
+    tags: ["*"]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        run: sbt "oracleServer/docker:publish;appServer/docker:publish"
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,15 +1,21 @@
 # https://docs.docker.com/ci-cd/github-actions/
 name: CI to Docker Hub
 on:
-  pull_request:
-
+  push:
+    branches: [master, main, adaptor-dlc, 2021-02-18-github-docker-workflow]
+    tags: ["*"]
 jobs:
-  login:
+  build:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Login to Docker Hub
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Build and push
+        run: sbt "oracleServer/docker:publish;appServer/docker:publish"
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@
 name: CI to Docker Hub
 on:
   push:
-    branches: [master, main, adaptor-dlc, 2021-02-18-github-docker-workflow]
+    branches: [master, main, adaptor-dlc]
     tags: ["*"]
 jobs:
   build:
@@ -19,5 +19,3 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Build and push
         run: sbt "oracleServer/docker:publish;appServer/docker:publish"
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtNativePackager.Docker
 import com.typesafe.sbt.SbtNativePackager.autoImport.packageName
 
 import java.nio.file.Paths
-import com.typesafe.sbt.packager.Keys.maintainer
+import com.typesafe.sbt.packager.Keys.{dockerRepository, maintainer}
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerBaseImage
 import sbt._
 import sbt.Keys._
@@ -151,6 +151,7 @@ object CommonSettings {
     Vector(
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
       dockerBaseImage := "openjdk",
+      dockerRepository := Some("bitcoinscala"),
       packageName in Docker := packageName.value,
       version in Docker := version.value
     )


### PR DESCRIPTION
This PR attempts to follow this guide to publish docker images on every CI merge and tag push

https://docs.docker.com/ci-cd/github-actions/

I've added the appropriate github secrets, so this _should_ work :tm:

I doubt I got this right on the first try, but i don't know if there is a way to debug without merging? 

Docker repos where images are published too:

https://hub.docker.com/repository/docker/bitcoinscala/bitcoin-s-server

https://hub.docker.com/repository/docker/bitcoinscala/bitcoin-s-oracle-server