### PR TITLE
Set fetch-depth to 500 so we don't take forever to clone repo on ci

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@v2.3.4
         with:
-          fetch-depth: 0
+          fetch-depth: 500
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
         with:
-          fetch-depth: 0
+          fetch-depth: 500
       - uses: olafurpg/setup-scala@v10
       - uses: olafurpg/setup-gpg@v3
       - run: sbt ci-release docs/publishWebsite


### PR DESCRIPTION
I think this may be the culprit for some slow release times on CI. The [latest publish](https://github.com/bitcoin-s/bitcoin-s/runs/1936680734) took 19 minutes, and i've seen them take upwards of 40 minutes.

Here is the [description for `fetch-depth`](https://github.com/actions/checkout#usage)
```
    # Number of commits to fetch. 0 indicates all history for all branches and tags.
    # Default: 1
```

As talked about in #2674 a full `git clone` with our repo currently takes 8 minutes on my machine (!)

I believe this also is slowly down builds on CI. 

This PR does this, but it does come with a tradeoff. If we don't fetch deep enough (specifically to our last official tag) we won't get correct versioning. I experienced this on #2684 and ended up with weird versions on docker hub that look like this

[0.0.0-1-a24e2278-SNAPSHOT](https://hub.docker.com/layers/bitcoinscala/bitcoin-s-server/0.0.0-1-a24e2278-SNAPSHOT/images/sha256-4b0f562c34cd9c512c37fbbfb5775e7777353e53228c9e3d79314639a223516a?context=explore)

note that we don't have the latest tag (`0.5.0`) so we revert to the default git tag (`0.0.0`). So we need to make sure strike a balance here.