### PR TITLE
Add guard for the case when listFiles returns null

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/util/FileUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/FileUtil.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.testkit.util
 
-import java.io.File
-import java.nio.file.{Path, Paths}
 import org.bitcoins.core.util.BitcoinSLogger
 
+import java.io.File
+import java.nio.file.{Path, Paths}
 import scala.annotation.tailrec
 import scala.util.{Properties, Random}
 
@@ -29,7 +29,13 @@ object FileUtil extends BitcoinSLogger {
     } else if (!dir.isDirectory) {
       dir.delete()
     } else {
-      dir.listFiles().foreach(deleteTmpDir)
+      val filesOpt = Option(dir.listFiles())
+      filesOpt match {
+        case Some(files) =>
+          files.foreach(deleteTmpDir)
+        case None =>
+        //do nothing since list files must have returned null
+      }
       dir.delete()
     }
   }


### PR DESCRIPTION
This should fix #2689 

It seems that the `.listFiles()` API from java returns `null` in certain cases (nulls are evil!). This wraps the call to the `listFiles()` api in an `Option` to properly account for the case when no files exists. 

This should prevent NPEs in the future.