### PR TITLE
Decrease false positive rate in BloomFilterTest to avoid spurious CI failures

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/bloom/BloomFilterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/bloom/BloomFilterTest.scala
@@ -88,7 +88,7 @@ class BloomFilterTest extends BitcoinSUnitTest {
     // for 2 keys
     val numElements = 4
     val bloom = BloomFilter(numElements = numElements,
-                            falsePositiveRate = 0.001,
+                            falsePositiveRate = 0.000001,
                             tweak = UInt32(100),
                             BloomUpdateNone)
 


### PR DESCRIPTION
fixes #2510 

This decreases the false positive rate to so that we avoid more false positives on CI.