### PR TITLE
2021 02 20 number byte representation

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -79,8 +79,6 @@ sealed abstract class Number[T <: Number[T]]
       Success(())
     }
   }
-
-  override def bytes: ByteVector = BytesUtil.decodeHex(hex)
 }
 
 /** Represents a signed number in our number system
@@ -100,7 +98,7 @@ sealed abstract class UnsignedNumber[T <: Number[T]] extends Number[T]
 sealed abstract class UInt5 extends UnsignedNumber[UInt5] {
   override def apply: A => UInt5 = UInt5(_)
 
-  override def andMask: BigInt = 0x1f
+  override val andMask: BigInt = 0x1f
 
   def byte: Byte = toInt.toByte
 
@@ -113,9 +111,8 @@ sealed abstract class UInt8 extends UnsignedNumber[UInt8] {
   override def apply: A => UInt8 = UInt8(_)
 
   override val bytes: ByteVector = ByteVector.fromInt(toInt, size = 1)
-  /*  override val hex: String = BytesUtil.encodeHex(toInt.toShort).slice(2, 4)*/
 
-  override def andMask = 0xff
+  override val andMask = 0xff
 
   def toUInt5: UInt5 = {
     //this will throw if not in range of a UInt5, come back and look later
@@ -127,26 +124,24 @@ sealed abstract class UInt8 extends UnsignedNumber[UInt8] {
   */
 sealed abstract class UInt16 extends UnsignedNumber[UInt16] {
   override def apply: A => UInt16 = UInt16(_)
-  override def hex: String = BytesUtil.encodeHex(toInt.toShort)
-  /*override val bytes: ByteVector = ByteVector.fromInt(toInt, size = 2)*/
+  override val bytes: ByteVector = ByteVector.fromInt(toInt, size = 2)
 
-  override def andMask = 0xffffL
+  override val andMask = 0xffffL
 }
 
 /** Represents a uint32_t in C
   */
 sealed abstract class UInt32 extends UnsignedNumber[UInt32] {
   override def apply: A => UInt32 = UInt32(_)
-  /*  override def hex: String = BytesUtil.encodeHex(toLong).slice(8, 16)*/
   override val bytes: ByteVector = ByteVector.fromLong(toLong, 4)
-  override def andMask = 0xffffffffL
+  override val andMask = 0xffffffffL
 }
 
 /** Represents a uint64_t in C
   */
 sealed abstract class UInt64 extends UnsignedNumber[UInt64] {
 
-  override val bytes = {
+  override val bytes: ByteVector = {
     if (underlying.isValidLong) {
       //optimization, if our number fits into a long
       //we can get much better performance from ByteVector
@@ -157,7 +152,7 @@ sealed abstract class UInt64 extends UnsignedNumber[UInt64] {
     }
   }
   override def apply: A => UInt64 = UInt64(_)
-  override def andMask = 0xffffffffffffffffL
+  override val andMask = 0xffffffffffffffffL
 
   /** Converts a [[BigInt]] to a 8 byte hex representation.
     * [[BigInt]] will only allocate 1 byte for numbers like 1 which require 1 byte, giving us the hex representation 01
@@ -182,8 +177,7 @@ sealed abstract class UInt64 extends UnsignedNumber[UInt64] {
   */
 sealed abstract class Int32 extends SignedNumber[Int32] {
   override def apply: A => Int32 = Int32(_)
-  override def andMask = 0xffffffff
-  /*override val hex: String = BytesUtil.encodeHex(toInt)*/
+  override val andMask = 0xffffffff
   override val bytes: ByteVector = ByteVector.fromInt(i = toInt, size = 4)
 }
 
@@ -191,8 +185,7 @@ sealed abstract class Int32 extends SignedNumber[Int32] {
   */
 sealed abstract class Int64 extends SignedNumber[Int64] {
   override def apply: A => Int64 = Int64(_)
-  override def andMask = 0xffffffffffffffffL
-  /*override val hex: String = BytesUtil.encodeHex(toLong)*/
+  override val andMask = 0xffffffffffffffffL
   override val bytes: ByteVector = ByteVector.fromLong(l = toLong, size = 8)
 }
 

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -183,7 +183,8 @@ sealed abstract class UInt64 extends UnsignedNumber[UInt64] {
 sealed abstract class Int32 extends SignedNumber[Int32] {
   override def apply: A => Int32 = Int32(_)
   override def andMask = 0xffffffff
-  override val hex: String = BytesUtil.encodeHex(toInt)
+  /*override val hex: String = BytesUtil.encodeHex(toInt)*/
+  override val bytes: ByteVector = ByteVector.fromInt(i = toInt, size = 4)
 }
 
 /** Represents a int64_t in C
@@ -191,7 +192,8 @@ sealed abstract class Int32 extends SignedNumber[Int32] {
 sealed abstract class Int64 extends SignedNumber[Int64] {
   override def apply: A => Int64 = Int64(_)
   override def andMask = 0xffffffffffffffffL
-  override val hex: String = BytesUtil.encodeHex(toLong)
+  /*override val hex: String = BytesUtil.encodeHex(toLong)*/
+  override val bytes: ByteVector = ByteVector.fromLong(l = toLong, size = 8)
 }
 
 /** Represents number types that are bounded by minimum and maximum values


### PR DESCRIPTION
Previously, we stored the String representation (hex) of a number in memory. Obviously this is inefficient, this PR changes the underlying representation to be a `ByteVector` rather than a `String`. 

This should improve performance throughout the entire code base as these numbers are a central part of the bitcoin protocol. 
