### PR TITLE
Allow implicit execution context to be passed in to RescanHandling.fi…

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -216,7 +216,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
         startOpt = startOpt,
         endOpt = endOpt)(ExecutionContext.fromExecutor(threadPool))
     } yield {
-      threadPool.shutdown()
       blocks.sortBy(_.blockHeight).map(_.blockHash.flip)
     }
 
@@ -260,8 +259,8 @@ private[wallet] trait RescanHandling extends WalletLogger {
 
   private def fetchFiltersInRange(
       scripts: Vector[ScriptPubKey],
-      parallelismLevel: Int)(
-      heightRange: Vector[Int]): Future[Vector[BlockMatchingResponse]] = {
+      parallelismLevel: Int)(heightRange: Vector[Int])(implicit
+      ec: ExecutionContext): Future[Vector[BlockMatchingResponse]] = {
     val startHeight = heightRange.head
     val endHeight = heightRange.last
     for {
@@ -280,7 +279,8 @@ private[wallet] trait RescanHandling extends WalletLogger {
   private[wallet] def findMatches(
       filters: Vector[FilterResponse],
       scripts: Vector[ScriptPubKey],
-      parallelismLevel: Int): Future[Vector[BlockMatchingResponse]] = {
+      parallelismLevel: Int)(implicit
+      ec: ExecutionContext): Future[Vector[BlockMatchingResponse]] = {
     if (filters.isEmpty) {
       logger.info("No Filters to check against")
       Future.successful(Vector.empty)


### PR DESCRIPTION
…ndMatches() & RescanHandling.fetchFiltersInRange()

We spin up a new thread pool solely dedicated for [compact filter rescans in the wallet](https://github.com/bitcoin-s/bitcoin-s/blob/0457bb6b101163b65a9f6e83ebec7053069286ea/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala#L217), but it doesn't get used because we don't implicitly pass the execution context. This means we end up using the [akka dispatcher](https://github.com/christewart/bitcoin-s-core/blob/89185338e04b413d64cfd3175a917e816601246a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala#L62) defined at the top level of the wallet.

In general, we should start trying to be more careful when making execution contexts implicitly available at the top level of the wallet IMO. Some things might be using it when it they aren't intended to use it.

![Screenshot from 2021-02-21 06-53-33](https://user-images.githubusercontent.com/3514957/108625619-889a1f00-7411-11eb-9888-562de3486700.png)
