### PR TITLE
Reintroduce parallelism in transaction processing

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/number/NumberCache.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberCache.scala
@@ -46,6 +46,11 @@ trait NumberCacheBigInt[T] extends NumberCache[T] {
   /** The max number cached (inclusive) */
   def maxCachedBigInt: BigInt = BigInt(maxCached)
 
+  /** [[org.bitcoins.core.protocol.CompactSizeUInt]] uses a UInt64
+    * which means we have larger uint64s used on a regular basis
+    */
+  override def maxCached: Long = 2048
+
   /** Checks if the given number is cached
     * if not, allocates a new object to represent the number
     */


### PR DESCRIPTION
This re-introduces parallelism in the wallet to begin addressing #2596 

This was reverted in #1823 erroneously (we did not understand that we can set the sqlite database thread pool to size=1 to get our intended behavior, which we did in https://github.com/bitcoin-s/bitcoin-s/pull/2113/files#diff-d1889eaa42a9c55c8f1783fc367505bd504a12742fe0f54d66ae528cce57ef20R18).

More discussion on database thread pool size and parallelism can be found here: https://github.com/bitcoin-s/bitcoin-s/issues/1844

It takes roughly 30 seconds to process a block now. This PR does "the dumb thing" and re-introduces parallelism for processing transaction inputs and outputs for a single tx. AFAIK there is no reason why we can't process these in parallel as outputs for a transaction can't be spent as inputs on _the same transaction_. 

This will not improve performance significantly in sqlite as there is a single database thread that controls access to a sqlite database. However, on my sophisticated database like postgres we can leverage multiple connections to make parallel requests to the db.