### PR TITLE
Reduce usage of .findAll() (doesn't scale for large dbs). Now pass in…

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/ScriptPubKeyDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/ScriptPubKeyDAOTest.scala
@@ -83,4 +83,16 @@ class ScriptPubKeyDAOTest extends WalletDAOFixture {
     }
   }
 
+  it must "find a scriptPubKey" in { daos =>
+    val scriptPubKeyDAO = daos.scriptPubKeyDAO
+    val pkh = P2PKHScriptPubKey(ECPublicKey.freshPublicKey)
+    val notInDb = P2PKHScriptPubKey(ECPublicKey.freshPublicKey)
+    for {
+      _ <- scriptPubKeyDAO.createIfNotExists(ScriptPubKeyDb(pkh))
+      found <- scriptPubKeyDAO.findScriptPubKeys(Vector(pkh, notInDb))
+    } yield {
+      assert(found.length == 1)
+      assert(found.head.scriptPubKey == pkh)
+    }
+  }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/ScriptPubKeyDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/ScriptPubKeyDAO.scala
@@ -41,6 +41,19 @@ case class ScriptPubKeyDAO()(implicit
     safeDatabase.run(actions.transactionally)
   }
 
+  /** Finds a scriptPubKey in the database, if it exists */
+  def findScriptPubKey(spk: ScriptPubKey): Future[Option[ScriptPubKeyDb]] = {
+    val foundVecF = findScriptPubKeys(Vector(spk))
+    foundVecF.map(_.headOption)
+  }
+
+  /** Searches for the given set of spks and returns the ones that exist in the db */
+  def findScriptPubKeys(
+      spks: Vector[ScriptPubKey]): Future[Vector[ScriptPubKeyDb]] = {
+    val query = table.filter(_.scriptPubKey.inSet(spks))
+    safeDatabase.runVec(query.result)
+  }
+
   case class ScriptPubKeyTable(tag: Tag)
       extends TableAutoInc[ScriptPubKeyDb](tag, schemaName, "pub_key_scripts") {
 


### PR DESCRIPTION
… the specific things we are searching for

This chips away at #2596 

Basically, allow the database engine to do the searching rather than calling `.findAll()` and returning _everything_ in the table. As the wallet tables grow, this is going to scale poorly. This PR now just passes in the things we are searching for in the database table.