### PR TITLE
Workaround for issue 2708

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check Out Repo
         uses: actions/checkout@v2.3.4
         with:
-          fetch-depth: 500
+          fetch-depth: 0
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
         with:
-          fetch-depth: 500
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
       - uses: olafurpg/setup-gpg@v3
       - run: sbt ci-release docs/publishWebsite


### PR DESCRIPTION
Workaround until #2708 can be fixed. This will mean _much_ slower build times on our merge github actions as we now have to clone the entire repo. See #2675 