### PR TITLE
Enforce segwit v0 DLC funding inputs

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCFundingInput.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCFundingInput.scala
@@ -66,6 +66,17 @@ object DLCFundingInput {
       case _: P2SHScriptPubKey =>
         redeemScriptOpt match {
           case Some(redeemScript) =>
+            redeemScript match {
+              case _: P2WPKHWitnessSPKV0 =>
+                require(
+                  maxWitnessLen == UInt16(107) || maxWitnessLen == UInt16(108),
+                  s"P2WPKH max witness length must be 107 or 108, got $maxWitnessLen")
+              case _: P2WSHWitnessSPKV0 => ()
+              case spk: UnassignedWitnessScriptPubKey =>
+                throw new IllegalArgumentException(
+                  s"Unknown segwit version: $spk")
+            }
+
             DLCFundingInputP2SHSegwit(inputSerialId,
                                       prevTx,
                                       prevTxVout,


### PR DESCRIPTION
For native segwit inputs we would enforce that the input is segwit v0

https://github.com/bitcoin-s/bitcoin-s/blob/d30186e690db595c3f684ddcf279400417569663/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCFundingInput.scala#L83

However we would allow any segwit version for p2sh(segwit) inputs and would not enforce the 107/108 max wit len for p2wpkh