### PR TITLE
Use Sign instead of ECPrivateKey in DLCTxSigner

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -244,6 +244,12 @@ sealed abstract class ExtPrivateKey
     key.signWithEntropyFunction
   }
 
+  override def adaptorSign(
+      adaptorPoint: ECPublicKey,
+      msg: ByteVector): ECAdaptorSignature = {
+    key.adaptorSign(adaptorPoint, msg)
+  }
+
   /** Signs the given bytes with the given [[BIP32Path path]] */
   override def deriveAndSignFuture: (
       ByteVector,

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtSign.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtSign.scala
@@ -1,14 +1,14 @@
 package org.bitcoins.core.crypto
 
 import org.bitcoins.core.hd.BIP32Path
-import org.bitcoins.crypto.{ECDigitalSignature, Sign}
+import org.bitcoins.crypto.{AdaptorSign, ECDigitalSignature}
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 
 /** A signing interface for [[ExtKey]] */
-trait ExtSign extends Sign {
+trait ExtSign extends AdaptorSign {
 
   def deriveAndSignFuture: (ByteVector, BIP32Path) => Future[ECDigitalSignature]
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
@@ -25,7 +25,7 @@ sealed abstract class BaseECKey extends NetworkElement
   */
 sealed abstract class ECPrivateKey
     extends BaseECKey
-    with Sign
+    with AdaptorSign
     with MaskedToString {
 
   override def signFunction: ByteVector => Future[ECDigitalSignature] = {
@@ -187,7 +187,7 @@ sealed abstract class ECPrivateKey
     BouncyCastleUtil.schnorrSignWithNonce(dataToSign, this, nonce)
   }
 
-  def adaptorSign(
+  override def adaptorSign(
       adaptorPoint: ECPublicKey,
       msg: ByteVector): ECAdaptorSignature = {
     adaptorSign(adaptorPoint, msg, CryptoContext.default)

--- a/crypto/src/main/scala/org/bitcoins/crypto/Sign.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/Sign.scala
@@ -127,3 +127,10 @@ object Sign {
     constant(EmptyDigitalSignature, publicKey)
   }
 }
+
+trait AdaptorSign extends Sign {
+
+  def adaptorSign(
+      adaptorPoint: ECPublicKey,
+      msg: ByteVector): ECAdaptorSignature
+}

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
@@ -3,7 +3,7 @@ package org.bitcoins.dlc.execution
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.protocol.dlc._
 import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
-import org.bitcoins.crypto.{ECPrivateKey, ECPublicKey}
+import org.bitcoins.crypto.{AdaptorSign, ECPublicKey}
 import org.bitcoins.dlc.builder.DLCTxBuilder
 import org.bitcoins.dlc.sign.DLCTxSigner
 
@@ -116,7 +116,7 @@ object DLCExecutor {
   def executeDLC(
       remoteCETInfos: Vector[(OracleOutcome, CETInfo)],
       oracleSigs: Vector[OracleSignatures],
-      fundingKey: ECPrivateKey,
+      fundingKey: AdaptorSign,
       remoteFundingPubKey: ECPublicKey,
       contractInfo: ContractInfo,
       fundingTx: Transaction

--- a/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
@@ -29,7 +29,7 @@ import scala.util.{Failure, Success, Try}
 case class DLCTxSigner(
     builder: DLCTxBuilder,
     isInitiator: Boolean,
-    fundingKey: ECPrivateKey,
+    fundingKey: AdaptorSign,
     finalAddress: BitcoinAddress,
     fundingUtxos: Vector[ScriptSignatureParams[InputInfo]])(implicit
     ec: ExecutionContext) {
@@ -209,7 +209,7 @@ object DLCTxSigner {
   def buildCETSigningInfo(
       fundingTx: Transaction,
       fundingMultiSig: MultiSignatureScriptPubKey,
-      fundingKey: ECPrivateKey): ECSignatureParams[P2WSHV0InputInfo] = {
+      fundingKey: Sign): ECSignatureParams[P2WSHV0InputInfo] = {
     val fundingOutPoint = TransactionOutPoint(fundingTx.txId, UInt32.zero)
 
     ECSignatureParams(
@@ -238,7 +238,7 @@ object DLCTxSigner {
   def signCETs(
       outcomesAndCETs: Vector[OutcomeCETPair],
       cetSigningInfo: ECSignatureParams[P2WSHV0InputInfo],
-      fundingKey: ECPrivateKey): Vector[(OracleOutcome, ECAdaptorSignature)] = {
+      fundingKey: AdaptorSign): Vector[(OracleOutcome, ECAdaptorSignature)] = {
     buildAndSignCETs(outcomesAndCETs, cetSigningInfo, fundingKey).map {
       case (outcome, _, sig) => outcome -> sig
     }
@@ -247,7 +247,7 @@ object DLCTxSigner {
   def buildAndSignCETs(
       outcomesAndCETs: Vector[OutcomeCETPair],
       cetSigningInfo: ECSignatureParams[P2WSHV0InputInfo],
-      fundingKey: ECPrivateKey): Vector[
+      fundingKey: AdaptorSign): Vector[
     (OracleOutcome, WitnessTransaction, ECAdaptorSignature)] = {
     outcomesAndCETs.map { case OutcomeCETPair(outcome, cet) =>
       val adaptorPoint = outcome.sigPoint

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -14,7 +14,7 @@ import org.bitcoins.core.wallet.keymanagement.{
   KeyManagerInitializeError,
   KeyManagerParams
 }
-import org.bitcoins.crypto.{AesPassword, Sign}
+import org.bitcoins.crypto.{AdaptorSign, AesPassword}
 import org.bitcoins.keymanager._
 import scodec.bits.BitVector
 
@@ -35,7 +35,7 @@ import scala.util.{Failure, Success, Try}
   * @see https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
   */
 class BIP39KeyManager(
-    private[bitcoins] val rootExtPrivKey: ExtPrivateKey,
+    private[this] val rootExtPrivKey: ExtPrivateKey,
     val kmParams: KeyManagerParams,
     val creationTime: Instant)
     extends BIP39KeyManagerApi
@@ -54,7 +54,7 @@ class BIP39KeyManager(
   /** Converts a non-sensitive DB representation of a UTXO into
     * a signable (and sensitive) real-world UTXO
     */
-  def toSign(privKeyPath: HDPath): Sign = {
+  def toSign(privKeyPath: HDPath): AdaptorSign = {
     val xpriv =
       rootExtPrivKey.deriveChildPrivKey(privKeyPath)
 


### PR DESCRIPTION
This is done so we can once again make the root key in the keymanager private.

The changes to `Sign` and the like should probably be added to #2652