### PR TITLE
Rework docker configuration to pass in a custom configuration file

### DIFF
--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -14,6 +14,10 @@ packageDescription := "A basic DLC oracle that allows you to commit to events an
 
 dockerExposedPorts ++= Seq(9998)
 
-dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-oracle-server",
-                        "--conf",
-                        "/opt/docker/docker-application.conf")
+dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-oracle-server")
+
+//this passes in our default configuration for docker
+//you can override this by passing in a custom conf file
+//when the docker container is started by using bind mount
+//https://docs.docker.com/storage/bind-mounts/#start-a-container-with-a-bind-mount
+dockerCmd ++= Seq("--conf", "/opt/docker/docker-application.conf")

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -15,6 +15,10 @@ packageDescription := "Runs a Bitcoin neutrino node and wallet, has functionalit
 
 dockerExposedPorts ++= Seq(9999)
 
-dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-server",
-                        "--conf",
-                        "/opt/docker/docker-application.conf")
+dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-server")
+
+//this passes in our default configuration for docker
+//you can override this by passing in a custom configuration
+//when the docker container is started by using bind mount
+//https://docs.docker.com/storage/bind-mounts/#start-a-container-with-a-bind-mount
+dockerCmd ++= Seq("--conf", "/opt/docker/docker-application.conf")

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -77,6 +77,7 @@ For more information on build configuration options with `sbt` please see the [s
 
 ## Configuration
 
+### Java binary configuration
 If you would like to pass in a custom datadir for your server, you can do
 
 ```bash
@@ -99,9 +100,42 @@ For more information on configuring the server please see our [configuration](..
 
 For more information on how to use our built in `cli` to interact with the server please see [cli.md](cli.md)
 
-### Server Endpoints
+### Docker configuration
 
-#### Blockchain
+You can use bitcoin-s with docker volumes. You can also pass in a custom configuration at container runtime.
+
+#### Using a docker volume
+
+```basrc
+docker volume create bitcoin-s
+docker run -p 9999:9999 \
+--mount source=bitcoin-s,target=/home/bitcoin-s/ app-server:latest
+```
+
+Now you can re-use this volume across container runs. It will keep the same oracle database
+and seeds directory located at `/home/bitcoin-s/.bitcoin-s/seeds` in the volume.
+
+#### Using a custom bitcoin-s configuration with docker
+
+You can also specify a custom bitcoin-s configuration at container runtime.
+You can mount the configuration file on the docker container and that
+configuration will be used in the docker container runtime rather than
+the default one we provide [here](https://github.com/bitcoin-s/bitcoin-s/blob/master/app/oracle-server/src/universal/docker-application.conf)
+
+You can do this with the following command
+
+```bashrc
+docker run -p 9999:9999 \
+--mount type=bind,source=/my/new/config/,target=/home/bitcoin-s/.bitcoin-s/ \
+app-server:latest --conf /home/bitcoin-s/.bitcoin-s/bitcoin-s.conf
+```
+
+Note: If you adjust the `bitcoin-s.server.rpcport` setting you will need to adjust
+the `-p 9999:9999` port mapping on the docker container to adjust for this.
+
+## Server Endpoints
+
+### Blockchain
 
  - `getblockcount` - Get the current block height
  - `getfiltercount` - Get the number of filters
@@ -110,7 +144,7 @@ For more information on how to use our built in `cli` to interact with the serve
  - `decoderawtransaction` `tx` - `Decode the given raw hex transaction`
      - `tx` - Transaction encoded in hex to decode
 
-#### Wallet
+### Wallet
  - `rescan` `[options]` - Rescan for wallet UTXOs
     - `--force` - Clears existing wallet records. Warning! Use with caution!
     - `--batch-size <value>` - Number of filters that can be matched in one batch
@@ -181,13 +215,13 @@ For more information on how to use our built in `cli` to interact with the serve
  - `keymanagerpassphraseset` `passphrase` - Encrypts the wallet with the given passphrase
     - `passphrase` - The passphrase to encrypt the wallet with
 
-#### Network
+### Network
  - `getpeers` - List the connected peers
  - `stop` - Request a graceful shutdown of Bitcoin-S
  - `sendrawtransaction` `tx` `Broadcasts the raw transaction`
     - `tx` - Transaction serialized in hex
 
-#### PSBT
+### PSBT
  - `decodepsbt` `psbt` - Return a JSON object representing the serialized, base64-encoded partially signed Bitcoin transaction.
     - `psbt` - PSBT serialized in hex or base64 format
  - `combinepsbts` `psbts` - Combines all the given PSBTs
@@ -201,13 +235,13 @@ For more information on how to use our built in `cli` to interact with the serve
  - `converttopsbt` `unsignedTx` - Creates an empty psbt from the given transaction
     - `unsignedTx` - serialized unsigned transaction in hex
 
-#### Util 
+### Util
  - `createmultisig` `nrequired` `keys` `[address_type]` - Creates a multi-signature address with n signature of m keys required.
     - `nrequired` - The number of required signatures out of the n keys.
     - `keys` - The hex-encoded public keys.
     - `address_type` -The address type to use. Options are "legacy", "p2sh-segwit", and "bech32"
 
-### Sign PSBT with Wallet Example
+## Sign PSBT with Wallet Example
 
 Bitcoin-S CLI:
 

--- a/docs/oracle/build-oracle-server.md
+++ b/docs/oracle/build-oracle-server.md
@@ -136,6 +136,33 @@ For more information on how to use our built in `cli` to interact with the serve
 
 ### Docker configuration
 
-Currently our docker configuration only allows for configuration at build time _not_ runtime.
+You can use bitcoin-s with docker volumes. You can also pass in a custom configuration at container runtime.
 
-To the configuration file for the docker application is called [docker-application.conf](../../app/oracle-server/src/universal/docker-application.conf)
+#### Using a docker volume
+
+```basrc
+docker volume create bitcoin-s
+docker run -p 9998:9998 \
+--mount source=bitcoin-s,target=/home/bitcoin-s/ oracle-server:latest
+```
+
+Now you can re-use this volume across container runs. It will keep the same oracle database
+and seeds directory located at `/home/bitcoin-s/.bitcoin-s/seeds` in the volume.
+
+#### Using a custom bitcoin-s configuration with docker
+
+You can also specify a custom bitcoin-s configuration at container runtime.
+You can mount the configuration file on the docker container and that
+configuration will be used in the docker container runtime rather than
+the default one we provide [here](https://github.com/bitcoin-s/bitcoin-s/blob/master/app/oracle-server/src/universal/docker-application.conf)
+
+You can do this with the following command
+
+```bashrc
+docker run -p 9998:9998 \
+--mount type=bind,source=/my/new/config/,target=/home/bitcoin-s/.bitcoin-s/ \
+oracle-server:latest --conf /home/bitcoin-s/.bitcoin-s/bitcoin-s.conf
+```
+
+Note: If you adjust the `bitcoin-s.oracle.rpcport` setting you will need to adjust
+the `-p 9998:9998` port mapping on the docker container to adjust for this.

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -3,7 +3,12 @@ import com.typesafe.sbt.SbtNativePackager.Docker
 import com.typesafe.sbt.SbtNativePackager.autoImport.packageName
 
 import java.nio.file.Paths
-import com.typesafe.sbt.packager.Keys.{dockerRepository, maintainer}
+import com.typesafe.sbt.packager.Keys.{
+  daemonUser,
+  daemonUserUid,
+  dockerRepository,
+  maintainer
+}
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerBaseImage
 import sbt._
 import sbt.Keys._
@@ -152,6 +157,10 @@ object CommonSettings {
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
       dockerBaseImage := "openjdk",
       dockerRepository := Some("bitcoinscala"),
+      //set the user to be 'bitcoin-s' rather than
+      //the default provided by sbt native packager
+      //which is 'demiourgos728'
+      daemonUser in Docker := "bitcoin-s",
       packageName in Docker := packageName.value,
       version in Docker := version.value
     )


### PR DESCRIPTION
This PR adjusts the docker build configuration to allow you to pass in a custom configuration file for the bitcoin-s application running inside of docker. Now the behavior is if no configuration file is specified (no `--conf`), use the `docker-application.conf` we ship with bitcoin-s

If a configuration file is specified (`--conf /my/config/file.conf`) use that. You can see mounting a directory on my local desktop (`/home/chris/dev/bitcoin-s/app/oracle-server/src/universal/,`) into the running docker container which allows the container to access my custom configuration inside the container at `/.bitcoin-s/`

This previously was not possible, because the configuration was hard coded in the `dockerEntrypoint` configuration.

```
$ docker build app/oracle-server/target/docker/stage -t oracle-server
$ docker run --rm -p 9998:9998 \  
--mount type=bind,source=/home/chris/dev/bitcoin-s/app/oracle-server/src/universal/,target=/.bitcoin-s/ \
oracle-server:latest --conf /.bitcoin-s/docker-application.conf
```

For more information on how binding a directory to a docker container works, please see

https://docs.docker.com/storage/bind-mounts/#start-a-container-with-a-bind-mount

https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html