### PR TITLE
Make sure DLCOracleAppConfig creates the oracle directory

### DIFF
--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
@@ -2,7 +2,7 @@ package org.bitcoins.dlc.oracle.config
 
 import com.typesafe.config.Config
 import org.bitcoins.core.api.dlcoracle.db.EventOutcomeDbHelper
-import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.config._
 import org.bitcoins.core.crypto.ExtKeyVersion.SegWitMainNetPriv
 import org.bitcoins.core.hd.HDPurpose
 import org.bitcoins.core.protocol.tlv.EnumEventDescriptorV0TLV
@@ -61,8 +61,18 @@ case class DLCOracleAppConfig(
         Files.createDirectories(datadir)
       }
 
+      val networkDir = {
+        val lastDirname = network match {
+          case MainNet  => "mainnet"
+          case TestNet3 => "testnet3"
+          case RegTest  => "regtest"
+          case SigNet   => "signet"
+        }
+        baseDatadir.resolve(lastDirname)
+      }
+
       // Move old db in network folder to oracle folder
-      val oldNetworkLocation = datadir.resolve("oracle.sqlite")
+      val oldNetworkLocation = networkDir.resolve("oracle.sqlite")
       if (!exists() && Files.exists(oldNetworkLocation)) {
         Files.move(oldNetworkLocation, dbPath)
       }

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
@@ -50,6 +50,10 @@ case class DLCOracleAppConfig(
   /** The path to our encrypted mnemonic seed */
   lazy val seedPath: Path = kmConf.seedPath
 
+  override lazy val datadir: Path = {
+    baseDatadir.resolve("oracle")
+  }
+
   override def start(): Future[Unit] = {
     logger.debug(s"Initializing dlc oracle setup")
     super.start().flatMap { _ =>


### PR DESCRIPTION
Fixes #2717 

Setting the `datadir` correctly will make the `start()` function create the directory.