### PR TITLE
2021 02 25 async utils

### DIFF
--- a/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
@@ -23,4 +23,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.12.12 downloadBitcoind coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls
+        run: sbt ++2.12.12 downloadBitcoind coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtils/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -23,4 +23,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.5 downloadBitcoind coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls
+        run: sbt ++2.13.5 downloadBitcoind coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtils/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -23,4 +23,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.5 downloadBitcoind coverage walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcOracleTest/test dlcOracle/coverageReport dlcOracle/coveralls
+        run: sbt ++2.13.5 downloadBitcoind coverage walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcOracleTest/test  asyncUtils/test dlcOracle/coverageReport dlcOracle/coveralls

--- a/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
+++ b/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.rpc.util
+package org.bitcoins.asyncutil
 
 import org.bitcoins.core.util.BitcoinSLogger
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.rpc
 
-import java.io.File
+import org.bitcoins.asyncutil.AsyncUtil
 
+import java.io.File
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.util.AsyncUtil.RpcRetryException
-import org.bitcoins.rpc.util.{AsyncUtil, RpcUtil}
+import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.{BitcoindRpcTest, FileUtil}
 
@@ -48,7 +48,7 @@ class TestRpcUtilTest extends BitcoindRpcTest {
   }
 
   it should "fail if condition is false" in {
-    recoverToSucceededIf[RpcRetryException] {
+    recoverToSucceededIf[AsyncUtil.RpcRetryException] {
       AsyncUtil.retryUntilSatisfiedF(conditionF =
                                        () => Future.successful(false),
                                      interval = 0.millis)
@@ -70,7 +70,7 @@ class TestRpcUtilTest extends BitcoindRpcTest {
   }
 
   it should "timeout if condition is false" in {
-    recoverToSucceededIf[RpcRetryException] {
+    recoverToSucceededIf[AsyncUtil.RpcRetryException] {
       AsyncUtil
         .awaitCondition(condition = () => false, interval = 0.millis)
         .map(_ => succeed)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.rpc.common
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockChainInfoResultPreV19
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.{
   AddNodeArgument,
@@ -9,7 +10,6 @@ import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
-import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoindRpcTest
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.rpc.v16
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.SignRawTransactionOutputParameter
 import org.bitcoins.core.crypto.ECPrivateKeyUtil
 import org.bitcoins.core.currency.Bitcoins
@@ -14,7 +15,6 @@ import org.bitcoins.core.protocol.transaction.{
 import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPrivateKey}
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.client.v16.BitcoindV16RpcClient
-import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoindRpcTest
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.rpc.v17
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.{
   AddressType,
   LabelPurpose,
@@ -14,7 +15,6 @@ import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionInput
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.rpc.client.v17.BitcoindV17RpcClient
-import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoindRpcTest
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.model._
 import akka.stream.StreamTcpException
 import akka.util.ByteString
 import com.fasterxml.jackson.core.JsonParseException
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts
 import org.bitcoins.commons.serializers.JsonSerializers._
 import org.bitcoins.core.config.{
@@ -27,7 +28,6 @@ import org.bitcoins.rpc.config.BitcoindAuthCredentials.{
   PasswordBased
 }
 import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstance}
-import org.bitcoins.rpc.util.AsyncUtil
 import play.api.libs.json._
 
 import scala.concurrent._

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/AsyncUtil.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/AsyncUtil.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.rpc.util
 
-import akka.actor.ActorSystem
 import org.bitcoins.core.util.BitcoinSLogger
 
+import java.util.concurrent.{Executors, TimeUnit}
 import scala.concurrent._
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
@@ -24,7 +24,7 @@ abstract class AsyncUtil extends BitcoinSLogger {
       condition: => Boolean,
       interval: FiniteDuration = AsyncUtil.DEFAULT_INTERVAL,
       maxTries: Int = DEFAULT_MAX_TRIES)(implicit
-      system: ActorSystem): Future[Unit] = {
+      ec: ExecutionContext): Future[Unit] = {
     val f = () => Future.successful(condition)
     retryUntilSatisfiedF(f, interval, maxTries)
   }
@@ -40,7 +40,7 @@ abstract class AsyncUtil extends BitcoinSLogger {
       conditionF: () => Future[Boolean],
       interval: FiniteDuration = AsyncUtil.DEFAULT_INTERVAL,
       maxTries: Int = DEFAULT_MAX_TRIES)(implicit
-      system: ActorSystem): Future[Unit] = {
+      ec: ExecutionContext): Future[Unit] = {
     val stackTrace: Array[StackTraceElement] =
       Thread.currentThread().getStackTrace
 
@@ -81,10 +81,7 @@ abstract class AsyncUtil extends BitcoinSLogger {
       counter: Int = 0,
       maxTries: Int,
       stackTrace: Array[StackTraceElement])(implicit
-      system: ActorSystem): Future[Unit] = {
-
-    import system.dispatcher
-
+      ec: ExecutionContext): Future[Unit] = {
     conditionF().flatMap { condition =>
       if (condition) {
         Future.unit
@@ -96,7 +93,8 @@ abstract class AsyncUtil extends BitcoinSLogger {
         val p = Promise[Boolean]()
         val runnable = retryRunnable(condition, p)
 
-        system.scheduler.scheduleOnce(delay = interval, runnable = runnable)
+        AsyncUtil.scheduler
+          .schedule(runnable, interval.toMillis, TimeUnit.MILLISECONDS)
 
         p.future.flatMap {
           case true => Future.unit
@@ -122,7 +120,7 @@ abstract class AsyncUtil extends BitcoinSLogger {
       condition: () => Boolean,
       interval: FiniteDuration = AsyncUtil.DEFAULT_INTERVAL,
       maxTries: Int = DEFAULT_MAX_TRIES)(implicit
-      system: ActorSystem): Future[Unit] = {
+      ec: ExecutionContext): Future[Unit] = {
 
     //type hackery here to go from () => Boolean to () => Future[Boolean]
     //to make sure we re-evaluate every time retryUntilSatisfied is called
@@ -137,7 +135,7 @@ abstract class AsyncUtil extends BitcoinSLogger {
       conditionF: () => Future[Boolean],
       interval: FiniteDuration = AsyncUtil.DEFAULT_INTERVAL,
       maxTries: Int = DEFAULT_MAX_TRIES)(implicit
-      system: ActorSystem): Future[Unit] = {
+      ec: ExecutionContext): Future[Unit] = {
 
     retryUntilSatisfiedF(conditionF = conditionF,
                          interval = interval,
@@ -148,6 +146,8 @@ abstract class AsyncUtil extends BitcoinSLogger {
 
 object AsyncUtil extends AsyncUtil {
 
+  private[bitcoins] val scheduler = Executors.newScheduledThreadPool(2)
+
   /** The default interval between async attempts
     */
   private[bitcoins] val DEFAULT_INTERVAL: FiniteDuration = 100.milliseconds
@@ -155,5 +155,4 @@ object AsyncUtil extends AsyncUtil {
   /** The default number of async attempts before timing out
     */
   private[bitcoins] val DEFAULT_MAX_TRIES: Int = 50
-
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/RpcUtil.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/RpcUtil.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.rpc.util
 
+import org.bitcoins.asyncutil.AsyncUtil
+
 import java.net.ServerSocket
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/RpcUtil.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/RpcUtil.scala
@@ -1,12 +1,10 @@
 package org.bitcoins.rpc.util
 
 import java.net.ServerSocket
-
-import akka.actor.ActorSystem
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 
 import scala.annotation.tailrec
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Random, Success, Try}
@@ -16,7 +14,7 @@ abstract class RpcUtil extends AsyncUtil {
   def awaitServerShutdown(
       server: BitcoindRpcClient,
       duration: FiniteDuration = 300.milliseconds,
-      maxTries: Int = 50)(implicit system: ActorSystem): Future[Unit] = {
+      maxTries: Int = 50)(implicit ec: ExecutionContext): Future[Unit] = {
     retryUntilSatisfiedF(() => server.isStoppedF, duration, maxTries)
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -37,15 +37,20 @@ lazy val bitcoindRpc = project
   .in(file("bitcoind-rpc"))
   .settings(CommonSettings.prodSettings: _*)
   .dependsOn(
+    asyncUtils,
     appCommons
   )
-lazy val eclairRpc = project in file("eclair-rpc")
+
+lazy val eclairRpc = project
+  .in(file("eclair-rpc"))
+  .dependsOn(asyncUtils, bitcoindRpc)
 
 // quoting the val name this way makes it appear as
 // 'bitcoin-s' in sbt/bloop instead of 'bitcoins'
 lazy val `bitcoin-s` = project
   .in(file("."))
   .aggregate(
+    asyncUtils,
     secp256k1jni,
     chain,
     chainTest,
@@ -267,6 +272,12 @@ lazy val coreTest = project
     testkit
   )
 
+lazy val asyncUtils = project
+  .in(file("async-utils"))
+  .settings(CommonSettings.prodSettings)
+  .settings(name := "bitcoin-s-async-utils")
+  .dependsOn(core)
+
 lazy val appCommons = project
   .in(file("app-commons"))
   .settings(CommonSettings.prodSettings: _*)
@@ -463,6 +474,7 @@ lazy val node =
       libraryDependencies ++= Deps.node
     )
     .dependsOn(
+      asyncUtils,
       core,
       chain,
       dbCommons,
@@ -500,6 +512,7 @@ lazy val testkit = project
     name := "bitcoin-s-testkit"
   )
   .dependsOn(
+    asyncUtils,
     core % testAndCompile,
     appServer,
     chain,

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.eclair.rpc
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.jsonmodels.eclair._
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
@@ -22,7 +23,6 @@ import org.bitcoins.eclair.rpc.api._
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
 import org.bitcoins.eclair.rpc.config.{EclairAuthCredentials, EclairInstance}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.testkit.async.TestAsyncUtil
 import org.bitcoins.testkit.eclair.rpc.{EclairNodes4, EclairRpcTestUtil}
 import org.bitcoins.testkit.util.{BitcoinSAsyncTest, EclairRpcTestClient}

--- a/eclair-rpc/eclair-rpc.sbt
+++ b/eclair-rpc/eclair-rpc.sbt
@@ -6,8 +6,6 @@ name := "bitcoin-s-eclair-rpc"
 
 libraryDependencies ++= Deps.eclairRpc
 
-dependsOn(Projects.bitcoindRpc)
-
 CommonSettings.prodSettings
 
 TaskKeys.downloadEclair := {

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials}
 import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.util.ByteString
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.jsonmodels.eclair._
 import org.bitcoins.commons.serializers.JsonReaders._
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
@@ -30,7 +31,6 @@ import org.bitcoins.eclair.rpc.api._
 import org.bitcoins.eclair.rpc.config.EclairInstance
 import org.bitcoins.eclair.rpc.network.NodeUri
 import org.bitcoins.rpc.client.common.BitcoindVersion
-import org.bitcoins.rpc.util.AsyncUtil
 import org.slf4j.LoggerFactory
 import play.api.libs.json._
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.node
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.script.MultiSignatureScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.rpc.client.common.BitcoindVersion
-import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.node.{

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.node
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.currency._
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.node.{

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -2,6 +2,7 @@ package org.bitcoins.node
 
 import akka.Done
 import akka.actor.ActorSystem
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.blockchain.ChainHandlerCached
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.{
@@ -25,7 +26,6 @@ import org.bitcoins.node.networking.peer.{
   PeerMessageReceiver,
   PeerMessageSender
 }
-import org.bitcoins.rpc.util.AsyncUtil
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future, Promise}

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -2,6 +2,7 @@ package org.bitcoins.node
 
 import akka.Done
 import akka.actor.ActorSystem
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.bloom.BloomFilter
@@ -10,7 +11,6 @@ import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.util.Mutable
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
-import org.bitcoins.rpc.util.AsyncUtil
 
 import scala.concurrent.{Future, Promise}
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/async/TestAsyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/async/TestAsyncUtil.scala
@@ -1,13 +1,12 @@
 package org.bitcoins.testkit.async
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.scalatest.exceptions.{StackDepthException, TestFailedException}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
 
-abstract class TestAsyncUtil
-    extends org.bitcoins.rpc.util.AsyncUtil
-    with Serializable {
+abstract class TestAsyncUtil extends AsyncUtil with Serializable {
 
   override protected def retryUntilSatisfiedWithCounter(
       conditionF: () => Future[Boolean],

--- a/testkit/src/main/scala/org/bitcoins/testkit/async/TestAsyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/async/TestAsyncUtil.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.testkit.async
 
-import akka.actor.ActorSystem
 import org.scalatest.exceptions.{StackDepthException, TestFailedException}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,7 +15,7 @@ abstract class TestAsyncUtil
       counter: Int,
       maxTries: Int,
       stackTrace: Array[StackTraceElement])(implicit
-      system: ActorSystem): Future[Unit] = {
+      ec: ExecutionContext): Future[Unit] = {
     val retryF = super
       .retryUntilSatisfiedWithCounter(conditionF,
                                       duration,
@@ -24,7 +23,7 @@ abstract class TestAsyncUtil
                                       maxTries,
                                       stackTrace)
 
-    TestAsyncUtil.transformRetryToTestFailure(retryF)(system.dispatcher)
+    TestAsyncUtil.transformRetryToTestFailure(retryF)
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -589,6 +589,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
       client: BitcoindRpcClient,
       interval: FiniteDuration = 100.milliseconds,
       maxTries: Int = 50)(implicit system: ActorSystem): Future[Unit] = {
+    import system.dispatcher
     AsyncUtil.retryUntilSatisfiedF(conditionF = { () => client.isStoppedF },
                                    interval = interval,
                                    maxTries = maxTries)

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.net.URI
 import java.nio.file.{Files, Path}
 import akka.actor.ActorSystem
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.AddNodeArgument
 import org.bitcoins.commons.jsonmodels.bitcoind.{
   GetBlockWithTransactionsResult,
@@ -43,7 +44,7 @@ import org.bitcoins.rpc.config.{
   BitcoindInstance,
   ZmqConfig
 }
-import org.bitcoins.rpc.util.{AsyncUtil, RpcUtil}
+import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.util.{BitcoindRpcTestClient, FileUtil}
 import org.bitcoins.util.ListUtil
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/TestRpcUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/TestRpcUtil.scala
@@ -1,9 +1,8 @@
 package org.bitcoins.testkit.rpc
 
-import akka.actor.ActorSystem
 import org.bitcoins.testkit.async.TestAsyncUtil
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
 
 abstract class TestRpcUtil extends org.bitcoins.rpc.util.RpcUtil {
@@ -14,7 +13,7 @@ abstract class TestRpcUtil extends org.bitcoins.rpc.util.RpcUtil {
       counter: Int,
       maxTries: Int,
       stackTrace: Array[StackTraceElement])(implicit
-      system: ActorSystem): Future[Unit] = {
+      ec: ExecutionContext): Future[Unit] = {
     val retryF = super
       .retryUntilSatisfiedWithCounter(conditionF,
                                       duration,
@@ -22,7 +21,7 @@ abstract class TestRpcUtil extends org.bitcoins.rpc.util.RpcUtil {
                                       maxTries,
                                       stackTrace)
 
-    TestAsyncUtil.transformRetryToTestFailure(retryF)(system.dispatcher)
+    TestAsyncUtil.transformRetryToTestFailure(retryF)
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
@@ -3,10 +3,10 @@ package org.bitcoins.testkit.util
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import akka.util.Timeout
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.config.{NetworkParameters, RegTest}
 import org.bitcoins.core.protocol.blockchain.ChainParams
 import org.bitcoins.core.util.BitcoinSLogger
-import org.bitcoins.rpc.util.AsyncUtil
 import org.scalacheck.{Gen, Shrink}
 import org.scalactic.anyvals.PosInt
 import org.scalatest._

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -736,7 +736,7 @@ object BitcoinSWalletTest extends WalletLogger {
       system: ActorSystem): Future[Unit] = {
     AsyncUtil.retryUntilSatisfiedF(conditionF =
                                      () => isSameWalletBalances(fundedWallet),
-                                   interval = 1.seconds)
+                                   interval = 1.seconds)(system.dispatcher)
   }
 
   private def isSameWalletBalances(fundedWallet: WalletWithBitcoind)(implicit

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.testkit.wallet
 
 import akka.actor.ActorSystem
 import com.typesafe.config.{Config, ConfigFactory}
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.api.feeprovider.FeeRateApi
@@ -23,7 +24,6 @@ import org.bitcoins.node.{
 }
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
-import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.server.BitcoinSAppConfig._
 import org.bitcoins.testkit.Implicits.GeneratorOps

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.protocol.script.EmptyScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutput
@@ -9,7 +10,6 @@ import org.bitcoins.core.wallet.utxo.{
   AddressLabelTagType,
   StorageLocationTagType
 }
-import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 import org.scalatest.FutureOutcome

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.wallet
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.currency._
 import org.bitcoins.db.AppConfig
-import org.bitcoins.rpc.util.AsyncUtil
 import org.bitcoins.server.{BitcoinSAppConfig, BitcoindRpcBackendUtil}
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.util.BitcoinSAsyncTest


### PR DESCRIPTION
fixes #2004

This creates a new module called `async-utils` that contains useful async utility functions. Right now it just contains one file, `AsyncUtil`.

The other thing this PR does it breaks the dependency between akka and `AsyncUtil`. We would previously run all callbacks on akka's `dispatcher`.

Now this PR creates a new  [java fixed size thread pool scheduler](https://github.com/bitcoin-s/bitcoin-s/compare/master...Christewart:2021-02-25-async-utils?expand=1#diff-b2ba0b35ce52569a1f57b343f2975fd50cc20035c1356a861603005235351821R149) that tasks are run on in the background rather than relying on an `ActorSystem`. It is important that this module is decoupled from akka so that the code can be used on scalajs.

I don't really like this design so far, I would rather using existing `executionContext`s to avoid creating more threads. I have asked a stackoverflow question for how to do this, and am waiting an answer

https://stackoverflow.com/q/66369884/967713

If I am unable to do this, we can remove the `implicit ec: ExecutionContext` parameters in the `AsyncUtil` API as it is useless, because all tasks are run on the java scheduler