### PR TITLE
Skip publishing of js projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,8 @@ lazy val commonJsSettings = {
   Seq(
     scalaJSLinkerConfig ~= {
       _.withModuleKind(ModuleKind.CommonJSModule)
-    }
+    },
+    sbt.Keys.publish / skip := true
   )
 }
 


### PR DESCRIPTION
fixes #2733 

We were attempting to publish both jvm and js projects to sonatype. This might be possible according to `sbt-ci-release` but I can't figure out how to do it, and don't want builds broken in the interim. 

https://github.com/olafurpg/sbt-ci-release#how-do-i-publish-cross-built-scalajs-projects