### PR TITLE
Fix unidoc issue with scala-js modules, this now ignores them from un…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,8 @@ lazy val eclairRpc = project
   .in(file("eclair-rpc"))
   .dependsOn(asyncUtils, bitcoindRpc)
 
+val jsProjects: Vector[ProjectReference] = Vector(cryptoJS)
+
 // quoting the val name this way makes it appear as
 // 'bitcoin-s' in sbt/bloop instead of 'bitcoins'
 lazy val `bitcoin-s` = project
@@ -170,6 +172,9 @@ lazy val `bitcoin-s` = project
   // unidoc aggregates Scaladocs for all subprojects into one big doc
   .enablePlugins(ScalaUnidocPlugin)
   .settings(
+    unidocProjectFilter in (ScalaUnidoc, unidoc) := {
+      inAnyProject -- inProjects(jsProjects: _*)
+    },
     // we modify the unidoc task to move the generated Scaladocs into the
     // website directory afterwards
     Compile / unidoc := {
@@ -177,7 +182,7 @@ lazy val `bitcoin-s` = project
       import scala.collection.JavaConverters._
       val logger = streams.value.log
 
-      def cleanPath(path: Path, isRoot: Boolean = true): Unit =
+      def cleanPath(path: Path, isRoot: Boolean = true): Unit = {
         if (Files.isDirectory(path)) {
           path.toFile.list().map { file =>
             val toClean = path.resolve(file)
@@ -192,6 +197,7 @@ lazy val `bitcoin-s` = project
         } else {
           Files.deleteIfExists(path)
         }
+      }
 
       val websiteScaladocDir =
         Paths.get("website", "static", "api").toAbsolutePath

--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,7 @@ lazy val `bitcoin-s` = project
   .enablePlugins(ScalaUnidocPlugin)
   .settings(
     //removes scalajs projects from unidoc, see
-    //https://github.com/bitcoin-s/bitcoin-s/issues/2741
+    //https://github.com/bitcoin-s/bitcoin-s/issues/2740
     unidocProjectFilter in (ScalaUnidoc, unidoc) := {
       inAnyProject -- inProjects(jsProjects: _*)
     },

--- a/build.sbt
+++ b/build.sbt
@@ -172,6 +172,8 @@ lazy val `bitcoin-s` = project
   // unidoc aggregates Scaladocs for all subprojects into one big doc
   .enablePlugins(ScalaUnidocPlugin)
   .settings(
+    //removes scalajs projects from unidoc, see
+    //https://github.com/bitcoin-s/bitcoin-s/issues/2741
     unidocProjectFilter in (ScalaUnidoc, unidoc) := {
       inAnyProject -- inProjects(jsProjects: _*)
     },


### PR DESCRIPTION
…idoc

fixes #2740 

Draws inspiration from this diff 

https://github.com/sbt/sbt-unidoc/pull/52/files#diff-064f9a8a343e3e0c6a72905ed8724f9c88b053f61a58e94c7d422ad1d14ec4feR1

and this PR: https://github.com/sbt/sbt-unidoc/pull/52

I tested this locally and don't get the same errors as detailed in #2740 , but there is no way to test that this works for sure without merging to master and seeing if website/scaladoc publishing works as that is where the credentials live to fully publish to the site.



