### PR TITLE
Move blockhash to tx table from spending info table

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -374,7 +374,6 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       EmptyScriptWitness,
       DoubleSha256DigestBE.empty,
       TxoState.PendingConfirmationsSpent,
-      None,
       None
     )
 
@@ -775,7 +774,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       val tx = Transaction(
         "020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000")
 
-      val txDb = TransactionDbHelper.fromTransaction(tx)
+      val txDb = TransactionDbHelper.fromTransaction(tx, None)
 
       (mockWalletApi
         .findTransaction(_: DoubleSha256DigestBE))

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -58,17 +58,17 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
       _ <- walletStateOpt match {
         case None =>
           for {
-            utxos <- wallet.listUtxos()
-            lastConfirmedOpt = utxos.filter(_.blockHash.isDefined).lastOption
+            txDbs <- wallet.listTransactions()
+            lastConfirmedOpt = txDbs.filter(_.blockHashOpt.isDefined).lastOption
             _ <- lastConfirmedOpt match {
               case None => Future.unit
-              case Some(utxo) =>
+              case Some(txDb) =>
                 for {
-                  heightOpt <- bitcoind.getBlockHeight(utxo.blockHash.get)
+                  heightOpt <- bitcoind.getBlockHeight(txDb.blockHashOpt.get)
                   _ <- heightOpt match {
                     case Some(height) =>
                       logger.info(
-                        s"Last utxo occurred at block $height, syncing from there")
+                        s"Last tx occurred at block $height, syncing from there")
                       doSync(height, bitcoindHeight)
                     case None => Future.unit
                   }

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/TransactionDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/TransactionDb.scala
@@ -30,7 +30,8 @@ case class TransactionDb(
     totalOutput: CurrencyUnit,
     numInputs: Int,
     numOutputs: Int,
-    lockTime: UInt32)
+    lockTime: UInt32,
+    blockHashOpt: Option[DoubleSha256DigestBE])
     extends TxDB {
   require(unsignedTx.inputs.forall(_.scriptSignature == EmptyScriptSignature),
           s"All ScriptSignatures must be empty, got $unsignedTx")
@@ -42,7 +43,9 @@ case class TransactionDb(
 
 object TransactionDbHelper {
 
-  def fromTransaction(tx: Transaction): TransactionDb = {
+  def fromTransaction(
+      tx: Transaction,
+      blockHashOpt: Option[DoubleSha256DigestBE]): TransactionDb = {
     val (unsignedTx, wTxIdBEOpt) = tx match {
       case btx: NonWitnessTransaction =>
         val unsignedInputs = btx.inputs.map(input =>
@@ -76,6 +79,7 @@ object TransactionDbHelper {
                   totalOutput,
                   tx.inputs.size,
                   tx.outputs.size,
-                  tx.lockTime)
+                  tx.lockTime,
+                  blockHashOpt)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
@@ -35,7 +35,8 @@ object TxoState extends StringFactory[TxoState] {
   final case object ConfirmedSpent extends SpentState
 
   val pendingConfStates: Set[TxoState] =
-    Set(TxoState.PendingConfirmationsReceived,
+    Set(TxoState.ImmatureCoinbase,
+        TxoState.PendingConfirmationsReceived,
         TxoState.PendingConfirmationsSpent)
 
   val confirmedStates: Set[TxoState] =

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -74,13 +74,13 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
     val result = walletDbManagement.migrate()
     walletAppConfig.driver match {
       case SQLite =>
-        val expected = 9
+        val expected = 10
         assert(result == expected)
         val flywayInfo = walletDbManagement.info()
         assert(flywayInfo.applied().length == expected)
         assert(flywayInfo.pending().length == 0)
       case PostgreSQL =>
-        val expected = 7
+        val expected = 8
         assert(result == expected)
         val flywayInfo = walletDbManagement.info()
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -9,7 +9,7 @@ import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.BlockFilter
-import org.bitcoins.core.protocol.BlockStamp
+import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee._
@@ -65,6 +65,9 @@ trait BitcoinSWalletTest extends BitcoinSFixture with EmbeddedPg {
   }
 
   def nodeApi: NodeApi = MockNodeApi
+
+  val testAddr: BitcoinAddress =
+    BitcoinAddress.fromString("bcrt1qlhctylgvdsvaanv539rg7hyn0sjkdm23y70kgq")
 
   val legacyWalletConf: Config =
     ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = legacy")

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.testkit.wallet
 
-import org.bitcoins.core.api.wallet.db
 import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.crypto._
@@ -125,14 +124,14 @@ object WalletTestUtil {
       TransactionOutput(1.bitcoin, spk)
     val scriptWitness = randomScriptWitness
     val privkeyPath = WalletTestUtil.sampleSegwitPath
-    db.SegwitV0SpendingInfo(
+    SegwitV0SpendingInfo(
       state = randomState,
       txid = randomTXID,
       outPoint = outpoint,
       output = output,
       privKeyPath = privkeyPath,
       scriptWitness = scriptWitness,
-      blockHash = Some(randomBlockHash)
+      spendingTxIdOpt = None
     )
   }
 
@@ -142,12 +141,12 @@ object WalletTestUtil {
     val output =
       TransactionOutput(1.bitcoin, spk)
     val privKeyPath = WalletTestUtil.sampleLegacyPath
-    db.LegacySpendingInfo(state = randomState,
-                          txid = randomTXID,
-                          outPoint = outpoint,
-                          output = output,
-                          privKeyPath = privKeyPath,
-                          blockHash = Some(randomBlockHash))
+    LegacySpendingInfo(state = randomState,
+                       txid = randomTXID,
+                       outPoint = outpoint,
+                       output = output,
+                       privKeyPath = privKeyPath,
+                       spendingTxIdOpt = None)
   }
 
   def sampleNestedSegwitUTXO(
@@ -158,7 +157,7 @@ object WalletTestUtil {
       TransactionOutput(1.bitcoin, P2SHScriptPubKey(wpkh))
     val scriptWitness = randomScriptWitness
     val privkeyPath = WalletTestUtil.sampleNestedSegwitPath
-    db.NestedSegwitV0SpendingInfo(
+    NestedSegwitV0SpendingInfo(
       state = randomState,
       txid = randomTXID,
       outPoint = outpoint,
@@ -166,7 +165,7 @@ object WalletTestUtil {
       privKeyPath = privkeyPath,
       redeemScript = wpkh,
       scriptWitness = scriptWitness,
-      blockHash = Some(randomBlockHash)
+      spendingTxIdOpt = None
     )
   }
 
@@ -201,7 +200,8 @@ object WalletTestUtil {
       totalOutput = Satoshis.zero,
       numInputs = 1,
       numOutputs = 1,
-      lockTime = UInt32.zero
+      lockTime = UInt32.zero,
+      blockHashOpt = Some(randomBlockHash)
     )
     val incomingDb = IncomingTransactionDb(utxo.txid, utxo.output.value)
     for {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/CoinSelectorTest.scala
@@ -41,7 +41,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
       output = TransactionOutput(10.sats, ScriptPubKey.empty),
       privKeyPath = WalletTestUtil.sampleSegwitPath,
       scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
-      blockHash = None
+      spendingTxIdOpt = None
     )
     val utxo2 = SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
@@ -51,7 +51,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
       output = TransactionOutput(90.sats, ScriptPubKey.empty),
       privKeyPath = WalletTestUtil.sampleSegwitPath,
       scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
-      blockHash = None
+      spendingTxIdOpt = None
     )
     val utxo3 = SegwitV0SpendingInfo(
       txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
@@ -61,7 +61,7 @@ class CoinSelectorTest extends BitcoinSWalletTest {
       output = TransactionOutput(20.sats, ScriptPubKey.empty),
       privKeyPath = WalletTestUtil.sampleSegwitPath,
       scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
-      blockHash = None
+      spendingTxIdOpt = None
     )
 
     test(CoinSelectionFixture(output, feeRate, utxo1, utxo2, utxo3))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -36,11 +36,13 @@ class ProcessBlockTest extends BitcoinSWalletTest {
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
       syncHeightOpt <- wallet.getSyncDescriptorOpt()
+      txDbOpt <- wallet.transactionDAO.findByTxId(txId)
     } yield {
+      assert(txDbOpt.isDefined)
+      assert(txDbOpt.get.blockHashOpt.contains(hash))
       assert(utxos.size == 1)
       assert(utxos.head.output.scriptPubKey == addr.scriptPubKey)
       assert(utxos.head.output.value == 1.bitcoin)
-      assert(utxos.head.blockHash.contains(hash))
       assert(utxos.head.txid == txId)
 
       assert(syncHeightOpt.contains(SyncHeightDescriptor(bestHash, height)))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -2,9 +2,9 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.api.wallet.WalletApi
 import org.bitcoins.core.currency._
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkitcore.Implicits._
 import org.bitcoins.testkitcore.gen.TransactionGenerators
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest.FutureOutcome
 import org.scalatest.compatible.Assertion
 
@@ -36,7 +36,8 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
     } yield {
       assert(oldConfirmed == newConfirmed)
       assert(oldUnconfirmed == newUnconfirmed)
-      assert(oldUtxos == newUtxos)
+      // make id not comparable
+      assert(oldUtxos.map(_.copyWithId(0)) == newUtxos.map(_.copyWithId(0)))
       assert(oldTransactions == newTransactions)
     }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -36,8 +36,12 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
     } yield {
       assert(oldConfirmed == newConfirmed)
       assert(oldUnconfirmed == newUnconfirmed)
-      // make id not comparable
-      assert(oldUtxos.map(_.copyWithId(0)) == newUtxos.map(_.copyWithId(0)))
+      // make utxos comparable
+      val comparableOldUtxos =
+        oldUtxos.map(_.copyWithId(0)).sortBy(_.outPoint.hex)
+      val comparableNewUtxos =
+        newUtxos.map(_.copyWithId(0)).sortBy(_.outPoint.hex)
+      assert(comparableOldUtxos == comparableNewUtxos)
       assert(oldTransactions == newTransactions)
     }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
@@ -1,0 +1,57 @@
+package org.bitcoins.wallet
+
+import org.bitcoins.core.protocol.script.EmptyScriptPubKey
+import org.bitcoins.core.wallet.utxo.TxoState._
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
+import org.bitcoins.testkit.wallet.WalletTestUtil._
+import org.scalatest.FutureOutcome
+
+class UTXOHandlingTest extends BitcoinSWalletTest {
+
+  behavior of "UTXOHandling"
+
+  override type FixtureParam = Wallet
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    withNewWallet(test, getBIP39PasswordOpt())
+  }
+
+  it must "correctly update txo state based on confirmations" in { wallet =>
+    val utxo = sampleSegwitUTXO(EmptyScriptPubKey)
+    val requiredConfs = 6
+    assert(wallet.walletConfig.requiredConfirmations == requiredConfs)
+
+    val immatureCoinbase = utxo.copyWithState(ImmatureCoinbase)
+    val pendingConfReceived = utxo.copyWithState(PendingConfirmationsReceived)
+    val pendingConfSpent = utxo.copyWithState(PendingConfirmationsSpent)
+    val confReceived = utxo.copyWithState(ConfirmedReceived)
+    val confSpent = utxo.copyWithState(ConfirmedSpent)
+    val reserved = utxo.copyWithState(Reserved)
+    val dne = utxo.copyWithState(DoesNotExist)
+
+    assert(wallet.updateTxoWithConfs(reserved, 1) == reserved)
+
+    assert(wallet.updateTxoWithConfs(immatureCoinbase, 10) == immatureCoinbase)
+    assert(wallet.updateTxoWithConfs(immatureCoinbase, 101) == confReceived)
+
+    assert(
+      wallet.updateTxoWithConfs(pendingConfReceived, 1) == pendingConfReceived)
+    assert(
+      wallet.updateTxoWithConfs(pendingConfReceived,
+                                requiredConfs) == confReceived)
+
+    assert(wallet.updateTxoWithConfs(pendingConfSpent, 1) == pendingConfSpent)
+    assert(
+      wallet.updateTxoWithConfs(pendingConfSpent, requiredConfs) == confSpent)
+
+    assert(wallet.updateTxoWithConfs(dne, 1) == dne)
+    assert(wallet.updateTxoWithConfs(dne, requiredConfs) == dne)
+
+    assert(wallet.updateTxoWithConfs(confSpent, 1) == confSpent)
+    assert(wallet.updateTxoWithConfs(confSpent, requiredConfs) == confSpent)
+
+    assert(wallet.updateTxoWithConfs(confReceived, 1) == confReceived)
+    assert(
+      wallet.updateTxoWithConfs(confReceived, requiredConfs) == confReceived)
+  }
+}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -2,15 +2,15 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.currency._
 import org.bitcoins.core.hd.HDChainType
+import org.bitcoins.core.number._
+import org.bitcoins.core.protocol.script.EmptyScriptSignature
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.rpc.BitcoindException.InvalidAddressOrKey
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest.RandomFeeProvider
-import org.bitcoins.testkit.wallet.{
-  BitcoinSWalletTest,
-  WalletTestUtil,
-  WalletWithBitcoind,
-  WalletWithBitcoindRpc
-}
+import org.bitcoins.testkit.wallet._
 import org.scalatest.FutureOutcome
 
 class WalletIntegrationTest extends BitcoinSWalletTest {
@@ -273,5 +273,77 @@ class WalletIntegrationTest extends BitcoinSWalletTest {
 
       walletBal2 <- wallet.getBalance()
     } yield assert(walletBal1 > walletBal2)
+  }
+
+  it should "correctly handle spending coinbase utxos" in {
+    walletWithBitcoind =>
+      val WalletWithBitcoindRpc(wallet, bitcoind) = walletWithBitcoind
+
+      val amountToSend = Bitcoins(49.99)
+
+      for {
+        // Mine to wallet
+        addr <- wallet.getNewAddress()
+        hash <- bitcoind.generateToAddress(1, addr).map(_.head)
+        block <- bitcoind.getBlockRaw(hash)
+
+        // Assert we mined to our address
+        coinbaseTx = block.transactions.head
+        _ = assert(
+          coinbaseTx.outputs.exists(_.scriptPubKey == addr.scriptPubKey))
+
+        _ <- wallet.processBlock(block)
+
+        // Verify we funded the wallet
+        allUtxos <- wallet.spendingInfoDAO.findAllSpendingInfos()
+        _ = assert(allUtxos.size == 1)
+        utxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
+        _ = assert(utxos.size == 1)
+
+        bitcoindAddr <- bitcoind.getNewAddress
+
+        // Attempt to spend utxo
+        _ <- recoverToSucceededIf[RuntimeException](
+          wallet.sendToAddress(bitcoindAddr, valueToBitcoind, None))
+
+        spendingTx = {
+          val inputs = utxos.map { db =>
+            TransactionInput(db.outPoint, EmptyScriptSignature, UInt32.zero)
+          }
+          val outputs =
+            Vector(TransactionOutput(amountToSend, bitcoindAddr.scriptPubKey))
+          BaseTransaction(Int32.two, inputs, outputs, UInt32.zero)
+        }
+
+        _ <- recoverToSucceededIf[RuntimeException](
+          wallet.processTransaction(spendingTx, None))
+
+        // Make coinbase mature
+        _ <- bitcoind.generateToAddress(101, bitcoindAddr)
+        _ <- wallet.updateUtxoPendingStates()
+
+        // Create valid spending tx
+        psbt = PSBT.fromUnsignedTx(spendingTx)
+        signedPSBT <- wallet.signPSBT(psbt)
+        signedTx = signedPSBT.finalizePSBT
+          .flatMap(_.extractTransactionAndValidate)
+          .get
+
+        // Process tx, validate correctly moved to
+        _ <- wallet.processTransaction(signedTx, None)
+        newCoinbaseUtxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
+        _ = assert(newCoinbaseUtxos.isEmpty)
+        spentUtxos <- wallet.listUtxos(TxoState.PendingConfirmationsSpent)
+        _ = assert(spentUtxos.size == 1)
+
+        // Assert spending tx valid to bitcoind
+        oldBalance <- bitcoind.getBalance
+        _ = assert(oldBalance == Satoshis(510000000000L))
+
+        _ <- bitcoind.sendRawTransaction(signedTx)
+        _ <- bitcoind.generateToAddress(1, bitcoindAddr)
+
+        newBalance <- bitcoind.getBalance
+      } yield assert(newBalance == oldBalance + amountToSend + Bitcoins(50))
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -192,7 +192,10 @@ class WalletIntegrationTest extends BitcoinSWalletTest {
       _ <- bitcoind.getNewAddress.flatMap(bitcoind.generateToAddress(6, _))
 
       replacementInfo <- bitcoind.getRawTransaction(replacementTx.txIdBE)
+
+      utxos <- wallet.spendingInfoDAO.findOutputsBeingSpent(replacementTx)
     } yield {
+      assert(utxos.forall(_.spendingTxIdOpt.contains(replacementTx.txIdBE)))
       // Check correct one was confirmed
       assert(replacementInfo.blockhash.isDefined)
     }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -200,7 +200,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
       spk = MultiSignatureScriptPubKey(2, Vector(dummyKey, walletKey))
       dummyPrevTx = dummyTx(spk = spk)
-      prevTxDb = TransactionDbHelper.fromTransaction(dummyPrevTx)
+      prevTxDb = TransactionDbHelper.fromTransaction(dummyPrevTx, None)
       _ <- wallet.transactionDAO.create(prevTxDb)
 
       psbt = dummyPSBT(prevTxId = dummyPrevTx.txId)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/IncomingTransactionDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/IncomingTransactionDAOTest.scala
@@ -1,18 +1,16 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.core.api.wallet.db.{
-  IncomingTransactionDb,
-  TransactionDb,
-  TransactionDbHelper
-}
+import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.testkit.fixtures.WalletDAOFixture
 import org.bitcoins.testkit.wallet.WalletTestUtil
 
 class IncomingTransactionDAOTest extends WalletDAOFixture {
 
   val txDb: TransactionDb =
-    TransactionDbHelper.fromTransaction(WalletTestUtil.sampleTransaction)
+    TransactionDbHelper.fromTransaction(WalletTestUtil.sampleTransaction,
+                                        Some(DoubleSha256DigestBE.empty))
 
   val incoming: IncomingTransactionDb =
     IncomingTransactionDb(WalletTestUtil.sampleTransaction.txIdBE,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/OutgoingTransactionDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/OutgoingTransactionDAOTest.scala
@@ -1,18 +1,16 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.core.api.wallet.db.{
-  OutgoingTransactionDb,
-  TransactionDb,
-  TransactionDbHelper
-}
+import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.testkit.fixtures.WalletDAOFixture
 import org.bitcoins.testkit.wallet.WalletTestUtil
 
 class OutgoingTransactionDAOTest extends WalletDAOFixture {
 
   val txDb: TransactionDb =
-    TransactionDbHelper.fromTransaction(WalletTestUtil.sampleTransaction)
+    TransactionDbHelper.fromTransaction(WalletTestUtil.sampleTransaction,
+                                        Some(DoubleSha256DigestBE.empty))
 
   val outgoing: OutgoingTransactionDb = OutgoingTransactionDb.fromTransaction(
     WalletTestUtil.sampleTransaction,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/TransactionDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/TransactionDAOTest.scala
@@ -7,7 +7,7 @@ import org.bitcoins.testkit.wallet.WalletTestUtil
 class TransactionDAOTest extends WalletDAOFixture {
 
   val txDb: TransactionDb =
-    TransactionDbHelper.fromTransaction(WalletTestUtil.sampleTransaction)
+    TransactionDbHelper.fromTransaction(WalletTestUtil.sampleTransaction, None)
 
   it should "insert and read an transaction into the database" in { daos =>
     val txDAO = daos.transactionDAO

--- a/wallet/src/main/resources/postgresql/wallet/migration/V11__blockhash_to_transaction_table.sql
+++ b/wallet/src/main/resources/postgresql/wallet/migration/V11__blockhash_to_transaction_table.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "tx_table"
+    ADD COLUMN "block_hash" TEXT;
+
+
+UPDATE "tx_table"
+set "block_hash" = (
+    select "txo_spending_info"."block_hash"
+    from "txo_spending_info"
+    where "txo_spending_info"."txid" = "tx_table"."txIdBE"
+);
+
+-- Delete block_hash column, add spending_tx_id column
+ALTER TABLE "txo_spending_info" DROP COLUMN "block_hash";
+ALTER TABLE "txo_spending_info" ADD COLUMN "spending_tx_id" TEXT;

--- a/wallet/src/main/resources/postgresql/wallet/migration/V11__blockhash_to_transaction_table.sql
+++ b/wallet/src/main/resources/postgresql/wallet/migration/V11__blockhash_to_transaction_table.sql
@@ -1,5 +1,7 @@
 ALTER TABLE "tx_table"
     ADD COLUMN "block_hash" TEXT;
+ALTER TABLE "tx_table"
+    Drop COLUMN "id";
 
 
 UPDATE "tx_table"

--- a/wallet/src/main/resources/postgresql/wallet/migration/V11__blockhash_to_transaction_table.sql
+++ b/wallet/src/main/resources/postgresql/wallet/migration/V11__blockhash_to_transaction_table.sql
@@ -9,6 +9,6 @@ set "block_hash" = (
     where "txo_spending_info"."txid" = "tx_table"."txIdBE"
 );
 
--- Delete block_hash column, add spending_tx_id column
+-- Delete block_hash column, add spending_txid column
 ALTER TABLE "txo_spending_info" DROP COLUMN "block_hash";
-ALTER TABLE "txo_spending_info" ADD COLUMN "spending_tx_id" TEXT;
+ALTER TABLE "txo_spending_info" ADD COLUMN "spending_txid" TEXT;

--- a/wallet/src/main/resources/sqlite/wallet/migration/V10__blockhash_to_transaction_table.sql
+++ b/wallet/src/main/resources/sqlite/wallet/migration/V10__blockhash_to_transaction_table.sql
@@ -1,0 +1,19 @@
+ALTER TABLE "tx_table"
+    ADD COLUMN "block_hash" VARCHAR(254);
+
+
+UPDATE "tx_table"
+set "block_hash" = (
+    select "txo_spending_info"."block_hash"
+    from "txo_spending_info"
+    where "txo_spending_info"."txid" = "tx_table"."txIdBE"
+);
+
+-- Delete block_hash column, add spending_tx_id column
+CREATE TABLE IF NOT EXISTS "txo_spending_info_backup" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,"tx_outpoint" VARCHAR(254) NOT NULL, "script_pub_key_id" INT NOT NULL,"value" INTEGER NOT NULL,"hd_privkey_path" VARCHAR(254) NOT NULL,"redeem_script" VARCHAR(254),"script_witness" VARCHAR(254),"txid" VARCHAR(254) NOT NULL,"block_hash" VARCHAR(254), "txo_state" VARCHAR(254) NOT NULL);
+INSERT INTO "txo_spending_info_backup" SELECT * FROM "txo_spending_info";
+DROP TABLE "txo_spending_info";
+CREATE TABLE IF NOT EXISTS "txo_spending_info" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,"tx_outpoint" VARCHAR(254) NOT NULL, "script_pub_key_id" INT NOT NULL,"value" INTEGER NOT NULL,"hd_privkey_path" VARCHAR(254) NOT NULL,"redeem_script" VARCHAR(254),"script_witness" VARCHAR(254),"txid" VARCHAR(254) NOT NULL, "txo_state" VARCHAR(254) NOT NULL, spending_tx_id VARCHAR(254), constraint "fk_scriptPubKey" foreign key("script_pub_key_id") references "pub_key_scripts"("id"), constraint "fk_incoming_txId" foreign key("txid") references "wallet_incoming_txs"("txIdBE") on update NO ACTION on delete NO ACTION);
+INSERT INTO "txo_spending_info" ("id","tx_outpoint","script_pub_key_id","value","hd_privkey_path","redeem_script","script_witness","txid","txo_state") SELECT t."id",t."tx_outpoint",t."script_pub_key_id",t.value,t."hd_privkey_path",t."redeem_script",t."script_witness",t."txid",t."txo_state" FROM "txo_spending_info_backup" t;
+CREATE INDEX "txo_spending_info_spk_idx" ON "txo_spending_info"("script_pub_key_id");
+DROP TABLE "txo_spending_info_backup";

--- a/wallet/src/main/resources/sqlite/wallet/migration/V10__blockhash_to_transaction_table.sql
+++ b/wallet/src/main/resources/sqlite/wallet/migration/V10__blockhash_to_transaction_table.sql
@@ -9,11 +9,11 @@ set "block_hash" = (
     where "txo_spending_info"."txid" = "tx_table"."txIdBE"
 );
 
--- Delete block_hash column, add spending_tx_id column
+-- Delete block_hash column, add spending_txid column
 CREATE TABLE IF NOT EXISTS "txo_spending_info_backup" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,"tx_outpoint" VARCHAR(254) NOT NULL, "script_pub_key_id" INT NOT NULL,"value" INTEGER NOT NULL,"hd_privkey_path" VARCHAR(254) NOT NULL,"redeem_script" VARCHAR(254),"script_witness" VARCHAR(254),"txid" VARCHAR(254) NOT NULL,"block_hash" VARCHAR(254), "txo_state" VARCHAR(254) NOT NULL);
 INSERT INTO "txo_spending_info_backup" SELECT * FROM "txo_spending_info";
 DROP TABLE "txo_spending_info";
-CREATE TABLE IF NOT EXISTS "txo_spending_info" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,"tx_outpoint" VARCHAR(254) NOT NULL, "script_pub_key_id" INT NOT NULL,"value" INTEGER NOT NULL,"hd_privkey_path" VARCHAR(254) NOT NULL,"redeem_script" VARCHAR(254),"script_witness" VARCHAR(254),"txid" VARCHAR(254) NOT NULL, "txo_state" VARCHAR(254) NOT NULL, spending_tx_id VARCHAR(254), constraint "fk_scriptPubKey" foreign key("script_pub_key_id") references "pub_key_scripts"("id"), constraint "fk_incoming_txId" foreign key("txid") references "wallet_incoming_txs"("txIdBE") on update NO ACTION on delete NO ACTION);
+CREATE TABLE IF NOT EXISTS "txo_spending_info" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,"tx_outpoint" VARCHAR(254) NOT NULL, "script_pub_key_id" INT NOT NULL,"value" INTEGER NOT NULL,"hd_privkey_path" VARCHAR(254) NOT NULL,"redeem_script" VARCHAR(254),"script_witness" VARCHAR(254),"txid" VARCHAR(254) NOT NULL, "txo_state" VARCHAR(254) NOT NULL, spending_txid VARCHAR(254), constraint "fk_scriptPubKey" foreign key("script_pub_key_id") references "pub_key_scripts"("id"), constraint "fk_incoming_txId" foreign key("txid") references "wallet_incoming_txs"("txIdBE") on update NO ACTION on delete NO ACTION);
 INSERT INTO "txo_spending_info" ("id","tx_outpoint","script_pub_key_id","value","hd_privkey_path","redeem_script","script_witness","txid","txo_state") SELECT t."id",t."tx_outpoint",t."script_pub_key_id",t.value,t."hd_privkey_path",t."redeem_script",t."script_witness",t."txid",t."txo_state" FROM "txo_spending_info_backup" t;
 CREATE INDEX "txo_spending_info_spk_idx" ON "txo_spending_info"("script_pub_key_id");
 DROP TABLE "txo_spending_info_backup";

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -251,11 +251,9 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
     logger.debug(
       s"Processing transaction=${transaction.txIdBE} with blockHash=$blockHashOpt")
 
-    val incomingF = processIncomingUtxos(transaction, blockHashOpt, newTags)
-    val outgoingF = processOutgoingUtxos(transaction, blockHashOpt)
     for {
-      incoming <- incomingF
-      outgoing <- outgoingF
+      incoming <- processIncomingUtxos(transaction, blockHashOpt, newTags)
+      outgoing <- processOutgoingUtxos(transaction, blockHashOpt)
       _ <- walletCallbacks.executeOnTransactionProcessed(logger, transaction)
     } yield {
       ProcessTxResult(incoming, outgoing)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -22,12 +22,12 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.wallet.utxo.TxoState._
 import org.bitcoins.core.wallet.utxo._
-import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 
 import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 /** Provides functionality related to handling UTXOs in our wallet.
   * The most notable examples of functionality here are enumerating
@@ -96,59 +96,78 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       spendingInfoDbs: Vector[SpendingInfoDb]): Future[
     Vector[SpendingInfoDb]] = {
 
-    val byBlock = spendingInfoDbs.groupBy(_.blockHash)
+    val txIds =
+      spendingInfoDbs.map(_.txid) ++ spendingInfoDbs.flatMap(_.spendingTxIdOpt)
 
-    val toUpdateFs = byBlock.map {
-      case (Some(blockHash), txos) =>
-        chainQueryApi.getNumberOfConfirmations(blockHash).map {
-          case None =>
-            logger.warn(
-              s"Given txos exist in block (${blockHash.hex}) that we do not have or that has been reorged! $txos")
-            Vector.empty
-          case Some(confs) =>
-            txos.flatMap { txo =>
-              txo.state match {
-                case TxoState.ImmatureCoinbase =>
-                  if (confs > Consensus.coinbaseMaturity) {
+    val byBlockF = {
+      transactionDAO.findByTxIdBEs(txIds).map { txDbs =>
+        val blockHashMap = txDbs.map(db => db.txIdBE -> db.blockHashOpt).toMap
+        val blockHashAndDb = spendingInfoDbs.map { txo =>
+          val txToUse = txo.state match {
+            case _: ReceivedState | DoesNotExist | ImmatureCoinbase =>
+              txo.txid
+            case _: SpentState => txo.spendingTxIdOpt.get
+          }
+          (blockHashMap(txToUse), txo)
+        }
+        blockHashAndDb.groupBy(_._1)
+      }
+    }
+
+    val toUpdateF = byBlockF.flatMap { z =>
+      val toUpdateFs = z.map {
+        case (Some(blockHash), txos) =>
+          chainQueryApi.getNumberOfConfirmations(blockHash).map {
+            case None =>
+              logger.warn(
+                s"Given txos exist in block (${blockHash.hex}) that we do not have or that has been reorged! $txos")
+              Vector.empty
+            case Some(confs) =>
+              txos.flatMap { case (_, txo) =>
+                txo.state match {
+                  case TxoState.ImmatureCoinbase =>
+                    if (confs > Consensus.coinbaseMaturity) {
+                      if (confs >= walletConfig.requiredConfirmations) {
+                        Some(txo.copyWithState(TxoState.ConfirmedReceived))
+                      } else {
+                        Some(txo.copyWithState(
+                          TxoState.PendingConfirmationsReceived))
+                      }
+                    } else {
+                      None
+                    }
+                  case TxoState.PendingConfirmationsReceived =>
                     if (confs >= walletConfig.requiredConfirmations) {
                       Some(txo.copyWithState(TxoState.ConfirmedReceived))
                     } else {
-                      Some(
-                        txo.copyWithState(
-                          TxoState.PendingConfirmationsReceived))
+                      None
                     }
-                  } else {
+                  case TxoState.PendingConfirmationsSpent =>
+                    if (confs >= walletConfig.requiredConfirmations) {
+                      Some(txo.copyWithState(TxoState.ConfirmedSpent))
+                    } else {
+                      None
+                    }
+                  case TxoState.Reserved =>
+                    // We should keep the utxo as reserved so it is not used in
+                    // a future transaction that it should not be in
                     None
-                  }
-                case TxoState.PendingConfirmationsReceived =>
-                  if (confs >= walletConfig.requiredConfirmations) {
-                    Some(txo.copyWithState(TxoState.ConfirmedReceived))
-                  } else {
+                  case TxoState.DoesNotExist | TxoState.ConfirmedReceived |
+                      TxoState.ConfirmedSpent =>
                     None
-                  }
-                case TxoState.PendingConfirmationsSpent =>
-                  if (confs >= walletConfig.requiredConfirmations) {
-                    Some(txo.copyWithState(TxoState.ConfirmedSpent))
-                  } else {
-                    None
-                  }
-                case TxoState.Reserved =>
-                  // We should keep the utxo as reserved so it is not used in
-                  // a future transaction that it should not be in
-                  None
-                case TxoState.DoesNotExist | TxoState.ConfirmedReceived |
-                    TxoState.ConfirmedSpent =>
-                  None
+                }
               }
-            }
-        }
-      case (None, txos) =>
-        logger.debug(s"Currently have ${txos.size} transactions in the mempool")
-        Future.successful(Vector.empty)
+          }
+        case (None, txos) =>
+          logger.debug(
+            s"Currently have ${txos.size} transactions in the mempool")
+          Future.successful(Vector.empty)
+      }
+      FutureUtil.collect(toUpdateFs)
     }
 
     for {
-      toUpdate <- FutureUtil.collect(toUpdateFs)
+      toUpdate <- toUpdateF
       _ =
         if (toUpdate.nonEmpty)
           logger.info(s"${toUpdate.size} txos are now confirmed!")
@@ -177,8 +196,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       state: TxoState,
       output: TransactionOutput,
       outPoint: TransactionOutPoint,
-      addressDb: AddressDb,
-      blockHash: Option[DoubleSha256DigestBE]): Future[SpendingInfoDb] = {
+      addressDb: AddressDb): Future[SpendingInfoDb] = {
 
     val utxo: SpendingInfoDb = addressDb match {
       case segwitAddr: SegWitAddressDb =>
@@ -189,7 +207,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
           output = output,
           privKeyPath = segwitAddr.path,
           scriptWitness = segwitAddr.witnessScript,
-          blockHash = blockHash
+          spendingTxIdOpt = None
         )
       case LegacyAddressDb(path, _, _, _, _) =>
         LegacySpendingInfo(state = state,
@@ -197,7 +215,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
                            outPoint = outPoint,
                            output = output,
                            privKeyPath = path,
-                           blockHash = blockHash)
+                           spendingTxIdOpt = None)
       case nested: NestedSegWitAddressDb =>
         NestedSegwitV0SpendingInfo(
           outPoint = outPoint,
@@ -207,8 +225,8 @@ private[wallet] trait UtxoHandling extends WalletLogger {
           scriptWitness = P2WPKHWitnessV0(nested.ecPublicKey),
           txid = tx.txIdBE,
           state = state,
-          id = None,
-          blockHash = blockHash
+          spendingTxIdOpt = None,
+          id = None
         )
     }
 
@@ -228,8 +246,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
   protected def addUtxo(
       transaction: Transaction,
       vout: UInt32,
-      state: TxoState,
-      blockHash: Option[DoubleSha256DigestBE]): Future[AddUtxoResult] = {
+      state: TxoState): Future[AddUtxoResult] = {
 
     logger.info(s"Adding UTXO to wallet: ${transaction.txId.hex}:${vout.toInt}")
 
@@ -266,11 +283,10 @@ private[wallet] trait UtxoHandling extends WalletLogger {
                             state = state,
                             output = output,
                             outPoint = outPoint,
-                            addressDb = addressDb,
-                            blockHash = blockHash)
+                            addressDb = addressDb)
         }
         .flatMap {
-          case Right(utxoF) => utxoF.map(AddUtxoSuccess(_))
+          case Right(utxoF) => utxoF.map(AddUtxoSuccess)
           case Left(e)      => Future.successful(e)
         }
     }
@@ -300,35 +316,19 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     require(unreserved.isEmpty, s"Some utxos are not reserved, got $unreserved")
 
     // unmark all utxos are reserved
-    val groupedUtxos = utxos
+    val updatedUtxos = utxos
       .map(_.copyWithState(TxoState.PendingConfirmationsReceived))
-      .groupBy(_.blockHash)
-
-    val mempoolUtxos = Try(groupedUtxos(None)).getOrElse(Vector.empty)
-
-    // get the ones in blocks
-    val utxosInBlocks = groupedUtxos.flatMap {
-      case (Some(_), utxos) =>
-        utxos
-      case (None, _) =>
-        None
-    }.toVector
 
     for {
-      // update utxos in the mempool
-      updatedMempoolUtxos <-
-        spendingInfoDAO.updateAllSpendingInfoDb(mempoolUtxos)
-
       // update the confirmed utxos
-      updatedConfirmed <- updateUtxoConfirmedStates(utxosInBlocks)
+      updatedConfirmed <- updateUtxoConfirmedStates(updatedUtxos)
 
       // update the utxos that are in blocks but not considered confirmed yet
-      pendingConf = utxosInBlocks.filterNot(utxo =>
+      pendingConf = updatedUtxos.filterNot(utxo =>
         updatedConfirmed.exists(_.outPoint == utxo.outPoint))
-      updatedPendingConf <- spendingInfoDAO.updateAllSpendingInfoDb(pendingConf)
+      updated <- spendingInfoDAO.updateAllSpendingInfoDb(
+        pendingConf ++ updatedConfirmed)
 
-      // Return all utxos that were updated
-      updated = updatedMempoolUtxos ++ updatedConfirmed ++ updatedPendingConf
       _ <- walletCallbacks.executeOnReservedUtxos(logger, updated)
     } yield updated
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -94,6 +94,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
   }
 
   /** Returns a map of the SpendingInfoDbs with their relevant block.
+    * If the block hash is None, then it is a mempool transaction.
     * The relevant block is determined by if the utxo has been spent or not.
     * If it has been spent it uses the block that included the spending transaction,
     * otherwise it uses the block that included the receiving transaction.

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -93,6 +93,11 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     updateUtxoConfirmedStates(Vector(txo)).map(_.headOption)
   }
 
+  /** Returns a map of the SpendingInfoDbs with their relevant block.
+    * The relevant block is determined by if the utxo has been spent or not.
+    * If it has been spent it uses the block that included the spending transaction,
+    * otherwise it uses the block that included the receiving transaction.
+    */
   private[wallet] def getDbsByRelevantBlock(
       spendingInfoDbs: Vector[SpendingInfoDb]): Future[
     Map[Option[DoubleSha256DigestBE], Vector[SpendingInfoDb]]] = {
@@ -123,6 +128,9 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     }
   }
 
+  /** Updates the SpendingInfoDb to the correct state based
+    * on the number of confirmations it has received
+    */
   private[wallet] def updateTxoWithConfs(
       txo: SpendingInfoDb,
       confs: Int): SpendingInfoDb = {
@@ -152,6 +160,9 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     }
   }
 
+  /** Updates all the given SpendingInfoDbs to the correct state
+    * based on how many confirmations they have received
+    */
   private[wallet] def updateUtxoConfirmedStates(
       spendingInfoDbs: Vector[SpendingInfoDb]): Future[
     Vector[SpendingInfoDb]] = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -483,7 +483,7 @@ case class SpendingInfoDAO()(implicit
     def scriptWitnessOpt: Rep[Option[ScriptWitness]] = column("script_witness")
 
     def spendingTxIdOpt: Rep[Option[DoubleSha256DigestBE]] = column(
-      "spending_tx_id")
+      "spending_txid")
 
     /** All UTXOs must have a SPK in the wallet that gets spent to */
     def fk_scriptPubKeyId: slick.lifted.ForeignKeyQuery[_, ScriptPubKeyDb] = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -1,7 +1,5 @@
 package org.bitcoins.wallet.models
 
-import java.sql.SQLException
-
 import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd._
@@ -17,6 +15,7 @@ import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.db.CRUDAutoInc
 import org.bitcoins.wallet.config._
 
+import java.sql.SQLException
 import scala.concurrent.{ExecutionContext, Future}
 
 case class SpendingInfoDAO()(implicit
@@ -483,7 +482,8 @@ case class SpendingInfoDAO()(implicit
 
     def scriptWitnessOpt: Rep[Option[ScriptWitness]] = column("script_witness")
 
-    def blockHash: Rep[Option[DoubleSha256DigestBE]] = column("block_hash")
+    def spendingTxIdOpt: Rep[Option[DoubleSha256DigestBE]] = column(
+      "spending_tx_id")
 
     /** All UTXOs must have a SPK in the wallet that gets spent to */
     def fk_scriptPubKeyId: slick.lifted.ForeignKeyQuery[_, ScriptPubKeyDb] = {
@@ -511,7 +511,7 @@ case class SpendingInfoDAO()(implicit
        privKeyPath,
        redeemScriptOpt,
        scriptWitnessOpt,
-       blockHash,
+       spendingTxIdOpt,
        id.?).<>((UTXORecord.apply _).tupled, UTXORecord.unapply)
   }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/TransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/TransactionDAO.scala
@@ -101,6 +101,18 @@ case class TransactionDAO()(implicit
 
   override val table = TableQuery[TransactionTable]
 
+  def findAllUnconfirmed(): Future[Vector[TransactionDb]] = {
+    val query = table.filter(_.blockHash === Rep.None[DoubleSha256DigestBE])
+
+    safeDatabase.runVec(query.result)
+  }
+
+  def findAllConfirmed(): Future[Vector[TransactionDb]] = {
+    val query = table.filterNot(_.blockHash === Rep.None[DoubleSha256DigestBE])
+
+    safeDatabase.runVec(query.result)
+  }
+
   class TransactionTable(tag: Tag)
       extends TxTable[TransactionDb](tag, schemaName, "tx_table") {
 
@@ -123,6 +135,8 @@ case class TransactionDAO()(implicit
 
     def locktime: Rep[UInt32] = column("locktime")
 
+    def blockHash: Rep[Option[DoubleSha256DigestBE]] = column("block_hash")
+
     def * : ProvenShape[TransactionDb] =
       (txIdBE,
        transaction,
@@ -132,7 +146,8 @@ case class TransactionDAO()(implicit
        totalOutput,
        numInputs,
        numOutputs,
-       locktime).<>(TransactionDb.tupled, TransactionDb.unapply)
+       locktime,
+       blockHash).<>(TransactionDb.tupled, TransactionDb.unapply)
 
     def primaryKey: PrimaryKey =
       primaryKey("pk_tx", sourceColumns = txIdBE)

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/TransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/TransactionDAO.scala
@@ -116,7 +116,7 @@ case class TransactionDAO()(implicit
   class TransactionTable(tag: Tag)
       extends TxTable[TransactionDb](tag, schemaName, "tx_table") {
 
-    def txIdBE: Rep[DoubleSha256DigestBE] = column("txIdBE", O.Unique)
+    def txIdBE: Rep[DoubleSha256DigestBE] = column("txIdBE", O.PrimaryKey)
 
     def transaction: Rep[Transaction] = column("transaction")
 


### PR DESCRIPTION
Fixes #2736

Moves the `blockhash` column from the spending info table to the tx table. Adds a `spending_txid` column to the spending info table 