### PR TITLE
Enable 'dockerUpdateLatest' option to give us the latest tag on publi…

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -6,7 +6,10 @@ import java.nio.file.Paths
 import com.typesafe.sbt.packager.Keys.{
   daemonUser,
   daemonUserUid,
+  dockerAlias,
+  dockerAliases,
   dockerRepository,
+  dockerUpdateLatest,
   maintainer
 }
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerBaseImage
@@ -165,7 +168,8 @@ object CommonSettings {
       //which is 'demiourgos728'
       daemonUser in Docker := "bitcoin-s",
       packageName in Docker := packageName.value,
-      version in Docker := version.value
+      version in Docker := version.value,
+      dockerUpdateLatest := isSnapshot.value
     )
   }
 


### PR DESCRIPTION
…shing artifacts

fixes #2751 

This now should make the latest thing published to docker hub have the `latest` tag

You can read more about the `dockerUpdateLatest` setting here: https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html#publishing-settings

```
REPOSITORY                             TAG                                        IMAGE ID       CREATED         SIZE
bitcoinscala/bitcoin-s-oracle-server   0.5.0-62-4a847c03-20210303-1323-SNAPSHOT   8f39b5d9ca77   5 minutes ago   547MB
bitcoinscala/bitcoin-s-oracle-server   latest                                     8f39b5d9ca77   5 minutes ago   547MB
bitcoinscala/bitcoin-s-oracle-server   0.5.0-62-4a847c03-SNAPSHOT                 3e90fbab46d8   28 hours ago    547MB
```