### PR TITLE
Make it clear on the getting-setup.md page that this is only for deve…

### DIFF
--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -3,6 +3,10 @@ id: getting-setup
 title: Getting Bitcoin-S installed on your machine
 ---
 
+> This documentation is intended for setting up development of bitcoin-s.
+> If you want to just install bitcoin-s rather than develop, 
+> see [getting-started](getting-started.md)
+
 ## Getting Setup With Bitcoin-S
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -17,6 +21,7 @@ title: Getting Bitcoin-S installed on your machine
 - [Step 6 (Optional): Moving To Testnet](#step-6-optional-moving-to-testnet)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 
 ## Step 1: Java and Scala
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,16 +15,23 @@ If you are a professional working a cryptocurrency business and
 have feedback on how to make your lives easier, please reach out on [slack](https://join.slack.com/t/suredbits/shared_invite/zt-eavycu0x-WQL7XOakzQo8tAy7jHHZUw),
 [gitter](https://gitter.im/bitcoin-s-core/) or [twitter](https://twitter.com/Chris_Stewart_5/)!
 
-## If you want to setup Bitcoin-S locally
-
-Then go to [this document](getting-setup.md).
-
 ## Getting prebuilt artifacts
 
-If you want to add Bitcoin-S to your project, follow the
-instructions for your build tool
+### Java binaries
 
-### Jars
+Please download these from our latest [release on github](https://github.com/bitcoin-s/bitcoin-s/releases/tag/v0.5.0)
+
+### Docker
+
+We publish docker images to docker hub on every PR merge and tag on github.
+You can obtain the images for both the app server and oracle server on these
+docker hub repos
+
+[bitcoin-s-server docker hub repo](https://hub.docker.com/r/bitcoinscala/bitcoin-s-server/tags?page=1&ordering=last_updated)
+
+[bitcoin-s-oracle-server docker hub repo](https://hub.docker.com/r/bitcoinscala/bitcoin-s-oracle-server/tags?page=1&ordering=last_updated)
+
+### Library jars
 
 Add this to your `build.sbt`:
 
@@ -79,20 +86,12 @@ The repo for snapshots, which are published after everytime something is merged 
 
 https://oss.sonatype.org/content/repositories/snapshots/org/bitcoin-s/
 
-### Docker
-
-We publish docker images to docker hub on every PR merge and tag on github.
-You can obtain the images for both the app server and oracle server on these
-docker hub repos
-
-[bitcoin-s docker hub repo](https://hub.docker.com/r/bitcoinscala/bitcoin-s-server/tags?page=1&ordering=last_updated)
-
-[oracle-server docker hub repo](https://hub.docker.com/r/bitcoinscala/bitcoin-s-oracle-server/tags?page=1&ordering=last_updated)
-
 ## Building JARs yourself
 
-If you want to build Bitcoin-S JARs yourself, you need to use the
-[sbt](https://www.scala-sbt.org/) build tool. Once you have sbt
-installed, run `sbt publishLocal`. This places the required JAR
-files in your `.ivy2/local` folder. On Linux, this is located at
-`$HOME/.ivy2/local/` by default.
+Please see [getting-setup.md](getting-setup.md)
+
+## If you want to setup Bitcoin-S locally for development
+
+Please see [getting-setup.md](getting-setup.md)
+
+


### PR DESCRIPTION
…lopment, you can find binaries in getting-started.md

fixes #2754

Makes it more clear on the `getting-setup` page that this is only for when you want to develop, you can just install binaries referenced on the `getting-started` page
