### PR TITLE
Add new JS projects to list in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,6 +100,8 @@ lazy val testkitCore = crossProject(JVMPlatform, JSPlatform)
 
 lazy val testkitCoreJVM = testkitCore.jvm
 
+lazy val testkitCoreJS = testkitCore.js
+
 lazy val bitcoindRpc = project
   .in(file("bitcoind-rpc"))
   .settings(CommonSettings.prodSettings: _*)
@@ -113,7 +115,7 @@ lazy val eclairRpc = project
   .dependsOn(asyncUtilsJVM, bitcoindRpc)
 
 lazy val jsProjects: Vector[ProjectReference] =
-  Vector(cryptoJS, coreJS, cryptoTestJS, coreTestJS)
+  Vector(cryptoJS, coreJS, cryptoTestJS, coreTestJS, testkitCoreJS)
 
 // quoting the val name this way makes it appear as
 // 'bitcoin-s' in sbt/bloop instead of 'bitcoins'
@@ -158,6 +160,7 @@ lazy val `bitcoin-s` = project
     appCommons,
     appCommonsTest,
     testkitCoreJVM,
+    testkitCoreJS,
     testkit,
     zmq,
     oracleServer,

--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,8 @@ lazy val eclairRpc = project
   .in(file("eclair-rpc"))
   .dependsOn(asyncUtilsJVM, bitcoindRpc)
 
-val jsProjects: Vector[ProjectReference] = Vector(cryptoJS)
+lazy val jsProjects: Vector[ProjectReference] =
+  Vector(cryptoJS, coreJS, cryptoTestJS, coreTestJS)
 
 // quoting the val name this way makes it appear as
 // 'bitcoin-s' in sbt/bloop instead of 'bitcoins'


### PR DESCRIPTION
In #2731 i forgot to add the new js projects to our list in build.sbt

Since I forgot to do this, this re-introduced #2740 that was originally fixed in #2742

This fixes the problem again.