### PR TITLE
Make website publish work with teh latest stable version

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
       - name: Cache

--- a/bitcoin-s-docs/docs.sbt
+++ b/bitcoin-s-docs/docs.sbt
@@ -25,7 +25,7 @@ mdocExtraArguments := List("--no-link-hygiene")
 // these variables gets passed to mdoc, and can be read
 // from there
 mdocVariables := Map(
-  "STABLE_VERSION" -> "0.4.0",
+  "STABLE_VERSION" -> previousStableVersion.value.get.toString,
   "UNSTABLE_VERSION" -> version.value
 )
 


### PR DESCRIPTION
We had a hard coded value before, now it's set dynamically. You can inspect it in sbt with this 

>sbt:bitcoin-s-docs> show mdocVariables
[info] Map(STABLE_VERSION -> 0.5.0, UNSTABLE_VERSION -> 0.5.0-71-34251001-20210306-1445-SNAPSHOT)
