### PR TITLE
Try to shutdown the http connection pool to avoid issue 2701

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -223,6 +223,7 @@ trait Client extends BitcoinSLogger with StartStopAsync[BitcoindRpcClient] {
     */
   def stop(): Future[BitcoindRpcClient] = {
     for {
+      _ <- httpClient.shutdownAllConnectionPools()
       _ <- bitcoindCall[String]("stop")
       _ <- {
         if (system.name == BitcoindRpcClient.ActorSystemName) {


### PR DESCRIPTION
attempt to fix #2701 

https://doc.akka.io/docs/akka-http/current/client-side/host-level.html#pool-shutdown

The error message: 
>The http server closed the connection unexpectedly before delivering responses for 1 outstanding requests

I'm hoping this forces the queued requests to be flushed before we go on to shutdown bitcoind. This hopefully means we don't shutdown bitcoind with outstanding requests.

