### PR TITLE
Add fetch depth zero to everything to fix bug introduced in #2766

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
       - name: Cache

--- a/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
       - name: Cache

--- a/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
       - name: Cache

--- a/.github/workflows/Linux_2.12_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.12_RPC_Tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:

--- a/.github/workflows/Linux_2.13_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Node_Core_Tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
       - name: Cache

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
       - name: Cache

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:

--- a/.github/workflows/Linux_2.13_ScalaJS_Tests.yml
+++ b/.github/workflows/Linux_2.13_ScalaJS_Tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
       - name: Cache

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
       - name: Cache

--- a/.github/workflows/Secp_Disabled_Tests.yml
+++ b/.github/workflows/Secp_Disabled_Tests.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
       - name: Cache

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -15,6 +15,8 @@ jobs:
         shell: bash
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
       - name: Cache

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -27,7 +27,10 @@ jobs:
             uploaded_filename: bitcoin-s-cli-x86_64-pc-win32.exe
             local_path: app\cli\target\native-image\bitcoin-s-cli.exe
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
       - run: git fetch --tags || true
       - run: sbt cli/nativeImage


### PR DESCRIPTION
With #2766, we require tags to be able to build everything. As stated in https://github.com/actions/checkout/issues/448 we cannot just get tags without fetching everything.