### PR TITLE
Give DLC from file functions destination optional param

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -245,7 +245,7 @@ object ConsoleCli {
                 case other => other
               })),
           arg[Path]("destination")
-            .required()
+            .optional()
             .action((dest, conf) =>
               conf.copy(command = conf.command match {
                 case accept: AcceptDLCOfferFromFile =>
@@ -280,7 +280,7 @@ object ConsoleCli {
                 case other => other
               })),
           arg[Path]("destination")
-            .required()
+            .optional()
             .action((dest, conf) =>
               conf.copy(command = conf.command match {
                 case accept: SignDLCFromFile =>

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptDLCDialog.scala
@@ -18,6 +18,11 @@ class AcceptDLCDialog
           DLCDialog.offerFileChosenLabel.text = file.toString
         }),
         DLCDialog.fileChosenStr -> DLCDialog.offerFileChosenLabel,
+        DLCDialog.dlcAcceptFileDestStr -> DLCDialog.fileChooserButton(file => {
+          DLCDialog.acceptDestDLCFile = Some(file)
+          DLCDialog.acceptDestFileChosenLabel.text = file.toString
+        }),
+        DLCDialog.fileChosenStr -> DLCDialog.acceptDestFileChosenLabel,
         DLCDialog.oracleAnnouncementStr -> new TextField() {
           promptText = "(optional)"
         }
@@ -43,7 +48,10 @@ class AcceptDLCDialog
         // TODO figure how to validate when using a file
         offerDLCFile = None // reset
         offerFileChosenLabel.text = "" // reset
-        AcceptDLCOfferFromFile(file.toPath)
+        acceptDestDLCFile = None // reset
+        acceptDestFileChosenLabel.text = "" // reset
+
+        AcceptDLCOfferFromFile(file.toPath, acceptDestDLCFile.map(_.toPath))
       case None =>
         val offerHex = readStringFromNode(inputs(dlcOfferStr))
         val offer = LnMessageFactory(DLCOfferTLV).fromHex(offerHex)

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialog.scala
@@ -168,9 +168,14 @@ object DLCDialog {
   var acceptDLCFile: Option[File] = None
   var signDLCFile: Option[File] = None
 
+  var acceptDestDLCFile: Option[File] = None
+  var signDestDLCFile: Option[File] = None
+
   val offerFileChosenLabel = new Label("")
   val acceptFileChosenLabel = new Label("")
+  val acceptDestFileChosenLabel = new Label("")
   val signFileChosenLabel = new Label("")
+  val signDestFileChosenLabel = new Label("")
 
   val oracleAnnouncementStr = "Oracle Announcement"
   val contractInfoStr = "Contract Info"
@@ -200,8 +205,12 @@ object DLCDialog {
   val dlcOfferStr = "DLC Offer"
   val dlcOfferFileStr = "Open Offer from File"
 
+  val dlcAcceptFileDestStr = "Accept file destination"
+
   val dlcAcceptStr = "DLC Accept Message"
   val dlcAcceptFileStr = "Open Accept from File"
+
+  val dlcSignFileDestStr = "Sign file destination"
 
   val dlcSigStr = "DLC Signatures"
   val dlcSignFileStr = "Open Sign from File"

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -17,7 +17,15 @@ class SignDLCDialog
                                                DLCDialog.acceptFileChosenLabel.text =
                                                  file.toString
                                              },
-                                           DLCDialog.fileChosenStr -> DLCDialog.acceptFileChosenLabel
+                                           DLCDialog.fileChosenStr -> DLCDialog.acceptFileChosenLabel,
+                                           DLCDialog.dlcSignFileDestStr ->
+                                             DLCDialog.fileChooserButton { file =>
+                                               DLCDialog.signDestDLCFile =
+                                                 Some(file)
+                                               DLCDialog.signDestFileChosenLabel.text =
+                                                 file.toString
+                                             },
+                                           DLCDialog.fileChosenStr -> DLCDialog.signDestFileChosenLabel
                                          ),
                                          Vector(DLCDialog.dlcAcceptStr,
                                                 DLCDialog.dlcAcceptFileStr)) {
@@ -29,7 +37,10 @@ class SignDLCDialog
       case Some(file) =>
         acceptDLCFile = None // reset
         acceptFileChosenLabel.text = "" // reset
-        SignDLCFromFile(file.toPath)
+        signDestDLCFile = None // reset
+        signFileChosenLabel.text = "" // reset
+
+        SignDLCFromFile(file.toPath, signDestDLCFile.map(_.toPath))
       case None =>
         val acceptHex = readStringFromNode(inputs(dlcAcceptStr))
 

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -740,7 +740,7 @@ object AddDLCSigs extends ServerJsonModels {
   }
 }
 
-case class DLCDataFromFile(path: Path)
+case class DLCDataFromFile(path: Path, destinationOpt: Option[Path])
 
 object DLCDataFromFile extends ServerJsonModels {
 
@@ -749,7 +749,13 @@ object DLCDataFromFile extends ServerJsonModels {
       case pathJs :: Nil =>
         Try {
           val path = new File(pathJs.str).toPath
-          DLCDataFromFile(path)
+          DLCDataFromFile(path, None)
+        }
+      case pathJs :: destJs :: Nil =>
+        Try {
+          val path = new File(pathJs.str).toPath
+          val dest = new File(destJs.str).toPath
+          DLCDataFromFile(path, Some(dest))
         }
       case Nil =>
         Failure(new IllegalArgumentException("Missing path argument"))

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -59,7 +59,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
     destinationOpt match {
       case Some(path) =>
         Files.write(path, returnedStr.getBytes)
-        path.toAbsolutePath.toString
+        val absPath = path.toAbsolutePath.toString
+        s"Written to $absPath"
       case None => returnedStr
     }
   }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -58,7 +58,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
   ): String = {
     destinationOpt match {
       case Some(path) =>
-        Files.writeString(path, returnedStr)
+        Files.write(path, returnedStr.getBytes)
         path.toAbsolutePath.toString
       case None => returnedStr
     }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -19,7 +19,7 @@ import org.bitcoins.wallet.config.WalletAppConfig
 import ujson._
 import upickle.default._
 
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
 import java.time.Instant
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
@@ -49,6 +49,18 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
       Future.successful(tx)
     } else {
       wallet.broadcastTransaction(tx).map(_ => tx.txIdBE)
+    }
+  }
+
+  private def handleDestinationOpt(
+      returnedStr: String,
+      destinationOpt: Option[Path]
+  ): String = {
+    destinationOpt match {
+      case Some(path) =>
+        Files.writeString(path, returnedStr)
+        path.toAbsolutePath.toString
+      case None => returnedStr
     }
   }
 
@@ -315,7 +327,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
       DLCDataFromFile.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
-        case Success(DLCDataFromFile(path)) =>
+        case Success(DLCDataFromFile(path, destOpt)) =>
           complete {
 
             val hex = Files.readAllLines(path).get(0)
@@ -325,7 +337,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
             wallet
               .acceptDLCOffer(offerMessage.tlv)
               .map { accept =>
-                Server.httpSuccess(accept.toMessage.hex)
+                val ret = handleDestinationOpt(accept.toMessage.hex, destOpt)
+                Server.httpSuccess(ret)
               }
           }
       }
@@ -348,7 +361,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
       DLCDataFromFile.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
-        case Success(DLCDataFromFile(path)) =>
+        case Success(DLCDataFromFile(path, destOpt)) =>
           complete {
 
             val hex = Files.readAllLines(path).get(0)
@@ -358,7 +371,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
             wallet
               .signDLC(acceptMessage.tlv)
               .map { sign =>
-                Server.httpSuccess(sign.toMessage.hex)
+                val ret = handleDestinationOpt(sign.toMessage.hex, destOpt)
+                Server.httpSuccess(ret)
               }
           }
       }
@@ -380,7 +394,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
       DLCDataFromFile.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
-        case Success(DLCDataFromFile(path)) =>
+        case Success(DLCDataFromFile(path, _)) =>
           complete {
 
             val hex = Files.readAllLines(path).get(0)


### PR DESCRIPTION
Adds a `destination` parameter to `acceptdlcfromfile` and `signdlcfromfile` that is a file destination and adds it to the GUI. This should allow us to get around the problems with the CLI timing out.