### PR TITLE
Refactor starting second bitcoind in MempoolRpcTest, remove Thread.sleep

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
@@ -7,7 +7,6 @@ import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.util.{AkkaUtil, BitcoinSAsyncTest}
 
-import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.reflect.io.Directory
 
@@ -33,11 +32,12 @@ class ServerRunTest extends BitcoinSAsyncTest {
     // Use Exception because different errors can occur
     recoverToSucceededIf[Exception] {
       val runMainF = new BitcoinSServerMain(args).startup
-      val deleteDirF = Future {
-        Thread.sleep(2000)
-        directory.deleteRecursively()
-        Thread.sleep(2000)
-      }
+      val deleteDirF = for {
+        _ <- AkkaUtil.nonBlockingSleep(2.seconds)
+        _ = directory.deleteRecursively()
+        _ <- AkkaUtil.nonBlockingSleep(2.seconds)
+      } yield ()
+
       for {
         _ <- runMainF
         _ <- deleteDirF

--- a/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
@@ -1,12 +1,11 @@
 package org.bitcoins.server
 
 import java.nio.file._
-
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
-import org.bitcoins.testkit.util.BitcoinSAsyncTest
+import org.bitcoins.testkit.util.{AkkaUtil, BitcoinSAsyncTest}
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -75,7 +74,7 @@ class ServerRunTest extends BitcoinSAsyncTest {
       _ = thread.start()
 
       // Wait for the server to have successfully started up
-      _ = Thread.sleep(10000)
+      _ <- AkkaUtil.nonBlockingSleep(1.second)
       binding <- BitcoinSServer.startedF
 
       // Stop the server

--- a/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
+++ b/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
@@ -145,7 +145,8 @@ abstract class AsyncUtil extends BitcoinSLogger {
 
 object AsyncUtil extends AsyncUtil {
 
-  private[bitcoins] val scheduler = Executors.newScheduledThreadPool(2)
+  private[bitcoins] val scheduler = Executors.newScheduledThreadPool(
+    Runtime.getRuntime.availableProcessors() * 2)
 
   /** The default interval between async attempts
     */

--- a/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
+++ b/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
@@ -145,8 +145,7 @@ abstract class AsyncUtil extends BitcoinSLogger {
 
 object AsyncUtil extends AsyncUtil {
 
-  private[bitcoins] val scheduler = Executors.newScheduledThreadPool(
-    Runtime.getRuntime.availableProcessors() * 2)
+  private[bitcoins] val scheduler = Executors.newScheduledThreadPool(2)
 
   /** The default interval between async attempts
     */

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
@@ -7,7 +7,7 @@ import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.{BitcoindRpcTest, FileUtil}
+import org.bitcoins.testkit.util.{AkkaUtil, BitcoindRpcTest, FileUtil}
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -19,10 +19,9 @@ class TestRpcUtilTest extends BitcoindRpcTest {
     BitcoindRpcTestUtil.createNodeTriple(clientAccum = clientAccum)
 
   private def trueLater(delay: Int): Future[Boolean] = {
-    Future {
-      Thread.sleep(delay)
-      true
-    }
+    AkkaUtil
+      .nonBlockingSleep(delay.millis)
+      .map(_ => true)
   }
 
   private def boolLaterDoneAnd(

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
@@ -24,34 +24,36 @@ class MempoolRpcTest extends BitcoindRpcTest {
   lazy val clientsF: Future[(BitcoindRpcClient, BitcoindRpcClient)] =
     BitcoindRpcTestUtil.createNodePairV18(clientAccum = clientAccum)
 
-  lazy val clientWithoutBroadcastF: Future[BitcoindRpcClient] =
-    clientsF.flatMap { case (client, otherClient) =>
-      val defaultConfig = BitcoindRpcTestUtil.standardConfig
+  lazy val clientWithoutBroadcastF: Future[BitcoindRpcClient] = {
+    val defaultConfig = BitcoindRpcTestUtil.standardConfig
 
-      val configNoBroadcast =
-        defaultConfig
-          .withOption("walletbroadcast", 0.toString)
+    val configNoBroadcast =
+      defaultConfig
+        .withOption("walletbroadcast", 0.toString)
 
-      val instanceWithoutBroadcast =
-        BitcoindInstance.fromConfig(configNoBroadcast,
-                                    BitcoindRpcTestUtil.getBinary(V18))
+    val instanceWithoutBroadcast =
+      BitcoindInstance.fromConfig(configNoBroadcast,
+                                  BitcoindRpcTestUtil.getBinary(V18))
 
-      val clientWithoutBroadcast =
-        BitcoindRpcClient.withActorSystem(instanceWithoutBroadcast)
-      clientAccum += clientWithoutBroadcast
+    val clientWithoutBroadcast =
+      BitcoindRpcClient.withActorSystem(instanceWithoutBroadcast)
 
-      val pairs = Vector(client -> clientWithoutBroadcast,
-                         otherClient -> clientWithoutBroadcast)
-
-      for {
-        _ <- clientWithoutBroadcast.start()
-        _ <- BitcoindRpcTestUtil.connectPairs(pairs)
-        _ <- BitcoindRpcTestUtil.syncPairs(pairs)
-        _ <- BitcoindRpcTestUtil.generateAndSync(
-          Vector(clientWithoutBroadcast, client, otherClient),
-          blocks = 200)
-      } yield clientWithoutBroadcast
-    }
+    val clientWithoutBroadcastF = clientWithoutBroadcast.start()
+    for {
+      (client, otherClient) <- clientsF
+      clientWithoutBroadcast <- clientWithoutBroadcastF
+      _ = {
+        clientAccum += clientWithoutBroadcast
+      }
+      pairs = Vector(client -> clientWithoutBroadcast,
+                     otherClient -> clientWithoutBroadcast)
+      _ <- BitcoindRpcTestUtil.connectPairs(pairs)
+      _ <- BitcoindRpcTestUtil.syncPairs(pairs)
+      _ <- BitcoindRpcTestUtil.generateAndSync(
+        Vector(clientWithoutBroadcast, client, otherClient),
+        blocks = 200)
+    } yield clientWithoutBroadcast
+  }
 
   behavior of "MempoolRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
@@ -2,7 +2,6 @@ package org.bitcoins.rpc.common
 
 import java.io.File
 import java.util.Scanner
-
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.AddressType
 import org.bitcoins.core.crypto.ECPrivateKeyUtil
@@ -16,9 +15,10 @@ import org.bitcoins.rpc._
 import org.bitcoins.rpc.client.common._
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.testkit.util.{AkkaUtil, BitcoindRpcTest}
 
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 
 /** These tests are all copied over from WalletRpcTest and changed to be for multi-wallet */
 class MultiWalletRpcTest extends BitcoindRpcTest {
@@ -50,11 +50,9 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
         // Restart so wallet is encrypted
         _ <- walletClient.stop()
         _ <- RpcUtil.awaitServerShutdown(walletClient)
-        _ <- Future {
-          // Very rarely we are prevented from starting the client again because Core
-          // hasn't released its locks on the datadir. This is prevent that.
-          Thread.sleep(1000)
-        }
+        // Very rarely we are prevented from starting the client again because Core
+        // hasn't released its locks on the datadir. This is prevent that.
+        _ <- AkkaUtil.nonBlockingSleep(1.second)
         _ <- walletClient.start()
         _ <- walletClient.loadWallet(walletName)
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -22,14 +22,14 @@ import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPrivateKey, ECPublicKey}
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.testkit.util.{AkkaUtil, BitcoindRpcTest}
 
 import java.io.File
 import java.util.Scanner
 import scala.annotation.nowarn
 import scala.async.Async.{async, await}
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.Future
 import scala.reflect.io.Directory
 
 @nowarn
@@ -52,11 +52,9 @@ class WalletRpcTest extends BitcoindRpcTest {
       _ <- walletClient.encryptWallet(password)
       _ <- walletClient.stop()
       _ <- RpcUtil.awaitServerShutdown(walletClient)
-      promise = Promise[Unit]()
       // Very rarely we are prevented from starting the client again because Core
       // hasn't released its locks on the datadir. This is prevent that.
-      _ = system.scheduler.scheduleOnce(1000.millis)(promise.success())
-      _ <- promise.future
+      _ <- AkkaUtil.nonBlockingSleep(1.second)
       _ <- walletClient.start()
     } yield walletClient
   }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
@@ -16,7 +16,7 @@ import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPrivateKey}
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.client.v16.BitcoindV16RpcClient
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.testkit.util.{AkkaUtil, BitcoindRpcTest}
 
 import scala.async.Async.{async, await}
 import scala.concurrent.Future
@@ -166,7 +166,7 @@ class BitcoindV16RpcClientTest extends BitcoindRpcTest {
                                    accountlessAddress,
                                    sendAmt))
 
-    if (Properties.isMac) Thread.sleep(10000)
+    if (Properties.isMac) await(AkkaUtil.nonBlockingSleep(10.seconds))
     val ourAccountAmount = await(client.getReceivedByAccount(ourAccount))
 
     assert(ourAccountAmount == sendAmt)

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -27,7 +27,7 @@ import org.bitcoins.testkit.chain.models.{
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.node.CachedChainAppConfig
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.ScalaTestUtil
+import org.bitcoins.testkit.util.{AkkaUtil, ScalaTestUtil}
 import org.bitcoins.testkit.{chain, BitcoinSTestAppConfig}
 import org.bitcoins.zmq.ZMQSubscriber
 import org.scalatest._
@@ -35,6 +35,7 @@ import play.api.libs.json.{JsError, JsSuccess, Json}
 
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.DurationInt
 
 trait ChainUnitTest
     extends BitcoinSFixture
@@ -253,9 +254,9 @@ trait ChainUnitTest
                         rawTxListener = None,
                         rawBlockListener = Some(handleRawBlock))
     zmqSubscriber.start()
-    Thread.sleep(1000)
 
     for {
+      _ <- AkkaUtil.nonBlockingSleep(1.second)
       chainHandler <- chainHandlerF
     } yield (chainHandler, zmqSubscriber)
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/AkkaUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/AkkaUtil.scala
@@ -1,0 +1,21 @@
+package org.bitcoins.testkit.util
+
+import akka.actor.ActorSystem
+
+import scala.concurrent.{Future, Promise}
+import scala.concurrent.duration.FiniteDuration
+
+trait AkkaUtil {
+
+  /** Returns a future that will sleep until the given duration has passed */
+  def nonBlockingSleep(duration: FiniteDuration)(implicit
+      system: ActorSystem): Future[Unit] = {
+    val p = Promise[Unit]()
+    system.scheduler
+      .scheduleOnce(duration)(p.success(()))(system.dispatcher)
+    p.future
+  }
+
+}
+
+object AkkaUtil extends AkkaUtil


### PR DESCRIPTION
I don't think this fixes the problems we are having with CI in master, but I don't think this hurts either.