### PR TITLE
2021 03 09 async utils tests

### DIFF
--- a/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
@@ -25,4 +25,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.12.12 downloadBitcoind coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtilsJVM/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls
+        run: sbt ++2.12.12 downloadBitcoind coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtilsTestJVM/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -25,4 +25,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.5 downloadBitcoind coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtilsJVM/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls
+        run: sbt ++2.13.5 downloadBitcoind coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtilsTestJVM/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -25,4 +25,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.5 downloadBitcoind coverage walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcOracleTest/test  asyncUtilsJVM/test dlcOracle/coverageReport dlcOracle/coveralls
+        run: sbt ++2.13.5 downloadBitcoind coverage walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcOracleTest/test asyncUtilsTestJVM/test dlcOracle/coverageReport dlcOracle/coveralls

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -28,5 +28,5 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: Windows Crypto, Core, and Database tests
-        run: sbt ++2.13.5 cryptoTestJVM/test coreTestJVM/test dbCommonsTest/test
+        run: sbt ++2.13.5 cryptoTestJVM/test coreTestJVM/test dbCommonsTest/test asyncUtilsTestJVM/test
         shell: bash

--- a/async-utils-test/src/test/scala/org/bitcoins/asyncutil/AsyncUtilTest.scala
+++ b/async-utils-test/src/test/scala/org/bitcoins/asyncutil/AsyncUtilTest.scala
@@ -1,0 +1,125 @@
+package org.bitcoins.asyncutil
+
+import org.bitcoins.core.util.TimeUtil
+import org.bitcoins.testkitcore.util.BitcoinSJvmTest
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+
+class AsyncUtilTest extends BitcoinSJvmTest {
+
+  behavior of "AsyncUtil"
+
+  it must "retry a predicate until it is satisfied" in {
+    val counter = new AtomicInteger(0)
+
+    def incrementAndCheck: Boolean = {
+      counter.incrementAndGet() == 10
+    }
+
+    AsyncUtil
+      .retryUntilSatisfied(incrementAndCheck)
+      .map(_ => succeed)
+  }
+
+  it must "retry a predicate that is a future until it is satisfied" in {
+    val counter = new AtomicInteger(0)
+
+    AsyncUtil
+      .retryUntilSatisfiedF(() => incrementAndCheckF(counter, 10))
+      .map(_ => succeed)
+  }
+
+  it must "be able to run 2 different futures in parallel" in {
+    val counter = new AtomicInteger(0)
+    val counter2 = new AtomicInteger(0)
+
+    val firstF =
+      AsyncUtil.retryUntilSatisfiedF(() => incrementAndCheckF(counter, 10))
+
+    val secondF =
+      AsyncUtil.retryUntilSatisfiedF(() => incrementAndCheckF(counter2, 10))
+
+    for {
+      _ <- firstF
+      _ <- secondF
+    } yield succeed
+  }
+
+  it must "be able to run 100 futures on the thread pool and have the all complete in a reasonable time" in {
+    val numCounters = 100
+    val expectedCount = 1000
+    val counters = Vector.fill(numCounters)(new AtomicInteger(0))
+
+    //try to run all these in parallel, and see if it works
+    val async: Vector[Future[Unit]] = counters.map { counter =>
+      AsyncUtil.retryUntilSatisfiedF(
+        () => incrementAndCheckF(counter, expectedCount),
+        interval = 1.millis,
+        maxTries = expectedCount)
+    }
+
+    Future.sequence(async).map(_ => succeed)
+  }
+
+  it must "handle blocking tasks ok" in {
+    val sleepMs = 10000
+    def blockingTask(): Boolean = {
+      Thread.sleep(sleepMs)
+      true
+    }
+
+    //schedule a blocking task first
+    val start = TimeUtil.currentEpochMs
+    val _ =
+      AsyncUtil.awaitCondition(blockingTask)
+
+    //schedule a non blocking task second
+    val counter1 = new AtomicInteger(0)
+    val secondF =
+      AsyncUtil.awaitCondition(() => incrementAndCheck(counter1, 10))
+
+    //the second task should not be blocked to completion by the first
+    for {
+      _ <- secondF
+    } yield {
+      val stop = TimeUtil.currentEpochMs
+      assert(stop - start < sleepMs)
+    }
+  }
+
+  it must "handle async blocking tasks ok" in {
+    val sleepMs = 10000
+    def blockingTask(): Future[Boolean] = Future {
+      Thread.sleep(sleepMs)
+      true
+    }
+
+    //schedule a blocking task first
+    val _ =
+      AsyncUtil.awaitConditionF(() => blockingTask())
+
+    //schedule a non blocking task second
+    val counter1 = new AtomicInteger(0)
+    val secondF =
+      AsyncUtil.awaitConditionF(() => incrementAndCheckF(counter1, 10))
+
+    //the second task should not be blocked to completion by the first
+    for {
+      _ <- secondF
+    } yield succeed
+  }
+
+  private def incrementAndCheck(
+      counter: AtomicInteger,
+      expected: Int): Boolean = {
+    counter.incrementAndGet() == expected
+  }
+
+  private def incrementAndCheckF(
+      counter: AtomicInteger,
+      expected: Int): Future[Boolean] = Future {
+    incrementAndCheck(counter, expected)
+  }
+}

--- a/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
+++ b/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
@@ -25,7 +25,7 @@ abstract class AsyncUtil extends BitcoinSLogger {
       interval: FiniteDuration = AsyncUtil.DEFAULT_INTERVAL,
       maxTries: Int = DEFAULT_MAX_TRIES)(implicit
       ec: ExecutionContext): Future[Unit] = {
-    val f = () => Future.successful(condition)
+    val f = () => Future(condition)
     retryUntilSatisfiedF(f, interval, maxTries)
   }
 
@@ -125,8 +125,7 @@ abstract class AsyncUtil extends BitcoinSLogger {
     //type hackery here to go from () => Boolean to () => Future[Boolean]
     //to make sure we re-evaluate every time retryUntilSatisfied is called
     def conditionDef: Boolean = condition()
-    val conditionF: () => Future[Boolean] = () =>
-      Future.successful(conditionDef)
+    val conditionF: () => Future[Boolean] = () => Future(conditionDef)
 
     awaitConditionF(conditionF, interval, maxTries)
   }
@@ -146,7 +145,7 @@ abstract class AsyncUtil extends BitcoinSLogger {
 
 object AsyncUtil extends AsyncUtil {
 
-  private[bitcoins] val scheduler = Executors.newScheduledThreadPool(2)
+  private[bitcoins] val scheduler = Executors.newScheduledThreadPool(1)
 
   /** The default interval between async attempts
     */

--- a/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
+++ b/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
@@ -145,7 +145,7 @@ abstract class AsyncUtil extends BitcoinSLogger {
 
 object AsyncUtil extends AsyncUtil {
 
-  private[bitcoins] val scheduler = Executors.newScheduledThreadPool(1)
+  private[bitcoins] val scheduler = Executors.newScheduledThreadPool(2)
 
   /** The default interval between async attempts
     */

--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,11 @@ lazy val asyncUtilsTest = crossProject(JVMPlatform, JSPlatform)
   .settings(name := "bitcoin-s-async-utils-test")
   .jvmSettings(CommonSettings.jvmSettings: _*)
   .jsSettings(commonJsSettings: _*)
-  .dependsOn(asyncUtils)
+  .dependsOn(asyncUtils, testkitCore)
+
+lazy val asyncUtilsTestJVM = asyncUtilsTest.jvm
+
+lazy val asyncUtilsTestJS = asyncUtilsTest.js
 
 lazy val testkitCore = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
@@ -134,6 +138,7 @@ lazy val eclairRpc = project
 
 lazy val jsProjects: Vector[ProjectReference] =
   Vector(asyncUtilsJS,
+         asyncUtilsTestJS,
          cryptoJS,
          coreJS,
          cryptoTestJS,

--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,15 @@ lazy val asyncUtilsJVM = asyncUtils.jvm
 
 lazy val asyncUtilsJS = asyncUtils.js
 
+lazy val asyncUtilsTest = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("async-utils-test"))
+  .settings(CommonSettings.testSettings: _*)
+  .settings(name := "bitcoin-s-async-utils-test")
+  .jvmSettings(CommonSettings.jvmSettings: _*)
+  .jsSettings(commonJsSettings: _*)
+  .dependsOn(asyncUtils)
+
 lazy val testkitCore = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .in(file("testkit-core"))


### PR DESCRIPTION
Adds `asyncUtilsTest` and adds test cases for expected behavior. 

One nasty thing that was uncovered on this was the use of `Future.successful()` with blocking code. 

https://github.com/bitcoin-s/bitcoin-s/compare/master...Christewart:2021-03-09-async-utils-tests?expand=1#diff-b2ba0b35ce52569a1f57b343f2975fd50cc20035c1356a861603005235351821R28

The way this behaves is to block the _calling thread_ until the the `condition` is completed. 

If the condition was defined as `Thread.sleep(1000)` or something like that, we would just block the calling thread for `1000 milliseconds`. I'm not sure if this is the root problem on CI, but it was not intended behavior. We want to have the blocking code run on separate thread so the calling thread can continue execution.