### PR TITLE
Fix DLCStatus JSON serialzation

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -351,14 +351,24 @@ object Picklers {
     )
   }
 
-  implicit val dlcStatusW: Writer[DLCStatus] = Writer.merge(offeredW,
-                                                            acceptedW,
-                                                            signedW,
-                                                            broadcastedW,
-                                                            confirmedW,
-                                                            claimedW,
-                                                            remoteClaimedW,
-                                                            refundedW)
+  implicit val dlcStatusW: Writer[DLCStatus] = writer[Value].comap {
+    case o: Offered =>
+      writeJs(o)(offeredW)
+    case a: Accepted =>
+      writeJs(a)(acceptedW)
+    case s: Signed =>
+      writeJs(s)(signedW)
+    case b: Broadcasted =>
+      writeJs(b)(broadcastedW)
+    case c: Confirmed =>
+      writeJs(c)(confirmedW)
+    case c: Claimed =>
+      writeJs(c)(claimedW)
+    case r: RemoteClaimed =>
+      writeJs(r)(remoteClaimedW)
+    case r: Refunded =>
+      writeJs(r)(refundedW)
+  }
 
   implicit val dlcStatusR: Reader[DLCStatus] = reader[Obj].map { obj =>
     val paramHash = Sha256DigestBE(obj("paramHash").str)

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCStatusTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCStatusTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.dlc
 
+import org.bitcoins.commons.serializers.Picklers
 import org.bitcoins.commons.serializers.Picklers._
 import org.bitcoins.core.protocol.dlc.DLCMessage._
 import org.bitcoins.testkit.core.gen.{CryptoGenerators, NumberGenerator, TLVGen}
@@ -29,6 +30,8 @@ class DLCStatusTest extends BitcoinSAsyncTest {
 
         assert(status.state == DLCState.Offered)
         assert(read[DLCStatus](write(status)) == status)
+        assert(read[DLCStatus](
+          write(status.asInstanceOf[DLCStatus])(Picklers.dlcStatusW)) == status)
     }
   }
 
@@ -56,6 +59,8 @@ class DLCStatusTest extends BitcoinSAsyncTest {
 
         assert(status.state == DLCState.Accepted)
         assert(read[DLCStatus](write(status)) == status)
+        assert(read[DLCStatus](
+          write(status.asInstanceOf[DLCStatus])(Picklers.dlcStatusW)) == status)
     }
   }
 
@@ -83,6 +88,8 @@ class DLCStatusTest extends BitcoinSAsyncTest {
 
         assert(status.state == DLCState.Signed)
         assert(read[DLCStatus](write(status)) == status)
+        assert(read[DLCStatus](
+          write(status.asInstanceOf[DLCStatus])(Picklers.dlcStatusW)) == status)
     }
   }
 
@@ -112,6 +119,8 @@ class DLCStatusTest extends BitcoinSAsyncTest {
 
         assert(status.state == DLCState.Broadcasted)
         assert(read[DLCStatus](write(status)) == status)
+        assert(read[DLCStatus](
+          write(status.asInstanceOf[DLCStatus])(Picklers.dlcStatusW)) == status)
     }
   }
 
@@ -141,6 +150,8 @@ class DLCStatusTest extends BitcoinSAsyncTest {
 
         assert(status.state == DLCState.Confirmed)
         assert(read[DLCStatus](write(status)) == status)
+        assert(read[DLCStatus](
+          write(status.asInstanceOf[DLCStatus])(Picklers.dlcStatusW)) == status)
     }
   }
 
@@ -180,6 +191,9 @@ class DLCStatusTest extends BitcoinSAsyncTest {
 
       assert(status.state == DLCState.Claimed)
       assert(read[DLCStatus](write(status)) == status)
+      assert(
+        read[DLCStatus](
+          write(status.asInstanceOf[DLCStatus])(Picklers.dlcStatusW)) == status)
     }
   }
 
@@ -219,6 +233,9 @@ class DLCStatusTest extends BitcoinSAsyncTest {
 
       assert(status.state == DLCState.RemoteClaimed)
       assert(read[DLCStatus](write(status)) == status)
+      assert(
+        read[DLCStatus](
+          write(status.asInstanceOf[DLCStatus])(Picklers.dlcStatusW)) == status)
     }
   }
 
@@ -251,6 +268,9 @@ class DLCStatusTest extends BitcoinSAsyncTest {
 
       assert(status.state == DLCState.Refunded)
       assert(read[DLCStatus](write(status)) == status)
+      assert(
+        read[DLCStatus](
+          write(status.asInstanceOf[DLCStatus])(Picklers.dlcStatusW)) == status)
     }
   }
 }


### PR DESCRIPTION
Fixes #2746

`Writer.merge` would call `asInstanceOf[TaggedWriter]` which would cause the error. This fixes it to use the correct writer