### PR TITLE
Bump timeout on bind to avoid spurious ci failures hopefully

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -25,7 +25,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     extends P2PLogger {
   private val socket = client.peer.socket
-  implicit private val timeout = Timeout(25.seconds)
+  implicit private val timeout = Timeout(30.seconds)
 
   /** Initiates a connection with the given peer */
   def connect(): Unit = {

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -30,7 +30,7 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
   /** Initiates a connection with the given peer */
   def connect(): Unit = {
     logger.info(s"Attempting to connect to peer=$socket")
-    (client.actor ! Tcp.Connect(socket))
+    (client.actor ! Tcp.Connect(socket, timeout = Some(timeout.duration)))
   }
 
   def isConnected()(implicit ec: ExecutionContext): Future[Boolean] = {

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -25,7 +25,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     extends P2PLogger {
   private val socket = client.peer.socket
-  implicit private val timeout = Timeout(10.seconds)
+  implicit private val timeout = Timeout(25.seconds)
 
   /** Initiates a connection with the given peer */
   def connect(): Unit = {


### PR DESCRIPTION
Bump the timeout acceptable for binding a TCP socket for the node project. This was timing out sometimes on CI

![Screenshot from 2021-03-11 07-36-01](https://user-images.githubusercontent.com/3514957/110795476-8111ad00-823c-11eb-83cd-ef5c270fc935.png)
