### PR TITLE
Implement caching of bitcoind in the walletTest,nodeTest, and partially bitcoindRpcTest project

### DIFF
--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -27,4 +27,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.5 downloadBitcoind downloadEclair coverage cryptoTestJVM/test coreTestJVM/test appCommonsTest/test bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls
+        run: sbt ++2.13.5 downloadBitcoind downloadEclair coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -25,4 +25,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.5 downloadBitcoind coverage walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcOracleTest/test asyncUtilsTestJVM/test dlcOracle/coverageReport dlcOracle/coveralls
+        run: sbt ++2.13.5 downloadBitcoind coverage cryptoTestJVM/test coreTestJVM/test appCommonsTest/test walletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcOracleTest/test asyncUtilsTestJVM/test dlcOracle/coverageReport dlcOracle/coveralls

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
@@ -40,19 +40,20 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
   /** Tests that the client can call the isStartedF method
     * without throwing and then start
     */
-  private def testClientStart(client: BitcoindRpcClient): Future[Assertion] = {
-    clientAccum += client
-    for {
-      firstStarted <- client.isStartedF
-      _ <- startClient(client)
-      secondStarted <- client.isStartedF
+  private def testClientStart(client: BitcoindRpcClient): Future[Assertion] =
+    synchronized {
+      clientAccum += client
+      for {
+        firstStarted <- client.isStartedF
+        _ <- startClient(client)
+        secondStarted <- client.isStartedF
 
-      _ <- client.getBalance
-    } yield {
-      assert(!firstStarted)
-      assert(secondStarted)
+        _ <- client.getBalance
+      } yield {
+        assert(!firstStarted)
+        assert(secondStarted)
+      }
     }
-  }
 
   behavior of "BitcoindInstance"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
@@ -7,15 +7,13 @@ import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedPairNewest,
   BitcoindRpcTestUtil
 }
-import org.bitcoins.testkit.util.{BitcoinSAsyncFixtureTest, FileUtil}
+import org.bitcoins.testkit.util.FileUtil
 import org.scalatest.{FutureOutcome, Outcome}
 
 import java.io.File
 import scala.concurrent.Future
 
-class TestRpcUtilTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesCachedPairNewest {
+class TestRpcUtilTest extends BitcoindFixturesCachedPairNewest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val outcomeF: Future[Outcome] = for {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
@@ -1,66 +1,49 @@
 package org.bitcoins.rpc
 
 import org.bitcoins.core.currency.Bitcoins
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.util.RpcUtil
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.{BitcoindRpcTest, FileUtil}
+import org.bitcoins.rpc.util.{NodeTriple, RpcUtil}
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesCachedTriple,
+  BitcoindRpcTestUtil
+}
+import org.bitcoins.testkit.util.{BitcoinSAsyncFixtureTest, FileUtil}
+import org.scalatest.{FutureOutcome, Outcome}
 
 import java.io.File
+import scala.concurrent.Future
 
-class TestRpcUtilTest extends BitcoindRpcTest {
+class TestRpcUtilTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCachedTriple {
 
-  private lazy val clientsF =
-    BitcoindRpcTestUtil.createNodeTriple(clientAccum = clientAccum)
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val outcomeF: Future[Outcome] = for {
+      clients <- clientsF
+      outcome = with3BitcoindsCached(test, clients)
+      fut <- outcome.toFuture
+    } yield fut
+
+    new FutureOutcome(outcomeF)
+  }
 
   behavior of "BitcoindRpcUtil"
 
   it should "create a temp bitcoin directory when creating a DaemonInstance, and then delete it" in {
-    val instance =
-      BitcoindRpcTestUtil.instance(RpcUtil.randomPort, RpcUtil.randomPort)
-    val dir = instance.datadir
-    assert(dir.isDirectory)
-    assert(dir.getPath().startsWith(scala.util.Properties.tmpDir))
-    assert(
-      dir.listFiles.contains(new File(dir.getAbsolutePath + "/bitcoin.conf")))
-    FileUtil.deleteTmpDir(dir)
-    assert(!dir.exists)
+    case _ =>
+      val instance =
+        BitcoindRpcTestUtil.instance(RpcUtil.randomPort, RpcUtil.randomPort)
+      val dir = instance.datadir
+      assert(dir.isDirectory)
+      assert(dir.getPath().startsWith(scala.util.Properties.tmpDir))
+      assert(
+        dir.listFiles.contains(new File(dir.getAbsolutePath + "/bitcoin.conf")))
+      FileUtil.deleteTmpDir(dir)
+      assert(!dir.exists)
   }
 
-  it should "be able to create a single node, wait for it to start and then delete it" in {
-    val instance = BitcoindRpcTestUtil.instance()
-    val client = BitcoindRpcClient.withActorSystem(instance)
-    val startedF = client.start()
-
-    startedF.map { _ =>
-      client.stop()
-      succeed
-    }
-  }
-
-  it should "be able to create a connected node pair with more than 100 blocks and then delete them" in {
+  it should "be able to generate and sync blocks" in { case nodes: NodeTriple =>
+    val Vector(first, second, third) = nodes.toVector
     for {
-      (client1, client2) <- BitcoindRpcTestUtil.createNodePair()
-      _ = assert(client1.getDaemon.datadir.isDirectory)
-      _ = assert(client2.getDaemon.datadir.isDirectory)
-
-      nodes <- client1.getAddedNodeInfo(client2.getDaemon.uri)
-      _ = assert(nodes.nonEmpty)
-
-      count1 <- client1.getBlockCount
-      count2 <- client2.getBlockCount
-      _ = assert(count1 > 100)
-      _ = assert(count2 > 100)
-      _ <- BitcoindRpcTestUtil.deleteNodePair(client1, client2)
-    } yield {
-      assert(!client1.getDaemon.datadir.exists)
-      assert(!client2.getDaemon.datadir.exists)
-    }
-  }
-
-  it should "be able to generate and sync blocks" in {
-    for {
-      (first, second, third) <- clientsF
       address <- second.getNewAddress
       txid <- first.sendToAddress(address, Bitcoins.one)
       _ <- BitcoindRpcTestUtil.generateAndSync(Vector(first, second, third))
@@ -74,37 +57,38 @@ class TestRpcUtilTest extends BitcoindRpcTest {
   }
 
   it should "ble able to generate blocks with multiple clients and sync inbetween" in {
-    val blocksToGenerate = 10
-
-    for {
-      (first, second, third) <- clientsF
-      allClients = Vector(first, second, third)
-      heightPreGeneration <- first.getBlockCount
-      _ <- BitcoindRpcTestUtil.generateAllAndSync(allClients,
-                                                  blocks = blocksToGenerate)
-      firstHash <- first.getBestBlockHash
-      secondHash <- second.getBestBlockHash
-      heightPostGeneration <- first.getBlockCount
-    } yield {
-      assert(firstHash == secondHash)
-      assert(
-        heightPostGeneration - heightPreGeneration == blocksToGenerate * allClients.length)
-    }
+    case nodes: NodeTriple =>
+      val blocksToGenerate = 10
+      val Vector(first, second, _) = nodes.toVector
+      val allClients = nodes.toVector
+      for {
+        heightPreGeneration <- first.getBlockCount
+        _ <- BitcoindRpcTestUtil.generateAllAndSync(allClients,
+                                                    blocks = blocksToGenerate)
+        firstHash <- first.getBestBlockHash
+        secondHash <- second.getBestBlockHash
+        heightPostGeneration <- first.getBlockCount
+      } yield {
+        assert(firstHash == secondHash)
+        assert(
+          heightPostGeneration - heightPreGeneration == blocksToGenerate * allClients.length)
+      }
   }
 
   it should "be able to find outputs of previous transactions" in {
-    for {
-      (first, second, _) <- clientsF
-      address <- second.getNewAddress
-      txid <- first.sendToAddress(address, Bitcoins.one)
-      hashes <- BitcoindRpcTestUtil.generateAndSync(Vector(first, second))
-      vout <- BitcoindRpcTestUtil.findOutput(first,
-                                             txid,
-                                             Bitcoins.one,
-                                             Some(hashes.head))
-      tx <- first.getRawTransaction(txid, Some(hashes.head))
-    } yield {
-      assert(tx.vout(vout.toInt).value == Bitcoins.one)
-    }
+    case nodes: NodeTriple =>
+      val Vector(first, second, _) = nodes.toVector
+      for {
+        address <- second.getNewAddress
+        txid <- first.sendToAddress(address, Bitcoins.one)
+        hashes <- BitcoindRpcTestUtil.generateAndSync(Vector(first, second))
+        vout <- BitcoindRpcTestUtil.findOutput(first,
+                                               txid,
+                                               Bitcoins.one,
+                                               Some(hashes.head))
+        tx <- first.getRawTransaction(txid, Some(hashes.head))
+      } yield {
+        assert(tx.vout(vout.toInt).value == Bitcoins.one)
+      }
   }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.rpc
 
 import org.bitcoins.core.currency.Bitcoins
+
 import org.bitcoins.rpc.util.{NodeTriple, RpcUtil}
 import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedTriple,
@@ -16,6 +17,8 @@ class TestRpcUtilTest
     extends BitcoinSAsyncFixtureTest
     with BitcoindFixturesCachedTriple {
 
+  override type FixtureParam = NodeTriple
+
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val outcomeF: Future[Outcome] = for {
       clients <- clientsF
@@ -29,7 +32,7 @@ class TestRpcUtilTest
   behavior of "BitcoindRpcUtil"
 
   it should "create a temp bitcoin directory when creating a DaemonInstance, and then delete it" in {
-    case _ =>
+    _: NodeTriple =>
       val instance =
         BitcoindRpcTestUtil.instance(RpcUtil.randomPort, RpcUtil.randomPort)
       val dir = instance.datadir
@@ -41,8 +44,8 @@ class TestRpcUtilTest
       assert(!dir.exists)
   }
 
-  it should "be able to generate and sync blocks" in { case nodes: NodeTriple =>
-    val Vector(first, second, third) = nodes.toVector
+  it should "be able to generate and sync blocks" in { nodes: NodeTriple =>
+    val NodeTriple(first, second, third) = nodes
     for {
       address <- second.getNewAddress
       txid <- first.sendToAddress(address, Bitcoins.one)
@@ -57,9 +60,9 @@ class TestRpcUtilTest
   }
 
   it should "ble able to generate blocks with multiple clients and sync inbetween" in {
-    case nodes: NodeTriple =>
+    nodes: NodeTriple =>
       val blocksToGenerate = 10
-      val Vector(first, second, _) = nodes.toVector
+      val NodeTriple(first, second, _) = nodes
       val allClients = nodes.toVector
       for {
         heightPreGeneration <- first.getBlockCount
@@ -76,8 +79,8 @@ class TestRpcUtilTest
   }
 
   it should "be able to find outputs of previous transactions" in {
-    case nodes: NodeTriple =>
-      val Vector(first, second, _) = nodes.toVector
+    nodes: NodeTriple =>
+      val NodeTriple(first, second, _) = nodes
       for {
         address <- second.getNewAddress
         txid <- first.sendToAddress(address, Bitcoins.one)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.rpc.common
 
 import java.io.File
-
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script.ScriptSignature
@@ -11,18 +10,34 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.rpc.BitcoindException
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.common.BitcoindVersion.V18
 import org.bitcoins.rpc.config.BitcoindInstance
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.rpc.util.NodePair
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesCachedPair,
+  BitcoindRpcTestUtil
+}
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
+import org.scalatest.{FutureOutcome, Outcome}
 
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
 
-class MempoolRpcTest extends BitcoindRpcTest {
+class MempoolRpcTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCachedPair {
+  override def version: BitcoindVersion = BitcoindVersion.V21
 
-  lazy val clientsF: Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodePairV18(clientAccum = clientAccum)
+  override type FixtureParam = NodePair
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val futOutcome: Future[Outcome] = for {
+      nodePair <- clientsF
+      futOutcome = with2BitcoindsCached(test, nodePair)
+      f <- futOutcome.toFuture
+    } yield f
+    new FutureOutcome(futOutcome)
+  }
 
   lazy val clientWithoutBroadcastF: Future[BitcoindRpcClient] = {
     val defaultConfig = BitcoindRpcTestUtil.standardConfig
@@ -40,11 +55,9 @@ class MempoolRpcTest extends BitcoindRpcTest {
 
     val clientWithoutBroadcastF = clientWithoutBroadcast.start()
     for {
-      (client, otherClient) <- clientsF
+      nodePair <- clientsF
+      (client, otherClient) = (nodePair.node1, nodePair.node2)
       clientWithoutBroadcast <- clientWithoutBroadcastF
-      _ = {
-        clientAccum += clientWithoutBroadcast
-      }
       pairs = Vector(client -> clientWithoutBroadcast,
                      otherClient -> clientWithoutBroadcast)
       _ <- BitcoindRpcTestUtil.connectPairs(pairs)
@@ -58,43 +71,49 @@ class MempoolRpcTest extends BitcoindRpcTest {
   behavior of "MempoolRpc"
 
   it should "be able to find a transaction sent to the mem pool" in {
-    for {
-      (client, otherClient) <- clientsF
-      transaction <-
-        BitcoindRpcTestUtil.sendCoinbaseTransaction(client, otherClient)
-      mempool <- client.getRawMemPool
-    } yield {
-      assert(mempool.length == 1)
-      assert(mempool.head == transaction.txid)
-    }
+    nodePair: NodePair =>
+      val client = nodePair.node1
+      val otherClient = nodePair.node2
+      for {
+        transaction <-
+          BitcoindRpcTestUtil.sendCoinbaseTransaction(client, otherClient)
+        mempool <- client.getRawMemPool
+      } yield {
+        assert(mempool.length == 1)
+        assert(mempool.head == transaction.txid)
+      }
   }
 
   it should "be able to find a verbose transaction in the mem pool" in {
-    for {
-      (client, otherClient) <- clientsF
-      transaction <-
-        BitcoindRpcTestUtil.sendCoinbaseTransaction(client, otherClient)
-      mempool <- client.getRawMemPoolWithTransactions
-    } yield {
-      val txid = mempool.keySet.head
-      assert(txid == transaction.txid)
-      assert(mempool(txid).size > 0)
-    }
+    nodePair: NodePair =>
+      val client = nodePair.node1
+      val otherClient = nodePair.node2
+      for {
+        transaction <-
+          BitcoindRpcTestUtil.sendCoinbaseTransaction(client, otherClient)
+        mempool <- client.getRawMemPoolWithTransactions
+      } yield {
+        val txid = mempool.keySet.head
+        assert(txid == transaction.txid)
+        assert(mempool(txid).size > 0)
+      }
   }
 
-  it should "be able to find a mem pool entry" in {
+  it should "be able to find a mem pool entry" in { nodePair: NodePair =>
+    val client = nodePair.node1
+    val otherClient = nodePair.node2
     for {
-      (client, otherClient) <- clientsF
       transaction <-
         BitcoindRpcTestUtil.sendCoinbaseTransaction(client, otherClient)
       _ <- client.getMemPoolEntry(transaction.txid)
     } yield succeed
   }
 
-  it must "fail to find a mempool entry" in {
+  it must "fail to find a mempool entry" in { nodePair: NodePair =>
+    val client = nodePair.node1
+    val txid = DoubleSha256Digest.empty
     val resultF = for {
-      (client, _) <- clientsF
-      txid = DoubleSha256Digest.empty
+
       result <- client.getMemPoolEntry(txid)
     } yield {
       result
@@ -104,18 +123,20 @@ class MempoolRpcTest extends BitcoindRpcTest {
   }
 
   it must "fail to find a mempool entry and return None" in {
-    val resultF = for {
-      (client, _) <- clientsF
-      txid = DoubleSha256Digest.empty
-      result <- client.getMemPoolEntryOpt(txid)
-    } yield {
-      assert(result.isEmpty)
-    }
-    resultF
+    nodePair: NodePair =>
+      val client = nodePair.node1
+      val txid = DoubleSha256Digest.empty
+      val resultF = for {
+        result <- client.getMemPoolEntryOpt(txid)
+      } yield {
+        assert(result.isEmpty)
+      }
+      resultF
   }
-  it should "be able to get mem pool info" in {
+  it should "be able to get mem pool info" in { nodePair: NodePair =>
+    val client = nodePair.node1
+    val otherClient = nodePair.node2
     for {
-      (client, otherClient) <- clientsF
       _ <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
       info <- client.getMemPoolInfo
       _ <-
@@ -129,72 +150,75 @@ class MempoolRpcTest extends BitcoindRpcTest {
   }
 
   it should "be able to prioritise a mem pool transaction" in {
-    for {
-      (client, otherClient) <- clientsF
-      address <- otherClient.getNewAddress
-      txid <-
-        BitcoindRpcTestUtil
-          .fundMemPoolTransaction(client, address, Bitcoins(3.2))
-      entry <- client.getMemPoolEntry(txid)
-      tt <- client.prioritiseTransaction(txid, Bitcoins(1).satoshis)
-      newEntry <- client.getMemPoolEntry(txid)
-    } yield {
-      assert(entry.fee == entry.modifiedfee)
-      assert(tt)
-      assert(newEntry.fee == entry.fee)
-      assert(newEntry.modifiedfee == newEntry.fee + Bitcoins(1))
-    }
+    nodePair: NodePair =>
+      val client = nodePair.node1
+      val otherClient = nodePair.node2
+      for {
+        address <- otherClient.getNewAddress
+        txid <-
+          BitcoindRpcTestUtil
+            .fundMemPoolTransaction(client, address, Bitcoins(3.2))
+        entry <- client.getMemPoolEntry(txid)
+        tt <- client.prioritiseTransaction(txid, Bitcoins(1).satoshis)
+        newEntry <- client.getMemPoolEntry(txid)
+      } yield {
+        assert(entry.fee == entry.modifiedfee)
+        assert(tt)
+        assert(newEntry.fee == entry.fee)
+        assert(newEntry.modifiedfee == newEntry.fee + Bitcoins(1))
+      }
   }
 
   it should "be able to find mem pool ancestors and descendants" in {
-    for {
-      (client, _) <- clientsF
-      _ <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
-      address1 <- client.getNewAddress
-      txid1 <- BitcoindRpcTestUtil.fundMemPoolTransaction(client,
-                                                          address1,
-                                                          Bitcoins(2))
-      mempool <- client.getRawMemPool
-      address2 <- client.getNewAddress
+    nodePair: NodePair =>
+      val client = nodePair.node1
+      for {
+        _ <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
+        address1 <- client.getNewAddress
+        txid1 <- BitcoindRpcTestUtil.fundMemPoolTransaction(client,
+                                                            address1,
+                                                            Bitcoins(2))
+        mempool <- client.getRawMemPool
+        address2 <- client.getNewAddress
 
-      createdTx <- {
-        val input: TransactionInput =
-          TransactionInput(TransactionOutPoint(txid1.flip, UInt32.zero),
-                           ScriptSignature.empty,
-                           UInt32.max - UInt32.one)
-        client
-          .createRawTransaction(Vector(input), Map(address2 -> Bitcoins.one))
+        createdTx <- {
+          val input: TransactionInput =
+            TransactionInput(TransactionOutPoint(txid1.flip, UInt32.zero),
+                             ScriptSignature.empty,
+                             UInt32.max - UInt32.one)
+          client
+            .createRawTransaction(Vector(input), Map(address2 -> Bitcoins.one))
+        }
+        signedTx <- BitcoindRpcTestUtil.signRawTransaction(client, createdTx)
+        txid2 <- client.sendRawTransaction(signedTx.hex, maxfeerate = 0)
+
+        descendantsTxid1 <- client.getMemPoolDescendants(txid1)
+        verboseDescendantsTxid1 <- client.getMemPoolDescendantsVerbose(txid1)
+        _ = {
+          assert(descendantsTxid1.head == txid2)
+          val (txid, mempoolresults) = verboseDescendantsTxid1.head
+          assert(txid == txid2)
+          assert(mempoolresults.ancestorcount == 2)
+        }
+
+        ancestorsTxid2 <- client.getMemPoolAncestors(txid2)
+        verboseAncestorsTxid2 <- client.getMemPoolAncestorsVerbose(txid2)
+        _ = {
+          assert(ancestorsTxid2.head == txid1)
+          val (txid, mempoolresults) = verboseAncestorsTxid2.head
+          assert(txid == txid1)
+          assert(mempoolresults.descendantcount == 2)
+        }
+
+      } yield {
+        assert(mempool.head == txid1)
+        assert(signedTx.complete)
       }
-      signedTx <- BitcoindRpcTestUtil.signRawTransaction(client, createdTx)
-      txid2 <- client.sendRawTransaction(signedTx.hex, maxfeerate = 0)
-
-      descendantsTxid1 <- client.getMemPoolDescendants(txid1)
-      verboseDescendantsTxid1 <- client.getMemPoolDescendantsVerbose(txid1)
-      _ = {
-        assert(descendantsTxid1.head == txid2)
-        val (txid, mempoolresults) = verboseDescendantsTxid1.head
-        assert(txid == txid2)
-        assert(mempoolresults.ancestorcount == 2)
-      }
-
-      ancestorsTxid2 <- client.getMemPoolAncestors(txid2)
-      verboseAncestorsTxid2 <- client.getMemPoolAncestorsVerbose(txid2)
-      _ = {
-        assert(ancestorsTxid2.head == txid1)
-        val (txid, mempoolresults) = verboseAncestorsTxid2.head
-        assert(txid == txid1)
-        assert(mempoolresults.descendantcount == 2)
-      }
-
-    } yield {
-      assert(mempool.head == txid1)
-      assert(signedTx.complete)
-    }
   }
 
-  it should "be able to abandon a transaction" in {
+  it should "be able to abandon a transaction" in { nodePair: NodePair =>
+    val otherClient = nodePair.node2
     for {
-      (_, otherClient) <- clientsF
       clientWithoutBroadcast <- clientWithoutBroadcastF
       recipient <- otherClient.getNewAddress
       txid <- clientWithoutBroadcast.sendToAddress(recipient, Bitcoins(1))
@@ -203,17 +227,21 @@ class MempoolRpcTest extends BitcoindRpcTest {
     } yield assert(maybeAbandoned.details.head.abandoned.contains(true))
   }
 
-  it should "be able to save the mem pool to disk" in {
+  it should "be able to save the mem pool to disk" in { nodePair: NodePair =>
+    val client = nodePair.node1
+    val regTest =
+      new File(client.getDaemon.datadir.getAbsolutePath + "/regtest")
+    assert(regTest.isDirectory)
+    assert(!regTest.list().contains("mempool.dat"))
     for {
-      (client, _) <- clientsF
-      regTest = {
-        val regTest =
-          new File(client.getDaemon.datadir.getAbsolutePath + "/regtest")
-        assert(regTest.isDirectory)
-        assert(!regTest.list().contains("mempool.dat"))
-        regTest
-      }
       _ <- client.saveMemPool()
     } yield assert(regTest.list().contains("mempool.dat"))
+  }
+
+  override def afterAll(): Unit = {
+    val stoppedF =
+      clientWithoutBroadcastF.flatMap(BitcoindRpcTestUtil.stopServer(_))
+    Await.result(stoppedF, duration)
+    super.afterAll()
   }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
@@ -13,15 +13,12 @@ import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedPairNewest,
   BitcoindRpcTestUtil
 }
-import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 import org.scalatest.{FutureOutcome, Outcome}
 
 import java.io.File
 import scala.concurrent.Future
 
-class MempoolRpcTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesCachedPairNewest {
+class MempoolRpcTest extends BitcoindFixturesCachedPairNewest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val futOutcome: Future[Outcome] = for {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
@@ -9,8 +9,7 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.rpc.BitcoindException
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.client.common.BitcoindVersion.V18
+import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.config.BitcoindInstance
 import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedPairNewest,
@@ -43,8 +42,9 @@ class MempoolRpcTest
         .withOption("walletbroadcast", 0.toString)
 
     val instanceWithoutBroadcast =
-      BitcoindInstance.fromConfig(configNoBroadcast,
-                                  BitcoindRpcTestUtil.getBinary(V18))
+      BitcoindInstance.fromConfig(
+        configNoBroadcast,
+        BitcoindRpcTestUtil.getBinary(BitcoindVersion.newest))
 
     val clientWithoutBroadcast =
       BitcoindRpcClient.withActorSystem(instanceWithoutBroadcast)
@@ -54,6 +54,7 @@ class MempoolRpcTest
       nodePair <- clientsF
       (client, otherClient) = (nodePair.node1, nodePair.node2)
       clientWithoutBroadcast <- clientWithoutBroadcastF
+      _ <- clientWithoutBroadcast.createWallet("")
       pairs = Vector(client -> clientWithoutBroadcast,
                      otherClient -> clientWithoutBroadcast)
       _ <- BitcoindRpcTestUtil.connectPairs(pairs)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MessageRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MessageRpcTest.scala
@@ -12,10 +12,8 @@ import scala.concurrent.Future
 class MessageRpcTest extends BitcoindRpcTest {
 
   val clientF: Future[BitcoindRpcClient] =
-    BitcoindRpcTestUtil.startedBitcoindRpcClient().map { client =>
-      clientAccum += client
-      client
-    }
+    BitcoindRpcTestUtil
+      .startedBitcoindRpcClient(clientAccum = clientAccum)
 
   behavior of "MessageRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
@@ -102,7 +102,7 @@ class MultiWalletRpcTest
       balance <- walletClient.getBalance(walletName)
     } yield {
       // Has one mature coinbase
-      assert(balance == Bitcoins(12.5))
+      assert(balance == Bitcoins(25))
     }
   }
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
@@ -1,7 +1,5 @@
 package org.bitcoins.rpc.common
 
-import java.io.File
-import java.util.Scanner
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.AddressType
 import org.bitcoins.core.crypto.ECPrivateKeyUtil
@@ -14,174 +12,176 @@ import org.bitcoins.crypto.{ECPrivateKey, ECPublicKey}
 import org.bitcoins.rpc._
 import org.bitcoins.rpc.client.common._
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
-import org.bitcoins.rpc.util.RpcUtil
+import org.bitcoins.rpc.util.{NodePair, RpcUtil}
 import org.bitcoins.testkit.rpc.{
-  BitcoindFixturesFundedCached,
-  BitcoindRpcTestUtil,
-  CachedBitcoindV19
+  BitcoindFixturesCachedPair,
+  BitcoindRpcTestUtil
 }
 import org.bitcoins.testkit.util.{AkkaUtil, BitcoinSAsyncFixtureTest}
+import org.scalatest.{FutureOutcome, Outcome}
 
-import scala.concurrent.{Await, Future}
+import java.io.File
+import java.util.Scanner
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 /** These tests are all copied over from WalletRpcTest and changed to be for multi-wallet */
 class MultiWalletRpcTest
     extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesFundedCached
-    with CachedBitcoindV19 {
-
+    with BitcoindFixturesCachedPair[BitcoindV19RpcClient] {
+  override val version = BitcoindVersion.V19
+  override type FixtureParam = NodePair[BitcoindV19RpcClient]
   val walletName = "other"
 
   var password = "password"
 
-  override type FixtureParam = BitcoindV19RpcClient
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedSetupClientsF
+      futOutcome = with2BitcoindsCached(test, bitcoind)
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
 
-  lazy val walletClientF: Future[BitcoindRpcClient] =
-    cachedBitcoindWithFundsF.flatMap { client =>
-      val walletClient =
-        BitcoindRpcClient.withActorSystem(BitcoindRpcTestUtil.instance())
+  private val cachedSetupClientsF: Future[NodePair[BitcoindV19RpcClient]] = {
+    clientsF.flatMap(setupWalletClient)
+  }
 
-      for {
-        _ <- startClient(walletClient)
-        _ <- walletClient.createWallet(walletName)
-        _ <- walletClient.encryptWallet(password, Some(walletName))
-        _ <-
-          walletClient
-            .getNewAddress(Some(walletName))
-            .flatMap(walletClient.generateToAddress(101, _))
-        _ <- client.createWallet(walletName)
+  /** We need to test bitcoin core's wallet specific features, so we need to set that up */
+  private def setupWalletClient(pair: NodePair[BitcoindV19RpcClient]): Future[
+    NodePair[BitcoindV19RpcClient]] = {
+    val NodePair(client: BitcoindV19RpcClient,
+                 walletClient: BitcoindV19RpcClient) = pair
+    for {
+      _ <- walletClient.createWallet(walletName)
+      _ <- walletClient.encryptWallet(password, Some(walletName))
+      _ <-
+        walletClient
+          .getNewAddress(Some(walletName))
+          .flatMap(walletClient.generateToAddress(101, _))
+      _ <- client.createWallet(walletName)
 
-        // Restart so wallet is encrypted
-        _ <- walletClient.stop()
-        _ <- RpcUtil.awaitServerShutdown(walletClient)
-        // Very rarely we are prevented from starting the client again because Core
-        // hasn't released its locks on the datadir. This is prevent that.
-        _ <- AkkaUtil.nonBlockingSleep(1.second)
-        _ <- walletClient.start()
-        _ <- walletClient.loadWallet(walletName)
+      // Restart so wallet is encrypted
+      _ <- walletClient.stop()
+      _ <- RpcUtil.awaitServerShutdown(walletClient)
+      // Very rarely we are prevented from starting the client again because Core
+      // hasn't released its locks on the datadir. This is prevent that.
+      _ <- AkkaUtil.nonBlockingSleep(1.second)
+      started <- walletClient.start()
+      _ <- walletClient.loadWallet(walletName)
 
-        wallets <- walletClient.listWallets
-        wallets2 <- client.listWallets
-        _ = require(wallets.size == 2)
-        _ = require(wallets2.size == 2)
-      } yield walletClient
-    }
+      wallets <- walletClient.listWallets
+      wallets2 <- client.listWallets
+      _ = require(wallets.size == 2)
+      _ = require(wallets2.size == 2)
+    } yield NodePair[BitcoindV19RpcClient](
+      client,
+      started.asInstanceOf[BitcoindV19RpcClient])
+  }
 
   behavior of "WalletRpc"
 
-  it must "setup correctly" in { _: BitcoindV19RpcClient =>
+  it must "setup correctly" in { nodePair =>
+    val walletClient = nodePair.node2
     for {
-      walletClient <- walletClientF
       wallets <- walletClient.listWallets
     } yield assert(wallets.size == 2)
   }
 
-  it must "fail when no wallet is set" in { _: BitcoindV19RpcClient =>
+  it must "fail when no wallet is set" in { nodePair =>
+    val walletClient = nodePair.node2
     recoverToSucceededIf[BitcoindWalletException](for {
-      walletClient <- walletClientF
       _ <- walletClient.getBalance
     } yield ())
   }
 
-  it must "get balance" in { _: BitcoindV19RpcClient =>
+  it must "get balance" in { nodePair =>
+    val walletClient = nodePair.node2
     for {
-      walletClient <- walletClientF
       balance <- walletClient.getBalance(walletName)
     } yield {
       // Has one mature coinbase
-      assert(balance == Bitcoins(50))
+      assert(balance == Bitcoins(12.5))
     }
   }
 
-  it should "be able to backup the wallet" in { _: BitcoindV19RpcClient =>
+  it should "be able to backup the wallet" in { nodePair =>
+    val walletClient = nodePair.node2
+    val datadir = walletClient.getDaemon.datadir.getAbsolutePath
     for {
-      client <- walletClientF
-      _ <- {
-        val datadir = client.getDaemon.datadir.getAbsolutePath
-        client.backupWallet(datadir + "/backup.dat", Some(walletName))
-      }
+      _ <- walletClient.backupWallet(datadir + "/backup.dat", Some(walletName))
     } yield {
-      val datadir = client.getDaemon.datadir.getAbsolutePath
       val file = new File(datadir + "/backup.dat")
       assert(file.exists)
       assert(file.isFile)
     }
   }
 
-  it should "be able to lock and unlock the wallet" in {
-    _: BitcoindV19RpcClient =>
-      for {
-        walletClient <- walletClientF
-        _ <- walletClient.walletLock(walletName)
-        _ <- walletClient.walletPassphrase(password, 1000, Some(walletName))
+  it should "be able to lock and unlock the wallet" in { nodePair =>
+    val walletClient = nodePair.node2
+    for {
+      _ <- walletClient.walletLock(walletName)
+      _ <- walletClient.walletPassphrase(password, 1000, Some(walletName))
 
-        info <- walletClient.getWalletInfo(walletName)
-        _ = assert(info.unlocked_until.nonEmpty)
-        _ = assert(info.unlocked_until.get > 0)
+      info <- walletClient.getWalletInfo(walletName)
+      _ = assert(info.unlocked_until.nonEmpty)
+      _ = assert(info.unlocked_until.get > 0)
 
-        _ <- walletClient.walletLock(walletName)
+      _ <- walletClient.walletLock(walletName)
 
-        newInfo <- walletClient.getWalletInfo(walletName)
-      } yield assert(newInfo.unlocked_until.contains(0))
+      newInfo <- walletClient.getWalletInfo(walletName)
+    } yield assert(newInfo.unlocked_until.contains(0))
   }
 
-  it should "be able to get an address from bitcoind" in {
-    _: BitcoindV19RpcClient =>
-      for {
-        client <- walletClientF
-        _ <- {
-          val addrFuts =
-            List(
-              client.getNewAddress("bech32", AddressType.Bech32, walletName),
-              client.getNewAddress("p2sh", AddressType.P2SHSegwit, walletName),
-              client.getNewAddress("legacy", AddressType.Legacy, walletName)
-            )
-          Future.sequence(addrFuts)
-        }
-      } yield succeed
+  it should "be able to get an address from bitcoind" in { nodePair =>
+    val client = nodePair.node2
+    val addrFuts =
+      List(
+        client.getNewAddress("bech32", AddressType.Bech32, walletName),
+        client.getNewAddress("p2sh", AddressType.P2SHSegwit, walletName),
+        client.getNewAddress("legacy", AddressType.Legacy, walletName)
+      )
+    Future
+      .sequence(addrFuts)
+      .map(_ => succeed)
   }
 
-  it should "be able to get a new raw change address" in {
-    _: BitcoindV19RpcClient =>
-      for {
-        client <- walletClientF
-        _ <- {
-          val addrFuts =
-            List(
-              client.getRawChangeAddress(walletName),
-              client.getRawChangeAddress(AddressType.Bech32, walletName),
-              client.getRawChangeAddress(AddressType.P2SHSegwit, walletName),
-              client.getRawChangeAddress(AddressType.Legacy, walletName)
-            )
-          Future.sequence(addrFuts)
-        }
-      } yield succeed
+  it should "be able to get a new raw change address" in { nodePair =>
+    val client = nodePair.node2
+    val addrFuts =
+      List(
+        client.getRawChangeAddress(walletName),
+        client.getRawChangeAddress(AddressType.Bech32, walletName),
+        client.getRawChangeAddress(AddressType.P2SHSegwit, walletName),
+        client.getRawChangeAddress(AddressType.Legacy, walletName)
+      )
+
+    Future.sequence(addrFuts).map(_ => succeed)
   }
 
   it should "be able to get the amount recieved by some address" in {
-    _: BitcoindV19RpcClient =>
+    nodePair =>
+      val client = nodePair.node2
       for {
-        client <- walletClientF
         address <- client.getNewAddress(Some(walletName))
         amount <-
           client.getReceivedByAddress(address, walletNameOpt = Some(walletName))
       } yield assert(amount == Bitcoins(0))
   }
 
-  it should "be able to get the unconfirmed balance" in {
-    _: BitcoindV19RpcClient =>
-      for {
-        client <- walletClientF
-        balance <- client.getUnconfirmedBalance(walletName)
-      } yield {
-        assert(balance == Bitcoins(0))
-      }
+  it should "be able to get the unconfirmed balance" in { nodePair =>
+    val client = nodePair.node2
+    for {
+      balance <- client.getUnconfirmedBalance(walletName)
+    } yield {
+      assert(balance == Bitcoins(0))
+    }
   }
 
-  it should "be able to get the wallet info" in { _: BitcoindV19RpcClient =>
+  it should "be able to get the wallet info" in { nodePair =>
+    val client = nodePair.node2
     for {
-      client <- walletClientF
       info <- client.getWalletInfo(walletName)
     } yield {
       assert(info.balance.toBigDecimal > 0)
@@ -191,9 +191,9 @@ class MultiWalletRpcTest
     }
   }
 
-  it should "be able to refill the keypool" in { _: BitcoindV19RpcClient =>
+  it should "be able to refill the keypool" in { nodePair =>
+    val client = nodePair.node2
     for {
-      client <- walletClientF
       _ <- client.walletPassphrase(password, 1000, Some(walletName))
       info <- client.getWalletInfo(walletName)
       _ <- client.keyPoolRefill(info.keypoolsize + 1, Some(walletName))
@@ -201,71 +201,68 @@ class MultiWalletRpcTest
     } yield assert(newInfo.keypoolsize == info.keypoolsize + 1)
   }
 
-  it should "be able to change the wallet password" in {
-    _: BitcoindV19RpcClient =>
-      val newPass = "new_password"
+  it should "be able to change the wallet password" in { nodePair =>
+    val walletClient = nodePair.node2
+    val newPass = "new_password"
 
-      for {
-        walletClient <- walletClientF
-        _ <- walletClient.walletLock(walletName)
-        _ <-
-          walletClient.walletPassphraseChange(password,
-                                              newPass,
-                                              Some(walletName))
-        _ = password = newPass
-
-        _ <- walletClient.walletPassphrase(password, 1000, Some(walletName))
-        info <- walletClient.getWalletInfo(walletName)
-        _ <- walletClient.walletLock(walletName)
-        newInfo <- walletClient.getWalletInfo(walletName)
-      } yield {
-
-        assert(info.unlocked_until.nonEmpty)
-        assert(info.unlocked_until.get > 0)
-        assert(newInfo.unlocked_until.contains(0))
-      }
-  }
-
-  it should "be able to send to an address" in {
-    otherClient: BitcoindV19RpcClient =>
-      for {
-        client <- walletClientF
-        address <- otherClient.getNewAddress(Some(walletName))
-        _ <- client.walletPassphrase(password, 1000, Some(walletName))
-        txid <- client.sendToAddress(address,
-                                     Bitcoins(1),
-                                     walletNameOpt = Some(walletName))
-        transaction <-
-          client.getTransaction(txid, walletNameOpt = Some(walletName))
-      } yield {
-        assert(transaction.amount == Bitcoins(-1))
-        assert(transaction.details.head.address.contains(address))
-      }
-  }
-
-  it should "be able to send btc to many addresses" in {
-    otherClient: BitcoindV19RpcClient =>
-      for {
-        client <- walletClientF
-        address1 <- otherClient.getNewAddress(Some(walletName))
-        address2 <- otherClient.getNewAddress(Some(walletName))
-        _ <- client.walletPassphrase(password, 1000, Some(walletName))
-        txid <-
-          client
-            .sendMany(Map(address1 -> Bitcoins(1), address2 -> Bitcoins(2)),
-                      walletNameOpt = Some(walletName))
-        transaction <-
-          client.getTransaction(txid, walletNameOpt = Some(walletName))
-      } yield {
-        assert(transaction.amount == Bitcoins(-3))
-        assert(transaction.details.exists(_.address.contains(address1)))
-        assert(transaction.details.exists(_.address.contains(address2)))
-      }
-  }
-
-  it should "be able to get the balance" in { _: BitcoindV19RpcClient =>
     for {
-      client <- walletClientF
+      _ <- walletClient.walletLock(walletName)
+      _ <-
+        walletClient.walletPassphraseChange(password, newPass, Some(walletName))
+      _ = password = newPass
+
+      _ <- walletClient.walletPassphrase(password, 1000, Some(walletName))
+      info <- walletClient.getWalletInfo(walletName)
+      _ <- walletClient.walletLock(walletName)
+      newInfo <- walletClient.getWalletInfo(walletName)
+    } yield {
+
+      assert(info.unlocked_until.nonEmpty)
+      assert(info.unlocked_until.get > 0)
+      assert(newInfo.unlocked_until.contains(0))
+    }
+  }
+
+  it should "be able to send to an address" in { nodePair =>
+    val otherClient = nodePair.node1
+    val client = nodePair.node2
+    for {
+      address <- otherClient.getNewAddress(Some(walletName))
+      _ <- client.walletPassphrase(password, 1000, Some(walletName))
+      txid <- client.sendToAddress(address,
+                                   Bitcoins(1),
+                                   walletNameOpt = Some(walletName))
+      transaction <-
+        client.getTransaction(txid, walletNameOpt = Some(walletName))
+    } yield {
+      assert(transaction.amount == Bitcoins(-1))
+      assert(transaction.details.head.address.contains(address))
+    }
+  }
+
+  it should "be able to send btc to many addresses" in { nodePair =>
+    val otherClient = nodePair.node1
+    val client = nodePair.node2
+    for {
+      address1 <- otherClient.getNewAddress(Some(walletName))
+      address2 <- otherClient.getNewAddress(Some(walletName))
+      _ <- client.walletPassphrase(password, 1000, Some(walletName))
+      txid <-
+        client
+          .sendMany(Map(address1 -> Bitcoins(1), address2 -> Bitcoins(2)),
+                    walletNameOpt = Some(walletName))
+      transaction <-
+        client.getTransaction(txid, walletNameOpt = Some(walletName))
+    } yield {
+      assert(transaction.amount == Bitcoins(-3))
+      assert(transaction.details.exists(_.address.contains(address1)))
+      assert(transaction.details.exists(_.address.contains(address2)))
+    }
+  }
+
+  it should "be able to get the balance" in { nodePair =>
+    val client = nodePair.node2
+    for {
       balance <- client.getBalance(walletName)
       _ <-
         client
@@ -278,21 +275,21 @@ class MultiWalletRpcTest
     }
   }
 
-  it should "be able to dump a private key" in { _: BitcoindV19RpcClient =>
+  it should "be able to dump a private key" in { nodePair =>
+    val client = nodePair.node2
     for {
-      client <- walletClientF
       address <- client.getNewAddress(Some(walletName))
       _ <- client.dumpPrivKey(address, Some(walletName))
     } yield succeed
   }
 
-  it should "be able to import a private key" in { _: BitcoindV19RpcClient =>
+  it should "be able to import a private key" in { nodePair =>
+    val client = nodePair.node2
     val ecPrivateKey = ECPrivateKey.freshPrivateKey
     val publicKey = ecPrivateKey.publicKey
     val address = P2PKHAddress(publicKey, networkParam)
 
     for {
-      client <- walletClientF
       _ <- client.importPrivKey(ecPrivateKey,
                                 rescan = false,
                                 walletNameOpt = Some(walletName))
@@ -315,16 +312,17 @@ class MultiWalletRpcTest
     }
   }
 
-  it should "be able to import a public key" in { _: BitcoindV19RpcClient =>
+  it should "be able to import a public key" in { nodePair =>
+    val client = nodePair.node2
     val pubKey = ECPublicKey.freshPublicKey
     for {
-      client <- walletClientF
       _ <- client.importPubKey(pubKey, walletNameOpt = Some(walletName))
     } yield succeed
   }
 
   it should "be able to import multiple addresses with importMulti" in {
-    _: BitcoindV19RpcClient =>
+    nodePair =>
+      val client = nodePair.node2
       val privKey = ECPrivateKey.freshPrivateKey
       val address1 = P2PKHAddress(privKey.publicKey, networkParam)
 
@@ -332,7 +330,6 @@ class MultiWalletRpcTest
       val privKey2 = ECPrivateKey.freshPrivateKey
 
       for {
-        client <- walletClientF
         firstResult <-
           client
             .createMultiSig(2,
@@ -358,10 +355,10 @@ class MultiWalletRpcTest
       }
   }
 
-  it should "be able to import a wallet" in { _: BitcoindV19RpcClient =>
+  it should "be able to import a wallet" in { nodePair =>
+    val client = nodePair.node2
+    val walletClient = client
     for {
-      client <- walletClientF
-      walletClient <- walletClientF
       address <- client.getNewAddress(Some(walletName))
       walletFile =
         client.getDaemon.datadir.getAbsolutePath + "/client_wallet.dat"
@@ -375,9 +372,9 @@ class MultiWalletRpcTest
 
   }
 
-  it should "be able to set the tx fee" in { _: BitcoindV19RpcClient =>
+  it should "be able to set the tx fee" in { nodePair =>
+    val client = nodePair.node2
     for {
-      client <- walletClientF
       success <- client.setTxFee(Bitcoins(0.01), Some(walletName))
       info <- client.getWalletInfo(walletName)
     } yield {
@@ -386,39 +383,33 @@ class MultiWalletRpcTest
     }
   }
 
-  it should "be able to sign a raw transaction with the wallet" in {
-    otherClient: BitcoindV19RpcClient =>
-      for {
-        client <- walletClientF
-        address <- otherClient.getNewAddress(Some(walletName))
-        transactionWithoutFunds <-
-          client
-            .createRawTransaction(Vector.empty, Map(address -> Bitcoins(1)))
-        transactionResult <-
-          client.fundRawTransaction(transactionWithoutFunds, walletName)
-        transaction = transactionResult.hex
-        singedTx <-
-          client
-            .signRawTransactionWithWallet(transaction, Some(walletName))
-            .map(_.hex)
+  it should "be able to sign a raw transaction with the wallet" in { nodePair =>
+    val otherClient = nodePair.node1
+    val client = nodePair.node2
+    for {
+      address <- otherClient.getNewAddress(Some(walletName))
+      transactionWithoutFunds <-
+        client
+          .createRawTransaction(Vector.empty, Map(address -> Bitcoins(1)))
+      transactionResult <-
+        client.fundRawTransaction(transactionWithoutFunds, walletName)
+      transaction = transactionResult.hex
+      singedTx <-
+        client
+          .signRawTransactionWithWallet(transaction, Some(walletName))
+          .map(_.hex)
 
-        // Will throw error if invalid
-        _ <- client.sendRawTransaction(singedTx)
-      } yield {
-        assert(transaction.inputs.length == 1)
-        assert(
-          transaction.outputs.contains(
-            TransactionOutput(Bitcoins(1), address.scriptPubKey)))
-      }
+      // Will throw error if invalid
+      _ <- client.sendRawTransaction(singedTx)
+    } yield {
+      assert(transaction.inputs.length == 1)
+      assert(
+        transaction.outputs.contains(
+          TransactionOutput(Bitcoins(1), address.scriptPubKey)))
+    }
   }
 
   def startClient(client: BitcoindRpcClient): Future[Unit] = {
     BitcoindRpcTestUtil.startServers(Vector(client))
-  }
-
-  override def afterAll(): Unit = {
-    val stopF = walletClientF.map(BitcoindRpcTestUtil.stopServer)
-    Await.result(stopF, duration)
-    super.afterAll()
   }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
@@ -13,29 +13,34 @@ import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.crypto.{ECPrivateKey, ECPublicKey}
 import org.bitcoins.rpc._
 import org.bitcoins.rpc.client.common._
+import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.rpc.util.RpcUtil
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.{AkkaUtil, BitcoindRpcTest}
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesFundedCached,
+  BitcoindRpcTestUtil,
+  CachedBitcoindV19
+}
+import org.bitcoins.testkit.util.{AkkaUtil, BitcoinSAsyncFixtureTest}
 
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.DurationInt
 
 /** These tests are all copied over from WalletRpcTest and changed to be for multi-wallet */
-class MultiWalletRpcTest extends BitcoindRpcTest {
+class MultiWalletRpcTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesFundedCached
+    with CachedBitcoindV19 {
 
   val walletName = "other"
 
   var password = "password"
 
-  lazy val clientsF: Future[
-    (BitcoindRpcClient, BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodeTripleV19(clientAccum = clientAccum)
+  override type FixtureParam = BitcoindV19RpcClient
 
-  lazy val walletClientF: Future[BitcoindRpcClient] = clientsF.flatMap {
-    clients =>
+  lazy val walletClientF: Future[BitcoindRpcClient] =
+    cachedBitcoindWithFundsF.flatMap { client =>
       val walletClient =
         BitcoindRpcClient.withActorSystem(BitcoindRpcTestUtil.instance())
-      clientAccum += walletClient
 
       for {
         _ <- startClient(walletClient)
@@ -45,7 +50,7 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
           walletClient
             .getNewAddress(Some(walletName))
             .flatMap(walletClient.generateToAddress(101, _))
-        _ <- clients._1.createWallet(walletName)
+        _ <- client.createWallet(walletName)
 
         // Restart so wallet is encrypted
         _ <- walletClient.stop()
@@ -57,29 +62,29 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
         _ <- walletClient.loadWallet(walletName)
 
         wallets <- walletClient.listWallets
-        wallets2 <- clients._1.listWallets
+        wallets2 <- client.listWallets
         _ = require(wallets.size == 2)
         _ = require(wallets2.size == 2)
       } yield walletClient
-  }
+    }
 
   behavior of "WalletRpc"
 
-  it must "setup correctly" in {
+  it must "setup correctly" in { _: BitcoindV19RpcClient =>
     for {
       walletClient <- walletClientF
       wallets <- walletClient.listWallets
     } yield assert(wallets.size == 2)
   }
 
-  it must "fail when no wallet is set" in {
+  it must "fail when no wallet is set" in { _: BitcoindV19RpcClient =>
     recoverToSucceededIf[BitcoindWalletException](for {
       walletClient <- walletClientF
       _ <- walletClient.getBalance
     } yield ())
   }
 
-  it must "get balance" in {
+  it must "get balance" in { _: BitcoindV19RpcClient =>
     for {
       walletClient <- walletClientF
       balance <- walletClient.getBalance(walletName)
@@ -89,7 +94,7 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to backup the wallet" in {
+  it should "be able to backup the wallet" in { _: BitcoindV19RpcClient =>
     for {
       client <- walletClientF
       _ <- {
@@ -105,71 +110,76 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
   }
 
   it should "be able to lock and unlock the wallet" in {
-    for {
-      walletClient <- walletClientF
-      _ <- walletClient.walletLock(walletName)
-      _ <- walletClient.walletPassphrase(password, 1000, Some(walletName))
+    _: BitcoindV19RpcClient =>
+      for {
+        walletClient <- walletClientF
+        _ <- walletClient.walletLock(walletName)
+        _ <- walletClient.walletPassphrase(password, 1000, Some(walletName))
 
-      info <- walletClient.getWalletInfo(walletName)
-      _ = assert(info.unlocked_until.nonEmpty)
-      _ = assert(info.unlocked_until.get > 0)
+        info <- walletClient.getWalletInfo(walletName)
+        _ = assert(info.unlocked_until.nonEmpty)
+        _ = assert(info.unlocked_until.get > 0)
 
-      _ <- walletClient.walletLock(walletName)
+        _ <- walletClient.walletLock(walletName)
 
-      newInfo <- walletClient.getWalletInfo(walletName)
-    } yield assert(newInfo.unlocked_until.contains(0))
+        newInfo <- walletClient.getWalletInfo(walletName)
+      } yield assert(newInfo.unlocked_until.contains(0))
   }
 
   it should "be able to get an address from bitcoind" in {
-    for {
-      client <- walletClientF
-      _ <- {
-        val addrFuts =
-          List(
-            client.getNewAddress("bech32", AddressType.Bech32, walletName),
-            client.getNewAddress("p2sh", AddressType.P2SHSegwit, walletName),
-            client.getNewAddress("legacy", AddressType.Legacy, walletName)
-          )
-        Future.sequence(addrFuts)
-      }
-    } yield succeed
+    _: BitcoindV19RpcClient =>
+      for {
+        client <- walletClientF
+        _ <- {
+          val addrFuts =
+            List(
+              client.getNewAddress("bech32", AddressType.Bech32, walletName),
+              client.getNewAddress("p2sh", AddressType.P2SHSegwit, walletName),
+              client.getNewAddress("legacy", AddressType.Legacy, walletName)
+            )
+          Future.sequence(addrFuts)
+        }
+      } yield succeed
   }
 
   it should "be able to get a new raw change address" in {
-    for {
-      client <- walletClientF
-      _ <- {
-        val addrFuts =
-          List(
-            client.getRawChangeAddress(walletName),
-            client.getRawChangeAddress(AddressType.Bech32, walletName),
-            client.getRawChangeAddress(AddressType.P2SHSegwit, walletName),
-            client.getRawChangeAddress(AddressType.Legacy, walletName)
-          )
-        Future.sequence(addrFuts)
-      }
-    } yield succeed
+    _: BitcoindV19RpcClient =>
+      for {
+        client <- walletClientF
+        _ <- {
+          val addrFuts =
+            List(
+              client.getRawChangeAddress(walletName),
+              client.getRawChangeAddress(AddressType.Bech32, walletName),
+              client.getRawChangeAddress(AddressType.P2SHSegwit, walletName),
+              client.getRawChangeAddress(AddressType.Legacy, walletName)
+            )
+          Future.sequence(addrFuts)
+        }
+      } yield succeed
   }
 
   it should "be able to get the amount recieved by some address" in {
-    for {
-      client <- walletClientF
-      address <- client.getNewAddress(Some(walletName))
-      amount <-
-        client.getReceivedByAddress(address, walletNameOpt = Some(walletName))
-    } yield assert(amount == Bitcoins(0))
+    _: BitcoindV19RpcClient =>
+      for {
+        client <- walletClientF
+        address <- client.getNewAddress(Some(walletName))
+        amount <-
+          client.getReceivedByAddress(address, walletNameOpt = Some(walletName))
+      } yield assert(amount == Bitcoins(0))
   }
 
   it should "be able to get the unconfirmed balance" in {
-    for {
-      client <- walletClientF
-      balance <- client.getUnconfirmedBalance(walletName)
-    } yield {
-      assert(balance == Bitcoins(0))
-    }
+    _: BitcoindV19RpcClient =>
+      for {
+        client <- walletClientF
+        balance <- client.getUnconfirmedBalance(walletName)
+      } yield {
+        assert(balance == Bitcoins(0))
+      }
   }
 
-  it should "be able to get the wallet info" in {
+  it should "be able to get the wallet info" in { _: BitcoindV19RpcClient =>
     for {
       client <- walletClientF
       info <- client.getWalletInfo(walletName)
@@ -181,7 +191,7 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to refill the keypool" in {
+  it should "be able to refill the keypool" in { _: BitcoindV19RpcClient =>
     for {
       client <- walletClientF
       _ <- client.walletPassphrase(password, 1000, Some(walletName))
@@ -192,65 +202,68 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
   }
 
   it should "be able to change the wallet password" in {
-    val newPass = "new_password"
+    _: BitcoindV19RpcClient =>
+      val newPass = "new_password"
 
-    for {
-      walletClient <- walletClientF
-      _ <- walletClient.walletLock(walletName)
-      _ <-
-        walletClient.walletPassphraseChange(password, newPass, Some(walletName))
-      _ = password = newPass
+      for {
+        walletClient <- walletClientF
+        _ <- walletClient.walletLock(walletName)
+        _ <-
+          walletClient.walletPassphraseChange(password,
+                                              newPass,
+                                              Some(walletName))
+        _ = password = newPass
 
-      _ <- walletClient.walletPassphrase(password, 1000, Some(walletName))
-      info <- walletClient.getWalletInfo(walletName)
-      _ <- walletClient.walletLock(walletName)
-      newInfo <- walletClient.getWalletInfo(walletName)
-    } yield {
+        _ <- walletClient.walletPassphrase(password, 1000, Some(walletName))
+        info <- walletClient.getWalletInfo(walletName)
+        _ <- walletClient.walletLock(walletName)
+        newInfo <- walletClient.getWalletInfo(walletName)
+      } yield {
 
-      assert(info.unlocked_until.nonEmpty)
-      assert(info.unlocked_until.get > 0)
-      assert(newInfo.unlocked_until.contains(0))
-    }
+        assert(info.unlocked_until.nonEmpty)
+        assert(info.unlocked_until.get > 0)
+        assert(newInfo.unlocked_until.contains(0))
+      }
   }
 
   it should "be able to send to an address" in {
-    for {
-      client <- walletClientF
-      (otherClient, _, _) <- clientsF
-      address <- otherClient.getNewAddress(Some(walletName))
-      _ <- client.walletPassphrase(password, 1000, Some(walletName))
-      txid <- client.sendToAddress(address,
-                                   Bitcoins(1),
-                                   walletNameOpt = Some(walletName))
-      transaction <-
-        client.getTransaction(txid, walletNameOpt = Some(walletName))
-    } yield {
-      assert(transaction.amount == Bitcoins(-1))
-      assert(transaction.details.head.address.contains(address))
-    }
+    otherClient: BitcoindV19RpcClient =>
+      for {
+        client <- walletClientF
+        address <- otherClient.getNewAddress(Some(walletName))
+        _ <- client.walletPassphrase(password, 1000, Some(walletName))
+        txid <- client.sendToAddress(address,
+                                     Bitcoins(1),
+                                     walletNameOpt = Some(walletName))
+        transaction <-
+          client.getTransaction(txid, walletNameOpt = Some(walletName))
+      } yield {
+        assert(transaction.amount == Bitcoins(-1))
+        assert(transaction.details.head.address.contains(address))
+      }
   }
 
   it should "be able to send btc to many addresses" in {
-    for {
-      client <- walletClientF
-      (otherClient, _, _) <- clientsF
-      address1 <- otherClient.getNewAddress(Some(walletName))
-      address2 <- otherClient.getNewAddress(Some(walletName))
-      _ <- client.walletPassphrase(password, 1000, Some(walletName))
-      txid <-
-        client
-          .sendMany(Map(address1 -> Bitcoins(1), address2 -> Bitcoins(2)),
-                    walletNameOpt = Some(walletName))
-      transaction <-
-        client.getTransaction(txid, walletNameOpt = Some(walletName))
-    } yield {
-      assert(transaction.amount == Bitcoins(-3))
-      assert(transaction.details.exists(_.address.contains(address1)))
-      assert(transaction.details.exists(_.address.contains(address2)))
-    }
+    otherClient: BitcoindV19RpcClient =>
+      for {
+        client <- walletClientF
+        address1 <- otherClient.getNewAddress(Some(walletName))
+        address2 <- otherClient.getNewAddress(Some(walletName))
+        _ <- client.walletPassphrase(password, 1000, Some(walletName))
+        txid <-
+          client
+            .sendMany(Map(address1 -> Bitcoins(1), address2 -> Bitcoins(2)),
+                      walletNameOpt = Some(walletName))
+        transaction <-
+          client.getTransaction(txid, walletNameOpt = Some(walletName))
+      } yield {
+        assert(transaction.amount == Bitcoins(-3))
+        assert(transaction.details.exists(_.address.contains(address1)))
+        assert(transaction.details.exists(_.address.contains(address2)))
+      }
   }
 
-  it should "be able to get the balance" in {
+  it should "be able to get the balance" in { _: BitcoindV19RpcClient =>
     for {
       client <- walletClientF
       balance <- client.getBalance(walletName)
@@ -265,7 +278,7 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to dump a private key" in {
+  it should "be able to dump a private key" in { _: BitcoindV19RpcClient =>
     for {
       client <- walletClientF
       address <- client.getNewAddress(Some(walletName))
@@ -273,7 +286,7 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
     } yield succeed
   }
 
-  it should "be able to import a private key" in {
+  it should "be able to import a private key" in { _: BitcoindV19RpcClient =>
     val ecPrivateKey = ECPrivateKey.freshPrivateKey
     val publicKey = ecPrivateKey.publicKey
     val address = P2PKHAddress(publicKey, networkParam)
@@ -302,7 +315,7 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to import a public key" in {
+  it should "be able to import a public key" in { _: BitcoindV19RpcClient =>
     val pubKey = ECPublicKey.freshPublicKey
     for {
       client <- walletClientF
@@ -311,40 +324,41 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
   }
 
   it should "be able to import multiple addresses with importMulti" in {
-    val privKey = ECPrivateKey.freshPrivateKey
-    val address1 = P2PKHAddress(privKey.publicKey, networkParam)
+    _: BitcoindV19RpcClient =>
+      val privKey = ECPrivateKey.freshPrivateKey
+      val address1 = P2PKHAddress(privKey.publicKey, networkParam)
 
-    val privKey1 = ECPrivateKey.freshPrivateKey
-    val privKey2 = ECPrivateKey.freshPrivateKey
+      val privKey1 = ECPrivateKey.freshPrivateKey
+      val privKey2 = ECPrivateKey.freshPrivateKey
 
-    for {
-      client <- walletClientF
-      firstResult <-
-        client
-          .createMultiSig(2,
-                          Vector(privKey1.publicKey, privKey2.publicKey),
-                          walletNameOpt = Some(walletName))
-      address2 = firstResult.address
+      for {
+        client <- walletClientF
+        firstResult <-
+          client
+            .createMultiSig(2,
+                            Vector(privKey1.publicKey, privKey2.publicKey),
+                            walletNameOpt = Some(walletName))
+        address2 = firstResult.address
 
-      secondResult <-
-        client
-          .importMulti(
-            Vector(
-              RpcOpts.ImportMultiRequest(RpcOpts.ImportMultiAddress(address1),
-                                         UInt32(0)),
-              RpcOpts.ImportMultiRequest(RpcOpts.ImportMultiAddress(address2),
-                                         UInt32(0))),
-            rescan = false,
-            walletNameOpt = Some(walletName)
-          )
-    } yield {
-      assert(secondResult.length == 2)
-      assert(secondResult(0).success)
-      assert(secondResult(1).success)
-    }
+        secondResult <-
+          client
+            .importMulti(
+              Vector(
+                RpcOpts.ImportMultiRequest(RpcOpts.ImportMultiAddress(address1),
+                                           UInt32(0)),
+                RpcOpts.ImportMultiRequest(RpcOpts.ImportMultiAddress(address2),
+                                           UInt32(0))),
+              rescan = false,
+              walletNameOpt = Some(walletName)
+            )
+      } yield {
+        assert(secondResult.length == 2)
+        assert(secondResult(0).success)
+        assert(secondResult(1).success)
+      }
   }
 
-  it should "be able to import a wallet" in {
+  it should "be able to import a wallet" in { _: BitcoindV19RpcClient =>
     for {
       client <- walletClientF
       walletClient <- walletClientF
@@ -361,7 +375,7 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
 
   }
 
-  it should "be able to set the tx fee" in {
+  it should "be able to set the tx fee" in { _: BitcoindV19RpcClient =>
     for {
       client <- walletClientF
       success <- client.setTxFee(Bitcoins(0.01), Some(walletName))
@@ -373,28 +387,38 @@ class MultiWalletRpcTest extends BitcoindRpcTest {
   }
 
   it should "be able to sign a raw transaction with the wallet" in {
-    for {
-      client <- walletClientF
-      (otherClient, _, _) <- clientsF
-      address <- otherClient.getNewAddress(Some(walletName))
-      transactionWithoutFunds <-
-        client
-          .createRawTransaction(Vector.empty, Map(address -> Bitcoins(1)))
-      transactionResult <-
-        client.fundRawTransaction(transactionWithoutFunds, walletName)
-      transaction = transactionResult.hex
-      singedTx <-
-        client
-          .signRawTransactionWithWallet(transaction, Some(walletName))
-          .map(_.hex)
+    otherClient: BitcoindV19RpcClient =>
+      for {
+        client <- walletClientF
+        address <- otherClient.getNewAddress(Some(walletName))
+        transactionWithoutFunds <-
+          client
+            .createRawTransaction(Vector.empty, Map(address -> Bitcoins(1)))
+        transactionResult <-
+          client.fundRawTransaction(transactionWithoutFunds, walletName)
+        transaction = transactionResult.hex
+        singedTx <-
+          client
+            .signRawTransactionWithWallet(transaction, Some(walletName))
+            .map(_.hex)
 
-      // Will throw error if invalid
-      _ <- client.sendRawTransaction(singedTx)
-    } yield {
-      assert(transaction.inputs.length == 1)
-      assert(
-        transaction.outputs.contains(
-          TransactionOutput(Bitcoins(1), address.scriptPubKey)))
-    }
+        // Will throw error if invalid
+        _ <- client.sendRawTransaction(singedTx)
+      } yield {
+        assert(transaction.inputs.length == 1)
+        assert(
+          transaction.outputs.contains(
+            TransactionOutput(Bitcoins(1), address.scriptPubKey)))
+      }
+  }
+
+  def startClient(client: BitcoindRpcClient): Future[Unit] = {
+    BitcoindRpcTestUtil.startServers(Vector(client))
+  }
+
+  override def afterAll(): Unit = {
+    val stopF = walletClientF.map(BitcoindRpcTestUtil.stopServer)
+    Await.result(stopF, duration)
+    super.afterAll()
   }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/PreciousBlockRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/PreciousBlockRpcTest.scala
@@ -1,0 +1,41 @@
+package org.bitcoins.rpc.common
+
+import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.AddNodeArgument
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesCachedPairV17,
+  BitcoindRpcTestUtil
+}
+
+class PreciousBlockRpcTest extends BitcoindFixturesCachedPairV17 {
+
+  it should "be able to mark a block as precious" in { nodePair =>
+    val freshClient = nodePair.node1
+    val otherFreshClient = nodePair.node2
+
+    for {
+      _ <- freshClient.disconnectNode(otherFreshClient.getDaemon.uri)
+      _ <- BitcoindRpcTestUtil.awaitDisconnected(freshClient, otherFreshClient)
+
+      blocks1 <-
+        freshClient.getNewAddress.flatMap(freshClient.generateToAddress(1, _))
+      blocks2 <- otherFreshClient.getNewAddress.flatMap(
+        otherFreshClient.generateToAddress(1, _))
+
+      bestHash1 <- freshClient.getBestBlockHash
+      _ = assert(bestHash1 == blocks1.head)
+      bestHash2 <- otherFreshClient.getBestBlockHash
+      _ = assert(bestHash2 == blocks2.head)
+
+      _ <-
+        freshClient
+          .addNode(otherFreshClient.getDaemon.uri, AddNodeArgument.OneTry)
+      _ <- AsyncUtil.retryUntilSatisfiedF(() =>
+        BitcoindRpcTestUtil.hasSeenBlock(otherFreshClient, bestHash1))
+
+      _ <- otherFreshClient.preciousBlock(bestHash1)
+      newBestHash <- otherFreshClient.getBestBlockHash
+
+    } yield assert(newBestHash == bestHash1)
+  }
+}

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -25,7 +25,7 @@ import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedPairNewest,
   BitcoindRpcTestUtil
 }
-import org.bitcoins.testkit.util.{AkkaUtil, BitcoinSAsyncFixtureTest}
+import org.bitcoins.testkit.util.AkkaUtil
 import org.scalatest.{FutureOutcome, Outcome}
 
 import java.io.File
@@ -34,9 +34,7 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.reflect.io.Directory
 
-class WalletRpcTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesCachedPairNewest {
+class WalletRpcTest extends BitcoindFixturesCachedPairNewest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -20,30 +20,44 @@ import org.bitcoins.core.wallet.signer.BitcoinSigner
 import org.bitcoins.core.wallet.utxo.{ECSignatureParams, P2WPKHV0InputInfo}
 import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPrivateKey, ECPublicKey}
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
-import org.bitcoins.rpc.util.RpcUtil
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.{AkkaUtil, BitcoindRpcTest}
+import org.bitcoins.rpc.util.{NodePair, RpcUtil}
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesCachedPair,
+  BitcoindRpcTestUtil,
+  CachedBitcoindPair
+}
+import org.bitcoins.testkit.util.{AkkaUtil, BitcoinSAsyncFixtureTest}
+import org.scalatest.{FutureOutcome, Outcome}
 
 import java.io.File
 import java.util.Scanner
-import scala.annotation.nowarn
-import scala.async.Async.{async, await}
+//import scala.annotation.nowarn
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
 import scala.reflect.io.Directory
 
-@nowarn
-class WalletRpcTest extends BitcoindRpcTest {
+//@nowarn
+class WalletRpcTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCachedPair
+    with CachedBitcoindPair {
 
-  lazy val clientsF: Future[
-    (BitcoindRpcClient, BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodeTripleV19(clientAccum = clientAccum)
+  override type FixtureParam = NodePair
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      clients <- clientsF
+      futOutcome = with2BitcoindsCached(test, clients)
+      fut <- futOutcome.toFuture
+    } yield fut
+
+    new FutureOutcome(f)
+  }
 
   // This client's wallet is encrypted
   lazy val walletClientF: Future[BitcoindRpcClient] = clientsF.flatMap { _ =>
     val walletClient =
       BitcoindRpcClient.withActorSystem(BitcoindRpcTestUtil.instance())
-    clientAccum += walletClient
 
     for {
       _ <- startClient(walletClient)
@@ -63,9 +77,9 @@ class WalletRpcTest extends BitcoindRpcTest {
 
   behavior of "WalletRpc"
 
-  it should "be able to dump the wallet" in {
+  it should "be able to dump the wallet" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       result <- {
         val datadir = client.getDaemon.datadir.getAbsolutePath
         client.dumpWallet(datadir + "/test.dat")
@@ -76,9 +90,9 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to list wallets" in {
+  it should "be able to list wallets" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       wallets <- client.listWallets
     } yield {
 
@@ -90,9 +104,9 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to backup the wallet" in {
+  it should "be able to backup the wallet" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       _ <- {
         val datadir = client.getDaemon.datadir.getAbsolutePath
         client.backupWallet(datadir + "/backup.dat")
@@ -105,7 +119,7 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to lock and unlock the wallet" in {
+  it should "be able to lock and unlock the wallet" in { _: NodePair =>
     for {
       walletClient <- walletClientF
       _ <- walletClient.walletLock()
@@ -121,9 +135,9 @@ class WalletRpcTest extends BitcoindRpcTest {
     } yield assert(newInfo.unlocked_until.contains(0))
   }
 
-  it should "be able to get an address from bitcoind" in {
+  it should "be able to get an address from bitcoind" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       _ <- {
         val addrFuts =
           List(client.getNewAddress,
@@ -135,9 +149,9 @@ class WalletRpcTest extends BitcoindRpcTest {
     } yield succeed
   }
 
-  it should "be able to get a new raw change address" in {
+  it should "be able to get a new raw change address" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       _ <- {
         val addrFuts =
           List(
@@ -152,16 +166,17 @@ class WalletRpcTest extends BitcoindRpcTest {
   }
 
   it should "be able to get the amount recieved by some address" in {
-    for {
-      (client, _, _) <- clientsF
-      address <- client.getNewAddress
-      amount <- client.getReceivedByAddress(address)
-    } yield assert(amount == Bitcoins(0))
+    nodePair: NodePair =>
+      val client = nodePair.node1
+      for {
+        address <- client.getNewAddress
+        amount <- client.getReceivedByAddress(address)
+      } yield assert(amount == Bitcoins(0))
   }
 
-  it should "be able to get the unconfirmed balance" in {
+  it should "be able to get the unconfirmed balance" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       balance <- client.getUnconfirmedBalance
       transaction <- BitcoindRpcTestUtil.sendCoinbaseTransaction(client, client)
       newBalance <- client.getUnconfirmedBalance
@@ -171,9 +186,9 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to get the wallet info" in {
+  it should "be able to get the wallet info" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       info <- client.getWalletInfo
     } yield {
       assert(info.balance.toBigDecimal > 0)
@@ -183,16 +198,16 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to refill the keypool" in {
+  it should "be able to refill the keypool" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       info <- client.getWalletInfo
       _ <- client.keyPoolRefill(info.keypoolsize + 1)
       newInfo <- client.getWalletInfo
     } yield assert(newInfo.keypoolsize == info.keypoolsize + 1)
   }
 
-  it should "be able to change the wallet password" in {
+  it should "be able to change the wallet password" in { _: NodePair =>
     val newPass = "new_password"
 
     for {
@@ -215,44 +230,9 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to import funds without rescan and then remove them" in async {
-    val (client, otherClient, thirdClient) = await(clientsF)
-
-    val address = await(thirdClient.getNewAddress)
-    val privKey = await(thirdClient.dumpPrivKey(address))
-
-    val txidF =
-      BitcoindRpcTestUtil
-        .fundBlockChainTransaction(client, thirdClient, address, Bitcoins(1.5))
-    val txid = await(txidF)
-
-    await(client.getNewAddress.flatMap(client.generateToAddress(1, _)))
-
-    val tx = await(client.getTransaction(txid))
-
-    val proof = await(client.getTxOutProof(Vector(txid)))
-
-    val balanceBefore = await(otherClient.getBalance)
-
-    await(otherClient.importPrivKey(privKey, rescan = false))
-    await(otherClient.importPrunedFunds(tx.hex, proof))
-
-    val balanceAfter = await(otherClient.getBalance)
-    assert(balanceAfter == balanceBefore + Bitcoins(1.5))
-
-    val addressInfo = await(otherClient.validateAddress(address))
-    if (otherClient.instance.getVersion == BitcoindVersion.V16) {
-      assert(addressInfo.ismine.contains(true))
-    }
-
-    await(otherClient.removePrunedFunds(txid))
-
-    val balance = await(otherClient.getBalance)
-    assert(balance == balanceBefore)
-  }
-
-  it should "be able to list address groupings" in {
-
+  it should "be able to list address groupings" in { nodePair: NodePair =>
+    val client = nodePair.node1
+    val otherClient = nodePair.node2
     val amount = Bitcoins(1.25)
 
     def getChangeAddressAndAmount(
@@ -274,7 +254,6 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
 
     for {
-      (client, otherClient, _) <- clientsF
       groupingsBefore <- client.listAddressGroupings
 
       address <- client.getNewAddress
@@ -316,9 +295,10 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to send to an address" in {
+  it should "be able to send to an address" in { nodePair: NodePair =>
+    val client = nodePair.node1
+    val otherClient = nodePair.node2
     for {
-      (client, otherClient, _) <- clientsF
       address <- otherClient.getNewAddress
       txid <- client.sendToAddress(address, Bitcoins(1))
       transaction <- client.getTransaction(txid)
@@ -328,9 +308,10 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to send btc to many addresses" in {
+  it should "be able to send btc to many addresses" in { nodePair: NodePair =>
+    val client = nodePair.node1
+    val otherClient = nodePair.node2
     for {
-      (client, otherClient, _) <- clientsF
       address1 <- otherClient.getNewAddress
       address2 <- otherClient.getNewAddress
       txid <-
@@ -345,35 +326,37 @@ class WalletRpcTest extends BitcoindRpcTest {
   }
 
   it should "be able to list transactions by receiving addresses" in {
-    for {
-      (client, otherClient, _) <- clientsF
-      address <- otherClient.getNewAddress
-      txid <-
-        BitcoindRpcTestUtil
-          .fundBlockChainTransaction(client,
-                                     otherClient,
-                                     address,
-                                     Bitcoins(1.5))
-      receivedList <- otherClient.listReceivedByAddress()
-    } yield {
-      val entryList =
-        receivedList.filter(entry => entry.address == address)
-      assert(entryList.length == 1)
-      val entry = entryList.head
-      assert(entry.txids.head == txid)
-      assert(entry.address == address)
-      assert(entry.amount == Bitcoins(1.5))
-      assert(entry.confirmations == 1)
-    }
+    nodePair: NodePair =>
+      val client = nodePair.node1
+      val otherClient = nodePair.node2
+      for {
+        address <- otherClient.getNewAddress
+        txid <-
+          BitcoindRpcTestUtil
+            .fundBlockChainTransaction(client,
+                                       otherClient,
+                                       address,
+                                       Bitcoins(1.5))
+        receivedList <- otherClient.listReceivedByAddress()
+      } yield {
+        val entryList =
+          receivedList.filter(entry => entry.address == address)
+        assert(entryList.length == 1)
+        val entry = entryList.head
+        assert(entry.txids.head == txid)
+        assert(entry.address == address)
+        assert(entry.amount == Bitcoins(1.5))
+        assert(entry.confirmations == 1)
+      }
   }
 
-  it should "be able to import an address" in {
-
+  it should "be able to import an address" in { nodePair: NodePair =>
+    val client = nodePair.node1
+    val otherClient = nodePair.node2
     val address = Bech32Address
       .fromString("bcrt1q9h9wkz6ad49szfl035wh3qdacuslkp6j9pfp4j")
 
     for {
-      (client, otherClient, _) <- clientsF
       _ <- otherClient.importAddress(address)
       txid <- BitcoindRpcTestUtil.fundBlockChainTransaction(client,
                                                             otherClient,
@@ -392,9 +375,9 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to get the balance" in {
+  it should "be able to get the balance" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       balance <- client.getBalance
       _ <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
       newBalance <- client.getBalance
@@ -404,21 +387,21 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to dump a private key" in {
+  it should "be able to dump a private key" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       address <- client.getNewAddress
       _ <- client.dumpPrivKey(address)
     } yield succeed
   }
 
-  it should "be able to import a private key" in {
+  it should "be able to import a private key" in { nodePair: NodePair =>
+    val client = nodePair.node1
     val ecPrivateKey = ECPrivateKey.freshPrivateKey
     val publicKey = ecPrivateKey.publicKey
     val address = P2PKHAddress(publicKey, networkParam)
 
     for {
-      (client, _, _) <- clientsF
       _ <- client.importPrivKey(ecPrivateKey, rescan = false)
       key <- client.dumpPrivKey(address)
       result <-
@@ -438,48 +421,49 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to import a public key" in {
+  it should "be able to import a public key" in { nodePair: NodePair =>
+    val client = nodePair.node1
     val pubKey = ECPublicKey.freshPublicKey
     for {
-      (client, _, _) <- clientsF
       _ <- client.importPubKey(pubKey)
     } yield succeed
   }
 
   it should "be able to import multiple addresses with importMulti" in {
-    val privKey = ECPrivateKey.freshPrivateKey
-    val address1 = P2PKHAddress(privKey.publicKey, networkParam)
+    nodePair: NodePair =>
+      val client = nodePair.node1
+      val privKey = ECPrivateKey.freshPrivateKey
+      val address1 = P2PKHAddress(privKey.publicKey, networkParam)
 
-    val privKey1 = ECPrivateKey.freshPrivateKey
-    val privKey2 = ECPrivateKey.freshPrivateKey
+      val privKey1 = ECPrivateKey.freshPrivateKey
+      val privKey2 = ECPrivateKey.freshPrivateKey
 
-    for {
-      (client, _, _) <- clientsF
-      firstResult <-
-        client
-          .createMultiSig(2, Vector(privKey1.publicKey, privKey2.publicKey))
-      address2 = firstResult.address
+      for {
+        firstResult <-
+          client
+            .createMultiSig(2, Vector(privKey1.publicKey, privKey2.publicKey))
+        address2 = firstResult.address
 
-      secondResult <-
-        client
-          .importMulti(
-            Vector(
-              RpcOpts.ImportMultiRequest(RpcOpts.ImportMultiAddress(address1),
-                                         UInt32(0)),
-              RpcOpts.ImportMultiRequest(RpcOpts.ImportMultiAddress(address2),
-                                         UInt32(0))),
-            rescan = false
-          )
-    } yield {
-      assert(secondResult.length == 2)
-      assert(secondResult(0).success)
-      assert(secondResult(1).success)
-    }
+        secondResult <-
+          client
+            .importMulti(
+              Vector(
+                RpcOpts.ImportMultiRequest(RpcOpts.ImportMultiAddress(address1),
+                                           UInt32(0)),
+                RpcOpts.ImportMultiRequest(RpcOpts.ImportMultiAddress(address2),
+                                           UInt32(0))),
+              rescan = false
+            )
+      } yield {
+        assert(secondResult.length == 2)
+        assert(secondResult(0).success)
+        assert(secondResult(1).success)
+      }
   }
 
-  it should "be able to import a wallet" in {
+  it should "be able to import a wallet" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       walletClient <- walletClientF
       address <- client.getNewAddress
       walletFile =
@@ -493,11 +477,11 @@ class WalletRpcTest extends BitcoindRpcTest {
 
   }
 
-  it should "be able to load a wallet" in {
+  it should "be able to load a wallet" in { nodePair: NodePair =>
+    val client = nodePair.node1
     val name = "tmp_wallet"
 
     for {
-      (client, _, _) <- clientsF
       walletClient <- walletClientF
       walletFile =
         client.getDaemon.datadir.getAbsolutePath + s"/regtest/wallets/$name"
@@ -514,9 +498,9 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to set the tx fee" in {
+  it should "be able to set the tx fee" in { nodePair: NodePair =>
+    val client = nodePair.node1
     for {
-      (client, _, _) <- clientsF
       success <- client.setTxFee(Bitcoins(0.01))
       info <- client.getWalletInfo
     } yield {
@@ -525,9 +509,10 @@ class WalletRpcTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to bump a mem pool tx fee" in {
+  it should "be able to bump a mem pool tx fee" in { nodePair: NodePair =>
+    val client = nodePair.node1
+    val otherClient = nodePair.node2
     for {
-      (client, otherClient, _) <- clientsF
       address <- otherClient.getNewAddress
       unspent <- client.listUnspent
       changeAddress <- client.getRawChangeAddress
@@ -555,65 +540,79 @@ class WalletRpcTest extends BitcoindRpcTest {
   }
 
   it should "be able to sign a raw transaction with the wallet" in {
-    for {
-      (client, otherClient, _) <- clientsF
-      address <- otherClient.getNewAddress
-      transactionWithoutFunds <-
-        client
-          .createRawTransaction(Vector.empty, Map(address -> Bitcoins(1)))
-      transactionResult <- client.fundRawTransaction(transactionWithoutFunds)
-      transaction = transactionResult.hex
-      singedTx <- client.signRawTransactionWithWallet(transaction).map(_.hex)
+    nodePair: NodePair =>
+      val client = nodePair.node1
+      val otherClient = nodePair.node2
+      for {
+        address <- otherClient.getNewAddress
+        transactionWithoutFunds <-
+          client
+            .createRawTransaction(Vector.empty, Map(address -> Bitcoins(1)))
+        transactionResult <- client.fundRawTransaction(transactionWithoutFunds)
+        transaction = transactionResult.hex
+        singedTx <- client.signRawTransactionWithWallet(transaction).map(_.hex)
 
-      // Will throw error if invalid
-      _ <- client.sendRawTransaction(singedTx)
-    } yield {
-      assert(transaction.inputs.length == 1)
-      assert(
-        transaction.outputs.contains(
-          TransactionOutput(Bitcoins(1), address.scriptPubKey)))
-    }
+        // Will throw error if invalid
+        _ <- client.sendRawTransaction(singedTx)
+      } yield {
+        assert(transaction.inputs.length == 2)
+        assert(
+          transaction.outputs.contains(
+            TransactionOutput(Bitcoins(1), address.scriptPubKey)))
+      }
   }
 
   it should "generate the same (low R) signatures as bitcoin-s" in {
-    for {
-      (client, otherClient, _) <- clientsF
-      address <- otherClient.getNewAddress
-      transactionWithoutFunds <-
-        client
-          .createRawTransaction(Vector.empty, Map(address -> Bitcoins(1)))
-      transactionResult <- client.fundRawTransaction(transactionWithoutFunds)
-      transaction = transactionResult.hex
-      signedTx <- client.signRawTransactionWithWallet(transaction).map(_.hex)
+    nodePair: NodePair =>
+      val client = nodePair.node1
+      val otherClient = nodePair.node2
+      for {
+        address <- otherClient.getNewAddress
+        transactionWithoutFunds <-
+          client
+            .createRawTransaction(Vector.empty, Map(address -> Bitcoins(1)))
+        transactionResult <- client.fundRawTransaction(transactionWithoutFunds)
+        transaction = transactionResult.hex
+        signedTx <- client.signRawTransactionWithWallet(transaction).map(_.hex)
 
-      // Validate signature against bitcoin-s generated one
-      outPoint = transaction.inputs.head.previousOutput
-      prevTx <- client.getRawTransactionRaw(outPoint.txIdBE)
-      output = prevTx.outputs(outPoint.vout.toInt)
-      privKey <- client.dumpPrivKey(
-        BitcoinAddress.fromScriptPubKey(output.scriptPubKey, RegTest))
-      partialSig <- BitcoinSigner.signSingle(
-        ECSignatureParams(
-          P2WPKHV0InputInfo(outPoint, output.value, privKey.publicKey),
-          prevTx,
-          privKey,
-          HashType.sigHashAll),
-        transaction,
-        isDummySignature = false)
-    } yield {
-      signedTx match {
-        case btx: NonWitnessTransaction =>
-          assert(
-            btx.inputs.head.scriptSignature.signatures.head == partialSig.signature)
-        case wtx: WitnessTransaction =>
-          wtx.witness.head match {
-            case p2wpkh: P2WPKHWitnessV0 =>
-              assert(p2wpkh.pubKey == partialSig.pubKey)
-              assert(p2wpkh.signature == partialSig.signature)
-            case _: P2WSHWitnessV0 | EmptyScriptWitness =>
-              fail("Expected P2WPKH")
-          }
+        // Validate signature against bitcoin-s generated one
+        outPoint = transaction.inputs.head.previousOutput
+        prevTx <- client.getRawTransactionRaw(outPoint.txIdBE)
+        output = prevTx.outputs(outPoint.vout.toInt)
+        privKey <- client.dumpPrivKey(
+          BitcoinAddress.fromScriptPubKey(output.scriptPubKey, RegTest))
+        partialSig <- BitcoinSigner.signSingle(
+          ECSignatureParams(
+            P2WPKHV0InputInfo(outPoint, output.value, privKey.publicKey),
+            prevTx,
+            privKey,
+            HashType.sigHashAll),
+          transaction,
+          isDummySignature = false)
+      } yield {
+        signedTx match {
+          case btx: NonWitnessTransaction =>
+            assert(
+              btx.inputs.head.scriptSignature.signatures.head == partialSig.signature)
+          case wtx: WitnessTransaction =>
+            wtx.witness.head match {
+              case p2wpkh: P2WPKHWitnessV0 =>
+                assert(p2wpkh.pubKey == partialSig.pubKey)
+                assert(p2wpkh.signature == partialSig.signature)
+              case _: P2WSHWitnessV0 | EmptyScriptWitness =>
+                fail("Expected P2WPKH")
+            }
+        }
       }
-    }
+  }
+
+  def startClient(client: BitcoindRpcClient): Future[Unit] = {
+    BitcoindRpcTestUtil.startServers(Vector(client))
+  }
+
+  override def afterAll(): Unit = {
+    val stopF = walletClientF.map(BitcoindRpcTestUtil.stopServer)
+    Await.result(stopF, duration)
+    super.afterAll()
   }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -31,12 +31,11 @@ import org.scalatest.{FutureOutcome, Outcome}
 
 import java.io.File
 import java.util.Scanner
-//import scala.annotation.nowarn
+
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.reflect.io.Directory
 
-//@nowarn
 class WalletRpcTest
     extends BitcoinSAsyncFixtureTest
     with BitcoindFixturesCachedPair

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
@@ -14,25 +14,21 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPrivateKey}
 import org.bitcoins.rpc.client.common.BitcoindVersion
-import org.bitcoins.rpc.client.v16.BitcoindV16RpcClient
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.{AkkaUtil, BitcoindRpcTest}
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesCachedPairV16,
+  BitcoindRpcTestUtil
+}
 
-import scala.async.Async.{async, await}
-import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
-import scala.util.Properties
 
-class BitcoindV16RpcClientTest extends BitcoindRpcTest {
-
-  lazy val clientsF: Future[(BitcoindV16RpcClient, BitcoindV16RpcClient)] =
-    BitcoindRpcTestUtil.createNodePairV16(clientAccum)
+class BitcoindV16RpcClientTest extends BitcoindFixturesCachedPairV16 {
 
   behavior of "BitcoindV16RpcClient"
 
-  it should "be able to get peer info" in {
+  it should "be able to get peer info" in { nodePair: FixtureParam =>
+    val freshClient = nodePair.node1
+    val otherFreshClient = nodePair.node2
     for {
-      (freshClient, otherFreshClient) <- clientsF
       infoList <- freshClient.getPeerInfo
     } yield {
       assert(infoList.length >= 0)
@@ -42,18 +38,17 @@ class BitcoindV16RpcClientTest extends BitcoindRpcTest {
     }
   }
 
-  it should "be able to start a V16 bitcoind" in {
-    for {
-      (client, otherClient) <- clientsF
-    } yield {
-      assert(client.version == BitcoindVersion.V16)
-      assert(otherClient.version == BitcoindVersion.V16)
-    }
+  it should "be able to start a V16 bitcoind" in { nodePair: FixtureParam =>
+    val client = nodePair.node1
+    val otherClient = nodePair.node2
+    assert(client.version == BitcoindVersion.V16)
+    assert(otherClient.version == BitcoindVersion.V16)
   }
 
-  it should "be able to sign a raw transaction" in {
+  it should "be able to sign a raw transaction" in { nodePair: FixtureParam =>
+    val client = nodePair.node1
+    val otherClient = nodePair.node2
     for {
-      (client, otherClient) <- clientsF
       addr <- client.getNewAddress
       _ <- otherClient.sendToAddress(addr, Bitcoins.one)
       _ <-
@@ -88,154 +83,106 @@ class BitcoindV16RpcClientTest extends BitcoindRpcTest {
 
   // copied form the equivalent test in BitcoindV17RpcClientTest
   it should "be able to sign a raw transaction with private keys" in {
-    val privkeys: List[ECPrivateKey] =
-      List("cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N",
-           "cVKpPfVKSJxKqVpE9awvXNWuLHCa5j5tiE7K6zbUSptFpTEtiFrA")
-        .map(ECPrivateKeyUtil.fromWIFToPrivateKey)
+    nodePair: FixtureParam =>
+      val client = nodePair.node1
+      val privkeys: List[ECPrivateKey] =
+        List("cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N",
+             "cVKpPfVKSJxKqVpE9awvXNWuLHCa5j5tiE7K6zbUSptFpTEtiFrA")
+          .map(ECPrivateKeyUtil.fromWIFToPrivateKey)
 
-    val txids =
-      List("9b907ef1e3c26fc71fe4a4b3580bc75264112f95050014157059c736f0202e71",
-           "83a4f6a6b73660e13ee6cb3c6063fa3759c50c9b7521d0536022961898f4fb02")
-        .map(DoubleSha256DigestBE.fromHex)
+      val txids =
+        List("9b907ef1e3c26fc71fe4a4b3580bc75264112f95050014157059c736f0202e71",
+             "83a4f6a6b73660e13ee6cb3c6063fa3759c50c9b7521d0536022961898f4fb02")
+          .map(DoubleSha256DigestBE.fromHex)
 
-    val vouts = List(0, 0)
+      val vouts = List(0, 0)
 
-    val inputs: Vector[TransactionInput] = txids
-      .zip(vouts)
-      .map { case (txid, vout) =>
-        TransactionInput.fromTxidAndVout(txid, UInt32(vout))
+      val inputs: Vector[TransactionInput] = txids
+        .zip(vouts)
+        .map { case (txid, vout) =>
+          TransactionInput.fromTxidAndVout(txid, UInt32(vout))
+        }
+        .toVector
+
+      val address =
+        BitcoinAddress.fromString("mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB")
+
+      val outputs: Map[BitcoinAddress, Bitcoins] =
+        Map(address -> Bitcoins(0.1))
+
+      val scriptPubKeys =
+        List("76a91460baa0f494b38ce3c940dea67f3804dc52d1fb9488ac",
+             "76a914669b857c03a5ed269d5d85a1ffac9ed5d663072788ac")
+          .map(ScriptPubKey.fromAsmHex)
+
+      val utxoDeps = inputs.zip(scriptPubKeys).map { case (input, pubKey) =>
+        SignRawTransactionOutputParameter.fromTransactionInput(input, pubKey)
       }
-      .toVector
 
-    val address =
-      BitcoinAddress.fromString("mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB")
-
-    val outputs: Map[BitcoinAddress, Bitcoins] =
-      Map(address -> Bitcoins(0.1))
-
-    val scriptPubKeys =
-      List("76a91460baa0f494b38ce3c940dea67f3804dc52d1fb9488ac",
-           "76a914669b857c03a5ed269d5d85a1ffac9ed5d663072788ac")
-        .map(ScriptPubKey.fromAsmHex)
-
-    val utxoDeps = inputs.zip(scriptPubKeys).map { case (input, pubKey) =>
-      SignRawTransactionOutputParameter.fromTransactionInput(input, pubKey)
-    }
-
-    for {
-      (client, _) <- clientsF
-      rawTx <- client.createRawTransaction(inputs, outputs)
-      signed <- client.signRawTransaction(rawTx, utxoDeps, privkeys.toVector)
-    } yield assert(signed.complete)
+      for {
+        rawTx <- client.createRawTransaction(inputs, outputs)
+        signed <- client.signRawTransaction(rawTx, utxoDeps, privkeys.toVector)
+      } yield assert(signed.complete)
   }
 
   it should "be able to send from an account to an addresss" in {
-    for {
-      (client, otherClient) <- clientsF
-      address <- otherClient.getNewAddress
-      txid <- client.sendFrom("", address, Bitcoins(1))
-      transaction <- client.getTransaction(txid)
-    } yield {
-      assert(transaction.amount == Bitcoins(-1))
-      assert(transaction.details.head.address.contains(address))
-    }
-  }
-
-  it should "be able to get the amount received by an account and list amounts received by all accounts" in async {
-    val (client, otherClient) = await(clientsF)
-
-    val ourAccount = "another_new_account"
-    val emptyAccount = "empty_account"
-
-    val ourAccountAddress = await(client.getNewAddress(ourAccount))
-    await(
-      BitcoindRpcTestUtil
-        .fundBlockChainTransaction(otherClient,
-                                   client,
-                                   ourAccountAddress,
-                                   Bitcoins(1.5)))
-
-    val accountlessAddress = await(client.getNewAddress)
-
-    val sendAmt = Bitcoins(1.5)
-
-    val _ = await(
-      BitcoindRpcTestUtil
-        .fundBlockChainTransaction(otherClient,
-                                   client,
-                                   accountlessAddress,
-                                   sendAmt))
-
-    if (Properties.isMac) await(AkkaUtil.nonBlockingSleep(10.seconds))
-    val ourAccountAmount = await(client.getReceivedByAccount(ourAccount))
-
-    assert(ourAccountAmount == sendAmt)
-
-    val receivedByAccount = await(client.listReceivedByAccount())
-
-    val ourAccountOpt =
-      receivedByAccount
-        .find(_.account == ourAccount)
-
-    assert(ourAccountOpt.isDefined)
-    assert(ourAccountOpt.get.amount == Bitcoins(1.5))
-
-    val accountLessOpt =
-      receivedByAccount
-        .find(_.account == "")
-
-    assert(accountLessOpt.isDefined)
-    assert(accountLessOpt.get.amount > Bitcoins(0))
-    assert(!receivedByAccount.exists(_.account == emptyAccount))
-
-    val accounts = await(client.listAccounts())
-
-    assert(accounts(ourAccount) == Bitcoins(1.5))
-    assert(accounts("") > Bitcoins(0))
-    assert(!accounts.keySet.contains(emptyAccount))
+    nodePair: FixtureParam =>
+      val client = nodePair.node1
+      val otherClient = nodePair.node2
+      for {
+        address <- otherClient.getNewAddress
+        txid <- client.sendFrom("", address, Bitcoins(1))
+        transaction <- client.getTransaction(txid)
+      } yield {
+        assert(transaction.amount == Bitcoins(-1))
+        assert(transaction.details.head.address.contains(address))
+      }
   }
 
   it should "be able to get and set the account for a given address" in {
-    val account1 = "account_1"
-    val account2 = "account_2"
-    for {
-      (client, _) <- clientsF
-      address <- client.getNewAddress(account1)
-      acc1 <- client.getAccount(address)
-      _ <- client.setAccount(address, account2)
-      acc2 <- client.getAccount(address)
-    } yield {
-      assert(acc1 == account1)
-      assert(acc2 == account2)
-    }
+    nodePair: FixtureParam =>
+      val client = nodePair.node1
+      val account1 = "account_1"
+      val account2 = "account_2"
+      for {
+        address <- client.getNewAddress(account1)
+        acc1 <- client.getAccount(address)
+        _ <- client.setAccount(address, account2)
+        acc2 <- client.getAccount(address)
+      } yield {
+        assert(acc1 == account1)
+        assert(acc2 == account2)
+      }
   }
 
   it should "be able to get all addresses belonging to an account" in {
-    for {
-      (client, _) <- clientsF
-      address <- client.getNewAddress
-      addresses <- client.getAddressesByAccount("")
-    } yield assert(addresses.contains(address))
+    nodePair: FixtureParam =>
+      val client = nodePair.node1
+      for {
+        address <- client.getNewAddress
+        addresses <- client.getAddressesByAccount("")
+      } yield assert(addresses.contains(address))
   }
 
-  it should "be able to get an account's address" in {
+  it should "be able to get an account's address" in { nodePair: FixtureParam =>
+    val client = nodePair.node1
     val account = "a_new_account"
     for {
-      (client, _) <- clientsF
       address <- client.getAccountAddress(account)
       result <- client.getAccount(address)
     } yield assert(result == account)
   }
 
   it should "be able to move funds from one account to another" in {
-    val account = "move_account"
-    for {
-      (client, _) <- clientsF
-      success <- client.move("", account, Bitcoins(1))
-      map <- client.listAccounts()
-    } yield {
-      assert(success)
-      assert(map(account) == Bitcoins(1))
-    }
+    nodePair: FixtureParam =>
+      val client = nodePair.node1
+      val account = "move_account"
+      for {
+        success <- client.move("", account, Bitcoins(1))
+        map <- client.listAccounts()
+      } yield {
+        assert(success)
+        assert(map(account) == Bitcoins(1))
+      }
   }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -19,13 +19,10 @@ import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedPairV17,
   BitcoindRpcTestUtil
 }
-import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
 import scala.concurrent.Future
 
-class BitcoindV17RpcClientTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesCachedPairV17 {
+class BitcoindV17RpcClientTest extends BitcoindFixturesCachedPairV17 {
   val usedLabel = "used_label"
   val unusedLabel = "unused_label"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -140,7 +140,6 @@ class BitcoindV17RpcClientTest extends BitcoindFixturesCachedPairV17 {
       } yield assert(info.address == addr)
   }
 
-  // needs #360 to be merged
   it should "be able to get the address info for a given Bech32 address" in {
     nodePair: FixtureParam =>
       val NodePair(client, _) = nodePair

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -43,6 +43,13 @@ class BitcoindV17RpcClientTest
     }
   }
 
+  it must "have our BitcoindRpcClient work with .hashCode() and equals" in {
+    nodePair =>
+      val NodePair(client1, client2) = nodePair
+      assert(client1 != client2)
+      assert(client1.hashCode() != client2.hashCode())
+  }
+
   it should "test mempool acceptance" in { nodePair: FixtureParam =>
     val NodePair(client, otherClient) = nodePair
     for {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/BitcoindV17RpcClientTest.scala
@@ -14,24 +14,26 @@ import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionInput
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.rpc.client.v17.BitcoindV17RpcClient
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.rpc.util.NodePair
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesCachedPairV17,
+  BitcoindRpcTestUtil
+}
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
 import scala.concurrent.Future
 
-class BitcoindV17RpcClientTest extends BitcoindRpcTest {
+class BitcoindV17RpcClientTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCachedPairV17 {
   val usedLabel = "used_label"
   val unusedLabel = "unused_label"
 
-  val clientsF: Future[(BitcoindV17RpcClient, BitcoindV17RpcClient)] =
-    BitcoindRpcTestUtil.createNodePairV17(clientAccum)
-
   behavior of "BitcoindV17RpcClient"
 
-  it should "be able to get peer info" in {
+  it should "be able to get peer info" in { nodePair: FixtureParam =>
+    val NodePair(freshClient, otherFreshClient) = nodePair
     for {
-      (freshClient, otherFreshClient) <- clientsF
       infoList <- freshClient.getPeerInfo
     } yield {
       assert(infoList.length >= 0)
@@ -41,9 +43,9 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
     }
   }
 
-  it should "test mempool acceptance" in {
+  it should "test mempool acceptance" in { nodePair: FixtureParam =>
+    val NodePair(client, otherClient) = nodePair
     for {
-      (client, otherClient) <- clientsF
       tx <-
         BitcoindRpcTestUtil.createRawCoinbaseTransaction(client, otherClient)
       acceptance <- client.testMempoolAccept(tx)
@@ -53,149 +55,155 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
   }
 
   it should "sign a raw transaction with wallet keys" in {
-    for {
-      (client, otherClient) <- clientsF
-      rawTx <-
-        BitcoindRpcTestUtil.createRawCoinbaseTransaction(client, otherClient)
-      signedTx <- client.signRawTransactionWithWallet(rawTx)
-    } yield assert(signedTx.complete)
+    nodePair: FixtureParam =>
+      val NodePair(client, otherClient) = nodePair
+      for {
+        rawTx <-
+          BitcoindRpcTestUtil.createRawCoinbaseTransaction(client, otherClient)
+        signedTx <- client.signRawTransactionWithWallet(rawTx)
+      } yield assert(signedTx.complete)
   }
 
   // copied from Bitcoin Core: https://github.com/bitcoin/bitcoin/blob/fa6180188b8ab89af97860e6497716405a48bab6/test/functional/rpc_signrawtransaction.py
   it should "sign a raw transaction with private keys" in {
-    val privkeys =
-      List("cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N",
-           "cVKpPfVKSJxKqVpE9awvXNWuLHCa5j5tiE7K6zbUSptFpTEtiFrA")
-        .map(ECPrivateKeyUtil.fromWIFToPrivateKey)
+    nodePair: FixtureParam =>
+      val NodePair(client, _) = nodePair
+      val privkeys =
+        List("cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N",
+             "cVKpPfVKSJxKqVpE9awvXNWuLHCa5j5tiE7K6zbUSptFpTEtiFrA")
+          .map(ECPrivateKeyUtil.fromWIFToPrivateKey)
 
-    val txids =
-      List("9b907ef1e3c26fc71fe4a4b3580bc75264112f95050014157059c736f0202e71",
-           "83a4f6a6b73660e13ee6cb3c6063fa3759c50c9b7521d0536022961898f4fb02")
-        .map(DoubleSha256DigestBE.fromHex)
+      val txids =
+        List("9b907ef1e3c26fc71fe4a4b3580bc75264112f95050014157059c736f0202e71",
+             "83a4f6a6b73660e13ee6cb3c6063fa3759c50c9b7521d0536022961898f4fb02")
+          .map(DoubleSha256DigestBE.fromHex)
 
-    val vouts = List(0, 0)
+      val vouts = List(0, 0)
 
-    val inputs: Vector[TransactionInput] = txids
-      .zip(vouts)
-      .map { case (txid, vout) =>
-        TransactionInput.fromTxidAndVout(txid, UInt32(vout))
+      val inputs: Vector[TransactionInput] = txids
+        .zip(vouts)
+        .map { case (txid, vout) =>
+          TransactionInput.fromTxidAndVout(txid, UInt32(vout))
+        }
+        .toVector
+
+      val address =
+        BitcoinAddress.fromString("mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB")
+
+      val outputs: Map[BitcoinAddress, Bitcoins] =
+        Map(address -> Bitcoins(0.1))
+
+      val scriptPubKeys =
+        List("76a91460baa0f494b38ce3c940dea67f3804dc52d1fb9488ac",
+             "76a914669b857c03a5ed269d5d85a1ffac9ed5d663072788ac")
+          .map(ScriptPubKey.fromAsmHex)
+
+      val utxoDeps = inputs.zip(scriptPubKeys).map { case (input, pubKey) =>
+        SignRawTransactionOutputParameter.fromTransactionInput(input, pubKey)
       }
-      .toVector
 
-    val address =
-      BitcoinAddress.fromString("mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB")
-
-    val outputs: Map[BitcoinAddress, Bitcoins] =
-      Map(address -> Bitcoins(0.1))
-
-    val scriptPubKeys =
-      List("76a91460baa0f494b38ce3c940dea67f3804dc52d1fb9488ac",
-           "76a914669b857c03a5ed269d5d85a1ffac9ed5d663072788ac")
-        .map(ScriptPubKey.fromAsmHex)
-
-    val utxoDeps = inputs.zip(scriptPubKeys).map { case (input, pubKey) =>
-      SignRawTransactionOutputParameter.fromTransactionInput(input, pubKey)
-    }
-
-    for {
-      (client, _) <- clientsF
-      rawTx <- client.createRawTransaction(inputs, outputs)
-      signed <-
-        client.signRawTransactionWithKey(rawTx, privkeys.toVector, utxoDeps)
-    } yield assert(signed.complete)
+      for {
+        rawTx <- client.createRawTransaction(inputs, outputs)
+        signed <-
+          client.signRawTransactionWithKey(rawTx, privkeys.toVector, utxoDeps)
+      } yield assert(signed.complete)
   }
 
   it should "be able to get the address info for a given address" in {
-    for {
-      (client, _) <- clientsF
-      addr <- client.getNewAddress
-      info <- client.getAddressInfo(addr)
-    } yield assert(info.address == addr)
+    nodePair: FixtureParam =>
+      val NodePair(client, _) = nodePair
+      for {
+        addr <- client.getNewAddress
+        info <- client.getAddressInfo(addr)
+      } yield assert(info.address == addr)
   }
 
   it should "be able to get the address info for a given P2SHSegwit address" in {
-    for {
-      (client, _) <- clientsF
-      addr <- client.getNewAddress(addressType = AddressType.P2SHSegwit)
-      info <- client.getAddressInfo(addr)
-    } yield assert(info.address == addr)
+    nodePair: FixtureParam =>
+      val NodePair(client, _) = nodePair
+      for {
+        addr <- client.getNewAddress(addressType = AddressType.P2SHSegwit)
+        info <- client.getAddressInfo(addr)
+      } yield assert(info.address == addr)
   }
 
   it should "be able to get the address info for a given Legacy address" in {
-    for {
-      (client, _) <- clientsF
-      addr <- client.getNewAddress(addressType = AddressType.Legacy)
-      info <- client.getAddressInfo(addr)
-    } yield assert(info.address == addr)
+    nodePair: FixtureParam =>
+      val NodePair(client, _) = nodePair
+      for {
+        addr <- client.getNewAddress(addressType = AddressType.Legacy)
+        info <- client.getAddressInfo(addr)
+      } yield assert(info.address == addr)
   }
 
   // needs #360 to be merged
   it should "be able to get the address info for a given Bech32 address" in {
-    for {
-      (client, _) <- clientsF
-      addr <- client.getNewAddress(AddressType.Bech32)
-      info <- client.getAddressInfo(addr)
-    } yield {
-      assert(info.address.networkParameters == RegTest)
-      assert(info.address == addr)
-    }
+    nodePair: FixtureParam =>
+      val NodePair(client, _) = nodePair
+      for {
+        addr <- client.getNewAddress(AddressType.Bech32)
+        info <- client.getAddressInfo(addr)
+      } yield {
+        assert(info.address.networkParameters == RegTest)
+        assert(info.address == addr)
+      }
   }
 
   it should "be able to get the amount received by a label" in {
-    for {
-      (client, otherClient) <- clientsF
-      address <- client.getNewAddress(usedLabel)
-      _ <-
-        BitcoindRpcTestUtil
-          .fundBlockChainTransaction(client,
-                                     otherClient,
-                                     address,
-                                     Bitcoins(1.5))
+    nodePair: FixtureParam =>
+      val NodePair(client, otherClient) = nodePair
+      for {
+        address <- client.getNewAddress(usedLabel)
+        _ <-
+          BitcoindRpcTestUtil
+            .fundBlockChainTransaction(client,
+                                       otherClient,
+                                       address,
+                                       Bitcoins(1.5))
 
-      amount <- client.getReceivedByLabel(usedLabel)
-    } yield assert(amount == Bitcoins(1.5))
+        amount <- client.getReceivedByLabel(usedLabel)
+      } yield assert(amount == Bitcoins(1.5))
   }
 
-  it should "list all labels" in {
+  it should "list all labels" in { nodePair: FixtureParam =>
+    val NodePair(client, _) = nodePair
     for {
-      (client, _) <- clientsF
       _ <- client.listLabels()
     } yield succeed
   }
 
-  it should "list all labels with purposes" in {
-    clientsF.flatMap { case (client, otherClient) =>
-      val sendLabel = "sendLabel"
+  it should "list all labels with purposes" in { nodePair: FixtureParam =>
+    val NodePair(client, otherClient) = nodePair
+    val sendLabel = "sendLabel"
 
-      val isImportDone = () =>
-        client.ping().map(_ => true).recover {
-          case exc if exc.getMessage.contains("rescanning") => false
-          case exc =>
-            logger.error(s"throwing $exc")
-            throw exc
-        }
+    val isImportDone = () =>
+      client.ping().map(_ => true).recover {
+        case exc if exc.getMessage.contains("rescanning") => false
+        case exc =>
+          logger.error(s"throwing $exc")
+          throw exc
+      }
 
-      def importTx(n: Int): Future[Unit] =
-        for {
-          address <- otherClient.getNewAddress
-          _ <- client.importAddress(address, sendLabel + n)
-          _ <- AsyncUtil.retryUntilSatisfiedF(isImportDone)
-        } yield ()
-
+    def importTx(n: Int): Future[Unit] =
       for {
-        _ <- importTx(0)
-        _ <- importTx(1)
-        receiveLabels <- client.listLabels(Some(LabelPurpose.Receive))
-        sendLabels <- client.listLabels(Some(LabelPurpose.Send))
-      } yield assert(receiveLabels != sendLabels)
-    }
+        address <- otherClient.getNewAddress
+        _ <- client.importAddress(address, sendLabel + n)
+        _ <- AsyncUtil.retryUntilSatisfiedF(isImportDone)
+      } yield ()
+
+    for {
+      _ <- importTx(0)
+      _ <- importTx(1)
+      receiveLabels <- client.listLabels(Some(LabelPurpose.Receive))
+      sendLabels <- client.listLabels(Some(LabelPurpose.Send))
+    } yield assert(receiveLabels != sendLabels)
   }
 
-  it should "set labels" in {
+  it should "set labels" in { nodePair: FixtureParam =>
+    val NodePair(client, otherClient) = nodePair
     val l = "setLabel"
     val btc = Bitcoins(1)
     for {
-      (client, otherClient) <- clientsF
       addr <- client.getNewAddress
       _ <- BitcoindRpcTestUtil.fundBlockChainTransaction(otherClient,
                                                          client,
@@ -214,9 +222,9 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
     } yield assert(newAmount == btc)
   }
 
-  it should "list amounts received by all labels" in {
+  it should "list amounts received by all labels" in { nodePair: FixtureParam =>
+    val NodePair(client, otherClient) = nodePair
     for {
-      (client, otherClient) <- clientsF
       addressWithLabel <- client.getNewAddress(usedLabel)
       addressNoLabel <- client.getNewAddress
       _ <- otherClient.sendToAddress(addressNoLabel, Bitcoins.one)
@@ -244,9 +252,9 @@ class BitcoindV17RpcClientTest extends BitcoindRpcTest {
     }
   }
 
-  it should "create a wallet" in {
+  it should "create a wallet" in { nodePair: FixtureParam =>
+    val NodePair(client, _) = nodePair
     for {
-      (client, _) <- clientsF
       _ <- client.createWallet("suredbits")
       wallets <- client.listWallets
     } yield {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/PsbtRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/PsbtRpcTest.scala
@@ -13,37 +13,21 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint
 }
 import org.bitcoins.core.psbt.PSBT
-import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.client.v17.BitcoindV17RpcClient
 import org.bitcoins.rpc.util.NodePair
 import org.bitcoins.testkit.rpc.{
-  BitcoindFixturesCachedPair,
+  BitcoindFixturesCachedPairV17,
   BitcoindRpcTestUtil
 }
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
-import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
 
 class PsbtRpcTest
     extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesCachedPair[BitcoindV17RpcClient] {
+    with BitcoindFixturesCachedPairV17 {
 
   behavior of "PsbtRpc"
-
-  override def version: BitcoindVersion = BitcoindVersion.V17
-
-  override type FixtureParam = NodePair[BitcoindV17RpcClient]
-
-  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    val f: Future[Outcome] = for {
-      clients <- clientsF
-      futOutcome = with2BitcoindsCached(test, clients)
-      fut <- futOutcome.toFuture
-    } yield fut
-
-    new FutureOutcome(f)
-  }
 
   // https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#Test_Vectors
   it should "decode all the BIP174 example PSBTs" in {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/PsbtRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/PsbtRpcTest.scala
@@ -13,11 +13,12 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint
 }
 import org.bitcoins.core.psbt.PSBT
+import org.bitcoins.rpc.client.common.BitcoindVersion
+import org.bitcoins.rpc.client.v17.BitcoindV17RpcClient
 import org.bitcoins.rpc.util.NodePair
 import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedPair,
-  BitcoindRpcTestUtil,
-  CachedBitcoindNewest
+  BitcoindRpcTestUtil
 }
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 import org.scalatest.{FutureOutcome, Outcome}
@@ -26,12 +27,13 @@ import scala.concurrent.Future
 
 class PsbtRpcTest
     extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesCachedPair
-    with CachedBitcoindNewest {
+    with BitcoindFixturesCachedPair[BitcoindV17RpcClient] {
 
   behavior of "PsbtRpc"
 
-  override type FixtureParam = NodePair
+  override def version: BitcoindVersion = BitcoindVersion.V17
+
+  override type FixtureParam = NodePair[BitcoindV17RpcClient]
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
@@ -44,25 +46,26 @@ class PsbtRpcTest
   }
 
   // https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#Test_Vectors
-  it should "decode all the BIP174 example PSBTs" in { nodePair: NodePair =>
-    val client = nodePair.node1
-    val psbts = Vector(
-      "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAAAA",
-      "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEHakcwRAIgR1lmF5fAGwNrJZKJSGhiGDR9iYZLcZ4ff89X0eURZYcCIFMJ6r9Wqk2Ikf/REf3xM286KdqGbX+EhtdVRs7tr5MZASEDXNxh/HupccC1AaZGoqg7ECy0OIEhfKaC3Ibi1z+ogpIAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIAAAA",
-      "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAQMEAQAAAAAAAA==",
-      "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEA3wIAAAABJoFxNx7f8oXpN63upLN7eAAMBWbLs61kZBcTykIXG/YAAAAAakcwRAIgcLIkUSPmv0dNYMW1DAQ9TGkaXSQ18Jo0p2YqncJReQoCIAEynKnazygL3zB0DsA5BCJCLIHLRYOUV663b8Eu3ZWzASECZX0RjTNXuOD0ws1G23s59tnDjZpwq8ubLeXcjb/kzjH+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIACICAurVlmh8qAYEPtw94RbN8p1eklfBls0FXPaYyNAr8k6ZELSmumcAAACAAAAAgAIAAIAAIgIDlPYr6d8ZlSxVh3aK63aYBhrSxKJciU9H2MFitNchPQUQtKa6ZwAAAIABAACAAgAAgAA=",
-      "cHNidP8BAFUCAAAAASeaIyOl37UfxF8iD6WLD8E+HjNCeSqF1+Ns1jM7XLw5AAAAAAD/////AaBa6gsAAAAAGXapFP/pwAYQl8w7Y28ssEYPpPxCfStFiKwAAAAAAAEBIJVe6gsAAAAAF6kUY0UgD2jRieGtwN8cTRbqjxTA2+uHIgIDsTQcy6doO2r08SOM1ul+cWfVafrEfx5I1HVBhENVvUZGMEMCIAQktY7/qqaU4VWepck7v9SokGQiQFXN8HC2dxRpRC0HAh9cjrD+plFtYLisszrWTt5g6Hhb+zqpS5m9+GFR25qaAQEEIgAgdx/RitRZZm3Unz1WTj28QvTIR3TjYK2haBao7UiNVoEBBUdSIQOxNBzLp2g7avTxI4zW6X5xZ9Vp+sR/HkjUdUGEQ1W9RiED3lXR4drIBeP4pYwfv5uUwC89uq/hJ/78pJlfJvggg71SriIGA7E0HMunaDtq9PEjjNbpfnFn1Wn6xH8eSNR1QYRDVb1GELSmumcAAACAAAAAgAQAAIAiBgPeVdHh2sgF4/iljB+/m5TALz26r+En/vykmV8m+CCDvRC0prpnAAAAgAAAAIAFAACAAAA=",
-      "cHNidP8BAD8CAAAAAf//////////////////////////////////////////AAAAAAD/////AQAAAAAAAAAAA2oBAAAAAAAACg8BAgMEBQYHCAkPAQIDBAUGBwgJCgsMDQ4PAAA=",
-      "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA==" // this one is from Core
-    ).map(PSBT.fromBase64)
+  it should "decode all the BIP174 example PSBTs" in {
+    nodePair: NodePair[BitcoindV17RpcClient] =>
+      val client = nodePair.node1
+      val psbts = Vector(
+        "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAAAA",
+        "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEHakcwRAIgR1lmF5fAGwNrJZKJSGhiGDR9iYZLcZ4ff89X0eURZYcCIFMJ6r9Wqk2Ikf/REf3xM286KdqGbX+EhtdVRs7tr5MZASEDXNxh/HupccC1AaZGoqg7ECy0OIEhfKaC3Ibi1z+ogpIAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIAAAA",
+        "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAQMEAQAAAAAAAA==",
+        "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEA3wIAAAABJoFxNx7f8oXpN63upLN7eAAMBWbLs61kZBcTykIXG/YAAAAAakcwRAIgcLIkUSPmv0dNYMW1DAQ9TGkaXSQ18Jo0p2YqncJReQoCIAEynKnazygL3zB0DsA5BCJCLIHLRYOUV663b8Eu3ZWzASECZX0RjTNXuOD0ws1G23s59tnDjZpwq8ubLeXcjb/kzjH+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIACICAurVlmh8qAYEPtw94RbN8p1eklfBls0FXPaYyNAr8k6ZELSmumcAAACAAAAAgAIAAIAAIgIDlPYr6d8ZlSxVh3aK63aYBhrSxKJciU9H2MFitNchPQUQtKa6ZwAAAIABAACAAgAAgAA=",
+        "cHNidP8BAFUCAAAAASeaIyOl37UfxF8iD6WLD8E+HjNCeSqF1+Ns1jM7XLw5AAAAAAD/////AaBa6gsAAAAAGXapFP/pwAYQl8w7Y28ssEYPpPxCfStFiKwAAAAAAAEBIJVe6gsAAAAAF6kUY0UgD2jRieGtwN8cTRbqjxTA2+uHIgIDsTQcy6doO2r08SOM1ul+cWfVafrEfx5I1HVBhENVvUZGMEMCIAQktY7/qqaU4VWepck7v9SokGQiQFXN8HC2dxRpRC0HAh9cjrD+plFtYLisszrWTt5g6Hhb+zqpS5m9+GFR25qaAQEEIgAgdx/RitRZZm3Unz1WTj28QvTIR3TjYK2haBao7UiNVoEBBUdSIQOxNBzLp2g7avTxI4zW6X5xZ9Vp+sR/HkjUdUGEQ1W9RiED3lXR4drIBeP4pYwfv5uUwC89uq/hJ/78pJlfJvggg71SriIGA7E0HMunaDtq9PEjjNbpfnFn1Wn6xH8eSNR1QYRDVb1GELSmumcAAACAAAAAgAQAAIAiBgPeVdHh2sgF4/iljB+/m5TALz26r+En/vykmV8m+CCDvRC0prpnAAAAgAAAAIAFAACAAAA=",
+        "cHNidP8BAD8CAAAAAf//////////////////////////////////////////AAAAAAD/////AQAAAAAAAAAAA2oBAAAAAAAACg8BAgMEBQYHCAkPAQIDBAUGBwgJCgsMDQ4PAAA=",
+        "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA==" // this one is from Core
+      ).map(PSBT.fromBase64)
 
-    for {
-      _ <- Future.sequence(psbts.map(client.decodePsbt))
-    } yield succeed
+      for {
+        _ <- Future.sequence(psbts.map(client.decodePsbt))
+      } yield succeed
   }
 
   it should "convert raw TXs to PSBTs, process them  and then decode them" in {
-    nodePair: NodePair =>
+    nodePair: FixtureParam =>
       val client = nodePair.node1
       for {
         address <- client.getNewAddress
@@ -80,7 +83,7 @@ class PsbtRpcTest
 
   }
 
-  it should "finalize a simple PSBT" in { nodePair: NodePair =>
+  it should "finalize a simple PSBT" in { nodePair: FixtureParam =>
     val client = nodePair.node1
     val otherClient = nodePair.node2
     for {
@@ -103,7 +106,7 @@ class PsbtRpcTest
   }
 
   // copies this test from Core: https://github.com/bitcoin/bitcoin/blob/master/test/functional/rpc_psbt.py#L158
-  it should "combine PSBTs from multiple sources" in { nodePair: NodePair =>
+  it should "combine PSBTs from multiple sources" in { nodePair: FixtureParam =>
     val client = nodePair.node1
     val otherClient = nodePair.node2
     for {
@@ -144,7 +147,7 @@ class PsbtRpcTest
     }
   }
 
-  it should "create a PSBT and then decode it" in { nodePair: NodePair =>
+  it should "create a PSBT and then decode it" in { nodePair: FixtureParam =>
     val client = nodePair.node1
     for {
       address <- client.getNewAddress
@@ -167,7 +170,7 @@ class PsbtRpcTest
   }
 
   it should "create a funded wallet PSBT and then decode it" in {
-    nodePair: NodePair =>
+    nodePair: FixtureParam =>
       val client = nodePair.node1
       for {
         address <- client.getNewAddress

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/PsbtRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v17/PsbtRpcTest.scala
@@ -19,13 +19,10 @@ import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedPairV17,
   BitcoindRpcTestUtil
 }
-import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
 import scala.concurrent.Future
 
-class PsbtRpcTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesCachedPairV17 {
+class PsbtRpcTest extends BitcoindFixturesCachedPairV17 {
 
   behavior of "PsbtRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
@@ -16,22 +16,12 @@ import org.bitcoins.testkit.rpc.{
   BitcoindRpcTestUtil
 }
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
-import org.scalatest.FutureOutcome
 
 import scala.concurrent.{Await, Future}
 
 class BitcoindV18RpcClientTest
     extends BitcoinSAsyncFixtureTest
     with BitcoindFixturesCachedPairV18 {
-
-  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    val futOutcome = for {
-      pair <- clientsF
-      futOutcome = with2BitcoindsCached(test, pair)
-      f <- futOutcome.toFuture
-    } yield f
-    new FutureOutcome(futOutcome)
-  }
 
   lazy val clientF: Future[BitcoindV18RpcClient] = {
     val client = new BitcoindV18RpcClient(BitcoindRpcTestUtil.v18Instance())

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
@@ -1,22 +1,32 @@
 package org.bitcoins.rpc.v18
 
-import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.AddNodeArgument
-import org.bitcoins.commons.jsonmodels.bitcoind.{
-  AddressInfoResultPostV18,
-  AddressInfoResultPostV21,
-  AddressInfoResultPreV18
-}
 import org.bitcoins.core.api.chain.db.BlockHeaderDbHelper
 import org.bitcoins.core.protocol.blockchain.RegTestNetChainParams
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.client.v18.BitcoindV18RpcClient
+import org.bitcoins.rpc.util.NodePair
 import org.bitcoins.testkit.chain.BlockHeaderHelper
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesCachedPairV18,
+  BitcoindRpcTestUtil
+}
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
+import org.scalatest.FutureOutcome
 
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
 
-class BitcoindV18RpcClientTest extends BitcoindRpcTest {
+class BitcoindV18RpcClientTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCachedPairV18 {
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val futOutcome = for {
+      pair <- clientsF
+      futOutcome = with2BitcoindsCached(test, pair)
+      f <- futOutcome.toFuture
+    } yield f
+    new FutureOutcome(futOutcome)
+  }
 
   lazy val clientF: Future[BitcoindV18RpcClient] = {
     val client = new BitcoindV18RpcClient(BitcoindRpcTestUtil.v18Instance())
@@ -24,16 +34,11 @@ class BitcoindV18RpcClientTest extends BitcoindRpcTest {
     clientIsStartedF.map(_ => client)
   }
 
-  lazy val clientPairF: Future[(BitcoindV18RpcClient, BitcoindV18RpcClient)] =
-    BitcoindRpcTestUtil.createNodePairV18(clientAccum)
-
-  clientF.foreach(c => clientAccum.+=(c))
-
   behavior of "BitcoindV18RpcClient"
 
-  it should "be able to get peer info" in {
+  it should "be able to get peer info" in { nodePair =>
+    val NodePair(freshClient, otherFreshClient) = nodePair
     for {
-      (freshClient, otherFreshClient) <- clientPairF
       infoList <- freshClient.getPeerInfo
     } yield {
       assert(infoList.length >= 0)
@@ -44,35 +49,32 @@ class BitcoindV18RpcClientTest extends BitcoindRpcTest {
   }
 
   it must "have our BitcoindRpcClient work with .hashCode() and equals" in {
-    for {
-      (client1, client2) <- clientPairF
-    } yield {
+    nodePair =>
+      val NodePair(client1, client2) = nodePair
       assert(client1 != client2)
       assert(client1.hashCode() != client2.hashCode())
-    }
   }
 
-  it should "be able to start a V18 bitcoind instance" in {
-
-    clientF.map { client =>
-      assert(client.version == BitcoindVersion.V18)
-    }
+  it should "be able to start a V18 bitcoind instance" in { nodePair =>
+    val NodePair(client, _) = nodePair
+    assert(client.version == BitcoindVersion.V18)
   }
 
-  it should "return active rpc commands" in {
-    val generatedF = clientF.flatMap(client =>
-      client.getNewAddress.flatMap(addr => client.generateToAddress(100, addr)))
+  it should "return active rpc commands" in { nodePair =>
+    val NodePair(client: BitcoindV18RpcClient, _) = nodePair
+    val generatedF =
+      client.getNewAddress.flatMap(addr => client.generateToAddress(100, addr))
     val rpcinfoF =
-      generatedF.flatMap(_ => clientF.flatMap(client => client.getRpcInfo()))
+      generatedF.flatMap(_ => client.getRpcInfo())
 
     rpcinfoF.map { result =>
       assert(result.active_commands.length == 1)
     }
   }
 
-  it should "return a list of wallets" in {
+  it should "return a list of wallets" in { nodePair =>
+    val NodePair(client: BitcoindV18RpcClient, _) = nodePair
     for {
-      client <- clientF
       _ <- client.createWallet("Suredbits")
       list <- client.listWalletDir()
     } yield {
@@ -80,13 +82,12 @@ class BitcoindV18RpcClientTest extends BitcoindRpcTest {
     }
   }
 
-  it should "analyze a descriptor" in {
-
+  it should "analyze a descriptor" in { nodePair =>
+    val NodePair(client: BitcoindV18RpcClient, _) = nodePair
     val descriptor =
       "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)"
 
-    val descriptorF =
-      clientF.flatMap(client => client.getDescriptorInfo(descriptor))
+    val descriptorF = client.getDescriptorInfo(descriptor)
 
     descriptorF.map { result =>
       assert(result.isrange.==(false))
@@ -95,39 +96,27 @@ class BitcoindV18RpcClientTest extends BitcoindRpcTest {
     }
   }
 
-  it should "get node address given a null parameter" in {
-    val nodeF = clientF.flatMap(client => client.getNodeAddresses())
+  it should "get node address given a null parameter" in { nodePair =>
+    val NodePair(client: BitcoindV18RpcClient, _) = nodePair
+    val nodeF = client.getNodeAddresses()
 
     nodeF.map { result =>
       assert(result.isEmpty)
     }
   }
 
-  //TODO: currently the test doesn't work because of how known nodes work (remove ignore and implement test)
-  it should "get node addresses given a count" ignore {
-    for {
-      (freshClient, otherFreshClient) <- clientPairF
-      _ <- freshClient.addNode(freshClient.getDaemon.uri, AddNodeArgument.Add)
-      nodeaddress <- freshClient.getNodeAddresses(1)
-    } yield {
-      assert(nodeaddress.head.address == otherFreshClient.instance.uri)
-      assert(nodeaddress.head.services == 1)
-    }
-
-  }
-
-  it should "successfully submit a header" in {
+  it should "successfully submit a header" in { nodePair =>
+    val NodePair(client: BitcoindV18RpcClient, _) = nodePair
     val genesisHeader = RegTestNetChainParams.genesisBlock.blockHeader
     val genesisHeaderDb =
       BlockHeaderDbHelper.fromBlockHeader(height = 1, BigInt(0), genesisHeader)
     val nextHeader = BlockHeaderHelper.buildNextHeader(genesisHeaderDb)
-    clientF.flatMap(client =>
-      client.submitHeader(nextHeader.blockHeader).map(_ => succeed))
+    client.submitHeader(nextHeader.blockHeader).map(_ => succeed)
   }
 
-  it should "have extra address information" in {
+  /*  it should "have extra address information" in { nodePair =>
+    val NodePair(client: BitcoindV18RpcClient, _) = nodePair
     for {
-      (client, _) <- clientPairF
       address <- client.getNewAddress
       info <- client.getAddressInfo(address)
     } yield {
@@ -138,6 +127,11 @@ class BitcoindV18RpcClientTest extends BitcoindRpcTest {
           assert(postV18Info.address == address)
       }
     }
-  }
+  }*/
 
+  override def afterAll(): Unit = {
+    val stoppedF = clientF.map(BitcoindRpcTestUtil.stopServer)
+    Await.result(stoppedF, duration)
+    super.afterAll()
+  }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
@@ -10,11 +10,8 @@ import org.bitcoins.core.protocol.blockchain.RegTestNetChainParams
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.testkit.chain.BlockHeaderHelper
 import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV18
-import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
-class BitcoindV18RpcClientTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesFundedCachedV18 {
+class BitcoindV18RpcClientTest extends BitcoindFixturesFundedCachedV18 {
 
   behavior of "BitcoindV18RpcClient"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/PsbtRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/PsbtRpcTest.scala
@@ -4,14 +4,11 @@ import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.rpc.client.v18.BitcoindV18RpcClient
 import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV18
-import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
 /** Tests for PSBT for RPC calls specific to V18 new PSBT calls
   * @see https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#test-vectors
   */
-class PsbtRpcTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesFundedCachedV18 {
+class PsbtRpcTest extends BitcoindFixturesFundedCachedV18 {
 
   behavior of "PsbtRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/PsbtRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/PsbtRpcTest.scala
@@ -3,66 +3,56 @@ package org.bitcoins.rpc.v18
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.rpc.client.v18.BitcoindV18RpcClient
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
-
-import scala.concurrent.Future
+import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV18
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
 /** Tests for PSBT for RPC calls specific to V18 new PSBT calls
   * @see https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#test-vectors
   */
-class PsbtRpcTest extends BitcoindRpcTest {
-
-  lazy val clientF: Future[BitcoindV18RpcClient] = {
-    val client = new BitcoindV18RpcClient(BitcoindRpcTestUtil.v18Instance())
-    val clientIsStartedF = BitcoindRpcTestUtil.startServers(Vector(client))
-    clientIsStartedF.map(_ => client)
-  }
-
-  clientF.foreach(c => clientAccum.+=(c))
+class PsbtRpcTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesFundedCachedV18 {
 
   behavior of "PsbtRpc"
 
   it should "return something when analyzePsbt is called" in {
-    //PSBT with one P2PKH input and one P2SH-P2WPKH input both with non-final scriptSigs. P2SH-P2WPKH input's redeemScript is available. Outputs filled.
-    val psbt =
-      "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEA3wIAAAABJoFxNx7f8oXpN63upLN7eAAMBWbLs61kZBcTykIXG/YAAAAAakcwRAIgcLIkUSPmv0dNYMW1DAQ9TGkaXSQ18Jo0p2YqncJReQoCIAEynKnazygL3zB0DsA5BCJCLIHLRYOUV663b8Eu3ZWzASECZX0RjTNXuOD0ws1G23s59tnDjZpwq8ubLeXcjb/kzjH+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIACICAurVlmh8qAYEPtw94RbN8p1eklfBls0FXPaYyNAr8k6ZELSmumcAAACAAAAAgAIAAIAAIgIDlPYr6d8ZlSxVh3aK63aYBhrSxKJciU9H2MFitNchPQUQtKa6ZwAAAIABAACAAgAAgAA="
+    client: BitcoindV18RpcClient =>
+      //PSBT with one P2PKH input and one P2SH-P2WPKH input both with non-final scriptSigs. P2SH-P2WPKH input's redeemScript is available. Outputs filled.
+      val psbt =
+        "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEA3wIAAAABJoFxNx7f8oXpN63upLN7eAAMBWbLs61kZBcTykIXG/YAAAAAakcwRAIgcLIkUSPmv0dNYMW1DAQ9TGkaXSQ18Jo0p2YqncJReQoCIAEynKnazygL3zB0DsA5BCJCLIHLRYOUV663b8Eu3ZWzASECZX0RjTNXuOD0ws1G23s59tnDjZpwq8ubLeXcjb/kzjH+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIACICAurVlmh8qAYEPtw94RbN8p1eklfBls0FXPaYyNAr8k6ZELSmumcAAACAAAAAgAIAAIAAIgIDlPYr6d8ZlSxVh3aK63aYBhrSxKJciU9H2MFitNchPQUQtKa6ZwAAAIABAACAAgAAgAA="
 
-    clientF.flatMap { client =>
       val resultF = client.analyzePsbt(PSBT.fromBase64(psbt))
       resultF.map { result =>
         val inputs = result.inputs
         assert(inputs.nonEmpty)
       }
-    }
   }
   it should "analyze a PSBT and return a non-empty result" in {
-    //PSBT with one P2PKH input and one P2SH-P2WPKH input both with non-final scriptSigs. P2SH-P2WPKH input's redeemScript is available. Outputs filled.
+    client: BitcoindV18RpcClient =>
+      //PSBT with one P2PKH input and one P2SH-P2WPKH input both with non-final scriptSigs. P2SH-P2WPKH input's redeemScript is available. Outputs filled.
 
-    val psbt =
-      "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEA3wIAAAABJoFxNx7f8oXpN63upLN7eAAMBWbLs61kZBcTykIXG/YAAAAAakcwRAIgcLIkUSPmv0dNYMW1DAQ9TGkaXSQ18Jo0p2YqncJReQoCIAEynKnazygL3zB0DsA5BCJCLIHLRYOUV663b8Eu3ZWzASECZX0RjTNXuOD0ws1G23s59tnDjZpwq8ubLeXcjb/kzjH+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIACICAurVlmh8qAYEPtw94RbN8p1eklfBls0FXPaYyNAr8k6ZELSmumcAAACAAAAAgAIAAIAAIgIDlPYr6d8ZlSxVh3aK63aYBhrSxKJciU9H2MFitNchPQUQtKa6ZwAAAIABAACAAgAAgAA="
-    val analyzedF =
-      clientF.flatMap(client => client.analyzePsbt(PSBT.fromBase64(psbt)))
+      val psbt =
+        "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEA3wIAAAABJoFxNx7f8oXpN63upLN7eAAMBWbLs61kZBcTykIXG/YAAAAAakcwRAIgcLIkUSPmv0dNYMW1DAQ9TGkaXSQ18Jo0p2YqncJReQoCIAEynKnazygL3zB0DsA5BCJCLIHLRYOUV663b8Eu3ZWzASECZX0RjTNXuOD0ws1G23s59tnDjZpwq8ubLeXcjb/kzjH+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIACICAurVlmh8qAYEPtw94RbN8p1eklfBls0FXPaYyNAr8k6ZELSmumcAAACAAAAAgAIAAIAAIgIDlPYr6d8ZlSxVh3aK63aYBhrSxKJciU9H2MFitNchPQUQtKa6ZwAAAIABAACAAgAAgAA="
+      val analyzedF = client.analyzePsbt(PSBT.fromBase64(psbt))
 
-    analyzedF.map { result =>
-      assert(result.inputs.exists(_.next.isDefined))
-      assert(result.inputs.exists(_.missing.head.pubkeys.head.nonEmpty))
-      assert(result.inputs.exists(_.missing.head.signatures.isEmpty))
-      assert(result.inputs.exists(_.missing.head.redeemscript.isEmpty))
-      assert(result.inputs.exists(_.missing.head.witnessscript.isEmpty))
-      assert(result.inputs.exists(_.is_final) == false)
-      assert(result.estimated_feerate.isDefined == false)
-      assert(result.estimated_vsize.isDefined == false)
-      assert(result.fee.isDefined)
-      assert(result.next.nonEmpty)
-    }
+      analyzedF.map { result =>
+        assert(result.inputs.exists(_.next.isDefined))
+        assert(result.inputs.exists(_.missing.head.pubkeys.head.nonEmpty))
+        assert(result.inputs.exists(_.missing.head.signatures.isEmpty))
+        assert(result.inputs.exists(_.missing.head.redeemscript.isEmpty))
+        assert(result.inputs.exists(_.missing.head.witnessscript.isEmpty))
+        assert(result.inputs.exists(_.is_final) == false)
+        assert(result.estimated_feerate.isDefined == false)
+        assert(result.estimated_vsize.isDefined == false)
+        assert(result.fee.isDefined)
+        assert(result.next.nonEmpty)
+      }
   }
-  it should "correctly analyze a psbt " in {
+  it should "correctly analyze a psbt " in { client: BitcoindV18RpcClient =>
     val psbt =
       //PSBT with one P2PKH input and one P2SH-P2WPKH input both with non-final scriptSigs. P2SH-P2WPKH input's redeemScript is available. Outputs filled.
       "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEA3wIAAAABJoFxNx7f8oXpN63upLN7eAAMBWbLs61kZBcTykIXG/YAAAAAakcwRAIgcLIkUSPmv0dNYMW1DAQ9TGkaXSQ18Jo0p2YqncJReQoCIAEynKnazygL3zB0DsA5BCJCLIHLRYOUV663b8Eu3ZWzASECZX0RjTNXuOD0ws1G23s59tnDjZpwq8ubLeXcjb/kzjH+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIACICAurVlmh8qAYEPtw94RbN8p1eklfBls0FXPaYyNAr8k6ZELSmumcAAACAAAAAgAIAAIAAIgIDlPYr6d8ZlSxVh3aK63aYBhrSxKJciU9H2MFitNchPQUQtKa6ZwAAAIABAACAAgAAgAA="
-    val analyzedF =
-      clientF.flatMap(client => client.analyzePsbt(PSBT.fromBase64(psbt)))
+    val analyzedF = client.analyzePsbt(PSBT.fromBase64(psbt))
     val expectedfee = Bitcoins(0.00090341)
     val expectedhasutxo = true
     val expectedisfinal = false
@@ -85,14 +75,15 @@ class PsbtRpcTest extends BitcoindRpcTest {
 
   //Todo: figure out how to implement a test here
   it should "check to see if the utxoUpdate input has been updated" in {
-    val psbt =
-      PSBT.fromBase64(
-        "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA==")
-    val updatedF = clientF.flatMap(client => client.utxoUpdatePsbt(psbt))
+    client: BitcoindV18RpcClient =>
+      val psbt =
+        PSBT.fromBase64(
+          "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA==")
+      val updatedF = client.utxoUpdatePsbt(psbt)
 
-    updatedF.map { result =>
-      assert(result == psbt)
-    }
+      updatedF.map { result =>
+        assert(result == psbt)
+      }
   }
 
   /** Join psbt looks at the characteristics of a vector of PSBTs and converts them into a singular PSBT.
@@ -100,7 +91,7 @@ class PsbtRpcTest extends BitcoindRpcTest {
     * together the resulting PSBT represented as a string is very different so we can't just search for parts of either
     * PSBT.
     */
-  it should "joinpsbts " in {
+  it should "joinpsbts " in { client: BitcoindV18RpcClient =>
     val seqofpsbts = Vector(
       PSBT.fromBase64(
         "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAAAA"),
@@ -110,7 +101,7 @@ class PsbtRpcTest extends BitcoindRpcTest {
       )
     )
 
-    val joinedF = clientF.flatMap(client => client.joinPsbts(seqofpsbts))
+    val joinedF = client.joinPsbts(seqofpsbts)
 
     joinedF.map { result =>
       assert(

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v19/BitcoindV19RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v19/BitcoindV19RpcClientTest.scala
@@ -1,149 +1,126 @@
 package org.bitcoins.rpc.v19
 
+import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.WalletFlag
 import org.bitcoins.commons.jsonmodels.bitcoind.{
   Bip9SoftforkPostV19,
   GetBlockChainInfoResultPostV19
 }
-import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.WalletFlag
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.core.gcs.{BlockFilter, FilterType}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV19
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
 import scala.concurrent.Future
 
-class BitcoindV19RpcClientTest extends BitcoindRpcTest {
-
-  lazy val clientF: Future[BitcoindV19RpcClient] = {
-    val client = new BitcoindV19RpcClient(BitcoindRpcTestUtil.v19Instance())
-    val clientIsStartedF = BitcoindRpcTestUtil.startServers(Vector(client))
-    clientIsStartedF.map(_ => client)
-  }
-
-  lazy val clientPairF: Future[(BitcoindV19RpcClient, BitcoindV19RpcClient)] =
-    BitcoindRpcTestUtil.createNodePairV19(clientAccum)
-
-  clientF.foreach(c => clientAccum.+=(c))
+class BitcoindV19RpcClientTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesFundedCachedV19 {
 
   behavior of "BitcoindV19RpcClient"
 
   it should "be able to start a V19 bitcoind instance" in {
-
-    clientF.map { client =>
+    client: BitcoindV19RpcClient =>
       assert(client.version == BitcoindVersion.V19)
-    }
-  }
-
-  it should "be able to get peer info" in {
-    for {
-      (freshClient, otherFreshClient) <- clientPairF
-      infoList <- freshClient.getPeerInfo
-    } yield {
-      assert(infoList.length >= 0)
-      val info = infoList.head
-      assert(info.addnode)
-      assert(info.networkInfo.addr == otherFreshClient.getDaemon.uri)
-    }
   }
 
   it should "get a block filter given a block hash" in {
-    for {
-      (client, _) <- clientPairF
-      blocks <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
-      blockFilter <- client.getBlockFilter(blocks.head, FilterType.Basic)
+    client: BitcoindV19RpcClient =>
+      for {
+        blocks <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
+        blockFilter <- client.getBlockFilter(blocks.head, FilterType.Basic)
 
-      block <- client.getBlockRaw(blocks.head)
-      txs <- Future.sequence(
-        block.transactions
-          .filterNot(_.isCoinbase)
-          .map(tx => client.getTransaction(tx.txIdBE)))
+        block <- client.getBlockRaw(blocks.head)
+        txs <- Future.sequence(
+          block.transactions
+            .filterNot(_.isCoinbase)
+            .map(tx => client.getTransaction(tx.txIdBE)))
 
-      prevFilter <- client.getBlockFilter(block.blockHeader.previousBlockHashBE,
-                                          FilterType.Basic)
-    } yield {
-      val pubKeys = txs.flatMap(_.hex.outputs.map(_.scriptPubKey)).toVector
-      val filter = BlockFilter(block, pubKeys)
-      assert(filter.hash == blockFilter.filter.hash)
-      assert(
-        blockFilter.header == filter
-          .getHeader(prevFilter.header.flip)
-          .hash
-          .flip)
-    }
+        prevFilter <- client.getBlockFilter(
+          block.blockHeader.previousBlockHashBE,
+          FilterType.Basic)
+      } yield {
+        val pubKeys = txs.flatMap(_.hex.outputs.map(_.scriptPubKey)).toVector
+        val filter = BlockFilter(block, pubKeys)
+        assert(filter.hash == blockFilter.filter.hash)
+        assert(
+          blockFilter.header == filter
+            .getHeader(prevFilter.header.flip)
+            .hash
+            .flip)
+      }
   }
 
-  it should "be able to get the balances" in {
+  it should "be able to get the balances" in { client: BitcoindV19RpcClient =>
     for {
-      (client, _) <- clientPairF
       immatureBalance <- client.getBalances
       _ <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
       newImmatureBalance <- client.getBalances
     } yield {
-      val blockReward = 12.5
+      val blockReward = 50
       assert(immatureBalance.mine.immature.toBigDecimal >= 0)
       assert(
-        immatureBalance.mine.immature.toBigDecimal + blockReward == newImmatureBalance.mine.immature.toBigDecimal)
+        immatureBalance.mine.trusted.toBigDecimal + blockReward == newImmatureBalance.mine.trusted.toBigDecimal)
     }
   }
 
   it should "be able to get blockchain info" in {
-    for {
-      (client, _) <- clientPairF
-      info <- client.getBlockChainInfo
-      bestHash <- client.getBestBlockHash
-    } yield {
-      assert(info.isInstanceOf[GetBlockChainInfoResultPostV19])
-      val preV19Info = info.asInstanceOf[GetBlockChainInfoResultPostV19]
-      assert(preV19Info.chain == RegTest)
-      assert(preV19Info.softforks.size >= 5)
-      assert(
-        preV19Info.softforks.values.exists(_.isInstanceOf[Bip9SoftforkPostV19]))
-      assert(preV19Info.bestblockhash == bestHash)
-    }
+    client: BitcoindV19RpcClient =>
+      for {
+        info <- client.getBlockChainInfo
+        bestHash <- client.getBestBlockHash
+      } yield {
+        assert(info.isInstanceOf[GetBlockChainInfoResultPostV19])
+        val preV19Info = info.asInstanceOf[GetBlockChainInfoResultPostV19]
+        assert(preV19Info.chain == RegTest)
+        assert(preV19Info.softforks.size >= 5)
+        assert(
+          preV19Info.softforks.values.exists(
+            _.isInstanceOf[Bip9SoftforkPostV19]))
+        assert(preV19Info.bestblockhash == bestHash)
+      }
   }
 
   it should "be able to set the wallet flag 'avoid_reuse'" in {
-    for {
-      (client, _) <- clientPairF
-      unspentPre <- client.listUnspent
-      result <- client.setWalletFlag(WalletFlag.AvoidReuse, value = true)
-      unspentPost <- client.listUnspent
-    } yield {
-      assert(result.flag_name == "avoid_reuse")
-      assert(result.flag_state)
-      assert(unspentPre.forall(utxo => utxo.reused.isEmpty))
-      assert(unspentPost.forall(utxo => utxo.reused.isDefined))
-    }
+    client: BitcoindV19RpcClient =>
+      for {
+        unspentPre <- client.listUnspent
+        result <- client.setWalletFlag(WalletFlag.AvoidReuse, value = true)
+        unspentPost <- client.listUnspent
+      } yield {
+        assert(result.flag_name == "avoid_reuse")
+        assert(result.flag_state)
+        assert(unspentPre.forall(utxo => utxo.reused.isEmpty))
+        assert(unspentPost.forall(utxo => utxo.reused.isDefined))
+      }
   }
 
   it should "create a wallet with a passphrase" in {
-    for {
-      (client, _) <- clientPairF
-      _ <- client.createWallet("suredbits", passphrase = "stackingsats")
-      wallets <- client.listWallets
-    } yield {
-      assert(wallets.contains("suredbits"))
-    }
+    client: BitcoindV19RpcClient =>
+      for {
+        _ <- client.createWallet("suredbits", passphrase = "stackingsats")
+        wallets <- client.listWallets
+      } yield {
+        assert(wallets.contains("suredbits"))
+      }
 
   }
 
   it should "check to see if the utxoUpdate input has been updated" in {
+    client: BitcoindV19RpcClient =>
+      val descriptor =
+        "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)"
 
-    val descriptor =
-      "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)"
+      val psbt =
+        PSBT.fromBase64(
+          "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA==")
 
-    val psbt =
-      PSBT.fromBase64(
-        "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA==")
-
-    for {
-      (client, _) <- clientPairF
-      result <- client.utxoUpdatePsbt(psbt, Seq(descriptor))
-    } yield {
-      assert(result == psbt)
-    }
+      for {
+        result <- client.utxoUpdatePsbt(psbt, Seq(descriptor))
+      } yield {
+        assert(result == psbt)
+      }
   }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v19/BitcoindV19RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v19/BitcoindV19RpcClientTest.scala
@@ -11,13 +11,10 @@ import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV19
-import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
 import scala.concurrent.Future
 
-class BitcoindV19RpcClientTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesFundedCachedV19 {
+class BitcoindV19RpcClientTest extends BitcoindFixturesFundedCachedV19 {
 
   behavior of "BitcoindV19RpcClient"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v20/BitcoindV20RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v20/BitcoindV20RpcClientTest.scala
@@ -9,17 +9,12 @@ import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.client.v20.BitcoindV20RpcClient
 import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV20
-import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
 import java.io.File
 import java.nio.file.Files
 import scala.concurrent.Future
 
-class BitcoindV20RpcClientTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesFundedCachedV20 {
-
-  override type FixtureParam = BitcoindV20RpcClient
+class BitcoindV20RpcClientTest extends BitcoindFixturesFundedCachedV20 {
 
   behavior of "BitcoindV20RpcClient"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v20/BitcoindV20RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v20/BitcoindV20RpcClientTest.scala
@@ -1,8 +1,5 @@
 package org.bitcoins.rpc.v20
 
-import java.io.File
-import java.nio.file.Files
-
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.WalletFlag
 import org.bitcoins.commons.jsonmodels.bitcoind._
 import org.bitcoins.core.config.RegTest
@@ -11,157 +8,142 @@ import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.client.v20.BitcoindV20RpcClient
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV20
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
+import java.io.File
+import java.nio.file.Files
 import scala.concurrent.Future
 
-class BitcoindV20RpcClientTest extends BitcoindRpcTest {
+class BitcoindV20RpcClientTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesFundedCachedV20 {
 
-  lazy val clientPairF: Future[(BitcoindV20RpcClient, BitcoindV20RpcClient)] =
-    BitcoindRpcTestUtil.createNodePairV20(clientAccum)
-
-  lazy val clientF: Future[BitcoindV20RpcClient] = clientPairF.map(_._1)
-
-  clientF.foreach(c => clientAccum.+=(c))
+  override type FixtureParam = BitcoindV20RpcClient
 
   behavior of "BitcoindV20RpcClient"
 
   it should "be able to start a V20 bitcoind instance" in {
-    clientF.map { client =>
+    client: BitcoindV20RpcClient =>
       assert(client.version == BitcoindVersion.V20)
-    }
-  }
-
-  it should "be able to get peer info" in {
-    for {
-      (freshClient, otherFreshClient) <- clientPairF
-      infoList <- freshClient.getPeerInfo
-    } yield {
-      assert(infoList.length >= 0)
-      val info = infoList.head
-      assert(info.addnode)
-      assert(info.networkInfo.addr == otherFreshClient.getDaemon.uri)
-    }
   }
 
   it should "get a block filter given a block hash" in {
-    for {
-      (client, _) <- clientPairF
-      blocks <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
-      blockFilter <- client.getBlockFilter(blocks.head, FilterType.Basic)
+    client: BitcoindV20RpcClient =>
+      for {
+        blocks <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
+        blockFilter <- client.getBlockFilter(blocks.head, FilterType.Basic)
 
-      block <- client.getBlockRaw(blocks.head)
-      txs <- Future.sequence(
-        block.transactions
-          .filterNot(_.isCoinbase)
-          .map(tx => client.getTransaction(tx.txIdBE)))
+        block <- client.getBlockRaw(blocks.head)
+        txs <- Future.sequence(
+          block.transactions
+            .filterNot(_.isCoinbase)
+            .map(tx => client.getTransaction(tx.txIdBE)))
 
-      prevFilter <- client.getBlockFilter(block.blockHeader.previousBlockHashBE,
-                                          FilterType.Basic)
-    } yield {
-      val pubKeys = txs.flatMap(_.hex.outputs.map(_.scriptPubKey)).toVector
-      val filter = BlockFilter(block, pubKeys)
-      assert(filter.hash == blockFilter.filter.hash)
-      assert(
-        blockFilter.header == filter
-          .getHeader(prevFilter.header.flip)
-          .hash
-          .flip)
-    }
+        prevFilter <- client.getBlockFilter(
+          block.blockHeader.previousBlockHashBE,
+          FilterType.Basic)
+      } yield {
+        val pubKeys = txs.flatMap(_.hex.outputs.map(_.scriptPubKey)).toVector
+        val filter = BlockFilter(block, pubKeys)
+        assert(filter.hash == blockFilter.filter.hash)
+        assert(
+          blockFilter.header == filter
+            .getHeader(prevFilter.header.flip)
+            .hash
+            .flip)
+      }
   }
 
-  it should "be able to get the balances" in {
+  it should "be able to get the balances" in { client: BitcoindV20RpcClient =>
     for {
-      (client, _) <- clientPairF
       immatureBalance <- client.getBalances
       _ <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
       newImmatureBalance <- client.getBalances
     } yield {
-      val blockReward = 12.5
+      val blockReward = 50
       assert(immatureBalance.mine.immature.toBigDecimal >= 0)
       assert(
-        immatureBalance.mine.immature.toBigDecimal + blockReward == newImmatureBalance.mine.immature.toBigDecimal)
+        immatureBalance.mine.trusted.toBigDecimal + blockReward == newImmatureBalance.mine.trusted.toBigDecimal)
     }
   }
 
   it should "be able to get blockchain info" in {
-    for {
-      (client, _) <- clientPairF
-      info <- client.getBlockChainInfo
-      bestHash <- client.getBestBlockHash
-    } yield {
-      assert(info.isInstanceOf[GetBlockChainInfoResultPostV19])
-      val preV19Info = info.asInstanceOf[GetBlockChainInfoResultPostV19]
-      assert(preV19Info.chain == RegTest)
-      assert(preV19Info.softforks.size >= 5)
-      assert(
-        preV19Info.softforks.values.exists(_.isInstanceOf[Bip9SoftforkPostV19]))
-      assert(preV19Info.bestblockhash == bestHash)
-    }
+    client: BitcoindV20RpcClient =>
+      for {
+        info <- client.getBlockChainInfo
+        bestHash <- client.getBestBlockHash
+      } yield {
+        assert(info.isInstanceOf[GetBlockChainInfoResultPostV19])
+        val preV19Info = info.asInstanceOf[GetBlockChainInfoResultPostV19]
+        assert(preV19Info.chain == RegTest)
+        assert(preV19Info.softforks.size >= 5)
+        assert(
+          preV19Info.softforks.values.exists(
+            _.isInstanceOf[Bip9SoftforkPostV19]))
+        assert(preV19Info.bestblockhash == bestHash)
+      }
   }
 
   it should "be able to set the wallet flag 'avoid_reuse'" in {
-    for {
-      (client, _) <- clientPairF
-      unspentPre <- client.listUnspent
-      result <- client.setWalletFlag(WalletFlag.AvoidReuse, value = true)
-      unspentPost <- client.listUnspent
-    } yield {
-      assert(result.flag_name == "avoid_reuse")
-      assert(result.flag_state)
-      assert(unspentPre.forall(utxo => utxo.reused.isEmpty))
-      assert(unspentPost.forall(utxo => utxo.reused.isDefined))
-    }
+    client: BitcoindV20RpcClient =>
+      for {
+        unspentPre <- client.listUnspent
+        result <- client.setWalletFlag(WalletFlag.AvoidReuse, value = true)
+        unspentPost <- client.listUnspent
+      } yield {
+        assert(result.flag_name == "avoid_reuse")
+        assert(result.flag_state)
+        assert(unspentPre.forall(utxo => utxo.reused.isEmpty))
+        assert(unspentPost.forall(utxo => utxo.reused.isDefined))
+      }
   }
 
   it should "create a wallet with a passphrase" in {
-    for {
-      (client, _) <- clientPairF
-      _ <- client.createWallet("suredbits", passphrase = "stackingsats")
-      wallets <- client.listWallets
-    } yield {
-      assert(wallets.contains("suredbits"))
-    }
+    client: BitcoindV20RpcClient =>
+      for {
+        _ <- client.createWallet("suredbits", passphrase = "stackingsats")
+        wallets <- client.listWallets
+      } yield {
+        assert(wallets.contains("suredbits"))
+      }
 
   }
 
   it should "check to see if the utxoUpdate input has been updated" in {
+    client: BitcoindV20RpcClient =>
+      val descriptor =
+        "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)"
 
-    val descriptor =
-      "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)"
+      val psbt =
+        PSBT.fromBase64(
+          "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA==")
 
-    val psbt =
-      PSBT.fromBase64(
-        "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA==")
-
-    for {
-      (client, _) <- clientPairF
-      result <- client.utxoUpdatePsbt(psbt, Seq(descriptor))
-    } yield {
-      assert(result == psbt)
-    }
+      for {
+        result <- client.utxoUpdatePsbt(psbt, Seq(descriptor))
+      } yield {
+        assert(result == psbt)
+      }
   }
 
   it should "correct create multisig and get its descriptor" in {
-    val pubKey1 = ECPublicKey.freshPublicKey
-    val pubKey2 = ECPublicKey.freshPublicKey
+    client: BitcoindV20RpcClient =>
+      val pubKey1 = ECPublicKey.freshPublicKey
+      val pubKey2 = ECPublicKey.freshPublicKey
 
-    for {
-      client <- clientF
-      multiSigResult <- client.createMultiSig(2, Vector(pubKey1, pubKey2))
-    } yield {
-      // just validate we are able to receive a sane descriptor
-      // no need to check checksum
-      assert(
-        multiSigResult.descriptor.startsWith(
-          s"sh(multi(2,${pubKey1.hex},${pubKey2.hex}))#"))
-    }
+      for {
+        multiSigResult <- client.createMultiSig(2, Vector(pubKey1, pubKey2))
+      } yield {
+        // just validate we are able to receive a sane descriptor
+        // no need to check checksum
+        assert(
+          multiSigResult.descriptor.startsWith(
+            s"sh(multi(2,${pubKey1.hex},${pubKey2.hex}))#"))
+      }
   }
 
-  it should "correctly dump tx out set" in {
+  it should "correctly dump tx out set" in { client: BitcoindV20RpcClient =>
     for {
-      client <- clientF
       hash <- client.getBestBlockHash
       height <- client.getBestHashBlockHeight()
       result <- client.dumpTxOutSet(new File("utxo.dat").toPath)
@@ -177,13 +159,13 @@ class BitcoindV20RpcClientTest extends BitcoindRpcTest {
   }
 
   it should "correct generate to a descriptor" in {
-    // 2-of-2 multisig descriptor
-    val descriptor =
-      "sh(sortedmulti(2,023f720438186fbdfde0c0a403e770a0f32a2d198623a8a982c47b621f8b307640,03ed261094d609d5e02ba6553c2d91e4fd056006ce2fe64aace72b69cb5be3ab9c))#nj9wx7up"
-    val numBlocks = 10
-    for {
-      client <- clientF
-      hashes <- client.generateToDescriptor(numBlocks, descriptor)
-    } yield assert(hashes.size == numBlocks)
+    client: BitcoindV20RpcClient =>
+      // 2-of-2 multisig descriptor
+      val descriptor =
+        "sh(sortedmulti(2,023f720438186fbdfde0c0a403e770a0f32a2d198623a8a982c47b621f8b307640,03ed261094d609d5e02ba6553c2d91e4fd056006ce2fe64aace72b69cb5be3ab9c))#nj9wx7up"
+      val numBlocks = 10
+      for {
+        hashes <- client.generateToDescriptor(numBlocks, descriptor)
+      } yield assert(hashes.size == numBlocks)
   }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v21/BitcoindV21RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v21/BitcoindV21RpcClientTest.scala
@@ -8,193 +8,174 @@ import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.client.v21.BitcoindV21RpcClient
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV21
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
 import java.io.File
 import java.nio.file.Files
 import scala.concurrent.Future
 
-class BitcoindV21RpcClientTest extends BitcoindRpcTest {
+class BitcoindV21RpcClientTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesFundedCachedV21 {
 
-  lazy val clientPairF: Future[(BitcoindV21RpcClient, BitcoindV21RpcClient)] =
-    BitcoindRpcTestUtil.createNodePairV21(clientAccum)
-
-  lazy val clientF: Future[BitcoindV21RpcClient] = clientPairF.map(_._1)
-
-  clientF.foreach(c => clientAccum.+=(c))
+  override type FixtureParam = BitcoindV21RpcClient
 
   behavior of "BitcoindV21RpcClient"
 
   it should "be able to start a V21 bitcoind instance" in {
-    clientF.map { client =>
+    client: BitcoindV21RpcClient =>
       assert(client.version == BitcoindVersion.V21)
-    }
-  }
-
-  it should "be able to get peer info" in {
-    for {
-      (freshClient, otherFreshClient) <- clientPairF
-      infoList <- freshClient.getPeerInfo
-    } yield {
-      assert(infoList.length >= 0)
-      val info = infoList.head
-      assert(info.addnode)
-      assert(info.networkInfo.addr == otherFreshClient.getDaemon.uri)
-    }
   }
 
   it should "be able to get network info" in {
-    for {
-      (freshClient, _) <- clientPairF
-      info <- freshClient.getNetworkInfo
-    } yield {
-      assert(info.networkactive)
-      assert(info.localrelay)
-      assert(info.connections == 1)
-    }
+    freshClient: BitcoindV21RpcClient =>
+      for {
+        info <- freshClient.getNetworkInfo
+      } yield {
+        assert(info.networkactive)
+        assert(info.localrelay)
+      }
   }
 
-  it should "get index info" in {
+  it should "get index info" in { client: BitcoindV21RpcClient =>
     for {
-      (client, _) <- clientPairF
       indexes <- client.getIndexInfo
     } yield {
       val txIndexInfo = indexes("txindex")
       assert(txIndexInfo.synced)
-      assert(txIndexInfo.best_block_height == 400)
+      assert(txIndexInfo.best_block_height == 101)
 
       val blockFilterIndexInfo = indexes("basic block filter index")
       assert(blockFilterIndexInfo.synced)
-      assert(blockFilterIndexInfo.best_block_height == 400)
+      assert(blockFilterIndexInfo.best_block_height == 101)
     }
   }
 
   it should "be able to get the address info for a given address" in {
-    for {
-      (client, _) <- clientPairF
-      addr <- client.getNewAddress
-      info <- client.getAddressInfo(addr)
-    } yield assert(info.address == addr)
+    client: BitcoindV21RpcClient =>
+      for {
+        addr <- client.getNewAddress
+        info <- client.getAddressInfo(addr)
+      } yield assert(info.address == addr)
   }
 
   it should "get a block filter given a block hash" in {
-    for {
-      (client, _) <- clientPairF
-      blocks <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
-      blockFilter <- client.getBlockFilter(blocks.head, FilterType.Basic)
+    client: BitcoindV21RpcClient =>
+      for {
+        blocks <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
+        blockFilter <- client.getBlockFilter(blocks.head, FilterType.Basic)
 
-      block <- client.getBlockRaw(blocks.head)
-      txs <- Future.sequence(
-        block.transactions
-          .filterNot(_.isCoinbase)
-          .map(tx => client.getTransaction(tx.txIdBE)))
+        block <- client.getBlockRaw(blocks.head)
+        txs <- Future.sequence(
+          block.transactions
+            .filterNot(_.isCoinbase)
+            .map(tx => client.getTransaction(tx.txIdBE)))
 
-      prevFilter <- client.getBlockFilter(block.blockHeader.previousBlockHashBE,
-                                          FilterType.Basic)
-    } yield {
-      val pubKeys = txs.flatMap(_.hex.outputs.map(_.scriptPubKey)).toVector
-      val filter = BlockFilter(block, pubKeys)
-      assert(filter.hash == blockFilter.filter.hash)
-      assert(
-        blockFilter.header == filter
-          .getHeader(prevFilter.header.flip)
-          .hash
-          .flip)
-    }
+        prevFilter <- client.getBlockFilter(
+          block.blockHeader.previousBlockHashBE,
+          FilterType.Basic)
+      } yield {
+        val pubKeys = txs.flatMap(_.hex.outputs.map(_.scriptPubKey)).toVector
+        val filter = BlockFilter(block, pubKeys)
+        assert(filter.hash == blockFilter.filter.hash)
+        assert(
+          blockFilter.header == filter
+            .getHeader(prevFilter.header.flip)
+            .hash
+            .flip)
+      }
   }
 
-  it should "be able to get the balances" in {
+  it should "be able to get the balances" in { client: BitcoindV21RpcClient =>
     for {
-      (client, _) <- clientPairF
       immatureBalance <- client.getBalances
       _ <- client.getNewAddress.flatMap(client.generateToAddress(1, _))
       newImmatureBalance <- client.getBalances
     } yield {
-      val blockReward = 12.5
+      val blockReward = 50
       assert(immatureBalance.mine.immature.toBigDecimal >= 0)
       assert(
-        immatureBalance.mine.immature.toBigDecimal + blockReward == newImmatureBalance.mine.immature.toBigDecimal)
+        immatureBalance.mine.trusted.toBigDecimal + blockReward == newImmatureBalance.mine.trusted.toBigDecimal)
     }
   }
 
   it should "be able to get blockchain info" in {
-    for {
-      (client, _) <- clientPairF
-      info <- client.getBlockChainInfo
-      bestHash <- client.getBestBlockHash
-    } yield {
-      assert(info.isInstanceOf[GetBlockChainInfoResultPostV19])
-      val preV19Info = info.asInstanceOf[GetBlockChainInfoResultPostV19]
-      assert(preV19Info.chain == RegTest)
-      assert(preV19Info.softforks.size >= 5)
-      assert(
-        preV19Info.softforks.values.exists(_.isInstanceOf[Bip9SoftforkPostV19]))
-      assert(preV19Info.bestblockhash == bestHash)
-    }
+    client: BitcoindV21RpcClient =>
+      for {
+        info <- client.getBlockChainInfo
+        bestHash <- client.getBestBlockHash
+      } yield {
+        assert(info.isInstanceOf[GetBlockChainInfoResultPostV19])
+        val preV19Info = info.asInstanceOf[GetBlockChainInfoResultPostV19]
+        assert(preV19Info.chain == RegTest)
+        assert(preV19Info.softforks.size >= 5)
+        assert(
+          preV19Info.softforks.values.exists(
+            _.isInstanceOf[Bip9SoftforkPostV19]))
+        assert(preV19Info.bestblockhash == bestHash)
+      }
   }
 
   it should "be able to set the wallet flag 'avoid_reuse'" in {
-    for {
-      (client, _) <- clientPairF
-      unspentPre <- client.listUnspent
-      result <- client.setWalletFlag(WalletFlag.AvoidReuse, value = true)
-      unspentPost <- client.listUnspent
-    } yield {
-      assert(result.flag_name == "avoid_reuse")
-      assert(result.flag_state)
-      assert(unspentPre.forall(utxo => utxo.reused.isEmpty))
-      assert(unspentPost.forall(utxo => utxo.reused.isDefined))
-    }
+    client: BitcoindV21RpcClient =>
+      for {
+        unspentPre <- client.listUnspent
+        result <- client.setWalletFlag(WalletFlag.AvoidReuse, value = true)
+        unspentPost <- client.listUnspent
+      } yield {
+        assert(result.flag_name == "avoid_reuse")
+        assert(result.flag_state)
+        assert(unspentPre.forall(utxo => utxo.reused.isEmpty))
+        assert(unspentPost.forall(utxo => utxo.reused.isDefined))
+      }
   }
 
   it should "create a wallet with a passphrase" in {
-    for {
-      (client, _) <- clientPairF
-      _ <- client.createWallet("suredbits", passphrase = "stackingsats")
-      wallets <- client.listWallets
-    } yield {
-      assert(wallets.contains("suredbits"))
-    }
+    client: BitcoindV21RpcClient =>
+      for {
+        _ <- client.createWallet("suredbits", passphrase = "stackingsats")
+        wallets <- client.listWallets
+      } yield {
+        assert(wallets.contains("suredbits"))
+      }
 
   }
 
   it should "check to see if the utxoUpdate input has been updated" in {
+    client: BitcoindV21RpcClient =>
+      val descriptor =
+        "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)"
 
-    val descriptor =
-      "pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)"
+      val psbt =
+        PSBT.fromBase64(
+          "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA==")
 
-    val psbt =
-      PSBT.fromBase64(
-        "cHNidP8BACoCAAAAAAFAQg8AAAAAABepFG6Rty1Vk+fUOR4v9E6R6YXDFkHwhwAAAAAAAA==")
-
-    for {
-      (client, _) <- clientPairF
-      result <- client.utxoUpdatePsbt(psbt, Seq(descriptor))
-    } yield {
-      assert(result == psbt)
-    }
+      for {
+        result <- client.utxoUpdatePsbt(psbt, Seq(descriptor))
+      } yield {
+        assert(result == psbt)
+      }
   }
 
   it should "correct create multisig and get its descriptor" in {
-    val pubKey1 = ECPublicKey.freshPublicKey
-    val pubKey2 = ECPublicKey.freshPublicKey
+    client: BitcoindV21RpcClient =>
+      val pubKey1 = ECPublicKey.freshPublicKey
+      val pubKey2 = ECPublicKey.freshPublicKey
 
-    for {
-      client <- clientF
-      multiSigResult <- client.createMultiSig(2, Vector(pubKey1, pubKey2))
-    } yield {
-      // just validate we are able to receive a sane descriptor
-      // no need to check checksum
-      assert(
-        multiSigResult.descriptor.startsWith(
-          s"sh(multi(2,${pubKey1.hex},${pubKey2.hex}))#"))
-    }
+      for {
+        multiSigResult <- client.createMultiSig(2, Vector(pubKey1, pubKey2))
+      } yield {
+        // just validate we are able to receive a sane descriptor
+        // no need to check checksum
+        assert(
+          multiSigResult.descriptor.startsWith(
+            s"sh(multi(2,${pubKey1.hex},${pubKey2.hex}))#"))
+      }
   }
 
-  it should "correctly dump tx out set" in {
+  it should "correctly dump tx out set" in { client: BitcoindV21RpcClient =>
     for {
-      client <- clientF
       hash <- client.getBestBlockHash
       height <- client.getBestHashBlockHeight()
       result <- client.dumpTxOutSet(new File("utxo.dat").toPath)
@@ -210,13 +191,13 @@ class BitcoindV21RpcClientTest extends BitcoindRpcTest {
   }
 
   it should "correct generate to a descriptor" in {
-    // 2-of-2 multisig descriptor
-    val descriptor =
-      "sh(sortedmulti(2,023f720438186fbdfde0c0a403e770a0f32a2d198623a8a982c47b621f8b307640,03ed261094d609d5e02ba6553c2d91e4fd056006ce2fe64aace72b69cb5be3ab9c))#nj9wx7up"
-    val numBlocks = 10
-    for {
-      client <- clientF
-      hashes <- client.generateToDescriptor(numBlocks, descriptor)
-    } yield assert(hashes.size == numBlocks)
+    client: BitcoindV21RpcClient =>
+      // 2-of-2 multisig descriptor
+      val descriptor =
+        "sh(sortedmulti(2,023f720438186fbdfde0c0a403e770a0f32a2d198623a8a982c47b621f8b307640,03ed261094d609d5e02ba6553c2d91e4fd056006ce2fe64aace72b69cb5be3ab9c))#nj9wx7up"
+      val numBlocks = 10
+      for {
+        hashes <- client.generateToDescriptor(numBlocks, descriptor)
+      } yield assert(hashes.size == numBlocks)
   }
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v21/BitcoindV21RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v21/BitcoindV21RpcClientTest.scala
@@ -39,8 +39,8 @@ class BitcoindV21RpcClientTest extends BitcoindFixturesFundedCachedV21 {
       client.getBlockCount.map(_ == 101)
     }
     for {
-      indexes <- client.getIndexInfo
       _ <- AsyncUtil.retryUntilSatisfiedF(() => isHeight101(client))
+      indexes <- client.getIndexInfo
     } yield {
       val txIndexInfo = indexes("txindex")
       assert(txIndexInfo.synced)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v21/BitcoindV21RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v21/BitcoindV21RpcClientTest.scala
@@ -10,17 +10,12 @@ import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v21.BitcoindV21RpcClient
 import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV21
-import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 
 import java.io.File
 import java.nio.file.Files
 import scala.concurrent.Future
 
-class BitcoindV21RpcClientTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesFundedCachedV21 {
-
-  override type FixtureParam = BitcoindV21RpcClient
+class BitcoindV21RpcClientTest extends BitcoindFixturesFundedCachedV21 {
 
   behavior of "BitcoindV21RpcClient"
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -182,7 +182,7 @@ trait Client
     started
   }
 
-  private def tryPing: Future[Boolean] = {
+  private def tryPing(): Future[Boolean] = {
     val request = buildRequest(instance, "ping", JsArray.empty)
     val responseF = sendRequest(request)
 
@@ -219,7 +219,7 @@ trait Client
         Future.successful(false)
       case (CookieBased(_, _) | PasswordBased(_, _)) =>
         if (isStartedFlag.get) {
-          tryPing
+          tryPing()
         } else {
           Future.successful(false)
         }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -31,6 +31,7 @@ import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstance}
 import org.bitcoins.rpc.util.NativeProcessFactory
 import play.api.libs.json._
 
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent._
 import scala.concurrent.duration.DurationInt
 import scala.util.control.NonFatal
@@ -97,7 +98,7 @@ trait Client
 
   def getDaemon: BitcoindInstance = instance
 
-  override def cmd: String = {
+  override lazy val cmd: String = {
     val binaryPath = instance.binary.getAbsolutePath
     val cmd = List(binaryPath,
                    "-datadir=" + instance.datadir,
@@ -124,17 +125,6 @@ trait Client
     }
 
     val startedF = startBinary()
-    def isStartedF: Future[Boolean] = {
-      val started: Promise[Boolean] = Promise()
-
-      val pingF = bitcoindCall[Unit]("ping", printError = false)
-      pingF.onComplete {
-        case Success(_) => started.success(true)
-        case Failure(_) => started.success(false)
-      }
-
-      started.future
-    }
 
     // if we're doing cookie based authentication, we might attempt
     // to read the cookie file before it's written. this ensures
@@ -157,6 +147,7 @@ trait Client
       for {
         _ <- startedF
         _ <- awaitCookie(instance.authCredentials)
+        _ = isStartedFlag.set(true)
         _ <- AsyncUtil.retryUntilSatisfiedF(() => isStartedF,
                                             interval = 1.seconds,
                                             maxTries = 60)
@@ -191,39 +182,47 @@ trait Client
     started
   }
 
+  private def tryPing: Future[Boolean] = {
+    val request = buildRequest(instance, "ping", JsArray.empty)
+    val responseF = sendRequest(request)
+
+    val payloadF: Future[JsValue] =
+      responseF.flatMap(getPayload(_))
+
+    // Ping successful if no error can be parsed from the payload
+    val parsedF = payloadF.map { payload =>
+      (payload \ errorKey).validate[BitcoindException] match {
+        case _: JsSuccess[BitcoindException] => false
+        case _: JsError                      => true
+      }
+    }
+
+    parsedF.recover {
+      case exc: StreamTcpException
+          if exc.getMessage.contains("Connection refused") =>
+        false
+      case _: JsonParseException =>
+        //see https://github.com/bitcoin-s/bitcoin-s/issues/527
+        false
+    }
+  }
+
+  private val isStartedFlag: AtomicBoolean = new AtomicBoolean(false)
+
   /** Checks whether the underlying bitcoind daemon is running
     */
   def isStartedF: Future[Boolean] = {
-    def tryPing: Future[Boolean] = {
-      val request = buildRequest(instance, "ping", JsArray.empty)
-      val responseF = sendRequest(request)
-
-      val payloadF: Future[JsValue] =
-        responseF.flatMap(getPayload(_))
-
-      // Ping successful if no error can be parsed from the payload
-      val parsedF = payloadF.map { payload =>
-        (payload \ errorKey).validate[BitcoindException] match {
-          case _: JsSuccess[BitcoindException] => false
-          case _: JsError                      => true
-        }
-      }
-
-      parsedF.recover {
-        case exc: StreamTcpException
-            if exc.getMessage.contains("Connection refused") =>
-          false
-        case _: JsonParseException =>
-          //see https://github.com/bitcoin-s/bitcoin-s/issues/527
-          false
-      }
-    }
 
     instance.authCredentials match {
       case cookie: CookieBased if Files.notExists(cookie.cookiePath) =>
         // if the cookie file doesn't exist we're not started
         Future.successful(false)
-      case (CookieBased(_, _) | PasswordBased(_, _)) => tryPing
+      case (CookieBased(_, _) | PasswordBased(_, _)) =>
+        if (isStartedFlag.get) {
+          tryPing
+        } else {
+          Future.successful(false)
+        }
     }
   }
 
@@ -233,6 +232,7 @@ trait Client
   def stop(): Future[BitcoindRpcClient] = {
     for {
       _ <- bitcoindCall[String]("stop")
+      _ = isStartedFlag.set(false)
       //do we want to call this right away?
       //i think bitcoind stops asynchronously
       //so it returns fast from the 'stop' rpc command

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/NodePair.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/NodePair.scala
@@ -2,13 +2,13 @@ package org.bitcoins.rpc.util
 
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 
-case class NodePair(node1: BitcoindRpcClient, node2: BitcoindRpcClient) {
-  val toVector: Vector[BitcoindRpcClient] = Vector(node1, node2)
+case class NodePair[T <: BitcoindRpcClient](node1: T, node2: T) {
+  val toVector: Vector[T] = Vector(node1, node2)
 }
 
 object NodePair {
 
-  def fromTuple(pair: (BitcoindRpcClient, BitcoindRpcClient)): NodePair = {
+  def fromTuple[T <: BitcoindRpcClient](pair: (T, T)): NodePair[T] = {
     NodePair(pair._1, pair._2)
   }
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/NodePair.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/NodePair.scala
@@ -1,0 +1,14 @@
+package org.bitcoins.rpc.util
+
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+
+case class NodePair(node1: BitcoindRpcClient, node2: BitcoindRpcClient) {
+  val toVector: Vector[BitcoindRpcClient] = Vector(node1, node2)
+}
+
+object NodePair {
+
+  def fromTuple(pair: (BitcoindRpcClient, BitcoindRpcClient)): NodePair = {
+    NodePair(pair._1, pair._2)
+  }
+}

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/NodeTriple.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/NodeTriple.scala
@@ -2,20 +2,13 @@ package org.bitcoins.rpc.util
 
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 
-case class NodeTriple(
-    node1: BitcoindRpcClient,
-    node2: BitcoindRpcClient,
-    node3: BitcoindRpcClient) {
-  val toVector: Vector[BitcoindRpcClient] = Vector(node1, node2, node3)
+case class NodeTriple[T <: BitcoindRpcClient](node1: T, node2: T, node3: T) {
+  val toVector: Vector[T] = Vector(node1, node2, node3)
 }
 
 object NodeTriple {
 
-  def fromTuple(
-      nodes: (
-          BitcoindRpcClient,
-          BitcoindRpcClient,
-          BitcoindRpcClient)): NodeTriple = {
+  def fromTuple[T <: BitcoindRpcClient](nodes: (T, T, T)): NodeTriple[T] = {
     NodeTriple(nodes._1, nodes._2, nodes._3)
   }
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/NodeTriple.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/NodeTriple.scala
@@ -1,0 +1,21 @@
+package org.bitcoins.rpc.util
+
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+
+case class NodeTriple(
+    node1: BitcoindRpcClient,
+    node2: BitcoindRpcClient,
+    node3: BitcoindRpcClient) {
+  val toVector: Vector[BitcoindRpcClient] = Vector(node1, node2, node3)
+}
+
+object NodeTriple {
+
+  def fromTuple(
+      nodes: (
+          BitcoindRpcClient,
+          BitcoindRpcClient,
+          BitcoindRpcClient)): NodeTriple = {
+    NodeTriple(nodes._1, nodes._2, nodes._3)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -595,7 +595,8 @@ lazy val eclairRpcTest = project
   .settings(CommonSettings.testSettings: _*)
   .settings(
     libraryDependencies ++= Deps.eclairRpcTest.value,
-    name := "bitcoin-s-eclair-rpc-test"
+    name := "bitcoin-s-eclair-rpc-test",
+    parallelExecution := !(isCI && Properties.isMac)
   )
   .dependsOn(coreJVM % testAndCompile, testkit)
 

--- a/build.sbt
+++ b/build.sbt
@@ -570,7 +570,8 @@ lazy val bitcoindRpcTest = project
   .in(file("bitcoind-rpc-test"))
   .settings(CommonSettings.testSettings: _*)
   .settings(name := "bitcoin-s-bitcoind-rpc-test",
-            libraryDependencies ++= Deps.bitcoindRpcTest.value)
+            libraryDependencies ++= Deps.bitcoindRpcTest.value,
+            parallelExecution := false)
   .dependsOn(coreJVM % testAndCompile, testkit)
 
 lazy val bench = project

--- a/build.sbt
+++ b/build.sbt
@@ -566,12 +566,18 @@ lazy val zmq = project
     coreJVM % testAndCompile
   )
 
+def isCI = {
+  Properties
+    .envOrNone("CI")
+    .isDefined
+}
+
 lazy val bitcoindRpcTest = project
   .in(file("bitcoind-rpc-test"))
   .settings(CommonSettings.testSettings: _*)
   .settings(name := "bitcoin-s-bitcoind-rpc-test",
             libraryDependencies ++= Deps.bitcoindRpcTest.value,
-            parallelExecution := false)
+            parallelExecution := !(isCI && Properties.isMac))
   .dependsOn(coreJVM % testAndCompile, testkit)
 
 lazy val bench = project

--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -66,7 +66,7 @@ implicit val ec = system.dispatcher
 //so let's start one (make sure you ran 'sbt downloadBitcoind')
 val instance = BitcoindRpcTestUtil.instance(versionOpt = Some(BitcoindVersion.Experimental))
 val p2pPort = instance.p2pPort
-val bitcoindF = BitcoindRpcTestUtil.startedBitcoindRpcClient(instance)
+val bitcoindF = BitcoindRpcTestUtil.startedBitcoindRpcClient(instance, Vector.newBuilder)
 
 //contains information on how to connect to bitcoin's p2p info
 val peerF = bitcoindF.map(b => NodeUnitTest.createPeer(b))

--- a/docs/testkit/testkit.md
+++ b/docs/testkit/testkit.md
@@ -51,7 +51,7 @@ val bitcoindV = BitcoindVersion.V19
 val instance = BitcoindRpcTestUtil.instance(versionOpt = Some(bitcoindV))
 
 //now let's create an rpc client off of that instance
-val bitcoindRpcClientF = BitcoindRpcTestUtil.startedBitcoindRpcClient(instance)
+val bitcoindRpcClientF = BitcoindRpcTestUtil.startedBitcoindRpcClient(instance, Vector.newBuilder)
 
 //yay! it's started. Now you can run tests against this.
 //let's just grab the block count for an example

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -1,26 +1,39 @@
 package org.bitcoins.node.networking.peer
 
 import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.node.models.Peer
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.async.TestAsyncUtil
-import org.bitcoins.testkit.node.{CachedBitcoinSAppConfig, NodeUnitTest}
-import org.scalatest.FutureOutcome
+import org.bitcoins.testkit.node.{
+  CachedBitcoinSAppConfig,
+  NodeTestWithCachedBitcoindNewest,
+  NodeUnitTest
+}
+import org.scalatest.{FutureOutcome, Outcome}
 
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 /** Created by chris on 7/1/16.
   */
-class PeerMessageHandlerTest extends NodeUnitTest with CachedBitcoinSAppConfig {
+class PeerMessageHandlerTest
+    extends NodeTestWithCachedBitcoindNewest
+    with CachedBitcoinSAppConfig {
 
   /** Wallet config with data directory set to user temp directory */
   implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvTestConfig()
 
-  override type FixtureParam = Unit
+  override type FixtureParam = Peer
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    test(())
+    val outcomeF: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      outcome = withBitcoindPeer(test, bitcoind)
+      f <- outcome.toFuture
+    } yield f
+    new FutureOutcome(outcomeF)
   }
 
   implicit protected lazy val chainConfig: ChainAppConfig =
@@ -28,15 +41,14 @@ class PeerMessageHandlerTest extends NodeUnitTest with CachedBitcoinSAppConfig {
 
   behavior of "PeerHandler"
 
-  it must "be able to fully initialize a PeerMessageReceiver" in { _ =>
-    val peerHandlerF =
-      bitcoindPeerF.flatMap(p => NodeUnitTest.buildPeerHandler(p))
+  it must "be able to fully initialize a PeerMessageReceiver" in { peer =>
+    val peerHandlerF = NodeUnitTest.buildPeerHandler(peer)
     val peerMsgSenderF = peerHandlerF.map(_.peerMsgSender)
     val p2pClientF = peerHandlerF.map(_.p2pClient)
 
-    val _ =
-      bitcoindPeerF.flatMap(_ => peerHandlerF.map(_.peerMsgSender.connect()))
-
+    //val _ =
+    //  bitcoindPeerF.flatMap(_ => peerHandlerF.map(_.peerMsgSender.connect()))
+    val _ = peerHandlerF.map(_.peerMsgSender.connect())
     val isConnectedF = TestAsyncUtil.retryUntilSatisfiedF(
       () => p2pClientF.flatMap(_.isConnected()),
       interval = 500.millis
@@ -196,9 +208,4 @@ class PeerMessageHandlerTest extends NodeUnitTest with CachedBitcoinSAppConfig {
           peerMsgHandler ! Tcp.Close
           probe.expectMsg(Tcp.Closed)
         }*/
-
-  override def afterAll(): Unit = {
-    startedBitcoindF.flatMap(_.stop())
-    super.afterAll()
-  }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -46,8 +46,6 @@ class PeerMessageHandlerTest
     val peerMsgSenderF = peerHandlerF.map(_.peerMsgSender)
     val p2pClientF = peerHandlerF.map(_.p2pClient)
 
-    //val _ =
-    //  bitcoindPeerF.flatMap(_ => peerHandlerF.map(_.peerMsgSender.connect()))
     val _ = peerHandlerF.map(_.peerMsgSender.connect())
     val isConnectedF = TestAsyncUtil.retryUntilSatisfiedF(
       () => p2pClientF.flatMap(_.isConnected()),

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -150,8 +150,7 @@ object CommonSettings {
     //show full stack trace (-oF) of failed tests and duration of tests (-oD)
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     logBuffered in Test := false,
-    skip.in(publish) := true,
-    parallelExecution.in(Test) := !isCI
+    skip.in(publish) := true
   ) ++ settings
 
   lazy val prodSettings: Seq[Setting[_]] = settings

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -20,7 +20,7 @@ import scala.util.Properties
 
 object CommonSettings {
 
-  private val isCI = {
+  private def isCI = {
     Properties
       .envOrNone("CI")
       .isDefined

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -21,8 +21,8 @@ import scala.util.Properties
 object CommonSettings {
 
   private val isCI = {
-    sys.props
-      .get("CI")
+    Properties
+      .envOrNone("CI")
       .isDefined
   }
 
@@ -151,7 +151,7 @@ object CommonSettings {
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     logBuffered in Test := false,
     skip.in(publish) := true,
-    parallelExecution.in(Test) := false
+    parallelExecution.in(Test) := !isCI
   ) ++ settings
 
   lazy val prodSettings: Seq[Setting[_]] = settings

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -150,8 +150,8 @@ object CommonSettings {
     //show full stack trace (-oF) of failed tests and duration of tests (-oD)
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     logBuffered in Test := false,
-    skip.in(publish) := true //,
-    //parallelExecution.in(Test) := false
+    skip.in(publish) := true,
+    parallelExecution.in(Test) := false
   ) ++ settings
 
   lazy val prodSettings: Seq[Setting[_]] = settings

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -150,8 +150,8 @@ object CommonSettings {
     //show full stack trace (-oF) of failed tests and duration of tests (-oD)
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     logBuffered in Test := false,
-    skip.in(publish) := true,
-    parallelExecution.in(Test) := false
+    skip.in(publish) := true //,
+    //parallelExecution.in(Test) := false
   ) ++ settings
 
   lazy val prodSettings: Seq[Setting[_]] = settings

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -150,7 +150,8 @@ object CommonSettings {
     //show full stack trace (-oF) of failed tests and duration of tests (-oD)
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     logBuffered in Test := false,
-    skip.in(publish) := true
+    skip.in(publish) := true,
+    parallelExecution.in(Test) := !isCI
   ) ++ settings
 
   lazy val prodSettings: Seq[Setting[_]] = settings

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -647,7 +647,7 @@ object ChainUnitTest extends ChainVerificationLogger {
       val chainHandlerF = makeChainHandler()
       for {
         chainHandler <- chainHandlerF
-        genHeader <- chainHandler.blockHeaderDAO.create(genesisHeaderDb)
+        genHeader <- chainHandler.blockHeaderDAO.upsert(genesisHeaderDb)
       } yield genHeader
     }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -57,7 +57,8 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
     */
   def startedBitcoindRpcClient(instance: BitcoindInstance = bitcoindInstance())(
       implicit actorSystem: ActorSystem): Future[BitcoindRpcClient] = {
-    BitcoindRpcTestUtil.startedBitcoindRpcClient(instance)
+    //need to do something with the Vector.newBuilder presumably?
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(instance, Vector.newBuilder)
   }
 
   /** Creates a bitcoind instance with the given parameters */

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -1,0 +1,164 @@
+package org.bitcoins.testkit.node
+
+import akka.actor.{ActorSystem, Cancellable}
+import org.bitcoins.core.api.chain.{ChainApi, ChainQueryApi, FilterSyncMarker}
+import org.bitcoins.core.api.chain.db.{
+  BlockHeaderDb,
+  CompactFilterDb,
+  CompactFilterHeaderDb
+}
+import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.gcs.FilterHeader
+import org.bitcoins.core.p2p.CompactFilterMessage
+import org.bitcoins.core.protocol.blockchain.BlockHeader
+import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
+import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.db.AppConfig
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.EmbeddedPg
+import org.bitcoins.testkit.chain.ChainUnitTest
+import org.bitcoins.testkit.fixtures.BitcoinSFixture
+import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
+
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+
+trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
+
+  /** Wallet config with data directory set to user temp directory */
+  implicit protected def getFreshConfig: BitcoinSAppConfig
+
+  implicit override lazy val np: NetworkParameters =
+    getFreshConfig.nodeConf.network
+
+  override def beforeAll(): Unit = {
+    AppConfig.throwIfDefaultDatadir(getFreshConfig.nodeConf)
+    super[EmbeddedPg].beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super[EmbeddedPg].afterAll()
+  }
+
+  lazy val junkAddress: BitcoinAddress =
+    BitcoinAddress("2NFyxovf6MyxfHqtVjstGzs6HeLqv92Nq4U")
+
+  /** Helper method to generate blocks every interval
+    * @return a cancellable that will stop generating blocks
+    */
+  def genBlockInterval(bitcoind: BitcoindRpcClient)(implicit
+      system: ActorSystem): Cancellable = {
+
+    var counter = 0
+    val desiredBlocks = 5
+    val interval = 500.millis
+
+    val genBlock = new Runnable {
+      override def run(): Unit = {
+        if (counter < desiredBlocks) {
+          bitcoind.getNewAddress.flatMap(bitcoind.generateToAddress(1, _))
+          counter = counter + 1
+        }
+      }
+    }
+
+    system.scheduler.scheduleAtFixedRate(2.second, interval)(genBlock)
+  }
+
+  def getBIP39PasswordOpt(): Option[String] =
+    KeyManagerTestUtil.bip39PasswordOpt
+
+  val genesisChainApi: ChainApi = new ChainApi {
+
+    override def processHeaders(
+        headers: Vector[BlockHeader]): Future[ChainApi] =
+      Future.successful(this)
+
+    override def getHeader(
+        hash: DoubleSha256DigestBE): Future[Option[BlockHeaderDb]] =
+      Future.successful(None)
+
+    override def getHeadersAtHeight(
+        height: Int): Future[Vector[BlockHeaderDb]] =
+      Future.successful(Vector.empty)
+
+    override def getBlockCount(): Future[Int] = Future.successful(0)
+
+    override def getBestBlockHeader(): Future[BlockHeaderDb] =
+      Future.successful(ChainUnitTest.genesisHeaderDb)
+
+    override def processFilterHeaders(
+        filterHeaders: Vector[FilterHeader],
+        stopHash: DoubleSha256DigestBE): Future[ChainApi] =
+      Future.successful(this)
+
+    override def nextBlockHeaderBatchRange(
+        stopHash: DoubleSha256DigestBE,
+        batchSize: Int): Future[Option[FilterSyncMarker]] =
+      Future.successful(None)
+
+    override def nextFilterHeaderBatchRange(
+        startHeight: Int,
+        batchSize: Int): Future[Option[FilterSyncMarker]] =
+      Future.successful(None)
+
+    override def processFilters(
+        message: Vector[CompactFilterMessage]): Future[ChainApi] =
+      Future.successful(this)
+
+    override def processCheckpoints(
+        checkpoints: Vector[DoubleSha256DigestBE],
+        blockHash: DoubleSha256DigestBE): Future[ChainApi] =
+      Future.successful(this)
+
+    override def getFilterHeaderCount(): Future[Int] = Future.successful(0)
+
+    override def getFilterHeadersAtHeight(
+        height: Int): Future[Vector[CompactFilterHeaderDb]] =
+      Future.successful(Vector.empty)
+
+    override def getBestFilterHeader(): Future[Option[CompactFilterHeaderDb]] =
+      Future.successful(None)
+
+    override def getFilterHeader(blockHash: DoubleSha256DigestBE): Future[
+      Option[CompactFilterHeaderDb]] = Future.successful(None)
+
+    override def getFilter(
+        hash: DoubleSha256DigestBE): Future[Option[CompactFilterDb]] =
+      Future.successful(None)
+
+    override def getFilterCount(): Future[Int] = Future.successful(0)
+
+    override def getFiltersAtHeight(
+        height: Int): Future[Vector[CompactFilterDb]] =
+      Future.successful(Vector.empty)
+
+    override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] =
+      Future.successful(0)
+
+    override def getHeadersBetween(
+        from: BlockHeaderDb,
+        to: BlockHeaderDb): Future[Vector[BlockHeaderDb]] =
+      Future.successful(Vector.empty)
+
+    override def getBlockHeight(
+        blockHash: DoubleSha256DigestBE): Future[Option[Int]] =
+      Future.successful(None)
+
+    override def getBestBlockHash(): Future[DoubleSha256DigestBE] =
+      Future.successful(DoubleSha256DigestBE.empty)
+
+    override def getNumberOfConfirmations(
+        blockHashOpt: DoubleSha256DigestBE): Future[Option[Int]] =
+      Future.successful(None)
+
+    override def getFiltersBetweenHeights(
+        startHeight: Int,
+        endHeight: Int): Future[Vector[ChainQueryApi.FilterResponse]] =
+      Future.successful(Vector.empty)
+
+    override def epochSecondToBlockHeight(time: Long): Future[Int] =
+      Future.successful(0)
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -24,6 +24,7 @@ import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
+/** A base test trait for all the tests in our nodeTest module */
 trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
 
   /** Wallet config with data directory set to user temp directory */

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -24,7 +24,7 @@ import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future
 
-trait NodeTestWithCachedBitcoind extends BaseNodeTest { _: CachedBitcoind =>
+trait NodeTestWithCachedBitcoind extends BaseNodeTest { _: CachedBitcoind[_] =>
 
   def withSpvNodeFundedWalletBitcoindCached(
       test: OneArgAsyncTest,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -1,0 +1,77 @@
+package org.bitcoins.testkit.node
+
+import akka.actor.ActorSystem
+import org.bitcoins.node.NodeType
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.node.NodeUnitTest.createPeer
+import org.bitcoins.testkit.node.fixture.SpvNodeConnectedWithBitcoindV19
+import org.bitcoins.testkit.rpc.{
+  CachedBitcoind,
+  CachedBitcoindNewest,
+  CachedBitcoindV19
+}
+import org.bitcoins.wallet.WalletCallbacks
+import org.scalatest.FutureOutcome
+
+import scala.concurrent.Future
+
+trait NodeTestWithCachedBitcoind extends BaseNodeTest { _: CachedBitcoind =>
+
+  def withSpvNodeFundedWalletBitcoindCached(
+      test: OneArgAsyncTest,
+      bip39PasswordOpt: Option[String],
+      bitcoind: BitcoindRpcClient)(implicit
+      system: ActorSystem,
+      appConfig: BitcoinSAppConfig): FutureOutcome = {
+
+    makeDependentFixture[SpvNodeFundedWalletBitcoind](
+      build = () =>
+        NodeUnitTest.createSpvNodeFundedWalletFromBitcoind(
+          walletCallbacks = WalletCallbacks.empty,
+          bip39PasswordOpt = bip39PasswordOpt,
+          bitcoind = bitcoind)(
+          system, // Force V18 because Spv is disabled on versions after
+          appConfig),
+      { case x: SpvNodeFundedWalletBitcoind =>
+        NodeUnitTest.destroyNode(x.node)
+      }
+    )(test)
+  }
+}
+
+trait NodeTestWithCachedBitcoindNewest
+    extends NodeTestWithCachedBitcoind
+    with CachedBitcoindNewest
+
+trait NodeTestWithCachedBitcoindV19
+    extends NodeTestWithCachedBitcoind
+    with CachedBitcoindV19 {
+
+  def withSpvNodeConnectedToBitcoindV19Cached(
+      test: OneArgAsyncTest,
+      bitcoind: BitcoindV19RpcClient)(implicit
+      system: ActorSystem,
+      appConfig: BitcoinSAppConfig): FutureOutcome = {
+    val nodeWithBitcoindBuilder: () => Future[
+      SpvNodeConnectedWithBitcoindV19] = { () =>
+      require(appConfig.nodeType == NodeType.SpvNode)
+      for {
+        node <- NodeUnitTest.createSpvNode(createPeer(bitcoind))(
+          system,
+          appConfig.chainConf,
+          appConfig.nodeConf)
+        started <- node.start()
+        _ <- NodeUnitTest.syncSpvNode(started, bitcoind)
+      } yield SpvNodeConnectedWithBitcoindV19(node, bitcoind)
+    }
+
+    makeDependentFixture[SpvNodeConnectedWithBitcoindV19](
+      build = nodeWithBitcoindBuilder,
+      { case x: SpvNodeConnectedWithBitcoindV19 =>
+        NodeUnitTest.destroyNode(x.node)
+      }
+    )(test)
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -24,6 +24,10 @@ import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future
 
+/** Test trait for using a bitcoin-s [[Node]] that requires a cached bitcoind.
+  * The cached bitcoind will be share across tests in the test suite that extends
+  * this trait.
+  */
 trait NodeTestWithCachedBitcoind extends BaseNodeTest { _: CachedBitcoind[_] =>
 
   def withSpvNodeFundedWalletBitcoindCached(

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -31,7 +31,7 @@ import org.bitcoins.testkit.node.fixture.{
   SpvNodeConnectedWithBitcoind,
   SpvNodeConnectedWithBitcoindV19
 }
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
+
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletWithBitcoindRpc}
 import org.bitcoins.testkitcore.node.P2PMessageTestUtil
 import org.bitcoins.wallet.WalletCallbacks
@@ -41,10 +41,6 @@ import java.net.InetSocketAddress
 import scala.concurrent.{ExecutionContext, Future}
 
 trait NodeUnitTest extends BaseNodeTest {
-
-  lazy val startedBitcoindF = BitcoindRpcTestUtil.startedBitcoindRpcClient()
-
-  lazy val bitcoindPeerF = startedBitcoindF.map(NodeTestUtil.getBitcoindPeer)
 
   def withDisconnectedSpvNode(test: OneArgAsyncTest)(implicit
       system: ActorSystem,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -1,21 +1,8 @@
 package org.bitcoins.testkit.node
 
-import java.net.InetSocketAddress
-import akka.actor.{ActorSystem, Cancellable}
+import akka.actor.ActorSystem
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.chain.{ChainApi, ChainQueryApi, FilterSyncMarker}
-import org.bitcoins.core.api.chain.db.{
-  BlockHeaderDb,
-  CompactFilterDb,
-  CompactFilterHeaderDb
-}
-import org.bitcoins.core.config.NetworkParameters
-import org.bitcoins.core.gcs.FilterHeader
-import org.bitcoins.core.p2p.CompactFilterMessage
-import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
-import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.db.AppConfig
+import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.node._
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
@@ -31,10 +18,8 @@ import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.server.BitcoinSAppConfig._
-import org.bitcoins.testkit.EmbeddedPg
 import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
-import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
 import org.bitcoins.testkit.node.NodeUnitTest.{
   createPeer,
   emptyPeer,
@@ -52,125 +37,14 @@ import org.bitcoins.testkitcore.node.P2PMessageTestUtil
 import org.bitcoins.wallet.WalletCallbacks
 import org.scalatest.FutureOutcome
 
-import scala.concurrent.duration._
+import java.net.InetSocketAddress
 import scala.concurrent.{ExecutionContext, Future}
 
-trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
-
-  override def beforeAll(): Unit = {
-    AppConfig.throwIfDefaultDatadir(getFreshConfig.nodeConf)
-    super[EmbeddedPg].beforeAll()
-  }
-
-  override def afterAll(): Unit = {
-    super[EmbeddedPg].afterAll()
-  }
-
-  /** Wallet config with data directory set to user temp directory */
-  implicit protected def getFreshConfig: BitcoinSAppConfig
-
-  implicit override lazy val np: NetworkParameters =
-    getFreshConfig.nodeConf.network
+trait NodeUnitTest extends BaseNodeTest {
 
   lazy val startedBitcoindF = BitcoindRpcTestUtil.startedBitcoindRpcClient()
 
   lazy val bitcoindPeerF = startedBitcoindF.map(NodeTestUtil.getBitcoindPeer)
-
-  lazy val junkAddress: BitcoinAddress =
-    BitcoinAddress("2NFyxovf6MyxfHqtVjstGzs6HeLqv92Nq4U")
-
-  val genesisChainApi: ChainApi = new ChainApi {
-
-    override def processHeaders(
-        headers: Vector[BlockHeader]): Future[ChainApi] =
-      Future.successful(this)
-
-    override def getHeader(
-        hash: DoubleSha256DigestBE): Future[Option[BlockHeaderDb]] =
-      Future.successful(None)
-
-    override def getHeadersAtHeight(
-        height: Int): Future[Vector[BlockHeaderDb]] =
-      Future.successful(Vector.empty)
-
-    override def getBlockCount(): Future[Int] = Future.successful(0)
-
-    override def getBestBlockHeader(): Future[BlockHeaderDb] =
-      Future.successful(ChainUnitTest.genesisHeaderDb)
-
-    override def processFilterHeaders(
-        filterHeaders: Vector[FilterHeader],
-        stopHash: DoubleSha256DigestBE): Future[ChainApi] =
-      Future.successful(this)
-
-    override def nextBlockHeaderBatchRange(
-        stopHash: DoubleSha256DigestBE,
-        batchSize: Int): Future[Option[FilterSyncMarker]] =
-      Future.successful(None)
-
-    override def nextFilterHeaderBatchRange(
-        startHeight: Int,
-        batchSize: Int): Future[Option[FilterSyncMarker]] =
-      Future.successful(None)
-
-    override def processFilters(
-        message: Vector[CompactFilterMessage]): Future[ChainApi] =
-      Future.successful(this)
-
-    override def processCheckpoints(
-        checkpoints: Vector[DoubleSha256DigestBE],
-        blockHash: DoubleSha256DigestBE): Future[ChainApi] =
-      Future.successful(this)
-
-    override def getFilterHeaderCount(): Future[Int] = Future.successful(0)
-
-    override def getFilterHeadersAtHeight(
-        height: Int): Future[Vector[CompactFilterHeaderDb]] =
-      Future.successful(Vector.empty)
-
-    override def getBestFilterHeader(): Future[Option[CompactFilterHeaderDb]] =
-      Future.successful(None)
-
-    override def getFilterHeader(blockHash: DoubleSha256DigestBE): Future[
-      Option[CompactFilterHeaderDb]] = Future.successful(None)
-
-    override def getFilter(
-        hash: DoubleSha256DigestBE): Future[Option[CompactFilterDb]] =
-      Future.successful(None)
-
-    override def getFilterCount(): Future[Int] = Future.successful(0)
-
-    override def getFiltersAtHeight(
-        height: Int): Future[Vector[CompactFilterDb]] =
-      Future.successful(Vector.empty)
-
-    override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] =
-      Future.successful(0)
-
-    override def getHeadersBetween(
-        from: BlockHeaderDb,
-        to: BlockHeaderDb): Future[Vector[BlockHeaderDb]] =
-      Future.successful(Vector.empty)
-
-    override def getBlockHeight(
-        blockHash: DoubleSha256DigestBE): Future[Option[Int]] =
-      Future.successful(None)
-
-    override def getBestBlockHash(): Future[DoubleSha256DigestBE] =
-      Future.successful(DoubleSha256DigestBE.empty)
-
-    override def getNumberOfConfirmations(
-        blockHashOpt: DoubleSha256DigestBE): Future[Option[Int]] =
-      Future.successful(None)
-
-    override def getFiltersBetweenHeights(
-        startHeight: Int,
-        endHeight: Int): Future[Vector[ChainQueryApi.FilterResponse]] =
-      Future.successful(Vector.empty)
-
-    override def epochSecondToBlockHeight(time: Long): Future[Int] =
-      Future.successful(0)
-  }
 
   def withDisconnectedSpvNode(test: OneArgAsyncTest)(implicit
       system: ActorSystem,
@@ -316,31 +190,6 @@ trait NodeUnitTest extends BitcoinSFixture with EmbeddedPg {
         _: NodeFundedWalletBitcoind)(system, appConfig)
     )(test)
   }
-
-  /** Helper method to generate blocks every interval
-    * @return a cancellable that will stop generating blocks
-    */
-  def genBlockInterval(bitcoind: BitcoindRpcClient)(implicit
-      system: ActorSystem): Cancellable = {
-
-    var counter = 0
-    val desiredBlocks = 5
-    val interval = 500.millis
-
-    val genBlock = new Runnable {
-      override def run(): Unit = {
-        if (counter < desiredBlocks) {
-          bitcoind.getNewAddress.flatMap(bitcoind.generateToAddress(1, _))
-          counter = counter + 1
-        }
-      }
-    }
-
-    system.scheduler.scheduleAtFixedRate(2.second, interval)(genBlock)
-  }
-
-  def getBIP39PasswordOpt(): Option[String] =
-    KeyManagerTestUtil.bip39PasswordOpt
 }
 
 object NodeUnitTest extends P2PLogger {
@@ -415,6 +264,25 @@ object NodeUnitTest extends P2PLogger {
     require(appConfig.nodeType == NodeType.SpvNode)
     for {
       bitcoind <- BitcoinSFixture.createBitcoindWithFunds(versionOpt)
+      spvNodeWithBitcoind <- createSpvNodeFundedWalletFromBitcoind(
+        walletCallbacks,
+        bip39PasswordOpt,
+        bitcoind)
+    } yield {
+      spvNodeWithBitcoind
+    }
+  }
+
+  /** Creates a spv node & funded wallet with the given bitcoind */
+  def createSpvNodeFundedWalletFromBitcoind(
+      walletCallbacks: WalletCallbacks,
+      bip39PasswordOpt: Option[String],
+      bitcoind: BitcoindRpcClient)(implicit
+      system: ActorSystem,
+      appConfig: BitcoinSAppConfig): Future[SpvNodeFundedWalletBitcoind] = {
+    import system.dispatcher
+    require(appConfig.nodeType == NodeType.SpvNode)
+    for {
       node <- createSpvNode(createPeer(bitcoind))
       fundedWallet <- BitcoinSWalletTest.fundedWalletAndBitcoind(
         bitcoind,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -229,7 +229,9 @@ object NodeUnitTest extends P2PLogger {
   def destroyNode(node: Node)(implicit ec: ExecutionContext): Future[Unit] = {
     for {
       _ <- node.stop()
-    } yield ()
+    } yield {
+      ()
+    }
   }
 
   def destroyNodeConnectedWithBitcoind(

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -14,6 +14,7 @@ import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
 
+/** A trait that is useful if you need bitcoind fixtures for your test suite */
 trait BitcoindFixtures extends BitcoinSFixture with EmbeddedPg {
   _: BitcoinSAsyncFixtureTest =>
 
@@ -70,6 +71,9 @@ trait BitcoindFixturesFundedCached extends BitcoindFixtures {
   }
 }
 
+/** Test trait that caches a [[BitcoindV18RpcClient]] that is funded
+  * and available to use with fixtures
+  */
 trait BitcoindFixturesFundedCachedV18
     extends BitcoindFixturesFundedCached
     with CachedBitcoindV18 { _: BitcoinSAsyncFixtureTest =>
@@ -96,6 +100,9 @@ trait BitcoindFixturesFundedCachedV18
   }
 }
 
+/** Test trait that caches a [[BitcoindV19RpcClient]] that is funded
+  * and available to use with fixtures
+  */
 trait BitcoindFixturesFundedCachedV19
     extends BitcoindFixturesFundedCached
     with CachedBitcoindV19 { _: BitcoinSAsyncFixtureTest =>
@@ -122,6 +129,9 @@ trait BitcoindFixturesFundedCachedV19
   }
 }
 
+/** Test trait that caches a [[BitcoindV20RpcClient]] that is funded
+  * and available to use with fixtures
+  */
 trait BitcoindFixturesFundedCachedV20
     extends BitcoindFixturesFundedCached
     with CachedBitcoindV20 { _: BitcoinSAsyncFixtureTest =>
@@ -147,6 +157,9 @@ trait BitcoindFixturesFundedCachedV20
   }
 }
 
+/** Test trait that caches a [[BitcoindV21RpcClient]] that is funded
+  * and available to use with fixtures
+  */
 trait BitcoindFixturesFundedCachedV21
     extends BitcoindFixturesFundedCached
     with CachedBitcoindV21 { _: BitcoinSAsyncFixtureTest =>
@@ -172,7 +185,7 @@ trait BitcoindFixturesFundedCachedV21
   }
 }
 
-/** Bitcoind fixtures with three cached bitcoins that are connected via p2p */
+/** Bitcoind fixtures with two cached bitcoind that are connected via p2p */
 trait BitcoindFixturesCachedPair[T <: BitcoindRpcClient]
     extends BitcoindFixturesCached
     with CachedBitcoindPair[T] {
@@ -192,6 +205,7 @@ trait BitcoindFixturesCachedPair[T <: BitcoindRpcClient]
   }
 }
 
+/** Bitcoind fixtures with two cached [[BitcoindV17RpcClient]] that are connected via p2p */
 trait BitcoindFixturesCachedPairV17
     extends BitcoindFixturesCachedPair[BitcoindV17RpcClient] {
   _: BitcoinSAsyncFixtureTest =>
@@ -200,6 +214,7 @@ trait BitcoindFixturesCachedPairV17
   override val version: BitcoindVersion = BitcoindVersion.V17
 }
 
+/** Bitcoind fixtures with two cached [[BitcoindV18RpcClient]] that are connected via p2p */
 trait BitcoindFixturesCachedPairV18
     extends BitcoindFixturesCachedPair[BitcoindV18RpcClient] {
   _: BitcoinSAsyncFixtureTest =>
@@ -208,6 +223,7 @@ trait BitcoindFixturesCachedPairV18
   override val version: BitcoindVersion = BitcoindVersion.V18
 }
 
+/** Bitcoind fixtures with two cached bitcoind rpc clients that are [[BitcoindVersion.newest]] that are connected via p2p */
 trait BitcoindFixturesCachedPairNewest
     extends BitcoindFixturesCachedPair[BitcoindV21RpcClient] {
   _: BitcoinSAsyncFixtureTest =>
@@ -216,7 +232,7 @@ trait BitcoindFixturesCachedPairNewest
   override val version: BitcoindVersion = BitcoindVersion.newest
 }
 
-/** Bitcoind fixtures with three cached bitcoins that are connected via p2p */
+/** Bitcoind fixtures with three cached bitcoind that are connected via p2p */
 trait BitcoindFixturesCachedTriple[T <: BitcoindRpcClient]
     extends BitcoindFixturesCached
     with CachedBitcoindTriple[T] {

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -40,7 +40,7 @@ trait BitcoindFixtures extends BitcoinSFixture with EmbeddedPg {
         BitcoindRpcClient,
         BitcoindRpcClient,
         BitcoindRpcClient)](
-      () => BitcoindRpcTestUtil.createNodeTriple(),
+      () => BitcoindRpcTestUtil.createNodeTriple(BitcoindVersion.newest),
       destroy = {
         case nodes: (BitcoindRpcClient, BitcoindRpcClient, BitcoindRpcClient) =>
           BitcoindRpcTestUtil.stopServers(Vector(nodes._1, nodes._2, nodes._3))

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -212,6 +212,15 @@ trait BitcoindFixturesCachedPairV17
   override type FixtureParam = NodePair[BitcoindV17RpcClient]
 
   override val version: BitcoindVersion = BitcoindVersion.V17
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val futOutcome = for {
+      pair <- clientsF
+      futOutcome = with2BitcoindsCached(test, pair)
+      f <- futOutcome.toFuture
+    } yield f
+    new FutureOutcome(futOutcome)
+  }
 }
 
 /** Bitcoind fixtures with two cached [[BitcoindV18RpcClient]] that are connected via p2p */
@@ -221,6 +230,15 @@ trait BitcoindFixturesCachedPairV18
   override type FixtureParam = NodePair[BitcoindV18RpcClient]
 
   override val version: BitcoindVersion = BitcoindVersion.V18
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val futOutcome = for {
+      pair <- clientsF
+      futOutcome = with2BitcoindsCached(test, pair)
+      f <- futOutcome.toFuture
+    } yield f
+    new FutureOutcome(futOutcome)
+  }
 }
 
 /** Bitcoind fixtures with two cached bitcoind rpc clients that are [[BitcoindVersion.newest]] that are connected via p2p */

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -1,6 +1,8 @@
 package org.bitcoins.testkit.rpc
 
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
+import org.bitcoins.rpc.client.v20.BitcoindV20RpcClient
+import org.bitcoins.rpc.client.v21.BitcoindV21RpcClient
 import org.bitcoins.rpc.util.{NodePair, NodeTriple}
 import org.bitcoins.testkit.EmbeddedPg
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
@@ -62,6 +64,54 @@ trait BitcoindFixturesFundedCached extends BitcoindFixtures {
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)
+  }
+}
+
+trait BitcoindFixturesFundedCachedV20
+    extends BitcoindFixturesFundedCached
+    with CachedBitcoindV20 { _: BitcoinSAsyncFixtureTest =>
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withV20FundedBitcoindCached(test, bitcoind)
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
+
+  def withV20FundedBitcoindCached(
+      test: OneArgAsyncTest,
+      bitcoind: BitcoindV20RpcClient): FutureOutcome = {
+    makeDependentFixture[BitcoindV20RpcClient](
+      () => Future.successful(bitcoind),
+      { case _ =>
+        Future.unit // don't want to destroy anything since it is cached
+      })(test)
+  }
+}
+
+trait BitcoindFixturesFundedCachedV21
+    extends BitcoindFixturesFundedCached
+    with CachedBitcoindV21 { _: BitcoinSAsyncFixtureTest =>
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withV21FundedBitcoindCached(test, bitcoind)
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
+
+  def withV21FundedBitcoindCached(
+      test: OneArgAsyncTest,
+      bitcoind: BitcoindV21RpcClient): FutureOutcome = {
+    makeDependentFixture[BitcoindV21RpcClient](
+      () => Future.successful(bitcoind),
+      { case _ =>
+        Future.unit // don't want to destroy anything since it is cached
+      })(test)
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -19,16 +19,6 @@ import scala.concurrent.Future
 trait BitcoindFixtures extends BitcoinSFixture with EmbeddedPg {
   _: BitcoinSAsyncFixtureTest =>
 
-  def withNewestFundedBitcoind(test: OneArgAsyncTest): FutureOutcome = {
-    makeDependentFixture[BitcoindRpcClient](
-      () =>
-        BitcoinSFixture.createBitcoindWithFunds(Some(BitcoindVersion.newest)),
-      { case bitcoind: BitcoindRpcClient =>
-        BitcoindRpcTestUtil.stopServer(bitcoind)
-      }
-    )(test)
-  }
-
   def withNewestFundedBitcoindCached(
       test: OneArgAsyncTest,
       bitcoind: BitcoindRpcClient): FutureOutcome = {
@@ -39,18 +29,6 @@ trait BitcoindFixtures extends BitcoinSFixture with EmbeddedPg {
       })(test)
   }
 
-  def with3Bitcoinds(test: OneArgAsyncTest): FutureOutcome = {
-    makeDependentFixture[(
-        BitcoindRpcClient,
-        BitcoindRpcClient,
-        BitcoindRpcClient)](
-      () => BitcoindRpcTestUtil.createNodeTriple(BitcoindVersion.newest),
-      destroy = {
-        case nodes: (BitcoindRpcClient, BitcoindRpcClient, BitcoindRpcClient) =>
-          BitcoindRpcTestUtil.stopServers(Vector(nodes._1, nodes._2, nodes._3))
-      }
-    )(test)
-  }
 }
 
 /** Bitcoind fixtures with a cached a bitcoind instance */

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -1,0 +1,47 @@
+package org.bitcoins.testkit.rpc
+
+import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
+import org.bitcoins.testkit.EmbeddedPg
+import org.bitcoins.testkit.fixtures.BitcoinSFixture
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
+
+import org.scalatest.{FutureOutcome, Outcome}
+
+import scala.concurrent.Future
+
+trait BitcoindFixtures extends BitcoinSFixture with EmbeddedPg {
+  _: BitcoinSAsyncFixtureTest =>
+
+  def withNewestFundedBitcoind(test: OneArgAsyncTest): FutureOutcome = {
+    makeDependentFixture[BitcoindRpcClient](
+      () =>
+        BitcoinSFixture.createBitcoindWithFunds(Some(BitcoindVersion.newest)),
+      { case bitcoind: BitcoindRpcClient =>
+        BitcoindRpcTestUtil.stopServer(bitcoind)
+      }
+    )(test)
+  }
+
+  def withNewestFundedBitcoindCached(
+      test: OneArgAsyncTest,
+      bitcoind: BitcoindRpcClient): FutureOutcome = {
+    makeDependentFixture[BitcoindRpcClient](
+      () => Future.successful(bitcoind),
+      { case _ =>
+        Future.unit // don't want to destroy anything since it is cached
+      })(test)
+  }
+}
+
+trait BitcoindFixturesCached extends BitcoindFixtures with CachedBitcoind {
+  _: BitcoinSAsyncFixtureTest =>
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withNewestFundedBitcoindCached(test, bitcoind)
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -68,7 +68,7 @@ trait BitcoindFixturesFundedCached extends BitcoindFixtures {
 /** Bitcoind fixtures with three cached bitcoins that are connected via p2p */
 trait BitcoindFixturesCachedPair
     extends BitcoindFixturesCached
-    with CachedBitcoindTriple {
+    with CachedBitcoindPair {
   _: BitcoinSAsyncFixtureTest =>
 
   def with2BitcoindsCached(

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.testkit.rpc
 
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
+import org.bitcoins.rpc.client.v16.BitcoindV16RpcClient
 import org.bitcoins.rpc.client.v17.BitcoindV17RpcClient
 import org.bitcoins.rpc.client.v18.BitcoindV18RpcClient
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
@@ -75,8 +76,9 @@ trait BitcoindFixturesFundedCached extends BitcoindFixtures {
   * and available to use with fixtures
   */
 trait BitcoindFixturesFundedCachedV18
-    extends BitcoindFixturesFundedCached
-    with CachedBitcoindV18 { _: BitcoinSAsyncFixtureTest =>
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesFundedCached
+    with CachedBitcoindV18 {
 
   override type FixtureParam = BitcoindV18RpcClient
 
@@ -98,14 +100,20 @@ trait BitcoindFixturesFundedCachedV18
         Future.unit // don't want to destroy anything since it is cached
       })(test)
   }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindV18].afterAll()
+    super[BitcoinSAsyncFixtureTest].afterAll()
+  }
 }
 
 /** Test trait that caches a [[BitcoindV19RpcClient]] that is funded
   * and available to use with fixtures
   */
 trait BitcoindFixturesFundedCachedV19
-    extends BitcoindFixturesFundedCached
-    with CachedBitcoindV19 { _: BitcoinSAsyncFixtureTest =>
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesFundedCached
+    with CachedBitcoindV19 {
 
   override type FixtureParam = BitcoindV19RpcClient
 
@@ -127,14 +135,20 @@ trait BitcoindFixturesFundedCachedV19
         Future.unit // don't want to destroy anything since it is cached
       })(test)
   }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindV19].afterAll()
+    super[BitcoinSAsyncFixtureTest].afterAll()
+  }
 }
 
 /** Test trait that caches a [[BitcoindV20RpcClient]] that is funded
   * and available to use with fixtures
   */
 trait BitcoindFixturesFundedCachedV20
-    extends BitcoindFixturesFundedCached
-    with CachedBitcoindV20 { _: BitcoinSAsyncFixtureTest =>
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesFundedCached
+    with CachedBitcoindV20 {
   override type FixtureParam = BitcoindV20RpcClient
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
@@ -155,14 +169,21 @@ trait BitcoindFixturesFundedCachedV20
         Future.unit // don't want to destroy anything since it is cached
       })(test)
   }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindV20].afterAll()
+    super[BitcoinSAsyncFixtureTest].afterAll()
+  }
+
 }
 
 /** Test trait that caches a [[BitcoindV21RpcClient]] that is funded
   * and available to use with fixtures
   */
 trait BitcoindFixturesFundedCachedV21
-    extends BitcoindFixturesFundedCached
-    with CachedBitcoindV21 { _: BitcoinSAsyncFixtureTest =>
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesFundedCached
+    with CachedBitcoindV21 {
   override type FixtureParam = BitcoindV21RpcClient
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
@@ -182,6 +203,11 @@ trait BitcoindFixturesFundedCachedV21
       { case _ =>
         Future.unit // don't want to destroy anything since it is cached
       })(test)
+  }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindV21].afterAll()
+    super[BitcoinSAsyncFixtureTest].afterAll()
   }
 }
 
@@ -205,10 +231,33 @@ trait BitcoindFixturesCachedPair[T <: BitcoindRpcClient]
   }
 }
 
+/** Bitcoind fixtures with two cached BitcoindV16RpcClient that are connected via p2p */
+trait BitcoindFixturesCachedPairV16
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCachedPair[BitcoindV16RpcClient] {
+  override type FixtureParam = NodePair[BitcoindV16RpcClient]
+
+  override val version: BitcoindVersion = BitcoindVersion.V16
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val futOutcome = for {
+      pair <- clientsF
+      futOutcome = with2BitcoindsCached(test, pair)
+      f <- futOutcome.toFuture
+    } yield f
+    new FutureOutcome(futOutcome)
+  }
+
+  override def afterAll(): Unit = {
+    super[BitcoindFixturesCachedPair].afterAll()
+    super[BitcoinSAsyncFixtureTest].afterAll()
+  }
+}
+
 /** Bitcoind fixtures with two cached [[BitcoindV17RpcClient]] that are connected via p2p */
 trait BitcoindFixturesCachedPairV17
-    extends BitcoindFixturesCachedPair[BitcoindV17RpcClient] {
-  _: BitcoinSAsyncFixtureTest =>
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCachedPair[BitcoindV17RpcClient] {
   override type FixtureParam = NodePair[BitcoindV17RpcClient]
 
   override val version: BitcoindVersion = BitcoindVersion.V17
@@ -221,12 +270,17 @@ trait BitcoindFixturesCachedPairV17
     } yield f
     new FutureOutcome(futOutcome)
   }
+
+  override def afterAll(): Unit = {
+    super[BitcoindFixturesCachedPair].afterAll()
+    super[BitcoinSAsyncFixtureTest].afterAll()
+  }
 }
 
 /** Bitcoind fixtures with two cached [[BitcoindV18RpcClient]] that are connected via p2p */
 trait BitcoindFixturesCachedPairV18
-    extends BitcoindFixturesCachedPair[BitcoindV18RpcClient] {
-  _: BitcoinSAsyncFixtureTest =>
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCachedPair[BitcoindV18RpcClient] {
   override type FixtureParam = NodePair[BitcoindV18RpcClient]
 
   override val version: BitcoindVersion = BitcoindVersion.V18
@@ -239,22 +293,32 @@ trait BitcoindFixturesCachedPairV18
     } yield f
     new FutureOutcome(futOutcome)
   }
+
+  override def afterAll(): Unit = {
+    super[BitcoindFixturesCachedPair].afterAll()
+    super[BitcoinSAsyncFixtureTest].afterAll()
+  }
 }
 
 /** Bitcoind fixtures with two cached bitcoind rpc clients that are [[BitcoindVersion.newest]] that are connected via p2p */
 trait BitcoindFixturesCachedPairNewest
-    extends BitcoindFixturesCachedPair[BitcoindV21RpcClient] {
-  _: BitcoinSAsyncFixtureTest =>
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCachedPair[BitcoindV21RpcClient] {
   override type FixtureParam = NodePair[BitcoindV21RpcClient]
 
   override val version: BitcoindVersion = BitcoindVersion.newest
+
+  override def afterAll(): Unit = {
+    super[BitcoindFixturesCachedPair].afterAll()
+    super[BitcoinSAsyncFixtureTest].afterAll()
+  }
 }
 
 /** Bitcoind fixtures with three cached bitcoind that are connected via p2p */
 trait BitcoindFixturesCachedTriple[T <: BitcoindRpcClient]
-    extends BitcoindFixturesCached
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCached
     with CachedBitcoindTriple[T] {
-  _: BitcoinSAsyncFixtureTest =>
 
   def with3BitcoindsCached(
       test: OneArgAsyncTest,
@@ -267,5 +331,10 @@ trait BitcoindFixturesCachedTriple[T <: BitcoindRpcClient]
         Future.unit
       }
     )(test)
+  }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindTriple].afterAll()
+    super[BitcoinSAsyncFixtureTest].afterAll()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.testkit.rpc
 
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
-import org.bitcoins.rpc.util.NodeTriple
+import org.bitcoins.rpc.util.{NodePair, NodeTriple}
 import org.bitcoins.testkit.EmbeddedPg
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
@@ -62,6 +62,26 @@ trait BitcoindFixturesFundedCached extends BitcoindFixtures {
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)
+  }
+}
+
+/** Bitcoind fixtures with three cached bitcoins that are connected via p2p */
+trait BitcoindFixturesCachedPair
+    extends BitcoindFixturesCached
+    with CachedBitcoindTriple {
+  _: BitcoinSAsyncFixtureTest =>
+
+  def with2BitcoindsCached(
+      test: OneArgAsyncTest,
+      bitcoinds: NodePair): FutureOutcome = {
+    makeDependentFixture[NodePair](
+      () => Future.successful(bitcoinds),
+      destroy = { case _: NodePair =>
+        //do nothing since we are caching bitcoinds
+        //the test trait may want to re-use them
+        Future.unit
+      }
+    )(test)
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -749,14 +749,14 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     */
   def createNodePair(clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
       system: ActorSystem): Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    createNodePair().map { pair =>
+    createNodePair(BitcoindVersion.newest).map { pair =>
       clientAccum.++=(Vector(pair._1, pair._2))
       pair
     }(system.dispatcher)
 
-  def createNodePair()(implicit
+  def createNodePair(version: BitcoindVersion)(implicit
       system: ActorSystem): Future[(BitcoindRpcClient, BitcoindRpcClient)] = {
-    createNodePairInternal(BitcoindVersion.newest)
+    createNodePairInternal(version)
   }
 
   /** Returns a pair of [[org.bitcoins.rpc.client.v16.BitcoindV16RpcClient BitcoindV16RpcClient]]
@@ -852,9 +852,10 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
   /** Returns a triple of org.bitcoins.rpc.client.common.BitcoindRpcClient BitcoindRpcClient
     * that are connected with some blocks in the chain
     */
-  def createNodeTriple()(implicit system: ActorSystem): Future[
+  def createNodeTriple(version: BitcoindVersion)(implicit
+      system: ActorSystem): Future[
     (BitcoindRpcClient, BitcoindRpcClient, BitcoindRpcClient)] = {
-    createNodeTripleInternal(BitcoindVersion.Unknown)
+    createNodeTripleInternal(version)
   }
 
   /** @return a triple of [[org.bitcoins.rpc.client.v17.BitcoindV17RpcClient BitcoindV17RpcClient]]

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -762,48 +762,42 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
   /** Returns a pair of [[org.bitcoins.rpc.client.v16.BitcoindV16RpcClient BitcoindV16RpcClient]]
     * that are connected with some blocks in the chain
     */
-  def createNodePairV16(
-      clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
+  def createNodePairV16(clientAccum: RpcClientAccum)(implicit
   system: ActorSystem): Future[(BitcoindV16RpcClient, BitcoindV16RpcClient)] =
     createNodePairInternal(BitcoindVersion.V16, clientAccum)
 
   /** Returns a pair of [[org.bitcoins.rpc.client.v17.BitcoindV17RpcClient BitcoindV17RpcClient]]
     * that are connected with some blocks in the chain
     */
-  def createNodePairV17(
-      clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
+  def createNodePairV17(clientAccum: RpcClientAccum)(implicit
   system: ActorSystem): Future[(BitcoindV17RpcClient, BitcoindV17RpcClient)] =
     createNodePairInternal(BitcoindVersion.V17, clientAccum)
 
   /** Returns a pair of [[org.bitcoins.rpc.client.v18.BitcoindV18RpcClient BitcoindV18RpcClient]]
     * that are connected with some blocks in the chain
     */
-  def createNodePairV18(
-      clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
+  def createNodePairV18(clientAccum: RpcClientAccum)(implicit
   system: ActorSystem): Future[(BitcoindV18RpcClient, BitcoindV18RpcClient)] =
     createNodePairInternal(BitcoindVersion.V18, clientAccum)
 
   /** Returns a pair of [[org.bitcoins.rpc.client.v19.BitcoindV19RpcClient BitcoindV19RpcClient]]
     * that are connected with some blocks in the chain
     */
-  def createNodePairV19(
-      clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
+  def createNodePairV19(clientAccum: RpcClientAccum)(implicit
   system: ActorSystem): Future[(BitcoindV19RpcClient, BitcoindV19RpcClient)] =
     createNodePairInternal(BitcoindVersion.V19, clientAccum)
 
   /** Returns a pair of [[org.bitcoins.rpc.client.v20.BitcoindV20RpcClient BitcoindV20RpcClient]]
     * that are connected with some blocks in the chain
     */
-  def createNodePairV20(
-      clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
+  def createNodePairV20(clientAccum: RpcClientAccum)(implicit
   system: ActorSystem): Future[(BitcoindV20RpcClient, BitcoindV20RpcClient)] =
     createNodePairInternal(BitcoindVersion.V20, clientAccum)
 
   /** Returns a pair of [[org.bitcoins.rpc.client.v21.BitcoindV21RpcClient BitcoindV21RpcClient]]
     * that are connected with some blocks in the chain
     */
-  def createNodePairV21(
-      clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
+  def createNodePairV21(clientAccum: RpcClientAccum)(implicit
   system: ActorSystem): Future[(BitcoindV21RpcClient, BitcoindV21RpcClient)] =
     createNodePairInternal(BitcoindVersion.V21, clientAccum)
 
@@ -843,7 +837,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     * that are connected with some blocks in the chain
     */
   def createNodeTriple(
-      clientAccum: RpcClientAccum = Vector.newBuilder
+      clientAccum: RpcClientAccum
   )(implicit system: ActorSystem): Future[
     (BitcoindRpcClient, BitcoindRpcClient, BitcoindRpcClient)] = {
     createNodeTripleInternal(BitcoindVersion.Unknown, clientAccum)
@@ -862,21 +856,21 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     * that are connected with some blocks in the chain
     */
   def createNodeTripleV17(
-      clientAccum: RpcClientAccum = Vector.newBuilder
+      clientAccum: RpcClientAccum
   )(implicit system: ActorSystem): Future[
     (BitcoindV17RpcClient, BitcoindV17RpcClient, BitcoindV17RpcClient)] = {
     createNodeTripleInternal(BitcoindVersion.V17, clientAccum)
   }
 
   def createNodeTripleV18(
-      clientAccum: RpcClientAccum = Vector.newBuilder
+      clientAccum: RpcClientAccum
   )(implicit system: ActorSystem): Future[
     (BitcoindV18RpcClient, BitcoindV18RpcClient, BitcoindV18RpcClient)] = {
     createNodeTripleInternal(BitcoindVersion.V18, clientAccum)
   }
 
   def createNodeTripleV19(
-      clientAccum: RpcClientAccum = Vector.newBuilder
+      clientAccum: RpcClientAccum
   )(implicit system: ActorSystem): Future[
     (BitcoindV19RpcClient, BitcoindV19RpcClient, BitcoindV19RpcClient)] = {
     createNodeTripleInternal(BitcoindVersion.V19, clientAccum)
@@ -1106,7 +1100,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     */
   def startedBitcoindRpcClient(
       instance: BitcoindInstance = BitcoindRpcTestUtil.instance(),
-      clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
+      clientAccum: RpcClientAccum)(implicit
       system: ActorSystem): Future[BitcoindRpcClient] = {
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     require(

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -756,7 +756,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
 
   def createNodePair()(implicit
       system: ActorSystem): Future[(BitcoindRpcClient, BitcoindRpcClient)] = {
-    createNodePairInternal(BitcoindVersion.Unknown)
+    createNodePairInternal(BitcoindVersion.newest)
   }
 
   /** Returns a pair of [[org.bitcoins.rpc.client.v16.BitcoindV16RpcClient BitcoindV16RpcClient]]
@@ -927,6 +927,10 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
         v17.signRawTransactionWithWallet(transaction, utxoDeps)
       case v16: BitcoindV16RpcClient =>
         v16.signRawTransaction(transaction, utxoDeps)
+      case v20: BitcoindV20RpcClient =>
+        v20.signRawTransactionWithWallet(transaction)
+      case v21: BitcoindV21RpcClient =>
+        v21.signRawTransactionWithWallet(transaction)
       case unknown: BitcoindRpcClient =>
         val v16T = BitcoindV16RpcClient.fromUnknownVersion(unknown)
         val v17T = BitcoindV17RpcClient.fromUnknownVersion(unknown)

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -482,7 +482,8 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
       system: ActorSystem): Future[Vector[Vector[DoubleSha256DigestBE]]] = {
     import system.dispatcher
 
-    val sliding = ListUtil.rotateHead(clients)
+    val sliding: Vector[Vector[BitcoindRpcClient]] =
+      ListUtil.rotateHead(clients)
 
     val initF = Future.successful(Vector.empty[Vector[DoubleSha256DigestBE]])
 
@@ -716,7 +717,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     for {
       pairs <- pairsF
       _ <- connectPairs(pairs)
-      _ <- BitcoindRpcTestUtil.generateAllAndSync(clients, blocks = 200)
+      _ <- BitcoindRpcTestUtil.generateAllAndSync(clients, blocks = 101)
     } yield clients
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -747,15 +747,16 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
   /** Returns a pair of [[org.bitcoins.rpc.client.common.BitcoindRpcClient BitcoindRpcClient]]
     * that are connected with some blocks in the chain
     */
-  def createNodePair(clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
+  def createNodePair[T <: BitcoindRpcClient](
+      clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
       system: ActorSystem): Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    createNodePair(BitcoindVersion.newest).map { pair =>
+    createNodePair[T](BitcoindVersion.newest).map { pair =>
       clientAccum.++=(Vector(pair._1, pair._2))
       pair
     }(system.dispatcher)
 
-  def createNodePair(version: BitcoindVersion)(implicit
-      system: ActorSystem): Future[(BitcoindRpcClient, BitcoindRpcClient)] = {
+  def createNodePair[T <: BitcoindRpcClient](version: BitcoindVersion)(implicit
+      system: ActorSystem): Future[(T, T)] = {
     createNodePairInternal(version)
   }
 
@@ -846,9 +847,8 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
   /** Returns a triple of org.bitcoins.rpc.client.common.BitcoindRpcClient BitcoindRpcClient
     * that are connected with some blocks in the chain
     */
-  def createNodeTriple(version: BitcoindVersion)(implicit
-      system: ActorSystem): Future[
-    (BitcoindRpcClient, BitcoindRpcClient, BitcoindRpcClient)] = {
+  def createNodeTriple[T <: BitcoindRpcClient](version: BitcoindVersion)(
+      implicit system: ActorSystem): Future[(T, T, T)] = {
     createNodeTripleInternal(version)
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -1,0 +1,53 @@
+package org.bitcoins.testkit.rpc
+
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.testkit.fixtures.BitcoinSFixture
+import org.bitcoins.testkit.util.BitcoinSAkkaAsyncTest
+
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.{Await, Future}
+
+/** A trait that holds a cached instance of a [[org.bitcoins.rpc.client.common.BitcoindRpcClient]]
+  * This is useful for using with fixtures to avoid creating a new bitcoind everytime a
+  * new test is run.
+  *
+  * The idea is our wallet/chain/node can just use the cached bitcoind rather than a fresh one.
+  * This does mean that test cases have to be written in such a way where assertions
+  * are not dependent on specific bitcoind state.
+  */
+trait CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
+
+  /** Flag to indicate if the bitcoind was used
+    *
+    * If we don't have this, we have no way
+    * to know if we should cleanup the cached bitcoind
+    * in the [[afterAll()]] method or not.
+    *
+    * We do not want to accidentally create a bitcoind
+    * inside of [[afterAll()]] just to have it
+    * cleaned up in the same method.
+    */
+  private[this] val isBitcoindUsed: AtomicBoolean = new AtomicBoolean(false)
+
+  /** The bitcoind instance, lazyily created */
+  protected lazy val cachedBitcoindWithFundsF: Future[BitcoindRpcClient] = {
+    isBitcoindUsed.set(true)
+    BitcoinSFixture
+      .createBitcoindWithFunds(None)
+  }
+
+  override def afterAll(): Unit = {
+    if (isBitcoindUsed.get()) {
+      //if it was used, shut down the cached bitcoind
+      val stoppedF = for {
+        cachedBitcoind <- cachedBitcoindWithFundsF
+        _ <- BitcoindRpcTestUtil.stopServer(cachedBitcoind)
+      } yield ()
+
+      Await.result(stoppedF, duration)
+    } else {
+      //do nothing since bitcoind wasn't used
+    }
+  }
+
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -138,7 +138,7 @@ trait CachedBitcoindCollection[T <: BitcoindRpcClient]
   /** The version of bitcoind we are creating in the collection
     * By default, we just use the newest version of bitcoind
     */
-  def version: BitcoindVersion = BitcoindVersion.newest
+  def version: BitcoindVersion
 
   /** Flag to indicate if the bitcoinds were used
     *

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -2,6 +2,7 @@ package org.bitcoins.testkit.rpc
 
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.rpc.util.NodeTriple
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.util.BitcoinSAkkaAsyncTest
 
@@ -16,7 +17,9 @@ import scala.concurrent.{Await, Future}
   * This does mean that test cases have to be written in such a way where assertions
   * are not dependent on specific bitcoind state.
   */
-trait CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
+trait CachedBitcoind { _: BitcoinSAkkaAsyncTest => }
+
+trait CachedBitcoindFunded extends CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
 
   /** Flag to indicate if the bitcoind was used
     *
@@ -52,7 +55,8 @@ trait CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
   }
 }
 
-trait CachedBitcoindNewest extends CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
+trait CachedBitcoindNewest extends CachedBitcoindFunded {
+  _: BitcoinSAkkaAsyncTest =>
 
   override protected lazy val cachedBitcoindWithFundsF: Future[
     BitcoindRpcClient] = {
@@ -62,7 +66,8 @@ trait CachedBitcoindNewest extends CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
   }
 }
 
-trait CachedBitcoindV19 extends CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
+trait CachedBitcoindV19 extends CachedBitcoindFunded {
+  _: BitcoinSAkkaAsyncTest =>
 
   override protected lazy val cachedBitcoindWithFundsF: Future[
     BitcoindV19RpcClient] = {
@@ -71,4 +76,41 @@ trait CachedBitcoindV19 extends CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
       .createBitcoindWithFunds(Some(BitcoindVersion.V19))
       .map(_.asInstanceOf[BitcoindV19RpcClient])
   }
+}
+
+trait CachedBitcoindTriple extends CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
+
+  /** Flag to indicate if the bitcoinds were used
+    *
+    * If we don't have this, we have no way
+    * to know if we should cleanup the cached bitcoind
+    * in the [[afterAll()]] method or not.
+    *
+    * We do not want to accidentally create a bitcoind
+    * inside of [[afterAll()]] just to have it
+    * cleaned up in the same method.
+    */
+  private val isClientsUsed: AtomicBoolean = new AtomicBoolean(false)
+
+  lazy val clientsF: Future[NodeTriple] = {
+    val _ = isClientsUsed.set(true)
+    BitcoindRpcTestUtil
+      .createNodeTriple()
+      .map(NodeTriple.fromTuple(_))
+  }
+
+  override def afterAll(): Unit = {
+    if (isClientsUsed.get()) {
+      //if it was used, shut down the cached bitcoind
+      val stoppedF = for {
+        clients <- clientsF
+        _ <- BitcoindRpcTestUtil.stopServers(clients.toVector)
+      } yield ()
+
+      Await.result(stoppedF, duration)
+    } else {
+      //do nothing since bitcoind wasn't used
+    }
+  }
+
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -91,11 +91,10 @@ trait CachedBitcoindCollection extends CachedBitcoind {
     * inside of [[afterAll()]] just to have it
     * cleaned up in the same method.
     */
-  private val isClientsUsed: AtomicBoolean = new AtomicBoolean(false)
+  protected val isClientsUsed: AtomicBoolean = new AtomicBoolean(false)
 
   protected lazy val cachedClients: AtomicReference[
     Vector[BitcoindRpcClient]] = {
-    isClientsUsed.set(true)
     new AtomicReference[Vector[BitcoindRpcClient]](Vector.empty)
   }
 
@@ -122,6 +121,7 @@ trait CachedBitcoindPair extends CachedBitcoindCollection {
       .createNodePair()
       .map(NodePair.fromTuple(_))
       .map { triple =>
+        isClientsUsed.set(true)
         cachedClients.set(triple.toVector)
         triple
       }
@@ -136,6 +136,7 @@ trait CachedBitcoindTriple extends CachedBitcoindCollection {
       .createNodeTriple()
       .map(NodeTriple.fromTuple(_))
       .map { triple =>
+        isClientsUsed.set(true)
         cachedClients.set(triple.toVector)
         triple
       }

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -2,6 +2,8 @@ package org.bitcoins.testkit.rpc
 
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.rpc.client.v20.BitcoindV20RpcClient
+import org.bitcoins.rpc.client.v21.BitcoindV21RpcClient
 import org.bitcoins.rpc.util.{NodePair, NodeTriple}
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.util.BitcoinSAkkaAsyncTest
@@ -75,6 +77,30 @@ trait CachedBitcoindV19 extends CachedBitcoindFunded {
     BitcoinSFixture
       .createBitcoindWithFunds(Some(BitcoindVersion.V19))
       .map(_.asInstanceOf[BitcoindV19RpcClient])
+  }
+}
+
+trait CachedBitcoindV20 extends CachedBitcoindFunded {
+  _: BitcoinSAkkaAsyncTest =>
+
+  override protected lazy val cachedBitcoindWithFundsF: Future[
+    BitcoindV20RpcClient] = {
+    val _ = isBitcoindUsed.set(true)
+    BitcoinSFixture
+      .createBitcoindWithFunds(Some(BitcoindVersion.V20))
+      .map(_.asInstanceOf[BitcoindV20RpcClient])
+  }
+}
+
+trait CachedBitcoindV21 extends CachedBitcoindFunded {
+  _: BitcoinSAkkaAsyncTest =>
+
+  override protected lazy val cachedBitcoindWithFundsF: Future[
+    BitcoindV21RpcClient] = {
+    val _ = isBitcoindUsed.set(true)
+    BitcoinSFixture
+      .createBitcoindWithFunds(Some(BitcoindVersion.V21))
+      .map(_.asInstanceOf[BitcoindV21RpcClient])
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.testkit.rpc
 
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
+import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.util.BitcoinSAkkaAsyncTest
 
@@ -27,11 +28,11 @@ trait CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
     * inside of [[afterAll()]] just to have it
     * cleaned up in the same method.
     */
-  private[this] val isBitcoindUsed: AtomicBoolean = new AtomicBoolean(false)
+  protected val isBitcoindUsed: AtomicBoolean = new AtomicBoolean(false)
 
   /** The bitcoind instance, lazyily created */
   protected lazy val cachedBitcoindWithFundsF: Future[BitcoindRpcClient] = {
-    isBitcoindUsed.set(true)
+    val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
       .createBitcoindWithFunds(None)
   }
@@ -49,5 +50,15 @@ trait CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
       //do nothing since bitcoind wasn't used
     }
   }
+}
 
+trait CachedBitcoindV19 extends CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
+
+  override protected lazy val cachedBitcoindWithFundsF: Future[
+    BitcoindV19RpcClient] = {
+    val _ = isBitcoindUsed.set(true)
+    BitcoinSFixture
+      .createBitcoindWithFunds(Some(BitcoindVersion.V19))
+      .map(_.asInstanceOf[BitcoindV19RpcClient])
+  }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -182,7 +182,8 @@ trait CachedBitcoindPair[T <: BitcoindRpcClient]
       .map(NodePair.fromTuple)
       .map { tuple =>
         isClientsUsed.set(true)
-        cachedClients.set(tuple.toVector)
+        val clients = cachedClients.get()
+        cachedClients.set(clients ++ tuple.toVector)
         tuple
       }
   }
@@ -198,7 +199,8 @@ trait CachedBitcoindTriple[T <: BitcoindRpcClient]
       .map(NodeTriple.fromTuple)
       .map { triple =>
         isClientsUsed.set(true)
-        cachedClients.set(triple.toVector)
+        val clients = cachedClients.get()
+        cachedClients.set(clients ++ triple.toVector)
         triple
       }
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -107,6 +107,11 @@ trait CachedBitcoindV21 extends CachedBitcoindFunded {
 trait CachedBitcoindCollection extends CachedBitcoind {
   _: BitcoinSAkkaAsyncTest =>
 
+  /** The version of bitcoind we are creating in the collection
+    * By default, we just use the newest version of bitcoind
+    */
+  def version: BitcoindVersion = BitcoindVersion.newest
+
   /** Flag to indicate if the bitcoinds were used
     *
     * If we don't have this, we have no way
@@ -144,7 +149,7 @@ trait CachedBitcoindPair extends CachedBitcoindCollection {
 
   lazy val clientsF: Future[NodePair] = {
     BitcoindRpcTestUtil
-      .createNodePair()
+      .createNodePair(version)
       .map(NodePair.fromTuple(_))
       .map { triple =>
         isClientsUsed.set(true)
@@ -159,7 +164,7 @@ trait CachedBitcoindTriple extends CachedBitcoindCollection {
 
   lazy val clientsF: Future[NodeTriple] = {
     BitcoindRpcTestUtil
-      .createNodeTriple()
+      .createNodeTriple(version)
       .map(NodeTriple.fromTuple(_))
       .map { triple =>
         isClientsUsed.set(true)

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -52,6 +52,16 @@ trait CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
   }
 }
 
+trait CachedBitcoindNewest extends CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
+
+  override protected lazy val cachedBitcoindWithFundsF: Future[
+    BitcoindRpcClient] = {
+    val _ = isBitcoindUsed.set(true)
+    BitcoinSFixture
+      .createBitcoindWithFunds(Some(BitcoindVersion.newest))
+  }
+}
+
 trait CachedBitcoindV19 extends CachedBitcoind { _: BitcoinSAkkaAsyncTest =>
 
   override protected lazy val cachedBitcoindWithFundsF: Future[

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
@@ -3,6 +3,8 @@ package org.bitcoins.testkit.util
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import akka.util.Timeout
+import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkitcore.util.BaseAsyncTest
 import org.scalatest._
 import org.scalatest.flatspec.{AsyncFlatSpec, FixtureAsyncFlatSpec}
@@ -18,6 +20,7 @@ trait BitcoinSAkkaAsyncTest extends BaseAsyncTest { this: AsyncTestSuite =>
   implicit val system: ActorSystem = {
     ActorSystem(s"${getClass.getSimpleName}-${System.currentTimeMillis()}")
   }
+  implicit val networkParam: NetworkParameters = BitcoindRpcTestUtil.network
 
   /** Needed because the default execution context will become overloaded
     * if we do not specify a unique execution context for each suite

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.testkit.util
 
 import java.nio.file.Files
-import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 
@@ -29,8 +28,6 @@ abstract class BitcoindRpcTest extends BitcoinSAsyncTest {
       msg
     }
   }
-
-  implicit val networkParam: NetworkParameters = BitcoindRpcTestUtil.network
 
   /** Bitcoind RPC clients can be added to this builder
     * as they are created in tests. After tests have

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
@@ -5,7 +5,7 @@ import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 
 import scala.collection.mutable
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
 
 abstract class BitcoindRpcTest extends BitcoinSAsyncTest {
 
@@ -39,7 +39,8 @@ abstract class BitcoindRpcTest extends BitcoinSAsyncTest {
     Vector[BitcoindRpcClient]] = Vector.newBuilder
 
   override def afterAll(): Unit = {
-    BitcoindRpcTestUtil.stopServers(clientAccum.result())
+    val stopF = BitcoindRpcTestUtil.stopServers(clientAccum.result())
+    Await.result(stopF, duration)
     super.afterAll()
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTestClient.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTestClient.scala
@@ -32,7 +32,9 @@ case class BitcoindRpcTestClient(
       case Some(client) => Future.successful(client)
       case None =>
         val clientF =
-          BitcoindRpcTestUtil.startedBitcoindRpcClient(bitcoindInstance)
+          BitcoindRpcTestUtil.startedBitcoindRpcClient(bitcoindInstance,
+                                                       clientAccum =
+                                                         Vector.newBuilder)
         clientF.map { c =>
           clientOpt = Some(c)
           c

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -16,6 +16,7 @@ import org.scalatest.AsyncTestSuite
 
 import scala.concurrent.Future
 
+/** Base test trait for all the tests in our walletTest module */
 trait BaseWalletTest extends EmbeddedPg { _: AsyncTestSuite =>
 
   override def beforeAll(): Unit = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -7,6 +7,7 @@ import org.bitcoins.core.gcs.BlockFilter
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.db.AppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
@@ -16,6 +17,15 @@ import org.scalatest.AsyncTestSuite
 import scala.concurrent.Future
 
 trait BaseWalletTest extends EmbeddedPg { _: AsyncTestSuite =>
+
+  override def beforeAll(): Unit = {
+    AppConfig.throwIfDefaultDatadir(getFreshConfig.walletConf)
+    super[EmbeddedPg].beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super[EmbeddedPg].afterAll()
+  }
 
   val legacyWalletConf: Config =
     ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = legacy")

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -1,0 +1,114 @@
+package org.bitcoins.testkit.wallet
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
+import org.bitcoins.core.gcs.BlockFilter
+import org.bitcoins.core.protocol.BlockStamp
+import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
+import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
+import org.bitcoins.wallet.config.WalletAppConfig
+import org.scalatest.AsyncTestSuite
+
+import scala.concurrent.Future
+
+trait BaseWalletTest extends EmbeddedPg { _: AsyncTestSuite =>
+
+  val legacyWalletConf: Config =
+    ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = legacy")
+
+  val segwitWalletConf: Config =
+    ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = segwit")
+
+  // This is a random block on testnet
+  val testBlockHash: DoubleSha256DigestBE = DoubleSha256DigestBE.fromHex(
+    "00000000496dcc754fabd97f3e2df0a7337eab417d75537fecf97a7ebb0e7c75")
+
+  /** Wallet config with data directory set to user temp directory */
+  implicit protected def getFreshConfig: BitcoinSAppConfig =
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
+
+  implicit protected def getFreshWalletAppConfig: WalletAppConfig = {
+    getFreshConfig.walletConf
+  }
+
+  def getBIP39PasswordOpt(): Option[String] =
+    KeyManagerTestUtil.bip39PasswordOpt
+
+  def chainQueryApi: ChainQueryApi =
+    new ChainQueryApi {
+
+      /** Gets the height of the given block */
+      override def getBlockHeight(
+          blockHash: DoubleSha256DigestBE): Future[Option[Int]] =
+        if (blockHash == testBlockHash)
+          Future.successful(Some(1))
+        else FutureUtil.none
+
+      /** Gets the hash of the block that is what we consider "best" */
+      override def getBestBlockHash(): Future[DoubleSha256DigestBE] =
+        Future.successful(testBlockHash)
+
+      /** Gets number of confirmations for the given block hash */
+      override def getNumberOfConfirmations(
+          blockHash: DoubleSha256DigestBE): Future[Option[Int]] =
+        if (blockHash == testBlockHash)
+          Future.successful(Some(6))
+        else FutureUtil.none
+
+      /** Gets the number of compact filters in the database */
+      override def getFilterCount(): Future[Int] = Future.successful(1)
+
+      /** Returns the block height of the given block stamp */
+      override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] =
+        Future.successful(1)
+
+      override def getFiltersBetweenHeights(
+          startHeight: Int,
+          endHeight: Int): Future[Vector[FilterResponse]] =
+        Future.successful {
+          import scodec.bits._
+
+          // This is a filter for the random block on testnet
+          val filterBytes: ByteVector =
+            hex"fd2701f0ed169ad16107a8a74609b9e4de3c6133c564f79923ca228805d3" ++
+              hex"8e3efc796c4b35034cb573b10b759cdda5efd19e1cdb4d343afcb06455fa" ++
+              hex"820b06eca828ad61d3377fa464f3bd06ff4432310a363f667e13d09ba993" ++
+              hex"264c703a0aa668b33eaa555bd3e93ac85dfde380ab723aafd407dfa13ffe" ++
+              hex"2e7ddf6f452bd0d977617c4ab2dc3b38c26810023984ad57890e3cf34cfc" ++
+              hex"2d4a6973b9430ede26bfd9f5bb24e043d48483d84b9025d0a940b15f13fc" ++
+              hex"0a1e77abd7626869f417c7710e9a6315477691d7c4e2c50f0e776755a62a" ++
+              hex"b6f0e8eb7a3be8d1a8c3d9dd4602efc5146f0d431d1669378d7afa03c7b9" ++
+              hex"84d9b0b78007abb6e7c036156e5186d1d79a2f37daecfcbe8821cf42851c" ++
+              hex"b10ef0c359307d54e53078eb631f02c067a474dceb484da20bc0e7c5451a" ++
+              hex"b957f46b306caa82938b19bb34fd76c5cc07e048932524704dec8f72c91c" ++
+              hex"d5ee1f4648de839047a0bea0d4d4d66c19cfccc2b5f285a84af18114f608" ++
+              hex"f144391648aedfb5ffcccbb51272512d6ba9a2e19a47cebe5b50a8a7073a" ++
+              hex"1c24059440444047a41bdbab16f61bc4b0ee8987de82fd25cc62abc86e2b" ++
+              hex"577fc55175be138680df7253a8bcae9d9954391d3bed806ce5a6869b4553" ++
+              hex"0f214486b1b7f0347efcfde58ca0882f059f7b1541c74506930897c78e23" ++
+              hex"a6c94b49856369606ed652b8c7402a49f289cb5d1098bb999112225327e0" ++
+              hex"a32efd2bcd192a2ffbd1997c6a3b7d1a9445bc31fb57485ebe0c431e482b" ++
+              hex"04e509e557cff107cee08a45c22aa3cbdcb9d305bd95c919e90239e0ec29" ++
+              hex"2a5418a6151f431e8ab82278b3d816ecd483f43d3d657dae9996cc523fdd" ++
+              hex"242c4e01935db91a2936e9398ff7278b8a3430eed99ad25fc2a41afc0b4a" ++
+              hex"e417f6c1785414607cfa13f04173740333a5b58655c74a51deddb38cf8c3" ++
+              hex"d50b7d2ccf380cad34a5c341e7155494cc4560dff3b19bf88b4d73e9ce76" ++
+              hex"cbeff573fe93674e4a752d06d5321ff00a4582d62683fb4986d36eaec825" ++
+              hex"c14d41b2d5aefaf539e989f7fa097eac657c70b975c56e26b73fb9401ce3" ++
+              hex"81502f0883d52c6a3bcc956e0ea1787f0717d0205fecfe55b01edb1ac0"
+          Vector(
+            FilterResponse(compactFilter = BlockFilter
+                             .fromBytes(filterBytes, testBlockHash.flip),
+                           blockHash = testBlockHash,
+                           blockHeight = 1))
+        }
+
+      override def epochSecondToBlockHeight(time: Long): Future[Int] =
+        Future.successful(0)
+    }
+
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -8,8 +8,7 @@ import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.currency._
-import org.bitcoins.core.gcs.BlockFilter
-import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee._
@@ -60,95 +59,6 @@ trait BitcoinSWalletTest
 
   def nodeApi: NodeApi = MockNodeApi
 
-<<<<<<< HEAD
-  val testAddr: BitcoinAddress =
-    BitcoinAddress.fromString("bcrt1qlhctylgvdsvaanv539rg7hyn0sjkdm23y70kgq")
-
-  val legacyWalletConf: Config =
-    ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = legacy")
-
-  val segwitWalletConf: Config =
-    ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = segwit")
-
-  // This is a random block on testnet
-  val testBlockHash: DoubleSha256DigestBE = DoubleSha256DigestBE.fromHex(
-    "00000000496dcc754fabd97f3e2df0a7337eab417d75537fecf97a7ebb0e7c75")
-
-  def chainQueryApi: ChainQueryApi =
-    new ChainQueryApi {
-
-      /** Gets the height of the given block */
-      override def getBlockHeight(
-          blockHash: DoubleSha256DigestBE): Future[Option[Int]] =
-        if (blockHash == testBlockHash)
-          Future.successful(Some(1))
-        else FutureUtil.none
-
-      /** Gets the hash of the block that is what we consider "best" */
-      override def getBestBlockHash(): Future[DoubleSha256DigestBE] =
-        Future.successful(testBlockHash)
-
-      /** Gets number of confirmations for the given block hash */
-      override def getNumberOfConfirmations(
-          blockHash: DoubleSha256DigestBE): Future[Option[Int]] =
-        if (blockHash == testBlockHash)
-          Future.successful(Some(6))
-        else FutureUtil.none
-
-      /** Gets the number of compact filters in the database */
-      override def getFilterCount(): Future[Int] = Future.successful(1)
-
-      /** Returns the block height of the given block stamp */
-      override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] =
-        Future.successful(1)
-
-      override def getFiltersBetweenHeights(
-          startHeight: Int,
-          endHeight: Int): Future[Vector[FilterResponse]] =
-        Future.successful {
-          import scodec.bits._
-
-          // This is a filter for the random block on testnet
-          val filterBytes: ByteVector =
-            hex"fd2701f0ed169ad16107a8a74609b9e4de3c6133c564f79923ca228805d3" ++
-              hex"8e3efc796c4b35034cb573b10b759cdda5efd19e1cdb4d343afcb06455fa" ++
-              hex"820b06eca828ad61d3377fa464f3bd06ff4432310a363f667e13d09ba993" ++
-              hex"264c703a0aa668b33eaa555bd3e93ac85dfde380ab723aafd407dfa13ffe" ++
-              hex"2e7ddf6f452bd0d977617c4ab2dc3b38c26810023984ad57890e3cf34cfc" ++
-              hex"2d4a6973b9430ede26bfd9f5bb24e043d48483d84b9025d0a940b15f13fc" ++
-              hex"0a1e77abd7626869f417c7710e9a6315477691d7c4e2c50f0e776755a62a" ++
-              hex"b6f0e8eb7a3be8d1a8c3d9dd4602efc5146f0d431d1669378d7afa03c7b9" ++
-              hex"84d9b0b78007abb6e7c036156e5186d1d79a2f37daecfcbe8821cf42851c" ++
-              hex"b10ef0c359307d54e53078eb631f02c067a474dceb484da20bc0e7c5451a" ++
-              hex"b957f46b306caa82938b19bb34fd76c5cc07e048932524704dec8f72c91c" ++
-              hex"d5ee1f4648de839047a0bea0d4d4d66c19cfccc2b5f285a84af18114f608" ++
-              hex"f144391648aedfb5ffcccbb51272512d6ba9a2e19a47cebe5b50a8a7073a" ++
-              hex"1c24059440444047a41bdbab16f61bc4b0ee8987de82fd25cc62abc86e2b" ++
-              hex"577fc55175be138680df7253a8bcae9d9954391d3bed806ce5a6869b4553" ++
-              hex"0f214486b1b7f0347efcfde58ca0882f059f7b1541c74506930897c78e23" ++
-              hex"a6c94b49856369606ed652b8c7402a49f289cb5d1098bb999112225327e0" ++
-              hex"a32efd2bcd192a2ffbd1997c6a3b7d1a9445bc31fb57485ebe0c431e482b" ++
-              hex"04e509e557cff107cee08a45c22aa3cbdcb9d305bd95c919e90239e0ec29" ++
-              hex"2a5418a6151f431e8ab82278b3d816ecd483f43d3d657dae9996cc523fdd" ++
-              hex"242c4e01935db91a2936e9398ff7278b8a3430eed99ad25fc2a41afc0b4a" ++
-              hex"e417f6c1785414607cfa13f04173740333a5b58655c74a51deddb38cf8c3" ++
-              hex"d50b7d2ccf380cad34a5c341e7155494cc4560dff3b19bf88b4d73e9ce76" ++
-              hex"cbeff573fe93674e4a752d06d5321ff00a4582d62683fb4986d36eaec825" ++
-              hex"c14d41b2d5aefaf539e989f7fa097eac657c70b975c56e26b73fb9401ce3" ++
-              hex"81502f0883d52c6a3bcc956e0ea1787f0717d0205fecfe55b01edb1ac0"
-          Vector(
-            FilterResponse(compactFilter = BlockFilter
-                             .fromBytes(filterBytes, testBlockHash.flip),
-                           blockHash = testBlockHash,
-                           blockHeight = 1))
-        }
-
-      override def epochSecondToBlockHeight(time: Long): Future[Int] =
-        Future.successful(0)
-    }
-
-=======
->>>>>>> Add BaseWalletTest, extend it with BitcoinSWalletTest & BitcoinSWalletTestCachedBitcoind, add CachedBitcoinV19 and use it RescanHandlingTest
   /** Lets you customize the parameters for the created wallet */
   val withNewConfiguredWallet: Config => OneArgAsyncTest => FutureOutcome = {
     walletConfig =>

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -273,8 +273,8 @@ trait BitcoinSWalletTest
     val resultF = for {
       bitcoind <- bitcoindF
       outcome = withFundedWalletAndBitcoindCached(test,
-                                                  bitcoind,
-                                                  bip39PasswordOpt)
+                                                  bip39PasswordOpt,
+                                                  bitcoind)
       f <- outcome.toFuture
     } yield f
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -51,17 +51,11 @@ trait BitcoinSWalletTest
     with CachedBitcoind {
   import BitcoinSWalletTest._
 
-  override def beforeAll(): Unit = {
-    AppConfig.throwIfDefaultDatadir(getFreshConfig.walletConf)
-    super[EmbeddedPg].beforeAll()
-  }
-
   override def afterAll(): Unit = {
-    super[CachedBitcoind].afterAll()
     Await.result(getFreshConfig.chainConf.stop(), 1.minute)
     Await.result(getFreshConfig.nodeConf.stop(), 1.minute)
     Await.result(getFreshConfig.walletConf.stop(), 1.minute)
-    super[EmbeddedPg].afterAll()
+    super.afterAll()
   }
 
   def nodeApi: NodeApi = MockNodeApi
@@ -707,12 +701,12 @@ object BitcoinSWalletTest extends WalletLogger {
 
   def destroyWalletWithBitcoind(walletWithBitcoind: WalletWithBitcoind)(implicit
       ec: ExecutionContext): Future[Unit] = {
-    val (wallet, _) =
+    val (wallet, bitcoind) =
       (walletWithBitcoind.wallet, walletWithBitcoind.bitcoind)
-    //val stopF = bitcoind.stop()
+    val stopF = bitcoind.stop()
     val destroyWalletF = destroyWallet(wallet)
     for {
-      //_ <- stopF
+      _ <- stopF
       _ <- destroyWalletF
     } yield ()
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -605,8 +605,18 @@ object BitcoinSWalletTest extends WalletLogger {
     import system.dispatcher
     for {
       created <- createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
-
     } yield WalletWithBitcoindV19(created.wallet, bitcoind)
+  }
+
+  def createWalletWithBitcoind(
+      bitcoind: BitcoindRpcClient,
+      bip39PasswordOpt: Option[String])(implicit
+      system: ActorSystem,
+      config: BitcoinSAppConfig): Future[WalletWithBitcoindRpc] = {
+    import system.dispatcher
+    for {
+      created <- createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
+    } yield WalletWithBitcoindRpc(created.wallet, bitcoind)
   }
 
   def createWalletWithBitcoind(

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -48,7 +48,7 @@ trait BitcoinSWalletTest
     with BaseWalletTest
     with BitcoinSFixture
     with EmbeddedPg
-    with CachedBitcoind {
+    with CachedBitcoind[BitcoindRpcClient] {
   import BitcoinSWalletTest._
 
   override def afterAll(): Unit = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -5,7 +5,11 @@ import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.testkit.EmbeddedPg
 import org.bitcoins.testkit.chain.SyncUtil
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
-import org.bitcoins.testkit.rpc.{CachedBitcoind, CachedBitcoindV19}
+import org.bitcoins.testkit.rpc.{
+  CachedBitcoind,
+  CachedBitcoindNewest,
+  CachedBitcoindV19
+}
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
   createWalletWithBitcoind,
   createWalletWithBitcoindCallbacks,
@@ -81,6 +85,10 @@ trait BitcoinSWalletTestCachedBitcoind
     new FutureOutcome(f)
   }
 }
+
+trait BitcoinSWalletTestCachedBitcoindNewest
+    extends BitcoinSWalletTestCachedBitcoind
+    with CachedBitcoindNewest
 
 trait BitcoinSWalletTestCachedBitcoinV19
     extends BitcoinSWalletTestCachedBitcoind

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -81,17 +81,6 @@ trait BitcoinSWalletTestCachedBitcoind
         destroyWallet(walletWithBitcoind.wallet)
       })(test)
   }
-
-  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    val f: Future[Outcome] = for {
-      bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withFundedWalletAndBitcoindCached(test,
-                                                     getBIP39PasswordOpt(),
-                                                     bitcoind)
-      fut <- futOutcome.toFuture
-    } yield fut
-    new FutureOutcome(f)
-  }
 }
 
 trait BitcoinSWalletTestCachedBitcoindNewest

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -1,0 +1,108 @@
+package org.bitcoins.testkit.wallet
+
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.testkit.EmbeddedPg
+import org.bitcoins.testkit.chain.SyncUtil
+import org.bitcoins.testkit.fixtures.BitcoinSFixture
+import org.bitcoins.testkit.rpc.{CachedBitcoind, CachedBitcoindV19}
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
+  createWalletWithBitcoindCallbacks,
+  destroyWalletWithBitcoind,
+  fundWalletWithBitcoind
+}
+import org.scalatest.{FutureOutcome, Outcome}
+
+import scala.concurrent.Future
+
+/** Bitcoin-s wallet test trait that uses cached bitcoinds
+  * rather than fresh bitcoinds.
+  *
+  * This should be used by default unless there is a reason your
+  * test suite needs fresh bitcoin's for every unit test inside of it
+  */
+trait BitcoinSWalletTestCachedBitcoind
+    extends BitcoinSFixture
+    with BaseWalletTest
+    with EmbeddedPg { _: CachedBitcoind =>
+
+  /** Creates a funded wallet fixture with bitcoind
+    * This is different than [[withFundedWalletAndBitcoind()]]
+    * in the sense that it does NOT destroy the given bitcoind.
+    * It is the responsibility of the caller of this method to
+    * do that, if needed.
+    */
+  def withFundedWalletAndBitcoindCached(
+      test: OneArgAsyncTest,
+      bitcoind: BitcoindRpcClient,
+      bip39PasswordOpt: Option[String]): FutureOutcome = {
+    val builder: () => Future[WalletWithBitcoind] = { () =>
+      for {
+        walletWithBitcoind <- createWalletWithBitcoindCallbacks(
+          bitcoind = bitcoind,
+          bip39PasswordOpt = bip39PasswordOpt)
+        fundedWallet <- fundWalletWithBitcoind(walletWithBitcoind)
+        _ <- SyncUtil.syncWalletFullBlocks(wallet = fundedWallet.wallet,
+                                           bitcoind = bitcoind)
+        _ <- BitcoinSWalletTest.awaitWalletBalances(fundedWallet)
+      } yield fundedWallet
+    }
+
+    makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
+  }
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withFundedWalletAndBitcoindCached(test,
+                                                     bitcoind,
+                                                     getBIP39PasswordOpt())
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
+}
+
+trait BitcoinSWalletTestCachedBitcoinV19
+    extends BitcoinSWalletTestCachedBitcoind
+    with CachedBitcoindV19 {
+
+  /** Creates a funded wallet fixture with bitcoind
+    * This is different than [[withFundedWalletAndBitcoind()]]
+    * in the sense that it does NOT destroy the given bitcoind.
+    * It is the responsibility of the caller of this method to
+    * do that, if needed.
+    */
+  def withFundedWalletAndBitcoindCachedV19(
+      test: OneArgAsyncTest,
+      bitcoind: BitcoindV19RpcClient,
+      bip39PasswordOpt: Option[String]): FutureOutcome = {
+    val builder: () => Future[WalletWithBitcoindV19] = { () =>
+      for {
+        walletWithBitcoind <- createWalletWithBitcoindCallbacks(
+          bitcoind = bitcoind,
+          bip39PasswordOpt = bip39PasswordOpt)
+        walletWithBitcoindV19 = WalletWithBitcoindV19(walletWithBitcoind.wallet,
+                                                      bitcoind)
+        fundedWallet <- fundWalletWithBitcoind[WalletWithBitcoindV19](
+          walletWithBitcoindV19)
+        _ <- SyncUtil.syncWalletFullBlocks(wallet = fundedWallet.wallet,
+                                           bitcoind = bitcoind)
+        _ <- BitcoinSWalletTest.awaitWalletBalances(fundedWallet)
+      } yield fundedWallet
+    }
+
+    makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
+  }
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withFundedWalletAndBitcoindCachedV19(test,
+                                                        bitcoind,
+                                                        getBIP39PasswordOpt())
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -39,8 +39,8 @@ trait BitcoinSWalletTestCachedBitcoind
     */
   def withFundedWalletAndBitcoindCached(
       test: OneArgAsyncTest,
-      bitcoind: BitcoindRpcClient,
-      bip39PasswordOpt: Option[String]): FutureOutcome = {
+      bip39PasswordOpt: Option[String],
+      bitcoind: BitcoindRpcClient): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind] = { () =>
       for {
         walletWithBitcoind <- createWalletWithBitcoindCallbacks(
@@ -86,8 +86,8 @@ trait BitcoinSWalletTestCachedBitcoind
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
       futOutcome = withFundedWalletAndBitcoindCached(test,
-                                                     bitcoind,
-                                                     getBIP39PasswordOpt())
+                                                     getBIP39PasswordOpt(),
+                                                     bitcoind)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)
@@ -119,8 +119,8 @@ trait BitcoinSWalletTestCachedBitcoinV19
     */
   def withFundedWalletAndBitcoindCachedV19(
       test: OneArgAsyncTest,
-      bitcoind: BitcoindV19RpcClient,
-      bip39PasswordOpt: Option[String]): FutureOutcome = {
+      bip39PasswordOpt: Option[String],
+      bitcoind: BitcoindV19RpcClient): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoindV19] = { () =>
       for {
         walletWithBitcoind <- createWalletWithBitcoindCallbacks(
@@ -171,8 +171,8 @@ trait BitcoinSWalletTestCachedBitcoinV19
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
       futOutcome = withFundedWalletAndBitcoindCachedV19(test,
-                                                        bitcoind,
-                                                        getBIP39PasswordOpt())
+                                                        getBIP39PasswordOpt(),
+                                                        bitcoind)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -29,7 +29,7 @@ import scala.concurrent.Future
 trait BitcoinSWalletTestCachedBitcoind
     extends BitcoinSFixture
     with BaseWalletTest
-    with EmbeddedPg { _: CachedBitcoind =>
+    with EmbeddedPg { _: CachedBitcoind[_] =>
 
   /** Creates a funded wallet fixture with bitcoind
     * This is different than [[withFundedWalletAndBitcoind()]]

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -13,7 +13,7 @@ import org.bitcoins.testkit.rpc.{
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
   createWalletWithBitcoind,
   createWalletWithBitcoindCallbacks,
-  destroyWalletWithBitcoind,
+  destroyWallet,
   fundWalletWithBitcoind
 }
 import org.scalatest.{FutureOutcome, Outcome}
@@ -53,7 +53,11 @@ trait BitcoinSWalletTestCachedBitcoind
       } yield fundedWallet
     }
 
-    makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
+    makeDependentFixture[WalletWithBitcoind](
+      builder,
+      { case walletWithBitcoind: WalletWithBitcoind =>
+        destroyWallet(walletWithBitcoind.wallet)
+      })(test)
   }
 
   def withNewWalletAndBitcoindCached(
@@ -71,7 +75,11 @@ trait BitcoinSWalletTestCachedBitcoind
         walletWithBitcoind
     )
 
-    makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
+    makeDependentFixture[WalletWithBitcoind](
+      builder,
+      { case walletWithBitcoind: WalletWithBitcoind =>
+        destroyWallet(walletWithBitcoind.wallet)
+      })(test)
   }
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
@@ -88,11 +96,20 @@ trait BitcoinSWalletTestCachedBitcoind
 
 trait BitcoinSWalletTestCachedBitcoindNewest
     extends BitcoinSWalletTestCachedBitcoind
-    with CachedBitcoindNewest
+    with CachedBitcoindNewest {
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindNewest].afterAll()
+  }
+}
 
 trait BitcoinSWalletTestCachedBitcoinV19
     extends BitcoinSWalletTestCachedBitcoind
     with CachedBitcoindV19 {
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindV19].afterAll()
+  }
 
   /** Creates a funded wallet fixture with bitcoind
     * This is different than [[withFundedWalletAndBitcoind()]]
@@ -119,7 +136,11 @@ trait BitcoinSWalletTestCachedBitcoinV19
       } yield fundedWallet
     }
 
-    makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
+    makeDependentFixture[WalletWithBitcoind](
+      builder,
+      destroy = { case walletWithBitcoind: WalletWithBitcoind =>
+        destroyWallet(walletWithBitcoind.wallet)
+      })(test)
   }
 
   def withNewWalletAndBitcoindCachedV19(
@@ -139,7 +160,11 @@ trait BitcoinSWalletTestCachedBitcoinV19
           walletWithBitcoind
     )
 
-    makeDependentFixture(builder, destroy = destroyWalletWithBitcoind)(test)
+    makeDependentFixture[WalletWithBitcoind](
+      builder,
+      { case walletWithBitcoind: WalletWithBitcoind =>
+        destroyWallet(walletWithBitcoind.wallet)
+      })(test)
   }
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -5,10 +5,13 @@ import org.bitcoins.core.currency._
 import org.bitcoins.db.AppConfig
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.{BitcoinSAppConfig, BitcoindRpcBackendUtil}
-import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
-import org.bitcoins.testkit.rpc.BitcoindFixturesCached
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesFundedCached,
+  CachedBitcoindNewest
+}
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
+import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.bitcoins.wallet.config.WalletAppConfig
 
 import scala.concurrent.Await
@@ -16,7 +19,8 @@ import scala.concurrent.duration.DurationInt
 
 class BitcoindBackendTest
     extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesCached
+    with BitcoindFixturesFundedCached
+    with CachedBitcoindNewest
     with EmbeddedPg {
 
   override type FixtureParam = BitcoindRpcClient

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -3,19 +3,26 @@ package org.bitcoins.wallet
 import org.bitcoins.commons.jsonmodels.wallet.SyncHeightDescriptor
 import org.bitcoins.core.currency._
 import org.bitcoins.db.AppConfig
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.{BitcoinSAppConfig, BitcoindRpcBackendUtil}
-import org.bitcoins.testkit.fixtures.BitcoinSFixture
-import org.bitcoins.testkit.util.BitcoinSAsyncTest
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
+import org.bitcoins.testkit.rpc.BitcoindFixturesCached
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.wallet.config.WalletAppConfig
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
-class BitcoindBackendTest extends BitcoinSAsyncTest with EmbeddedPg {
+class BitcoindBackendTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCached
+    with EmbeddedPg {
+
+  override type FixtureParam = BitcoindRpcClient
 
   /** Wallet config with data directory set to user temp directory */
+
   implicit protected def config: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
 
@@ -32,15 +39,13 @@ class BitcoindBackendTest extends BitcoinSAsyncTest with EmbeddedPg {
     Await.result(config.chainConf.stop(), 1.minute)
     Await.result(config.nodeConf.stop(), 1.minute)
     Await.result(config.walletConf.stop(), 1.minute)
-    super[EmbeddedPg].afterAll()
+    super.afterAll()
   }
 
-  it must "correctly catch up to bitcoind" in {
+  it must "correctly catch up to bitcoind" in { bitcoind =>
     val amountToSend = Bitcoins.one
 
     for {
-      // Setup bitcoind
-      bitcoind <- BitcoinSFixture.createBitcoindWithFunds()
       header <- bitcoind.getBestBlockHeader()
 
       // Setup wallet

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
@@ -5,7 +5,10 @@ import org.bitcoins.core.currency._
 import org.bitcoins.db.AppConfig
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.{BitcoinSAppConfig, BitcoindRpcBackendUtil}
-import org.bitcoins.testkit.rpc.BitcoindFixturesCached
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesFundedCached,
+  CachedBitcoindNewest
+}
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
@@ -16,7 +19,8 @@ import scala.concurrent.duration.DurationInt
 
 class BitcoindBlockPollingTest
     extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesCached
+    with BitcoindFixturesFundedCached
+    with CachedBitcoindNewest
     with EmbeddedPg {
 
   override type FixtureParam = BitcoindRpcClient

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
@@ -3,9 +3,10 @@ package org.bitcoins.wallet
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.currency._
 import org.bitcoins.db.AppConfig
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.{BitcoinSAppConfig, BitcoindRpcBackendUtil}
-import org.bitcoins.testkit.fixtures.BitcoinSFixture
-import org.bitcoins.testkit.util.BitcoinSAsyncTest
+import org.bitcoins.testkit.rpc.BitcoindFixturesCached
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.bitcoins.wallet.config.WalletAppConfig
@@ -13,7 +14,12 @@ import org.bitcoins.wallet.config.WalletAppConfig
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
-class BitcoindBlockPollingTest extends BitcoinSAsyncTest with EmbeddedPg {
+class BitcoindBlockPollingTest
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCached
+    with EmbeddedPg {
+
+  override type FixtureParam = BitcoindRpcClient
 
   /** Wallet config with data directory set to user temp directory */
   implicit protected def config: BitcoinSAppConfig =
@@ -32,15 +38,13 @@ class BitcoindBlockPollingTest extends BitcoinSAsyncTest with EmbeddedPg {
     Await.result(config.chainConf.stop(), 1.minute)
     Await.result(config.nodeConf.stop(), 1.minute)
     Await.result(config.walletConf.stop(), 1.minute)
-    super[EmbeddedPg].afterAll()
+    super.afterAll()
   }
 
-  it must "properly setup and poll blocks from bitcoind" in {
+  it must "properly setup and poll blocks from bitcoind" in { bitcoind =>
     val amountToSend = Bitcoins.one
 
     for {
-      // Setup bitcoind
-      bitcoind <- BitcoinSFixture.createBitcoindWithFunds()
       blockCount <- bitcoind.getBlockCount
 
       // Setup wallet

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -11,7 +11,7 @@ import org.bitcoins.testkit.wallet.{
   WalletWithBitcoind
 }
 import org.bitcoins.testkitcore.util.TestUtil
-import org.scalatest.Assertion
+import org.scalatest.{Assertion, FutureOutcome, Outcome}
 
 import scala.concurrent.Future
 
@@ -19,6 +19,17 @@ class FundTransactionHandlingTest
     extends BitcoinSWalletTestCachedBitcoindNewest {
 
   override type FixtureParam = WalletWithBitcoind
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withFundedWalletAndBitcoindCached(test,
+                                                     getBIP39PasswordOpt(),
+                                                     bitcoind)
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
 
   val destination: TransactionOutput =
     TransactionOutput(Bitcoins(0.5), TestUtil.p2pkhScriptPubKey)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -11,7 +11,7 @@ import org.bitcoins.testkit.wallet.{
   WalletWithBitcoind
 }
 import org.bitcoins.testkitcore.util.TestUtil
-import org.scalatest.{Assertion, FutureOutcome}
+import org.scalatest.{Assertion, FutureOutcome, Outcome}
 
 import scala.concurrent.Future
 
@@ -20,7 +20,14 @@ class FundTransactionHandlingTest extends BitcoinSWalletTest {
   override type FixtureParam = WalletWithBitcoind
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWalletAndBitcoind(test, getBIP39PasswordOpt())
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withFundedWalletAndBitcoindCached(test,
+                                                     bitcoind,
+                                                     getBIP39PasswordOpt())
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
   }
 
   val destination: TransactionOutput =

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -11,24 +11,13 @@ import org.bitcoins.testkit.wallet.{
   WalletWithBitcoind
 }
 import org.bitcoins.testkitcore.util.TestUtil
-import org.scalatest.{Assertion, FutureOutcome, Outcome}
+import org.scalatest.Assertion
 
 import scala.concurrent.Future
 
 class FundTransactionHandlingTest extends BitcoinSWalletTest {
 
   override type FixtureParam = WalletWithBitcoind
-
-  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    val f: Future[Outcome] = for {
-      bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withFundedWalletAndBitcoindCached(test,
-                                                     bitcoind,
-                                                     getBIP39PasswordOpt())
-      fut <- futOutcome.toFuture
-    } yield fut
-    new FutureOutcome(f)
-  }
 
   val destination: TransactionOutput =
     TransactionOutput(Bitcoins(0.5), TestUtil.p2pkhScriptPubKey)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.wallet.builder.RawTxSigner
 import org.bitcoins.core.wallet.utxo.StorageLocationTag.HotStorage
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.testkit.wallet.{
-  BitcoinSWalletTest,
+  BitcoinSWalletTestCachedBitcoindNewest,
   WalletTestUtil,
   WalletWithBitcoind
 }
@@ -15,7 +15,8 @@ import org.scalatest.Assertion
 
 import scala.concurrent.Future
 
-class FundTransactionHandlingTest extends BitcoinSWalletTest {
+class FundTransactionHandlingTest
+    extends BitcoinSWalletTestCachedBitcoindNewest {
 
   override type FixtureParam = WalletWithBitcoind
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 class ProcessTransactionTest extends BitcoinSWalletTest {
   override type FixtureParam = WalletApi
 
-  def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     withNewWallet(test, getBIP39PasswordOpt())
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -7,25 +7,20 @@ import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.wallet.{
-  BitcoinSWalletTest,
+  BitcoinSWalletTestCachedBitcoinV19,
   WalletWithBitcoind,
   WalletWithBitcoindV19
 }
-import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future
 
-class RescanHandlingTest extends BitcoinSWalletTest {
+class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoinV19 {
 
   /** Wallet config with data directory set to user temp directory */
   implicit override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = WalletWithBitcoind
-
-  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWalletAndBitcoindV19(test, getBIP39PasswordOpt())
-  }
 
   behavior of "Wallet rescans"
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number._
+import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.wallet.fee.SatoshisPerByte

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -9,21 +9,20 @@ import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.core.wallet.utxo.TxoState._
 import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.testkit.wallet.{
-  BitcoinSWalletTest,
+  BitcoinSWalletTestCachedBitcoindNewest,
   WalletWithBitcoind,
   WalletWithBitcoindRpc
 }
-import org.scalatest.FutureOutcome
 
-class UTXOLifeCycleTest extends BitcoinSWalletTest {
+class UTXOLifeCycleTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   behavior of "Wallet Txo States"
 
   override type FixtureParam = WalletWithBitcoind
 
-  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWalletAndBitcoind(test, getBIP39PasswordOpt())
-  }
+  val testAddr: BitcoinAddress =
+    BitcoinAddress
+      .fromString("bcrt1qlhctylgvdsvaanv539rg7hyn0sjkdm23y70kgq")
 
   it should "track a utxo state change to broadcast spent" in { param =>
     val WalletWithBitcoindRpc(wallet, _) = param

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -13,12 +13,26 @@ import org.bitcoins.testkit.wallet.{
   WalletWithBitcoind,
   WalletWithBitcoindRpc
 }
+import org.scalatest.{FutureOutcome, Outcome}
+
+import scala.concurrent.Future
 
 class UTXOLifeCycleTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   behavior of "Wallet Txo States"
 
   override type FixtureParam = WalletWithBitcoind
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withFundedWalletAndBitcoindCached(test,
+                                                     getBIP39PasswordOpt(),
+                                                     bitcoind)
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
 
   val testAddr: BitcoinAddress =
     BitcoinAddress

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletBloomTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletBloomTest.scala
@@ -3,19 +3,15 @@ package org.bitcoins.wallet
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.testkitcore.Implicits._
 import org.bitcoins.testkit.wallet.{
-  BitcoinSWalletTest,
+  BitcoinSWalletTestCachedBitcoindNewest,
   WalletWithBitcoind,
   WalletWithBitcoindRpc
 }
-import org.scalatest.FutureOutcome
 
-class WalletBloomTest extends BitcoinSWalletTest {
+class WalletBloomTest extends BitcoinSWalletTestCachedBitcoindNewest {
   behavior of "Wallet bloom filter"
 
   override type FixtureParam = WalletWithBitcoind
-
-  override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withFundedWalletAndBitcoind(test, getBIP39PasswordOpt())
 
   it should "generate a bloom filter that matches the pubkeys in our wallet" in {
     param =>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletBloomTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletBloomTest.scala
@@ -7,11 +7,25 @@ import org.bitcoins.testkit.wallet.{
   WalletWithBitcoind,
   WalletWithBitcoindRpc
 }
+import org.scalatest.{FutureOutcome, Outcome}
+
+import scala.concurrent.Future
 
 class WalletBloomTest extends BitcoinSWalletTestCachedBitcoindNewest {
   behavior of "Wallet bloom filter"
 
   override type FixtureParam = WalletWithBitcoind
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withFundedWalletAndBitcoindCached(test,
+                                                     getBIP39PasswordOpt(),
+                                                     bitcoind)
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
 
   it should "generate a bloom filter that matches the pubkeys in our wallet" in {
     param =>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -353,7 +353,6 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
         // Assert spending tx valid to bitcoind
         oldBalance <- bitcoind.getBalance
-        _ = assert(oldBalance == Satoshis(510000000000L))
 
         _ <- bitcoind.sendRawTransaction(signedTx)
         _ <- bitcoind.generateToAddress(1, bitcoindAddr)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/sync/WalletSyncTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/sync/WalletSyncTest.scala
@@ -1,17 +1,16 @@
 package org.bitcoins.wallet.sync
 
 import org.bitcoins.testkit.chain.SyncUtil
-import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletWithBitcoindV19}
-import org.scalatest.FutureOutcome
+import org.bitcoins.testkit.wallet.{
+  BitcoinSWalletTestCachedBitcoinV19,
+  WalletWithBitcoindV19
+}
 
-class WalletSyncTest extends BitcoinSWalletTest {
+class WalletSyncTest extends BitcoinSWalletTestCachedBitcoinV19 {
 
   behavior of "WalletSync"
 
   override type FixtureParam = WalletWithBitcoindV19
-
-  override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withNewWalletAndBitcoindV19(test, getBIP39PasswordOpt())
 
   it must "sync a wallet with bitcoind" in { param =>
     val wallet = param.wallet


### PR DESCRIPTION
This is an attempt to reduce the number of bitcoind's used in our test suites. 

From #2788 

>I believe that a new bitcoind is getting spun up for every test we have in that test suite. If I counted correctly, that means we are using 11 (!) bitcoinds for that suite.I would imagine this is done elsewhere as well. This is the problem with using bitcoind in the fixture code. You can imagine if test suites are run in parallel, how a ton of bitcoinds could be created and the underlying OS might a problem.

I'm opening this for now to see how CI reacts, I'm going to try and use this in other test suites as well.
