### PR TITLE
Move tests out of bitcoindRpcTest that belong in async-utils

### DIFF
--- a/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
+++ b/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
@@ -154,4 +154,11 @@ object AsyncUtil extends AsyncUtil {
   /** The default number of async attempts before timing out
     */
   private[bitcoins] val DEFAULT_MAX_TRIES: Int = 50
+
+  def nonBlockingSleep(duration: FiniteDuration): Future[Unit] = {
+    val p = Promise[Unit]()
+    val r: Runnable = () => p.success(())
+    scheduler.schedule(r, duration.toMillis, TimeUnit.MILLISECONDS)
+    p.future
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/api/asyncutil/AsyncUtilApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/asyncutil/AsyncUtilApi.scala
@@ -1,0 +1,12 @@
+package org.bitcoins.core.api.asyncutil
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+trait AsyncUtilApi {
+
+  /** Returns a future that completes after the given duration
+    * This is useful for simulating a non blocking Thread.sleep()
+    */
+  def nonBlockingSleep(duration: FiniteDuration): Future[Unit]
+}


### PR DESCRIPTION
This should have been done in #2725 , but was missed.