### PR TITLE
update Base docker image to a ubuntu buster

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -164,7 +164,7 @@ object CommonSettings {
   lazy val dockerSettings: Seq[Setting[_]] = {
     Vector(
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
-      dockerBaseImage := "openjdk",
+      dockerBaseImage := "openjdk:15.0.2-jdk-buster",
       dockerRepository := Some("bitcoinscala"),
       //set the user to be 'bitcoin-s' rather than
       //the default provided by sbt native packager


### PR DESCRIPTION
https://hub.docker.com/layers/openjdk/library/openjdk/15.0.2-jdk-buster/images/sha256-a9541ea67502d00c80af49ac7c24201adc4e6a0f42f9b2b367323f07747abb64?context=explore

Gives access to utilties like `apt` to install things for debugging. 