### PR TITLE
Reduce fee rate for spending coinbase utxos test

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -294,7 +294,8 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
     walletWithBitcoind =>
       val WalletWithBitcoindRpc(wallet, bitcoind) = walletWithBitcoind
 
-      val amountToSend = Bitcoins(49.99)
+      // Makes fee rate for tx ~5 sat/vbyte
+      val amountToSend = Bitcoins(49.99999000)
 
       for {
         // Mine to wallet


### PR DESCRIPTION
Fixes #2814

Previously we were doing a tx with around a 5k sats/vbyte fee rate, now it is 5 sats/vbyte