### PR TITLE
Fix potential unordered nonces in announcement

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/dlcoracle/OracleEvent.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlcoracle/OracleEvent.scala
@@ -243,9 +243,11 @@ object OracleEvent {
         require(eventDbs.forall(_.attestationOpt.isEmpty),
                 "Cannot have a partially signed event")
 
+        val sortedEventDbs = eventDbs.sortBy(_.nonceIndex)
+
         PendingDigitDecompositionV0OracleEvent(
           eventDb.pubkey,
-          eventDbs.map(_.nonce),
+          sortedEventDbs.map(_.nonce),
           eventDb.eventName,
           eventDb.signingVersion,
           eventDb.maturationTime,


### PR DESCRIPTION
We weren't enforcing the `nonceIndex` ordering on the pending decomp events so it was possible that the nonces could be returned in the incorrect order. This fixes that and adds a test to make sure (test fails without the fix).