### PR TITLE
Update akka to v10.2.4

### DIFF
--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -80,7 +80,9 @@ case class Server(
 
   def start(): Future[Http.ServerBinding] = {
     val httpFut =
-      Http().bindAndHandle(route, rpcbindOpt.getOrElse("localhost"), rpcport)
+      Http()
+        .newServerAt(rpcbindOpt.getOrElse("localhost"), rpcport)
+        .bindFlow(route)
     httpFut.foreach { http =>
       logger.info(s"Started Bitcoin-S HTTP server at ${http.localAddress}")
     }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -17,7 +17,7 @@ object Deps {
     val slf4j = "1.7.30"
     val spray = "1.3.6"
     val zeromq = "0.5.2"
-    val akkav = "10.1.14"
+    val akkav = "10.2.4"
     val playv = "2.9.2"
     val akkaStreamv = "2.6.13"
     val scodecV = "1.1.24"


### PR DESCRIPTION
Closes #2721

Was playing around with gRPC and noticed we needed to update akka to `v10.2.4`, fixed the one compiler error that comes with it.