### PR TITLE
Update gitignore file with recommendations from unidoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,10 +75,13 @@ src/stamp-h1
 libsecp256k1.pc
 
 # Docusaurs
-node_modules
-website/build
+website/translated_docs
+website/build/
+website/yarn.lock
+website/node_modules
+website/i18n/*
+!website/i18n/en.json
 website/static/api
-
 
 #bloop 
 .bloop/


### PR DESCRIPTION
Attempts to start addressing #2830

I'm just adding the suggested files/directories for `.gitignore` that are recommended in the docusaraus docs

https://scalameta.org/mdoc/docs/docusaurus.html#include-scaladoc-in-site