### PR TITLE
Enable publishing of scalajs artifacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,8 +33,7 @@ lazy val commonJsSettings = {
   Seq(
     scalaJSLinkerConfig ~= {
       _.withModuleKind(ModuleKind.CommonJSModule)
-    },
-    skip.in(publish) := true
+    }
   ) ++ CommonSettings.settings
 }
 


### PR DESCRIPTION
Hopefully fixes #2733 

and fixes #2840 

it seems we had some trouble in the past with it, but from the documentation on issue #2733 i can't tell what it exactly was. We just disabled publishing in #2734 

