### PR TITLE
2021 04 02 fix missing plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ lazy val coreJVM = core.jvm
 
 lazy val coreJS = core.js
   .settings(libraryDependencies ++= Deps.coreJs.value)
+  .enablePlugins(ScalaJSBundlerPlugin)
 
 lazy val asyncUtils = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)


### PR DESCRIPTION
https://scalacenter.github.io/scalajs-bundler/cookbook.html#publish

A lot of time spent to find this small bug :cry: 

>Finally, to use the facade from another Scala.js project, this one needs both to add a dependency on the facade and to enable the ScalaJSBundlerPlugin plugin.

Related to #2849 

