### PR TITLE
Add helper functions for hashing annoucements for SbExplorerClient

### DIFF
--- a/oracle-explorer-client/src/main/scala/org/bitcoins/explorer/client/SbExplorerClient.scala
+++ b/oracle-explorer-client/src/main/scala/org/bitcoins/explorer/client/SbExplorerClient.scala
@@ -10,6 +10,7 @@ import akka.http.scaladsl.model.{
 }
 import akka.http.scaladsl.{Http, HttpExt}
 import akka.util.ByteString
+import org.bitcoins.core.protocol.tlv.OracleAnnouncementTLV
 import org.bitcoins.crypto.Sha256Digest
 import org.bitcoins.explorer.env.ExplorerEnv
 import org.bitcoins.explorer.model.{
@@ -48,6 +49,14 @@ case class SbExplorerClient(env: ExplorerEnv)(implicit system: ActorSystem) {
               s"Failed to parse response for listevents, err=$err"))
       }
     }
+  }
+
+  /** Gets an announcement from the oracle explorer
+    * @see https://gist.github.com/Christewart/a9e55d9ba582ac9a5ceffa96db9d7e1f#get-event
+    */
+  def getEvent(
+      announcement: OracleAnnouncementTLV): Future[SbAnnouncementEvent] = {
+    getEvent(announcement.sha256)
   }
 
   /** Gets an announcement from the oracle explorer

--- a/oracle-explorer-client/src/main/scala/org/bitcoins/explorer/model/CreateAttestations.scala
+++ b/oracle-explorer-client/src/main/scala/org/bitcoins/explorer/model/CreateAttestations.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.explorer.model
 
-import org.bitcoins.core.protocol.tlv.OracleAttestmentV0TLV
+import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.crypto.Sha256Digest
 
 case class CreateAttestations(
@@ -9,5 +9,14 @@ case class CreateAttestations(
 
   override def toString: String = {
     s"attestations=${attestment.hex}"
+  }
+}
+
+object CreateAttestations {
+
+  def apply(
+      announcement: OracleAnnouncementTLV,
+      attestment: OracleAttestmentV0TLV): CreateAttestations = {
+    CreateAttestations(announcement.sha256, attestment)
   }
 }


### PR DESCRIPTION
Adds an easy helper function so you don't need to hash the announcement yourself