### PR TITLE
Rework oracle explorer client to use new api paths

### DIFF
--- a/oracle-explorer-client/src/main/scala/org/bitcoins/explorer/client/SbExplorerClient.scala
+++ b/oracle-explorer-client/src/main/scala/org/bitcoins/explorer/client/SbExplorerClient.scala
@@ -35,7 +35,7 @@ case class SbExplorerClient(env: ExplorerEnv)(implicit system: ActorSystem) {
     */
   def listEvents(): Future[Vector[SbAnnouncementEvent]] = {
     val base = env.baseUri
-    val uri = Uri(base + "events")
+    val uri = Uri(base + "announcements")
     val httpReq = HttpRequest(uri = uri)
     val responseF = sendRequest(httpReq)
     responseF.flatMap { response =>
@@ -64,7 +64,7 @@ case class SbExplorerClient(env: ExplorerEnv)(implicit system: ActorSystem) {
     */
   def getEvent(announcementHash: Sha256Digest): Future[SbAnnouncementEvent] = {
     val base = env.baseUri
-    val uri = Uri(base + s"events/${announcementHash.hex}")
+    val uri = Uri(base + s"announcements/${announcementHash.hex}")
     val httpReq = HttpRequest(uri = uri)
     val responseF = sendRequest(httpReq)
     responseF.flatMap { response =>
@@ -86,7 +86,7 @@ case class SbExplorerClient(env: ExplorerEnv)(implicit system: ActorSystem) {
   def createAnnouncement(
       oracleEventExplorer: CreateAnnouncementExplorer): Future[Unit] = {
     val base = env.baseUri
-    val uri = Uri(base + s"events")
+    val uri = Uri(base + s"announcements")
     val string = oracleEventExplorer.toString
     val httpReq =
       HttpRequest(
@@ -104,7 +104,7 @@ case class SbExplorerClient(env: ExplorerEnv)(implicit system: ActorSystem) {
   def createAttestations(attestations: CreateAttestations): Future[Unit] = {
     val base = env.baseUri
     val uri = Uri(
-      base + s"events/${attestations.announcementHash.hex}/attestations")
+      base + s"announcements/${attestations.announcementHash.hex}/attestations")
     val string = attestations.toString
     val httpReq =
       HttpRequest(

--- a/oracle-explorer-client/src/test/scala/org/bitcoins/explorer/client/SbExplorerClientTest.scala
+++ b/oracle-explorer-client/src/test/scala/org/bitcoins/explorer/client/SbExplorerClientTest.scala
@@ -19,7 +19,7 @@ class SbExplorerClientTest extends BitcoinSAsyncTest {
 
   behavior of "SbExplorerClient"
 
-  val explorerClient = SbExplorerClient(ExplorerEnv.Local)
+  val explorerClient = SbExplorerClient(ExplorerEnv.Test)
 
   //https://test.oracle.suredbits.com/event/57505dcdfe8746d9adf3454df538244a425f302c07642d9dc4a4f635fbf08d30
   private val announcementHex: String =

--- a/oracle-explorer-client/src/test/scala/org/bitcoins/explorer/client/SbExplorerClientTest.scala
+++ b/oracle-explorer-client/src/test/scala/org/bitcoins/explorer/client/SbExplorerClientTest.scala
@@ -19,7 +19,7 @@ class SbExplorerClientTest extends BitcoinSAsyncTest {
 
   behavior of "SbExplorerClient"
 
-  val explorerClient = SbExplorerClient(ExplorerEnv.Test)
+  val explorerClient = SbExplorerClient(ExplorerEnv.Local)
 
   //https://test.oracle.suredbits.com/event/57505dcdfe8746d9adf3454df538244a425f302c07642d9dc4a4f635fbf08d30
   private val announcementHex: String =


### PR DESCRIPTION
Changes the API paths for the oracle explorer client from using `events/` -> `announcements/`