### PR TITLE
2021 04 07 issue 2875

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -624,6 +624,7 @@ lazy val docs = project
     cryptoJVM,
     coreJVM,
     dbCommons,
+    oracleExplorerClient,
     feeProvider,
     dlcOracle,
     eclairRpc,

--- a/docs/oracle-explorer-client/oracle-explorer-client.md
+++ b/docs/oracle-explorer-client/oracle-explorer-client.md
@@ -1,0 +1,74 @@
+---
+id: oracle-explorer-client
+title: Oracle Explorer Client
+---
+
+[Suredbits offers a tool called an Oracle Explorer](https://oracle.suredbits.com) for oracles to post their
+announcements and attestments at a later time.
+
+Bitcoin-s provides an open source oracle explorer client for
+interacting with the oracle explorer.
+
+### Environments
+
+There are 2 live environments that can be used with the explorer client
+
+1. ExplorerEnv.Production
+2. ExplorerEnv.Test
+
+As the names indicate, one references the [production oracle explorer](https://oracle.suredbits.com)
+while the other references the [test environment](https://test.oracle.suredbits.com)
+```scala mdoc:invisible
+import akka.actor.ActorSystem
+import org.bitcoins.explorer.client._
+import org.bitcoins.explorer.env._
+import org.bitcoins.explorer.model._
+import org.bitcoins.crypto.Sha256Digest
+import org.bitcoins.core.protocol.tlv.{OracleAnnouncementV0TLV,OracleAttestmentV0TLV}
+
+import scala.concurrent.Future
+```
+
+```scala mdoc:compile-only
+implicit val system = ActorSystem("explorer-client-actor-system")
+
+//use test environment for this little example
+val env = ExplorerEnv.Test
+val explorerClient = SbExplorerClient(env)
+
+//list all announcemnts on the explorer
+val announcementsF: Future[Vector[SbAnnouncementEvent]] = explorerClient.listAnnouncements()
+
+
+//example announcement taken from
+//https://oracle.suredbits.com/event/e0a5624edbc854120982165b0eef53f0777a49febd79a0c21bf75e5582021e33
+val announcementHex = "fdd824c8bf634b2d76f6d8c6499aa977a7b0ae2b84bc206d800f8448e46d63d6ca31778ddb023e39df098c7e109b3d6ee7273d18be62e10f8481dae6531dbe3e0647f6e95d1bcfab252c6dd9edd7aea4c5eeeef138f7ff7346061ea40143a9f5ae80baa9fdd82264000190ef605e3450e16b47745e7a33e26ac9437f6ec2ed660d829a064dceee3699c8605fc700fdd806270005076e67616e6e6f75066d696f63696304647261770a6e6f2d636f6e74657374056f74686572124d696f6369632076204e67616e6e6f752032"
+val announcement = OracleAnnouncementV0TLV.fromHex(announcementHex)
+
+//you can query by announcement
+val announcementF: Future[SbAnnouncementEvent] = explorerClient.getAnnouncement(announcement)
+
+//or query by hash 
+val sameAnnouncementF: Future[SbAnnouncementEvent] = explorerClient.getAnnouncement(announcement.sha256)
+
+//you can post an announcement to the oracle explorer
+val oracleName = "Chris_Stewart_5"
+val description = "2021-03-24-sunny-in-chicago"
+val uriOpt = Some("https://twitter.com/Chris_Stewart_5")
+
+val sbAnnouncement = CreateAnnouncementExplorer(announcement, oracleName, description, uriOpt)
+
+val createdF = explorerClient.createAnnouncement(sbAnnouncement)
+
+//and then you can follow up and post the attestations
+val attestationsHex =
+  "fdd868821b323032312d30332d32342d73756e6e792d696e2d6368696361676f1d5dcdba2e64cb116cc0c375a0856298f0058b778f46bfe625ac6576204889e40001efdf735567ae0a00a515e313d20029de5d7525da7b8367bc843d28b672d4db4db5de4dbff689f3b742be634a9c92c615dbcf2eadbdd470f514b1ac250a30db6d03594553"
+
+val attestations = OracleAttestmentV0TLV.fromHex(attestationsHex)
+
+val announcementHash = announcement.sha256
+val sbAttestations = CreateAttestations(announcementHash, attestations)
+val createdAttestationsF = explorerClient.createAttestations(sbAttestations)
+
+```
+

--- a/oracle-explorer-client/src/main/scala/org/bitcoins/explorer/client/SbExplorerClient.scala
+++ b/oracle-explorer-client/src/main/scala/org/bitcoins/explorer/client/SbExplorerClient.scala
@@ -33,7 +33,7 @@ case class SbExplorerClient(env: ExplorerEnv)(implicit system: ActorSystem) {
     * @see https://gist.github.com/Christewart/a9e55d9ba582ac9a5ceffa96db9d7e1f#list-all-events
     * @return
     */
-  def listEvents(): Future[Vector[SbAnnouncementEvent]] = {
+  def listAnnouncements(): Future[Vector[SbAnnouncementEvent]] = {
     val base = env.baseUri
     val uri = Uri(base + "announcements")
     val httpReq = HttpRequest(uri = uri)
@@ -54,15 +54,16 @@ case class SbExplorerClient(env: ExplorerEnv)(implicit system: ActorSystem) {
   /** Gets an announcement from the oracle explorer
     * @see https://gist.github.com/Christewart/a9e55d9ba582ac9a5ceffa96db9d7e1f#get-event
     */
-  def getEvent(
+  def getAnnouncement(
       announcement: OracleAnnouncementTLV): Future[SbAnnouncementEvent] = {
-    getEvent(announcement.sha256)
+    getAnnouncement(announcement.sha256)
   }
 
   /** Gets an announcement from the oracle explorer
     * @see https://gist.github.com/Christewart/a9e55d9ba582ac9a5ceffa96db9d7e1f#get-event
     */
-  def getEvent(announcementHash: Sha256Digest): Future[SbAnnouncementEvent] = {
+  def getAnnouncement(
+      announcementHash: Sha256Digest): Future[SbAnnouncementEvent] = {
     val base = env.baseUri
     val uri = Uri(base + s"announcements/${announcementHash.hex}")
     val httpReq = HttpRequest(uri = uri)

--- a/oracle-explorer-client/src/test/scala/org/bitcoins/explorer/client/SbExplorerClientTest.scala
+++ b/oracle-explorer-client/src/test/scala/org/bitcoins/explorer/client/SbExplorerClientTest.scala
@@ -30,7 +30,7 @@ class SbExplorerClientTest extends BitcoinSAsyncTest {
 
   it must "list events" in {
     val eventsF: Future[Vector[SbAnnouncementEvent]] =
-      explorerClient.listEvents()
+      explorerClient.listAnnouncements()
     for {
       events <- eventsF
     } yield {
@@ -40,7 +40,7 @@ class SbExplorerClientTest extends BitcoinSAsyncTest {
 
   it must "get an event" in {
     val hash = announcement.sha256
-    val eventsF = explorerClient.getEvent(hash)
+    val eventsF = explorerClient.getAnnouncement(hash)
     for {
       event <- eventsF
     } yield {
@@ -51,7 +51,7 @@ class SbExplorerClientTest extends BitcoinSAsyncTest {
   it must "return failure from get an event if the event DNE" in {
     val hash = Sha256Digest.empty
     recoverToSucceededIf[RuntimeException] {
-      explorerClient.getEvent(hash)
+      explorerClient.getAnnouncement(hash)
     }
   }
 
@@ -67,7 +67,7 @@ class SbExplorerClientTest extends BitcoinSAsyncTest {
     val createdF = explorerClient.createAnnouncement(event)
     for {
       _ <- createdF
-      event <- explorerClient.getEvent(event.oracleAnnouncementV0.sha256)
+      event <- explorerClient.getAnnouncement(event.oracleAnnouncementV0.sha256)
     } yield {
       assert(event.announcement == announcement)
       assert(event.attestations.isEmpty)
@@ -92,7 +92,7 @@ class SbExplorerClientTest extends BitcoinSAsyncTest {
     for {
       _ <- createdF
       //now we must have the attesations
-      event <- explorerClient.getEvent(announcementHash)
+      event <- explorerClient.getAnnouncement(announcementHash)
     } yield {
       assert(event.attestations.isDefined)
       assert(event.attestations.get == attestations)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -75,6 +75,9 @@
       "oracle/oracle-election-example",
       "oracle/oracle-price-example"
     ],
+    "Oracle Explorer Client": [
+      "oracle-explorer-client/oracle-explorer-client"
+    ],
     "Contributing": [
       "contributing",
       "contributing-website"


### PR DESCRIPTION
fixes #2875 

This PR does two things 

1. Rename existing methods on the oracle explorer client to use `announcement` in the method name. For instance `getEvent()` -> `getAnnouncement()`
2. Adds a page to bitcoin-s.org detailing the explorer client
