### PR TITLE
Implement BIP32Path.fromHardenedString().

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/bip32/BIP32PathTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/bip32/BIP32PathTest.scala
@@ -232,4 +232,34 @@ class BIP32PathTest extends BitcoinSUnitTest {
 
     }
   }
+
+  it must "ensure that all paths are hardened when using BIP32.fromHardenedString" in {
+    val string = "m/1'/2'/3'/4'/5'"
+    val bip32Path = BIP32Path.fromHardenedString(string)
+    assert(bip32Path.toString == string)
+
+    //bad paths
+    val badPath1 = "m/1/2'/3'/4'/5'"
+    assertThrows[IllegalArgumentException] {
+      BIP32Path.fromHardenedString(badPath1)
+    }
+
+    val badPath2 = "m/1'/2'/3'/4'/5"
+
+    assertThrows[IllegalArgumentException] {
+      BIP32Path.fromHardenedString(badPath2)
+    }
+
+    val badPath3 = "m/1'/2'/3/4'/5"
+
+    assertThrows[IllegalArgumentException] {
+      BIP32Path.fromHardenedString(badPath3)
+    }
+
+    val badPath4 = "m/1/2/3/4/5"
+
+    assertThrows[IllegalArgumentException] {
+      BIP32Path.fromHardenedString(badPath4)
+    }
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/hd/BIP32Path.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/BIP32Path.scala
@@ -147,40 +147,13 @@ object BIP32Path extends Factory[BIP32Path] with StringFactory[BIP32Path] {
   }
 
   /** Takes in a BIP32 Path and verifies all paths are hardened
-    * @throws IllegalArgumentException is a non hardened path is found
+    * @throws RuntimeException is a non hardened path is found
     */
   def fromHardenedString(string: String): BIP32Path = {
-    val parts: Vector[String] = {
-      val p = string
-        .split("/")
-        .toVector
-        // BIP32 path segments are written both with whitespace between (https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#examples)
-        // and without (https://wiki.trezor.io/Standard_derivation_paths)
-        .map(_.trim)
-
-      val head +: rest = p
-      require(head == "m",
-              """The first element in a BIP32 path string must be "m"""")
-      rest
-    }
-
-    val isAllPathsHardened = parts.forall(string => isHardened(string))
-
-    if (isAllPathsHardened) {
-      BIP32Path.fromString(string)
-    } else {
-      throw new IllegalArgumentException(
-        s"Did not receive all hardened paths from string, got=$string")
-    }
-  }
-
-  /** Takes in a single element path and checks if it is hardened
-    */
-  private def isHardened(string: String): Boolean = {
-    require(
-      string.count(_ == '\'') == 1,
-      s"Receive multiple paths in string=$string, can only check one path for hardness")
-    string.endsWith("'")
+    val path = BIP32Path.fromString(string)
+    require(path.forall(_.hardened),
+            s"Found non hardened path in string=$string")
+    path
   }
 
   private def fromBytes(bytes: ByteVector, littleEndian: Boolean): BIP32Path = {

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -54,7 +54,7 @@ class DLCOracle(private[this] val extPrivateKey: ExtPrivateKeyHardened)(implicit
     val chain = HDChainType.External
     val index = 0
 
-    val path = BIP32Path.fromString(
+    val path = BIP32Path.fromHardenedString(
       s"m/${purpose.constant}'/${coin.coinType.toInt}'/${account.index}'/${chain.index}'/$index'")
 
     extPrivateKey.deriveChildPrivKey(path).key


### PR DESCRIPTION
fixes #2750 

This is a safety feature to make sure we are using only hardened paths with dlc oracle