### PR TITLE
Bump hikari logging interval to 10 minutes

### DIFF
--- a/app/oracle-server/src/main/resources/reference.conf
+++ b/app/oracle-server/src/main/resources/reference.conf
@@ -3,7 +3,7 @@ bitcoin-s {
         rpcport = 9998
         rpcbind = "127.0.0.1"
         hikari-logging = true
-        hikari-logging-interval = 5 minute
+        hikari-logging-interval = 10 minute
     }
 }
 

--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -3,12 +3,12 @@ bitcoin-s {
 
     chain {
         hikari-logging = true
-        hikari-logging-interval = 1 minute
+        hikari-logging-interval = 10 minute
     }
 
     wallet {
         hikari-logging = true
-        hikari-logging-interval = 1 minute
+        hikari-logging-interval = 10 minute
     }
 
     node {
@@ -16,7 +16,7 @@ bitcoin-s {
         peers = ["neutrino.suredbits.com:8333"]
 
         hikari-logging = true
-        hikari-logging-interval = 1 minute
+        hikari-logging-interval = 10 minute
     }
 
     server {

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -24,7 +24,7 @@ bitcoin-s {
       registerMbeans = true
     }
     hikari-logging = false
-    hikari-logging-interval = 1 minute
+    hikari-logging-interval = 10 minute
   }
 
   node = ${bitcoin-s.dbDefault}

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -121,7 +121,7 @@ bitcoin-s {
         registerMbeans = true
       }
       hikari-logging = false
-      hikari-logging-interval = 1 minute
+      hikari-logging-interval = 10 minute
     }
     
     bitcoind-rpc {
@@ -155,7 +155,7 @@ bitcoin-s {
         # 18333 for testnet and 18444 for regtest.
         
         hikari-logging = true
-        hikari-logging-interval = 1 minute
+        hikari-logging-interval = 10 minute
     }
 
     chain {
@@ -173,7 +173,7 @@ bitcoin-s {
         }
         
         hikari-logging = true
-        hikari-logging-interval = 1 minute
+        hikari-logging-interval = 10 minute
     }
 
     # settings for wallet module
@@ -207,7 +207,7 @@ bitcoin-s {
         rebroadcastFrequency = 4 hours
         
         hikari-logging = true
-        hikari-logging-interval = 1 minute
+        hikari-logging-interval = 10 minute
    }
 
     keymanager {
@@ -257,7 +257,7 @@ bitcoin-s {
         rpcbind = "127.0.0.1"
 
         hikari-logging = true
-        hikari-logging-interval = 1 minute
+        hikari-logging-interval = 10 minute
 
         db {
           path = ${bitcoin-s.datadir}/oracle/


### PR DESCRIPTION
fixes #2887 

Now it will only log database metrics by default every 10 minutes.

You can always adjust this upwards if needed.