### PR TITLE
Allow executing a losing DLC

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1495,11 +1495,6 @@ abstract class DLCWallet extends Wallet with AnyDLCHDWalletApi {
     for {
       (executor, setup) <- executorAndSetupFromDb(contractId)
 
-      payout = executor.getPayout(oracleSigs)
-      _ = if (payout <= 0.satoshis)
-        throw new UnsupportedOperationException(
-          "Cannot execute a losing outcome")
-
       executed = executor.executeDLC(setup, oracleSigs)
       (tx, outcome, sigsUsed) =
         (executed.cet, executed.outcome, executed.sigsUsed)


### PR DESCRIPTION
There was no real reason to forbid this and we should have a way for either party to close the contract, if they have the oracle signatures.