### PR TITLE
Allow for remote bitcoind backend

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -65,8 +65,10 @@ class BitcoindRpcClient(val instance: BitcoindInstance)(implicit
     with UtilRpc {
 
   override def version: BitcoindVersion = instance.getVersion
-  require(version == BitcoindVersion.Unknown || version == instance.getVersion,
-          s"bitcoind version must be $version, got ${instance.getVersion}")
+  require(
+    instance.isRemote ||
+      version == BitcoindVersion.Unknown || version == instance.getVersion,
+    s"bitcoind version must be $version, got ${instance.getVersion}")
 
   // Fee Rate Provider
 


### PR DESCRIPTION
We have a bunch of invariants that assume that the bitcoind rpc client is a local binary, this allows us to connect to one that is remote