### PR TITLE
Add timeouts to our CI workflows

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -1,4 +1,5 @@
 name: Compile & Formatting
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -1,4 +1,5 @@
 name: Docs
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
@@ -1,4 +1,5 @@
 name: Linux 2.12 App, Chain, Node, and Core Tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
@@ -1,4 +1,5 @@
 name: Linux 2.12 KeyManager, Wallet, and DLC tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Linux_2.12_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.12_RPC_Tests.yml
@@ -1,4 +1,5 @@
 name: Linux 2.12 bitcoind, eclair, and lnd rpc tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Linux_2.13_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Node_Core_Tests.yml
@@ -1,4 +1,5 @@
 name: Linux 2.13 App, Chain, Node, and Core Tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -1,4 +1,5 @@
 name: Linux 2.13 KeyManager, Wallet, and DLC tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -1,4 +1,5 @@
 name: Linux 2.13 bitcoind, eclair, and lnd rpc tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Linux_2.13_ScalaJS_Tests.yml
+++ b/.github/workflows/Linux_2.13_ScalaJS_Tests.yml
@@ -1,4 +1,5 @@
 name: Linux 2.13 Scala.js tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -1,4 +1,5 @@
 name: Mac 2.13 bitcoind, eclair, and lnd rpc tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -1,4 +1,5 @@
 name: Mac 2.13 Wallet, Node, and DLC tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -1,4 +1,5 @@
 name: PostgreSQL Tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Secp_Disabled_Tests.yml
+++ b/.github/workflows/Secp_Disabled_Tests.yml
@@ -1,4 +1,5 @@
 name: Secp256k1 Disabled Core Test
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,4 +1,5 @@
 name: Windows Tests
+timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,6 @@
 # https://docs.docker.com/ci-cd/github-actions/
 name: CI to Docker Hub
+timeout-minutes: 60
 on:
   push:
     branches: [master, main, adaptor-dlc]

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -1,6 +1,7 @@
 # Docs:
 # https://github.com/scalameta/sbt-native-image#generate-native-image-from-github-actions
 name: Native Image bitcoin-s-cli
+timeout-minutes: 60
 on:
   push:
     branches: [master, main, adaptor-dlc]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+timeout-minutes: 60
 on:
   push:
     branches: [master, main, adaptor-dlc]


### PR DESCRIPTION
https://stackoverflow.com/a/63643845/967713

There isn't a reason AFAICT that we should wait 6 hours for a CI job to timeout (360 minutes)