### PR TITLE
2021 04 17 spendinfodb invariant

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -1,5 +1,4 @@
 name: Compile & Formatting
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   compile:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -1,5 +1,4 @@
 name: Docs
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   Compile-Website:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
@@ -1,5 +1,4 @@
 name: Linux 2.12 App, Chain, Node, and Core Tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout

--- a/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
@@ -1,5 +1,4 @@
 name: Linux 2.12 KeyManager, Wallet, and DLC tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout

--- a/.github/workflows/Linux_2.12_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.12_RPC_Tests.yml
@@ -1,5 +1,4 @@
 name: Linux 2.12 bitcoind, eclair, and lnd rpc tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout

--- a/.github/workflows/Linux_2.13_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Node_Core_Tests.yml
@@ -1,5 +1,4 @@
 name: Linux 2.13 App, Chain, Node, and Core Tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -1,5 +1,4 @@
 name: Linux 2.13 KeyManager, Wallet, and DLC tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -1,5 +1,4 @@
 name: Linux 2.13 bitcoind, eclair, and lnd rpc tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout

--- a/.github/workflows/Linux_2.13_ScalaJS_Tests.yml
+++ b/.github/workflows/Linux_2.13_ScalaJS_Tests.yml
@@ -1,5 +1,4 @@
 name: Linux 2.13 Scala.js tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -1,5 +1,4 @@
 name: Mac 2.13 bitcoind, eclair, and lnd rpc tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: macos-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -1,5 +1,4 @@
 name: Mac 2.13 Wallet, Node, and DLC tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: macos-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -1,5 +1,4 @@
 name: PostgreSQL Tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     env:
       PG_ENABLED: "1"

--- a/.github/workflows/Secp_Disabled_Tests.yml
+++ b/.github/workflows/Secp_Disabled_Tests.yml
@@ -1,5 +1,4 @@
 name: Secp256k1 Disabled Core Test
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     env:
       DISABLE_SECP256K1: "true"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,5 +1,4 @@
 name: Windows Tests
-timeout-minutes: 60
 env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
@@ -9,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: windows-latest
+    timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Configure git

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,5 @@
 # https://docs.docker.com/ci-cd/github-actions/
 name: CI to Docker Hub
-timeout-minutes: 60
 on:
   push:
     branches: [master, main, adaptor-dlc]
@@ -8,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -1,7 +1,6 @@
 # Docs:
 # https://github.com/scalameta/sbt-native-image#generate-native-image-from-github-actions
 name: Native Image bitcoin-s-cli
-timeout-minutes: 60
 on:
   push:
     branches: [master, main, adaptor-dlc]
@@ -13,6 +12,7 @@ jobs:
   unix:
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 name: Release
-timeout-minutes: 60
 on:
   push:
     branches: [master, main, adaptor-dlc]
@@ -7,6 +6,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -368,13 +368,14 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     }
 
     val spendingInfoDb = SegwitV0SpendingInfo(
-      TransactionOutPoint(DoubleSha256DigestBE.empty, UInt32.zero),
-      EmptyTransactionOutput,
-      SegWitHDPath(HDCoinType.Testnet, 0, HDChainType.External, 0),
-      EmptyScriptWitness,
-      DoubleSha256DigestBE.empty,
-      TxoState.PendingConfirmationsSpent,
-      None
+      outPoint = TransactionOutPoint(DoubleSha256DigestBE.empty, UInt32.zero),
+      output = EmptyTransactionOutput,
+      privKeyPath =
+        SegWitHDPath(HDCoinType.Testnet, 0, HDChainType.External, 0),
+      scriptWitness = EmptyScriptWitness,
+      txid = DoubleSha256DigestBE.empty,
+      state = TxoState.PendingConfirmationsSpent,
+      spendingTxIdOpt = Some(DoubleSha256DigestBE.empty)
     )
 
     "return the wallet utxos" in {

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
@@ -120,6 +120,12 @@ case class NestedSegwitV0SpendingInfo(
   */
 sealed trait SpendingInfoDb extends DbRowAutoInc[SpendingInfoDb] {
 
+  if (TxoState.spentStates.contains(state)) {
+    require(
+      spendingTxIdOpt.isDefined,
+      s"If we have spent a spendinginfodb, the spendingTxId must be defined")
+  }
+
   protected type PathType <: HDPath
 
   /** This type is here to ensure copyWithSpent returns the same

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
@@ -58,9 +58,7 @@ object TxoState extends StringFactory[TxoState] {
     Set(PendingConfirmationsReceived, ConfirmedReceived, BroadcastReceived)
 
   val spentStates: Set[TxoState] =
-    Set(PendingConfirmationsSpent,
-        TxoState.ConfirmedSpent,
-        BroadcastSpent)
+    Set(PendingConfirmationsSpent, TxoState.ConfirmedSpent, BroadcastSpent)
 
   val broadcastStates: Set[TxoState] = Set(BroadcastReceived, BroadcastSpent)
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
@@ -60,7 +60,7 @@ object TxoState extends StringFactory[TxoState] {
   val spentStates: Set[TxoState] =
     Set(PendingConfirmationsSpent,
         TxoState.ConfirmedSpent,
-        Reserved,
+        /*        Reserved,*/
         BroadcastSpent)
 
   val broadcastStates: Set[TxoState] = Set(BroadcastReceived, BroadcastSpent)

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
@@ -60,7 +60,6 @@ object TxoState extends StringFactory[TxoState] {
   val spentStates: Set[TxoState] =
     Set(PendingConfirmationsSpent,
         TxoState.ConfirmedSpent,
-        /*        Reserved,*/
         BroadcastSpent)
 
   val broadcastStates: Set[TxoState] = Set(BroadcastReceived, BroadcastSpent)

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -67,7 +67,7 @@ trait CachedBitcoindNewest extends CachedBitcoindFunded[BitcoindRpcClient] {
     BitcoindRpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(BitcoindVersion.V19))
+      .createBitcoindWithFunds(Some(BitcoindVersion.newest))
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -67,7 +67,7 @@ trait CachedBitcoindNewest extends CachedBitcoindFunded[BitcoindRpcClient] {
     BitcoindRpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(BitcoindVersion.newest))
+      .createBitcoindWithFunds(Some(BitcoindVersion.V19))
   }
 }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
@@ -23,9 +23,15 @@ class UTXOHandlingTest extends BitcoinSWalletTest {
 
     val immatureCoinbase = utxo.copyWithState(ImmatureCoinbase)
     val pendingConfReceived = utxo.copyWithState(PendingConfirmationsReceived)
-    val pendingConfSpent = utxo.copyWithState(PendingConfirmationsSpent)
-    val confReceived = utxo.copyWithState(ConfirmedReceived)
-    val confSpent = utxo.copyWithState(ConfirmedSpent)
+    val spendingTxId = randomTXID
+    val pendingConfSpent = utxo
+      .copyWithSpendingTxId(spendingTxId)
+      .copyWithState(PendingConfirmationsSpent)
+    val confReceived = utxo
+      .copyWithState(ConfirmedReceived)
+    val confSpent = utxo
+      .copyWithSpendingTxId(spendingTxId)
+      .copyWithState(ConfirmedSpent)
     val reserved = utxo.copyWithState(Reserved)
     val dne = utxo.copyWithState(DoesNotExist)
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.wallet
 
 import org.bitcoins.core.protocol.script.EmptyScriptPubKey
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.core.wallet.utxo.TxoState._
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.wallet.WalletTestUtil._
@@ -17,7 +18,9 @@ class UTXOHandlingTest extends BitcoinSWalletTest {
   }
 
   it must "correctly update txo state based on confirmations" in { wallet =>
-    val utxo = sampleSegwitUTXO(EmptyScriptPubKey)
+    val utxo = sampleSegwitUTXO(EmptyScriptPubKey,
+                                state = TxoState.Reserved
+    ) //state doesn't matter here
     val requiredConfs = 6
     assert(wallet.walletConfig.requiredConfirmations == requiredConfs)
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -403,7 +403,11 @@ class WalletSendingTest extends BitcoinSWalletTest {
       for {
         allUtxos <- wallet.listUtxos()
         // Make one already spent
-        spent = allUtxos.head.copyWithState(TxoState.PendingConfirmationsSpent)
+        spent = allUtxos.head
+          .copyWithSpendingTxId(
+            DoubleSha256DigestBE.empty
+          ) // dummy spending txid
+          .copyWithState(TxoState.PendingConfirmationsSpent)
         _ <- wallet.spendingInfoDAO.update(spent)
         test <- recoverToSucceededIf[IllegalArgumentException](
           wallet.sendFromOutPoints(allUtxos.map(_.outPoint),

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
@@ -137,25 +137,6 @@ class SpendingInfoDAOTest extends WalletDAOFixture {
     }
   }
 
-  it must "insert an unspent TXO and then mark it as spent" in { daos =>
-    val spendingInfoDAO = daos.utxoDAO
-    for {
-      utxo <- WalletTestUtil.insertSegWitUTXO(daos)
-      _ <- spendingInfoDAO.update(
-        utxo.copy(state = TxoState.PendingConfirmationsReceived))
-      unspent <- spendingInfoDAO.findAllUnspent()
-      updated <-
-        spendingInfoDAO.updateTxoState(outputs = unspent.map(_.output),
-                                       state =
-                                         TxoState.PendingConfirmationsSpent)
-      unspentPostUpdate <- spendingInfoDAO.findAllUnspent()
-    } yield {
-      assert(unspent.nonEmpty)
-      assert(updated.length == unspent.length)
-      assert(unspentPostUpdate.isEmpty)
-    }
-  }
-
   it must "insert an unspent TXO and find it as unspent" in { daos =>
     val spendingInfoDAO = daos.utxoDAO
     for {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -326,8 +326,8 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
           BroadcastReceived =>
         val updated =
           out
-            .copyWithState(state = BroadcastSpent)
             .copyWithSpendingTxId(spendingTxId)
+            .copyWithState(state = BroadcastSpent)
         val updatedF =
           spendingInfoDAO.update(updated)
         updatedF.foreach(updated =>


### PR DESCRIPTION
I thought about adding this invariant when looking for the source of #2910

This adds an invariant to `SpendingInfoDb` that says if the `SpendingInfoDb.txoState` is in `TxoState.spentStates`, then the `SpendingInfoDb.spendingTxIdOpt` must be defined. 

In plain english, we must have the spending transactions id before we can transition the state of the `SpendingInfoDb` to spent. 

This PR also removes `TxoStates.Reserved` from `TxoState.spentStates`. This is because if a utxo is reserved, it doesn't necessarily mean it has been fully spent yet (no `spendingTxId`).

Finally this removes `SpendingInfoDAO.updateTxoState()` as this method was only used in test code and not source code. 

