### PR TITLE
2021 04 18 wallet received txo state

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
@@ -17,7 +17,7 @@ object TxoState extends StringFactory[TxoState] {
   /** A coinbase output that has not reached maturity and cannot be spent yet.
     * https://bitcoin.stackexchange.com/questions/1991/what-is-the-block-maturation-time
     */
-  final case object ImmatureCoinbase extends TxoState
+  final case object ImmatureCoinbase extends ReceivedState
 
   /** Means we have received funds to this utxo, and they have not been confirmed in a block */
   final case object BroadcastReceived extends ReceivedState

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
@@ -55,7 +55,10 @@ object TxoState extends StringFactory[TxoState] {
     Set(TxoState.ConfirmedReceived, TxoState.ConfirmedSpent)
 
   val receivedStates: Set[TxoState] =
-    Set(PendingConfirmationsReceived, ConfirmedReceived, BroadcastReceived)
+    Set(PendingConfirmationsReceived,
+        ConfirmedReceived,
+        BroadcastReceived,
+        TxoState.ImmatureCoinbase)
 
   val spentStates: Set[TxoState] =
     Set(PendingConfirmationsSpent, TxoState.ConfirmedSpent, BroadcastSpent)

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -67,7 +67,7 @@ trait CachedBitcoindNewest extends CachedBitcoindFunded[BitcoindRpcClient] {
     BitcoindRpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(BitcoindVersion.V19))
+      .createBitcoindWithFunds(Some(BitcoindVersion.newest))
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -67,7 +67,7 @@ trait CachedBitcoindNewest extends CachedBitcoindFunded[BitcoindRpcClient] {
     BitcoindRpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(BitcoindVersion.newest))
+      .createBitcoindWithFunds(Some(BitcoindVersion.V19))
   }
 }
 


### PR DESCRIPTION
This PR isn't intended to change any functionality, rather tighten types from `TxoState` -> `ReceivedState` inside of our wallet code for handling a utxo we are receiving. This is intended to be ground work to get to the bottom of #2910

Previously, we would be too general with our types which allows invalid states inside of the code flow for receiving a txo in our wallet.

Finally, this PR adds `ImmatureCoinbase` to the `ReceivedState` ADT. I have mixed feelings about this. When we added `ImmatureCoinbase` in #2029 it seems there wasn't much deliberation (on the PR any way) about how to classify this state. 

It is complicated, as it is technically receiving funds, but unlike all other `ReceivedStates` they aren't spendable immediately. I guess `ImmatureCoinbase` should be treated how we treat funds with immature locktimes, would we consider those received? I think so, but they aren't necessarily spendable. 

IMO, probably need to add more types to the ADT to allow for more expressiveness in what _exact_ states txos are in when we receive them, but that seems out of scope of this PR. 

If this sounds accurate, I will file an issue to address this in the next release. 