### PR TITLE
2021 04 18 Use akka streams in BitcoindRpcBackendUtil.syncWalletToBitcoind

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -396,6 +396,7 @@ object Deps {
       Compile.logback,
       Compile.akkaActor,
       Compile.akkaHttp,
+      Compile.akkaStream,
       Compile.akkaSlf4j
     )
   }


### PR DESCRIPTION
This reworks parts of the block fetching logic to use akka streams to hopefully improve performance for #2915 .

Now rather than fetching things in batches, we will fetch them on demand using akka streams backpressure. This means things will be fetched when there is demand downstream for them ([see backpressure explaination](https://doc.akka.io/docs/akka/current/stream/stream-flows-and-basics.html#core-concepts))

I have not investigated how much this improves performance yet (if any!). I suspect this isn't a huge bottleneck in performance, rather `Wallet.processBlock()` is mostly likely the bottleneck as detailed in #2596