### PR TITLE
Implement workaround for spendinginfodb by rescanning to find missing spendingTxId

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -94,7 +94,12 @@ class BitcoinSServerMain(override val args: Array[String])
         node <- configuredNodeF
         wallet <- configuredWalletF
         _ <- node.start()
-        _ <- wallet.start()
+        _ <- wallet.start().recoverWith {
+          //https://github.com/bitcoin-s/bitcoin-s/issues/2917
+          case err: IllegalArgumentException
+              if err.getMessage.contains("If we have spent a spendinginfodb") =>
+            handleMissingSpendingInfoDb(err, wallet)
+        }
         cachedChainApi <- node.chainApiFromDb()
         chainApi = ChainHandler.fromChainHandlerCached(cachedChainApi)
         binding <- startHttpServer(nodeApi = node,
@@ -143,7 +148,12 @@ class BitcoinSServerMain(override val args: Array[String])
           bitcoind,
           tmpWallet)
         _ = logger.info("Starting wallet")
-        _ <- wallet.start()
+        _ <- wallet.start().recoverWith {
+          //https://github.com/bitcoin-s/bitcoin-s/issues/2917
+          case err: IllegalArgumentException
+              if err.getMessage.contains("If we have spent a spendinginfodb") =>
+            handleMissingSpendingInfoDb(err, wallet)
+        }
         _ <- BitcoindRpcBackendUtil.syncWalletToBitcoind(bitcoind, wallet)
 
         blockCount <- bitcoind.getBlockCount
@@ -343,6 +353,31 @@ class BitcoinSServerMain(override val args: Array[String])
 
     logger.info(s"Using fee provider: $feeProvider")
     feeProvider
+  }
+
+  /** Handles a bug we had in our wallet with missing the spendingTxId for transactions spent from our wallet database.
+    * This clears the utxos/addresses from the wallet and then
+    * starts a rescan to find the missing spending txids
+    *
+    * @see https://github.com/bitcoin-s/bitcoin-s/issues/2917
+    * @see
+    */
+  private def handleMissingSpendingInfoDb(err: Throwable, wallet: Wallet)(
+      implicit walletConf: WalletAppConfig): Future[Unit] = {
+    logger.warn(
+      s"Found corrupted wallet, rescanning to find spendinginfodbs.spendingTxId as detailed in issue 2917",
+      err)
+
+    //clear the entire wallet, then rescan to make sure we get out of a corrupted state
+    val clearedF = wallet.clearAllUtxosAndAddresses()
+    for {
+      clearedWallet <- clearedF
+      _ <- clearedWallet.rescanNeutrinoWallet(startOpt = None,
+                                              endOpt = None,
+                                              addressBatchSize =
+                                                walletConf.discoveryBatchSize,
+                                              useCreationTime = true)
+    } yield clearedWallet
   }
 }
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -371,7 +371,7 @@ class BitcoinSServerMain(override val args: Array[String])
 
     //clear the entire wallet, then rescan to make sure we get out of a corrupted state
     val clearedF = wallet.clearAllUtxosAndAddresses()
-    for {
+    val walletF = for {
       clearedWallet <- clearedF
       _ <- clearedWallet.rescanNeutrinoWallet(startOpt = None,
                                               endOpt = None,
@@ -379,6 +379,7 @@ class BitcoinSServerMain(override val args: Array[String])
                                                 walletConf.discoveryBatchSize,
                                               useCreationTime = true)
     } yield clearedWallet
+    walletF.map(_ => ())
   }
 }
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -96,6 +96,7 @@ class BitcoinSServerMain(override val args: Array[String])
         _ <- node.start()
         _ <- wallet.start().recoverWith {
           //https://github.com/bitcoin-s/bitcoin-s/issues/2917
+          //https://github.com/bitcoin-s/bitcoin-s/pull/2918
           case err: IllegalArgumentException
               if err.getMessage.contains("If we have spent a spendinginfodb") =>
             handleMissingSpendingInfoDb(err, wallet)
@@ -150,6 +151,7 @@ class BitcoinSServerMain(override val args: Array[String])
         _ = logger.info("Starting wallet")
         _ <- wallet.start().recoverWith {
           //https://github.com/bitcoin-s/bitcoin-s/issues/2917
+          //https://github.com/bitcoin-s/bitcoin-s/pull/2918
           case err: IllegalArgumentException
               if err.getMessage.contains("If we have spent a spendinginfodb") =>
             handleMissingSpendingInfoDb(err, wallet)
@@ -358,9 +360,8 @@ class BitcoinSServerMain(override val args: Array[String])
   /** Handles a bug we had in our wallet with missing the spendingTxId for transactions spent from our wallet database.
     * This clears the utxos/addresses from the wallet and then
     * starts a rescan to find the missing spending txids
-    *
     * @see https://github.com/bitcoin-s/bitcoin-s/issues/2917
-    * @see
+    * @see https://github.com/bitcoin-s/bitcoin-s/pull/2918
     */
   private def handleMissingSpendingInfoDb(err: Throwable, wallet: Wallet)(
       implicit walletConf: WalletAppConfig): Future[Unit] = {

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
@@ -123,7 +123,7 @@ sealed trait SpendingInfoDb extends DbRowAutoInc[SpendingInfoDb] {
   if (TxoState.spentStates.contains(state)) {
     require(
       spendingTxIdOpt.isDefined,
-      s"If we have spent a spendinginfodb, the spendingTxId must be defined")
+      s"If we have spent a spendinginfodb, the spendingTxId must be defined. Outpoint=${outPoint.toString}")
   }
 
   protected type PathType <: HDPath


### PR DESCRIPTION
fixes #2917 

In #2912 we introduced an invariant to make sure if we had a `TxoState.spentStates`, then `SpendingInfoDb.spendingTxIdOpt` must be defined. 

Wallets that have been operational for awhile may be operating in a corrupted state (no spendingTxId). This means when you start your node, you will get exceptions on startup.

This PR introduces a way to recover from those exceptions, by clearing and then starting a rescan of your wallet. I'm not exactly in love with this solution as clearing all addresses from the wallet isn't great, but I don't know of another way to do this. 

I've run this on my local testnet wallet and it seemed to work, although I think someone else should try to run this as well.