### PR TITLE
2021 04 18 Reset txo state when overwriting spendingTxId

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -67,7 +67,7 @@ trait CachedBitcoindNewest extends CachedBitcoindFunded[BitcoindRpcClient] {
     BitcoindRpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(BitcoindVersion.V19))
+      .createBitcoindWithFunds(Some(BitcoindVersion.newest))
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -67,7 +67,7 @@ trait CachedBitcoindNewest extends CachedBitcoindFunded[BitcoindRpcClient] {
     BitcoindRpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(BitcoindVersion.newest))
+      .createBitcoindWithFunds(Some(BitcoindVersion.V19))
   }
 }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -275,21 +275,9 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
           insertTransaction(transaction, blockHashOpt)
         else Future.unit
 
-      // unreserved outputs now they are in a block
-      outputsToUse = blockHashOpt match {
-        case Some(_) =>
-          outputsBeingSpent.map { out =>
-            if (out.state == TxoState.Reserved)
-              out.copyWithState(TxoState.PendingConfirmationsReceived)
-            else out
-          }
-        case None =>
-          outputsBeingSpent
-      }
-
       processed <- Future
         .sequence {
-          outputsToUse.map(markAsSpent(_, transaction.txIdBE))
+          outputsBeingSpent.map(markAsSpent(_, transaction.txIdBE))
         }
         .map(_.toVector.flatten)
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -338,12 +338,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
           s"Updating the spendingTxId of a transaction that is already spent, " +
             s"old state=${TxoState.BroadcastSpent} old spendingTxId=${out.spendingTxIdOpt} new spendingTxId=${spendingTxId}")
         val updated =
-          out
-            .copyWithSpendingTxId(spendingTxId)
-            //we need to go back to the BroadcastSpent state
-            //as we are overriding the previous spending tx
-            //therefore we can no longer use the old Txo state
-            .copyWithState(state = BroadcastSpent)
+          out.copyWithSpendingTxId(spendingTxId)
         val updatedF = spendingInfoDAO.update(updated)
         updatedF.map(Some(_))
       case TxoState.ImmatureCoinbase =>


### PR DESCRIPTION
This fixes a bug where we weren't resetting the state of a txo when changing the `spendingTxIdOpt`. If we change the `spendingTxId`, we need to change the txo state to be `TxoState.BroadcastSpent`

We can't use the old spending txids state.