### PR TITLE
2021 04 19 Cleanup after ourselves in postgres tests

### DIFF
--- a/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
+++ b/async-utils/src/main/scala/org/bitcoins/asyncutil/AsyncUtil.scala
@@ -154,16 +154,7 @@ abstract class AsyncUtil extends AsyncUtilApi {
 
 object AsyncUtil extends AsyncUtil {
 
-  private[this] val threadFactory = new ThreadFactory {
-    private val atomicInteger = new AtomicInteger(0)
-
-    override def newThread(r: Runnable): Thread = {
-      val t = new Thread(
-        r,
-        s"bitcoin-s-async-util-${atomicInteger.getAndIncrement()}")
-      t
-    }
-  }
+  private[this] val threadFactory = getNewThreadFactory("bitcoin-s-async-util")
 
   private[bitcoins] val scheduler =
     Executors.newScheduledThreadPool(2, threadFactory)
@@ -175,4 +166,16 @@ object AsyncUtil extends AsyncUtil {
   /** The default number of async attempts before timing out
     */
   private[bitcoins] val DEFAULT_MAX_TRIES: Int = 50
+
+  /** Gives you a thread factory with the given prefix with a counter appended to the name */
+  def getNewThreadFactory(prefix: String): ThreadFactory = {
+    new ThreadFactory {
+      private val atomicInteger = new AtomicInteger(0)
+
+      override def newThread(r: Runnable): Thread = {
+        val t = new Thread(r, s"$prefix-${atomicInteger.getAndIncrement()}")
+        t
+      }
+    }
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -659,7 +659,7 @@ lazy val wallet = project
     name := "bitcoin-s-wallet",
     libraryDependencies ++= Deps.wallet(scalaVersion.value)
   )
-  .dependsOn(coreJVM, appCommons, dbCommons, keyManager)
+  .dependsOn(coreJVM, appCommons, dbCommons, keyManager, asyncUtilsJVM)
   .enablePlugins(FlywayPlugin)
 
 lazy val walletTest = project

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/WalletDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/WalletDAOFixture.scala
@@ -6,7 +6,7 @@ import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.models._
 import org.scalatest._
 
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
 
 case class WalletDAOs(
     accountDAO: AccountDAO,
@@ -75,5 +75,11 @@ trait WalletDAOFixture extends BitcoinSFixture with EmbeddedPg {
     } yield ()
     res.failed.foreach(_.printStackTrace())
     res
+  }
+
+  override def afterAll(): Unit = {
+    val stoppedF = config.stop()
+    val _ = Await.ready(stoppedF, akkaTimeout.duration)
+    super[EmbeddedPg].afterAll()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -123,6 +123,10 @@ trait BitcoinSWalletTestCachedBitcoind
       _ <- BitcoindRpcTestUtil.stopServer(bitcoind)
     } yield ()
   }
+
+  override def afterAll(): Unit = {
+    super[BaseWalletTest].afterAll()
+  }
 }
 
 trait BitcoinSWalletTestCachedBitcoindNewest
@@ -131,6 +135,7 @@ trait BitcoinSWalletTestCachedBitcoindNewest
 
   override def afterAll(): Unit = {
     super[CachedBitcoindNewest].afterAll()
+    super[BitcoinSWalletTestCachedBitcoind].afterAll()
   }
 }
 
@@ -140,6 +145,7 @@ trait BitcoinSWalletTestCachedBitcoinV19
 
   override def afterAll(): Unit = {
     super[CachedBitcoindV19].afterAll()
+    super[BitcoinSWalletTestCachedBitcoind].afterAll()
   }
 
   /** Creates a funded wallet fixture with bitcoind

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
@@ -33,6 +33,7 @@ class BitcoindBlockPollingTest
   }
 
   override def afterAll(): Unit = {
+    super[CachedBitcoindNewest].afterAll()
     super[EmbeddedPg].afterAll()
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -176,7 +176,7 @@ case class WalletAppConfig(
     if (isHikariLoggingEnabled) {
       val _ = stopHikariLogger()
     }
-    Future.unit
+    super.stop()
   }
 
   /** The path to our encrypted mnemonic seed */


### PR DESCRIPTION
This fixes #2920 

This makes sure we are shutting down database connection pools when `WalletAppConfig.stop()` is called.

This PR also fixes test cases `BitcoindBackendTest` & `BitcoindBlockPollingTest` which don't use our test fixtures in a conventional way, which means we need to stop the wallet manually inside the test case itself.