### PR TITLE
2021 04 19 Zip Bitcoin-s datadir

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/file/FileUtil.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/file/FileUtil.scala
@@ -1,0 +1,41 @@
+package org.bitcoins.commons.file
+
+import grizzled.slf4j.Logging
+
+import java.io.{FileOutputStream, IOException}
+import java.nio.file.Path
+import java.util.zip.ZipOutputStream
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.zip.ZipEntry
+
+object FileUtil extends Logging {
+
+  /** Zips the [[directory]] into a zip file and then stores it at [[target]]
+    * @see https://www.quickprogrammingtips.com/java/how-to-zip-a-folder-in-java.html
+    */
+  def zipDirectory(source: Path, target: Path): Path = {
+    val zos = new ZipOutputStream(new FileOutputStream(target.toFile()))
+    Files.walkFileTree(
+      source,
+      new SimpleFileVisitor[Path]() {
+        @throws[IOException]
+        override def visitFile(
+            file: Path,
+            attrs: BasicFileAttributes): FileVisitResult = {
+          logger.info(
+            s"Zipping file=${file.toAbsolutePath} to ${target.toAbsolutePath}")
+          zos.putNextEntry(new ZipEntry(source.relativize(file).toString))
+          Files.copy(file, zos)
+          zos.closeEntry()
+          logger.info(s"Done zipping file=${file.toAbsolutePath}")
+          FileVisitResult.CONTINUE
+        }
+      }
+    )
+    zos.close()
+    target
+  }
+}

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -2,6 +2,7 @@ package org.bitcoins.server
 
 import com.typesafe.config.{Config, ConfigFactory}
 import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.commons.file.FileUtil
 import org.bitcoins.core.util.StartStopAsync
 import org.bitcoins.db.AppConfig
 import org.bitcoins.keymanager.config.KeyManagerAppConfig

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -74,6 +74,16 @@ case class BitcoinSAppConfig(
       None
     }
   }
+
+  /** Zips $HOME/.bitcoin-s
+    */
+  def zipDatadir(target: Path): Path = {
+    FileUtil.zipDirectory(source = directory,
+                          target = target,
+                          //we don't want to store chaindb.sqlite as these
+                          //databases are huge
+                          fileNameFilter = Vector("chaindb.sqlite"))
+  }
 }
 
 /** Implicit conversions that allow a unified configuration


### PR DESCRIPTION
Adds `FileUtil.zipDirectory()` to provide a utility to zip a file. 

This leaves a script that can be run `ZipDatadir` to zip your `$HOME/.bitcoin-s/` directory. You should have the option to pick it if you do `appServer/run`

This also adds `BitcoinSAppConfig.zipDatadir(target)` that can be used to zip the datadir too.  

It should be noted, that the chaindb.sqlite takes forever to zip. On mainnet, it takes me ~15 minutes on my machine.

>[info] 2021-04-19T20:31:09UTC INFO [FileUtil$] Zipping file=/home/chris/.bitcoin-s/mainnet/chaindb.sqlite to /tmp/zip-datadir.zip
[info] 2021-04-19T20:46:40UTC INFO [FileUtil$] Done zipping file=/home/chris/.bitcoin-s/mainnet/chaindb.sqlite

I've added a filter for `chaindb.sqlite` to avoid storing this. This of course comes with the trade off of having to sync the chainstate again when restoring from the zip.
