### PR TITLE
Reduce number of threads in postgres connection pool for tests 

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -181,7 +181,7 @@ object BitcoinSTestAppConfig {
          |   user = "postgres"
          |   password = "postgres"
          |   port = $port
-         |   numThreads = 2
+         |   numThreads = 1
          |   keepAliveConnection = true
          | }""".stripMargin
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -181,7 +181,7 @@ object BitcoinSTestAppConfig {
          |   user = "postgres"
          |   password = "postgres"
          |   port = $port
-         |   numThreads = 10
+         |   numThreads = 2
          |   keepAliveConnection = true
          | }""".stripMargin
     }


### PR DESCRIPTION
This reduces the number of threads that are used in postgres test cases from 10 -> 2. 

There is no reason we need 10 threads allocated in a postgres database test suite, and it is likely causing problems on CI machines that don't have many resources (related to: #2920) 

 