### PR TITLE
Add test for tx that doesn't originate from wallet

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -288,9 +288,10 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
         .sequence {
           outputsToUse.map(markAsSpent(_, transaction.txIdBE))
         }
-        .map(_.toVector)
-    } yield processed.flatten
+        .map(_.toVector.flatten)
 
+      _ <- updateUtxoConfirmedStates(processed)
+    } yield processed
   }
 
   /** Does the grunt work of processing a TX.


### PR DESCRIPTION
Also found that we would mark the utxo as `BroadcastSpent` even after processing in a block, this is fixed