### PR TITLE
Move wallet scheduler into WalletAppConfig

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -20,6 +20,7 @@ bitcoin-s {
       # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
       numThreads = 1
       queueSize=5000
+      poolName = "bitcoin-s-db-pool"
       connectionPool = "HikariCP"
       registerMbeans = true
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -180,6 +180,7 @@ object BitcoinSTestAppConfig {
          |   driver = "org.postgresql.Driver"
          |   user = "postgres"
          |   password = "postgres"
+         |   poolName = "bitcoin-s-db-pool"
          |   port = $port
          |   numThreads = 1
          |   keepAliveConnection = true

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -41,7 +41,6 @@ import org.bitcoins.wallet.models._
 import scodec.bits.ByteVector
 
 import java.time.Instant
-import java.util.concurrent._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Random, Success}
 
@@ -61,7 +60,7 @@ abstract class Wallet
 
   implicit val walletConfig: WalletAppConfig
 
-  private[wallet] val scheduler = Executors.newScheduledThreadPool(1)
+  private[wallet] lazy val scheduler = walletConfig.scheduler
 
   val chainParams: ChainParams = walletConfig.chain
 
@@ -158,7 +157,6 @@ abstract class Wallet
     for {
       _ <- walletConfig.stop()
     } yield {
-      scheduler.shutdown()
       stopRebroadcastTxsScheduler()
       this
     }

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -188,13 +188,13 @@ case class WalletAppConfig(
 
   override def stop(): Future[Unit] = {
     if (isHikariLoggingEnabled) {
-      val _ = stopHikariLogger()
+      stopHikariLogger()
     }
     //this eagerly shuts down all scheduled tasks on the scheduler
     //in the future, we should actually cancel all things that are scheduled
     //manually, and then shutdown the scheduler
-    val _ = scheduler.shutdownNow()
-    val _ = rescanThreadPool.shutdownNow()
+    scheduler.shutdownNow()
+    rescanThreadPool.shutdownNow()
     super.stop()
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -449,7 +449,7 @@ private[wallet] trait AddressHandling extends WalletLogger {
     */
   lazy val addressQueueThread = {
     val t = new Thread(AddressQueueRunnable)
-    t.setName(s"bitcoin-s-ad  dress-queue-${System.currentTimeMillis()}")
+    t.setName(s"bitcoin-s-address-queue-${System.currentTimeMillis()}")
     t
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -447,7 +447,11 @@ private[wallet] trait AddressHandling extends WalletLogger {
     * With this background thread, we poll the [[addressRequestQueue]] seeing if there
     * are any elements in it, if there are, we process them and complete the Promise in the queue.
     */
-  lazy val addressQueueThread = new Thread(AddressQueueRunnable)
+  lazy val addressQueueThread = {
+    val t = new Thread(AddressQueueRunnable)
+    t.setName(s"bitcoin-s-ad  dress-queue-${System.currentTimeMillis()}")
+    t
+  }
 
   lazy val addressRequestQueue = {
     val queue = new java.util.concurrent.ArrayBlockingQueue[(

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.wallet.internal
 
-import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.chain.ChainQueryApi.{
   FilterResponse,
   InvalidBlockRange
@@ -15,7 +14,6 @@ import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 
-import java.util.concurrent.{ExecutorService, Executors}
 import scala.concurrent.{ExecutionContext, Future}
 
 private[wallet] trait RescanHandling extends WalletLogger {
@@ -212,7 +210,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
       blocks <- getMatchingBlocks(scripts = scriptPubKeys,
                                   startOpt = startOpt,
                                   endOpt = endOpt)(
-        ExecutionContext.fromExecutor(RescanHandling.threadPool))
+        ExecutionContext.fromExecutor(walletConfig.rescanThreadPool))
     } yield {
       blocks.sortBy(_.blockHeight).map(_.blockHash.flip)
     }
@@ -322,15 +320,4 @@ private[wallet] trait RescanHandling extends WalletLogger {
       vectorSize / parallelismLevel + 1
     else vectorSize / parallelismLevel
   }
-
-}
-
-object RescanHandling {
-
-  private lazy val threadFactory =
-    AsyncUtil.getNewThreadFactory("bitcoin-s-rescan")
-
-  private[internal] lazy val threadPool: ExecutorService =
-    Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors() * 2,
-                                 threadFactory)
 }


### PR DESCRIPTION
We currently have a bug in our wallet code wrt to [`Wallet.scheduler`](https://github.com/bitcoin-s/bitcoin-s/blob/8ce22583a55d926033edf1a14e539ed2a815ecd6/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala#L64).

As you can see, this is a val on the abstract class. This means everytime we create a new `Wallet` object, a scheduler gets allocated for it. This means we get a TON of scheduler threads in tests.

Even worse, it appears when [`Wallet.stop()`](https://github.com/bitcoin-s/bitcoin-s/blob/8ce22583a55d926033edf1a14e539ed2a815ecd6/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala#L161) is called, the scheduler doesn't get shutdown (!!). 

This PR does two things

1. Moves the scheduler into `WalletAppConfig`. This is because we should be sharing the same `WalletAppConfig` across all instances of the wallet similar to how we just create one `ActorSystem` for the entire application.
2. Changes from `scheduler.shutdown()` -> `scheduler.shutdownNow()`. This seems to actually shutdown the tasks. I'm still not 100% sure if this is what we want, or there is another underlying problem here. 

This is what our visualvm state looks like on current master ( 9e60f187a3d1fe12f74ff585b4d55c23369bd094 ) . Notice how many threads are still running even after the entire `walletTest/test` suite is complete! You can see there is still `190` live threads after the test suite is done!

You can see there is a bunch of unamed threads in this image (`pool-#-thread-1`).
![Screenshot from 2021-04-20 13-08-34](https://user-images.githubusercontent.com/3514957/115444033-a7325180-a1d9-11eb-8e78-dd23c5a93532.png)

This second image is from 9b73443 . This names the threads with a `ThreadFactory` (`bitcoin-s-wallet-scheduler`). After running this we have 86 live threads, almost 100 threads less. 

![Screenshot from 2021-04-20 13-13-58](https://user-images.githubusercontent.com/3514957/115444535-4c4d2a00-a1da-11eb-94d5-4fca8f7c2499.png)



