### PR TITLE
Peer Message Receiver Refactor

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -61,7 +61,7 @@ class BitcoinSServerMain(override val args: Array[String])
 
       //get a node that isn't started
       val nodeF = configInitializedF.flatMap { _ =>
-        nodeConf.createNode(peer, None)(chainConf, system)
+        nodeConf.createNode(peer)(chainConf, system)
       }
 
       //get our wallet

--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -44,6 +44,7 @@ For your node to be able to service these filters you will need set
 import akka.actor.ActorSystem
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.node._
+import org.bitcoins.node.networking.peer._
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.testkit.node._
 import org.bitcoins.testkit.node.fixture._
@@ -108,14 +109,15 @@ val chainApiF = for {
 
 //yay! All setup done, let's create a node and then start it!
 val nodeF = for {
-  _ <- chainApiF
+  chainApi <- chainApiF
   peer <- peerF
 } yield {
+    val dataMessageHandler = DataMessageHandler(chainApi)
     NeutrinoNode(nodePeer = peer,
+               dataMessageHandler = dataMessageHandler,
                nodeConfig = nodeConfig,
                chainConfig = chainConfig,
-               actorSystem = system,
-               initialSyncDone = None)
+               actorSystem = system)
 }
 
 //let's start it

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -11,7 +11,11 @@ import org.bitcoins.crypto.{CryptoUtil, DoubleSha256Digest}
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.PeerMessageReceiver
 import org.bitcoins.testkit.async.TestAsyncUtil
-import org.bitcoins.testkit.node.{CachedBitcoinSAppConfig, NodeTestUtil}
+import org.bitcoins.testkit.node.{
+  CachedBitcoinSAppConfig,
+  NodeTestUtil,
+  NodeUnitTest
+}
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoindRpcTest
 import org.scalatest._
@@ -168,7 +172,9 @@ class P2PClientTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
     val probe = TestProbe()
     val remote = peer.socket
     val peerMessageReceiverF =
-      PeerMessageReceiver.preConnection(peer, None)
+      for {
+        node <- NodeUnitTest.buildNode(peer)
+      } yield PeerMessageReceiver.preConnection(peer, node)
 
     val clientActorF: Future[TestActorRef[P2PClientActor]] =
       peerMessageReceiverF.map { peerMsgRecv =>

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -32,8 +32,8 @@ class DataMessageHandlerTest extends NodeUnitTest {
     param: SpvNodeConnectedWithBitcoindV19 =>
       val SpvNodeConnectedWithBitcoindV19(spv, _) = param
 
+      val sender = spv.peerMsgSender
       for {
-        sender <- spv.peerMsgSenderF
         chainApi <- spv.chainApiFromDb()
         dataMessageHandler = DataMessageHandler(chainApi)(spv.executionContext,
                                                           spv.nodeAppConfig,
@@ -66,9 +66,8 @@ class DataMessageHandlerTest extends NodeUnitTest {
           }
       }
 
+      val sender = spv.peerMsgSender
       for {
-        sender <- spv.peerMsgSenderF
-
         txId <- bitcoind.sendToAddress(junkAddress, 1.bitcoin)
         tx <- bitcoind.getRawTransactionRaw(txId)
         _ <- bitcoind.generateToAddress(blocks = 1, junkAddress)
@@ -102,9 +101,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
           ()
         }
       }
-      for {
-        sender <- spv.peerMsgSenderF
+      val sender = spv.peerMsgSender
 
+      for {
         hash <- bitcoind.generateToAddress(blocks = 1, junkAddress).map(_.head)
         block <- bitcoind.getBlockRaw(hash)
 
@@ -137,9 +136,8 @@ class DataMessageHandlerTest extends NodeUnitTest {
         }
       }
 
+      val sender = spv.peerMsgSender
       for {
-        sender <- spv.peerMsgSenderF
-
         hash <- bitcoind.generateToAddress(blocks = 1, junkAddress).map(_.head)
         header <- bitcoind.getBlockHeaderRaw(hash)
 
@@ -171,9 +169,8 @@ class DataMessageHandlerTest extends NodeUnitTest {
             ()
           }
       }
+      val sender = spv.peerMsgSender
       for {
-        sender <- spv.peerMsgSenderF
-
         hash <- bitcoind.generateToAddress(blocks = 1, junkAddress).map(_.head)
         filter <- bitcoind.getBlockFilter(hash, FilterType.Basic)
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -72,7 +72,10 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
 
   def sendVersionMessage(chainApi: ChainApi)(implicit
       ec: ExecutionContext): Future[Unit] = {
-    chainApi.getBestHashBlockHeight().flatMap { height =>
+    val heightF =
+      chainApi.getBestHashBlockHeight().recover { case _: Throwable => 0 }
+
+    heightF.flatMap { height =>
       val transmittingIpAddress = java.net.InetAddress.getLocalHost
       val receivingIpAddress = client.peer.socket.getAddress
       val versionMsg =

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -72,10 +72,7 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
 
   def sendVersionMessage(chainApi: ChainApi)(implicit
       ec: ExecutionContext): Future[Unit] = {
-    val heightF =
-      chainApi.getBestHashBlockHeight()
-
-    heightF.flatMap { height =>
+    chainApi.getBestHashBlockHeight().flatMap { height =>
       val transmittingIpAddress = java.net.InetAddress.getLocalHost
       val receivingIpAddress = client.peer.socket.getAddress
       val versionMsg =

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -73,7 +73,7 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
   def sendVersionMessage(chainApi: ChainApi)(implicit
       ec: ExecutionContext): Future[Unit] = {
     val heightF =
-      chainApi.getBestHashBlockHeight().recover { case _: Throwable => 0 }
+      chainApi.getBestHashBlockHeight()
 
     heightF.flatMap { height =>
       val transmittingIpAddress = java.net.InetAddress.getLocalHost

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -23,7 +23,7 @@ sealed trait CachedAppConfig { _: BitcoinSAkkaAsyncTest =>
 trait CachedBitcoinSAppConfig { _: BitcoinSAkkaAsyncTest =>
 
   implicit protected lazy val cachedConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig()
+    BitcoinSTestAppConfig.getNeutrinoTestConfig()
 
   implicit protected lazy val cachedNodeConf: NodeAppConfig = {
     cachedConfig.nodeConf


### PR DESCRIPTION
Refactors `PeerMessageReceiver` to have it's parent `Node` instead of a `DataMessageHandler` and then give the `DataMessageHandler` to the `Node` this will allow the `Node` to have different peers that are all contributing and looking at the same view of the blockchain