### PR TITLE
Fix missing super.stop() to shutdown DbAppConfig db connection pool

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.blockchain
 
-import akka.actor.ActorSystem
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.chain.ChainDbUnitTest
 import org.bitcoins.testkit.chain.fixture.BitcoindChainHandlerViaZmq
@@ -9,9 +8,6 @@ import org.scalatest.FutureOutcome
 class BitcoindChainHandlerViaZmqTest extends ChainDbUnitTest {
 
   override type FixtureParam = BitcoindChainHandlerViaZmq
-
-  implicit override val system: ActorSystem = ActorSystem(
-    "BitcoindChainHandlerViaZmqTest")
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBitcoindChainHandlerViaZmq(test)

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.blockchain
 
-import akka.actor.ActorSystem
 import org.bitcoins.chain.validation.TipUpdateResult
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.number.UInt32
@@ -16,8 +15,6 @@ class BlockchainTest extends ChainUnitTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withChainFixture(test)
-
-  implicit override val system: ActorSystem = ActorSystem("BlockchainTest")
 
   behavior of "Blockchain"
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.blockchain.sync
 
-import akka.actor.ActorSystem
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.crypto.DoubleSha256DigestBE
@@ -12,9 +11,6 @@ import scala.concurrent.Future
 
 class ChainSyncTest extends ChainDbUnitTest {
   override type FixtureParam = BitcoindChainHandlerViaRpc
-
-  implicit override val system = ActorSystem(
-    s"chain-sync-test-${System.currentTimeMillis()}")
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     withBitcoindChainHandlerViaRpc(test)

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.models
 
-import akka.actor.ActorSystem
 import org.bitcoins.chain.blockchain.Blockchain
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, BlockHeaderDbHelper}
 import org.bitcoins.core.number.{Int32, UInt32}
@@ -26,8 +25,6 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBlockHeaderDAO(test)
-
-  implicit override val system: ActorSystem = ActorSystem("BlockHeaderDAOTest")
 
   behavior of "BlockHeaderDAO"
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.pow
 
-import akka.actor.ActorSystem
 import org.bitcoins.chain.blockchain.Blockchain
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.BlockHeaderDAO
@@ -28,8 +27,6 @@ class BitcoinPowTest extends ChainDbUnitTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withChainFixture(test)
-
-  implicit override val system: ActorSystem = ActorSystem("BitcoinPowTest")
 
   behavior of "BitcoinPow"
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.chain.validation
 
-import akka.actor.ActorSystem
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.chain.pow.Pow
 import org.bitcoins.core.api.chain.db.BlockHeaderDbHelper
@@ -19,8 +18,6 @@ class TipValidationTest extends ChainDbUnitTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBlockHeaderDAO(test)
-
-  implicit override val system: ActorSystem = ActorSystem("TipValidationTest")
 
   behavior of "TipValidation"
 

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -104,7 +104,7 @@ case class ChainAppConfig(
 
   override def stop(): Future[Unit] = {
     val _ = stopHikariLogger()
-    Future.unit
+    super.stop()
   }
 
   lazy val filterHeaderBatchSize: Int = {

--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -18,7 +18,7 @@ import scala.util.control.NonFatal
 class BroadcastTransactionTest extends NodeTestWithCachedBitcoindV19 {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoindV19

--- a/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.FutureOutcome
 
 class DisconnectedPeerTest extends NodeUnitTest with CachedBitcoinSAppConfig {
 
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   /** Wallet config with data directory set to user temp directory */

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
 class NeutrinoNodeTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoind
@@ -25,7 +25,9 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindNewest {
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val outcomeF: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      outcome = withNeutrinoNodeConnectedToBitcoind(test, bitcoind)
+      outcome = withNeutrinoNodeConnectedToBitcoind(test, bitcoind)(
+        system,
+        getFreshConfig)
       f <- outcome.toFuture
     } yield f
     new FutureOutcome(outcomeF)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Future
 class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration.DurationInt
 class SpvNodeTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoind
@@ -26,7 +26,9 @@ class SpvNodeTest extends NodeTestWithCachedBitcoindNewest {
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val outcomeF: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      outcome = withSpvNodeConnectedToBitcoindCached(test, bitcoind)
+      outcome = withSpvNodeConnectedToBitcoindCached(test, bitcoind)(
+        system,
+        getFreshConfig)
       f <- outcome.toFuture
     } yield f
     new FutureOutcome(outcomeF)

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Future
 class SpvNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = SpvNodeFundedWalletBitcoind
@@ -26,9 +26,10 @@ class SpvNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val outcomeF: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      outcome = withSpvNodeFundedWalletBitcoindCached(test,
-                                                      getBIP39PasswordOpt(),
-                                                      bitcoind)
+      outcome = withSpvNodeFundedWalletBitcoindCached(
+        test,
+        getBIP39PasswordOpt(),
+        bitcoind)(system, getFreshConfig)
       f <- outcome.toFuture
     } yield f
     new FutureOutcome(outcomeF)

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -12,9 +12,7 @@ import org.scalatest.{BeforeAndAfter, FutureOutcome, Outcome}
 
 import scala.concurrent.Future
 
-class UpdateBloomFilterTest
-    extends NodeTestWithCachedBitcoindNewest
-    with BeforeAndAfter {
+class UpdateBloomFilterTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   implicit override protected def getFreshConfig: BitcoinSAppConfig =

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -8,7 +8,7 @@ import org.bitcoins.testkit.node.{
   NodeTestWithCachedBitcoindNewest,
   SpvNodeFundedWalletBitcoind
 }
-import org.scalatest.{BeforeAndAfter, FutureOutcome, Outcome}
+import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
 

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 class UpdateBloomFilterTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = SpvNodeFundedWalletBitcoind
@@ -23,9 +23,10 @@ class UpdateBloomFilterTest extends NodeTestWithCachedBitcoindNewest {
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val outcome: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      outcome = withSpvNodeFundedWalletBitcoindCached(test,
-                                                      getBIP39PasswordOpt(),
-                                                      bitcoind)
+      outcome = withSpvNodeFundedWalletBitcoindCached(
+        test,
+        getBIP39PasswordOpt(),
+        bitcoind)(system, getFreshConfig)
       f <- outcome.toFuture
     } yield f
     new FutureOutcome(outcome)

--- a/node-test/src/test/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAOTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAOTest.scala
@@ -9,7 +9,7 @@ import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 class BroadcastAbleTransactionDAOTest extends NodeDAOFixture with EmbeddedPg {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   behavior of "BroadcastAbleTransactionDAO"

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -20,13 +20,13 @@ import scala.concurrent.{Future, Promise}
 class DataMessageHandlerTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoindV19
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withSpvNodeConnectedToBitcoindV19(test)
+    withSpvNodeConnectedToBitcoindV19(test)(system, getFreshConfig)
 
   it must "catch errors and not fail when processing an invalid payload" in {
     param: SpvNodeConnectedWithBitcoindV19 =>

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -22,7 +22,7 @@ class PeerMessageHandlerTest
     with CachedBitcoinSAppConfig {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvTestConfig()
 
   override type FixtureParam = Peer

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -65,7 +65,7 @@ case class NodeAppConfig(
 
   override def stop(): Future[Unit] = {
     val _ = stopHikariLogger()
-    Future.unit
+    super.stop()
   }
 
   lazy val nodeType: NodeType =

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainDbUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainDbUnitTest.scala
@@ -24,4 +24,8 @@ trait ChainDbUnitTest extends ChainUnitTest with EmbeddedPg {
     chainConfig.withOverrides(memoryDb)
   }
 
+  override def afterAll(): Unit = {
+    super[EmbeddedPg].afterAll()
+    super[ChainUnitTest].afterAll()
+  }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -7,7 +7,7 @@ import org.bitcoins.core.api.chain.db.{
   CompactFilterDb,
   CompactFilterHeaderDb
 }
-import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.config.{NetworkParameters, RegTest}
 import org.bitcoins.core.gcs.FilterHeader
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.BlockHeader
@@ -28,10 +28,9 @@ import scala.concurrent.duration.DurationInt
 trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit protected def getFreshConfig: BitcoinSAppConfig
+  protected def getFreshConfig: BitcoinSAppConfig
 
-  implicit override lazy val np: NetworkParameters =
-    getFreshConfig.nodeConf.network
+  implicit override lazy val np: NetworkParameters = RegTest
 
   override def beforeAll(): Unit = {
     AppConfig.throwIfDefaultDatadir(getFreshConfig.nodeConf)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -40,6 +40,7 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
 
   override def afterAll(): Unit = {
     super[EmbeddedPg].afterAll()
+    super.afterAll()
   }
 
   lazy val junkAddress: BitcoinAddress =

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -42,7 +42,17 @@ trait CachedBitcoinSAppConfig { _: BitcoinSAkkaAsyncTest =>
   }
 }
 
-trait CachedChainAppConfig extends CachedBitcoinSAppConfig {
+trait CachedChainAppConfig {
   _: BitcoinSAkkaAsyncTest =>
 
+  private[this] lazy val cachedConfig: BitcoinSAppConfig =
+    BitcoinSTestAppConfig.getSpvTestConfig()
+
+  implicit protected lazy val cachedChainConf: ChainAppConfig = {
+    cachedConfig.chainConf
+  }
+
+  override def afterAll(): Unit = {
+    Await.result(cachedChainConf.stop(), duration)
+  }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -148,6 +148,8 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest { _: CachedBitcoind[_] =>
       _ <- destroyNodeF
       _ <- ChainUnitTest.destroyAllTables()(node.chainAppConfig,
                                             system.dispatcher)
+      //need to stop chainAppConfig too since this is a test
+      _ <- node.chainAppConfig.stop()
     } yield ()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -154,7 +154,13 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest { _: CachedBitcoind[_] =>
 
 trait NodeTestWithCachedBitcoindNewest
     extends NodeTestWithCachedBitcoind
-    with CachedBitcoindNewest
+    with CachedBitcoindNewest {
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindNewest].afterAll()
+    super[NodeTestWithCachedBitcoind].afterAll()
+  }
+}
 
 trait NodeTestWithCachedBitcoindV19
     extends NodeTestWithCachedBitcoind
@@ -184,5 +190,10 @@ trait NodeTestWithCachedBitcoindV19
         NodeUnitTest.destroyNode(x.node)
       }
     )(test)
+  }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindV19].afterAll()
+    super[NodeTestWithCachedBitcoind].afterAll()
   }
 }


### PR DESCRIPTION
The intention of this PR is to clean up test resources. 

1. We were not shutting down database connection pools in the `NodeAppConfig` and `ChainAppConfig` projects. 
2. In the `chainTest` project, we were overriding the `actorSystem` val in subclasses, which caused them not to be shutdown
3. Decouples `CachedChainAppConfig` from `CachedAppConfig` in testkit. This is needed because when you use a specific app config (such as `ChainAppConfig`), you might not have started the other app configs like `NodeAppConfig`. This means when we you try to call [`BitcoinSAppConfig.stop()`](https://github.com/bitcoin-s/bitcoin-s/blob/735c074d17f412caee47e7aa48ecda777a006020/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala#L51) you might fail in the for comprehension before stopping the project you are interested in. 
4. Make [`BaseNodeTest.getFreshConfig()`](https://github.com/bitcoin-s/bitcoin-s/pull/2943/files#diff-bd95ba575a9aae2ab70669ff00767dd9c0edba1815dbb9f59c778cf59bc7c8e4R31) not be implicit. This is done for safety reasons to make sure we aren't accidentally (implicitly) binding config objects without meaning to do so. For instance, you could have had a cached config that you meant to pass in, but the implicit silently passes this in. 


here is a screenshot of threads after running `chainTest/test` on 9811434f190cdb811dd47a179dcd2c434ab0571c (93 live threads)

![Screenshot from 2021-04-22 12-22-27](https://user-images.githubusercontent.com/3514957/115759649-1a68ce80-a366-11eb-9115-d40818b4f5b9.png)


and then this is running `chainTest/test` on f05bffd (57 live threads)

![Screenshot from 2021-04-22 12-26-48](https://user-images.githubusercontent.com/3514957/115759683-248acd00-a366-11eb-94e8-c4cbecc54294.png)


So we are shutting down about ~40 threads now that were previously left running.