### PR TITLE
Fix missing teardown code for MultiWalletRpcTest

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
@@ -14,10 +14,10 @@ import org.bitcoins.rpc.client.common._
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.rpc.util.{NodePair, RpcUtil}
 import org.bitcoins.testkit.rpc.{
-  BitcoindFixturesCachedPair,
+  BitcoindFixturesCachedPairV19,
   BitcoindRpcTestUtil
 }
-import org.bitcoins.testkit.util.{AkkaUtil, BitcoinSAsyncFixtureTest}
+import org.bitcoins.testkit.util.AkkaUtil
 import org.scalatest.{FutureOutcome, Outcome}
 
 import java.io.File
@@ -26,11 +26,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 /** These tests are all copied over from WalletRpcTest and changed to be for multi-wallet */
-class MultiWalletRpcTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesCachedPair[BitcoindV19RpcClient] {
-  override val version = BitcoindVersion.V19
-  override type FixtureParam = NodePair[BitcoindV19RpcClient]
+class MultiWalletRpcTest extends BitcoindFixturesCachedPairV19 {
+
   val walletName = "other"
 
   var password = "password"

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -278,6 +278,28 @@ trait BitcoindFixturesCachedPairV18
   }
 }
 
+trait BitcoindFixturesCachedPairV19
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCachedPair[BitcoindV19RpcClient] {
+  override type FixtureParam = NodePair[BitcoindV19RpcClient]
+
+  override val version: BitcoindVersion = BitcoindVersion.V19
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val futOutcome = for {
+      pair <- clientsF
+      futOutcome = with2BitcoindsCached(test, pair)
+      f <- futOutcome.toFuture
+    } yield f
+    new FutureOutcome(futOutcome)
+  }
+
+  override def afterAll(): Unit = {
+    super[BitcoindFixturesCachedPair].afterAll()
+    super[BitcoinSAsyncFixtureTest].afterAll()
+  }
+}
+
 /** Bitcoind fixtures with two cached bitcoind rpc clients that are [[BitcoindVersion.newest]] that are connected via p2p */
 trait BitcoindFixturesCachedPairV21
     extends BitcoinSAsyncFixtureTest


### PR DESCRIPTION
We weren't shutting down the actor system and de-allocating resources for this test suite in bitcoind-rpc