### PR TITLE
Get FilterSync test working with cached bitcoind in chainTest project

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/ChainSyncTest.scala
@@ -3,14 +3,14 @@ package org.bitcoins.chain.blockchain.sync
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.testkit.chain.fixture.BitcoindChainHandlerViaRpc
+import org.bitcoins.testkit.chain.fixture.BitcoindBaseVersionChainHandlerViaRpc
 import org.bitcoins.testkit.chain.{ChainDbUnitTest, SyncUtil}
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future
 
 class ChainSyncTest extends ChainDbUnitTest {
-  override type FixtureParam = BitcoindChainHandlerViaRpc
+  override type FixtureParam = BitcoindBaseVersionChainHandlerViaRpc
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     withBitcoindChainHandlerViaRpc(test)
@@ -19,7 +19,7 @@ class ChainSyncTest extends ChainDbUnitTest {
   behavior of "ChainSync"
 
   it must "sync our chain handler when it is not synced with bitcoind" in {
-    bitcoindWithChainHandler: BitcoindChainHandlerViaRpc =>
+    bitcoindWithChainHandler: BitcoindBaseVersionChainHandlerViaRpc =>
       val bitcoind = bitcoindWithChainHandler.bitcoindRpc
       val chainHandler = bitcoindWithChainHandler.chainHandler
       //first we need to implement the 'getBestBlockHashFunc' and 'getBlockHeaderFunc' functions
@@ -43,7 +43,7 @@ class ChainSyncTest extends ChainDbUnitTest {
   }
 
   it must "not fail when syncing a chain handler that is synced with it's external data source" in {
-    bitcoindWithChainHandler: BitcoindChainHandlerViaRpc =>
+    bitcoindWithChainHandler: BitcoindBaseVersionChainHandlerViaRpc =>
       val bitcoind = bitcoindWithChainHandler.bitcoindRpc
       val chainHandler = bitcoindWithChainHandler.chainHandler
       //first we need to implement the 'getBestBlockHashFunc' and 'getBlockHeaderFunc' functions

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
@@ -68,7 +68,6 @@ abstract class ChainSync extends ChainVerificationLogger {
       getBlockHeaderFunc: DoubleSha256DigestBE => Future[BlockHeader])(implicit
       ec: ExecutionContext): Future[ChainApi] = {
     require(tips.nonEmpty, s"Cannot sync without the genesis block")
-
     //we need to walk backwards on the chain until we get to one of our tips
     val tipsBH = tips.map(_.blockHeader)
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/FilterWithHeaderHash.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/FilterWithHeaderHash.scala
@@ -5,7 +5,8 @@ import org.bitcoins.crypto.DoubleSha256DigestBE
 
 /** Represents a [[GolombFilter]] with it's [[org.bitcoins.core.gcs.FilterHeader]] associated with it
   * This is needed because bitcoin core's 'getblockfilter' rpc returns things in this structure
+  * @see https://developer.bitcoin.org/reference/rpc/getblockfilter.html#argument-2-filtertype
   */
 case class FilterWithHeaderHash(
     filter: GolombFilter,
-    headerHash: DoubleSha256DigestBE)
+    filterHeaderHash: DoubleSha256DigestBE)

--- a/docs/chain/filter-sync.md
+++ b/docs/chain/filter-sync.md
@@ -64,7 +64,7 @@ implicit val chainAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig().chai
 val bitcoindWithChainApiF: Future[BitcoindV19ChainHandler] = {
   ChainUnitTest.createBitcoindV19ChainHandler()
 }
-val bitcoindF = bitcoindWithChainApiF.map(_.bitcoind)
+val bitcoindF = bitcoindWithChainApiF.map(_.bitcoindRpc)
 val chainApiF = bitcoindWithChainApiF.map(_.chainHandler)
 
 val filterType = FilterType.Basic

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -173,6 +173,7 @@ akka {
 
             event-stream=off
         }
+        # https://doc.akka.io/docs/akka/current/dispatchers.html#classic-dispatchers
         default-dispatcher {
             # The goal here is to reduce the number of threads spun up for test suites.
             # Since every test suite currently

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -194,20 +194,20 @@ akka {
             executor = "thread-pool-executor"
             throughput = 1
             thread-pool-executor {
-                fixed-pool-size = 2
+                fixed-pool-size = 1
             }
         }
         internal-dispatcher {
             # minimum of one thread for tests
             parallelism-min = 1
 
-            # maximum of 2 threads for tests
-            parallelism-max = 2
+            # maximum of 1 threads for tests
+            parallelism-max = 1
             type = "Dispatcher"
             executor = "thread-pool-executor"
             throughput = 1
             thread-pool-executor {
-                fixed-pool-size = 2
+                fixed-pool-size = 1
             }
         }
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -706,4 +706,13 @@ object ChainUnitTest extends ChainVerificationLogger {
       bitcoindV19ChainHandler.chainHandler)
     destroyBitcoindChainApiViaRpc(b)
   }
+
+  /** Destroys the chain api, but leaves the bitcoind instance running
+    * so we can cache it
+    */
+  def destroyChainApi()(implicit
+      system: ActorSystem,
+      chainAppConfig: ChainAppConfig): Future[Unit] = {
+    ChainUnitTest.destroyAllTables()(chainAppConfig, system.dispatcher)
+  }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/BitcoindChainHandlerViaRpc.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/BitcoindChainHandlerViaRpc.scala
@@ -2,8 +2,23 @@ package org.bitcoins.testkit.chain.fixture
 
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 
-/** Represents a bitcoind instance paired with a chain handler via rpc */
-case class BitcoindChainHandlerViaRpc(
+sealed trait BitcoindChainHandlerViaRpc {
+  def bitcoindRpc: BitcoindRpcClient
+  def chainHandler: ChainHandler
+}
+
+/** Represents a bitcoind instance paired with a chain handler via rpc
+  * This is useful for when the bitcoind version doesn't matter, you
+  * just need a generic [[BitcoindRpcClient]]
+  */
+case class BitcoindBaseVersionChainHandlerViaRpc(
     bitcoindRpc: BitcoindRpcClient,
     chainHandler: ChainHandler)
+    extends BitcoindChainHandlerViaRpc
+
+case class BitcoindV19ChainHandler(
+    override val bitcoindRpc: BitcoindV19RpcClient,
+    chainHandler: ChainHandler)
+    extends BitcoindChainHandlerViaRpc

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/BitcoindV19ChainHandler.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/BitcoindV19ChainHandler.scala
@@ -1,9 +1,0 @@
-package org.bitcoins.testkit.chain.fixture
-
-import org.bitcoins.chain.blockchain.ChainHandler
-import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
-
-/** Useful for neutrino RPCs from bitcoind */
-case class BitcoindV19ChainHandler(
-    bitcoind: BitcoindV19RpcClient,
-    chainHandler: ChainHandler)

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
@@ -1,9 +1,13 @@
 package org.bitcoins.testkit.chain.fixture
 
-import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.testkit.chain.{ChainDbUnitTest, ChainUnitTest}
-import org.bitcoins.testkit.rpc.{CachedBitcoind, CachedBitcoindV19}
+import org.bitcoins.testkit.rpc.{
+  CachedBitcoind,
+  CachedBitcoindNewest,
+  CachedBitcoindV19
+}
 import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
@@ -11,6 +15,36 @@ import scala.concurrent.Future
 /** Chain unit test that requires a cached bitcoind type to be injected */
 trait ChainWithBitcoindUnitTest extends ChainDbUnitTest {
   _: CachedBitcoind[_] =>
+
+}
+
+trait ChainWithBitcoindNewestCachedUnitTest
+    extends ChainWithBitcoindUnitTest
+    with CachedBitcoindNewest {
+
+  override type FixtureParam = BitcoindBaseVersionChainHandlerViaRpc
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withBitcoindNewestChainHandlerViaRpc(test, bitcoind)
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
+
+  def withBitcoindNewestChainHandlerViaRpc(
+      test: OneArgAsyncTest,
+      bitcoindRpcClient: BitcoindRpcClient): FutureOutcome = {
+    val builder: () => Future[BitcoindBaseVersionChainHandlerViaRpc] = { () =>
+      ChainUnitTest.createChainApiWithBitcoindRpc(bitcoindRpcClient)
+    }
+    val destroy: BitcoindBaseVersionChainHandlerViaRpc => Future[Unit] = {
+      case _: BitcoindBaseVersionChainHandlerViaRpc =>
+        ChainUnitTest.destroyChainApi()
+    }
+    makeDependentFixture(builder, destroy)(test)
+  }
 
 }
 
@@ -36,16 +70,12 @@ trait ChainWithBitcoindV19CachedUnitTest
     val builder: () => Future[BitcoindV19ChainHandler] = { () =>
       ChainUnitTest.createBitcoindV19ChainHandler(bitcoindV19RpcClient)
     }
-    makeDependentFixture(builder, destroyChainApi)(test)
-  }
 
-  /** Destroys the chain api, but leaves the bitcoind instance running
-    * so we can cache it
-    */
-  def destroyChainApi(bitcoindV19ChainHandler: BitcoindV19ChainHandler)(implicit
-      chainAppConfig: ChainAppConfig): Future[Unit] = {
-    val _ = bitcoindV19ChainHandler
-    ChainUnitTest.destroyAllTables()(chainAppConfig, system.dispatcher)
+    val destroy: BitcoindV19ChainHandler => Future[Unit] = {
+      case _: BitcoindV19ChainHandler =>
+        ChainUnitTest.destroyChainApi()
+    }
+    makeDependentFixture(builder, destroy)(test)
   }
 
   override def afterAll(): Unit = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
@@ -46,6 +46,10 @@ trait ChainWithBitcoindNewestCachedUnitTest
     makeDependentFixture(builder, destroy)(test)
   }
 
+  override def afterAll(): Unit = {
+    super[CachedBitcoindNewest].afterAll()
+    super[ChainWithBitcoindUnitTest].afterAll()
+  }
 }
 
 /** Chain Unit test suite that has a cached bitcoind v19 instance */

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
@@ -1,0 +1,84 @@
+package org.bitcoins.testkit.chain.fixture
+
+import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.testkit.chain.{ChainDbUnitTest, ChainUnitTest, SyncUtil}
+import org.bitcoins.testkit.rpc.{CachedBitcoind, CachedBitcoindV19}
+import org.scalatest.{FutureOutcome, Outcome}
+
+import scala.concurrent.Future
+
+/** Chain unit test that requires a cached bitcoind type to be injected */
+trait ChainWithBitcoindUnitTest extends ChainDbUnitTest {
+  _: CachedBitcoind[_] =>
+
+}
+
+/** Chain Unit test suite that has a cached bitcoind v19 instance */
+trait ChainWithBitcoindV19CachedUnitTest
+    extends ChainWithBitcoindUnitTest
+    with CachedBitcoindV19 {
+
+  override type FixtureParam = BitcoindV19ChainHandler
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withBitcoindV19ChainHandlerViaRpc(test, bitcoind)
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
+
+  def withBitcoindV19ChainHandlerViaRpc(
+      test: OneArgAsyncTest,
+      bitcoindV19RpcClient: BitcoindV19RpcClient): FutureOutcome = {
+    val builder: () => Future[BitcoindV19ChainHandler] = { () =>
+      createBitcoindV19ChainHandler(bitcoindV19RpcClient)
+    }
+    makeDependentFixture(builder, destroyChainApi)(test)
+  }
+
+  def createBitcoindV19ChainHandler(
+      bitcoindV19RpcClient: BitcoindV19RpcClient): Future[
+    BitcoindV19ChainHandler] = {
+
+    val chainApiWithBitcoindF = createChainApiWithBitcoindV19Rpc(
+      bitcoindV19RpcClient)
+
+    //now sync the chain api to the bitcoind node
+    val syncedBitcoindWithChainHandlerF = for {
+      chainApiWithBitcoind <- chainApiWithBitcoindF
+      bitcoindWithChainHandler <- SyncUtil.syncBitcoindV19WithChainHandler(
+        chainApiWithBitcoind)
+    } yield bitcoindWithChainHandler
+
+    syncedBitcoindWithChainHandlerF
+  }
+
+  /** Destroys the chain api, but leaves the bitcoind instance running
+    * so we can cache it
+    */
+  def destroyChainApi(bitcoindV19ChainHandler: BitcoindV19ChainHandler)(implicit
+      chainAppConfig: ChainAppConfig): Future[Unit] = {
+    val _ = bitcoindV19ChainHandler
+    ChainUnitTest.destroyAllTables()(chainAppConfig, system.dispatcher)
+  }
+
+  private def createChainApiWithBitcoindV19Rpc(
+      bitcoind: BitcoindV19RpcClient): Future[BitcoindV19ChainHandler] = {
+    val handlerWithGenesisHeaderF =
+      ChainUnitTest.setupHeaderTableWithGenesisHeader()
+
+    val chainHandlerF = handlerWithGenesisHeaderF.map(_._1)
+
+    chainHandlerF.map { handler =>
+      BitcoindV19ChainHandler(bitcoind, handler)
+    }
+  }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindV19].afterAll()
+    super[ChainWithBitcoindUnitTest].afterAll()
+  }
+}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -5,7 +5,6 @@ import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.utxo.TxoState
-import org.bitcoins.testkit.rpc.CachedBitcoindV19
 import org.bitcoins.testkit.wallet.{
   BitcoinSWalletTestCachedBitcoinV19,
   WalletWithBitcoindV19
@@ -14,9 +13,7 @@ import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
 
-class ProcessBlockTest
-    extends BitcoinSWalletTestCachedBitcoinV19
-    with CachedBitcoindV19 {
+class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
 
   override type FixtureParam = WalletWithBitcoindV19
 


### PR DESCRIPTION
Fixes #2948

This introduces caching of bitcoinds in the `chainTest` project. 

This re-implements two test suites to use the cached bitcoind

1. `FilterSyncTest`
2. `ChainSyncTest`