### PR TITLE
2021 04 23 issue Move rebroadcast scheduling into WalletAppConfig

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -147,20 +147,13 @@ abstract class Wallet
       _ <- walletConfig.start()
       _ <- checkRootAccount
       _ <- downloadMissingUtxos
+      _ = walletConfig.startRebroadcastTxsScheduler(this)
     } yield {
-      startRebroadcastTxsScheduler()
       this
     }
   }
 
-  override def stop(): Future[Wallet] = {
-    for {
-      _ <- walletConfig.stop()
-    } yield {
-      stopRebroadcastTxsScheduler()
-      this
-    }
-  }
+  override def stop(): Future[Wallet] = Future.successful(this)
 
   def getSyncDescriptorOpt(): Future[Option[SyncHeightDescriptor]] = {
     stateDescriptorDAO.getSyncDescriptorOpt()

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -284,6 +284,7 @@ case class WalletAppConfig(
         //already scheduled, do nothing
         ()
       case None =>
+        logger.info(s"Starting wallet rebroadcast task")
         val interval = rebroadcastFrequency.toSeconds
 
         val future =
@@ -301,6 +302,7 @@ case class WalletAppConfig(
     rebroadcastTransactionsCancelOpt match {
       case Some(cancel) =>
         if (!cancel.isCancelled) {
+          logger.info(s"Stopping wallet rebroadcast task")
           cancel.cancel(true)
         } else {
           rebroadcastTransactionsCancelOpt = None

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -15,9 +15,7 @@ import org.bitcoins.core.wallet.utxo.{AddressTag, ReceivedState, TxoState}
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.wallet._
 
-import java.util.concurrent.{ScheduledFuture, TimeUnit}
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
 
 /** Provides functionality for processing transactions. This
@@ -27,57 +25,6 @@ import scala.util.{Failure, Success, Try}
   */
 private[wallet] trait TransactionProcessing extends WalletLogger {
   self: Wallet =>
-
-  private case object RebroadcastTransactionsRunnable extends Runnable {
-
-    override def run(): Unit = {
-      val f = for {
-        txs <- getTransactionsToBroadcast
-
-        _ = {
-          if (txs.size > 1)
-            logger.info(s"Rebroadcasting ${txs.size} transactions")
-          else if (txs.size == 1)
-            logger.info(s"Rebroadcasting ${txs.size} transaction")
-        }
-
-        _ <- nodeApi.broadcastTransactions(txs)
-      } yield ()
-
-      // Make sure broadcasting completes
-      // Wrap in try in case of spurious failure
-      Try(Await.result(f, 60.seconds))
-      ()
-    }
-  }
-
-  private[this] var rebroadcastTransactionsCancelOpt: Option[
-    ScheduledFuture[_]] = None
-
-  /** Starts the wallet's rebroadcast transaction scheduler */
-  private[wallet] def startRebroadcastTxsScheduler(): Unit = {
-    val interval = walletConfig.rebroadcastFrequency.toSeconds
-
-    val future = scheduler.scheduleAtFixedRate(RebroadcastTransactionsRunnable,
-                                               interval,
-                                               interval,
-                                               TimeUnit.SECONDS)
-    rebroadcastTransactionsCancelOpt = Some(future)
-  }
-
-  /** Kills the wallet's rebroadcast transaction scheduler */
-  private[wallet] def stopRebroadcastTxsScheduler(): Unit = {
-    rebroadcastTransactionsCancelOpt match {
-      case Some(cancel) =>
-        if (!cancel.isCancelled) {
-          cancel.cancel(true)
-        } else {
-          rebroadcastTransactionsCancelOpt = None
-        }
-        ()
-      case None => ()
-    }
-  }
 
   /////////////////////
   // Public facing API


### PR DESCRIPTION
This fixes #2955 

This PR moves the rebroadcast logic out of `TransactionProcessing` and into `WalletAppConfig`. Since this requires scheduling a task on the scheduler, we need to move it into `WalletAppConfig` so we have one scheduled task for all wallets that use this `WalletAppConfig` rather than having `n` of them.

As a byproduct, this makes `Wallet.stop()` a no-op. There are no resources that need to be de-allocated when we are done using the `Wallet` instance anymore, so we can safely let it by GC'd by the JVM.