### PR TITLE
2021 04 24 bitcoin s scripts

### DIFF
--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
@@ -3,11 +3,7 @@ package org.bitcoins.scripts
 import akka.NotUsed
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import org.bitcoins.core.protocol.blockchain.Block
-import org.bitcoins.core.protocol.transaction.{
-  BaseTransaction,
-  EmptyTransaction,
-  WitnessTransaction
-}
+import org.bitcoins.core.protocol.transaction.WitnessTransaction
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.BitcoindRpcAppConfig
 import org.bitcoins.server.routes.BitcoinSRunner

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
@@ -1,0 +1,104 @@
+package org.bitcoins.scripts
+
+import akka.NotUsed
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import org.bitcoins.core.protocol.blockchain.Block
+import org.bitcoins.core.protocol.transaction.{
+  BaseTransaction,
+  EmptyTransaction,
+  WitnessTransaction
+}
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.server.BitcoindRpcAppConfig
+import org.bitcoins.server.routes.BitcoinSRunner
+
+import scala.concurrent.Future
+
+/** Useful script for scanning bitcoind
+  * This file assumes you have pre-configured the connection
+  * between bitcoin-s and bitcoind inside of bitcoin-s.conf
+  * @see https://bitcoin-s.org/docs/config/configuration#example-configuration-file
+  */
+class ScanBitcoind(override val args: Array[String]) extends BitcoinSRunner {
+  override val actorSystemName = "scan-bitcoind"
+
+  implicit val rpcAppConfig: BitcoindRpcAppConfig =
+    BitcoindRpcAppConfig(datadir, baseConfig)
+
+  override def startup: Future[Unit] = {
+
+    val bitcoind = rpcAppConfig.client
+
+    val startHeight = 675000
+    val endHeightF: Future[Int] = bitcoind.getBlockCount
+
+    for {
+      endHeight <- endHeightF
+      _ <- countSegwitTxs(bitcoind, startHeight, endHeight)
+      _ <- system.terminate()
+    } yield {
+      sys.exit(0)
+    }
+
+  }
+
+  /** Searches a given Source[Int] that represents block heights applying f to them and returning a Seq[T] with the results */
+  def searchBlocks[T](
+      bitcoind: BitcoindRpcClient,
+      source: Source[Int, NotUsed],
+      f: Block => T,
+      numParallelism: Int =
+        Runtime.getRuntime.availableProcessors() * 2): Future[Seq[T]] = {
+    source
+      .mapAsync(parallelism = numParallelism) { height =>
+        bitcoind
+          .getBlockHash(height)
+          .flatMap(h => bitcoind.getBlockRaw(h))
+          .map(b => (b, height))
+      }
+      .map { case (block, height) =>
+        logger.info(
+          s"Searching block at height=$height hashBE=${block.blockHeader.hashBE.hex}")
+        f(block)
+      }
+      .toMat(Sink.seq)(Keep.right)
+      .run()
+  }
+
+  def countSegwitTxs(
+      bitcoind: BitcoindRpcClient,
+      startHeight: Int,
+      endHeight: Int): Future[Unit] = {
+    val startTime = System.currentTimeMillis()
+    val source: Source[Int, NotUsed] = Source(startHeight.to(endHeight))
+
+    //in this simple example, we are going to count the number of witness transactions
+    val countSegwitTxs: Block => Int = { block: Block =>
+      var counter = 0
+      block.transactions.map {
+        case _: WitnessTransaction =>
+          counter = counter + 1
+        case _: BaseTransaction | EmptyTransaction =>
+        //do nothing
+      }
+      counter
+    }
+
+    val countsF: Future[Seq[Int]] = for {
+      counts <- searchBlocks[Int](bitcoind, source, countSegwitTxs)
+    } yield counts
+
+    val countF: Future[Int] = countsF.map(_.sum)
+
+    for {
+      count <- countF
+      endTime = System.currentTimeMillis()
+      _ = println(
+        s"Count of segwit txs from height${startHeight} to endHeight=${endHeight} is ${count}. It took ${endTime - startTime}ms ")
+    } yield ()
+  }
+}
+
+object ScanBitcoind extends App {
+  new ScanBitcoind(args).run()
+}

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
@@ -76,16 +76,8 @@ class ScanBitcoind(override val args: Array[String]) extends BitcoinSRunner {
 
     //in this simple example, we are going to count the number of witness transactions
     val countSegwitTxs: Block => Int = { block: Block =>
-      var counter = 0
-      block.transactions.map {
-        case _: WitnessTransaction =>
-          counter = counter + 1
-        case _: BaseTransaction | EmptyTransaction =>
-        //do nothing
-      }
-      counter
+      block.transactions.count(_.isInstanceOf[WitnessTransaction])
     }
-
     val countsF: Future[Seq[Int]] = for {
       counts <- searchBlocks[Int](bitcoind, source, countSegwitTxs)
     } yield counts

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
@@ -3,7 +3,7 @@ package org.bitcoins.scripts
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.server.routes.BitcoinSRunner
 
-import java.nio.file.Path
+import java.nio.file.Paths
 import scala.concurrent.Future
 
 /** This script zips your $HOME/.bitcoin-s/ directory to a specified path, excluding chaindb.sqlite */
@@ -17,7 +17,7 @@ class ZipDatadir(override val args: Array[String]) extends BitcoinSRunner {
   override def startup: Future[Unit] = {
 
     //replace the line below with where you want to zip too
-    val path = Path.of("/tmp", "bitcoin-s.zip")
+    val path = Paths.get("/tmp", "bitcoin-s.zip")
     val target = conf.zipDatadir(path)
     logger.info(s"Done zipping to $target!")
     for {

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
@@ -4,8 +4,6 @@ import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.server.routes.BitcoinSRunner
 
 import java.nio.file.Path
-
-//import java.nio.file.Path
 import scala.concurrent.Future
 
 /** This script zips your $HOME/.bitcoin-s/ directory to a specified path, excluding chaindb.sqlite */

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
@@ -1,0 +1,33 @@
+package org.bitcoins.scripts
+
+import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.server.routes.BitcoinSRunner
+
+import java.nio.file.Path
+
+//import java.nio.file.Path
+import scala.concurrent.Future
+
+/** This script zips your $HOME/.bitcoin-s/ directory to a specified path, excluding chaindb.sqlite */
+class ZipDatadir(override val args: Array[String]) extends BitcoinSRunner {
+
+  override def actorSystemName: String = "Zip-datadir"
+
+  implicit lazy val conf: BitcoinSAppConfig =
+    BitcoinSAppConfig(datadir, baseConfig)
+
+  override def startup: Future[Unit] = {
+
+    //replace the line below with where you want to zip too
+    val path = Path.of("/tmp", "bitcoin-s.zip")
+    val target = conf.zipDatadir(path)
+    logger.info(s"Done zipping to $target!")
+    for {
+      _ <- system.terminate()
+    } yield sys.exit(0)
+  }
+}
+
+object Zip extends App {
+  new ZipDatadir(args).run()
+}

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcAppConfig.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.server
 
-import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import org.bitcoins.db._
 import org.bitcoins.node.NodeType
@@ -128,9 +127,7 @@ case class BitcoindRpcAppConfig(
 
   lazy val client: BitcoindRpcClient = {
     val version = bitcoindInstance.getVersion
-    implicit val system: ActorSystem =
-      ActorSystem.create("bitcoind-rpc-client-created-by-bitcoin-s", config)
-    BitcoindRpcClient.fromVersion(version, bitcoindInstance)
+    BitcoindRpcClient.fromVersionNoSystem(version, bitcoindInstance)
   }
 
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -222,6 +222,8 @@ object BitcoindRpcClient {
     */
   private[rpc] val ActorSystemName = "bitcoind-rpc-client-created-by-bitcoin-s"
 
+  implicit private lazy val system = ActorSystem.create(ActorSystemName)
+
   /** Creates an RPC client from the given instance.
     *
     * Behind the scenes, we create an actor system for
@@ -229,8 +231,7 @@ object BitcoindRpcClient {
     * manually specify an actor system for the RPC client.
     */
   def apply(instance: BitcoindInstance): BitcoindRpcClient = {
-    implicit val system = ActorSystem.create(ActorSystemName)
-    withActorSystem(instance)
+    withActorSystem(instance)(system)
   }
 
   /** Creates an RPC client from the given instance,

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -273,6 +273,12 @@ object BitcoindRpcClient {
 
     bitcoind
   }
+
+  def fromVersionNoSystem(
+      version: BitcoindVersion,
+      instance: BitcoindInstance): BitcoindRpcClient = {
+    fromVersion(version, instance)(system)
+  }
 }
 
 sealed trait BitcoindVersion

--- a/build.sbt
+++ b/build.sbt
@@ -207,7 +207,8 @@ lazy val `bitcoin-s` = project
     oracleServerTest,
     serverRoutes,
     lndRpc,
-    lndRpcTest
+    lndRpcTest,
+    scripts
   )
   .dependsOn(
     secp256k1jni,
@@ -253,7 +254,8 @@ lazy val `bitcoin-s` = project
     oracleServerTest,
     serverRoutes,
     lndRpc,
-    lndRpcTest
+    lndRpcTest,
+    scripts
   )
   .settings(CommonSettings.settings: _*)
   // unidoc aggregates Scaladocs for all subprojects into one big doc
@@ -699,6 +701,15 @@ lazy val oracleExplorerClient = project
     libraryDependencies ++= Deps.oracleExplorerClient
   )
   .dependsOn(coreJVM, appCommons, testkit % "test->test")
+
+lazy val scripts = project
+  .in(file("app/scripts"))
+  .settings(CommonSettings.settings: _*)
+  .settings(
+    name := "bitcoin-s-scripts",
+    publishArtifact := false //do not want to publish our scripts
+  )
+  .dependsOn(appServer)
 
 /** Given a database name, returns the appropriate
   * Flyway settings we apply to a project (chain, node, wallet)

--- a/build.sbt
+++ b/build.sbt
@@ -710,6 +710,7 @@ lazy val scripts = project
     publishArtifact := false //do not want to publish our scripts
   )
   .dependsOn(appServer)
+  .enablePlugins(JavaAppPackaging)
 
 /** Given a database name, returns the appropriate
   * Flyway settings we apply to a project (chain, node, wallet)

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ConditionalScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ConditionalScriptPubKeyTest.scala
@@ -1,0 +1,36 @@
+package org.bitcoins.core.protocol.script
+
+import org.bitcoins.core.script.constant.ScriptConstant
+import org.bitcoins.testkitcore.util.BitcoinSJvmTest
+
+class ConditionalScriptPubKeyTest extends BitcoinSJvmTest {
+
+  behavior of "ConditionalScriptPubKey"
+
+  it must "be able to parse a conditional spk with a nested p2sh script" in {
+    //see: https://github.com/bitcoin-s/bitcoin-s/issues/2962
+    val scriptSigHex =
+      "48304502207ffb30631d837895ac1b415408b70a809090b25d4070198043299fe247f62d2602210089b52f0d243dea1e4313ef67723b0d0642ff77bb6ca05ea85296b2539c797f5c81513d632103184b16f5d6c01e2d6ded3f8a292e5b81608318ecb8e93aa3747bc88b8dbf256cac67a914f5862841f254a1483eab66909ae588e45d617c5e8768"
+
+    val scriptSig = ScriptSignature.fromAsmHex(scriptSigHex)
+
+    scriptSig match {
+      case p2sh: P2SHScriptSignature =>
+        assert(p2sh.redeemScript.isInstanceOf[IfConditionalScriptPubKey])
+      case x => fail(s"Did not parse a p2sh script sig, got=$x")
+    }
+  }
+
+  it must "consider a redeem script that contains OP_IF in it with a nested p2sh script pubkey in it" in {
+    //see: https://github.com/bitcoin-s/bitcoin-s/issues/2962
+    val hex =
+      "632103184b16f5d6c01e2d6ded3f8a292e5b81608318ecb8e93aa3747bc88b8dbf256cac67a914f5862841f254a1483eab66909ae588e45d617c5e8768"
+    val scriptPubKey = RawScriptPubKey.fromAsmHex(hex)
+
+    assert(scriptPubKey.isInstanceOf[IfConditionalScriptPubKey])
+
+    val constant = ScriptConstant.fromHex(hex)
+
+    assert(P2SHScriptSignature.isRedeemScript(constant))
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -613,9 +613,6 @@ sealed trait ConditionalScriptPubKey extends RawScriptPubKey {
 
   val opElseIndex: Int = opElseIndexOpt.get
 
-  require(!P2SHScriptPubKey.isValidAsm(trueSPK.asm) && !P2SHScriptPubKey
-            .isValidAsm(falseSPK.asm),
-          s"ConditionalScriptPubKey cannot wrap P2SH asm=$asm")
   require(
     !WitnessScriptPubKey
       .isValidAsm(trueSPK.asm) && !WitnessScriptPubKey

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -615,7 +615,7 @@ sealed trait ConditionalScriptPubKey extends RawScriptPubKey {
 
   require(!P2SHScriptPubKey.isValidAsm(trueSPK.asm) && !P2SHScriptPubKey
             .isValidAsm(falseSPK.asm),
-          "ConditionalScriptPubKey cannot wrap P2SH")
+          s"ConditionalScriptPubKey cannot wrap P2SH asm=$asm")
   require(
     !WitnessScriptPubKey
       .isValidAsm(trueSPK.asm) && !WitnessScriptPubKey


### PR DESCRIPTION
This adds a dedicated bitcoin-s scripts project. This is meant to be a place to place useful utilities for running occasionally against bitcoin-s. 

There are two scripts to stat
1. `ScanBitcoind` - scan against bitcoind between a height range
2. `ZipDatadir` - Zip's the bitcoin-s datadir 

As an example, here is the result of `ScanBitcoind` when counting segwit txs between `675,000-tip`

>Count of segwit txs from height675000 to endHeight=680427 is 5707220. It took 335069ms