### PR TITLE
Rework P2SHScriptSignature.isStandardNonP2SH()

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ConditionalScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ConditionalScriptPubKeyTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.script
 
+import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.script.constant.ScriptConstant
 import org.bitcoins.testkitcore.util.BitcoinSJvmTest
 
@@ -32,5 +33,10 @@ class ConditionalScriptPubKeyTest extends BitcoinSJvmTest {
     val constant = ScriptConstant.fromHex(hex)
 
     assert(P2SHScriptSignature.isRedeemScript(constant))
+
+    //we should be able to parse the tx that contains it with no problem
+    val txHex =
+      "010000000193983cb2f1f3d83615f10e1ca33f49c72250acbebd840793aaa8bc7a6b28b76b000000008848304502207ffb30631d837895ac1b415408b70a809090b25d4070198043299fe247f62d2602210089b52f0d243dea1e4313ef67723b0d0642ff77bb6ca05ea85296b2539c797f5c81513d632103184b16f5d6c01e2d6ded3f8a292e5b81608318ecb8e93aa3747bc88b8dbf256cac67a914f5862841f254a1483eab66909ae588e45d617c5e8768ffffffff01a0860100000000001976a914a07aa8415d34d0db44f220ff9522609641c0bfbf88ac00000000"
+    assert(Transaction.fromHexT(txHex).isSuccess)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ConditionalScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ConditionalScriptPubKeyTest.scala
@@ -28,8 +28,15 @@ class ConditionalScriptPubKeyTest extends BitcoinSJvmTest {
       "632103184b16f5d6c01e2d6ded3f8a292e5b81608318ecb8e93aa3747bc88b8dbf256cac67a914f5862841f254a1483eab66909ae588e45d617c5e8768"
     val scriptPubKey = RawScriptPubKey.fromAsmHex(hex)
 
-    assert(scriptPubKey.isInstanceOf[IfConditionalScriptPubKey])
-
+    scriptPubKey match {
+      case conditional: IfConditionalScriptPubKey =>
+        assert(
+          conditional.secondSPK.isInstanceOf[NonStandardScriptPubKey],
+          s"Although we have same op codes as p2sh spk, " +
+            s"this combination isn't used in a standalone output, rather a redeemScript"
+        )
+      case x => fail(s"Incorrect type for the spk, got=$x")
+    }
     val constant = ScriptConstant.fromHex(hex)
 
     assert(P2SHScriptSignature.isRedeemScript(constant))

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -273,8 +273,6 @@ object P2SHScriptSignature extends ScriptFactory[P2SHScriptSignature] {
           _: P2PKScriptPubKey | _: P2PKWithTimeoutScriptPubKey |
           _: WitnessScriptPubKeyV0 | _: UnassignedWitnessScriptPubKey =>
         true
-      case _: P2SHScriptPubKey =>
-        true
       case EmptyScriptPubKey => isRecursiveCall // Fine if nested
       case conditional: ConditionalScriptPubKey =>
         val first =
@@ -308,7 +306,8 @@ object P2SHScriptSignature extends ScriptFactory[P2SHScriptSignature] {
         } else {
           false
         }
-      case _: NonStandardScriptPubKey | _: WitnessCommitment =>
+      case _: NonStandardScriptPubKey | _: WitnessCommitment |
+          _: P2SHScriptPubKey =>
         false
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -275,31 +275,8 @@ object P2SHScriptSignature extends ScriptFactory[P2SHScriptSignature] {
         true
       case EmptyScriptPubKey => isRecursiveCall // Fine if nested
       case conditional: ConditionalScriptPubKey =>
-        val first =
-          isStandardNonP2SH(conditional.firstSPK, isRecursiveCall = true)
-
-        val second =
-          isStandardNonP2SH(conditional.secondSPK, isRecursiveCall = true)
-
-        //we need to see if we have a p2sh scriptpubkey nested
-        //inside of the conditional spk. This can actually happen
-        //when you literally just want to use the script OP_HASH160 <bytes> OP_EQUAL
-        //independent of the normal p2sh flow
-        //see: https://github.com/bitcoin-s/bitcoin-s/issues/2962
-        (first, second) match {
-          case (true, true) => true
-          case (true, false) =>
-            P2SHScriptPubKey.isValidAsm(conditional.secondSPK.asm)
-          case (false, true) =>
-            P2SHScriptPubKey.isValidAsm(conditional.firstSPK.asm)
-          case (false, false) =>
-            val isP2SHFirst =
-              P2SHScriptPubKey.isValidAsm(conditional.firstSPK.asm)
-            val isP2SHSecond =
-              P2SHScriptPubKey.isValidAsm(conditional.secondSPK.asm)
-
-            isP2SHFirst && isP2SHSecond
-        }
+        isStandardNonP2SH(conditional.firstSPK, true) &&
+          isStandardNonP2SH(conditional.secondSPK, true)
       case locktime: LockTimeScriptPubKey =>
         if (Try(locktime.locktime).isSuccess) {
           isStandardNonP2SH(locktime.nestedScriptPubKey, isRecursiveCall = true)


### PR DESCRIPTION
fixes #2962 

and

fixes #2960 

There is no reason we cannot have the script op codes `OP_HASH160 <bytes> OP_EQUAL` in a nested conditional script. It does occur a few times in the mainnet and testnet blockchains. This PR adjusts our parsing logic to account for this possible case. 