### PR TITLE
Allow `HttpFeeRateProvider` to have a specified return type

### DIFF
--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/BitGoFeeRateProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/BitGoFeeRateProvider.scala
@@ -14,7 +14,7 @@ import scala.util.{Failure, Success, Try}
   */
 case class BitGoFeeRateProvider(blockTargetOpt: Option[Int])(implicit
     override val system: ActorSystem)
-    extends CachedHttpFeeRateProvider {
+    extends CachedHttpFeeRateProvider[SatoshisPerKiloByte] {
 
   override val uri: Uri = Uri("https://www.bitgo.com/api/v2/btc/tx/fee")
 

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/BitcoinerLiveFeeRateProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/BitcoinerLiveFeeRateProvider.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Success, Try}
 
 case class BitcoinerLiveFeeRateProvider(minutes: Int)(implicit
     override val system: ActorSystem)
-    extends CachedHttpFeeRateProvider {
+    extends CachedHttpFeeRateProvider[SatoshisPerVirtualByte] {
 
   require(validMinutes.contains(minutes),
           s"$minutes is not a valid selection, must be from $validMinutes")

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/MempoolSpaceProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/MempoolSpaceProvider.scala
@@ -15,7 +15,7 @@ import scala.util.{Failure, Success, Try}
   */
 case class MempoolSpaceProvider(target: MempoolSpaceTarget)(implicit
     override val system: ActorSystem)
-    extends CachedHttpFeeRateProvider {
+    extends CachedHttpFeeRateProvider[SatoshisPerVirtualByte] {
 
   override val uri: Uri =
     Uri("https://mempool.space/api/v1/fees/recommended")


### PR DESCRIPTION
Makes it so we don't have to call `.asInstanceOf` when using a specific fee rate provider 