### PR TITLE
Name each database connection pool uniquely

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -20,7 +20,6 @@ bitcoin-s {
       # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
       numThreads = 1
       queueSize=5000
-      poolName = "bitcoin-s-db-pool"
       connectionPool = "HikariCP"
       registerMbeans = true
     }
@@ -39,6 +38,7 @@ bitcoin-s {
     # this config key is read by Slick
     db {
       name = nodedb
+      poolName = "bitcoin-s-node-db"
     }
     # PostgreSQL example:
     # db {
@@ -66,6 +66,7 @@ bitcoin-s {
     # this config key is read by Slick
     db {
         name = chaindb
+        poolName = "bitcoin-s-chain-db"
     }
     # PostgreSQL example:
     # db {
@@ -99,6 +100,7 @@ bitcoin-s {
     # this config key is read by Slick
     db {
       name = walletdb
+      poolName = "bitcoin-s-wallet-db"
     }
     # PostgreSQL example:
     # db {
@@ -121,6 +123,7 @@ bitcoin-s {
     db {
       name = oracle
       path = ${bitcoin-s.datadir}/oracle/
+      poolName = "bitcoin-s-oracle-db"
     }
     # PostgreSQL example:
     # db {


### PR DESCRIPTION
This fixes #2956 

Now each database connection pool in a module will have a unique name associated with them.