### PR TITLE
Reduce pg connections from 300 -> 50 in test cases

### DIFF
--- a/oracle-explorer-client/src/test/scala/org/bitcoins/explorer/client/SbExplorerClientTest.scala
+++ b/oracle-explorer-client/src/test/scala/org/bitcoins/explorer/client/SbExplorerClientTest.scala
@@ -19,7 +19,7 @@ class SbExplorerClientTest extends BitcoinSAsyncTest {
 
   behavior of "SbExplorerClient"
 
-  val explorerClient = SbExplorerClient(ExplorerEnv.Test)
+  val explorerClient = SbExplorerClient(ExplorerEnv.Production)
 
   //https://test.oracle.suredbits.com/event/57505dcdfe8746d9adf3454df538244a425f302c07642d9dc4a4f635fbf08d30
   private val announcementHex: String =

--- a/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
@@ -12,7 +12,8 @@ trait EmbeddedPg extends BeforeAndAfterAll { this: Suite =>
     if (pgEnabled) {
       val p = EmbeddedPostgres
         .builder()
-        .setServerConfig("max_connections", "50")
+        .setServerConfig("max_connections", "25")
+        .setServerConfig("shared_buffers", "32MB")
         .start()
       Some(p)
     } else {

--- a/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
@@ -13,7 +13,7 @@ trait EmbeddedPg extends BeforeAndAfterAll { this: Suite =>
       val p = EmbeddedPostgres
         .builder()
         .setServerConfig("max_connections", "25")
-        .setServerConfig("shared_buffers", "32MB")
+        .setServerConfig("shared_buffers", "1MB")
         .start()
       Some(p)
     } else {

--- a/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
@@ -7,8 +7,18 @@ trait EmbeddedPg extends BeforeAndAfterAll { this: Suite =>
 
   lazy val pgEnabled: Boolean = sys.env.contains("PG_ENABLED")
 
-  lazy val pg: Option[EmbeddedPostgres] =
-    if (pgEnabled) Some(EmbeddedPostgres.start()) else None
+  lazy val pg: Option[EmbeddedPostgres] = {
+
+    if (pgEnabled) {
+      val p = EmbeddedPostgres
+        .builder()
+        .setServerConfig("max_connections", "50")
+        .start()
+      Some(p)
+    } else {
+      None
+    }
+  }
 
   def pgUrl(): Option[String] =
     pg.map(_.getJdbcUrl(userName = "postgres", dbName = "postgres"))


### PR DESCRIPTION
This reduces the number of db connections used by `EmbeddedPg` from `300` -> `50`.

300 seems to be teh default for the library

```
        Builder() {
            config.put("timezone", "UTC");
            config.put("synchronous_commit", "off");
            config.put("max_connections", "300");
        }
```

https://github.com/opentable/otj-pg-embedded/blob/e303387659f6e7eaaec106fc57cadc5482cc53aa/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java#L463