### PR TITLE
Call WalletAppConfig.stop() when destroying wallet in test fixtures

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -583,6 +583,7 @@ object BitcoinSWalletTest extends WalletLogger {
       _ <- wallet.walletConfig.dropTable("flyway_schema_history")
       _ <- wallet.walletConfig.dropAll()
       _ <- wallet.stop()
+      _ <- wallet.walletConfig.stop()
     } yield ()
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -74,7 +74,7 @@ class BitcoindBackendTest
       syncHeightOpt <- wallet.getSyncDescriptorOpt()
       _ = assert(balance == amountToSend)
       _ = assert(syncHeightOpt.contains(SyncHeightDescriptor(bestHash, height)))
-      _ <- wallet.stop()
+      _ <- wallet.walletConfig.stop()
     } yield succeed
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
@@ -72,7 +72,7 @@ class BitcoindBlockPollingTest
 
       balance <- wallet.getBalance()
       //clean up
-      _ <- wallet.stop()
+      _ <- wallet.walletConfig.stop()
     } yield assert(balance == amountToSend)
   }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -25,7 +25,9 @@ import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.{
   ExecutorService,
   Executors,
+  ScheduledExecutorService,
   ScheduledFuture,
+  ThreadFactory,
   TimeUnit
 }
 import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
@@ -57,12 +59,14 @@ case class WalletAppConfig(
 
   override def appConfig: WalletAppConfig = this
 
-  private[wallet] lazy val scheduler = Executors.newScheduledThreadPool(
-    1,
-    AsyncUtil.getNewThreadFactory(
-      s"bitcoin-s-wallet-scheduler-${System.currentTimeMillis()}"))
+  private[wallet] lazy val scheduler: ScheduledExecutorService = {
+    Executors.newScheduledThreadPool(
+      1,
+      AsyncUtil.getNewThreadFactory(
+        s"bitcoin-s-wallet-scheduler-${System.currentTimeMillis()}"))
+  }
 
-  private lazy val rescanThreadFactory =
+  private lazy val rescanThreadFactory: ThreadFactory =
     AsyncUtil.getNewThreadFactory("bitcoin-s-rescan")
 
   /** Threads for rescanning the wallet */


### PR DESCRIPTION
In #2957  we made it so that `Wallet.stop()` no longer calls `WalletAppConfig.stop()`. 

However, in test fixtures, specifically when destroying the wallet, we need to make sure we call `WalletAppConfig.stop()` to free resources.