### PR TITLE
2021 04 27 wallet fixtures config

### DIFF
--- a/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
@@ -29,3 +29,4 @@ jobs:
           key: ${{ runner.os }}-cache
       - name: run tests
         run: sbt ++2.12.12 downloadBitcoind coverage chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls cryptoJVM/test cryptoTestJVM/test cryptoJVM/coverageReport cryptoJVM/coverageAggregate cryptoJVM/coveralls coreTestJVM/test coreJVM/coverageReport coreJVM/coverageAggregate coreJVM/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test oracleServerTest/test
+>chainTest/test;nodeTest/test;cryptoJVM/test;cryptoTestJVM/test;coreTestJVM/test;secp256k1jni/test;zmq/test;appCommonsTest/test;appServerTest/test;oracleServerTest/test

--- a/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
@@ -29,4 +29,3 @@ jobs:
           key: ${{ runner.os }}-cache
       - name: run tests
         run: sbt ++2.12.12 downloadBitcoind coverage chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls cryptoJVM/test cryptoTestJVM/test cryptoJVM/coverageReport cryptoJVM/coverageAggregate cryptoJVM/coveralls coreTestJVM/test coreJVM/coverageReport coreJVM/coverageAggregate coreJVM/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test oracleServerTest/test
->chainTest/test;nodeTest/test;cryptoJVM/test;cryptoTestJVM/test;coreTestJVM/test;secp256k1jni/test;zmq/test;appCommonsTest/test;appServerTest/test;oracleServerTest/test

--- a/docs/wallet/wallet-rescan.md
+++ b/docs/wallet/wallet-rescan.md
@@ -44,6 +44,7 @@ import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.fixtures._
 import org.bitcoins.testkit.wallet._
 import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.wallet.config.WalletAppConfig
 import akka.actor.ActorSystem
 import scala.concurrent.{ExecutionContext, Future, Await}
 import scala.concurrent.duration.DurationInt
@@ -55,6 +56,7 @@ import scala.concurrent.duration.DurationInt
 implicit val system: ActorSystem = ActorSystem(s"wallet-rescan-example")
 implicit val ec: ExecutionContext = system.dispatcher
 implicit val appConfig: BitcoinSAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig()
+implicit val walletAppConfig: WalletAppConfig = appConfig.walletConf
 
 val bip39PasswordOpt = None
 //ok now let's spin up a bitcoind and a bitcoin-s wallet with funds in it

--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -19,7 +19,7 @@ class BroadcastTransactionTest extends NodeTestWithCachedBitcoindV19 {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoindV19
 

--- a/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.FutureOutcome
 class DisconnectedPeerTest extends NodeUnitTest with CachedBitcoinSAppConfig {
 
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
 
   /** Wallet config with data directory set to user temp directory */
   implicit override protected lazy val cachedConfig: BitcoinSAppConfig =

--- a/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
@@ -2,24 +2,20 @@ package org.bitcoins.node
 
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.node.NodeUnitTest
 import org.bitcoins.testkitcore.Implicits._
 import org.bitcoins.testkitcore.gen.TransactionGenerators
-import org.bitcoins.testkit.node.{CachedBitcoinSAppConfig, NodeUnitTest}
 import org.scalatest.FutureOutcome
 
-class DisconnectedPeerTest extends NodeUnitTest with CachedBitcoinSAppConfig {
+class DisconnectedPeerTest extends NodeUnitTest {
 
   override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
 
-  /** Wallet config with data directory set to user temp directory */
-  implicit override protected lazy val cachedConfig: BitcoinSAppConfig =
-    getFreshConfig
-
   override type FixtureParam = SpvNode
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withDisconnectedSpvNode(test)(system, cachedConfig)
+    withDisconnectedSpvNode(test)(system, getFreshConfig)
 
   it must "fail to broadcast a transaction when disconnected" in { node =>
     val tx = TransactionGenerators.transaction.sampleSome

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -4,7 +4,6 @@ import akka.actor.Cancellable
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
-import org.bitcoins.testkit.fixtures.UsesExperimentalBitcoind
 import org.bitcoins.testkit.node.fixture.NeutrinoNodeConnectedWithBitcoind
 import org.bitcoins.testkit.node.{
   NodeTestUtil,
@@ -35,7 +34,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindNewest {
 
   behavior of "NeutrinoNode"
 
-  it must "receive notification that a block occurred on the p2p network" taggedAs UsesExperimentalBitcoind in {
+  it must "receive notification that a block occurred on the p2p network for neutrino" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoind =>
       val node = nodeConnectedWithBitcoind.node
 
@@ -62,7 +61,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindNewest {
       }
   }
 
-  it must "stay in sync with a bitcoind instance" taggedAs UsesExperimentalBitcoind in {
+  it must "stay in sync with a bitcoind instance for neutrino" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoind =>
       val node = nodeConnectedWithBitcoind.node
       val bitcoind = nodeConnectedWithBitcoind.bitcoind

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
@@ -19,7 +19,7 @@ class SpvNodeTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
@@ -19,7 +19,7 @@ class SpvNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
 
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -16,7 +16,7 @@ class UpdateBloomFilterTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
 
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAOTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAOTest.scala
@@ -10,7 +10,7 @@ class BroadcastAbleTransactionDAOTest extends NodeDAOFixture with EmbeddedPg {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
 
   behavior of "BroadcastAbleTransactionDAO"
 

--- a/node-test/src/test/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAOTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAOTest.scala
@@ -1,16 +1,10 @@
 package org.bitcoins.node.models
 
-import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.fixtures.NodeDAOFixture
 import org.bitcoins.testkitcore.Implicits._
 import org.bitcoins.testkitcore.gen.TransactionGenerators
-import org.bitcoins.testkit.fixtures.NodeDAOFixture
-import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 
-class BroadcastAbleTransactionDAOTest extends NodeDAOFixture with EmbeddedPg {
-
-  /** Wallet config with data directory set to user temp directory */
-  override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
+class BroadcastAbleTransactionDAOTest extends NodeDAOFixture {
 
   behavior of "BroadcastAbleTransactionDAO"
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -21,7 +21,7 @@ class DataMessageHandlerTest extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoindV19
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/MerkleBuffersTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/MerkleBuffersTest.scala
@@ -78,6 +78,10 @@ class MerkleBuffersTest extends BitcoinSAsyncTest with CachedBitcoinSAppConfig {
       }
 
     }
+  }
 
+  override def afterAll(): Unit = {
+    super[CachedBitcoinSAppConfig].afterAll()
+    super[BitcoinSAsyncTest].afterAll()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -52,7 +52,8 @@ object BitcoinSTestAppConfig {
 
   def getSpvWithEmbeddedDbTestConfig(
       pgUrl: () => Option[String],
-      config: Config*)(implicit ec: ExecutionContext): BitcoinSAppConfig = {
+      config: Vector[Config])(implicit
+      ec: ExecutionContext): BitcoinSAppConfig = {
     val overrideConf = ConfigFactory
       .parseString {
         """

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -580,7 +580,11 @@ object ChainUnitTest extends ChainVerificationLogger {
     val stopBitcoindF =
       BitcoindRpcTestUtil.stopServer(bitcoindChainHandler.bitcoindRpc)
     val dropTableF = ChainUnitTest.destroyAllTables()
-    stopBitcoindF.flatMap(_ => dropTableF)
+    val stoppedChainAppConfigF = dropTableF.flatMap(_ => chainAppConfig.stop())
+    for {
+      _ <- stopBitcoindF
+      _ <- stoppedChainAppConfigF
+    } yield ()
   }
 
   def destroyBitcoind(bitcoind: BitcoindRpcClient)(implicit

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/NodeDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/NodeDAOFixture.scala
@@ -1,7 +1,10 @@
 package org.bitcoins.testkit.fixtures
 
+import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.BroadcastAbleTransactionDAO
+import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.node.{CachedBitcoinSAppConfig, NodeUnitTest}
 import org.scalatest._
 
@@ -12,6 +15,10 @@ case class NodeDAOs(txDAO: BroadcastAbleTransactionDAO)
 /** Provides a fixture where all DAOs used by the node projects are provided */
 trait NodeDAOFixture extends NodeUnitTest with CachedBitcoinSAppConfig {
 
+  /** Wallet config with data directory set to user temp directory */
+  override protected def getFreshConfig: BitcoinSAppConfig =
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
+
   private lazy val daos = {
     val tx = BroadcastAbleTransactionDAO()
     NodeDAOs(tx)
@@ -21,17 +28,29 @@ trait NodeDAOFixture extends NodeUnitTest with CachedBitcoinSAppConfig {
 
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     makeFixture(build = () => {
-                  cachedNodeConf
-                    .start()
-                    .map(_ => daos)
+                  for {
+                    _ <- cachedChainConf.start()
+                    _ <- cachedNodeConf.start()
+                  } yield daos
                 },
-                destroy = () => destroyAppConfig(cachedNodeConf))(test)
+                destroy =
+                  () => destroyAppConfig(cachedChainConf, cachedNodeConf))(test)
   }
 
-  private def destroyAppConfig(nodeConfig: NodeAppConfig): Future[Unit] = {
+  private def destroyAppConfig(
+      chainConfig: ChainAppConfig,
+      nodeConfig: NodeAppConfig): Future[Unit] = {
+
     for {
       _ <- nodeConfig.dropAll()
       _ <- nodeConfig.stop()
+      _ <- chainConfig.dropAll()
+      _ <- chainConfig.stop()
     } yield ()
+  }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoinSAppConfig].afterAll()
+    super[NodeUnitTest].afterAll()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -1,12 +1,11 @@
 package org.bitcoins.testkit.node
 
 import akka.actor.ActorSystem
-import org.bitcoins.node.{Node, NodeType}
 import org.bitcoins.node.models.Peer
+import org.bitcoins.node.{Node, NodeType}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.server.BitcoinSAppConfig
-import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.node.NodeUnitTest.{createPeer, syncNeutrinoNode}
 import org.bitcoins.testkit.node.fixture.{
   NeutrinoNodeConnectedWithBitcoind,
@@ -146,8 +145,6 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest { _: CachedBitcoind[_] =>
     val destroyNodeF = NodeUnitTest.destroyNode(node)
     for {
       _ <- destroyNodeF
-      _ <- ChainUnitTest.destroyAllTables()(node.chainAppConfig,
-                                            system.dispatcher)
       //need to stop chainAppConfig too since this is a test
       _ <- node.chainAppConfig.stop()
     } yield ()

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -246,6 +246,7 @@ object NodeUnitTest extends P2PLogger {
   def destroyNode(node: Node)(implicit ec: ExecutionContext): Future[Unit] = {
     for {
       _ <- node.stop()
+      _ <- node.chainAppConfig.stop()
     } yield {
       ()
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -303,6 +303,7 @@ object NodeUnitTest extends P2PLogger {
     require(appConfig.nodeType == NodeType.SpvNode)
     for {
       node <- createSpvNode(createPeer(bitcoind))
+      _ <- appConfig.walletConf.start()
       fundedWallet <- BitcoinSWalletTest.fundedWalletAndBitcoind(
         bitcoind,
         node,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -14,7 +14,7 @@ import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.scalatest.AsyncTestSuite
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /** Base test trait for all the tests in our walletTest module */
 trait BaseWalletTest extends EmbeddedPg { _: AsyncTestSuite =>
@@ -39,10 +39,10 @@ trait BaseWalletTest extends EmbeddedPg { _: AsyncTestSuite =>
     "00000000496dcc754fabd97f3e2df0a7337eab417d75537fecf97a7ebb0e7c75")
 
   /** Wallet config with data directory set to user temp directory */
-  implicit protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl)
+  protected def getFreshConfig: BitcoinSAppConfig =
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
 
-  implicit protected def getFreshWalletAppConfig: WalletAppConfig = {
+  protected def getFreshWalletAppConfig: WalletAppConfig = {
     getFreshConfig.walletConf
   }
 
@@ -121,5 +121,21 @@ trait BaseWalletTest extends EmbeddedPg { _: AsyncTestSuite =>
       override def epochSecondToBlockHeight(time: Long): Future[Int] =
         Future.successful(0)
     }
+
+}
+
+object BaseWalletTest {
+
+  def getFreshConfig(pgUrl: () => Option[String], config: Vector[Config])(
+      implicit ec: ExecutionContext): BitcoinSAppConfig = {
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, config)
+  }
+
+  def getFreshWalletAppConfig(
+      pgUrl: () => Option[String],
+      config: Vector[Config])(implicit
+      ec: ExecutionContext): WalletAppConfig = {
+    getFreshConfig(pgUrl, config).walletConf
+  }
 
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -40,7 +40,7 @@ trait BaseWalletTest extends EmbeddedPg { _: AsyncTestSuite =>
 
   /** Wallet config with data directory set to user temp directory */
   protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
+    BaseWalletTest.getFreshConfig(pgUrl, Vector.empty)
 
   protected def getFreshWalletAppConfig: WalletAppConfig = {
     getFreshConfig.walletConf

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -46,13 +46,6 @@ trait BitcoinSWalletTest
     with EmbeddedPg {
   import BitcoinSWalletTest._
 
-  override def afterAll(): Unit = {
-    Await.result(getFreshConfig.chainConf.stop(), 1.minute)
-    Await.result(getFreshConfig.nodeConf.stop(), 1.minute)
-    Await.result(getFreshConfig.walletConf.stop(), 1.minute)
-    super.afterAll()
-  }
-
   def nodeApi: NodeApi = MockNodeApi
 
   /** Lets you customize the parameters for the created wallet */

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -29,7 +29,6 @@ import org.bitcoins.testkit.EmbeddedPg
 import org.bitcoins.testkit.chain.SyncUtil
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
-import org.bitcoins.testkit.util.FileUtil
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
 import org.bitcoins.testkitcore.Implicits.GeneratorOps
 import org.bitcoins.testkitcore.gen._
@@ -588,13 +587,9 @@ object BitcoinSWalletTest extends WalletLogger {
     } yield ()
   }
 
-  def destroyWalletAppConfig(walletAppConfig: WalletAppConfig)(implicit
-      ec: ExecutionContext): Future[Unit] = {
+  def destroyWalletAppConfig(walletAppConfig: WalletAppConfig): Future[Unit] = {
     val stoppedF = walletAppConfig.stop()
-    for {
-      _ <- stoppedF
-      _ = FileUtil.deleteTmpDir(walletAppConfig.datadir)
-    } yield ()
+    stoppedF
   }
 
   /** Constructs callbacks for the wallet from the node to process blocks and compact filters */

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -17,6 +17,7 @@ import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
   destroyWallet,
   fundWalletWithBitcoind
 }
+import org.bitcoins.wallet.config.WalletAppConfig
 import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
@@ -42,7 +43,8 @@ trait BitcoinSWalletTestCachedBitcoind
   def withFundedWalletAndBitcoindCached(
       test: OneArgAsyncTest,
       bip39PasswordOpt: Option[String],
-      bitcoind: BitcoindRpcClient): FutureOutcome = {
+      bitcoind: BitcoindRpcClient)(implicit
+      walletAppConfig: WalletAppConfig): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind] = { () =>
       for {
         walletWithBitcoind <- createWalletWithBitcoindCallbacks(
@@ -65,7 +67,8 @@ trait BitcoinSWalletTestCachedBitcoind
   def withNewWalletAndBitcoindCached(
       test: OneArgAsyncTest,
       bip39PasswordOpt: Option[String],
-      bitcoind: BitcoindRpcClient): FutureOutcome = {
+      bitcoind: BitcoindRpcClient)(implicit
+      walletAppConfig: WalletAppConfig): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind] = composeBuildersAndWrap(
       builder = { () =>
         Future.successful(bitcoind)
@@ -86,7 +89,8 @@ trait BitcoinSWalletTestCachedBitcoind
 
   def withFundedWalletAndBitcoind(
       test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String]): FutureOutcome = {
+      bip39PasswordOpt: Option[String])(implicit
+      walletAppConfig: WalletAppConfig): FutureOutcome = {
     val bitcoindF = BitcoinSFixture
       .createBitcoindWithFunds(None)
 
@@ -157,7 +161,8 @@ trait BitcoinSWalletTestCachedBitcoinV19
   def withFundedWalletAndBitcoindCachedV19(
       test: OneArgAsyncTest,
       bip39PasswordOpt: Option[String],
-      bitcoind: BitcoindV19RpcClient): FutureOutcome = {
+      bitcoind: BitcoindV19RpcClient)(implicit
+      walletAppConfig: WalletAppConfig): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoindV19] = { () =>
       for {
         walletWithBitcoind <- createWalletWithBitcoindCallbacks(
@@ -183,7 +188,8 @@ trait BitcoinSWalletTestCachedBitcoinV19
   def withNewWalletAndBitcoindCachedV19(
       test: OneArgAsyncTest,
       bip39PasswordOpt: Option[String],
-      bitcoind: BitcoindV19RpcClient): FutureOutcome = {
+      bitcoind: BitcoindV19RpcClient)(implicit
+      walletAppConfig: WalletAppConfig): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind] = composeBuildersAndWrap(
       builder = { () =>
         Future.successful(bitcoind)
@@ -207,9 +213,10 @@ trait BitcoinSWalletTestCachedBitcoinV19
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withFundedWalletAndBitcoindCachedV19(test,
-                                                        getBIP39PasswordOpt(),
-                                                        bitcoind)
+      futOutcome = withFundedWalletAndBitcoindCachedV19(
+        test,
+        getBIP39PasswordOpt(),
+        bitcoind)(getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -2,19 +2,19 @@ package org.bitcoins.testkit.wallet
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import grizzled.slf4j.Logging
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.TransactionOutput
-import grizzled.slf4j.Logging
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
 import org.bitcoins.testkitcore.util.TransactionTestUtil
 import org.bitcoins.wallet.Wallet
+import org.bitcoins.wallet.config.WalletAppConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -129,7 +129,7 @@ object FundWalletUtil extends FundWalletUtil {
       chainQueryApi: ChainQueryApi,
       bip39PasswordOpt: Option[String],
       extraConfig: Option[Config] = None)(implicit
-      config: BitcoinSAppConfig,
+      config: WalletAppConfig,
       system: ActorSystem): Future[FundedWallet] = {
 
     import system.dispatcher

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletAppConfigWithBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletAppConfigWithBitcoind.scala
@@ -1,0 +1,13 @@
+package org.bitcoins.testkit.wallet
+
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.wallet.config.WalletAppConfig
+
+sealed trait WalletAppConfigWithBitcoind {
+  def bitcoind: BitcoindRpcClient
+  def walletAppConfig: WalletAppConfig
+}
+
+case class WalletAppConfigWithBitcoindRpc(
+    walletAppConfig: WalletAppConfig,
+    bitcoind: BitcoindRpcClient)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletAppConfigWithBitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletAppConfigWithBitcoindFixtures.scala
@@ -1,0 +1,63 @@
+package org.bitcoins.testkit.wallet
+
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.testkit.EmbeddedPg
+import org.bitcoins.testkit.rpc.{
+  BitcoindFixturesCached,
+  CachedBitcoind,
+  CachedBitcoindNewest
+}
+import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
+import org.scalatest.{FutureOutcome, Outcome}
+
+import scala.concurrent.Future
+
+trait WalletAppConfigWithBitcoindFixtures
+    extends BitcoinSAsyncFixtureTest
+    with BitcoindFixturesCached
+    with EmbeddedPg { _: CachedBitcoind[_] =>
+
+  override def afterAll(): Unit = {
+    super[BitcoinSAsyncFixtureTest].afterAll()
+  }
+}
+
+trait WalletAppConfigWithBitcoindNewestFixtures
+    extends WalletAppConfigWithBitcoindFixtures
+    with CachedBitcoindNewest {
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindNewest].afterAll()
+    super[WalletAppConfigWithBitcoindFixtures].afterAll()
+  }
+
+  override type FixtureParam = WalletAppConfigWithBitcoindRpc
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val f: Future[Outcome] = for {
+      bitcoind <- cachedBitcoindWithFundsF
+      futOutcome = withWalletAppConfigBitcoindCached(test, bitcoind)
+      fut <- futOutcome.toFuture
+    } yield fut
+    new FutureOutcome(f)
+  }
+
+  def withWalletAppConfigBitcoindCached(
+      test: OneArgAsyncTest,
+      bitcoind: BitcoindRpcClient): FutureOutcome = {
+    makeDependentFixture[WalletAppConfigWithBitcoindRpc](
+      () => {
+        val walletConfig =
+          BaseWalletTest.getFreshWalletAppConfig(pgUrl, Vector.empty)
+        val model = WalletAppConfigWithBitcoindRpc(walletConfig, bitcoind)
+        Future.successful(model)
+      },
+      { case walletAppConfigWithBitcoindRpc =>
+        BitcoinSWalletTest.destroyWalletAppConfig(
+          walletAppConfigWithBitcoindRpc.walletAppConfig)
+      }
+    )(test)
+  }
+}
+
+object WalletAppConfigWithBitcoindFixtures {}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -21,7 +21,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
   type FixtureParam = FundedWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWallet(test, getBIP39PasswordOpt())
+    withFundedWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
   }
 
   behavior of "AddressHandling"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
@@ -18,7 +18,7 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
   override type FixtureParam = WalletWithBitcoind
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withNewWalletAndBitcoind(test)
+    withNewWalletAndBitcoind(test)(getFreshWalletAppConfig)
 
   behavior of "Address Tag - integration test"
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -2,43 +2,18 @@ package org.bitcoins.wallet
 
 import org.bitcoins.commons.jsonmodels.wallet.SyncHeightDescriptor
 import org.bitcoins.core.currency._
-import org.bitcoins.db.AppConfig
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.server.{BitcoinSAppConfig, BitcoindRpcBackendUtil}
-import org.bitcoins.testkit.rpc.{
-  BitcoindFixturesFundedCached,
-  CachedBitcoindNewest
+import org.bitcoins.server.BitcoindRpcBackendUtil
+import org.bitcoins.testkit.wallet.{
+  BitcoinSWalletTest,
+  WalletAppConfigWithBitcoindNewestFixtures
 }
-import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 
-class BitcoindBackendTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesFundedCached
-    with CachedBitcoindNewest
-    with EmbeddedPg {
+class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
 
-  override type FixtureParam = BitcoindRpcClient
-
-  /** Wallet config with data directory set to user temp directory */
-
-  implicit protected def config: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
-
-  override def beforeAll(): Unit = {
-    AppConfig.throwIfDefaultDatadir(config.walletConf)
-    super[EmbeddedPg].beforeAll()
-  }
-
-  override def afterAll(): Unit = {
-    super[CachedBitcoindNewest].afterAll()
-    super[EmbeddedPg].afterAll()
-  }
-
-  it must "correctly catch up to bitcoind" in { bitcoind =>
+  it must "correctly catch up to bitcoind" in { walletAppConfigWithBitcoind =>
+    val bitcoind = walletAppConfigWithBitcoind.bitcoind
+    implicit val walletAppConfig = walletAppConfigWithBitcoind.walletAppConfig
     val amountToSend = Bitcoins.one
-
     for {
       header <- bitcoind.getBestBlockHeader()
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
@@ -2,77 +2,57 @@ package org.bitcoins.wallet
 
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.currency._
-import org.bitcoins.db.AppConfig
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.server.{BitcoinSAppConfig, BitcoindRpcBackendUtil}
-import org.bitcoins.testkit.rpc.{
-  BitcoindFixturesFundedCached,
-  CachedBitcoindNewest
+import org.bitcoins.server.BitcoindRpcBackendUtil
+import org.bitcoins.testkit.wallet.{
+  BitcoinSWalletTest,
+  WalletAppConfigWithBitcoindNewestFixtures
 }
-import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
-import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 
 import scala.concurrent.duration.DurationInt
 
 class BitcoindBlockPollingTest
-    extends BitcoinSAsyncFixtureTest
-    with BitcoindFixturesFundedCached
-    with CachedBitcoindNewest
-    with EmbeddedPg {
+    extends WalletAppConfigWithBitcoindNewestFixtures {
 
-  override type FixtureParam = BitcoindRpcClient
+  it must "properly setup and poll blocks from bitcoind" in {
+    walletAppConfigWithBitcoind =>
+      val bitcoind = walletAppConfigWithBitcoind.bitcoind
+      implicit val walletAppConfig = walletAppConfigWithBitcoind.walletAppConfig
 
-  /** Wallet config with data directory set to user temp directory */
-  implicit protected def config: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+      val amountToSend = Bitcoins.one
 
-  override def beforeAll(): Unit = {
-    AppConfig.throwIfDefaultDatadir(config.walletConf)
-    super[EmbeddedPg].beforeAll()
-  }
+      for {
+        // Setup wallet
+        tmpWallet <-
+          BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind, None)
+        wallet =
+          BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(bitcoind,
+                                                                   tmpWallet)
+        // Assert wallet is empty
+        isEmpty <- wallet.isEmpty()
+        _ = assert(isEmpty)
 
-  override def afterAll(): Unit = {
-    super[CachedBitcoindNewest].afterAll()
-    super[EmbeddedPg].afterAll()
-  }
+        // Send to wallet
+        addr <- wallet.getNewAddress()
+        _ <- bitcoind.sendToAddress(addr, amountToSend)
 
-  it must "properly setup and poll blocks from bitcoind" in { bitcoind =>
-    val amountToSend = Bitcoins.one
+        // assert wallet hasn't seen it yet
+        firstBalance <- wallet.getBalance()
+        _ = assert(firstBalance == Satoshis.zero)
 
-    for {
-      // Setup wallet
-      tmpWallet <-
-        BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind, None)
-      wallet =
-        BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(bitcoind,
-                                                                 tmpWallet)
-      // Assert wallet is empty
-      isEmpty <- wallet.isEmpty()
-      _ = assert(isEmpty)
+        // Setup block polling
+        _ = BitcoindRpcBackendUtil.startBitcoindBlockPolling(wallet,
+                                                             bitcoind,
+                                                             1.second)
+        _ <- bitcoind.generateToAddress(6, addr)
 
-      // Send to wallet
-      addr <- wallet.getNewAddress()
-      _ <- bitcoind.sendToAddress(addr, amountToSend)
+        // Wait for it to process
+        _ <- AsyncUtil.awaitConditionF(
+          () => wallet.getBalance().map(_ > Satoshis.zero),
+          1.second)
 
-      // assert wallet hasn't seen it yet
-      firstBalance <- wallet.getBalance()
-      _ = assert(firstBalance == Satoshis.zero)
-
-      // Setup block polling
-      _ = BitcoindRpcBackendUtil.startBitcoindBlockPolling(wallet,
-                                                           bitcoind,
-                                                           1.second)
-      _ <- bitcoind.generateToAddress(6, addr)
-
-      // Wait for it to process
-      _ <- AsyncUtil.awaitConditionF(
-        () => wallet.getBalance().map(_ > Satoshis.zero),
-        1.second)
-
-      balance <- wallet.getBalance()
-      //clean up
-      _ <- wallet.walletConfig.stop()
-    } yield assert(balance == amountToSend)
+        balance <- wallet.getBalance()
+        //clean up
+        _ <- wallet.walletConfig.stop()
+      } yield assert(balance == amountToSend)
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -23,9 +23,10 @@ class FundTransactionHandlingTest
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withFundedWalletAndBitcoindCached(test,
-                                                     getBIP39PasswordOpt(),
-                                                     bitcoind)
+      futOutcome = withFundedWalletAndBitcoindCached(
+        test,
+        getBIP39PasswordOpt(),
+        bitcoind)(getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -20,9 +20,10 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withNewWalletAndBitcoindCachedV19(test,
-                                                     getBIP39PasswordOpt(),
-                                                     bitcoind)
+      futOutcome = withNewWalletAndBitcoindCachedV19(
+        test,
+        getBIP39PasswordOpt(),
+        bitcoind)(getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -14,7 +14,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
   override type FixtureParam = WalletApi
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withNewWallet(test, getBIP39PasswordOpt())
+    withNewWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
   }
 
   behavior of "Wallet.processTransaction"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
 class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoinV19 {
 
   /** Wallet config with data directory set to user temp directory */
-  implicit override protected def getFreshConfig: BitcoinSAppConfig =
+  override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = WalletWithBitcoind

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -241,7 +241,7 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
       case other                   => fail(s"unknown purpose: $other")
     }
 
-    for {
+    val assertionsF: Future[Seq[Assertion]] = for {
       wallet <- getWallet(conf)
       existingAccounts <- wallet.listAccounts(purpose)
       _ <- createNeededAccounts(wallet,
@@ -290,9 +290,11 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
           }
         nestedAssertions.flatten
       }
+      assertions
+    }
 
-      wallet.stop()
-      assert(assertions.forall(_.isCompleted))
+    assertionsF.flatMap { _ =>
+      conf.stop().map(_ => succeed)
     }
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
@@ -14,7 +14,7 @@ class UTXOHandlingTest extends BitcoinSWalletTest {
   override type FixtureParam = Wallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withNewWallet(test, getBIP39PasswordOpt())
+    withNewWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
   }
 
   it must "correctly update txo state based on confirmations" in { wallet =>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -28,9 +28,10 @@ class UTXOLifeCycleTest extends BitcoinSWalletTestCachedBitcoindNewest {
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withFundedWalletAndBitcoindCached(test,
-                                                     getBIP39PasswordOpt(),
-                                                     bitcoind)
+      futOutcome = withFundedWalletAndBitcoindCached(
+        test,
+        getBIP39PasswordOpt(),
+        bitcoind)(getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletBloomTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletBloomTest.scala
@@ -19,9 +19,10 @@ class WalletBloomTest extends BitcoinSWalletTestCachedBitcoindNewest {
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withFundedWalletAndBitcoindCached(test,
-                                                     getBIP39PasswordOpt(),
-                                                     bitcoind)
+      futOutcome = withFundedWalletAndBitcoindCached(
+        test,
+        getBIP39PasswordOpt(),
+        bitcoind)(getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
@@ -13,7 +13,7 @@ class WalletCallbackTest extends BitcoinSWalletTest {
   type FixtureParam = FundedWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWallet(test, getBIP39PasswordOpt())
+    withFundedWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
   }
 
   behavior of "WalletCallbacks"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -27,9 +27,10 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withNewWalletAndBitcoindCached(test,
-                                                  getBIP39PasswordOpt(),
-                                                  bitcoind)
+      futOutcome = withNewWalletAndBitcoindCached(
+        test,
+        getBIP39PasswordOpt(),
+        bitcoind)(getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -33,7 +33,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
   override type FixtureParam = FundedWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withFundedWallet(test, getBIP39PasswordOpt())
+    withFundedWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
 
   behavior of "Wallet"
 


### PR DESCRIPTION
More cleanup of Wallet test fixtures.

This PR removes the `implicit` modifier from `def getFreshConfig` from `BaseWalletTest`

https://github.com/bitcoin-s/bitcoin-s/compare/master...Christewart:2021-04-27-wallet-fixtures-config?expand=1#diff-153e9b9a23d5616b9a3449a5c020050af40ae9679d399fb8fca9368959441e6bL42

The reason for doing this is because it is dangerous to bind things implicitly that allocate underlying resources on the OS as it isn't entirely clear that it is happening. For instance, in the `WalletUnitTest` we were binding a fresh configuration rather than using a pre-existing one. As a by product of this, we weren't cleaning up the resources of the thing being implicitly allocated because it wasn't clear that it was happening.

https://github.com/bitcoin-s/bitcoin-s/compare/master...Christewart:2021-04-27-wallet-fixtures-config?expand=1#diff-fc0a23e53629ded335e1f4a9b8b9fbe88cd884bd0ae992e63a8cc5283ccf0204L166

The purpose of this PR is to remove the implicit configuration and make it explicitly passed in places. Now that it is explicitly passed, it is easier to see when it needs to be cleaned up.

In general, we should move the configuration allocation into the fixtures rather than having them as class level parameters  in super classes. That way our normal fixture allocation and destruction code can handle the cleaning up of resources.