### PR TITLE
Make sure call ci matrixs run on java11

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -17,6 +17,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -16,6 +16,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.12_App_Chain_Node_Core_Tests.yml
@@ -17,6 +17,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
@@ -17,6 +17,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Linux_2.12_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.12_RPC_Tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Linux_2.13_App_Chain_Node_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Node_Core_Tests.yml
@@ -17,6 +17,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -17,6 +17,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Linux_2.13_ScalaJS_Tests.yml
+++ b/.github/workflows/Linux_2.13_ScalaJS_Tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -17,6 +17,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -19,6 +19,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Secp_Disabled_Tests.yml
+++ b/.github/workflows/Secp_Disabled_Tests.yml
@@ -19,6 +19,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -20,6 +20,8 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - run: git fetch --tags || true
       - run: sbt cli/nativeImage
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: zulu@1.11
       - uses: olafurpg/setup-gpg@v3
       - run: sbt ci-release docs/publishWebsite
         env:


### PR DESCRIPTION
By default, our ci workflow `setup-scala` uses java8. Now with #2976 we require developers working on bitcoin-s to have at least java9 (`-release` was introduced in java9). 

This PR bumps our CI workflows to use java11, which is the oldest LTS that supports `-release`. 