### PR TITLE
Refactor BitcoinSRunner to use StartStop[Async]

### DIFF
--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
@@ -21,7 +21,7 @@ class ScanBitcoind(override val args: Array[String]) extends BitcoinSRunner {
   implicit val rpcAppConfig: BitcoindRpcAppConfig =
     BitcoindRpcAppConfig(datadir, baseConfig)
 
-  override def startup: Future[Unit] = {
+  override def start(): Future[Unit] = {
 
     val bitcoind = rpcAppConfig.client
 
@@ -31,11 +31,15 @@ class ScanBitcoind(override val args: Array[String]) extends BitcoinSRunner {
     for {
       endHeight <- endHeightF
       _ <- countSegwitTxs(bitcoind, startHeight, endHeight)
-      _ <- system.terminate()
     } yield {
       sys.exit(0)
     }
+  }
 
+  override def stop(): Future[Unit] = {
+    system
+      .terminate()
+      .map(_ => ())
   }
 
   /** Searches a given Source[Int] that represents block heights applying f to them and returning a Seq[T] with the results */

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
@@ -14,7 +14,7 @@ class ZipDatadir(override val args: Array[String]) extends BitcoinSRunner {
   implicit lazy val conf: BitcoinSAppConfig =
     BitcoinSAppConfig(datadir, baseConfig)
 
-  override def startup: Future[Unit] = {
+  override def start(): Future[Unit] = {
 
     //replace the line below with where you want to zip too
     val path = Paths.get("/tmp", "bitcoin-s.zip")
@@ -24,6 +24,8 @@ class ZipDatadir(override val args: Array[String]) extends BitcoinSRunner {
       _ <- system.terminate()
     } yield sys.exit(0)
   }
+
+  override def stop(): Future[Unit] = Future.unit
 }
 
 object Zip extends App {

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
@@ -4,15 +4,15 @@ import akka.actor.ActorSystem
 import com.typesafe.config.{Config, ConfigFactory}
 import grizzled.slf4j.Logging
 import org.bitcoins.core.config._
-import org.bitcoins.core.util.EnvUtil
+import org.bitcoins.core.util.{EnvUtil, StartStopAsync}
 import org.bitcoins.db.AppConfig
 import org.bitcoins.db.AppConfig.safePathToString
 
 import java.nio.file.{Path, Paths}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 import scala.util.Properties
 
-trait BitcoinSRunner extends Logging {
+trait BitcoinSRunner extends StartStopAsync[Unit] with Logging {
 
   protected def args: Array[String]
 
@@ -88,8 +88,6 @@ trait BitcoinSRunner extends Logging {
   lazy val datadir: Path =
     Paths.get(baseConfig.getString("bitcoin-s.datadir"))
 
-  def startup: Future[Unit]
-
   // start everything!
   final def run(customFinalDirOpt: Option[String] = None): Unit = {
 
@@ -131,7 +129,7 @@ trait BitcoinSRunner extends Logging {
     logger.info(s"version=${EnvUtil.getVersion}")
 
     logger.info(s"using directory ${usedDir.toAbsolutePath.toString}")
-    val runner = startup
+    val runner = start()
     runner.failed.foreach { err =>
       logger.error(s"Failed to startup server!", err)
       sys.exit(1)

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
@@ -9,7 +9,7 @@ import org.bitcoins.db.AppConfig
 import org.bitcoins.db.AppConfig.safePathToString
 
 import java.nio.file.{Path, Paths}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Properties
 
 trait BitcoinSRunner extends StartStopAsync[Unit] with Logging {
@@ -129,10 +129,9 @@ trait BitcoinSRunner extends StartStopAsync[Unit] with Logging {
     logger.info(s"version=${EnvUtil.getVersion}")
 
     logger.info(s"using directory ${usedDir.toAbsolutePath.toString}")
-    val runner = start()
+    val runner: Future[Unit] = start()
     runner.failed.foreach { err =>
       logger.error(s"Failed to startup server!", err)
-      sys.exit(1)
     }(scala.concurrent.ExecutionContext.Implicits.global)
   }
 }

--- a/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.server
 
-import java.nio.file._
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.BitcoinSTestAppConfig
@@ -8,6 +7,7 @@ import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.util.{AkkaUtil, BitcoinSAsyncTest}
 import org.scalatest.Assertion
 
+import java.nio.file._
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.reflect.io.Directory
@@ -75,13 +75,16 @@ class ServerRunTest extends BitcoinSAsyncTest {
                    "--rpcport",
                    randPort.toString)
 
+      main = new BitcoinSServerMain(args)
+
       // Start the server in a separate thread
       runnable = new Runnable {
-        override def run(): Unit = new BitcoinSServerMain(args).run()
+        override def run(): Unit = {
+          main.run()
+        }
       }
       thread = new Thread(runnable)
       _ = thread.start()
-
       // Wait for the server to have successfully started up
       _ <- AkkaUtil.nonBlockingSleep(1.second)
       binding <- BitcoinSServer.startedF
@@ -90,6 +93,7 @@ class ServerRunTest extends BitcoinSAsyncTest {
       _ <- bitcoind.stop()
       _ <- binding.terminate(5.seconds)
       _ = thread.interrupt()
+      _ <- main.stop()
     } yield {
       // Cleanup
       directory.deleteRecursively()

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -23,7 +23,8 @@ import org.bitcoins.server.routes.{BitcoinSRunner, Server}
 import org.bitcoins.wallet.Wallet
 import org.bitcoins.wallet.config.WalletAppConfig
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 
 class BitcoinSServerMain(override val args: Array[String])
     extends BitcoinSRunner {
@@ -33,164 +34,12 @@ class BitcoinSServerMain(override val args: Array[String])
   implicit lazy val conf: BitcoinSAppConfig =
     BitcoinSAppConfig(datadir, baseConfig)
 
-  def startup: Future[Unit] = {
+  implicit lazy val walletConf: WalletAppConfig = conf.walletConf
+  implicit lazy val nodeConf: NodeAppConfig = conf.nodeConf
+  implicit lazy val chainConf: ChainAppConfig = conf.chainConf
+  implicit lazy val bitcoindRpcConf: BitcoindRpcAppConfig = conf.bitcoindRpcConf
 
-    implicit val walletConf: WalletAppConfig = conf.walletConf
-    implicit val nodeConf: NodeAppConfig = conf.nodeConf
-    implicit val chainConf: ChainAppConfig = conf.chainConf
-    implicit val bitcoindRpcConf: BitcoindRpcAppConfig = conf.bitcoindRpcConf
-
-    def startBitcoinSBackend(): Future[Unit] = {
-      if (nodeConf.peers.isEmpty) {
-        throw new IllegalArgumentException(
-          "No peers specified, unable to start node")
-      }
-
-      val peerSocket =
-        NetworkUtil.parseInetSocketAddress(nodeConf.peers.head,
-                                           nodeConf.network.port)
-      val peer = Peer.fromSocket(peerSocket)
-
-      //initialize the config, run migrations
-      val configInitializedF = conf.start()
-
-      //run chain work migration
-      val chainApiF = configInitializedF.flatMap { _ =>
-        runChainWorkCalc(forceChainWorkRecalc || chainConf.forceRecalcChainWork)
-      }
-
-      //get a node that isn't started
-      val nodeF = configInitializedF.flatMap { _ =>
-        nodeConf.createNode(peer)(chainConf, system)
-      }
-
-      //get our wallet
-      val configuredWalletF = for {
-        _ <- configInitializedF
-        node <- nodeF
-        chainApi <- chainApiF
-        _ = logger.info("Initialized chain api")
-        feeProvider = getFeeProviderOrElse(MempoolSpaceProvider(HourFeeTarget))
-        wallet <- walletConf.createHDWallet(node, chainApi, feeProvider)
-        callbacks <- createCallbacks(wallet)
-        _ = nodeConf.addCallbacks(callbacks)
-      } yield {
-        logger.info(s"Done configuring wallet")
-        wallet
-      }
-
-      //add callbacks to our uninitialized node
-      val configuredNodeF = for {
-        node <- nodeF
-        wallet <- configuredWalletF
-        initNode <- setBloomFilter(node, wallet)
-      } yield {
-        logger.info(s"Done configuring node")
-        initNode
-      }
-
-      //start our http server now that we are synced
-      for {
-        node <- configuredNodeF
-        wallet <- configuredWalletF
-        _ <- node.start()
-        _ <- wallet.start().recoverWith {
-          //https://github.com/bitcoin-s/bitcoin-s/issues/2917
-          //https://github.com/bitcoin-s/bitcoin-s/pull/2918
-          case err: IllegalArgumentException
-              if err.getMessage.contains("If we have spent a spendinginfodb") =>
-            handleMissingSpendingInfoDb(err, wallet)
-        }
-        cachedChainApi <- node.chainApiFromDb()
-        chainApi = ChainHandler.fromChainHandlerCached(cachedChainApi)
-        binding <- startHttpServer(nodeApi = node,
-                                   chainApi = chainApi,
-                                   wallet = wallet,
-                                   rpcbindOpt = rpcBindOpt,
-                                   rpcPortOpt = rpcPortOpt)
-        _ = {
-          logger.info(s"Starting ${nodeConf.nodeType.shortName} node sync")
-        }
-        _ = BitcoinSServer.startedFP.success(Future.successful(binding))
-
-        _ <- node.sync()
-      } yield {
-        logger.info(s"Done starting Main!")
-        sys.addShutdownHook {
-          logger.error(s"Exiting process")
-
-          wallet.stop()
-
-          node
-            .stop()
-            .foreach(_ =>
-              logger.info(s"Stopped ${nodeConf.nodeType.shortName} node"))
-          system
-            .terminate()
-            .foreach(_ => logger.info(s"Actor system terminated"))
-        }
-        ()
-      }
-    }
-
-    def startBitcoindBackend(): Future[Unit] = {
-      val bitcoind = bitcoindRpcConf.client
-
-      for {
-        _ <- conf.start()
-        _ = logger.info("Starting bitcoind")
-        _ <- bitcoindRpcConf.start()
-        _ = logger.info("Creating wallet")
-        feeProvider = getFeeProviderOrElse(bitcoind)
-        tmpWallet <- walletConf.createHDWallet(nodeApi = bitcoind,
-                                               chainQueryApi = bitcoind,
-                                               feeRateApi = feeProvider)
-        wallet = BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(
-          bitcoind,
-          tmpWallet)
-        _ = logger.info("Starting wallet")
-        _ <- wallet.start().recoverWith {
-          //https://github.com/bitcoin-s/bitcoin-s/issues/2917
-          //https://github.com/bitcoin-s/bitcoin-s/pull/2918
-          case err: IllegalArgumentException
-              if err.getMessage.contains("If we have spent a spendinginfodb") =>
-            handleMissingSpendingInfoDb(err, wallet)
-        }
-        _ = BitcoindRpcBackendUtil
-          .syncWalletToBitcoind(bitcoind, wallet)
-          .flatMap { _ =>
-            if (bitcoindRpcConf.zmqConfig == ZmqConfig.empty) {
-              BitcoindRpcBackendUtil.startBitcoindBlockPolling(wallet, bitcoind)
-            } else Future.unit
-          }
-
-        // Create callbacks for processing new blocks
-        _ =
-          if (bitcoindRpcConf.zmqConfig != ZmqConfig.empty) {
-            BitcoindRpcBackendUtil.startZMQWalletCallbacks(wallet)
-          }
-
-        binding <- startHttpServer(nodeApi = bitcoind,
-                                   chainApi = bitcoind,
-                                   wallet = wallet,
-                                   rpcbindOpt = rpcBindOpt,
-                                   rpcPortOpt = rpcPortOpt)
-        _ = BitcoinSServer.startedFP.success(Future.successful(binding))
-      } yield {
-        logger.info(s"Done starting Main!")
-        sys.addShutdownHook {
-          logger.error(s"Exiting process")
-
-          wallet.stop()
-
-          system
-            .terminate()
-            .foreach(_ => logger.info(s"Actor system terminated"))
-        }
-        ()
-      }
-    }
-
+  override def start(): Future[Unit] = {
     val startFut = nodeConf.nodeType match {
       case _: InternalImplementationNodeType =>
         startBitcoinSBackend()
@@ -204,6 +53,161 @@ class BitcoinSServerMain(override val args: Array[String])
       throw err
     }
     startFut
+  }
+
+  override def stop(): Future[Unit] = {
+    logger.error(s"Exiting process")
+    for {
+      _ <- walletConf.stop()
+      _ <- nodeConf.stop()
+      _ <- chainConf.stop()
+      _ = logger.info(s"Stopped ${nodeConf.nodeType.shortName} node")
+      _ <- system.terminate()
+    } yield {
+      logger.info(s"Actor system terminated")
+      ()
+    }
+  }
+
+  def startBitcoinSBackend(): Future[Unit] = {
+    if (nodeConf.peers.isEmpty) {
+      throw new IllegalArgumentException(
+        "No peers specified, unable to start node")
+    }
+
+    val peerSocket =
+      NetworkUtil.parseInetSocketAddress(nodeConf.peers.head,
+                                         nodeConf.network.port)
+    val peer = Peer.fromSocket(peerSocket)
+
+    //initialize the config, run migrations
+    val configInitializedF = conf.start()
+
+    //run chain work migration
+    val chainApiF = configInitializedF.flatMap { _ =>
+      runChainWorkCalc(forceChainWorkRecalc || chainConf.forceRecalcChainWork)
+    }
+
+    //get a node that isn't started
+    val nodeF = configInitializedF.flatMap { _ =>
+      nodeConf.createNode(peer)(chainConf, system)
+    }
+
+    //get our wallet
+    val configuredWalletF = for {
+      _ <- configInitializedF
+      node <- nodeF
+      chainApi <- chainApiF
+      _ = logger.info("Initialized chain api")
+      feeProvider = getFeeProviderOrElse(MempoolSpaceProvider(HourFeeTarget))
+      wallet <- walletConf.createHDWallet(node, chainApi, feeProvider)
+      callbacks <- createCallbacks(wallet)
+      _ = nodeConf.addCallbacks(callbacks)
+    } yield {
+      logger.info(s"Done configuring wallet")
+      wallet
+    }
+
+    //add callbacks to our uninitialized node
+    val configuredNodeF = for {
+      node <- nodeF
+      wallet <- configuredWalletF
+      initNode <- setBloomFilter(node, wallet)
+    } yield {
+      logger.info(s"Done configuring node")
+      initNode
+    }
+
+    //start our http server now that we are synced
+    for {
+      node <- configuredNodeF
+      wallet <- configuredWalletF
+      _ <- node.start()
+      _ <- wallet.start().recoverWith {
+        //https://github.com/bitcoin-s/bitcoin-s/issues/2917
+        //https://github.com/bitcoin-s/bitcoin-s/pull/2918
+        case err: IllegalArgumentException
+            if err.getMessage.contains("If we have spent a spendinginfodb") =>
+          handleMissingSpendingInfoDb(err, wallet)
+      }
+      cachedChainApi <- node.chainApiFromDb()
+      chainApi = ChainHandler.fromChainHandlerCached(cachedChainApi)
+      binding <- startHttpServer(nodeApi = node,
+                                 chainApi = chainApi,
+                                 wallet = wallet,
+                                 rpcbindOpt = rpcBindOpt,
+                                 rpcPortOpt = rpcPortOpt)
+      _ = {
+        logger.info(s"Starting ${nodeConf.nodeType.shortName} node sync")
+      }
+      _ = BitcoinSServer.startedFP.success(Future.successful(binding))
+
+      _ <- node.sync()
+    } yield {
+      logger.info(s"Done starting Main!")
+      sys.addShutdownHook {
+        Await.result(stop(), 10.seconds)
+      }
+      ()
+    }
+  }
+
+  def startBitcoindBackend(): Future[Unit] = {
+    val bitcoind = bitcoindRpcConf.client
+
+    for {
+      _ <- conf.start()
+      _ = logger.info("Starting bitcoind")
+      _ <- bitcoindRpcConf.start()
+      _ = logger.info("Creating wallet")
+      feeProvider = getFeeProviderOrElse(bitcoind)
+      tmpWallet <- walletConf.createHDWallet(nodeApi = bitcoind,
+                                             chainQueryApi = bitcoind,
+                                             feeRateApi = feeProvider)
+      wallet = BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(
+        bitcoind,
+        tmpWallet)
+      _ = logger.info("Starting wallet")
+      _ <- wallet.start().recoverWith {
+        //https://github.com/bitcoin-s/bitcoin-s/issues/2917
+        //https://github.com/bitcoin-s/bitcoin-s/pull/2918
+        case err: IllegalArgumentException
+            if err.getMessage.contains("If we have spent a spendinginfodb") =>
+          handleMissingSpendingInfoDb(err, wallet)
+      }
+      _ = BitcoindRpcBackendUtil
+        .syncWalletToBitcoind(bitcoind, wallet)
+        .flatMap { _ =>
+          if (bitcoindRpcConf.zmqConfig == ZmqConfig.empty) {
+            BitcoindRpcBackendUtil.startBitcoindBlockPolling(wallet, bitcoind)
+          } else Future.unit
+        }
+
+      // Create callbacks for processing new blocks
+      _ =
+        if (bitcoindRpcConf.zmqConfig != ZmqConfig.empty) {
+          BitcoindRpcBackendUtil.startZMQWalletCallbacks(wallet)
+        }
+
+      binding <- startHttpServer(nodeApi = bitcoind,
+                                 chainApi = bitcoind,
+                                 wallet = wallet,
+                                 rpcbindOpt = rpcBindOpt,
+                                 rpcPortOpt = rpcPortOpt)
+      _ = BitcoinSServer.startedFP.success(Future.successful(binding))
+    } yield {
+      logger.info(s"Done starting Main!")
+      sys.addShutdownHook {
+        logger.error(s"Exiting process")
+
+        wallet.stop()
+
+        system
+          .terminate()
+          .foreach(_ => logger.info(s"Actor system terminated"))
+      }
+      ()
+    }
   }
 
   private def createCallbacks(wallet: Wallet)(implicit
@@ -265,14 +269,13 @@ class BitcoinSServerMain(override val args: Array[String])
 
   /** This is needed for migrations V2/V3 on the chain project to re-calculate the total work for the chain */
   private def runChainWorkCalc(force: Boolean)(implicit
-      chainAppConfig: ChainAppConfig,
       system: ActorSystem): Future[ChainApi] = {
     val blockEC =
       system.dispatchers.lookup(Dispatchers.DefaultBlockingDispatcherId)
     val chainApi = ChainHandler.fromDatabase(
-      blockHeaderDAO = BlockHeaderDAO()(blockEC, chainAppConfig),
-      CompactFilterHeaderDAO()(blockEC, chainAppConfig),
-      CompactFilterDAO()(blockEC, chainAppConfig))
+      blockHeaderDAO = BlockHeaderDAO()(blockEC, chainConf),
+      CompactFilterHeaderDAO()(blockEC, chainConf),
+      CompactFilterDAO()(blockEC, chainConf))
     for {
       isMissingChainWork <- chainApi.isMissingChainWork
       chainApiWithWork <-


### PR DESCRIPTION
It seems we have some code in `appServerTest` that doesn't clean up after itself. Since `BitcoinSRunner` did not have a uniform way to stop itself, i decided to refactor this code to use the `StartStopAsync` interface we use elsewhere in the codebase. 

Now we have `.stop()` calls in our unit tests that destroy resources allocated by `ServerRunTest`. 