### PR TITLE
Call decompression on public keys less

### DIFF
--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockTest.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockTest.scala
@@ -45,8 +45,7 @@ class BlockTest extends BitcoinSJvmTest {
 
   it must "have serialization symmetry" in {
     forAllParallel(BlockchainElementsGenerator.block) { block =>
-      val result = Block(block.hex) == block
-      assert(result)
+      assert(Block(block.hex) == block)
     }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -181,9 +181,8 @@ object ScriptWitness extends Factory[ScriptWitness] {
     //https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#restrictions-on-public-key-type
     val isPubKey = {
       stack.nonEmpty &&
-      (stack.head.size == 33
-        || stack.head.size == 65) &&
-      ECPublicKey.isFullyValid(stack.head)
+      ((stack.head.size == 33 && (stack.head.head == 0x02 || stack.head.head == 0x03))
+        || (stack.head.size == 65 && stack.head.head == 0x04))
     }
     if (stack.isEmpty) {
       EmptyScriptWitness

--- a/crypto-test/.js/src/test/scala/org/bitcoins/crypto/KeysTest.scala
+++ b/crypto-test/.js/src/test/scala/org/bitcoins/crypto/KeysTest.scala
@@ -9,10 +9,8 @@ class KeysTest extends BitcoinSCryptoTest {
 
     val pubkey = privkey.publicKey
     assert(pubkey != null)
-    assert(BCryptoCryptoRuntime.isValidPubKey(pubkey.bytes))
 
     assert(!BCryptoCryptoRuntime.secKeyVerify(pubkey.bytes))
-    assert(!BCryptoCryptoRuntime.isValidPubKey(privkey.bytes))
   }
 
 }

--- a/crypto-test/.jvm/src/test/scala/org/bitcoins/crypto/BouncyCastleSecp256k1Test.scala
+++ b/crypto-test/.jvm/src/test/scala/org/bitcoins/crypto/BouncyCastleSecp256k1Test.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.crypto
 
 import org.scalatest.{Assertion, Outcome, Succeeded}
+import scodec.bits.ByteVector
 
 class BouncyCastleSecp256k1Test extends BitcoinSCryptoTest {
 
@@ -44,6 +45,12 @@ class BouncyCastleSecp256k1Test extends BitcoinSCryptoTest {
     forAll(CryptoGenerators.publicKey) { pubKey =>
       testCompatibility(_.decompressed(pubKey))
     }
+  }
+
+  it must "decompress edge case keys the same" in {
+    val pubKeyBytes = ByteVector.fromValidHex(
+      "03fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c")
+    testCompatibility(_.decompressed(pubKeyBytes))
   }
 
   it must "compute public keys the same" in {

--- a/crypto-test/.jvm/src/test/scala/org/bitcoins/crypto/BouncyCastleSecp256k1Test.scala
+++ b/crypto-test/.jvm/src/test/scala/org/bitcoins/crypto/BouncyCastleSecp256k1Test.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.crypto
 
-import org.scalacheck.Gen
 import org.scalatest.{Assertion, Outcome, Succeeded}
 
 class BouncyCastleSecp256k1Test extends BitcoinSCryptoTest {
@@ -38,15 +37,6 @@ class BouncyCastleSecp256k1Test extends BitcoinSCryptoTest {
   it must "multiply keys the same" in {
     forAll(CryptoGenerators.publicKey, CryptoGenerators.fieldElement) {
       case (pubKey, tweak) => testCompatibility(_.tweakMultiply(pubKey, tweak))
-    }
-  }
-
-  it must "validate keys the same" in {
-    val keyOrGarbageGen =
-      Gen.oneOf(CryptoGenerators.publicKey.map(_.bytes),
-                NumberGenerator.bytevector(33))
-    forAll(keyOrGarbageGen) { bytes =>
-      testCompatibility(_.isValidPubKey(bytes))
     }
   }
 

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/ECPublicKeyTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/ECPublicKeyTest.scala
@@ -47,7 +47,7 @@ class ECPublicKeyTest extends BitcoinSCryptoTest {
     // 31 bytes
     val badHex =
       "02020202020202020202020202020202020202020202020202020202020202"
-    assert(!ECPublicKey.isFullyValid(ByteVector.fromHex(badHex).get))
+    assertThrows[RuntimeException](ECPublicKey(badHex))
   }
 
   it must "be able to compress/decompress public keys" in {
@@ -58,19 +58,15 @@ class ECPublicKeyTest extends BitcoinSCryptoTest {
     val notCompressedKey =
       ECPrivateKeyBytes(bytes = privkey.bytes, isCompressed = false)
     val pubkey = notCompressedKey.publicKeyBytes
-    assert(CryptoUtil.isValidPubKey(pubkey.bytes))
     assert(!pubkey.isCompressed)
 
     val compressed = privkey.publicKeyBytes
-    assert(CryptoUtil.isValidPubKey(compressed.bytes))
     assert(compressed.isCompressed)
 
     val converted = pubkey.compressed
-    assert(CryptoUtil.isValidPubKey(converted.bytes))
     assert(converted.isCompressed)
 
     val decompressed = compressed.decompressed
-    assert(CryptoUtil.isValidPubKey(decompressed.bytes))
     assert(!decompressed.isCompressed)
 
     assert(pubkey.bytes != converted.bytes)

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/ECPublicKeyTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/ECPublicKeyTest.scala
@@ -48,6 +48,12 @@ class ECPublicKeyTest extends BitcoinSCryptoTest {
     val badHex =
       "02020202020202020202020202020202020202020202020202020202020202"
     assertThrows[RuntimeException](ECPublicKey(badHex))
+    assertThrows[RuntimeException](
+      ECPublicKey(
+        "02FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"))
+    assertThrows[RuntimeException](
+      ECPublicKey(
+        "03FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"))
   }
 
   it must "be able to compress/decompress public keys" in {
@@ -140,6 +146,16 @@ class ECPublicKeyTest extends BitcoinSCryptoTest {
           ._1
           .tail)
     }
+  }
+
+  it must "succeed with valid coordinates above the curve order" in {
+    val _ = {
+      ECPublicKey(
+        "02fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c").toPoint
+      ECPublicKey(
+        "03fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c").toPoint
+    }
+    succeed
   }
 
 }

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/FieldElementTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/FieldElementTest.scala
@@ -74,9 +74,11 @@ class FieldElementTest extends BitcoinSCryptoTest {
   }
 
   it must "wrap around correctly" in {
-    assert(FieldElement.nMinusOne.add(FieldElement.one) == FieldElement.zero)
     assert(
-      FieldElement.zero.subtract(FieldElement.one) == FieldElement.nMinusOne)
+      FieldElement.orderMinusOne.add(FieldElement.one) == FieldElement.zero)
+    assert(
+      FieldElement.zero.subtract(
+        FieldElement.one) == FieldElement.orderMinusOne)
   }
 
   it must "multiply small numbers correctly" in {

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/SchnorrNonceTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/SchnorrNonceTest.scala
@@ -27,6 +27,12 @@ class SchnorrNonceTest extends BitcoinSCryptoTest {
         "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"))
   }
 
+  it must "succeed for valid large x coordinates above the curve order" in {
+    val _ = SchnorrNonce(
+      "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c").xCoord
+    succeed
+  }
+
   it must "have serialization symmetry" in {
     forAll(CryptoGenerators.schnorrNonce) { pubKey =>
       assert(SchnorrNonce(pubKey.bytes) == pubKey)

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/SchnorrPublicKeyTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/SchnorrPublicKeyTest.scala
@@ -27,6 +27,12 @@ class SchnorrPublicKeyTest extends BitcoinSCryptoTest {
         "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"))
   }
 
+  it must "succeed for valid large x coordinates above the curve order" in {
+    val _ = SchnorrPublicKey(
+      "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c").xCoord
+    succeed
+  }
+
   it must "have serialization symmetry" in {
     forAll(CryptoGenerators.schnorrPublicKey) { pubKey =>
       assert(SchnorrPublicKey(pubKey.bytes) == pubKey)

--- a/crypto/.js/src/main/scala/org/bitcoins/crypto/BCryptoCryptoRuntime.scala
+++ b/crypto/.js/src/main/scala/org/bitcoins/crypto/BCryptoCryptoRuntime.scala
@@ -231,11 +231,6 @@ trait BCryptoCryptoRuntime extends CryptoRuntime {
     ECPublicKey.fromBytes(keyByteVec)
   }
 
-  override def isValidPubKey(bytes: ByteVector): Boolean = {
-    val buffer = CryptoJsUtil.toNodeBuffer(bytes)
-    SECP256k1.publicKeyVerify(buffer)
-  }
-
   override def sipHash(item: ByteVector, key: SipHashKey): Long = {
     val itemBuffer = CryptoJsUtil.toNodeBuffer(item)
     val keyBuffer = CryptoJsUtil.toNodeBuffer(key.bytes)
@@ -243,6 +238,11 @@ trait BCryptoCryptoRuntime extends CryptoRuntime {
     val hi = (siphash(0).toLong & 0x00000000ffffffffL) << 32
     val lo = siphash(1).toLong & 0x00000000ffffffffL
     hi | lo
+  }
+
+  override def isValidPubKey(pubKey: PublicKey): Boolean = {
+    val buffer = CryptoJsUtil.toNodeBuffer(pubKey.bytes)
+    SECP256k1.publicKeyVerify(buffer)
   }
 
   override def decodePoint(bytes: ByteVector): SecpPoint = {

--- a/crypto/.js/src/main/scala/org/bitcoins/crypto/BCryptoCryptoRuntime.scala
+++ b/crypto/.js/src/main/scala/org/bitcoins/crypto/BCryptoCryptoRuntime.scala
@@ -176,7 +176,7 @@ trait BCryptoCryptoRuntime extends CryptoRuntime {
   }
 
   override def verify(
-      publicKey: PublicKey[_],
+      publicKey: PublicKey,
       data: ByteVector,
       signature: ECDigitalSignature): Boolean = {
     val dataBuffer = CryptoJsUtil.toNodeBuffer(data)

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
@@ -41,12 +41,6 @@ object BouncyCastleUtil {
     ECPublicKey.fromBytes(ByteVector(bytes))
   }
 
-  def validatePublicKey(bytes: ByteVector): Boolean = {
-    bytes != ByteVector(0x00) && Try(decodePoint(bytes))
-      .map(_.getCurve == curve)
-      .getOrElse(false)
-  }
-
   def pubKeyTweakMul(pubKey: ECPublicKey, tweak: FieldElement): ECPublicKey = {
     val tweakedPoint = decodePoint(pubKey).multiply(tweak.toBigInteger)
     decodePubKey(tweakedPoint, pubKey.isCompressed)
@@ -67,10 +61,6 @@ object BouncyCastleUtil {
     val priv = getBigInteger(privateKey.bytes)
     val point = G.multiply(priv)
     val pubBytes = ByteVector(point.getEncoded(false))
-    require(
-      ECPublicKey.isFullyValid(pubBytes),
-      s"Bouncy Castle failed to generate a valid public key, got: ${CryptoBytesUtil
-        .encodeHex(pubBytes)}")
     ECPublicKey(pubBytes)
   }
 
@@ -80,10 +70,6 @@ object BouncyCastleUtil {
     } else {
       val point = decodePoint(key)
       val pubBytes = ByteVector(point.getEncoded(compressed))
-      require(
-        ECPublicKey.isFullyValid(pubBytes),
-        s"Bouncy Castle failed to generate a valid public key, got: ${CryptoBytesUtil
-          .encodeHex(pubBytes)}")
       ECPublicKey(pubBytes)
     }
   }

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
@@ -147,7 +147,7 @@ object BouncyCastleUtil {
 
   def verifyDigitalSignature(
       data: ByteVector,
-      publicKey: PublicKey[_],
+      publicKey: PublicKey,
       signature: ECDigitalSignature): Boolean = {
     val resultTry = Try {
       val publicKeyParams =

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncycastleCryptoRuntime.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncycastleCryptoRuntime.scala
@@ -146,7 +146,7 @@ trait BouncycastleCryptoRuntime extends CryptoRuntime {
   }
 
   override def verify(
-      publicKey: PublicKey[_],
+      publicKey: PublicKey,
       data: ByteVector,
       signature: ECDigitalSignature): Boolean =
     BouncyCastleUtil.verifyDigitalSignature(data, publicKey, signature)

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncycastleCryptoRuntime.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncycastleCryptoRuntime.scala
@@ -173,9 +173,6 @@ trait BouncycastleCryptoRuntime extends CryptoRuntime {
     pubkey.add(tweak)
   }
 
-  override def isValidPubKey(bytes: ByteVector): Boolean =
-    BouncyCastleUtil.validatePublicKey(bytes)
-
   override def sipHash(item: ByteVector, key: SipHashKey): Long = {
     val sipHashCParam = 2
     val sipHashDParam = 4

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/LibSecp256k1CryptoRuntime.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/LibSecp256k1CryptoRuntime.scala
@@ -46,10 +46,6 @@ trait LibSecp256k1CryptoRuntime extends CryptoRuntime {
     val pubKeyBytes: Array[Byte] =
       NativeSecp256k1.computePubkey(privateKey.bytes.toArray, false)
     val pubBytes = ByteVector(pubKeyBytes)
-    require(
-      ECPublicKey.isFullyValid(pubBytes),
-      s"secp256k1 failed to generate a valid public key, got: ${CryptoBytesUtil
-        .encodeHex(pubBytes)}")
     ECPublicKey(pubBytes)
   }
 
@@ -104,10 +100,6 @@ trait LibSecp256k1CryptoRuntime extends CryptoRuntime {
     val pubKeyBytes: Array[Byte] =
       NativeSecp256k1.computePubkey(privateKey.bytes.toArray, false)
     val pubBytes = ByteVector(pubKeyBytes)
-    require(
-      ECPublicKey.isFullyValid(pubBytes),
-      s"secp256k1 failed to generate a valid public key, got: ${CryptoBytesUtil
-        .encodeHex(pubBytes)}")
     ECPublicKey(pubBytes)
   }
 
@@ -156,15 +148,6 @@ trait LibSecp256k1CryptoRuntime extends CryptoRuntime {
       privkey.bytes.toArray,
       false)
     ECPublicKey(ByteVector(tweaked))
-  }
-
-  override def isValidPubKey(bytes: ByteVector): Boolean = {
-    try {
-      NativeSecp256k1.isValidPubKey(bytes.toArray)
-    } catch {
-      case scala.util.control.NonFatal(_) =>
-        false
-    }
   }
 
   override def schnorrSign(

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/LibSecp256k1CryptoRuntime.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/LibSecp256k1CryptoRuntime.scala
@@ -76,7 +76,7 @@ trait LibSecp256k1CryptoRuntime extends CryptoRuntime {
     NativeSecp256k1.secKeyVerify(privateKeyBytes.toArray)
 
   override def verify(
-      publicKey: PublicKey[_],
+      publicKey: PublicKey,
       data: ByteVector,
       signature: ECDigitalSignature): Boolean = {
     val result =
@@ -95,11 +95,9 @@ trait LibSecp256k1CryptoRuntime extends CryptoRuntime {
     } else result
   }
 
-  override def decompressed[PK <: PublicKey[PK]](publicKey: PK): PK = {
-    if (publicKey.isCompressed) {
-      val decompressed = NativeSecp256k1.decompress(publicKey.bytes.toArray)
-      publicKey.fromBytes(ByteVector(decompressed))
-    } else publicKey
+  override def decompressed(pubKeyBytes: ByteVector): ByteVector = {
+    val decompressed = NativeSecp256k1.decompress(pubKeyBytes.toArray)
+    ByteVector(decompressed)
   }
 
   override def publicKey(privateKey: ECPrivateKey): ECPublicKey = {

--- a/crypto/src/main/scala/org/bitcoins/crypto/AdaptorUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/AdaptorUtil.scala
@@ -124,7 +124,8 @@ object AdaptorUtil {
     )
 
     if (validProof) {
-      val tweakedNoncex = FieldElement(adaptorSig.tweakedNonce.bytes.tail)
+      val tweakedNoncex = FieldElement(
+        CurveCoordinate(adaptorSig.tweakedNonce.bytes.tail).toBigInteger)
       val untweakedNoncex = FieldElement(adaptorSig.untweakedNonce.bytes.tail)
 
       if (tweakedNoncex.isZero || untweakedNoncex.isZero) {

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoParams.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoParams.scala
@@ -9,6 +9,12 @@ import java.math.BigInteger
   */
 sealed abstract class CryptoParams {
 
+  private val curvePrimeConstant =
+    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F"
+
+  val getCurvePrime: BigInteger =
+    new BigInteger(1, ByteVector.fromValidHex(curvePrimeConstant).toArray)
+
   /** Hex constant for curve group constant
     */
   private val nConstant =

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
@@ -254,7 +254,8 @@ trait CryptoRuntime {
   def pubKeyTweakAdd(pubkey: ECPublicKey, privkey: ECPrivateKey): ECPublicKey
 
   def isValidPubKey(pubKey: PublicKey): Boolean = {
-    pubKey.decompressedBytesT.isSuccess
+    pubKey.decompressedBytesT.isSuccess &&
+    pubKey.decompressedBytesT.get != ByteVector(0x00)
   }
 
   def decodePoint(bytes: ByteVector): SecpPoint

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
@@ -253,7 +253,9 @@ trait CryptoRuntime {
 
   def pubKeyTweakAdd(pubkey: ECPublicKey, privkey: ECPrivateKey): ECPublicKey
 
-  def isValidPubKey(bytes: ByteVector): Boolean
+  def isValidPubKey(pubKey: PublicKey): Boolean = {
+    pubKey.decompressedBytesT.isSuccess
+  }
 
   def decodePoint(bytes: ByteVector): SecpPoint
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoUtil.scala
@@ -98,12 +98,15 @@ trait CryptoUtil extends CryptoRuntime {
     cryptoRuntime.secKeyVerify(privateKeybytes)
 
   override def verify(
-      publicKey: PublicKey[_],
+      publicKey: PublicKey,
       data: ByteVector,
       signature: ECDigitalSignature): Boolean =
     cryptoRuntime.verify(publicKey, data, signature)
 
-  override def decompressed[PK <: PublicKey[PK]](publicKey: PK): PK =
+  override def decompressed(pubKeyBytes: ByteVector): ByteVector =
+    cryptoRuntime.decompressed(pubKeyBytes)
+
+  override def decompressed[PK <: PublicKey](publicKey: PK): publicKey.type =
     cryptoRuntime.decompressed(publicKey)
 
   override def tweakMultiply(

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoUtil.scala
@@ -134,8 +134,8 @@ trait CryptoUtil extends CryptoRuntime {
       privkey: ECPrivateKey): ECPublicKey =
     cryptoRuntime.pubKeyTweakAdd(pubkey, privkey)
 
-  override def isValidPubKey(bytes: ByteVector): Boolean =
-    cryptoRuntime.isValidPubKey(bytes)
+  override def isValidPubKey(pubKey: PublicKey): Boolean =
+    cryptoRuntime.isValidPubKey(pubKey)
 
   override def schnorrSign(
       dataToSign: ByteVector,

--- a/crypto/src/main/scala/org/bitcoins/crypto/CurveCoordinate.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CurveCoordinate.scala
@@ -1,0 +1,17 @@
+package org.bitcoins.crypto
+
+import scodec.bits.ByteVector
+
+case class CurveCoordinate(bytes: ByteVector)
+    extends FiniteFieldMember[CurveCoordinate](CryptoParams.getCurvePrime, 32) {
+
+  override def fieldObj: FiniteFieldObject[CurveCoordinate] = CurveCoordinate
+}
+
+object CurveCoordinate
+    extends FiniteFieldObject[CurveCoordinate](CryptoParams.getCurvePrime, 32) {
+
+  override def fieldMemberConstructor(bytes: ByteVector): CurveCoordinate = {
+    new CurveCoordinate(bytes)
+  }
+}

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECAdaptorSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECAdaptorSignature.scala
@@ -16,13 +16,6 @@ case class ECAdaptorSignature(bytes: ByteVector) extends NetworkElement {
 
   val dleqProofE: FieldElement = FieldElement(dleqProof.take(32))
   val dleqProofS: FieldElement = FieldElement(dleqProof.drop(32))
-
-  require(
-    tweakedNonce.bytes.nonEmpty && CryptoUtil.isValidPubKey(tweakedNonce.bytes),
-    s"Tweaked nonce (R) must be a valid public key: $tweakedNonce")
-  require(untweakedNonce.bytes.nonEmpty && CryptoUtil.isValidPubKey(
-            untweakedNonce.bytes),
-          s"Untweaked nonce (R') must be a valid public key: $untweakedNonce")
 }
 
 object ECAdaptorSignature extends Factory[ECAdaptorSignature] {

--- a/crypto/src/main/scala/org/bitcoins/crypto/FieldElement.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/FieldElement.scala
@@ -2,145 +2,43 @@ package org.bitcoins.crypto
 
 import scodec.bits.ByteVector
 
-import java.math.BigInteger
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 /** Represents integers modulo the secp256k1 field size: pow(2,256) - 0x1000003D1.
   *
   * Supports arithmetic for these elements including +, -, *, and inverses.
   * Supports 32 byte serialization as is needed for ECPrivateKeys.
   */
-case class FieldElement(bytes: ByteVector) extends NetworkElement {
-  require(bytes.length == 32, s"Field elements must have 32 bytes, got $bytes")
-
+case class FieldElement(bytes: ByteVector)
+    extends FiniteFieldMember[FieldElement](CryptoParams.getN, 32) {
   private val privKeyT: Try[ECPrivateKey] = Try(ECPrivateKey(bytes))
 
-  private val privKeyOverT: Try[ECPrivateKey] = Try(
-    ECPrivateKey(
-      ByteVector(toBigInteger.mod(FieldElement.N).toByteArray).padLeft(32)))
-
   require(
-    privKeyT.isSuccess || isZero || privKeyOverT.isSuccess,
+    privKeyT.isSuccess || isZero,
     s"$bytes is not a valid field element: ${privKeyT.failed.get.getMessage}")
-
-  def isZero: Boolean = bytes.toArray.forall(_ == 0.toByte)
-
-  def isEven: Boolean = {
-    (bytes.last & 0x01) == 0
-  }
-
-  def isOdd: Boolean = !isEven
 
   def toPrivateKey: ECPrivateKey =
     if (!isZero) {
-      privKeyT match {
-        case Success(privKey) => privKey
-        case Failure(_)       => privKeyOverT.get
-      }
+      privKeyT.get
     } else {
       throw new RuntimeException("Cannot turn zero into a private key")
     }
 
-  def toBigInteger: BigInteger = FieldElement.getBigInteger(bytes)
-
-  def add(other: FieldElement): FieldElement = {
-    FieldElement.add(this, other)
-  }
-
-  def subtract(other: FieldElement): FieldElement = {
-    add(other.negate)
-  }
-
-  def multiply(other: FieldElement): FieldElement = {
-    FieldElement.multiply(this, other)
-  }
-
-  def multInv(other: FieldElement): FieldElement = {
-    multiply(other.inverse)
-  }
-
-  def negate: FieldElement = {
-    FieldElement.negate(this)
-  }
-
   def getPublicKey: ECPublicKey = toPrivateKey.publicKey
 
-  def inverse: FieldElement = FieldElement.computeInverse(this)
+  override def fieldObj: FiniteFieldObject[FieldElement] = FieldElement
 }
 
-object FieldElement extends Factory[FieldElement] {
+object FieldElement
+    extends FiniteFieldObject[FieldElement](CryptoParams.getN, 32) {
 
-  override def fromBytes(bytes: ByteVector): FieldElement = {
-    if (bytes.length < 32) {
-      new FieldElement(bytes.padLeft(32))
-    } else if (bytes.length == 32) {
-      new FieldElement(bytes)
-    } else if (bytes.length == 33 && bytes.head == 0.toByte) {
-      new FieldElement(bytes.tail)
-    } else {
-      throw new IllegalArgumentException(
-        s"Field element cannot have more than 32 bytes, got $bytes")
-    }
+  override def fieldMemberConstructor(bytes: ByteVector): FieldElement = {
+    new FieldElement(bytes)
   }
-
-  def apply(num: BigInt): FieldElement = {
-    FieldElement(num.underlying())
-  }
-
-  def apply(num: BigInteger): FieldElement = {
-    FieldElement.fromByteArray(num.mod(N).toByteArray)
-  }
-
-  def fromByteArray(bytes: Array[Byte]): FieldElement = {
-    FieldElement(ByteVector(bytes))
-  }
-
-  val zero: FieldElement = FieldElement(ByteVector.empty)
-  val one: FieldElement = FieldElement(ByteVector.fromByte(1))
-
-  val nMinusOne: FieldElement = FieldElement(
-    "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140")
 
   // CryptoParams.curve.getG
   private val G: ECPublicKey = ECPublicKey(
     "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
 
-  // CryptoParams.curve.getN
-  private val N: BigInteger = new BigInteger(
-    "115792089237316195423570985008687907852837564279074904382605163141518161494337")
-
-  private def getBigInteger(bytes: ByteVector): BigInteger = {
-    new BigInteger(1, bytes.toArray)
-  }
-
-  def add(fe1: FieldElement, fe2: FieldElement): FieldElement = {
-    val num1 = fe1.toBigInteger
-    val num2 = fe2.toBigInteger
-
-    val sum = num1.add(num2).mod(N)
-    FieldElement(sum)
-  }
-
-  def multiply(fe1: FieldElement, fe2: FieldElement): FieldElement = {
-    val num1 = fe1.toBigInteger
-    val num2 = fe2.toBigInteger
-
-    val sum = num1.multiply(num2).mod(N)
-    FieldElement(sum)
-  }
-
-  def negate(fe: FieldElement): FieldElement = {
-    val neg = N.subtract(fe.toBigInteger)
-    FieldElement(neg)
-  }
-
   def computePoint(fe: FieldElement): ECPublicKey = G.tweakMultiply(fe)
-
-  /** Computes the inverse (mod M) of the input using the Euclidean Algorithm (log time)
-    * Cribbed from [[https://www.geeksforgeeks.org/multiplicative-inverse-under-modulo-m/]]
-    */
-  def computeInverse(fe: FieldElement): FieldElement = {
-    val inv = fe.toBigInteger.modInverse(N)
-    FieldElement(inv)
-  }
 }

--- a/crypto/src/main/scala/org/bitcoins/crypto/FiniteField.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/FiniteField.scala
@@ -1,0 +1,122 @@
+package org.bitcoins.crypto
+
+import scodec.bits.ByteVector
+
+import java.math.BigInteger
+
+abstract class FiniteFieldMember[F <: FiniteFieldMember[F]](
+    fieldOrder: BigInteger,
+    byteSize: Int)
+    extends NetworkElement {
+  require(bytes.length == byteSize,
+          s"Finite field member must have $byteSize bytes, got $bytes")
+  require(
+    toBigInteger.compareTo(fieldOrder) < 0,
+    s"$bytes is not a valid field member (was not less than $fieldOrder).")
+
+  def isZero: Boolean = bytes.toArray.forall(_ == 0.toByte)
+
+  def isEven: Boolean = {
+    (bytes.last & 0x01) == 0
+  }
+
+  def isOdd: Boolean = !isEven
+
+  def fieldObj: FiniteFieldObject[F]
+
+  def thisAsF: F = this.asInstanceOf[F]
+
+  def toBigInteger: BigInteger = fieldObj.getBigInteger(bytes)
+
+  def add(other: F): F = {
+    fieldObj.add(thisAsF, other)
+  }
+
+  def subtract(other: F): F = {
+    add(other.negate)
+  }
+
+  def multiply(other: F): F = {
+    fieldObj.multiply(thisAsF, other)
+  }
+
+  def multInv(other: F): F = {
+    multiply(other.inverse)
+  }
+
+  def negate: F = {
+    fieldObj.negate(thisAsF)
+  }
+
+  def inverse: F = fieldObj.computeInverse(thisAsF)
+}
+
+abstract class FiniteFieldObject[F <: FiniteFieldMember[F]](
+    fieldOrder: BigInteger,
+    byteSize: Int)
+    extends Factory[F] {
+
+  def fieldMemberConstructor(bytes: ByteVector): F
+
+  override def fromBytes(bytes: ByteVector): F = {
+    if (bytes.length < byteSize) {
+      fieldMemberConstructor(bytes.padLeft(byteSize))
+    } else if (bytes.length == byteSize) {
+      fieldMemberConstructor(bytes)
+    } else if (bytes.length == byteSize + 1 && bytes.head == 0.toByte) {
+      fieldMemberConstructor(bytes.tail)
+    } else {
+      throw new IllegalArgumentException(
+        s"Field element cannot have more than 32 bytes, got $bytes")
+    }
+  }
+
+  def apply(num: BigInt): F = {
+    apply(num.underlying())
+  }
+
+  def apply(num: BigInteger): F = {
+    fromByteArray(num.mod(fieldOrder).toByteArray)
+  }
+
+  def fromByteArray(bytes: Array[Byte]): F = {
+    fromBytes(ByteVector(bytes))
+  }
+
+  lazy val zero: F = fromBytes(ByteVector.empty)
+  lazy val one: F = fromBytes(ByteVector.fromByte(1))
+  lazy val orderMinusOne: F = apply(fieldOrder.subtract(BigInteger.ONE))
+
+  def getBigInteger(bytes: ByteVector): BigInteger = {
+    new BigInteger(1, bytes.toArray)
+  }
+
+  def add(fe1: F, fe2: F): F = {
+    val num1 = fe1.toBigInteger
+    val num2 = fe2.toBigInteger
+
+    val sum = num1.add(num2).mod(fieldOrder)
+    apply(sum)
+  }
+
+  def multiply(fe1: F, fe2: F): F = {
+    val num1 = fe1.toBigInteger
+    val num2 = fe2.toBigInteger
+
+    val sum = num1.multiply(num2).mod(fieldOrder)
+    apply(sum)
+  }
+
+  def negate(fe: F): F = {
+    val neg = fieldOrder.subtract(fe.toBigInteger)
+    apply(neg)
+  }
+
+  /** Computes the inverse (mod fieldOrder) of the input using the Euclidean Algorithm (log time)
+    * Cribbed from [[https://www.geeksforgeeks.org/multiplicative-inverse-under-modulo-m/]]
+    */
+  def computeInverse(fe: F): F = {
+    val inv = fe.toBigInteger.modInverse(fieldOrder)
+    apply(inv)
+  }
+}

--- a/crypto/src/main/scala/org/bitcoins/crypto/SchnorrNonce.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SchnorrNonce.scala
@@ -9,8 +9,8 @@ case class SchnorrNonce(bytes: ByteVector) extends NetworkElement {
 
   val publicKey: ECPublicKey = schnorrPublicKey.publicKey
 
-  def xCoord: FieldElement = {
-    FieldElement(bytes)
+  def xCoord: CurveCoordinate = {
+    CurveCoordinate(bytes)
   }
 }
 
@@ -48,7 +48,7 @@ object SchnorrNonce extends Factory[SchnorrNonce] {
     k.publicKey.schnorrNonce
   }
 
-  def apply(xCoor: FieldElement): SchnorrNonce = {
+  def apply(xCoor: CurveCoordinate): SchnorrNonce = {
     SchnorrNonce(xCoor.bytes)
   }
 }

--- a/crypto/src/main/scala/org/bitcoins/crypto/SchnorrPublicKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SchnorrPublicKey.scala
@@ -59,12 +59,6 @@ case class SchnorrPublicKey(bytes: ByteVector) extends NetworkElement {
   def publicKey: ECPublicKey = {
     val pubKeyBytes = ByteVector.fromByte(2) ++ bytes
 
-    val validPubKey = CryptoUtil.isValidPubKey(pubKeyBytes)
-
-    require(
-      validPubKey,
-      s"Cannot construct schnorr public key from invalid x coordinate: $bytes")
-
     ECPublicKey(pubKeyBytes)
   }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/SchnorrPublicKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SchnorrPublicKey.scala
@@ -62,7 +62,7 @@ case class SchnorrPublicKey(bytes: ByteVector) extends NetworkElement {
     ECPublicKey(pubKeyBytes)
   }
 
-  def xCoord: FieldElement = FieldElement(bytes)
+  def xCoord: CurveCoordinate = CurveCoordinate(bytes)
 }
 
 object SchnorrPublicKey extends Factory[SchnorrPublicKey] {
@@ -87,7 +87,7 @@ object SchnorrPublicKey extends Factory[SchnorrPublicKey] {
     }
   }
 
-  def apply(xCoor: FieldElement): SchnorrPublicKey = {
+  def apply(xCoor: CurveCoordinate): SchnorrPublicKey = {
     SchnorrPublicKey(xCoor.bytes)
   }
 }

--- a/crypto/src/main/scala/org/bitcoins/crypto/SecpPoint.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SecpPoint.scala
@@ -27,7 +27,8 @@ case object SecpPointInfinity extends SecpPoint {
 
 /** A non-identity point, (x, y), on the secp256k1 elliptic curve.
   */
-case class SecpPointFinite(x: FieldElement, y: FieldElement) extends SecpPoint {
+case class SecpPointFinite(x: CurveCoordinate, y: CurveCoordinate)
+    extends SecpPoint {
 
   override def bytes: ByteVector = {
     ByteVector(0x04) ++ x.bytes ++ y.bytes
@@ -42,22 +43,22 @@ object SecpPoint {
 
   def fromPublicKey(key: ECPublicKey): SecpPointFinite = {
     val (x, y) = key.decompressedBytes.tail.splitAt(32)
-    SecpPointFinite(FieldElement.fromBytes(x), FieldElement.fromBytes(y))
+    SecpPointFinite(CurveCoordinate.fromBytes(x), CurveCoordinate.fromBytes(y))
   }
 
   def apply(x: ByteVector, y: ByteVector): SecpPointFinite =
-    SecpPointFinite(FieldElement.fromBytes(x), FieldElement.fromBytes(y))
+    SecpPointFinite(CurveCoordinate.fromBytes(x), CurveCoordinate.fromBytes(y))
 
   def apply(x: Array[Byte], y: Array[Byte]): SecpPointFinite =
-    SecpPointFinite(FieldElement.fromByteArray(x),
-                    FieldElement.fromByteArray(y))
+    SecpPointFinite(CurveCoordinate.fromByteArray(x),
+                    CurveCoordinate.fromByteArray(y))
 
   def apply(x: BigInteger, y: BigInteger): SecpPointFinite =
-    SecpPointFinite(FieldElement(x), FieldElement(y))
+    SecpPointFinite(CurveCoordinate(x), CurveCoordinate(y))
 
   def apply(x: BigInt, y: BigInt): SecpPointFinite =
-    SecpPointFinite(FieldElement(x), FieldElement(y))
+    SecpPointFinite(CurveCoordinate(x), CurveCoordinate(y))
 
   def apply(x: String, y: String): SecpPointFinite =
-    SecpPointFinite(FieldElement.fromHex(x), FieldElement.fromHex(y))
+    SecpPointFinite(CurveCoordinate.fromHex(x), CurveCoordinate.fromHex(y))
 }


### PR DESCRIPTION
Built on top of #2936

De-duplicates call to decompression on `ECPublicKey::isFullyValid` and removes decompression entirely from `ScriptWitness` parsing.

EDIT: This PR now also introduces `CurveCoordinate` which is for use in places where 32 bytes represent an x or y coordinate of a secp point (as opposed to `FieldElement` which represents a scalar that can be multiplied by a point, e.g. `fe*G`)