### PR TITLE
Fix race condition with BitcoindChainHandlerViaZmqTest

### DIFF
--- a/bitcoin-s-docs/docs.sbt
+++ b/bitcoin-s-docs/docs.sbt
@@ -21,7 +21,7 @@ mdocExtraArguments := List("--no-link-hygiene")
 // these variables gets passed to mdoc, and can be read
 // from there
 mdocVariables := Map(
-  "STABLE_VERSION" -> previousStableVersion.value.get.toString,
+  "STABLE_VERSION" -> "0.5.0",
   "UNSTABLE_VERSION" -> version.value
 )
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -145,7 +145,7 @@ trait Client
         _ = isStartedFlag.set(true)
         _ <- AsyncUtil.retryUntilSatisfiedF(() => isStartedF,
                                             interval = 1.seconds,
-                                            maxTries = 60)
+                                            maxTries = 120)
       } yield this.asInstanceOf[BitcoindRpcClient]
     }
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
@@ -398,6 +398,8 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
         blockchains <- blockchainsF
       } yield {
         assert(blockchains.length == 1)
+        assert(blockchains.head.length == 1)
+        assert(blockchains.head.headers.head.hashBE == genesisHeaderDb.hashBE)
       }
   }
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -975,6 +975,18 @@ object ChainHandler {
                      blockFilterCheckpoints = Map.empty)
   }
 
+  def fromDatabase()(implicit
+      ec: ExecutionContext,
+      chainConfig: ChainAppConfig): ChainHandler = {
+    lazy val blockHeaderDAO = BlockHeaderDAO()
+    lazy val filterHeaderDAO = CompactFilterHeaderDAO()
+    lazy val filterDAO = CompactFilterDAO()
+
+    ChainHandler.fromDatabase(blockHeaderDAO = blockHeaderDAO,
+                              filterHeaderDAO = filterHeaderDAO,
+                              filterDAO = filterDAO)
+  }
+
   /** Converts a [[ChainHandler]] to [[ChainHandlerCached]] by calling [[BlockHeaderDAO.getBlockchains()]] */
   def toChainHandlerCached(chainHandler: ChainHandler)(implicit
       ec: ExecutionContext): Future[ChainHandlerCached] = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -91,6 +91,9 @@ trait BitcoindRpcTestUtil extends Logging {
       blockFilterIndex: Boolean = false): BitcoindConfig = {
     val pass = FileUtil.randomDirName
     val username = "random_user_name"
+
+    /* pruning and txindex are not compatible */
+    val txindex = if (pruneMode) 0 else 1
     val conf = s"""
                   |regtest=1
                   |daemon=1
@@ -103,8 +106,7 @@ trait BitcoindRpcTestUtil extends Logging {
                   |walletbroadcast=1
                   |peerbloomfilters=1
                   |fallbackfee=0.0002
-                  |txindex=${if (pruneMode) 0
-    else 1 /* pruning and txindex are not compatible */}
+                  |txindex=$txindex
                   |zmqpubhashtx=tcp://${zmqConfig.hashTx.get.getHostString}:${zmqConfig.hashTx.get.getPort}
                   |zmqpubhashblock=tcp://${zmqConfig.hashBlock.get.getHostString}:${zmqConfig.hashBlock.get.getPort}
                   |zmqpubrawtx=tcp://${zmqConfig.rawTx.get.getHostString}:${zmqConfig.rawTx.get.getPort}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -455,7 +455,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
       newTags: Vector[AddressTag]): Future[Seq[SpendingInfoDb]] = {
     getRelevantOutputs(transaction).flatMap {
       case Nil =>
-        logger.debug(
+        logger.trace(
           s"Found no outputs relevant to us in transaction${transaction.txIdBE.hex}")
         Future.successful(Vector.empty)
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -193,7 +193,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       _ =
         if (toUpdate.nonEmpty)
           logger.info(s"${toUpdate.size} txos are now confirmed!")
-        else logger.debug("No txos to be confirmed")
+        else logger.trace("No txos to be confirmed")
       updated <- spendingInfoDAO.upsertAllSpendingInfoDb(toUpdate.flatten)
     } yield updated
   }


### PR DESCRIPTION
Fixes race condition inside of `ChainUnitTest.createChainHandlerWithBitcoindZmq`

The problem is we weren't making sure we mapped on `chainHandlerF`. This means we could start generating a block with bitcoind before our chain infrastructure was setup in the fixture.

I also added a few sanity tests on `BlockHeaderDAO.getBlockchains()` to make sure we are getting the correct header, rather than just asserting we got one chain.

In the future, we really need to get rid of `CachedChainAppConfig` as it can lead to unintended resources allocated -- or unintended resources shared between individual unit tests. Similar to #2980 