### PR TITLE
refactor BitcoindRpcTestUtil test methods to take ZmqConfig

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/RpcUtil.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/RpcUtil.scala
@@ -1,8 +1,10 @@
 package org.bitcoins.rpc.util
 
 import org.bitcoins.asyncutil.AsyncUtil
-import java.net.ServerSocket
+
+import java.net.{InetSocketAddress, ServerSocket}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.config.ZmqConfig
 
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
@@ -36,6 +38,16 @@ abstract class RpcUtil extends AsyncUtil {
       case Success(value) => value
       case Failure(_)     => randomPort
     }
+  }
+
+  /** Genreates a zmq config with unused ports */
+  def zmqConfig: ZmqConfig = {
+    ZmqConfig(
+      hashBlock = Some(new InetSocketAddress(randomPort)),
+      hashTx = Some(new InetSocketAddress(randomPort)),
+      rawTx = Some(new InetSocketAddress(randomPort)),
+      rawBlock = Some(new InetSocketAddress(randomPort))
+    )
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -23,7 +23,11 @@ import org.bitcoins.eclair.rpc.api._
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
 import org.bitcoins.eclair.rpc.config.EclairInstance
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
-import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstance}
+import org.bitcoins.rpc.config.{
+  BitcoindAuthCredentials,
+  BitcoindInstance,
+  ZmqConfig
+}
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.async.TestAsyncUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
@@ -65,41 +69,13 @@ trait EclairRpcTestUtil extends Logging {
   def bitcoindInstance(
       port: Int = RpcUtil.randomPort,
       rpcPort: Int = RpcUtil.randomPort,
-      zmqPort: Int = RpcUtil.randomPort,
+      zmqConfig: ZmqConfig = RpcUtil.zmqConfig,
       bitcoindV: BitcoindVersion =
         EclairRpcClient.bitcoindV): BitcoindInstance = {
-    bitcoindV match {
-      case BitcoindVersion.V21 =>
-        BitcoindRpcTestUtil.v21Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.V20 =>
-        BitcoindRpcTestUtil.v20Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.V19 =>
-        BitcoindRpcTestUtil.v19Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.V18 =>
-        BitcoindRpcTestUtil.v18Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.V17 =>
-        BitcoindRpcTestUtil.v17Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.V16 =>
-        BitcoindRpcTestUtil.v16Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.Experimental =>
-        BitcoindRpcTestUtil.vExperimentalInstance(port = port,
-                                                  rpcPort = rpcPort,
-                                                  zmqPort = zmqPort)
-      case BitcoindVersion.Unknown =>
-        sys.error(s"Cannot start eclair with an unknown instance of bitcoind")
-    }
+    BitcoindRpcTestUtil.getInstance(bitcoindVersion = bitcoindV,
+                                    port = port,
+                                    rpcPort = rpcPort,
+                                    zmqConfig = zmqConfig)
   }
 
   //cribbed from https://github.com/Christewart/eclair/blob/bad02e2c0e8bd039336998d318a861736edfa0ad/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala#L140-L153

--- a/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestUtil.scala
@@ -10,7 +10,11 @@ import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.lnd.rpc.LndRpcClient
 import org.bitcoins.lnd.rpc.config.LndInstance
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
-import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstance}
+import org.bitcoins.rpc.config.{
+  BitcoindAuthCredentials,
+  BitcoindInstance,
+  ZmqConfig
+}
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.async.TestAsyncUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
@@ -45,40 +49,12 @@ trait LndRpcTestUtil extends Logging {
   def bitcoindInstance(
       port: Int = RpcUtil.randomPort,
       rpcPort: Int = RpcUtil.randomPort,
-      zmqPort: Int = RpcUtil.randomPort,
+      zmqConfig: ZmqConfig = RpcUtil.zmqConfig,
       bitcoindV: BitcoindVersion = BitcoindVersion.V21): BitcoindInstance = {
-    bitcoindV match {
-      case BitcoindVersion.V21 =>
-        BitcoindRpcTestUtil.v21Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.V20 =>
-        BitcoindRpcTestUtil.v20Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.V19 =>
-        BitcoindRpcTestUtil.v19Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.V18 =>
-        BitcoindRpcTestUtil.v18Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.V17 =>
-        BitcoindRpcTestUtil.v17Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.V16 =>
-        BitcoindRpcTestUtil.v16Instance(port = port,
-                                        rpcPort = rpcPort,
-                                        zmqPort = zmqPort)
-      case BitcoindVersion.Experimental =>
-        BitcoindRpcTestUtil.vExperimentalInstance(port = port,
-                                                  rpcPort = rpcPort,
-                                                  zmqPort = zmqPort)
-      case BitcoindVersion.Unknown =>
-        sys.error(s"Cannot start lnd with an unknown instance of bitcoind")
-    }
+    BitcoindRpcTestUtil.getInstance(bitcoindVersion = bitcoindV,
+                                    port = port,
+                                    rpcPort = rpcPort,
+                                    zmqConfig = zmqConfig)
   }
 
   def commonConfig(


### PR DESCRIPTION
…an zmqPort

This fixes #3001 and possibly #2700

Basically we need to make sure the zmq ports are free on the underlying OS. This is what [`RpcUtil.randomPort`](https://github.com/bitcoin-s/bitcoin-s/blob/ced8670ab5dc3d75f06740a863cbc18b20ab23b4/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/RpcUtil.scala#L27) does.

Now we shouldn't run into silent failures around ports already being bound on the underlying OS with respect to zmq test cases. 