### PR TITLE
Remove remove request rejection duplication in ServerRoute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ project/plugins/project/
 .idea/*
 *.iml
 .bsp
+.vscode
 
 # secp256k1 ignore files
 bench_inv

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -67,7 +67,7 @@ case class Server(
         pathSingleSlash {
           post {
             entity(as[ServerCommand]) { cmd =>
-              val init = PartialFunction.empty[ServerCommand, StandardRoute]
+              val init = PartialFunction.empty[ServerCommand, Route]
               val handler = handlers.foldLeft(init) { case (accum, curr) =>
                 accum.orElse(curr.handleCommand)
               }

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/ServerRoute.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/ServerRoute.scala
@@ -1,7 +1,18 @@
 package org.bitcoins.server.routes
 
-import akka.http.scaladsl.server.StandardRoute
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.ValidationRejection
+
+import scala.util.Try
 
 trait ServerRoute {
-  def handleCommand: PartialFunction[ServerCommand, StandardRoute]
+  def handleCommand: PartialFunction[ServerCommand, Route]
+
+  def withValidServerCommand[R](validator: Try[R]): Directive1[R] =
+    validator.fold(
+      e => reject(ValidationRejection("failure", Some(e))),
+      provide
+    )
 }


### PR DESCRIPTION
Hey 👋
Some unsolicited refactoring:
This is removing request rejection duplication when handling server commands.
Also, you don't seem to be converting routes to directives anywhere, so no need for `StandardRoute` (basic `Route` should suffice).