### PR TITLE
Add protoc exception for apples new chip arch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ Test / flywayClean / aggregate := true
 
 lazy val Benchmark = config("bench") extend Test
 
+
 lazy val benchSettings: Seq[Def.SettingsDefinition] = {
   //for scalameter
   //https://scalameter.github.io/home/download/

--- a/lnd-rpc/lnd-rpc.sbt
+++ b/lnd-rpc/lnd-rpc.sbt
@@ -5,6 +5,7 @@ name := "bitcoin-s-lnd-rpc"
 
 libraryDependencies ++= Deps.lndRpc
 
+
 CommonSettings.prodSettings
 
 enablePlugins(AkkaGrpcPlugin)

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -3,18 +3,11 @@ import com.typesafe.sbt.SbtNativePackager.Docker
 import com.typesafe.sbt.SbtNativePackager.autoImport.packageName
 
 import java.nio.file.Paths
-import com.typesafe.sbt.packager.Keys.{
-  daemonUser,
-  daemonUserUid,
-  dockerAlias,
-  dockerAliases,
-  dockerRepository,
-  dockerUpdateLatest,
-  maintainer
-}
+import com.typesafe.sbt.packager.Keys.{daemonUser, daemonUserUid, dockerAlias, dockerAliases, dockerRepository, dockerUpdateLatest, maintainer}
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerBaseImage
 import sbt._
 import sbt.Keys._
+import sbtprotoc.ProtocPlugin.autoImport.PB
 
 import scala.util.Properties
 
@@ -54,7 +47,16 @@ object CommonSettings {
       s == "-Xfatal-warnings")),
     Test / console / scalacOptions ++= (Compile / console / scalacOptions).value,
     Test / scalacOptions ++= testCompilerOpts(scalaVersion.value),
-    licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
+    licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
+    //you need to build protoc manually to get it working on the new
+    //mac m1 chip. For instructions on how to do so see
+    //see: https://github.com/scalapb/ScalaPB/issues/1024
+      PB.protocExecutable := (
+    if (protocbridge.SystemDetector.detectedClassifier()=="osx-aarch_64")
+      file("/usr/local/bin/protoc") // to change if needed, this is where protobuf manual compilation put it for me
+    else
+      PB.protocExecutable.value
+    )
   )
 
   lazy val jvmSettings: Seq[Setting[_]] = List(


### PR DESCRIPTION
It appears that the protobuf project does not ship new m1 binaries yet

I followed the instrucitons in this issue to

1. Build `protoc` from source so i can support m1
2. Adding an exception for this chip architecture to use the manually compiled binary rather than the one shipped with protobufs

https://github.com/scalapb/ScalaPB/issues/1024