### PR TITLE
Fix javafx on mac osx new m1 arch

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -100,13 +100,20 @@ object Deps {
     val scalaFx =
       "org.scalafx" %% "scalafx" % V.scalaFxV withSources () withJavadoc ()
 
+    lazy val arch = System.getProperty("os.arch")
     lazy val osName = System.getProperty("os.name") match {
       case n if n.startsWith("Linux")   => "linux"
-      case n if n.startsWith("Mac")     => "mac"
+      case n if n.startsWith("Mac")     =>
+        if (arch == "aarch64" ) {
+          //needed to accommodate the different chip
+          //arch for M1
+          s"mac-${arch}"
+        } else {
+          "mac"
+        }
       case n if n.startsWith("Windows") => "win"
-      case _                            => throw new Exception("Unknown platform!")
+      case x                            => throw new Exception(s"Unknown platform $x!")
     }
-
     // Not sure if all of these are needed, some might be possible to remove
     lazy val javaFxBase =
       "org.openjfx" % s"javafx-base" % V.javaFxV classifier osName withSources () withJavadoc ()


### PR DESCRIPTION
fixes #3039 

The new m1 arch has a specific binary for javafx. You can look to see how they version it here: 

https://repo1.maven.org/maven2/org/openjfx/javafx-base/17-ea+8/

>javafx-base-17-ea+8-mac-**aarch64**.jar  

As you can see, the chip set is appended to the dep. If it is a normal `x86_64`, the chip set isn't appended.