### PR TITLE
2021 05 06 cet sigs async

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
@@ -103,9 +103,16 @@ object FutureUtil {
       elements: Vector[T],
       f: Vector[T] => Future[U],
       batchSize: Int)(implicit ec: ExecutionContext): Future[Vector[U]] = {
-    val batches = elements.grouped(batchSize).toVector
-    val execute: Vector[Future[U]] = batches.map(b => f(b))
-    val doneF = Future.sequence(execute)
-    doneF
+    require(
+      batchSize > 0,
+      s"Cannot have batch size less than or equal to zero, got=$batchSize")
+    if (elements.isEmpty) {
+      Future.successful(Vector.empty)
+    } else {
+      val batches = elements.grouped(batchSize).toVector
+      val execute: Vector[Future[U]] = batches.map(b => f(b))
+      val doneF = Future.sequence(execute)
+      doneF
+    }
   }
 }

--- a/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
@@ -192,9 +192,7 @@ case class DLCTxSigner(
   /** Computes the CET sigs asynchronously */
   def createCETSigsAsync()(implicit
       ec: ExecutionContext): Future[CETSignatures] = {
-    val startOutcomes = System.currentTimeMillis()
     val outcomes = builder.contractInfo.allOutcomes
-    val startSigning = System.currentTimeMillis()
 
     //divide and conquer
     val size = outcomes.length / Runtime.getRuntime.availableProcessors()

--- a/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
@@ -197,7 +197,7 @@ case class DLCTxSigner(
     val startSigning = System.currentTimeMillis()
 
     //divide and conquer
-    val size = outcomes.length % Runtime.getRuntime.availableProcessors()
+    val size = outcomes.length / Runtime.getRuntime.availableProcessors()
 
     //this gives us a iterator of size Runtime.getRuntime.availableProcess()
     val dividedOutcomes: Iterator[Vector[OracleOutcome]] = {

--- a/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/sign/DLCTxSigner.scala
@@ -194,9 +194,11 @@ case class DLCTxSigner(
   def createCETSigsAsync()(implicit
       ec: ExecutionContext): Future[CETSignatures] = {
     val outcomes = builder.contractInfo.allOutcomes
-
     //divide and conquer
-    val size = outcomes.length / Runtime.getRuntime.availableProcessors()
+
+    //we want a batch size of at least 1
+    val size =
+      Math.max(outcomes.length / Runtime.getRuntime.availableProcessors(), 1)
 
     val computeBatchFn: Vector[OracleOutcome] => Future[
       Vector[(OracleOutcome, ECAdaptorSignature)]] = {


### PR DESCRIPTION
This is PR adds a new method called `createCETSigsAsync()`. This is the bottleneck when creating accept and sign messages. 

This method determines how many cores (`c`) you have available on your machine, and the creates `c` batches of of cets to be computed rather than `createCETSigs()` which just has one batch of signatures. 

This optimization scales relative to the number of cores available on your machine, on a single core machine this optimization is likely slightly slower (thread/execution context overhead) than its synchronous counterpart `createCETSigs()`. Most modern machines have multiple cores. 

I benchmarked it by running 

>dlcWalletTest/testOnly *DLCMultiOracleNumericExecutionTest* -- -z "execute as the recipient"


and observing the accept flow. On my machine, it seems that `createCETSigsAsync` takes 1/6  the time for the test case above

1137ms on 28d2ac5

6419ms on db8af3759b217cbd64d0418fbe391dc0ad6a2f20