### PR TITLE
2021 05 09 received utxos

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
@@ -181,7 +181,7 @@ class SpendingInfoDAOTest extends WalletDAOFixture {
     for {
       utxo <- WalletTestUtil.insertLegacyUTXO(daos,
                                               state = TxoState.DoesNotExist)
-      foundTxos <- spendingInfoDAO.findTx(utxo.txid)
+      foundTxos <- spendingInfoDAO.findOutputsReceived(utxo.txid)
     } yield assert(foundTxos.contains(utxo))
 
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -450,7 +450,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
   }
 
   private def getRelevantOutputs(
-      transaction: Transaction): Future[Seq[OutputWithIndex]] = {
+      transaction: Transaction): Future[Vector[OutputWithIndex]] = {
     val spks = transaction.outputs.map(_.scriptPubKey)
     scriptPubKeyDAO.findScriptPubKeys(spks.toVector).map { addrs =>
       val withIndex =
@@ -459,7 +459,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
         case (out, idx)
             if addrs.map(_.scriptPubKey).contains(out.scriptPubKey) =>
           OutputWithIndex(out, idx)
-      }
+      }.toVector
     }
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -255,7 +255,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
     val receivedSpendingInfoDbsF: Future[Vector[SpendingInfoDb]] = {
       spendingInfoDAO.findTx(transaction)
     }
-    val spentSpendingInfoDbsF: Future[Seq[SpendingInfoDb]] = {
+    val spentSpendingInfoDbsF: Future[Vector[SpendingInfoDb]] = {
       spendingInfoDAO.findOutputsBeingSpent(transaction)
     }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -219,7 +219,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
     */
   protected def processSpentUtxos(
       transaction: Transaction,
-      outputsBeingSpent: Seq[SpendingInfoDb],
+      outputsBeingSpent: Vector[SpendingInfoDb],
       blockHashOpt: Option[DoubleSha256DigestBE]): Future[
     Vector[SpendingInfoDb]] = {
     for {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -473,7 +473,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
       newTags: Vector[AddressTag]): Future[Seq[SpendingInfoDb]] = {
     val outputsF = getRelevantOutputs(transaction)
     outputsF.flatMap {
-      case Nil =>
+      case Vector() =>
         logger.trace(
           s"Found no outputs relevant to us in transaction${transaction.txIdBE.hex}")
         Future.successful(Vector.empty)

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -190,22 +190,22 @@ case class SpendingInfoDAO()(implicit
   def findTx(tx: Transaction): Future[Vector[SpendingInfoDb]] =
     findOutputsReceived(tx.txIdBE)
 
+  private def _findOutputsBeingSpent(
+      tx: Transaction): Future[Vector[UTXORecord]] = {
+    val filtered = table
+      .filter { case txo =>
+        txo.outPoint.inSet(tx.inputs.map(_.previousOutput))
+      }
+
+    safeDatabase.runVec(filtered.result)
+  }
+
   /** Finds all the outputs being spent in the given
     * transaction
     */
-  def findOutputsBeingSpent(tx: Transaction): Future[Seq[SpendingInfoDb]] = {
-
-    def _findOutputsBeingSpent: Future[Seq[UTXORecord]] = {
-      val filtered = table
-        .filter { case txo =>
-          txo.outPoint.inSet(tx.inputs.map(_.previousOutput))
-        }
-
-      safeDatabase.run(filtered.result)
-    }
-
+  def findOutputsBeingSpent(tx: Transaction): Future[Vector[SpendingInfoDb]] = {
     for {
-      utxos <- _findOutputsBeingSpent
+      utxos <- _findOutputsBeingSpent(tx)
       spks <- findScriptPubKeysByUtxos(utxos)
     } yield {
       utxos.map(utxo =>
@@ -254,7 +254,8 @@ case class SpendingInfoDAO()(implicit
   /** Fetches all the incoming TXOs in our DB that are in
     * the transaction with the given TXID
     */
-  def findOutputsReceived(txid: DoubleSha256DigestBE): Future[Vector[SpendingInfoDb]] = {
+  def findOutputsReceived(
+      txid: DoubleSha256DigestBE): Future[Vector[SpendingInfoDb]] = {
     val filtered = spkJoinQuery.filter(_._1.txid === txid)
     safeDatabase
       .runVec(filtered.result)
@@ -423,7 +424,7 @@ case class SpendingInfoDAO()(implicit
   }
 
   private def findScriptPubKeysByUtxos(
-      utxos: Seq[UTXORecord]): Future[Map[Long, ScriptPubKeyDb]] = {
+      utxos: Vector[UTXORecord]): Future[Map[Long, ScriptPubKeyDb]] = {
     val ids = utxos.map(_.scriptPubKeyId)
     findScriptPubKeys(ids)
   }


### PR DESCRIPTION
This PR does a few things in the wallet project

1. Renames `Incoming` -> `Received` in wallet methods. This is to be consistent with our `TxoState.Received` type hierarchy
2. Adds parameters `spendingInfoDbs` to `processedReceivedUtxos()` and `processedSpentUtxos()`. This allows us to read from the database in parallel and pass in the appropriate `SpendingInfoDb`s into those methods. Since we can't call these two methods in parallel, hopefully this is a step to re-introducing parallel behavior by determining if the transaction needs to be inserted at all. In the future we should be able to insert the tx if either of those methods returns something, and remove transaction table insertions inside of `processReceivedUtxos()` and `processSpentUtxos()`. See #2801 for more details.
3. Change some `Seq` types to `Vector`. `Seq` can have surprising performance behavior, while Vector is near constant time for every operation on the `Vector`. 

