### PR TITLE
Introduces pre-computed table for adaptor point computation

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -895,10 +895,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
     val dummyOutcomeSigs =
       Vector(
-        EnumOracleOutcome(Vector(oracleInfo),
-                          EnumOutcome(winStr)) -> ECAdaptorSignature.dummy,
-        EnumOracleOutcome(Vector(oracleInfo),
-                          EnumOutcome(loseStr)) -> ECAdaptorSignature.dummy
+        EnumOracleOutcome(
+          Vector(oracleInfo),
+          EnumOutcome(winStr)).sigPoint -> ECAdaptorSignature.dummy,
+        EnumOracleOutcome(
+          Vector(oracleInfo),
+          EnumOutcome(loseStr)).sigPoint -> ECAdaptorSignature.dummy
       )
 
     val contractInfo = ContractInfo(contractDesc, oracleInfo)

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
@@ -80,11 +80,12 @@ class DLCMessageTest extends BitcoinSJvmTest {
         dummyAddress,
         payoutSerialId = UInt64.zero,
         changeSerialId = UInt64.one,
-        CETSignatures(Vector(
-                        EnumOracleOutcome(
-                          Vector(dummyOracle),
-                          EnumOutcome(dummyStr)) -> ECAdaptorSignature.dummy),
-                      dummySig),
+        CETSignatures(
+          Vector(
+            EnumOracleOutcome(
+              Vector(dummyOracle),
+              EnumOutcome(dummyStr)).sigPoint -> ECAdaptorSignature.dummy),
+          dummySig),
         DLCAccept.NoNegotiationFields,
         Sha256Digest.empty
       )

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/ContractInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/ContractInfo.scala
@@ -134,19 +134,16 @@ case class ContractInfo(
 
   /** Maps adpator points to their corresponding OracleOutcomes (which correspond to CETs) */
   lazy val sigPointMap: Map[ECPublicKey, OracleOutcome] =
-    allOutcomes.zipWithIndex.map { case (outcome, index) =>
-      adaptorPoints(index) -> outcome
-    }.toMap
+    adaptorPoints.zip(allOutcomes).toMap
 
   /** Map OracleOutcomes (which correspond to CETs) to their adpator point and payouts */
   lazy val outcomeMap: Map[OracleOutcome, (ECPublicKey, Satoshis, Satoshis)] = {
     val builder =
       HashMap.newBuilder[OracleOutcome, (ECPublicKey, Satoshis, Satoshis)]
 
-    allOutcomesAndPayouts.zipWithIndex.foreach {
-      case ((outcome, offerPayout), index) =>
+    allOutcomesAndPayouts.zip(adaptorPoints).foreach {
+      case ((outcome, offerPayout), adaptorPoint) =>
         val acceptPayout = (totalCollateral - offerPayout).satoshis
-        val adaptorPoint = adaptorPoints(index)
 
         builder.+=((outcome, (adaptorPoint, offerPayout, acceptPayout)))
     }

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCAdaptorPointComputer.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCAdaptorPointComputer.scala
@@ -18,9 +18,18 @@ object DLCAdaptorPointComputer {
 
   private val base: Int = 2
 
+  private lazy val numericPossibleOutcomes: Vector[ByteVector] = {
+    0
+      .until(base)
+      .toVector
+      .map(_.toString)
+      .map(CryptoUtil.serializeForHash)
+  }
+
   /** Computes:
     *     nonce + outcomeHash*pubKey
     * where outcomeHash is as specified in the DLC spec.
+    * @see https://github.com/discreetlogcontracts/dlcspecs/blob/master/Oracle.md#signing-algorithm
     */
   def computePoint(
       pubKey: SchnorrPublicKey,
@@ -45,12 +54,7 @@ object DLCAdaptorPointComputer {
       contractInfo.contractDescriptor match {
         case enum: EnumContractDescriptor =>
           enum.keys.map(_.outcome).map(CryptoUtil.serializeForHash)
-        case _: NumericContractDescriptor =>
-          0
-            .until(base)
-            .toVector
-            .map(_.toString)
-            .map(CryptoUtil.serializeForHash)
+        case _: NumericContractDescriptor => numericPossibleOutcomes
       }
 
     // Oracle -> Nonce -> Outcome -> SubSigPoint

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCAdaptorPointComputer.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCAdaptorPointComputer.scala
@@ -1,0 +1,88 @@
+package org.bitcoins.core.protocol.dlc
+
+import org.bitcoins.core.protocol.tlv.{
+  EnumOutcome,
+  SignedNumericOutcome,
+  UnsignedNumericOutcome
+}
+import org.bitcoins.crypto.{
+  CryptoUtil,
+  ECPublicKey,
+  FieldElement,
+  SchnorrPublicKey
+}
+import scodec.bits.ByteVector
+
+object DLCAdaptorPointComputer {
+
+  private val base: Int = 2
+
+  def computePoint(
+      pubKey: SchnorrPublicKey,
+      nonce: ECPublicKey,
+      outcome: ByteVector): ECPublicKey = {
+    val hash = CryptoUtil
+      .sha256SchnorrChallenge(
+        nonce.schnorrNonce.bytes ++ pubKey.bytes ++ CryptoUtil
+          .sha256DLCAttestation(outcome)
+          .bytes)
+      .bytes
+
+    nonce.add(pubKey.publicKey.tweakMultiply(FieldElement(hash)))
+  }
+
+  def computeAdaptorPoints(contractInfo: ContractInfo): Vector[ECPublicKey] = {
+    val possibleOutcomes: Vector[ByteVector] =
+      contractInfo.contractDescriptor match {
+        case enum: EnumContractDescriptor =>
+          enum.keys.map(_.outcome).map(CryptoUtil.serializeForHash)
+        case _: NumericContractDescriptor =>
+          0
+            .until(base)
+            .toVector
+            .map(_.toString)
+            .map(CryptoUtil.serializeForHash)
+      }
+
+    // Oracle -> Nonce -> Outcome -> SubSigPoint
+    val preComputeTable: Vector[Vector[Vector[ECPublicKey]]] =
+      contractInfo.oracleInfo.singleOracleInfos.map { info =>
+        val announcement = info.announcement
+        val pubKey = announcement.publicKey
+        val nonces = announcement.eventTLV.nonces.map(_.publicKey)
+
+        nonces.map { nonce =>
+          possibleOutcomes.map { outcome =>
+            computePoint(pubKey, nonce, outcome)
+          }
+        }
+      }
+
+    val oraclesAndOutcomes = contractInfo.allOutcomes.map(_.oraclesAndOutcomes)
+
+    oraclesAndOutcomes.map { oracleAndOutcome =>
+      val subSigPoints = oracleAndOutcome.flatMap { case (info, outcome) =>
+        val oracleIndex =
+          contractInfo.oracleInfo.singleOracleInfos.indexOf(info)
+        val outcomeIndices = outcome match {
+          case outcome: EnumOutcome =>
+            Vector(
+              contractInfo.contractDescriptor
+                .asInstanceOf[EnumContractDescriptor]
+                .keys
+                .indexOf(outcome))
+          case UnsignedNumericOutcome(digits) => digits
+          case _: SignedNumericOutcome =>
+            throw new UnsupportedOperationException(
+              "Signed numeric outcomes not supported!")
+        }
+
+        outcomeIndices.zipWithIndex.map { case (outcomeIndex, nonceIndex) =>
+          preComputeTable(oracleIndex)(nonceIndex)(outcomeIndex)
+        }
+      }
+
+      CryptoUtil.combinePubKeys(subSigPoints)
+    }
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCMessage.scala
@@ -308,9 +308,7 @@ object DLCMessage {
         accept: DLCAcceptTLV,
         network: NetworkParameters,
         contractInfo: ContractInfo): DLCAccept = {
-      fromTLV(accept,
-              network,
-              DLCAdaptorPointComputer.computeAdaptorPoints(contractInfo))
+      fromTLV(accept, network, contractInfo.adaptorPoints)
     }
 
     def fromTLV(accept: DLCAcceptTLV, offer: DLCOffer): DLCAccept = {
@@ -378,7 +376,7 @@ object DLCMessage {
     def fromTLV(sign: DLCSignTLV, offer: DLCOffer): DLCSign = {
       fromTLV(sign,
               offer.pubKeys.fundingKey,
-              DLCAdaptorPointComputer.computeAdaptorPoints(offer.contractInfo),
+              offer.contractInfo.adaptorPoints,
               offer.fundingInputs.map(_.outPoint))
     }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCMessage.scala
@@ -275,10 +275,10 @@ object DLCMessage {
     def fromTLV(
         accept: DLCAcceptTLV,
         network: NetworkParameters,
-        outcomes: Vector[OracleOutcome]): DLCAccept = {
+        adaptorPoints: Vector[ECPublicKey]): DLCAccept = {
       val outcomeSigs = accept.cetSignatures match {
         case CETSignaturesV0TLV(sigs) =>
-          outcomes.zip(sigs)
+          adaptorPoints.zip(sigs)
       }
 
       DLCAccept(
@@ -308,7 +308,9 @@ object DLCMessage {
         accept: DLCAcceptTLV,
         network: NetworkParameters,
         contractInfo: ContractInfo): DLCAccept = {
-      fromTLV(accept, network, contractInfo.allOutcomes)
+      fromTLV(accept,
+              network,
+              DLCAdaptorPointComputer.computeAdaptorPoints(contractInfo))
     }
 
     def fromTLV(accept: DLCAcceptTLV, offer: DLCOffer): DLCAccept = {
@@ -348,11 +350,11 @@ object DLCMessage {
     def fromTLV(
         sign: DLCSignTLV,
         fundingPubKey: ECPublicKey,
-        outcomes: Vector[OracleOutcome],
+        adaptorPoints: Vector[ECPublicKey],
         fundingOutPoints: Vector[TransactionOutPoint]): DLCSign = {
       val outcomeSigs = sign.cetSignatures match {
         case CETSignaturesV0TLV(sigs) =>
-          outcomes.zip(sigs)
+          adaptorPoints.zip(sigs)
       }
 
       val sigs = sign.fundingSignatures match {
@@ -376,7 +378,7 @@ object DLCMessage {
     def fromTLV(sign: DLCSignTLV, offer: DLCOffer): DLCSign = {
       fromTLV(sign,
               offer.pubKeys.fundingKey,
-              offer.contractInfo.allOutcomes,
+              DLCAdaptorPointComputer.computeAdaptorPoints(offer.contractInfo),
               offer.fundingInputs.map(_.outPoint))
     }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCSignatures.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCSignatures.scala
@@ -4,7 +4,7 @@ import org.bitcoins.core.protocol.script.ScriptWitnessV0
 import org.bitcoins.core.protocol.tlv.FundingSignaturesV0TLV
 import org.bitcoins.core.protocol.transaction.TransactionOutPoint
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
-import org.bitcoins.core.util.SeqWrapper
+import org.bitcoins.core.util.{Indexed, SeqWrapper}
 import org.bitcoins.crypto.{ECAdaptorSignature, ECPublicKey}
 
 sealed trait DLCSignatures
@@ -40,6 +40,12 @@ case class CETSignatures(
     extends DLCSignatures {
   lazy val keys: Vector[ECPublicKey] = outcomeSigs.map(_._1)
   lazy val adaptorSigs: Vector[ECAdaptorSignature] = outcomeSigs.map(_._2)
+
+  def indexedOutcomeSigs: Vector[(Indexed[ECPublicKey], ECAdaptorSignature)] = {
+    outcomeSigs.zipWithIndex.map { case ((adaptorPoint, sig), index) =>
+      (Indexed(adaptorPoint, index), sig)
+    }
+  }
 
   def apply(key: ECPublicKey): ECAdaptorSignature = {
     outcomeSigs

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCSignatures.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCSignatures.scala
@@ -5,7 +5,7 @@ import org.bitcoins.core.protocol.tlv.FundingSignaturesV0TLV
 import org.bitcoins.core.protocol.transaction.TransactionOutPoint
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.util.SeqWrapper
-import org.bitcoins.crypto.ECAdaptorSignature
+import org.bitcoins.crypto.{ECAdaptorSignature, ECPublicKey}
 
 sealed trait DLCSignatures
 
@@ -35,13 +35,13 @@ case class FundingSignatures(
 }
 
 case class CETSignatures(
-    outcomeSigs: Vector[(OracleOutcome, ECAdaptorSignature)],
+    outcomeSigs: Vector[(ECPublicKey, ECAdaptorSignature)],
     refundSig: PartialSignature)
     extends DLCSignatures {
-  lazy val keys: Vector[OracleOutcome] = outcomeSigs.map(_._1)
+  lazy val keys: Vector[ECPublicKey] = outcomeSigs.map(_._1)
   lazy val adaptorSigs: Vector[ECAdaptorSignature] = outcomeSigs.map(_._2)
 
-  def apply(key: OracleOutcome): ECAdaptorSignature = {
+  def apply(key: ECPublicKey): ECAdaptorSignature = {
     outcomeSigs
       .find(_._1 == key)
       .map(_._2)

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCUtil.scala
@@ -73,8 +73,7 @@ object DLCUtil {
       localAdaptorSigs: Vector[(ECPublicKey, ECAdaptorSignature)],
       cet: WitnessTransaction): Option[
     (SchnorrDigitalSignature, OracleOutcome)] = {
-    val allAdaptorPoints =
-      DLCAdaptorPointComputer.computeAdaptorPoints(contractInfo)
+    val allAdaptorPoints = contractInfo.adaptorPoints
 
     val cetSigs = cet.witness.head
       .asInstanceOf[P2WSHWitnessV0]
@@ -99,12 +98,7 @@ object DLCUtil {
         Math.abs((amts.head - outcomeValues.head).satoshis.toLong) <= 1 && Math
           .abs((amts.last - outcomeValues.last).satoshis.toLong) <= 1
       }
-      .map { case ((outcome, _), index) =>
-        val sigPoint = allAdaptorPoints(index)
-        require(outcome.sigPoint == sigPoint, "Something went wrong.")
-
-        sigPoint
-      }
+      .map { case (_, index) => allAdaptorPoints(index) }
 
     val (offerCETSig, acceptCETSig) =
       if (offerFundingKey.hex.compareTo(acceptFundingKey.hex) > 0) {
@@ -126,7 +120,6 @@ object DLCUtil {
     computeOutcome(cetSig, outcomeSigs).map { case (s, adaptorPoint) =>
       val index = allAdaptorPoints.indexOf(adaptorPoint)
       val outcome: OracleOutcome = contractInfo.allOutcomes(index)
-      require(outcome.sigPoint == adaptorPoint, "Something went wrong.")
 
       (SchnorrDigitalSignature(outcome.aggregateNonce, s), outcome)
     }

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/OracleOutcome.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/OracleOutcome.scala
@@ -108,7 +108,5 @@ object NumericOracleOutcome {
   }
 }
 
-/** An oracle outcome and it's corresponding CET */
-case class OutcomeCETPair(outcome: OracleOutcome, wtx: WitnessTransaction)
-
+/** An adaptor point and it's corresponding CET */
 case class AdaptorPointCETPair(sigPoint: ECPublicKey, wtx: WitnessTransaction)

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/OracleOutcome.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/OracleOutcome.scala
@@ -25,6 +25,8 @@ sealed trait OracleOutcome {
     */
   def outcome: DLCOutcomeType
 
+  def oraclesAndOutcomes: Vector[(SingleOracleInfo, DLCOutcomeType)]
+
   protected def computeSigPoint: ECPublicKey
 
   /** The adaptor point used to encrypt the signatures for this corresponding CET. */
@@ -48,6 +50,9 @@ case class EnumOracleOutcome(
     oracles.map(_.sigPoint(outcome)).reduce(_.add(_))
   }
 
+  override val oraclesAndOutcomes: Vector[(EnumSingleOracleInfo, EnumOutcome)] =
+    oracles.map((_, outcome))
+
   override lazy val aggregateNonce: SchnorrNonce = {
     oracles
       .map(_.aggregateNonce(outcome))
@@ -60,7 +65,7 @@ case class EnumOracleOutcome(
 /** Corresponds to a CET in an Numeric Outcome DLC where some set of `threshold`
   * oracles have each signed some NumericOutcome.
   */
-case class NumericOracleOutcome(oraclesAndOutcomes: Vector[
+case class NumericOracleOutcome(override val oraclesAndOutcomes: Vector[
   (NumericSingleOracleInfo, UnsignedNumericOutcome)])
     extends OracleOutcome {
 
@@ -105,3 +110,5 @@ object NumericOracleOutcome {
 
 /** An oracle outcome and it's corresponding CET */
 case class OutcomeCETPair(outcome: OracleOutcome, wtx: WitnessTransaction)
+
+case class AdaptorPointCETPair(sigPoint: ECPublicKey, wtx: WitnessTransaction)

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DLCClientTest.scala
@@ -356,15 +356,16 @@ class DLCClientTest extends BitcoinSJvmTest with DLCTest {
       val oracleSig = genEnumOracleSignature(oracleInfo, outcome.outcome)
 
       assertThrows[RuntimeException] {
-        offerClient.dlcTxSigner.completeCET(oracleOutcome,
-                                            badAcceptCETSigs(oracleOutcome),
-                                            Vector(oracleSig))
+        offerClient.dlcTxSigner.completeCET(
+          oracleOutcome,
+          badAcceptCETSigs(oracleOutcome.sigPoint),
+          Vector(oracleSig))
       }
 
       assertThrows[RuntimeException] {
         acceptClient.dlcTxSigner
           .completeCET(oracleOutcome,
-                       badOfferCETSigs(oracleOutcome),
+                       badOfferCETSigs(oracleOutcome.sigPoint),
                        Vector(oracleSig))
       }
     }
@@ -382,8 +383,12 @@ class DLCClientTest extends BitcoinSJvmTest with DLCTest {
         Vector(offerClient.offer.oracleInfo.asInstanceOf[EnumSingleOracleInfo]),
         outcomeUncast.asInstanceOf[EnumOutcome])
 
-      assert(offerVerifier.verifyCETSig(outcome, acceptCETSigs(outcome)))
-      assert(acceptVerifier.verifyCETSig(outcome, offerCETSigs(outcome)))
+      assert(
+        offerVerifier.verifyCETSig(outcome.sigPoint,
+                                   acceptCETSigs(outcome.sigPoint)))
+      assert(
+        acceptVerifier.verifyCETSig(outcome.sigPoint,
+                                    offerCETSigs(outcome.sigPoint)))
     }
     assert(offerVerifier.verifyRefundSig(acceptCETSigs.refundSig))
     assert(offerVerifier.verifyRefundSig(offerCETSigs.refundSig))
@@ -395,11 +400,19 @@ class DLCClientTest extends BitcoinSJvmTest with DLCTest {
         Vector(offerClient.offer.oracleInfo.asInstanceOf[EnumSingleOracleInfo]),
         outcomeUncast.asInstanceOf[EnumOutcome])
 
-      assert(!offerVerifier.verifyCETSig(outcome, badAcceptCETSigs(outcome)))
-      assert(!acceptVerifier.verifyCETSig(outcome, badOfferCETSigs(outcome)))
+      assert(
+        !offerVerifier.verifyCETSig(outcome.sigPoint,
+                                    badAcceptCETSigs(outcome.sigPoint)))
+      assert(
+        !acceptVerifier.verifyCETSig(outcome.sigPoint,
+                                     badOfferCETSigs(outcome.sigPoint)))
 
-      assert(!offerVerifier.verifyCETSig(outcome, offerCETSigs(outcome)))
-      assert(!acceptVerifier.verifyCETSig(outcome, acceptCETSigs(outcome)))
+      assert(
+        !offerVerifier.verifyCETSig(outcome.sigPoint,
+                                    offerCETSigs(outcome.sigPoint)))
+      assert(
+        !acceptVerifier.verifyCETSig(outcome.sigPoint,
+                                     acceptCETSigs(outcome.sigPoint)))
     }
     assert(!offerVerifier.verifyRefundSig(badAcceptCETSigs.refundSig))
     assert(!offerVerifier.verifyRefundSig(badOfferCETSigs.refundSig))

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/SetupDLCTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/SetupDLCTest.scala
@@ -51,9 +51,10 @@ class SetupDLCTest extends BitcoinSJvmTest {
       refundTx: WitnessTransaction = validRefundTx): SetupDLC = {
     SetupDLC(
       fundingTx = fundingTx,
-      cets = Vector(
-        EnumOracleOutcome(Vector(oracleInfo), EnumOutcome("WIN")) -> cet0,
-        EnumOracleOutcome(Vector(oracleInfo), EnumOutcome("LOSE")) -> cet1),
+      cets = Vector(EnumOracleOutcome(Vector(oracleInfo),
+                                      EnumOutcome("WIN")).sigPoint -> cet0,
+                    EnumOracleOutcome(Vector(oracleInfo),
+                                      EnumOutcome("LOSE")).sigPoint -> cet1),
       refundTx = refundTx
     )
   }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -106,7 +106,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
       assert(sign.cetSigs.outcomeSigs.forall { case (outcome, sig) =>
         outcomeSigs.exists(dbSig =>
-          (dbSig.sigPoint, dbSig.signature) == ((outcome.sigPoint, sig)))
+          (dbSig.sigPoint, dbSig.signature) == ((outcome, sig)))
       })
 
       // Test that the Addresses are in the wallet's database
@@ -206,7 +206,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
         assert(sign.cetSigs.outcomeSigs.forall { case (outcome, sig) =>
           outcomeSigs.exists(dbSig =>
-            (dbSig.sigPoint, dbSig.signature) == ((outcome.sigPoint, sig)))
+            (dbSig.sigPoint, dbSig.signature) == ((outcome, sig)))
         })
 
         // Test that the Addresses are in the wallet's database
@@ -545,7 +545,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
           assert(sign.cetSigs.outcomeSigs.forall { case (outcome, sig) =>
             outcomeSigs.exists(dbSig =>
-              (dbSig.sigPoint, dbSig.signature) == ((outcome.sigPoint, sig)))
+              (dbSig.sigPoint, dbSig.signature) == ((outcome, sig)))
           })
           // Test that the Addresses are in the wallet's database
           assert(walletAChange.isDefined)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDb.scala
@@ -20,7 +20,7 @@ case class DLCAcceptDb(
 
   def toDLCAccept(
       fundingInputs: Vector[DLCFundingInput],
-      outcomeSigs: Vector[(OracleOutcome, ECAdaptorSignature)],
+      outcomeSigs: Vector[(ECPublicKey, ECAdaptorSignature)],
       refundSig: PartialSignature): DLCAccept = {
     val pubKeys =
       DLCPublicKeys(fundingKey, finalAddress)

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
@@ -4,6 +4,7 @@ import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.protocol.dlc._
 import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
+import org.bitcoins.core.util.Indexed
 import org.bitcoins.crypto.{AdaptorSign, ECPublicKey}
 import org.bitcoins.dlc.builder.DLCTxBuilder
 import org.bitcoins.dlc.sign.DLCTxSigner
@@ -50,7 +51,7 @@ case class DLCExecutor(signer: DLCTxSigner) {
     }
 
     val CETSignatures(outcomeSigs, refundSig) = cetSigs
-    val msgs = outcomeSigs.map(_._1)
+    val msgs = Indexed(outcomeSigs.map(_._1))
     val cets = cetsOpt match {
       case Some(cets) => cets
       case None       => builder.buildCETs(msgs)

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/DLCExecutor.scala
@@ -122,7 +122,7 @@ object DLCExecutor {
     * a valid set of expected oracle signatures as per the oracle announcements in the ContractInfo.
     */
   def executeDLC(
-      remoteCETInfos: Vector[(OracleOutcome, CETInfo)],
+      remoteCETInfos: Vector[(ECPublicKey, CETInfo)],
       oracleSigs: Vector[OracleSignatures],
       fundingKey: AdaptorSign,
       remoteFundingPubKey: ECPublicKey,
@@ -140,7 +140,9 @@ object DLCExecutor {
     }
 
     val msgAndCETInfoOpt = msgOpt.flatMap { msg =>
-      remoteCETInfos.find(_._1 == msg)
+      remoteCETInfos
+        .find(_._1 == msg.sigPoint)
+        .map { case (_, info) => (msg, info) }
     }
 
     val (msg, ucet, remoteAdaptorSig) = msgAndCETInfoOpt match {

--- a/dlc/src/main/scala/org/bitcoins/dlc/execution/SetupDLC.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/execution/SetupDLC.scala
@@ -1,12 +1,11 @@
 package org.bitcoins.dlc.execution
 
-import org.bitcoins.core.protocol.dlc.OracleOutcome
 import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
-import org.bitcoins.crypto.ECAdaptorSignature
+import org.bitcoins.crypto.{ECAdaptorSignature, ECPublicKey}
 
 case class SetupDLC(
     fundingTx: Transaction,
-    cets: Vector[(OracleOutcome, CETInfo)],
+    cets: Vector[(ECPublicKey, CETInfo)],
     refundTx: WitnessTransaction) {
   cets.foreach { case (msg, cetInfo) =>
     require(
@@ -25,12 +24,12 @@ case class SetupDLC(
     s"RefundTx is not spending the funding tx, ${refundTx.inputs.head}"
   )
 
-  def getCETInfo(outcome: OracleOutcome): CETInfo = {
-    cets.find(_._1 == outcome) match {
+  def getCETInfo(adaptorPoint: ECPublicKey): CETInfo = {
+    cets.find(_._1 == adaptorPoint) match {
       case Some((_, info)) => info
       case None =>
         throw new IllegalArgumentException(
-          s"No CET found for the given outcome $outcome")
+          s"No CET found for the given adaptor point $adaptorPoint")
     }
   }
 }

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTLVGen.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTLVGen.scala
@@ -202,7 +202,7 @@ object DLCTLVGen {
         ECPublicKey.freshPublicKey): CETSignatures = {
     CETSignatures(
       outcomes.map(outcome =>
-        EnumOracleOutcome(Vector(oracleInfo), outcome) -> adaptorSig),
+        EnumOracleOutcome(Vector(oracleInfo), outcome).sigPoint -> adaptorSig),
       partialSig(fundingPubKey, sigHashByte = false))
   }
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
@@ -187,6 +187,7 @@ case class ValidTestInputs(
         .map(_.preImage)
         .map(EnumOutcome.apply)
         .map(outcome => EnumOracleOutcome(Vector(params.oracleInfo), outcome))
+        .map(_.sigPoint)
         .map(builder.buildCET)
     val refundTx = builder.buildRefundTx
 

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
@@ -17,6 +17,7 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockTimeStamp}
 import org.bitcoins.core.script.crypto.HashType
+import org.bitcoins.core.util.Indexed
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{
   ConditionalPath,
@@ -182,13 +183,13 @@ case class ValidTestInputs(
   def buildTransactions: DLCTransactions = {
     val builder = this.builder
     val fundingTx = builder.buildFundingTx
-    val cets =
+    val adaptorPoints =
       params.contractInfo
         .map(_.preImage)
         .map(EnumOutcome.apply)
         .map(outcome => EnumOracleOutcome(Vector(params.oracleInfo), outcome))
         .map(_.sigPoint)
-        .map(builder.buildCET)
+    val cets = builder.buildCETs(Indexed(adaptorPoints))
     val refundTx = builder.buildRefundTx
 
     DLCTransactions(fundingTx, cets, refundTx)

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTxGen.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTxGen.scala
@@ -259,14 +259,14 @@ object DLCTxGen {
 
       val offerSignedCET = offerSigner.completeCET(
         outcome,
-        accpetCETSigs(outcome),
+        accpetCETSigs(outcome.sigPoint),
         Vector(
           EnumOracleSignature(inputs.params.oracleInfo,
                               inputs.params.oracleSignature)))
 
       val acceptSignedCET = acceptSigner.completeCET(
         outcome,
-        offerCETSigs(outcome),
+        offerCETSigs(outcome.sigPoint),
         Vector(
           EnumOracleSignature(inputs.params.oracleInfo,
                               inputs.params.oracleSignature)))

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTxGen.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/DLCTxGen.scala
@@ -245,7 +245,7 @@ object DLCTxGen {
       EnumOracleOutcome(Vector(inputs.params.oracleInfo),
                         EnumOutcome(outcomeStr))
 
-    val accpetCETSigs = acceptSigner.createCETSigs()
+    val acceptCETSigs = acceptSigner.createCETSigs()
     val offerCETSigs = offerSigner.createCETSigs()
 
     for {
@@ -255,11 +255,11 @@ object DLCTxGen {
 
       signedFundingTx <- acceptSigner.completeFundingTx(offerFundingSigs)
     } yield {
-      val signedRefundTx = offerSigner.completeRefundTx(accpetCETSigs.refundSig)
+      val signedRefundTx = offerSigner.completeRefundTx(acceptCETSigs.refundSig)
 
       val offerSignedCET = offerSigner.completeCET(
         outcome,
-        accpetCETSigs(outcome.sigPoint),
+        acceptCETSigs(outcome.sigPoint),
         Vector(
           EnumOracleSignature(inputs.params.oracleInfo,
                               inputs.params.oracleSignature)))
@@ -271,7 +271,7 @@ object DLCTxGen {
           EnumOracleSignature(inputs.params.oracleInfo,
                               inputs.params.oracleSignature)))
 
-      val accept = acceptWithoutSigs.withSigs(accpetCETSigs)
+      val accept = acceptWithoutSigs.withSigs(acceptCETSigs)
 
       val contractId = fundingTx.txIdBE.bytes.xor(accept.tempContractId.bytes)
       val sign = DLCSign(offerCETSigs, offerFundingSigs, contractId)

--- a/dlc/src/main/scala/org/bitcoins/dlc/testgen/TestDLCClient.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/testgen/TestDLCClient.scala
@@ -99,7 +99,7 @@ case class TestDLCClient(
       }
       cetSigs =
         dlcTxSigner.createCETSigs(setupDLCWithoutFundingTxSigs.cets.map {
-          case (msg, info) => OutcomeCETPair(msg, info.tx)
+          case (msg, info) => AdaptorPointCETPair(msg, info.tx)
         })
       localFundingSigs <- Future.fromTry {
         dlcTxSigner.signFundingTx()

--- a/dlc/src/main/scala/org/bitcoins/dlc/verify/DLCSignatureVerifier.scala
+++ b/dlc/src/main/scala/org/bitcoins/dlc/verify/DLCSignatureVerifier.scala
@@ -7,11 +7,7 @@ import org.bitcoins.core.crypto.{
 }
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
-import org.bitcoins.core.protocol.dlc.{
-  DLCFundingInput,
-  FundingSignatures,
-  OracleOutcome
-}
+import org.bitcoins.core.protocol.dlc.{DLCFundingInput, FundingSignatures}
 import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
@@ -37,15 +33,17 @@ case class DLCSignatureVerifier(builder: DLCTxBuilder, isInitiator: Boolean) {
   }
 
   /** Verifies remote's CET signature for a given outcome hash */
-  def verifyCETSig(outcome: OracleOutcome, sig: ECAdaptorSignature): Boolean = {
+  def verifyCETSig(
+      adaptorPoint: ECPublicKey,
+      sig: ECAdaptorSignature): Boolean = {
     val remoteFundingPubKey = if (isInitiator) {
       builder.acceptFundingKey
     } else {
       builder.offerFundingKey
     }
-    val cet = builder.buildCET(outcome)
+    val cet = builder.buildCET(adaptorPoint)
 
-    DLCSignatureVerifier.validateCETSignature(outcome,
+    DLCSignatureVerifier.validateCETSignature(adaptorPoint,
                                               sig,
                                               remoteFundingPubKey,
                                               fundingTx,
@@ -53,13 +51,13 @@ case class DLCSignatureVerifier(builder: DLCTxBuilder, isInitiator: Boolean) {
                                               cet)
   }
 
-  def verifyCETSigs(sigs: Vector[(OracleOutcome, ECAdaptorSignature)])(implicit
+  def verifyCETSigs(sigs: Vector[(ECPublicKey, ECAdaptorSignature)])(implicit
       ec: ExecutionContext): Future[Boolean] = {
     val correctNumberOfSigs =
       sigs.size >= builder.contractInfo.allOutcomes.length
 
     def runVerify(
-        outcomeSigs: Vector[(OracleOutcome, ECAdaptorSignature)]): Future[
+        outcomeSigs: Vector[(ECPublicKey, ECAdaptorSignature)]): Future[
       Boolean] = {
       Future {
         outcomeSigs.foldLeft(true) { case (ret, (outcome, sig)) =>
@@ -89,15 +87,13 @@ case class DLCSignatureVerifier(builder: DLCTxBuilder, isInitiator: Boolean) {
 object DLCSignatureVerifier {
 
   def validateCETSignature(
-      outcome: OracleOutcome,
+      adaptorPoint: ECPublicKey,
       sig: ECAdaptorSignature,
       remoteFundingPubKey: ECPublicKey,
       fundingTx: Transaction,
       fundOutputIndex: Int,
       cet: WitnessTransaction
   ): Boolean = {
-    val adaptorPoint = outcome.sigPoint
-
     val sigComponent = WitnessTxSigComponentRaw(
       transaction = cet,
       inputIndex = UInt32.zero,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -155,12 +155,14 @@ object DLCWalletUtil {
   lazy val sampleDLCParamHash: Sha256DigestBE =
     DLCMessage.calcParamHash(sampleContractInfo, dummyTimeouts)
 
-  lazy val dummyOutcomeSigs: Vector[(EnumOracleOutcome, ECAdaptorSignature)] =
+  lazy val dummyOutcomeSigs: Vector[(ECPublicKey, ECAdaptorSignature)] =
     Vector(
-      EnumOracleOutcome(Vector(sampleOracleInfo),
-                        EnumOutcome(winStr)) -> ECAdaptorSignature.dummy,
-      EnumOracleOutcome(Vector(sampleOracleInfo),
-                        EnumOutcome(loseStr)) -> ECAdaptorSignature.dummy
+      EnumOracleOutcome(
+        Vector(sampleOracleInfo),
+        EnumOutcome(winStr)).sigPoint -> ECAdaptorSignature.dummy,
+      EnumOracleOutcome(
+        Vector(sampleOracleInfo),
+        EnumOutcome(loseStr)).sigPoint -> ECAdaptorSignature.dummy
     )
 
   lazy val dummyCETSigs: CETSignatures =


### PR DESCRIPTION
replaces `OracleOutcome` with `sigPoint` in many places

Interesting new code is all in `core/src/main/scala/org/bitcoins/core/protocol/dlc/DLCAdaptorPointComputer.scala`