### PR TITLE
Fix CachedHttpFeeRateProvider

### DIFF
--- a/fee-provider-test/src/test/scala/org/bitcoins/feeprovider/FeeRateProviderTest.scala
+++ b/fee-provider-test/src/test/scala/org/bitcoins/feeprovider/FeeRateProviderTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.feeprovider
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
@@ -8,6 +9,7 @@ import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import org.scalatest.Assertion
 
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 
 class FeeRateProviderTest extends BitcoinSAsyncTest {
 
@@ -42,9 +44,10 @@ class FeeRateProviderTest extends BitcoinSAsyncTest {
   }
 
   it must "get a cached fee rate from a cachedHttpFeeRateProvider" in {
-    val provider = BitcoinerLiveFeeRateProvider(60)
+    val provider = MempoolSpaceProvider(FastestFeeTarget)
     for {
       feeRate <- provider.getFeeRate
+      _ <- AsyncUtil.nonBlockingSleep(20.seconds)
       cached <- provider.getFeeRate
     } yield assert(feeRate == cached)
   }

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/HttpFeeRateProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/HttpFeeRateProvider.scala
@@ -61,7 +61,8 @@ abstract class CachedHttpFeeRateProvider[T <: FeeUnit]
         updateFeeRate()
       case Some((cachedFeeRate, time)) =>
         val now = TimeUtil.now
-        if (time.plus(cacheDuration).isAfter(now)) {
+        val timeout = time.plus(cacheDuration)
+        if (now.isAfter(timeout)) {
           updateFeeRate()
         } else {
           Future.successful(cachedFeeRate)


### PR DESCRIPTION
Fixes #2944

We we're doing the inverse of what we wanted, would only fetch a new fee rate unless it was before the cache duration.

Changed the test to a fee provider that is more likely to change and added a delay so we are more likely to catch this.