### PR TITLE
Remove zmq configurations for bitcoind backend setup

### DIFF
--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -82,8 +82,6 @@ blockfilterindex=1
 peerblockfilters=1
 debug=1
 txindex=1
-zmqpubrawblock=tcp://127.0.0.1:29000
-zmqpubrawtx=tcp://127.0.0.1:29000
 ```
 
 ## Step 4: Setting Up A Bitcoin-S Node
@@ -153,11 +151,8 @@ bitcoin-s {
         rpcbind = localhost
         # bitcoind rpc port
         rpcport = 8332
-        # bitcoind zmq raw tx
-        zmqpubrawtx = "tcp://127.0.0.1:28332"
-        # bitcoind zmq raw block
-        zmqpubrawblock = "tcp://127.0.0.1:28333"
     }
+}
 ```
 
 </details>


### PR DESCRIPTION
I don't think they are necessary because we just do bitcoind block polling, which is probably a better default as it is more tested IMO. This should also avoid things like #3078  

https://github.com/bitcoin-s/bitcoin-s/blob/84661bd122a962c30690d4fe5e02070d735d7ac9/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala#L175



