### PR TITLE
Remove old ZMQ config from documentation

### DIFF
--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -142,8 +142,6 @@ bitcoin-s {
         rpcbind = localhost
         # bitcoind rpc port
         rpcport = 8332
-        # bitcoind zmq port for all services
-        zmqport = 29000
         # bitcoind zmq raw tx
         zmqpubrawtx = "tcp://127.0.0.1:28332"
         # bitcoind zmq raw block


### PR DESCRIPTION
Fixes #3078

This should have been removed in #2897 