### PR TITLE
Optimize updateUtxoConfirmedStates() to fetch confirmations in parallel

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/util/BlockHashWithConfs.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BlockHashWithConfs.scala
@@ -1,0 +1,10 @@
+package org.bitcoins.core.util
+
+import org.bitcoins.crypto.DoubleSha256DigestBE
+
+/** Block hash with the number of confirmations associated with it.
+  * If confirmationsOpt is None, that means the block hash has zero confirmations
+  */
+case class BlockHashWithConfs(
+    blockHash: DoubleSha256DigestBE,
+    confirmationsOpt: Option[Int])

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -232,7 +232,7 @@ private[wallet] trait TransactionProcessing extends WalletLogger {
         .sequence {
           outputsBeingSpent.map(markAsSpent(_, transaction.txIdBE))
         }
-        .map(_.toVector.flatten)
+        .map(_.flatten)
 
       _ <- updateUtxoConfirmedStates(processed)
     } yield processed


### PR DESCRIPTION
This chips away at #2596 

The idea here is to fetch the confirmations for all blocks we are interested in inside of `updateUtxoConfirmedStates` in parallel rather than fetching them sequentially. This should improve performance when updating confirmations on existing txos. 

