### PR TITLE
Add assembly instructions for bundle project

### DIFF
--- a/app/bundle/bundle.sbt
+++ b/app/bundle/bundle.sbt
@@ -1,10 +1,20 @@
+
 name := "bitcoin-s-bundle"
 
 mainClass := Some("org.bitcoins.bundle.AppBundle")
 
-enablePlugins(JavaAppPackaging)
+
+
 
 publish / skip := true
 
 // Fork a new JVM for 'run' and 'test:run' to avoid JavaFX double initialization problems
 fork := true
+
+assembly / mainClass := Some("org.bitcoins.bundle.AppBundle")
+
+assemblyMergeStrategy in assembly := {
+  case PathList("META-INF", _ @ _*) => MergeStrategy.discard
+  case PathList("reference.conf", _ @ _*) => MergeStrategy.concat
+  case _ => MergeStrategy.first
+}

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 bitcoin-s {
-  network = regtest # regtest, testnet3, mainnet, signet
+  network = mainnet # regtest, testnet3, mainnet, signet
   datadir = ${HOME}/.bitcoin-s
 
   dbDefault = {
@@ -30,7 +30,7 @@ bitcoin-s {
   node = ${bitcoin-s.dbDefault}
 
   node {
-    peers = ["localhost"] # a list of peer addresses in form "hostname:portnumber"
+    peers = ["localhost:8333"] # a list of peer addresses in form "hostname:portnumber"
                           # (e.g. "neutrino.testnet3.suredbits.com:18333")
                           # Port number is optional, the default value is 8333 for mainnet,
                           # 18333 for testnet and 18444 for regtest.

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 bitcoin-s {
-  network = mainnet # regtest, testnet3, mainnet, signet
+  network = regtest # regtest, testnet3, mainnet, signet
   datadir = ${HOME}/.bitcoin-s
 
   dbDefault = {
@@ -30,7 +30,7 @@ bitcoin-s {
   node = ${bitcoin-s.dbDefault}
 
   node {
-    peers = ["localhost:8333"] # a list of peer addresses in form "hostname:portnumber"
+    peers = ["localhost"] # a list of peer addresses in form "hostname:portnumber"
                           # (e.g. "neutrino.testnet3.suredbits.com:18333")
                           # Port number is optional, the default value is 8333 for mainnet,
                           # 18333 for testnet and 18444 for regtest.

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -8,7 +8,7 @@ import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerBaseImage
 import sbt._
 import sbt.Keys._
 import sbtprotoc.ProtocPlugin.autoImport.PB
-
+import sbtassembly.AssemblyKeys._
 import scala.util.Properties
 
 object CommonSettings {
@@ -56,7 +56,8 @@ object CommonSettings {
       file("/usr/local/bin/protoc") // to change if needed, this is where protobuf manual compilation put it for me
     else
       PB.protocExecutable.value
-    )
+    ),
+    assembly / test := {}
   )
 
   lazy val jvmSettings: Seq[Setting[_]] = List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -45,3 +45,5 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")


### PR DESCRIPTION
related to #2626 

This adds the abillity to package bitcoin-s' `bundle` project as a fat jar with sbt-assembly. 

For more information on sbt assembly see here: 

https://github.com/sbt/sbt-assembly

The `mergeStrategy` instructions are copied from krystal-bull: 

https://github.com/bitcoin-s/krystal-bull/blob/eed2f3d96933fbe86e773a8ae6fc86984ce28e9e/build.sbt#L24

The end goal is to get automated `deb`/`dmg`/`msi` packaging for bitcoin-s, but the first step is just to get a fat jar working. 

You can build this with `sbt bundle/assembly` which will produce a fat jar inside of `app/bundle/target/scala-2.13/`

<img width="1432" alt="Screen Shot 2021-05-18 at 1 56 40 PM" src="https://user-images.githubusercontent.com/3514957/118708079-e788ed80-b7e0-11eb-8e31-eac90d2649b5.png">
 
You can run this jar like this: 

>java -jar app/bundle/target/scala-2.13/bitcoin-s-bundle-assembly-0.0.0-2810-25852e48-20210518-1351-SNAPSHOT.jar

which gives me 

<img width="1440" alt="Screen Shot 2021-05-18 at 2 00 01 PM" src="https://user-images.githubusercontent.com/3514957/118708509-6e3dca80-b7e1-11eb-9359-2f9a89b22698.png">

