### PR TITLE
DLC Adaptor Point Computation Memoization

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/AdditionTrieNodeTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/AdditionTrieNodeTest.scala
@@ -1,0 +1,55 @@
+package org.bitcoins.core.protocol.dlc
+
+import org.bitcoins.core.protocol.dlc.compute.DLCAdaptorPointComputer.AdditionTrieNode
+import org.bitcoins.crypto.{CryptoUtil, ECPublicKey}
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+
+import scala.annotation.tailrec
+
+class AdditionTrieNodeTest extends BitcoinSUnitTest {
+  behavior of "AdditionTrieNode"
+
+  val base: Int = 2
+  val nonces: Int = 10
+
+  @tailrec
+  private def computeAllPrefixes(accum: Vector[Vector[Vector[Int]]] =
+    Vector.empty): Vector[Vector[Int]] = {
+    if (accum.length == nonces) {
+      accum.flatten
+    } else {
+      val newPrefixes = if (accum.isEmpty) {
+        0.until(base).toVector.map(Vector(_))
+      } else {
+        accum.last.flatMap { prefix =>
+          0.until(base).toVector.map(digit => prefix.:+(digit))
+        }
+      }
+      computeAllPrefixes(accum.:+(newPrefixes))
+    }
+  }
+
+  val allPrefixes: Vector[Vector[Int]] = {
+    computeAllPrefixes()
+  }
+
+  val preComputeTable: Vector[Vector[ECPublicKey]] =
+    Vector.fill(nonces)(Vector.fill(base)(ECPublicKey.freshPublicKey))
+
+  def newTrie(): AdditionTrieNode = {
+    AdditionTrieNode.makeRoot(preComputeTable)
+  }
+
+  it should "correctly compute all elements" in {
+    val trie = newTrie()
+    allPrefixes.foreach { prefix =>
+      val ptsToAdd = prefix.zipWithIndex.map {
+        case (outcomeIndex, nonceIndex) =>
+          preComputeTable(nonceIndex)(outcomeIndex)
+      }
+      val expected = CryptoUtil.combinePubKeys(ptsToAdd)
+
+      assert(trie.computeSum(prefix) == expected)
+    }
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCAdaptorPointComputer.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCAdaptorPointComputer.scala
@@ -60,8 +60,8 @@ object DLCAdaptorPointComputer {
   case class AdditionTrieNode(
       preComputeTable: Vector[Vector[ECPublicKey]], // Nonce -> Outcome -> Point
       depth: Int = 0,
-      var children: Vector[AdditionTrieNode] = Vector.empty,
-      var pointOpt: Option[SecpPoint] = None) {
+      private var children: Vector[AdditionTrieNode] = Vector.empty,
+      private var pointOpt: Option[SecpPoint] = None) {
 
     /** Populates children field with base empty nodes.
       *
@@ -109,6 +109,15 @@ object DLCAdaptorPointComputer {
     }
   }
 
+  object AdditionTrieNode {
+
+    /** Creates a fresh AdditionTreeNode for a given preComputeTable */
+    def makeRoot(
+        preComputeTable: Vector[Vector[ECPublicKey]]): AdditionTrieNode = {
+      AdditionTrieNode(preComputeTable, pointOpt = Some(SecpPointInfinity))
+    }
+  }
+
   /** Efficiently computes all adaptor points, in order, for a given ContractInfo.
     * @see https://medium.com/crypto-garage/optimizing-numeric-outcome-dlc-creation-6d6091ac0e47
     */
@@ -137,7 +146,7 @@ object DLCAdaptorPointComputer {
       }
 
     lazy val additionTries = preComputeTable.map { table =>
-      AdditionTrieNode(table, pointOpt = Some(SecpPointInfinity))
+      AdditionTrieNode.makeRoot(table)
     }
 
     val oraclesAndOutcomes = contractInfo.allOutcomes.map(_.oraclesAndOutcomes)


### PR DESCRIPTION
Introduced memoization into the adaptor point computation for non-libsecp CryptoContexts. This results in ~6x speedup in adaptor point computation (but in the secp CryptoContext it actually leads to a slow-down due to JNI overhead as there is less batching in this approach as memoized computation only does one step at a time).