### PR TITLE
Remove logback from the cli module

### DIFF
--- a/app/cli/src/main/resources/logback.xml
+++ b/app/cli/src/main/resources/logback.xml
@@ -1,1 +1,0 @@
-<configuration />

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -388,7 +388,6 @@ object Deps {
     List(
       Compile.sttp,
       Compile.newMicroPickle.value,
-      Compile.logback,
       Compile.scopt,
       //we can remove this dependency when this is fixed
       //https://github.com/oracle/graal/issues/1943


### PR DESCRIPTION
This fixes a bug that was occuring when we do `bundle/assembly`. The merge strategy for `logback.xml` is `MergeStrategy.first` which takes the first logback.xml file and ignores the rest. 

https://github.com/bitcoin-s/bitcoin-s/blob/1e87cb0fdecea0e67eb2679ee6c7b47ad644d72c/app/bundle/bundle.sbt#L18

The file that happened to be resolved to was the `logback.xml` file in `cli` which HAS LOGGING TURNED OFF. 

https://github.com/bitcoin-s/bitcoin-s/blob/1e87cb0fdecea0e67eb2679ee6c7b47ad644d72c/app/cli/src/main/resources/logback.xml#L1

This means we never get any logging output from the bundle we are publishing.

It doesn't appear we were logging anything in the `cli` module, so this just removes the dependency all together.