### PR TITLE
Add application.conf to bundle

### DIFF
--- a/app/bundle/src/main/resources/application.conf
+++ b/app/bundle/src/main/resources/application.conf
@@ -1,5 +1,6 @@
 bitcoin-s {
     network = mainnet
+
     node {
         mode = neutrino # neutrino, spv, bitcoind
         peers = ["neutrino.suredbits.com:8333"]

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -23,7 +23,7 @@ bitcoin-s {
       connectionPool = "HikariCP"
       registerMbeans = true
     }
-    hikari-logging = false
+    hikari-logging = true
     hikari-logging-interval = 10 minute
   }
 

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -23,7 +23,7 @@ bitcoin-s {
       connectionPool = "HikariCP"
       registerMbeans = true
     }
-    hikari-logging = true
+    hikari-logging = false
     hikari-logging-interval = 10 minute
   }
 


### PR DESCRIPTION
Fixes #3113 

The problem detailed in #3113 boils down to concating `reference.conf` together into one big file. Then we are at the whim of how typesafe config resolves that one big `reference.conf` with duplicate configuration settings inside of it. For instance, we would be getting all of the `bitcoin-s.node` settings from `db-commons/reference.conf` rather than `app-server/reference.conf`.

This PR solves this by 

1. Creating an `application.conf` inside of `bundle`. `application.conf` overrides all `reference.conf` when the typesafe config library is resolving configuration
2. Moving more default configurations into `db-commons/reference.conf`. That way we have to worry about less conflicts being resolved.