### PR TITLE
Remove calls to Future.apply which apparently runs only on one thread

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
@@ -207,9 +207,7 @@ case class DLCTxSigner(
     val computeBatchFn: Vector[Indexed[ECPublicKey]] => Future[
       Vector[(ECPublicKey, ECAdaptorSignature)]] = {
       adaptorPoints: Vector[Indexed[ECPublicKey]] =>
-        Future {
-          signCETs(adaptorPoints)
-        }
+        FutureUtil.makeAsync(() => signCETs(adaptorPoints))
     }
 
     val cetSigsF: Future[Vector[(ECPublicKey, ECAdaptorSignature)]] = {
@@ -239,9 +237,7 @@ case class DLCTxSigner(
   ec: ExecutionContext): Future[(CETSignatures, Vector[WitnessTransaction])] = {
     val adaptorPoints = builder.contractInfo.adaptorPointsIndexed
     val fn = { adaptorPoints: Vector[Indexed[ECPublicKey]] =>
-      Future {
-        buildAndSignCETs(adaptorPoints)
-      }
+      FutureUtil.makeAsync(() => buildAndSignCETs(adaptorPoints))
     }
     val cetsAndSigsF: Future[
       Vector[Vector[(ECPublicKey, WitnessTransaction, ECAdaptorSignature)]]] = {

--- a/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.util
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
 object FutureUtil {
 
@@ -94,6 +94,17 @@ object FutureUtil {
         }
       }
     } yield batchExecution
+  }
+
+  def makeAsync[T](func: () => T)(implicit ec: ExecutionContext): Future[T] = {
+    val resultP = Promise[T]()
+
+    ec.execute { () =>
+      val result = func()
+      resultP.success(result)
+    }
+
+    resultP.future
   }
 
   /** Batches the [[elements]] by [[batchSize]] and then calls [[f]] on them in parallel


### PR DESCRIPTION
Created `FutureUtil.makeAsync` function that replaces calls to `Future(_)` and actually executes in a multi-threaded way.

First commit introduces the function and implements it in `DLCTxSigner` leading to a HUGE optimization for DLCs. If people aren't a fan of the larger PR, we should at least merge the first commit.

EDIT: Reverted to just the first commit due to weird interactions on some of the other changes.