### PR TITLE
2021 05 21 fetch height parallel

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -173,6 +173,8 @@ abstract class Wallet
     Wallet] = {
     val utxosF = listUtxos()
     val spksF = listScriptPubKeys()
+    val hash = blockFilters.last._1.flip
+    val heightF = chainQueryApi.getBlockHeight(hash)
     for {
       utxos <- utxosF
       scripts <- spksF
@@ -194,7 +196,7 @@ abstract class Wallet
         }
       }
       hash = blockFilters.last._1.flip
-      height <- chainQueryApi.getBlockHeight(hash)
+      height <- heightF
       _ <- stateDescriptorDAO.updateSyncHeight(hash, height.get)
     } yield {
       this


### PR DESCRIPTION
This optimizes `Wallet.processCompactFilters()` slightly, and makes it more safe. Previously it could fail on inputs like `Vector.empty`