### PR TITLE
2021 05 23 Sync race condition

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -94,9 +94,14 @@ case class NeutrinoNode(
             filterHeaderBatchSize = chainConfig.filterHeaderBatchSize,
             prevStopHash = bestFilterHeader.blockHashBE)
         }
-        sendCompactFilterHeaderMsgF.flatMap { _ =>
+        sendCompactFilterHeaderMsgF.flatMap { isSyncFilterHeaders =>
           // If we have started syncing filters
-          if (filterCount != bestFilterHeader.height && filterCount != 0) {
+          if (
+            !isSyncFilterHeaders &&
+            filterCount != bestFilterHeader.height
+            && filterCount != 0
+          ) {
+            logger.info(s"Starting sync filters in NeutrinoNode.sync()")
             peerMsgSender
               .sendNextGetCompactFilterCommand(chainApi = chainApi,
                                                filterBatchSize =

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -69,9 +69,8 @@ case class DataMessageHandler(
                 peerMsgSender,
                 filterHeader.stopHash.flip).map(_ => syncing)
             } else {
-              logger.debug(
-                s"Received filter headers=${filterHeaders.size} in one message, " +
-                  "which is less than max. This means we are synced.")
+              logger.info(
+                s"Done syncing filter headers, beginning to sync filters in datamessagehandler")
               sendFirstGetCompactFilterCommand(peerMsgSender).map { synced =>
                 if (!synced) logger.info("We are synced")
                 syncing
@@ -226,6 +225,8 @@ case class DataMessageHandler(
                     (filterHeaderHeightOpt.isEmpty &&
                       filterHeightOpt.isEmpty))
                 ) {
+                  logger.info(
+                    s"Starting to fetch filter headers in data message handler")
                   sendFirstGetCompactFilterHeadersCommand(peerMsgSender)
                 } else {
                   Try(initialSyncDone.map(_.success(Done)))


### PR DESCRIPTION
fixes #3128

This fixes a race condition we had between `DataMessageHandler` and `NeutrinoNode.sync()` in the case where when we are starting up the node we were only behind `< 2000` block headers. This means we are would start syncing filter headers `DataMessageHandler` and start syncing filter headers/filter in `NeutrinoNode.sync()`. 

This PR fixes this race condition by  checking if our filter headers were in sync with our block headers when we last shutdown the node. If so, we can assume our event drive archiecture will take of syncing the filters/filter headers. We don't need to explicitly request them in `NeutrinoNode.sync()`