### PR TITLE
Only sync filters since wallet creation time

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -30,6 +30,7 @@ import org.bitcoins.rpc.client.v21.BitcoindV21RpcClient
 import org.bitcoins.rpc.config.{BitcoindConfig, BitcoindInstance}
 
 import java.io.File
+import java.time.Instant
 import scala.concurrent.Future
 
 /** This class is not guaranteed to be compatible with any particular
@@ -177,6 +178,15 @@ class BitcoindRpcClient(val instance: BitcoindInstance)(implicit
     Future.failed(
       new UnsupportedOperationException(
         s"Bitcoind chainApi doesn't allow you fetch filter header batch range"))
+
+  override def nextFilterHeaderBatchRange(
+      walletCreationTimestamp: Instant,
+      batchSize: Int,
+      forceSyncFilters: Boolean): Future[Option[FilterSyncMarker]] = {
+    Future.failed(
+      new UnsupportedOperationException(
+        s"Bitcoind chainApi doesn't allow you fetch filter header batch range"))
+  }
 
   override def processFilters(
       message: Vector[CompactFilterMessage]): Future[ChainApi] =

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -11,6 +11,7 @@ import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.crypto.DoubleSha256DigestBE
 
+import java.time.Instant
 import scala.concurrent.Future
 
 /** Entry api to the chain project for adding new things to our blockchain
@@ -79,6 +80,17 @@ trait ChainApi extends ChainQueryApi {
   def nextFilterHeaderBatchRange(
       startHeight: Int,
       batchSize: Int): Future[Option[FilterSyncMarker]]
+
+  /** Fetches the next filter header batch range by using the wallet's creation time.
+    * This optimizes IBD as filters are the bottleneck. We do not need filters older than the wallet
+    * @param walletCreationTimestamp when the wallet was created
+    * @batchSize how large of filter batches we should fetch from our peer
+    * @forceSyncFilters ignore optimization logic, sync all compact filters
+    */
+  def nextFilterHeaderBatchRange(
+      walletCreationTimestamp: Instant,
+      batchSize: Int,
+      forceSyncFilters: Boolean): Future[Option[FilterSyncMarker]]
 
   /** Adds a compact filter into the filter database.
     */

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -173,7 +173,7 @@ class P2PClientTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
     val remote = peer.socket
     val peerMessageReceiverF =
       for {
-        node <- NodeUnitTest.buildNode(peer)
+        node <- NodeUnitTest.buildNode(peer, None)
       } yield PeerMessageReceiver.preConnection(peer, node)
 
     val clientActorF: Future[TestActorRef[P2PClientActor]] =

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -35,9 +35,10 @@ class DataMessageHandlerTest extends NodeUnitTest {
       val sender = spv.peerMsgSender
       for {
         chainApi <- spv.chainApiFromDb()
-        dataMessageHandler = DataMessageHandler(chainApi)(spv.executionContext,
-                                                          spv.nodeAppConfig,
-                                                          spv.chainConfig)
+        dataMessageHandler = DataMessageHandler(chainApi, None)(
+          spv.executionContext,
+          spv.nodeAppConfig,
+          spv.chainConfig)
 
         // Use signet genesis block header, this should be invalid for regtest
         invalidPayload =
@@ -80,9 +81,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
         _ = spv.nodeAppConfig.addCallbacks(nodeCallbacks)
 
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi)(spv.executionContext,
-                                              spv.nodeAppConfig,
-                                              spv.chainConfig)
+          DataMessageHandler(genesisChainApi, None)(spv.executionContext,
+                                                    spv.nodeAppConfig,
+                                                    spv.chainConfig)
         _ <- dataMessageHandler.handleDataPayload(payload1, sender)
         _ <- dataMessageHandler.handleDataPayload(payload2, sender)
         result <- resultP.future
@@ -113,9 +114,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
         _ = spv.nodeAppConfig.addCallbacks(nodeCallbacks)
 
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi)(spv.executionContext,
-                                              spv.nodeAppConfig,
-                                              spv.chainConfig)
+          DataMessageHandler(genesisChainApi, None)(spv.executionContext,
+                                                    spv.nodeAppConfig,
+                                                    spv.chainConfig)
         _ <- dataMessageHandler.handleDataPayload(payload, sender)
         result <- resultP.future
       } yield assert(result == block)
@@ -147,9 +148,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
 
         _ = spv.nodeAppConfig.addCallbacks(callbacks)
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi)(spv.executionContext,
-                                              spv.nodeAppConfig,
-                                              spv.chainConfig)
+          DataMessageHandler(genesisChainApi, None)(spv.executionContext,
+                                                    spv.nodeAppConfig,
+                                                    spv.chainConfig)
 
         _ <- dataMessageHandler.handleDataPayload(payload, sender)
         result <- resultP.future
@@ -180,9 +181,9 @@ class DataMessageHandlerTest extends NodeUnitTest {
         nodeCallbacks = NodeCallbacks.onCompactFilterReceived(callback)
         _ = spv.nodeAppConfig.addCallbacks(nodeCallbacks)
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi)(spv.executionContext,
-                                              spv.nodeAppConfig,
-                                              spv.chainConfig)
+          DataMessageHandler(genesisChainApi, None)(spv.executionContext,
+                                                    spv.nodeAppConfig,
+                                                    spv.chainConfig)
 
         _ <- dataMessageHandler.handleDataPayload(payload, sender)
         result <- resultP.future

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -55,7 +55,7 @@ class PeerMessageHandlerTest
 
   it must "be able to fully initialize a PeerMessageReceiver" in { peer =>
     for {
-      peerHandler <- NodeUnitTest.buildPeerHandler(peer)
+      peerHandler <- NodeUnitTest.buildPeerHandler(peer, None)
       peerMsgSender = peerHandler.peerMsgSender
       p2pClient = peerHandler.p2pClient
 

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -136,7 +136,7 @@ case class NeutrinoNode(
           .sendNextGetCompactFilterCommand(chainApi = chainApi,
                                            filterBatchSize =
                                              chainConfig.filterBatchSize,
-                                           startHeight = filterCount)
+                                           walletCreationTimeOpt = None)
           .map(_ => ())
       } else {
         Future.unit

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -21,6 +21,7 @@ import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
 
+import java.time.Instant
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
@@ -103,6 +104,13 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
         startHeight: Int,
         batchSize: Int): Future[Option[FilterSyncMarker]] =
       Future.successful(None)
+
+    override def nextFilterHeaderBatchRange(
+        walletCreationTimestamp: Instant,
+        batchSize: Int,
+        forceSyncFilters: Boolean): Future[Option[FilterSyncMarker]] = {
+      Future.successful(None)
+    }
 
     override def processFilters(
         message: Vector[CompactFilterMessage]): Future[ChainApi] =

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -84,9 +84,11 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest { _: CachedBitcoind[_] =>
       NeutrinoNodeConnectedWithBitcoind] = { () =>
       require(appConfig.nodeType == NodeType.NeutrinoNode)
       for {
-        node <- NodeUnitTest.createNeutrinoNode(bitcoind)(system,
-                                                          appConfig.chainConf,
-                                                          appConfig.nodeConf)
+        node <- NodeUnitTest.createNeutrinoNode(bitcoind = bitcoind,
+                                                walletCreationTimeOpt = None)(
+          system,
+          appConfig.chainConf,
+          appConfig.nodeConf)
         startedNode <- node.start()
         syncedNode <- syncNeutrinoNode(startedNode, bitcoind)
       } yield NeutrinoNodeConnectedWithBitcoind(syncedNode, bitcoind)


### PR DESCRIPTION
fixes #1731 

The current bottleneck with IBD is compact filter syncing. This PR adds logic to only sync compact filters since the wallet was created on mainnet. Testnet, regtest, and signet do not have this functionality enabled. 

I'm still testing this out locally, but wanted to get it opened up.