### PR TITLE
parallelize matching compact filters as this is a bottleneck during IBD

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -219,9 +219,10 @@ abstract class Wallet
   private def searchFilterMatches(spks: Vector[ScriptPubKey])(
       blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
     Vector[DoubleSha256Digest]] = FutureUtil.makeAsync { () =>
+    val asmVec = spks.map(_.asmBytes)
     blockFilters.flatMap { case (blockHash, blockFilter) =>
       val matcher = SimpleFilterMatcher(blockFilter)
-      if (matcher.matchesAny(spks.map(_.asmBytes))) {
+      if (matcher.matchesAny(asmVec)) {
         Vector(blockHash)
       } else {
         Vector.empty

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -218,7 +218,7 @@ abstract class Wallet
 
   private def searchFilterMatches(spks: Vector[ScriptPubKey])(
       blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
-    Vector[DoubleSha256Digest]] = Future {
+    Vector[DoubleSha256Digest]] = FutureUtil.makeAsync { () =>
     blockFilters.flatMap { case (blockHash, blockFilter) =>
       val matcher = SimpleFilterMatcher(blockFilter)
       if (matcher.matchesAny(spks.map(_.asmBytes))) {

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -184,21 +184,21 @@ abstract class Wallet
       scripts <- spksF
       scriptPubKeys =
         utxos.flatMap(_.redeemScriptOpt).toSet ++ scripts.map(_.scriptPubKey)
-      _ <- {
+      blockHashToDownload <- {
         if (scriptPubKeys.isEmpty) {
           //do nothing as an optimization, if we have nothing in the wallet
           //we don't need to search the filters
-          Future.unit
+          Future.successful(Vector.empty)
         } else {
-          FutureUtil.sequentially(blockFilters) {
-            case (blockHash, blockFilter) =>
-              val matcher = SimpleFilterMatcher(blockFilter)
-              if (matcher.matchesAny(scriptPubKeys.toVector.map(_.asmBytes))) {
-                nodeApi.downloadBlocks(Vector(blockHash))
-              } else Future.unit
-          }
+          FutureUtil
+            .batchAndParallelExecute(
+              blockFilters,
+              searchFilterMatches(scriptPubKeys.toVector)
+            )
+            .map(_.flatten)
         }
       }
+      _ <- nodeApi.downloadBlocks(blockHashToDownload)
       hash = blockFilters.last._1.flip
       heightOpt <- heightOptF
       _ <- {
@@ -213,6 +213,19 @@ abstract class Wallet
       }
     } yield {
       this
+    }
+  }
+
+  private def searchFilterMatches(spks: Vector[ScriptPubKey])(
+      blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
+    Vector[DoubleSha256Digest]] = Future {
+    blockFilters.flatMap { case (blockHash, blockFilter) =>
+      val matcher = SimpleFilterMatcher(blockFilter)
+      if (matcher.matchesAny(spks.map(_.asmBytes))) {
+        Vector(blockHash)
+      } else {
+        Vector.empty
+      }
     }
   }
 


### PR DESCRIPTION
This actually is a bottleneck rather than I/O. It is computationally expensive to match these filters, and when it is single threaded it takes even longer.

Here is an example on visualvm with filter height ~660,000 on mainnet with sqlite

![Screenshot from 2021-05-25 09-20-35](https://user-images.githubusercontent.com/3514957/119528758-17874200-bd47-11eb-9556-b9dab9313002.png)
