### PR TITLE
Make sure secp256k1 is published for java8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -290,7 +290,11 @@ lazy val secp256k1jni = project
     //since this is not a scala module, we have no code coverage
     //this also doesn't place nice with scoverage, see
     //https://github.com/scoverage/sbt-scoverage/issues/275
-    coverageEnabled := false
+    coverageEnabled := false,
+    Compile / compile / javacOptions ++= {
+      //https://github.com/eclipse/jetty.project/issues/3244#issuecomment-495322586
+      Seq("--release", "8")
+    }
   )
 
 val testAndCompile = "compile->compile;test->test"

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -3,7 +3,15 @@ import com.typesafe.sbt.SbtNativePackager.Docker
 import com.typesafe.sbt.SbtNativePackager.autoImport.packageName
 
 import java.nio.file.Paths
-import com.typesafe.sbt.packager.Keys.{daemonUser, daemonUserUid, dockerAlias, dockerAliases, dockerRepository, dockerUpdateLatest, maintainer}
+import com.typesafe.sbt.packager.Keys.{
+  daemonUser,
+  daemonUserUid,
+  dockerAlias,
+  dockerAliases,
+  dockerRepository,
+  dockerUpdateLatest,
+  maintainer
+}
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerBaseImage
 import sbt._
 import sbt.Keys._
@@ -51,11 +59,13 @@ object CommonSettings {
     //you need to build protoc manually to get it working on the new
     //mac m1 chip. For instructions on how to do so see
     //see: https://github.com/scalapb/ScalaPB/issues/1024
-      PB.protocExecutable := (
-    if (protocbridge.SystemDetector.detectedClassifier()=="osx-aarch_64")
-      file("/usr/local/bin/protoc") // to change if needed, this is where protobuf manual compilation put it for me
-    else
-      PB.protocExecutable.value
+    PB.protocExecutable := (
+      if (protocbridge.SystemDetector.detectedClassifier() == "osx-aarch_64")
+        file(
+          "/usr/local/bin/protoc"
+        ) // to change if needed, this is where protobuf manual compilation put it for me
+      else
+        PB.protocExecutable.value
     ),
     assembly / test := {}
   )


### PR DESCRIPTION
Previously it would just be published for the jdk it was built on. Now it will be published for java8 so machines that are running java8 can use it.