### PR TITLE
2021 05 26 uint64 mapper

### DIFF
--- a/db-commons-test/src/test/scala/org/bitcoins/db/UInt64MapperTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/UInt64MapperTest.scala
@@ -1,0 +1,36 @@
+package org.bitcoins.db
+
+import org.bitcoins.core.number.UInt64
+import org.bitcoins.testkitcore.gen.NumberGenerator
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import slick.jdbc.{PostgresProfile, SQLiteProfile}
+
+class UInt64MapperTest extends BitcoinSUnitTest {
+  behavior of "UInt64Mapper"
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = {
+    generatorDrivenConfigNewCode
+  }
+  val sqlite = new DbCommonsColumnMappers(SQLiteProfile)
+
+  val postgres = new DbCommonsColumnMappers(PostgresProfile)
+  it must "map a large uint64 to bytes and back" in {
+    val u64 = UInt64.max
+    val sqliteHex = sqlite.uInt64ToHex(UInt64.max)
+    val sqliteu64 = UInt64.fromHex(sqliteHex)
+    assert(sqliteu64 == u64)
+
+    val pgHex = postgres.uInt64ToHex(UInt64.max - UInt64.one)
+    val pgu64 = UInt64.fromHex(pgHex)
+    assert(pgu64 == u64)
+
+  }
+  it must "map uint64 to bytes and back" in {
+    forAll(NumberGenerator.uInt64) { u64 =>
+      val sqliteu64 = sqlite.uInt64ToHex(u64)
+      assert(sqliteu64 == u64)
+      val pgu64 = postgres.uInt64ToHex(u64)
+      assert(pgu64 == u64)
+    }
+  }
+}

--- a/db-commons-test/src/test/scala/org/bitcoins/db/UInt64MapperTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/UInt64MapperTest.scala
@@ -11,25 +11,39 @@ class UInt64MapperTest extends BitcoinSUnitTest {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = {
     generatorDrivenConfigNewCode
   }
-  val sqlite = new DbCommonsColumnMappers(SQLiteProfile)
+  private val sqlite = new DbCommonsColumnMappers(SQLiteProfile)
 
-  val postgres = new DbCommonsColumnMappers(PostgresProfile)
+  private val postgres = new DbCommonsColumnMappers(PostgresProfile)
+
   it must "map a large uint64 to bytes and back" in {
     val u64 = UInt64.max
-    val sqliteHex = sqlite.uInt64ToHex(UInt64.max)
+    val sqliteHex = sqlite.uInt64ToHex(u64)
     val sqliteu64 = UInt64.fromHex(sqliteHex)
     assert(sqliteu64 == u64)
 
-    val pgHex = postgres.uInt64ToHex(UInt64.max - UInt64.one)
+    val pgHex = postgres.uInt64ToHex(u64)
     val pgu64 = UInt64.fromHex(pgHex)
     assert(pgu64 == u64)
-
   }
+
+  it must "map UInt64.zero to bytes and back" in {
+    val u64 = UInt64.zero
+    val sqliteHex = sqlite.uInt64ToHex(u64)
+    val sqliteu64 = UInt64.fromHex(sqliteHex)
+    assert(sqliteu64 == u64)
+
+    val pgHex = postgres.uInt64ToHex(u64)
+    val pgu64 = UInt64.fromHex(pgHex)
+    assert(pgu64 == u64)
+  }
+
   it must "map uint64 to bytes and back" in {
     forAll(NumberGenerator.uInt64) { u64 =>
-      val sqliteu64 = sqlite.uInt64ToHex(u64)
+      val sqliteHex = sqlite.uInt64ToHex(u64)
+      val sqliteu64 = UInt64.fromHex(sqliteHex)
       assert(sqliteu64 == u64)
-      val pgu64 = postgres.uInt64ToHex(u64)
+      val pgHex = postgres.uInt64ToHex(u64)
+      val pgu64 = UInt64.fromHex(pgHex)
       assert(pgu64 == u64)
     }
   }

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -155,15 +155,19 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
   implicit val uint64Mapper: BaseColumnType[UInt64] = {
     MappedColumnType.base[UInt64, String](
       { u64: UInt64 =>
-        val bytes = u64.bytes
-        val padded = if (bytes.length <= 8) {
-          bytes.padLeft(8)
-        } else bytes
-
-        padded.toHex
+        uInt64ToHex(u64)
       },
       UInt64.fromHex
     )
+  }
+
+  def uInt64ToHex(u64: UInt64): String = {
+    val bytes = u64.bytes
+    val padded = if (bytes.length <= 8) {
+      bytes.padLeft(8)
+    } else bytes
+
+    padded.toHex
   }
 
   implicit val transactionOutPointMapper: BaseColumnType[


### PR DESCRIPTION
Simply adds unit tests for db column mappers for `UInt64`. This does not fix any bugs, but might detect issues on CI in the future.

