### PR TITLE
Don't fetch all DLC data when canceling DLC

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -174,11 +174,12 @@ class DLCPaneModel(resultArea: TextArea) extends Logging {
   }
 
   def cancelDLC(status: DLCStatus): Unit = {
-    status.state match {
+    val eventId =
+      status.oracleInfo.singleOracleInfos.head.announcement.eventTLV.eventId
+
+    val confirmed = status.state match {
       case DLCState.Offered | DLCState.Accepted =>
-        val eventId =
-          status.oracleInfo.singleOracleInfos.head.announcement.eventTLV.eventId
-        val confirmed = new Alert(AlertType.Confirmation) {
+        new Alert(AlertType.Confirmation) {
           initOwner(owner)
           headerText = "Confirm Canceling DLC"
           contentText =
@@ -188,28 +189,40 @@ class DLCPaneModel(resultArea: TextArea) extends Logging {
           case Some(ButtonType.OK) => true
           case None | Some(_)      => false
         }
-
-        if (confirmed) {
-          taskRunner.run(
-            caption = "Canceling DLC",
-            op = {
-              ConsoleCli.exec(CancelDLC(status.dlcId),
-                              GlobalData.consoleCliConfig) match {
-                case Success(_)   => ()
-                case Failure(err) => throw err
-              }
-              updateDLCs()
-            }
-          )
+      case DLCState.Signed =>
+        new Alert(AlertType.Confirmation) {
+          initOwner(owner)
+          headerText = "Confirm Unsafe Canceling DLC"
+          contentText =
+            "Danger! If your counter-party has received your sign message then they will be able to execute the DLC even if you cancel!\n"
+          s"Are you sure you want to cancel this DLC for $eventId?\n" +
+            "This cannot be undone.\n"
+        }.showAndWait() match {
+          case Some(ButtonType.OK) => true
+          case None | Some(_)      => false
         }
-      case DLCState.Signed | DLCState.Broadcasted | DLCState.Confirmed |
-          DLCState.Claimed | DLCState.RemoteClaimed | DLCState.Refunded =>
+      case DLCState.Broadcasted | DLCState.Confirmed | DLCState.Claimed |
+          DLCState.RemoteClaimed | DLCState.Refunded =>
         new Alert(AlertType.Error) {
           initOwner(owner)
           headerText = "Failed to Cancel DLC"
           contentText = "Cannot cancel a DLC after it has been signed"
         }.showAndWait()
-        ()
+        false
+    }
+
+    if (confirmed) {
+      taskRunner.run(
+        caption = "Canceling DLC",
+        op = {
+          ConsoleCli.exec(CancelDLC(status.dlcId),
+                          GlobalData.consoleCliConfig) match {
+            case Success(_)   => ()
+            case Failure(err) => throw err
+          }
+          updateDLCs()
+        }
+      )
     }
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -252,14 +252,14 @@ abstract class DLCWallet
       dbs <- spendingInfoDAO.findByOutPoints(inputs.map(_.outPoint))
       _ <- unmarkUTXOsAsReserved(dbs)
 
-      dlcOpt <- findDLC(dlcId)
+      dlcOpt <- dlcDAO.read(dlcId)
       _ = dlcOpt match {
         case Some(db) =>
           require(db.state == DLCState.Offered || db.state == DLCState.Accepted,
                   "Cannot cancel a DLC after it has been signed")
         case None =>
           throw new IllegalArgumentException(
-            s"No DLC Found with param hash ${dlcId.hex}")
+            s"No DLC Found with dlc id ${dlcId.hex}")
       }
 
       _ <- dlcSigsDAO.deleteByDLCId(dlcId)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -250,7 +250,8 @@ abstract class DLCWallet
     for {
       inputs <- dlcInputsDAO.findByDLCId(dlcId)
       dbs <- spendingInfoDAO.findByOutPoints(inputs.map(_.outPoint))
-      _ <- unmarkUTXOsAsReserved(dbs)
+      // allow this to fail in the case they have already been unreserved
+      _ <- unmarkUTXOsAsReserved(dbs).recover { case _: Throwable => () }
 
       dlcOpt <- dlcDAO.read(dlcId)
       _ = dlcOpt match {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -256,8 +256,9 @@ abstract class DLCWallet
       dlcOpt <- dlcDAO.read(dlcId)
       _ = dlcOpt match {
         case Some(db) =>
-          require(db.state == DLCState.Offered || db.state == DLCState.Accepted,
-                  "Cannot cancel a DLC after it has been signed")
+          require(
+            db.state == DLCState.Offered || db.state == DLCState.Accepted || db.state == DLCState.Signed,
+            "Cannot cancel a DLC after it has been signed")
         case None =>
           throw new IllegalArgumentException(
             s"No DLC Found with dlc id ${dlcId.hex}")


### PR DESCRIPTION
This is useful in the case where we would have a corrupted DLC and couldn't cancel because `findDLC` would try to build the `DLCStatus`