### PR TITLE
Fix serialId columns to use a String instead of Integer

### DIFF
--- a/dlc-wallet/src/main/resources/postgresql/dlc/migration/V1__dlc_db_baseline.sql
+++ b/dlc-wallet/src/main/resources/postgresql/dlc/migration/V1__dlc_db_baseline.sql
@@ -1,33 +1,33 @@
 CREATE TABLE "global_dlc_data"
 (
-    "dlc_id"              TEXT PRIMARY KEY,
-    "temp_contract_id"    TEXT    NOT NULL UNIQUE,
-    "contract_id"         TEXT UNIQUE,
-    "protocol_version"    INTEGER NOT NULL,
-    "state"               TEXT    NOT NULL,
-    "is_initiator"        INTEGER NOT NULL,
-    "account"             TEXT    NOT NULL,
-    "change_index"        INTEGER NOT NULL,
-    "key_index"           INTEGER NOT NULL,
+    "dlc_id"                TEXT PRIMARY KEY,
+    "temp_contract_id"      TEXT    NOT NULL UNIQUE,
+    "contract_id"           TEXT UNIQUE,
+    "protocol_version"      INTEGER NOT NULL,
+    "state"                 TEXT    NOT NULL,
+    "is_initiator"          INTEGER NOT NULL,
+    "account"               TEXT    NOT NULL,
+    "change_index"          INTEGER NOT NULL,
+    "key_index"             INTEGER NOT NULL,
 
-    "fee_rate"              VARCHAR(254) NOT NULL,
-    "fund_output_serial_id" INTEGER      NOT NULL,
+    "fee_rate"              TEXT    NOT NULL,
+    "fund_output_serial_id" TEXT    NOT NULL,
 
-    "funding_outpoint"    TEXT,
-    "funding_tx_id"       TEXT,
-    "closing_tx_id"       TEXT,
-    "aggregate_signature" TEXT
+    "funding_outpoint"      TEXT,
+    "funding_tx_id"         TEXT,
+    "closing_tx_id"         TEXT,
+    "aggregate_signature"   TEXT
 );
 
 CREATE TABLE "contract_data"
 (
-    "dlc_id"                TEXT PRIMARY KEY,
-    "oracle_threshold"      INTEGER NOT NULL,
-    "oracle_params"         TEXT,
-    "contract_descriptor"   TEXT    NOT NULL,
-    "contract_maturity"     INTEGER NOT NULL,
-    "contract_timeout"      INTEGER NOT NULL,
-    "total_collateral"      INTEGER NOT NULL,
+    "dlc_id"              TEXT PRIMARY KEY,
+    "oracle_threshold"    INTEGER NOT NULL,
+    "oracle_params"       TEXT,
+    "contract_descriptor" TEXT    NOT NULL,
+    "contract_maturity"   INTEGER NOT NULL,
+    "contract_timeout"    INTEGER NOT NULL,
+    "total_collateral"    INTEGER NOT NULL,
     constraint "fk_dlc_id" foreign key ("dlc_id") references "global_dlc_data" ("dlc_id") on update NO ACTION on delete NO ACTION
 );
 
@@ -78,10 +78,10 @@ CREATE TABLE "offer_dlc_data"
     "dlc_id"           TEXT PRIMARY KEY,
     "funding_pub_key"  TEXT    NOT NULL,
     "payout_address"   TEXT    NOT NULL,
-    "payout_serial_id" INTEGER NOT NULL,
+    "payout_serial_id" TEXT    NOT NULL,
     "collateral"       INTEGER NOT NULL,
     "change_address"   TEXT    NOT NULL,
-    "change_serial_id" INTEGER NOT NULL,
+    "change_serial_id" TEXT    NOT NULL,
     constraint "fk_dlc_id" foreign key ("dlc_id") references "global_dlc_data" ("dlc_id") on update NO ACTION on delete NO ACTION
 );
 
@@ -90,10 +90,10 @@ CREATE TABLE "accept_dlc_data"
     "dlc_id"             TEXT PRIMARY KEY,
     "funding_pub_key"    TEXT    NOT NULL,
     "payout_address"     TEXT    NOT NULL,
-    "payout_serial_id"   INTEGER NOT NULL,
+    "payout_serial_id"   TEXT    NOT NULL,
     "collateral"         INTEGER NOT NULL,
     "change_address"     TEXT    NOT NULL,
-    "change_serial_id"   INTEGER NOT NULL,
+    "change_serial_id"   TEXT    NOT NULL,
     "negotiation_fields" TEXT    NOT NULL,
     constraint "fk_dlc_id" foreign key ("dlc_id") references "global_dlc_data" ("dlc_id") on update NO ACTION on delete NO ACTION
 );
@@ -103,7 +103,7 @@ CREATE TABLE "funding_inputs"
     "out_point"          TEXT PRIMARY KEY,
     "dlc_id"             TEXT    NOT NULL,
     "is_initiator"       INTEGER NOT NULL,
-    "input_serial_id"    INTEGER NOT NULL,
+    "input_serial_id"    TEXT    NOT NULL,
     "output"             TEXT    NOT NULL,
     "max_witness_length" INTEGER NOT NULL,
     "redeem_script_opt"  TEXT,

--- a/dlc-wallet/src/main/resources/sqlite/dlc/migration/V1__dlc_db_baseline.sql
+++ b/dlc-wallet/src/main/resources/sqlite/dlc/migration/V1__dlc_db_baseline.sql
@@ -11,7 +11,7 @@ CREATE TABLE "global_dlc_data"
     "key_index"             INTEGER      NOT NULL,
 
     "fee_rate"              VARCHAR(254) NOT NULL,
-    "fund_output_serial_id" INTEGER      NOT NULL,
+    "fund_output_serial_id" VARCHAR(254) NOT NULL,
 
     "funding_outpoint"      VARCHAR(254),
     "funding_tx_id"         VARCHAR(254),
@@ -78,10 +78,10 @@ CREATE TABLE "offer_dlc_data"
     "dlc_id"           VARCHAR(254) PRIMARY KEY,
     "funding_pub_key"  VARCHAR(254) NOT NULL,
     "payout_address"   VARCHAR(254) NOT NULL,
-    "payout_serial_id" INTEGER      NOT NULL,
+    "payout_serial_id" VARCHAR(254) NOT NULL,
     "collateral"       INTEGER      NOT NULL,
     "change_address"   VARCHAR(254) NOT NULL,
-    "change_serial_id" INTEGER      NOT NULL,
+    "change_serial_id" VARCHAR(254) NOT NULL,
     constraint "fk_dlc_id" foreign key ("dlc_id") references "global_dlc_data" ("dlc_id") on update NO ACTION on delete NO ACTION
 );
 
@@ -90,10 +90,10 @@ CREATE TABLE "accept_dlc_data"
     "dlc_id"             VARCHAR(254) PRIMARY KEY,
     "funding_pub_key"    VARCHAR(254) NOT NULL,
     "payout_address"     VARCHAR(254) NOT NULL,
-    "payout_serial_id"   INTEGER      NOT NULL,
+    "payout_serial_id"   VARCHAR(254) NOT NULL,
     "collateral"         INTEGER      NOT NULL,
     "change_address"     VARCHAR(254) NOT NULL,
-    "change_serial_id"   INTEGER      NOT NULL,
+    "change_serial_id"   VARCHAR(254) NOT NULL,
     "negotiation_fields" VARCHAR(254) NOT NULL,
     constraint "fk_dlc_id" foreign key ("dlc_id") references "global_dlc_data" ("dlc_id") on update NO ACTION on delete NO ACTION
 );
@@ -103,7 +103,7 @@ CREATE TABLE "funding_inputs"
     "out_point"          VARCHAR(254) PRIMARY KEY,
     "dlc_id"             VARCHAR(254) NOT NULL,
     "is_initiator"       INTEGER      NOT NULL,
-    "input_serial_id"    INTEGER      NOT NULL,
+    "input_serial_id"    VARCHAR(254) NOT NULL,
     "output"             VARCHAR(254) NOT NULL,
     "max_witness_length" INTEGER      NOT NULL,
     "redeem_script_opt"  VARCHAR(254),


### PR DESCRIPTION
Fixes that annoying error where we get `java.lang.IllegalArgumentException: Invalid hexadecimal character 'I' at index 0` from the `UInt64` Mapper.

This was occurring because the uint64 mapper uses a string whereas the db columns were using `INTEGER` so sometimes sqlite would store `Inf` instead of the hex.