### PR TITLE
Send txId instead of full serialized transaction

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -1054,8 +1054,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
         assert(
-          responseAs[
-            String] == s"""{"result":"${EmptyTransaction.hex}","error":null}""")
+          responseAs[String] == s"""{"result":"${EmptyTransaction.txIdBE.hex}","error":null}""")
       }
     }
 
@@ -1121,8 +1120,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
         assert(
-          responseAs[
-            String] == s"""{"result":"${EmptyTransaction.hex}","error":null}""")
+          responseAs[String] == s"""{"result":"${EmptyTransaction.txIdBE.hex}","error":null}""")
       }
     }
 
@@ -1162,8 +1160,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
         assert(
-          responseAs[
-            String] == s"""{"result":"${EmptyTransaction.hex}","error":null}""")
+          responseAs[String] == s"""{"result":"${EmptyTransaction.txIdBE.hex}","error":null}""")
       }
     }
 

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -439,7 +439,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
         case Success(BroadcastDLCFundingTx(contractId)) =>
           complete {
             wallet.broadcastDLCFundingTx(contractId).map { tx =>
-              Server.httpSuccess(tx.hex)
+              Server.httpSuccess(tx.txIdBE.hex)
             }
           }
       }
@@ -452,9 +452,9 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
           complete {
             for {
               tx <- wallet.executeDLC(contractId, sigs)
-              _ <- handleBroadcastable(tx, noBroadcast)
+              ret <- handleBroadcastable(tx, noBroadcast)
             } yield {
-              Server.httpSuccess(tx.hex)
+              Server.httpSuccess(ret.hex)
             }
           }
       }
@@ -467,9 +467,9 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
           complete {
             for {
               tx <- wallet.executeDLCRefund(contractId)
-              _ <- handleBroadcastable(tx, noBroadcast)
+              ret <- handleBroadcastable(tx, noBroadcast)
             } yield {
-              Server.httpSuccess(tx.hex)
+              Server.httpSuccess(ret.hex)
             }
           }
       }


### PR DESCRIPTION
We changed this a while back to send the full transaction in the case that it failed to broadcast so the user could do it through something like blockstream.info

Now that we have diffferent backend types and the wallet will auto re-broadcast transactions it should be less of a concern.