### PR TITLE
Add unit test we can handle spending funds and receiving funds in same tx

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -65,6 +65,15 @@ trait WalletApi extends StartStopAsync[WalletApi] {
 
   def findTransaction(txId: DoubleSha256DigestBE): Future[Option[TransactionDb]]
 
+  /** Funds a transaction from the wallet.
+    * @return funded transaction send funds to desinations with the given fee rate
+    */
+  def fundRawTransaction(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromTagOpt: Option[AddressTag],
+      markAsReserved: Boolean): Future[Transaction]
+
   def listTransactions(): Future[Vector[TransactionDb]]
 
   /** Takes in a block header and updates our TxoStates to the new chain tip

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -126,6 +126,7 @@ trait BitcoinSWalletTest
     withNewConfiguredWallet(segwitWalletConf)(test)
   }
 
+  /** Fixture for a wallet with default configuration with no funds in it */
   def withNewWallet(test: OneArgAsyncTest, bip39PasswordOpt: Option[String])(
       implicit walletAppConfig: WalletAppConfig): FutureOutcome =
     makeDependentFixture(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -2,9 +2,20 @@ package org.bitcoins.wallet
 
 import org.bitcoins.core.api.wallet.WalletApi
 import org.bitcoins.core.currency._
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.script.ScriptSignature
+import org.bitcoins.core.protocol.transaction.{
+  BaseTransaction,
+  Transaction,
+  TransactionConstants,
+  TransactionInput,
+  TransactionOutPoint,
+  TransactionOutput
+}
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkitcore.Implicits._
-import org.bitcoins.testkitcore.gen.TransactionGenerators
+import org.bitcoins.testkitcore.gen.{CryptoGenerators, TransactionGenerators}
 import org.scalatest.FutureOutcome
 import org.scalatest.compatible.Assertion
 
@@ -134,6 +145,51 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
         assert(balance == 0.sats)
         assert(unconfirmed == 0.sats)
       }
+  }
 
+  it must "spend and receive funds in the same transaction" in { wallet =>
+    val fundingAddressF = wallet.getNewAddress()
+    val receivingAddressF = wallet.getNewAddress()
+    val amount = Bitcoins.one
+
+    //build funding tx
+    val fundingTxF: Future[(Transaction, UInt32)] = for {
+      fundingAddr <- fundingAddressF
+      fundingTx = TransactionGenerators.buildCreditingTransaction(
+        fundingAddr.scriptPubKey,
+        amount)
+    } yield fundingTx
+
+    val processedFundingTxF: Future[WalletApi] = for {
+      (fundingTx, _) <- fundingTxF
+      //make sure wallet is empty
+      balance <- wallet.getBalance()
+      _ = assert(balance == Bitcoins.zero)
+      processed <- wallet.processTransaction(fundingTx,
+                                             Some(DoubleSha256DigestBE.empty))
+      balance <- wallet.getBalance()
+      _ = assert(balance == amount)
+    } yield processed
+
+    //build spending tx
+    val spendingTxF = for {
+      receivingAddress <- receivingAddressF
+      (fundingTx, outputIdx) <- fundingTxF
+      outPoint = TransactionOutPoint(fundingTx.txIdBE, outputIdx)
+      inputs = Vector(
+        TransactionInput(outPoint, ScriptSignature.empty, UInt32.zero))
+      outputs = Vector(TransactionOutput(amount, receivingAddress.scriptPubKey))
+      spendingTx = BaseTransaction(TransactionConstants.version,
+                                   inputs,
+                                   outputs,
+                                   UInt32.zero)
+      wallet <- processedFundingTxF
+      processedSpendingTx <- wallet.processTransaction(
+        transaction = spendingTx,
+        blockHash = Some(CryptoGenerators.doubleSha256DigestBE.sampleSome))
+      balance <- processedSpendingTx.getBalance()
+    } yield assert(balance == amount)
+
+    spendingTxF
   }
 }


### PR DESCRIPTION
I thought this would a bug @nkohen was running into, apparently it is something else. I still think this unit test is useful though.