### PR TITLE
Fix verify funding sigs

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
@@ -49,7 +49,8 @@ case class DLCTxSigner(
             "Given keys do not match public key and address in offer")
     val fundingUtxosAsInputs =
       fundingUtxos
-        .zip(offer.fundingInputs)
+        .sortBy(_.outPoint.bytes)
+        .zip(offer.fundingInputs.sortBy(_.outPoint.bytes))
         .map { case (utxo, fund) =>
           DLCFundingInput.fromInputSigningInfo(utxo, fund.inputSerialId)
         }
@@ -64,7 +65,8 @@ case class DLCTxSigner(
     )
     val fundingUtxosAsInputs =
       fundingUtxos
-        .zip(accept.fundingInputs)
+        .sortBy(_.outPoint.bytes)
+        .zip(accept.fundingInputs.sortBy(_.outPoint.bytes))
         .map { case (utxo, fund) =>
           DLCFundingInput.fromInputSigningInfo(utxo, fund.inputSerialId)
         }

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
@@ -48,10 +48,13 @@ case class DLCTxSigner(
               finalAddress == offer.pubKeys.payoutAddress,
             "Given keys do not match public key and address in offer")
     val fundingUtxosAsInputs =
-      fundingUtxos.zip(offer.fundingInputs).map { case (utxo, fund) =>
-        DLCFundingInput.fromInputSigningInfo(utxo, fund.inputSerialId)
-      }
-    require(fundingUtxosAsInputs == offer.fundingInputs,
+      fundingUtxos
+        .zip(offer.fundingInputs)
+        .map { case (utxo, fund) =>
+          DLCFundingInput.fromInputSigningInfo(utxo, fund.inputSerialId)
+        }
+        .sortBy(_.inputSerialId)
+    require(fundingUtxosAsInputs == offer.fundingInputs.sortBy(_.inputSerialId),
             "Funding ScriptSignatureParams did not match offer funding inputs")
   } else {
     require(
@@ -60,11 +63,16 @@ case class DLCTxSigner(
       "Given keys do not match public key and address in accept"
     )
     val fundingUtxosAsInputs =
-      fundingUtxos.zip(accept.fundingInputs).map { case (utxo, fund) =>
-        DLCFundingInput.fromInputSigningInfo(utxo, fund.inputSerialId)
-      }
-    require(fundingUtxosAsInputs == accept.fundingInputs,
-            "Funding ScriptSignatureParams did not match accept funding inputs")
+      fundingUtxos
+        .zip(accept.fundingInputs)
+        .map { case (utxo, fund) =>
+          DLCFundingInput.fromInputSigningInfo(utxo, fund.inputSerialId)
+        }
+        .sortBy(_.inputSerialId)
+    require(
+      fundingUtxosAsInputs == accept.fundingInputs.sortBy(_.inputSerialId),
+      "Funding ScriptSignatureParams did not match accept funding inputs"
+    )
   }
 
   /** Return's this party's payout for a given oracle signature */

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/verify/DLCSignatureVerifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/verify/DLCSignatureVerifier.scala
@@ -184,7 +184,7 @@ object DLCSignatureVerifier {
             }.flatten match {
               case Success(finalized) =>
                 finalized.verifyFinalizedInput(idx)
-              case Failure(err) =>
+              case Failure(_) =>
                 false
             }
           }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleEnumExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleEnumExecutionTest.scala
@@ -27,7 +27,7 @@ class DLCMultiOracleEnumExecutionTest extends BitcoinSDualWalletTest {
   val outcomes: Vector[String] = DLCTestUtil.genOutcomes(numOutcomes)
 
   val (contractDescriptor, _) =
-    DLCTestUtil.genContractDescriptors(outcomes, Satoshis(10000))
+    DLCTestUtil.genContractDescriptors(outcomes, total)
 
   val announcements: Vector[OracleAnnouncementTLV] =
     privateKeys.zip(kValues).map { case (priv, kValue) =>

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -994,16 +994,16 @@ abstract class DLCWallet
       contractData <- contractDataDAO.read(dlcDb.dlcId).map(_.get)
       offerDbOpt <- dlcOfferDAO.findByDLCId(dlcDb.dlcId)
       offerDb = offerDbOpt.get
-      fundingInputDbs <- dlcInputsDAO.findByDLCId(dlcDb.dlcId)
+      fundingInputDbs <- dlcInputsDAO.findByDLCId(dlcDb.dlcId,
+                                                  isInitiator = true)
 
       txIds = fundingInputDbs.map(_.outPoint.txIdBE)
       remotePrevTxs <- remoteTxDAO.findByTxIdBEs(txIds)
-      localPrevTxs <- transactionDAO.findByTxIdBEs(txIds)
 
       (announcements, announcementData, nonceDbs) <- getDLCAnnouncementDbs(
         dlcDb.dlcId)
 
-      prevTxs = (remotePrevTxs ++ localPrevTxs).map(_.transaction)
+      prevTxs = remotePrevTxs.map(_.transaction)
       txs = prevTxs.groupBy(_.txIdBE)
 
       fundingInputs = fundingInputDbs.map(input =>

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -937,7 +937,7 @@ abstract class DLCWallet
   def verifyFundingSigs(
       inputs: Vector[DLCFundingInputDb],
       sign: DLCSign): Future[Boolean] = {
-    if (inputs.count(!_.isInitiator) == sign.fundingSigs.length) {
+    if (inputs.count(_.isInitiator) == sign.fundingSigs.length) {
       verifierFromDb(sign.contractId).map { verifier =>
         verifier.verifyRemoteFundingSigs(sign.fundingSigs)
       }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
@@ -84,7 +84,8 @@ trait BitcoinSDualWalletTest extends BitcoinSWalletTest {
         for {
           walletA <- walletAF
           walletB <- walletBF
-          contractInfo = ContractInfo(Satoshis(10000), contractOraclePair)
+          amt = expectedDefaultAmt / Satoshis(2)
+          contractInfo = ContractInfo(amt.satoshis, contractOraclePair)
           (dlcWalletA, dlcWalletB) <-
             DLCWalletUtil.initDLC(walletA, walletB, contractInfo)
         } yield (dlcWalletA, dlcWalletB)


### PR DESCRIPTION
We were filtering for the accepter's inputs instead of the initiator's inputs for funding input verifcation. This wasn't caught because all of our tests use small enough amounts that we only need 1 input.