### PR TITLE
Better error message for invalid DLC refunds

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -95,8 +95,8 @@ object DLCWalletUtil extends Logging {
   lazy val multiNonceContractInfo: ContractInfo =
     ContractInfo(total, multiNonceContractOraclePair)
 
-  lazy val dummyContractMaturity: BlockTimeStamp = BlockTimeStamp(1666335)
-  lazy val dummyContractTimeout: BlockTimeStamp = BlockTimeStamp(1666337)
+  lazy val dummyContractMaturity: BlockTimeStamp = BlockTimeStamp(0)
+  lazy val dummyContractTimeout: BlockTimeStamp = BlockTimeStamp(1)
 
   lazy val dummyTimeouts: DLCTimeouts =
     DLCTimeouts(dummyContractMaturity, dummyContractTimeout)


### PR DESCRIPTION
Fixes #2953

My only concern with this is that you would need to wait for your node to sync to broadcast a refund transaction, if you're using a height based locktime, however, currently our GUI uses a time based one so we would not be susceptible 