### PR TITLE
Rework findDLC()

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCState.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCState.scala
@@ -6,49 +6,57 @@ sealed abstract class DLCState
 
 object DLCState extends StringFactory[DLCState] {
 
+  sealed abstract class InProgressState extends DLCState
+
+  /** Means that someone has attempted to claim the DLC */
+  sealed abstract class ClosedState extends DLCState
+
+  /** A state that requires an oracle outcome to be valid */
+  sealed trait ClosedViaOracleOutcomeState extends ClosedState
+
   /** The state where an offer has been created but no
     * accept message has yet been created/received.
     */
-  final case object Offered extends DLCState
+  final case object Offered extends InProgressState
 
   /** The state where an offer has been accepted but
     * no sign message has yet been created/received.
     */
-  final case object Accepted extends DLCState
+  final case object Accepted extends InProgressState
 
   /** The state where the initiating party has created
     * a sign message in response to an accept message
     * but the DLC funding transaction has not yet been
     * broadcasted to the network.
     */
-  final case object Signed extends DLCState
+  final case object Signed extends InProgressState
 
   /** The state where the accepting (non-initiating)
     * party has broadcasted the DLC funding transaction
     * to the blockchain, and it has not yet been confirmed.
     */
-  final case object Broadcasted extends DLCState
+  final case object Broadcasted extends InProgressState
 
   /** The state where the DLC funding transaction has been
     * confirmed on-chain and no execution paths have yet been
     * initiated.
     */
-  final case object Confirmed extends DLCState
+  final case object Confirmed extends InProgressState
 
   /** The state where one of the CETs has been accepted by the network
     * and executed by ourselves.
     */
-  final case object Claimed extends DLCState
+  final case object Claimed extends ClosedViaOracleOutcomeState
 
   /** The state where one of the CETs has been accepted by the network
     * and executed by a remote party.
     */
-  final case object RemoteClaimed extends DLCState
+  final case object RemoteClaimed extends ClosedViaOracleOutcomeState
 
   /** The state where the DLC refund transaction has been
     * accepted by the network.
     */
-  final case object Refunded extends DLCState
+  final case object Refunded extends ClosedState
 
   val all: Vector[DLCState] = Vector(Offered,
                                      Accepted,

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCStatus.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCStatus.scala
@@ -254,4 +254,5 @@ object DLCStatus {
                            localAdaptorSigs,
                            cet)
   }
+
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1234,7 +1234,6 @@ abstract class DLCWallet
   }
 
   override def findDLC(dlcId: Sha256Digest): Future[Option[DLCStatus]] = {
-    logger.debug(s"Finding dlcId=$dlcId")
     val start = System.currentTimeMillis()
     val dlcDbOptF = dlcDAO.read(dlcId)
     val contractDataOptF = contractDataDAO.read(dlcId)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/accounting/AccountingUtil.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/accounting/AccountingUtil.scala
@@ -1,0 +1,48 @@
+package org.bitcoins.dlc.wallet.accounting
+
+import org.bitcoins.core.dlc.accounting.DLCAccounting
+import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.dlc.wallet.models.{DLCAcceptDb, DLCDb, DLCOfferDb}
+
+object AccountingUtil {
+
+  /** Calculates the profit and loss for the given dlc */
+  def calculatePnl(
+      dlcDb: DLCDb,
+      offerDb: DLCOfferDb,
+      acceptDb: DLCAcceptDb,
+      closingTx: Transaction): DLCAccounting = {
+    val (myCollateral, theirCollateral, myPayoutAddress, theirPayoutAddress) = {
+      if (dlcDb.isInitiator) {
+        val myCollateral = offerDb.collateral
+        val theirCollateral = acceptDb.collateral
+        val myPayoutAddress = offerDb.payoutAddress
+        val theirPayoutAddress = acceptDb.payoutAddress
+        (myCollateral, theirCollateral, myPayoutAddress, theirPayoutAddress)
+
+      } else {
+        val myCollateral = acceptDb.collateral
+        val theirCollateral = offerDb.collateral
+        val myPayoutAddress = acceptDb.payoutAddress
+        val theirPayoutAddress = offerDb.payoutAddress
+        (myCollateral, theirCollateral, myPayoutAddress, theirPayoutAddress)
+      }
+    }
+
+    val myPayout = closingTx.outputs
+      .filter(_.scriptPubKey == myPayoutAddress.scriptPubKey)
+      .map(_.value)
+      .sum
+    val theirPayout = closingTx.outputs
+      .filter(_.scriptPubKey == theirPayoutAddress.scriptPubKey)
+      .map(_.value)
+      .sum
+    DLCAccounting(
+      dlcId = dlcDb.dlcId,
+      myCollateral = myCollateral,
+      theirCollateral = theirCollateral,
+      myPayout = myPayout,
+      theirPayout = theirPayout
+    )
+  }
+}

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCStatusBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCStatusBuilder.scala
@@ -1,0 +1,245 @@
+package org.bitcoins.dlc.wallet.util
+
+import org.bitcoins.core.dlc.accounting.DLCAccounting
+import org.bitcoins.core.protocol.dlc.models.{
+  ClosedDLCStatus,
+  ContractInfo,
+  DLCState,
+  DLCStatus,
+  OracleOutcome
+}
+import org.bitcoins.core.protocol.dlc.models.DLCStatus.{
+  Accepted,
+  Broadcasted,
+  Claimed,
+  Confirmed,
+  Offered,
+  Refunded,
+  RemoteClaimed,
+  Signed
+}
+import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.crypto.SchnorrDigitalSignature
+import org.bitcoins.dlc.wallet.accounting.AccountingUtil
+import org.bitcoins.dlc.wallet.models.{
+  DLCAcceptDb,
+  DLCContractDataDb,
+  DLCDb,
+  DLCOfferDb,
+  OracleNonceDb
+}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object DLCStatusBuilder {
+
+  /** Helper method to convert a bunch of indepdendent datastructures into a in progress dlc status */
+  def buildInProgressDLCStatus(
+      state: DLCState.InProgressState,
+      dlcDb: DLCDb,
+      contractInfo: ContractInfo,
+      contractData: DLCContractDataDb,
+      offerDb: DLCOfferDb): DLCStatus = {
+    require(
+      dlcDb.state == state,
+      s"Cannot have divergent states beteween dlcDb and the parameter state, got= dlcDb.state=${dlcDb.state} state=${state}")
+    val dlcId = dlcDb.dlcId
+
+    val totalCollateral = contractData.totalCollateral
+
+    val localCollateral = if (dlcDb.isInitiator) {
+      offerDb.collateral
+    } else {
+      totalCollateral - offerDb.collateral
+    }
+
+    val status = state match {
+      case DLCState.Offered =>
+        Offered(
+          dlcId,
+          dlcDb.isInitiator,
+          dlcDb.tempContractId,
+          contractInfo,
+          contractData.dlcTimeouts,
+          dlcDb.feeRate,
+          totalCollateral,
+          localCollateral
+        )
+      case DLCState.Accepted =>
+        Accepted(
+          dlcId,
+          dlcDb.isInitiator,
+          dlcDb.tempContractId,
+          dlcDb.contractIdOpt.get,
+          contractInfo,
+          contractData.dlcTimeouts,
+          dlcDb.feeRate,
+          totalCollateral,
+          localCollateral
+        )
+      case DLCState.Signed =>
+        Signed(
+          dlcId,
+          dlcDb.isInitiator,
+          dlcDb.tempContractId,
+          dlcDb.contractIdOpt.get,
+          contractInfo,
+          contractData.dlcTimeouts,
+          dlcDb.feeRate,
+          totalCollateral,
+          localCollateral
+        )
+      case DLCState.Broadcasted =>
+        Broadcasted(
+          dlcId,
+          dlcDb.isInitiator,
+          dlcDb.tempContractId,
+          dlcDb.contractIdOpt.get,
+          contractInfo,
+          contractData.dlcTimeouts,
+          dlcDb.feeRate,
+          totalCollateral,
+          localCollateral,
+          dlcDb.fundingTxIdOpt.get
+        )
+      case DLCState.Confirmed =>
+        Confirmed(
+          dlcId,
+          dlcDb.isInitiator,
+          dlcDb.tempContractId,
+          dlcDb.contractIdOpt.get,
+          contractInfo,
+          contractData.dlcTimeouts,
+          dlcDb.feeRate,
+          totalCollateral,
+          localCollateral,
+          dlcDb.fundingTxIdOpt.get
+        )
+    }
+
+    status
+  }
+
+  def buildClosedDLCStatus(
+      state: DLCState.ClosedState,
+      dlcDb: DLCDb,
+      contractInfo: ContractInfo,
+      contractData: DLCContractDataDb,
+      nonceDbs: Vector[OracleNonceDb],
+      offerDb: DLCOfferDb,
+      acceptDb: DLCAcceptDb,
+      closingTx: Transaction)(implicit
+      ec: ExecutionContext): Future[ClosedDLCStatus] = {
+    require(
+      dlcDb.state == state,
+      s"Cannot have divergent states beteween dlcDb and the parameter state, got= dlcDb.state=${dlcDb.state} state=${state}")
+    val dlcId = dlcDb.dlcId
+    val accounting: DLCAccounting =
+      AccountingUtil.calculatePnl(dlcDb, offerDb, acceptDb, closingTx)
+
+    //start calculation up here in parallel as this is a bottleneck currently
+    val outcomesOptF: Future[
+      Option[(OracleOutcome, Vector[SchnorrDigitalSignature])]] =
+      for {
+        oracleOutcomeSigsOpt <- getOracleOutcomeAndSigs(dlcDb = dlcDb,
+                                                        contractInfo =
+                                                          contractInfo,
+                                                        nonceDbs = nonceDbs)
+      } yield oracleOutcomeSigsOpt
+
+    val totalCollateral = contractData.totalCollateral
+
+    val localCollateral = if (dlcDb.isInitiator) {
+      offerDb.collateral
+    } else {
+      totalCollateral - offerDb.collateral
+    }
+    val statusF = state match {
+      case DLCState.Refunded =>
+        //no oracle information in the refund case
+        val refund = Refunded(
+          dlcId,
+          dlcDb.isInitiator,
+          dlcDb.tempContractId,
+          dlcDb.contractIdOpt.get,
+          contractInfo,
+          contractData.dlcTimeouts,
+          dlcDb.feeRate,
+          totalCollateral,
+          localCollateral,
+          dlcDb.fundingTxIdOpt.get,
+          closingTx.txIdBE,
+          myPayout = accounting.myPayout,
+          counterPartyPayout = accounting.theirPayout
+        )
+        Future.successful(refund)
+      case oracleOutcomeState: DLCState.ClosedViaOracleOutcomeState =>
+        //a state that requires an oracle outcome
+        //the .get below should always be valid
+        for {
+          outcomesOpt <- outcomesOptF
+          (oracleOutcome, sigs) = outcomesOpt.get
+        } yield {
+          oracleOutcomeState match {
+            case DLCState.Claimed =>
+              Claimed(
+                dlcId,
+                dlcDb.isInitiator,
+                dlcDb.tempContractId,
+                dlcDb.contractIdOpt.get,
+                contractInfo,
+                contractData.dlcTimeouts,
+                dlcDb.feeRate,
+                totalCollateral,
+                localCollateral,
+                dlcDb.fundingTxIdOpt.get,
+                closingTx.txIdBE,
+                sigs,
+                oracleOutcome,
+                myPayout = accounting.myPayout,
+                counterPartyPayout = accounting.theirPayout
+              )
+            case DLCState.RemoteClaimed =>
+              RemoteClaimed(
+                dlcId,
+                dlcDb.isInitiator,
+                dlcDb.tempContractId,
+                dlcDb.contractIdOpt.get,
+                contractInfo,
+                contractData.dlcTimeouts,
+                dlcDb.feeRate,
+                totalCollateral,
+                localCollateral,
+                dlcDb.fundingTxIdOpt.get,
+                closingTx.txIdBE,
+                dlcDb.aggregateSignatureOpt.get,
+                oracleOutcome,
+                myPayout = accounting.myPayout,
+                counterPartyPayout = accounting.theirPayout
+              )
+          }
+        }
+    }
+    statusF
+  }
+
+  /** Calculates oracle outcome and signatures. Returns none if the dlc is not in a valid state to
+    * calculate the outcome
+    */
+  def getOracleOutcomeAndSigs(
+      dlcDb: DLCDb,
+      contractInfo: ContractInfo,
+      nonceDbs: Vector[OracleNonceDb])(implicit ec: ExecutionContext): Future[
+    Option[(OracleOutcome, Vector[SchnorrDigitalSignature])]] = {
+    Future {
+      dlcDb.aggregateSignatureOpt match {
+        case Some(aggSig) =>
+          val outcome =
+            contractInfo.sigPointMap(aggSig.sig.toPrivateKey.publicKey)
+          val sigs = nonceDbs.flatMap(_.signatureOpt)
+          Some((outcome, sigs))
+        case None => None
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR was an attempt to address #3213 but ended up just being a refactor. This PR is *NOT* intended to change functionality

There is way too much stuff going on in `DLCWallet`, this breaks things out into helper classes 

1. `DLCStatusBuilder`
2. `AccountingUtil`

As a by product, I added a few new states to `DLCState` 

1. `InProgressState` - this means that the DLC is being setup or exists onchain waiting for settlement
2. `ClosedState` - this means the DLC has been settled (not necessarily onchain, but someone has attempted to close it)
3. `ClosedViaOracleOutcomeState` - this means the DLC has been closed with an oracle attestment. This is different than the `Refund` state where there isn't an oracle attestment used.

I don't think this significantly improves performance, but it definitely helps readability, maintainability and correctness