### PR TITLE
Remove all flyway plugin sbt config

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -27,9 +27,6 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 // write markdown files with type-checked Scala
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.21")
 
-// SQL migrations
-addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % "6.4.2")
-
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
This removes the sbt plugin for flyway. We keep flyway around, but just as a normal scala dependency. 

The motivation for doing this is because

1. We aren't using it
2. We are experiencing reports from users about the `~/.bitcoin-s` directory not existing. I'm worried us developer are missing bugs because -- as @benthecarman pointed out -- this flyway logic would create the directories

![Screenshot from 2021-06-01 14-49-20](https://user-images.githubusercontent.com/3514957/120381891-a0beeb80-c2e8-11eb-951f-6080c0d1c7bc.png)
