### PR TITLE
2021 06 02 adddlcsigsfromfile

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -316,6 +316,21 @@ object ConsoleCli {
                 case other => other
               }))
         ),
+      cmd("adddlcsigsandbroadcastfromfile")
+        .action((_, conf) =>
+          conf.copy(command =
+            AddDLCSigsAndBroadcastFromFile(new File("").toPath)))
+        .text("Adds DLC Signatures into the database")
+        .children(
+          arg[Path]("path")
+            .required()
+            .action((path, conf) =>
+              conf.copy(command = conf.command match {
+                case addDLCSigs: AddDLCSigsAndBroadcastFromFile =>
+                  addDLCSigs.copy(path = path)
+                case other => other
+              }))
+        ),
       cmd("adddlcsigsandbroadcast")
         .action((_, conf) => conf.copy(command = AddDLCSigsAndBroadcast(null)))
         .text("Adds DLC Signatures into the database and broadcasts the funding transaction")
@@ -1506,6 +1521,8 @@ object ConsoleCli {
         RequestParam("adddlcsigsfromfile", Seq(up.writeJs(path)))
       case AddDLCSigsAndBroadcast(sigs) =>
         RequestParam("adddlcsigsandbroadcast", Seq(up.writeJs(sigs)))
+      case AddDLCSigsAndBroadcastFromFile(path) =>
+        RequestParam("adddlcsigsandbroadcastfromfile", Seq(up.writeJs(path)))
       case ExecuteDLC(contractId, oracleSigs, noBroadcast) =>
         RequestParam("executedlc",
                      Seq(up.writeJs(contractId),
@@ -1876,6 +1893,9 @@ object CliCommand {
       extends AddDLCSigsCliCommand
 
   case class AddDLCSigsFromFile(path: Path) extends AddDLCSigsCliCommand
+
+  case class AddDLCSigsAndBroadcastFromFile(path: Path)
+      extends AddDLCSigsCliCommand
 
   case class AddDLCSigsAndBroadcast(sigs: LnMessage[DLCSignTLV])
       extends AddDLCSigsCliCommand

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -133,28 +133,7 @@ class DLCPaneModel(resultArea: TextArea) extends Logging {
   }
 
   def onSign(): Unit = {
-    val result = SignDLCDialog.showAndWait(parentWindow.value)
-
-    result match {
-      case Some(command) =>
-        taskRunner.run(
-          caption = "Sign DLC",
-          op = {
-            ConsoleCli.exec(command, GlobalData.consoleCliConfig) match {
-              case Success(commandReturn) =>
-                val string = if (commandReturn.isEmpty) {
-                  "Signing DLC timed out! Try again in a bit."
-                } else commandReturn
-                resultArea.text = string
-              case Failure(err) =>
-                err.printStackTrace()
-                resultArea.text = s"Error executing command:\n${err.getMessage}"
-            }
-            updateDLCs()
-          }
-        )
-      case None => ()
-    }
+    printDLCDialogResult("Add DLC sigs", new SignDLCDialog)
   }
 
   def onBroadcastDLC(): Unit = {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
@@ -33,7 +33,7 @@ class BroadcastDLCDialog
       case Some(file) =>
         signDLCFile = None // reset
         signFileChosenLabel.text = "" // reset
-        AddDLCSigsFromFile(file.toPath)
+        AddDLCSigsAndBroadcastFromFile(file.toPath)
       case None =>
         val signHex = readStringFromNode(inputs(dlcSigStr))
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -1,190 +1,220 @@
 package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand._
-import org.bitcoins.core.protocol.dlc.models.{DLCStatus, EnumContractDescriptor}
 import org.bitcoins.core.protocol.tlv._
-import org.bitcoins.gui.GlobalData
-import org.bitcoins.gui.dlc.GlobalDLCData.dlcs
-import org.bitcoins.gui.util.GUIUtil
-import scalafx.Includes._
-import scalafx.geometry.{Insets, Pos}
-import scalafx.scene.control._
-import scalafx.scene.layout._
-import scalafx.stage.Window
 
-import scala.collection._
-import scala.util.{Failure, Success, Try}
+import org.bitcoins.gui.dlc.GlobalDLCData
 
-object SignDLCDialog {
+import scalafx.scene.Node
 
-  def showAndWait(parentWindow: Window): Option[SignDLCCliCommand] = {
-    val dialog = new Dialog[Option[SignDLCCliCommand]]() {
-      initOwner(parentWindow)
-      title = "Sign DLC"
-      headerText = "Enter DLC Accept message"
-    }
+class SignDLCDialog
+    extends DLCDialog[SignDLCCliCommand]("Sign DLC",
+                                         "Enter DLC Accept message",
+                                         Vector(
+                                           DLCDialog.dlcAcceptStr -> DLCDialog
+                                             .textArea(),
+                                           DLCDialog.dlcAcceptFileStr ->
+                                             DLCDialog.fileChooserButton(
+                                               open = true,
+                                               { file =>
+                                                 DLCDialog.acceptDLCFile =
+                                                   Some(file)
+                                                 DLCDialog.acceptFileChosenLabel.text =
+                                                   file.toString
+                                               }),
+                                           DLCDialog.fileChosenStr -> DLCDialog.acceptFileChosenLabel
+                                         ),
+                                         Vector(DLCDialog.dlcAcceptStr,
+                                                DLCDialog.dlcAcceptFileStr)) {
 
-    dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
-    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
-    dialog.resizable = true
+//  override def showAndWait(parentWindow: Window): Option[SignDLCCliCommand] = {
+//    val dialog = new Dialog[Option[SignDLCCliCommand]]() {
+//      initOwner(parentWindow)
+//      title = "Sign DLC"
+//      headerText = "Enter DLC Accept message"
+//    }
+//
+//    dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
+//    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+//    dialog.resizable = true
+//
+//    var dlcDetailsShown = false
+//    val acceptTLVTF = new TextField() {
+//      minWidth = 300
+//    }
+//
+//    var nextRow: Int = 2
+//    val gridPane = new GridPane {
+//      alignment = Pos.Center
+//      padding = Insets(top = 10, right = 10, bottom = 10, left = 10)
+//      hgap = 5
+//      vgap = 5
+//
+//      add(new Label("DLC Accept"), 0, 0)
+//      add(acceptTLVTF, 1, 0)
+//    }
+//
+//    def showDLCTerms(status: DLCStatus): Unit = {
+//      val descriptor = status.contractInfo.contractDescriptor.toTLV match {
+//        case v0: ContractDescriptorV0TLV =>
+//          EnumContractDescriptor
+//            .fromTLV(v0)
+//            .flip(status.totalCollateral.satoshis)
+//        case _: ContractDescriptorV1TLV =>
+//          throw new RuntimeException("This is impossible.")
+//      }
+//
+//      val (oracleKey, eventId) = status.contractInfo.oracleInfo.toTLV match {
+//        case OracleInfoV0TLV(announcement) =>
+//          (announcement.publicKey.hex, announcement.eventTLV.eventId)
+//        case _: MultiOracleInfoTLV =>
+//          throw new RuntimeException("This is impossible.")
+//      }
+//
+//      gridPane.add(new Label("Event Id"), 0, nextRow)
+//      gridPane.add(
+//        new TextField() {
+//          text = eventId
+//          editable = false
+//        },
+//        1,
+//        nextRow
+//      )
+//      nextRow += 1
+//
+//      gridPane.add(new Label("Oracle Public Key"), 0, nextRow)
+//      gridPane.add(
+//        new TextField() {
+//          text = oracleKey
+//          editable = false
+//        },
+//        1,
+//        nextRow
+//      )
+//      nextRow += 1
+//
+//      gridPane.add(new Label("Your Collateral"), 0, nextRow)
+//      gridPane.add(new TextField() {
+//                     text = status.localCollateral.satoshis.toString
+//                     editable = false
+//                   },
+//                   1,
+//                   nextRow)
+//      nextRow += 1
+//
+//      gridPane.add(new Label("Counter Party Collateral"), 0, nextRow)
+//      gridPane.add(new TextField() {
+//                     text = status.remoteCollateral.satoshis.toString
+//                     editable = false
+//                   },
+//                   1,
+//                   nextRow)
+//      nextRow += 1
+//
+//      gridPane.add(new Label("Potential Outcome"), 0, nextRow)
+//      gridPane.add(new Label("Payouts"), 1, nextRow)
+//      nextRow += 1
+//
+//      descriptor.foreach { case (str, satoshis) =>
+//        gridPane.add(new TextField() {
+//                       text = str.outcome
+//                       editable = false
+//                     },
+//                     0,
+//                     nextRow)
+//        gridPane.add(new TextField() {
+//                       text = satoshis.toString
+//                       editable = false
+//                     },
+//                     1,
+//                     nextRow)
+//        nextRow += 1
+//      }
+//
+//      gridPane.add(new Label("Fee Rate"), 0, nextRow)
+//      gridPane.add(new TextField() {
+//                     text = status.feeRate.toString
+//                     editable = false
+//                   },
+//                   1,
+//                   nextRow)
+//      nextRow += 1
+//
+//      gridPane.add(new Label("Refund Date"), 0, nextRow)
+//      gridPane.add(
+//        new TextField() {
+//          text = GUIUtil.epochToDateString(status.timeouts.contractTimeout)
+//          editable = false
+//        },
+//        1,
+//        nextRow)
+//      nextRow += 1
+//    }
+//
+//    acceptTLVTF.onKeyTyped = _ => {
+//      if (!dlcDetailsShown) {
+//        Try(
+//          LnMessageFactory(DLCAcceptTLV).fromHex(
+//            acceptTLVTF.text.value)) match {
+//          case Failure(_) => ()
+//          case Success(lnMessage) =>
+//            val tempId = lnMessage.tlv.tempContractId
+//            dlcs.find(_.tempContractId == tempId) match {
+//              case Some(dlc) =>
+//                dlc.contractInfo.contractDescriptor.toTLV match {
+//                  case _: ContractDescriptorV0TLV =>
+//                    dlcDetailsShown = true
+//                    showDLCTerms(dlc)
+//                    dialog.dialogPane().getScene.getWindow.sizeToScene()
+//                  case _: ContractDescriptorV1TLV =>
+//                    () // todo not supported
+//                }
+//              case None => ()
+//            }
+//        }
+//      }
+//    }
+//
+//    dialog.dialogPane().content = new ScrollPane {
+//      content = new VBox(gridPane)
+//    }
+//
+//    // When the OK button is clicked, convert the result to a SignDLC.
+//    dialog.resultConverter = dialogButton =>
+//      if (dialogButton == ButtonType.OK) {
+//
+//        val acceptHex = acceptTLVTF.text.value
+//        val accept = LnMessageFactory(DLCAcceptTLV).fromHex(acceptHex)
+//
+//        Some(SignDLC(accept))
+//      } else None
+//
+//    val result = dialog.showAndWait()
+//
+//    result match {
+//      case Some(Some(cmd: SignDLCCliCommand)) =>
+//        Some(cmd)
+//      case Some(_) | None => None
+//    }
+//  }
 
-    var dlcDetailsShown = false
-    val acceptTLVTF = new TextField() {
-      minWidth = 300
-    }
+  override def constructFromInput(
+      inputs: Predef.Map[String, Node]): SignDLCCliCommand = {
+    DLCDialog.acceptDLCFile match {
+      case Some(file) =>
+        DLCDialog.acceptDLCFile = None // reset
+        DLCDialog.acceptFileChosenLabel.text = "" // reset
+        SignDLCFromFile(file.toPath, destination = None) //is none right here?
+      case None =>
+        val acceptHex = readStringFromNode(inputs(DLCDialog.dlcAcceptStr))
 
-    var nextRow: Int = 2
-    val gridPane = new GridPane {
-      alignment = Pos.Center
-      padding = Insets(top = 10, right = 10, bottom = 10, left = 10)
-      hgap = 5
-      vgap = 5
-
-      add(new Label("DLC Accept"), 0, 0)
-      add(acceptTLVTF, 1, 0)
-    }
-
-    def showDLCTerms(status: DLCStatus): Unit = {
-      val descriptor = status.contractInfo.contractDescriptor.toTLV match {
-        case v0: ContractDescriptorV0TLV =>
-          EnumContractDescriptor
-            .fromTLV(v0)
-            .flip(status.totalCollateral.satoshis)
-        case _: ContractDescriptorV1TLV =>
-          throw new RuntimeException("This is impossible.")
-      }
-
-      val (oracleKey, eventId) = status.contractInfo.oracleInfo.toTLV match {
-        case OracleInfoV0TLV(announcement) =>
-          (announcement.publicKey.hex, announcement.eventTLV.eventId)
-        case _: MultiOracleInfoTLV =>
-          throw new RuntimeException("This is impossible.")
-      }
-
-      gridPane.add(new Label("Event Id"), 0, nextRow)
-      gridPane.add(
-        new TextField() {
-          text = eventId
-          editable = false
-        },
-        1,
-        nextRow
-      )
-      nextRow += 1
-
-      gridPane.add(new Label("Oracle Public Key"), 0, nextRow)
-      gridPane.add(
-        new TextField() {
-          text = oracleKey
-          editable = false
-        },
-        1,
-        nextRow
-      )
-      nextRow += 1
-
-      gridPane.add(new Label("Your Collateral"), 0, nextRow)
-      gridPane.add(new TextField() {
-                     text = status.localCollateral.satoshis.toString
-                     editable = false
-                   },
-                   1,
-                   nextRow)
-      nextRow += 1
-
-      gridPane.add(new Label("Counter Party Collateral"), 0, nextRow)
-      gridPane.add(new TextField() {
-                     text = status.remoteCollateral.satoshis.toString
-                     editable = false
-                   },
-                   1,
-                   nextRow)
-      nextRow += 1
-
-      gridPane.add(new Label("Potential Outcome"), 0, nextRow)
-      gridPane.add(new Label("Payouts"), 1, nextRow)
-      nextRow += 1
-
-      descriptor.foreach { case (str, satoshis) =>
-        gridPane.add(new TextField() {
-                       text = str.outcome
-                       editable = false
-                     },
-                     0,
-                     nextRow)
-        gridPane.add(new TextField() {
-                       text = satoshis.toString
-                       editable = false
-                     },
-                     1,
-                     nextRow)
-        nextRow += 1
-      }
-
-      gridPane.add(new Label("Fee Rate"), 0, nextRow)
-      gridPane.add(new TextField() {
-                     text = status.feeRate.toString
-                     editable = false
-                   },
-                   1,
-                   nextRow)
-      nextRow += 1
-
-      gridPane.add(new Label("Refund Date"), 0, nextRow)
-      gridPane.add(
-        new TextField() {
-          text = GUIUtil.epochToDateString(status.timeouts.contractTimeout)
-          editable = false
-        },
-        1,
-        nextRow)
-      nextRow += 1
-    }
-
-    acceptTLVTF.onKeyTyped = _ => {
-      if (!dlcDetailsShown) {
-        Try(
-          LnMessageFactory(DLCAcceptTLV).fromHex(
-            acceptTLVTF.text.value)) match {
-          case Failure(_) => ()
-          case Success(lnMessage) =>
-            val tempId = lnMessage.tlv.tempContractId
-            dlcs.find(_.tempContractId == tempId) match {
-              case Some(dlc) =>
-                dlc.contractInfo.contractDescriptor.toTLV match {
-                  case _: ContractDescriptorV0TLV =>
-                    dlcDetailsShown = true
-                    showDLCTerms(dlc)
-                    dialog.dialogPane().getScene.getWindow.sizeToScene()
-                  case _: ContractDescriptorV1TLV =>
-                    () // todo not supported
-                }
-              case None => ()
-            }
-        }
-      }
-    }
-
-    dialog.dialogPane().content = new ScrollPane {
-      content = new VBox(gridPane)
-    }
-
-    // When the OK button is clicked, convert the result to a SignDLC.
-    dialog.resultConverter = dialogButton =>
-      if (dialogButton == ButtonType.OK) {
-
-        val acceptHex = acceptTLVTF.text.value
         val accept = LnMessageFactory(DLCAcceptTLV).fromHex(acceptHex)
 
-        Some(SignDLC(accept))
-      } else None
+        //is this right???
+        GlobalDLCData.lastContractId = accept.tlv.tempContractId.hex
 
-    val result = dialog.showAndWait()
+        SignDLC(accept)
 
-    result match {
-      case Some(Some(cmd: SignDLCCliCommand)) =>
-        Some(cmd)
-      case Some(_) | None => None
     }
   }
 }


### PR DESCRIPTION
This is the same as #3219 with some bonus features

1. Makes `adddlcsigsandbroadcastfromfile` so that we can broadcast a tx immediately after adding sigs
2. Restores the abillity for `signdlcfromdialog` to be from a file too

This ends up being a bottleneck that i've encountered with users executing numeric DLCs.