### PR TITLE
Make getDLCs async to improve performance

### DIFF
--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
@@ -47,10 +47,7 @@ class LandingPaneModel()(implicit system: ActorSystem) extends Logging {
         // Launch wallet
         val promise = Promise[Unit]()
         BitcoinSServer.startedF.map { _ =>
-          val start = System.currentTimeMillis()
           fetchStartingData()
-          logger.info(
-            s"fetchStartingData took=${System.currentTimeMillis() - start}ms")
           changeToWalletGUIScene()
           promise.success(())
         }(global)

--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
@@ -2,6 +2,7 @@ package org.bitcoins.bundle.gui
 
 import akka.actor.ActorSystem
 import com.typesafe.config._
+import grizzled.slf4j.Logging
 import org.bitcoins.bundle.gui.BundleGUI._
 import org.bitcoins.gui._
 import org.bitcoins.server.BitcoinSAppConfig.toNodeConf
@@ -15,7 +16,8 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Promise}
 import scala.jdk.CollectionConverters._
 
-class LandingPaneModel()(implicit system: ActorSystem) {
+class LandingPaneModel()(implicit system: ActorSystem) extends Logging {
+
   var taskRunner: TaskRunner = _
 
   // Sadly, it is a Java "pattern" to pass null into
@@ -45,7 +47,10 @@ class LandingPaneModel()(implicit system: ActorSystem) {
         // Launch wallet
         val promise = Promise[Unit]()
         BitcoinSServer.startedF.map { _ =>
+          val start = System.currentTimeMillis()
           fetchStartingData()
+          logger.info(
+            s"fetchStartingData took=${System.currentTimeMillis() - start}ms")
           changeToWalletGUIScene()
           promise.success(())
         }(global)

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
@@ -27,7 +27,6 @@ abstract class WalletGUI extends Logging {
 
   def fetchStartingData(): Unit = {
     model.startWalletInfoScheduler()
-    val start = System.currentTimeMillis()
     model.updateFeeRate()
     dlcPane.model.setUp()
   }

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
@@ -1,13 +1,14 @@
 package org.bitcoins.gui
 
 import akka.actor.ActorSystem
+import grizzled.slf4j.Logging
 import org.bitcoins.gui.dlc.DLCPane
 import scalafx.beans.property.StringProperty
 import scalafx.geometry._
 import scalafx.scene.control._
 import scalafx.scene.layout._
 
-abstract class WalletGUI {
+abstract class WalletGUI extends Logging {
 
   def glassPane: VBox
 
@@ -26,7 +27,10 @@ abstract class WalletGUI {
 
   def fetchStartingData(): Unit = {
     model.startWalletInfoScheduler()
+    val start = System.currentTimeMillis()
     model.updateFeeRate()
+    logger.info(
+      s"update fee rate, it took=${System.currentTimeMillis() - start}ms")
     dlcPane.model.setUp()
   }
 
@@ -61,7 +65,7 @@ abstract class WalletGUI {
     text <== StringProperty("Rate of Return:\t\t\t") + GlobalData.rateOfReturn
   }
 
-  private[gui] lazy val dlcPane = new DLCPane(glassPane)
+  private[gui] lazy val dlcPane = new DLCPane(glassPane)(system.dispatcher)
   private[gui] lazy val model = new WalletGUIModel(dlcPane.model)
 
   private lazy val balanceBox = new VBox {

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
@@ -29,8 +29,6 @@ abstract class WalletGUI extends Logging {
     model.startWalletInfoScheduler()
     val start = System.currentTimeMillis()
     model.updateFeeRate()
-    logger.info(
-      s"update fee rate, it took=${System.currentTimeMillis() - start}ms")
     dlcPane.model.setUp()
   }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -12,9 +12,10 @@ import java.awt.Toolkit.getDefaultToolkit
 import java.awt.datatransfer.StringSelection
 import java.io.File
 import java.nio.file.Files
+import scala.concurrent.ExecutionContext
 import scala.util.Properties
 
-class DLCPane(glassPane: VBox) {
+class DLCPane(glassPane: VBox)(implicit ec: ExecutionContext) {
 
   private val resultTextArea = new TextArea {
     editable = false

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -44,15 +44,9 @@ class DLCPaneModel(val resultArea: TextArea)(implicit ec: ExecutionContext)
 
   def setUp(): Unit = {
     dlcs.clear()
-    val start = System.currentTimeMillis()
-    logger.info("Starting getDlcs")
     getDLCs.map { walletDlcs =>
       dlcs ++= walletDlcs
-      logger.info(
-        s"Done getDLCs async, it took=${System.currentTimeMillis() - start}ms")
     }
-    logger.info(
-      s"Done getDLCs, it took=${System.currentTimeMillis() - start}ms")
     //purposely drop the future on the floor for now
     //as our GUI is not async safe at all
     ()


### PR DESCRIPTION
Startup is very slow after you configure which backend you want. This is primary because of the call to `getDLCs()`. The performance of `getDLCs()` gets worse and worse as more DLCs are added to your wallet. This causes a long delay when opening the wallet appearing that it has frozen.


On d0321a0

>2021-06-03T12:00:29UTC INFO [LandingPaneModel] fetchStartingData took=976ms
2021-06-03T12:00:29UTC INFO [DLCPaneModel] Done getDLCs async, it took=23ms
