### PR TITLE
Skip adding DLC sigs if we already have them

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -1034,7 +1034,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
       (mockWalletApi
         .broadcastDLCFundingTx(_: ByteVector))
-        .expects(contractId)
+        .expects(sign.contractId)
         .returning(Future.successful(EmptyTransaction))
 
       val route = walletRoutes.handleCommand(

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.server
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.Materializer

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.server
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.Materializer

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -427,8 +427,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
         case Success(AddDLCSigs(sigs)) =>
           complete {
             for {
-              db <- wallet.addDLCSigs(sigs.tlv)
-              tx <- wallet.broadcastDLCFundingTx(db.contractIdOpt.get)
+              _ <- wallet.addDLCSigs(sigs.tlv)
+              tx <- wallet.broadcastDLCFundingTx(sigs.tlv.contractId)
             } yield Server.httpSuccess(tx.txIdBE.hex)
           }
       }
@@ -443,8 +443,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
           val signMessage = LnMessageFactory(DLCSignTLV).fromHex(hex)
           complete {
             for {
-              db <- wallet.addDLCSigs(signMessage.tlv)
-              tx <- wallet.broadcastDLCFundingTx(db.contractIdOpt.get)
+              _ <- wallet.addDLCSigs(signMessage.tlv)
+              tx <- wallet.broadcastDLCFundingTx(signMessage.tlv.contractId)
             } yield Server.httpSuccess(tx.txIdBE.hex)
           }
       }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -13,6 +13,7 @@ import org.bitcoins.core.protocol._
 import org.bitcoins.core.protocol.dlc.build.DLCTxBuilder
 import org.bitcoins.core.protocol.dlc.models.DLCMessage.DLCAccept._
 import org.bitcoins.core.protocol.dlc.models.DLCMessage._
+import org.bitcoins.core.protocol.dlc.models.DLCState._
 import org.bitcoins.core.protocol.dlc.models._
 import org.bitcoins.core.protocol.dlc.sign._
 import org.bitcoins.core.protocol.script._
@@ -1033,41 +1034,52 @@ abstract class DLCWallet
   override def addDLCSigs(sign: DLCSign): Future[DLCDb] = {
     dlcDAO.findByContractId(sign.contractId).flatMap {
       case Some(dlc) =>
-        logger.info(
-          s"Verifying CET Signatures for contract ${sign.contractId.toHex}")
-        for {
-          isRefundSigValid <- verifyRefundSig(sign)
-          _ = if (!isRefundSigValid)
-            throw new IllegalArgumentException(
-              s"Refund sig provided is not valid! got ${sign.cetSigs.refundSig}")
+        dlc.state match {
+          case Offered =>
+            Future.failed(
+              new RuntimeException(
+                "Cannot add sigs to a DLC before it has been accepted"))
+          case Accepted =>
+            logger.info(
+              s"Verifying CET Signatures for contract ${sign.contractId.toHex}")
+            for {
+              isRefundSigValid <- verifyRefundSig(sign)
+              _ = if (!isRefundSigValid)
+                throw new IllegalArgumentException(
+                  s"Refund sig provided is not valid! got ${sign.cetSigs.refundSig}")
 
-          isCETSigsValid <- verifyCETSigs(sign)
-          _ = if (!isCETSigsValid)
-            throw new IllegalArgumentException(
-              s"CET sigs provided are not valid! got ${sign.cetSigs.outcomeSigs}")
+              isCETSigsValid <- verifyCETSigs(sign)
+              _ = if (!isCETSigsValid)
+                throw new IllegalArgumentException(
+                  s"CET sigs provided are not valid! got ${sign.cetSigs.outcomeSigs}")
 
-          refundSigsDb <- dlcRefundSigDAO.findByDLCId(dlc.dlcId).map(_.get)
-          sigsDbs <- dlcSigsDAO.findByDLCId(dlc.dlcId)
+              refundSigsDb <- dlcRefundSigDAO.findByDLCId(dlc.dlcId).map(_.get)
+              sigsDbs <- dlcSigsDAO.findByDLCId(dlc.dlcId)
 
-          updatedRefund = refundSigsDb.copy(initiatorSig =
-            Some(sign.cetSigs.refundSig))
-          updatedSigsDbs = sigsDbs
-            .sortBy(_.index)
-            .zip(sign.cetSigs.outcomeSigs)
-            .map { case (db, (_, sig)) =>
-              db.copy(initiatorSig = Some(sig))
-            }
+              updatedRefund = refundSigsDb.copy(initiatorSig =
+                Some(sign.cetSigs.refundSig))
+              updatedSigsDbs = sigsDbs
+                .sortBy(_.index)
+                .zip(sign.cetSigs.outcomeSigs)
+                .map { case (db, (_, sig)) =>
+                  db.copy(initiatorSig = Some(sig))
+                }
 
-          _ = logger.info(
-            s"CET Signatures are valid for contract ${sign.contractId.toHex}")
+              _ = logger.info(
+                s"CET Signatures are valid for contract ${sign.contractId.toHex}")
 
-          _ <- addFundingSigs(sign)
-          _ <- dlcSigsDAO.updateAll(updatedSigsDbs)
-          _ <- dlcRefundSigDAO.update(updatedRefund)
-          updated <- dlcDAO.update(dlc.updateState(DLCState.Signed))
-          _ = logger.info(
-            s"DLC ${sign.contractId.toHex} sigs are verified and stored, ready to broadcast")
-        } yield updated
+              _ <- addFundingSigs(sign)
+              _ <- dlcSigsDAO.updateAll(updatedSigsDbs)
+              _ <- dlcRefundSigDAO.update(updatedRefund)
+              updated <- dlcDAO.update(dlc.updateState(DLCState.Signed))
+              _ = logger.info(
+                s"DLC ${sign.contractId.toHex} sigs are verified and stored, ready to broadcast")
+            } yield updated
+          case _: DLCState.ClosedState | Broadcasted | Confirmed | Signed =>
+            logger.info(
+              s"DLC sigs already added for ${sign.contractId.toHex}, skipping..")
+            Future.successful(dlc)
+        }
       case None =>
         Future.failed(new NoSuchElementException(
           s"No DLC found with corresponding contractId ${sign.contractId.toHex}"))


### PR DESCRIPTION
This should help make `adddlcsigsandbroadcast` better if you are using very large messages, if the first attempt times out, when you redo it, you don't need to attempt to add all the sigs again and can instead just broadcast the ready dlc funding tx