### PR TITLE
Fix for showing txid on send

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/GlobalData.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/GlobalData.scala
@@ -20,8 +20,6 @@ object GlobalData {
 
   var network: BitcoinNetwork = _
 
-  val log: StringProperty = StringProperty("")
-
   val statusText: StringProperty = StringProperty("")
 
   var darkThemeEnabled: Boolean = true

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
@@ -14,8 +14,8 @@ import org.bitcoins.gui.dlc.DLCPaneModel
 import org.bitcoins.gui.util.GUIUtil
 import scalafx.application.Platform
 import scalafx.beans.property._
-import scalafx.scene.control.Alert
 import scalafx.scene.control.Alert.AlertType
+import scalafx.scene.control.{Alert, TextArea}
 import scalafx.stage.Window
 
 import scala.concurrent.duration.DurationInt
@@ -24,6 +24,7 @@ import scala.util.{Failure, Success, Try}
 
 class WalletGUIModel(dlcModel: DLCPaneModel)(implicit system: ActorSystem)
     extends Logging {
+  val textArea: TextArea = dlcModel.resultArea
   var taskRunner: TaskRunner = _
   import system.dispatcher
 
@@ -95,8 +96,7 @@ class WalletGUIModel(dlcModel: DLCPaneModel)(implicit system: ActorSystem)
               GlobalData.consoleCliConfig
             ) match {
               case Success(txid) =>
-                GlobalData.log.value =
-                  s"Sent $amount to $address in tx: $txid\n\n${GlobalData.log()}"
+                textArea.text = s"Transaction sent! $txid"
               case Failure(err) => throw err
             }
           }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.nio.file.Files
 import scala.util.{Failure, Properties, Success}
 
-class DLCPaneModel(resultArea: TextArea) extends Logging {
+class DLCPaneModel(val resultArea: TextArea) extends Logging {
   var taskRunner: TaskRunner = _
 
   // Sadly, it is a Java "pattern" to pass null into


### PR DESCRIPTION
We were writting to the `GlobalData.log` which is no longer used. This fixes it to be in the result area