### PR TITLE
Move addressDb database read out of inner loop

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -469,6 +469,9 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
     nested.flatten
   }
 
+  /** Tries to convert the provided spk to an address, and then checks if we have
+    * it in our address table
+    */
   private def getAddressDbs(
       spks: Vector[ScriptPubKey]): Future[Vector[AddressDb]] = {
     val addressDbF: Future[Vector[AddressDb]] =

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -7,6 +7,7 @@ import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.blockchain.Block
+import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutput}
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.core.wallet.fee.FeeUnit
@@ -344,9 +345,13 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
   private def processReceivedUtxo(
       transaction: Transaction,
       index: Int,
-      state: ReceivedState): Future[SpendingInfoDb] = {
+      state: ReceivedState,
+      addressDbE: Either[AddUtxoError, AddressDb]): Future[SpendingInfoDb] = {
     val addIncomingUtxoF =
-      addUtxo(transaction = transaction, vout = UInt32(index), state = state)
+      addUtxo(transaction = transaction,
+              vout = UInt32(index),
+              state = state,
+              addressDbE = addressDbE)
     addIncomingUtxoF.flatMap {
       case AddUtxoSuccess(utxo) => Future.successful(utxo)
       case err: AddUtxoError =>
@@ -437,16 +442,60 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
         }
     }
 
-    stateF.flatMap { state =>
-      val outputsVec = outputsWithIndex.map { out =>
+    val addressDbsF: Future[Vector[AddressDb]] = {
+      getAddressDbs(outputsWithIndex.map(_.output.scriptPubKey).toVector)
+    }
+
+    val addressDbWithOutputF = for {
+      addressDbs <- addressDbsF
+    } yield matchAddressDbWithOutputs(addressDbs, outputsWithIndex.toVector)
+
+    val nested = for {
+      state <- stateF
+      addressDbWithOutput <- addressDbWithOutputF
+    } yield {
+      val outputsVec = addressDbWithOutput.map { case (addressDb, out) =>
+        require(addressDb.scriptPubKey == out.output.scriptPubKey)
         processReceivedUtxo(
           transaction,
           out.index,
-          state = state
+          state = state,
+          Right(addressDb)
         )
       }
       Future.sequence(outputsVec)
     }
+
+    nested.flatten
+  }
+
+  private def getAddressDbs(
+      spks: Vector[ScriptPubKey]): Future[Vector[AddressDb]] = {
+    val addressDbF: Future[Vector[AddressDb]] =
+      addressDAO.findByScriptPubKeys(spks)
+    addressDbF
+  }
+
+  /** Matches address dbs with outputs, drops addressDb/outputs that do not have matches */
+  private def matchAddressDbWithOutputs(
+      addressDbs: Vector[AddressDb],
+      outputsWithIndex: Vector[OutputWithIndex]): Vector[
+    (AddressDb, OutputWithIndex)] = {
+
+    val addressDbsWithOutputsOpt = outputsWithIndex.map { out =>
+      //find address associated with spk
+      val addressDbOpt =
+        addressDbs.find(_.scriptPubKey == out.output.scriptPubKey)
+      addressDbOpt match {
+        case None =>
+          logger.warn(s"Could not find address associated with output=${out}")
+          None
+        case Some(addressDb) =>
+          Some((addressDb, out))
+      }
+    }
+    //get rid of outputs we couldn't match to an address
+    addressDbsWithOutputsOpt.flatten
   }
 
   private[wallet] def insertIncomingTransaction(

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -232,20 +232,6 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       .map(_.toMap)
   }
 
-  /** Tries to convert the provided spk to an address, and then checks if we have
-    * it in our address table
-    */
-  /*    private def findAddress(
-      spk: ScriptPubKey): Future[Either[AddUtxoError, AddressDb]] =
-    BitcoinAddress.fromScriptPubKeyT(spk, networkParameters) match {
-      case Success(address) =>
-        addressDAO.findAddress(address).map {
-          case Some(addrDb) => Right(addrDb)
-          case None         => Left(AddUtxoError.AddressNotFound)
-        }
-      case Failure(_) => Future.successful(Left(AddUtxoError.BadSPK))
-    }*/
-
   /** Constructs a DB level representation of the given UTXO, and persist it to disk */
   private def writeUtxo(
       tx: Transaction,
@@ -297,11 +283,6 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     }
   }
 
-  /*  private def getAddressDbEitherF(
-      output: TransactionOutput): Future[Either[AddUtxoError, AddressDb]] = {
-    findAddress(output.scriptPubKey)
-  }*/
-
   /** Adds the provided UTXO to the wallet
     */
   protected def addUtxo(
@@ -320,14 +301,14 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       val outPoint = TransactionOutPoint(transaction.txId, vout)
 
       // insert the UTXO into the DB
-      val x: Either[AddUtxoError, Future[SpendingInfoDb]] = for {
+      val insertedUtxoEF: Either[AddUtxoError, Future[SpendingInfoDb]] = for {
         addressDb <- addressDbE
       } yield writeUtxo(tx = transaction,
                         state = state,
                         output = output,
                         outPoint = outPoint,
                         addressDb = addressDb)
-      x match {
+      insertedUtxoEF match {
         case Right(utxoF) => utxoF.map(AddUtxoSuccess)
         case Left(e)      => Future.successful(e)
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -10,12 +10,7 @@ import org.bitcoins.core.api.wallet.{
 import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.core.protocol.script.{
-  P2WPKHWitnessSPKV0,
-  P2WPKHWitnessV0,
-  ScriptPubKey
-}
+import org.bitcoins.core.protocol.script.{P2WPKHWitnessSPKV0, P2WPKHWitnessV0}
 import org.bitcoins.core.protocol.transaction.{
   Transaction,
   TransactionOutPoint,
@@ -28,7 +23,6 @@ import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 
 import scala.concurrent.Future
-import scala.util.{Failure, Success}
 
 /** Provides functionality related to handling UTXOs in our wallet.
   * The most notable examples of functionality here are enumerating
@@ -241,7 +235,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
   /** Tries to convert the provided spk to an address, and then checks if we have
     * it in our address table
     */
-  private def findAddress(
+  /*    private def findAddress(
       spk: ScriptPubKey): Future[Either[AddUtxoError, AddressDb]] =
     BitcoinAddress.fromScriptPubKeyT(spk, networkParameters) match {
       case Success(address) =>
@@ -250,7 +244,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
           case None         => Left(AddUtxoError.AddressNotFound)
         }
       case Failure(_) => Future.successful(Left(AddUtxoError.BadSPK))
-    }
+    }*/
 
   /** Constructs a DB level representation of the given UTXO, and persist it to disk */
   private def writeUtxo(
@@ -303,17 +297,18 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     }
   }
 
-  private def getAddressDbEitherF(
+  /*  private def getAddressDbEitherF(
       output: TransactionOutput): Future[Either[AddUtxoError, AddressDb]] = {
     findAddress(output.scriptPubKey)
-  }
+  }*/
 
   /** Adds the provided UTXO to the wallet
     */
   protected def addUtxo(
       transaction: Transaction,
       vout: UInt32,
-      state: ReceivedState): Future[AddUtxoResult] = {
+      state: ReceivedState,
+      addressDbE: Either[AddUtxoError, AddressDb]): Future[AddUtxoResult] = {
 
     logger.info(s"Adding UTXO to wallet: ${transaction.txId.hex}:${vout.toInt}")
 
@@ -323,22 +318,19 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     } else {
       val output = transaction.outputs(vout.toInt)
       val outPoint = TransactionOutPoint(transaction.txId, vout)
-      val addressDbEitherF = getAddressDbEitherF(output)
+
       // insert the UTXO into the DB
-      addressDbEitherF
-        .map { addressDbE =>
-          for {
-            addressDb <- addressDbE
-          } yield writeUtxo(tx = transaction,
-                            state = state,
-                            output = output,
-                            outPoint = outPoint,
-                            addressDb = addressDb)
-        }
-        .flatMap {
-          case Right(utxoF) => utxoF.map(AddUtxoSuccess)
-          case Left(e)      => Future.successful(e)
-        }
+      val x: Either[AddUtxoError, Future[SpendingInfoDb]] = for {
+        addressDb <- addressDbE
+      } yield writeUtxo(tx = transaction,
+                        state = state,
+                        output = output,
+                        outPoint = outPoint,
+                        addressDb = addressDb)
+      x match {
+        case Right(utxoF) => utxoF.map(AddUtxoSuccess)
+        case Left(e)      => Future.successful(e)
+      }
     }
   }
 


### PR DESCRIPTION
Related to #2596

A small optimization to avoid more reads from the database than necessary in `processTransactionImpl`. Basically read all relevant addressDb up front in `processReceivedUtxo()` and then pass them into `addUtxo()`. Previously the database read would happen on every utxo we were processing. 