### PR TITLE
2021 06 07 markasspent optimization

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -289,8 +289,8 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
 
   /** If the given UTXO is marked as unspent and returns it so it can be updated
     * Otherwise returns None.
-   *
-   * If the utxo is transitioning into an invalid state it throws ane exception.
+    *
+    * If the utxo is transitioning into an invalid state it throws ane exception.
     */
   private def markAsSpent(
       out: SpendingInfoDb,


### PR DESCRIPTION
Related to #2596 

Refactors database writes to be outside of `markAsSpent`. Now we determine all the state changes for the utxos, and then write them all together in a batch.