### PR TITLE
Fix DLC Accounting errors

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/dlc/accounting/PayoutAccounting.scala
+++ b/core/src/main/scala/org/bitcoins/core/dlc/accounting/PayoutAccounting.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.dlc.accounting
 
-import org.bitcoins.core.currency.CurrencyUnit
+import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 
 /** Utility trait for metrics we need to do accounting */
 trait PayoutAccounting {
@@ -20,7 +20,9 @@ trait PayoutAccounting {
   /** Rate of return for the DLC
     * @see https://www.investopedia.com/terms/r/rateofreturn.asp
     */
-  def rateOfReturn: BigDecimal = pnl.toBigDecimal / myCollateral.toBigDecimal
+  def rateOfReturn: BigDecimal = if (myCollateral != Satoshis.zero)
+    pnl.toBigDecimal / myCollateral.toBigDecimal
+  else BigDecimal(0)
 
   def rorPrettyPrint: String = {
     RateOfReturnUtil.prettyPrint(rateOfReturn)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1218,9 +1218,9 @@ abstract class DLCWallet
     val dlcsF = listDLCs()
     for {
       dlcs <- dlcsF
-      closed = dlcs.collect { case c: ClosedDLCStatus =>
+      closed = dlcs.collect { case c: ClaimedDLCStatus =>
         c
-      } //only get closed dlcs for accounting
+      } //only get claimed dlcs for accounting
       accountings = closed.map(_.accounting)
       walletAccounting = DLCWalletAccounting.fromDLCAccounting(accountings)
     } yield walletAccounting


### PR DESCRIPTION
Fixes #3242

Also DLC Accounting was taking into account refunds as `Refunded` is a `ClosedDLCStatus`