### PR TITLE
Removes dead symlinks for secp256k1 on osx_arm64

### DIFF
--- a/secp256k1jni/natives/osx_arm64/libsecp256k1.la
+++ b/secp256k1jni/natives/osx_arm64/libsecp256k1.la
@@ -1,1 +1,0 @@
-../libsecp256k1.la

--- a/secp256k1jni/natives/osx_arm64/libsecp256k1_jni.la
+++ b/secp256k1jni/natives/osx_arm64/libsecp256k1_jni.la
@@ -1,1 +1,0 @@
-../libsecp256k1_jni.la


### PR DESCRIPTION
fixes #3278 

