### PR TITLE
Try downgrading the jdk to 15 for linux release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: openjdk@1.16.0-1
+          java-version: openjdk@1.15.0-2
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"


### PR DESCRIPTION
I do not understand how / why this got introduced in #3210, but for some reason we are getting these failures on master with the release process. 

The only thing i've seen fix these things before is downgrading the jdk used to build. So I'm downgrading to jdk 15 here similar to what is used on mac.