### PR TITLE
Remove previous stable version usage for windows builds

### DIFF
--- a/app/bundle/bundle.sbt
+++ b/app/bundle/bundle.sbt
@@ -18,7 +18,7 @@ assembly / assemblyJarName := s"${name.value}.jar"
 
 //need compatibility with windows versioning scheme which is
 //w.x.y.z
-Windows / version := previousStableVersion.value.get
+Windows / version := CommonSettings.previousStableVersion
 
 assembly / assemblyMergeStrategy := {
   case PathList("META-INF", _ @_*)       => MergeStrategy.discard

--- a/bitcoin-s-docs/docs.sbt
+++ b/bitcoin-s-docs/docs.sbt
@@ -21,7 +21,7 @@ mdocExtraArguments := List("--no-link-hygiene")
 // these variables gets passed to mdoc, and can be read
 // from there
 mdocVariables ++= Map(
-  "STABLE_VERSION" -> "0.6.0",
+  "STABLE_VERSION" -> CommonSettings.previousStableVersion,
   "UNSTABLE_VERSION" -> version.value
 )
 

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -21,6 +21,8 @@ import scala.util.Properties
 
 object CommonSettings {
 
+  val previousStableVersion: String = "0.6.0"
+
   private def isCI = {
     Properties
       .envOrNone("CI")


### PR DESCRIPTION
Reported by a user setting up the dev environment for the first time. Introduced in #3210 

>sbt appServer/universal:stage

>[info] welcome to sbt 1.5.4 (AdoptOpenJDK Java 1.8.0_292)
[info] loading settings for project bitcoin-s-build from plugins.sbt ...
[info] loading project definition from /home/giamme/dev/bitcoin-s/project
[info] loading settings for project bitcoin-s from build.sbt,inThisBuild.sbt ...
[info] loading settings for project bitcoindRpc from bitcoind-rpc.sbt ...
[info] loading settings for project eclairRpc from eclair-rpc.sbt ...
[info] loading settings for project lndRpc from lnd-rpc.sbt ...
[info] loading settings for project tor from tor.sbt ...
[info] loading settings for project secp256k1jni from secp256k1jni.sbt ...
[info] loading settings for project appCommons from commons.sbt ...
[info] loading settings for project oracleServer from oracle-server.sbt ...
[info] loading settings for project oracleServerTest from oracle-server-test.sbt ...
[info] loading settings for project appServer from server.sbt ...
[info] loading settings for project appServerTest from server-test.sbt ...
[info] loading settings for project cli from cli.sbt ...
[info] loading settings for project cliTest from cli-test.sbt ...
[info] loading settings for project bundle from bundle.sbt ...
[info] loading settings for project gui from gui.sbt ...
[info] loading settings for project chain from chain.sbt ...
[info] loading settings for project bitcoindRpcTest from bitcoind-rpc-test.sbt ...
[info] loading settings for project eclairRpcTest from eclair-rpc-test.sbt ...
[info] loading settings for project docs from docs.sbt ...
[info] loading settings for project keyManager from key-manager.sbt ...
[info] resolving key references (76730 settings) ...
java.util.NoSuchElementException: None.get
        at scala.None$.get(Option.scala:529)
        at scala.None$.get(Option.scala:527)
        at $c2f946f2be3c49bc13f3$.$anonfun$$sbtdef$1(/home/giamme/dev/bitcoin-s/app/bundle/bundle.sbt:21)
        at scala.Function1.$anonfun$compose$1(Function1.scala:49)
        at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:228)
        at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:170)
        at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:87)
        at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:99)
        at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:94)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
[error] java.util.NoSuchElementException: None.get
[error] Use 'last' for the full log.
[warn] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)