### PR TITLE
Adjust --depth doc from 100 -> 500

### DIFF
--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -36,13 +36,13 @@ Simply follow the instructions in [this short blog](https://www.scala-lang.org/2
 Now, it is time to clone the [Bitcoin-S repository](https://github.com/bitcoin-s/bitcoin-s/) by running
 
 ```bashrc
-git clone --depth 100 --recursive git@github.com:bitcoin-s/bitcoin-s.git
+git clone --depth 500 --recursive git@github.com:bitcoin-s/bitcoin-s.git
 ```
 
 or alternatively, if you do not have ssh setup with github, you can run
 
 ```bashrc
-git clone --depth 100 --recursive https://github.com/bitcoin-s/bitcoin-s.git
+git clone --depth 500 --recursive https://github.com/bitcoin-s/bitcoin-s.git
 ```
 
 


### PR DESCRIPTION
fixes #3295 

related to #2830

Unfortunately it seems like there is still something in our git history that can take significant time to clone. I've ran two comparisons between using `--depth 500` and no `--depth` flag. 

It seems that no `--depth` flag takes ~45 seconds and `--depth 500` takes 2 seconds

`--depth 500`

```
time git clone --depth 500 --recursive git@github.com:bitcoin-s/bitcoin-s.git                                                    ✔  10405  07:24:11

Cloning into 'bitcoin-s'...
remote: Enumerating objects: 14696, done.
remote: Counting objects: 100% (14696/14696), done.
remote: Compressing objects: 100% (5559/5559), done.
remote: Total 14696 (delta 6155), reused 12255 (delta 4648), pack-reused 0
Receiving objects: 100% (14696/14696), 8.70 MiB | 3.91 MiB/s, done.
Resolving deltas: 100% (6155/6155), done.
Submodule 'secp256k1-zkp' (git@github.com:bitcoin-s/secp256k1-zkp.git) registered for path 'secp256k1-zkp'
Cloning into '/tmp/git-test/bitcoin-s/secp256k1-zkp'...
remote: Enumerating objects: 8459, done.
remote: Counting objects: 100% (466/466), done.
remote: Compressing objects: 100% (269/269), done.
remote: Total 8459 (delta 239), reused 321 (delta 187), pack-reused 7993
Receiving objects: 100% (8459/8459), 3.22 MiB | 591.00 KiB/s, done.
Resolving deltas: 100% (5998/5998), done.
Submodule path 'secp256k1-zkp': checked out '6dd724b72bb2d47de514eb92e96c6ae6d26ae160'
git clone --depth 500 --recursive git@github.com:bitcoin-s/bitcoin-s.git  2.31s user 0.38s system 12% cpu 22.333 total
```

and no `--depth`

```
 time git clone --recursive git@github.com:bitcoin-s/bitcoin-s.git                                                                ✔  10398  07:18:42

Cloning into 'bitcoin-s'...
remote: Enumerating objects: 213134, done.
remote: Counting objects: 100% (9541/9541), done.
remote: Compressing objects: 100% (1854/1854), done.
remote: Total 213134 (delta 5884), reused 9262 (delta 5696), pack-reused 203593
Receiving objects: 100% (213134/213134), 81.68 MiB | 1.94 MiB/s, done.
Resolving deltas: 100% (106144/106144), done.
Submodule 'secp256k1-zkp' (git@github.com:bitcoin-s/secp256k1-zkp.git) registered for path 'secp256k1-zkp'
Cloning into '/tmp/git-test/bitcoin-s/secp256k1-zkp'...
remote: Enumerating objects: 8459, done.
remote: Counting objects: 100% (466/466), done.
remote: Compressing objects: 100% (269/269), done.
remote: Total 8459 (delta 239), reused 321 (delta 187), pack-reused 7993
Receiving objects: 100% (8459/8459), 3.22 MiB | 719.00 KiB/s, done.
Resolving deltas: 100% (5998/5998), done.
Submodule path 'secp256k1-zkp': checked out '6dd724b72bb2d47de514eb92e96c6ae6d26ae160'
git clone --recursive git@github.com:bitcoin-s/bitcoin-s.git  41.54s user 2.05s system 50% cpu 1:25.71 total

```