### PR TITLE
Silence warning log if no error

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -392,10 +392,12 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
 
         Some(updated)
       case TxoState.BroadcastSpent =>
-        logger.warn(
-          s"Updating the spendingTxId of a transaction that is already spent, " +
-            s"old state=${TxoState.BroadcastSpent} old spendingTxId=${out.spendingTxIdOpt
-              .map(_.hex)} new spendingTxId=${spendingTxId.hex}")
+        if (!out.spendingTxIdOpt.contains(spendingTxId)) {
+          logger.warn(
+            s"Updating the spendingTxId of a transaction that is already spent, " +
+              s"old state=${TxoState.BroadcastSpent} old spendingTxId=${out.spendingTxIdOpt
+                .map(_.hex)} new spendingTxId=${spendingTxId.hex}")
+        }
         val updated =
           out.copyWithSpendingTxId(spendingTxId)
         Some(updated)


### PR DESCRIPTION
Previously this would warn even if the "new" txid wasn't really a different tx, example:

```
2021-06-21T17:56:34UTC WARN [DLCWallet$DLCWalletImpl] Updating the spendingTxId of a transaction that is already spent, old state=BroadcastSpent old spendingTxId=Some(0e0554dd38d747f80c36b45cce605e420267314c1d75918f4ae2557f2951d808) new spendingTxId=0e0554dd38d747f80c36b45cce605e420267314c1d75918f4ae2557f2951d808
```

This will silence this log if it is the same txid