### PR TITLE
Fix DLC Table View not being updated

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -69,8 +69,8 @@ class DLCPaneModel(val resultArea: TextArea)(implicit ec: ExecutionContext)
       toAdd <- toAddF
       toRemove <- toRemoveF
     } yield {
-      dlcs ++= toAdd
       dlcs --= toRemove
+      dlcs ++= toAdd
       ()
     }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -56,8 +56,8 @@ class DLCPaneModel(val resultArea: TextArea)(implicit ec: ExecutionContext)
     ConsoleCli.exec(GetDLC(dlcId), GlobalData.consoleCliConfig) match {
       case Failure(exception) => throw exception
       case Success(dlcStatus) =>
-        dlcs += read[DLCStatus](ujson.read(dlcStatus))
         dlcs.find(_.dlcId == dlcId).foreach(dlcs -= _)
+        dlcs += read[DLCStatus](ujson.read(dlcStatus))
     }
   }
 


### PR DESCRIPTION
Fixes #3268

because we do 

```
    val newDLCsF = getDLCs
    val toAddF = newDLCsF.map(_.diff(dlcs))
    val toRemoveF = newDLCsF.map(dlcs.diff)
```

the new DLC would be in both `toAdd` and `toRemove`, since previously we did

```
      dlcs ++= toAdd
      dlcs --= toRemove
```

it would be added and then removed immediately.

This fixes it to do the removing first so we correctly update the table.