### PR TITLE
Make mempool.space fee provider network specific

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -95,7 +95,8 @@ class BitcoinSServerMain(override val args: Array[String])(implicit
     //get a node that isn't started
     val nodeF = nodeConf.createNode(peer)(chainConf, system)
 
-    val feeProvider = getFeeProviderOrElse(MempoolSpaceProvider(HourFeeTarget))
+    val feeProvider = getFeeProviderOrElse(
+      MempoolSpaceProvider(HourFeeTarget, walletConf.network))
     //get our wallet
     val configuredWalletF = for {
       node <- nodeF
@@ -347,9 +348,9 @@ class BitcoinSServerMain(override val args: Array[String])(implicit
         case (Some(BitGo), targetOpt) =>
           BitGoFeeRateProvider(targetOpt)
         case (Some(MempoolSpace), None) =>
-          MempoolSpaceProvider(HourFeeTarget)
+          MempoolSpaceProvider(HourFeeTarget, walletConf.network)
         case (Some(MempoolSpace), Some(target)) =>
-          MempoolSpaceProvider.fromBlockTarget(target)
+          MempoolSpaceProvider.fromBlockTarget(target, walletConf.network)
         case (Some(Constant), Some(num)) =>
           ConstantFeeRateProvider(SatoshisPerVirtualByte.fromLong(num))
         case (Some(Constant), None) =>

--- a/fee-provider-test/src/test/scala/org/bitcoins/feeprovider/FeeRateProviderTest.scala
+++ b/fee-provider-test/src/test/scala/org/bitcoins/feeprovider/FeeRateProviderTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.feeprovider
 
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.feeprovider.FeeRateApi
+import org.bitcoins.core.config._
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.feeprovider.MempoolSpaceTarget._
@@ -29,22 +30,52 @@ class FeeRateProviderTest extends BitcoinSAsyncTest {
   }
 
   it must "get a valid fee rate from mempool.space using the fastest fee target" in {
-    val provider = MempoolSpaceProvider(FastestFeeTarget)
+    val provider = MempoolSpaceProvider(FastestFeeTarget, MainNet)
     testProvider(provider)
   }
 
   it must "get a valid fee rate from mempool.space using a half hour fee target" in {
-    val provider = MempoolSpaceProvider(HalfHourFeeTarget)
+    val provider = MempoolSpaceProvider(HalfHourFeeTarget, MainNet)
     testProvider(provider)
   }
 
   it must "get a valid fee rate from mempool.space using an hour fee target" in {
-    val provider = MempoolSpaceProvider(HourFeeTarget)
+    val provider = MempoolSpaceProvider(HourFeeTarget, MainNet)
+    testProvider(provider)
+  }
+
+  it must "get a valid fee rate from mempool.space/testnet using the fastest fee target" in {
+    val provider = MempoolSpaceProvider(FastestFeeTarget, TestNet3)
+    testProvider(provider)
+  }
+
+  it must "get a valid fee rate from mempool.space/testnet using a half hour fee target" in {
+    val provider = MempoolSpaceProvider(HalfHourFeeTarget, TestNet3)
+    testProvider(provider)
+  }
+
+  it must "get a valid fee rate from mempool.space/testnet using an hour fee target" in {
+    val provider = MempoolSpaceProvider(HourFeeTarget, TestNet3)
+    testProvider(provider)
+  }
+
+  it must "get a valid fee rate from mempool.space/signet using the fastest fee target" in {
+    val provider = MempoolSpaceProvider(FastestFeeTarget, SigNet)
+    testProvider(provider)
+  }
+
+  it must "get a valid fee rate from mempool.space/signet using a half hour fee target" in {
+    val provider = MempoolSpaceProvider(HalfHourFeeTarget, SigNet)
+    testProvider(provider)
+  }
+
+  it must "get a valid fee rate from mempool.space/signet using an hour fee target" in {
+    val provider = MempoolSpaceProvider(HourFeeTarget, SigNet)
     testProvider(provider)
   }
 
   it must "get a cached fee rate from a cachedHttpFeeRateProvider" in {
-    val provider = MempoolSpaceProvider(FastestFeeTarget)
+    val provider = MempoolSpaceProvider(FastestFeeTarget, MainNet)
     for {
       feeRate <- provider.getFeeRate
       _ <- AsyncUtil.nonBlockingSleep(20.seconds)

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/MempoolSpaceProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/MempoolSpaceProvider.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
 import org.bitcoins.commons.jsonmodels.wallet.MempoolSpaceResult
 import org.bitcoins.commons.serializers.JsonSerializers._
+import org.bitcoins.core.config._
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.feeprovider.MempoolSpaceTarget._
 import play.api.libs.json.{JsError, JsSuccess, Json}
@@ -13,12 +14,22 @@ import scala.util.{Failure, Success, Try}
 /** Fetches fee rate from mempool.space's API
   * Documentation found here: https://mempool.space/about
   */
-case class MempoolSpaceProvider(target: MempoolSpaceTarget)(implicit
-    override val system: ActorSystem)
+case class MempoolSpaceProvider(
+    target: MempoolSpaceTarget,
+    network: BitcoinNetwork)(implicit override val system: ActorSystem)
     extends CachedHttpFeeRateProvider[SatoshisPerVirtualByte] {
 
-  override val uri: Uri =
-    Uri("https://mempool.space/api/v1/fees/recommended")
+  override val uri: Uri = network match {
+    case MainNet =>
+      Uri("https://mempool.space/api/v1/fees/recommended")
+    case TestNet3 =>
+      Uri("https://mempool.space/testnet/api/v1/fees/recommended")
+    case SigNet =>
+      Uri("https://mempool.space/signet/api/v1/fees/recommended")
+    case RegTest =>
+      // just use testnet here, shouldn't matter
+      Uri("https://mempool.space/testnet/api/v1/fees/recommended")
+  }
 
   override def converter(str: String): Try[SatoshisPerVirtualByte] = {
     val json = Json.parse(str)
@@ -45,7 +56,13 @@ object MempoolSpaceProvider extends FeeProviderFactory[MempoolSpaceProvider] {
   override def fromBlockTarget(blocks: Int)(implicit
       system: ActorSystem): MempoolSpaceProvider = {
     val target = MempoolSpaceTarget.fromBlockTarget(blocks)
-    MempoolSpaceProvider(target)
+    MempoolSpaceProvider(target, MainNet)
+  }
+
+  def fromBlockTarget(blocks: Int, network: BitcoinNetwork)(implicit
+      system: ActorSystem): MempoolSpaceProvider = {
+    val target = MempoolSpaceTarget.fromBlockTarget(blocks)
+    MempoolSpaceProvider(target, network)
   }
 }
 


### PR DESCRIPTION
Fixes #3306

Makes `MempoolSpaceProvider` use network specific api instead of always mainnet. For regtest I had it use testnet, could see the argument for having it use mainnet too since testnet is always 1sat/vbyte