### PR TITLE
2021 06 23 scalafx dep

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/GUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/GUI.scala
@@ -6,7 +6,7 @@ import org.bitcoins.cli.ConsoleCli
 import org.bitcoins.commons.jsonmodels.BitcoinSServerInfo
 import org.bitcoins.core.config._
 import org.bitcoins.gui.util.GUIUtil._
-import scalafx.application.JFXApp
+import scalafx.application.JFXApp3
 import scalafx.geometry.Pos
 import scalafx.scene.Scene
 import scalafx.scene.control.Alert.AlertType
@@ -16,7 +16,7 @@ import scalafx.scene.layout.VBox
 
 import scala.util._
 
-object GUI extends WalletGUI with JFXApp {
+object GUI extends WalletGUI with JFXApp3 {
 
   implicit lazy val system: ActorSystem = ActorSystem(
     s"bitcoin-s-gui-${System.currentTimeMillis()}")
@@ -88,7 +88,7 @@ object GUI extends WalletGUI with JFXApp {
       (logoSignet, "Bitcoin-S Wallet - [signet]")
   }
 
-  stage = new JFXApp.PrimaryStage {
+  stage = new JFXApp3.PrimaryStage {
     title = titleStr
     scene = walletScene
     icons.add(img)

--- a/app/gui/src/main/scala/org/bitcoins/gui/GUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/GUI.scala
@@ -18,7 +18,7 @@ import scala.util._
 
 object GUI extends WalletGUI with JFXApp3 {
 
-  implicit lazy val system: ActorSystem = ActorSystem(
+  implicit override lazy val system: ActorSystem = ActorSystem(
     s"bitcoin-s-gui-${System.currentTimeMillis()}")
 
   // Catch unhandled exceptions on FX Application thread
@@ -34,30 +34,7 @@ object GUI extends WalletGUI with JFXApp3 {
       }.showAndWait()
     })
 
-  lazy val argsWithIndex: Vector[(String, Int)] =
-    parameters.raw.zipWithIndex.toVector
-
-  lazy val rpcPortOpt: Option[Int] = {
-    lazy val portOpt = argsWithIndex.find(_._1.toLowerCase == "--rpcport")
-    portOpt.map { case (_, idx) =>
-      parameters.raw(idx + 1).toInt
-    }
-  }
-
-  GlobalData.rpcPortOpt = rpcPortOpt
-
-  lazy val debug: Boolean = {
-    parameters.raw.exists(_.toLowerCase == "--debug")
-  }
-
-  GlobalData.debug = debug
-
-  lazy val walletScene: Scene = new Scene(1400, 800) {
-    root = rootView
-    stylesheets = GlobalData.currentStyleSheets
-  }
-
-  lazy val glassPane: VBox = new VBox {
+  override lazy val glassPane: VBox = new VBox {
     children = new ProgressIndicator {
       progress = ProgressIndicator.IndeterminateProgress
       visible = true
@@ -66,34 +43,60 @@ object GUI extends WalletGUI with JFXApp3 {
     visible = false
   }
 
-  lazy val info: BitcoinSServerInfo =
-    ConsoleCli.exec(GetInfo, GlobalData.consoleCliConfig) match {
-      case Failure(exception) =>
-        throw exception
-      case Success(str) =>
-        val json = ujson.read(str)
-        BitcoinSServerInfo.fromJson(json)
+  override def start(): Unit = {
+    lazy val argsWithIndex: Vector[(String, Int)] =
+      parameters.raw.zipWithIndex.toVector
+
+    lazy val rpcPortOpt: Option[Int] = {
+      lazy val portOpt = argsWithIndex.find(_._1.toLowerCase == "--rpcport")
+      portOpt.map { case (_, idx) =>
+        parameters.raw(idx + 1).toInt
+      }
     }
 
-  GlobalData.network = info.network
+    GlobalData.rpcPortOpt = rpcPortOpt
 
-  lazy val (img, titleStr): (Image, String) = info.network match {
-    case MainNet =>
-      (logo, "Bitcoin-S Wallet")
-    case TestNet3 =>
-      (logoTestnet, "Bitcoin-S Wallet - [testnet]")
-    case RegTest =>
-      (logoRegtest, "Bitcoin-S Wallet - [regtest]")
-    case SigNet =>
-      (logoSignet, "Bitcoin-S Wallet - [signet]")
+    lazy val debug: Boolean = {
+      parameters.raw.exists(_.toLowerCase == "--debug")
+    }
+
+    GlobalData.debug = debug
+
+    lazy val walletScene: Scene = new Scene(1400, 800) {
+      root = rootView
+      stylesheets = GlobalData.currentStyleSheets
+    }
+
+    lazy val info: BitcoinSServerInfo =
+      ConsoleCli.exec(GetInfo, GlobalData.consoleCliConfig) match {
+        case Failure(exception) =>
+          throw exception
+        case Success(str) =>
+          val json = ujson.read(str)
+          BitcoinSServerInfo.fromJson(json)
+      }
+
+    GlobalData.network = info.network
+
+    lazy val (img, titleStr): (Image, String) = info.network match {
+      case MainNet =>
+        (logo, "Bitcoin-S Wallet")
+      case TestNet3 =>
+        (logoTestnet, "Bitcoin-S Wallet - [testnet]")
+      case RegTest =>
+        (logoRegtest, "Bitcoin-S Wallet - [regtest]")
+      case SigNet =>
+        (logoSignet, "Bitcoin-S Wallet - [signet]")
+    }
+
+    stage = new JFXApp3.PrimaryStage {
+      title = titleStr
+      scene = walletScene
+      icons.add(img)
+    }
+
+    fetchStartingData()
+    taskRunner
+    ()
   }
-
-  stage = new JFXApp3.PrimaryStage {
-    title = titleStr
-    scene = walletScene
-    icons.add(img)
-  }
-
-  fetchStartingData()
-  taskRunner
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -24,7 +24,7 @@ object Deps {
     val nativeLoaderV = "2.3.5"
     val typesafeConfigV = "1.4.1"
 
-    val scalaFxV = "16.0.0-R22"
+    val scalaFxV = "16.0.0-R24"
     val javaFxV = "17-ea+8"
 
     val asyncNewScalaV = "0.10.0"


### PR DESCRIPTION
replaces #3096 

The reason the automatic upgrade didn't work is because `JFXApp` is deprecated. We now need to use `JFXApp3` 

I hope i moved everything correctly into the `start()` method. I did `bundle/run` locally and everything seemed to work.

Here are the scalafx release notes that discuss why: 

https://github.com/scalafx/scalafx/releases/tag/v.16.0.0-R23