### PR TITLE
Add ExplorerEnv.fromBitcoinNetwork() and use for View on Oracle Explorer siteUrl

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ExplorerEnv.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ExplorerEnv.scala
@@ -1,5 +1,12 @@
 package org.bitcoins.commons.jsonmodels
 
+import org.bitcoins.core.config.{
+  BitcoinNetwork,
+  MainNet,
+  RegTest,
+  SigNet,
+  TestNet3
+}
 import org.bitcoins.crypto.StringFactory
 
 sealed trait ExplorerEnv {
@@ -33,6 +40,13 @@ object ExplorerEnv extends StringFactory[ExplorerEnv] {
       case Some(env) => env
       case None =>
         sys.error(s"Failed to parse explorer env from str=$string")
+    }
+  }
+
+  def fromBitcoinNetwork(network: BitcoinNetwork): ExplorerEnv = {
+    network match {
+      case MainNet                     => Production
+      case TestNet3 | RegTest | SigNet => Test
     }
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
@@ -4,7 +4,7 @@ import org.bitcoins.commons.jsonmodels.ExplorerEnv
 import org.bitcoins.core.dlc.accounting.RateOfReturnUtil
 import org.bitcoins.core.protocol.dlc.models.DLCStatus._
 import org.bitcoins.core.protocol.dlc.models._
-import org.bitcoins.gui.GUI
+import org.bitcoins.gui.{GUI, GlobalData}
 import org.bitcoins.gui.util.GUIUtil
 import scalafx.beans.property.StringProperty
 import scalafx.geometry.Insets
@@ -137,10 +137,11 @@ class DLCTableView(model: DLCPaneModel) {
 
       val viewOnExplorer: MenuItem = new MenuItem("View on Oracle Explorer") {
         onAction = _ => {
-          val status = selectionModel.value.getSelectedItem
+          val dlc = selectionModel.value.getSelectedItem
           val primaryOracle =
-            status.oracleInfo.singleOracleInfos.head.announcement
-          val baseUrl = ExplorerEnv.Production.siteUrl
+            dlc.oracleInfo.singleOracleInfos.head.announcement
+          val baseUrl =
+            ExplorerEnv.fromBitcoinNetwork(GlobalData.network).siteUrl
           val url =
             s"${baseUrl}announcement/${primaryOracle.sha256.hex}"
           GUI.hostServices.showDocument(url)


### PR DESCRIPTION
This PR adds a utility function to ExlorerEnv to resolve bitcoin network to local env to resolve with and uses it to assign network specific siteUrl for View on Oracle Explorer link