### PR TITLE
Silence all scaladoc warnings

### DIFF
--- a/app/bundle/bundle.sbt
+++ b/app/bundle/bundle.sbt
@@ -26,7 +26,6 @@ assembly / assemblyMergeStrategy := {
   case _                                 => MergeStrategy.first
 }
 
-Compile / doc := (target.value / "none")
 // general package information (can be scoped to Windows)
 maintainer := "Chris Stewart <stewart.chris1234@gmail.com>"
 // Will say "Welcome to the <packageSummary> Setup Wizard"

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -55,6 +55,9 @@ object CommonSettings {
     //we don't want -Xfatal-warnings for publishing with publish/publishLocal either
     Compile / doc / scalacOptions ~= (_ filterNot (s =>
       s == "-Xfatal-warnings")),
+    //silence all scaladoc warnings generated from invalid syntax
+    //see: https://github.com/bitcoin-s/bitcoin-s/issues/3232
+    Compile / doc / scalacOptions ++= Vector(s"-Wconf:any:ws"),
     Test / console / scalacOptions ++= (Compile / console / scalacOptions).value,
     Test / scalacOptions ++= testCompilerOpts(scalaVersion.value),
     licenses += ("MIT", url("http://opensource.org/licenses/MIT")),


### PR DESCRIPTION
fixes #3232

This silences all scaladoc warnings that are output from invalid syntax in the scaladoc. 

I hope this doesn't break other parts of the build, but we won't know for sure until we merge :crossed_fingers: 

Here is what `universal:stage` looks like when running on acbf68c

![Screenshot from 2021-06-28 06-48-50](https://user-images.githubusercontent.com/3514957/123632094-239a6f80-d7dd-11eb-9012-3e6bea6badcf.png)
