### PR TITLE
Add invariant and better error message for invalid numeric contract descriptor

### DIFF
--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BundleGUI.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BundleGUI.scala
@@ -18,25 +18,25 @@ import java.nio.file.{Path, Paths}
 
 object BundleGUI extends WalletGUI with JFXApp3 {
 
-  // Catch unhandled exceptions on FX Application thread
-  Thread
-    .currentThread()
-    .setUncaughtExceptionHandler((_: Thread, ex: Throwable) => {
-      ex.printStackTrace()
-      lazy val _ = new Alert(AlertType.Error) {
-        initOwner(owner)
-        title = "Unhandled exception"
-        headerText = "Exception: " + ex.getClass + ""
-        contentText = Option(ex.getMessage).getOrElse("")
-      }.showAndWait()
-    })
-
   implicit override lazy val system: ActorSystem = ActorSystem(
     s"bitcoin-s-gui-${System.currentTimeMillis()}")
 
   lazy val args = parameters.raw
 
   override def start(): Unit = {
+    // Catch unhandled exceptions on FX Application thread
+    Thread
+      .currentThread()
+      .setUncaughtExceptionHandler((_: Thread, ex: Throwable) => {
+        ex.printStackTrace()
+        lazy val _ = new Alert(AlertType.Error) {
+          initOwner(owner)
+          title = "Unhandled exception"
+          headerText = "Exception: " + ex.getClass + ""
+          contentText = Option(ex.getMessage).getOrElse("")
+        }.showAndWait()
+      })
+
     // Set log location
     val baseConfig: Config = AppConfig
       .getBaseConfig(DEFAULT_BITCOIN_S_DATADIR)

--- a/app/gui/src/main/scala/org/bitcoins/gui/GUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/GUI.scala
@@ -21,19 +21,6 @@ object GUI extends WalletGUI with JFXApp3 {
   implicit override lazy val system: ActorSystem = ActorSystem(
     s"bitcoin-s-gui-${System.currentTimeMillis()}")
 
-  // Catch unhandled exceptions on FX Application thread
-  Thread
-    .currentThread()
-    .setUncaughtExceptionHandler((_: Thread, ex: Throwable) => {
-      ex.printStackTrace()
-      lazy val _ = new Alert(AlertType.Error) {
-        initOwner(owner)
-        title = "Unhandled exception"
-        headerText = "Exception: " + ex.getClass + ""
-        contentText = Option(ex.getMessage).getOrElse("")
-      }.showAndWait()
-    })
-
   override lazy val glassPane: VBox = new VBox {
     children = new ProgressIndicator {
       progress = ProgressIndicator.IndeterminateProgress
@@ -44,6 +31,19 @@ object GUI extends WalletGUI with JFXApp3 {
   }
 
   override def start(): Unit = {
+    // Catch unhandled exceptions on FX Application thread
+    Thread
+      .currentThread()
+      .setUncaughtExceptionHandler((_: Thread, ex: Throwable) => {
+        ex.printStackTrace()
+        lazy val _ = new Alert(AlertType.Error) {
+          initOwner(owner)
+          title = "Unhandled exception"
+          headerText = "Exception: " + ex.getClass + ""
+          contentText = Option(ex.getMessage).getOrElse("")
+        }.showAndWait()
+      })
+
     lazy val argsWithIndex: Vector[(String, Int)] =
       parameters.raw.zipWithIndex.toVector
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -585,8 +585,12 @@ object CreateDLCOfferDialog {
         }
         contractInfoT match {
           case Success(contractInfo) => contractInfo
-          case Failure(err) =>
-            val errorMsg = err.getMessage.replace("requirement failed: ", "")
+          case Failure(err)          =>
+            // Do some basic processing of the message so it's prettier
+            val errorMsg = err.getMessage
+              .replace("requirement failed: ", "")
+              .replace(". You must define", ".\nYou must define")
+
             new Alert(AlertType.Error) {
               initOwner(owner)
               title = "Error construction Contract Info"

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/ContractDescriptorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/ContractDescriptorTest.scala
@@ -1,0 +1,89 @@
+package org.bitcoins.core.protocol.dlc
+
+import org.bitcoins.core.currency._
+import org.bitcoins.core.protocol.dlc.models._
+import org.bitcoins.core.protocol.tlv.ContractDescriptorV1TLV
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+
+class ContractDescriptorTest extends BitcoinSUnitTest {
+
+  behavior of "ContractDescriptor"
+
+  it should "fail to create an empty EnumContractDescriptor" in {
+    assertThrows[IllegalArgumentException](EnumContractDescriptor(Vector.empty))
+  }
+
+  it should "fail for not starting with a endpoint" in {
+    val func = DLCPayoutCurve(
+      Vector(
+        OutcomePayoutPoint(0, Satoshis(0), isEndpoint = false),
+        OutcomePayoutPoint(3, Satoshis(100), isEndpoint = true)
+      ))
+    assertThrows[IllegalArgumentException](
+      NumericContractDescriptor(func, 2, RoundingIntervals.noRounding))
+  }
+
+  it should "fail for not ending with a endpoint" in {
+    val func = DLCPayoutCurve(
+      Vector(
+        OutcomePayoutPoint(0, Satoshis(0), isEndpoint = true),
+        OutcomePayoutPoint(3, Satoshis(100), isEndpoint = false)
+      ))
+    assertThrows[IllegalArgumentException](
+      NumericContractDescriptor(func, 2, RoundingIntervals.noRounding))
+  }
+
+  it should "fail for starting below the minimum" in {
+    val func = DLCPayoutCurve(
+      Vector(
+        OutcomePayoutPoint(-1, Satoshis(0), isEndpoint = true),
+        OutcomePayoutPoint(3, Satoshis(100), isEndpoint = true)
+      ))
+    assertThrows[IllegalArgumentException](
+      NumericContractDescriptor(func, 2, RoundingIntervals.noRounding))
+  }
+
+  it should "fail for starting above the minimum" in {
+    val func = DLCPayoutCurve(
+      Vector(
+        OutcomePayoutPoint(1, Satoshis(0), isEndpoint = true),
+        OutcomePayoutPoint(3, Satoshis(100), isEndpoint = true)
+      ))
+    assertThrows[IllegalArgumentException](
+      NumericContractDescriptor(func, 2, RoundingIntervals.noRounding))
+  }
+
+  it should "fail for starting below the maximum" in {
+    val func = DLCPayoutCurve(
+      Vector(
+        OutcomePayoutPoint(0, Satoshis(0), isEndpoint = true),
+        OutcomePayoutPoint(2, Satoshis(100), isEndpoint = true)
+      ))
+    assertThrows[IllegalArgumentException](
+      NumericContractDescriptor(func, 2, RoundingIntervals.noRounding))
+  }
+
+  it should "fail for starting above the maximum" in {
+    val func = DLCPayoutCurve(
+      Vector(
+        OutcomePayoutPoint(0, Satoshis(0), isEndpoint = true),
+        OutcomePayoutPoint(4, Satoshis(100), isEndpoint = true)
+      ))
+    assertThrows[IllegalArgumentException](
+      NumericContractDescriptor(func, 2, RoundingIntervals.noRounding))
+  }
+
+  it should "correctly create a NumericContractDescriptor" in {
+    val func = DLCPayoutCurve(
+      Vector(
+        OutcomePayoutPoint(0, Satoshis(0), isEndpoint = true),
+        OutcomePayoutPoint(3, Satoshis(100), isEndpoint = true)
+      ))
+
+    val descriptor =
+      NumericContractDescriptor(func, 2, RoundingIntervals.noRounding)
+
+    assert(descriptor.toTLV == ContractDescriptorV1TLV(
+      "fda720260002fda7261a0002010000000000000000000000010300000000000000640000fda724020000"))
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/ContractDescriptorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/ContractDescriptorTest.scala
@@ -53,7 +53,7 @@ class ContractDescriptorTest extends BitcoinSUnitTest {
       NumericContractDescriptor(func, 2, RoundingIntervals.noRounding))
   }
 
-  it should "fail for starting below the maximum" in {
+  it should "fail for ending below the maximum" in {
     val func = DLCPayoutCurve(
       Vector(
         OutcomePayoutPoint(0, Satoshis(0), isEndpoint = true),
@@ -63,7 +63,7 @@ class ContractDescriptorTest extends BitcoinSUnitTest {
       NumericContractDescriptor(func, 2, RoundingIntervals.noRounding))
   }
 
-  it should "fail for starting above the maximum" in {
+  it should "fail for ending above the maximum" in {
     val func = DLCPayoutCurve(
       Vector(
         OutcomePayoutPoint(0, Satoshis(0), isEndpoint = true),

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractDescriptor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractDescriptor.scala
@@ -52,6 +52,8 @@ case class EnumContractDescriptor(
     with TLVSerializable[ContractDescriptorV0TLV]
     with SeqWrapper[(EnumOutcome, Satoshis)] {
 
+  require(outcomeValueMap.nonEmpty, "Cannot give an empty set of outcomes")
+
   override def wrapped: Vector[(EnumOutcome, Satoshis)] = outcomeValueMap
 
   def keys: Vector[EnumOutcome] = outcomeValueMap.map(_._1)
@@ -96,6 +98,22 @@ case class NumericContractDescriptor(
     roundingIntervals: RoundingIntervals)
     extends ContractDescriptor
     with TLVSerializable[ContractDescriptorV1TLV] {
+
+  private val maxValue: Long = (Math.pow(2, numDigits) - 1).toLong
+
+  require(outcomeValueFunc.points.head.isEndpoint,
+          "Payout curve must start with an end point")
+  require(
+    outcomeValueFunc.points.head.outcome == 0,
+    s"Payout curve must start with its minimum value, 0, got ${outcomeValueFunc.points.head.outcome}")
+
+  require(outcomeValueFunc.points.last.isEndpoint,
+          "Payout curve must end with an end point")
+
+  require(
+    outcomeValueFunc.points.last.outcome == maxValue,
+    s"Payout curve must end with its maximum value, $maxValue, got ${outcomeValueFunc.points.last.outcome}"
+  )
 
   override def flip(totalCollateral: Satoshis): NumericContractDescriptor = {
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractDescriptor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractDescriptor.scala
@@ -99,20 +99,24 @@ case class NumericContractDescriptor(
     extends ContractDescriptor
     with TLVSerializable[ContractDescriptorV1TLV] {
 
+  private val minValue: Long = 0L
   private val maxValue: Long = (Math.pow(2, numDigits) - 1).toLong
 
   require(outcomeValueFunc.points.head.isEndpoint,
           "Payout curve must start with an end point")
   require(
     outcomeValueFunc.points.head.outcome == 0,
-    s"Payout curve must start with its minimum value, 0, got ${outcomeValueFunc.points.head.outcome}")
+    s"Payout curve must start with its minimum value, $minValue, got ${outcomeValueFunc.points.head.outcome}. " +
+      s"You must define the payout curve from $minValue - $maxValue"
+  )
 
   require(outcomeValueFunc.points.last.isEndpoint,
           "Payout curve must end with an end point")
 
   require(
     outcomeValueFunc.points.last.outcome == maxValue,
-    s"Payout curve must end with its maximum value, $maxValue, got ${outcomeValueFunc.points.last.outcome}"
+    s"Payout curve must end with its maximum value, $maxValue, got ${outcomeValueFunc.points.last.outcome}. " +
+      s"You must define the payout curve from $minValue - $maxValue"
   )
 
   override def flip(totalCollateral: Satoshis): NumericContractDescriptor = {


### PR DESCRIPTION
Fixes #3296
Fixes #3288

Example error message:

![image](https://user-images.githubusercontent.com/15256660/123646223-a24ad900-d7ec-11eb-8e41-22ced2495c82.png)
