### PR TITLE
Remove unneeded asInstanceOf calls in DLCWallet

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -356,9 +356,7 @@ abstract class DLCWallet
 
       changeSPK =
         txBuilder.finalizer.changeSPK
-          .asInstanceOf[WitnessScriptPubKey]
-      network = networkParameters.asInstanceOf[BitcoinNetwork]
-      changeAddr = Bech32Address(changeSPK, network)
+      changeAddr = BitcoinAddress.fromScriptPubKey(changeSPK, networkParameters)
 
       dlcPubKeys = calcDLCPubKeys(account.xpub, chainType, nextIndex)
 
@@ -594,7 +592,6 @@ abstract class DLCWallet
         fromTagOpt = None,
         markAsReserved = true
       )
-      network = networkParameters.asInstanceOf[BitcoinNetwork]
 
       serialIds = DLCMessage.genSerialIds(
         spendingInfos.size,
@@ -603,8 +600,8 @@ abstract class DLCWallet
         DLCFundingInput.fromInputSigningInfo(utxo, id)
       }
 
-      changeSPK = txBuilder.finalizer.changeSPK.asInstanceOf[P2WPKHWitnessSPKV0]
-      changeAddr = Bech32Address(changeSPK, network)
+      changeSPK = txBuilder.finalizer.changeSPK
+      changeAddr = BitcoinAddress.fromScriptPubKey(changeSPK, networkParameters)
 
       bip32Path = BIP32Path(
         account.hdAccount.path ++ Vector(BIP32Node(0, hardened = false),

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -11,7 +11,7 @@ import org.bitcoins.core.api.wallet.{
   CoinSelectionAlgo
 }
 import org.bitcoins.core.bloom.{BloomFilter, BloomUpdateAll}
-import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.{GolombFilter, SimpleFilterMatcher}
@@ -64,7 +64,7 @@ abstract class Wallet
 
   val chainParams: ChainParams = walletConfig.chain
 
-  val networkParameters: NetworkParameters = walletConfig.network
+  val networkParameters: BitcoinNetwork = walletConfig.network
 
   override val discoveryBatchSize: Int = walletConfig.discoveryBatchSize
 


### PR DESCRIPTION
These were here originally from when we restricted the change types to be segwit only.