### PR TITLE
Fix removing canceled DLCs from table

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -80,6 +80,8 @@ class DLCPaneModel(pane: DLCPane)(implicit ec: ExecutionContext)
   def updateDLCs(): Unit = {
     getDLCs.map { dlcs =>
       dlcs.foreach(updateDLCInList)
+      val toRemove = GlobalDLCData.dlcs.diff(dlcs)
+      GlobalDLCData.dlcs --= toRemove
       pane.sortTable()
     }
 


### PR DESCRIPTION
Bug caused by #3321

We were not removing canceled DLCs from the table. 