### PR TITLE
Use OrderedNonces type in DLC data types

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCAdaptorPointComputer.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCAdaptorPointComputer.scala
@@ -136,7 +136,7 @@ object DLCAdaptorPointComputer {
       contractInfo.oracleInfo.singleOracleInfos.map { info =>
         val announcement = info.announcement
         val pubKey = announcement.publicKey
-        val nonces = announcement.eventTLV.nonces.map(_.publicKey)
+        val nonces = announcement.eventTLV.nonces.vec.map(_.publicKey)
 
         nonces.map { nonce =>
           possibleOutcomes.map { outcome =>

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/OracleInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/OracleInfo.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.core.protocol.dlc.models
 
 import org.bitcoins.core.protocol.tlv._
+import org.bitcoins.core.util.sorted.OrderedNonces
 import org.bitcoins.crypto._
 
 /** Specifies the set of oracles and their corresponding announcements
@@ -68,7 +69,7 @@ sealed trait SingleOracleInfo
   def publicKey: SchnorrPublicKey = announcement.publicKey
 
   /** The oracle's pre-committed nonces, in the correct order */
-  def nonces: Vector[SchnorrNonce] = announcement.eventTLV.nonces
+  def nonces: OrderedNonces = announcement.eventTLV.nonces
 
   /** The order of the given sigs should correspond to the given outcome. */
   def verifySigs(outcome: DLCOutcomeType, sigs: OracleSignatures): Boolean
@@ -77,7 +78,7 @@ sealed trait SingleOracleInfo
     * This point is used for adaptor signing.
     */
   def sigPoint(outcome: DLCOutcomeType): ECPublicKey = {
-    publicKey.computeSigPoint(outcome.serialized, nonces)
+    publicKey.computeSigPoint(outcome.serialized, nonces.vec)
   }
 
   /** Computes the sum of all nonces used in a given outcome */

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -2,8 +2,8 @@ package org.bitcoins.core.protocol.tlv
 
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number._
-import org.bitcoins.core.protocol.dlc.compute.SigningVersion.DLCOracleV0SigningVersion
 import org.bitcoins.core.protocol.dlc.compute.SigningVersion
+import org.bitcoins.core.protocol.dlc.compute.SigningVersion.DLCOracleV0SigningVersion
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.tlv.TLV.{
   DecodeTLVResult,
@@ -12,6 +12,7 @@ import org.bitcoins.core.protocol.tlv.TLV.{
 }
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.protocol.{BigSizeUInt, BlockTimeStamp}
+import org.bitcoins.core.util.sorted.OrderedNonces
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto._
 import scodec.bits.ByteVector
@@ -703,25 +704,25 @@ object DigitDecompositionEventDescriptorV0TLV
 
 sealed trait OracleEventTLV extends TLV {
   def eventDescriptor: EventDescriptorTLV
-  def nonces: Vector[SchnorrNonce]
+  def nonces: OrderedNonces
   def eventId: NormalizedString
   def eventMaturityEpoch: UInt32
 }
 
 case class OracleEventV0TLV(
-    nonces: Vector[SchnorrNonce],
+    nonces: OrderedNonces,
     eventMaturityEpoch: UInt32,
     eventDescriptor: EventDescriptorTLV,
     eventId: NormalizedString
 ) extends OracleEventTLV {
 
-  require(eventDescriptor.noncesNeeded == nonces.size,
+  require(eventDescriptor.noncesNeeded == nonces.vec.size,
           "Not enough nonces for this event descriptor")
 
   override def tpe: BigSizeUInt = OracleEventV0TLV.tpe
 
   override val value: ByteVector = {
-    u16PrefixedList(nonces) ++
+    u16PrefixedList(nonces.vec) ++
       eventMaturityEpoch.bytes ++
       eventDescriptor.bytes ++
       strBytes(eventId)
@@ -744,7 +745,10 @@ object OracleEventV0TLV extends TLVFactory[OracleEventV0TLV] {
     val eventDescriptor = iter.take(EventDescriptorTLV)
     val eventId = iter.takeString()
 
-    OracleEventV0TLV(nonces, eventMaturity, eventDescriptor, eventId)
+    OracleEventV0TLV(OrderedNonces(nonces),
+                     eventMaturity,
+                     eventDescriptor,
+                     eventId)
   }
 
   override val typeName: String = "OracleEventV0TLV"
@@ -799,7 +803,7 @@ object OracleAnnouncementV0TLV extends TLVFactory[OracleAnnouncementV0TLV] {
 
   lazy val dummy: OracleAnnouncementV0TLV = {
     val priv = ECPrivateKey.freshPrivateKey
-    val event = OracleEventV0TLV(Vector(priv.schnorrNonce),
+    val event = OracleEventV0TLV(OrderedNonces(Vector(priv.schnorrNonce)),
                                  UInt32.zero,
                                  EnumEventDescriptorV0TLV.dummy,
                                  "dummy")
@@ -814,7 +818,7 @@ object OracleAnnouncementV0TLV extends TLVFactory[OracleAnnouncementV0TLV] {
       nonce: SchnorrNonce,
       events: Vector[EnumOutcome]): OracleAnnouncementTLV = {
     val event = OracleEventV0TLV(
-      Vector(nonce),
+      OrderedNonces(Vector(nonce)),
       UInt32.zero,
       EnumEventDescriptorV0TLV(events.map(outcome => outcome.outcome)),
       "dummy")
@@ -833,7 +837,10 @@ object OracleAnnouncementV0TLV extends TLVFactory[OracleAnnouncementV0TLV] {
                                                                  nonces.length,
                                                                  "dummy",
                                                                  Int32.zero)
-    val event = OracleEventV0TLV(nonces, UInt32.zero, eventDescriptor, "dummy")
+    val event = OracleEventV0TLV(OrderedNonces(nonces),
+                                 UInt32.zero,
+                                 eventDescriptor,
+                                 "dummy")
     val sig =
       privKey.schnorrSign(CryptoUtil.sha256DLCAnnouncement(event.bytes).bytes)
 

--- a/core/src/main/scala/org/bitcoins/core/util/sorted/OrderedNonces.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/sorted/OrderedNonces.scala
@@ -6,3 +6,10 @@ import org.bitcoins.crypto.SchnorrNonce
 case class OrderedNonces(vec: Vector[SchnorrNonce])
     extends SortedVec[SchnorrNonce, SchnorrNonce](vec,
                                                   SortedVec.forOrdered(vec))
+
+object OrderedNonces {
+
+  def apply(single: SchnorrNonce): OrderedNonces = {
+    OrderedNonces(Vector(single))
+  }
+}

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -10,6 +10,7 @@ import org.bitcoins.core.protocol.dlc.compute.SigningVersion
 import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.util.TimeUtil
+import org.bitcoins.core.util.sorted.OrderedNonces
 import org.bitcoins.crypto._
 import org.bitcoins.testkit.fixtures.DLCOracleFixture
 import org.bitcoins.testkitcore.Implicits._
@@ -205,7 +206,7 @@ class DLCOracleTest extends DLCOracleFixture {
         assert(event.maturationTime.getEpochSecond == time.getEpochSecond)
 
         val expectedEventTLV =
-          OracleEventV0TLV(Vector(event.nonces.head),
+          OracleEventV0TLV(OrderedNonces(event.nonces.head),
                            UInt32(event.maturationTime.getEpochSecond),
                            testDescriptor,
                            eventName)

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -12,6 +12,7 @@ import org.bitcoins.core.protocol.Bech32Address
 import org.bitcoins.core.protocol.dlc.compute.SigningVersion
 import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
 import org.bitcoins.core.protocol.tlv._
+import org.bitcoins.core.util.sorted.OrderedNonces
 import org.bitcoins.core.util.{FutureUtil, NumberUtil, TimeUtil}
 import org.bitcoins.crypto._
 import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
@@ -198,7 +199,10 @@ class DLCOracle(private[this] val extPrivateKey: ExtPrivateKeyHardened)(implicit
 
       nonces = rValueDbs.map(_.nonce)
 
-      eventTLV = OracleEventV0TLV(nonces, epoch, descriptor, eventName)
+      eventTLV = OracleEventV0TLV(OrderedNonces(nonces),
+                                  epoch,
+                                  descriptor,
+                                  eventName)
 
       announcementBytes = signingVersion.calcAnnouncementHash(eventTLV)
       announcementSignature = signingKey.schnorrSign(announcementBytes)

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/util/EventDbUtil.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/util/EventDbUtil.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.dlc.oracle.util
 
-import org.bitcoins.core.api.dlcoracle.db._
 import org.bitcoins.core.api.dlcoracle._
+import org.bitcoins.core.api.dlcoracle.db._
 import org.bitcoins.core.protocol.dlc.compute.SigningVersion
 import org.bitcoins.core.protocol.tlv._
-import org.bitcoins.crypto.SchnorrNonce
+import org.bitcoins.core.util.sorted.OrderedNonces
 
 trait EventDbUtil {
 
@@ -13,7 +13,7 @@ trait EventDbUtil {
     */
   def toEventOutcomeDbs(
       descriptor: EventDescriptorTLV,
-      nonces: Vector[SchnorrNonce],
+      nonces: OrderedNonces,
       signingVersion: SigningVersion): Vector[EventOutcomeDb] = {
     descriptor match {
       case enum: EnumEventDescriptorV0TLV =>
@@ -70,7 +70,7 @@ trait EventDbUtil {
       eventName: String,
       signingVersion: SigningVersion = SigningVersion.latest): Vector[
     EventDb] = {
-    val nonces = oracleAnnouncementV0TLV.eventTLV.nonces
+    val nonces = oracleAnnouncementV0TLV.eventTLV.nonces.vec
     nonces.zipWithIndex.map { case (nonce, index) =>
       EventDb(
         nonce = nonce,

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCParsingTestVector.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCParsingTestVector.scala
@@ -425,7 +425,7 @@ object DLCParsingTestVector extends TestVectorParser[DLCParsingTestVector] {
         val fields = Vector(
           "tpe" -> Element(OracleEventV0TLV.tpe),
           "length" -> Element(tlv.length),
-          "oracleNonces" -> MultiElement(nonces.map(Element(_))),
+          "oracleNonces" -> MultiElement(nonces.vec.map(Element(_))),
           "eventMaturityEpoch" -> Element(eventMaturity),
           "eventDescriptor" -> Element(descriptor),
           "event_uri" -> Element(CryptoUtil.serializeForHash(uri))

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
@@ -11,6 +11,7 @@ import org.bitcoins.core.protocol.dlc.verify.DLCSignatureVerifier
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.util.sorted.OrderedNonces
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.Sha256Digest
 import org.bitcoins.dlc.wallet.DLCWallet
@@ -63,7 +64,7 @@ private[bitcoins] trait DLCDataManagement { self: DLCWallet =>
               .exists(_.used)
             if (used) {
               val nonces = nonceDbs.sortBy(_.index).map(_.nonce)
-              val eventTLV = OracleEventV0TLV(nonces,
+              val eventTLV = OracleEventV0TLV(OrderedNonces(nonces),
                                               data.eventMaturity,
                                               data.eventDescriptor,
                                               data.eventId)
@@ -102,7 +103,7 @@ private[bitcoins] trait DLCDataManagement { self: DLCWallet =>
         announcementData.find(_.id.contains(id)) match {
           case Some(data) =>
             val nonces = nonceDbs.sortBy(_.index).map(_.nonce)
-            val eventTLV = OracleEventV0TLV(nonces,
+            val eventTLV = OracleEventV0TLV(OrderedNonces(nonces),
                                             data.eventMaturity,
                                             data.eventDescriptor,
                                             data.eventId)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleNonceDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleNonceDb.scala
@@ -17,7 +17,7 @@ object OracleNonceDbHelper {
   def fromAnnouncement(
       id: Long,
       tlv: OracleAnnouncementTLV): Vector[OracleNonceDb] = {
-    tlv.eventTLV.nonces.zipWithIndex.map { case (nonce, index) =>
+    tlv.eventTLV.nonces.vec.zipWithIndex.map { case (nonce, index) =>
       OracleNonceDb(id, index, SchnorrDigitalSignature.dummy, nonce, None, None)
     }
   }

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
@@ -13,6 +13,7 @@ import org.bitcoins.core.protocol.dlc.models.{
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.protocol.{BigSizeUInt, BlockTimeStamp}
+import org.bitcoins.core.util.sorted.OrderedNonces
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto.ECPrivateKey
 import org.bitcoins.testkitcore.dlc.DLCTestUtil
@@ -89,7 +90,7 @@ trait TLVGen {
         Gen
           .listOfN(desc.noncesNeeded, CryptoGenerators.schnorrNonce)
           .map(_.toVector)
-    } yield OracleEventV0TLV(nonces, maturity, desc, uri)
+    } yield OracleEventV0TLV(OrderedNonces(nonces), maturity, desc, uri)
   }
 
   def oracleAnnouncementV0TLV: Gen[OracleAnnouncementV0TLV] = {


### PR DESCRIPTION
Closes #3330 

Uses `OrderedNonces` in the DLC data types like the announcement, then implements it in the `DLCWallet` and `DLCOracle`