### PR TITLE
Fix showing error popups in GUI

### DIFF
--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BundleGUI.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BundleGUI.scala
@@ -29,7 +29,7 @@ object BundleGUI extends WalletGUI with JFXApp3 {
       .currentThread()
       .setUncaughtExceptionHandler((_: Thread, ex: Throwable) => {
         ex.printStackTrace()
-        lazy val _ = new Alert(AlertType.Error) {
+        val _ = new Alert(AlertType.Error) {
           initOwner(owner)
           title = "Unhandled exception"
           headerText = "Exception: " + ex.getClass + ""

--- a/app/gui/src/main/scala/org/bitcoins/gui/GUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/GUI.scala
@@ -36,7 +36,7 @@ object GUI extends WalletGUI with JFXApp3 {
       .currentThread()
       .setUncaughtExceptionHandler((_: Thread, ex: Throwable) => {
         ex.printStackTrace()
-        lazy val _ = new Alert(AlertType.Error) {
+        val _ = new Alert(AlertType.Error) {
           initOwner(owner)
           title = "Unhandled exception"
           headerText = "Exception: " + ex.getClass + ""


### PR DESCRIPTION
The popup was defined as `lazy val _ = ..` so it would never been shown