### PR TITLE
Add logs to make it more apparent that No Common Ancestors isn't necessarily bad

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -112,7 +112,7 @@ private[blockchain] trait BaseBlockChainCompObject
       findPrevBlockHeaderIdx(header, blockchain) match {
         case None =>
           logger.warn(
-            s"No common ancestor found in the chain with tip=${blockchain.tip.hashBE.hex} to connect to hash=${header.hashBE} prevHash=${header.previousBlockHashBE}")
+            s"No common ancestor found in the chain with tip=${blockchain.tip.hashBE.hex} to connect to hash=${header.hashBE.hex} prevHash=${header.previousBlockHashBE.hex}. This may be because we have a competing reorg!")
           val err = TipUpdateResult.BadPreviousBlockHash(header)
           val failed = ConnectTipResult.BadTip(err)
           failed
@@ -128,7 +128,7 @@ private[blockchain] trait BaseBlockChainCompObject
 
           tipResult match {
             case success: TipUpdateResult.Success =>
-              logger.debug(
+              logger.info(
                 s"Successfully verified=${success.header.hashBE.hex}, connecting to chain")
               val connectionIdx = blockchain.length - prevHeaderIdx
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -111,7 +111,7 @@ private[blockchain] trait BaseBlockChainCompObject
     val tipResult: ConnectTipResult = {
       findPrevBlockHeaderIdx(header, blockchain) match {
         case None =>
-          logger.warn(
+          logger.debug(
             s"No common ancestor found in the chain with tip=${blockchain.tip.hashBE.hex} to connect to hash=${header.hashBE.hex} prevHash=${header.previousBlockHashBE.hex}. This may be because we have a competing reorg!")
           val err = TipUpdateResult.BadPreviousBlockHash(header)
           val failed = ConnectTipResult.BadTip(err)
@@ -128,7 +128,7 @@ private[blockchain] trait BaseBlockChainCompObject
 
           tipResult match {
             case success: TipUpdateResult.Success =>
-              logger.info(
+              logger.debug(
                 s"Successfully verified=${success.header.hashBE.hex}, connecting to chain")
               val connectionIdx = blockchain.length - prevHeaderIdx
 


### PR DESCRIPTION
fixes #3337 

TLDR, there is no bugs here. Just misleading log messages. What was happening on my node was we have a competing chain split in the blockchain. On the tip that is dying, everytime we get a new block header we log this `warn` message

>[info] 2021-06-29T19:21:09UTC WARN [Blockchain$] No common ancestor found in the chain with tip=0000000069833246687fdb88a73b55e7cf1694f10c47d892ad00d90173234c6c to connect to hash=000000008576169f92b556ba1662530a2876287704da31e511145354bcee8fbc prevHash=000000000000003be5dab5ccebec3da4c29795d1378f14efae1f5e4ced4d6e17

HOWEVER, we silently succeed connecting the tip to the _other_ side of the chainsplit behind the scenes. 

This PR modifies the `No common ancestor` log message to indicate that this might be on the wrong side of a chain split.

Right now, i've modified this log message 

>[info] 2021-06-30T13:50:50UTC INFO [Blockchain$] Successfully verified=000000000000000a020b9d3be275137d35a53950e511e245f1ae9c701dbfb851, connecting to chain

to be `INFO` rather than `DEBUG` like it was before. The downside of this approach though is during IBD, we will get a _ton_ of those log messages. I'm open to moving it back to `DEBUG`, but would like opinions from others first. 