### PR TITLE
Fix logging for appServer

### DIFF
--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
@@ -82,7 +82,7 @@ class LandingPaneModel()(implicit system: ActorSystem) extends Logging {
           val extraArgs = Vector("--conf", path.toAbsolutePath.toString)
           val usedArgs = extraArgs ++ args
           // use class base constructor to share the actor system
-          new BitcoinSServerMain(usedArgs.toArray).run()
+          new BitcoinSServerMain(usedArgs.toArray, () => system).run()
         }
 
         Await.result(promise.future, 60.seconds)

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
@@ -124,8 +124,10 @@ trait BitcoinSRunner extends StartStopAsync[Unit] with Logging {
     System.setProperty("bitcoins.log.location", usedDir.toAbsolutePath.toString)
 
     logger.info(s"version=${EnvUtil.getVersion}")
+    logger.info(
+      s"Set log location to: ${System.getProperty("bitcoins.log.location")}")
 
-    logger.info(s"using directory ${usedDir.toAbsolutePath.toString}")
+    logger.info(s"Using directory ${usedDir.toAbsolutePath.toString}")
     val runner: Future[Unit] = start()
     runner.failed.foreach { err =>
       logger.error(s"Failed to startup server!", err)

--- a/app/server-test/src/test/scala/org/bitcoins/server/LogLocationTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/LogLocationTest.scala
@@ -34,7 +34,7 @@ class LogLocationTest extends BitcoinSAsyncTest {
                    "--rpcport",
                    randPort.toString)
 
-      main = new BitcoinSServerMain(args)
+      main = new BitcoinSServerMain(args, () => system)
 
       // Start the server in a separate thread
       runnable = new Runnable {

--- a/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
@@ -28,7 +28,7 @@ class ServerRunTest extends BitcoinSAsyncTest {
                      "--rpcport",
                      randPort.toString)
 
-    val main = new BitcoinSServerMain(args)
+    val main = new BitcoinSServerMain(args, () => system)
     val runMainF = main.start()
     // Use Exception because different errors can occur
     val assertionF: Future[Assertion] = recoverToSucceededIf[Exception] {

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -27,9 +27,12 @@ import org.bitcoins.wallet.config.WalletAppConfig
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
-class BitcoinSServerMain(override val args: Array[String])(implicit
-    override val system: ActorSystem)
+class BitcoinSServerMain(
+    override val args: Array[String],
+    getSystem: () => ActorSystem)
     extends BitcoinSRunner {
+
+  implicit override lazy val system: ActorSystem = getSystem()
 
   implicit lazy val conf: BitcoinSAppConfig =
     BitcoinSAppConfig(datadir, baseConfig)
@@ -395,7 +398,7 @@ object BitcoinSServerMain extends BitcoinSApp {
   override val actorSystemName =
     s"bitcoin-s-server-${System.currentTimeMillis()}"
 
-  new BitcoinSServerMain(args).run()
+  new BitcoinSServerMain(args, () => system).run()
 }
 
 object BitcoinSServer {


### PR DESCRIPTION
Fixes #3304

I think this was caused by #3220

Logging was breaking from us starting the `ActorSystem` before properly setting the `bitcoin-s.log.location` property.