### PR TITLE
Set sync height on new wallet

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -81,7 +81,7 @@ abstract class Wallet
     OutgoingTransactionDAO()
   private[bitcoins] val addressTagDAO: AddressTagDAO = AddressTagDAO()
 
-  private[wallet] val stateDescriptorDAO: WalletStateDescriptorDAO =
+  private[bitcoins] val stateDescriptorDAO: WalletStateDescriptorDAO =
     WalletStateDescriptorDAO()
 
   val nodeApi: NodeApi


### PR DESCRIPTION
This would cause an error where if the user received their first funds while offline they would not see it because it would sync above the first tx.