### PR TITLE
Export Result and Save Backup handle no file selection

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/AppMenuBar.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/AppMenuBar.scala
@@ -35,8 +35,9 @@ private class FileMenu() {
         initialFileName = "bitcoin-s-backup.zip"
       }
       val chosenFile = fileChooser.showSaveDialog(null)
-      ConsoleCli.exec(ZipDataDir(chosenFile.toPath),
-                      GlobalData.consoleCliConfig)
+      if (chosenFile != null)
+        ConsoleCli.exec(ZipDataDir(chosenFile.toPath),
+                        GlobalData.consoleCliConfig)
       ()
     }
   }

--- a/app/gui/src/main/scala/org/bitcoins/gui/AppMenuBar.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/AppMenuBar.scala
@@ -37,7 +37,9 @@ private class FileMenu() {
       val chosenFileOpt = Option(fileChooser.showSaveDialog(null))
       chosenFileOpt match {
         case Some(chosenFile) =>
-          ConsoleCli.exec(ZipDataDir(chosenFile.toPath),GlobalData.consoleCliConfig)
+          ConsoleCli.exec(ZipDataDir(chosenFile.toPath),
+                          GlobalData.consoleCliConfig)
+          ()
         case None => // User canceled in dialog
       }
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/AppMenuBar.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/AppMenuBar.scala
@@ -34,11 +34,12 @@ private class FileMenu() {
         initialDirectory = new File(Properties.userHome)
         initialFileName = "bitcoin-s-backup.zip"
       }
-      val chosenFile = fileChooser.showSaveDialog(null)
-      if (chosenFile != null)
-        ConsoleCli.exec(ZipDataDir(chosenFile.toPath),
-                        GlobalData.consoleCliConfig)
-      ()
+      val chosenFileOpt = Option(fileChooser.showSaveDialog(null))
+      chosenFileOpt match {
+        case Some(chosenFile) =>
+          ConsoleCli.exec(ZipDataDir(chosenFile.toPath),GlobalData.consoleCliConfig)
+        case None => // User canceled in dialog
+      }
     }
   }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -124,10 +124,12 @@ class DLCPane(glassPane: VBox)(implicit ec: ExecutionContext) {
         selectedExtensionFilter = txtExtensionFilter
         initialDirectory = new File(Properties.userHome)
       }
-      val chosenFile = fileChooser.showSaveDialog(null)
-      if (chosenFile != null)
-        Files.write(chosenFile.toPath, resultTextArea.text.value.getBytes)
-      ()
+      val chosenFileOpt = Option(fileChooser.showSaveDialog(null))
+      chosenFileOpt match {
+        case Some(chosenFile) =>
+          Files.write(chosenFile.toPath, resultTextArea.text.value.getBytes)
+        case None => // User canceled in dialog
+      }
     }
   }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -128,6 +128,7 @@ class DLCPane(glassPane: VBox)(implicit ec: ExecutionContext) {
       chosenFileOpt match {
         case Some(chosenFile) =>
           Files.write(chosenFile.toPath, resultTextArea.text.value.getBytes)
+          ()
         case None => // User canceled in dialog
       }
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -125,7 +125,8 @@ class DLCPane(glassPane: VBox)(implicit ec: ExecutionContext) {
         initialDirectory = new File(Properties.userHome)
       }
       val chosenFile = fileChooser.showSaveDialog(null)
-      Files.write(chosenFile.toPath, resultTextArea.text.value.getBytes)
+      if (chosenFile != null)
+        Files.write(chosenFile.toPath, resultTextArea.text.value.getBytes)
       ()
     }
   }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -369,7 +369,7 @@ class CreateDLCOfferDialog extends Logging {
           decompOpt = Some(digitDecomp)
 
           val addPointButton: Button = new Button("+") {
-            onAction = _ => addPointRow(isEndPoint = false)
+            onAction = _ => addPointRow()
           }
           val label: HBox = new HBox {
             alignment = Pos.Center

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -369,7 +369,7 @@ class CreateDLCOfferDialog extends Logging {
           decompOpt = Some(digitDecomp)
 
           val addPointButton: Button = new Button("+") {
-            onAction = _ => addPointRow()
+            onAction = _ => addPointRow(isEndPoint = false)
           }
           val label: HBox = new HBox {
             alignment = Pos.Center


### PR DESCRIPTION
Basic Bugfix PR from working with things today

Handle null (no file) selection from FileChooser save dialogs for Save Backup menu item and Export Result DLCPane button.

<img width="425" alt="Screen Shot 2021-07-06 at 1 52 36 PM" src="https://user-images.githubusercontent.com/22351459/124659106-d3b54b80-de61-11eb-900c-a04d39e1a119.png">
