### PR TITLE
Use Wallet's transactionDAO instead of creating a copy

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -29,7 +29,6 @@ import org.bitcoins.dlc.wallet.models._
 import org.bitcoins.dlc.wallet.util.DLCStatusBuilder
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.wallet.config.WalletAppConfig
-import org.bitcoins.wallet.models.TransactionDAO
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 import scodec.bits.ByteVector
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -61,7 +61,6 @@ abstract class DLCWallet
   private[bitcoins] val dlcSigsDAO: DLCCETSignaturesDAO = DLCCETSignaturesDAO()
   private[bitcoins] val dlcRefundSigDAO: DLCRefundSigsDAO = DLCRefundSigsDAO()
   private[bitcoins] val remoteTxDAO: DLCRemoteTxDAO = DLCRemoteTxDAO()
-  private[bitcoins] val txDAO: TransactionDAO = TransactionDAO()
 
   private def calcContractId(offer: DLCOffer, accept: DLCAccept): ByteVector = {
     val builder = DLCTxBuilder(offer, accept.withoutSigs)
@@ -1283,7 +1282,8 @@ abstract class DLCWallet
   }
 
   private def getClosingTxOpt(dlcDb: DLCDb): Future[Option[TransactionDb]] = {
-    val result = dlcDb.closingTxIdOpt.map(txid => txDAO.findByTxId(txid))
+    val result =
+      dlcDb.closingTxIdOpt.map(txid => transactionDAO.findByTxId(txid))
     result match {
       case None    => Future.successful(None)
       case Some(r) => r


### PR DESCRIPTION
`Wallet` has its own `transactionDAO` so we don't need `DLCWallet` to create it own instaniation.