### PR TITLE
Add missing release webhook on the release.yml file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [master, main]
     tags: ["*"]
+  release:
+    types: [ published ]
 
 env:
   pkg-assembly: 'bitcoin-s-bundle.jar'


### PR DESCRIPTION
I created a draft release this morning and had the `bitcoin-s-cli` artifacts build automatically, but no artifacts defined in the `release.yml` file. 

This is because this is missing on the `release.yml` file 

https://github.com/bitcoin-s/bitcoin-s/blob/93822c71ec268c462123b8b4be9e6aea9cd33659/.github/workflows/native.yml#L10