### PR TITLE
Add ability to label DLCs

### DIFF
--- a/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
@@ -23,6 +23,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
 
         val status =
           DLCStatus.Offered(Sha256Digest.empty,
+                            "label",
                             isInit,
                             offer.tempContractId,
                             offer.contractInfo,
@@ -50,6 +51,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
         val status =
           DLCStatus.Accepted(
             Sha256Digest.empty,
+            "label",
             isInit,
             offer.tempContractId,
             contractId,
@@ -79,6 +81,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
         val status =
           DLCStatus.Signed(
             Sha256Digest.empty,
+            "label",
             isInit,
             offer.tempContractId,
             contractId,
@@ -109,6 +112,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
         val status =
           DLCStatus.Broadcasted(
             Sha256Digest.empty,
+            "label",
             isInit,
             offer.tempContractId,
             contractId,
@@ -140,6 +144,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
         val status =
           DLCStatus.Confirmed(
             Sha256Digest.empty,
+            "label",
             isInit,
             offer.tempContractId,
             contractId,
@@ -182,6 +187,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
       val status =
         DLCStatus.Claimed(
           Sha256Digest.empty,
+          "label",
           isInit,
           offer.tempContractId,
           contractId,
@@ -232,6 +238,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
       val status =
         DLCStatus.RemoteClaimed(
           Sha256Digest.empty,
+          "label",
           isInit,
           offer.tempContractId,
           contractId,
@@ -278,6 +285,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
       val status =
         DLCStatus.Refunded(
           Sha256Digest.empty,
+          "label",
           isInit,
           offer.tempContractId,
           contractId,

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -162,6 +162,7 @@ object Picklers {
       import offered._
       Obj(
         "state" -> Str(statusString),
+        "label" -> Str(label),
         "dlcId" -> Str(dlcId.hex),
         "isInitiator" -> Bool(isInitiator),
         "tempContractId" -> Str(tempContractId.hex),
@@ -181,6 +182,7 @@ object Picklers {
     import accepted._
     Obj(
       "state" -> Str(statusString),
+      "label" -> Str(label),
       "dlcId" -> Str(dlcId.hex),
       "isInitiator" -> Bool(isInitiator),
       "tempContractId" -> Str(tempContractId.hex),
@@ -201,6 +203,7 @@ object Picklers {
     import signed._
     Obj(
       "state" -> Str(statusString),
+      "label" -> Str(label),
       "dlcId" -> Str(dlcId.hex),
       "isInitiator" -> Bool(isInitiator),
       "tempContractId" -> Str(tempContractId.hex),
@@ -222,6 +225,7 @@ object Picklers {
       import broadcasted._
       Obj(
         "state" -> Str(statusString),
+        "label" -> Str(label),
         "dlcId" -> Str(dlcId.hex),
         "isInitiator" -> Bool(isInitiator),
         "tempContractId" -> Str(tempContractId.hex),
@@ -244,6 +248,7 @@ object Picklers {
       import confirmed._
       Obj(
         "state" -> Str(statusString),
+        "label" -> Str(label),
         "dlcId" -> Str(dlcId.hex),
         "isInitiator" -> Bool(isInitiator),
         "tempContractId" -> Str(tempContractId.hex),
@@ -276,6 +281,7 @@ object Picklers {
 
     Obj(
       "state" -> Str(statusString),
+      "label" -> Str(label),
       "dlcId" -> Str(dlcId.hex),
       "isInitiator" -> Bool(isInitiator),
       "tempContractId" -> Str(tempContractId.hex),
@@ -316,6 +322,7 @@ object Picklers {
 
       Obj(
         "state" -> Str(statusString),
+        "label" -> Str(label),
         "dlcId" -> Str(dlcId.hex),
         "isInitiator" -> Bool(isInitiator),
         "tempContractId" -> Str(tempContractId.hex),
@@ -347,6 +354,7 @@ object Picklers {
     import refunded._
     Obj(
       "state" -> Str(statusString),
+      "label" -> Str(label),
       "dlcId" -> Str(dlcId.hex),
       "isInitiator" -> Bool(isInitiator),
       "tempContractId" -> Str(tempContractId.hex),
@@ -391,6 +399,7 @@ object Picklers {
 
   implicit val dlcStatusR: Reader[DLCStatus] = reader[Obj].map { obj =>
     val dlcId = Sha256Digest(obj("dlcId").str)
+    val label = obj("label").str
     val state = DLCState.fromString(obj("state").str)
     val isInitiator = obj("isInitiator").bool
     val tempContractId = Sha256Digest(obj("tempContractId").str)
@@ -450,6 +459,7 @@ object Picklers {
       case DLCState.Offered =>
         Offered(
           dlcId,
+          label,
           isInitiator,
           tempContractId,
           ContractInfo.fromTLV(contractInfoTLV),
@@ -461,6 +471,7 @@ object Picklers {
       case DLCState.Accepted =>
         Accepted(
           dlcId,
+          label,
           isInitiator,
           tempContractId,
           contractId,
@@ -473,6 +484,7 @@ object Picklers {
       case DLCState.Signed =>
         Signed(
           dlcId,
+          label,
           isInitiator,
           tempContractId,
           contractId,
@@ -485,6 +497,7 @@ object Picklers {
       case DLCState.Broadcasted =>
         Broadcasted(
           dlcId,
+          label,
           isInitiator,
           tempContractId,
           contractId,
@@ -498,6 +511,7 @@ object Picklers {
       case DLCState.Confirmed =>
         Confirmed(
           dlcId,
+          label,
           isInitiator,
           tempContractId,
           contractId,
@@ -511,6 +525,7 @@ object Picklers {
       case DLCState.Claimed =>
         Claimed(
           dlcId,
+          label,
           isInitiator,
           tempContractId,
           contractId,
@@ -531,6 +546,7 @@ object Picklers {
                 "Remote claimed should only have one oracle sig")
         RemoteClaimed(
           dlcId,
+          label,
           isInitiator,
           tempContractId,
           contractId,
@@ -549,6 +565,7 @@ object Picklers {
       case DLCState.Refunded =>
         Refunded(
           dlcId,
+          label,
           isInitiator,
           tempContractId,
           contractId,

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
@@ -4,8 +4,8 @@ import org.bitcoins.commons.jsonmodels.ExplorerEnv
 import org.bitcoins.core.dlc.accounting.RateOfReturnUtil
 import org.bitcoins.core.protocol.dlc.models.DLCStatus._
 import org.bitcoins.core.protocol.dlc.models._
-import org.bitcoins.gui.{GUI, GlobalData}
 import org.bitcoins.gui.util.GUIUtil
+import org.bitcoins.gui.{GUI, GlobalData}
 import scalafx.beans.property.StringProperty
 import scalafx.geometry.Insets
 import scalafx.scene.control.TableColumn.SortType
@@ -30,17 +30,11 @@ class DLCTableView(model: DLCPaneModel) {
       }
     }
 
-    val contractIdCol = new TableColumn[DLCStatus, String] {
-      text = "Contract Id"
+    val labelCol = new TableColumn[DLCStatus, String] {
+      text = "Label"
       prefWidth = 100
       cellValueFactory = { status =>
-        val contractIdStr = status.value match {
-          case _: Offered => ""
-          case signed: AcceptedDLCStatus =>
-            signed.contractId.toHex
-        }
-
-        new StringProperty(status, "Contract Id", contractIdStr)
+        new StringProperty(status, "Label", status.value.label)
       }
     }
 
@@ -116,7 +110,7 @@ class DLCTableView(model: DLCPaneModel) {
 
     new TableView[DLCStatus](GlobalDLCData.dlcs) {
       columns ++= Seq(eventIdCol,
-                      contractIdCol,
+                      labelCol,
                       statusCol,
                       pnlCol,
                       rorCol,
@@ -124,7 +118,7 @@ class DLCTableView(model: DLCPaneModel) {
                       otherCollateralCol,
                       totalCollateralCol)
       margin = Insets(10, 0, 10, 0)
-      sortOrder.addAll(statusCol, eventIdCol, contractIdCol)
+      sortOrder.addAll(statusCol)
 
       val infoItem: MenuItem = new MenuItem("View DLC") {
         onAction = _ => {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
@@ -32,6 +32,7 @@ class AcceptOfferDialog {
     val offerTLVTF = new TextField() {
       minWidth = 300
     }
+    val labelTF = new TextField()
 
     var nextRow: Int = 2
     val gridPane = new GridPane {
@@ -47,6 +48,8 @@ class AcceptOfferDialog {
           0,
           0)
       add(offerTLVTF, 1, 0)
+      add(new Label("Label"), 0, 1)
+      add(labelTF, 1, 1)
     }
 
     def showOfferTerms(offer: DLCOfferTLV): Unit = {
@@ -220,11 +223,12 @@ class AcceptOfferDialog {
     // When the OK button is clicked, convert the result to a CreateDLCOffer.
     dialog.resultConverter = dialogButton =>
       if (dialogButton == ButtonType.OK) {
+        val label = labelTF.text.value
 
         val offerHex = offerTLVTF.text.value
         val offer = LnMessageFactory(DLCOfferTLV).fromHex(offerHex)
 
-        Some(AcceptDLCOffer(offer))
+        Some(AcceptDLCOffer(label, offer))
       } else None
 
     val result = dialog.showAndWait()

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -39,9 +39,10 @@ class CreateDLCOfferDialog extends Logging {
 
     var announcementDetailsShown = false
     val announcementOrContractInfoTF = new TextField()
+    val labelTF = new TextField()
     var decompOpt: Option[DigitDecompositionEventDescriptorV0TLV] = None
 
-    var nextRow: Int = 3
+    var nextRow: Int = 4
     val gridPane = new GridPane {
       alignment = Pos.Center
       padding = Insets(top = 10, right = 10, bottom = 10, left = 10)
@@ -338,18 +339,22 @@ class CreateDLCOfferDialog extends Logging {
         contractInfoOpt: Option[ContractInfoV0TLV]): Unit = {
       announcementDetailsShown = true
       announcementOrContractInfoTF.disable = true
-      gridPane.add(new Label("Event Id"), 0, 1)
+
+      gridPane.add(new Label("Label"), 0, 1)
+      gridPane.add(labelTF, 1, 1)
+
+      gridPane.add(new Label("Event Id"), 0, 2)
       gridPane.add(new TextField() {
                      text = announcement.eventTLV.eventId
                      editable = false
                    },
                    1,
-                   1)
+                   2)
 
       announcement.eventTLV.eventDescriptor match {
         case EnumEventDescriptorV0TLV(outcomes) =>
-          gridPane.add(new Label("Outcomes"), 0, 2)
-          gridPane.add(new Label("Values"), 1, 2)
+          gridPane.add(new Label("Outcomes"), 0, 3)
+          gridPane.add(new Label("Values"), 1, 3)
           contractInfoOpt match {
             case Some(contractInfo) =>
               contractInfo.contractDescriptor match {
@@ -363,7 +368,7 @@ class CreateDLCOfferDialog extends Logging {
             case None =>
               outcomes.foreach(str => addEnumOutcomeRow(str.normStr, None))
           }
-          nextRow = 3
+          nextRow = 4
           addRemainingFields()
         case digitDecomp: UnsignedDigitDecompositionEventDescriptor =>
           decompOpt = Some(digitDecomp)
@@ -462,6 +467,8 @@ class CreateDLCOfferDialog extends Logging {
       if (dialogButton == ButtonType.OK) {
         val oracleInfo = getOracleInfo.get
 
+        val label = labelTF.text.value
+
         val collateralLong =
           numberFormatter.parse(collateralTF.text.value).longValue()
         val collateral = Satoshis(collateralLong)
@@ -513,6 +520,7 @@ class CreateDLCOfferDialog extends Logging {
 
         Some(
           CreateDLCOffer(
+            label = label,
             contractInfo = contractInfo,
             collateral = collateral,
             feeRateOpt = feeRateOpt,

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
@@ -51,6 +51,15 @@ object ViewDLCDialog {
           rowIndex = row)
 
       row += 1
+      add(new Label("Label:"), 0, row)
+      add(new TextField() {
+            text = status.label
+            editable = false
+          },
+          columnIndex = 1,
+          rowIndex = row)
+
+      row += 1
       add(new Label("Event Id:"), 0, row)
       add(
         new TextField() {

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -924,12 +924,14 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
     "create a dlc offer" in {
       (mockWalletApi
-        .createDLCOffer(_: ContractInfoV0TLV,
+        .createDLCOffer(_: String,
+                        _: ContractInfoV0TLV,
                         _: Satoshis,
                         _: Option[SatoshisPerVirtualByte],
                         _: UInt32,
                         _: UInt32))
         .expects(
+          "label",
           contractInfoTLV,
           Satoshis(2500),
           Some(SatoshisPerVirtualByte(Satoshis.one)),
@@ -942,6 +944,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         ServerCommand(
           "createdlcoffer",
           Arr(
+            Str("label"),
             Str(contractInfoTLV.hex),
             Num(2500),
             Num(1),
@@ -972,12 +975,13 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
     "accept a dlc offer" in {
       (mockWalletApi
-        .acceptDLCOffer(_: DLCOfferTLV))
-        .expects(offer.toTLV)
+        .acceptDLCOffer(_: String, _: DLCOfferTLV))
+        .expects("label", offer.toTLV)
         .returning(Future.successful(accept))
 
       val route = walletRoutes.handleCommand(
-        ServerCommand("acceptdlcoffer", Arr(Str(LnMessage(offer.toTLV).hex))))
+        ServerCommand("acceptdlcoffer",
+                      Arr(Str("label"), Str(LnMessage(offer.toTLV).hex))))
 
       Post() ~> route ~> check {
         assert(contentType == `application/json`)

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -292,7 +292,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
         case Success(
-              CreateDLCOffer(contractInfo,
+              CreateDLCOffer(label,
+                             contractInfo,
                              collateral,
                              feeRateOpt,
                              locktime,
@@ -310,7 +311,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
             }
 
             wallet
-              .createDLCOffer(contractInfo,
+              .createDLCOffer(label,
+                              contractInfo,
                               collateral,
                               feeRateOpt,
                               locktime,
@@ -325,10 +327,10 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
       AcceptDLCOffer.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
-        case Success(AcceptDLCOffer(offer)) =>
+        case Success(AcceptDLCOffer(label, offer)) =>
           complete {
             wallet
-              .acceptDLCOffer(offer.tlv)
+              .acceptDLCOffer(label, offer.tlv)
               .map { accept =>
                 Server.httpSuccess(accept.toMessage.hex)
               }
@@ -347,7 +349,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
             val offerMessage = LnMessageFactory(DLCOfferTLV).fromHex(hex)
 
             wallet
-              .acceptDLCOffer(offerMessage.tlv)
+              .acceptDLCOffer("", offerMessage.tlv)
               .map { accept =>
                 val ret = handleDestinationOpt(accept.toMessage.hex, destOpt)
                 Server.httpSuccess(ret)

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCStatus.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCStatus.scala
@@ -15,8 +15,9 @@ import scodec.bits.ByteVector
 
 sealed trait DLCStatus {
 
-  /** The flipped sha256 hash of oracleInfo ++ contractInfo ++ timeoutes */
+  /** The sha256 hash of lexicographically sorted outpoints */
   def dlcId: Sha256Digest
+  def label: String
   def isInitiator: Boolean
   def state: DLCState
   def tempContractId: Sha256Digest
@@ -68,6 +69,7 @@ object DLCStatus {
 
   case class Offered(
       dlcId: Sha256Digest,
+      label: String,
       isInitiator: Boolean,
       tempContractId: Sha256Digest,
       contractInfo: ContractInfo,
@@ -81,6 +83,7 @@ object DLCStatus {
 
   case class Accepted(
       dlcId: Sha256Digest,
+      label: String,
       isInitiator: Boolean,
       tempContractId: Sha256Digest,
       contractId: ByteVector,
@@ -95,6 +98,7 @@ object DLCStatus {
 
   case class Signed(
       dlcId: Sha256Digest,
+      label: String,
       isInitiator: Boolean,
       tempContractId: Sha256Digest,
       contractId: ByteVector,
@@ -109,6 +113,7 @@ object DLCStatus {
 
   case class Broadcasted(
       dlcId: Sha256Digest,
+      label: String,
       isInitiator: Boolean,
       tempContractId: Sha256Digest,
       contractId: ByteVector,
@@ -124,6 +129,7 @@ object DLCStatus {
 
   case class Confirmed(
       dlcId: Sha256Digest,
+      label: String,
       isInitiator: Boolean,
       tempContractId: Sha256Digest,
       contractId: ByteVector,
@@ -139,6 +145,7 @@ object DLCStatus {
 
   case class Claimed(
       dlcId: Sha256Digest,
+      label: String,
       isInitiator: Boolean,
       tempContractId: Sha256Digest,
       contractId: ByteVector,
@@ -159,6 +166,7 @@ object DLCStatus {
 
   case class RemoteClaimed(
       dlcId: Sha256Digest,
+      label: String,
       isInitiator: Boolean,
       tempContractId: Sha256Digest,
       contractId: ByteVector,
@@ -180,6 +188,7 @@ object DLCStatus {
 
   case class Refunded(
       dlcId: Sha256Digest,
+      label: String,
       isInitiator: Boolean,
       tempContractId: Sha256Digest,
       contractId: ByteVector,

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -82,13 +82,13 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
     val result = dlcDbManagement.migrate()
     dlcAppConfig.driver match {
       case SQLite =>
-        val expected = 2
+        val expected = 3
         assert(result == expected)
         val flywayInfo = dlcAppConfig.info()
         assert(flywayInfo.applied().length == expected)
         assert(flywayInfo.pending().length == 0)
       case PostgreSQL =>
-        val expected = 2
+        val expected = 3
         assert(result == expected)
         val flywayInfo = dlcAppConfig.info()
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -362,7 +362,8 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
 
     //helper method to make an offer
     def makeOffer(): Future[DLCOffer] = {
-      walletA.createDLCOffer(contractInfoTLV = contractInfo,
+      walletA.createDLCOffer(label = "test",
+                             contractInfoTLV = contractInfo,
                              collateral = totalCollateral,
                              feeRateOpt = feeRateOpt,
                              locktime = UInt32.zero,
@@ -402,7 +403,8 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
                                    expectedOutputs = 1)
         _ = assert(result)
 
-        _ <- walletA.createDLCOffer(status.contractInfo,
+        _ <- walletA.createDLCOffer("test",
+                                    status.contractInfo,
                                     status.localCollateral.satoshis,
                                     None,
                                     UInt32.zero,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
@@ -45,7 +45,8 @@ class MultiWalletDLCTest extends BitcoinSWalletTest {
 
       _ = assert(accountA.xpub != accountB.xpub)
 
-      _ <- walletA.createDLCOffer(sampleContractInfo,
+      _ <- walletA.createDLCOffer("test",
+                                  sampleContractInfo,
                                   half,
                                   Some(SatoshisPerVirtualByte.one),
                                   UInt32.zero,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -34,11 +34,12 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
     for {
       offer <- walletA.createDLCOffer(
-        offerData.contractInfo,
-        offerData.totalCollateral,
-        Some(offerData.feeRate),
-        offerData.timeouts.contractMaturity.toUInt32,
-        offerData.timeouts.contractTimeout.toUInt32
+        label = "test",
+        contractInfo = offerData.contractInfo,
+        collateral = offerData.totalCollateral,
+        feeRateOpt = Some(offerData.feeRate),
+        locktime = offerData.timeouts.contractMaturity.toUInt32,
+        refundLocktime = offerData.timeouts.contractTimeout.toUInt32
       )
       dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))
       dlcA1Opt <- walletA.dlcDAO.read(dlcId)
@@ -55,7 +56,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         assert(offer.changeAddress.value.nonEmpty)
       }
 
-      accept <- walletB.acceptDLCOffer(offer)
+      accept <- walletB.acceptDLCOffer(label = "test", offer = offer)
       dlcB1Opt <- walletB.dlcDAO.read(dlcId)
       _ = {
         assert(dlcB1Opt.isDefined)
@@ -145,11 +146,12 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
       for {
         offer <- walletA.createDLCOffer(
-          offerData.contractInfo.toTLV,
-          offerData.totalCollateral,
-          Some(offerData.feeRate),
-          offerData.timeouts.contractMaturity.toUInt32,
-          offerData.timeouts.contractTimeout.toUInt32
+          label = "test",
+          contractInfoTLV = offerData.contractInfo.toTLV,
+          collateral = offerData.totalCollateral,
+          feeRateOpt = Some(offerData.feeRate),
+          locktime = offerData.timeouts.contractMaturity.toUInt32,
+          refundLT = offerData.timeouts.contractTimeout.toUInt32
         )
         dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))
         dlcA1Opt <- walletA.dlcDAO.read(dlcId)
@@ -165,7 +167,8 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
           assert(offer.changeAddress.value.nonEmpty)
         }
 
-        accept <- walletB.acceptDLCOffer(offer.toTLV)
+        accept <- walletB.acceptDLCOffer(label = "test",
+                                         dlcOfferTLV = offer.toTLV)
         dlcB1Opt <- walletB.dlcDAO.read(dlcId)
         _ = {
           assert(dlcB1Opt.isDefined)
@@ -239,6 +242,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       offerData: DLCOffer = DLCWalletUtil.sampleDLCOffer): Future[DLCAccept] = {
     for {
       offer <- walletA.createDLCOffer(
+        "test",
         offerData.contractInfo,
         offerData.totalCollateral,
         Some(offerData.feeRate),
@@ -246,7 +250,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         offerData.timeouts.contractTimeout.toUInt32
       )
 
-      accept <- walletB.acceptDLCOffer(offer)
+      accept <- walletB.acceptDLCOffer("test", offer)
     } yield accept
   }
 
@@ -379,6 +383,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         _ = assert(oldReserved.isEmpty)
 
         offer <- walletA.createDLCOffer(
+          "test",
           offerData.contractInfo,
           offerData.totalCollateral,
           Some(offerData.feeRate),
@@ -422,13 +427,14 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         _ = assert(oldReserved.isEmpty)
 
         offer <- walletA.createDLCOffer(
+          "test",
           offerData.contractInfo,
           offerData.totalCollateral,
           Some(offerData.feeRate),
           offerData.timeouts.contractMaturity.toUInt32,
           offerData.timeouts.contractTimeout.toUInt32
         )
-        _ <- walletB.acceptDLCOffer(offer)
+        _ <- walletB.acceptDLCOffer("test", offer)
 
         dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))
 
@@ -463,13 +469,14 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         _ = assert(oldReservedB.isEmpty)
 
         offer <- walletA.createDLCOffer(
+          "test",
           offerData.contractInfo,
           offerData.totalCollateral,
           Some(offerData.feeRate),
           offerData.timeouts.contractMaturity.toUInt32,
           offerData.timeouts.contractTimeout.toUInt32
         )
-        accept <- walletB.acceptDLCOffer(offer)
+        accept <- walletB.acceptDLCOffer("test", offer)
         sign <- walletA.signDLC(accept)
         _ <- walletB.addDLCSigs(sign)
 
@@ -505,13 +512,14 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
       for {
         offer <- walletA.createDLCOffer(
+          "test",
           offerData.contractInfo,
           offerData.totalCollateral,
           Some(offerData.feeRate),
           offerData.timeouts.contractMaturity.toUInt32,
           offerData.timeouts.contractTimeout.toUInt32
         )
-        accept <- walletB.acceptDLCOffer(offer)
+        accept <- walletB.acceptDLCOffer("test", offer)
         sign <- walletA.signDLC(accept)
         _ <- walletB.addDLCSigs(sign)
 
@@ -538,13 +546,14 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
       for {
         offer <- walletA.createDLCOffer(
+          "test",
           offerData.contractInfo,
           offerData.totalCollateral,
           Some(offerData.feeRate),
           offerData.timeouts.contractMaturity.toUInt32,
           UInt32.max
         )
-        accept <- walletB.acceptDLCOffer(offer)
+        accept <- walletB.acceptDLCOffer("test", offer)
         sign <- walletA.signDLC(accept)
         _ <- walletB.addDLCSigs(sign)
 
@@ -602,6 +611,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
       for {
         offer <- walletA.createDLCOffer(
+          "test",
           offerData.contractInfo,
           offerData.totalCollateral,
           Some(offerData.feeRate),
@@ -620,7 +630,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
         dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))
 
-        accept <- walletB.acceptDLCOffer(offer)
+        accept <- walletB.acceptDLCOffer("test", offer)
         _ = {
           assert(accept.fundingInputs.nonEmpty)
           assert(
@@ -695,7 +705,8 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
     val totalCollateral = Satoshis(5000)
 
     def makeOffer(contractInfo: ContractInfoV0TLV): Future[DLCOffer] = {
-      walletA.createDLCOffer(contractInfoTLV = contractInfo,
+      walletA.createDLCOffer(label = "test",
+                             contractInfoTLV = contractInfo,
                              collateral = totalCollateral,
                              feeRateOpt = feeRateOpt,
                              locktime = UInt32.zero,
@@ -706,8 +717,8 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       offerA <- makeOffer(contractInfoA)
       offerB <- makeOffer(contractInfoB)
 
-      _ <- walletB.acceptDLCOffer(offerA)
-      _ <- walletB.acceptDLCOffer(offerB)
+      _ <- walletB.acceptDLCOffer("testA", offerA)
+      _ <- walletB.acceptDLCOffer("testB", offerB)
     } yield succeed
   }
 

--- a/dlc-wallet/src/main/resources/postgresql/dlc/migration/V3__add_label_column.sql
+++ b/dlc-wallet/src/main/resources/postgresql/dlc/migration/V3__add_label_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "global_dlc_data"
+    ADD COLUMN "label" TEXT NOT NULL DEFAULT '';

--- a/dlc-wallet/src/main/resources/postgresql/dlc/migration/V4__add_label_column.sql
+++ b/dlc-wallet/src/main/resources/postgresql/dlc/migration/V4__add_label_column.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "global_dlc_data"
-    ADD COLUMN "label" TEXT NOT NULL DEFAULT "";

--- a/dlc-wallet/src/main/resources/postgresql/dlc/migration/V4__add_label_column.sql
+++ b/dlc-wallet/src/main/resources/postgresql/dlc/migration/V4__add_label_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "global_dlc_data"
+    ADD COLUMN "label" TEXT NOT NULL DEFAULT "";

--- a/dlc-wallet/src/main/resources/sqlite/dlc/migration/V4__add_label_column.sql
+++ b/dlc-wallet/src/main/resources/sqlite/dlc/migration/V4__add_label_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "global_dlc_data"
+    ADD COLUMN "label" VARCHAR(254) NOT NULL DEFAULT "";

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -284,6 +284,7 @@ abstract class DLCWallet
     * This is the first step of the initiator
     */
   override def createDLCOffer(
+      label: String,
       contractInfo: ContractInfo,
       collateral: Satoshis,
       feeRateOpt: Option[SatoshisPerVirtualByte],
@@ -388,6 +389,7 @@ abstract class DLCWallet
 
       dlcDb = DLCDb(
         dlcId = dlcId,
+        label = label,
         tempContractId = offer.tempContractId,
         contractIdOpt = None,
         protocolVersion = 0,
@@ -440,7 +442,9 @@ abstract class DLCWallet
     } yield offer
   }
 
-  private def initDLCForAccept(offer: DLCOffer): Future[(DLCDb, AccountDb)] = {
+  private def initDLCForAccept(
+      label: String,
+      offer: DLCOffer): Future[(DLCDb, AccountDb)] = {
     logger.info(
       s"Initializing DLC from received offer with tempContractId ${offer.tempContractId.hex}")
     dlcDAO.findByTempContractId(offer.tempContractId).flatMap {
@@ -469,6 +473,7 @@ abstract class DLCWallet
           dlc =
             DLCDb(
               dlcId = dlcId,
+              label = label,
               tempContractId = offer.tempContractId,
               contractIdOpt = None,
               protocolVersion = 0,
@@ -541,7 +546,9 @@ abstract class DLCWallet
     *
     * This is the first step of the recipient
     */
-  override def acceptDLCOffer(offer: DLCOffer): Future[DLCAccept] = {
+  override def acceptDLCOffer(
+      label: String,
+      offer: DLCOffer): Future[DLCAccept] = {
     logger.debug("Calculating relevant wallet data for DLC Accept")
 
     val dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))
@@ -550,7 +557,7 @@ abstract class DLCWallet
 
     logger.debug(s"Checking if Accept (${dlcId.hex}) has already been made")
     for {
-      (dlc, account) <- initDLCForAccept(offer)
+      (dlc, account) <- initDLCForAccept(label, offer)
       dlcAcceptDbOpt <- dlcAcceptDAO.findByDLCId(dlcId)
       dlcAccept <- dlcAcceptDbOpt match {
         case Some(dlcAcceptDb) =>

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWalletApi.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWalletApi.scala
@@ -26,37 +26,36 @@ import scala.concurrent.Future
 trait DLCWalletApi { self: WalletApi =>
 
   def createDLCOffer(
+      label: String,
       contractInfoTLV: ContractInfoV0TLV,
       collateral: Satoshis,
       feeRateOpt: Option[SatoshisPerVirtualByte],
       locktime: UInt32,
       refundLT: UInt32): Future[DLCOffer] = {
     val contractInfo = ContractInfo.fromTLV(contractInfoTLV)
-    createDLCOffer(contractInfo, collateral, feeRateOpt, locktime, refundLT)
+    createDLCOffer(label,
+                   contractInfo,
+                   collateral,
+                   feeRateOpt,
+                   locktime,
+                   refundLT)
   }
 
   def createDLCOffer(
+      label: String,
       contractInfo: ContractInfo,
       collateral: Satoshis,
       feeRateOpt: Option[SatoshisPerVirtualByte],
       locktime: UInt32,
       refundLT: UInt32): Future[DLCOffer]
 
-  def registerDLCOffer(dlcOffer: DLCOffer): Future[DLCOffer] = {
-    createDLCOffer(
-      dlcOffer.contractInfo,
-      dlcOffer.totalCollateral,
-      Some(dlcOffer.feeRate),
-      dlcOffer.timeouts.contractMaturity.toUInt32,
-      dlcOffer.timeouts.contractTimeout.toUInt32
-    )
+  def acceptDLCOffer(
+      label: String,
+      dlcOfferTLV: DLCOfferTLV): Future[DLCAccept] = {
+    acceptDLCOffer(label, DLCOffer.fromTLV(dlcOfferTLV))
   }
 
-  def acceptDLCOffer(dlcOfferTLV: DLCOfferTLV): Future[DLCAccept] = {
-    acceptDLCOffer(DLCOffer.fromTLV(dlcOfferTLV))
-  }
-
-  def acceptDLCOffer(dlcOffer: DLCOffer): Future[DLCAccept]
+  def acceptDLCOffer(label: String, dlcOffer: DLCOffer): Future[DLCAccept]
 
   def signDLC(acceptTLV: DLCAcceptTLV): Future[DLCSign]
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
@@ -117,6 +117,8 @@ case class DLCDAO()(implicit
 
     def dlcId: Rep[Sha256Digest] = column("dlc_id", O.PrimaryKey)
 
+    def label: Rep[String] = column("label")
+
     def tempContractId: Rep[Sha256Digest] =
       column("temp_contract_id", O.Unique)
 
@@ -153,6 +155,7 @@ case class DLCDAO()(implicit
 
     def * : ProvenShape[DLCDb] =
       (dlcId,
+       label,
        tempContractId,
        contractId,
        protocolVersion,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDb.scala
@@ -13,6 +13,7 @@ import scodec.bits.ByteVector
   */
 case class DLCDb(
     dlcId: Sha256Digest,
+    label: String,
     tempContractId: Sha256Digest,
     contractIdOpt: Option[ByteVector],
     protocolVersion: Int,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCStatusBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCStatusBuilder.scala
@@ -36,6 +36,7 @@ object DLCStatusBuilder {
       case DLCState.Offered =>
         Offered(
           dlcId,
+          dlcDb.label,
           dlcDb.isInitiator,
           dlcDb.tempContractId,
           contractInfo,
@@ -47,6 +48,7 @@ object DLCStatusBuilder {
       case DLCState.Accepted =>
         Accepted(
           dlcId,
+          dlcDb.label,
           dlcDb.isInitiator,
           dlcDb.tempContractId,
           dlcDb.contractIdOpt.get,
@@ -59,6 +61,7 @@ object DLCStatusBuilder {
       case DLCState.Signed =>
         Signed(
           dlcId,
+          dlcDb.label,
           dlcDb.isInitiator,
           dlcDb.tempContractId,
           dlcDb.contractIdOpt.get,
@@ -71,6 +74,7 @@ object DLCStatusBuilder {
       case DLCState.Broadcasted =>
         Broadcasted(
           dlcId,
+          dlcDb.label,
           dlcDb.isInitiator,
           dlcDb.tempContractId,
           dlcDb.contractIdOpt.get,
@@ -84,6 +88,7 @@ object DLCStatusBuilder {
       case DLCState.Confirmed =>
         Confirmed(
           dlcId,
+          dlcDb.label,
           dlcDb.isInitiator,
           dlcDb.tempContractId,
           dlcDb.contractIdOpt.get,
@@ -131,6 +136,7 @@ object DLCStatusBuilder {
         //no oracle information in the refund case
         val refund = Refunded(
           dlcId,
+          dlcDb.label,
           dlcDb.isInitiator,
           dlcDb.tempContractId,
           dlcDb.contractIdOpt.get,
@@ -155,6 +161,7 @@ object DLCStatusBuilder {
           case DLCState.Claimed =>
             Claimed(
               dlcId,
+              dlcDb.label,
               dlcDb.isInitiator,
               dlcDb.tempContractId,
               dlcDb.contractIdOpt.get,
@@ -173,6 +180,7 @@ object DLCStatusBuilder {
           case DLCState.RemoteClaimed =>
             RemoteClaimed(
               dlcId,
+              dlcDb.label,
               dlcDb.isInitiator,
               dlcDb.tempContractId,
               dlcDb.contractIdOpt.get,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -201,6 +201,7 @@ object DLCWalletUtil extends Logging {
   lazy val sampleDLCDb: DLCDb = DLCDb(
     dlcId = Sha256Digest(
       "9da9922b9067007f8d9c56c37f202a568f0cdb104e5ef9752ad6cbc1834f0334"),
+    label = "sample",
     tempContractId = sampleDLCOffer.tempContractId,
     contractIdOpt = None,
     protocolVersion = 0,
@@ -237,13 +238,14 @@ object DLCWalletUtil extends Logging {
 
     for {
       offer <- walletA.createDLCOffer(
+        label = "test",
         contractInfo = contractInfo,
         collateral = half,
         feeRateOpt = Some(SatoshisPerVirtualByte.fromLong(10)),
         locktime = dummyTimeouts.contractMaturity.toUInt32,
         refundLocktime = dummyTimeouts.contractTimeout.toUInt32
       )
-      accept <- walletB.acceptDLCOffer(offer)
+      accept <- walletB.acceptDLCOffer(label = "test", offer = offer)
       sigs <- walletA.signDLC(accept)
       _ <- walletB.addDLCSigs(sigs)
 


### PR DESCRIPTION
Closes #3374

Adds the ability to add a label to a DLC so the user can better identify what the contract is.