### PR TITLE
Allow accepting multi oracle announcements

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
@@ -53,8 +53,10 @@ class AcceptOfferDialog {
       val (oracleKey, eventId) = offer.contractInfo.oracleInfo match {
         case OracleInfoV0TLV(announcement) =>
           (announcement.publicKey.hex, announcement.eventTLV.eventId)
-        case _: MultiOracleInfoTLV =>
-          throw new RuntimeException("This is impossible.")
+        case multi: MultiOracleInfoTLV =>
+          // todo display all oracles
+          val announcement = multi.oracles.head
+          (announcement.publicKey.hex, announcement.eventTLV.eventId)
       }
 
       gridPane.add(new Label("Event Id"), 0, nextRow)


### PR DESCRIPTION
Technially we allowed for creating multi oracle offers if you input a contract info so we should do the same for the accept flow

https://github.com/bitcoin-s/bitcoin-s/blob/253f7444c6e61131bd840b48d6e901646ce1e2eb/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala#L324