### PR TITLE
Add ability to configure postgres database backends for test cases 

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -164,6 +164,13 @@ bitcoin-s {
       name = testdb
     }
   }
+
+  testkit {
+    pg {
+      #enabled postgres backend database for all test cases
+      enabled = false
+    }
+  }
 }
 
 akka {

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -277,6 +277,13 @@ bitcoin-s {
           path = ${bitcoin-s.datadir}/oracle/
         }
     }
+    
+    testkit {
+      pg {
+        #enabled postgres backend database for all test cases
+        enabled = false
+      }
+    }
 }
 
 

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -142,6 +142,13 @@ bitcoin-s {
             password = ""
         }
     }
+
+    testkit {
+        pg {
+            #enabled postgres backend database for all test cases
+            enabled = false
+        }
+    }
 }
 
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
@@ -1,11 +1,24 @@
 package org.bitcoins.testkit
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
+import com.typesafe.config.ConfigFactory
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
 trait EmbeddedPg extends BeforeAndAfterAll { this: Suite =>
 
-  lazy val pgEnabled: Boolean = sys.env.contains("PG_ENABLED")
+  lazy val pgEnabled: Boolean = {
+    val config = ConfigFactory.load()
+    val isEnv = sys.env.contains("PG_ENABLED")
+    val isConfig = {
+      if (config.hasPath("bitcoin-s.testkit.pg.enabled")) {
+        config.getBoolean("bitcoin-s.testkit.pg.enabled")
+      } else {
+        false
+      }
+    }
+    val isPgEnabled = isEnv || isConfig
+    isPgEnabled
+  }
 
   lazy val pg: Option[EmbeddedPostgres] = {
 


### PR DESCRIPTION
fixes #3418

This adds a new configuration setting called 

>bitcoin-s.testkit.pg.enabled

The idea is to allow library developers to set this setting in their `reference.conf` rather than having to configure their developement environment to _always_ have `PG_ENABLED` set for projects that don't every use sqlite as a database backend. This is something that I need on the oracle explorer to completed the suredbits oracle bot.

There are some limitations to this approach, namely it doesn't allow for this [setting to be set at runtime like we do with other configurations options](https://github.com/bitcoin-s/bitcoin-s/blob/8b663d91b647e8e22e4ee1a4f6cd976b00c6a766/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala#L142). I don't think this is a big deal as this is strictly for developers testing and not meant to be used in prod.