### PR TITLE
Fix bug where we couldn't execute a DLC twice

### DIFF
--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -217,6 +217,18 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
     }
   }
 
+  it must "execute a DLC twice and get the same transaction" in { wallets =>
+    val wallet = wallets._1.wallet
+    for {
+      contractId <- getContractId(wallet)
+      status <- getDLCStatus(wallet)
+      (sig, _) = getSigs(status.contractInfo)
+
+      tx1 <- wallet.executeDLC(contractId, sig)
+      tx2 <- wallet.executeDLC(contractId, sig)
+    } yield assert(tx1 == tx2)
+  }
+
   it must "execute a losing dlc" in { wallets =>
     val dlcA = wallets._1.wallet
 


### PR DESCRIPTION
This should fix a bug that a user expierenced where they couldn't execute a DLC twice even with the same oracle sigs.