### PR TITLE
Add nonces to error message for easier debugging

### DIFF
--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -295,8 +295,10 @@ class DLCOracle(private[this] val extPrivateKey: ExtPrivateKeyHardened)(implicit
       sigVersion = eventDb.signingVersion
 
       kVal = getKValue(rValDb, sigVersion)
-      _ = require(kVal.schnorrNonce == rValDb.nonce,
-                  "The nonce from derived seed did not match database")
+      _ = require(
+        kVal.schnorrNonce == rValDb.nonce,
+        s"The nonce from derived seed did not match database, db=${rValDb.nonce} derived=${kVal.schnorrNonce}, rValDb=$rValDb"
+      )
 
       hashBytes = eventOutcomeDb.hashedMessage
       sig = signingKey.schnorrSignWithNonce(hashBytes, kVal)

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -297,7 +297,7 @@ class DLCOracle(private[this] val extPrivateKey: ExtPrivateKeyHardened)(implicit
       kVal = getKValue(rValDb, sigVersion)
       _ = require(
         kVal.schnorrNonce == rValDb.nonce,
-        s"The nonce from derived seed did not match database, db=${rValDb.nonce} derived=${kVal.schnorrNonce}, rValDb=$rValDb"
+        s"The nonce from derived seed did not match database, db=${rValDb.nonce.hex} derived=${kVal.schnorrNonce.hex}, rValDb=$rValDb"
       )
 
       hashBytes = eventOutcomeDb.hashedMessage


### PR DESCRIPTION
I'm running into this issue on the sb oracle bot, and wanted to add some useful information to the invariant error message.

This needs to be reviewed to make sure i'm not leaking sensitive information in the case that an error is thrown via the logs.