### PR TITLE
Use AtomicInteger for keyIndex in DLCOracle

### DIFF
--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -174,6 +174,37 @@ class DLCOracleTest extends DLCOracleFixture {
       }
   }
 
+  it must "create two events and use incrementing key indexes" in {
+    dlcOracle: DLCOracle =>
+      val create1F = dlcOracle.createNewDigitDecompEvent(eventName = "test1",
+                                                         maturationTime =
+                                                           futureTime,
+                                                         base = UInt16(10),
+                                                         isSigned = false,
+                                                         numDigits = 3,
+                                                         unit = "units",
+                                                         precision = Int32.zero)
+
+      val create2F = dlcOracle.createNewDigitDecompEvent(eventName = "test2",
+                                                         maturationTime =
+                                                           futureTime,
+                                                         base = UInt16(10),
+                                                         isSigned = false,
+                                                         numDigits = 3,
+                                                         unit = "units",
+                                                         precision = Int32.zero)
+
+      for {
+        _ <- create1F
+        _ <- create2F
+
+        rValDbs <- dlcOracle.rValueDAO.findAll()
+      } yield {
+        val indexes = rValDbs.map(_.keyIndex).sorted
+        assert(indexes == Vector(0, 1, 2, 3, 4, 5))
+      }
+  }
+
   it must "fail to create an event with the same name" in {
     dlcOracle: DLCOracle =>
       for {

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -72,10 +72,11 @@ class DLCOracle(private[this] val extPrivateKey: ExtPrivateKeyHardened)(implicit
   protected[bitcoins] val eventDAO: EventDAO = EventDAO()
   protected[bitcoins] val eventOutcomeDAO: EventOutcomeDAO = EventOutcomeDAO()
 
-  lazy val nextKeyIndexF: Future[AtomicInteger] = rValueDAO.maxKeyIndex.map {
-    case Some(idx) => new AtomicInteger(idx + 1)
-    case None      => new AtomicInteger(0)
-  }
+  private lazy val nextKeyIndexF: Future[AtomicInteger] =
+    rValueDAO.maxKeyIndex.map {
+      case Some(idx) => new AtomicInteger(idx + 1)
+      case None      => new AtomicInteger(0)
+    }
 
   private def getPath(keyIndex: Int): BIP32Path = {
     val accountIndex = rValAccount.index


### PR DESCRIPTION
Fixes #3428

This should give us safety for concurrency when using the DLC Oracle