### PR TITLE
Disallow signing your own DLCAccept

### DIFF
--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -723,4 +723,24 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
     } yield succeed
   }
 
+  it must "not be able to sign its own accept" in { wallets =>
+    val walletA = wallets._1.wallet
+    val walletB = wallets._2.wallet
+
+    val offerData: DLCOffer = DLCWalletUtil.sampleDLCOffer
+
+    for {
+      offer <- walletA.createDLCOffer(
+        offerData.contractInfo,
+        offerData.totalCollateral,
+        Some(offerData.feeRate),
+        offerData.timeouts.contractMaturity.toUInt32,
+        UInt32.max
+      )
+      accept <- walletB.acceptDLCOffer(offer)
+      res <- recoverToSucceededIf[IllegalArgumentException](
+        walletB.signDLC(accept))
+    } yield res
+  }
+
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -749,7 +749,8 @@ abstract class DLCWallet
       dlcDbOpt <- dlcDAO.findByTempContractId(accept.tempContractId)
       (dlcDb, acceptDbOpt) <- dlcDbOpt match {
         case Some(db) =>
-          require(db.isInitiator, "Cannot call DLC Sign on our own DLC Accept message")
+          require(db.isInitiator,
+                  "Cannot call DLC Sign on our own DLC Accept message")
           dlcAcceptDAO
             .findByDLCId(db.dlcId)
             .map(acceptDbOpt => (db, acceptDbOpt))

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -749,6 +749,7 @@ abstract class DLCWallet
       dlcDbOpt <- dlcDAO.findByTempContractId(accept.tempContractId)
       (dlcDb, acceptDbOpt) <- dlcDbOpt match {
         case Some(db) =>
+          require(db.isInitiator, "Cannot call DLC Sign on our own DLC Accept message")
           dlcAcceptDAO
             .findByDLCId(db.dlcId)
             .map(acceptDbOpt => (db, acceptDbOpt))


### PR DESCRIPTION
Found while working on #3402

We would not throw an immediate error if we were to sign our own DLC Accept message.