### PR TITLE
Dialogs to CliCommandProducers with buildView(), common fileChooser

### DIFF
--- a/app/gui/src/main/resources/themes/dark-theme.css
+++ b/app/gui/src/main/resources/themes/dark-theme.css
@@ -21,6 +21,9 @@
 .label {
     -fx-text-fill: white;
 }
+.error-label {
+    -fx-text-fill: red;
+}
 
 .titulo{
     -fx-font-weight: bold;

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -3,18 +3,12 @@ package org.bitcoins.gui.dlc
 import javafx.event.{ActionEvent, EventHandler}
 import org.bitcoins.core.protocol.dlc.models.DLCStatus
 import org.bitcoins.gui.TaskRunner
+import org.bitcoins.gui.util.GUIUtil
 import scalafx.geometry.{Insets, Pos}
 import scalafx.scene.control._
 import scalafx.scene.layout._
-import scalafx.stage.FileChooser
-import scalafx.stage.FileChooser.ExtensionFilter
 
-import java.awt.Toolkit.getDefaultToolkit
-import java.awt.datatransfer.StringSelection
-import java.io.File
-import java.nio.file.Files
 import scala.concurrent.ExecutionContext
-import scala.util.Properties
 
 class DLCPane(glassPane: VBox)(implicit ec: ExecutionContext) {
 
@@ -117,28 +111,13 @@ class DLCPane(glassPane: VBox)(implicit ec: ExecutionContext) {
 
   val exportResultButton: Button = new Button("Export Result") {
     onAction = _ => {
-      val txtExtensionFilter = new ExtensionFilter("Text Files", "*.txt")
-      val allExtensionFilter = new ExtensionFilter("All Files", "*")
-      val fileChooser = new FileChooser() {
-        extensionFilters.addAll(txtExtensionFilter, allExtensionFilter)
-        selectedExtensionFilter = txtExtensionFilter
-        initialDirectory = new File(Properties.userHome)
-      }
-      val chosenFileOpt = Option(fileChooser.showSaveDialog(null))
-      chosenFileOpt match {
-        case Some(chosenFile) =>
-          Files.write(chosenFile.toPath, resultTextArea.text.value.getBytes)
-          ()
-        case None => // User canceled in dialog
-      }
+      GUIUtil.showSaveDialog(resultTextArea.text.value, "Result")
     }
   }
 
   val copyResultButton: Button = new Button("Copy Result") {
     onAction = _ => {
-      val clipboard = getDefaultToolkit.getSystemClipboard
-      val sel = new StringSelection(resultTextArea.text.value)
-      clipboard.setContents(sel, sel)
+      GUIUtil.setStringToClipboard(resultTextArea.text.value)
     }
   }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -111,7 +111,7 @@ class DLCPane(glassPane: VBox)(implicit ec: ExecutionContext) {
 
   val exportResultButton: Button = new Button("Export Result") {
     onAction = _ => {
-      GUIUtil.showSaveDialog(resultTextArea.text.value, "Result")
+      GUIUtil.showSaveDialog("Result", Some(resultTextArea.text.value), None)
     }
   }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
@@ -6,19 +6,14 @@ import org.bitcoins.core.protocol.dlc.models.DLCStatus._
 import org.bitcoins.core.protocol.dlc.models._
 import org.bitcoins.gui.{GUI, GlobalData}
 import org.bitcoins.gui.util.GUIUtil
-import scalafx.beans.property.StringProperty
-import scalafx.geometry.Insets
+import scalafx.beans.property.{StringProperty}
 import scalafx.scene.control.TableColumn.SortType
 import scalafx.scene.control.TableView.TableViewFocusModel
 import scalafx.scene.control.{ContextMenu, MenuItem, TableColumn, TableView}
 
-import java.awt.Toolkit.getDefaultToolkit
-import java.awt.datatransfer.StringSelection
-
 class DLCTableView(model: DLCPaneModel) {
 
   val tableView: TableView[DLCStatus] = {
-
     val eventIdCol = new TableColumn[DLCStatus, String] {
       text = "Event Id"
       prefWidth = 160
@@ -154,10 +149,7 @@ class DLCTableView(model: DLCPaneModel) {
           val dlc = selectionModel.value.getSelectedItem
           getContractId(dlc).foreach { id =>
             GlobalDLCData.lastContractId = id.toHex
-
-            val clipboard = getDefaultToolkit.getSystemClipboard
-            val sel = new StringSelection(id.toHex)
-            clipboard.setContents(sel, sel)
+            GUIUtil.setStringToClipboard(id.toHex)
           }
         }
       }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
@@ -119,7 +119,7 @@ class DLCTableView(model: DLCPaneModel) {
                       collateralCol,
                       otherCollateralCol,
                       totalCollateralCol)
-      margin = Insets(10, 0, 10, 0)
+//      margin = Insets(10, 0, 10, 0)
       sortOrder.addAll(statusCol, eventIdCol, contractIdCol)
 
       val infoItem: MenuItem = new MenuItem("View DLC") {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
@@ -119,7 +119,6 @@ class DLCTableView(model: DLCPaneModel) {
                       collateralCol,
                       otherCollateralCol,
                       totalCollateralCol)
-//      margin = Insets(10, 0, 10, 0)
       sortOrder.addAll(statusCol, eventIdCol, contractIdCol)
 
       val infoItem: MenuItem = new MenuItem("View DLC") {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
@@ -23,12 +23,12 @@ class AcceptOfferDialog extends CliCommandProducer[AcceptDLCOffer] {
     AcceptDLCOffer(offer)
   }
 
-  private var dialog: Dialog[Option[AcceptDLCCliCommand]] = null
+  private var dialogOpt: Option[Dialog[Option[AcceptDLCCliCommand]]] = None
 
   def showAndWait(
       parentWindow: Window,
       hex: String = ""): Option[AcceptDLCCliCommand] = {
-    dialog = new Dialog[Option[AcceptDLCCliCommand]]() {
+    val dialog = new Dialog[Option[AcceptDLCCliCommand]]() {
       initOwner(parentWindow)
       title = "Accept DLC Offer"
       headerText = "Enter DLC Offer to accept"
@@ -48,7 +48,8 @@ class AcceptOfferDialog extends CliCommandProducer[AcceptDLCOffer] {
         Some(getCliCommand())
       } else None
 
-    val result = dialog.showAndWait()
+    dialogOpt = Some(dialog)
+    val result = dialogOpt.map(_.showAndWait())
 
     result match {
       case Some(Some(cmd: AcceptDLCCliCommand)) =>
@@ -242,8 +243,8 @@ class AcceptOfferDialog extends CliCommandProducer[AcceptDLCOffer] {
             dlcDetailsShown = true
             showOfferTerms(lnMessage.tlv)
             offerTLVTF.editable = false
-            if (dialog != null)
-              dialog.dialogPane().getScene.getWindow.sizeToScene()
+            if (dialogOpt.isDefined)
+              dialogOpt.get.dialogPane().getScene.getWindow.sizeToScene()
         }
       }
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
@@ -58,7 +58,7 @@ class AcceptOfferDialog extends CliCommandProducer[AcceptDLCOffer] {
     }
   }
 
-  lazy val offerTLVTF = new TextField {
+  private lazy val offerTLVTF = new TextField {
     minWidth = 300
   }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
@@ -15,9 +15,9 @@ import scalafx.stage.Window
 import scala.collection._
 import scala.util.{Failure, Success, Try}
 
-class AcceptOfferDialog extends CliCommandProducer {
+class AcceptOfferDialog extends CliCommandProducer[AcceptDLCOffer] {
 
-  def getCliCommand() = {
+  override def getCliCommand(): Some[AcceptDLCOffer] = {
     val offerHex = offerTLVTF.text.value
     val offer = LnMessageFactory(DLCOfferTLV).fromHex(offerHex)
     Some(AcceptDLCOffer(offer))

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
@@ -17,10 +17,10 @@ import scala.util.{Failure, Success, Try}
 
 class AcceptOfferDialog extends CliCommandProducer[AcceptDLCOffer] {
 
-  override def getCliCommand(): Some[AcceptDLCOffer] = {
+  override def getCliCommand(): AcceptDLCOffer = {
     val offerHex = offerTLVTF.text.value
     val offer = LnMessageFactory(DLCOfferTLV).fromHex(offerHex)
-    Some(AcceptDLCOffer(offer))
+    AcceptDLCOffer(offer)
   }
 
   private var dialog: Dialog[Option[AcceptDLCCliCommand]] = null
@@ -45,7 +45,7 @@ class AcceptOfferDialog extends CliCommandProducer[AcceptDLCOffer] {
     // When the OK button is clicked, convert the result to a CreateDLCOffer.
     dialog.resultConverter = dialogButton =>
       if (dialogButton == ButtonType.OK) {
-        getCliCommand()
+        Some(getCliCommand())
       } else None
 
     val result = dialog.showAndWait()

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
@@ -35,12 +35,12 @@ object BroadcastDLCDialog
     }
   }
 
-  var dialog: Dialog[Option[AddDLCSigsAndBroadcastCliCommand]] = null
+  var dialogOpt: Option[Dialog[Option[AddDLCSigsAndBroadcastCliCommand]]] = None
 
   def showAndWait(
       parentWindow: Window,
       hex: String = ""): Option[AddDLCSigsAndBroadcastCliCommand] = {
-    dialog = new Dialog[Option[AddDLCSigsAndBroadcastCliCommand]]() {
+    val dialog = new Dialog[Option[AddDLCSigsAndBroadcastCliCommand]]() {
       initOwner(parentWindow)
       title = "Add DLC Signatures"
       headerText = "Enter DLC signatures message"
@@ -68,7 +68,8 @@ object BroadcastDLCDialog
       res
     }
 
-    val result = dialog.showAndWait()
+    dialogOpt = Some(dialog)
+    val result = dialogOpt.map(_.showAndWait())
 
     result match {
       case Some(Some(cmd: AddDLCSigsAndBroadcastCliCommand)) =>
@@ -281,7 +282,8 @@ object BroadcastDLCDialog
           errorLabel.text = errMsg
           vbox.children.add(errorLabel)
       }
-      if (dialog != null) dialog.dialogPane().getScene.getWindow.sizeToScene()
+      if (dialogOpt.isDefined)
+        dialogOpt.get.dialogPane().getScene.getWindow.sizeToScene()
       ()
     }
 
@@ -299,8 +301,8 @@ object BroadcastDLCDialog
           logger.error(errMsg)
           errorLabel.text = errMsg
           vbox.children.add(errorLabel)
-          if (dialog != null)
-            dialog.dialogPane().getScene.getWindow.sizeToScene()
+          if (dialogOpt.isDefined)
+            dialogOpt.get.dialogPane().getScene.getWindow.sizeToScene()
         case Success(sign) =>
           showDetails(sign, isFromFile = true)
       }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
@@ -100,7 +100,7 @@ object BroadcastDLCDialog
 
     // TODO : Externalize error styling to CSS
     val errorLabel = new Label("") {
-      style = "-fx-text-fill: red"
+      styleClass = Seq("error-label")
     }
 
     val fromFileHBox = new HBox() {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
@@ -35,7 +35,8 @@ object BroadcastDLCDialog
     }
   }
 
-  var dialogOpt: Option[Dialog[Option[AddDLCSigsAndBroadcastCliCommand]]] = None
+  private var dialogOpt: Option[
+    Dialog[Option[AddDLCSigsAndBroadcastCliCommand]]] = None
 
   def showAndWait(
       parentWindow: Window,

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
@@ -24,14 +24,14 @@ object BroadcastDLCDialog
     extends Logging
     with CliCommandProducer[AddDLCSigsAndBroadcastCliCommand] {
 
-  override def getCliCommand(): Some[AddDLCSigsAndBroadcastCliCommand] = {
+  override def getCliCommand(): AddDLCSigsAndBroadcastCliCommand = {
     DLCDialog.signDLCFile match {
       case Some(file) =>
-        Some(AddDLCSigsAndBroadcastFromFile(file.toPath))
+        AddDLCSigsAndBroadcastFromFile(file.toPath)
       case None =>
         val hex = signTLVTF.text.value
         val signTLV = LnMessageFactory(DLCSignTLV)(hex)
-        Some(AddDLCSigsAndBroadcast(signTLV))
+        AddDLCSigsAndBroadcast(signTLV)
     }
   }
 
@@ -58,7 +58,7 @@ object BroadcastDLCDialog
     // When the OK button is clicked, convert the result to a SignDLC.
     dialog.resultConverter = dialogButton => {
       val res = if (dialogButton == ButtonType.OK) {
-        getCliCommand()
+        Some(getCliCommand())
       } else None
 
       // reset

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/BroadcastDLCDialog.scala
@@ -20,9 +20,11 @@ import java.nio.file.Files
 import scala.collection._
 import scala.util.{Failure, Success, Try}
 
-object BroadcastDLCDialog extends Logging with CliCommandProducer {
+object BroadcastDLCDialog
+    extends Logging
+    with CliCommandProducer[AddDLCSigsAndBroadcastCliCommand] {
 
-  def getCliCommand(): Some[AddDLCSigsAndBroadcastCliCommand] = {
+  override def getCliCommand(): Some[AddDLCSigsAndBroadcastCliCommand] = {
     DLCDialog.signDLCFile match {
       case Some(file) =>
         Some(AddDLCSigsAndBroadcastFromFile(file.toPath))

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CliCommandProducer.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CliCommandProducer.scala
@@ -1,0 +1,8 @@
+package org.bitcoins.gui.dlc.dialog
+
+import org.bitcoins.cli.CliCommand
+
+trait CliCommandProducer {
+  def getCliCommand(): Option[CliCommand]
+//  def buildView(params vary per dialog)
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CliCommandProducer.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CliCommandProducer.scala
@@ -2,7 +2,7 @@ package org.bitcoins.gui.dlc.dialog
 
 import org.bitcoins.cli.CliCommand
 
-trait CliCommandProducer {
-  def getCliCommand(): Option[CliCommand]
+trait CliCommandProducer[T <: CliCommand] {
+  def getCliCommand(): Option[T]
 //  def buildView(params vary per dialog)
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CliCommandProducer.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CliCommandProducer.scala
@@ -3,6 +3,6 @@ package org.bitcoins.gui.dlc.dialog
 import org.bitcoins.cli.CliCommand
 
 trait CliCommandProducer[T <: CliCommand] {
-  def getCliCommand(): Option[T]
+  def getCliCommand(): T
 //  def buildView(params vary per dialog)
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -44,7 +44,7 @@ class CreateDLCOfferDialog
     dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
     dialog.resizable = true
 
-    val vbox = buildView(hex, null, None)
+    val vbox = buildView(hex, None, None)
 
     dialog.dialogPane().content = new ScrollPane {
       content = vbox

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -22,9 +22,11 @@ import java.time.ZoneOffset
 import scala.collection._
 import scala.util.{Failure, Success, Try}
 
-class CreateDLCOfferDialog extends Logging with CliCommandProducer {
+class CreateDLCOfferDialog
+    extends Logging
+    with CliCommandProducer[CreateDLCOffer] {
 
-  def getCliCommand() = {
+  override def getCliCommand(): Some[CreateDLCOffer] = {
     createDLCOffer()
   }
 
@@ -503,7 +505,7 @@ class CreateDLCOfferDialog extends Logging with CliCommandProducer {
     }
   }
 
-  def createDLCOffer() = {
+  def createDLCOffer(): Some[CreateDLCOffer] = {
     val oracleInfo = getOracleInfo.get
 
     val collateralLong =

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -64,31 +64,34 @@ class CreateDLCOfferDialog
     }
   }
 
-  val fields: mutable.Map[Int, (TextField, TextField)] = mutable.Map.empty
+  private val fields: mutable.Map[Int, (TextField, TextField)] =
+    mutable.Map.empty
 
-  var announcementDetailsShown = false
-  lazy val announcementOrContractInfoTF = new TextField()
-  var decompOpt: Option[DigitDecompositionEventDescriptorV0TLV] = None
+  private var announcementDetailsShown = false
+  private lazy val announcementOrContractInfoTF = new TextField()
+  private var decompOpt: Option[DigitDecompositionEventDescriptorV0TLV] = None
 
-  val pointMap: scala.collection.mutable.Map[
+  private val pointMap: scala.collection.mutable.Map[
     Int,
     (TextField, TextField, CheckBox)] =
     scala.collection.mutable.Map.empty
 
-  val roundingMap: scala.collection.mutable.Map[Int, (TextField, TextField)] =
+  private val roundingMap: scala.collection.mutable.Map[
+    Int,
+    (TextField, TextField)] =
     scala.collection.mutable.Map.empty
 
-  lazy val feeRateTF = new TextField() {
+  private lazy val feeRateTF = new TextField() {
     text = GlobalData.feeRate.toLong.toString
     promptText = "(optional)"
   }
 
-  lazy val collateralTF = new TextField() {
+  private lazy val collateralTF = new TextField() {
     promptText = "Satoshis"
   }
   setNumericInput(collateralTF)
 
-  lazy val refundDatePicker = new DatePicker()
+  private lazy val refundDatePicker = new DatePicker()
 
   def buildView(
       announcementOpt: Option[OracleAnnouncementV0TLV],

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -35,28 +35,27 @@ class CreateDLCOfferDialog
   def showAndWait(
       parentWindow: Window,
       hex: String = ""): Option[CreateDLCOffer] = {
-    val newDialog = new Dialog[Option[CreateDLCOffer]]() {
+    val dialog = new Dialog[Option[CreateDLCOffer]]() {
       initOwner(parentWindow)
       title = "Create DLC Offer"
       headerText = "Enter DLC Contract Details"
     }
-    newDialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
-    newDialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
-    newDialog.resizable = true
+    dialog.dialogPane().buttonTypes = Seq(ButtonType.OK, ButtonType.Cancel)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+    dialog.resizable = true
 
     val vbox = buildView(hex, null, None)
 
-    newDialog.dialogPane().content = new ScrollPane {
+    dialog.dialogPane().content = new ScrollPane {
       content = vbox
     }
     // When the OK button is clicked, convert the result to a CreateDLCOffer.
-    newDialog.resultConverter = dialogButton =>
+    dialog.resultConverter = dialogButton =>
       if (dialogButton == ButtonType.OK) {
         Some(getCliCommand())
       } else None
 
-    dialogOpt = Some(newDialog)
-
+    dialogOpt = Some(dialog)
     val result = dialogOpt.map(_.showAndWait())
 
     result match {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -363,13 +363,6 @@ class CreateDLCOfferDialog extends Logging with CliCommandProducer {
                 }
             }
           case Success(announcement) =>
-            println("Announcement only case")
-            Try(ContractInfoV0TLV.fromHex(text)) match {
-              case Failure(_) =>
-                println("not ContractInfoV0TLV")
-              case Success(contractInfo) =>
-                println("found ContractInfoV0TLV" + contractInfo.oracleInfo)
-            }
             onAnnouncementEntered(announcement, None)
         }
       }
@@ -378,7 +371,6 @@ class CreateDLCOfferDialog extends Logging with CliCommandProducer {
     def onAnnouncementEntered(
         announcement: OracleAnnouncementV0TLV,
         contractInfoOpt: Option[ContractInfoV0TLV]): Unit = {
-      println("onAnnouncementEntered contractInfoOpt:" + contractInfoOpt)
       announcementDetailsShown = true
       announcementOrContractInfoTF.disable = true
       gridPane.add(new Label("Event Id"), 0, 1)

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -26,7 +26,7 @@ class CreateDLCOfferDialog
     extends Logging
     with CliCommandProducer[CreateDLCOffer] {
 
-  override def getCliCommand(): Some[CreateDLCOffer] = {
+  override def getCliCommand(): CreateDLCOffer = {
     createDLCOffer()
   }
 
@@ -54,7 +54,7 @@ class CreateDLCOfferDialog
     // When the OK button is clicked, convert the result to a CreateDLCOffer.
     dialog.resultConverter = dialogButton =>
       if (dialogButton == ButtonType.OK) {
-        getCliCommand()
+        Some(getCliCommand())
       } else None
 
     val result = dialog.showAndWait()
@@ -505,7 +505,7 @@ class CreateDLCOfferDialog
     }
   }
 
-  def createDLCOffer(): Some[CreateDLCOffer] = {
+  def createDLCOffer(): CreateDLCOffer = {
     val oracleInfo = getOracleInfo.get
 
     val collateralLong =
@@ -557,14 +557,13 @@ class CreateDLCOfferDialog
         ContractInfo(totalCol, numeric, oracleInfo).toTLV
     }
 
-    Some(
-      CreateDLCOffer(
-        contractInfo = contractInfo,
-        collateral = collateral,
-        feeRateOpt = feeRateOpt,
-        locktime = UInt32.zero,
-        refundLT = refundLocktime
-      ))
+    CreateDLCOffer(
+      contractInfo = contractInfo,
+      collateral = collateral,
+      feeRateOpt = feeRateOpt,
+      locktime = UInt32.zero,
+      refundLT = refundLocktime
+    )
   }
 }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -44,7 +44,7 @@ class CreateDLCOfferDialog
     dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
     dialog.resizable = true
 
-    val vbox = buildView(hex, None, None)
+    val vbox = buildView(None, None, hex)
 
     dialog.dialogPane().content = new ScrollPane {
       content = vbox
@@ -91,9 +91,9 @@ class CreateDLCOfferDialog
   lazy val refundDatePicker = new DatePicker()
 
   def buildView(
-      initialContract: String = "",
       announcementOpt: Option[OracleAnnouncementV0TLV],
-      contractInfoOpt: Option[ContractInfoV0TLV]) = {
+      contractInfoOpt: Option[ContractInfoV0TLV],
+      initialContract: String = "") = {
     var nextRow: Int = 3
     val gridPane = new GridPane {
       alignment = Pos.Center
@@ -492,13 +492,11 @@ class CreateDLCOfferDialog
   }
 
   def getOracleInfo: Option[OracleInfo] = {
-    Try(
-      OracleAnnouncementV0TLV.fromHex(
-        announcementOrContractInfoTF.text.value)) match {
+    OracleAnnouncementV0TLV.fromHexT(
+      announcementOrContractInfoTF.text.value) match {
       case Failure(_) =>
-        Try(
-          ContractInfoV0TLV.fromHex(
-            announcementOrContractInfoTF.text.value)) match {
+        ContractInfoV0TLV.fromHexT(
+          announcementOrContractInfoTF.text.value) match {
           case Failure(_) => None
           case Success(contractInfo) =>
             Some(OracleInfo.fromTLV(contractInfo.oracleInfo))

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -127,12 +127,12 @@ object SignDLCDialog
     }
 
     val destinationChooser = GUIUtil.getFileSaveButton(
-      "",
       "signed.txt",
-      file => {
+      None,
+      Some(file => {
         DLCDialog.signDestDLCFile = Some(file)
         DLCDialog.signDestFileChosenLabel.text = file.toString
-      })
+      }))
 
     val destChooserHBox = new HBox() {
       spacing = 5

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -102,7 +102,7 @@ object SignDLCDialog
 
     // TODO : Externalize error styling to CSS
     val errorLabel = new Label("") {
-      style = "-fx-text-fill: red"
+      styleClass = Seq("error-label")
     }
 
     val fromFileHBox = new HBox() {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -35,12 +35,12 @@ object SignDLCDialog
     }
   }
 
-  var dialog: Dialog[Option[SignDLCCliCommand]] = null
+  var dialogOpt: Option[Dialog[Option[SignDLCCliCommand]]] = None
 
   def showAndWait(
       parentWindow: Window,
       hex: String = ""): Option[SignDLCCliCommand] = {
-    dialog = new Dialog[Option[SignDLCCliCommand]]() {
+    val dialog = new Dialog[Option[SignDLCCliCommand]]() {
       initOwner(parentWindow)
       title = "Sign DLC"
       headerText = "Enter DLC Accept message"
@@ -70,7 +70,8 @@ object SignDLCDialog
       res
     }
 
-    val result = dialog.showAndWait()
+    dialogOpt = Some(dialog)
+    val result = dialogOpt.map(_.showAndWait())
 
     result match {
       case Some(Some(cmd: SignDLCCliCommand)) =>
@@ -301,7 +302,8 @@ object SignDLCDialog
           errorLabel.text = errMsg
           vbox.children.add(errorLabel)
       }
-      if (dialog != null) dialog.dialogPane().getScene.getWindow.sizeToScene()
+      if (dialogOpt.isDefined)
+        dialogOpt.get.dialogPane().getScene.getWindow.sizeToScene()
       ()
     }
 
@@ -319,8 +321,8 @@ object SignDLCDialog
           logger.error(errMsg)
           errorLabel.text = errMsg
           vbox.children.add(errorLabel)
-          if (dialog != null)
-            dialog.dialogPane().getScene.getWindow.sizeToScene()
+          if (dialogOpt.isDefined)
+            dialogOpt.get.dialogPane().getScene.getWindow.sizeToScene()
         case Success(acceptMessage) =>
           showDetails(acceptMessage, isFromFile = true)
       }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -23,15 +23,15 @@ object SignDLCDialog
     extends Logging
     with CliCommandProducer[SignDLCCliCommand] {
 
-  override def getCliCommand(): Some[SignDLCCliCommand] = {
+  override def getCliCommand(): SignDLCCliCommand = {
     DLCDialog.acceptDLCFile match {
       case Some(file) =>
         val destOpt = DLCDialog.signDestDLCFile.map(_.toPath)
-        Some(SignDLCFromFile(file.toPath, destOpt))
+        SignDLCFromFile(file.toPath, destOpt)
       case None =>
         val acceptHex = acceptTLVTF.text.value
         val accept = LnMessageFactory(DLCAcceptTLV).fromHex(acceptHex)
-        Some(SignDLC(accept))
+        SignDLC(accept)
     }
   }
 
@@ -58,7 +58,7 @@ object SignDLCDialog
     // When the OK button is clicked, convert the result to a SignDLC.
     dialog.resultConverter = dialogButton => {
       val res = if (dialogButton == ButtonType.OK) {
-        getCliCommand()
+        Some(getCliCommand())
       } else None
 
       // reset

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -19,9 +19,11 @@ import java.nio.file.Files
 import scala.collection._
 import scala.util.{Failure, Success, Try}
 
-object SignDLCDialog extends Logging with CliCommandProducer {
+object SignDLCDialog
+    extends Logging
+    with CliCommandProducer[SignDLCCliCommand] {
 
-  def getCliCommand(): Some[SignDLCCliCommand] = {
+  override def getCliCommand(): Some[SignDLCCliCommand] = {
     DLCDialog.acceptDLCFile match {
       case Some(file) =>
         val destOpt = DLCDialog.signDestDLCFile.map(_.toPath)

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/SignDLCDialog.scala
@@ -19,10 +19,26 @@ import java.nio.file.Files
 import scala.collection._
 import scala.util.{Failure, Success, Try}
 
-object SignDLCDialog extends Logging {
+object SignDLCDialog extends Logging with CliCommandProducer {
 
-  def showAndWait(parentWindow: Window): Option[SignDLCCliCommand] = {
-    val dialog = new Dialog[Option[SignDLCCliCommand]]() {
+  def getCliCommand(): Some[SignDLCCliCommand] = {
+    DLCDialog.acceptDLCFile match {
+      case Some(file) =>
+        val destOpt = DLCDialog.signDestDLCFile.map(_.toPath)
+        Some(SignDLCFromFile(file.toPath, destOpt))
+      case None =>
+        val acceptHex = acceptTLVTF.text.value
+        val accept = LnMessageFactory(DLCAcceptTLV).fromHex(acceptHex)
+        Some(SignDLC(accept))
+    }
+  }
+
+  var dialog: Dialog[Option[SignDLCCliCommand]] = null
+
+  def showAndWait(
+      parentWindow: Window,
+      hex: String = ""): Option[SignDLCCliCommand] = {
+    dialog = new Dialog[Option[SignDLCCliCommand]]() {
       initOwner(parentWindow)
       title = "Sign DLC"
       headerText = "Enter DLC Accept message"
@@ -32,12 +48,44 @@ object SignDLCDialog extends Logging {
     dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
     dialog.resizable = true
 
-    var dlcDetailsShown = false
-    val acceptTLVTF = new TextField() {
-      minWidth = 300
+    dialog.dialogPane().content = new ScrollPane {
+      margin = Insets(10)
+      content = buildView(hex, None)
     }
 
+    // When the OK button is clicked, convert the result to a SignDLC.
+    dialog.resultConverter = dialogButton => {
+      val res = if (dialogButton == ButtonType.OK) {
+        getCliCommand()
+      } else None
+
+      // reset
+      DLCDialog.acceptDLCFile = None
+      DLCDialog.acceptFileChosenLabel.text = ""
+      DLCDialog.signDestDLCFile = None
+      DLCDialog.signDestFileChosenLabel.text = ""
+
+      res
+    }
+
+    val result = dialog.showAndWait()
+
+    result match {
+      case Some(Some(cmd: SignDLCCliCommand)) =>
+        Some(cmd)
+      case Some(_) | None => None
+    }
+  }
+
+  private lazy val acceptTLVTF = new TextField() {
+    minWidth = 300
+  }
+
+  def buildView(initialAccept: String = "", file: Option[File]) = {
+    var dlcDetailsShown = false
+
     val acceptTFHBox = new HBox() {
+      alignment = Pos.Center
       spacing = 5
       children = Vector(new Label("DLC Accept"), acceptTLVTF)
     }
@@ -50,12 +98,14 @@ object SignDLCDialog extends Logging {
       children = Vector(new Separator(), new Label("or"), new Separator())
     }
 
+    // TODO : Externalize error styling to CSS
     val errorLabel = new Label("") {
       style = "-fx-text-fill: red"
     }
 
     val fromFileHBox = new HBox() {
       spacing = 5
+      alignment = Pos.Center
       children = Vector(new Label("DLC Accept File"))
     }
 
@@ -73,15 +123,17 @@ object SignDLCDialog extends Logging {
       vgap = 5
     }
 
-    val destinationChooser = DLCDialog.fileChooserButton(
-      open = false,
-      { file =>
+    val destinationChooser = GUIUtil.getFileSaveButton(
+      "",
+      "signed.txt",
+      file => {
         DLCDialog.signDestDLCFile = Some(file)
         DLCDialog.signDestFileChosenLabel.text = file.toString
       })
 
     val destChooserHBox = new HBox() {
       spacing = 5
+      alignment = Pos.CenterLeft
       children = Vector(destinationChooser, DLCDialog.signDestFileChosenLabel)
     }
 
@@ -218,7 +270,9 @@ object SignDLCDialog extends Logging {
       }
     }
 
-    acceptTLVTF.onKeyTyped = _ => {
+    acceptTLVTF.onKeyTyped = _ => onAcceptKeyTyped()
+
+    def onAcceptKeyTyped() = {
       if (!dlcDetailsShown) {
         Try(
           LnMessageFactory(DLCAcceptTLV).fromHex(
@@ -245,10 +299,13 @@ object SignDLCDialog extends Logging {
           errorLabel.text = errMsg
           vbox.children.add(errorLabel)
       }
-      dialog.dialogPane().getScene.getWindow.sizeToScene()
+      if (dialog != null) dialog.dialogPane().getScene.getWindow.sizeToScene()
+      ()
     }
 
     def handleFileChosen(file: File): Unit = {
+      DLCDialog.acceptDLCFile = Some(file)
+      DLCDialog.acceptFileChosenLabel.text = file.toString
       val acceptMessageT = Try {
         val hex = Files.readAllLines(file.toPath).get(0)
         LnMessageFactory(DLCAcceptTLV).fromHex(hex)
@@ -260,58 +317,30 @@ object SignDLCDialog extends Logging {
           logger.error(errMsg)
           errorLabel.text = errMsg
           vbox.children.add(errorLabel)
-          dialog.dialogPane().getScene.getWindow.sizeToScene()
+          if (dialog != null)
+            dialog.dialogPane().getScene.getWindow.sizeToScene()
         case Success(acceptMessage) =>
           showDetails(acceptMessage, isFromFile = true)
       }
       ()
     }
 
-    val fileChooser = DLCDialog.fileChooserButton(
-      open = true,
-      { file =>
-        DLCDialog.acceptDLCFile = Some(file)
-        DLCDialog.acceptFileChosenLabel.text = file.toString
-        handleFileChosen(file)
-      })
+    val fileChooser =
+      GUIUtil.getFileChooserButton(file => handleFileChosen(file))
 
     fromFileHBox.children.addAll(fileChooser, DLCDialog.acceptFileChosenLabel)
 
-    dialog.dialogPane().content = new ScrollPane {
-      margin = Insets(10)
-      content = vbox
-    }
-
-    // When the OK button is clicked, convert the result to a SignDLC.
-    dialog.resultConverter = dialogButton => {
-      val res = if (dialogButton == ButtonType.OK) {
-        DLCDialog.acceptDLCFile match {
-          case Some(file) =>
-            val destOpt = DLCDialog.signDestDLCFile.map(_.toPath)
-            Some(SignDLCFromFile(file.toPath, destOpt))
-          case None =>
-            val acceptHex = acceptTLVTF.text.value
-            val accept = LnMessageFactory(DLCAcceptTLV).fromHex(acceptHex)
-
-            Some(SignDLC(accept))
+    // Set initial state
+    file match {
+      case Some(f) =>
+        handleFileChosen(f)
+      case None =>
+        if (initialAccept.nonEmpty) {
+          acceptTLVTF.text.value = initialAccept
+          onAcceptKeyTyped()
         }
-      } else None
-
-      // reset
-      DLCDialog.acceptDLCFile = None
-      DLCDialog.acceptFileChosenLabel.text = ""
-      DLCDialog.signDestDLCFile = None
-      DLCDialog.signDestFileChosenLabel.text = ""
-
-      res
     }
 
-    val result = dialog.showAndWait()
-
-    result match {
-      case Some(Some(cmd: SignDLCCliCommand)) =>
-        Some(cmd)
-      case Some(_) | None => None
-    }
+    vbox
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
@@ -12,7 +12,7 @@ import org.bitcoins.gui.dlc.{DLCPaneModel, DLCPlotUtil, GlobalDLCData}
 import org.bitcoins.gui.util.GUIUtil
 import scalafx.Includes._
 import scalafx.beans.property.StringProperty
-import scalafx.geometry.Insets
+import scalafx.geometry.{Insets, Pos}
 import scalafx.scene.Node
 import scalafx.scene.control._
 import scalafx.scene.layout.GridPane
@@ -29,17 +29,23 @@ object ViewDLCDialog {
       title = "View DLC"
     }
 
-    val closingTxId: StringProperty = StringProperty(
-      DLCStatus.getClosingTxId(status).map(_.hex).getOrElse(""))
-
     dialog.dialogPane().buttonTypes = Seq(ButtonType.Close)
     dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
     dialog.resizable = true
 
-    dialog.dialogPane().content = new GridPane() {
+    dialog.dialogPane().content = buildView(status, model)
+
+    val _ = dialog.showAndWait()
+  }
+
+  def buildView(status: DLCStatus, model: DLCPaneModel) = {
+    val closingTxId: StringProperty = StringProperty(
+      DLCStatus.getClosingTxId(status).map(_.hex).getOrElse(""))
+    new GridPane() {
+      alignment = Pos.Center
+      padding = Insets(10)
       hgap = 10
       vgap = 10
-      padding = Insets(20, 100, 10, 10)
 
       private var row = 0
       add(new Label("DLC Id:"), 0, row)
@@ -261,7 +267,5 @@ object ViewDLCDialog {
           add(previewGraphButton, 1, row)
       }
     }
-
-    val _ = dialog.showAndWait()
   }
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
@@ -59,9 +59,9 @@ object GUIUtil {
   private lazy val allExtensionFilter = new ExtensionFilter("All Files", "*")
 
   def showSaveDialog(
-                      filename: String,
-                      bytesOpt: Option[String],
-                      handleFileOpt: Option[File => Unit]): Unit = {
+      filename: String,
+      bytesOpt: Option[String],
+      handleFileOpt: Option[File => Unit]): Unit = {
     fileChooser.initialFileName = filename
     val chosenFileOpt = Option(fileChooser.showSaveDialog(null))
     chosenFileOpt match {
@@ -71,12 +71,12 @@ object GUIUtil {
 
         bytesOpt match {
           case Some(bytes) => Files.write(chosenFile.toPath, bytes.getBytes)
-          case None    => // There was nothing sent in to write out
+          case None        => // There was nothing sent in to write out
         }
 
         handleFileOpt match {
           case Some(handleFile) => handleFile(chosenFile)
-          case None    => // No callback defined
+          case None             => // No callback defined
         }
       case None => // User canceled in dialog
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
@@ -2,12 +2,19 @@ package org.bitcoins.gui.util
 
 import javafx.beans.value.ObservableValue
 import org.bitcoins.core.protocol.BlockTimeStamp
-import scalafx.scene.control.TextField
+import scalafx.scene.control.{Button, TextField}
 import scalafx.scene.image.Image
+import scalafx.stage.FileChooser
+import scalafx.stage.FileChooser.ExtensionFilter
 
+import java.awt.Toolkit.getDefaultToolkit
+import java.awt.datatransfer.StringSelection
+import java.io.File
+import java.nio.file.Files
 import java.text.NumberFormat
 import java.time.format.{DateTimeFormatter, FormatStyle}
 import java.time.{Instant, ZoneOffset}
+import scala.util.Properties
 import scala.util.matching.Regex
 
 object GUIUtil {
@@ -29,6 +36,78 @@ object GUIUtil {
     DateTimeFormatter
       .ofLocalizedDate(FormatStyle.MEDIUM)
       .format(instant)
+  }
+
+  def setStringToClipboard(str: String): Unit = {
+    val clipboard = getDefaultToolkit.getSystemClipboard
+    val sel = new StringSelection(str)
+    clipboard.setContents(sel, sel)
+  }
+
+  // fileChooser persists so initialDirectory can update across interactions
+  private lazy val fileChooser = new FileChooser() {
+    extensionFilters.addAll(txtExtensionFilter, allExtensionFilter)
+    selectedExtensionFilter = txtExtensionFilter
+    initialDirectory = new File(Properties.userHome)
+  }
+
+  private lazy val txtExtensionFilter =
+    new ExtensionFilter("Text Files", "*.txt")
+  private lazy val allExtensionFilter = new ExtensionFilter("All Files", "*")
+
+  def showSaveDialog(
+      bytes: String = null,
+      filename: String = "",
+      handleFile: File => Unit = null): Unit = {
+    if (filename.nonEmpty) fileChooser.initialFileName = filename
+    val chosenFileOpt = Option(fileChooser.showSaveDialog(null))
+    chosenFileOpt match {
+      case Some(chosenFile) =>
+        if (bytes != null) {
+          val _ = Files.write(chosenFile.toPath, bytes.getBytes)
+        }
+        // Remember last-used directory
+        fileChooser.initialDirectory = chosenFile.getParentFile
+
+        if (handleFile != null) {
+          handleFile(chosenFile)
+        }
+      case None => // User canceled in dialog
+    }
+  }
+
+  def showOpenDialog(handleFile: File => Unit = null): Option[File] = {
+    val chosenFileOpt = Option(fileChooser.showOpenDialog(null))
+    chosenFileOpt match {
+      case Some(chosenFile) =>
+        // Remember last-used directory
+        fileChooser.initialDirectory = chosenFile.getParentFile
+
+        if (handleFile != null) {
+          handleFile(chosenFile)
+        }
+      case None => // User canceled in dialog
+    }
+    chosenFileOpt
+  }
+
+  def getFileChooserButton(handleFile: File => Unit = null) = {
+    new Button("Browse...") {
+      onAction = _ => {
+        val _ = GUIUtil.showOpenDialog(handleFile)
+      }
+    }
+  }
+
+  def getFileSaveButton(
+      bytes: String = null,
+      filename: String = "",
+      handleFile: File => Unit = null) = {
+    new Button("Browse...") {
+      onAction = _ => {
+        val _ = GUIUtil.showSaveDialog(bytes, filename, handleFile)
+      }
+    }
   }
 
   val logo = new Image("/icons/bitcoin-s.png")

--- a/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
@@ -59,9 +59,9 @@ object GUIUtil {
   private lazy val allExtensionFilter = new ExtensionFilter("All Files", "*")
 
   def showSaveDialog(
-      filename: String,
-      bytes: Option[String],
-      handleFile: Option[File => Unit]): Unit = {
+                      filename: String,
+                      bytesOpt: Option[String],
+                      handleFileOpt: Option[File => Unit]): Unit = {
     fileChooser.initialFileName = filename
     val chosenFileOpt = Option(fileChooser.showSaveDialog(null))
     chosenFileOpt match {
@@ -69,13 +69,13 @@ object GUIUtil {
         // Remember last-used directory
         fileChooser.initialDirectory = chosenFile.getParentFile
 
-        bytes match {
-          case Some(_) => Files.write(chosenFile.toPath, bytes.get.getBytes)
+        bytesOpt match {
+          case Some(bytes) => Files.write(chosenFile.toPath, bytes.getBytes)
           case None    => // There was nothing sent in to write out
         }
 
-        handleFile match {
-          case Some(_) => handleFile.get(chosenFile)
+        handleFileOpt match {
+          case Some(handleFile) => handleFile(chosenFile)
           case None    => // No callback defined
         }
       case None => // User canceled in dialog

--- a/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
@@ -66,14 +66,17 @@ object GUIUtil {
     val chosenFileOpt = Option(fileChooser.showSaveDialog(null))
     chosenFileOpt match {
       case Some(chosenFile) =>
-        if (bytes.isDefined) {
-          val _ = Files.write(chosenFile.toPath, bytes.get.getBytes)
-        }
         // Remember last-used directory
         fileChooser.initialDirectory = chosenFile.getParentFile
 
-        if (handleFile.isDefined) {
-          handleFile.get(chosenFile)
+        bytes match {
+          case Some(_) => Files.write(chosenFile.toPath, bytes.get.getBytes)
+          case None    => // There was nothing sent in to write out
+        }
+
+        handleFile match {
+          case Some(_) => handleFile.get(chosenFile)
+          case None    => // No callback defined
         }
       case None => // User canceled in dialog
     }


### PR DESCRIPTION
Starting point for pulling fileChooser creation to common spot to persist folder location and common buildView() / getCliCommand() for dialogs so their views can be re-used for flat views