### PR TITLE
DLC P2P in AppServer and GUI

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -28,6 +28,7 @@ import ujson._
 import upickle.default._
 
 import java.io.File
+import java.net.{InetSocketAddress, URI}
 import java.nio.file.Path
 import java.time.Instant
 import java.util.Date
@@ -36,6 +37,14 @@ object Picklers {
 
   implicit val pathPickler: ReadWriter[Path] =
     readwriter[String].bimap(_.toString, str => new File(str).toPath)
+
+  implicit val inetSocketAddress: ReadWriter[InetSocketAddress] =
+    readwriter[String].bimap(
+      addr => s"${addr.getHostName}:${addr.getPort}",
+      str => {
+        val uri = new URI("tcp://" + str)
+        InetSocketAddress.createUnresolved(uri.getHost, uri.getPort)
+      })
 
   implicit val byteVectorPickler: ReadWriter[ByteVector] =
     readwriter[String].bimap(_.toHex, str => ByteVector.fromValidHex(str))

--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -22,6 +22,7 @@ import scodec.bits.ByteVector
 import scopt._
 
 import java.io.File
+import java.net.{InetSocketAddress, URI}
 import java.nio.file.Path
 import java.time.{Instant, ZoneId, ZonedDateTime}
 import java.util.Date
@@ -34,6 +35,16 @@ object CliReaders {
 
     val reads: String => Path = str => new File(str).toPath
   }
+
+  implicit val inetSocketAddressReads: Read[InetSocketAddress] =
+    new Read[InetSocketAddress] {
+      val arity = 1
+
+      val reads: String => InetSocketAddress = str => {
+        val uri = new URI("tcp://" + str)
+        InetSocketAddress.createUnresolved(uri.getHost, uri.getPort)
+      }
+    }
 
   implicit val npReads: Read[NetworkParameters] =
     new Read[NetworkParameters] {

--- a/app/server/src/main/scala/org/bitcoins/server/DLCRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCRoutes.scala
@@ -1,0 +1,33 @@
+package org.bitcoins.server
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import org.bitcoins.core.api.dlc.node.DLCNodeApi
+import org.bitcoins.server.routes._
+
+case class DLCRoutes(dlcNode: DLCNodeApi)(implicit system: ActorSystem)
+    extends ServerRoute {
+  import system.dispatcher
+
+  def handleCommand: PartialFunction[ServerCommand, Route] = {
+    case ServerCommand("getdlchostaddress", _) =>
+      complete {
+        dlcNode.getHostAddress.map { addr =>
+          // need to do this otherwise string will contain <unresolved>
+          val str = s"${addr.getHostName}:${addr.getPort}"
+          Server.httpSuccess(str)
+        }
+      }
+
+    case ServerCommand("acceptdlc", arr) =>
+      withValidServerCommand(AcceptDLC.fromJsArr(arr)) {
+        case AcceptDLC(offer, address) =>
+          complete {
+            dlcNode.acceptDLCOffer(address, offer).map { _ =>
+              Server.httpSuccess(ujson.Null)
+            }
+          }
+      }
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/api/dlc/node/DLCNodeApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlc/node/DLCNodeApi.scala
@@ -1,0 +1,19 @@
+package org.bitcoins.core.api.dlc.node
+
+import org.bitcoins.core.api.dlc.wallet.DLCWalletApi
+import org.bitcoins.core.protocol.tlv._
+import org.bitcoins.core.util.StartStopAsync
+
+import java.net.InetSocketAddress
+import scala.concurrent.Future
+
+trait DLCNodeApi extends StartStopAsync[Unit] {
+
+  def wallet: DLCWalletApi
+
+  def acceptDLCOffer(
+      peerAddress: InetSocketAddress,
+      dlcOffer: LnMessage[DLCOfferTLV]): Future[Unit]
+
+  def getHostAddress: Future[InetSocketAddress]
+}

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
@@ -60,7 +60,8 @@ case class DLCNodeAppConfig(
 
   lazy val torParams: Option[TorParams] = {
     if (config.getBoolean("bitcoin-s.tor.enabled")) {
-      val controlURI = new URI(config.getString("bitcoin-s.tor.control"))
+      val controlURI = new URI(
+        "tcp://" + config.getString("bitcoin-s.tor.control"))
       val control = InetSocketAddress.createUnresolved(controlURI.getHost,
                                                        controlURI.getPort)
 

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -177,7 +177,7 @@ bitcoin-s {
     tor {
         # You can enable Tor for incoming connections
         enabled = false
-        control = 127.0.0.1:9051
+        control = "127.0.0.1:9051"
 
         # The password used to arrive at the HashedControlPassword for the control port.
         # If provided, the HASHEDPASSWORD authentication method will be used instead of

--- a/docs/tor/tor.md
+++ b/docs/tor/tor.md
@@ -1,0 +1,145 @@
+---
+id: tor
+title: Tor Setup
+---
+
+It is possible to run Bitcoin-S through tor.
+[Tor](https://www.torproject.org/) is an onion routed private network that allows us to send and receive messages in an
+anonymous manner. Using tor in conjunction with Bitcoin-S allows you to be more private when syncing the blockchain, as
+well as allows for sending and receiving DLC messages without the need for a static IP address or opening/forwarding of
+ports.
+
+## Installing Tor
+
+### Debian
+
+You can install tor using `sudo apt install tor` if on a debian system.
+
+After installing you can start it with `sudo systemctl start tor`
+
+### Brew
+
+You can install tor using `brew install tor` if on a mac osx system.
+
+After installing you can start it with `brew services start tor`
+
+### Other
+
+Otherwise, you can install the Tor Browser from [here](https://www.torproject.org/download/).
+
+## Starting Tor
+
+To connect to onion addresses you need th enable the tor proxy. To do so you need to have tor currently running, this
+can be checked by using the command `sudo systemctl status tor`. This should give you an output similar to:
+
+```bash
+$ sudo systemctl status tor
+● tor.service - Anonymizing overlay network for TCP (multi-instance-master)
+     Loaded: loaded (/lib/systemd/system/tor.service; enabled; vendor preset: enabled)
+     Active: active (exited) since Wed 2021-07-28 13:06:42 CDT; 48min ago
+   Main PID: 804 (code=exited, status=0/SUCCESS)
+      Tasks: 0 (limit: 18696)
+     Memory: 0B
+     CGroup: /system.slice/tor.service
+```
+
+If the output says `Active: active`, then it is running and good to go.
+
+## Enabling the Tor proxy
+
+Enabling the tor proxy allows you to create outgoing connections over tor. This is needed if you want to sync the
+blockchain over tor, or to accept DLCs over tor.
+
+To enable the tor proxy you simply need to set a couple config options after you have tor running.
+
+You need to enable the proxy and set the host and port configuration options. If you are using the default settings you
+should only need to set `bitcoin-s.proxy.enabled = true`.
+
+```$xslt
+bitcoin-s {
+    proxy {
+        # You can configure SOCKS5 proxy to use Tor for outgoing connections
+        enabled = true
+        sock5 = "127.0.0.1:9050"
+    }
+}
+```
+
+## Creating our own Tor hidden service
+
+Enabling the tor hidden services allows for inbound connections over tor.
+This is needed if you want to create DLCs over tor.
+
+To enable the tor hidden services you need to set a couple config options after you have tor running in your bitcoin-s
+config, as well as have tor configured for it.
+
+### Configuring Tor
+
+You may need to set up the Tor Control Port. On Linux distributions there may be some or all of the following settings
+in `/etc/tor/torrc` for linux or `/opt/homebrew/etc/tor/torcc` for mac, generally commented out by default (if not, add
+them):
+
+```
+ControlPort 9051
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+```
+
+Add or uncomment those, save, and restart Tor (usually `systemctl restart tor`
+or `sudo systemctl restart tor` on most systemd-based systems, including recent Debian and Ubuntu, or just restart the
+computer).
+
+On some systems (such as Arch Linux), you may also need to add the following line:
+
+```
+DataDirectoryGroupReadable 1
+```
+
+You may also need permissions for the auth cookie file, this can be done doing
+
+```bash
+sudo usermod -a -G debian-tor $USER
+```
+
+After changing these settings, you will need to restart your computer.
+
+### Configuring Bitcoin-S
+
+You need to enable tor and set the control option, `127.0.0.1:9051` is the default. If you are using the default
+settings you should only need to set `bitcoin-s.tor.enabled = true`.
+
+```$xslt
+bitcoin-s {
+    tor {
+        # You can enable Tor for incoming connections
+        enabled = true
+        control = "127.0.0.1:9051"
+
+        # The password used to arrive at the HashedControlPassword for the control port.
+        # If provided, the HASHEDPASSWORD authentication method will be used instead of
+        # the SAFECOOKIE one.
+        # password = securePassword
+
+        # The path to the private key of the onion service being created
+        # privateKeyPath = /path/to/priv/key
+    }
+}
+```
+
+### Manually Creating a Tor Hidden Service
+
+Alternatively, you can manually create a tor hidden service.
+
+You can also manually configure your node to be reachable from the Tor network. Add these lines to
+your `/etc/tor/torrc` (or equivalent config file, mac is located at `/opt/homebrew/etc/tor/torcc`):
+
+```
+HiddenServiceDir /var/lib/tor/dlc-service/
+HiddenServicePort 2862 127.0.0.1:2862
+```
+
+Then to get your host address simply do this after restarting your tor daemon.
+
+```bash
+sudo cat /var/lib/tor/dlc-service/hostname
+```

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -95,6 +95,9 @@
       "node/node": {
         "title": "Light Client"
       },
+      "node/tor": {
+        "title": "Setting up Tor with Light Client"
+      },
       "oracle-explorer-client/oracle-explorer-client": {
         "title": "Oracle Explorer Client"
       },
@@ -136,6 +139,9 @@
       },
       "testkit/testkit": {
         "title": "Testkit"
+      },
+      "tor/tor": {
+        "title": "Tor"
       },
       "wallet/address-tagging": {
         "title": "Address and UTXO tagging"
@@ -786,6 +792,7 @@
       "Key Manager": "Key Manager",
       "Node": "Node",
       "Wallet": "Wallet",
+      "Tor": "Tor",
       "RPC Clients": "RPC Clients",
       "Secp256k1": "Secp256k1",
       "Testkit": "Testkit",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -59,6 +59,9 @@
       "wallet/wallet-rpc",
       "wallet/backups"
     ],
+    "Tor": [
+      "tor/tor"
+    ],
     "RPC Clients": [
       "rpc/rpc-clients-intro",
       "rpc/rpc-eclair",


### PR DESCRIPTION
This hooks up the `DLCNode` from #3402 to the app server, cli, and gui.

Adds tor docs

@Christewart and I were able to execute 2 DLCs using this (numeric and enum)