### PR TITLE
Add preferences for wallet window x,y,w,h persistence

### DIFF
--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BundleGUI.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BundleGUI.scala
@@ -67,11 +67,8 @@ object BundleGUI extends WalletGUI with BitcoinSAppJFX3 {
   }
 
   def writePreferenceValues(): Unit = {
-    println(
-      "writePreferenceValues w: " + stage.getWidth + " h: " + stage.getHeight)
     preferences.putDouble(WINDOW_WIDTH, stage.getWidth)
     preferences.putDouble(WINDOW_HEIGHT, stage.getHeight)
-    println("stage x: " + stage.getX + " y: " + stage.getY)
     preferences.putDouble(WINDOW_X, stage.getX)
     preferences.putDouble(WINDOW_Y, stage.getY)
     preferences.flush()

--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BundleGUI.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BundleGUI.scala
@@ -11,6 +11,9 @@ import scalafx.scene.Scene
 import scalafx.scene.control.Alert.AlertType
 import scalafx.scene.control._
 import scalafx.scene.layout.VBox
+import scalafx.stage.Screen
+
+import java.util.prefs.Preferences
 
 object BundleGUI extends WalletGUI with BitcoinSAppJFX3 {
 
@@ -20,6 +23,59 @@ object BundleGUI extends WalletGUI with BitcoinSAppJFX3 {
     s"bitcoin-s-gui-${System.currentTimeMillis()}"
 
   override lazy val commandLineArgs: Array[String] = parameters.raw.toArray
+
+  // Application Preference Keys
+  val WINDOW_HEIGHT = "windowH"
+  val WINDOW_WIDTH = "windowW"
+  val WINDOW_X = "windowX"
+  val WINDOW_Y = "windowY"
+  val NODE_NAME = "BundleGUI"
+  val preferences = Preferences.userRoot().node(NODE_NAME)
+
+  val DEFAULT_WIDTH = 1400.0
+  val DEFAULT_HEIGHT = 800.0
+  val DEFAULT_MAXIMIZED = false
+  val NOT_SET = Double.MinValue
+  val MINIMUM_WIDTH = 800.0
+  val MINIMUM_HEIGHT = 500.0
+
+  var stageWidth =
+    preferences.getDouble(WINDOW_WIDTH, DEFAULT_WIDTH)
+
+  var stageHeight =
+    preferences.getDouble(WINDOW_HEIGHT, DEFAULT_HEIGHT)
+
+  var stageX = getPreferenceDoubleOpt(WINDOW_X, NOT_SET)
+  var stageY = getPreferenceDoubleOpt(WINDOW_Y, NOT_SET)
+
+  def getPreferenceDoubleOpt(pref: String, default: Double): Option[Double] = {
+    val d = preferences.getDouble(pref, default)
+    if (d != default) Some(d) else None
+  }
+
+  def validatePreferenceValues(): Unit = {
+    // If the screen rectangle is not on some Screens, wipe saved x,y and use default position
+    (stageX, stageY) match {
+      case (Some(x), Some(y)) =>
+        val screens = Screen.screensForRectangle(x, y, stageWidth, stageHeight)
+        if (screens.isEmpty) {
+          stageX = None
+          stageY = None
+        }
+      case _ => // Not set, no validation
+    }
+  }
+
+  def writePreferenceValues(): Unit = {
+    println(
+      "writePreferenceValues w: " + stage.getWidth + " h: " + stage.getHeight)
+    preferences.putDouble(WINDOW_WIDTH, stage.getWidth)
+    preferences.putDouble(WINDOW_HEIGHT, stage.getHeight)
+    println("stage x: " + stage.getX + " y: " + stage.getY)
+    preferences.putDouble(WINDOW_X, stage.getX)
+    preferences.putDouble(WINDOW_Y, stage.getY)
+    preferences.flush()
+  }
 
   override def start(): Unit = {
     // Catch unhandled exceptions on FX Application thread
@@ -53,11 +109,13 @@ object BundleGUI extends WalletGUI with BitcoinSAppJFX3 {
         datadirParser.datadir,
         serverArgParser)(system.dispatcher)
 
+    validatePreferenceValues()
+
     val landingPane = new LandingPane(glassPane, serverArgParser)
 
     rootView.children = Vector(landingPane.view, glassPane)
 
-    lazy val guiScene: Scene = new Scene(1400, 600) {
+    lazy val guiScene: Scene = new Scene() {
       root = rootView
       stylesheets = GlobalData.currentStyleSheets
     }
@@ -66,9 +124,12 @@ object BundleGUI extends WalletGUI with BitcoinSAppJFX3 {
       title = "Bitcoin-S Wallet"
       scene = guiScene
       icons.add(GUIUtil.logo)
+      minWidth = MINIMUM_WIDTH
+      minHeight = MINIMUM_HEIGHT
     }
-    taskRunner
+    positionStage()
 
+    taskRunner
     ()
   }
 
@@ -81,16 +142,39 @@ object BundleGUI extends WalletGUI with BitcoinSAppJFX3 {
     visible = false
   }
 
+  def applyStagePreferences(): Unit = {
+    stage.setWidth(stageWidth)
+    stage.setHeight(stageHeight)
+    positionStage()
+  }
+
+  def positionStage(): Unit = {
+    (stageX, stageY) match {
+      case (Some(x), Some(y)) =>
+        stage.setX(x)
+        stage.setY(y)
+      case _ =>
+        stage.centerOnScreen()
+    }
+  }
+
+  var walletLoaded = false
+
   def changeToWalletGUIScene(): Unit = {
-    Platform.runLater(
+    Platform.runLater(() => {
       rootView.children = Vector(
         borderPane,
         glassPane
-      ))
+      )
+      applyStagePreferences()
+      walletLoaded = true
+    })
   }
 
   override def stopApp(): Unit = {
     super.stopApp()
+    // Only save window position/size preferences if wallet was loaded
+    if (walletLoaded) writePreferenceValues()
     sys.exit()
   }
 }


### PR DESCRIPTION
Add preference keys and loading for main stage x, y, width, and height.

Set window minimum width, height to try to avoid any kind of issues with tiny windows getting saved out.

Checks screens at boot to make sure window will layout on one or more or fail out to default screen, centered.

Tested with second monitor to left and right of primary monitor including failing over after repositioning monitor in between app runs. Worked to fail over to default monitor.