### PR TITLE
Create TorAppConfig

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -11,6 +11,7 @@ import org.bitcoins.dlc.node.config.DLCNodeAppConfig
 import org.bitcoins.dlc.wallet.DLCAppConfig
 import org.bitcoins.keymanager.config.KeyManagerAppConfig
 import org.bitcoins.node.config.NodeAppConfig
+import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.wallet.config.WalletAppConfig
 
 import java.nio.file.{Files, Path, Paths}
@@ -33,6 +34,7 @@ case class BitcoinSAppConfig(
   lazy val nodeConf: NodeAppConfig = NodeAppConfig(directory, confs: _*)
   lazy val chainConf: ChainAppConfig = ChainAppConfig(directory, confs: _*)
   lazy val dlcConf: DLCAppConfig = DLCAppConfig(directory, confs: _*)
+  lazy val torConf: TorAppConfig = TorAppConfig(directory, confs: _*)
 
   lazy val dlcNodeConf: DLCNodeAppConfig =
     DLCNodeAppConfig(directory, confs: _*)
@@ -52,6 +54,7 @@ case class BitcoinSAppConfig(
   override def start(): Future[Unit] = {
     val futures = List(kmConf.start(),
                        walletConf.start(),
+                       torConf.start(),
                        nodeConf.start(),
                        chainConf.start(),
                        bitcoindRpcConf.start(),
@@ -66,6 +69,7 @@ case class BitcoinSAppConfig(
       _ <- walletConf.stop()
       _ <- chainConf.stop()
       _ <- bitcoindRpcConf.stop()
+      _ <- torConf.stop()
     } yield ()
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcAppConfig.scala
@@ -2,13 +2,13 @@ package org.bitcoins.server
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.db._
 import org.bitcoins.node.NodeType
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.config._
 import org.bitcoins.tor.Socks5ProxyParams
+import org.bitcoins.tor.config.TorAppConfig
 
 import java.io.File
 import java.net.{InetSocketAddress, URI}
@@ -92,21 +92,11 @@ case class BitcoindRpcAppConfig(
   lazy val rpcPassword: String =
     config.getString("bitcoin-s.bitcoind-rpc.rpcpassword")
 
-  lazy val socks5ProxyParams: Option[Socks5ProxyParams] = {
-    if (config.getBoolean("bitcoin-s.proxy.enabled")) {
-      Some(
-        Socks5ProxyParams(
-          address = NetworkUtil.parseInetSocketAddress(
-            config.getString("bitcoin-s.proxy.socks5"),
-            Socks5ProxyParams.DefaultPort),
-          credentialsOpt = None,
-          randomizeCredentials = true
-        )
-      )
-    } else {
-      None
-    }
-  }
+  lazy val torConf: TorAppConfig =
+    TorAppConfig(directory, confs: _*)
+
+  lazy val socks5ProxyParams: Option[Socks5ProxyParams] =
+    torConf.socks5ProxyParams
 
   lazy val versionOpt: Option[BitcoindVersion] =
     config

--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,7 @@ lazy val lndRpc = project
 lazy val tor = project
   .in(file("tor"))
   .settings(CommonSettings.prodSettings: _*)
-  .dependsOn(cryptoJVM)
+  .dependsOn(coreJVM, dbCommons)
 
 lazy val torTest = project
   .in(file("tor-test"))

--- a/tor/src/main/scala/org/bitcoins/tor/TorParams.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/TorParams.scala
@@ -10,3 +10,7 @@ case class TorParams(
     authentication: Authentication,
     privateKeyPath: Path
 )
+
+object TorParams {
+  val DefaultControlPort: Int = 9051
+}

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -1,0 +1,86 @@
+package org.bitcoins.tor.config
+
+import com.typesafe.config.Config
+import org.bitcoins.core.util.NetworkUtil
+import org.bitcoins.db.{AppConfig, AppConfigFactory, ConfigOps}
+import org.bitcoins.tor.TorProtocolHandler.{Password, SafeCookie}
+import org.bitcoins.tor.{Socks5ProxyParams, TorParams}
+
+import java.io.File
+import java.nio.file.Path
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Configuration for the Bitcoin-S node
+  * @param directory The data directory of the node
+  * @param confs Optional sequence of configuration overrides
+  */
+case class TorAppConfig(private val directory: Path, private val confs: Config*)
+    extends AppConfig {
+  override protected[bitcoins] def configOverrides: List[Config] = confs.toList
+  override protected[bitcoins] def moduleName: String = TorAppConfig.moduleName
+  override protected[bitcoins] type ConfigType = TorAppConfig
+
+  override protected[bitcoins] def newConfigOfType(
+      configs: Seq[Config]): TorAppConfig =
+    TorAppConfig(directory, configs: _*)
+
+  protected[bitcoins] def baseDatadir: Path = directory
+
+  /** Ensures correct tables and other required information is in
+    * place for our node.
+    */
+  override def start(): Future[Unit] = Future.unit
+
+  override def stop(): Future[Unit] = Future.unit
+
+  lazy val socks5ProxyParams: Option[Socks5ProxyParams] = {
+    if (config.getBoolean("bitcoin-s.proxy.enabled")) {
+      Some(
+        Socks5ProxyParams(
+          address = NetworkUtil.parseInetSocketAddress(
+            config.getString("bitcoin-s.proxy.socks5"),
+            Socks5ProxyParams.DefaultPort),
+          credentialsOpt = None,
+          randomizeCredentials = true
+        )
+      )
+    } else {
+      None
+    }
+  }
+
+  lazy val torParams: Option[TorParams] = {
+    if (config.getBoolean("bitcoin-s.tor.enabled")) {
+      val control = NetworkUtil.parseInetSocketAddress(
+        config.getString("bitcoin-s.tor.control"),
+        TorParams.DefaultControlPort)
+
+      val auth = config.getStringOrNone("bitcoin-s.tor.password") match {
+        case Some(pass) => Password(pass)
+        case None       => SafeCookie()
+      }
+
+      val privKeyPath =
+        config.getStringOrNone("bitcoin-s.tor.privateKeyPath") match {
+          case Some(path) => new File(path).toPath
+          case None       => datadir.resolve("tor_priv_key")
+        }
+
+      Some(TorParams(control, auth, privKeyPath))
+    } else {
+      None
+    }
+  }
+}
+
+object TorAppConfig extends AppConfigFactory[TorAppConfig] {
+
+  override val moduleName: String = "tor"
+
+  /** Constructs a tor configuration from the default Bitcoin-S
+    * data directory and given list of configuration overrides.
+    */
+  override def fromDatadir(datadir: Path, confs: Vector[Config])(implicit
+      ec: ExecutionContext): TorAppConfig =
+    TorAppConfig(datadir, confs: _*)
+}


### PR DESCRIPTION
Part of work for tor packaging

Makes it so we have a single place we get the tor configs from instead of having to copy paste the same thing in the node, dlcNode, and bitcoindRpc configs.