### PR TITLE
Evenly space footer status items

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
@@ -3,6 +3,7 @@ package org.bitcoins.gui
 import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
 import org.bitcoins.gui.dlc.DLCPane
+import org.bitcoins.gui.util.GUIUtil
 import scalafx.beans.property.StringProperty
 import scalafx.geometry._
 import scalafx.scene.control._
@@ -16,17 +17,14 @@ abstract class WalletGUI extends Logging {
 
   private lazy val statusLabel = new Label {
     maxWidth = Double.MaxValue
-    padding = Insets(0, 10, 10, 10)
     text <== GlobalData.statusText
   }
 
   private lazy val infoLabel = new Label {
-    padding = Insets(top = 0, right = 0, bottom = 10, left = 0)
     text <== StringProperty("Sync Height: ") + GlobalData.syncHeight
   }
 
   private lazy val connectedLabel = new Label {
-    padding = Insets(top = 0, right = 0, bottom = 10, left = 1200)
     text <== GlobalData.connectedStr
   }
 
@@ -106,8 +104,14 @@ abstract class WalletGUI extends Logging {
       Vector(balanceBox, walletAccountingBox, getNewAddressButton, sendButton)
   }
 
-  lazy val bottomStack: StackPane = new StackPane() {
-    children = Vector(statusLabel, infoLabel, connectedLabel)
+  lazy val bottomStack: HBox = new HBox {
+    padding = Insets(5, 10, 5, 10)
+    hgrow = Priority.Always
+    children = Vector(statusLabel,
+                      GUIUtil.getHSpacer(),
+                      infoLabel,
+                      GUIUtil.getHSpacer(),
+                      connectedLabel)
   }
 
   lazy val borderPane: BorderPane = new BorderPane {


### PR DESCRIPTION
Setup footer status bar items to evenly space over any window size

Doesn't functionally do much right now, but will allow for wide range of window sizing with evenly spaced labels

![Screen Shot 2021-08-04 at 3 14 03 PM](https://user-images.githubusercontent.com/22351459/128255823-951c16a1-32dc-48bc-9515-7d082d684020.png)
[Other UI change not relevant]