### PR TITLE
2021 08 06 app config refacotr

### DIFF
--- a/app-commons-test/src/test/scala/org/bitcoins/commons/config/AppConfigTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/config/AppConfigTest.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.db
+package org.bitcoins.commons.config
 
 import com.typesafe.config.ConfigFactory
 import org.bitcoins.core.config._

--- a/app-commons-test/src/test/scala/org/bitcoins/commons/util/ServerArgParserTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/util/ServerArgParserTest.scala
@@ -1,7 +1,6 @@
-package org.bitcoins.db.util
+package org.bitcoins.commons.util
 
 import com.typesafe.config.ConfigFactory
-import org.bitcoins.commons.util.ServerArgParser
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -8,7 +8,7 @@ import org.bitcoins.core.util.StartStopAsync
 
 import java.nio.file._
 import scala.concurrent.Future
-import scala.jdk.CollectionConverters.CollectionHasAsScala
+import org.bitcoins.core.compat.JavaConverters._
 import scala.util.Properties
 import scala.util.matching.Regex
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -1,14 +1,14 @@
-package org.bitcoins.db
+package org.bitcoins.commons.config
 
-import com.typesafe.config._
+import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions}
 import grizzled.slf4j.Logging
-import org.bitcoins.core.compat.JavaConverters._
 import org.bitcoins.core.config._
 import org.bitcoins.core.protocol.blockchain.BitcoinChainParams
 import org.bitcoins.core.util.StartStopAsync
 
 import java.nio.file._
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.util.Properties
 import scala.util.matching.Regex
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfigFactory.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfigFactory.scala
@@ -1,9 +1,8 @@
-package org.bitcoins.db
-
-import java.nio.file.{Path, Paths}
+package org.bitcoins.commons.config
 
 import com.typesafe.config.{Config, ConfigFactory}
 
+import java.nio.file.{Path, Paths}
 import scala.concurrent.ExecutionContext
 
 trait AppConfigFactory[C <: AppConfig] {

--- a/app-commons/src/main/scala/org/bitcoins/commons/config/package.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/package.scala
@@ -1,11 +1,11 @@
-package org.bitcoins
+package org.bitcoins.commons
 
 import com.typesafe.config.{Config, ConfigRenderOptions}
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
-package object db {
+package object config {
 
   implicit class ConfigOps(private val config: Config) extends AnyVal {
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/util/DatadirParser.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/DatadirParser.scala
@@ -1,8 +1,7 @@
-package org.bitcoins.db.util
+package org.bitcoins.commons.util
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.bitcoins.db.AppConfig
-import org.bitcoins.db.AppConfig.safePathToString
+import org.bitcoins.commons.config.AppConfig
 
 import java.nio.file.{Path, Paths}
 
@@ -23,7 +22,7 @@ case class DatadirParser(
 
   lazy val datadirConfig: Config =
     ConfigFactory.parseString(
-      s"bitcoin-s.datadir = ${safePathToString(datadirPath)}")
+      s"bitcoin-s.datadir = ${AppConfig.safePathToString(datadirPath)}")
 
   lazy val networkConfig: Config = serverArgs.networkOpt match {
     case Some(network) =>

--- a/app-commons/src/main/scala/org/bitcoins/commons/util/DatadirUtil.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/DatadirUtil.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.db.util
+package org.bitcoins.commons.util
 
 import com.typesafe.config.Config
 import org.bitcoins.core.config._

--- a/app-commons/src/main/scala/org/bitcoins/commons/util/ServerArgParser.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/ServerArgParser.scala
@@ -1,8 +1,8 @@
-package org.bitcoins.db.util
+package org.bitcoins.commons.util
 
 import com.typesafe.config.{Config, ConfigFactory}
+import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.core.config._
-import org.bitcoins.db.AppConfig
 
 import java.nio.file.{Path, Paths}
 import scala.util.Properties

--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BundleGUI.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BundleGUI.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.bundle.gui
 
 import org.bitcoins.bundle.util.BitcoinSAppJFX3
-import org.bitcoins.db.util.{DatadirParser, ServerArgParser}
+import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.gui._
 import org.bitcoins.gui.util.GUIUtil
 import org.bitcoins.server.BitcoinSAppConfig

--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPane.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPane.scala
@@ -2,7 +2,7 @@ package org.bitcoins.bundle.gui
 
 import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
-import org.bitcoins.db.util.ServerArgParser
+import org.bitcoins.commons.util.ServerArgParser
 import org.bitcoins.gui._
 import org.bitcoins.node.NodeType
 import org.bitcoins.server.BitcoinSAppConfig

--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
@@ -4,8 +4,8 @@ import akka.actor.ActorSystem
 import com.typesafe.config._
 import grizzled.slf4j.Logging
 import org.bitcoins.bundle.gui.BundleGUI._
-import org.bitcoins.db.AppConfig
-import org.bitcoins.db.util.{DatadirUtil, ServerArgParser}
+import org.bitcoins.commons.config.AppConfig
+import org.bitcoins.commons.util.{DatadirUtil, ServerArgParser}
 import org.bitcoins.gui._
 import org.bitcoins.node.NodeType._
 import org.bitcoins.node._

--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/NeutrinoConfigPane.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/NeutrinoConfigPane.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.bundle.gui
 
 import com.typesafe.config.{Config, ConfigFactory}
+import org.bitcoins.commons.util.DatadirUtil
 import org.bitcoins.core.config._
-import org.bitcoins.db.util.DatadirUtil
 import org.bitcoins.gui.util.GUIUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.server.BitcoinSAppConfig.toNodeConf

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.oracle.server
 
 import akka.actor.ActorSystem
-import org.bitcoins.db.util.{DatadirParser, ServerArgParser}
+import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
 import org.bitcoins.server.routes.{BitcoinSServerRunner, Server}
 import org.bitcoins.server.util.BitcoinSAppScalaDaemon

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.scripts
 
 import akka.actor.ActorSystem
-import org.bitcoins.db.util.{DatadirParser, ServerArgParser}
+import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.server.BitcoinSAppConfig
-import org.bitcoins.server.routes.{BitcoinSServerRunner}
-import org.bitcoins.server.util.{BitcoinSAppScalaDaemon}
+import org.bitcoins.server.routes.BitcoinSServerRunner
+import org.bitcoins.server.util.BitcoinSAppScalaDaemon
 
 import java.nio.file.Paths
 import scala.concurrent.Future

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
@@ -2,8 +2,8 @@ package org.bitcoins.server.routes
 
 import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
+import org.bitcoins.commons.util.ServerArgParser
 import org.bitcoins.core.util.{EnvUtil, StartStopAsync}
-import org.bitcoins.db.util.ServerArgParser
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.directives.DebuggingDirectives
 import de.heikoseeberger.akkahttpupickle.UpickleSupport._
-import org.bitcoins.db.AppConfig
+import org.bitcoins.commons.config.AppConfig
 import upickle.{default => up}
 
 import scala.concurrent.Future

--- a/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.server
 
-import org.bitcoins.db.util.ServerArgParser
+import org.bitcoins.commons.util.ServerArgParser
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.util.{AkkaUtil, BitcoinSAsyncTest}

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -3,10 +3,10 @@ package org.bitcoins.server
 import com.typesafe.config.{Config, ConfigFactory}
 import grizzled.slf4j.Logging
 import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.commons.file.FileUtil
+import org.bitcoins.commons.util.ServerArgParser
 import org.bitcoins.core.util.StartStopAsync
-import org.bitcoins.db.AppConfig
-import org.bitcoins.db.util.ServerArgParser
 import org.bitcoins.dlc.node.config.DLCNodeAppConfig
 import org.bitcoins.dlc.wallet.DLCAppConfig
 import org.bitcoins.keymanager.config.KeyManagerAppConfig

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -6,13 +6,13 @@ import akka.http.scaladsl.Http
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models._
+import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.core.Core
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
-import org.bitcoins.db.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.dlc.node.DLCNode
 import org.bitcoins.dlc.node.config.DLCNodeAppConfig
 import org.bitcoins.dlc.wallet._

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcAppConfig.scala
@@ -2,7 +2,7 @@ package org.bitcoins.server
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import org.bitcoins.db._
+import org.bitcoins.commons.config.{AppConfig, AppConfigFactory, ConfigOps}
 import org.bitcoins.node.NodeType
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}

--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,7 @@ lazy val lndRpc = project
 lazy val tor = project
   .in(file("tor"))
   .settings(CommonSettings.prodSettings: _*)
-  .dependsOn(coreJVM, dbCommons)
+  .dependsOn(coreJVM, appCommons)
 
 lazy val torTest = project
   .in(file("tor-test"))
@@ -659,7 +659,7 @@ lazy val docs = project
 lazy val keyManager = project
   .in(file("key-manager"))
   .settings(CommonSettings.prodSettings: _*)
-  .dependsOn(coreJVM, dbCommons)
+  .dependsOn(coreJVM, appCommons)
 
 lazy val keyManagerTest = project
   .in(file("key-manager-test"))

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -5,6 +5,7 @@ import org.bitcoins.chain.ChainCallbacks
 import org.bitcoins.chain.db.ChainDbManagement
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.chain.pow.Pow
+import org.bitcoins.commons.config.{AppConfigFactory, ConfigOps}
 import org.bitcoins.core.api.chain.db.BlockHeaderDbHelper
 import org.bitcoins.core.util.Mutable
 import org.bitcoins.db._

--- a/db-commons-test/src/test/scala/org/bitcoins/db/util/ServerArgParserTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/util/ServerArgParserTest.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.db.util
 
 import com.typesafe.config.ConfigFactory
+import org.bitcoins.commons.util.ServerArgParser
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.db
 
 import com.typesafe.config._
-import org.bitcoins.db.AppConfig.safePathToString
+import org.bitcoins.commons.config._
 import org.bitcoins.db.DatabaseDriver.{PostgreSQL, SQLite}
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
@@ -34,7 +34,7 @@ abstract class DbAppConfig extends AppConfig {
   lazy val jdbcUrl: String = {
     driver match {
       case SQLite =>
-        s""""jdbc:sqlite:"${safePathToString(dbPath)}/$dbName"""
+        s""""jdbc:sqlite:"${AppConfig.safePathToString(dbPath)}/$dbName"""
       case PostgreSQL =>
         s""""jdbc:postgresql://$dbHost:$dbPort/$dbName""""
     }
@@ -96,7 +96,7 @@ abstract class DbAppConfig extends AppConfig {
          |bitcoin-s {
          |  $moduleName {
          |     db {
-         |        path = ${safePathToString(dbPath)}
+         |        path = ${AppConfig.safePathToString(dbPath)}
          |        name = $dbName
          |        url = $jdbcUrl
          |     }

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
@@ -2,9 +2,9 @@ package org.bitcoins.dlc.node.config
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.core.api.dlc.wallet.DLCWalletApi
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.db._
 import org.bitcoins.dlc.node.DLCNode
 import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.tor.{Socks5ProxyParams, TorParams}

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.dlc.oracle.config
 
 import com.typesafe.config.Config
+import org.bitcoins.commons.config.AppConfigFactory
 import org.bitcoins.core.api.dlcoracle.db.EventOutcomeDbHelper
 import org.bitcoins.core.config._
 import org.bitcoins.core.hd.HDPurpose

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.dlc.wallet
 
 import com.typesafe.config.Config
+import org.bitcoins.commons.config.{AppConfigFactory, ConfigOps}
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.keymanager.config
 
 import com.typesafe.config.Config
+import org.bitcoins.commons.config.{AppConfig, AppConfigFactory, ConfigOps}
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.crypto.AesPassword
-import org.bitcoins.db._
 import org.bitcoins.keymanager.WalletStorage
 
 import java.nio.file.{Files, Path}

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -9,8 +9,9 @@ import org.bitcoins.chain.models.{
   CompactFilterDAO,
   CompactFilterHeaderDAO
 }
+import org.bitcoins.commons.config.AppConfigFactory
 import org.bitcoins.core.util.Mutable
-import org.bitcoins.db.{AppConfigFactory, DbAppConfig, JdbcProfileComponent}
+import org.bitcoins.db.{DbAppConfig, JdbcProfileComponent}
 import org.bitcoins.node._
 import org.bitcoins.node.db.NodeDbManagement
 import org.bitcoins.node.models.Peer

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -291,7 +291,8 @@ object Deps {
       Compile.newMicroPickle.value,
       Compile.playJson,
       Compile.slf4j,
-      Compile.grizzledSlf4j
+      Compile.grizzledSlf4j,
+      Compile.typesafeConfig
     )
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -9,13 +9,13 @@ import org.bitcoins.chain.blockchain.{ChainHandler, ChainHandlerCached}
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models._
 import org.bitcoins.chain.pow.Pow
+import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.chain.db._
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.db.AppConfig
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.testkit.chain.ChainUnitTest.createChainHandler

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/TestDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/TestDAOFixture.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.testkit.db
 
-import org.bitcoins.db.AppConfig
+import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig.ProjectType
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.testkit.node
 
 import akka.actor.{ActorSystem, Cancellable}
+import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.core.api.chain.{ChainApi, ChainQueryApi, FilterSyncMarker}
 import org.bitcoins.core.api.chain.db.{
   BlockHeaderDb,
@@ -13,7 +14,6 @@ import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.db.AppConfig
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.EmbeddedPg

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.testkit.node
 
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.db.AppConfig
+import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -1,13 +1,13 @@
 package org.bitcoins.testkit.wallet
 
 import com.typesafe.config.{Config, ConfigFactory}
+import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.gcs.BlockFilter
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.db.AppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.testkit.wallet
 
+import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.protocol.dlc.models.{ContractInfo, ContractOraclePair}
-import org.bitcoins.db.AppConfig
 import org.bitcoins.dlc.wallet.DLCAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.testkit.wallet
 import akka.actor.ActorSystem
 import com.typesafe.config.{Config, ConfigFactory}
 import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.api.feeprovider.FeeRateApi
@@ -13,7 +14,6 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee._
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
-import org.bitcoins.db.AppConfig
 import org.bitcoins.dlc.wallet.{DLCAppConfig, DLCWallet}
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.node.{

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -1,8 +1,8 @@
 package org.bitcoins.tor.config
 
 import com.typesafe.config.Config
+import org.bitcoins.commons.config.{AppConfig, AppConfigFactory, ConfigOps}
 import org.bitcoins.core.util.NetworkUtil
-import org.bitcoins.db.{AppConfig, AppConfigFactory, ConfigOps}
 import org.bitcoins.tor.TorProtocolHandler.{Password, SafeCookie}
 import org.bitcoins.tor.{Socks5ProxyParams, TorParams}
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -2,6 +2,7 @@ package org.bitcoins.wallet.config
 
 import com.typesafe.config.Config
 import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.commons.config.{AppConfigFactory, ConfigOps}
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi


### PR DESCRIPTION
This makes it so projects like `keyManager` and `tor` projects don't get all these database drivers included in their classpath. 

This does not change any functionality, strictly a move only PR.