### PR TITLE
Don't use tor proxy for localhost connections

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -333,13 +333,17 @@ trait Client
   private lazy val httpConnectionPoolSettings: ConnectionPoolSettings =
     instance.proxyParams match {
       case Some(proxyParams) =>
-        val socks5ClientTransport = new Socks5ClientTransport(proxyParams)
+        val host = instance.rpcUri.getHost
+        if (!host.contains("localhost") && !host.contains("127.0.0.1")) {
+          val socks5ClientTransport = new Socks5ClientTransport(proxyParams)
 
-        val clientConnectionSettings =
-          ClientConnectionSettings(system).withTransport(socks5ClientTransport)
+          val clientConnectionSettings =
+            ClientConnectionSettings(system).withTransport(
+              socks5ClientTransport)
 
-        ConnectionPoolSettings(system).withConnectionSettings(
-          clientConnectionSettings)
+          ConnectionPoolSettings(system).withConnectionSettings(
+            clientConnectionSettings)
+        } else ConnectionPoolSettings(system)
       case None => ConnectionPoolSettings(system)
     }
 

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -102,9 +102,16 @@ case class P2PClientActor(
       val (peerOrProxyAddress, proxyParams) =
         peer.socks5ProxyParams match {
           case Some(proxyParams) =>
-            val proxyAddress = proxyParams.address
-            logger.info(s"connecting to SOCKS5 proxy $proxyAddress")
-            (proxyAddress, Some(proxyParams))
+            val host = peer.socket.getHostName
+            if (!host.contains("localhost") && !host.contains("127.0.0.1")) {
+              val proxyAddress = proxyParams.address
+              logger.info(s"connecting to SOCKS5 proxy $proxyAddress")
+              (proxyAddress, Some(proxyParams))
+            } else {
+              val remoteAddress = peer.socket
+              logger.info(s"connecting to $remoteAddress")
+              (peer.socket, None)
+            }
           case None =>
             val remoteAddress = peer.socket
             logger.info(s"connecting to $remoteAddress")


### PR DESCRIPTION
The tor proxy can't connect to localhost, so we have to ignore the proxy settings when doing so