### PR TITLE
SplitPane flat Dialog UI

### DIFF
--- a/app/gui/src/main/resources/themes/dark-theme.css
+++ b/app/gui/src/main/resources/themes/dark-theme.css
@@ -66,10 +66,22 @@
     -fx-border-width: 1px;
 }
 
-/* Accordion Group heading content */
+/* Accordion TitledPane heading content */
 .small {
     -fx-font-size: 0.8em;
 }
+
+/* Accordion TitledPane heading textfield */
+.title-textfield {
+    -fx-pref-width: 90;
+}
+
+/* Adjust divider visibility and padding */
+/*
+.split-pane > .split-pane-divider {
+    -fx-padding: 0;
+}
+*/
 
 /* Right content area */
 .scroll-pane {

--- a/app/gui/src/main/scala/org/bitcoins/gui/AppMenuBar.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/AppMenuBar.scala
@@ -2,6 +2,7 @@ package org.bitcoins.gui
 
 import org.bitcoins.cli.CliCommand.ZipDataDir
 import org.bitcoins.cli.ConsoleCli
+import org.bitcoins.gui.dlc.DLCPane
 import org.bitcoins.gui.settings.Themes
 import scalafx.application.Platform
 import scalafx.scene.control._
@@ -14,10 +15,10 @@ import scala.util.Properties
 
 object AppMenuBar {
 
-  def menuBar(model: WalletGUIModel): MenuBar = {
+  def menuBar(model: WalletGUIModel, dlcPane: DLCPane): MenuBar = {
     val menuBar = new MenuBar {
       menus = List(new FileMenu().fileMenu,
-                   new ViewMenu().viewMenu,
+                   new ViewMenu(dlcPane).viewMenu,
                    new HelpMenu(model).helpMenu)
     }
     // Use MacOS native menuing
@@ -53,10 +54,7 @@ private class FileMenu() {
 
   private val quit: MenuItem = new MenuItem("_Quit") {
     mnemonicParsing = true
-    accelerator =
-      new KeyCodeCombination(KeyCode.Q,
-                             KeyCombination.ShortcutDown
-      ) // Ctrl/Cmd + Q
+    accelerator = new KeyCodeCombination(KeyCode.Q, KeyCombination.ShortcutDown)
     onAction = _ => Platform.exit()
   }
 
@@ -67,7 +65,7 @@ private class FileMenu() {
     }
 }
 
-private class ViewMenu() {
+private class ViewMenu(dlcPane: DLCPane) {
 
   private val themeToggle: ToggleGroup = new ToggleGroup()
 
@@ -109,9 +107,15 @@ private class ViewMenu() {
     }
   }
 
+  private val dlcWindow = new MenuItem("DLC Operations") {
+    accelerator =
+      new KeyCodeCombination(KeyCode.Digit1, KeyCombination.ShortcutDown)
+    onAction = _ => dlcPane.showWindow()
+  }
+
   val viewMenu: Menu = new Menu("_View") {
     mnemonicParsing = true
-    items = List(themes)
+    items = List(themes, new SeparatorMenuItem(), dlcWindow)
   }
 }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/ContractGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/ContractGUI.scala
@@ -60,7 +60,7 @@ class ContractGUI(glassPane: VBox) {
       val event = model.addEvent(this.text.value.trim)
       event match {
         case Some(tup) =>
-          this.clear()
+          clearEventTF()
           eventTableView.sort()
           // Set focus on new item
           eventTableView.getSelectionModel().select(tup)
@@ -69,6 +69,10 @@ class ContractGUI(glassPane: VBox) {
         case None =>
       }
     }
+  }
+
+  private def clearEventTF(): Unit = {
+    addEventTF.clear()
   }
 
   lazy val addEventHBox = new HBox {
@@ -81,9 +85,13 @@ class ContractGUI(glassPane: VBox) {
     promptText = "Contract Hex"
     onKeyTyped = _ => {
       val bool = onContractAdded(text.value.trim, None)
-      if (bool) this.clear() // Clear on valid data
+      if (bool) clearContractTF() // Clear on valid data
       ()
     }
+  }
+
+  private def clearContractTF(): Unit = {
+    addContractTF.clear()
   }
 
   private lazy val fileChooserButton = GUIUtil.getFileChooserButton(file => {
@@ -145,7 +153,7 @@ class ContractGUI(glassPane: VBox) {
 
       val removeContract: MenuItem = new MenuItem("Remove Contract") {
         onAction = _ => {
-          val selected = selectionModel.value.getSelectedItem
+          val selected = selectionModel().getSelectedItem
           model.onRemoveContract(selected._1, selected._2)
         }
       }
@@ -155,7 +163,7 @@ class ContractGUI(glassPane: VBox) {
       }
 
       onMouseClicked = _ => {
-        val i = this.getSelectionModel.getSelectedItem
+        val i = selectionModel().getSelectedItem
         if (i != null) {
           showCreateOfferPane(i._1, i._2)
         }

--- a/app/gui/src/main/scala/org/bitcoins/gui/ContractGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/ContractGUI.scala
@@ -1,0 +1,266 @@
+package org.bitcoins.gui
+
+//import akka.actor.ActorSystem
+import org.bitcoins.cli.CliCommand.{
+  AcceptDLCCliCommand,
+  AddDLCSigsAndBroadcastCliCommand,
+  CreateDLCOffer,
+  SignDLCCliCommand
+}
+import org.bitcoins.core.protocol.dlc.models.DLCStatus
+import org.bitcoins.core.protocol.tlv.{
+  ContractInfoV0TLV,
+  DLCAcceptTLV,
+  DLCOfferTLV,
+  DLCSignTLV,
+  LnMessageFactory,
+  OracleAnnouncementV0TLV
+}
+import org.bitcoins.gui.contract.GlobalContractData
+import org.bitcoins.gui.dlc.DLCPaneModel
+import org.bitcoins.gui.dlc.dialog.{
+  AcceptOfferDialog,
+  BroadcastDLCDialog,
+  CreateDLCOfferDialog,
+  DLCDialogContainer,
+  SignDLCDialog,
+  ViewDLCDialog
+}
+import org.bitcoins.gui.util.GUIUtil
+import scalafx.beans.property.StringProperty
+import scalafx.geometry._
+import scalafx.scene.Parent
+import scalafx.scene.control.{
+  ContextMenu,
+  MenuItem,
+  TableColumn,
+  TableView,
+  TextField
+}
+import scalafx.scene.layout._
+
+import java.io.File
+import java.nio.file.Files
+import java.text.SimpleDateFormat
+import java.util.Date
+import scala.util.{Failure, Success}
+
+class ContractGUI(glassPane: VBox) {
+
+  def fetchStartingData(): Unit = {
+    // Nothing to fetch for state yet...
+  }
+
+  private[gui] lazy val model = new ContractGUIModel()
+
+  private lazy val addEventTF = new TextField {
+    styleClass += "title-textfield"
+    promptText = "New Event Hex"
+    onKeyTyped = _ => {
+      val event = model.addEvent(this.text.value.trim)
+      event match {
+        case Some(tup) =>
+          this.clear()
+          eventTableView.sort()
+          // Set focus on new item
+          eventTableView.getSelectionModel().select(tup)
+          // Show view
+          showCreateOfferPane(tup._1, tup._2)
+        case None =>
+      }
+    }
+  }
+
+  lazy val addEventHBox = new HBox {
+    styleClass += "small"
+    children = Seq(addEventTF)
+  }
+
+  private lazy val addContractTF = new TextField {
+    styleClass += "title-textfield"
+    promptText = "Contract Hex"
+    onKeyTyped = _ => {
+      val bool = onContractAdded(text.value.trim, None)
+      if (bool) this.clear() // Clear on valid data
+      ()
+    }
+  }
+
+  private lazy val fileChooserButton = GUIUtil.getFileChooserButton(file => {
+    val hex = Files.readAllLines(file.toPath).get(0)
+    val bool = onContractAdded(hex, Some(file))
+    if (bool) addContractTF.clear()
+  })
+
+  lazy val addContractHBox = new HBox {
+    styleClass += "small"
+    children = Seq(fileChooserButton, addContractTF)
+  }
+
+  private lazy val eventIdCol = new TableColumn[
+    (OracleAnnouncementV0TLV, Option[ContractInfoV0TLV]),
+    String] {
+    text = "Event Id"
+    prefWidth = 160
+    cellValueFactory = { status =>
+      val eventIdStr = status.value._1.eventTLV.eventId
+      new StringProperty(status, "Event Id", eventIdStr)
+    }
+  }
+
+  private val ISO_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'")
+
+  private lazy val maturityCol = new TableColumn[
+    (OracleAnnouncementV0TLV, Option[ContractInfoV0TLV]),
+    String] {
+    text = "Matures"
+    prefWidth = 130
+    cellValueFactory = { status =>
+      val d = new Date(
+        status.value._1.eventTLV.eventMaturityEpoch.toLong * 1000)
+      new StringProperty(status, "Matures", ISO_FORMAT.format(d))
+    }
+  }
+
+  private lazy val contractCol = new TableColumn[
+    (OracleAnnouncementV0TLV, Option[ContractInfoV0TLV]),
+    String] {
+    text = "Contract"
+    prefWidth = 160
+    cellValueFactory = { status =>
+      val contractStr =
+        status.value._2 match {
+          case None        => ""
+          case Some(value) => value.contractDescriptor.toString()
+        }
+      new StringProperty(status, "Contract", contractStr)
+    }
+  }
+
+  private lazy val eventTableView =
+    new TableView[(OracleAnnouncementV0TLV, Option[ContractInfoV0TLV])](
+      GlobalContractData.announcements) {
+      columns ++= Seq(eventIdCol, maturityCol, contractCol)
+      sortOrder.add(maturityCol)
+
+      val removeContract: MenuItem = new MenuItem("Remove Contract") {
+        onAction = _ => {
+          val selected = selectionModel.value.getSelectedItem
+          model.onRemoveContract(selected._1, selected._2)
+        }
+      }
+
+      contextMenu = new ContextMenu() {
+        items += removeContract
+      }
+
+      onMouseClicked = _ => {
+        val i = this.getSelectionModel.getSelectedItem
+        if (i != null) {
+          showCreateOfferPane(i._1, i._2)
+        }
+      }
+    }
+
+  lazy val eventPane = new VBox {
+    padding = Insets(0)
+    children = Seq(eventTableView)
+  }
+
+  // Text paste / file browse handler
+  private def onContractAdded(hex: String, file: Option[File]): Boolean = {
+    var success = true
+    // Accept / Sign / Broadcast identifier
+    LnMessageFactory(DLCOfferTLV).fromHexT(hex) match { // Accept
+      case Success(_) =>
+        showAcceptOfferPane(hex)
+      case Failure(_) =>
+        LnMessageFactory(DLCAcceptTLV).fromHexT(hex) match { // Sign
+          case Success(_) =>
+            showSignDLCPane(hex, file)
+          case Failure(_) =>
+            LnMessageFactory(DLCSignTLV).fromHexT(hex) match { // Broadcast
+              case Success(_) =>
+                showBroadcastDLCPane(hex, file)
+              case Failure(_) => success = false // Nothing else to check for
+            }
+        }
+    }
+    success
+  }
+
+  private lazy val contractStepPane: VBox = new VBox
+
+  private def showContractStep(view: Parent): Unit = {
+    contentDetailVBox.children = Seq()
+    contractStepPane.children = Seq(view)
+  }
+
+  private lazy val contentDetailVBox = new VBox {
+    alignment = Pos.Center
+    hgrow = Priority.Always
+  }
+
+  lazy val contractViews = new VBox {
+    margin = Insets(0, 0, 0, 4) // match sidebarAccordian Insets
+    children = Seq(contractStepPane, contentDetailVBox)
+  }
+
+  def showDLCView(status: DLCStatus, model: DLCPaneModel): Unit = {
+    contractStepPane.children = Seq()
+    contentDetailVBox.children = Seq(ViewDLCDialog.buildView(status, model))
+  }
+
+  private def showCreateOfferPane(
+      announcement: OracleAnnouncementV0TLV,
+      contractInfoOpt: Option[ContractInfoV0TLV]): Unit = {
+    val offerDialog = new CreateDLCOfferDialog()
+    val view = offerDialog.buildView(Some(announcement), contractInfoOpt)
+    val container =
+      new DLCDialogContainer[CreateDLCOffer]("New Offer",
+                                             view,
+                                             offerDialog,
+                                             model.taskRunner,
+                                             "offer")
+    showContractStep(container.view)
+  }
+
+  private def showAcceptOfferPane(hex: String): Unit = {
+    val dialog = new AcceptOfferDialog()
+    val container =
+      // AcceptDLCOffer -> AcceptDLCCliCommand
+      new DLCDialogContainer[AcceptDLCCliCommand]("Accept Offer",
+                                                  dialog.buildView(hex),
+                                                  dialog,
+                                                  model.taskRunner,
+                                                  "accepted")
+    showContractStep(container.view)
+  }
+
+  private def showSignDLCPane(hex: String, file: Option[File]): Unit = {
+    val container =
+      new DLCDialogContainer[SignDLCCliCommand](
+        "Sign DLC",
+        SignDLCDialog.buildView(hex, file),
+        SignDLCDialog,
+        model.taskRunner,
+        "signed")
+    container.toFileButton.visible = false
+    container.toClipboardButton.visible = false
+    showContractStep(container.view)
+  }
+
+  private def showBroadcastDLCPane(hex: String, file: Option[File]): Unit = {
+    val container =
+      new DLCDialogContainer[AddDLCSigsAndBroadcastCliCommand](
+        "Broadcast DLC",
+        BroadcastDLCDialog.buildView(hex, file),
+        BroadcastDLCDialog,
+        model.taskRunner,
+        "broadcast")
+    showContractStep(container.view)
+  }
+
+  private val taskRunner = new TaskRunner(contractViews, glassPane)
+  model.taskRunner = taskRunner
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/ContractGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/ContractGUIModel.scala
@@ -1,0 +1,70 @@
+package org.bitcoins.gui
+
+import grizzled.slf4j.Logging
+import org.bitcoins.core.protocol.tlv.{
+  ContractInfoV0TLV,
+  MultiOracleInfoTLV,
+  OracleAnnouncementV0TLV,
+  OracleInfoV0TLV
+}
+import org.bitcoins.gui.contract.GlobalContractData
+
+import scalafx.beans.property._
+import scalafx.stage.Window
+
+import scala.util.{Failure, Success}
+
+class ContractGUIModel() extends Logging {
+  var taskRunner: TaskRunner = _
+
+  // Sadly, it is a Java "pattern" to pass null into
+  // constructors to signal that you want some default
+  lazy val parentWindow: ObjectProperty[Window] =
+    ObjectProperty[Window](null.asInstanceOf[Window])
+
+  // Text paste handler
+  def addEvent(eventHex: String): Option[
+    (OracleAnnouncementV0TLV, Option[ContractInfoV0TLV])] = {
+    OracleAnnouncementV0TLV.fromHexT(eventHex) match {
+      case Failure(_) =>
+        ContractInfoV0TLV.fromHexT(eventHex) match {
+          case Failure(_) => None
+          case Success(contractInfo) =>
+            contractInfo.oracleInfo match {
+              case OracleInfoV0TLV(announcement) =>
+                onAddContract(
+                  announcement.asInstanceOf[OracleAnnouncementV0TLV],
+                  Some(contractInfo))
+              case multi: MultiOracleInfoTLV =>
+                // todo display all oracles
+                onAddContract(
+                  multi.oracles.head.asInstanceOf[OracleAnnouncementV0TLV],
+                  Some(contractInfo))
+            }
+        }
+      case Success(announcement) =>
+        onAddContract(announcement, None)
+    }
+  }
+
+  // Add an announcement/contract to GlobalContractData.announcements
+  def onAddContract(
+      announcement: OracleAnnouncementV0TLV,
+      contractInfoOpt: Option[ContractInfoV0TLV]): Option[
+    (OracleAnnouncementV0TLV, Option[ContractInfoV0TLV])] = {
+    val tup = (announcement, contractInfoOpt)
+    // Check for a duplicate announcement/contract
+    if (!GlobalContractData.announcements.contains(tup)) {
+      GlobalContractData.announcements += tup
+    }
+    Some(tup)
+  }
+
+  // Remove an announcement/contract from GlobalContractData.announcements
+  def onRemoveContract(
+      announcement: OracleAnnouncementV0TLV,
+      contractInfoOpt: Option[ContractInfoV0TLV]): Unit = {
+    GlobalContractData.announcements -= ((announcement, contractInfoOpt))
+  }
+
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
 import org.bitcoins.gui.dlc.DLCPane
 import org.bitcoins.gui.util.GUIUtil
-import scalafx.beans.property.StringProperty
+import scalafx.beans.property.{StringProperty}
 import scalafx.geometry._
 import scalafx.scene.control._
 import scalafx.scene.layout._
@@ -37,25 +37,24 @@ abstract class WalletGUI extends Logging {
 
   private[gui] lazy val dlcPane = new DLCPane(glassPane)(system.dispatcher)
   private[gui] lazy val model = new WalletGUIModel(dlcPane.model)
+  private[gui] lazy val contractGUI = new ContractGUI(glassPane)
 
   private lazy val getNewAddressButton = new Button {
     text = "Get New Address"
     onAction = _ => model.onGetNewAddress()
+    hgrow = Priority.Always
+    maxWidth = 240
   }
 
   private lazy val sendButton = new Button {
     text = "Send"
     onAction = _ => model.onSend()
+    hgrow = Priority.Always
+    maxWidth = 240
   }
 
   private lazy val buttonBox = new HBox {
     spacing = 10
-    getNewAddressButton.prefWidth <== width / 2
-    sendButton.prefWidth <== width / 2
-    getNewAddressButton.minWidth = 120
-    sendButton.minWidth = 120
-    getNewAddressButton.maxWidth = 240
-    sendButton.maxWidth = 240
     children = Vector(getNewAddressButton, sendButton)
   }
 
@@ -70,7 +69,7 @@ abstract class WalletGUI extends Logging {
   private def getSatsLabel(): Label = new Label("sats")
 
   private lazy val walletGrid = new GridPane() {
-    minWidth = 490 // Matches button widths, this sets minWidth of sidebar
+    // Could force minWidth here to avoid text/value compression from SplitPane
     styleClass += "no-text-input-readonly-style"
     nextRow = 0
     add(new Label("Confirmed Balance"), 0, nextRow)
@@ -111,6 +110,7 @@ abstract class WalletGUI extends Logging {
       new ColumnConstraints(),
       new ColumnConstraints() {
         prefWidth = 110
+        minWidth = 110 // Don't compress numerics
       },
       new ColumnConstraints(),
       new ColumnConstraints() { // spacer column
@@ -119,6 +119,7 @@ abstract class WalletGUI extends Logging {
       new ColumnConstraints(),
       new ColumnConstraints() {
         prefWidth = 90
+        minWidth = 90 // Don't compress numerics
       }
     )
   }
@@ -129,11 +130,69 @@ abstract class WalletGUI extends Logging {
     children = Vector(walletGrid, buttonBox)
   }
 
+  private lazy val eventsLabel = new Label("Events")
+
+  private lazy val eventsTitleHbox = new HBox {
+    alignment = Pos.Center
+    children = Seq(eventsLabel, GUIUtil.getHSpacer(), contractGUI.addEventHBox)
+  }
+
+  private lazy val contractLabel = new Label("Contracts")
+
+  private lazy val contractsTitleHbox = new HBox {
+    alignment = Pos.Center
+    children =
+      Seq(contractLabel, GUIUtil.getHSpacer(), contractGUI.addContractHBox)
+  }
+
+  // Magic indent so text doesn't write passed edge of TitledPane
+  private val TITLEPANE_RIGHT_GUTTER = 35
+
+  private lazy val sidebarAccordian = new VBox {
+    padding = Insets(4)
+
+    val contractUI = new TitledPane {
+      graphic = contractsTitleHbox
+      content = dlcPane.tableView
+      dlcPane.tableView.onMouseClicked = _ => {
+        val i = dlcPane.tableView.getSelectionModel.getSelectedItem
+        if (i != null) {
+          contractGUI.showDLCView(i, dlcPane.model)
+        }
+      }
+    }
+    contractsTitleHbox.minWidth <== contractUI.width - TITLEPANE_RIGHT_GUTTER
+
+    val eventUI = new TitledPane {
+      graphic = eventsTitleHbox
+      content = contractGUI.eventPane
+      expanded = false
+    }
+    eventsTitleHbox.minWidth <== eventUI.width - TITLEPANE_RIGHT_GUTTER
+
+    val walletUI = new TitledPane {
+      content = wallet
+      text = "Wallet"
+    }
+
+    children = Vector(
+      contractUI,
+      eventUI,
+      walletUI,
+      GUIUtil.getVSpacer(),
+      stateDetails
+    )
+  }
+
+  private lazy val rightPaneContent: VBox = new VBox {
+    children = Vector(contractGUI.contractViews)
+  }
+
   private lazy val stateDetails = new GridPane {
     visible <== GlobalData.torAddress.isNotEmpty
+    padding = Insets(4, 0, 0, 0)
     hgap = 5
     vgap = 5
-    prefWidth = 490 // to match wallet
     columnConstraints = Seq(new ColumnConstraints { hgrow = Priority.Always },
                             new ColumnConstraints { hgrow = Priority.Always })
 
@@ -153,15 +212,18 @@ abstract class WalletGUI extends Logging {
     nextRow += 1
   }
 
-  private lazy val sidebar = new VBox {
-    padding = Insets(10)
-    spacing = 20
+  lazy val rightPane: ScrollPane = new ScrollPane {
+    padding = Insets(4, 4, 4, 0) // There's native pad on the SplitPane divider
+    styleClass = Seq("scroll-pane")
+    fitToHeight = true
+    fitToWidth = true
+//    minWidth = 300 // May want this set only if there is content
+    content = rightPaneContent
+  }
 
-    getNewAddressButton.prefWidth <== width
-    sendButton.prefWidth <== width
-    getNewAddressButton.maxWidth = 240
-    sendButton.maxWidth = 240
-    children = Vector(wallet, GUIUtil.getVSpacer(), stateDetails)
+  lazy val splitPane: SplitPane = new SplitPane {
+    items ++= Seq(sidebarAccordian, rightPane)
+    setDividerPosition(0, 0.6)
   }
 
   lazy val bottomStack: HBox = new HBox {
@@ -175,9 +237,8 @@ abstract class WalletGUI extends Logging {
   }
 
   lazy val borderPane: BorderPane = new BorderPane {
-    top = AppMenuBar.menuBar(model)
-    left = sidebar
-    center = dlcPane.borderPane
+    top = AppMenuBar.menuBar(model, dlcPane)
+    center = splitPane
     bottom = bottomStack
   }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/contract/GlobalContractData.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/contract/GlobalContractData.scala
@@ -1,0 +1,14 @@
+package org.bitcoins.gui.contract
+
+import org.bitcoins.core.protocol.tlv.{
+  ContractInfoV0TLV,
+  OracleAnnouncementV0TLV
+}
+import scalafx.collections.ObservableBuffer
+
+object GlobalContractData {
+
+  val announcements: ObservableBuffer[
+    (OracleAnnouncementV0TLV, Option[ContractInfoV0TLV])] =
+    new ObservableBuffer[(OracleAnnouncementV0TLV, Option[ContractInfoV0TLV])]()
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPane.scala
@@ -135,18 +135,27 @@ class DLCPane(glassPane: VBox)(implicit ec: ExecutionContext) {
   def sortTable(): Unit = tableView.sort()
 
   private val textAreasAndTableViewVBox = new VBox {
-    children = Seq(textAreaHBox, resultButtonHBox, tableView)
+    children = Seq(textAreaHBox, resultButtonHBox)
     spacing = 10
   }
 
   val borderPane: BorderPane = new BorderPane {
-    padding = Insets(top = 10, right = 10, bottom = 0, left = 10)
+    padding = Insets(10)
     top = buttonSpacer
     center = textAreasAndTableViewVBox
   }
 
-  resultArea.prefHeight <== (borderPane.height * 2) / 3
-  tableView.prefHeight <== borderPane.height / 3
+  private lazy val window =
+    GUIUtil.getWindow("DLC Operations", 650, 350, borderPane)
+
+  def showWindow(): Unit = {
+    window.show()
+    window.requestFocus()
+    window.toFront()
+  }
+
+  buttonSpacer.prefWidth <== borderPane.width
+  resultArea.prefWidth <== borderPane.width
 
   private val taskRunner = new TaskRunner(buttonSpacer, glassPane)
   model.taskRunner = taskRunner

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialogContainer.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/DLCDialogContainer.scala
@@ -1,0 +1,97 @@
+package org.bitcoins.gui.dlc.dialog
+
+import org.bitcoins.cli.{CliCommand, ConsoleCli}
+import org.bitcoins.gui.util.GUIUtil
+import org.bitcoins.gui.{GlobalData, TaskRunner}
+import scalafx.beans.property.StringProperty
+import scalafx.geometry.{Insets, Pos}
+import scalafx.scene.Node
+import scalafx.scene.control.{Button, TextField}
+import scalafx.scene.layout.{HBox, Priority, VBox}
+
+import scala.util.{Failure, Success}
+
+class DLCDialogContainer[T <: CliCommand](
+    caption: String,
+    nestedView: Node,
+    producer: CliCommandProducer[T],
+    taskRunner: TaskRunner,
+    filename: String = "") {
+
+  private val returnValue = new StringProperty()
+
+  private val textField = new TextField {
+    text <== StringProperty(caption)
+  }
+
+  private val executeButton = new Button("Execute") {
+    onAction = _ => {
+      val command = producer.getCliCommand()
+      disable = true // Disable button while processing task
+      taskRunner.run(
+        caption = caption,
+        op = {
+          ConsoleCli.exec(command, GlobalData.consoleCliConfig) match {
+            case Success(commandReturn) =>
+              // Could fire a success callback here
+              disable = false
+              returnValue.value = commandReturn
+            case Failure(_) =>
+              // TaskRunner handles modal error and logging
+              disable = false
+          }
+        }
+      )
+    }
+  }
+
+  private val greenCheck = GUIUtil.getGreenCheck()
+  greenCheck.visible <== returnValue.isNotEmpty
+
+  private val outputTF = new TextField {
+    disable <== returnValue.isEmpty
+    text <== returnValue
+    editable = false
+  }
+
+  val toClipboardButton = GUIUtil.getCopyToClipboardButton(returnValue)
+
+  private val outputHBox = new HBox {
+    alignment = Pos.Center
+    children = Seq(outputTF, toClipboardButton)
+  }
+
+  val toFileButton = new Button("Save to File...") {
+    disable <== returnValue.isEmpty
+    onAction = _ =>
+      GUIUtil.showSaveDialog(filename, Some(returnValue.value), None)
+  }
+
+  private val buttonFirstRow = new HBox {
+    hgrow = Priority.Always
+    alignment = Pos.CenterRight
+    spacing = 10
+    children = Seq(executeButton)
+  }
+
+  private val buttonSecondRow = new HBox {
+    padding = Insets(10, 0, 10, 0)
+    hgrow = Priority.Always
+    alignment = Pos.CenterRight
+    spacing = 10
+    children = Seq(greenCheck, outputHBox, toFileButton)
+  }
+
+  private val buttonBox = new VBox {
+    styleClass += "dialog-button-group"
+    padding = Insets(10)
+    hgrow = Priority.Always
+    alignment = Pos.CenterRight
+    children = Seq(buttonFirstRow, buttonSecondRow)
+  }
+
+  val view = new VBox {
+    children = Seq(textField, nestedView, buttonBox)
+  }
+
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
@@ -7,6 +7,7 @@ import scalafx.beans.property.StringProperty
 import scalafx.scene.{Parent, Scene}
 import scalafx.scene.control.{Button, TextField, Tooltip}
 import scalafx.scene.image.{Image, ImageView}
+import scalafx.scene.input.{KeyCode, KeyCodeCombination, KeyCombination}
 import scalafx.scene.layout.{Priority, Region}
 import scalafx.stage.{FileChooser, Stage}
 import scalafx.stage.FileChooser.ExtensionFilter
@@ -155,6 +156,16 @@ object GUIUtil {
       title = windowTitle
       scene = windowScene
       // Icon?
+    }
+    if (Properties.isMac || Properties.isLinux) {
+      windowScene.accelerators.put(
+        new KeyCodeCombination(KeyCode.W, KeyCombination.ShortcutDown),
+        () => stage.close())
+    }
+    if (Properties.isWin || Properties.isLinux) {
+      windowScene.accelerators.put(
+        new KeyCodeCombination(KeyCode.F4, KeyCombination.AltDown),
+        () => stage.close())
     }
     stage
   }


### PR DESCRIPTION
Moves UI to a SplitPane based main view with Dialog content in the main view.

<img width="1027" alt="Screen Shot 2021-08-09 at 11 22 54 AM" src="https://user-images.githubusercontent.com/22351459/128748401-6059675c-90f8-43ff-a3bf-91a24ceb792c.png">

A new event can be pasted into the 'New Event Hex' textfield to load a New Offer pane. A contract being exchanged to create a DLC can be pasted into the 'Contract Hex' textfield or selected from the 'Browse...' button in the Contracts TitledPane.

DLC specific operations are accessible in an additional window:

<img width="301" alt="Screen Shot 2021-08-09 at 11 30 38 AM" src="https://user-images.githubusercontent.com/22351459/128748563-89010177-f466-457d-9a5a-84c4b933d256.png">
<img width="674" alt="Screen Shot 2021-08-09 at 11 23 07 AM" src="https://user-images.githubusercontent.com/22351459/128748572-f5eaede7-8027-42d0-a561-7beaf167d693.png">

The DLC window is closable with OS standard key commands.

Here's what creating a new Offer from Event Hex looks like after Executing the operation:

<img width="1024" alt="Screen Shot 2021-08-09 at 11 24 40 AM" src="https://user-images.githubusercontent.com/22351459/128748737-02469b02-ff52-4bb8-aedd-a7463cd829eb.png">
