### PR TITLE
2021 08 09 init delay broadcast freq

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -290,11 +290,12 @@ case class WalletAppConfig(
         ()
       case None =>
         logger.info(s"Starting wallet rebroadcast task")
+        val initDelay = 60
         val interval = rebroadcastFrequency.toSeconds
 
         val future =
           scheduler.scheduleAtFixedRate(RebroadcastTransactionsRunnable(wallet),
-                                        interval,
+                                        initDelay,
                                         interval,
                                         TimeUnit.SECONDS)
         rebroadcastTransactionsCancelOpt = Some(future)
@@ -402,7 +403,12 @@ object WalletAppConfig
 
       // Make sure broadcasting completes
       // Wrap in try in case of spurious failure
-      Try(Await.result(f, 60.seconds))
+      try {
+        Await.result(f, 60.seconds)
+      } catch {
+        case scala.util.control.NonFatal(exn) =>
+          logger.error(s"Failed to broadcast txs", exn)
+      }
       ()
     }
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -33,7 +33,6 @@ import java.util.concurrent.{
 }
 import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.util.Try
 
 /** Configuration for the Bitcoin-S wallet
   * @param directory The data directory of the wallet


### PR DESCRIPTION
I think when the node is started up we don't need to wait the entire delay to broadcast queued transactions. This is especially useful in situations where the user knows a bug occurred in the wallet. We can tell them to restart their node to rebroadcast the tx after 1 minute rather than 4 hours.