### PR TITLE
Add better CETSignaturesV0TLV.toString so we don't accidentally DOS

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -1404,6 +1404,15 @@ case class CETSignaturesV0TLV(sigs: Vector[ECAdaptorSignature])
   override val value: ByteVector = {
     bigSizePrefixedList(sigs)
   }
+
+  override def toString: String = {
+    if (sigs.length <= 5) {
+      super.toString
+    } else {
+      s"CETSignaturesV0TLV(sigs=${sigs.take(
+        2)}..., omitting remainingSigs of length=${sigs.length - 2})"
+    }
+  }
 }
 
 object CETSignaturesV0TLV extends TLVFactory[CETSignaturesV0TLV] {


### PR DESCRIPTION
 When reporting #3520 I tried to dump my logs in there. It isn't useful to have 10,000 signatures in the log (in my case). Now it just prints 2 signatures and tells you how many signatures are remaining.