### PR TITLE
Reduce logs for inv messages and wallet callbacks to DEBUG

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -247,7 +247,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       nodeConf: NodeAppConfig,
       ec: ExecutionContext): Future[NodeCallbacks] = {
     lazy val onTx: OnTxReceived = { tx =>
-      logger.info(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")
+      logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")
       wallet.processTransaction(tx, blockHashOpt = None).map(_ => ())
     }
     lazy val onCompactFilters: OnCompactFiltersReceived = { blockFilters =>

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -375,7 +375,7 @@ case class DataMessageHandler(
   private def handleInventoryMsg(
       invMsg: InventoryMessage,
       peerMsgSender: PeerMessageSender): Future[DataMessageHandler] = {
-    logger.info(s"Received inv=${invMsg}")
+    logger.debug(s"Received inv=${invMsg}")
     val getData = GetDataMessage(invMsg.inventories.flatMap {
       case Inventory(TypeIdentifier.MsgBlock, hash) =>
         // only request the merkle block if we are spv enabled


### PR DESCRIPTION
Otherwise if you have `bitcoin-s.node.relay=true` you get these noisy logs

![Screenshot from 2021-08-11 10-33-09](https://user-images.githubusercontent.com/3514957/129058880-1ec5d9bd-71ad-48ed-9ef0-65afcd63995a.png)
