### PR TITLE
Invert updating of DLC state and broadcasting the funding tx

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1157,9 +1157,9 @@ abstract class DLCWallet
       contractId: ByteVector): Future[Transaction] = {
     for {
       tx <- getDLCFundingTx(contractId)
+      _ <- updateDLCState(contractId, DLCState.Broadcasted)
       _ = logger.info(
         s"Broadcasting funding transaction ${tx.txIdBE.hex} for contract ${contractId.toHex}")
-      _ <- updateDLCState(contractId, DLCState.Broadcasted)
       _ <- broadcastTransaction(tx)
     } yield tx
   }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1159,9 +1159,8 @@ abstract class DLCWallet
       tx <- getDLCFundingTx(contractId)
       _ = logger.info(
         s"Broadcasting funding transaction ${tx.txIdBE.hex} for contract ${contractId.toHex}")
-      _ <- broadcastTransaction(tx)
-
       _ <- updateDLCState(contractId, DLCState.Broadcasted)
+      _ <- broadcastTransaction(tx)
     } yield tx
   }
 


### PR DESCRIPTION
fixes #3502 

The problem that can happen here that we could _actually_ broadcast the tx, but not have the state updated to broadcast if something internal to `updateDLCState()` fails. This means we _could_ have allowed a transaction to leave our wallet, without making sure we had actually updated the internal state of the DLC.

A secondary concern here is what I talk about in #3502, if we want to broadcast the tx manually (and have implemented #3424 ). I failed to broadcast because i wasn't properly connected on p2p. I want to eventually be able to fetch the funding transaction manually so you can broadcast it out of band if needed.