### PR TITLE
Add TorBundle, make all mac files executable that are required

### DIFF
--- a/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
@@ -132,9 +132,7 @@ object TorClient extends Logging {
         Files.copy(stream, writePath, StandardCopyOption.REPLACE_EXISTING)
       }
 
-      // set tor/tor.exe file as executable
-      //executableFileName.setExecutable(true)
-
+      //set files as executable
       torBundle.executables.foreach { f =>
         val executable = datadir.resolve(f)
         executable.toFile.setExecutable(true)


### PR DESCRIPTION
fixes #3533 

There are multiple files that need to bet set to executable on mac osx, so make a helper class called `TorBundle` to deal with multiple files that need to be set to executable.