### PR TITLE
Add debug window to view log fixes #3516

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/AppMenuBar.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/AppMenuBar.scala
@@ -18,7 +18,7 @@ object AppMenuBar {
   def menuBar(model: WalletGUIModel, dlcPane: DLCPane): MenuBar = {
     val menuBar = new MenuBar {
       menus = List(new FileMenu().fileMenu,
-                   new ViewMenu(dlcPane).viewMenu,
+                   new ViewMenu(model, dlcPane).viewMenu,
                    new HelpMenu(model).helpMenu)
     }
     // Use MacOS native menuing
@@ -65,7 +65,7 @@ private class FileMenu() {
     }
 }
 
-private class ViewMenu(dlcPane: DLCPane) {
+private class ViewMenu(model: WalletGUIModel, dlcPane: DLCPane) {
 
   private val themeToggle: ToggleGroup = new ToggleGroup()
 
@@ -113,9 +113,15 @@ private class ViewMenu(dlcPane: DLCPane) {
     onAction = _ => dlcPane.showWindow()
   }
 
+  private val debugWindow = new MenuItem("Debug Operations") {
+    accelerator =
+      new KeyCodeCombination(KeyCode.Digit2, KeyCombination.ShortcutDown)
+    onAction = _ => model.onDebug()
+  }
+
   val viewMenu: Menu = new Menu("_View") {
     mnemonicParsing = true
-    items = List(themes, new SeparatorMenuItem(), dlcWindow)
+    items = List(themes, new SeparatorMenuItem(), dlcWindow, debugWindow)
   }
 }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
@@ -109,6 +109,10 @@ class WalletGUIModel(dlcModel: DLCPaneModel)(implicit system: ActorSystem)
     AboutDialog.showAndWait(parentWindow.value)
   }
 
+  def onDebug(): Unit = {
+    DebugDialog.show(parentWindow.value)
+  }
+
   /** Updates the wallet sync height
     * @return if the update was successful
     */

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
@@ -31,19 +31,21 @@ object DebugDialog {
         val location = System.getProperty("bitcoins.log.location")
         val path = Paths.get(location, LOGFILE_NAME)
         if (Files.exists(path)) {
-          val file = new File(path.toString)
           // Ubuntu seems to support Desktop and Desktop.open(), but hangs on opening file
+          // This is an issue in JavaFX and the common workaround is to call on another thread
+          // I was not having any luck with Platform.runLater wrapping call to Desktop.open getting around the bug
           if (Properties.isLinux) {
+            // Work around native file-open alternative that works on Ubuntu
             val _ = Runtime
               .getRuntime()
-              .exec("/usr/bin/evince \"" + file.getAbsolutePath() + "\"")
+              .exec(s"/usr/bin/xdg-open ${path.toString}")
           } else if (
             Desktop.isDesktopSupported && Desktop
               .getDesktop()
               .isSupported(Desktop.Action.OPEN)
           ) {
             // Open file in default log reader per OS
-            Desktop.getDesktop().open(file)
+            Desktop.getDesktop().open(new File(path.toString))
           } else {
             println(
               "File is missing or Desktop operations are not supported on this platform")

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
@@ -39,17 +39,12 @@ object DebugDialog {
             val _ = Runtime
               .getRuntime()
               .exec(s"/usr/bin/xdg-open ${path.toString}")
-          } else if (
-            Desktop.isDesktopSupported && Desktop
-              .getDesktop()
-              .isSupported(Desktop.Action.OPEN)
-          ) {
-            // Open file in default log reader per OS
-            Desktop.getDesktop().open(new File(path.toString))
-          } else {
-            println(
-              "File is missing or Desktop operations are not supported on this platform")
-          }
+          } else if (Desktop.isDesktopSupported) {
+            val d = Desktop.getDesktop
+            if (d.isSupported(Desktop.Action.OPEN)) {
+              // Open file in default log reader per OS
+              d.open(new File(path.toString))
+            }
         }
       }
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
@@ -29,10 +29,16 @@ object DebugDialog {
         // Get root active network directory
         val location = System.getProperty("bitcoins.log.location")
         val path = Paths.get(location, LOGFILE_NAME)
-        if (Files.exists(path)) {
-          val file = new File(path.toString)
+        if (
+          Files.exists(path) && Desktop.isDesktopSupported && Desktop
+            .getDesktop()
+            .isSupported(Desktop.Action.OPEN)
+        ) {
           // Open file in default log reader per OS
-          Desktop.getDesktop().edit(file)
+          Desktop.getDesktop().open(new File(path.toString))
+        } else {
+          println(
+            "File is missing or Desktop operations are not supported on this platform")
         }
       }
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
@@ -1,0 +1,48 @@
+package org.bitcoins.gui.dialog
+
+import org.bitcoins.gui.GlobalData
+import scalafx.Includes._
+import scalafx.scene.control.{Button, ButtonType, Dialog}
+import scalafx.scene.layout.VBox
+import scalafx.stage.{Modality, Window}
+
+import java.awt.Desktop
+import java.io.File
+import java.nio.file.{Files, Paths}
+
+object DebugDialog {
+
+  private val LOGFILE_NAME = "bitcoin-s.log"
+
+  def show(parentWindow: Window): Unit = {
+    val dialog = new Dialog[Unit]() {
+      initOwner(parentWindow)
+      initModality(Modality.None)
+      title = "Debug Operations"
+    }
+
+    dialog.dialogPane().buttonTypes = Seq(ButtonType.Close)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+
+    val openLogButton = new Button("Open Bitcoin-S Log") {
+      onAction = _ => {
+        // Get root active network directory
+        val location = System.getProperty("bitcoins.log.location")
+        val path = Paths.get(location, LOGFILE_NAME)
+        if (Files.exists(path)) {
+          val file = new File(path.toString)
+          // Open file in default log reader per OS
+          Desktop.getDesktop().edit(file)
+        }
+      }
+    }
+
+    dialog.dialogPane().content = new VBox {
+      minWidth = 300
+      minHeight = 300
+      children = Seq(openLogButton)
+    }
+
+    val _ = dialog.show()
+  }
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
@@ -45,6 +45,7 @@ object DebugDialog {
               // Open file in default log reader per OS
               d.open(new File(path.toString))
             }
+          }
         }
       }
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.gui.dialog
 
+import grizzled.slf4j.Logging
 import org.bitcoins.gui.GlobalData
 import scalafx.Includes._
 import scalafx.scene.control.{Button, ButtonType, Dialog}
@@ -11,7 +12,7 @@ import java.io.File
 import java.nio.file.{Files, Paths}
 import scala.util.Properties
 
-object DebugDialog {
+object DebugDialog extends Logging {
 
   private val LOGFILE_NAME = "bitcoin-s.log"
 
@@ -44,8 +45,16 @@ object DebugDialog {
             if (d.isSupported(Desktop.Action.OPEN)) {
               // Open file in default log reader per OS
               d.open(new File(path.toString))
+            } else {
+              logger.error("Desktop.Action.OPEN on log file not supported")
             }
+          } else {
+            logger.error(
+              "This platform is non-Linux or does not support Desktop")
           }
+        } else {
+          logger.error(
+            s"Expected log file location does not exist ${path.toString}")
         }
       }
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/DebugDialog.scala
@@ -9,6 +9,7 @@ import scalafx.stage.{Modality, Window}
 import java.awt.Desktop
 import java.io.File
 import java.nio.file.{Files, Paths}
+import scala.util.Properties
 
 object DebugDialog {
 
@@ -29,16 +30,24 @@ object DebugDialog {
         // Get root active network directory
         val location = System.getProperty("bitcoins.log.location")
         val path = Paths.get(location, LOGFILE_NAME)
-        if (
-          Files.exists(path) && Desktop.isDesktopSupported && Desktop
-            .getDesktop()
-            .isSupported(Desktop.Action.OPEN)
-        ) {
-          // Open file in default log reader per OS
-          Desktop.getDesktop().open(new File(path.toString))
-        } else {
-          println(
-            "File is missing or Desktop operations are not supported on this platform")
+        if (Files.exists(path)) {
+          val file = new File(path.toString)
+          // Ubuntu seems to support Desktop and Desktop.open(), but hangs on opening file
+          if (Properties.isLinux) {
+            val _ = Runtime
+              .getRuntime()
+              .exec("/usr/bin/evince \"" + file.getAbsolutePath() + "\"")
+          } else if (
+            Desktop.isDesktopSupported && Desktop
+              .getDesktop()
+              .isSupported(Desktop.Action.OPEN)
+          ) {
+            // Open file in default log reader per OS
+            Desktop.getDesktop().open(file)
+          } else {
+            println(
+              "File is missing or Desktop operations are not supported on this platform")
+          }
         }
       }
     }


### PR DESCRIPTION
fixes #3516

Adds a debug window to host any debugging operation we want to expose to users. First available: open the log file in default OS editor

![Screen Shot 2021-08-12 at 11 11 45 AM](https://user-images.githubusercontent.com/22351459/129239629-48133886-36fa-4747-a100-e3ea0f56cc5c.png)
![Screen Shot 2021-08-12 at 11 07 52 AM](https://user-images.githubusercontent.com/22351459/129239637-0d45fd4a-a23a-4f02-8b61-4e789f404f91.png)

I don't know if this is the preferred way to grab the path to the current data folder, copied strategy from BundleGUI:94
