### PR TITLE
Wallet on top UI, minWidth on DLC View fields

### DIFF
--- a/app/gui/src/main/resources/themes/dark-theme.css
+++ b/app/gui/src/main/resources/themes/dark-theme.css
@@ -76,7 +76,7 @@
     -fx-pref-width: 90;
 }
 
-/* Adjust divider visibility and padding */
+/* Adjust SplitPane divider visibility and padding */
 /*
 .split-pane > .split-pane-divider {
     -fx-padding: 0;
@@ -99,6 +99,15 @@
     -fx-border-style: solid none none none;
     -fx-border-width: 1;
     -fx-border-color: black;
+}
+
+/* View DLC Dialog */
+.view-dlc-label {
+    -fx-min-width: 115; /* Counterparty payout */
+    -fx-alignment: center-right;
+}
+.view-dlc-textfield {
+    -fx-pref-width: 300;
 }
 
 /* New Offer Dialog */

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
@@ -69,7 +69,7 @@ abstract class WalletGUI extends Logging {
   private def getSatsLabel(): Label = new Label("sats")
 
   private lazy val walletGrid = new GridPane() {
-    // Could force minWidth here to avoid text/value compression from SplitPane
+    minWidth = 490 // avoid text/value compression from SplitPane
     styleClass += "no-text-input-readonly-style"
     nextRow = 0
     add(new Label("Confirmed Balance"), 0, nextRow)
@@ -151,6 +151,18 @@ abstract class WalletGUI extends Logging {
   private lazy val sidebarAccordian = new VBox {
     padding = Insets(4)
 
+    val walletUI = new TitledPane {
+      content = wallet
+      text = "Wallet"
+    }
+
+    val eventUI = new TitledPane {
+      graphic = eventsTitleHbox
+      content = contractGUI.eventPane
+      expanded = false
+    }
+    eventsTitleHbox.minWidth <== eventUI.width - TITLEPANE_RIGHT_GUTTER
+
     val contractUI = new TitledPane {
       graphic = contractsTitleHbox
       content = dlcPane.tableView
@@ -163,22 +175,10 @@ abstract class WalletGUI extends Logging {
     }
     contractsTitleHbox.minWidth <== contractUI.width - TITLEPANE_RIGHT_GUTTER
 
-    val eventUI = new TitledPane {
-      graphic = eventsTitleHbox
-      content = contractGUI.eventPane
-      expanded = false
-    }
-    eventsTitleHbox.minWidth <== eventUI.width - TITLEPANE_RIGHT_GUTTER
-
-    val walletUI = new TitledPane {
-      content = wallet
-      text = "Wallet"
-    }
-
     children = Vector(
-      contractUI,
-      eventUI,
       walletUI,
+      eventUI,
+      contractUI,
       GUIUtil.getVSpacer(),
       stateDetails
     )
@@ -217,13 +217,13 @@ abstract class WalletGUI extends Logging {
     styleClass = Seq("scroll-pane")
     fitToHeight = true
     fitToWidth = true
-//    minWidth = 300 // May want this set only if there is content
+    minWidth = 270
+    hbarPolicy = ScrollPane.ScrollBarPolicy.Never
     content = rightPaneContent
   }
 
   lazy val splitPane: SplitPane = new SplitPane {
     items ++= Seq(sidebarAccordian, rightPane)
-    setDividerPosition(0, 0.6)
   }
 
   lazy val bottomStack: HBox = new HBox {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
@@ -38,6 +38,29 @@ object ViewDLCDialog {
     val _ = dialog.showAndWait()
   }
 
+  private def getLabel(label: String): Label = {
+    new Label {
+      styleClass += "view-dlc-label"
+      text = label
+    }
+  }
+
+  private def getTextField(value: String): TextField = {
+    new TextField {
+      styleClass += "view-dlc-textfield"
+      text = value
+      editable = false
+    }
+  }
+
+  private def getTextField(property: StringProperty): TextField = {
+    new TextField {
+      styleClass += "view-dlc-textfield"
+      text <== property
+      editable = false
+    }
+  }
+
   def buildView(status: DLCStatus, model: DLCPaneModel) = {
     val closingTxId: StringProperty = StringProperty(
       DLCStatus.getClosingTxId(status).map(_.hex).getOrElse(""))
@@ -45,107 +68,67 @@ object ViewDLCDialog {
       alignment = Pos.Center
       padding = Insets(10)
       hgap = 10
-      vgap = 10
+      vgap = 5
 
       private var row = 0
-      add(new Label("DLC Id"), 0, row)
-      add(new TextField() {
-            text = status.dlcId.hex
-            editable = false
-          },
-          columnIndex = 1,
-          rowIndex = row)
+      add(getLabel("DLC Id"), 0, row)
+      add(getTextField(status.dlcId.hex), columnIndex = 1, rowIndex = row)
 
       row += 1
-      add(new Label("Event Id"), 0, row)
+      add(getLabel("Event Id"), 0, row)
       add(
-        new TextField() {
-          text =
-            status.oracleInfo.singleOracleInfos.head.announcement.eventTLV.eventId
-          editable = false
-          minWidth = 300
-        },
+        getTextField(
+          status.oracleInfo.singleOracleInfos.head.announcement.eventTLV.eventId),
         columnIndex = 1,
-        rowIndex = row
-      )
+        rowIndex = row)
 
       row += 1
-      add(new Label("Initiator"), 0, row)
-      add(new TextField() {
-            text = if (status.isInitiator) "Yes" else "No"
-            editable = false
-          },
+      add(getLabel("Initiator"), 0, row)
+      add(getTextField(if (status.isInitiator) "Yes" else "No"),
           columnIndex = 1,
           rowIndex = row)
 
       row += 1
-      add(new Label("State"), 0, row)
-      add(new TextField() {
-            text = status.statusString
-            editable = false
-          },
-          columnIndex = 1,
-          rowIndex = row)
+      add(getLabel("State"), 0, row)
+      add(getTextField(status.statusString), columnIndex = 1, rowIndex = row)
 
       row += 1
-      add(new Label("Contract Id"), 0, row)
+      add(getLabel("Contract Id"), 0, row)
       val contractId: String = DLCStatus
         .getContractId(status)
         .map(_.toHex)
         .getOrElse("")
 
-      add(new TextField() {
-            text = contractId
-            editable = false
-          },
-          columnIndex = 1,
-          rowIndex = row)
+      add(getTextField(contractId), columnIndex = 1, rowIndex = row)
 
       row += 1
-      add(new Label("Contract Info"), 0, row)
+      add(getLabel("Contract Info"), 0, row)
 
-      add(new TextField() {
-            text = status.contractInfo.toTLV.hex
-            editable = false
-          },
+      add(getTextField(status.contractInfo.toTLV.hex),
           columnIndex = 1,
           rowIndex = row)
 
       status match {
         case closed: ClosedDLCStatus =>
           row += 1
-          add(new Label("My payout"), 0, row)
-          add(new TextField() {
-                text = s"${closed.myPayout}"
-                editable = false
-              },
+          add(getLabel("My payout"), 0, row)
+          add(getTextField(s"${closed.myPayout}"),
               columnIndex = 1,
               rowIndex = row)
 
           row += 1
-          add(new Label("Counter party payout"), 0, row)
-          add(new TextField() {
-                text = s"${closed.counterPartyPayout}"
-                editable = false
-              },
+          add(getLabel("Counterparty payout"), 0, row)
+          add(getTextField(s"${closed.counterPartyPayout}"),
               columnIndex = 1,
               rowIndex = row)
 
           row += 1
-          add(new Label("PNL"), 0, row)
-          add(new TextField() {
-                text = s"${closed.pnl}"
-                editable = false
-              },
-              columnIndex = 1,
-              rowIndex = row)
+          add(getLabel("PNL"), 0, row)
+          add(getTextField(s"${closed.pnl}"), columnIndex = 1, rowIndex = row)
 
           row += 1
-          add(new Label("Rate of Return"), 0, row)
-          add(new TextField() {
-                text = s"${closed.rateOfReturnPrettyPrint}"
-                editable = false
-              },
+          add(getLabel("Rate of Return"), 0, row)
+          add(getTextField(s"${closed.rateOfReturnPrettyPrint}"),
               columnIndex = 1,
               rowIndex = row)
         case _: AcceptedDLCStatus | _: Offered =>
@@ -153,56 +136,37 @@ object ViewDLCDialog {
       }
 
       row += 1
-      add(new Label("Fee Rate"), 0, row)
-      add(new TextField() {
-            text = s"${status.feeRate.toLong} sats/vbyte"
-            editable = false
-          },
+      add(getLabel("Fee Rate"), 0, row)
+      add(getTextField(s"${status.feeRate.toLong} sats/vbyte"),
           columnIndex = 1,
           rowIndex = row)
 
       row += 1
-      add(new Label("Contract Timeout"), 0, row)
+      add(getLabel("Contract Timeout"), 0, row)
+      add(getTextField(
+            GUIUtil.epochToDateString(status.timeouts.contractTimeout)),
+          columnIndex = 1,
+          rowIndex = row)
+
+      row += 1
+      add(getLabel("Collateral"), 0, row)
+      add(getTextField(status.totalCollateral.satoshis.toLong.toString),
+          columnIndex = 1,
+          rowIndex = row)
+
+      row += 1
+      add(getLabel("Funding TxId"), 0, row)
       add(
-        new TextField() {
-          text = GUIUtil.epochToDateString(status.timeouts.contractTimeout)
-          editable = false
-        },
+        getTextField(DLCStatus.getFundingTxId(status).map(_.hex).getOrElse("")),
         columnIndex = 1,
-        rowIndex = row
-      )
+        rowIndex = row)
 
       row += 1
-      add(new Label("Collateral"), 0, row)
-      add(
-        new TextField() {
-          text = status.totalCollateral.satoshis.toLong.toString
-          editable = false
-        },
-        columnIndex = 1,
-        rowIndex = row
-      )
+      add(getLabel("Closing TxId"), 0, row)
+      add(getTextField(closingTxId), columnIndex = 1, rowIndex = row)
 
       row += 1
-      add(new Label("Funding TxId"), 0, row)
-      add(new TextField() {
-            text = DLCStatus.getFundingTxId(status).map(_.hex).getOrElse("")
-            editable = false
-          },
-          columnIndex = 1,
-          rowIndex = row)
-
-      row += 1
-      add(new Label("Closing TxId"), 0, row)
-      add(new TextField() {
-            text <== closingTxId
-            editable = false
-          },
-          columnIndex = 1,
-          rowIndex = row)
-
-      row += 1
-      add(new Label("Oracle Signatures"), 0, row)
+      add(getLabel("Oracle Signatures"), 0, row)
 
       val sigsOpt: Option[String] = DLCStatus
         .getOracleSignatures(status)
@@ -228,6 +192,8 @@ object ViewDLCDialog {
           }
       }
       add(node, columnIndex = 1, rowIndex = row)
+
+      // TODO : Refund button and discriminator
 
       row += 1
       status.contractInfo.contractDescriptor match {


### PR DESCRIPTION
Puts the wallet back on top of the accordion. Sets minWidths on each side of the SplitPane and adds minWidths to the DLC View fields

Left minWidth:
![Screen Shot 2021-08-12 at 5 59 36 PM](https://user-images.githubusercontent.com/22351459/129285026-8ea13f53-df72-4f32-b6f5-42de430d7f24.png)

Right minWidth:
![Screen Shot 2021-08-12 at 5 59 51 PM](https://user-images.githubusercontent.com/22351459/129285039-41057951-8810-40c2-bf57-7ff4c321bd49.png)
