### PR TITLE
Stop tor binary when server is shutdown

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -81,6 +81,13 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       _ <- walletConf.stop()
       _ <- nodeConf.stop()
       _ <- chainConf.stop()
+      _ <- {
+        if (torConf.enabled) {
+          torConf.createClient.stopBinary()
+        } else {
+          Future.unit
+        }
+      }
       _ = logger.info(s"Stopped ${nodeConf.nodeType.shortName} node")
       _ <- system.terminate()
     } yield {


### PR DESCRIPTION
Stop the tor binary when the server is shutdown.

I don't really understand our current startup/shutdown logic for `TorAppConfig` -- in my opinion this logic should be moved [here](https://github.com/bitcoin-s/bitcoin-s/blob/43e0287fed10a2552b0cba8a867028334b019467/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala#L33-L35)  -- but for the sake of getting something working for now, we definitely need to shutdown the tor binary when the server stops.