### PR TITLE
Implement TorAppConfig.start(), use tor logs to detect when the tor is fully started

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -56,13 +56,6 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
 
     for {
       _ <- startedConfigF
-
-      _ <-
-        if (torConf.enabled) {
-          val tor = torConf.createClient
-          tor.startBinary()
-        } else Future.unit
-
       start <- {
         nodeConf.nodeType match {
           case _: InternalImplementationNodeType =>
@@ -81,13 +74,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       _ <- walletConf.stop()
       _ <- nodeConf.stop()
       _ <- chainConf.stop()
-      _ <- {
-        if (torConf.enabled) {
-          torConf.createClient.stopBinary()
-        } else {
-          Future.unit
-        }
-      }
+      _ <- torConf.stop()
       _ = logger.info(s"Stopped ${nodeConf.nodeType.shortName} node")
       _ <- system.terminate()
     } yield {

--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,7 @@ lazy val lndRpc = project
 lazy val tor = project
   .in(file("tor"))
   .settings(CommonSettings.prodSettings: _*)
-  .dependsOn(coreJVM, appCommons)
+  .dependsOn(coreJVM, appCommons, asyncUtilsJVM)
 
 lazy val torTest = project
   .in(file("tor-test"))

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
@@ -20,7 +20,7 @@ import scala.concurrent._
   */
 case class DLCNodeAppConfig(
     private val directory: Path,
-    private val conf: Config*)
+    private val conf: Config*)(implicit ec: ExecutionContext)
     extends AppConfig {
   override protected[bitcoins] def configOverrides: List[Config] = conf.toList
 

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -88,6 +88,10 @@ case class TorAppConfig(
 
   override def stop(): Future[Unit] = {
     createClient.stopBinary()
+      .map { _ =>
+        isStarted.set(false)
+        ()
+      }
   }
 
   lazy val socks5ProxyParams: Option[Socks5ProxyParams] = {

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -34,20 +34,26 @@ case class TorAppConfig(
     * place for our node.
     */
   override def start(): Future[Unit] = {
-    val start = System.currentTimeMillis()
-    //remove old tor log file so we accurately tell when
-    //the binary is started, if we don't remove this
-    //we could have that log line appear from previous runs
-    if (torLogFile.toFile.exists()) {
-      torLogFile.toFile.delete()
-    }
-    val startedBinary: Future[Unit] = createClient.startBinary()
-    for {
-      _ <- startedBinary
-      _ <- isBinaryFullyStarted()
-    } yield {
-      logger.info(
-        s"Tor binary is fully started, it took=${System.currentTimeMillis() - start}ms")
+    if (torParams.isDefined) {
+      val start = System.currentTimeMillis()
+      //remove old tor log file so we accurately tell when
+      //the binary is started, if we don't remove this
+      //we could have that log line appear from previous runs
+      if (torLogFile.toFile.exists()) {
+        torLogFile.toFile.delete()
+      }
+      val startedBinary: Future[Unit] = createClient.startBinary()
+      for {
+        _ <- startedBinary
+        _ <- isBinaryFullyStarted()
+      } yield {
+        logger.info(
+          s"Tor binary is fully started, it took=${System.currentTimeMillis() - start}ms")
+      }
+    } else {
+      logger.warn(
+        s"Tor was requested to start, but it is diabled in the configuration file. Not starting tor")
+      Future.unit
     }
   }
 

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -87,7 +87,8 @@ case class TorAppConfig(
   }
 
   override def stop(): Future[Unit] = {
-    createClient.stopBinary()
+    createClient
+      .stopBinary()
       .map { _ =>
         isStarted.set(false)
         ()

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -36,7 +36,8 @@ case class TorAppConfig(
   override def start(): Future[Unit] = {
     val start = System.currentTimeMillis()
     //remove old tor log file so we accurately tell when
-    //the binary is started
+    //the binary is started, if we don't remove this
+    //we could have that log line appear from previous runs
     if (torLogFile.toFile.exists()) {
       torLogFile.toFile.delete()
     }
@@ -64,9 +65,6 @@ case class TorAppConfig(
 
   /** Checks it the [[isBootstrappedLogLine]] exists in the tor log file */
   private def checkIfLogExists: Boolean = {
-    //NEED TO FIGURE OUT HOW TO CHECK LOG FILE FOR ONLY THESE
-    //LINES AFTER WE START THE BINARY SO WE DON'T
-    //COUNT OLD LOGS
     val stream = Files.lines(torLogFile)
     try {
       stream


### PR DESCRIPTION
The purpose of this is to try and fix #3547 

This tries to fix the race condition where we could have started the tor binary, but it isn't fully initialized and ready to receive messages. 

The way I do this is by looking inside of the `torLogFile` to detect this log line 

>Bootstrapped 100% (done): Done

If that log is seen, we complete the Future and indicate that tor binary start is done

Here are log lines from running the tor binary

![Screenshot from 2021-08-14 07-45-36](https://user-images.githubusercontent.com/3514957/129446808-c8327cd9-26ff-4ffa-8d03-c17daa79e77e.png)


Maybe we don't need to wait for that line and can use a earlier one, but I decided to make the conservative choice to wait for that bootstrapping log. On my machine this takes ~4 seconds.

This probably conflicts with #3484 in some regards.