### PR TITLE
2021 08 16 remote local instance

### DIFF
--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BitcoindConfigPane.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BitcoindConfigPane.scala
@@ -10,7 +10,6 @@ import scalafx.scene.control._
 import scalafx.scene.layout._
 import scalafx.scene.text.{Font, TextAlignment}
 
-
 class BitcoindConfigPane(
     appConfig: BitcoinSAppConfig,
     model: LandingPaneModel) {

--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BitcoindConfigPane.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/BitcoindConfigPane.scala
@@ -10,7 +10,6 @@ import scalafx.scene.control._
 import scalafx.scene.layout._
 import scalafx.scene.text.{Font, TextAlignment}
 
-import scala.util.Try
 
 class BitcoindConfigPane(
     appConfig: BitcoinSAppConfig,
@@ -39,12 +38,12 @@ class BitcoindConfigPane(
   GUIUtil.setNumericInput(portTF)
 
   private val rpcUserTF: TextField = new TextField {
-    text = Try(appConfig.rpcUser).getOrElse("")
+    text = appConfig.rpcUser.getOrElse("")
     minWidth = 300
   }
 
   private val rpcPasswordTF: TextField = new TextField {
-    text = Try(appConfig.rpcPassword).getOrElse("")
+    text = appConfig.rpcPassword.getOrElse("")
     minWidth = 300
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcAppConfig.scala
@@ -54,7 +54,7 @@ case class BitcoindRpcAppConfig(
   override def stop(): Future[Unit] = Future.unit
 
   lazy val DEFAULT_BINARY_PATH: Option[File] =
-    BitcoindInstance.DEFAULT_BITCOIND_LOCATION
+    BitcoindInstanceLocal.DEFAULT_BITCOIND_LOCATION
 
   lazy val binaryOpt: Option[File] =
     config.getStringOrNone("bitcoin-s.bitcoind-rpc.binary").map(new File(_))
@@ -146,9 +146,8 @@ case class BitcoindRpcAppConfig(
   lazy val zmqConfig: ZmqConfig =
     ZmqConfig(zmqHashBlock, zmqRawBlock, zmqHashTx, zmqRawTx)
 
-  lazy val bitcoindInstance: BitcoindInstance = {
-
-    BitcoindInstance(
+  lazy val bitcoindInstance: BitcoindInstanceLocal = {
+    BitcoindInstanceLocal(
       network = network,
       uri = uri,
       rpcUri = rpcUri,
@@ -160,9 +159,7 @@ case class BitcoindRpcAppConfig(
           new File(config.getString("bitcoin-s.bitcoind-rpc.binary"))
         }
       },
-      datadir = bitcoindDataDir,
-      isRemote = isRemote,
-      proxyParams = socks5ProxyParams
+      datadir = bitcoindDataDir
     )
   }
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
@@ -6,7 +6,7 @@ import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.config.{
   BitcoindAuthCredentials,
   BitcoindConfig,
-  BitcoindInstance
+  BitcoindInstanceLocal
 }
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
@@ -66,7 +66,7 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
     """.stripMargin
 
     val conf = BitcoindConfig(confStr, FileUtil.tmpDir())
-    val instance = BitcoindInstance.fromConfig(conf, newestBitcoindBinary)
+    val instance = BitcoindInstanceLocal.fromConfig(conf, newestBitcoindBinary)
     assert(
       instance.authCredentials
         .isInstanceOf[BitcoindAuthCredentials.CookieBased])
@@ -86,7 +86,7 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
       """.stripMargin
 
     val conf = BitcoindConfig(confStr, FileUtil.tmpDir())
-    val instance = BitcoindInstance.fromConfig(conf, newestBitcoindBinary)
+    val instance = BitcoindInstanceLocal.fromConfig(conf, newestBitcoindBinary)
     assert(
       instance.authCredentials
         .isInstanceOf[BitcoindAuthCredentials.PasswordBased])
@@ -117,7 +117,7 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
       BitcoindAuthCredentials.PasswordBased(username = "bitcoin-s",
                                             password = "strong_password")
     val instance =
-      BitcoindInstance(
+      BitcoindInstanceLocal(
         network = RegTest,
         uri = new URI(s"http://localhost:$port"),
         rpcUri = new URI(s"http://localhost:$rpcPort"),
@@ -131,7 +131,7 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
 
   it should "parse a bitcoin.conf file, start bitcoind, mine some blocks and quit" in {
     val instance =
-      BitcoindInstance.fromDatadir(datadir.toFile, newestBitcoindBinary)
+      BitcoindInstanceLocal.fromDatadir(datadir.toFile, newestBitcoindBinary)
     val client = BitcoindRpcClient.withActorSystem(instance)
 
     for {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
@@ -9,6 +9,7 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.rpc.BitcoindException
+import org.bitcoins.rpc.config.{BitcoindInstanceLocal, BitcoindInstanceRemote}
 import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedPairV21,
   BitcoindRpcTestUtil
@@ -180,8 +181,13 @@ class MempoolRpcTest extends BitcoindFixturesCachedPairV21 {
   it should "be able to save the mem pool to disk" in {
     nodePair: FixtureParam =>
       val client = nodePair.node1
+      val localInstance = client.getDaemon match {
+        case _: BitcoindInstanceRemote =>
+          sys.error(s"Cannot have remote bitcoind instance in tests")
+        case local: BitcoindInstanceLocal => local
+      }
       val regTest =
-        new File(client.getDaemon.datadir.getAbsolutePath + "/regtest")
+        new File(localInstance.datadir.getAbsolutePath + "/regtest")
       assert(regTest.isDirectory)
       assert(!regTest.list().contains("mempool.dat"))
       for {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -20,6 +20,7 @@ import org.bitcoins.core.wallet.signer.BitcoinSigner
 import org.bitcoins.core.wallet.utxo.{ECSignatureParams, P2WPKHV0InputInfo}
 import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPrivateKey, ECPublicKey}
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
+import org.bitcoins.rpc.config.{BitcoindInstanceLocal, BitcoindInstanceRemote}
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedPairV21,
@@ -71,9 +72,15 @@ class WalletRpcTest extends BitcoindFixturesCachedPairV21 {
 
   it should "be able to dump the wallet" in { nodePair: FixtureParam =>
     val client = nodePair.node1
+    val localInstance = client.getDaemon match {
+      case _: BitcoindInstanceRemote =>
+        sys.error(s"Cannot use remote bitocind instance in test cases")
+      case local: BitcoindInstanceLocal =>
+        local
+    }
     for {
       result <- {
-        val datadir = client.getDaemon.datadir.getAbsolutePath
+        val datadir = localInstance.datadir.getAbsolutePath
         client.dumpWallet(datadir + "/test.dat")
       }
     } yield {
@@ -84,12 +91,18 @@ class WalletRpcTest extends BitcoindFixturesCachedPairV21 {
 
   it should "be able to list wallets" in { nodePair: FixtureParam =>
     val client = nodePair.node1
+    val localInstance = client.getDaemon match {
+      case _: BitcoindInstanceRemote =>
+        sys.error(s"Cannot use remote bitocind instance in test cases")
+      case local: BitcoindInstanceLocal =>
+        local
+    }
     for {
       wallets <- client.listWallets
     } yield {
 
       val expectedFileName =
-        if (client.instance.getVersion == BitcoindVersion.V16) "wallet.dat"
+        if (localInstance.getVersion == BitcoindVersion.V16) "wallet.dat"
         else ""
 
       assert(wallets == Vector(expectedFileName))
@@ -98,13 +111,19 @@ class WalletRpcTest extends BitcoindFixturesCachedPairV21 {
 
   it should "be able to backup the wallet" in { nodePair: FixtureParam =>
     val client = nodePair.node1
+    val localInstance = client.getDaemon match {
+      case _: BitcoindInstanceRemote =>
+        sys.error(s"Cannot use remote bitocind instance in test cases")
+      case local: BitcoindInstanceLocal =>
+        local
+    }
     for {
       _ <- {
-        val datadir = client.getDaemon.datadir.getAbsolutePath
+        val datadir = localInstance.datadir.getAbsolutePath
         client.backupWallet(datadir + "/backup.dat")
       }
     } yield {
-      val datadir = client.getDaemon.datadir.getAbsolutePath
+      val datadir = localInstance.datadir.getAbsolutePath
       val file = new File(datadir + "/backup.dat")
       assert(file.exists)
       assert(file.isFile)
@@ -397,7 +416,12 @@ class WalletRpcTest extends BitcoindFixturesCachedPairV21 {
     val ecPrivateKey = ECPrivateKey.freshPrivateKey
     val publicKey = ecPrivateKey.publicKey
     val address = P2PKHAddress(publicKey, networkParam)
-
+    val localInstance = client.getDaemon match {
+      case _: BitcoindInstanceRemote =>
+        sys.error(s"Cannot use remote bitocind instance in test cases")
+      case local: BitcoindInstanceLocal =>
+        local
+    }
     for {
       _ <- client.importPrivKey(ecPrivateKey.toPrivateKeyBytes(),
                                 rescan = false)
@@ -405,7 +429,7 @@ class WalletRpcTest extends BitcoindFixturesCachedPairV21 {
       result <-
         client
           .dumpWallet(
-            client.getDaemon.datadir.getAbsolutePath + "/wallet_dump.dat")
+            localInstance.datadir.getAbsolutePath + "/wallet_dump.dat")
     } yield {
       assert(key.toPrivateKey == ecPrivateKey)
       val reader = new Scanner(result.filename)
@@ -465,11 +489,17 @@ class WalletRpcTest extends BitcoindFixturesCachedPairV21 {
 
   it should "be able to import a wallet" in { nodePair: FixtureParam =>
     val client = nodePair.node1
+    val localInstance = client.getDaemon match {
+      case _: BitcoindInstanceRemote =>
+        sys.error(s"Cannot use remote bitocind instance in test cases")
+      case local: BitcoindInstanceLocal =>
+        local
+    }
     for {
       walletClient <- walletClientF
       address <- client.getNewAddress
       walletFile =
-        client.getDaemon.datadir.getAbsolutePath + "/client_wallet.dat"
+        localInstance.datadir.getAbsolutePath + "/client_wallet.dat"
 
       fileResult <- client.dumpWallet(walletFile)
       _ <- walletClient.walletPassphrase(password, 1000)
@@ -482,11 +512,16 @@ class WalletRpcTest extends BitcoindFixturesCachedPairV21 {
   it should "be able to load a wallet" in { nodePair: FixtureParam =>
     val client = nodePair.node1
     val name = "tmp_wallet"
-
+    val localInstance = client.getDaemon match {
+      case _: BitcoindInstanceRemote =>
+        sys.error(s"Cannot use remote bitocind instance in test cases")
+      case local: BitcoindInstanceLocal =>
+        local
+    }
     for {
       walletClient <- walletClientF
       walletFile =
-        client.getDaemon.datadir.getAbsolutePath + s"/regtest/wallets/$name"
+        localInstance.datadir.getAbsolutePath + s"/regtest/wallets/$name"
 
       _ <- client.createWallet(walletFile)
       _ <- client.unloadWallet(walletFile)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
@@ -19,7 +19,6 @@ import org.bitcoins.testkit.rpc.{
   BitcoindRpcTestUtil
 }
 
-import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 class BitcoindV16RpcClientTest extends BitcoindFixturesCachedPairV16 {
@@ -42,8 +41,13 @@ class BitcoindV16RpcClientTest extends BitcoindFixturesCachedPairV16 {
   it should "be able to start a V16 bitcoind" in { nodePair: FixtureParam =>
     val client = nodePair.node1
     val otherClient = nodePair.node2
-    assert(client.version == Future.successful(BitcoindVersion.V16))
-    assert(otherClient.version == Future.successful(BitcoindVersion.V16))
+    for {
+      v <- client.version
+      v1 <- otherClient.version
+    } yield {
+      assert(v == BitcoindVersion.V16)
+      assert(v1 == BitcoindVersion.V16)
+    }
   }
 
   it should "be able to sign a raw transaction" in { nodePair: FixtureParam =>

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v16/BitcoindV16RpcClientTest.scala
@@ -19,6 +19,7 @@ import org.bitcoins.testkit.rpc.{
   BitcoindRpcTestUtil
 }
 
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 class BitcoindV16RpcClientTest extends BitcoindFixturesCachedPairV16 {
@@ -41,8 +42,8 @@ class BitcoindV16RpcClientTest extends BitcoindFixturesCachedPairV16 {
   it should "be able to start a V16 bitcoind" in { nodePair: FixtureParam =>
     val client = nodePair.node1
     val otherClient = nodePair.node2
-    assert(client.version == BitcoindVersion.V16)
-    assert(otherClient.version == BitcoindVersion.V16)
+    assert(client.version == Future.successful(BitcoindVersion.V16))
+    assert(otherClient.version == Future.successful(BitcoindVersion.V16))
   }
 
   it should "be able to sign a raw transaction" in { nodePair: FixtureParam =>

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
@@ -11,8 +11,6 @@ import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.testkit.chain.BlockHeaderHelper
 import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV18
 
-import scala.concurrent.Future
-
 class BitcoindV18RpcClientTest extends BitcoindFixturesFundedCachedV18 {
 
   behavior of "BitcoindV18RpcClient"
@@ -32,7 +30,9 @@ class BitcoindV18RpcClientTest extends BitcoindFixturesFundedCachedV18 {
   }
 
   it should "be able to start a V18 bitcoind instance" in { client =>
-    assert(client.version == Future.successful(BitcoindVersion.V18))
+    for {
+      v <- client.version
+    } yield assert(v == BitcoindVersion.V18)
   }
 
   it should "return active rpc commands" in { client =>

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v18/BitcoindV18RpcClientTest.scala
@@ -11,6 +11,8 @@ import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.testkit.chain.BlockHeaderHelper
 import org.bitcoins.testkit.rpc.BitcoindFixturesFundedCachedV18
 
+import scala.concurrent.Future
+
 class BitcoindV18RpcClientTest extends BitcoindFixturesFundedCachedV18 {
 
   behavior of "BitcoindV18RpcClient"
@@ -30,7 +32,7 @@ class BitcoindV18RpcClientTest extends BitcoindFixturesFundedCachedV18 {
   }
 
   it should "be able to start a V18 bitcoind instance" in { client =>
-    assert(client.version == BitcoindVersion.V18)
+    assert(client.version == Future.successful(BitcoindVersion.V18))
   }
 
   it should "return active rpc commands" in { client =>

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v19/BitcoindV19RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v19/BitcoindV19RpcClientTest.scala
@@ -20,7 +20,11 @@ class BitcoindV19RpcClientTest extends BitcoindFixturesFundedCachedV19 {
 
   it should "be able to start a V19 bitcoind instance" in {
     client: BitcoindV19RpcClient =>
-      assert(client.version == Future.successful(BitcoindVersion.V19))
+      for {
+        v <- client.version
+      } yield {
+        assert(v == BitcoindVersion.V19)
+      }
   }
 
   it should "get a block filter given a block hash" in {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v19/BitcoindV19RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v19/BitcoindV19RpcClientTest.scala
@@ -20,7 +20,7 @@ class BitcoindV19RpcClientTest extends BitcoindFixturesFundedCachedV19 {
 
   it should "be able to start a V19 bitcoind instance" in {
     client: BitcoindV19RpcClient =>
-      assert(client.version == BitcoindVersion.V19)
+      assert(client.version == Future.successful(BitcoindVersion.V19))
   }
 
   it should "get a block filter given a block hash" in {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v20/BitcoindV20RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v20/BitcoindV20RpcClientTest.scala
@@ -20,7 +20,9 @@ class BitcoindV20RpcClientTest extends BitcoindFixturesFundedCachedV20 {
 
   it should "be able to start a V20 bitcoind instance" in {
     client: BitcoindV20RpcClient =>
-      assert(client.version == Future.successful(BitcoindVersion.V20))
+      for {
+        v <- client.version
+      } yield assert(v == BitcoindVersion.V20)
   }
 
   it should "get a block filter given a block hash" in {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v20/BitcoindV20RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v20/BitcoindV20RpcClientTest.scala
@@ -20,7 +20,7 @@ class BitcoindV20RpcClientTest extends BitcoindFixturesFundedCachedV20 {
 
   it should "be able to start a V20 bitcoind instance" in {
     client: BitcoindV20RpcClient =>
-      assert(client.version == BitcoindVersion.V20)
+      assert(client.version == Future.successful(BitcoindVersion.V20))
   }
 
   it should "get a block filter given a block hash" in {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v21/BitcoindV21RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v21/BitcoindV21RpcClientTest.scala
@@ -21,7 +21,7 @@ class BitcoindV21RpcClientTest extends BitcoindFixturesFundedCachedV21 {
 
   it should "be able to start a V21 bitcoind instance" in {
     client: BitcoindV21RpcClient =>
-      assert(client.version == BitcoindVersion.V21)
+      assert(client.version == Future.successful(BitcoindVersion.V21))
   }
 
   it should "be able to get network info" in {

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v21/BitcoindV21RpcClientTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/v21/BitcoindV21RpcClientTest.scala
@@ -21,7 +21,9 @@ class BitcoindV21RpcClientTest extends BitcoindFixturesFundedCachedV21 {
 
   it should "be able to start a V21 bitcoind instance" in {
     client: BitcoindV21RpcClient =>
-      assert(client.version == Future.successful(BitcoindVersion.V21))
+      for {
+        v <- client.version
+      } yield assert(v == BitcoindVersion.V21)
   }
 
   it should "be able to get network info" in {

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BlockchainRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BlockchainRpc.scala
@@ -28,7 +28,7 @@ trait BlockchainRpc { self: Client =>
   }
 
   def getBlockChainInfo: Future[GetBlockChainInfoResult] = {
-    self.version match {
+    self.version.flatMap {
       case V16 | V17 | V18 =>
         bitcoindCall[GetBlockChainInfoResultPreV19]("getblockchaininfo")
       case V21 | V20 | V19 | Experimental | Unknown =>

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -22,7 +22,12 @@ import org.bitcoins.rpc.config.BitcoindAuthCredentials.{
   CookieBased,
   PasswordBased
 }
-import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstance}
+import org.bitcoins.rpc.config.{
+  BitcoindAuthCredentials,
+  BitcoindInstance,
+  BitcoindInstanceLocal,
+  BitcoindInstanceRemote
+}
 import org.bitcoins.tor.Socks5ClientTransport
 import play.api.libs.json._
 
@@ -45,28 +50,48 @@ trait Client
     extends Logging
     with StartStopAsync[BitcoindRpcClient]
     with NativeProcessFactory {
-  def version: BitcoindVersion
+  def version: Future[BitcoindVersion]
   protected val instance: BitcoindInstance
 
   protected def walletExtension(walletName: String): String =
     s"/wallet/$walletName"
 
-  /** The log file of the Bitcoin Core daemon
+  /** The log file of the Bitcoin Core daemon.
+    * This returns the log file if the underlying instance is
+    * [[org.bitcoins.rpc.config.BitcoindInstanceLocal]], and
+    * None if the underlying instance is [[BitcoindInstanceRemote]]
     */
-  lazy val logFile: Path = {
-
-    val prefix = instance.network match {
-      case MainNet  => ""
-      case TestNet3 => "testnet"
-      case RegTest  => "regtest"
-      case SigNet   => "signet"
+  lazy val logFileOpt: Option[Path] = {
+    instance match {
+      case _: BitcoindInstanceRemote => None
+      case local: BitcoindInstanceLocal =>
+        val prefix = instance.network match {
+          case MainNet  => ""
+          case TestNet3 => "testnet"
+          case RegTest  => "regtest"
+          case SigNet   => "signet"
+        }
+        val path = local.datadir.toPath.resolve(prefix).resolve("debug.log")
+        Some(path)
     }
-    instance.datadir.toPath.resolve(prefix).resolve("debug.log")
   }
 
-  /** The configuration file of the Bitcoin Core daemon */
-  lazy val confFile: Path =
-    instance.datadir.toPath.resolve("bitcoin.conf")
+  /** The configuration file of the Bitcoin Core daemon
+    * This returns the conf file is the underlying instance is
+    * [[BitcoindInstanceLocal]] and None if the underlying
+    * instance is [[BitcoindInstanceRemote]]
+    */
+  lazy val confFileOpt: Option[Path] = {
+    instance match {
+      case _: BitcoindInstanceRemote =>
+        None
+      case local: BitcoindInstanceLocal =>
+        val path = local.datadir.toPath.resolve("bitcoin.conf")
+        Some(path)
+
+    }
+
+  }
 
   implicit protected val system: ActorSystem
 
@@ -108,15 +133,22 @@ trait Client
   def getDaemon: BitcoindInstance = instance
 
   override lazy val cmd: String = {
-    val binaryPath = instance.binary.getAbsolutePath
-    val cmd = List(binaryPath,
-                   "-datadir=" + instance.datadir,
-                   "-rpcport=" + instance.rpcUri.getPort,
-                   "-port=" + instance.uri.getPort)
-    logger.debug(
-      s"starting bitcoind with datadir ${instance.datadir} and binary path $binaryPath")
+    instance match {
+      case _: BitcoindInstanceRemote =>
+        sys.error(
+          s"Cannot start remote instance with local binary command. You've likely misconfigured something")
+      case local: BitcoindInstanceLocal =>
+        val binaryPath = local.binary.getAbsolutePath
+        val cmd = List(binaryPath,
+                       "-datadir=" + local.datadir,
+                       "-rpcport=" + instance.rpcUri.getPort,
+                       "-port=" + instance.uri.getPort)
+        logger.debug(
+          s"starting bitcoind with datadir ${local.datadir} and binary path $binaryPath")
 
-    cmd.mkString(" ")
+        cmd.mkString(" ")
+
+    }
   }
 
   /** Starts bitcoind on the local system.
@@ -144,27 +176,34 @@ trait Client
     }
     val isAlreadyStarted: Future[Boolean] = isStartedF
 
-    val started: Future[Future[BitcoindRpcClient]] = isAlreadyStarted map {
+    val started: Future[Future[BitcoindRpcClient]] = isAlreadyStarted.map {
       case false =>
-        if (version != BitcoindVersion.Unknown) {
-          val foundVersion = instance.getVersion
-          if (foundVersion != version) {
-            throw new RuntimeException(
-              s"Wrong version for bitcoind RPC client! Expected $version, got $foundVersion")
-          }
+        instance match {
+          case _: BitcoindInstanceRemote =>
+            sys.error(
+              s"Cannot start a remote instance, it needs to be started on the remote host machine")
+          case local: BitcoindInstanceLocal =>
+            val versionCheckF = version.map { v =>
+              if (v != BitcoindVersion.Unknown) {
+                val foundVersion = local.getVersion
+                if (foundVersion != v) {
+                  throw new RuntimeException(
+                    s"Wrong version for bitcoind RPC client! Expected $version, got $foundVersion")
+                }
+              }
+            }
+
+            val startedF = versionCheckF.flatMap(_ => startBinary())
+
+            for {
+              _ <- startedF
+              _ <- awaitCookie(instance.authCredentials)
+              _ = isStartedFlag.set(true)
+              _ <- AsyncUtil.retryUntilSatisfiedF(() => isStartedF,
+                                                  interval = 1.seconds,
+                                                  maxTries = 120)
+            } yield this.asInstanceOf[BitcoindRpcClient]
         }
-
-        val startedF = startBinary()
-
-        for {
-          _ <- startedF
-          _ <- awaitCookie(instance.authCredentials)
-          _ = isStartedFlag.set(true)
-          _ <- AsyncUtil.retryUntilSatisfiedF(() => isStartedF,
-                                              interval = 1.seconds,
-                                              maxTries = 120)
-        } yield this.asInstanceOf[BitcoindRpcClient]
-
       case true =>
         for {
           _ <- awaitCookie(instance.authCredentials)
@@ -185,17 +224,24 @@ trait Client
         // of our instances. We don't want to do this on mainnet,
         // as both the logs and conf file most likely contain sensitive
         // information
-        if (network != MainNet) {
-          val tempfile = Files.createTempFile("bitcoind-log-", ".dump")
-          val logfile = Files.readAllBytes(logFile)
-          Files.write(tempfile, logfile)
-          logger.info(s"Dumped debug.log to $tempfile")
 
-          val otherTempfile = Files.createTempFile("bitcoin-conf-", ".dump")
-          val conffile = Files.readAllBytes(confFile)
-          Files.write(otherTempfile, conffile)
-          logger.info(s"Dumped bitcoin.conf to $otherTempfile")
+        instance match {
+          case _: BitcoindInstanceRemote =>
+            ()
+          case _: BitcoindInstanceLocal =>
+            if (network != MainNet) {
+              val tempfile = Files.createTempFile("bitcoind-log-", ".dump")
+              val logfile = Files.readAllBytes(logFileOpt.get)
+              Files.write(tempfile, logfile)
+              logger.info(s"Dumped debug.log to $tempfile")
+
+              val otherTempfile = Files.createTempFile("bitcoin-conf-", ".dump")
+              val conffile = Files.readAllBytes(confFileOpt.get)
+              Files.write(otherTempfile, conffile)
+              logger.info(s"Dumped bitcoin.conf to $otherTempfile")
+            }
         }
+
     }
 
     started.flatten
@@ -333,9 +379,16 @@ trait Client
   /** Cached http client to send requests to bitcoind with */
   private lazy val httpClient: HttpExt = Http(system)
 
-  private lazy val httpConnectionPoolSettings: ConnectionPoolSettings =
-    Socks5ClientTransport.createConnectionPoolSettings(instance.rpcUri,
-                                                       instance.proxyParams)
+  private lazy val httpConnectionPoolSettings: ConnectionPoolSettings = {
+    instance match {
+      case remote: BitcoindInstanceRemote =>
+        Socks5ClientTransport.createConnectionPoolSettings(instance.rpcUri,
+                                                           remote.proxyParams)
+      case _: BitcoindInstanceLocal =>
+        Socks5ClientTransport.createConnectionPoolSettings(instance.rpcUri,
+                                                           None)
+    }
+  }
 
   protected def sendRequest(req: HttpRequest): Future[HttpResponse] = {
     httpClient.singleRequest(req, settings = httpConnectionPoolSettings)

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MempoolRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MempoolRpc.scala
@@ -31,7 +31,7 @@ trait MempoolRpc { self: Client =>
   def getMemPoolAncestorsVerbose(txid: DoubleSha256DigestBE): Future[
     Map[DoubleSha256DigestBE, GetMemPoolResult]] = {
 
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | V19 | Experimental | Unknown =>
         bitcoindCall[Map[DoubleSha256DigestBE, GetMemPoolResultPostV19]](
           "getmempoolancestors",
@@ -62,7 +62,7 @@ trait MempoolRpc { self: Client =>
 
   def getMemPoolDescendantsVerbose(txid: DoubleSha256DigestBE): Future[
     Map[DoubleSha256DigestBE, GetMemPoolResult]] = {
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | V19 | Experimental | Unknown =>
         bitcoindCall[Map[DoubleSha256DigestBE, GetMemPoolResultPostV19]](
           "getmempooldescendants",
@@ -82,7 +82,7 @@ trait MempoolRpc { self: Client =>
   def getMemPoolEntry(
       txid: DoubleSha256DigestBE): Future[GetMemPoolEntryResult] = {
 
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | V19 | Experimental | Unknown =>
         bitcoindCall[GetMemPoolEntryResultPostV19]("getmempoolentry",
                                                    List(JsString(txid.hex)))
@@ -124,7 +124,7 @@ trait MempoolRpc { self: Client =>
   def getRawMemPoolWithTransactions: Future[
     Map[DoubleSha256DigestBE, GetMemPoolResult]] = {
 
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | V19 | Experimental | Unknown =>
         bitcoindCall[Map[DoubleSha256DigestBE, GetMemPoolResultPostV19]](
           "getrawmempool",

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MultisigRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MultisigRpc.scala
@@ -40,7 +40,7 @@ trait MultisigRpc { self: Client =>
            JsArray(keys.map(keyToString)),
            JsString(account)) ++ addressType.map(Json.toJson(_)).toList
 
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | Unknown =>
         bitcoindCall[MultiSigResultPostV20](
           "addmultisigaddress",
@@ -82,7 +82,7 @@ trait MultisigRpc { self: Client =>
       minSignatures: Int,
       keys: Vector[ECPublicKey],
       walletNameOpt: Option[String] = None): Future[MultiSigResult] = {
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | Unknown =>
         bitcoindCall[MultiSigResultPostV20](
           "createmultisig",

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/P2PRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/P2PRpc.scala
@@ -56,7 +56,7 @@ trait P2PRpc { self: Client =>
   }
 
   def getNetworkInfo: Future[GetNetworkInfoResult] = {
-    version match {
+    version.flatMap {
       case V21 | Unknown =>
         bitcoindCall[GetNetworkInfoResultPostV21]("getnetworkinfo")
       case V16 | V17 | V18 | V19 | V20 | Experimental =>
@@ -65,7 +65,7 @@ trait P2PRpc { self: Client =>
   }
 
   def getPeerInfo: Future[Vector[Peer]] = {
-    self.version match {
+    self.version.flatMap {
       case V21 | Unknown =>
         bitcoindCall[Vector[PeerPostV21]]("getpeerinfo")
       case V20 =>
@@ -76,7 +76,7 @@ trait P2PRpc { self: Client =>
   }
 
   def listBanned: Future[Vector[NodeBan]] = {
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | Unknown =>
         bitcoindCall[Vector[NodeBanPostV20]]("listbanned")
       case V16 | V17 | V18 | V19 | Experimental =>

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/RawTransactionRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/RawTransactionRpc.scala
@@ -110,16 +110,18 @@ trait RawTransactionRpc { self: Client =>
       transaction: Transaction,
       maxfeerate: Double = 0.10): Future[DoubleSha256DigestBE] = {
 
-    val feeParameter = self.version match {
+    val feeParameterF = self.version.map {
       case V21 | V20 | V19 | Experimental | Unknown =>
         JsNumber(maxfeerate)
       case V16 | V17 | V18 =>
         JsBoolean(maxfeerate == 0)
     }
 
-    bitcoindCall[DoubleSha256DigestBE](
-      "sendrawtransaction",
-      List(JsString(transaction.hex), feeParameter))
+    feeParameterF.flatMap { feeParameter =>
+      bitcoindCall[DoubleSha256DigestBE](
+        "sendrawtransaction",
+        List(JsString(transaction.hex), feeParameter))
+    }
   }
 
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/UtilRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/UtilRpc.scala
@@ -25,7 +25,7 @@ trait UtilRpc { self: Client =>
   }
 
   def getIndexInfo: Future[Map[String, IndexInfoResult]] = {
-    version match {
+    version.flatMap {
       case V21 | Unknown =>
         bitcoindCall[Map[String, IndexInfoResult]]("getindexinfo")
       case V16 | V17 | V18 | V19 | V20 | Experimental =>
@@ -36,7 +36,7 @@ trait UtilRpc { self: Client =>
   }
 
   def getIndexInfo(indexName: String): Future[IndexInfoResult] = {
-    version match {
+    version.flatMap {
       case V21 | Unknown =>
         bitcoindCall[Map[String, IndexInfoResult]](
           "getindexinfo",

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/WalletRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/WalletRpc.scala
@@ -306,7 +306,7 @@ trait WalletRpc { self: Client =>
       walletNameOpt: Option[String] = None
   ): Future[SetWalletFlagResult] = {
 
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | V19 | Experimental | Unknown =>
         bitcoindCall[SetWalletFlagResult](
           "setwalletflag",
@@ -320,7 +320,7 @@ trait WalletRpc { self: Client =>
   }
 
   def getBalances: Future[GetBalancesResult] = {
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | V19 | Experimental | Unknown =>
         bitcoindCall[GetBalancesResult]("getbalances")
       case V16 | V17 | V18 =>
@@ -331,7 +331,7 @@ trait WalletRpc { self: Client =>
   }
 
   def getBalances(walletName: String): Future[GetBalancesResult] = {
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | V19 | Experimental | Unknown =>
         bitcoindCall[GetBalancesResult]("getbalances",
                                         uriExtensionOpt =
@@ -404,7 +404,7 @@ trait WalletRpc { self: Client =>
       disablePrivateKeys: Boolean = false,
       blank: Boolean = false,
       passphrase: String = ""): Future[CreateWalletResult] =
-    self.version match {
+    self.version.flatMap {
       case V21 | V20 | V19 | Experimental | Unknown =>
         bitcoindCall[CreateWalletResult]("createwallet",
                                          List(JsString(walletName),
@@ -422,7 +422,7 @@ trait WalletRpc { self: Client =>
   def getAddressInfo(
       address: BitcoinAddress,
       walletNameOpt: Option[String] = None): Future[AddressInfoResult] = {
-    self.version match {
+    self.version.flatMap {
       case V16 | V17 =>
         bitcoindCall[AddressInfoResultPreV18](
           "getaddressinfo",

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v16/BitcoindV16RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v16/BitcoindV16RpcClient.scala
@@ -29,7 +29,8 @@ class BitcoindV16RpcClient(override val instance: BitcoindInstance)(implicit
     with V16AccountRpc
     with V16SendRpc {
 
-  override def version: BitcoindVersion = BitcoindVersion.V16
+  override def version: Future[BitcoindVersion] =
+    Future.successful(BitcoindVersion.V16)
 
   override def getFilterCount(): Future[Int] = filtersUnsupported
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v17/BitcoindV17RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v17/BitcoindV17RpcClient.scala
@@ -35,7 +35,8 @@ class BitcoindV17RpcClient(override val instance: BitcoindInstance)(implicit
     extends BitcoindRpcClient(instance)
     with V17LabelRpc {
 
-  override def version: BitcoindVersion = BitcoindVersion.V17
+  override def version: Future[BitcoindVersion.V17.type] =
+    Future.successful(BitcoindVersion.V17)
 
   override def getFilterCount(): Future[Int] = filtersUnsupported
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v18/BitcoindV18RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v18/BitcoindV18RpcClient.scala
@@ -35,7 +35,8 @@ class BitcoindV18RpcClient(override val instance: BitcoindInstance)(implicit
     with PsbtRpc
     with V18AssortedRpc {
 
-  override lazy val version: BitcoindVersion = BitcoindVersion.V18
+  override lazy val version: Future[BitcoindVersion.V18.type] =
+    Future.successful(BitcoindVersion.V18)
 
   override def getFilterCount(): Future[Int] = filtersUnsupported
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
@@ -78,7 +78,8 @@ class BitcoindV19RpcClient(override val instance: BitcoindInstance)(implicit
     } yield Vector(filter.filterDb(height))
   }
 
-  override lazy val version: BitcoindVersion = BitcoindVersion.V19
+  override lazy val version: Future[BitcoindVersion.V19.type] =
+    Future.successful(BitcoindVersion.V19)
 
   /** $signRawTx
     *

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/BitcoindV20RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/BitcoindV20RpcClient.scala
@@ -78,7 +78,8 @@ class BitcoindV20RpcClient(override val instance: BitcoindInstance)(implicit
     } yield Vector(filter.filterDb(height))
   }
 
-  override lazy val version: BitcoindVersion = BitcoindVersion.V20
+  override lazy val version: Future[BitcoindVersion.V20.type] =
+    Future.successful(BitcoindVersion.V20)
 
   /** $signRawTx
     *

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/V20MultisigRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/V20MultisigRpc.scala
@@ -36,7 +36,7 @@ trait V20MultisigRpc extends MultisigRpc { self: Client =>
            JsArray(keys.map(keyToString)),
            JsString(account)) ++ addressType.map(Json.toJson(_)).toList
 
-    self.version match {
+    self.version.flatMap {
       case V20 | V21 | Unknown =>
         bitcoindCall[MultiSigResultPostV20]("addmultisigaddress", params)
       case version @ (V16 | V17 | V18 | V19 | Experimental) =>
@@ -74,7 +74,7 @@ trait V20MultisigRpc extends MultisigRpc { self: Client =>
       minSignatures: Int,
       keys: Vector[ECPublicKey],
       walletNameOpt: Option[String] = None): Future[MultiSigResultPostV20] = {
-    self.version match {
+    self.version.flatMap {
       case V20 | V21 | Unknown =>
         bitcoindCall[MultiSigResultPostV20](
           "createmultisig",

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v21/BitcoindV21RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v21/BitcoindV21RpcClient.scala
@@ -79,7 +79,8 @@ class BitcoindV21RpcClient(override val instance: BitcoindInstance)(implicit
     } yield Vector(filter.filterDb(height))
   }
 
-  override lazy val version: BitcoindVersion = BitcoindVersion.V21
+  override lazy val version: Future[BitcoindVersion.V21.type] =
+    Future.successful(BitcoindVersion.V21)
 
   /** $signRawTx
     *

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.rpc.config
 
+import com.typesafe.config.ConfigFactory
 import grizzled.slf4j.Logging
 import org.bitcoins.commons.util.NativeProcessFactory
 import org.bitcoins.core.api.commons.InstanceFactory
@@ -7,7 +8,7 @@ import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.tor.Socks5ProxyParams
 
-import java.io.{File, FileNotFoundException}
+import java.io.File
 import java.net.URI
 import java.nio.file.{Files, Path, Paths}
 import scala.sys.process._
@@ -91,7 +92,16 @@ object BitcoindInstance extends InstanceFactory[BitcoindInstance] {
       rpcUri: URI,
       authCredentials: BitcoindAuthCredentials,
       zmqConfig: ZmqConfig = ZmqConfig(),
-      binary: File = DEFAULT_BITCOIND_LOCATION,
+      binary: File = DEFAULT_BITCOIND_LOCATION match {
+        case Some(file) => file
+        case None => {
+          val homeVar = sys.env("HOME");
+          val config = ConfigFactory
+            .parseFile(new File(homeVar + "/.bitcoin-s/bitcoin-s.conf"))
+            .resolve()
+          new File(config.getString("bitcoin-s.bitcoind-rpc.binary"))
+        }
+      },
       datadir: File = BitcoindConfig.DEFAULT_DATADIR,
       isRemote: Boolean = false,
       proxyParams: Option[Socks5ProxyParams] = None
@@ -107,7 +117,7 @@ object BitcoindInstance extends InstanceFactory[BitcoindInstance] {
                          proxyParams = proxyParams)
   }
 
-  lazy val DEFAULT_BITCOIND_LOCATION: File = {
+  lazy val DEFAULT_BITCOIND_LOCATION: Option[File] = {
     val cmd =
       if (Properties.isWin) {
         NativeProcessFactory.findExecutableOnPath("bitcoind.exe")
@@ -115,8 +125,7 @@ object BitcoindInstance extends InstanceFactory[BitcoindInstance] {
         NativeProcessFactory.findExecutableOnPath("bitcoind")
       }
 
-    cmd.getOrElse(
-      throw new FileNotFoundException("Cannot find a path to bitcoind"))
+    cmd
   }
 
   lazy val remoteFilePath: File = {
@@ -130,7 +139,16 @@ object BitcoindInstance extends InstanceFactory[BitcoindInstance] {
     */
   def fromDatadir(
       datadir: File = BitcoindConfig.DEFAULT_DATADIR,
-      binary: File = DEFAULT_BITCOIND_LOCATION
+      binary: File = DEFAULT_BITCOIND_LOCATION match {
+        case Some(file) => file
+        case None => {
+          val homeVar = sys.env("HOME");
+          val config = ConfigFactory
+            .parseFile(new File(homeVar + "/.bitcoin-s/bitcoin-s.conf"))
+            .resolve()
+          new File(config.getString("bitcoin-s.bitcoind-rpc.binary"))
+        }
+      }
   ): BitcoindInstance = {
     require(datadir.exists, s"${datadir.getPath} does not exist!")
     require(datadir.isDirectory, s"${datadir.getPath} is not a directory!")
@@ -146,7 +164,19 @@ object BitcoindInstance extends InstanceFactory[BitcoindInstance] {
   }
 
   override def fromDataDir(dir: File): BitcoindInstance = {
-    fromDatadir(dir, DEFAULT_BITCOIND_LOCATION)
+    fromDatadir(
+      dir,
+      DEFAULT_BITCOIND_LOCATION match {
+        case Some(file) => file
+        case None => {
+          val homeVar = sys.env("HOME");
+          val config = ConfigFactory
+            .parseFile(new File(homeVar + "/.bitcoin-s/bitcoin-s.conf"))
+            .resolve()
+          new File(config.getString("bitcoin-s.bitcoind-rpc.binary"))
+        }
+      }
+    )
   }
 
   /** Construct a `bitcoind` from the given config file. If no `datadir` setting
@@ -156,7 +186,16 @@ object BitcoindInstance extends InstanceFactory[BitcoindInstance] {
     */
   def fromConfFile(
       file: File = BitcoindConfig.DEFAULT_CONF_FILE,
-      binary: File = DEFAULT_BITCOIND_LOCATION
+      binary: File = DEFAULT_BITCOIND_LOCATION match {
+        case Some(file) => file
+        case None => {
+          val homeVar = sys.env("HOME");
+          val config = ConfigFactory
+            .parseFile(new File(homeVar + "/.bitcoin-s/bitcoin-s.conf"))
+            .resolve()
+          new File(config.getString("bitcoin-s.bitcoind-rpc.binary"))
+        }
+      }
   ): BitcoindInstance = {
     require(file.exists, s"${file.getPath} does not exist!")
     require(file.isFile, s"${file.getPath} is not a file!")
@@ -167,13 +206,34 @@ object BitcoindInstance extends InstanceFactory[BitcoindInstance] {
   }
 
   override def fromConfigFile(file: File): BitcoindInstance = {
-    fromConfFile(file, DEFAULT_BITCOIND_LOCATION)
+    fromConfFile(
+      file,
+      DEFAULT_BITCOIND_LOCATION match {
+        case Some(file) => file
+        case None => {
+          val homeVar = sys.env("HOME");
+          val config = ConfigFactory
+            .parseFile(new File(homeVar + "/.bitcoin-s/bitcoin-s.conf"))
+            .resolve()
+          new File(config.getString("bitcoin-s.bitcoind-rpc.binary"))
+        }
+      }
+    )
   }
 
   /** Constructs a `bitcoind` instance from the given config */
   def fromConfig(
       config: BitcoindConfig,
-      binary: File = DEFAULT_BITCOIND_LOCATION
+      binary: File = DEFAULT_BITCOIND_LOCATION match {
+        case Some(file) => file
+        case None => {
+          val homeVar = sys.env("HOME");
+          val config = ConfigFactory
+            .parseFile(new File(homeVar + "/.bitcoin-s/bitcoin-s.conf"))
+            .resolve()
+          new File(config.getString("bitcoin-s.bitcoind-rpc.binary"))
+        }
+      }
   ): BitcoindInstance = {
 
     val authCredentials = BitcoindAuthCredentials.fromConfig(config)

--- a/core/src/main/scala/org/bitcoins/core/api/commons/InstanceFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/commons/InstanceFactory.scala
@@ -4,10 +4,12 @@ import java.io.File
 import java.nio.file.Path
 
 trait InstanceFactory[+T] {
+  def fromConfigFile(file: File): T
+
+  def fromDataDir(dir: File): T
+}
+
+trait InstanceFactoryLocal[+T] extends InstanceFactory[T] {
   def DEFAULT_DATADIR: Path
   def DEFAULT_CONF_FILE: Path
-
-  def fromConfigFile(file: File = DEFAULT_CONF_FILE.toFile): T
-
-  def fromDataDir(dir: File = DEFAULT_DATADIR.toFile): T
 }

--- a/docs/chain/chain-query-api.md
+++ b/docs/chain/chain-query-api.md
@@ -17,7 +17,7 @@ import org.bitcoins.feeprovider._
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.node._
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
-import org.bitcoins.rpc.config.BitcoindInstance
+import org.bitcoins.rpc.config._
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.wallet.Wallet
@@ -77,7 +77,8 @@ implicit val walletConf: WalletAppConfig =
 
 // let's use a helper method to get a v19 bitcoind
 // and a ChainApi
-val bitcoind = BitcoindV19RpcClient(BitcoindInstance.fromConfigFile())
+val instance = BitcoindInstanceLocal.fromConfigFile(BitcoindConfig.DEFAULT_CONF_FILE)
+val bitcoind = BitcoindV19RpcClient(instance)
 val nodeApi = BitcoinSWalletTest.MockNodeApi
 
 // Create our key manager

--- a/docs/chain/chain.md
+++ b/docs/chain/chain.md
@@ -21,7 +21,7 @@ import org.bitcoins.chain.blockchain._
 import org.bitcoins.chain.blockchain.sync._
 import org.bitcoins.chain.models._
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.rpc.config.BitcoindInstance
+import org.bitcoins.rpc.config.BitcoindInstanceLocal
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.chain._
 
@@ -37,7 +37,7 @@ implicit val ec = ExecutionContext.global
 // You can see our `bitcoind` guides to see how to connect
 // to a local or remote `bitcoind` node.
 
-val bitcoindInstance = BitcoindInstance.fromDatadir()
+val bitcoindInstance = BitcoindInstanceLocal.fromDatadir()
 val rpcCli = BitcoindRpcClient(bitcoindInstance)
 
 // Next, we need to create a way to monitor the chain:

--- a/docs/node/node-api.md
+++ b/docs/node/node-api.md
@@ -14,7 +14,7 @@ import org.bitcoins.feeprovider._
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.node._
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
-import org.bitcoins.rpc.config.BitcoindInstance
+import org.bitcoins.rpc.config._
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.wallet.Wallet
@@ -55,7 +55,8 @@ implicit val walletConf: WalletAppConfig =
 
 // let's use a helper method to get a v19 bitcoind
 // and a ChainApi
-val bitcoind = BitcoindV19RpcClient(BitcoindInstance.fromConfigFile())
+val instance = BitcoindInstanceLocal.fromConfigFile(BitcoindConfig.DEFAULT_CONF_FILE)
+val bitcoind = BitcoindV19RpcClient(instance)
 val chainApi = BitcoinSWalletTest.MockChainQueryApi
 val aesPasswordOpt = Some(AesPassword.fromString("password"))
 

--- a/docs/rpc/bitcoind.md
+++ b/docs/rpc/bitcoind.md
@@ -106,7 +106,7 @@ val authCredentials = BitcoindAuthCredentials.PasswordBased(
 )
 
 val bitcoindInstance = {
-  BitcoindInstance (
+  BitcoindInstanceLocal(
     network = MainNet,
     uri = new URI(s"http://localhost:${MainNet.port}"),
     rpcUri = new URI(s"http://localhost:${MainNet.rpcPort}"),

--- a/docs/rpc/eclair.md
+++ b/docs/rpc/eclair.md
@@ -36,7 +36,7 @@ Here is an example of how to start eclair:
 ```scala mdoc:invisible
 import akka.actor.ActorSystem
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
-import org.bitcoins.eclair.rpc.config.EclairInstance
+import org.bitcoins.eclair.rpc.config.EclairInstanceLocal
 import java.nio.file.Paths
 ```
 
@@ -47,7 +47,7 @@ implicit val ec = system.dispatcher
 
 val datadirPath = Paths.get("path", "to", "datadir")
 val binaryPath = Paths.get("path", "to", "eclair-node-0.5.0-ac08560", "bin", "eclair-node.sh")
-val instance = EclairInstance.fromDatadir(datadirPath.toFile, logbackXml = None, proxyParams = None)
+val instance = EclairInstanceLocal.fromDatadir(datadirPath.toFile, logbackXml = None, proxyParams = None)
 val client = new EclairRpcClient(instance, Some(binaryPath.toFile))
 
 val startedF = client.start()

--- a/docs/rpc/lnd.md
+++ b/docs/rpc/lnd.md
@@ -43,7 +43,7 @@ implicit val ec = system.dispatcher
 
 val datadirPath = Paths.get("path", "to", "datadir")
 val binaryPath = Paths.get("path", "to", "lnd-linux-amd64-v0.13.1-beta", "lnd")
-val instance = LndInstance.fromDataDir(datadirPath.toFile)
+val instance = LndInstanceLocal.fromDataDir(datadirPath.toFile)
 val client = new LndRpcClient(instance, Some(binaryPath.toFile))
 
 val startedF = client.start()

--- a/docs/wallet/wallet-callbacks.md
+++ b/docs/wallet/wallet-callbacks.md
@@ -29,7 +29,7 @@ import org.bitcoins.core.wallet.fee._
 import org.bitcoins.feeprovider._
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
-import org.bitcoins.rpc.config.BitcoindInstance
+import org.bitcoins.rpc.config.BitcoindInstanceLocal
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.wallet._
 import org.bitcoins.wallet.config.WalletAppConfig
@@ -46,7 +46,8 @@ implicit val walletConf: WalletAppConfig =
 
 // let's use a helper method to get a v19 bitcoind
 // and a ChainApi
-val bitcoind = BitcoindV19RpcClient(BitcoindInstance.fromConfigFile())
+
+val bitcoind = BitcoindV19RpcClient(BitcoindInstanceLocal.fromConfFile())
 val aesPasswordOpt = Some(AesPassword.fromString("password"))
 
 // Create our key manager

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -62,7 +62,7 @@ import org.bitcoins.core.wallet.fee._
 import org.bitcoins.feeprovider._
 import org.bitcoins.keymanager.bip39._
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.config.BitcoindInstance
+import org.bitcoins.rpc.config._
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.core.api.wallet.WalletApi
 import org.bitcoins.wallet.Wallet
@@ -113,7 +113,7 @@ val configF: Future[Unit] = for {
     _ <- chainConfig.start()
 } yield ()
 
-val bitcoindInstance = BitcoindInstance.fromDatadir()
+val bitcoindInstance = BitcoindInstanceLocal.fromDatadir()
 
 val bitcoind = BitcoindRpcClient(bitcoindInstance)
 

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -21,7 +21,10 @@ import org.bitcoins.core.protocol.ln.{
 }
 import org.bitcoins.eclair.rpc.api._
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
-import org.bitcoins.eclair.rpc.config.{EclairAuthCredentials, EclairInstance}
+import org.bitcoins.eclair.rpc.config.{
+  EclairAuthCredentials,
+  EclairInstanceLocal
+}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.async.TestAsyncUtil
 import org.bitcoins.testkit.eclair.rpc.{EclairNodes4, EclairRpcTestUtil}
@@ -512,7 +515,7 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
 
     val badInstanceF = badCredentialsF.flatMap { badCredentials =>
       val getBadInstance = (client: EclairRpcClient, _: EclairRpcClient) => {
-        val instance = EclairInstance(
+        val instance = EclairInstanceLocal(
           network = client.instance.network,
           uri = client.instance.uri,
           rpcUri = client.instance.rpcUri,

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/EclairInstance.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/EclairInstance.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.eclair.rpc.config
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.bitcoins.core.api.commons.InstanceFactory
+import org.bitcoins.core.api.commons.InstanceFactoryLocal
 import org.bitcoins.core.config.{MainNet, NetworkParameters, RegTest, TestNet3}
 import org.bitcoins.core.protocol.ln.LnPolicy
 import org.bitcoins.core.util.NetworkUtil
@@ -25,15 +25,19 @@ sealed trait EclairInstance {
   def proxyParams: Option[Socks5ProxyParams]
 }
 
+sealed trait EclairInstanceLocal extends EclairInstance
+
+sealed trait EclairInstanceRemote extends EclairInstance
+
 /** @define fromConfigDoc
   * Parses a [[com.typesafe.config.Config Config]] in the format of this
   * [[https://github.com/ACINQ/eclair/blob/master/eclair-core/src/main/resources/reference.conf sample reference.conf]]
   * file to a
   * [[org.bitcoins.eclair.rpc.config.EclairInstance EclairInstance]]
   */
-object EclairInstance extends InstanceFactory[EclairInstance] {
+object EclairInstanceLocal extends InstanceFactoryLocal[EclairInstanceLocal] {
 
-  private case class EclairInstanceImpl(
+  private case class EclairInstanceLocalImpl(
       network: NetworkParameters,
       uri: URI,
       rpcUri: URI,
@@ -43,7 +47,7 @@ object EclairInstance extends InstanceFactory[EclairInstance] {
       bitcoindAuthCredentials: Option[BitcoindAuthCredentials],
       zmqConfig: Option[ZmqConfig],
       proxyParams: Option[Socks5ProxyParams])
-      extends EclairInstance
+      extends EclairInstanceLocal
 
   def apply(
       network: NetworkParameters,
@@ -56,15 +60,15 @@ object EclairInstance extends InstanceFactory[EclairInstance] {
       bitcoindAuthCredentials: Option[BitcoindAuthCredentials] = None,
       zmqConfig: Option[ZmqConfig] = None
   ): EclairInstance = {
-    EclairInstanceImpl(network,
-                       uri,
-                       rpcUri,
-                       authCredentials,
-                       logbackXmlPath,
-                       bitcoindRpcUri,
-                       bitcoindAuthCredentials,
-                       zmqConfig,
-                       proxyParams)
+    EclairInstanceLocalImpl(network,
+                            uri,
+                            rpcUri,
+                            authCredentials,
+                            logbackXmlPath,
+                            bitcoindRpcUri,
+                            bitcoindAuthCredentials,
+                            zmqConfig,
+                            proxyParams)
   }
 
   override val DEFAULT_DATADIR: Path = Paths.get(Properties.userHome, ".eclair")
@@ -80,7 +84,7 @@ object EclairInstance extends InstanceFactory[EclairInstance] {
   def fromDatadir(
       datadir: File = DEFAULT_DATADIR.toFile,
       logbackXml: Option[String],
-      proxyParams: Option[Socks5ProxyParams]): EclairInstance = {
+      proxyParams: Option[Socks5ProxyParams]): EclairInstanceLocal = {
     require(datadir.exists, s"${datadir.getPath} does not exist!")
     require(datadir.isDirectory, s"${datadir.getPath} is not a directory!")
 
@@ -91,13 +95,13 @@ object EclairInstance extends InstanceFactory[EclairInstance] {
   }
 
   override def fromConfigFile(
-      file: File = DEFAULT_CONF_FILE.toFile): EclairInstance =
+      file: File = DEFAULT_CONF_FILE.toFile): EclairInstanceLocal =
     fromConfFile(file, None, None)
 
   def fromConfFile(
       file: File = DEFAULT_CONF_FILE.toFile,
       logbackXml: Option[String],
-      proxyParams: Option[Socks5ProxyParams]): EclairInstance = {
+      proxyParams: Option[Socks5ProxyParams]): EclairInstanceLocal = {
     require(file.exists, s"${file.getPath} does not exist!")
     require(file.isFile, s"${file.getPath} is not a file!")
 
@@ -107,7 +111,7 @@ object EclairInstance extends InstanceFactory[EclairInstance] {
   }
 
   override def fromDataDir(
-      dir: File = DEFAULT_DATADIR.toFile): EclairInstance = {
+      dir: File = DEFAULT_DATADIR.toFile): EclairInstanceLocal = {
     require(dir.exists, s"${dir.getPath} does not exist!")
     require(dir.isDirectory, s"${dir.getPath} is not a directory!")
 
@@ -121,7 +125,7 @@ object EclairInstance extends InstanceFactory[EclairInstance] {
       config: Config,
       datadir: File,
       logbackXml: Option[String],
-      proxyParams: Option[Socks5ProxyParams]): EclairInstance = {
+      proxyParams: Option[Socks5ProxyParams]): EclairInstanceLocal = {
     fromConfig(config, Some(datadir), logbackXml, proxyParams)
   }
 
@@ -135,7 +139,7 @@ object EclairInstance extends InstanceFactory[EclairInstance] {
       config: Config,
       datadir: Option[File],
       logbackXml: Option[String],
-      proxyParams: Option[Socks5ProxyParams]): EclairInstance = {
+      proxyParams: Option[Socks5ProxyParams]): EclairInstanceLocal = {
     val chain = ConfigUtil.getStringOrElse(config, "eclair.chain", "testnet")
 
     //  default conf: https://github.com/ACINQ/eclair/blob/master/eclair-core/src/main/resources/reference.conf
@@ -193,7 +197,7 @@ object EclairInstance extends InstanceFactory[EclairInstance] {
 
     val zmqConfig = ZmqConfig(rawBlock = rawBlock, rawTx = rawTx)
 
-    EclairInstance(
+    EclairInstanceLocalImpl(
       network = np,
       uri = uri,
       rpcUri = rpcUri,

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/config/LndConfig.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/config/LndConfig.scala
@@ -153,7 +153,7 @@ case class LndConfig(private[bitcoins] val lines: Seq[String], datadir: File)
     LndConfig(lines, newDatadir)
   }
 
-  lazy val lndInstance: LndInstance = LndInstance(
+  lazy val lndInstance: LndInstanceLocal = LndInstanceLocal(
     datadir.toPath,
     network,
     listenBinding,

--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -21,11 +21,12 @@ import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.crypto.Sha256Digest
 import org.bitcoins.eclair.rpc.api._
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
-import org.bitcoins.eclair.rpc.config.EclairInstance
+import org.bitcoins.eclair.rpc.config.EclairInstanceLocal
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.config.{
   BitcoindAuthCredentials,
   BitcoindInstance,
+  BitcoindInstanceLocal,
   ZmqConfig
 }
 import org.bitcoins.rpc.util.RpcUtil
@@ -59,8 +60,9 @@ trait EclairRpcTestUtil extends Logging {
 
   /** Makes a best effort to get a 0.16 bitcoind instance
     */
-  def startedBitcoindRpcClient(instance: BitcoindInstance = bitcoindInstance())(
-      implicit actorSystem: ActorSystem): Future[BitcoindRpcClient] = {
+  def startedBitcoindRpcClient(
+      instance: BitcoindInstanceLocal = bitcoindInstance())(implicit
+      actorSystem: ActorSystem): Future[BitcoindRpcClient] = {
     //need to do something with the Vector.newBuilder presumably?
     BitcoindRpcTestUtil.startedBitcoindRpcClient(instance, Vector.newBuilder)
   }
@@ -71,7 +73,7 @@ trait EclairRpcTestUtil extends Logging {
       rpcPort: Int = RpcUtil.randomPort,
       zmqConfig: ZmqConfig = RpcUtil.zmqConfig,
       bitcoindV: BitcoindVersion =
-        EclairRpcClient.bitcoindV): BitcoindInstance = {
+        EclairRpcClient.bitcoindV): BitcoindInstanceLocal = {
     BitcoindRpcTestUtil.getInstance(bitcoindVersion = bitcoindV,
                                     port = port,
                                     rpcPort = rpcPort,
@@ -147,29 +149,29 @@ trait EclairRpcTestUtil extends Logging {
 
   /** Assumes bitcoind is running already and you have specified correct bindings in eclair.conf */
   def cannonicalEclairInstance(
-      logbackXml: Option[String] = None): EclairInstance = {
+      logbackXml: Option[String] = None): EclairInstanceLocal = {
     val datadir = cannonicalDatadir
     eclairInstance(datadir, logbackXml)
   }
 
   def eclairInstance(
       datadir: File,
-      logbackXml: Option[String]): EclairInstance = {
-    val instance = EclairInstance.fromDatadir(datadir, logbackXml, None)
+      logbackXml: Option[String]): EclairInstanceLocal = {
+    val instance = EclairInstanceLocal.fromDatadir(datadir, logbackXml, None)
     instance
   }
 
   /** Starts the given bitcoind instance and then starts the eclair instance */
   def eclairInstance(
       bitcoindRpc: BitcoindRpcClient,
-      logbackXml: Option[String] = None): EclairInstance = {
+      logbackXml: Option[String] = None): EclairInstanceLocal = {
     val datadir = eclairDataDir(bitcoindRpc, false)
     eclairInstance(datadir, logbackXml)
   }
 
   def randomEclairInstance(
       bitcoindRpc: BitcoindRpcClient,
-      logbackXml: Option[String] = None): EclairInstance = {
+      logbackXml: Option[String] = None): EclairInstanceLocal = {
     val datadir = eclairDataDir(bitcoindRpc, false)
     eclairInstance(datadir, logbackXml)
   }
@@ -682,7 +684,7 @@ trait EclairRpcTestUtil extends Logging {
     val bitcoindRpc = {
       val instance = eclairRpcClient.instance
       val auth = instance.authCredentials
-      val bitcoindInstance = BitcoindInstance(
+      val bitcoindInstance = BitcoindInstanceLocal(
         network = instance.network,
         uri = new URI("http://localhost:18333"),
         rpcUri = auth.bitcoindRpcUri,

--- a/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestUtil.scala
@@ -8,11 +8,12 @@ import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.core.protocol.transaction.TransactionOutPoint
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.lnd.rpc.LndRpcClient
-import org.bitcoins.lnd.rpc.config.LndInstance
+import org.bitcoins.lnd.rpc.config.LndInstanceLocal
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.config.{
   BitcoindAuthCredentials,
   BitcoindInstance,
+  BitcoindInstanceLocal,
   ZmqConfig
 }
 import org.bitcoins.rpc.util.RpcUtil
@@ -39,8 +40,9 @@ trait LndRpcTestUtil extends Logging {
 
   /** Makes a best effort to get a 0.21 bitcoind instance
     */
-  def startedBitcoindRpcClient(instance: BitcoindInstance = bitcoindInstance())(
-      implicit actorSystem: ActorSystem): Future[BitcoindRpcClient] = {
+  def startedBitcoindRpcClient(
+      instance: BitcoindInstanceLocal = bitcoindInstance())(implicit
+      actorSystem: ActorSystem): Future[BitcoindRpcClient] = {
     //need to do something with the Vector.newBuilder presumably?
     BitcoindRpcTestUtil.startedBitcoindRpcClient(instance, Vector.newBuilder)
   }
@@ -50,7 +52,8 @@ trait LndRpcTestUtil extends Logging {
       port: Int = RpcUtil.randomPort,
       rpcPort: Int = RpcUtil.randomPort,
       zmqConfig: ZmqConfig = RpcUtil.zmqConfig,
-      bitcoindV: BitcoindVersion = BitcoindVersion.V21): BitcoindInstance = {
+      bitcoindV: BitcoindVersion =
+        BitcoindVersion.V21): BitcoindInstanceLocal = {
     BitcoindRpcTestUtil.getInstance(bitcoindVersion = bitcoindV,
                                     port = port,
                                     rpcPort = rpcPort,
@@ -107,13 +110,13 @@ trait LndRpcTestUtil extends Logging {
     }
   }
 
-  def lndInstance(bitcoindRpc: BitcoindRpcClient): LndInstance = {
+  def lndInstance(bitcoindRpc: BitcoindRpcClient): LndInstanceLocal = {
     val datadir = lndDataDir(bitcoindRpc, isCannonical = false)
     lndInstance(datadir)
   }
 
-  def lndInstance(datadir: File): LndInstance = {
-    LndInstance.fromDataDir(datadir)
+  def lndInstance(datadir: File): LndInstanceLocal = {
+    LndInstanceLocal.fromDataDir(datadir)
   }
 
   /** Returns a `Future` that is completed when both lnd and bitcoind have the same block height

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTestClient.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTestClient.scala
@@ -2,7 +2,7 @@ package org.bitcoins.testkit.util
 
 import akka.actor.ActorSystem
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
-import org.bitcoins.rpc.config.BitcoindInstance
+import org.bitcoins.rpc.config.BitcoindInstanceLocal
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 
 import java.nio.file.{Files, Path}
@@ -17,7 +17,7 @@ case class BitcoindRpcTestClient(
           s"Path did not exist! got=${binary.toAbsolutePath.toString}")
   import system.dispatcher
 
-  private lazy val bitcoindInstance: BitcoindInstance = {
+  private lazy val bitcoindInstance: BitcoindInstanceLocal = {
     BitcoindRpcTestUtil.getInstance(bitcoindVersion = version,
                                     binaryDirectory = binaryDirectory)
   }


### PR DESCRIPTION
Built on top of #3551 

This makes our `BitcoindInstance` into an Algebraic Data Type (ADT). The two cases we have are 

1. `BitcoindInstanceLocal` - a bitcoind running locally on the same host machine
2. `BitcoindInstanceRemote` - a bitcoind instance running remotely somewhere

I partly did `EclairInstance` and `LndInstance`, but in particular it was hard for me to understand with lnd what information should be local and remote. I will come back and fully implement those.