### PR TITLE
Revert 60 second delay on broadcast to go back to 4 hour default to n…

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -293,9 +293,9 @@ case class WalletAppConfig(
         ()
       case None =>
         logger.info(s"Starting wallet rebroadcast task")
-        val initDelay = 60
-        val interval = rebroadcastFrequency.toSeconds
 
+        val interval = rebroadcastFrequency.toSeconds
+        val initDelay = interval
         val future =
           scheduler.scheduleAtFixedRate(RebroadcastTransactionsRunnable(wallet),
                                         initDelay,


### PR DESCRIPTION
fixes #3554 

In #3509 i introduced logic to broadcast txs in the wallet after a 60 second delay on startup. Apparently there is a bitcoin p2p logic rule that says you cannot broadcast a tx until you are done doing IBD. This PR reverts #3509 to the previous behavior