### PR TITLE
Add guard for the case where tor binary hasn't created log file yet

### DIFF
--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -78,12 +78,19 @@ case class TorAppConfig(
 
   /** Checks it the [[isBootstrappedLogLine]] exists in the tor log file */
   private def checkIfLogExists: Boolean = {
-    val stream = Files.lines(torLogFile)
-    try {
-      stream
-        .filter((line: String) => line.contains(isBootstrappedLogLine))
-        .count() > 0
-    } finally if (stream != null) stream.close()
+    if (Files.exists(torLogFile)) {
+      val stream = Files.lines(torLogFile)
+      try {
+        stream
+          .filter((line: String) => line.contains(isBootstrappedLogLine))
+          .count() > 0
+      } finally if (stream != null) stream.close()
+    } else {
+      //log file may not exist quite yet as we just started the tor binary
+      //it may take a bit for the tor binary to write the log file
+      false
+    }
+
   }
 
   override def stop(): Future[Unit] = {

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -74,7 +74,9 @@ case class TorAppConfig(
     *  }}}
     */
   private def isBinaryFullyStarted(): Future[Unit] = {
-    AsyncUtil.retryUntilSatisfied(checkIfLogExists, 200.millis)
+    //tor can take at least 25 seconds to start at times
+    //see: https://github.com/bitcoin-s/bitcoin-s/pull/3558#issuecomment-899819698
+    AsyncUtil.retryUntilSatisfied(checkIfLogExists, 1.second, 60)
   }
 
   /** Checks it the [[isBootstrappedLogLine]] exists in the tor log file */

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -11,6 +11,7 @@ import org.bitcoins.tor.{Socks5ProxyParams, TorParams}
 import java.io.File
 import java.nio.file.{Files, Path}
 import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
 /** Configuration for the Bitcoin-S node
@@ -73,7 +74,7 @@ case class TorAppConfig(
     *  }}}
     */
   private def isBinaryFullyStarted(): Future[Unit] = {
-    AsyncUtil.retryUntilSatisfied(checkIfLogExists)
+    AsyncUtil.retryUntilSatisfied(checkIfLogExists, 200.millis)
   }
 
   /** Checks it the [[isBootstrappedLogLine]] exists in the tor log file */


### PR DESCRIPTION
fixes #3556 

There is a race condition between our application code and the tor binary to create tor's log file in #3549 . Previously we did not have a guard to check if the log file even exists, which would result in Scala throwing a `NoSuchFileException`. 

It is safe to assume the tor binary is not fully started if it hasn't even written the log file yet, so just return false in the case the log file doesn't exist.