### PR TITLE
Move DLC/Event loading operations to Pane

### DIFF
--- a/app/gui/src/main/resources/themes/dark-theme.css
+++ b/app/gui/src/main/resources/themes/dark-theme.css
@@ -66,14 +66,13 @@
     -fx-border-width: 1px;
 }
 
-/* Accordion TitledPane heading content */
-.small {
-    -fx-font-size: 0.8em;
+/* Load DLC / Event Pane */
+.load-label {
+    -fx-padding: 0 10 0 0;
 }
-
-/* Accordion TitledPane heading textfield */
-.title-textfield {
-    -fx-pref-width: 90;
+.load-textfield {
+    -fx-pref-width: 130;
+    -fx-prompt-text-fill: #b0b0b0;
 }
 
 /* Adjust SplitPane divider visibility and padding */

--- a/app/gui/src/main/resources/themes/dark-theme.css
+++ b/app/gui/src/main/resources/themes/dark-theme.css
@@ -66,7 +66,7 @@
     -fx-border-width: 1px;
 }
 
-/* Load DLC / Event Pane */
+/* Accept / Build Offer Pane */
 .load-label {
     -fx-padding: 0 10 0 0;
 }

--- a/app/gui/src/main/scala/org/bitcoins/gui/ContractGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/ContractGUI.scala
@@ -31,6 +31,7 @@ import scalafx.geometry._
 import scalafx.scene.Parent
 import scalafx.scene.control.{
   ContextMenu,
+  Label,
   MenuItem,
   TableColumn,
   TableView,
@@ -48,9 +49,13 @@ class ContractGUI(glassPane: VBox) {
 
   private[gui] lazy val model = new ContractGUIModel()
 
+  private lazy val addEventLabel = new Label("Load Event") {
+    styleClass += "load-label"
+  }
+
   private lazy val addEventTF = new TextField {
-    styleClass += "title-textfield"
-    promptText = "New Event Hex"
+    styleClass += "load-textfield"
+    promptText = "Paste Event Hex"
     onKeyTyped = _ => {
       val event = model.addEvent(this.text.value.trim)
       event match {
@@ -70,14 +75,13 @@ class ContractGUI(glassPane: VBox) {
     addEventTF.clear()
   }
 
-  lazy val addEventHBox = new HBox {
-    styleClass += "small"
-    children = Seq(addEventTF)
+  private lazy val addContractLabel = new Label("Load DLC") {
+    styleClass += "load-label"
   }
 
   private lazy val addContractTF = new TextField {
-    styleClass += "title-textfield"
-    promptText = "Contract Hex"
+    styleClass += "load-textfield"
+    promptText = "Paste Contract Hex"
     onKeyTyped = _ => {
       val validAddition = onContractAdded(text.value.trim, None)
       if (validAddition) clearContractTF() // Clear on valid data
@@ -95,9 +99,16 @@ class ContractGUI(glassPane: VBox) {
     if (validAddition) clearContractTF() // Clear on valid data
   })
 
-  lazy val addContractHBox = new HBox {
-    styleClass += "small"
-    children = Seq(fileChooserButton, addContractTF)
+  lazy val loadPane = new GridPane {
+    styleClass += "load-pane"
+    padding = Insets(10, 0, 10, 4)
+    hgap = 5
+    add(addContractLabel, 0, 0)
+    add(addContractTF, 1, 0)
+    add(fileChooserButton, 2, 0)
+    add(new Region { prefWidth = 15 }, 3, 0)
+    add(addEventLabel, 4, 0)
+    add(addEventTF, 5, 0)
   }
 
   private lazy val eventIdCol = new TableColumn[

--- a/app/gui/src/main/scala/org/bitcoins/gui/ContractGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/ContractGUI.scala
@@ -25,7 +25,6 @@ import org.bitcoins.gui.dlc.dialog.{
   SignDLCDialog,
   ViewDLCDialog
 }
-import org.bitcoins.gui.util.GUIUtil
 import scalafx.beans.property.StringProperty
 import scalafx.geometry._
 import scalafx.scene.Parent
@@ -40,7 +39,6 @@ import scalafx.scene.control.{
 import scalafx.scene.layout._
 
 import java.io.File
-import java.nio.file.Files
 import java.text.SimpleDateFormat
 import java.util.Date
 import scala.util.{Failure, Success}
@@ -49,13 +47,13 @@ class ContractGUI(glassPane: VBox) {
 
   private[gui] lazy val model = new ContractGUIModel()
 
-  private lazy val addEventLabel = new Label("Load Event") {
+  private lazy val addEventLabel = new Label("Build Offer") {
     styleClass += "load-label"
   }
 
   private lazy val addEventTF = new TextField {
     styleClass += "load-textfield"
-    promptText = "Paste Event Hex"
+    promptText = "Paste Hex"
     onKeyTyped = _ => {
       val event = model.addEvent(this.text.value.trim)
       event match {
@@ -75,13 +73,13 @@ class ContractGUI(glassPane: VBox) {
     addEventTF.clear()
   }
 
-  private lazy val addContractLabel = new Label("Load DLC") {
+  private lazy val addContractLabel = new Label("Accept Offer") {
     styleClass += "load-label"
   }
 
   private lazy val addContractTF = new TextField {
     styleClass += "load-textfield"
-    promptText = "Paste Contract Hex"
+    promptText = "Paste Hex"
     onKeyTyped = _ => {
       val validAddition = onContractAdded(text.value.trim, None)
       if (validAddition) clearContractTF() // Clear on valid data
@@ -93,22 +91,15 @@ class ContractGUI(glassPane: VBox) {
     addContractTF.clear()
   }
 
-  private lazy val fileChooserButton = GUIUtil.getFileChooserButton(file => {
-    val hex = Files.readAllLines(file.toPath).get(0)
-    val validAddition = onContractAdded(hex, Some(file))
-    if (validAddition) clearContractTF() // Clear on valid data
-  })
-
   lazy val loadPane = new GridPane {
     styleClass += "load-pane"
-    padding = Insets(10, 0, 10, 4)
+    padding = Insets(10, 0, 10, 11)
     hgap = 5
     add(addContractLabel, 0, 0)
     add(addContractTF, 1, 0)
-    add(fileChooserButton, 2, 0)
-    add(new Region { prefWidth = 15 }, 3, 0)
-    add(addEventLabel, 4, 0)
-    add(addEventTF, 5, 0)
+    add(new Region { prefWidth = 57 }, 2, 0)
+    add(addEventLabel, 3, 0)
+    add(addEventTF, 4, 0)
   }
 
   private lazy val eventIdCol = new TableColumn[

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUI.scala
@@ -135,24 +135,6 @@ abstract class WalletGUI extends Logging {
     children = Vector(walletGrid, buttonBox)
   }
 
-  private lazy val eventsLabel = new Label("Events")
-
-  private lazy val eventsTitleHbox = new HBox {
-    alignment = Pos.Center
-    children = Seq(eventsLabel, GUIUtil.getHSpacer(), contractGUI.addEventHBox)
-  }
-
-  private lazy val contractLabel = new Label("Contracts")
-
-  private lazy val contractsTitleHbox = new HBox {
-    alignment = Pos.Center
-    children =
-      Seq(contractLabel, GUIUtil.getHSpacer(), contractGUI.addContractHBox)
-  }
-
-  // Magic indent so text doesn't write passed edge of TitledPane
-  private val TITLEPANE_RIGHT_GUTTER = 35
-
   private lazy val sidebarAccordian = new VBox {
     padding = Insets(4)
 
@@ -162,15 +144,14 @@ abstract class WalletGUI extends Logging {
     }
 
     val eventUI = new TitledPane {
-      graphic = eventsTitleHbox
       content = contractGUI.eventPane
+      text = "Events"
       expanded = false
     }
-    eventsTitleHbox.minWidth <== eventUI.width - TITLEPANE_RIGHT_GUTTER
 
     val contractUI = new TitledPane {
-      graphic = contractsTitleHbox
       content = dlcPane.tableView
+      text = "Contracts"
       dlcPane.tableView.onMouseClicked = _ => {
         val i = dlcPane.tableView.getSelectionModel.getSelectedItem
         if (i != null) {
@@ -178,12 +159,12 @@ abstract class WalletGUI extends Logging {
         }
       }
     }
-    contractsTitleHbox.minWidth <== contractUI.width - TITLEPANE_RIGHT_GUTTER
 
     children = Vector(
+      contractGUI.loadPane,
       walletUI,
-      eventUI,
       contractUI,
+      eventUI,
       GUIUtil.getVSpacer(),
       stateDetails
     )


### PR DESCRIPTION
Moves the hex/file loading operations in the section accordion headers above the accordion.

![Screen Shot 2021-08-19 at 9 51 49 AM](https://user-images.githubusercontent.com/22351459/130101186-aca00822-58d7-4696-9633-fe4de7ddaad2.png)

