### PR TITLE
Enum outcome labels to match numeric outcome labels

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -411,7 +411,7 @@ class CreateDLCOfferDialog
 
       announcement.eventTLV.eventDescriptor match {
         case EnumEventDescriptorV0TLV(outcomes) =>
-          gridPane.add(new Region { prefHeight = 10 }, 0, 2)
+          gridPane.add(new Region { prefHeight = 20 }, 0, 2)
           gridPane.add(new Label("Outcome") {
                          maxWidth = Double.MaxValue
                          alignment = Pos.Center

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -97,7 +97,7 @@ class CreateDLCOfferDialog
       announcementOpt: Option[OracleAnnouncementV0TLV],
       contractInfoOpt: Option[ContractInfoV0TLV],
       initialContract: String = "") = {
-    var nextRow: Int = 3
+    var nextRow: Int = 4
     val gridPane = new GridPane {
       alignment = Pos.Center
       padding = Insets(top = 10, right = 10, bottom = 10, left = 10)
@@ -411,18 +411,19 @@ class CreateDLCOfferDialog
 
       announcement.eventTLV.eventDescriptor match {
         case EnumEventDescriptorV0TLV(outcomes) =>
+          gridPane.add(new Region { prefHeight = 10 }, 0, 2)
           gridPane.add(new Label("Outcome") {
                          maxWidth = Double.MaxValue
                          alignment = Pos.Center
                        },
                        0,
-                       2)
+                       3)
           gridPane.add(new Label("Payout") {
                          maxWidth = Double.MaxValue
                          alignment = Pos.Center
                        },
                        1,
-                       2)
+                       3)
           contractInfoOpt match {
             case Some(contractInfo) =>
               contractInfo.contractDescriptor match {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/CreateDLCOfferDialog.scala
@@ -411,8 +411,18 @@ class CreateDLCOfferDialog
 
       announcement.eventTLV.eventDescriptor match {
         case EnumEventDescriptorV0TLV(outcomes) =>
-          gridPane.add(new Label("Outcomes"), 0, 2)
-          gridPane.add(new Label("Values"), 1, 2)
+          gridPane.add(new Label("Outcome") {
+                         maxWidth = Double.MaxValue
+                         alignment = Pos.Center
+                       },
+                       0,
+                       2)
+          gridPane.add(new Label("Payout") {
+                         maxWidth = Double.MaxValue
+                         alignment = Pos.Center
+                       },
+                       1,
+                       2)
           contractInfoOpt match {
             case Some(contractInfo) =>
               contractInfo.contractDescriptor match {


### PR DESCRIPTION
Center outcome labels on Enum offer building. Change label text to match numeric contract labels. Add some vertical space above outcomes.

Current:
![Screen Shot 2021-08-17 at 3 57 37 PM](https://user-images.githubusercontent.com/22351459/129809992-f3202775-c097-4b93-b20b-f8147706e8f2.png)
Numeric:
![Screen Shot 2021-08-17 at 4 00 19 PM](https://user-images.githubusercontent.com/22351459/129810009-7ea4262f-f439-4848-82da-06be447cd597.png)
Enum after this PR:
![Screen Shot 2021-08-17 at 4 39 34 PM](https://user-images.githubusercontent.com/22351459/129810051-b8b7b883-a3df-4c23-a866-941b43568ba5.png)
