### PR TITLE
Implement reconnection logic for the case where maxconnections is full

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/util/NativeProcessFactory.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/NativeProcessFactory.scala
@@ -44,6 +44,13 @@ trait NativeProcessFactory extends Logging {
     }
   }
 
+  /** Restarts the binary. If the binary isn't currently running this is
+    * equivalent to calling [[startBinary()]]
+    */
+  def restartBinary(): Future[Unit] = {
+    stopBinary().flatMap(_ => startBinary())
+  }
+
   /** Stops the binary by destroying the underlying operating system process
     *
     * If the client is a remote client (not started on the host operating system)

--- a/app-commons/src/main/scala/org/bitcoins/commons/util/NativeProcessFactory.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/NativeProcessFactory.scala
@@ -44,13 +44,6 @@ trait NativeProcessFactory extends Logging {
     }
   }
 
-  /** Restarts the binary. If the binary isn't currently running this is
-    * equivalent to calling [[startBinary()]]
-    */
-  def restartBinary(): Future[Unit] = {
-    stopBinary().flatMap(_ => startBinary())
-  }
-
   /** Stops the binary by destroying the underlying operating system process
     *
     * If the client is a remote client (not started on the host operating system)

--- a/node-test/src/test/scala/org/bitcoins/node/networking/MaxConnectionsTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/MaxConnectionsTest.scala
@@ -62,7 +62,7 @@ class MaxConnectionsTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
       //we need to wait for the re-connection attempts
       //to at least a 16 second delay before reconnecting
       //so we have time to restart bitcoind
-      _ = AkkaUtil.nonBlockingSleep(10.seconds)
+      _ <- AkkaUtil.nonBlockingSleep(10.seconds)
       _ <- bitcoindRpc.stop()
       //write updated configuration, this sets maxconnections=1
       //which allows us to connect

--- a/node-test/src/test/scala/org/bitcoins/node/networking/MaxConnectionsTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/MaxConnectionsTest.scala
@@ -64,11 +64,13 @@ class MaxConnectionsTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
       //so we have time to restart bitcoind
       _ <- AkkaUtil.nonBlockingSleep(10.seconds)
       _ <- bitcoindRpc.stop()
+      //need to wait for mac to unlock the datadir
+      //before we can restart the bitcoind binary
+      _ <- AkkaUtil.nonBlockingSleep(3.seconds)
       //write updated configuration, this sets maxconnections=1
       //which allows us to connect
       _ = standardConfig.withOption("maxconnections", "125")
       _ <- bitcoindRpc.start()
-      _ = logger.error(s"Done starting bitcoind again")
       //now we should eventually automatically reconnect
       _ <- AsyncUtil.retryUntilSatisfiedF(
         conditionF = () => peerHandler.p2pClient.isConnected(),

--- a/node-test/src/test/scala/org/bitcoins/node/networking/MaxConnectionsTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/MaxConnectionsTest.scala
@@ -4,6 +4,7 @@ import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.asyncutil.AsyncUtil.RpcRetryException
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.PeerHandler
+import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.rpc.config.BitcoindInstance
 import org.bitcoins.testkit.node.{
   CachedBitcoinSAppConfig,
@@ -26,7 +27,10 @@ class MaxConnectionsTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
   val maxConnections0Config =
     standardConfig.withOption("maxconnections", "0")
 
-  val instance = BitcoindInstance.fromConfig(maxConnections0Config)
+  val binary = BitcoindRpcTestUtil.getBinary(BitcoindVersion.newest)
+
+  val instance =
+    BitcoindInstance.fromConfig(config = maxConnections0Config, binary = binary)
 
   lazy val bitcoindRpcF =
     BitcoindRpcTestUtil.startedBitcoindRpcClient(instance = instance,

--- a/node-test/src/test/scala/org/bitcoins/node/networking/MaxConnectionsTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/MaxConnectionsTest.scala
@@ -1,27 +1,30 @@
 package org.bitcoins.node.networking
 
 import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.asyncutil.AsyncUtil.RpcRetryException
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.PeerHandler
-import org.bitcoins.rpc.config.{BitcoindConfig, BitcoindInstance}
+import org.bitcoins.rpc.config.BitcoindInstance
 import org.bitcoins.testkit.node.{
   CachedBitcoinSAppConfig,
   NodeTestUtil,
   NodeUnitTest
 }
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.testkit.util.{AkkaUtil, BitcoindRpcTest}
 
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 
 class MaxConnectionsTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
 
-  //we need a custom bitcoind config with maxconnections=0
-  def writeNormalConfig: BitcoindConfig = BitcoindRpcTestUtil.standardConfig
+  val standardConfig = BitcoindRpcTestUtil.standardConfig
+
+  val datadir = standardConfig.datadir
 
   //need to start with maxconnections=0
   val maxConnections0Config =
-    writeNormalConfig.withOption("maxconnections", "0")
+    standardConfig.withOption("maxconnections", "0")
 
   val instance = BitcoindInstance.fromConfig(maxConnections0Config)
 
@@ -42,10 +45,33 @@ class MaxConnectionsTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
 
     val connectedF = for {
       peerHandler <- peerHandlerF
+      bitcoindRpc <- bitcoindRpcF
+
       _ = peerHandler.peerMsgSender.connect()
-      _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-        peerHandler.p2pClient.isConnected())
+      _ <- AsyncUtil
+        .retryUntilSatisfiedF(() => peerHandler.p2pClient.isConnected())
+        .recover { case _: RpcRetryException =>
+          //expect this to fail, we cannot connect
+          //because maxconnections=0
+          ()
+        }
+      //we need to wait for the re-connection attempts
+      //to at least a 16 second delay before reconnecting
+      //so we have time to restart bitcoind
+      _ = AkkaUtil.nonBlockingSleep(10.seconds)
+      _ <- bitcoindRpc.stop()
+      //write updated configuration, this sets maxconnections=1
+      //which allows us to connect
+      _ = standardConfig.withOption("maxconnections", "125")
+      _ <- bitcoindRpc.start()
+      _ = logger.error(s"Done starting bitcoind again")
+      //now we should eventually automatically reconnect
+      _ <- AsyncUtil.retryUntilSatisfiedF(
+        conditionF = () => peerHandler.p2pClient.isConnected(),
+        interval = 500.millis,
+        maxTries = 60)
     } yield succeed
+
     connectedF
   }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/MaxConnectionsTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/MaxConnectionsTest.scala
@@ -1,0 +1,51 @@
+package org.bitcoins.node.networking
+
+import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.node.models.Peer
+import org.bitcoins.node.networking.peer.PeerHandler
+import org.bitcoins.rpc.config.{BitcoindConfig, BitcoindInstance}
+import org.bitcoins.testkit.node.{
+  CachedBitcoinSAppConfig,
+  NodeTestUtil,
+  NodeUnitTest
+}
+import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
+import org.bitcoins.testkit.util.BitcoindRpcTest
+
+import scala.concurrent.Future
+
+class MaxConnectionsTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
+
+  //we need a custom bitcoind config with maxconnections=0
+  def writeNormalConfig: BitcoindConfig = BitcoindRpcTestUtil.standardConfig
+
+  //need to start with maxconnections=0
+  val maxConnections0Config =
+    writeNormalConfig.withOption("maxconnections", "0")
+
+  val instance = BitcoindInstance.fromConfig(maxConnections0Config)
+
+  lazy val bitcoindRpcF =
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(instance = instance,
+                                                 clientAccum = clientAccum)
+
+  lazy val bitcoindPeerF: Future[Peer] =
+    bitcoindRpcF.flatMap(b => NodeTestUtil.getBitcoindPeer(b))
+
+  behavior of "MaxConnectionsTest"
+
+  it must "attempt to reconnect if max connections are full" in {
+    val peerHandlerF: Future[PeerHandler] = for {
+      _ <- cachedConfig.start()
+      peer <- bitcoindPeerF.flatMap(p => NodeUnitTest.buildPeerHandler(p))
+    } yield peer
+
+    val connectedF = for {
+      peerHandler <- peerHandlerF
+      _ = peerHandler.peerMsgSender.connect()
+      _ <- AsyncUtil.retryUntilSatisfiedF(() =>
+        peerHandler.p2pClient.isConnected())
+    } yield succeed
+    connectedF
+  }
+}

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -60,7 +60,7 @@
     <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="INFO"/>
 
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->


### PR DESCRIPTION
Partially addresses #1821 

A common problem we run into with our lite client is that the bitcoind we host (`neutrino.suredbits.com`) has its `maxconnections` reached. In this case, what happens is 

1. Our lite client establishes a Tcp Connection with bitcoind
2. We send a version message
3. Our tcp connection gets disconnected (due to max connections being reached on bitcoind)

What this PR implements is re-connection logic for this case. The reconnection attempts back off exponentially. 

I'm going to add a unit test for this, but wanted to get this in front of people.

I've been testing locally with a bitcoind that has `maxconnections=0` which means no inbound connections are allowed.