### PR TITLE
Add dialog to show transaction id and link after wallet Send

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/GlobalData.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/GlobalData.scala
@@ -3,7 +3,6 @@ package org.bitcoins.gui
 import org.bitcoins.cli.Config
 import org.bitcoins.core.config._
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
-import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.gui.settings.Themes
 import scalafx.beans.property._
 
@@ -67,12 +66,12 @@ object GlobalData {
   }
 
   /** Builds a url for the blockstream explorer to view the tx */
-  def buildTxUrl(txid: DoubleSha256DigestBE): String = {
+  def buildTxUrl(txIdHex: String): String = {
     network match {
       case MainNet =>
-        s"https://blockstream.info/tx/${txid.hex}"
+        s"https://blockstream.info/tx/${txIdHex}"
       case TestNet3 =>
-        s"https://blockstream.info/testnet/tx/${txid.hex}"
+        s"https://blockstream.info/testnet/tx/${txIdHex}"
       case net @ (RegTest | SigNet) =>
         s"View transaction on your own node on $net"
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/GlobalData.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/GlobalData.scala
@@ -65,13 +65,39 @@ object GlobalData {
     case net @ (RegTest | SigNet) => s"Broadcast from your own node on $net"
   }
 
-  /** Builds a url for the blockstream explorer to view the tx */
-  def buildTxUrl(txIdHex: String): String = {
+  /** Builds a url for the Blockstream Explorer to view the tx */
+  def buildBlockstreamExplorerTxUrl(txIdHex: String): String = {
     network match {
       case MainNet =>
         s"https://blockstream.info/tx/${txIdHex}"
       case TestNet3 =>
         s"https://blockstream.info/testnet/tx/${txIdHex}"
+      case net @ (RegTest | SigNet) =>
+        s"View transaction on your own node on $net"
+    }
+  }
+
+  /** Builds a url for the mempool.space to view the tx */
+  def buildMempoolSpaceTxUrl(txIdHex: String): String = {
+    network match {
+      case MainNet =>
+        s"https://mempool.space/tx/${txIdHex}"
+      case TestNet3 =>
+        s"https://mempool.space/testnet/tx/${txIdHex}"
+      case net @ RegTest =>
+        s"View transaction on your own node on $net"
+      case SigNet =>
+        s"https://mempool.space/signet/tx/${txIdHex}"
+    }
+  }
+
+  /** Builds a url for the Oracle Explorer to view an Announcement */
+  def buildAnnouncementUrl(announcementHash: String): String = {
+    network match {
+      case MainNet =>
+        s"https://oracle.suredbits.com/announcement/${announcementHash}"
+      case TestNet3 =>
+        s"https://test.oracle.suredbits.com/announcement/${announcementHash}"
       case net @ (RegTest | SigNet) =>
         s"View transaction on your own node on $net"
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
@@ -93,6 +93,7 @@ class WalletGUIModel(dlcModel: DLCPaneModel)(implicit system: ActorSystem)
                   textArea.text = "Error, server did not return anything"
                 } else {
                   textArea.text = s"Transaction sent! $txid"
+                  TransactionSentDialog.show(GUI.stage, txid)
                 }
               case Failure(err) => throw err
             }

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
@@ -93,7 +93,7 @@ class WalletGUIModel(dlcModel: DLCPaneModel)(implicit system: ActorSystem)
                   textArea.text = "Error, server did not return anything"
                 } else {
                   textArea.text = s"Transaction sent! $txid"
-                  TransactionSentDialog.show(GUI.stage, txid)
+                  TransactionSentDialog.show(parentWindow.value, txid)
                 }
               case Failure(err) => throw err
             }

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
@@ -93,7 +93,8 @@ class WalletGUIModel(dlcModel: DLCPaneModel)(implicit system: ActorSystem)
                   textArea.text = "Error, server did not return anything"
                 } else {
                   textArea.text = s"Transaction sent! $txid"
-                  TransactionSentDialog.show(parentWindow.value, txid)
+                  Platform.runLater(
+                    TransactionSentDialog.show(parentWindow.value, txid))
                 }
               case Failure(err) => throw err
             }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/FundingTransactionDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/FundingTransactionDialog.scala
@@ -1,0 +1,74 @@
+package org.bitcoins.gui.dialog
+
+import org.bitcoins.gui.GlobalData
+import org.bitcoins.gui.util.GUIUtil
+import scalafx.Includes._
+import scalafx.geometry.{Insets, Pos}
+import scalafx.scene.control.{ButtonType, Dialog, Hyperlink, Label, TextField}
+import scalafx.scene.layout.{HBox, Priority, VBox}
+import scalafx.stage.{Modality, Window}
+
+object FundingTransactionDialog {
+
+  private val MAX_WIDTH = 400
+
+  def show(
+      parentWindow: Window,
+      fundingTxId: String,
+      refundDateTime: String,
+      oracleLink: String,
+      rebroadcast: Boolean = false): Unit = {
+    val dialog = new Dialog[Unit]() {
+      initOwner(parentWindow)
+      initModality(Modality.None)
+      title = "Funding Transaction Broadcast"
+    }
+    if (rebroadcast) dialog.title = "Funding Transaction Rebroadcast"
+
+    dialog.dialogPane().buttonTypes = Seq(ButtonType.Close)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+
+    dialog.dialogPane().content = new VBox {
+      padding = Insets(20)
+      alignment = Pos.Center
+      spacing = 15
+      children = Seq(
+        new Label("You successfully entered a DLC with your counterparty!"),
+        new HBox {
+          alignment = Pos.CenterLeft
+          spacing = 5
+          maxWidth = MAX_WIDTH
+          children = Seq(new Label("Funding Transaction Id"),
+                         new TextField {
+                           text = fundingTxId
+                           editable = false
+                           hgrow = Priority.Always
+                         })
+        },
+        new Hyperlink("View transaction on mempool.space") {
+          onAction =
+            _ => GUIUtil.openUrl(GlobalData.buildMempoolSpaceTxUrl(fundingTxId))
+        },
+        new Hyperlink("View transaction on Blockstream Explorer") {
+          onAction = _ =>
+            GUIUtil.openUrl(
+              GlobalData.buildBlockstreamExplorerTxUrl(fundingTxId))
+        },
+        new Label(
+          "It will take a few seconds for the transaction to show up in the block explorer. Refresh your browser tab momentarily if the transaction is not immediately available.") {
+          wrapText = true
+          maxWidth = MAX_WIDTH
+        },
+        new Label(
+          s"You can execute the refund clause of your DLC at ${refundDateTime}."),
+        new Hyperlink("View Oracle Announcement") {
+          onAction = _ => {
+            GUIUtil.openUrl(oracleLink)
+          }
+        }
+      )
+    }
+
+    val _ = dialog.show()
+  }
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/TransactionSentDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/TransactionSentDialog.scala
@@ -26,16 +26,21 @@ object TransactionSentDialog {
       children = Seq(
         new HBox {
           alignment = Pos.Center
-          spacing = 10
-          children = Seq(new Label("Transaction Id:"),
+          spacing = 15
+          children = Seq(new Label("Transaction Id"),
                          new TextField {
                            text = txId
                            minWidth = 200
                            editable = false
                          })
         },
+        new Hyperlink("View transaction on mempool.space") {
+          onAction =
+            _ => GUIUtil.openUrl(GlobalData.buildMempoolSpaceTxUrl(txId))
+        },
         new Hyperlink("View transaction on Blockstream Explorer") {
-          onAction = _ => GUIUtil.openUrl(GlobalData.buildTxUrl(txId))
+          onAction =
+            _ => GUIUtil.openUrl(GlobalData.buildBlockstreamExplorerTxUrl(txId))
         },
         new Label(
           "It will take a few seconds for the transaction to show up in the block explorer. Refresh your browser tab momentarily if the transaction is not immediately available.") {

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/TransactionSentDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/TransactionSentDialog.scala
@@ -1,0 +1,46 @@
+package org.bitcoins.gui.dialog
+
+import org.bitcoins.gui.GlobalData
+import org.bitcoins.gui.util.GUIUtil
+import scalafx.Includes._
+import scalafx.geometry.Pos
+import scalafx.scene.control.{ButtonType, Dialog, Hyperlink, Label, TextField}
+import scalafx.scene.layout.{HBox, VBox}
+import scalafx.stage.{Modality, Window}
+
+object TransactionSentDialog {
+
+  def show(parentWindow: Window, txId: String): Unit = {
+    val dialog = new Dialog[Unit]() {
+      initOwner(parentWindow)
+      initModality(Modality.None)
+      title = "Transaction Sent"
+    }
+    dialog.dialogPane().buttonTypes = Seq(ButtonType.Close)
+    dialog.dialogPane().stylesheets = GlobalData.currentStyleSheets
+
+    dialog.dialogPane().content = new VBox {
+      alignment = Pos.Center
+      spacing = 10
+      minHeight = 100
+      children = Seq(
+        new HBox {
+          alignment = Pos.Center
+          spacing = 10
+          children = Seq(new Label("Transaction Id:"),
+                         new TextField {
+                           text = txId
+                           minWidth = 200
+                           editable = false
+                         })
+        },
+        new Hyperlink("View transaction on Blockstream Explorer") {
+          onAction = _ => GUIUtil.openUrl(GlobalData.buildTxUrl(txId))
+        }
+      )
+    }
+
+    val _ = dialog.show()
+  }
+
+}

--- a/app/gui/src/main/scala/org/bitcoins/gui/dialog/TransactionSentDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dialog/TransactionSentDialog.scala
@@ -36,6 +36,11 @@ object TransactionSentDialog {
         },
         new Hyperlink("View transaction on Blockstream Explorer") {
           onAction = _ => GUIUtil.openUrl(GlobalData.buildTxUrl(txId))
+        },
+        new Label(
+          "It will take a few seconds for the transaction to show up in the block explorer. Refresh your browser tab momentarily if the transaction is not immediately available.") {
+          wrapText = true
+          maxWidth = 285
         }
       )
     }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
@@ -1,10 +1,9 @@
 package org.bitcoins.gui.dlc
 
-import org.bitcoins.commons.jsonmodels.ExplorerEnv
 import org.bitcoins.core.dlc.accounting.RateOfReturnUtil
 import org.bitcoins.core.protocol.dlc.models.DLCStatus._
 import org.bitcoins.core.protocol.dlc.models._
-import org.bitcoins.gui.{GUI, GlobalData}
+import org.bitcoins.gui.GlobalData
 import org.bitcoins.gui.util.GUIUtil
 import scalafx.beans.property.StringProperty
 import scalafx.scene.control.TableColumn.SortType
@@ -144,12 +143,9 @@ class DLCTableView(model: DLCPaneModel) {
               val dlc = selectionModel.value.getSelectedItem
               val primaryOracle =
                 dlc.oracleInfo.singleOracleInfos.head.announcement
-              // TODO : GlobalData.network is currently null here, showing error dialog
-              val baseUrl =
-                ExplorerEnv.fromBitcoinNetwork(GlobalData.network).siteUrl
               val url =
-                s"${baseUrl}announcement/${primaryOracle.sha256.hex}"
-              GUI.hostServices.showDocument(url)
+                GUIUtil.getAnnouncementUrl(GlobalData.network, primaryOracle)
+              GUIUtil.openUrl(url)
             }
           }
 

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
@@ -157,13 +157,9 @@ object ViewDLCDialog {
           },
           new Button("Rebroadcast") {
             minWidth = 90
-            disable = !DLCStatus.getFundingTxId(status).isDefined
-            onAction = _ => {
-              DLCStatus.getContractId(status) match {
-                case Some(contractId) => model.rebroadcastFundingTx(contractId)
-                case None             => // Nothing to do
-              }
-            }
+            disable =
+              !(status.state == DLCState.Broadcasted || status.state == DLCState.Signed)
+            onAction = _ => model.rebroadcastFundingTx(status)
           }
         )
       }

--- a/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/util/GUIUtil.scala
@@ -1,8 +1,11 @@
 package org.bitcoins.gui.util
 
 import javafx.beans.value.ObservableValue
+import org.bitcoins.commons.jsonmodels.ExplorerEnv
+import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.protocol.BlockTimeStamp
-import org.bitcoins.gui.GlobalData
+import org.bitcoins.core.protocol.tlv.OracleAnnouncementTLV
+import org.bitcoins.gui.{GUI, GlobalData}
 import scalafx.beans.property.StringProperty
 import scalafx.scene.{Parent, Scene}
 import scalafx.scene.control.{Button, TextField, Tooltip}
@@ -168,6 +171,18 @@ object GUIUtil {
         () => stage.close())
     }
     stage
+  }
+
+  def getAnnouncementUrl(
+      network: BitcoinNetwork,
+      primaryOracle: OracleAnnouncementTLV): String = {
+    val baseUrl =
+      ExplorerEnv.fromBitcoinNetwork(network).siteUrl
+    s"${baseUrl}announcement/${primaryOracle.sha256.hex}"
+  }
+
+  def openUrl(url: String): Unit = {
+    GUI.hostServices.showDocument(url)
   }
 
   val logo = new Image("/icons/bitcoin-s.png")


### PR DESCRIPTION
This adds a dialog that pops up after a wallet Send and closing tx Rebroadcast that shows the transaction and a hyperlink that will open a browser window to the transaction data on the Blockstream Explorer or mempool.space.

This also adds another dialog specific to funding transactions with a message and links to the Oracle Explorer.

Fixes #3486

![Screen Shot 2021-08-19 at 9 31 26 AM](https://user-images.githubusercontent.com/22351459/130098738-bff25ebe-d596-4ac8-805d-cd490859c351.png)

I still need to do more work to plug in the funding transaction broadcast everywhere it can be used.
