### PR TITLE
Turn on bitcoin-s.node.relay=true by default on bundle/appServer

### DIFF
--- a/app/bundle/src/main/resources/application.conf
+++ b/app/bundle/src/main/resources/application.conf
@@ -4,6 +4,7 @@ bitcoin-s {
     node {
         mode = neutrino # neutrino, spv, bitcoind
         peers = ["neutrino.suredbits.com:8333"]
+        relay = true
     }
     proxy {
         # Configure SOCKS5 proxy to use Tor for outgoing connections

--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -3,6 +3,7 @@ bitcoin-s {
     node {
         mode = neutrino # neutrino, spv, bitcoind
         peers = ["neutrino.suredbits.com:8333"]
+        relay = true
     }
     proxy {
         # Configure SOCKS5 proxy to use Tor for outgoing connections


### PR DESCRIPTION
This allows for the offerer and the non closer of a DLC to learn about their unconfirmed txs being relayed around the network. This does increase bandwidth requirements on our nodes, but since we expect users to be running on a desktop environment, this should be fine. Partially addresses #3525 