### PR TITLE
Add guard to not allow us to check the network configuration on bitcoind

### DIFF
--- a/app/bundle/src/main/resources/application.conf
+++ b/app/bundle/src/main/resources/application.conf
@@ -8,12 +8,12 @@ bitcoin-s {
     }
     proxy {
         # Configure SOCKS5 proxy to use Tor for outgoing connections
-        enabled = true
+        enabled = false
         socks5 = "127.0.0.1:9050"
     }
     tor {
         # Enable Tor for incoming DLC connections
-        enabled = true
+        enabled = false
         control = "127.0.0.1:9051"
     }
 }

--- a/app/bundle/src/main/resources/application.conf
+++ b/app/bundle/src/main/resources/application.conf
@@ -8,12 +8,12 @@ bitcoin-s {
     }
     proxy {
         # Configure SOCKS5 proxy to use Tor for outgoing connections
-        enabled = false
+        enabled = true
         socks5 = "127.0.0.1:9050"
     }
     tor {
         # Enable Tor for incoming DLC connections
-        enabled = false
+        enabled = true
         control = "127.0.0.1:9051"
     }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -45,6 +45,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
   implicit lazy val torConf: TorAppConfig = conf.torConf
 
   override def start(): Future[Unit] = {
+    logger.info("Starting appServer")
     val startedConfigF = conf.start()
 
     logger.info(s"Start on network ${walletConf.network}")

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -41,6 +41,7 @@ case class TorAppConfig(
   override def start(): Future[Unit] = {
     lazy val torRunning = checkIfTorAlreadyRunning
     if (enabled && !isStarted.get && !torRunning) {
+      logger.info(s"Starting tor")
       isStarted.set(true)
       val start = System.currentTimeMillis()
       //remove old tor log file so we accurately tell when


### PR DESCRIPTION
We haven't started tor at this point, so when we introduced tor on by default in #3537 we no longer can check for the bitcoind rpc network. 

This is a bug a user ran into this morning when trying to connect the wallet to a running bitcoind rpc instance