### PR TITLE
Implement PeerMessageReceiverState.InitializedDisconnect

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -48,16 +48,10 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
 
       val initAssertion = isInitializedF.map(assert(_))
 
-      //checking all peers can be disconnected
-      def isAllDisconnectedF: Future[Boolean] = {
-        val disconnFs = node.peers.indices.map(node.isDisconnected)
-        val res = Future.sequence(disconnFs).map(_.forall(_ == true))
-        res
-      }
       val disconnF = for {
         _ <- initAssertion
         _ <- node.stop()
-        f <- isAllDisconnectedF
+        f <- isAllDisconnectedF(node)
       } yield f
       disconnF.map(assert(_))
   }
@@ -133,4 +127,10 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       }
   }
 
+  //checking all peers can be disconnected
+  private def isAllDisconnectedF(node: Node): Future[Boolean] = {
+    val disconnFs = node.peers.indices.map(node.isDisconnected)
+    val res = Future.sequence(disconnFs).map(_.forall(_ == true))
+    res
+  }
 }

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -230,7 +230,7 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     } yield disconnect
 
     def isAllDisconnectedF: Future[Boolean] = {
-      val connF = peerMsgSenders.indices.map(peerMsgSenders(_).isDisconnected())
+      val connF = peerMsgSenders.map(_.isDisconnected())
       val res = Future.sequence(connF).map(_.forall(_ == true))
       res
     }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverState.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverState.scala
@@ -163,6 +163,23 @@ object PeerMessageReceiverState {
     override def toString: String = "Normal"
   }
 
+  /** The state for when we initialized as disconnect from our peer */
+  case class InitializedDisconnect(
+      clientConnectP: Promise[P2PClient],
+      clientDisconnectP: Promise[Unit],
+      versionMsgP: Promise[VersionMessage],
+      verackMsgP: Promise[VerAckMessage.type])
+      extends PeerMessageReceiverState {
+    require(
+      isConnected,
+      s"We cannot have a PeerMessageReceiverState.Normal if the Peer is not connected")
+    require(
+      isInitialized,
+      s"We cannot have a PeerMessageReceiverState.Normal if the Peer is not initialized")
+
+    override def toString: String = "InitializedDisconnect"
+  }
+
   case class Disconnected(
       clientConnectP: Promise[P2PClient],
       clientDisconnectP: Promise[Unit],

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.node.networking.peer
 
 import akka.actor.ActorRef
-import akka.io.Tcp
 import akka.util.Timeout
 import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
 import org.bitcoins.core.bloom.BloomFilter
@@ -48,7 +47,7 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     isConnected().flatMap {
       case true =>
         logger.info(s"Disconnecting peer at socket=${socket}")
-        (client.actor ! Tcp.Close)
+        (client.actor ! P2PClient.CloseCommand)
         Future.unit
       case false =>
         val err =


### PR DESCRIPTION
In #3572 we implemented reconnection logic. What we did not account for is the case when _we_ initialized the disconnection. We do not want to reconnect if we initialized the reconnection. This is why all of our CI jobs were failing on #3572. 

This PR implements a new `PeerMessageReceiverState` called `InitializeDisconnect` and implements it in `P2pClientActor` so we don't attempt to keep reconnecting when we initialized the disconnect from a peer