### PR TITLE
Fix missing afterAll in ReConnectionTest

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -57,4 +57,9 @@ class ReConnectionTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
 
     connectedF
   }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoinSAppConfig].afterAll()
+    super[BitcoindRpcTest].afterAll()
+  }
 }


### PR DESCRIPTION
Missed in #3572 , this makes sure we shut down the actor system and clean up the bitcoind.