### PR TITLE
Add AppConfigActorSystem

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfigFactory.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfigFactory.scala
@@ -5,24 +5,27 @@ import com.typesafe.config.{Config, ConfigFactory}
 import java.nio.file.{Path, Paths}
 import scala.concurrent.ExecutionContext
 
-trait AppConfigFactory[C <: AppConfig] {
-
+/** @tparam I - the implicit argument. This is usually an execution context or an actor system */
+trait AppConfigFactoryBase[C <: AppConfig, I] {
   def moduleName: String
 
-  def fromConfig(config: Config)(implicit ec: ExecutionContext): C = {
+  def fromConfig(config: Config)(implicit i: I): C = {
     val configDataDir: Path = Paths.get(config.getString("bitcoin-s.datadir"))
     fromDatadir(configDataDir, Vector(config))
   }
 
-  def fromClassPathConfig()(implicit ec: ExecutionContext): C = {
+  def fromClassPathConfig()(implicit i: I): C = {
     fromConfig(ConfigFactory.load())
   }
 
   def fromDefaultDatadir(confs: Vector[Config] = Vector.empty)(implicit
-      ec: ExecutionContext): C = {
+      i: I): C = {
     fromDatadir(AppConfig.DEFAULT_BITCOIN_S_DATADIR, confs)
   }
 
   def fromDatadir(datadir: Path, confs: Vector[Config] = Vector.empty)(implicit
-      ec: ExecutionContext): C
+      i: I): C
 }
+
+trait AppConfigFactory[C <: AppConfig]
+    extends AppConfigFactoryBase[C, ExecutionContext]

--- a/app/server/src/main/scala/org/bitcoins/server/util/AppConfigFactoryActorSystem.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/AppConfigFactoryActorSystem.scala
@@ -1,0 +1,8 @@
+package org.bitcoins.server.util
+
+import akka.actor.ActorSystem
+import org.bitcoins.commons.config.{AppConfig, AppConfigFactoryBase}
+
+/** An AppConfigFactory that has implicit actor systems passed into the datadir */
+trait AppConfigFactoryActorSystem[C <: AppConfig]
+    extends AppConfigFactoryBase[C, ActorSystem]


### PR DESCRIPTION
This is needed by @shruthii625 . The `BitcoinRpcAppConfig` depends on an actor system not just an execution context. We should be able to use both `ExecutionContext` and `ActorSystem` as implicit args for our `fromDatadir()` and `fromClasspathConfig()` etc.

