### PR TITLE
Move BitcoindRpcAppConfig into the bitcoind-rpc project

### DIFF
--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPane.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPane.scala
@@ -3,8 +3,8 @@ package org.bitcoins.bundle.gui
 import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
 import org.bitcoins.commons.util.ServerArgParser
+import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.gui._
-import org.bitcoins.node.NodeType
 import org.bitcoins.server.BitcoinSAppConfig
 import scalafx.geometry._
 import scalafx.scene.control.TabPane.TabClosingPolicy

--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
@@ -6,9 +6,9 @@ import grizzled.slf4j.Logging
 import org.bitcoins.bundle.gui.BundleGUI._
 import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.commons.util.{DatadirUtil, ServerArgParser}
+import org.bitcoins.core.api.node.InternalImplementationNodeType
 import org.bitcoins.gui._
-import org.bitcoins.node.NodeType._
-import org.bitcoins.node._
+import org.bitcoins.core.api.node.NodeType._
 import org.bitcoins.server.BitcoinSAppConfig.toNodeConf
 import org.bitcoins.server._
 import scalafx.beans.property.ObjectProperty

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
@@ -6,9 +6,9 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.WitnessTransaction
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.server.BitcoindRpcAppConfig
+import org.bitcoins.rpc.config.BitcoindRpcAppConfig
 import org.bitcoins.server.routes.BitcoinSRunner
-import org.bitcoins.server.util.{BitcoinSAppScalaDaemon}
+import org.bitcoins.server.util.BitcoinSAppScalaDaemon
 
 import scala.concurrent.Future
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/BitcoindRpcAppConfigTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/BitcoindRpcAppConfigTest.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.server
 
 import java.nio.file._
-
 import com.typesafe.config.ConfigFactory
 import org.bitcoins.core.config._
+import org.bitcoins.rpc.config.BitcoindRpcAppConfig
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 
 import scala.reflect.io.Directory

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -12,6 +12,7 @@ import org.bitcoins.dlc.node.config.DLCNodeAppConfig
 import org.bitcoins.dlc.wallet.DLCAppConfig
 import org.bitcoins.keymanager.config.KeyManagerAppConfig
 import org.bitcoins.node.config.NodeAppConfig
+import org.bitcoins.rpc.config.BitcoindRpcAppConfig
 import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.wallet.config.WalletAppConfig
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -9,7 +9,12 @@ import org.bitcoins.chain.models._
 import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
-import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.node.{
+  ExternalImplementationNodeType,
+  InternalImplementationNodeType,
+  NodeApi,
+  NodeType
+}
 import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.dlc.node.DLCNode
@@ -21,7 +26,7 @@ import org.bitcoins.feeprovider._
 import org.bitcoins.node._
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
-import org.bitcoins.rpc.config.ZmqConfig
+import org.bitcoins.rpc.config.{BitcoindRpcAppConfig, ZmqConfig}
 import org.bitcoins.server.routes.{BitcoinSServerRunner, Server}
 import org.bitcoins.server.util.BitcoinSAppScalaDaemon
 import org.bitcoins.tor.config.TorAppConfig

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
@@ -1,13 +1,10 @@
-package org.bitcoins.server
+package org.bitcoins.rpc.config
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import org.bitcoins.commons.config.{AppConfig, ConfigOps}
-import org.bitcoins.node.NodeType
-import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
-import org.bitcoins.rpc.config._
-import org.bitcoins.server.util.AppConfigFactoryActorSystem
+import org.bitcoins.rpc.util.AppConfigFactoryActorSystem
 import org.bitcoins.tor.Socks5ProxyParams
 import org.bitcoins.tor.config.TorAppConfig
 
@@ -37,21 +34,7 @@ case class BitcoindRpcAppConfig(
 
   protected[bitcoins] def baseDatadir: Path = directory
 
-  lazy val nodeConf: NodeAppConfig = NodeAppConfig(directory, confs: _*)
-
-  override def start(): Future[Unit] = {
-    nodeConf.nodeType match {
-      case NodeType.BitcoindBackend =>
-        binaryOpt match {
-          case Some(_) =>
-            client.start().map(_ => ())
-          case None =>
-            Future.unit
-        }
-      case NodeType.SpvNode | NodeType.NeutrinoNode | NodeType.FullNode =>
-        Future.unit
-    }
-  }
+  override def start(): Future[Unit] = Future.unit
 
   override def stop(): Future[Unit] = Future.unit
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/AppConfigFactoryActorSystem.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/AppConfigFactoryActorSystem.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.server.util
+package org.bitcoins.rpc.util
 
 import akka.actor.ActorSystem
 import org.bitcoins.commons.config.{AppConfig, AppConfigFactoryBase}

--- a/core/src/main/scala/org/bitcoins/core/api/node/NodeType.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/NodeType.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.node
+package org.bitcoins.core.api.node
 
 import org.bitcoins.crypto.StringFactory
 

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -10,6 +10,7 @@ import org.bitcoins.core.api.chain.db.{
   CompactFilterDb,
   CompactFilterHeaderDb
 }
+import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -10,7 +10,7 @@ import org.bitcoins.chain.models.{
   CompactFilterHeaderDAO
 }
 import org.bitcoins.core.api.chain._
-import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.node.{NodeApi, NodeType}
 import org.bitcoins.core.p2p.{NetworkPayload, ServiceIdentifier, TypeIdentifier}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
+import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.core.bloom.BloomFilter
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -3,12 +3,13 @@ package org.bitcoins.node.networking.peer
 import akka.Done
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.chain.ChainApi
+import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.core.gcs.BlockFilter
 import org.bitcoins.core.p2p._
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.BroadcastAbleTransactionDAO
-import org.bitcoins.node.{Node, NodeType, P2PLogger}
+import org.bitcoins.node.{Node, P2PLogger}
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Try

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -1,12 +1,13 @@
 package org.bitcoins.node.networking.peer
 
 import akka.actor.ActorRefFactory
+import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.core.p2p._
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.P2PClient
 import org.bitcoins.node.networking.peer.PeerMessageReceiverState._
-import org.bitcoins.node.{Node, NodeType, P2PLogger}
+import org.bitcoins.node.{Node, P2PLogger}
 
 import scala.concurrent.Future
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -592,6 +592,7 @@ object Deps {
   }
 
   val walletServerTest = List(
+    Compile.typesafeConfig,
     Test.scalaMock,
     Test.akkaHttpTestkit,
     Test.akkaStream

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -1,8 +1,9 @@
 package org.bitcoins.testkit.node
 
 import akka.actor.ActorSystem
+import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.node.models.Peer
-import org.bitcoins.node.{Node, NodeType}
+import org.bitcoins.node.Node
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.client.v21.BitcoindV21RpcClient
 import org.bitcoins.server.BitcoinSAppConfig

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -5,6 +5,7 @@ import org.bitcoins.chain.blockchain.ChainHandlerCached
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models._
 import org.bitcoins.core.api.chain.ChainApi
+import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.node._
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer


### PR DESCRIPTION
Needed for #3600 

This PR moves the `BitcoindRpcConfig` from the `appServer` module -> `bitcoindRpc` module.