### PR TITLE
Write unit test for SpendingInfoDAO.upsert()

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -278,11 +278,21 @@ abstract class Wallet
   }
 
   override def clearAllUtxosAndAddresses(): Future[Wallet] = {
-    for {
+    val resultedF = for {
       _ <- spendingInfoDAO.deleteAll()
       _ <- addressDAO.deleteAll()
       _ <- scriptPubKeyDAO.deleteAll()
-    } yield this
+    } yield {
+      logger.info(
+        s"Done clearing all utxos, addresses and scripts from the database")
+      this
+    }
+    resultedF.failed.foreach(err =>
+      logger.error(
+        s"Failed to clear utxos, addresses and scripts from the database",
+        err))
+
+    resultedF
   }
 
   /** Sums up the value of all unspent

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -291,15 +291,14 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       state: ReceivedState,
       addressDbE: Either[AddUtxoError, AddressDb]): Future[AddUtxoResult] = {
 
-    logger.info(s"Adding UTXO to wallet: ${transaction.txId.hex}:${vout.toInt}")
-
     if (vout.toInt >= transaction.outputs.length) {
       //out of bounds output
       Future.successful(VoutIndexOutOfBounds)
     } else {
       val output = transaction.outputs(vout.toInt)
       val outPoint = TransactionOutPoint(transaction.txId, vout)
-
+      logger.info(
+        s"Adding UTXO to wallet: ${transaction.txId.hex}:${vout.toInt} amt=${output.value}")
       // insert the UTXO into the DB
       val insertedUtxoEF: Either[AddUtxoError, Future[SpendingInfoDb]] = for {
         addressDb <- addressDbE

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -156,7 +156,7 @@ case class SpendingInfoDAO()(implicit
           } yield table.insertOrUpdate(
             UTXORecord.fromSpendingInfoDb(si, newSpkId))).flatten
       }
-      utxo <- table.filter(_.id === si.id.get).result.headOption
+      utxo <- table.filter(_.outPoint === si.outPoint).result.headOption
       spk <-
         spkTable
           .filter(_.scriptPubKey === si.output.scriptPubKey)


### PR DESCRIPTION
This might solve #3617 

The previous implementation of `SpendingInfoDAO().upsert()` assumed that the `si.id` was defined. We previously used

```scala
table.filter(_.id === si.id.get).result.headOption
```

`si.id` is not always defined, especially in rescan scenarios, so we can't reliably filter on it.

I've switched the implementation to match on the outpoint which should be unique. 