### PR TITLE
Move block generation and synchronization of the wallet in NeutrinoNodeWithWalletTest

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -194,6 +194,11 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       utxos <- wallet.listDefaultAccountUtxos()
       _ = assert(addresses.size == 7)
       _ = assert(utxos.size == 3)
+      _ <-
+        bitcoind.getNewAddress
+          .flatMap(bitcoind.generateToAddress(1, _))
+      _ <- NodeTestUtil.awaitSync(node, bitcoind)
+      _ <- NodeTestUtil.awaitCompactFiltersSync(node, bitcoind)
 
       _ <- wallet.clearAllUtxosAndAddresses()
 
@@ -201,12 +206,6 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       utxos <- wallet.listDefaultAccountUtxos()
       _ = assert(addresses.isEmpty)
       _ = assert(utxos.isEmpty)
-
-      _ <-
-        bitcoind.getNewAddress
-          .flatMap(bitcoind.generateToAddress(1, _))
-      _ <- NodeTestUtil.awaitSync(node, bitcoind)
-      _ <- NodeTestUtil.awaitCompactFiltersSync(node, bitcoind)
 
       _ <- wallet.fullRescanNeutrinoWallet(addressBatchSize = 7)
 


### PR DESCRIPTION
hopefully fixes #3618 and #3621

We have some strange asynchronous wallet interactions on callback with this code that can lead to an indeteriminant state of the wallet before starting the rescan. When i move this above clearing addreses/utxos, things seem to pass more consistently in #3615 

