### PR TITLE
Bump fee by more to make sure our fee rate is increasing the test case

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
@@ -39,7 +39,7 @@ class ServerRunTest extends BitcoinSAsyncTest {
         _ <- runMainF
         _ <- AkkaUtil.nonBlockingSleep(2.seconds)
         _ = directory.deleteRecursively()
-        _ <- AkkaUtil.nonBlockingSleep(2.seconds)
+        _ <- AkkaUtil.nonBlockingSleep(5.seconds)
       } yield ()
 
       for {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -317,7 +317,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
 
       firstBal <- wallet.getBalance()
 
-      newFeeRate = SatoshisPerByte(feeRate.currencyUnit + Satoshis.one)
+      newFeeRate = SatoshisPerByte(feeRate.currencyUnit + Satoshis(50))
       bumpedTx <- wallet.bumpFeeRBF(tx.txIdBE, newFeeRate)
 
       txDb1Opt <- wallet.outgoingTxDAO.findByTxId(tx.txIdBE)


### PR DESCRIPTION
fixes #3624 

I belive this is caused by the fact our DER signatures are not deterministic, so we could go from a very small signature to a large signature and cause the fee rate to be diluted on the new tx