### PR TITLE
Begin TorAppConfig refactor

### DIFF
--- a/.github/workflows/Linux_2.12_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.12_App_Chain_Core_Tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
+    env:
+      TOR: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Linux_2.12_Node_Tests.yml
+++ b/.github/workflows/Linux_2.12_Node_Tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
+    env:
+      TOR: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
+    env:
+      TOR: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
+    env:
+      TOR: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Linux_2.13_Node_Tests.yml
+++ b/.github/workflows/Linux_2.13_Node_Tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
+    env:
+      TOR: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
+    env:
+      TOR: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
+    env:
+      TOR: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -12,6 +12,7 @@ jobs:
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     env:
       PG_ENABLED: "1"
+      TOR: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/TorTests.yml
+++ b/.github/workflows/TorTests.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     env:
-      TOR: "1"
+      TOR: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/app-commons-test/src/test/scala/org/bitcoins/commons/config/AppConfigTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/config/AppConfigTest.scala
@@ -17,7 +17,9 @@ class AppConfigTest extends BitcoinSAsyncTest {
     val networkOverride =
       ConfigFactory.parseString("bitcoin-s.network = testnet3")
 
-    val config = BitcoinSTestAppConfig.getSpvTestConfig(networkOverride)
+    val config =
+      BitcoinSTestAppConfig.getSpvTestConfig(config = Vector(networkOverride),
+                                             torAppConfigOpt = None)
     val chainConf = config.chainConf
     val walletConf = config.walletConf
     val nodeConf = config.nodeConf
@@ -31,7 +33,8 @@ class AppConfigTest extends BitcoinSAsyncTest {
   }
 
   it must "have the same DB path" in {
-    val conf = BitcoinSTestAppConfig.getSpvTestConfig()
+    val conf = BitcoinSTestAppConfig.getSpvTestConfig(config = Vector.empty,
+                                                      torAppConfigOpt = None)
     val chainConf = conf.chainConf
     val walletConf = conf.walletConf
     val nodeConf = conf.nodeConf
@@ -40,7 +43,8 @@ class AppConfigTest extends BitcoinSAsyncTest {
   }
 
   it must "have distinct databases" in {
-    val conf = BitcoinSTestAppConfig.getSpvTestConfig()
+    val conf = BitcoinSTestAppConfig.getSpvTestConfig(config = Vector.empty,
+                                                      torAppConfigOpt = None)
     val chainConf = conf.chainConf
     val walletConf = conf.walletConf
     val nodeConf = conf.nodeConf

--- a/app/oracle-server/src/main/resources/reference.conf
+++ b/app/oracle-server/src/main/resources/reference.conf
@@ -15,3 +15,4 @@ akka {
   http.server.parsing.max-content-length = 8m
   http.client.parsing.max-content-length = 8m
 }
+

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
@@ -44,7 +44,8 @@ object Zip extends BitcoinSAppScalaDaemon {
   System.setProperty("bitcoins.log.location", datadirParser.networkDir.toString)
 
   implicit lazy val conf: BitcoinSAppConfig =
-    BitcoinSAppConfig(datadirParser.datadir, datadirParser.baseConfig)(system)
+    BitcoinSAppConfig(datadirParser.datadir, Vector(datadirParser.baseConfig))(
+      system)
 
   new ZipDatadir(serverCmdLineArgs).run()
 }

--- a/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTorTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTorTest.scala
@@ -14,7 +14,9 @@ class BitcoinSServerMainBitcoindTorTest
 
   it must "start our app server with bitcoind as a backend with tor" in {
     config: BitcoinSAppConfig =>
-      val server = new BitcoinSServerMain(ServerArgParser.empty)(system, config)
+      val server =
+        new BitcoinSServerMain(serverArgParser = ServerArgParser.empty,
+                               torConfOpt = Some(torConfig))(system, config)
 
       val cliConfig: Config = Config(rpcPortOpt = Some(config.rpcPort))
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTorTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTorTest.scala
@@ -3,12 +3,10 @@ package org.bitcoins.server
 import org.bitcoins.cli.{CliCommand, Config, ConsoleCli}
 import org.bitcoins.commons.util.ServerArgParser
 import org.bitcoins.testkit.fixtures.BitcoinSAppConfigBitcoinFixtureNotStarted
-import org.bitcoins.testkit.tor.CachedTor
 
 /** Test starting bitcoin-s with bitcoind as the backend for app */
 class BitcoinSServerMainBitcoindTorTest
-    extends BitcoinSAppConfigBitcoinFixtureNotStarted
-    with CachedTor {
+    extends BitcoinSAppConfigBitcoinFixtureNotStarted {
 
   behavior of "BitcoinSServerMain"
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTorTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTorTest.scala
@@ -13,8 +13,8 @@ class BitcoinSServerMainBitcoindTorTest
   it must "start our app server with bitcoind as a backend with tor" in {
     config: BitcoinSAppConfig =>
       val server =
-        new BitcoinSServerMain(serverArgParser = ServerArgParser.empty,
-                               torConfOpt = Some(torConfig))(system, config)
+        new BitcoinSServerMain(serverArgParser = ServerArgParser.empty)(system,
+                                                                        config)
 
       val cliConfig: Config = Config(rpcPortOpt = Some(config.rpcPort))
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/BitcoindRpcAppConfigTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/BitcoindRpcAppConfigTest.scala
@@ -13,7 +13,7 @@ class BitcoindRpcAppConfigTest extends BitcoinSAsyncTest {
   val tempDir: Path = Files.createTempDirectory("bitcoin-s")
 
   val config: BitcoindRpcAppConfig =
-    BitcoindRpcAppConfig(directory = tempDir)
+    BitcoindRpcAppConfig(directory = tempDir, Vector.empty, None)
 
   override def afterAll(): Unit = {
     super.afterAll()
@@ -39,7 +39,8 @@ class BitcoindRpcAppConfigTest extends BitcoinSAsyncTest {
     val overrider =
       ConfigFactory.parseString(s"bitcoin-s.bitcoind-rpc.rpcport = 5555")
 
-    val throughConstructor = BitcoindRpcAppConfig(tempDir, overrider)
+    val throughConstructor =
+      BitcoindRpcAppConfig(tempDir, Vector(overrider), None)
     val throughWithOverrides = config.withOverrides(overrider)
     assert(throughWithOverrides.rpcPort == 5555)
     assert(throughWithOverrides.rpcPort == throughConstructor.rpcPort)
@@ -89,7 +90,8 @@ class BitcoindRpcAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig = BitcoindRpcAppConfig(directory = tempDir)
+    val appConfig =
+      BitcoindRpcAppConfig(directory = tempDir, Vector.empty, None)
 
     assert(appConfig.datadir == tempDir.resolve("testnet3"))
     assert(appConfig.network == TestNet3)

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -57,7 +57,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
   implicit val conf: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig()
+    BitcoinSTestAppConfig.getSpvTestConfig(config = Vector.empty,
+                                           torAppConfigOpt = None)
 
   implicit val timeout: RouteTestTimeout = RouteTestTimeout(5.seconds)
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/ServerRunTest.scala
@@ -23,7 +23,7 @@ class ServerRunTest extends BitcoinSAsyncTest {
     val noPeersConfig =
       ConfigFactory.parseString(s"""bitcoin-s.node.peers=[]""")
     implicit val config =
-      BitcoinSTestAppConfig.getNeutrinoTestConfig(noPeersConfig)
+      BitcoinSTestAppConfig.getNeutrinoTestConfig(Vector(noPeersConfig))
     val datadir = config.chainConf.datadir
 
     val invalidPort = -1

--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -8,11 +8,13 @@ bitcoin-s {
     proxy {
         # Configure SOCKS5 proxy to use Tor for outgoing connections
         enabled = true
+        enabled = ${?TOR}
         socks5 = "127.0.0.1:9050"
     }
     tor {
         # Enable Tor for incoming DLC connections
         enabled = true
+        enabled = ${?TOR}
         control = "127.0.0.1:9051"
     }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -82,7 +82,14 @@ case class BitcoinSAppConfig(
       _ <- walletConf.stop()
       _ <- chainConf.stop()
       _ <- bitcoindRpcConf.stop()
-      _ <- torConf.stop()
+      _ <- {
+        if (torAppConfigOpt.isDefined) {
+          //do not stop tor if it was passed in as a parameter
+          Future.unit
+        } else {
+          torConf.stop()
+        }
+      }
     } yield ()
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -36,7 +36,9 @@ case class BitcoinSAppConfig(
     extends StartStopAsync[Unit] {
   import system.dispatcher
   lazy val walletConf: WalletAppConfig = WalletAppConfig(directory, confs: _*)
-  lazy val nodeConf: NodeAppConfig = NodeAppConfig(directory, confs: _*)
+
+  lazy val nodeConf: NodeAppConfig =
+    NodeAppConfig(directory, confs, torAppConfigOpt)
   lazy val chainConf: ChainAppConfig = ChainAppConfig(directory, confs: _*)
   lazy val dlcConf: DLCAppConfig = DLCAppConfig(directory, confs: _*)
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -41,7 +41,7 @@ case class BitcoinSAppConfig(
   lazy val torConf: TorAppConfig = TorAppConfig(directory, confs: _*)
 
   lazy val dlcNodeConf: DLCNodeAppConfig =
-    DLCNodeAppConfig(directory, confs: _*)
+    DLCNodeAppConfig(directory, confs: _*)(system.dispatcher, torConf)
 
   def copyWithConfig(newConfs: Vector[Config]): BitcoinSAppConfig = {
     val configs = newConfs ++ confs

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -61,7 +61,7 @@ case class BitcoinSAppConfig(
     KeyManagerAppConfig(directory, confs: _*)
 
   lazy val bitcoindRpcConf: BitcoindRpcAppConfig =
-    BitcoindRpcAppConfig(directory, confs: _*)
+    BitcoindRpcAppConfig(directory, confs, torAppConfigOpt)
 
   lazy val network: NetworkParameters = chainConf.network
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -119,7 +119,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val feeProvider = getFeeProviderOrElse(
       MempoolSpaceProvider(HourFeeTarget,
                            walletConf.network,
-                           Some(torConf.socks5ProxyParams)))
+                           torConf.socks5ProxyParams))
     //get our wallet
     val configuredWalletF = for {
       node <- nodeF
@@ -379,20 +379,17 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
         case (None, None) | (None, Some(_)) =>
           default
         case (Some(BitcoinerLive), None) =>
-          BitcoinerLiveFeeRateProvider.fromBlockTarget(6, Some(proxyParams))
+          BitcoinerLiveFeeRateProvider.fromBlockTarget(6, proxyParams)
         case (Some(BitcoinerLive), Some(target)) =>
-          BitcoinerLiveFeeRateProvider.fromBlockTarget(target,
-                                                       Some(proxyParams))
+          BitcoinerLiveFeeRateProvider.fromBlockTarget(target, proxyParams)
         case (Some(BitGo), targetOpt) =>
-          BitGoFeeRateProvider(targetOpt, Some(proxyParams))
+          BitGoFeeRateProvider(targetOpt, proxyParams)
         case (Some(MempoolSpace), None) =>
-          MempoolSpaceProvider(HourFeeTarget,
-                               walletConf.network,
-                               Some(proxyParams))
+          MempoolSpaceProvider(HourFeeTarget, walletConf.network, proxyParams)
         case (Some(MempoolSpace), Some(target)) =>
           MempoolSpaceProvider.fromBlockTarget(target,
                                                walletConf.network,
-                                               Some(proxyParams))
+                                               proxyParams)
         case (Some(Constant), Some(num)) =>
           ConstantFeeRateProvider(SatoshisPerVirtualByte.fromLong(num))
         case (Some(Constant), None) =>

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -56,8 +56,10 @@ class BitcoinSServerMain(
 
   implicit lazy val torConf: TorAppConfig = {
     torConfOpt match {
-      case Some(torConf) => torConf
-      case None          => conf.torConf
+      case Some(torConf) =>
+        logger.info(s"Using cached tor configuration")
+        torConf
+      case None => conf.torConf
     }
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -114,7 +114,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val feeProvider = getFeeProviderOrElse(
       MempoolSpaceProvider(HourFeeTarget,
                            walletConf.network,
-                           walletConf.torConf.socks5ProxyParams))
+                           Some(torConf.socks5ProxyParams)))
     //get our wallet
     val configuredWalletF = for {
       node <- nodeF
@@ -374,17 +374,20 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
         case (None, None) | (None, Some(_)) =>
           default
         case (Some(BitcoinerLive), None) =>
-          BitcoinerLiveFeeRateProvider.fromBlockTarget(6, proxyParams)
+          BitcoinerLiveFeeRateProvider.fromBlockTarget(6, Some(proxyParams))
         case (Some(BitcoinerLive), Some(target)) =>
-          BitcoinerLiveFeeRateProvider.fromBlockTarget(target, proxyParams)
+          BitcoinerLiveFeeRateProvider.fromBlockTarget(target,
+                                                       Some(proxyParams))
         case (Some(BitGo), targetOpt) =>
-          BitGoFeeRateProvider(targetOpt, proxyParams)
+          BitGoFeeRateProvider(targetOpt, Some(proxyParams))
         case (Some(MempoolSpace), None) =>
-          MempoolSpaceProvider(HourFeeTarget, walletConf.network, proxyParams)
+          MempoolSpaceProvider(HourFeeTarget,
+                               walletConf.network,
+                               Some(proxyParams))
         case (Some(MempoolSpace), Some(target)) =>
           MempoolSpaceProvider.fromBlockTarget(target,
                                                walletConf.network,
-                                               proxyParams)
+                                               Some(proxyParams))
         case (Some(Constant), Some(num)) =>
           ConstantFeeRateProvider(SatoshisPerVirtualByte.fromLong(num))
         case (Some(Constant), None) =>

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -40,9 +40,7 @@ import scala.concurrent.{ExecutionContext, Future, Promise}
   * @param serverArgParser - the command line arguments passed to the server
   * @param torConfOpt a running tor app config that should be used instead of building one
   */
-class BitcoinSServerMain(
-    override val serverArgParser: ServerArgParser,
-    torConfOpt: Option[TorAppConfig] = None)(implicit
+class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     override val system: ActorSystem,
     conf: BitcoinSAppConfig)
     extends BitcoinSServerRunner {
@@ -54,14 +52,7 @@ class BitcoinSServerMain(
   implicit lazy val dlcNodeConf: DLCNodeAppConfig = conf.dlcNodeConf
   implicit lazy val bitcoindRpcConf: BitcoindRpcAppConfig = conf.bitcoindRpcConf
 
-  implicit lazy val torConf: TorAppConfig = {
-    torConfOpt match {
-      case Some(torConf) =>
-        logger.info(s"Using cached tor configuration")
-        torConf
-      case None => conf.torConf
-    }
-  }
+  implicit lazy val torConf: TorAppConfig = conf.torConf
 
   override def start(): Future[Unit] = {
     logger.info("Starting appServer")
@@ -489,9 +480,9 @@ object BitcoinSServerMain extends BitcoinSAppScalaDaemon {
   System.setProperty("bitcoins.log.location", datadirParser.networkDir.toString)
 
   implicit lazy val conf: BitcoinSAppConfig =
-    BitcoinSAppConfig(datadirParser.datadir,
-                      datadirParser.baseConfig,
-                      serverCmdLineArgs.toConfig)(system)
+    BitcoinSAppConfig(
+      datadirParser.datadir,
+      Vector(datadirParser.baseConfig, serverCmdLineArgs.toConfig))(system)
 
   new BitcoinSServerMain(serverCmdLineArgs).run()
 }

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -36,7 +36,13 @@ import org.bitcoins.wallet.config.WalletAppConfig
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
-class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
+/** The entry point for our backend server
+  * @param serverArgParser - the command line arguments passed to the server
+  * @param torConfOpt a running tor app config that should be used instead of building one
+  */
+class BitcoinSServerMain(
+    override val serverArgParser: ServerArgParser,
+    torConfOpt: Option[TorAppConfig] = None)(implicit
     override val system: ActorSystem,
     conf: BitcoinSAppConfig)
     extends BitcoinSServerRunner {
@@ -47,7 +53,13 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
   implicit lazy val dlcConf: DLCAppConfig = conf.dlcConf
   implicit lazy val dlcNodeConf: DLCNodeAppConfig = conf.dlcNodeConf
   implicit lazy val bitcoindRpcConf: BitcoindRpcAppConfig = conf.bitcoindRpcConf
-  implicit lazy val torConf: TorAppConfig = conf.torConf
+
+  implicit lazy val torConf: TorAppConfig = {
+    torConfOpt match {
+      case Some(torConf) => torConf
+      case None          => conf.torConf
+    }
+  }
 
   override def start(): Future[Unit] = {
     logger.info("Starting appServer")

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/TestRpcUtilTest.scala
@@ -30,7 +30,9 @@ class TestRpcUtilTest extends BitcoindFixturesCachedPairV21 {
   it should "create a temp bitcoin directory when creating a DaemonInstance, and then delete it" in {
     _: NodePair[BitcoindV21RpcClient] =>
       val instance =
-        BitcoindRpcTestUtil.instance(RpcUtil.randomPort, RpcUtil.randomPort)
+        BitcoindRpcTestUtil.instance(torAppConfigOpt = None,
+                                     port = RpcUtil.randomPort,
+                                     rpcPort = RpcUtil.randomPort)
       val dir = instance.datadir
       assert(dir.isDirectory)
       assert(dir.getPath().startsWith(scala.util.Properties.tmpDir))

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
@@ -19,7 +19,9 @@ class BlockchainRpcTest extends BitcoindFixturesCachedPairV17 {
     val pruneClient =
       BitcoindRpcClient.withActorSystem(
         BitcoindRpcTestUtil
-          .instance(pruneMode = true, versionOpt = Some(BitcoindVersion.V17)))
+          .instance(torAppConfigOpt = None,
+                    pruneMode = true,
+                    versionOpt = Some(BitcoindVersion.V17)))
 
     for {
       _ <- pruneClient.start()

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MessageRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MessageRpcTest.scala
@@ -13,7 +13,8 @@ class MessageRpcTest extends BitcoindRpcTest {
 
   val clientF: Future[BitcoindRpcClient] =
     BitcoindRpcTestUtil
-      .startedBitcoindRpcClient(clientAccum = clientAccum)
+      .startedBitcoindRpcClient(torAppConfigOpt = None,
+                                clientAccum = clientAccum)
 
   behavior of "MessageRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MiningRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MiningRpcTest.scala
@@ -10,7 +10,8 @@ import org.bitcoins.rpc.BitcoindP2PException.NotConnected
 class MiningRpcTest extends BitcoindRpcTest {
 
   lazy val clientsF: Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodePairV17(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.createNodePairV17(torAppConfigOpt = None,
+                                          clientAccum = clientAccum)
 
   behavior of "MiningRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultisigRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultisigRpcTest.scala
@@ -12,7 +12,8 @@ import scala.concurrent.Future
 class MultisigRpcTest extends BitcoindRpcTest {
 
   lazy val clientF: Future[BitcoindRpcClient] =
-    BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None,
+                                                 clientAccum = clientAccum)
 
   behavior of "MultisigRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/NodeRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/NodeRpcTest.scala
@@ -12,7 +12,8 @@ import org.bitcoins.rpc.BitcoindException.MiscError
 class NodeRpcTest extends BitcoindRpcTest {
 
   lazy val clientF: Future[BitcoindRpcClient] =
-    BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None,
+                                                 clientAccum = clientAccum)
 
   behavior of "NodeRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/P2PRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/P2PRpcTest.scala
@@ -16,10 +16,12 @@ import scala.concurrent.Future
 class P2PRpcTest extends BitcoindRpcTest {
 
   lazy val clientF: Future[BitcoindRpcClient] =
-    BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None,
+                                                 clientAccum = clientAccum)
 
   lazy val clientPairF: Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodePair(clientAccum)
+    BitcoindRpcTestUtil.createNodePair(torAppConfigOpt = None,
+                                       clientAccum = clientAccum)
 
   behavior of "P2PRpcTest"
 
@@ -64,7 +66,8 @@ class P2PRpcTest extends BitcoindRpcTest {
     for {
 
       (client1, _) <-
-        BitcoindRpcTestUtil.createNodePair(clientAccum = clientAccum)
+        BitcoindRpcTestUtil.createNodePair(torAppConfigOpt = None,
+                                           clientAccum = clientAccum)
       _ <- client1.setBan(loopBack, SetBanCommand.Add)
 
       list <- client1.listBanned
@@ -107,7 +110,8 @@ class P2PRpcTest extends BitcoindRpcTest {
     for {
 
       (client1, _) <-
-        BitcoindRpcTestUtil.createNodePair(clientAccum = clientAccum)
+        BitcoindRpcTestUtil.createNodePair(torAppConfigOpt = None,
+                                           clientAccum = clientAccum)
       _ <- client1.setBan(URI.create("http://127.0.0.1"), SetBanCommand.Add)
       _ <- client1.setBan(URI.create("http://127.0.0.2"), SetBanCommand.Add)
       list <- client1.listBanned

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/RawTransactionRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/RawTransactionRpcTest.scala
@@ -22,7 +22,8 @@ import scala.concurrent.Future
 class RawTransactionRpcTest extends BitcoindRpcTest {
 
   lazy val clientsF: Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodePairV17(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.createNodePairV17(torAppConfigOpt = None,
+                                          clientAccum = clientAccum)
 
   behavior of "RawTransactionRpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/UTXORpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/UTXORpcTest.scala
@@ -10,7 +10,8 @@ import scala.concurrent.Future
 class UTXORpcTest extends BitcoindRpcTest {
 
   lazy val clientF: Future[BitcoindRpcClient] =
-    BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None,
+                                                 clientAccum = clientAccum)
 
   behavior of "UTXORpc"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/UtilRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/UtilRpcTest.scala
@@ -13,7 +13,8 @@ import scala.concurrent.Future
 class UtilRpcTest extends BitcoindRpcTest {
 
   lazy val clientsF: Future[(BitcoindRpcClient, BitcoindRpcClient)] =
-    BitcoindRpcTestUtil.createNodePair(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.createNodePair(torAppConfigOpt = None,
+                                       clientAccum = clientAccum)
 
   behavior of "RpcUtilTest"
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -50,7 +50,8 @@ class WalletRpcTest extends BitcoindFixturesCachedPairV21 {
   // This client's wallet is encrypted
   lazy val walletClientF: Future[BitcoindRpcClient] = clientsF.flatMap { _ =>
     val walletClient =
-      BitcoindRpcClient.withActorSystem(BitcoindRpcTestUtil.instance())
+      BitcoindRpcClient.withActorSystem(
+        BitcoindRpcTestUtil.instance(torAppConfigOpt = None))
 
     for {
       _ <- startClient(walletClient)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/config/BitcoindConfigTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/config/BitcoindConfigTest.scala
@@ -9,7 +9,7 @@ class BitcoindConfigTest extends BitcoinSUnitTest {
 
   def tmpDir = FileUtil.tmpDir()
   it must "have to/fromString symmetry" in {
-    val conf = BitcoindRpcTestUtil.standardConfig
+    val conf = BitcoindRpcTestUtil.standardConfig(torAppConfigOpt = None)
     val confStr = conf.toWriteableString
     val otherConf = BitcoindConfig(confStr, tmpDir)
     val otherConfStr = otherConf.toWriteableString
@@ -124,7 +124,7 @@ class BitcoindConfigTest extends BitcoinSUnitTest {
   }
 
   it must "have a default config in test utils" in {
-    val conf = BitcoindRpcTestUtil.standardConfig
+    val conf = BitcoindRpcTestUtil.standardConfig(torAppConfigOpt = None)
     assert(conf.username.isDefined)
     assert(conf.password.isDefined)
     assert(conf.zmqpubhashblock.isDefined)

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -264,7 +264,9 @@ object BitcoindInstanceRemote
     require(file.exists, s"${file.getPath} does not exist!")
     require(file.isFile, s"${file.getPath} is not a file!")
 
-    val conf = BitcoindRpcAppConfig(file.toPath)
+    val conf = BitcoindRpcAppConfig(directory = file.toPath,
+                                    confs = Vector.empty,
+                                    torAppConfigOpt = None)
     fromConfig(conf)
   }
 
@@ -291,7 +293,7 @@ object BitcoindInstanceRemote
       system: ActorSystem): BitcoindInstanceRemote = {
     require(dir.exists, s"${dir.getPath} does not exist!")
     require(dir.isDirectory, s"${dir.getPath} is not a directory!")
-    val conf = BitcoindRpcAppConfig(dir.toPath)
+    val conf = BitcoindRpcAppConfig(dir.toPath, Vector.empty, None)
     fromConfig(conf)
   }
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
@@ -19,7 +19,8 @@ import scala.concurrent.Future
   */
 case class BitcoindRpcAppConfig(
     private val directory: Path,
-    private val confs: Config*)(implicit val system: ActorSystem)
+    private val confs: Vector[Config],
+    torAppConfigOpt: Option[TorAppConfig])(implicit val system: ActorSystem)
     extends AppConfig {
 
   import system.dispatcher
@@ -33,7 +34,7 @@ case class BitcoindRpcAppConfig(
 
   override protected[bitcoins] def newConfigOfType(
       configs: Seq[Config]): BitcoindRpcAppConfig =
-    BitcoindRpcAppConfig(directory, configs: _*)
+    BitcoindRpcAppConfig(directory, configs.toVector, torAppConfigOpt)
 
   protected[bitcoins] def baseDatadir: Path = directory
 
@@ -190,7 +191,7 @@ object BitcoindRpcAppConfig
     */
 
   override def fromDatadir(datadir: Path, confs: Vector[Config])(implicit
-      system: ActorSystem): BitcoindRpcAppConfig =
-    BitcoindRpcAppConfig(datadir, confs: _*)
-
+      system: ActorSystem): BitcoindRpcAppConfig = {
+    BitcoindRpcAppConfig(datadir, confs, None)
+  }
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
@@ -40,7 +40,13 @@ case class BitcoindRpcAppConfig(
 
   override def start(): Future[Unit] = Future.unit
 
-  override def stop(): Future[Unit] = Future.unit
+  override def stop(): Future[Unit] = {
+    if (!torAppConfigOpt.isDefined) {
+      torConf.stop()
+    } else {
+      Future.unit
+    }
+  }
 
   lazy val DEFAULT_BINARY_PATH: Option[File] =
     BitcoindInstanceLocal.DEFAULT_BITCOIND_LOCATION
@@ -82,8 +88,13 @@ case class BitcoindRpcAppConfig(
   lazy val rpcPassword: Option[String] =
     config.getStringOrNone("bitcoin-s.bitcoind-rpc.rpcpassword")
 
-  lazy val torConf: TorAppConfig =
-    TorAppConfig(directory, confs: _*)
+  lazy val torConf: TorAppConfig = {
+    torAppConfigOpt match {
+      case Some(cached) => cached
+      case None =>
+        TorAppConfig(directory, confs: _*)
+    }
+  }
 
   lazy val socks5ProxyParams: Option[Socks5ProxyParams] =
     torConf.socks5ProxyParams

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
@@ -85,7 +85,7 @@ case class BitcoindRpcAppConfig(
     TorAppConfig(directory, confs: _*)
 
   lazy val socks5ProxyParams: Option[Socks5ProxyParams] =
-    torConf.socks5ProxyParams
+    Some(torConf.socks5ProxyParams)
 
   lazy val versionOpt: Option[BitcoindVersion] =
     config

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
@@ -85,7 +85,7 @@ case class BitcoindRpcAppConfig(
     TorAppConfig(directory, confs: _*)
 
   lazy val socks5ProxyParams: Option[Socks5ProxyParams] =
-    Some(torConf.socks5ProxyParams)
+    torConf.socks5ProxyParams
 
   lazy val versionOpt: Option[BitcoindVersion] =
     config

--- a/build.sbt
+++ b/build.sbt
@@ -507,10 +507,11 @@ def isCI = {
     .isDefined
 }
 
-def isTor = {
+def isTor: Boolean = {
   Properties
     .envOrNone("TOR")
-    .isDefined
+    .map(_.toLowerCase == "true")
+    .getOrElse(false)
 }
 
 lazy val bitcoindRpcTest = project

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -45,7 +45,6 @@ class ChainHandler(
 
   /** @inheritdoc */
   override def getBlockCount(): Future[Int] = {
-    logger.debug(s"Querying for block count")
     blockHeaderDAO.bestHeight.map { height =>
       logger.debug(s"getBlockCount result: count=$height")
       height
@@ -543,7 +542,6 @@ class ChainHandler(
 
   /** @inheritdoc */
   override def getFilterHeaderCount(): Future[Int] = {
-    logger.debug(s"Querying for filter header count")
     filterHeaderDAO.getBestFilterHeaderHeight.map { height =>
       logger.debug(s"getFilterHeaderCount result: count=$height")
       height
@@ -656,7 +654,6 @@ class ChainHandler(
 
   /** @inheritdoc */
   override def getFilterCount(): Future[Int] = {
-    logger.debug(s"Querying for filter count")
     filterDAO.getBestFilterHeight.map { height =>
       logger.debug(s"getFilterCount result: count=$height")
       height

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -317,11 +317,7 @@ case class BlockHeaderDAO()(implicit
   def getBestChainTips: Future[Vector[BlockHeaderDb]] = {
     val aggregate = {
       maxWorkQuery.flatMap { work =>
-        logger.debug(s"Max block work: $work")
         val atChainWork = getAtChainWorkQuery(work)
-        atChainWork.map { headers =>
-          logger.debug(s"Headers at $work: $headers")
-        }
         atChainWork
       }
     }

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DBConfigTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DBConfigTest.scala
@@ -26,7 +26,7 @@ class DBConfigTest extends BitcoinSAsyncTest {
                   StandardOpenOption.WRITE)
 
       val chainConfig = ChainAppConfig(dataDir)
-      val nodeConfig = NodeAppConfig(dataDir)
+      val nodeConfig = NodeAppConfig(dataDir, Vector.empty, None)
       val walletConfig = WalletAppConfig(dataDir)
 
       val slickChainConfig = chainConfig.slickDbConfig
@@ -60,7 +60,7 @@ class DBConfigTest extends BitcoinSAsyncTest {
         slickChainConfig.config.getString("db.connectionPool") == "disabled")
       assert(slickChainConfig.config.getInt("db.queueSize") == 5000)
 
-      val nodeConfig = NodeAppConfig(dataDir)
+      val nodeConfig = NodeAppConfig(dataDir, Vector.empty, None)
       val slickNodeConfig = nodeConfig.slickDbConfig
       assert(slickNodeConfig.profileName == "slick.jdbc.SQLiteProfile")
       assert(slickNodeConfig.config.hasPath("db.numThreads"))

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DBConfigTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DBConfigTest.scala
@@ -86,7 +86,9 @@ class DBConfigTest extends BitcoinSAsyncTest {
                                                  () => None)
     val mainnetConf = ConfigFactory.parseString("bitcoin-s.network = mainnet")
     val chainConfig: ChainAppConfig = {
-      BitcoinSTestAppConfig.getSpvTestConfig(mainnetConf).chainConf
+      BitcoinSTestAppConfig
+        .getSpvTestConfig(Vector(mainnetConf), None)
+        .chainConf
     }
 
     assert(chainConfig.network == MainNet)

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -124,7 +124,9 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
 
   it must "run migrations for node db" in {
     val nodeAppConfig =
-      NodeAppConfig(BitcoinSTestAppConfig.tmpDir(), dbConfig(ProjectType.Node))
+      NodeAppConfig(BitcoinSTestAppConfig.tmpDir(),
+                    Vector(dbConfig(ProjectType.Node)),
+                    None)
     val nodeDbManagement = createNodeDbManagement(nodeAppConfig)
     val result = nodeDbManagement.migrate()
     nodeAppConfig.driver match {

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
@@ -48,10 +48,10 @@ case class DLCNodeAppConfig(
   override def stop(): Future[Unit] = Future.unit
 
   lazy val socks5ProxyParams: Option[Socks5ProxyParams] =
-    Some(torAppConfig.socks5ProxyParams)
+    torAppConfig.socks5ProxyParams
 
   lazy val torParams: Option[TorParams] = {
-    Some(torAppConfig.torParams)
+    torAppConfig.torParams
   }
 
   lazy val listenAddress: InetSocketAddress = {

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/integration/DLCClientIntegrationTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/integration/DLCClientIntegrationTest.scala
@@ -33,7 +33,9 @@ import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success}
 
 class DLCClientIntegrationTest extends BitcoindRpcTest with DLCTest {
-  private val clientsF = BitcoindRpcTestUtil.createNodePairV18(clientAccum)
+
+  private val clientsF =
+    BitcoindRpcTestUtil.createNodePairV18(torAppConfigOpt = None, clientAccum)
   private val clientF = clientsF.map(_._1)
   private val addressForMiningF = clientF.flatMap(_.getNewAddress)
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
@@ -28,7 +28,8 @@ class MultiWalletDLCTest extends BitcoinSWalletTest {
 
     val dir = BitcoinSTestAppConfig.tmpDir()
 
-    val configB = BitcoinSAppConfig(dir, walletNameConfB.withFallback(dbConf))
+    val configB =
+      BitcoinSAppConfig(dir, Vector(walletNameConfB.withFallback(dbConf)))
 
     val walletA = fundedWallet.wallet
 

--- a/docs/chain/chain-query-api.md
+++ b/docs/chain/chain-query-api.md
@@ -70,7 +70,7 @@ As an example, we will show you how to use the `ChainQueryApi` and bitcoind to q
 implicit val system: ActorSystem = ActorSystem(s"node-api-example")
 implicit val ec: ExecutionContextExecutor = system.dispatcher
 implicit val walletConf: WalletAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig().walletConf
+    BitcoinSTestAppConfig.getSpvTestConfig(Vector.empty,None).walletConf
 
 // let's use a helper method to get a v19 bitcoind
 // and a ChainApi

--- a/docs/chain/filter-sync.md
+++ b/docs/chain/filter-sync.md
@@ -53,7 +53,7 @@ We are going to implement `getFilterFunc` with bitcoind and then sync a few filt
 
 implicit val system = ActorSystem(s"filter-sync-example")
 implicit val ec = system.dispatcher
-implicit val chainAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig().chainConf
+implicit val chainAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig(Vector.empty).chainConf
 
 //let's use a helper method to get a v19 bitcoind
 //instance and a chainApi

--- a/docs/node/node-api.md
+++ b/docs/node/node-api.md
@@ -49,7 +49,7 @@ As an example, we will show you how to use the `NodeApi` and bitcoind to downloa
 implicit val system: ActorSystem = ActorSystem(s"node-api-example")
 implicit val ec: ExecutionContextExecutor = system.dispatcher
 implicit val walletConf: WalletAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig().walletConf
+    BitcoinSTestAppConfig.getSpvTestConfig(Vector.empty, None).walletConf
 
 // let's use a helper method to get a v19 bitcoind
 // and a ChainApi

--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -65,12 +65,12 @@ implicit val ec = system.dispatcher
 
 //we also require a bitcoind instance to connect to
 //so let's start one (make sure you ran 'sbt downloadBitcoind')
-val instance = BitcoindRpcTestUtil.instance(versionOpt = Some(BitcoindVersion.Experimental))
+val instance = BitcoindRpcTestUtil.instance(torAppConfigOpt = None, versionOpt = Some(BitcoindVersion.Experimental))
 val p2pPort = instance.p2pPort
-val bitcoindF = BitcoindRpcTestUtil.startedBitcoindRpcClient(Some(instance), Vector.newBuilder)
+val bitcoindF = BitcoindRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None, Vector.newBuilder, Some(instance))
 
 //contains information on how to connect to bitcoin's p2p info
-val peerF = bitcoindF.flatMap(b => NodeUnitTest.createPeer(b))
+val peerF = bitcoindF.flatMap(b => NodeUnitTest.createPeer(b, None))
 
 // set a data directory
 val prefix = s"node-example-${System.currentTimeMillis()}"

--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -94,7 +94,7 @@ val config = ConfigFactory.parseString {
     |""".stripMargin
 }
 
-implicit val appConfig = BitcoinSAppConfig(datadir, config)
+implicit val appConfig = BitcoinSAppConfig(datadir, Vector(config))
 implicit val chainConfig = appConfig.chainConf
 implicit val nodeConfig = appConfig.nodeConf
 

--- a/docs/testkit/testkit.md
+++ b/docs/testkit/testkit.md
@@ -45,10 +45,10 @@ implicit val ec = system.dispatcher
 val bitcoindV = BitcoindVersion.V19
 
 //create an instance
-val instance = BitcoindRpcTestUtil.instance(versionOpt = Some(bitcoindV))
+val instance = BitcoindRpcTestUtil.instance(torAppConfigOpt = None, versionOpt = Some(bitcoindV))
 
 //now let's create an rpc client off of that instance
-val bitcoindRpcClientF = BitcoindRpcTestUtil.startedBitcoindRpcClient(Some(instance), Vector.newBuilder)
+val bitcoindRpcClientF = BitcoindRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None,clientAccum= Vector.newBuilder,instanceOpt = Some(instance))
 
 //yay! it's started. Now you can run tests against this.
 //let's just grab the block count for an example
@@ -116,7 +116,7 @@ implicit val ec = system.dispatcher
 //we need a bitcoind to connect eclair nodes to
 lazy val bitcoindRpcClientF: Future[BitcoindRpcClient] = {
     for {
-      cli <- EclairRpcTestUtil.startedBitcoindRpcClient()
+      cli <- EclairRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None)
       // make sure we have enough money to open channels
       address <- cli.getNewAddress
       _ <- cli.generateToAddress(200, address)

--- a/docs/wallet/wallet-callbacks.md
+++ b/docs/wallet/wallet-callbacks.md
@@ -40,7 +40,7 @@ import scala.concurrent.{ExecutionContextExecutor, Future}
 implicit val system: ActorSystem = ActorSystem("example")
 implicit val ec: ExecutionContextExecutor = system.dispatcher
 implicit val walletConf: WalletAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoTestConfig().walletConf
+    BitcoinSTestAppConfig.getNeutrinoTestConfig(Vector.empty).walletConf
 
 // let's use a helper method to get a v19 bitcoind
 // and a ChainApi

--- a/docs/wallet/wallet-rescan.md
+++ b/docs/wallet/wallet-rescan.md
@@ -61,7 +61,7 @@ implicit val walletAppConfig: WalletAppConfig = appConfig.walletConf
 val bip39PasswordOpt = None
 //ok now let's spin up a bitcoind and a bitcoin-s wallet with funds in it
 val walletWithBitcoindF = for {
-  bitcoind <- BitcoinSFixture.createBitcoindWithFunds()
+  bitcoind <- BitcoinSFixture.createBitcoindWithFunds(torAppConfigOpt = None)
   walletWithBitcoind <- BitcoinSWalletTest.createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
 } yield walletWithBitcoind
 

--- a/docs/wallet/wallet-rescan.md
+++ b/docs/wallet/wallet-rescan.md
@@ -55,7 +55,7 @@ import scala.concurrent.duration.DurationInt
 //we need an actor system and app config to power this
 implicit val system: ActorSystem = ActorSystem(s"wallet-rescan-example")
 implicit val ec: ExecutionContext = system.dispatcher
-implicit val appConfig: BitcoinSAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig()
+implicit val appConfig: BitcoinSAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig(Vector.empty)
 implicit val walletAppConfig: WalletAppConfig = appConfig.walletConf
 
 val bip39PasswordOpt = None

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -59,7 +59,7 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
 
   lazy val bitcoindRpcClientF: Future[BitcoindRpcClient] = {
     for {
-      cli <- EclairRpcTestUtil.startedBitcoindRpcClient()
+      cli <- EclairRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None)
       // make sure we have enough money to open channels
       address <- cli.getNewAddress
       _ <- cli.generateToAddress(200, address)

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtilTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcTestUtilTest.scala
@@ -12,7 +12,7 @@ class EclairRpcTestUtilTest extends BitcoinSAsyncTest {
 
   private lazy val bitcoindRpcF =
     for {
-      cli <- EclairRpcTestUtil.startedBitcoindRpcClient()
+      cli <- EclairRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None)
       address <- cli.getNewAddress
       _ <- cli.generateToAddress(200, address)
     } yield cli

--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -26,7 +26,7 @@ class BroadcastTransactionTest extends NodeTestWithCachedBitcoindNewest {
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(
       pgUrl = pgUrl,
       config = Vector.empty,
-      torAppConfigOpt = Some(torConfig))
+      torAppConfigOpt = torConfigOpt)
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -16,7 +16,9 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
-                                                              Vector.empty)
+                                                              Vector.empty,
+                                                              torAppConfigOpt =
+                                                                Some(torConfig))
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoinds
 
@@ -25,7 +27,9 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
 
     val outcomeF: Future[Outcome] = for {
       _ <- torClientF
+      _ = println(s"Done with torClientF")
       bitcoinds <- clientsF
+      _ = println(s"Done with bitcoinds")
       outcome = withNeutrinoNodeConnectedToBitcoinds(test, bitcoinds.toVector)(
         system,
         getFreshConfig)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -6,7 +6,6 @@ import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.node.fixture.NeutrinoNodeConnectedWithBitcoinds
 import org.bitcoins.testkit.node.{NodeTestUtil, NodeTestWithCachedBitcoindPair}
-import org.bitcoins.testkit.util.TorUtil
 import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
@@ -23,13 +22,8 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoinds
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    val torClientF = if (TorUtil.torEnabled) torF else Future.unit
-
     val outcomeF: Future[Outcome] = for {
-      _ <- torClientF
-      _ = println(s"Done with torClientF")
       bitcoinds <- clientsF
-      _ = println(s"Done with bitcoinds")
       outcome = withNeutrinoNodeConnectedToBitcoinds(test, bitcoinds.toVector)(
         system,
         getFreshConfig)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -17,7 +17,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
                                                               Vector.empty,
                                                               torAppConfigOpt =
-                                                                Some(torConfig))
+                                                                torConfigOpt)
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoinds
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -15,7 +15,8 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoinds
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -25,7 +25,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
                                                               Vector.empty,
                                                               torAppConfigOpt =
-                                                                Some(torConfig))
+                                                                torConfigOpt)
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -23,7 +23,9 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
-                                                              Vector.empty)
+                                                              Vector.empty,
+                                                              torAppConfigOpt =
+                                                                Some(torConfig))
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -22,7 +22,8 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoUnsupportedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoUnsupportedPeerTest.scala
@@ -15,7 +15,7 @@ class NeutrinoUnsupportedPeerTest extends NodeTestWithCachedBitcoindV19 {
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
                                                               Vector.empty,
                                                               torAppConfigOpt =
-                                                                Some(torConfig))
+                                                                torConfigOpt)
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoUnsupportedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoUnsupportedPeerTest.scala
@@ -13,7 +13,9 @@ class NeutrinoUnsupportedPeerTest extends NodeTestWithCachedBitcoindV19 {
 
   override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
-                                                              Vector.empty)
+                                                              Vector.empty,
+                                                              torAppConfigOpt =
+                                                                Some(torConfig))
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoUnsupportedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoUnsupportedPeerTest.scala
@@ -12,7 +12,8 @@ import scala.concurrent.Future
 class NeutrinoUnsupportedPeerTest extends NodeTestWithCachedBitcoindV19 {
 
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/NodeAppConfigTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeAppConfigTest.scala
@@ -14,7 +14,7 @@ class NodeAppConfigTest extends BitcoinSAsyncTest {
   val tempDir = Files.createTempDirectory("bitcoin-s")
 
   val config: NodeAppConfig =
-    NodeAppConfig(directory = tempDir)
+    NodeAppConfig(directory = tempDir, Vector.empty, None)
 
   it must "be overridable" in {
     assert(config.network == RegTest)
@@ -59,7 +59,7 @@ class NodeAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig = NodeAppConfig(directory = tempDir)
+    val appConfig = NodeAppConfig(directory = tempDir, Vector.empty, None)
 
     assert(appConfig.datadir == tempDir.resolve("testnet3"))
     assert(appConfig.network == TestNet3)

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
@@ -23,7 +23,7 @@ class SpvNodeTest extends NodeTestWithCachedBitcoindNewest {
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl,
                                                          Vector.empty,
                                                          torAppConfigOpt =
-                                                           Some(torConfig))
+                                                           torConfigOpt)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeTest.scala
@@ -20,7 +20,10 @@ class SpvNodeTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl,
+                                                         Vector.empty,
+                                                         torAppConfigOpt =
+                                                           Some(torConfig))
 
   override type FixtureParam = SpvNodeConnectedWithBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
@@ -22,7 +22,7 @@ class SpvNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl,
                                                          Vector.empty,
                                                          torAppConfigOpt =
-                                                           Some(torConfig))
+                                                           torConfigOpt)
 
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/SpvNodeWithWalletTest.scala
@@ -19,7 +19,10 @@ class SpvNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl,
+                                                         Vector.empty,
+                                                         torAppConfigOpt =
+                                                           Some(torConfig))
 
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -20,7 +20,7 @@ class UpdateBloomFilterTest extends NodeTestWithCachedBitcoindNewest {
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl,
                                                          Vector.empty,
                                                          torAppConfigOpt =
-                                                           Some(torConfig))
+                                                           torConfigOpt)
 
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/UpdateBloomFilterTest.scala
@@ -17,7 +17,10 @@ class UpdateBloomFilterTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl,
+                                                         Vector.empty,
+                                                         torAppConfigOpt =
+                                                           Some(torConfig))
 
   override type FixtureParam = SpvNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -21,18 +21,26 @@ import scala.concurrent.duration.DurationInt
 
 class P2PClientTest extends BitcoindRpcTorTest {
 
-  lazy val bitcoindRpcF =
-    BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
+  lazy val bitcoindRpcF = for {
+    rpc <- BitcoindRpcTestUtil.startedBitcoindRpcClient(
+      torAppConfigOpt = Some(torConfig),
+      clientAccum = clientAccum)
+  } yield rpc
 
   lazy val bitcoindPeerF = bitcoindRpcF.flatMap { bitcoind =>
-    NodeTestUtil.getBitcoindPeer(bitcoind)
+    NodeTestUtil.getBitcoindPeer(bitcoind, torConfig.socks5ProxyParams)
   }
 
-  lazy val bitcoindRpc2F =
-    BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
+  lazy val bitcoindRpc2F = {
+    for {
+      rpc <- BitcoindRpcTestUtil.startedBitcoindRpcClient(
+        torAppConfigOpt = Some(torConfig),
+        clientAccum = clientAccum)
+    } yield rpc
+  }
 
   lazy val bitcoindPeer2F = bitcoindRpcF.flatMap { bitcoind =>
-    NodeTestUtil.getBitcoindPeer(bitcoind)
+    NodeTestUtil.getBitcoindPeer(bitcoind, torConfig.socks5ProxyParams)
   }
   behavior of "parseIndividualMessages"
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -11,24 +11,15 @@ import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.P2PClient.ConnectCommand
 import org.bitcoins.node.networking.peer.PeerMessageReceiver
 import org.bitcoins.testkit.async.TestAsyncUtil
-import org.bitcoins.testkit.node.{
-  CachedBitcoinSAppConfig,
-  NodeTestUtil,
-  NodeUnitTest
-}
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.tor.CachedTor
-import org.bitcoins.testkit.util.BitcoindRpcTest
+import org.bitcoins.testkit.node.{NodeTestUtil, NodeUnitTest}
+import org.bitcoins.testkit.rpc.{BitcoindRpcTestUtil, BitcoindRpcTorTest}
 import org.scalatest._
 import scodec.bits._
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
-class P2PClientTest
-    extends BitcoindRpcTest
-    with CachedBitcoinSAppConfig
-    with CachedTor {
+class P2PClientTest extends BitcoindRpcTorTest {
 
   lazy val bitcoindRpcF =
     BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
@@ -128,27 +119,6 @@ class P2PClientTest
   }
 
   behavior of "P2PClient"
-
-  override def beforeAll(): Unit = {
-    implicit val chainConf = cachedConfig.chainConf
-    chainConf.migrate()
-    ()
-  }
-
-  override def afterAll(): Unit = {
-    implicit val chainConf = cachedConfig.chainConf
-    val shutdownConfigF = for {
-      _ <- chainConf.dropTable("flyway_schema_history")
-      _ <- chainConf.dropAll()
-    } yield {
-      super[CachedBitcoinSAppConfig].afterAll()
-    }
-
-    shutdownConfigF.onComplete { _ =>
-      super[BitcoindRpcTest].afterAll()
-    }
-
-  }
 
   it must "establish a tcp connection with a bitcoin node" in {
     bitcoindPeerF.flatMap { remote =>

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -23,24 +23,26 @@ class P2PClientTest extends BitcoindRpcTorTest {
 
   lazy val bitcoindRpcF = for {
     rpc <- BitcoindRpcTestUtil.startedBitcoindRpcClient(
-      torAppConfigOpt = Some(torConfig),
+      torAppConfigOpt = torConfigOpt,
       clientAccum = clientAccum)
   } yield rpc
 
   lazy val bitcoindPeerF = bitcoindRpcF.flatMap { bitcoind =>
-    NodeTestUtil.getBitcoindPeer(bitcoind, torConfig.socks5ProxyParams)
+    NodeTestUtil.getBitcoindPeer(bitcoind,
+                                 torConfigOpt.flatMap(_.socks5ProxyParams))
   }
 
   lazy val bitcoindRpc2F = {
     for {
       rpc <- BitcoindRpcTestUtil.startedBitcoindRpcClient(
-        torAppConfigOpt = Some(torConfig),
+        torAppConfigOpt = torConfigOpt,
         clientAccum = clientAccum)
     } yield rpc
   }
 
   lazy val bitcoindPeer2F = bitcoindRpcF.flatMap { bitcoind =>
-    NodeTestUtil.getBitcoindPeer(bitcoind, torConfig.socks5ProxyParams)
+    NodeTestUtil.getBitcoindPeer(bitcoind,
+                                 torConfigOpt.flatMap(_.socks5ProxyParams))
   }
   behavior of "parseIndividualMessages"
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -14,13 +14,13 @@ import scala.concurrent.duration.DurationInt
 class ReConnectionTest extends BitcoindRpcTorTest {
 
   lazy val bitcoindRpcF =
-    BitcoindRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt =
-                                                   Some(torConfig),
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = torConfigOpt,
                                                  clientAccum = clientAccum)
 
   lazy val bitcoindPeerF: Future[Peer] =
     bitcoindRpcF.flatMap(b =>
-      NodeTestUtil.getBitcoindPeer(b, torConfig.socks5ProxyParams))
+      NodeTestUtil.getBitcoindPeer(b,
+                                   torConfigOpt.flatMap(_.socks5ProxyParams)))
 
   behavior of "ReConnectionTest"
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -14,10 +14,13 @@ import scala.concurrent.duration.DurationInt
 class ReConnectionTest extends BitcoindRpcTorTest {
 
   lazy val bitcoindRpcF =
-    BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt =
+                                                   Some(torConfig),
+                                                 clientAccum = clientAccum)
 
   lazy val bitcoindPeerF: Future[Peer] =
-    bitcoindRpcF.flatMap(b => NodeTestUtil.getBitcoindPeer(b))
+    bitcoindRpcF.flatMap(b =>
+      NodeTestUtil.getBitcoindPeer(b, torConfig.socks5ProxyParams))
 
   behavior of "ReConnectionTest"
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -4,18 +4,14 @@ import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.asyncutil.AsyncUtil.RpcRetryException
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.PeerHandler
-import org.bitcoins.testkit.node.{
-  CachedBitcoinSAppConfig,
-  NodeTestUtil,
-  NodeUnitTest
-}
-import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
-import org.bitcoins.testkit.util.{AkkaUtil, BitcoindRpcTest}
+import org.bitcoins.testkit.node.{NodeTestUtil, NodeUnitTest}
+import org.bitcoins.testkit.rpc.{BitcoindRpcTestUtil, BitcoindRpcTorTest}
+import org.bitcoins.testkit.util.AkkaUtil
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
-class ReConnectionTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
+class ReConnectionTest extends BitcoindRpcTorTest {
 
   lazy val bitcoindRpcF =
     BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
@@ -56,10 +52,5 @@ class ReConnectionTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
     } yield succeed
 
     connectedF
-  }
-
-  override def afterAll(): Unit = {
-    super[CachedBitcoinSAppConfig].afterAll()
-    super[BitcoindRpcTest].afterAll()
   }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerNeutrinoNodesTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerNeutrinoNodesTest.scala
@@ -20,7 +20,9 @@ class DataMessageHandlerNeutrinoNodesTest
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
-                                                              Vector.empty)
+                                                              Vector.empty,
+                                                              torAppConfigOpt =
+                                                                Some(torConfig))
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerNeutrinoNodesTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerNeutrinoNodesTest.scala
@@ -22,7 +22,7 @@ class DataMessageHandlerNeutrinoNxodesTest
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
                                                               Vector.empty,
                                                               torAppConfigOpt =
-                                                                Some(torConfig))
+                                                                torConfigOpt)
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerNeutrinoNodesTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerNeutrinoNodesTest.scala
@@ -19,7 +19,8 @@ class DataMessageHandlerNeutrinoNodesTest
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerNeutrinoNodesTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerNeutrinoNodesTest.scala
@@ -14,7 +14,7 @@ import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.{Future, Promise}
 
-class DataMessageHandlerNeutrinoNodesTest
+class DataMessageHandlerNeutrinoNxodesTest
     extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -22,7 +22,9 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl, Vector.empty)
+    BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl,
+                                                         Vector.empty,
+                                                         Some(torConfig))
 
   override type FixtureParam = SpvNodeConnectedWithBitcoindV21
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -24,7 +24,8 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
   override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvWithEmbeddedDbTestConfig(pgUrl,
                                                          Vector.empty,
-                                                         Some(torConfig))
+                                                         torAppConfigOpt =
+                                                           torConfigOpt)
 
   override type FixtureParam = SpvNodeConnectedWithBitcoindV21
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -25,7 +25,7 @@ class PeerMessageHandlerTest
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig(Vector.empty, Some(torConfig))
+    BitcoinSTestAppConfig.getSpvTestConfig(Vector.empty, torConfigOpt)
 
   override type FixtureParam = Peer
 
@@ -35,7 +35,9 @@ class PeerMessageHandlerTest
     val outcomeF: Future[Outcome] = for {
       _ <- torClientF
       bitcoind <- cachedBitcoindWithFundsF
-      outcome = withBitcoindPeer(test, bitcoind, torConfig.socks5ProxyParams)
+      outcome = withBitcoindPeer(test,
+                                 bitcoind,
+                                 torConfigOpt.flatMap(_.socks5ProxyParams))
       f <- outcome.toFuture
     } yield f
     new FutureOutcome(outcomeF)

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -35,7 +35,7 @@ class PeerMessageHandlerTest
     val outcomeF: Future[Outcome] = for {
       _ <- torClientF
       bitcoind <- cachedBitcoindWithFundsF
-      outcome = withBitcoindPeer(test, bitcoind)
+      outcome = withBitcoindPeer(test, bitcoind, torConfig.socks5ProxyParams)
       f <- outcome.toFuture
     } yield f
     new FutureOutcome(outcomeF)

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -25,7 +25,7 @@ class PeerMessageHandlerTest
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig()
+    BitcoinSTestAppConfig.getSpvTestConfig(Vector.empty, Some(torConfig))
 
   override type FixtureParam = Peer
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverTest.scala
@@ -21,7 +21,9 @@ class PeerMessageReceiverTest extends NodeTestWithCachedBitcoindPair {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl = pgUrl,
+                                                              config =
+                                                                Vector.empty)
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoinds
 

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -164,8 +164,8 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
         peerMsgSenders(idx).connect()
         val isInitializedF = for {
           _ <- AsyncUtil.retryUntilSatisfiedF(() => isInitialized(idx),
-                                              maxTries = 1024,
-                                              interval = 250.millis)
+                                              maxTries = 60,
+                                              interval = 1.second)
         } yield ()
         isInitializedF.failed.foreach { err =>
           logger.error(

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -115,9 +115,9 @@ case class NodeAppConfig(
     TorAppConfig(directory, confs: _*)
 
   lazy val socks5ProxyParams: Option[Socks5ProxyParams] =
-    Some(torConf.socks5ProxyParams)
+    torConf.socks5ProxyParams
 
-  lazy val torParams: Option[TorParams] = Some(torConf.torParams)
+  lazy val torParams: Option[TorParams] = torConf.torParams
 
   lazy val relay: Boolean = {
     if (config.hasPath("bitcoin-s.node.relay")) {

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -67,7 +67,7 @@ case class NodeAppConfig(
         nodeType match {
           case NodeType.BitcoindBackend =>
             val bitcoindRpcAppConfig =
-              BitcoindRpcAppConfig(directory, confs: _*)(system)
+              BitcoindRpcAppConfig(directory, confs, torAppConfigOpt)(system)
             bitcoindRpcAppConfig.binaryOpt match {
               case Some(_) =>
                 bitcoindRpcAppConfig.clientF

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -115,9 +115,9 @@ case class NodeAppConfig(
     TorAppConfig(directory, confs: _*)
 
   lazy val socks5ProxyParams: Option[Socks5ProxyParams] =
-    torConf.socks5ProxyParams
+    Some(torConf.socks5ProxyParams)
 
-  lazy val torParams: Option[TorParams] = torConf.torParams
+  lazy val torParams: Option[TorParams] = Some(torConf.torParams)
 
   lazy val relay: Boolean = {
     if (config.hasPath("bitcoin-s.node.relay")) {

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -258,7 +258,8 @@ case class P2PClientActor(
 
           import context.dispatcher
           context.become(reconnecting)
-          context.system.scheduler.scheduleOnce(delay)(self ! ReconnectCommand)
+          context.system.scheduler.scheduleOnce(delay)(
+            self ! P2PClient.ReconnectCommand)
           ()
         }
     }

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -51,16 +51,16 @@
     <!-- ╚═════════════════╝ -->
 
     <!-- See incoming message names and the peer it's sent from -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="DEBUG"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="DEBUG"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="DEBUG"/>
 
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="DEBUG"/>
 
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -51,16 +51,16 @@
     <!-- ╚═════════════════╝ -->
 
     <!-- See incoming message names and the peer it's sent from -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="DEBUG"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="DEBUG"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="INFO"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="DEBUG"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="DEBUG"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="INFO"/>
 
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -46,21 +46,23 @@
     <logger name="org.bitcoins.node.db" level="WARN"/>
     <logger name="org.bitcoins.wallet.db" level="WARN"/>
 
+    <logger name="org.bitcoins.wallet" level="WARN"/>
+
     <!-- ╔═════════════════╗ -->
     <!-- ║   Node module   ║ -->
     <!-- ╚═════════════════╝ -->
 
     <!-- See incoming message names and the peer it's sent from -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="DEBUG"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="DEBUG"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
     <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="DEBUG"/>
 
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->
@@ -107,5 +109,7 @@
 
     <!-- get rid of "Setting level of logger" messages -->
     <logger name="ch.qos.logback" level="OFF"/>
+
+    <logger name="org.flywaydb" level="OFF"/>
 
 </configuration>

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -122,7 +122,7 @@ object BitcoinSTestAppConfig {
            |  }
            |  proxy.enabled = $torEnabled
            |  tor.enabled = $torEnabled
-           |  tor.use-random-ports = false  
+           |  tor.use-random-ports = true
            |}
       """.stripMargin
       }

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -52,7 +52,7 @@ object BitcoinSTestAppConfig {
          |
          |  proxy.enabled = $torEnabled
          |  tor.enabled = $torEnabled
-         |  tor.use-random-ports = false
+         |  tor.use-random-ports = true
          |}
       """.stripMargin
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -59,7 +59,8 @@ object BitcoinSTestAppConfig {
 
   def getSpvWithEmbeddedDbTestConfig(
       pgUrl: () => Option[String],
-      config: Vector[Config])(implicit
+      config: Vector[Config],
+      torAppConfigOpt: Option[TorAppConfig] = None)(implicit
       system: ActorSystem): BitcoinSAppConfig = {
     val overrideConf = ConfigFactory
       .parseString {
@@ -79,7 +80,7 @@ object BitcoinSTestAppConfig {
     val configs: Vector[Config] = {
       (overrideConf +: configWithEmbeddedDb(project = None, pgUrl) +: config)
     }
-    BitcoinSAppConfig(tmpDir(), configs)
+    BitcoinSAppConfig(tmpDir(), configs, torAppConfigOpt)
   }
 
   def getNeutrinoTestConfig(

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -9,6 +9,7 @@ import org.bitcoins.testkit.util.FileUtil
 import org.bitcoins.testkit.util.TorUtil.torEnabled
 import org.bitcoins.testkitcore.Implicits.GeneratorOps
 import org.bitcoins.testkitcore.gen.{NumberGenerator, StringGenerators}
+import org.bitcoins.tor.config.TorAppConfig
 
 import java.nio.file._
 import scala.concurrent.ExecutionContext
@@ -81,7 +82,9 @@ object BitcoinSTestAppConfig {
     BitcoinSAppConfig(tmpDir(), configs)
   }
 
-  def getNeutrinoTestConfig(config: Config*)(implicit
+  def getNeutrinoTestConfig(
+      config: Vector[Config],
+      torAppConfigOpt: Option[TorAppConfig] = None)(implicit
       system: ActorSystem): BitcoinSAppConfig = {
     val overrideConf = ConfigFactory.parseString {
       s"""
@@ -98,12 +101,14 @@ object BitcoinSTestAppConfig {
       """.stripMargin
     }
     val configs = (overrideConf +: config).toVector
-    BitcoinSAppConfig(tmpDir(), configs)
+    BitcoinSAppConfig(tmpDir(), configs, torAppConfigOpt)
   }
 
   def getNeutrinoWithEmbeddedDbTestConfig(
       pgUrl: () => Option[String],
-      config: Config*)(implicit system: ActorSystem): BitcoinSAppConfig = {
+      config: Vector[Config],
+      torAppConfigOpt: Option[TorAppConfig] = None)(implicit
+      system: ActorSystem): BitcoinSAppConfig = {
     val overrideConf = ConfigFactory
       .parseString {
         s"""
@@ -121,10 +126,9 @@ object BitcoinSTestAppConfig {
       .withFallback(genWalletNameConf)
 
     val configs = {
-      (overrideConf +: configWithEmbeddedDb(project = None,
-                                            pgUrl) +: config).toVector
+      (overrideConf +: configWithEmbeddedDb(project = None, pgUrl) +: config)
     }
-    BitcoinSAppConfig(tmpDir(), configs)
+    BitcoinSAppConfig(tmpDir(), configs, torAppConfigOpt)
   }
 
   def getDLCOracleAppConfig(config: Config*)(implicit

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -53,7 +53,7 @@ object BitcoinSTestAppConfig {
          |}
       """.stripMargin
     }
-    BitcoinSAppConfig(tmpDir(), (overrideConf +: config): _*)
+    BitcoinSAppConfig(tmpDir(), (overrideConf +: config).toVector)
   }
 
   def getSpvWithEmbeddedDbTestConfig(
@@ -75,10 +75,10 @@ object BitcoinSTestAppConfig {
       }
       .withFallback(genWalletNameConf)
 
-    BitcoinSAppConfig(
-      tmpDir(),
-      (overrideConf +: configWithEmbeddedDb(project = None,
-                                            pgUrl) +: config): _*)
+    val configs: Vector[Config] = {
+      (overrideConf +: configWithEmbeddedDb(project = None, pgUrl) +: config)
+    }
+    BitcoinSAppConfig(tmpDir(), configs)
   }
 
   def getNeutrinoTestConfig(config: Config*)(implicit
@@ -97,7 +97,8 @@ object BitcoinSTestAppConfig {
          |}
       """.stripMargin
     }
-    BitcoinSAppConfig(tmpDir(), (overrideConf +: config): _*)
+    val configs = (overrideConf +: config).toVector
+    BitcoinSAppConfig(tmpDir(), configs)
   }
 
   def getNeutrinoWithEmbeddedDbTestConfig(
@@ -119,10 +120,11 @@ object BitcoinSTestAppConfig {
       }
       .withFallback(genWalletNameConf)
 
-    BitcoinSAppConfig(
-      tmpDir(),
+    val configs = {
       (overrideConf +: configWithEmbeddedDb(project = None,
-                                            pgUrl) +: config): _*)
+                                            pgUrl) +: config).toVector
+    }
+    BitcoinSAppConfig(tmpDir(), configs)
   }
 
   def getDLCOracleAppConfig(config: Config*)(implicit
@@ -137,8 +139,8 @@ object BitcoinSTestAppConfig {
       case None =>
         ConfigFactory.empty()
     }
-
-    DLCOracleAppConfig(tmpDir(), overrideConf +: config: _*)
+    val configs = (overrideConf +: config).toVector
+    DLCOracleAppConfig(tmpDir(), configs: _*)
   }
 
   def getDLCOracleWithEmbeddedDbTestConfig(

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -39,7 +39,9 @@ object BitcoinSTestAppConfig {
     * 1) Data directory is set to user temp directory
     * 2) Logging is turned down to WARN
     */
-  def getSpvTestConfig(config: Config*)(implicit
+  def getSpvTestConfig(
+      config: Vector[Config],
+      torAppConfigOpt: Option[TorAppConfig])(implicit
       system: ActorSystem): BitcoinSAppConfig = {
     val overrideConf = ConfigFactory.parseString {
       s"""
@@ -54,7 +56,7 @@ object BitcoinSTestAppConfig {
          |}
       """.stripMargin
     }
-    BitcoinSAppConfig(tmpDir(), (overrideConf +: config).toVector)
+    BitcoinSAppConfig(tmpDir(), (overrideConf +: config), torAppConfigOpt)
   }
 
   def getSpvWithEmbeddedDbTestConfig(

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainDbUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainDbUnitTest.scala
@@ -11,7 +11,9 @@ trait ChainDbUnitTest extends ChainUnitTest with EmbeddedPg {
     val memoryDb =
       BitcoinSTestAppConfig.configWithEmbeddedDb(Some(ProjectType.Chain), pgUrl)
     val chainConfig: ChainAppConfig =
-      BitcoinSTestAppConfig.getSpvTestConfig().chainConf
+      BitcoinSTestAppConfig
+        .getSpvTestConfig(config = Vector.empty, torAppConfigOpt = None)
+        .chainConf
     chainConfig.withOverrides(memoryDb)
   }
 
@@ -20,7 +22,10 @@ trait ChainDbUnitTest extends ChainUnitTest with EmbeddedPg {
       BitcoinSTestAppConfig.configWithEmbeddedDb(Some(ProjectType.Chain), pgUrl)
     val mainnetConf = ConfigFactory.parseString("bitcoin-s.network = mainnet")
     val chainConfig: ChainAppConfig =
-      BitcoinSTestAppConfig.getSpvTestConfig(mainnetConf).chainConf
+      BitcoinSTestAppConfig
+        .getSpvTestConfig(config = Vector(mainnetConf), torAppConfigOpt = None)
+        .chainConf
+
     chainConfig.withOverrides(memoryDb)
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -48,7 +48,7 @@ trait ChainUnitTest
     */
   lazy val mainnetAppConfig: ChainAppConfig = {
     val mainnetConf = ConfigFactory.parseString("bitcoin-s.network = mainnet")
-    BitcoinSTestAppConfig.getSpvTestConfig(mainnetConf).chainConf
+    BitcoinSTestAppConfig.getSpvTestConfig(Vector(mainnetConf), None).chainConf
   }
 
   override def beforeAll(): Unit = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -278,9 +278,10 @@ trait ChainUnitTest
   }
 
   def createBitcoindChainHandlerViaZmq(): Future[BitcoindChainHandlerViaZmq] = {
-    composeBuildersAndWrap(() => BitcoinSFixture.createBitcoind(),
-                           createChainHandlerWithBitcoindZmq,
-                           BitcoindChainHandlerViaZmq.apply)()
+    composeBuildersAndWrap(
+      () => BitcoinSFixture.createBitcoind(torAppConfigOpt = None),
+      createChainHandlerWithBitcoindZmq,
+      BitcoindChainHandlerViaZmq.apply)()
   }
 
   def destroyBitcoindChainHandlerViaZmq(
@@ -308,7 +309,7 @@ trait ChainUnitTest
       chainAppConfig: ChainAppConfig): FutureOutcome = {
     val builder: () => Future[BitcoindChainHandlerViaZmq] =
       composeBuildersAndWrap(
-        builder = () => BitcoinSFixture.createBitcoind(),
+        builder = () => BitcoinSFixture.createBitcoind(torAppConfigOpt = None),
         dependentBuilder = { rpc: BitcoindRpcClient =>
           createChainHandlerWithBitcoindZmq(rpc)(chainAppConfig)
         },
@@ -322,7 +323,7 @@ trait ChainUnitTest
       system: ActorSystem): FutureOutcome = {
     val builder: () => Future[BitcoindBaseVersionChainHandlerViaRpc] = { () =>
       BitcoinSFixture
-        .createBitcoind()
+        .createBitcoind(torAppConfigOpt = None)
         .flatMap(ChainUnitTest.createChainApiWithBitcoindRpc)
     }
 
@@ -684,7 +685,7 @@ object ChainUnitTest extends ChainVerificationLogger {
     import system.dispatcher
     val bitcoindV = BitcoindVersion.V19
     val bitcoindF = BitcoinSFixture
-      .createBitcoind(Some(bitcoindV))
+      .createBitcoind(torAppConfigOpt = None, versionOpt = Some(bitcoindV))
       .map(_.asInstanceOf[BitcoindV19RpcClient])
     bitcoindF.flatMap(b => createBitcoindV19ChainHandler(b))
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
@@ -8,6 +8,7 @@ import org.bitcoins.testkit.rpc.{
   CachedBitcoindNewest,
   CachedBitcoindV19
 }
+import org.bitcoins.testkit.tor.CachedTor
 import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
@@ -20,7 +21,8 @@ trait ChainWithBitcoindUnitTest extends ChainDbUnitTest {
 
 trait ChainWithBitcoindNewestCachedUnitTest
     extends ChainWithBitcoindUnitTest
-    with CachedBitcoindNewest {
+    with CachedBitcoindNewest
+    with CachedTor {
 
   override type FixtureParam = BitcoindBaseVersionChainHandlerViaRpc
 
@@ -49,13 +51,15 @@ trait ChainWithBitcoindNewestCachedUnitTest
   override def afterAll(): Unit = {
     super[CachedBitcoindNewest].afterAll()
     super[ChainWithBitcoindUnitTest].afterAll()
+    super[CachedTor].afterAll()
   }
 }
 
 /** Chain Unit test suite that has a cached bitcoind v19 instance */
 trait ChainWithBitcoindV19CachedUnitTest
     extends ChainWithBitcoindUnitTest
-    with CachedBitcoindV19 {
+    with CachedBitcoindV19
+    with CachedTor {
 
   override type FixtureParam = BitcoindV19ChainHandler
 
@@ -85,5 +89,6 @@ trait ChainWithBitcoindV19CachedUnitTest
   override def afterAll(): Unit = {
     super[CachedBitcoindV19].afterAll()
     super[ChainWithBitcoindUnitTest].afterAll()
+    super[CachedTor].afterAll()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
@@ -48,7 +48,7 @@ trait BitcoinSAppConfigBitcoinFixtureNotStarted
         conf = buildConfig(bitcoind.instance)
         bitcoinSAppConfig = BitcoinSAppConfig(customDatadir,
                                               Vector(conf),
-                                              torAppConfigOpt = Some(torConfig))
+                                              torAppConfigOpt = torConfigOpt)
       } yield {
         bitcoinSAppConfig
       }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
@@ -9,11 +9,12 @@ import org.bitcoins.rpc.config.{
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.rpc.CachedBitcoindNewest
-import org.bitcoins.testkit.tor.CachedTor
+import org.bitcoins.testkit.tor.{CachedTorCustomDatadir}
 import org.bitcoins.testkit.util.TorUtil
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.scalatest.FutureOutcome
 
+import java.nio.file.Path
 import scala.concurrent.Future
 
 sealed trait BitcoinSAppConfigFixture extends BitcoinSFixture with EmbeddedPg {
@@ -33,9 +34,12 @@ sealed trait BitcoinSAppConfigFixture extends BitcoinSFixture with EmbeddedPg {
 trait BitcoinSAppConfigBitcoinFixtureNotStarted
     extends BitcoinSAppConfigFixture
     with CachedBitcoindNewest
-    with CachedTor {
+    with CachedTorCustomDatadir {
 
   override type FixtureParam = BitcoinSAppConfig
+
+  override def customDatadir: Future[Path] =
+    cachedBitcoindWithFundsF.map(_.instance.datadir.toPath)
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val builder: () => Future[BitcoinSAppConfig] = () => {

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
@@ -44,14 +44,14 @@ trait BitcoinSAppConfigBitcoinFixtureNotStarted
     val builder: () => Future[BitcoinSAppConfig] = () => {
       for {
         bitcoind <- cachedBitcoindWithFundsF
-        datadir = bitcoind.instance match {
-          case local: BitcoindInstanceLocal => local.datadir
-          case _: BitcoindInstanceRemote =>
-            sys.error("Remote instance should not be used in tests")
-        }
+        _ <- torF
         conf = buildConfig(bitcoind.instance)
-        bitcoinSAppConfig = BitcoinSAppConfig(datadir.toPath, conf)
-      } yield bitcoinSAppConfig
+        bitcoinSAppConfig = BitcoinSAppConfig(customDatadir,
+                                              Vector(conf),
+                                              torAppConfigOpt = Some(torConfig))
+      } yield {
+        bitcoinSAppConfig
+      }
     }
 
     val destroyF: BitcoinSAppConfig => Future[Unit] = { appConfig =>

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
@@ -9,6 +9,7 @@ import org.bitcoins.rpc.config.{
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.rpc.CachedBitcoindNewest
+import org.bitcoins.testkit.tor.CachedTor
 import org.bitcoins.testkit.util.TorUtil
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.scalatest.FutureOutcome
@@ -31,7 +32,8 @@ sealed trait BitcoinSAppConfigFixture extends BitcoinSFixture with EmbeddedPg {
   */
 trait BitcoinSAppConfigBitcoinFixtureNotStarted
     extends BitcoinSAppConfigFixture
-    with CachedBitcoindNewest {
+    with CachedBitcoindNewest
+    with CachedTor {
 
   override type FixtureParam = BitcoinSAppConfig
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
@@ -9,8 +9,8 @@ import org.bitcoins.rpc.config.{
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.rpc.CachedBitcoindNewest
-import org.bitcoins.testkit.tor.{CachedTorCustomDatadir}
-import org.bitcoins.testkit.util.TorUtil
+import org.bitcoins.testkit.tor.CachedTorCustomDatadir
+import org.bitcoins.testkit.util.{FileUtil, TorUtil}
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 import org.scalatest.FutureOutcome
 
@@ -38,8 +38,7 @@ trait BitcoinSAppConfigBitcoinFixtureNotStarted
 
   override type FixtureParam = BitcoinSAppConfig
 
-  override def customDatadir: Future[Path] =
-    cachedBitcoindWithFundsF.map(_.instance.datadir.toPath)
+  override lazy val customDatadir: Path = FileUtil.tmpDir().toPath
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val builder: () => Future[BitcoinSAppConfig] = () => {

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -5,6 +5,7 @@ import grizzled.slf4j.Logging
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
+import org.bitcoins.tor.config.TorAppConfig
 import org.scalatest._
 
 import scala.concurrent.{Future, Promise}
@@ -141,21 +142,26 @@ trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
 
 object BitcoinSFixture extends Logging {
 
-  def createBitcoindWithFunds(versionOpt: Option[BitcoindVersion] = None)(
-      implicit system: ActorSystem): Future[BitcoindRpcClient] = {
+  def createBitcoindWithFunds(
+      torAppConfigOpt: Option[TorAppConfig],
+      versionOpt: Option[BitcoindVersion] = None)(implicit
+      system: ActorSystem): Future[BitcoindRpcClient] = {
     import system.dispatcher
     for {
-      bitcoind <- createBitcoind(versionOpt = versionOpt)
+      bitcoind <- createBitcoind(torAppConfigOpt, versionOpt = versionOpt)
       address <- bitcoind.getNewAddress
       _ <- bitcoind.generateToAddress(blocks = 101, address)
     } yield bitcoind
   }
 
   /** Creates a new bitcoind instance */
-  def createBitcoind(versionOpt: Option[BitcoindVersion] = None)(implicit
+  def createBitcoind(
+      torAppConfigOpt: Option[TorAppConfig],
+      versionOpt: Option[BitcoindVersion] = None)(implicit
       system: ActorSystem): Future[BitcoindRpcClient] = {
     import system.dispatcher
-    val instance = BitcoindRpcTestUtil.instance(versionOpt = versionOpt)
+    val instance =
+      BitcoindRpcTestUtil.instance(torAppConfigOpt, versionOpt = versionOpt)
     logger.error(
       s"Creating bitcoind with datadir=${instance.datadir.toPath.toAbsolutePath}")
     val bitcoind = versionOpt match {

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.testkit.fixtures
 
 import akka.actor.ActorSystem
+import grizzled.slf4j.Logging
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
@@ -138,7 +139,7 @@ trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
 
 }
 
-object BitcoinSFixture {
+object BitcoinSFixture extends Logging {
 
   def createBitcoindWithFunds(versionOpt: Option[BitcoindVersion] = None)(
       implicit system: ActorSystem): Future[BitcoindRpcClient] = {
@@ -155,6 +156,8 @@ object BitcoinSFixture {
       system: ActorSystem): Future[BitcoindRpcClient] = {
     import system.dispatcher
     val instance = BitcoindRpcTestUtil.instance(versionOpt = versionOpt)
+    logger.error(
+      s"Creating bitcoind with datadir=${instance.datadir.toPath.toAbsolutePath}")
     val bitcoind = versionOpt match {
       case Some(v) => BitcoindRpcClient.fromVersion(v, instance)
       case None    => new BitcoindRpcClient(instance)

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCDAOFixture.scala
@@ -70,7 +70,7 @@ trait DLCDAOFixture extends BitcoinSFixture with EmbeddedPg {
 
   implicit protected val config: BitcoinSAppConfig =
     BitcoinSTestAppConfig
-      .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl())
+      .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl(), Vector.empty)
 
   implicit private val dlcConfig: DLCAppConfig = config.dlcConf
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/LndFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/LndFixture.scala
@@ -4,10 +4,11 @@ import org.bitcoins.lnd.rpc.LndRpcClient
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.lnd._
 import org.bitcoins.testkit.rpc._
+import org.bitcoins.testkit.tor.CachedTor
 import org.scalatest.FutureOutcome
 
 /** A trait that is useful if you need Lnd fixtures for your test suite */
-trait LndFixture extends BitcoinSFixture with CachedBitcoindV21 {
+trait LndFixture extends BitcoinSFixture with CachedBitcoindV21 with CachedTor {
 
   override type FixtureParam = LndRpcClient
 
@@ -35,7 +36,10 @@ trait LndFixture extends BitcoinSFixture with CachedBitcoindV21 {
 }
 
 /** A trait that is useful if you need Lnd fixtures for your test suite */
-trait DualLndFixture extends BitcoinSFixture with CachedBitcoindV21 {
+trait DualLndFixture
+    extends BitcoinSFixture
+    with CachedBitcoindV21
+    with CachedTor {
 
   override type FixtureParam = (BitcoindRpcClient, LndRpcClient, LndRpcClient)
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/WalletDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/WalletDAOFixture.scala
@@ -34,7 +34,7 @@ trait WalletDAOFixture extends BitcoinSFixture with EmbeddedPg {
 
   implicit protected val config: WalletAppConfig =
     BitcoinSTestAppConfig
-      .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl())
+      .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl(), Vector.empty)
       .walletConf
 
   final override type FixtureParam = WalletDAOs

--- a/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestUtil.scala
@@ -20,6 +20,7 @@ import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.testkit.async.TestAsyncUtil
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.{FileUtil, TestkitBinaries}
+import org.bitcoins.tor.config.TorAppConfig
 
 import java.io.{File, PrintWriter}
 import java.net.InetSocketAddress
@@ -44,17 +45,22 @@ trait LndRpcTestUtil extends Logging {
       instanceOpt: Option[BitcoindInstanceLocal] = None)(implicit
       actorSystem: ActorSystem): Future[BitcoindRpcClient] = {
     //need to do something with the Vector.newBuilder presumably?
-    BitcoindRpcTestUtil.startedBitcoindRpcClient(instanceOpt, Vector.newBuilder)
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None,
+                                                 clientAccum =
+                                                   Vector.newBuilder,
+                                                 instanceOpt = instanceOpt)
   }
 
   /** Creates a bitcoind instance with the given parameters */
   def bitcoindInstance(
+      torAppConfigOpt: Option[TorAppConfig],
       port: Int = RpcUtil.randomPort,
       rpcPort: Int = RpcUtil.randomPort,
       zmqConfig: ZmqConfig = RpcUtil.zmqConfig,
       bitcoindV: BitcoindVersion = BitcoindVersion.V21)(implicit
       system: ActorSystem): BitcoindInstanceLocal = {
     BitcoindRpcTestUtil.getInstance(bitcoindVersion = bitcoindV,
+                                    torAppConfigOpt = torAppConfigOpt,
                                     port = port,
                                     rpcPort = rpcPort,
                                     zmqConfig = zmqConfig)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -10,6 +10,7 @@ import org.bitcoins.testkit.util.BitcoinSAkkaAsyncTest
 import org.bitcoins.wallet.config.WalletAppConfig
 
 import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
 
 sealed trait CachedAppConfig { _: BitcoinSAkkaAsyncTest =>
 
@@ -39,7 +40,8 @@ trait CachedBitcoinSAppConfig { _: BitcoinSAkkaAsyncTest =>
   }
 
   override def beforeAll(): Unit = {
-    Await.result(cachedConfig.start(), duration)
+    //takes awhile for tor to start
+    Await.result(cachedConfig.start(), 45.seconds)
   }
 
   override def afterAll(): Unit = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -65,7 +65,7 @@ trait CachedBitcoinSAppConfigCachedTor
   }
 
   implicit override protected lazy val cachedConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoTestConfig(Vector.empty, Some(torConfig))
+    BitcoinSTestAppConfig.getNeutrinoTestConfig(Vector.empty, torConfigOpt)
 }
 
 trait CachedChainAppConfig {

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -72,7 +72,8 @@ trait CachedChainAppConfig {
   _: BitcoinSAkkaAsyncTest =>
 
   private[this] lazy val cachedConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig()
+    BitcoinSTestAppConfig.getSpvTestConfig(config = Vector.empty,
+                                           torAppConfigOpt = None)
 
   implicit protected lazy val cachedChainConf: ChainAppConfig = {
     cachedConfig.chainConf

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -49,8 +49,20 @@ trait CachedBitcoinSAppConfig { _: BitcoinSAkkaAsyncTest =>
   }
 }
 
-trait CachedBitcoinSAppConfigCachedTor extends CachedBitcoinSAppConfig {
-  _: BitcoinSAkkaAsyncTest with CachedTor =>
+trait CachedBitcoinSAppConfigCachedTor
+    extends CachedBitcoinSAppConfig
+    with CachedTor {
+  _: BitcoinSAkkaAsyncTest =>
+
+  override def beforeAll(): Unit = {
+    super[CachedTor].beforeAll()
+    super[CachedBitcoinSAppConfig].beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoinSAppConfig].afterAll()
+    super[CachedTor].afterAll()
+  }
 
   implicit override protected lazy val cachedConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoTestConfig(Vector.empty, Some(torConfig))

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -5,6 +5,7 @@ import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.tor.CachedTor
 import org.bitcoins.testkit.util.BitcoinSAkkaAsyncTest
 import org.bitcoins.wallet.config.WalletAppConfig
 
@@ -23,7 +24,7 @@ sealed trait CachedAppConfig { _: BitcoinSAkkaAsyncTest =>
 trait CachedBitcoinSAppConfig { _: BitcoinSAkkaAsyncTest =>
 
   implicit protected lazy val cachedConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoTestConfig()
+    BitcoinSTestAppConfig.getNeutrinoTestConfig(Vector.empty)
 
   implicit protected lazy val cachedNodeConf: NodeAppConfig = {
     cachedConfig.nodeConf
@@ -37,9 +38,20 @@ trait CachedBitcoinSAppConfig { _: BitcoinSAkkaAsyncTest =>
     cachedConfig.chainConf
   }
 
+  override def beforeAll(): Unit = {
+    Await.result(cachedConfig.start(), duration)
+  }
+
   override def afterAll(): Unit = {
     Await.result(cachedConfig.stop(), duration)
   }
+}
+
+trait CachedBitcoinSAppConfigCachedTor extends CachedBitcoinSAppConfig {
+  _: BitcoinSAkkaAsyncTest with CachedTor =>
+
+  implicit override protected lazy val cachedConfig: BitcoinSAppConfig =
+    BitcoinSTestAppConfig.getNeutrinoTestConfig(Vector.empty, Some(torConfig))
 }
 
 trait CachedChainAppConfig {

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -42,7 +42,6 @@ abstract class NodeTestUtil extends P2PLogger {
 
         InetSocketAddress.createUnresolved(onionAddress.address,
                                            onionAddress.port)
-
       }
     } else {
       val instance = bitcoindRpcClient.instance
@@ -51,27 +50,20 @@ abstract class NodeTestUtil extends P2PLogger {
     }
   }
 
-  def getSocks5ProxyParams: Option[Socks5ProxyParams] = {
-    if (TorUtil.torEnabled) {
-      Some(
-        Socks5ProxyParams(
-          address = InetSocketAddress.createUnresolved("127.0.0.1", 9050),
-          credentialsOpt = None,
-          randomizeCredentials = true
-        ))
-    } else None
-  }
-
   /** Gets the [[org.bitcoins.node.models.Peer]] that
     * corresponds to [[org.bitcoins.rpc.client.common.BitcoindRpcClient]]
+    * @param bitcoindRpcClient the bitcoind that we want to peer with
+    * @param socks5ProxyParamsOpt the proxy parameters needed to connect to the peer if it is on tor
+    * @return
     */
-  def getBitcoindPeer(bitcoindRpcClient: BitcoindRpcClient)(implicit
+  def getBitcoindPeer(
+      bitcoindRpcClient: BitcoindRpcClient,
+      socks5ProxyParamsOpt: Option[Socks5ProxyParams])(implicit
       executionContext: ExecutionContext): Future[Peer] = {
     for {
       socket <- getBitcoindSocketAddress(bitcoindRpcClient)
     } yield {
-      val socks5ProxyParams = getSocks5ProxyParams
-      Peer(socket, socks5ProxyParams = socks5ProxyParams)
+      Peer(socket, socks5ProxyParams = socks5ProxyParamsOpt)
     }
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -141,7 +141,7 @@ abstract class NodeTestUtil extends P2PLogger {
     TestAsyncUtil
       .retryUntilSatisfiedF(() => isSameBestFilterHeaderHeight(node, rpc),
                             1.second,
-                            maxTries = 60)
+                            maxTries = 120)
   }
 
   /** Awaits sync between the given node and bitcoind client */

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -66,13 +66,14 @@ abstract class NodeTestUtil extends P2PLogger {
     * corresponds to [[org.bitcoins.rpc.client.common.BitcoindRpcClient]]
     */
   def getBitcoindPeer(bitcoindRpcClient: BitcoindRpcClient)(implicit
-      executionContext: ExecutionContext): Future[Peer] =
+      executionContext: ExecutionContext): Future[Peer] = {
     for {
       socket <- getBitcoindSocketAddress(bitcoindRpcClient)
     } yield {
       val socks5ProxyParams = getSocks5ProxyParams
       Peer(socket, socks5ProxyParams = socks5ProxyParams)
     }
+  }
 
   /** Checks if the given node and bitcoind is synced */
   def isSameBestHash(node: Node, rpc: BitcoindRpcClient)(implicit

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -79,11 +79,16 @@ abstract class NodeTestUtil extends P2PLogger {
   def isSameBestHash(node: Node, rpc: BitcoindRpcClient)(implicit
       ec: ExecutionContext): Future[Boolean] = {
     val hashF = rpc.getBestBlockHash
+    val bitcoindHeightF = rpc.getBlockCount
     for {
       chainApi <- node.chainApiFromDb()
       bestHash <- chainApi.getBestBlockHash()
+      height <- chainApi.getBlockCount()
       hash <- hashF
+      bitcoindHeight <- bitcoindHeightF
     } yield {
+      logger.error(
+        s"Bitcoind.bestHash=${hash.hex} chainApi.bestHash=${bestHash.hex} bitcoindHeight=$bitcoindHeight height=$height")
       bestHash == hash
     }
   }
@@ -134,7 +139,7 @@ abstract class NodeTestUtil extends P2PLogger {
     TestAsyncUtil
       .retryUntilSatisfiedF(() => isSameBestHash(node, rpc),
                             1.second,
-                            maxTries = 200)
+                            maxTries = 60)
   }
 
   /** Awaits sync between the given node and bitcoind client */
@@ -144,7 +149,7 @@ abstract class NodeTestUtil extends P2PLogger {
     TestAsyncUtil
       .retryUntilSatisfiedF(() => isSameBestFilterHeaderHeight(node, rpc),
                             1.second,
-                            maxTries = 200)
+                            maxTries = 60)
   }
 
   /** Awaits sync between the given node and bitcoind client */
@@ -154,7 +159,7 @@ abstract class NodeTestUtil extends P2PLogger {
     TestAsyncUtil
       .retryUntilSatisfiedF(() => isSameBestFilterHeight(node, rpc),
                             1.second,
-                            maxTries = 200)
+                            maxTries = 60)
   }
 
   /** The future doesn't complete until the nodes best hash is the given hash */

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -38,7 +38,7 @@ abstract class NodeTestUtil extends P2PLogger {
         val onionAddress = networkInfo.localaddresses
           .find(_.address.endsWith(".onion"))
           .getOrElse(throw new IllegalArgumentException(
-            s"bitcoind instance is not configured to use Tor: ${bitcoindRpcClient}"))
+            s"bitcoind instance is not configured to use Tor: ${bitcoindRpcClient}, addresses=${networkInfo.localaddresses}"))
 
         InetSocketAddress.createUnresolved(onionAddress.address,
                                            onionAddress.port)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -22,6 +22,7 @@ import org.bitcoins.testkit.rpc.{
 }
 import org.bitcoins.testkit.tor.CachedTor
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
+import org.bitcoins.tor.Socks5ProxyParams
 import org.bitcoins.wallet.WalletCallbacks
 import org.scalatest.FutureOutcome
 
@@ -64,7 +65,10 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
       () =>
         require(appConfig.nodeConf.nodeType == NodeType.SpvNode)
         for {
-          peer <- createPeer(bitcoind)
+          peer <- createPeer(
+            bitcoind = bitcoind,
+            socks5ProxyParamsOpt =
+              appConfig.torAppConfigOpt.flatMap(_.socks5ProxyParams))
           node <- NodeUnitTest.createSpvNode(peer)(system,
                                                    appConfig.chainConf,
                                                    appConfig.nodeConf)
@@ -147,9 +151,10 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
 
   def withBitcoindPeer(
       test: OneArgAsyncTest,
-      bitcoind: BitcoindRpcClient): FutureOutcome = {
+      bitcoind: BitcoindRpcClient,
+      socks5ProxyParamsOpt: Option[Socks5ProxyParams]): FutureOutcome = {
     makeDependentFixture[Peer](
-      () => NodeTestUtil.getBitcoindPeer(bitcoind),
+      () => NodeTestUtil.getBitcoindPeer(bitcoind, socks5ProxyParamsOpt),
       _ => Future.unit
     )(test)
   }
@@ -209,7 +214,10 @@ trait NodeTestWithCachedBitcoindV19
       SpvNodeConnectedWithBitcoindV21] = { () =>
       require(appConfig.nodeConf.nodeType == NodeType.SpvNode)
       for {
-        peer <- createPeer(bitcoind)
+        peer <- createPeer(
+          bitcoind = bitcoind,
+          socks5ProxyParamsOpt =
+            appConfig.torAppConfigOpt.flatMap(_.socks5ProxyParams))
         node <- NodeUnitTest.createSpvNode(peer)(system,
                                                  appConfig.chainConf,
                                                  appConfig.nodeConf)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -35,6 +35,11 @@ import scala.concurrent.Future
 trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
   _: CachedBitcoind[_] =>
 
+  override def beforeAll(): Unit = {
+    super[CachedTor].beforeAll()
+    super[BaseNodeTest].beforeAll()
+  }
+
   def withSpvNodeFundedWalletBitcoindCached(
       test: OneArgAsyncTest,
       bip39PasswordOpt: Option[String],

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -544,7 +544,6 @@ object NodeUnitTest extends P2PLogger {
     import system.dispatcher
     for {
       height <- bitcoind.getBlockCount
-      _ = Thread.sleep(1000)
       _ = logger.error(s"bitcoindHeight=${height} before start sync")
       _ <- node.sync()
       _ <- NodeTestUtil.awaitSync(node, bitcoind)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -543,7 +543,9 @@ object NodeUnitTest extends P2PLogger {
       system: ActorSystem): Future[NeutrinoNode] = {
     import system.dispatcher
     for {
-
+      height <- bitcoind.getBlockCount
+      _ = Thread.sleep(1000)
+      _ = logger.error(s"bitcoindHeight=${height} before start sync")
       _ <- node.sync()
       _ <- NodeTestUtil.awaitSync(node, bitcoind)
       _ <- NodeTestUtil.awaitCompactFilterHeadersSync(node, bitcoind)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -76,7 +76,9 @@ trait NodeUnitTest extends BaseNodeTest {
       () =>
         require(appConfig.nodeConf.nodeType == NodeType.SpvNode)
         for {
-          bitcoind <- BitcoinSFixture.createBitcoind(versionOpt)
+          bitcoind <- BitcoinSFixture.createBitcoind(
+            torAppConfigOpt = appConfig.torAppConfigOpt,
+            versionOpt = versionOpt)
           peer <- createPeer(bitcoind)
           node <- NodeUnitTest.createSpvNode(peer)(system,
                                                    appConfig.chainConf,
@@ -102,7 +104,9 @@ trait NodeUnitTest extends BaseNodeTest {
       for {
         bitcoind <-
           BitcoinSFixture
-            .createBitcoindWithFunds(Some(V21))
+            .createBitcoindWithFunds(torAppConfigOpt =
+                                       appConfig.torAppConfigOpt,
+                                     versionOpt = Some(V21))
             .map(_.asInstanceOf[BitcoindV21RpcClient])
         peer <- createPeer(bitcoind)
         node <- NodeUnitTest.createSpvNode(peer)(system,
@@ -129,7 +133,9 @@ trait NodeUnitTest extends BaseNodeTest {
       NeutrinoNodeConnectedWithBitcoind] = { () =>
       require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
       for {
-        bitcoind <- BitcoinSFixture.createBitcoind(versionOpt)
+        bitcoind <- BitcoinSFixture.createBitcoind(torAppConfigOpt =
+                                                     appConfig.torAppConfigOpt,
+                                                   versionOpt = versionOpt)
         node <- NodeUnitTest.createNeutrinoNode(bitcoind)(system,
                                                           appConfig.chainConf,
                                                           appConfig.nodeConf)
@@ -286,7 +292,9 @@ object NodeUnitTest extends P2PLogger {
     import system.dispatcher
     require(appConfig.nodeConf.nodeType == NodeType.SpvNode)
     for {
-      bitcoind <- BitcoinSFixture.createBitcoindWithFunds(versionOpt)
+      bitcoind <- BitcoinSFixture.createBitcoindWithFunds(
+        torAppConfigOpt = appConfig.torAppConfigOpt,
+        versionOpt)
       spvNodeWithBitcoind <- createSpvNodeFundedWalletFromBitcoind(
         walletCallbacks,
         bip39PasswordOpt,
@@ -347,7 +355,9 @@ object NodeUnitTest extends P2PLogger {
     import system.dispatcher
     require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
     for {
-      bitcoind <- BitcoinSFixture.createBitcoindWithFunds(versionOpt)
+      bitcoind <- BitcoinSFixture.createBitcoindWithFunds(
+        torAppConfigOpt = appConfig.torAppConfigOpt,
+        versionOpt)
       node <- createNeutrinoNode(bitcoind)(system,
                                            appConfig.chainConf,
                                            appConfig.nodeConf)

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindFixtures.scala
@@ -10,6 +10,7 @@ import org.bitcoins.rpc.client.v21.BitcoindV21RpcClient
 import org.bitcoins.rpc.util.{NodePair, NodeTriple}
 import org.bitcoins.testkit.EmbeddedPg
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
+import org.bitcoins.testkit.tor.CachedTor
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 import org.scalatest.{FutureOutcome, Outcome}
 
@@ -32,12 +33,12 @@ trait BitcoindFixtures extends BitcoinSFixture with EmbeddedPg {
 }
 
 /** Bitcoind fixtures with a cached a bitcoind instance */
-trait BitcoindFixturesCached extends BitcoindFixtures {
+trait BitcoindFixturesCached extends BitcoindFixtures with CachedTor {
   _: BitcoinSAsyncFixtureTest with CachedBitcoind[_] =>
 }
 
 /** Bitcoind fixtures with a cached a bitcoind instance that is funded */
-trait BitcoindFixturesFundedCached extends BitcoindFixtures {
+trait BitcoindFixturesFundedCached extends BitcoindFixtures with CachedTor {
   _: BitcoinSAsyncFixtureTest with CachedBitcoindFunded[_] =>
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -138,6 +138,7 @@ trait BitcoindRpcTestUtil extends Logging {
           s"""
              |[regtest]
              |proxy=127.0.0.1:${torAppConfig.socks5ProxyParams.get.address.getPort}
+             |torcontrol=127.0.0.1:${torAppConfig.torParams.get.controlAddress.getPort}
              |listen=1
              |bind=127.0.0.1
              |""".stripMargin

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -440,7 +440,7 @@ trait BitcoindRpcTestUtil extends Logging {
       for {
         _ <- stopF
         _ <- awaitStopped(s)
-        _ <- removeDataDirectory(s)
+        //_ <- removeDataDirectory(s)
       } yield ()
     }
     Future.sequence(serverStops).map(_ => ())

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTorTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTorTest.scala
@@ -1,16 +1,13 @@
 package org.bitcoins.testkit.rpc
 
 import org.bitcoins.testkit.node.{CachedBitcoinSAppConfigCachedTor}
-import org.bitcoins.testkit.tor.CachedTor
 import org.bitcoins.testkit.util.BitcoindRpcTest
 
 trait BitcoindRpcTorTest
     extends BitcoindRpcTest
-    with CachedBitcoinSAppConfigCachedTor
-    with CachedTor {
+    with CachedBitcoinSAppConfigCachedTor {
 
   override def beforeAll(): Unit = {
-    super[CachedTor].beforeAll()
     super[CachedBitcoinSAppConfigCachedTor].beforeAll()
     super[BitcoindRpcTest].beforeAll()
   }
@@ -18,6 +15,5 @@ trait BitcoindRpcTorTest
   override def afterAll(): Unit = {
     super[BitcoindRpcTest].afterAll()
     super[CachedBitcoinSAppConfigCachedTor].afterAll()
-    super[CachedTor].afterAll()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTorTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTorTest.scala
@@ -1,0 +1,23 @@
+package org.bitcoins.testkit.rpc
+
+import org.bitcoins.testkit.node.{CachedBitcoinSAppConfigCachedTor}
+import org.bitcoins.testkit.tor.CachedTor
+import org.bitcoins.testkit.util.BitcoindRpcTest
+
+trait BitcoindRpcTorTest
+    extends BitcoindRpcTest
+    with CachedBitcoinSAppConfigCachedTor
+    with CachedTor {
+
+  override def beforeAll(): Unit = {
+    super[CachedTor].beforeAll()
+    super[CachedBitcoinSAppConfigCachedTor].beforeAll()
+    super[BitcoindRpcTest].beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super[BitcoindRpcTest].afterAll()
+    super[CachedBitcoinSAppConfigCachedTor].afterAll()
+    super[CachedTor].afterAll()
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -50,8 +50,6 @@ trait CachedBitcoindFunded[T <: BitcoindRpcClient] extends CachedBitcoind[T] {
       //if it was used, shut down the cached bitcoind
       val stoppedF = for {
         cachedBitcoind <- cachedBitcoindWithFundsF
-        _ = logger.error(
-          s"cachedBitcoind.datadir=${cachedBitcoind.instance.datadir.toPath}")
         _ <- BitcoindRpcTestUtil.stopServer(cachedBitcoind)
       } yield ()
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -70,7 +70,7 @@ trait CachedBitcoindNewest extends CachedBitcoindFunded[BitcoindRpcClient] {
     BitcoindRpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(torAppConfigOpt = Some(torConfig),
+      .createBitcoindWithFunds(torAppConfigOpt = torConfigOpt,
                                versionOpt = Some(BitcoindVersion.newest))
   }
 }
@@ -82,7 +82,7 @@ trait CachedBitcoindV17 extends CachedBitcoindFunded[BitcoindV17RpcClient] {
     BitcoindV17RpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(torConfig), Some(BitcoindVersion.V17))
+      .createBitcoindWithFunds(torConfigOpt, Some(BitcoindVersion.V17))
       .map(_.asInstanceOf[BitcoindV17RpcClient])
   }
 }
@@ -94,7 +94,7 @@ trait CachedBitcoindV18 extends CachedBitcoindFunded[BitcoindV18RpcClient] {
     BitcoindV18RpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(torConfig), Some(BitcoindVersion.V18))
+      .createBitcoindWithFunds(torConfigOpt, Some(BitcoindVersion.V18))
       .map(_.asInstanceOf[BitcoindV18RpcClient])
   }
 }
@@ -106,7 +106,7 @@ trait CachedBitcoindV19 extends CachedBitcoindFunded[BitcoindV19RpcClient] {
     BitcoindV19RpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(torConfig), Some(BitcoindVersion.V19))
+      .createBitcoindWithFunds(torConfigOpt, Some(BitcoindVersion.V19))
       .map(_.asInstanceOf[BitcoindV19RpcClient])
   }
 }
@@ -118,7 +118,7 @@ trait CachedBitcoindV20 extends CachedBitcoindFunded[BitcoindV20RpcClient] {
     BitcoindV20RpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(torConfig), Some(BitcoindVersion.V20))
+      .createBitcoindWithFunds(torConfigOpt, Some(BitcoindVersion.V20))
       .map(_.asInstanceOf[BitcoindV20RpcClient])
   }
 }
@@ -130,7 +130,7 @@ trait CachedBitcoindV21 extends CachedBitcoindFunded[BitcoindV21RpcClient] {
     BitcoindV21RpcClient] = {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
-      .createBitcoindWithFunds(Some(torConfig), Some(BitcoindVersion.V21))
+      .createBitcoindWithFunds(torConfigOpt, Some(BitcoindVersion.V21))
       .map(_.asInstanceOf[BitcoindV21RpcClient])
   }
 }
@@ -182,7 +182,7 @@ trait CachedBitcoindPair[T <: BitcoindRpcClient]
 
   lazy val clientsF: Future[NodePair[T]] = {
     BitcoindRpcTestUtil
-      .createNodePair[T](version, Some(torConfig))
+      .createNodePair[T](version, torConfigOpt)
       .map(NodePair.fromTuple)
       .map { tuple =>
         isClientsUsed.set(true)
@@ -201,7 +201,7 @@ trait CachedBitcoindPairV21
 
   lazy val clientsF: Future[NodePair[BitcoindV21RpcClient]] = {
     BitcoindRpcTestUtil
-      .createNodePair[BitcoindV21RpcClient](version, Some(torConfig))
+      .createNodePair[BitcoindV21RpcClient](version, torConfigOpt)
       .map(NodePair.fromTuple)
       .map { tuple =>
         isClientsUsed.set(true)
@@ -218,7 +218,7 @@ trait CachedBitcoindTriple[T <: BitcoindRpcClient]
 
   lazy val clientsF: Future[NodeTriple[T]] = {
     BitcoindRpcTestUtil
-      .createNodeTriple[T](version, Some(torConfig))
+      .createNodeTriple[T](version, torConfigOpt)
       .map(NodeTriple.fromTuple)
       .map { triple =>
         isClientsUsed.set(true)

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -50,6 +50,8 @@ trait CachedBitcoindFunded[T <: BitcoindRpcClient] extends CachedBitcoind[T] {
       //if it was used, shut down the cached bitcoind
       val stoppedF = for {
         cachedBitcoind <- cachedBitcoindWithFundsF
+        _ = logger.error(
+          s"cachedBitcoind.datadir=${cachedBitcoind.instance.datadir.toPath}")
         _ <- BitcoindRpcTestUtil.stopServer(cachedBitcoind)
       } yield ()
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
@@ -45,10 +45,9 @@ trait CachedTor {
 trait CachedTorCustomDatadir extends CachedTor { _: BitcoinSAkkaAsyncTest =>
 
   /** The specific datadir we should start the tor instance from */
-  def customDatadir: Future[Path]
+  def customDatadir: Path
 
   implicit override protected lazy val torConfig: TorAppConfig = {
-    TorAppConfig.fromDatadir(Await.result(customDatadir, akkaTimeout.duration),
-                             Vector.empty)
+    TorAppConfig.fromDatadir(customDatadir, Vector.empty)
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
@@ -4,6 +4,7 @@ import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.util.{BitcoinSAkkaAsyncTest, TorUtil}
 import org.bitcoins.tor.config.TorAppConfig
 
+import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
@@ -38,5 +39,16 @@ trait CachedTor {
       Await.result(torConfig.stop(), akkaTimeout.duration)
     }
     ()
+  }
+}
+
+trait CachedTorCustomDatadir extends CachedTor { _: BitcoinSAkkaAsyncTest =>
+
+  /** The specific datadir we should start the tor instance from */
+  def customDatadir: Future[Path]
+
+  implicit override protected lazy val torConfig: TorAppConfig = {
+    TorAppConfig.fromDatadir(Await.result(customDatadir, akkaTimeout.duration),
+                             Vector.empty)
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
@@ -32,4 +32,11 @@ trait CachedTor {
     }
     ()
   }
+
+  override def afterAll(): Unit = {
+    if (TorUtil.torEnabled && isTorStarted.get) {
+      Await.result(torConfig.stop(), akkaTimeout.duration)
+    }
+    ()
+  }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.testkit.tor
 
+import grizzled.slf4j.Logging
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.util.{BitcoinSAkkaAsyncTest, TorUtil}
 import org.bitcoins.tor.config.TorAppConfig
@@ -13,7 +14,7 @@ import scala.concurrent.{Await, Future}
   * This is useful for using with fixtures to avoid starting tor everytime a
   * new test is run.
   */
-trait CachedTor {
+trait CachedTor extends Logging {
   _: BitcoinSAkkaAsyncTest =>
 
   implicit protected lazy val torConfig: TorAppConfig =
@@ -28,6 +29,7 @@ trait CachedTor {
   }
 
   override def beforeAll(): Unit = {
+    logger.error(s"------------------ CACHEDTOR BEFOREALL ------------------")
     if (TorUtil.torEnabled && !isTorStarted.get()) {
       Await.result(torF, 70.seconds)
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
@@ -29,7 +29,6 @@ trait CachedTor extends Logging {
   }
 
   override def beforeAll(): Unit = {
-    logger.error(s"------------------ CACHEDTOR BEFOREALL ------------------")
     if (TorUtil.torEnabled && !isTorStarted.get()) {
       Await.result(torF, 70.seconds)
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/tor/CachedTor.scala
@@ -17,7 +17,7 @@ trait CachedTor {
   _: BitcoinSAkkaAsyncTest =>
 
   implicit protected lazy val torConfig: TorAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig().torConf
+    BitcoinSTestAppConfig.getSpvTestConfig(Vector.empty, None).torConf
 
   protected val isTorStarted: AtomicBoolean = new AtomicBoolean(false)
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
@@ -9,7 +9,7 @@ import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import scala.collection.mutable
 import scala.concurrent.{Await, Future}
 
-abstract class BitcoindRpcTest extends BitcoinSAsyncTest with Logging {
+trait BitcoindRpcTest extends BitcoinSAsyncTest with Logging {
 
   private val dirExists =
     Files.exists(BitcoindRpcTestClient.sbtBinaryDirectory)

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTestClient.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTestClient.scala
@@ -19,6 +19,7 @@ case class BitcoindRpcTestClient(
 
   private lazy val bitcoindInstance: BitcoindInstanceLocal = {
     BitcoindRpcTestUtil.getInstance(bitcoindVersion = version,
+                                    torAppConfigOpt = None,
                                     binaryDirectory = binaryDirectory)
   }
 
@@ -32,9 +33,10 @@ case class BitcoindRpcTestClient(
       case Some(client) => Future.successful(client)
       case None =>
         val clientF =
-          BitcoindRpcTestUtil.startedBitcoindRpcClient(Some(bitcoindInstance),
-                                                       clientAccum =
-                                                         Vector.newBuilder)
+          BitcoindRpcTestUtil.startedBitcoindRpcClient(
+            torAppConfigOpt = None,
+            clientAccum = Vector.newBuilder,
+            instanceOpt = Some(bitcoindInstance))
         clientF.map { c =>
           clientOpt = Some(c)
           c

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/EclairRpcTestClient.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/EclairRpcTestClient.scala
@@ -24,7 +24,7 @@ case class EclairRpcTestClient(
     bitcoindRpcClientOpt match {
       case Some(bitcoindRpcClient) => Future.successful(bitcoindRpcClient)
       case None =>
-        EclairRpcTestUtil.startedBitcoindRpcClient()
+        EclairRpcTestUtil.startedBitcoindRpcClient(torAppConfigOpt = None)
     }
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/TorUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/TorUtil.scala
@@ -12,7 +12,7 @@ object TorUtil extends Logging {
   val torEnabled: Boolean = {
     Properties
       .envOrNone("TOR")
-      .map(_ == "true")
+      .map(_.toLowerCase == "true")
       .getOrElse(false)
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/TorUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/TorUtil.scala
@@ -9,9 +9,12 @@ import scala.util.Properties
 
 object TorUtil extends Logging {
 
-  val torEnabled: Boolean = Properties
-    .envOrNone("TOR")
-    .isDefined
+  val torEnabled: Boolean = {
+    Properties
+      .envOrNone("TOR")
+      .map(_ == "true")
+      .getOrElse(false)
+  }
 
   def torProxyAddress =
     new InetSocketAddress(InetAddress.getLoopbackAddress,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
@@ -15,7 +15,8 @@ trait BitcoinSDualWalletTest extends BitcoinSWalletTest {
   import BitcoinSWalletTest._
 
   implicit protected def config2: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig()
+    BitcoinSTestAppConfig.getSpvTestConfig(config = Vector.empty,
+                                           torAppConfigOpt = None)
 
   implicit protected def wallet2AppConfig: WalletAppConfig = {
     config2.walletConf

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -170,7 +170,7 @@ trait BitcoinSWalletTest
       walletAppConfig: WalletAppConfig): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind] = composeBuildersAndWrap(
       builder = { () =>
-        BitcoinSFixture.createBitcoindWithFunds()
+        BitcoinSFixture.createBitcoindWithFunds(torAppConfigOpt = None)
       },
       dependentBuilder = { (bitcoind: BitcoindRpcClient) =>
         createWalletWithBitcoind(bitcoind)
@@ -189,7 +189,8 @@ trait BitcoinSWalletTest
     val builder: () => Future[WalletWithBitcoind] = composeBuildersAndWrap(
       builder = { () =>
         BitcoinSFixture
-          .createBitcoindWithFunds(Some(BitcoindVersion.V19))
+          .createBitcoindWithFunds(torAppConfigOpt = None,
+                                   Some(BitcoindVersion.V19))
           .map(_.asInstanceOf[BitcoindV19RpcClient])
       },
       dependentBuilder = { (bitcoind: BitcoindV19RpcClient) =>
@@ -211,7 +212,8 @@ trait BitcoinSWalletTest
       for {
         bitcoind <-
           BitcoinSFixture
-            .createBitcoindWithFunds(Some(BitcoindVersion.V19))
+            .createBitcoindWithFunds(torAppConfigOpt = None,
+                                     Some(BitcoindVersion.V19))
             .map(_.asInstanceOf[BitcoindV19RpcClient])
         wallet <- createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
         fundedWallet <- fundWalletWithBitcoind(wallet)
@@ -538,7 +540,8 @@ object BitcoinSWalletTest extends WalletLogger {
   def createWalletWithBitcoind(
       wallet: Wallet
   )(implicit system: ActorSystem): Future[WalletWithBitcoind] = {
-    val bitcoindF = BitcoinSFixture.createBitcoindWithFunds()
+    val bitcoindF =
+      BitcoinSFixture.createBitcoindWithFunds(torAppConfigOpt = None)
     bitcoindF.map(WalletWithBitcoindRpc(wallet, _))(system.dispatcher)
   }
 
@@ -548,7 +551,9 @@ object BitcoinSWalletTest extends WalletLogger {
       versionOpt: Option[BitcoindVersion]
   )(implicit system: ActorSystem): Future[WalletWithBitcoind] = {
     import system.dispatcher
-    val bitcoindF = BitcoinSFixture.createBitcoindWithFunds(versionOpt)
+    val bitcoindF = BitcoinSFixture.createBitcoindWithFunds(torAppConfigOpt =
+                                                              None,
+                                                            versionOpt)
     bitcoindF.map(WalletWithBitcoindRpc(wallet, _))
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -342,7 +342,7 @@ object BitcoinSWalletTest extends WalletLogger {
 
         BitcoinSAppConfig(
           baseConf.baseDatadir,
-          (walletNameOverride +: baseConf.configOverrides): _*).walletConf
+          (walletNameOverride +: baseConf.configOverrides).toVector).walletConf
       case None => baseConf
     }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -11,6 +11,7 @@ import org.bitcoins.testkit.rpc.{
   CachedBitcoindNewest,
   CachedBitcoindV19
 }
+import org.bitcoins.testkit.tor.CachedTor
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
   createWalletWithBitcoind,
   createWalletWithBitcoindCallbacks,
@@ -32,7 +33,8 @@ import scala.util.{Failure, Success}
 trait BitcoinSWalletTestCachedBitcoind
     extends BitcoinSFixture
     with BaseWalletTest
-    with EmbeddedPg { _: CachedBitcoind[_] =>
+    with EmbeddedPg
+    with CachedTor { _: CachedBitcoind[_] =>
 
   /** Creates a funded wallet fixture with bitcoind
     * This is different than [[withFundedWalletAndBitcoind()]]

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DualWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DualWalletTestCachedBitcoind.scala
@@ -16,7 +16,8 @@ trait DualWalletTestCachedBitcoind
   import BitcoinSWalletTest._
 
   implicit protected def config2: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getSpvTestConfig()
+    BitcoinSTestAppConfig.getSpvTestConfig(config = Vector.empty,
+                                           torAppConfigOpt = None)
 
   implicit protected def wallet2AppConfig: WalletAppConfig = {
     config2.walletConf

--- a/tor-test/src/test/scala/org/bitcoins/tor/Socks5ClientTransportSpec.scala
+++ b/tor-test/src/test/scala/org/bitcoins/tor/Socks5ClientTransportSpec.scala
@@ -14,7 +14,7 @@ class Socks5ClientTransportSpec extends BitcoinSAsyncTest with CachedTor {
 
   implicit val ec = system.dispatcher
 
-  val proxyParams = torConfig.socks5ProxyParams
+  val proxyParams = torConfig.socks5ProxyParams.get
 
   val socks5ClientTransport = new Socks5ClientTransport(proxyParams)
 

--- a/tor-test/src/test/scala/org/bitcoins/tor/Socks5ClientTransportSpec.scala
+++ b/tor-test/src/test/scala/org/bitcoins/tor/Socks5ClientTransportSpec.scala
@@ -14,14 +14,14 @@ class Socks5ClientTransportSpec extends BitcoinSAsyncTest with CachedTor {
 
   implicit val ec = system.dispatcher
 
-  val proxyParams = torConfig.socks5ProxyParams.get
+  def proxyParams = torConfigOpt.flatMap(_.socks5ProxyParams).get
 
-  val socks5ClientTransport = new Socks5ClientTransport(proxyParams)
+  lazy val socks5ClientTransport = new Socks5ClientTransport(proxyParams)
 
-  val clientConnectionSettings =
+  lazy val clientConnectionSettings =
     ClientConnectionSettings(system).withTransport(socks5ClientTransport)
 
-  val settings = ConnectionPoolSettings(system).withConnectionSettings(
+  lazy val settings = ConnectionPoolSettings(system).withConnectionSettings(
     clientConnectionSettings)
 
   it should "handle clear net addresses" in {

--- a/tor-test/src/test/scala/org/bitcoins/tor/Socks5ClientTransportSpec.scala
+++ b/tor-test/src/test/scala/org/bitcoins/tor/Socks5ClientTransportSpec.scala
@@ -14,7 +14,7 @@ class Socks5ClientTransportSpec extends BitcoinSAsyncTest with CachedTor {
 
   implicit val ec = system.dispatcher
 
-  val proxyParams = torConfig.socks5ProxyParams.get
+  val proxyParams = torConfig.socks5ProxyParams
 
   val socks5ClientTransport = new Socks5ClientTransport(proxyParams)
 

--- a/tor/src/main/scala/org/bitcoins/tor/Socks5ClientTransport.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/Socks5ClientTransport.scala
@@ -12,6 +12,7 @@ import akka.stream.scaladsl.{BidiFlow, Flow, Keep}
 import akka.stream.stage._
 import akka.stream.{Attributes, BidiShape, Inlet, Outlet}
 import akka.util.ByteString
+import grizzled.slf4j.Logging
 import org.bitcoins.core.util.NetworkUtil
 
 import java.net.{InetSocketAddress, URI}
@@ -113,7 +114,8 @@ class Socks5ProxyGraphStage(
     targetPort: Int,
     proxyParams: Socks5ProxyParams)
     extends GraphStage[
-      BidiShape[ByteString, ByteString, ByteString, ByteString]] {
+      BidiShape[ByteString, ByteString, ByteString, ByteString]]
+    with Logging {
 
   val bytesIn: Inlet[ByteString] = Inlet("OutgoingTCP.in")
   val bytesOut: Outlet[ByteString] = Outlet("OutgoingTCP.out")
@@ -170,6 +172,7 @@ class Socks5ProxyGraphStage(
       }
 
       def parseResponse(data: ByteString): Unit = {
+        logger.info(s"parseResponse() state=$state data=$data")
         state match {
           case Greeting =>
             tryParseGreetings(data, credentialsOpt.nonEmpty) match {

--- a/tor/src/main/scala/org/bitcoins/tor/Socks5Connection.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/Socks5Connection.scala
@@ -209,8 +209,11 @@ object Socks5Connection {
     } else {
       val status = data(1)
       if (status != 0) {
-        throw Socks5Error(
-          connectErrors.getOrElse(status, s"Unknown SOCKS5 error $status"))
+        val errorOpt = connectErrors.get(status)
+        val errWithDataOpt: Option[String] = errorOpt.map(_ + s", data=$data")
+        val err: String = errWithDataOpt
+          .getOrElse(s"Unknown SOCKS5 error $status, data=${data}")
+        throw Socks5Error(err)
       }
       data(3) match {
         case 0x01 =>

--- a/tor/src/main/scala/org/bitcoins/tor/TorController.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/TorController.scala
@@ -96,8 +96,9 @@ object TorController {
       authentication: Authentication,
       privateKeyPath: Path,
       virtualPort: Int,
-      targets: Seq[String] = Seq())(implicit
+      targets: Seq[String] = Seq.empty)(implicit
       system: ActorSystem): Future[InetSocketAddress] = {
+    println(s"@@@@@@@@@@@@@@@@ Setting up hidden service @@@@@@@@@@@@@@@@")
 
     val promiseTorAddress = Promise[InetSocketAddress]()
 

--- a/tor/src/main/scala/org/bitcoins/tor/TorProtocolHandler.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/TorProtocolHandler.scala
@@ -3,6 +3,7 @@ package org.bitcoins.tor
 import akka.actor.{Actor, ActorLogging, ActorRef, Props, Stash}
 import akka.io.Tcp.Connected
 import akka.util.ByteString
+import grizzled.slf4j.Logging
 import org.bitcoins.crypto.CryptoUtil
 import org.bitcoins.tor.TorProtocolHandler.{Authentication, OnionServiceVersion}
 import scodec.bits.ByteVector
@@ -39,7 +40,8 @@ class TorProtocolHandler(
     onionAdded: Option[Promise[InetSocketAddress]])
     extends Actor
     with Stash
-    with ActorLogging {
+    with ActorLogging
+    with Logging {
 
   import TorProtocolHandler._
 
@@ -55,6 +57,7 @@ class TorProtocolHandler(
 
   def protocolInfo: Receive = { case data: ByteString =>
     val res = parseResponse(readResponse(data))
+    logger.info(s"Parsed response=$res")
     val methods: String =
       res.getOrElse("METHODS", throw TorException("auth methods not found"))
     val torVersion = unquote(
@@ -185,6 +188,7 @@ class TorProtocolHandler(
   }
 
   private def sendCommand(cmd: String): Unit = {
+    logger.info(s"sending command=$cmd")
     receiver ! ByteString(s"$cmd\r\n")
   }
 }

--- a/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
@@ -3,75 +3,17 @@ package org.bitcoins.tor.client
 import grizzled.slf4j.Logging
 import org.bitcoins.commons.util.NativeProcessFactory
 import org.bitcoins.core.util.EnvUtil
-import org.bitcoins.tor.TorProtocolHandler._
 import org.bitcoins.tor.config.TorAppConfig
-import org.bitcoins.tor.{Socks5ProxyParams, TorParams}
 
-import java.io.{File, FileNotFoundException}
-import java.net.{InetAddress, InetSocketAddress}
-import java.nio.file.{Files, Path, StandardCopyOption}
+import java.io.File
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success, Try}
 
 /** A trait that helps start bitcoind/eclair when it is started via bitcoin-s */
 class TorClient()(implicit
     val executionContext: ExecutionContext,
     conf: TorAppConfig)
-    extends NativeProcessFactory
-    with Logging {
-
-  lazy val socks5ProxyParams: Socks5ProxyParams = conf.socks5ProxyParams match {
-    case Some(params) => params
-    case None =>
-      val addr = new InetSocketAddress(InetAddress.getLoopbackAddress,
-                                       Socks5ProxyParams.DefaultPort)
-      Socks5ProxyParams(
-        address = addr,
-        credentialsOpt = None,
-        randomizeCredentials = true
-      )
-  }
-
-  lazy val torParams: TorParams = conf.torParams match {
-    case Some(params) => params
-    case None =>
-      val control = new InetSocketAddress(InetAddress.getLoopbackAddress,
-                                          TorParams.DefaultControlPort)
-
-      val auth = SafeCookie()
-      val privKeyPath = conf.datadir.resolve("tor_priv_key")
-
-      TorParams(control, auth, privKeyPath)
-  }
-
-  private lazy val authenticationArg = torParams.authentication match {
-    case Password(_) =>
-//      s"--HashedControlPassword $password" // todo: need to hash the password correctly
-      throw new RuntimeException("Password authentication not yet supported")
-    case _: SafeCookie =>
-      "--CookieAuthentication 1"
-  }
-
-  private lazy val executable = TorClient.torBinaryFromResource(conf.torDir)
-
-  /** The command to start the daemon on the underlying OS */
-  lazy val cmd: String = {
-
-    val args = Vector(
-      "--ExitRelay 0", // ensure we aren't an exit relay
-      "--BridgeRelay 0", // ensure we aren't an bridge relay
-      s"--SOCKSPort ${socks5ProxyParams.address.getHostName}:${socks5ProxyParams.address.getPort}",
-      s"--ControlPort ${torParams.controlAddress.getPort}",
-      authenticationArg,
-      s"""--DataDirectory "${conf.torDir.toAbsolutePath}" """,
-      s"""--Log "notice file ${conf.torLogFile.toAbsolutePath}" """,
-      s"""--GeoIPFile "${conf.torDir.toAbsolutePath.resolve("geoip")}" """,
-      s"""--GeoIPv6File "${conf.torDir.toAbsolutePath.resolve("geoip6")}" """
-    ).mkString(" ")
-
-    s"$executable $args"
-  }
-
+    extends Logging {
+  println(s"conf=$conf")
 }
 
 object TorClient extends Logging {
@@ -86,152 +28,5 @@ object TorClient extends Logging {
     } else {
       NativeProcessFactory.findExecutableOnPath("tor")
     }
-  }
-
-  /** Copies the tor executable and needed files to the given datadir
-    * Returns the tor executable file
-    * @param datadir Directory where to write files
-    * @return Tor executable file
-    */
-  private def torBinaryFromResource(datadir: Path): File = {
-    val torBundle = if (EnvUtil.isLinux) {
-      linuxTorBundle
-    } else if (EnvUtil.isMac) {
-      osxTorBundle
-    } else if (EnvUtil.isWindows) {
-      windowsTorBundle
-    } else throw new RuntimeException("Unknown platform")
-
-    val executableFileName = datadir.resolve(torBundle.primaryExecutable).toFile
-
-    logger.info(
-      s"Using prepackaged Tor from bitcoin-s resources, $executableFileName")
-
-    if (existsAndIsExecutable(datadir, torBundle)) {
-      logger.info(
-        s"Using tor daemon already written to datadir=${datadir.toAbsolutePath}")
-      executableFileName
-    } else {
-      logger.info(
-        s"Tor executable is not written to datadir $datadir, creating...")
-
-      torBundle.allFilesNames.foreach { fileName =>
-        val writePath = datadir.resolve(fileName)
-
-        val parentDir = writePath.getParent.toFile
-
-        if (!parentDir.exists()) {
-          Files.createDirectories(parentDir.toPath)
-        }
-
-        writeFileFromResource(fileName, writePath)
-      }
-
-      //set files as executable
-      torBundle.executables.foreach { f =>
-        val executable = datadir.resolve(f)
-        executable.toFile.setExecutable(true)
-      }
-
-      // write geoip files
-      writeFileFromResource("geoip/geoip", datadir.resolve("geoip"))
-      writeFileFromResource("geoip/geoip6", datadir.resolve("geoip6"))
-
-      // write version file
-      Files.write(datadir.resolve(versionFileName), TOR_VERSION.getBytes)
-
-      logger.info(
-        s"Using prepackaged Tor from bitcoin-s resources, $executableFileName")
-
-      executableFileName
-    }
-  }
-
-  private def writeFileFromResource(
-      resourceName: String,
-      writePath: Path): Long = {
-    val stream =
-      Try(getClass.getResource("/" + resourceName).openStream()) match {
-        case Failure(_)      => throw new FileNotFoundException(resourceName)
-        case Success(stream) => stream
-      }
-    Files.copy(stream, writePath, StandardCopyOption.REPLACE_EXISTING)
-  }
-
-  /** The executables and lists of library files needed to run tor on a specific platform
-    *
-    * @param executables the files that need to be set to executable
-    * @param fileList shared object files or library files for tor to operate
-    */
-  private case class TorFileBundle(
-      executables: Vector[String],
-      fileList: Vector[String]) {
-    val allFilesNames: Vector[String] = executables ++ fileList
-
-    /** By convention, make the primary executable the first element passed into executables
-      * This is needed because some platforms like osx require two tor executables (tor, tor.real)
-      */
-    def primaryExecutable: String = executables.head
-  }
-
-  private lazy val linuxTorBundle: TorFileBundle = {
-    TorFileBundle(
-      executables = Vector("linux_64/tor", "linux_64/tor.real"),
-      fileList = Vector(
-        "linux_64/LICENSE",
-        "linux_64/libssl.so.1.1",
-        "linux_64/libevent-2.1.so.7",
-        "linux_64/libcrypto.so.1.1",
-        "linux_64/libstdc++/libstdc++.so.6"
-      )
-    )
-  }
-
-  private lazy val osxTorBundle: TorFileBundle = {
-    TorFileBundle(
-      executables = Vector(
-        "osx_64/tor",
-        "osx_64/tor.real"
-      ),
-      fileList = Vector("osx_64/LICENSE", "osx_64/libevent-2.1.7.dylib")
-    )
-  }
-
-  private lazy val windowsTorBundle: TorFileBundle = {
-    TorFileBundle(
-      executables = Vector("windows_64/tor.exe"),
-      fileList = Vector(
-        "windows_64/libcrypto-1_1-x64.dll",
-        "windows_64/libevent-2-1-7.dll",
-        "windows_64/libevent_core-2-1-7.dll",
-        "windows_64/libevent_extra-2-1-7.dll",
-        "windows_64/libgcc_s_seh-1.dll",
-        "windows_64/libssl-1_1-x64.dll",
-        "windows_64/libssp-0.dll",
-        "windows_64/libwinpthread-1.dll",
-        "windows_64/LICENSE",
-        "windows_64/zlib1.dll"
-      )
-    )
-  }
-
-  /** Checks if the executable files exists in the given datadir and are executable */
-  private def existsAndIsExecutable(
-      datadir: Path,
-      bundle: TorFileBundle): Boolean = {
-
-    val versionFile = datadir.resolve(versionFileName)
-
-    lazy val currentVersion = new String(Files.readAllBytes(versionFile))
-
-    val latestVersion =
-      versionFile.toFile.exists() && currentVersion == TOR_VERSION
-
-    lazy val hasFiles = bundle.executables.forall { executableFileName =>
-      val executableFile = datadir.resolve(executableFileName).toFile
-      executableFile.exists() && executableFile.canExecute
-    }
-
-    latestVersion && hasFiles
   }
 }

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -129,7 +129,7 @@ case class TorAppConfig(
     * place for our node.
     */
   override def start(): Future[Unit] = {
-    if (torProvided) {
+    if (torProvided || isAlive()) {
       Future.unit
     } else {
       lazy val torRunning = checkIfTorAlreadyRunning

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -129,7 +129,8 @@ case class TorAppConfig(
     * place for our node.
     */
   override def start(): Future[Unit] = {
-    if (torProvided || isAlive()) {
+    if (torProvided) {
+      logger.info(s"Tor provided, ignoring TorAppConfig.start()")
       Future.unit
     } else {
       lazy val torRunning = checkIfTorAlreadyRunning
@@ -206,7 +207,7 @@ case class TorAppConfig(
   private def checkIfTorAlreadyRunning: Boolean = {
     val toCheck = socks5ProxyParams.address
 
-    NetworkUtil.portIsBound(toCheck)
+    NetworkUtil.portIsBound(toCheck) || isAlive()
   }
 
   private lazy val authenticationArg: String =

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -167,8 +167,11 @@ case class TorAppConfig(
 
   override def stop(): Future[Unit] = {
     if (torProvided) {
+      logger.info(
+        s"Ignoring request to stop tor binary, as tor was given to us")
       Future.unit
     } else {
+      logger.info(s"Stopping tor binary")
       stopBinary().map(_ => isStarted.set(false))
     }
   }

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -50,6 +50,7 @@ case class TorAppConfig(
   lazy val useRandomPorts = config.getBoolean("bitcoin-s.tor.use-random-ports")
 
   lazy val socks5ProxyParams: Option[Socks5ProxyParams] = {
+    logger.error(s"@@@@@@@@@ useRandomPorts=$useRandomPorts @@@@@@@@@")
     if (config.getBoolean("bitcoin-s.proxy.enabled")) {
       val address = if (torProvided) {
         NetworkUtil.parseInetSocketAddress(
@@ -259,13 +260,13 @@ object TorAppConfig extends AppConfigFactory[TorAppConfig] with Logging {
       ec: ExecutionContext): TorAppConfig =
     TorAppConfig(datadir, confs: _*)
 
-  lazy val randomSocks5Port: Int = ports.proxyPort
+  def randomSocks5Port: Int = ports.proxyPort
 
-  lazy val randomControlPort: Int = ports.controlPort
+  def randomControlPort: Int = ports.controlPort
 
   private case class TorPorts(proxyPort: Int, controlPort: Int)
 
-  private lazy val ports = {
+  private def ports: TorPorts = {
     val proxyPort = NetworkUtil.randomPort()
 
     def findControlPort: Int = {

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -207,7 +207,7 @@ case class TorAppConfig(
   private def checkIfTorAlreadyRunning: Boolean = {
     val toCheck = socks5ProxyParams.address
 
-    NetworkUtil.portIsBound(toCheck) || isAlive()
+    NetworkUtil.portIsBound(toCheck) && isAlive()
   }
 
   private lazy val authenticationArg: String =

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -130,7 +130,8 @@ case class TorAppConfig(
       lazy val torRunning = checkIfTorAlreadyRunning
       if (enabled && !isStarted.get && !torRunning) {
         isStarted.set(true)
-        logger.info(s"Starting Tor daemon")
+        logger.info(
+          s"Starting Tor daemon with socksProxy=${socks5ProxyParams.get.address} control=${torParams.get.controlAddress}")
         val start = System.currentTimeMillis()
         //remove old tor log file so we accurately tell when
         //the binary is started, if we don't remove this
@@ -152,7 +153,7 @@ case class TorAppConfig(
             s"Tor daemon is fully started, it took=${System.currentTimeMillis() - start}ms")
         }
       } else if (isStarted.get) {
-        logger.debug(s"Tor daemon already started")
+        logger.info(s"Tor daemon already started")
         Future.unit
       } else if (torRunning) {
         logger.warn(

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -1,19 +1,22 @@
 package org.bitcoins.tor.config
 
 import com.typesafe.config.Config
+import grizzled.slf4j.Logging
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.config.{AppConfig, AppConfigFactory, ConfigOps}
-import org.bitcoins.core.util.NetworkUtil
+import org.bitcoins.commons.util.NativeProcessFactory
+import org.bitcoins.core.util.{EnvUtil, NetworkUtil}
 import org.bitcoins.tor.TorProtocolHandler.{Password, SafeCookie}
 import org.bitcoins.tor.client.TorClient
 import org.bitcoins.tor.{Socks5ProxyParams, TorParams}
 
-import java.io.File
+import java.io.{File, FileNotFoundException}
 import java.net.{InetAddress, InetSocketAddress}
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, Path, StandardCopyOption}
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
 /** Configuration for the Bitcoin-S node
   * @param directory The data directory of the node
@@ -21,8 +24,11 @@ import scala.concurrent.{Await, ExecutionContext, Future}
   */
 case class TorAppConfig(
     private val directory: Path,
-    private val confs: Config*)(implicit ec: ExecutionContext)
-    extends AppConfig {
+    private val confs: Config*)(implicit
+    override val executionContext: ExecutionContext)
+    extends AppConfig
+    with NativeProcessFactory
+    with Logging {
   override protected[bitcoins] def configOverrides: List[Config] = confs.toList
   override protected[bitcoins] def moduleName: String = TorAppConfig.moduleName
   override protected[bitcoins] type ConfigType = TorAppConfig
@@ -43,7 +49,7 @@ case class TorAppConfig(
 
   lazy val useRandomPorts = config.getBoolean("bitcoin-s.tor.use-random-ports")
 
-  lazy val socks5ProxyParams: Option[Socks5ProxyParams] = {
+  lazy val socks5ProxyParams: Socks5ProxyParams = {
     if (config.getBoolean("bitcoin-s.proxy.enabled")) {
       val address = if (torProvided) {
         NetworkUtil.parseInetSocketAddress(
@@ -55,19 +61,23 @@ case class TorAppConfig(
                                 TorAppConfig.randomSocks5Port
                               else TorParams.DefaultProxyPort)
       }
-      Some(
-        Socks5ProxyParams(
-          address = address,
-          credentialsOpt = None,
-          randomizeCredentials = true
-        )
+      Socks5ProxyParams(
+        address = address,
+        credentialsOpt = None,
+        randomizeCredentials = true
       )
     } else {
-      None
+      val addr = new InetSocketAddress(InetAddress.getLoopbackAddress,
+                                       Socks5ProxyParams.DefaultPort)
+      Socks5ProxyParams(
+        address = addr,
+        credentialsOpt = None,
+        randomizeCredentials = true
+      )
     }
   }
 
-  lazy val torParams: Option[TorParams] = {
+  lazy val torParams: TorParams = {
     if (config.getBoolean("bitcoin-s.tor.enabled")) {
       val address = if (torProvided) {
         NetworkUtil.parseInetSocketAddress(
@@ -91,13 +101,23 @@ case class TorAppConfig(
           case None       => datadir.resolve("tor_priv_key")
         }
 
-      Some(TorParams(address, auth, privKeyPath))
+      TorParams(address, auth, privKeyPath)
     } else {
-      None
+      val control = new InetSocketAddress(InetAddress.getLoopbackAddress,
+                                          TorParams.DefaultControlPort)
+
+      val auth = SafeCookie()
+      val privKeyPath = datadir.resolve("tor_priv_key")
+
+      TorParams(control, auth, privKeyPath)
     }
   }
 
-  lazy val enabled: Boolean = socks5ProxyParams.isDefined || torParams.isDefined
+  lazy val enabled: Boolean = {
+    //always enabled now ? Seems so because we always define the
+    //torParams and socks5Params
+    true
+  }
 
   private val isBootstrappedLogLine = "Bootstrapped 100% (done): Done"
 
@@ -123,13 +143,12 @@ case class TorAppConfig(
         if (torLogFile.toFile.exists()) {
           torLogFile.toFile.delete()
         }
-        val client = createClient
         for {
-          _ <- client.startBinary()
+          _ <- startBinary()
           _ = Runtime.getRuntime.addShutdownHook(new Thread() {
             override def run(): Unit = {
               // don't forget to stop the daemon on exit
-              Await.result(client.stopBinary(), 30.seconds)
+              Await.result(stopBinary(), 30.seconds)
             }
           })
           _ <- isBinaryFullyStarted()
@@ -156,7 +175,7 @@ case class TorAppConfig(
     if (torProvided) {
       Future.unit
     } else {
-      createClient.stopBinary().map(_ => isStarted.set(false))
+      stopBinary().map(_ => isStarted.set(false))
     }
   }
 
@@ -185,22 +204,42 @@ case class TorAppConfig(
   }
 
   private def checkIfTorAlreadyRunning: Boolean = {
-    val toCheck = socks5ProxyParams match {
-      case Some(params) => params.address
-      case None =>
-        torParams match {
-          case Some(params) => params.controlAddress
-          case None =>
-            new InetSocketAddress(InetAddress.getLoopbackAddress,
-                                  TorParams.DefaultProxyPort)
-        }
-    }
+    val toCheck = socks5ProxyParams.address
 
     NetworkUtil.portIsBound(toCheck)
   }
+
+  private lazy val authenticationArg: String =
+    torParams.authentication match {
+      case Password(_) =>
+        //      s"--HashedControlPassword $password" // todo: need to hash the password correctly
+        throw new RuntimeException("Password authentication not yet supported")
+      case _: SafeCookie =>
+        "--CookieAuthentication 1"
+    }
+
+  private lazy val executable = TorAppConfig.torBinaryFromResource(torDir)
+
+  /** The command to start the daemon on the underlying OS */
+  override lazy val cmd: String = {
+
+    val args = Vector(
+      "--ExitRelay 0", // ensure we aren't an exit relay
+      "--BridgeRelay 0", // ensure we aren't an bridge relay
+      s"--SOCKSPort ${socks5ProxyParams.address.getHostName}:${socks5ProxyParams.address.getPort}",
+      s"--ControlPort ${torParams.controlAddress.getPort}",
+      authenticationArg,
+      s"""--DataDirectory "${torDir.toAbsolutePath}" """,
+      s"""--Log "notice file ${torLogFile.toAbsolutePath}" """,
+      s"""--GeoIPFile "${torDir.toAbsolutePath.resolve("geoip")}" """,
+      s"""--GeoIPv6File "${torDir.toAbsolutePath.resolve("geoip6")}" """
+    ).mkString(" ")
+
+    s"$executable $args"
+  }
 }
 
-object TorAppConfig extends AppConfigFactory[TorAppConfig] {
+object TorAppConfig extends AppConfigFactory[TorAppConfig] with Logging {
 
   override val moduleName: String = "tor"
 
@@ -233,4 +272,151 @@ object TorAppConfig extends AppConfigFactory[TorAppConfig] {
     TorPorts(proxyPort, findControlPort)
   }
 
+  /** Copies the tor executable and needed files to the given datadir
+    * Returns the tor executable file
+    * @param datadir Directory where to write files
+    * @return Tor executable file
+    */
+  private def torBinaryFromResource(datadir: Path): File = {
+    val torBundle = if (EnvUtil.isLinux) {
+      linuxTorBundle
+    } else if (EnvUtil.isMac) {
+      osxTorBundle
+    } else if (EnvUtil.isWindows) {
+      windowsTorBundle
+    } else throw new RuntimeException("Unknown platform")
+
+    val executableFileName = datadir.resolve(torBundle.primaryExecutable).toFile
+
+    logger.info(
+      s"Using prepackaged Tor from bitcoin-s resources, $executableFileName")
+
+    if (existsAndIsExecutable(datadir, torBundle)) {
+      logger.info(
+        s"Using tor daemon already written to datadir=${datadir.toAbsolutePath}")
+      executableFileName
+    } else {
+      logger.info(
+        s"Tor executable is not written to datadir $datadir, creating...")
+
+      torBundle.allFilesNames.foreach { fileName =>
+        val writePath = datadir.resolve(fileName)
+
+        val parentDir = writePath.getParent.toFile
+
+        if (!parentDir.exists()) {
+          Files.createDirectories(parentDir.toPath)
+        }
+
+        writeFileFromResource(fileName, writePath)
+      }
+
+      //set files as executable
+      torBundle.executables.foreach { f =>
+        val executable = datadir.resolve(f)
+        executable.toFile.setExecutable(true)
+      }
+
+      // write geoip files
+      writeFileFromResource("geoip/geoip", datadir.resolve("geoip"))
+      writeFileFromResource("geoip/geoip6", datadir.resolve("geoip6"))
+
+      // write version file
+      Files.write(datadir.resolve(TorClient.versionFileName),
+                  TorClient.TOR_VERSION.getBytes)
+
+      logger.info(
+        s"Using prepackaged Tor from bitcoin-s resources, $executableFileName")
+
+      executableFileName
+    }
+  }
+
+  private def writeFileFromResource(
+      resourceName: String,
+      writePath: Path): Long = {
+    val stream =
+      Try(getClass.getResource("/" + resourceName).openStream()) match {
+        case Failure(_)      => throw new FileNotFoundException(resourceName)
+        case Success(stream) => stream
+      }
+    Files.copy(stream, writePath, StandardCopyOption.REPLACE_EXISTING)
+  }
+
+  /** The executables and lists of library files needed to run tor on a specific platform
+    *
+    * @param executables the files that need to be set to executable
+    * @param fileList shared object files or library files for tor to operate
+    */
+  private case class TorFileBundle(
+      executables: Vector[String],
+      fileList: Vector[String]) {
+    val allFilesNames: Vector[String] = executables ++ fileList
+
+    /** By convention, make the primary executable the first element passed into executables
+      * This is needed because some platforms like osx require two tor executables (tor, tor.real)
+      */
+    def primaryExecutable: String = executables.head
+  }
+
+  private lazy val linuxTorBundle: TorFileBundle = {
+    TorFileBundle(
+      executables = Vector("linux_64/tor", "linux_64/tor.real"),
+      fileList = Vector(
+        "linux_64/LICENSE",
+        "linux_64/libssl.so.1.1",
+        "linux_64/libevent-2.1.so.7",
+        "linux_64/libcrypto.so.1.1",
+        "linux_64/libstdc++/libstdc++.so.6"
+      )
+    )
+  }
+
+  private lazy val osxTorBundle: TorFileBundle = {
+    TorFileBundle(
+      executables = Vector(
+        "osx_64/tor",
+        "osx_64/tor.real"
+      ),
+      fileList = Vector("osx_64/LICENSE", "osx_64/libevent-2.1.7.dylib")
+    )
+  }
+
+  private lazy val windowsTorBundle: TorFileBundle = {
+    TorFileBundle(
+      executables = Vector("windows_64/tor.exe"),
+      fileList = Vector(
+        "windows_64/libcrypto-1_1-x64.dll",
+        "windows_64/libevent-2-1-7.dll",
+        "windows_64/libevent_core-2-1-7.dll",
+        "windows_64/libevent_extra-2-1-7.dll",
+        "windows_64/libgcc_s_seh-1.dll",
+        "windows_64/libssl-1_1-x64.dll",
+        "windows_64/libssp-0.dll",
+        "windows_64/libwinpthread-1.dll",
+        "windows_64/LICENSE",
+        "windows_64/zlib1.dll"
+      )
+    )
+  }
+
+  /** Checks if the executable files exists in the given datadir and are executable */
+  private def existsAndIsExecutable(
+      datadir: Path,
+      bundle: TorFileBundle): Boolean = {
+
+    val versionFile = datadir.resolve(TorClient.versionFileName)
+
+    lazy val currentVersion = new String(Files.readAllBytes(versionFile))
+
+    val latestVersion =
+      versionFile.toFile.exists() && currentVersion == TorClient.TOR_VERSION
+
+    lazy val hasFiles = bundle.executables.forall { executableFileName =>
+      val executableFile = datadir.resolve(executableFileName).toFile
+      executableFile.exists() && executableFile.canExecute
+    }
+
+    latestVersion && hasFiles
+  }
 }

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -114,9 +114,8 @@ case class TorAppConfig(
   }
 
   lazy val enabled: Boolean = {
-    //always enabled now ? Seems so because we always define the
-    //torParams and socks5Params
-    true
+    config.getBoolean("bitcoin-s.tor.enabled") &&
+    config.getBoolean("bitcoin-s.proxy.enabled")
   }
 
   private val isBootstrappedLogLine = "Bootstrapped 100% (done): Done"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/MultiWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/MultiWalletTest.scala
@@ -24,8 +24,10 @@ class MultiWalletTest extends BitcoinSAsyncTest with EmbeddedPg {
 
     val dir = BitcoinSTestAppConfig.tmpDir()
 
-    val configA = BitcoinSAppConfig(dir, walletNameConfA.withFallback(dbConf))
-    val configB = BitcoinSAppConfig(dir, walletNameConfB.withFallback(dbConf))
+    val configA =
+      BitcoinSAppConfig(dir, Vector(walletNameConfA.withFallback(dbConf)))
+    val configB =
+      BitcoinSAppConfig(dir, Vector(walletNameConfB.withFallback(dbConf)))
 
     val walletAF = BitcoinSWalletTest.createDefaultWallet(
       MockNodeApi,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -18,7 +18,8 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoinV19 {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   override type FixtureParam = WalletWithBitcoind
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -224,7 +224,9 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
   private def testAccountType(purpose: HDPurpose): Future[Assertion] = {
     val confOverride = configForPurposeAndSeed(purpose)
     implicit val conf: WalletAppConfig =
-      BitcoinSTestAppConfig.getSpvTestConfig(confOverride).walletConf
+      BitcoinSTestAppConfig
+        .getSpvTestConfig(Vector(confOverride), None)
+        .walletConf
 
     val testVectors = purpose match {
       case HDPurposes.Legacy       => legacyVectors


### PR DESCRIPTION
We have a design issue with how we handle tor binaries currently. Users are encouraged to call `torConf.createClient` to obtain a `TorClient`. They then need to `torClient.start()` to start a new binary on the underlying OS to use tor correctly.

The problem is that we don't have a way to pass around the same reference to the running tor binary across the application. This PR moves the reference to the running binary inside of `TorAppConfig`, and begins passing references of `TorAppConfig` to projects that are dependent upon it on startup. This means we should be able to share one running tor binary across the application if we so choose. 

If you don't want to share the same binary, you can still spin up another `TorAppConfig` class and use the random ports feature in #3604 to have multiple tor binaries in the application.

This hopefully makes our test cases more robust and should _eventually_ allow for re-enabling async execution on CI