### PR TITLE
Give funding txid in DLC Signed state

### DIFF
--- a/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.protocol.dlc.models.DLCMessage._
 import org.bitcoins.core.protocol.dlc.models.{DLCState, DLCStatus}
 import org.bitcoins.core.util.TimeUtil
-import org.bitcoins.crypto.{DoubleSha256DigestBE, Sha256Digest}
+import org.bitcoins.crypto.Sha256Digest
 import org.bitcoins.testkitcore.gen.{CryptoGenerators, NumberGenerator, TLVGen}
 import org.bitcoins.testkitcore.util.BitcoinSJvmTest
 import org.scalacheck.Gen
@@ -73,8 +73,9 @@ class DLCStatusTest extends BitcoinSJvmTest {
   it must "have json symmetry in DLCStatus.Signed" in {
     forAllParallel(NumberGenerator.bool,
                    TLVGen.dlcOfferTLV,
-                   NumberGenerator.bytevector) {
-      case (isInit, offerTLV, contractId) =>
+                   NumberGenerator.bytevector,
+                   CryptoGenerators.doubleSha256DigestBE) {
+      case (isInit, offerTLV, contractId, txId) =>
         val offer = DLCOffer.fromTLV(offerTLV)
 
         val totalCollateral = offer.contractInfo.max
@@ -91,7 +92,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
             offer.feeRate,
             totalCollateral,
             offer.totalCollateral,
-            DoubleSha256DigestBE.empty
+            txId
           )
 
         assert(status.state == DLCState.Signed)

--- a/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.protocol.dlc.models.DLCMessage._
 import org.bitcoins.core.protocol.dlc.models.{DLCState, DLCStatus}
 import org.bitcoins.core.util.TimeUtil
-import org.bitcoins.crypto.Sha256Digest
+import org.bitcoins.crypto.{DoubleSha256DigestBE, Sha256Digest}
 import org.bitcoins.testkitcore.gen.{CryptoGenerators, NumberGenerator, TLVGen}
 import org.bitcoins.testkitcore.util.BitcoinSJvmTest
 import org.scalacheck.Gen
@@ -90,7 +90,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
             offer.timeouts,
             offer.feeRate,
             totalCollateral,
-            offer.totalCollateral
+            offer.totalCollateral,
+            DoubleSha256DigestBE.empty
           )
 
         assert(status.state == DLCState.Signed)

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -221,7 +221,8 @@ object Picklers {
       "feeRate" -> Num(feeRate.toLong.toDouble),
       "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
       "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
-      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble)
+      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
+      "fundingTxId" -> Str(fundingTxId.hex)
     )
   }
 
@@ -497,7 +498,8 @@ object Picklers {
           DLCTimeouts(contractMaturity, contractTimeout),
           feeRate,
           totalCollateral,
-          localCollateral
+          localCollateral,
+          fundingTxId
         )
       case DLCState.Broadcasted =>
         Broadcasted(

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
@@ -110,7 +110,7 @@ class DLCTableView(model: DLCPaneModel) {
           case closed: ClosedDLCStatus =>
             val amt = GUIUtil.numberFormatter.format(closed.pnl.satoshis.toLong)
             new StringProperty(status, "PNL", s"$amt sats")
-          case _: BroadcastedDLCStatus | _: AcceptedDLCStatus | _: Offered =>
+          case _: SignedDLCStatus | _: AcceptedDLCStatus | _: Offered =>
             new StringProperty(status, "PNL", "In progress")
         }
       }
@@ -126,7 +126,7 @@ class DLCTableView(model: DLCPaneModel) {
               status,
               "Rate of Return",
               s"${RateOfReturnUtil.prettyPrint(closed.rateOfReturn)}")
-          case _: BroadcastedDLCStatus | _: AcceptedDLCStatus | _: Offered =>
+          case _: SignedDLCStatus | _: AcceptedDLCStatus | _: Offered =>
             new StringProperty(status, "Rate of Return", "In progress")
         }
       }

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/ViewDLCDialog.scala
@@ -157,8 +157,7 @@ object ViewDLCDialog {
           },
           new Button("Rebroadcast") {
             minWidth = 90
-            disable =
-              !(status.state == DLCState.Broadcasted || status.state == DLCState.Signed)
+            disable = !(status.state == DLCState.Broadcasted)
             onAction = _ => model.rebroadcastFundingTx(status)
           }
         )

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCStatus.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCStatus.scala
@@ -38,11 +38,11 @@ sealed trait AcceptedDLCStatus extends DLCStatus {
   def contractId: ByteVector
 }
 
-sealed trait BroadcastedDLCStatus extends AcceptedDLCStatus {
+sealed trait SignedDLCStatus extends AcceptedDLCStatus {
   def fundingTxId: DoubleSha256DigestBE
 }
 
-sealed trait ClosedDLCStatus extends BroadcastedDLCStatus {
+sealed trait ClosedDLCStatus extends SignedDLCStatus {
   def closingTxId: DoubleSha256DigestBE
   def myPayout: CurrencyUnit
   def counterPartyPayout: CurrencyUnit
@@ -108,8 +108,9 @@ object DLCStatus {
       timeouts: DLCTimeouts,
       feeRate: FeeUnit,
       totalCollateral: CurrencyUnit,
-      localCollateral: CurrencyUnit)
-      extends AcceptedDLCStatus {
+      localCollateral: CurrencyUnit,
+      fundingTxId: DoubleSha256DigestBE)
+      extends SignedDLCStatus {
     override val state: DLCState.Signed.type = DLCState.Signed
   }
 
@@ -125,7 +126,7 @@ object DLCStatus {
       totalCollateral: CurrencyUnit,
       localCollateral: CurrencyUnit,
       fundingTxId: DoubleSha256DigestBE)
-      extends BroadcastedDLCStatus {
+      extends SignedDLCStatus {
     override val state: DLCState.Broadcasted.type = DLCState.Broadcasted
   }
 
@@ -141,7 +142,7 @@ object DLCStatus {
       totalCollateral: CurrencyUnit,
       localCollateral: CurrencyUnit,
       fundingTxId: DoubleSha256DigestBE)
-      extends BroadcastedDLCStatus {
+      extends SignedDLCStatus {
     override val state: DLCState.Confirmed.type = DLCState.Confirmed
   }
 
@@ -218,7 +219,7 @@ object DLCStatus {
 
   def getFundingTxId(status: DLCStatus): Option[DoubleSha256DigestBE] = {
     status match {
-      case status: BroadcastedDLCStatus =>
+      case status: SignedDLCStatus =>
         Some(status.fundingTxId)
       case _: Offered | _: Accepted | _: Signed =>
         None
@@ -239,8 +240,7 @@ object DLCStatus {
     status match {
       case claimed: ClaimedDLCStatus =>
         Some(claimed.oracleSigs)
-      case _: Offered | _: Accepted | _: Signed | _: BroadcastedDLCStatus |
-          _: Refunded =>
+      case _: Offered | _: Accepted | _: SignedDLCStatus | _: Refunded =>
         None
     }
   }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCStatusBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCStatusBuilder.scala
@@ -69,7 +69,8 @@ object DLCStatusBuilder {
           contractData.dlcTimeouts,
           dlcDb.feeRate,
           totalCollateral,
-          localCollateral
+          localCollateral,
+          dlcDb.fundingTxIdOpt.get
         )
       case DLCState.Broadcasted =>
         Broadcasted(


### PR DESCRIPTION
We know this value by the `Signed` state, but don't display it. This is nice so we can check on a block explorer after our peer has broadcasted