### PR TITLE
Decide which coin selection solution to use based on waste metric

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/CoinSelectorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/CoinSelectorTest.scala
@@ -1,0 +1,172 @@
+package org.bitcoins.core.wallet
+
+import org.bitcoins.core.api.wallet.CoinSelector
+import org.bitcoins.core.api.wallet.db._
+import org.bitcoins.core.currency._
+import org.bitcoins.core.hd._
+import org.bitcoins.core.protocol.script._
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.wallet.fee._
+import org.bitcoins.core.wallet.utxo.TxoState
+import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPublicKey}
+import org.bitcoins.testkitcore.gen.FeeUnitGen
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+
+class CoinSelectorTest extends BitcoinSUnitTest {
+
+  behavior of "CoinSelector"
+
+  val utxos: Vector[SpendingInfoDb] =
+    createSpendingInfoDbs(Vector(Bitcoins(1), Bitcoins(2)))
+  val inAmt: CurrencyUnit = utxos.map(_.output.value).sum
+  val target: Bitcoins = Bitcoins(2)
+  val changeCost: Satoshis = Satoshis.one
+
+  it must "calculate waste correctly" in {
+    forAll(FeeUnitGen.satsPerVirtualByte, FeeUnitGen.satsPerVirtualByte) {
+      case (feeRateA, feeRateB) =>
+        val (feeRate, longTermFeeRate) = correctFeeRates(feeRateA, feeRateB)
+
+        val utxosFee =
+          utxos.map(u => CoinSelector.calculateUtxoFee(u, feeRate)).sum
+
+        // difference of fee rate between feeRate and longTermFeeRate
+        val feeRateDiff =
+          SatoshisPerVirtualByte.fromLong(
+            feeRate.toLong - longTermFeeRate.toLong)
+
+        // difference fees it costs to spend our utxos between feeRate and longTermFeeRate
+        val utxoFeeDiffs =
+          utxos.map(u => CoinSelector.calculateUtxoFee(u, feeRateDiff)).sum
+
+        // how much change we have
+        val excess = inAmt - utxosFee - target
+
+        // Waste with change is the change cost and difference between fee and long term fee
+        val waste1 =
+          CoinSelector.calculateSelectionWaste(utxos = utxos,
+                                               changeCostOpt = Some(changeCost),
+                                               target = target,
+                                               feeRate = feeRate,
+                                               longTermFeeRate =
+                                                 longTermFeeRate)
+
+        assert(waste1 == utxoFeeDiffs + changeCost)
+
+        // Waste without change is the excess and difference between fee and long term fee
+        val waste2 =
+          CoinSelector.calculateSelectionWaste(utxos = utxos,
+                                               changeCostOpt = None,
+                                               target = target,
+                                               feeRate = feeRate,
+                                               longTermFeeRate =
+                                                 longTermFeeRate)
+
+        assert(waste2 == utxoFeeDiffs + excess)
+
+        // Waste with change and fee == long term fee is just cost of change
+        val waste3 =
+          CoinSelector.calculateSelectionWaste(utxos = utxos,
+                                               changeCostOpt = Some(changeCost),
+                                               target = target,
+                                               feeRate = feeRate,
+                                               longTermFeeRate = feeRate)
+
+        assert(waste3 == changeCost)
+
+        // Waste without change and fee == long term fee is just the excess
+        val waste4 =
+          CoinSelector.calculateSelectionWaste(utxos = utxos,
+                                               changeCostOpt = None,
+                                               target = target,
+                                               feeRate = feeRate,
+                                               longTermFeeRate = feeRate)
+
+        assert(waste4 == excess)
+
+        // Waste will be greater when fee is greater, but long term fee is the same
+        val biggerFeeRate = SatoshisPerVirtualByte(feeRate.currencyUnit * 2)
+        val waste5 =
+          CoinSelector.calculateSelectionWaste(utxos = utxos,
+                                               changeCostOpt = Some(changeCost),
+                                               target = target,
+                                               feeRate = biggerFeeRate,
+                                               longTermFeeRate =
+                                                 longTermFeeRate)
+
+        // waste 1 is the same params but feeRate
+        assert(waste5 > waste1)
+
+        // Waste with change is the change cost and difference between fee and long term fee
+        // With long term fee greater than fee, waste should be less than when long term fee is less than fee
+        val waste6 =
+          CoinSelector.calculateSelectionWaste(utxos = utxos,
+                                               changeCostOpt = Some(changeCost),
+                                               target = target,
+                                               feeRate = longTermFeeRate,
+                                               longTermFeeRate = feeRate)
+
+        assert(waste6 == -utxoFeeDiffs + changeCost)
+        // waste 1 is the same params but feeRate and longTermFeeRate swapped
+        assert(waste6 < waste1)
+
+        // 0 Waste only when fee == long term fee, no change, and no excess
+        val waste7 =
+          CoinSelector.calculateSelectionWaste(utxos = utxos,
+                                               changeCostOpt = None,
+                                               target = inAmt - utxosFee,
+                                               feeRate = feeRate,
+                                               longTermFeeRate = feeRate)
+
+        assert(waste7 == CurrencyUnits.zero)
+    }
+  }
+
+  def createSpendingInfoDbs(
+      amounts: Vector[CurrencyUnit]): Vector[SpendingInfoDb] = {
+    amounts.map { amt =>
+      val key = ECPublicKey.freshPublicKey
+      val spk = P2WPKHWitnessSPKV0(key)
+      val output = TransactionOutput(amt, spk)
+      val scriptWitness = P2WPKHWitnessV0(key)
+      val path = SegWitHDPath(HDCoinType.Testnet,
+                              accountIndex = 0,
+                              HDChainType.External,
+                              addressIndex = 0)
+
+      SegwitV0SpendingInfo(
+        outPoint = EmptyTransactionOutPoint,
+        output = output,
+        privKeyPath = path,
+        scriptWitness = scriptWitness,
+        txid = DoubleSha256DigestBE.empty,
+        state = TxoState.ConfirmedReceived,
+        spendingTxIdOpt = None
+      )
+    }
+  }
+
+  /** The test assumes feeRate is greater than longTermFeeRate
+    * After generating fee rates this will order them correctly
+    * so the tests will pass
+    *
+    * @param feeRateA first fee rate generated
+    * @param feeRateB second fee rate generated
+    * @return (feeRate, longTermFeeRate)
+    */
+  def correctFeeRates(
+      feeRateA: SatoshisPerVirtualByte,
+      feeRateB: SatoshisPerVirtualByte): (
+      SatoshisPerVirtualByte,
+      SatoshisPerVirtualByte) = {
+    if (feeRateA.toLong > feeRateB.toLong) {
+      (feeRateA, feeRateB)
+    } else if (feeRateA.toLong < feeRateB.toLong) {
+      (feeRateB, feeRateA)
+    } else { // equal
+      // one them needs to be higher
+      val plusOne = SatoshisPerVirtualByte.fromLong(feeRateA.toLong + 1)
+      (plusOne, feeRateB)
+    }
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelectionAlgo.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelectionAlgo.scala
@@ -27,11 +27,21 @@ object CoinSelectionAlgo extends StringFactory[CoinSelectionAlgo] {
   /** Greedily selects from walletUtxos in order, skipping outputs with values below their fees */
   final case object StandardAccumulate extends CoinSelectionAlgo
 
-  val all: Vector[CoinSelectionAlgo] =
+  /** Tries all coin selection algos and uses the one with the least waste */
+  case object LeastWaste extends CoinSelectionAlgo
+
+  /** Coin selection algos that don't call other ones */
+  val independentAlgos: Vector[CoinSelectionAlgo] =
     Vector(RandomSelection,
            AccumulateLargest,
            AccumulateSmallestViable,
            StandardAccumulate)
+
+  /** Coin selection algos that call upon other ones and choose the best */
+  val multiCoinSelectionAlgos: Vector[CoinSelectionAlgo] = Vector(LeastWaste)
+
+  val all: Vector[CoinSelectionAlgo] =
+    independentAlgos ++ multiCoinSelectionAlgos
 
   override def fromStringOpt(str: String): Option[CoinSelectionAlgo] = {
     all.find(state => str.toLowerCase() == state.toString.toLowerCase)

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelector.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelector.scala
@@ -2,12 +2,12 @@ package org.bitcoins.core.api.wallet
 
 import org.bitcoins.core.api.wallet.CoinSelectionAlgo._
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
-import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
+import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.FeeUnit
 
 import scala.annotation.tailrec
-import scala.util.Random
+import scala.util.{Random, Try}
 
 /** Implements algorithms for selecting from a UTXO set to spend to an output set at a given fee rate. */
 trait CoinSelector {
@@ -74,13 +74,13 @@ trait CoinSelector {
           s"Not enough value in given outputs ($valueSoFar) to make transaction spending $totalValue plus fees $fee")
       } else {
         val nextUtxo = utxosLeft.head
-        val approxUtxoSize = CoinSelector.approximateUtxoSize(nextUtxo)
-        val nextUtxoFee = feeRate * approxUtxoSize
-        if (nextUtxo.output.value < nextUtxoFee) {
+        val effectiveValue = calcEffectiveValue(nextUtxo, feeRate)
+        if (effectiveValue <= Satoshis.zero) {
           addUtxos(alreadyAdded, valueSoFar, bytesSoFar, utxosLeft.tail)
         } else {
           val newAdded = alreadyAdded.:+(nextUtxo)
           val newValue = valueSoFar + nextUtxo.output.value
+          val approxUtxoSize = CoinSelector.approximateUtxoSize(nextUtxo)
 
           addUtxos(newAdded,
                    newValue,
@@ -91,6 +91,18 @@ trait CoinSelector {
     }
 
     addUtxos(Vector.empty, CurrencyUnits.zero, bytesSoFar = 0L, walletUtxos)
+  }
+
+  def calculateUtxoFee(utxo: SpendingInfoDb, feeRate: FeeUnit): CurrencyUnit = {
+    val approxUtxoSize = CoinSelector.approximateUtxoSize(utxo)
+    feeRate * approxUtxoSize
+  }
+
+  def calcEffectiveValue(
+      utxo: SpendingInfoDb,
+      feeRate: FeeUnit): CurrencyUnit = {
+    val utxoFee = calculateUtxoFee(utxo, feeRate)
+    utxo.output.value - utxoFee
   }
 }
 
@@ -115,7 +127,8 @@ object CoinSelector extends CoinSelector {
       coinSelectionAlgo: CoinSelectionAlgo,
       walletUtxos: Vector[SpendingInfoDb],
       outputs: Vector[TransactionOutput],
-      feeRate: FeeUnit): Vector[SpendingInfoDb] =
+      feeRate: FeeUnit,
+      longTermFeeRateOpt: Option[FeeUnit] = None): Vector[SpendingInfoDb] =
     coinSelectionAlgo match {
       case RandomSelection =>
         randomSelection(walletUtxos, outputs, feeRate)
@@ -125,5 +138,119 @@ object CoinSelector extends CoinSelector {
         accumulateSmallestViable(walletUtxos, outputs, feeRate)
       case StandardAccumulate =>
         accumulate(walletUtxos, outputs, feeRate)
+      case LeastWaste =>
+        longTermFeeRateOpt match {
+          case Some(longTermFeeRate) =>
+            selectByLeastWaste(walletUtxos, outputs, feeRate, longTermFeeRate)
+          case None =>
+            throw new IllegalArgumentException(
+              "longTermFeeRateOpt must be defined for LeastWaste")
+        }
     }
+
+  private case class CoinSelectionResults(
+      waste: CurrencyUnit,
+      totalSpent: CurrencyUnit,
+      selection: Vector[SpendingInfoDb])
+
+  implicit
+  private val coinSelectionResultsOrder: Ordering[CoinSelectionResults] = {
+    case (a: CoinSelectionResults, b: CoinSelectionResults) =>
+      if (a.waste == b.waste) {
+        a.selection.size.compare(b.selection.size)
+      } else a.waste.compare(b.waste)
+  }
+
+  def selectByLeastWaste(
+      walletUtxos: Vector[SpendingInfoDb],
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      longTermFeeRate: FeeUnit
+  ): Vector[SpendingInfoDb] = {
+    val target = outputs.map(_.value).sum
+    val results = CoinSelectionAlgo.independentAlgos.flatMap { algo =>
+      // Skip failed selection attempts
+      Try {
+        val selection =
+          selectByAlgo(algo,
+                       walletUtxos,
+                       outputs,
+                       feeRate,
+                       Some(longTermFeeRate))
+
+        // todo for now just use 1 sat, when we have more complex selection algos
+        // that just don't result in change (Branch and Bound), this will need to be calculated
+        val changeCostOpt = Some(Satoshis.one)
+
+        val waste = calculateSelectionWaste(selection,
+                                            changeCostOpt,
+                                            target,
+                                            feeRate,
+                                            longTermFeeRate)
+
+        val totalSpent = selection.map(_.output.value).sum
+        CoinSelectionResults(waste, totalSpent, selection)
+      }.toOption
+    }
+
+    require(
+      results.nonEmpty,
+      s"Not enough value in given outputs to make transaction spending $target plus fees")
+
+    results.min.selection
+  }
+
+  /** Compute the waste for this result given the cost of change
+    * and the opportunity cost of spending these inputs now vs in the future.
+    * If change exists, waste = changeCost + inputs * (effective_feerate - long_term_feerate)
+    * If no change, waste = excess + inputs * (effective_feerate - long_term_feerate)
+    * where excess = totalEffectiveValue - target
+    * change_cost = effective_feerate * change_output_size + long_term_feerate * change_spend_size
+    *
+    * Copied from
+    * @see https://github.com/achow101/bitcoin/blob/4f5ad43b1e05cd7b403f87aae4c4d42e5aea810b/src/wallet/coinselection.cpp#L345
+    *
+    * @param utxos The selected inputs
+    * @param changeCostOpt The cost of creating change and spending it in the future. None if there is no change.
+    * @param target The amount targeted by the coin selection algorithm.
+    * @param longTermFeeRate The expected average fee rate used over the long term
+    * @return The waste
+    */
+  def calculateSelectionWaste(
+      utxos: Vector[SpendingInfoDb],
+      changeCostOpt: Option[CurrencyUnit],
+      target: CurrencyUnit,
+      feeRate: FeeUnit,
+      longTermFeeRate: FeeUnit): CurrencyUnit = {
+    require(
+      utxos.nonEmpty,
+      "This function should not be called with empty inputs as that would mean the selection failed")
+
+    val (waste, selectedEffectiveValue) =
+      utxos.foldLeft((CurrencyUnits.zero, CurrencyUnits.zero)) {
+        case ((waste, selectedEffectiveValue), utxo) =>
+          val fee = calculateUtxoFee(utxo, feeRate)
+          val longTermFee = calculateUtxoFee(utxo, longTermFeeRate)
+          val effectiveValue = calcEffectiveValue(utxo, feeRate)
+
+          val newWaste = waste + fee - longTermFee
+          val newSelectedEffectiveValue =
+            selectedEffectiveValue + effectiveValue
+
+          (newWaste, newSelectedEffectiveValue)
+      }
+
+    changeCostOpt match {
+      case Some(changeCost) =>
+        // Consider the cost of making change and spending it in the future
+        // If we aren't making change, the caller should've set changeCost to 0
+        require(changeCost > Satoshis.zero,
+                "Cannot have a change cost less than 1")
+        waste + changeCost
+      case None =>
+        // When we are not making change (changeCost == 0), consider the excess we are throwing away to fees
+        require(selectedEffectiveValue >= target)
+        waste + selectedEffectiveValue - target
+    }
+  }
 }

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -120,6 +120,12 @@ bitcoin-s {
       discoveryBatchSize = 100
 
       requiredConfirmations = 6
+
+      # Expected average fee rate over the long term
+      # in satoshis per virtual byte
+      # Copied the same value as Bitcoin Core
+      longTermFeeRate = 10
+
       # How big the address queue size is before we throw an exception
       # because of an overflow
       addressQueueSize = 10

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -408,7 +408,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       val walletA = FundedDLCWallets._1.wallet
       val walletB = FundedDLCWallets._2.wallet
 
-      testDLCSignVerification[NoSuchElementException](
+      testDLCSignVerification[IllegalArgumentException](
         walletA,
         walletB,
         (sign: DLCSign) =>

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -244,6 +244,10 @@ bitcoin-s {
 
         requiredConfirmations = 6
 
+        # Expected average fee rate over the long term
+        # in satoshis per virtual byte
+        longTermFeeRate = 10
+
         # How big the address queue size is before we throw an exception
         # because of an overflow
         addressQueueSize = 10

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/CoinSelectorTest.scala
@@ -109,6 +109,22 @@ class CoinSelectorTest extends BitcoinSWalletTest {
     assert(selections.exists(_ != first))
   }
 
+  it must "select the least wasteful outputs" in { fixture =>
+    val selection =
+      CoinSelector.selectByLeastWaste(walletUtxos = fixture.utxoSet,
+                                      outputs = Vector(fixture.output),
+                                      feeRate = fixture.feeRate,
+                                      longTermFeeRate =
+                                        SatoshisPerByte.fromLong(10))
+
+    // Need to sort as ordering will be different sometimes
+    val sortedSelection = selection.sortBy(_.outPoint.hex)
+    val sortedExpected =
+      Vector(fixture.utxo2, fixture.utxo1, fixture.utxo3).sortBy(_.outPoint.hex)
+
+    assert(sortedSelection == sortedExpected)
+  }
+
   it must "correctly approximate transaction input size" in { fixture =>
     val expected1 =
       32 + 4 + 1 + 4 + fixture.utxo1.scriptWitnessOpt.get.bytes.length

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -87,8 +87,9 @@ class FundTransactionHandlingTest
                                               fromTagOpt = None,
                                               markAsReserved = false)
       } yield {
-        assert(fundedTx.inputs.length == 1,
-               s"We should only need one input to fund this tx")
+        // Can be different depending on waste calculation
+        assert(fundedTx.inputs.length == 1 || fundedTx.inputs.length == 2,
+               s"We should only need one or two inputs to fund this tx")
 
         destinations.foreach(d => assert(fundedTx.outputs.contains(d)))
         assert(fundedTx.outputs.length == 6,

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -669,7 +669,7 @@ abstract class Wallet
     sendWithAlgo(address,
                  amount,
                  feeRate,
-                 CoinSelectionAlgo.AccumulateLargest,
+                 CoinSelectionAlgo.LeastWaste,
                  fromAccount)
 
   override def sendToAddress(
@@ -682,7 +682,7 @@ abstract class Wallet
     sendWithAlgo(address,
                  amount,
                  feeRate,
-                 CoinSelectionAlgo.AccumulateLargest,
+                 CoinSelectionAlgo.LeastWaste,
                  fromAccount,
                  newTags)
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -8,7 +8,8 @@ import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.hd._
 import org.bitcoins.core.util.Mutable
-import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
+import org.bitcoins.core.wallet.keymanagement._
+import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto.AesPassword
 import org.bitcoins.db.DatabaseDriver.{PostgreSQL, SQLite}
 import org.bitcoins.db._
@@ -122,6 +123,13 @@ case class WalletAppConfig(
     require(confs >= 1,
             s"requiredConfirmations cannot be less than 1, got: $confs")
     confs
+  }
+
+  lazy val longTermFeeRate: SatoshisPerVirtualByte = {
+    val feeRate = config.getInt("bitcoin-s.wallet.longTermFeeRate")
+    require(feeRate >= 0,
+            s"longTermFeeRate cannot be less than 0, got: $feeRate")
+    SatoshisPerVirtualByte.fromLong(feeRate)
   }
 
   lazy val rebroadcastFrequency: Duration = {


### PR DESCRIPTION
Did for fun, take your time to review

Supposed to be a copy of https://github.com/bitcoin/bitcoin/pull/22009

Adds a waste metric to coin selection, so now when selecting coins it tries all of our algos and picks the best one based on waste.

This requires a `longTermFeeRate` which is what the wallet assumes will be the average fee rate for the wallet over the long term. I added this to the wallet config and gave it a default of 10 sats/vbyte which is the same default bitcoin core chose