### PR TITLE
Add ordering of funding inputs to DLC Wallet

### DIFF
--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -82,13 +82,13 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
     val result = dlcDbManagement.migrate()
     dlcAppConfig.driver match {
       case SQLite =>
-        val expected = 3
+        val expected = 4
         assert(result == expected)
         val flywayInfo = dlcAppConfig.info()
         assert(flywayInfo.applied().length == expected)
         assert(flywayInfo.pending().length == 0)
       case PostgreSQL =>
-        val expected = 3
+        val expected = 4
         assert(result == expected)
         val flywayInfo = dlcAppConfig.info()
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCDAOTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCDAOTest.scala
@@ -74,6 +74,7 @@ class DLCDAOTest extends BitcoinSWalletTest with DLCDAOFixture {
     val input = DLCFundingInputDb(
       dlcId = dlcId,
       isInitiator = true,
+      index = 0,
       inputSerialId = UInt64.zero,
       outPoint = TransactionOutPoint(testBlockHash, UInt32.zero),
       output = TransactionOutput(Satoshis.one, EmptyScriptPubKey),
@@ -95,6 +96,7 @@ class DLCDAOTest extends BitcoinSWalletTest with DLCDAOFixture {
         DLCFundingInputDb(
           dlcId = dlcId,
           isInitiator = true,
+          index = 0,
           inputSerialId = UInt64.zero,
           outPoint = TransactionOutPoint(testBlockHash, UInt32.zero),
           output = TransactionOutput(Satoshis.one, EmptyScriptPubKey),
@@ -106,6 +108,7 @@ class DLCDAOTest extends BitcoinSWalletTest with DLCDAOFixture {
         DLCFundingInputDb(
           dlcId = dlcId,
           isInitiator = false,
+          index = 0,
           inputSerialId = UInt64.one,
           outPoint = TransactionOutPoint(testBlockHash, UInt32.one),
           output = TransactionOutput(Satoshis.one, EmptyScriptPubKey),
@@ -117,6 +120,7 @@ class DLCDAOTest extends BitcoinSWalletTest with DLCDAOFixture {
         DLCFundingInputDb(
           dlcId = dlcId,
           isInitiator = true,
+          index = 1,
           inputSerialId = UInt64(2),
           outPoint = TransactionOutPoint(testBlockHash, UInt32(3)),
           output = TransactionOutput(Satoshis.one, EmptyScriptPubKey),

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -408,7 +408,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       val walletA = FundedDLCWallets._1.wallet
       val walletB = FundedDLCWallets._2.wallet
 
-      testDLCSignVerification[IllegalArgumentException](
+      testDLCSignVerification[NoSuchElementException](
         walletA,
         walletB,
         (sign: DLCSign) =>

--- a/dlc-wallet/src/main/resources/postgresql/dlc/migration/V4__index_col_funding_input.sql
+++ b/dlc-wallet/src/main/resources/postgresql/dlc/migration/V4__index_col_funding_input.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "funding_inputs"
+    ADD COLUMN "index" INTEGER NOT NULL DEFAULT 0;

--- a/dlc-wallet/src/main/resources/sqlite/dlc/migration/V4__index_col_funding_input.sql
+++ b/dlc-wallet/src/main/resources/sqlite/dlc/migration/V4__index_col_funding_input.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "funding_inputs"
+    ADD COLUMN "index" INTEGER NOT NULL DEFAULT 0;

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
@@ -219,7 +219,9 @@ private[bitcoins] trait DLCDataManagement { self: DLCWallet =>
                                      announcements,
                                      announcementData,
                                      nonceDbs)
-    } yield (dlcDb, contractData, dlcOffer, fundingInputs, contractInfo)
+
+      sortedInputs = fundingInputs.sortBy(_.index)
+    } yield (dlcDb, contractData, dlcOffer, sortedInputs, contractInfo)
   }
 
   private[wallet] def getDLCFundingData(dlcId: Sha256Digest): Future[
@@ -421,7 +423,7 @@ private[bitcoins] trait DLCDataManagement { self: DLCWallet =>
   private[wallet] def matchPrevTxsWithInputs(
       inputs: Vector[DLCFundingInputDb],
       prevTxs: Vector[TransactionDb]): Vector[DLCFundingInput] = {
-    inputs.map { i =>
+    inputs.sortBy(_.index).map { i =>
       prevTxs.find(_.txId == i.outPoint.txId) match {
         case Some(txDb) => i.toFundingInput(txDb.transaction)
         case None =>

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -79,7 +79,9 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
         contractData <- contractDataDAO.read(dlcId).map(_.get)
         offerDbOpt <- dlcOfferDAO.findByDLCId(dlcId)
         acceptDbOpt <- dlcAcceptDAO.findByDLCId(dlcId)
-        fundingInputDbs <- dlcInputsDAO.findByDLCId(dlcId)
+        fundingInputDbs <- dlcInputsDAO
+          .findByDLCId(dlcId)
+          .map(_.sortBy(_.index))
         txIds = fundingInputDbs.map(_.outPoint.txIdBE)
         remotePrevTxs <- remoteTxDAO.findByTxIdBEs(txIds)
         localPrevTxs <- transactionDAO.findByTxIdBEs(txIds)
@@ -154,7 +156,7 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
 
           DLCStatus.calculateOutcomeAndSig(isInit, offer, accept, sign, cet).get
         }
-        (outcomes, oracleInfos) = getOutcomeDbInfo(outcome)
+        (_, oracleInfos) = getOutcomeDbInfo(outcome)
 
         noncesByAnnouncement = nonceDbs
           .groupBy(_.announcementId)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDAO.scala
@@ -85,6 +85,8 @@ case class DLCFundingInputDAO()(implicit
 
     def inputSerialId: Rep[UInt64] = column("input_serial_id")
 
+    def index: Rep[Int] = column("index")
+
     def isInitiator: Rep[Boolean] = column("is_initiator")
 
     def output: Rep[TransactionOutput] = column("output")
@@ -101,6 +103,7 @@ case class DLCFundingInputDAO()(implicit
     def * : ProvenShape[DLCFundingInputDb] =
       (dlcId,
        isInitiator,
+       index,
        inputSerialId,
        outPoint,
        output,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDb.scala
@@ -12,6 +12,7 @@ import org.bitcoins.crypto.Sha256Digest
 case class DLCFundingInputDb(
     dlcId: Sha256Digest,
     isInitiator: Boolean,
+    index: Int,
     inputSerialId: UInt64,
     outPoint: TransactionOutPoint,
     output: TransactionOutput,


### PR DESCRIPTION
Found from #3646

We did not preserve the order of the funding inputs in the dlc wallet

This is needed because for the DLCSign the signatures should be in the same order as they were in the original offer

https://github.com/discreetlogcontracts/dlcspecs/blob/master/Protocol.md#requirements-2