### PR TITLE
Sbt docker multi platform

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@
 name: CI to Docker Hub
 on:
   push:
-    branches: [master, main, sbt-docker-multi-platform]
+    branches: [master, main]
     tags: ["*"]
 jobs:
   build:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@
 name: CI to Docker Hub
 on:
   push:
-    branches: [master, main, adaptor-dlc]
+    branches: [master, main, sbt-docker-multi-platform]
     tags: ["*"]
 jobs:
   build:

--- a/build.sbt
+++ b/build.sbt
@@ -388,7 +388,7 @@ lazy val oracleServer = project
   .in(file("app/oracle-server"))
   .settings(CommonSettings.appSettings: _*)
   .settings(CommonSettings.dockerSettings: _*)
-  .settings(dockerBuildxSettings)
+  .settings(dockerBuildxSettings: _*)
   .dependsOn(
     dlcOracle,
     serverRoutes

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import com.typesafe.sbt.SbtGit.GitKeys._
+import sbt.Keys.{publish, publishLocal}
 
 import scala.util.Properties
 
@@ -350,10 +351,44 @@ lazy val appCommonsTest = project
   .settings(CommonSettings.testSettings: _*)
   .dependsOn(appCommons, testkit)
 
+// See https://softwaremill.com/how-to-build-multi-platform-docker-image-with-sbt-and-docker-buildx/
+lazy val ensureDockerBuildx =
+  taskKey[Unit]("Ensure that docker buildx configuration exists")
+
+lazy val dockerBuildWithBuildx =
+  taskKey[Unit]("Build docker images using buildx")
+
+import scala.sys.process.Process
+
+lazy val dockerBuildxSettings = Seq(
+  ensureDockerBuildx := {
+    if (Process("docker buildx inspect multi-arch-builder").! == 1) {
+      Process("docker buildx create --use --name multi-arch-builder",
+              baseDirectory.value).!
+    }
+  },
+  dockerBuildWithBuildx := {
+    streams.value.log("Building and pushing image with Buildx")
+    dockerAliases.value.foreach(alias =>
+      Process(
+        "docker buildx build --platform=linux/amd64,linux/arm64 --push -t " +
+          alias + " .",
+        baseDirectory.value / "target" / "docker" / "stage").!)
+  },
+  Docker / publish := Def
+    .sequential(
+      Docker / publishLocal,
+      ensureDockerBuildx,
+      dockerBuildWithBuildx
+    )
+    .value
+)
+
 lazy val oracleServer = project
   .in(file("app/oracle-server"))
   .settings(CommonSettings.appSettings: _*)
   .settings(CommonSettings.dockerSettings: _*)
+  .settings(dockerBuildxSettings)
   .dependsOn(
     dlcOracle,
     serverRoutes
@@ -380,6 +415,7 @@ lazy val appServer = project
   .in(file("app/server"))
   .settings(CommonSettings.appSettings: _*)
   .settings(CommonSettings.dockerSettings: _*)
+  .settings(dockerBuildxSettings: _*)
   .dependsOn(
     serverRoutes,
     appCommons,


### PR DESCRIPTION
Adds a new target platform for our docker images, `arm64` which is needed for raspberry pi environments. 

Credit to @user411 for doing the heavy lifting. 

