### PR TITLE
Update base docker image to openjdk:16-slim

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -177,7 +177,7 @@ object CommonSettings {
   lazy val dockerSettings: Seq[Setting[_]] = {
     Vector(
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
-      dockerBaseImage := "openjdk:15.0.2-jdk-buster",
+      dockerBaseImage := "openjdk:16-alpine",
       dockerRepository := Some("bitcoinscala"),
       //set the user to be 'bitcoin-s' rather than
       //the default provided by sbt native packager

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -177,7 +177,7 @@ object CommonSettings {
   lazy val dockerSettings: Seq[Setting[_]] = {
     Vector(
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
-      dockerBaseImage := "openjdk:16-alpine",
+      dockerBaseImage := "openjdk:16-slim",
       dockerRepository := Some("bitcoinscala"),
       //set the user to be 'bitcoin-s' rather than
       //the default provided by sbt native packager


### PR DESCRIPTION
This PR updates our old base docker image from

https://hub.docker.com/layers/openjdk/library/openjdk/15.0.2-jdk-buster/images/sha256-5d1a8616e0afe562f4364169836591659104f8b5ce9e03c66f07d58a814a3db4?context=explore

to 

https://hub.docker.com/layers/openjdk/library/openjdk/16-slim/images/sha256-d7e6afd5155486baacd0895276cc74d534babc17153776730509df4550db450d?context=explore

This should reduce image size by ~100MB

