### PR TITLE
Fix case where we forget to correctly assign currentPeerMsgHandlerRecv

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -108,7 +108,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       _ <- wallet.getConfirmedBalance()
       _ <- NodeTestUtil.awaitSync(node, bitcoind)
       _ <- NodeTestUtil.awaitCompactFiltersSync(node, bitcoind)
-      _ <- AsyncUtil.awaitConditionF(condition1)
+      _ <- AsyncUtil.awaitConditionF(condition1, maxTries = 100) //10 seconds
       // receive
       address <- wallet.getNewAddress()
       txId <- bitcoind.sendToAddress(address, TestAmount)

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverTest.scala
@@ -117,5 +117,13 @@ class PeerMessageReceiverTest extends NodeTestWithCachedBitcoindPair {
         newMsgReceiver.state
           .isInstanceOf[PeerMessageReceiverState.InitializedDisconnect])
       assert(!newMsgReceiver.isDisconnected)
+
+      val disconnectRecv = newMsgReceiver.disconnect()
+
+      assert(
+        disconnectRecv.state
+          .isInstanceOf[PeerMessageReceiverState.InitializedDisconnectDone])
+      assert(disconnectRecv.isDisconnected)
+      assert(disconnectRecv.state.clientDisconnectP.isCompleted)
   }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverTest.scala
@@ -1,0 +1,121 @@
+package org.bitcoins.node.networking.peer
+
+import akka.actor.ActorRef
+import org.bitcoins.core.config.RegTest
+import org.bitcoins.core.number.Int32
+import org.bitcoins.core.p2p.{InetAddress, VerAckMessage, VersionMessage}
+import org.bitcoins.node.constant.NodeConstants
+import org.bitcoins.node.models.Peer
+import org.bitcoins.node.networking.P2PClient
+import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.node.NodeTestWithCachedBitcoindPair
+import org.bitcoins.testkit.node.fixture.NeutrinoNodeConnectedWithBitcoinds
+import org.bitcoins.testkit.util.TorUtil
+import org.scalatest.{FutureOutcome, Outcome}
+
+import java.net.InetSocketAddress
+import scala.concurrent.{Future, Promise}
+
+class PeerMessageReceiverTest extends NodeTestWithCachedBitcoindPair {
+
+  /** Wallet config with data directory set to user temp directory */
+  override protected def getFreshConfig: BitcoinSAppConfig =
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+
+  override type FixtureParam = NeutrinoNodeConnectedWithBitcoinds
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val torClientF = if (TorUtil.torEnabled) torF else Future.unit
+
+    val outcomeF: Future[Outcome] = for {
+      _ <- torClientF
+      bitcoinds <- clientsF
+      outcome = withNeutrinoNodeConnectedToBitcoinds(test, bitcoinds.toVector)(
+        system,
+        getFreshConfig)
+      f <- outcome.toFuture
+    } yield f
+    new FutureOutcome(outcomeF)
+  }
+
+  behavior of "PeerMessageReceiverTest"
+
+  it must "change a peer message receiver to be disconnected" in {
+    nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
+      val node = nodeConnectedWithBitcoind.node
+      val socket = InetSocketAddress.createUnresolved("google.com", 12345)
+      val client = P2PClient(ActorRef.noSender, Peer(socket, None, None))
+      val clientP = Promise[P2PClient]()
+      clientP.success(client)
+
+      val versionMsgP = Promise[VersionMessage]()
+      val localhost = java.net.InetAddress.getLocalHost
+      val versionMsg = VersionMessage(RegTest,
+                                      NodeConstants.userAgent,
+                                      Int32.one,
+                                      InetAddress(localhost.getAddress),
+                                      InetAddress(localhost.getAddress),
+                                      false)
+      versionMsgP.success(versionMsg)
+
+      val verackMsgP = Promise[VerAckMessage.type]()
+      verackMsgP.success(VerAckMessage)
+
+      val normal = PeerMessageReceiverState.Normal(clientConnectP = clientP,
+                                                   clientDisconnectP =
+                                                     Promise[Unit](),
+                                                   versionMsgP = versionMsgP,
+                                                   verackMsgP = verackMsgP)
+
+      val peerMsgReceiver =
+        PeerMessageReceiver(normal, node, node.peers.head)(system,
+                                                           node.nodeAppConfig)
+
+      val newMsgReceiver = peerMsgReceiver.disconnect()
+
+      assert(
+        newMsgReceiver.state
+          .isInstanceOf[PeerMessageReceiverState.Disconnected])
+      assert(newMsgReceiver.isDisconnected)
+  }
+
+  it must "change a peer message receiver to be initializing disconnect" in {
+    nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
+      val node = nodeConnectedWithBitcoind.node
+      val socket = InetSocketAddress.createUnresolved("google.com", 12345)
+      val client = P2PClient(ActorRef.noSender, Peer(socket, None, None))
+      val clientP = Promise[P2PClient]()
+      clientP.success(client)
+
+      val versionMsgP = Promise[VersionMessage]()
+      val localhost = java.net.InetAddress.getLocalHost
+      val versionMsg = VersionMessage(RegTest,
+                                      NodeConstants.userAgent,
+                                      Int32.one,
+                                      InetAddress(localhost.getAddress),
+                                      InetAddress(localhost.getAddress),
+                                      false)
+      versionMsgP.success(versionMsg)
+
+      val verackMsgP = Promise[VerAckMessage.type]()
+      verackMsgP.success(VerAckMessage)
+
+      val normal = PeerMessageReceiverState.Normal(clientConnectP = clientP,
+                                                   clientDisconnectP =
+                                                     Promise[Unit](),
+                                                   versionMsgP = versionMsgP,
+                                                   verackMsgP = verackMsgP)
+
+      val peerMsgReceiver =
+        PeerMessageReceiver(normal, node, node.peers.head)(system,
+                                                           node.nodeAppConfig)
+
+      val newMsgReceiver = peerMsgReceiver.initializeDisconnect()
+
+      assert(
+        newMsgReceiver.state
+          .isInstanceOf[PeerMessageReceiverState.InitializedDisconnect])
+      assert(!newMsgReceiver.isDisconnected)
+  }
+}

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -70,8 +70,6 @@ case class P2PClientActor(
     extends Actor
     with P2PLogger {
 
-  private case object ReconnectCommand extends NodeCommand
-
   private var currentPeerMsgHandlerRecv = initPeerMsgHandlerReceiver
 
   private var reconnectHandlerOpt: Option[() => Future[Unit]] = None
@@ -112,10 +110,8 @@ case class P2PClientActor(
           handleEvent(message, peerConnection, unalignedBytes)
         context.become(awaitNetworkRequest(peerConnection, newUnalignedBytes))
       case P2PClient.CloseCommand =>
-        logger.info(s"disconnecting from peer $peer")
-        currentPeerMsgHandlerRecv =
-          currentPeerMsgHandlerRecv.initializeDisconnect()
-        peerConnection ! Tcp.Close
+        handleNodeCommand(cmd = P2PClient.CloseCommand,
+                          peerConnectionOpt = Some(peerConnection))
       case metaMsg: P2PClient.MetaMsg =>
         sender() ! handleMetaMsg(metaMsg)
       case Terminated(actor) if actor == peerConnection =>
@@ -123,17 +119,21 @@ case class P2PClientActor(
     }
 
   override def receive: Receive = LoggingReceive {
-    case P2PClient.ConnectCommand =>
-      connect()
+    case cmd: NodeCommand =>
+      handleNodeCommand(cmd = cmd, peerConnectionOpt = None)
     case metaMsg: P2PClient.MetaMsg =>
       sender() ! handleMetaMsgDisconnected(metaMsg)
   }
 
   def reconnecting: Receive = LoggingReceive {
-    case ReconnectCommand =>
+    case P2PClient.ReconnectCommand =>
       logger.info(s"reconnecting to ${peer.socket}")
       reconnectHandlerOpt = Some(onReconnect)
       connect()
+    case P2PClient.CloseCommand =>
+      handleNodeCommand(P2PClient.CloseCommand, None)
+    case P2PClient.ConnectCommand =>
+      handleNodeCommand(P2PClient.ConnectCommand, None)
     case metaMsg: P2PClient.MetaMsg =>
       sender() ! handleMetaMsgDisconnected(metaMsg)
   }
@@ -246,7 +246,8 @@ case class P2PClientActor(
           reconnectionTry = reconnectionTry + 1
 
           import context.dispatcher
-          context.system.scheduler.scheduleOnce(delay)(self ! ReconnectCommand)
+          context.system.scheduler.scheduleOnce(delay)(
+            self ! P2PClient.ReconnectCommand)
 
           context.become(reconnecting)
         }
@@ -383,6 +384,32 @@ case class P2PClientActor(
     peerConnection ! Tcp.ResumeReading
   }
 
+  /** Handles the commands that can be sent to our node
+    * @param cmd the command to execute
+    * @param peerConnectionOpt the connection to a peer, if it exists
+    */
+  private def handleNodeCommand(
+      cmd: NodeCommand,
+      peerConnectionOpt: Option[ActorRef]): Unit = {
+    cmd match {
+      case P2PClient.ConnectCommand =>
+        connect()
+      case P2PClient.ReconnectCommand =>
+        reconnect()
+      case P2PClient.CloseCommand =>
+        peerConnectionOpt match {
+          case Some(peerConnection) =>
+            logger.info(s"Disconnecting from peer $peer")
+            currentPeerMsgHandlerRecv =
+              currentPeerMsgHandlerRecv.initializeDisconnect()
+            peerConnection ! Tcp.Close
+          case None =>
+            logger.warn(
+              s"Attempting to disconnect peer that was not connected!")
+        }
+    }
+  }
+
 }
 
 case class P2PClient(actor: ActorRef, peer: Peer) extends P2PLogger {
@@ -424,6 +451,7 @@ object P2PClient extends P2PLogger {
 
   sealed trait NodeCommand
   case object ConnectCommand extends NodeCommand
+  case object ReconnectCommand extends NodeCommand
   case object CloseCommand extends NodeCommand
 
   /** A message hierarchy that canbe sent to [[P2PClientActor P2P Client Actor]]

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -288,7 +288,7 @@ case class P2PClientActor(
       case closeCmd @ (Tcp.ConfirmedClosed | Tcp.Closed | Tcp.Aborted |
           Tcp.PeerClosed | Tcp.ErrorClosed(_)) =>
         logger.info(s"We've been disconnected by $peer command=${closeCmd}")
-        currentPeerMsgHandlerRecv.disconnect()
+        currentPeerMsgHandlerRecv = currentPeerMsgHandlerRecv.disconnect()
         unalignedBytes
 
       case Tcp.Received(byteString: ByteString) =>

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -38,7 +38,7 @@ class PeerMessageReceiver(
 
     state match {
       case bad @ (_: Initializing | _: Normal | _: InitializedDisconnect |
-          _: Disconnected) =>
+          _: InitializedDisconnectDone | _: Disconnected) =>
         throw new RuntimeException(s"Cannot call connect when in state=${bad}")
       case Preconnection =>
         logger.info(s"Connection established with peer=${peer}")
@@ -61,7 +61,8 @@ class PeerMessageReceiver(
     */
   private[networking] def initializeDisconnect(): PeerMessageReceiver = {
     state match {
-      case bad @ (_: Disconnected | Preconnection) =>
+      case bad @ (_: Disconnected | _: InitializedDisconnectDone |
+          Preconnection) =>
         throw new RuntimeException(
           s"Cannot initialize disconnect from peer=$peer when in state=$bad")
       case _: InitializedDisconnect =>
@@ -80,10 +81,20 @@ class PeerMessageReceiver(
   protected[networking] def disconnect(): PeerMessageReceiver = {
     logger.trace(s"Disconnecting with internalstate=${state}")
     state match {
-      case bad @ (_: Disconnected | Preconnection) =>
+      case bad @ (_: Disconnected | Preconnection |
+          _: InitializedDisconnectDone) =>
         throw new RuntimeException(
           s"Cannot disconnect from peer=${peer} when in state=${bad}")
-      case good @ (_: Initializing | _: Normal | _: InitializedDisconnect) =>
+      case good: InitializedDisconnect =>
+        val newState = InitializedDisconnectDone(
+          clientConnectP = good.clientConnectP,
+          clientDisconnectP = good.clientDisconnectP.success(()),
+          versionMsgP = good.versionMsgP,
+          verackMsgP = good.verackMsgP)
+        val newNode =
+          node.updateDataMessageHandler(node.getDataMessageHandler.reset)
+        new PeerMessageReceiver(newNode, newState, peer)
+      case good @ (_: Initializing | _: Normal) =>
         logger.debug(s"Disconnected bitcoin peer=${peer}")
         val newState = Disconnected(
           clientConnectP = good.clientConnectP,
@@ -164,7 +175,7 @@ class PeerMessageReceiver(
 
         state match {
           case bad @ (_: Disconnected | _: Normal | Preconnection |
-              _: InitializedDisconnect) =>
+              _: InitializedDisconnect | _: InitializedDisconnectDone) =>
             Future.failed(
               new RuntimeException(
                 s"Cannot handle version message while in state=${bad}"))
@@ -183,7 +194,7 @@ class PeerMessageReceiver(
       case VerAckMessage =>
         state match {
           case bad @ (_: Disconnected | _: InitializedDisconnect | _: Normal |
-              Preconnection) =>
+              _: InitializedDisconnectDone | Preconnection) =>
             Future.failed(
               new RuntimeException(
                 s"Cannot handle version message while in state=${bad}"))

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -60,7 +60,7 @@
     <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="DEBUG"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
 
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -60,7 +60,7 @@
     <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="DEBUG"/>
 
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->


### PR DESCRIPTION
Fix missing update to `currentPeerMsgHandlerRecv` when we are disconnecting the node.