### PR TITLE
LndRpcClient: Fix listUnspent only showing unconfirmed utxos

### DIFF
--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -199,10 +199,15 @@ class LndRpcClient(val instance: LndInstance, binaryOpt: Option[File] = None)(
   }
 
   def listUnspent: Future[Vector[UTXOResult]] = {
+    val request = ListUnspentRequest(0, Int.MaxValue)
+    listUnspent(request)
+  }
+
+  def listUnspent(request: ListUnspentRequest): Future[Vector[UTXOResult]] = {
     logger.trace("lnd calling listunspent")
 
     lnd
-      .listUnspent(ListUnspentRequest())
+      .listUnspent(request)
       .map(_.utxos.toVector.map { utxo =>
         val outPointOpt = utxo.outpoint.map { out =>
           val txId = DoubleSha256DigestBE(out.txidStr)


### PR DESCRIPTION
`listUnspent` would only return unconfirmed utxos because the gprc generated default of `ListUnspentRequest` for `minConfs` and `maxConfs` were both `0`.