### PR TITLE
Try to fix race condition when shutting down bitcoind connection pool

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/BitcoindInstanceTest.scala
@@ -191,6 +191,7 @@ class BitcoindInstanceTest extends BitcoindRpcTest {
         proxyParams = None
       )
       remoteClient = BitcoindRpcClient.withActorSystem(remoteInstance)
+      _ <- remoteClient.start()
       _ <- remoteClient.isStartedF.map {
         case false =>
           client.stop()

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -282,7 +282,11 @@ trait Client
         // if the cookie file doesn't exist we're not started
         Future.successful(false)
       case (CookieBased(_, _) | PasswordBased(_, _)) =>
-        tryPing()
+        if (isStartedFlag.get) {
+          tryPing()
+        } else {
+          Future.successful(false)
+        }
     }
   }
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -282,11 +282,21 @@ trait Client
         // if the cookie file doesn't exist we're not started
         Future.successful(false)
       case (CookieBased(_, _) | PasswordBased(_, _)) =>
-        if (isStartedFlag.get) {
-          tryPing()
-        } else {
-          Future.successful(false)
+        instance match {
+          case _: BitcoindInstanceRemote =>
+            //we cannot check locally if it has been started
+            //so best we can do is try to ping
+            tryPing()
+          case _: BitcoindInstanceLocal =>
+            //check if the binary has been started
+            //and then tryPing() if it has
+            if (isStartedFlag.get) {
+              tryPing()
+            } else {
+              Future.successful(false)
+            }
         }
+
     }
   }
 


### PR DESCRIPTION
It seems this exception is occuring again on CI. We originally filed an issue for this in #531

https://github.com/bitcoin-s/bitcoin-s/pull/3664/checks?check_run_id=3601062088#step:5:559

What I believe to be the problem is a race condition when shutting down bitcoind in unit tests. To determine if bitcoind is shutdown, we send a ping against the bitcoind server and see if we get a response. 

This seems to have got re-introduced in #3600 some how. 

Now we use the flag `isStartedFlag` to determine if we should even attempt to send a ping to bitcoind.\

I haven't been able to reliably reproduce this, but the maintainer of akka http seems to indicate that this only happens when there is a race condition between a request being sent and the server being shutdown 

https://github.com/akka/akka-http/issues/3481