### PR TITLE
Change userId to work with umbrel

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -183,6 +183,8 @@ object CommonSettings {
       //the default provided by sbt native packager
       //which is 'demiourgos728'
       Docker / daemonUser := "bitcoin-s",
+      //needed for umbrel to run
+      Docker / daemonUserUid := Some("1000"),
       Docker / packageName := packageName.value,
       Docker / version := version.value,
       dockerUpdateLatest := isSnapshot.value


### PR DESCRIPTION
fixes #3666 

I'm still testing this locally, but wanted to get the CI runners started on this.

Apparently umbrel requires that all images run on the platform run under the same user. This user is `1000`. We need to run our docker image under this userid.