### PR TITLE
Fix approximateUtxoSize calculation for p2wpkh

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelector.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelector.scala
@@ -104,7 +104,7 @@ object CoinSelector extends CoinSelector {
       case None =>
         utxo.scriptWitnessOpt match {
           case Some(script) => script.bytes.length
-          case None         => 25 // PUBKEYHASH
+          case None         => 107 // PUBKEYHASH
         }
     }
 


### PR DESCRIPTION
In the comment for this fuction it says it was cribbed from https://github.com/bitcoinjs/coinselect/blob/master/utils.js

looks like `TX_OUTPUT_PUBKEYHASH` was copied instead of `TX_INPUT_PUBKEYHASH`