### PR TITLE
Implement ability to provide external entropy to bitcoin-s

### DIFF
--- a/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.12.14 downloadBitcoind coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test dlcWalletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test oracleExplorerClient/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls
+        run: sbt ++2.12.14 downloadBitcoind keyManagerTest/test feeProviderTest/test walletTest/test dlcWalletTest/test dlcOracleTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test oracleExplorerClient/test

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
@@ -2,6 +2,7 @@ package org.bitcoins.oracle.server
 
 import akka.actor.ActorSystem
 import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
+import org.bitcoins.dlc.oracle.DLCOracle
 import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
 import org.bitcoins.server.routes.{BitcoinSServerRunner, Server}
 import org.bitcoins.server.util.BitcoinSAppScalaDaemon
@@ -22,8 +23,7 @@ class OracleServerMain(override val serverArgParser: ServerArgParser)(implicit
 
     for {
       _ <- conf.start()
-      oracle <- conf.initialize()
-
+      oracle = new DLCOracle()
       routes = Seq(OracleRoutes(oracle))
       server = serverArgParser.rpcPortOpt match {
         case Some(rpcport) =>

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -117,13 +117,11 @@ object BitcoindRpcBackendUtil extends Logging {
     val walletCallbackP = Promise[Wallet]()
 
     val pairedWallet = Wallet(
-      keyManager = wallet.keyManager,
       nodeApi =
         BitcoindRpcBackendUtil.getNodeApiWalletCallback(bitcoind,
                                                         walletCallbackP.future),
       chainQueryApi = bitcoind,
-      feeRateApi = wallet.feeRateApi,
-      creationTime = wallet.keyManager.creationTime
+      feeRateApi = wallet.feeRateApi
     )(wallet.walletConfig, wallet.ec)
 
     walletCallbackP.success(pairedWallet)
@@ -178,13 +176,11 @@ object BitcoindRpcBackendUtil extends Logging {
     val walletCallbackP = Promise[Wallet]()
 
     val pairedWallet = DLCWallet(
-      keyManager = wallet.keyManager,
       nodeApi =
         BitcoindRpcBackendUtil.getNodeApiWalletCallback(bitcoind,
                                                         walletCallbackP.future),
       chainQueryApi = bitcoind,
-      feeRateApi = wallet.feeRateApi,
-      creationTime = wallet.keyManager.creationTime
+      feeRateApi = wallet.feeRateApi
     )(wallet.walletConfig, wallet.dlcConfig, wallet.ec)
 
     walletCallbackP.success(pairedWallet)

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/CryptoUtilTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/CryptoUtilTest.scala
@@ -220,4 +220,22 @@ class CryptoUtilTest extends BitcoinSCryptoTest {
       })
     }
   }
+
+  it must "do basic sanity checks on entropy" in {
+    assert(!CryptoUtil.checkEntropy(BitVector.empty))
+    val sameBytes1 = ByteVector.fill(32)(0x0)
+    val sameBytes2 = ByteVector.fill(32)(0xff)
+    assert(!CryptoUtil.checkEntropy(sameBytes1.toBitVector))
+    assert(!CryptoUtil.checkEntropy(sameBytes2.toBitVector))
+
+    //to short of entropy
+    val toShort = ByteVector.fromValidHex("0123456789abcdef")
+    assert(!CryptoUtil.checkEntropy(toShort.toBitVector))
+  }
+
+  it must "always pass our basic sanity tests for entropy with our real PRNG" in {
+    forAll(Gen.const(CryptoUtil.randomBytes(32))) { bytes =>
+      assert(CryptoUtil.checkEntropy(bytes))
+    }
+  }
 }

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
@@ -396,4 +396,25 @@ trait CryptoRuntime {
       derivedKeyLength: Int): ByteVector
 
   def randomBytes(n: Int): ByteVector
+
+  /** Implements basic sanity tests for checking entropy like
+    * making sure it isn't all the same bytes,
+    * it isn't all 0x00...00
+    * or it isn't all 0xffff...fff
+    */
+  def checkEntropy(bitVector: BitVector): Boolean = {
+    val byteArr = bitVector.toByteArray
+    if (bitVector.length < 128) {
+      //not enough entropy
+      false
+    } else if (byteArr.toSet.size == 1) {
+      //means all byte were the same
+      //we need more diversity with entropy
+      false
+    } else {
+      true
+    }
+  }
+
+  def checkEntropy(bytes: ByteVector): Boolean = checkEntropy(bytes.toBitVector)
 }

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -109,7 +109,8 @@ class DLCOracleTest extends DLCOracleFixture {
         Vector(ConfigFactory.parseString("bitcoin-s.network = mainnet"),
                ConfigFactory.parseString("bitcoin-s.oracle.db.name = oracle1")))
 
-      newConf.initialize().flatMap { oracleB =>
+      newConf.start().flatMap { _ =>
+        val oracleB = new DLCOracle()(newConf)
         assert(oracleA.publicKey == oracleB.publicKey)
 
         val eventName = "test"

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.api.dlcoracle._
 import org.bitcoins.core.api.dlcoracle.db._
 import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto.ExtKeyVersion.SegWitMainNetPriv
-import org.bitcoins.core.crypto.{ExtPrivateKeyHardened, MnemonicCode}
+import org.bitcoins.core.crypto.ExtPrivateKeyHardened
 import org.bitcoins.core.hd._
 import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.Bech32Address
@@ -19,7 +19,7 @@ import org.bitcoins.crypto._
 import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
 import org.bitcoins.dlc.oracle.storage._
 import org.bitcoins.dlc.oracle.util.EventDbUtil
-import org.bitcoins.keymanager.{DecryptedMnemonic, WalletStorage}
+import org.bitcoins.keymanager.WalletStorage
 import scodec.bits.ByteVector
 
 import java.nio.file.Path
@@ -435,20 +435,6 @@ object DLCOracle {
 
   // 585 is a random one I picked, unclaimed in https://github.com/satoshilabs/slips/blob/master/slip-0044.md
   val R_VALUE_PURPOSE = 585
-
-  def apply(mnemonicCode: MnemonicCode)(implicit
-      conf: DLCOracleAppConfig): DLCOracle = {
-    val decryptedMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now)
-    val toWrite = conf.aesPasswordOpt match {
-      case Some(password) => decryptedMnemonic.encrypt(password)
-      case None           => decryptedMnemonic
-    }
-    if (!conf.seedExists()) {
-      WalletStorage.writeSeedToDisk(conf.kmConf.seedPath, toWrite)
-    }
-
-    new DLCOracle()
-  }
 
   /** Gets the DLC oracle from the given datadir */
   def fromDatadir(path: Path, configs: Vector[Config])(implicit

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -29,12 +29,10 @@ import org.bitcoins.crypto._
 import org.bitcoins.dlc.wallet.internal._
 import org.bitcoins.dlc.wallet.models._
 import org.bitcoins.dlc.wallet.util.DLCStatusBuilder
-import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 import scodec.bits.ByteVector
 
-import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 
 /** A [[Wallet]] with full DLC Functionality */
@@ -1504,11 +1502,9 @@ abstract class DLCWallet
 object DLCWallet extends WalletLogger {
 
   private case class DLCWalletImpl(
-      keyManager: BIP39KeyManager,
       nodeApi: NodeApi,
       chainQueryApi: ChainQueryApi,
-      feeRateApi: FeeRateApi,
-      override val creationTime: Instant
+      feeRateApi: FeeRateApi
   )(implicit
       val walletConfig: WalletAppConfig,
       val dlcConfig: DLCAppConfig,
@@ -1516,14 +1512,12 @@ object DLCWallet extends WalletLogger {
   ) extends DLCWallet
 
   def apply(
-      keyManager: BIP39KeyManager,
       nodeApi: NodeApi,
       chainQueryApi: ChainQueryApi,
-      feeRateApi: FeeRateApi,
-      creationTime: Instant)(implicit
+      feeRateApi: FeeRateApi)(implicit
       config: WalletAppConfig,
       dlcConfig: DLCAppConfig,
       ec: ExecutionContext): DLCWallet = {
-    DLCWalletImpl(keyManager, nodeApi, chainQueryApi, feeRateApi, creationTime)
+    DLCWalletImpl(nodeApi, chainQueryApi, feeRateApi)
   }
 }

--- a/docs/chain/chain-query-api.md
+++ b/docs/chain/chain-query-api.md
@@ -14,7 +14,6 @@ import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.fee._
 import org.bitcoins.feeprovider._
-import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.node._
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.rpc.config._
@@ -22,8 +21,6 @@ import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.wallet.Wallet
 import org.bitcoins.wallet.config.WalletAppConfig
-
-import java.time.Instant
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
 ```
@@ -80,17 +77,6 @@ implicit val walletConf: WalletAppConfig =
 val instance = BitcoindInstanceLocal.fromConfigFile(BitcoindConfig.DEFAULT_CONF_FILE)
 val bitcoind = BitcoindV19RpcClient(instance)
 val nodeApi = BitcoinSWalletTest.MockNodeApi
-
-// Create our key manager
-val keyManagerE = BIP39KeyManager.initialize(aesPasswordOpt = Some(AesPassword.fromString("password")),
-                                               kmParams = walletConf.kmParams,
-                                               bip39PasswordOpt = None)
-
-val keyManager = keyManagerE match {
-    case Right(keyManager) => keyManager
-    case Left(err) =>
-      throw new RuntimeException(s"Cannot initialize key manager err=$err")
-  }
 
 // This function can be used to create a callback for when our chain api receives a transaction, block, or
 // a block filter, the returned NodeCallbacks will contain the necessary items to initialize the callbacks
@@ -198,7 +184,7 @@ val chainApi = new ChainQueryApi {
 
 // Finally, we can initialize our wallet with our own node api
 val wallet =
-    Wallet(keyManager = keyManager, nodeApi = nodeApi, chainQueryApi = chainApi, feeRateApi = ConstantFeeRateProvider(SatoshisPerVirtualByte.one), creationTime = Instant.now)
+    Wallet(nodeApi = nodeApi, chainQueryApi = chainApi, feeRateApi = ConstantFeeRateProvider(SatoshisPerVirtualByte.one))
 
 // Then to trigger one of the events we can run
 wallet.chainQueryApi.getFiltersBetweenHeights(100, 150)

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -265,6 +265,11 @@ bitcoin-s {
 
         # Password that your seed is encrypted with
         aesPassword = changeMe
+        
+        # At least 16 bytes of entropy encoded in hex
+        # This will be used as the seed for any
+        # project that is dependent on the keymanager
+        entropy = ""
     }
 
     # Bitcoin-S provides manny different fee providers

--- a/docs/node/node-api.md
+++ b/docs/node/node-api.md
@@ -11,7 +11,6 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.fee._
 import org.bitcoins.core.util._
 import org.bitcoins.feeprovider._
-import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.node._
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.rpc.config._
@@ -20,7 +19,6 @@ import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.wallet.Wallet
 import org.bitcoins.wallet.config.WalletAppConfig
 
-import java.time.Instant
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
 ```
@@ -60,17 +58,6 @@ val bitcoind = BitcoindV19RpcClient(instance)
 val chainApi = BitcoinSWalletTest.MockChainQueryApi
 val aesPasswordOpt = Some(AesPassword.fromString("password"))
 
-// Create our key manager
-val keyManagerE = BIP39KeyManager.initialize(aesPasswordOpt = aesPasswordOpt,
-                                               kmParams = walletConf.kmParams,
-                                               bip39PasswordOpt = None)
-
-val keyManager = keyManagerE match {
-    case Right(keyManager) => keyManager
-    case Left(err) =>
-      throw new RuntimeException(s"Cannot initialize key manager err=$err")
-  }
-
 // This function can be used to create a callback for when our node api calls downloadBlocks,
 // more specifically it will call the function every time we receive a block, the returned
 // NodeCallbacks will contain the necessary items to initialize the callbacks
@@ -105,7 +92,7 @@ val exampleCallback = createCallback(exampleProcessBlock)
 
 // Finally, we can initialize our wallet with our own node api
 val wallet =
-    Wallet(keyManager = keyManager, nodeApi = nodeApi, chainQueryApi = chainApi, feeRateApi = ConstantFeeRateProvider(SatoshisPerVirtualByte.one), creationTime = Instant.now)
+    Wallet(nodeApi = nodeApi, chainQueryApi = chainApi, feeRateApi = ConstantFeeRateProvider(SatoshisPerVirtualByte.one))
 
 // Then to trigger the event we can run
 val exampleBlock = DoubleSha256Digest(

--- a/docs/wallet/wallet-callbacks.md
+++ b/docs/wallet/wallet-callbacks.md
@@ -27,13 +27,11 @@ import org.bitcoins.crypto._
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.fee._
 import org.bitcoins.feeprovider._
-import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.rpc.config.BitcoindInstanceLocal
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.wallet._
 import org.bitcoins.wallet.config.WalletAppConfig
-import java.time.Instant
 import scala.concurrent.{ExecutionContextExecutor, Future}
 ```
 
@@ -50,17 +48,6 @@ implicit val walletConf: WalletAppConfig =
 val bitcoind = BitcoindV19RpcClient(BitcoindInstanceLocal.fromConfFile())
 val aesPasswordOpt = Some(AesPassword.fromString("password"))
 
-// Create our key manager
-  val keyManagerE = BIP39KeyManager.initialize(aesPasswordOpt = aesPasswordOpt,
-                                               kmParams = walletConf.kmParams,
-                                               bip39PasswordOpt = None)
-
-val keyManager = keyManagerE match {
-    case Right(keyManager) => keyManager
-    case Left(err) =>
-      throw new RuntimeException(s"Cannot initialize key manager err=$err")
-  }
-
 // Here is a super simple example of a callback, this could be replaced with anything, from
 // relaying the transaction on the network, finding relevant wallet outputs, verifying the transaction,
 // or writing it to disk
@@ -73,11 +60,10 @@ val exampleCallbacks = WalletCallbacks(
 
 // Now we can create a wallet
 val wallet =
-    Wallet(keyManager = keyManager,
+    Wallet(
            nodeApi = bitcoind,
            chainQueryApi = bitcoind,
-           feeRateApi = ConstantFeeRateProvider(SatoshisPerVirtualByte.one),
-           creationTime = Instant.now)
+           feeRateApi = ConstantFeeRateProvider(SatoshisPerVirtualByte.one))
 
 // Finally, we can add the callbacks to our wallet config
 walletConf.addCallbacks(exampleCallbacks)

--- a/docs/wallet/wallet-sync.md
+++ b/docs/wallet/wallet-sync.md
@@ -115,12 +115,9 @@ val getBlockFunc = {hash: DoubleSha256DigestBE => bitcoind.getBlockRaw(hash) }
 //yay! We are now all setup. Using our 3 functions above and a wallet, we can now sync
 //a fresh wallet
 implicit val walletAppConfig = WalletAppConfig.fromDefaultDatadir()
-implicit val kmAppConfig = KeyManagerAppConfig.fromDefaultDatadir()
-val keyManager: BIP39KeyManager = {
-  BIP39KeyManager.fromParams(walletAppConfig.kmParams,None,None).right.get
-}
+
 val feeRateProvider: FeeRateApi = MempoolSpaceProvider.fromBlockTarget(6, proxyParams = None)
-val wallet = Wallet(keyManager, bitcoind, bitcoind, feeRateProvider, keyManager.creationTime)
+val wallet = Wallet(bitcoind, bitcoind, feeRateProvider)
 
 //yay! we have a synced wallet
 val syncedWalletF = WalletSync.syncFullBlocks(wallet,

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -143,23 +143,14 @@ val syncF: Future[ChainApi] = configF.flatMap { _ =>
     ChainSync.sync(chainHandler, getBlockHeaderFunc, getBestBlockHashFunc)
 }
 
-//initialize our key manager, where we store our keys
-val aesPasswordOpt = Some(AesPassword.fromString("password"))
-//you can add a password here if you want
-//val bip39PasswordOpt = Some("my-password-here")
-val bip39PasswordOpt = None
-val keyManager = BIP39KeyManager.initialize(aesPasswordOpt, walletConfig.kmParams, bip39PasswordOpt).getOrElse {
-  throw new RuntimeException(s"Failed to initalize key manager")
-}
-
 // once this future completes, we have a initialized
 // wallet
-val wallet = Wallet(keyManager, new NodeApi {
+val wallet = Wallet(new NodeApi {
     override def broadcastTransactions(txs: Vector[Transaction]): Future[Unit] = Future.successful(())
     override def downloadBlocks(blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = Future.successful(())
-  }, chainApi, ConstantFeeRateProvider(SatoshisPerVirtualByte.one), creationTime = Instant.now)
+  }, chainApi, ConstantFeeRateProvider(SatoshisPerVirtualByte.one))
 val walletF: Future[WalletApi] = configF.flatMap { _ =>
-  Wallet.initialize(wallet,bip39PasswordOpt)
+  Wallet.initialize(wallet, None)
 }
 
 // when this future completes, ww have sent a transaction

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
@@ -20,7 +20,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   override type FixtureParam = WalletAppConfig
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withWalletConfig(test)
+    withWalletConfigNotStarted(test)
 
   def getSeedPath(config: WalletAppConfig): Path = {
     config.kmConf.seedPath

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
@@ -143,6 +143,22 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
     }
   }
 
+  it must "initialize correctly with entropy set in the config file" in {
+    val tmpDir2 = BitcoinSTestAppConfig.tmpDir()
+    val tempFile = Files.createFile(tmpDir2.resolve("bitcoin-s.conf"))
+    val confStr = s"""
+                     | bitcoin-s {
+                     |   network = testnet3
+                     | }
+    """.stripMargin
+    val _ = Files.write(tempFile, confStr.getBytes())
+
+    val appConfig1 = KeyManagerAppConfig(directory = tmpDir2)
+    appConfig1
+      .start()
+      .map(_ => succeed)
+  }
+
   it must "fail to start the key manager when there isn't enough entropy" in {
     val tmpDir2 = BitcoinSTestAppConfig.tmpDir()
     val tempFile = Files.createFile(tmpDir2.resolve("bitcoin-s.conf"))
@@ -177,6 +193,24 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
 
     assertThrows[RuntimeException] {
       appConfig1.start()
+    }
+  }
+
+  it must "fail to get bip39KeyManager when we haven't called start" in {
+    val tmpDir2 = BitcoinSTestAppConfig.tmpDir()
+    val tempFile = Files.createFile(tmpDir2.resolve("bitcoin-s.conf"))
+    val confStr = s"""
+                     | bitcoin-s {
+                     |   network = testnet3
+                     |   keymanager.entropy=invalidhexcharactersfortestcase
+                     | }
+    """.stripMargin
+    val _ = Files.write(tempFile, confStr.getBytes())
+
+    val appConfig1 = KeyManagerAppConfig(directory = tmpDir2)
+
+    assertThrows[RuntimeException] {
+      appConfig1.toBip39KeyManager
     }
   }
 }

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
@@ -142,4 +142,41 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
       assert(xpub == appConfig1.toBip39KeyManager.getRootXPub)
     }
   }
+
+  it must "fail to start the key manager when there isn't enough entropy" in {
+    val tmpDir2 = BitcoinSTestAppConfig.tmpDir()
+    val tempFile = Files.createFile(tmpDir2.resolve("bitcoin-s.conf"))
+    val entropy = CryptoUtil.randomBytes(15)
+    val confStr = s"""
+                     | bitcoin-s {
+                     |   network = testnet3
+                     |   keymanager.entropy=${entropy.toHex}
+                     | }
+    """.stripMargin
+    val _ = Files.write(tempFile, confStr.getBytes())
+
+    val appConfig1 = KeyManagerAppConfig(directory = tmpDir2)
+
+    assertThrows[RuntimeException] {
+      appConfig1.start()
+    }
+  }
+
+  it must "fail to start the key manager when the entropy isn't hex chars" in {
+    val tmpDir2 = BitcoinSTestAppConfig.tmpDir()
+    val tempFile = Files.createFile(tmpDir2.resolve("bitcoin-s.conf"))
+    val confStr = s"""
+                     | bitcoin-s {
+                     |   network = testnet3
+                     |   keymanager.entropy=invalidhexcharactersfortestcase
+                     | }
+    """.stripMargin
+    val _ = Files.write(tempFile, confStr.getBytes())
+
+    val appConfig1 = KeyManagerAppConfig(directory = tmpDir2)
+
+    assertThrows[RuntimeException] {
+      appConfig1.start()
+    }
+  }
 }

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -98,7 +98,7 @@ object BIP39KeyManager
 
     val time = TimeUtil.now
 
-    val writtenToDiskE: Either[KeyManagerInitializeError, KeyManagerApi] =
+    val writtenToDiskE: Either[KeyManagerInitializeError, KeyManagerApi] = {
       if (Files.notExists(seedPath)) {
         logger.info(
           s"Seed path parent directory does not exist, creating ${seedPath.getParent}")
@@ -159,6 +159,7 @@ object BIP39KeyManager
                 JsonParsingError(err.toString)))
         }
       }
+    }
 
     //verify we can unlock it for a sanity check
     val unlocked = BIP39LockedKeyManager.unlock(passphraseOpt = aesPasswordOpt,

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
@@ -46,7 +46,16 @@ case class KeyManagerAppConfig(
     seedFolder.resolve(s"$prefix${WalletStorage.ENCRYPTED_SEED_FILE_NAME}")
   }
 
+  /** Entropy provided by the a user in their bitcoin-s.conf
+    * configuration file. This should be used to seed the keymanager
+    * rather than randomly generating entropy.
+    */
+  private lazy val externalEntropy: Option[String] = {
+    config.getStringOrNone("bitcoin-s.keymanager.entropy")
+  }
+
   override def start(): Future[Unit] = {
+    val _ = externalEntropy
     val oldDefaultFile =
       baseDatadir.resolve(WalletStorage.ENCRYPTED_SEED_FILE_NAME)
 

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
@@ -66,7 +66,8 @@ case class KeyManagerAppConfig(
     * rather than randomly generating entropy.
     */
   private lazy val externalEntropy: Option[String] = {
-    config.getStringOrNone("bitcoin-s.keymanager.entropy")
+    val opt = config.getStringOrNone("bitcoin-s.keymanager.entropy")
+    opt
   }
 
   private val kmParams: KeyManagerParams = {

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
@@ -114,7 +114,7 @@ sealed abstract class CryptoGenerators {
     * @see https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#From_mnemonic_to_seed
     */
   def bip39Password: Gen[String] = {
-    Gen.asciiStr
+    Gen.alphaNumStr
   }
 
   /** Generates a valid BIP39 seed from

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleFixture.scala
@@ -18,8 +18,9 @@ trait DLCOracleFixture extends BitcoinSFixture with EmbeddedPg {
         BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(pgUrl)
       val _ = conf.migrate()
 
-      val oracleF: Future[DLCOracle] = conf.initialize()
-      oracleF
+      val oracleConfF: Future[Unit] = conf.start()
+
+      oracleConfF.map(_ => new DLCOracle()(conf))
     }
 
     val destroy: DLCOracle => Future[Unit] = dlcOracle => {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -130,15 +130,18 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
   lazy val nestedVectors =
     vectors.filter(_.pathType == HDPurposes.NestedSegWit)
 
-  def configForPurpose(purpose: HDPurpose): Config = {
+  def configForPurposeAndSeed(purpose: HDPurpose): Config = {
     val purposeStr = purpose match {
       case HDPurposes.Legacy       => "legacy"
       case HDPurposes.SegWit       => "segwit"
       case HDPurposes.NestedSegWit => "nested-segwit"
       case other                   => fail(s"unexpected purpose: $other")
     }
+    val entropy = mnemonic.toEntropy.toHex
     val confStr = s"""bitcoin-s.wallet.defaultAccountType = $purposeStr
-                     |bitcoin-s.network = mainnet""".stripMargin
+                     |bitcoin-s.network = mainnet
+                     |bitcoin-s.keymanager.entropy=${entropy}
+                     |""".stripMargin
     ConfigFactory.parseString(confStr)
   }
 
@@ -219,7 +222,7 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
   }
 
   private def testAccountType(purpose: HDPurpose): Future[Assertion] = {
-    val confOverride = configForPurpose(purpose)
+    val confOverride = configForPurposeAndSeed(purpose)
     implicit val conf: WalletAppConfig =
       BitcoinSTestAppConfig.getSpvTestConfig(confOverride).walletConf
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -7,9 +7,7 @@ import org.bitcoins.core.hd.{AddressType, HDAccount, HDChainType}
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.core.wallet.keymanagement.KeyManagerUnlockError
-import org.bitcoins.core.wallet.keymanagement.KeyManagerUnlockError.MnemonicNotFound
-import org.bitcoins.crypto.{AesPassword, DoubleSha256DigestBE, ECPublicKey}
+import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPublicKey}
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkitcore.util.TransactionTestUtil._
 import org.scalatest.FutureOutcome
@@ -124,21 +122,6 @@ class WalletUnitTest extends BitcoinSWalletTest {
       _ <- testChain(hdAccount = account.hdAccount, External)
       res <- testChain(hdAccount = account.hdAccount, Change)
     } yield res
-  }
-
-  it should "fail to unlock the wallet with a bad aes password" in {
-    wallet: Wallet =>
-      val badPassphrase = Some(AesPassword.fromNonEmptyString("bad"))
-
-      val errorType = wallet.unlock(badPassphrase, None) match {
-        case Right(_)  => fail("Unlocked wallet with bad password!")
-        case Left(err) => err
-      }
-      errorType match {
-        case KeyManagerUnlockError.MnemonicNotFound          => fail(MnemonicNotFound)
-        case KeyManagerUnlockError.BadPassword               => succeed
-        case KeyManagerUnlockError.JsonParsingError(message) => fail(message)
-      }
   }
 
   it should "match block filters" in { wallet: Wallet =>

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -52,7 +52,7 @@ abstract class Wallet
     with WalletLogger {
 
   override def keyManager: BIP39KeyManager = {
-    walletConfig.kmConf.toBip39KeyManager(walletConfig.kmParams.purpose)
+    walletConfig.kmConf.toBip39KeyManager
   }
 
   implicit val ec: ExecutionContext


### PR DESCRIPTION
fixes #3670

Now you provide external entropy to bitcoin-s by using the configuration key `bitcoin-s.keymanager.entropy` in your `bitcoin-s.conf` file. 

Projects that are dependent on the keymanager -- such as the wallet and dlc oracle -- will now use this entropy.

As a by product of adding this feature, I consolidated a lot of key manager code. Previously we would pass around the keymanger as a parameter to wallet methods. This made little sense as we should be able to re-create the keymanager from `WalletAppConfig.kmConf`. 

This PR adds a new method [`KeyManagerAppConfig.toBip39KeyManager`](https://github.com/bitcoin-s/bitcoin-s/blob/3ec35d3cdd3f3c58b58057a1e64538f668d36f84/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala#L120) that allows anyone with a reference to `KeyManagerAppConfig` to get the bip39 key manager. 

Now if you have a reference to a `WalletAppConfig`, you can just do `walletConf.kmConf.toBip39KeyManager` if you need direct access to a key manager.
