### PR TITLE
Add sha256 announcement/event ids on oracleServer 'getevent' for use …

### DIFF
--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -173,7 +173,10 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
                   "announcementTLV" -> Str(event.announcementTLV.hex),
                   "attestations" -> attestationJson,
                   "outcomes" -> outcomesJson,
-                  "signedOutcome" -> signedOutcomeJs
+                  "signedOutcome" -> signedOutcomeJs,
+                  // TLV shas for UI to have ids
+                  "announcementTLVsha256" -> event.announcementTLV.sha256.hex,
+                  "eventDescriptorTLVsha256" -> event.eventDescriptorTLV.sha256.hex
                 )
                 Server.httpSuccess(json)
               case None =>


### PR DESCRIPTION
…in UI

This is required for https://github.com/bitcoin-s/bitcoin-s-ts/pull/10