### PR TITLE
Allow for enternal entropy to be passed into a docker container

### DIFF
--- a/app/oracle-server/src/universal/docker-application.conf
+++ b/app/oracle-server/src/universal/docker-application.conf
@@ -3,3 +3,5 @@ bitcoin-s.network = regtest
 # need to bind to all interfaces so we can
 # have host machine forward requests to the docker container
 bitcoin-s.oracle.rpcbind="0.0.0.0"
+
+bitcoin-s.keymanager.entropy=${?BITCOIN_S_KEYMANAGER_ENTROPY}

--- a/app/server/src/universal/docker-application.conf
+++ b/app/server/src/universal/docker-application.conf
@@ -2,3 +2,5 @@ bitcoin-s.network = mainnet
 # need to bind to all interfaces so we can
 # have host machine forward requests to the docker container
 bitcoin-s.server.rpcbind="0.0.0.0"
+
+bitcoin-s.keymanager.entropy=${?BITCOIN_S_KEYMANAGER_ENTROPY}


### PR DESCRIPTION
This PR introduces the environment variable `BITCOIN_S_KEYMANAGER_ENTROPY` in docker environments. If this environment variable is set, our docker configuration will read that value as the entropy to seed the key manager for the wallet and oracle projects.

This should allow for external entropy to be passed in from platforms like umbrel so a user can just back up the umbrel root entropy rather than having to backup umbrel AND bitcoin-s entropy.

You should be able to test this PR by building the `Dockerfile` with `oracleServer/docker:stage` and then going to build the docker file inside of `app/oracle-server/target/docker/stage` 

```
docker build -t bitcoinscala/bitcoin-s-oracle-server:latest .
```

after building the file, you can test it by running 

```
docker run --rm  -p 9998:9998 -e BITCOIN_S_KEYMANAGER_ENTROPY=7b936b0808ed2d7a21d7219397077ae0  bitcoinscala/bitcoin-s-oracle-server:latest
```

If things are working, you should see logs from the keymanager that indicate external entropy was used to seed the keymanager.

![Screenshot from 2021-09-20 13-15-48](https://user-images.githubusercontent.com/3514957/134053415-498539cf-6409-4136-a049-058b324bb4a3.png)


