### PR TITLE
Add 'getversion' endpoint to fetch the version from the backend

### DIFF
--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.dlc.oracle.DLCOracle
 import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
-import org.bitcoins.server.routes.{BitcoinSServerRunner, Server}
+import org.bitcoins.server.routes.{BitcoinSServerRunner, CommonRoutes, Server}
 import org.bitcoins.server.util.BitcoinSAppScalaDaemon
 
 import scala.concurrent.Future
@@ -21,10 +21,12 @@ class OracleServerMain(override val serverArgParser: ServerArgParser)(implicit
       case None          => conf.rpcBindOpt
     }
 
+    val commonRoutes = CommonRoutes()
+
     for {
       _ <- conf.start()
       oracle = new DLCOracle()
-      routes = Seq(OracleRoutes(oracle))
+      routes = Seq(OracleRoutes(oracle), commonRoutes)
       server = serverArgParser.rpcPortOpt match {
         case Some(rpcport) =>
           Server(conf = conf,

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/CommonRoutes.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/CommonRoutes.scala
@@ -1,0 +1,17 @@
+package org.bitcoins.server.routes
+
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.directives.RouteDirectives
+import org.bitcoins.core.util.EnvUtil
+
+case class CommonRoutes() extends ServerRoute {
+
+  override def handleCommand: PartialFunction[ServerCommand, Route] = {
+    case ServerCommand("getversion", _) =>
+      RouteDirectives.complete {
+        val vec = Vector(("version", ujson.Str(EnvUtil.getVersion)))
+        val obj = ujson.Obj.from(vec)
+        Server.httpSuccess(obj)
+      }
+  }
+}

--- a/app/server-test/src/test/scala/org/bitcoins/server/CommonRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CommonRoutesSpec.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.server
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.bitcoins.core.util.EnvUtil
 import org.bitcoins.server.routes.{CommonRoutes, ServerCommand}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.wordspec.AnyWordSpec
@@ -19,7 +20,7 @@ class CommonRoutesSpec
         commonRoutes.handleCommand(ServerCommand("getversion", ujson.Arr()))
       Get() ~> route ~> check {
         s"""
-           |{ "version" : "${getClass.getPackage.getImplementationVersion}" }
+           |{ "version" : "${EnvUtil.getVersion}" }
            |""".stripMargin
       }
     }

--- a/app/server-test/src/test/scala/org/bitcoins/server/CommonRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CommonRoutesSpec.scala
@@ -1,0 +1,27 @@
+package org.bitcoins.server
+
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.bitcoins.server.routes.{CommonRoutes, ServerCommand}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.wordspec.AnyWordSpec
+
+class CommonRoutesSpec
+    extends AnyWordSpec
+    with ScalatestRouteTest
+    with MockFactory {
+
+  val commonRoutes = CommonRoutes()
+
+  "CommonRoutes" should {
+    "getversion" in {
+
+      val route =
+        commonRoutes.handleCommand(ServerCommand("getversion", ujson.Arr()))
+      Get() ~> route ~> check {
+        s"""
+           |{ "version" : "${getClass.getPackage.getImplementationVersion}" }
+           |""".stripMargin
+      }
+    }
+  }
+}

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -38,7 +38,7 @@ import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto._
 import org.bitcoins.node.Node
-import org.bitcoins.server.routes.ServerCommand
+import org.bitcoins.server.routes.{CommonRoutes, ServerCommand}
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.wallet.DLCWalletUtil
 import org.bitcoins.wallet.MockWalletApi
@@ -80,6 +80,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
   val coreRoutes: CoreRoutes = CoreRoutes()
 
+  val commonRoutes: CommonRoutes = CommonRoutes()
   "The server" should {
 
     "combine PSBTs" in {

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -27,7 +27,7 @@ import org.bitcoins.node._
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
 import org.bitcoins.rpc.config.{BitcoindRpcAppConfig, ZmqConfig}
-import org.bitcoins.server.routes.{BitcoinSServerRunner, Server}
+import org.bitcoins.server.routes.{BitcoinSServerRunner, CommonRoutes, Server}
 import org.bitcoins.server.util.BitcoinSAppScalaDaemon
 import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.wallet.Wallet
@@ -338,9 +338,15 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val chainRoutes = ChainRoutes(chainApi, nodeConf.network)
     val coreRoutes = CoreRoutes()
     val dlcRoutes = DLCRoutes(dlcNode)
+    val commonRoutes = CommonRoutes()
 
     val handlers =
-      Seq(walletRoutes, nodeRoutes, chainRoutes, coreRoutes, dlcRoutes)
+      Seq(walletRoutes,
+          nodeRoutes,
+          chainRoutes,
+          coreRoutes,
+          dlcRoutes,
+          commonRoutes)
 
     val bindConfOpt = serverCmdLineArgs.rpcBindOpt match {
       case Some(rpcbind) => Some(rpcbind)

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -138,6 +138,9 @@ the `-p 9999:9999` port mapping on the docker container to adjust for this.
 
 ## Server Endpoints
 
+### Common 
+ - `getversion` - The version of our application you are using
+
 ### Blockchain
  - `getblockcount` - Get the current block height
  - `getfiltercount` - Get the number of filters


### PR DESCRIPTION
Adds a `getversion` endpoint that can be queried in Docker environments, this should allow us to show the backend commit too on https://github.com/bitcoin-s/bitcoin-s-ts/pull/19