### PR TITLE
Fix signet parsing of LnInvoices

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePartTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePartTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.protocol.ln
 
-import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
+import org.bitcoins.core.config._
 import org.bitcoins.core.protocol.ln.LnParams._
 import org.bitcoins.core.protocol.ln.currency.{LnCurrencyUnits, MilliBitcoins}
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
@@ -14,6 +14,7 @@ class LnHumanReadablePartTest extends BitcoinSUnitTest {
     LnHumanReadablePart(MainNet) must be(LnHumanReadablePart(LnBitcoinMainNet))
     LnHumanReadablePart(TestNet3) must be(LnHumanReadablePart(LnBitcoinTestNet))
     LnHumanReadablePart(RegTest) must be(LnHumanReadablePart(LnBitcoinRegTest))
+    LnHumanReadablePart(SigNet) must be(LnHumanReadablePart(LnBitcoinSigNet))
 
     LnHumanReadablePart(MainNet, mBtc) must be(
       LnHumanReadablePart(LnBitcoinMainNet, mBtcOpt))
@@ -21,16 +22,20 @@ class LnHumanReadablePartTest extends BitcoinSUnitTest {
       LnHumanReadablePart(LnBitcoinTestNet, mBtcOpt))
     LnHumanReadablePart(RegTest, mBtc) must be(
       LnHumanReadablePart(LnBitcoinRegTest, mBtcOpt))
+    LnHumanReadablePart(SigNet, mBtc) must be(
+      LnHumanReadablePart(LnBitcoinSigNet, mBtcOpt))
   }
 
   it must "correctly serialize the hrp to string" in {
     LnHumanReadablePart(LnBitcoinMainNet, mBtcOpt).toString must be("lnbc1m")
     LnHumanReadablePart(LnBitcoinTestNet, mBtcOpt).toString must be("lntb1m")
     LnHumanReadablePart(LnBitcoinRegTest, mBtcOpt).toString must be("lnbcrt1m")
+    LnHumanReadablePart(LnBitcoinSigNet, mBtcOpt).toString must be("lntbs1m")
 
     LnHumanReadablePart(LnBitcoinMainNet).toString must be("lnbc")
     LnHumanReadablePart(LnBitcoinTestNet).toString must be("lntb")
     LnHumanReadablePart(LnBitcoinRegTest).toString must be("lnbcrt")
+    LnHumanReadablePart(LnBitcoinSigNet).toString must be("lntbs")
   }
 
   it must "fail to create hrp from invalid amount" in {
@@ -52,6 +57,8 @@ class LnHumanReadablePartTest extends BitcoinSUnitTest {
       LnHumanReadablePart(LnBitcoinTestNet))
     LnHumanReadablePart.fromString("lnbcrt") must be(
       LnHumanReadablePart(LnBitcoinRegTest))
+    LnHumanReadablePart.fromString("lntbs") must be(
+      LnHumanReadablePart(LnBitcoinSigNet))
 
     LnHumanReadablePart.fromString("lnbc1m") must be(
       LnHumanReadablePart(LnBitcoinMainNet, mBtcOpt))
@@ -59,6 +66,8 @@ class LnHumanReadablePartTest extends BitcoinSUnitTest {
       LnHumanReadablePart(LnBitcoinTestNet, mBtcOpt))
     LnHumanReadablePart.fromString("lnbcrt1m") must be(
       LnHumanReadablePart(LnBitcoinRegTest, mBtcOpt))
+    LnHumanReadablePart.fromString("lntbs1m") must be(
+      LnHumanReadablePart(LnBitcoinSigNet, mBtcOpt))
   }
 
   it must "fail to deserialize hrp from invalid string" in {

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
@@ -553,4 +553,10 @@ class LnInvoiceUnitTest extends BitcoinSUnitTest {
       "039c14dd6dbea913d3fa21b8aaa328cbacb9d6f1f967c3ead9a895c857958ed38a"
     )
   }
+
+  it must "parse a signet invoice" in {
+    val str =
+      "lntbs1ps5um52pp562zjpdyec3hjga5sdeh90v09km7ugasretujf3wwj3ueutyujz3sdqqcqzpgxqyz5vqsp5an8lqngrz6w3vd449eqqtvwu2x4v9ltdf9r6hpwxf4x404fhv6zs9qyyssqfdmmsuldkyy7v29kwuuc9egwkthtf3aaf79p3w93ddffq65fs5zs6vys9et89u0yv5kearpnuyttsvufzjnsnup2ehp4nteelz39exqpgd78w8"
+    assert(LnInvoice.fromStringT(str).isSuccess)
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePart.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePart.scala
@@ -49,6 +49,11 @@ object LnHumanReadablePart extends StringFactory[LnHumanReadablePart] {
     override def network: LnParams = LnBitcoinTestNet
   }
 
+  case class lntbs(override val amount: Option[LnCurrencyUnit])
+      extends LnHumanReadablePart {
+    override def network: LnParams = LnBitcoinSigNet
+  }
+
   /** Prefix for genearting a LN invoice on the Bitcoin RegTest */
   case class lnbcrt(override val amount: Option[LnCurrencyUnit])
       extends LnHumanReadablePart {
@@ -97,6 +102,7 @@ object LnHumanReadablePart extends StringFactory[LnHumanReadablePart] {
       case LnParams.LnBitcoinMainNet => lnbc(amount)
       case LnParams.LnBitcoinTestNet => lntb(amount)
       case LnParams.LnBitcoinRegTest => lnbcrt(amount)
+      case LnParams.LnBitcoinSigNet  => lntbs(amount)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnParams.scala
@@ -41,6 +41,16 @@ object LnParams {
     override val invoicePrefix: String = "lntb"
   }
 
+  case object LnBitcoinSigNet extends LnParams {
+    override def network: SigNet.type = SigNet
+
+    override def lnRpcPort = 8080
+
+    override def lnPort = 9735
+
+    override val invoicePrefix: String = "lntbs"
+  }
+
   case object LnBitcoinRegTest extends LnParams {
     override def network: RegTest.type = RegTest
 
@@ -56,11 +66,14 @@ object LnParams {
       case MainNet  => LnBitcoinMainNet
       case TestNet3 => LnBitcoinTestNet
       case RegTest  => LnBitcoinRegTest
-      case SigNet   => LnBitcoinTestNet
+      case SigNet   => LnBitcoinSigNet
     }
 
-  private val allNetworks: Vector[LnParams] =
-    Vector(LnBitcoinMainNet, LnBitcoinTestNet, LnBitcoinRegTest)
+  val allNetworks: Vector[LnParams] =
+    Vector(LnBitcoinMainNet,
+           LnBitcoinTestNet,
+           LnBitcoinSigNet,
+           LnBitcoinRegTest)
 
   private val prefixes: Map[String, LnParams] = {
     val vec: Vector[(String, LnParams)] = {

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ChainParamsGenerator.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ChainParamsGenerator.scala
@@ -14,9 +14,7 @@ sealed abstract class ChainParamsGenerator {
     Gen.oneOf(MainNet, TestNet3, RegTest, SigNet)
 
   def lnNetworkParams: Gen[LnParams] = {
-    Gen.oneOf(LnParams.LnBitcoinMainNet,
-              LnParams.LnBitcoinTestNet,
-              LnParams.LnBitcoinRegTest)
+    Gen.oneOf(LnParams.allNetworks)
   }
 }
 


### PR DESCRIPTION
Looks like we just defaulted to it as a testnet invoice before