### PR TITLE
Make it so bitcoind backend exceptions don't get swallowed

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -5,6 +5,7 @@ import akka.actor.{ActorSystem, Cancellable}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import grizzled.slf4j.Logging
 import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.wallet.WalletApi
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.Transaction
@@ -259,7 +260,7 @@ object BitcoindRpcBackendUtil extends Logging {
     *                 as the wallet will need to process the new blocks
     */
   def startBitcoindBlockPolling(
-      wallet: Wallet,
+      wallet: WalletApi,
       bitcoind: BitcoindRpcClient,
       interval: FiniteDuration = 10.seconds)(implicit
       system: ActorSystem,


### PR DESCRIPTION
This was found when looking into #3695 . 

We have a problem when using bitcoind as a backend for our bitcoin-s wallet. The problem is we don't want to wait for the entire wallet to sync before we actually bind the http server to allow for incoming http requests. We do this by not mapping on the future returned from `BitcoindRpcBackendUtil.syncWalletToBitcoind()`. 

A by product of this though is that if an exception is thrown by `syncWalletToBitcoind()`, we completely ignore it.

This PR adds a callback to make sure we log the error if something is thrown by `syncWalletToBitcoind()`. 