### PR TITLE
Implement ability to get proper version of BitcoindRpcClient from BitcoindRpcAppConfig

### DIFF
--- a/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
+++ b/app/bundle/src/main/scala/org/bitcoins/bundle/gui/LandingPaneModel.scala
@@ -53,11 +53,15 @@ class LandingPaneModel(serverArgParser: ServerArgParser)(implicit
               Future.successful(ConfigFactory.empty())
             case BitcoindBackend =>
               if (!appConfig.torConf.enabled) {
-                tmpConf.bitcoindRpcConf.client.getBlockChainInfo.map { info =>
-                  val networkStr =
-                    DatadirUtil.networkStrToDirName(info.chain.name)
-                  ConfigFactory.parseString(s"bitcoin-s.network = $networkStr")
-                }
+                val bitcoindF = tmpConf.bitcoindRpcConf.clientF
+                bitcoindF
+                  .flatMap(_.getBlockChainInfo)
+                  .map { info =>
+                    val networkStr =
+                      DatadirUtil.networkStrToDirName(info.chain.name)
+                    ConfigFactory.parseString(
+                      s"bitcoin-s.network = $networkStr")
+                  }
               } else {
                 //we cannot connect to bitcoind and determine
                 //the network over tor since tor isn't started

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
@@ -24,13 +24,14 @@ class ScanBitcoind()(implicit
 
   override def start(): Future[Unit] = {
 
-    val bitcoind = rpcAppConfig.client
+    val bitcoindF = rpcAppConfig.clientF
 
     val startHeight = 675000
-    val endHeightF: Future[Int] = bitcoind.getBlockCount
+    val endHeightF: Future[Int] = bitcoindF.flatMap(_.getBlockCount)
 
     for {
       endHeight <- endHeightF
+      bitcoind <- bitcoindF
       _ <- countSegwitTxs(bitcoind, startHeight, endHeight)
     } yield {
       sys.exit(0)

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -184,10 +184,11 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
   }
 
   def startBitcoindBackend(): Future[Unit] = {
-    val bitcoind = bitcoindRpcConf.client
+    val bitcoindF = bitcoindRpcConf.clientF
 
     for {
       _ <- bitcoindRpcConf.start()
+      bitcoind <- bitcoindF
       _ = logger.info("Started bitcoind")
 
       bitcoindNetwork <- bitcoind.getBlockChainInfo.map(_.chain)

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -69,8 +69,8 @@ case class NodeAppConfig(
               BitcoindRpcAppConfig(directory, confs: _*)(system)
             bitcoindRpcAppConfig.binaryOpt match {
               case Some(_) =>
-                bitcoindRpcAppConfig.client
-                  .start()
+                bitcoindRpcAppConfig.clientF
+                  .flatMap(_.start())
                   .map(_ => ())
               case None =>
                 Future.unit


### PR DESCRIPTION
fixes #3695 

The bug was caused by [`BitcoindRpcAppConfig.client`](https://github.com/bitcoin-s/bitcoin-s/blob/d53f16447836183331a2b6e783c600ff19c58c08/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala#L158). Previously when we called this method, if the bitcoind instance was remote, we had no context on what version of bitcoind we were using. We would create a generic `BitcoindRpcClient` that supports rpc calls that have remained static across bitcoind versions `v16-v21`. 

In my case, I was attempting to use a `getFilter()` rpc command that was added in bitcoind `v19`. Although my underlying bitcoind node i was connected to was v21, the [`BitcoindRpcClient.getFilter()`](https://github.com/bitcoin-s/bitcoin-s/blob/d53f16447836183331a2b6e783c600ff19c58c08/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala#L213) method is unimplemented in `BitcoindRpcClient` which caused an exception to happen. 

Due to #3697 the exception didn't get propagated upward to make it apparent what was happening.