### PR TITLE
2021 09 29 delete announcement

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1900,6 +1900,10 @@ object ConsoleCli {
       case SignMessage(message) =>
         RequestParam("signmessage", Seq(up.writeJs(message)))
 
+      case DeleteAnnouncement(eventName) =>
+        RequestParam("deleteannouncement", Seq(up.writeJs(eventName)))
+      case DeleteAttestation(eventName) =>
+        RequestParam("deleteattestations", Seq(up.writeJs(eventName)))
       case BackupOracle(dest) =>
         RequestParam("backuporacle", Seq(up.writeJs(dest)))
 
@@ -2322,6 +2326,11 @@ object CliCommand {
   case class GetSignatures(eventName: String) extends OracleServerCliCommand
 
   case class SignMessage(message: String) extends OracleServerCliCommand
+
+  case class DeleteAnnouncement(eventName: String)
+      extends OracleServerCliCommand
+
+  case class DeleteAttestation(eventName: String) extends OracleServerCliCommand
 
   case class BackupOracle(destination: String) extends OracleServerCliCommand
 }

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1438,6 +1438,34 @@ object ConsoleCli {
                 case other => other
               }))
         ),
+      cmd("deleteannouncement")
+        .action((_, conf) => conf.copy(command = DeleteAnnouncement("")))
+        .text("Delete an announcement. WARNING: THIS CAN LEAD TO DLCs NOT SETTLING IF USERS HAVE BUILT DLCS OFF OF THIS ANNOUNCEMENT. USE WITH CARE.")
+        .children(
+          arg[String]("eventName")
+            .text("The event's name")
+            .required()
+            .action((eventName, conf) =>
+              conf.copy(command = conf.command match {
+                case delete: DeleteAnnouncement =>
+                  delete.copy(eventName = eventName)
+                case other => other
+              }))
+        ),
+      cmd("deleteattestation")
+        .action((_, conf) => conf.copy(command = DeleteAttestation("")))
+        .text("Delete an announcement. WARNING THIS CAN LEAD TO PRIVATE KEY LEAK IF YOU SIGN ANOTHER ATTESTATION AFTER DELETING A PREVIOUS ONE. USE WITH CARE.")
+        .children(
+          arg[String]("eventName")
+            .text("The event's name")
+            .required()
+            .action((eventName, conf) =>
+              conf.copy(command = conf.command match {
+                case delete: DeleteAttestation =>
+                  delete.copy(eventName = eventName)
+                case other => other
+              }))
+        ),
       cmd("getevent")
         .action((_, conf) => conf.copy(command = GetEvent("")))
         .text("Get an event's details")
@@ -1903,7 +1931,7 @@ object ConsoleCli {
       case DeleteAnnouncement(eventName) =>
         RequestParam("deleteannouncement", Seq(up.writeJs(eventName)))
       case DeleteAttestation(eventName) =>
-        RequestParam("deleteattestations", Seq(up.writeJs(eventName)))
+        RequestParam("deleteattestation", Seq(up.writeJs(eventName)))
       case BackupOracle(dest) =>
         RequestParam("backuporacle", Seq(up.writeJs(dest)))
 

--- a/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
+++ b/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
@@ -384,6 +384,23 @@ class OracleRoutesSpec
       }
     }
 
+    "delete attestations" in {
+      val eventName = "test"
+      (mockOracleApi
+        .deleteAttestations(_: String))
+        .expects(eventName)
+        .returning(Future.successful(dummyOracleEvent))
+
+      val cmd = ServerCommand("deleteattestations", Arr(Str(eventName)))
+      val route = oracleRoutes.handleCommand(cmd)
+
+      Post() ~> route ~> check {
+        assert(contentType == `application/json`)
+        assert(responseAs[
+          String] == s"""{"result":"${dummyOracleEvent.announcementTLV.hex}","error":null}""")
+      }
+    }
+
     "backup" in {
       val dest = FileSystems.getDefault.getPath("/tmp/location")
       (mockOracleApi

--- a/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
+++ b/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
@@ -384,6 +384,22 @@ class OracleRoutesSpec
       }
     }
 
+    "delete announcement" in {
+      val eventName = "test"
+      (mockOracleApi
+        .deleteAnnouncement(_: String))
+        .expects(eventName)
+        .returning(Future.successful(dummyOracleEvent.announcementTLV))
+
+      val cmd = ServerCommand("deleteannouncement", Arr(Str(eventName)))
+      val route = oracleRoutes.handleCommand(cmd)
+      Post() ~> route ~> check {
+        assert(contentType == `application/json`)
+        assert(responseAs[
+          String] == s"""{"result":"${dummyOracleEvent.announcementTLV.hex}","error":null}""")
+      }
+    }
+
     "delete attestations" in {
       val eventName = "test"
       (mockOracleApi

--- a/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
+++ b/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
@@ -403,11 +403,11 @@ class OracleRoutesSpec
     "delete attestations" in {
       val eventName = "test"
       (mockOracleApi
-        .deleteAttestations(_: String))
+        .deleteAttestation(_: String))
         .expects(eventName)
         .returning(Future.successful(dummyOracleEvent))
 
-      val cmd = ServerCommand("deleteattestations", Arr(Str(eventName)))
+      val cmd = ServerCommand("deleteattestation", Arr(Str(eventName)))
       val route = oracleRoutes.handleCommand(cmd)
 
       Post() ~> route ~> check {

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -301,14 +301,14 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
             }
           }
       }
-    case ServerCommand("deleteattestations", arr) =>
+    case ServerCommand("deleteattestation", arr) =>
       DeleteAttestation.fromJsArry(arr) match {
         case Failure(err) =>
           reject(ValidationRejection("failure", Some(err)))
         case Success(deleteAttestation) =>
           complete {
             val deletedF =
-              oracle.deleteAttestations(deleteAttestation.eventName)
+              oracle.deleteAttestation(deleteAttestation.eventName)
             deletedF.map { d =>
               Server.httpSuccess(d.announcementTLV.hex)
             }

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -287,7 +287,19 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
             Server.httpSuccess(ujson.Null)
           }
       }
-
+    case ServerCommand("deleteattestations", arr) =>
+      DeleteAttestation.fromJsArry(arr) match {
+        case Failure(err) =>
+          reject(ValidationRejection("failure", Some(err)))
+        case Success(deleteAttestation) =>
+          complete {
+            val deletedF =
+              oracle.deleteAttestations(deleteAttestation.eventName)
+            deletedF.map { d =>
+              Server.httpSuccess(d.announcementTLV.hex)
+            }
+          }
+      }
     case ServerCommand("backuporacle", arr) =>
       complete {
         val dest = FileSystems.getDefault.getPath(arr.arr.head.str)

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -287,6 +287,20 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
             Server.httpSuccess(ujson.Null)
           }
       }
+
+    case ServerCommand("deleteannouncement", arr) =>
+      DeleteAnnouncement.fromJsArray(arr) match {
+        case Failure(err) =>
+          reject(ValidationRejection("failure", Some(err)))
+        case Success(deleteAnnouncement) =>
+          complete {
+            val deletedF =
+              oracle.deleteAnnouncement(deleteAnnouncement.eventName)
+            deletedF.map { d =>
+              Server.httpSuccess(d.hex)
+            }
+          }
+      }
     case ServerCommand("deleteattestations", arr) =>
       DeleteAttestation.fromJsArry(arr) match {
         case Failure(err) =>

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/ServerJsonModels.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/ServerJsonModels.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.util.TimeUtil
-import org.bitcoins.crypto.AesPassword
+import org.bitcoins.crypto.{AesPassword, StringFactory}
 import ujson._
 
 import java.time.Instant
@@ -258,6 +258,32 @@ object KeyManagerPassphraseSet extends ServerJsonModels {
           new IllegalArgumentException(
             s"Bad number of arguments: ${other.length}. Expected: 1"))
     }
+  }
+}
+
+case class DeleteAttestation(eventName: String)
+
+object DeleteAttestation
+    extends ServerJsonModels
+    with StringFactory[DeleteAttestation] {
+
+  def fromJsArry(jsArr: ujson.Arr): Try[DeleteAttestation] = {
+    jsArr.arr.toVector match {
+      case eventName +: Vector() =>
+        Try {
+          DeleteAttestation.fromString(eventName.str)
+        }
+      case Vector() =>
+        Failure(new IllegalArgumentException("Missing event name argument"))
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 1"))
+    }
+  }
+
+  override def fromString(string: String): DeleteAttestation = {
+    DeleteAttestation(string)
   }
 }
 

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/ServerJsonModels.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/ServerJsonModels.scala
@@ -261,6 +261,31 @@ object KeyManagerPassphraseSet extends ServerJsonModels {
   }
 }
 
+case class DeleteAnnouncement(eventName: String)
+
+object DeleteAnnouncement
+    extends ServerJsonModels
+    with StringFactory[DeleteAnnouncement] {
+
+  def fromJsArray(jsArr: ujson.Arr): Try[DeleteAnnouncement] = {
+    jsArr.arr.toVector match {
+      case eventName +: Vector() =>
+        Try {
+          DeleteAnnouncement.fromString(eventName.str)
+        }
+      case Vector() =>
+        Failure(new IllegalArgumentException(s"Missing event name argument"))
+      case other =>
+        Failure(new IllegalArgumentException(
+          s"Bad number of arguments to deleteannouncement, got=${other.length} expected: 1"))
+    }
+  }
+
+  override def fromString(string: String): DeleteAnnouncement = {
+    DeleteAnnouncement(string)
+  }
+}
+
 case class DeleteAttestation(eventName: String)
 
 object DeleteAttestation

--- a/core/src/main/scala/org/bitcoins/core/api/dlcoracle/DLCOracleApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlcoracle/DLCOracleApi.scala
@@ -144,14 +144,14 @@ trait DLCOracleApi {
     * WARNING: if previous signatures have been made public
     * the oracle private key will be revealed.
     */
-  def deleteAttestations(eventName: String): Future[OracleEvent]
+  def deleteAttestation(eventName: String): Future[OracleEvent]
 
   /** Deletes attestations for the given event
     *
     * WARNING: if previous signatures have been made public
     * the oracle private key will be revealed.
     */
-  def deleteAttestations(oracleEventTLV: OracleEventTLV): Future[OracleEvent]
+  def deleteAttestation(oracleEventTLV: OracleEventTLV): Future[OracleEvent]
 
   /** Signs the SHA256 hash of the given string using the oracle's signing key */
   def signMessage(message: String): SchnorrDigitalSignature = {

--- a/core/src/main/scala/org/bitcoins/core/api/dlcoracle/DLCOracleApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlcoracle/DLCOracleApi.scala
@@ -122,6 +122,23 @@ trait DLCOracleApi {
 
   def signDigits(oracleEventTLV: OracleEventTLV, num: Long): Future[OracleEvent]
 
+  /** Deletes an announcement with the given name
+    * WARNING: If this announcement has been published widely
+    * users will not be able to settle their DLCs.
+    * You likely should only use this in testing scenarios
+    * @return the deleted announcement
+    */
+  def deleteAnnouncement(eventName: String): Future[OracleAnnouncementTLV]
+
+  /** Deletes an announcement with the given name
+    * WARNING: If this announcement has been published widely
+    * users will not be able to settle their DLCs.
+    * You likely should only use this in testing scenarios
+    * @return the deleted announcement
+    */
+  def deleteAnnouncement(
+      announcementTLV: OracleAnnouncementTLV): Future[OracleAnnouncementTLV]
+
   /** Deletes attestations for the given event
     *
     * WARNING: if previous signatures have been made public

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -327,6 +327,7 @@ object UInt16
 
   lazy val zero = checkCached(0)
   lazy val one = checkCached(1)
+  lazy val two = checkCached(2)
 
   private lazy val minUnderlying: A = 0
   private lazy val maxUnderlying: A = BigInt(65535L)

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
@@ -113,6 +113,11 @@ abstract class CRUD[T, PrimaryKeyType](implicit
     safeDatabase.run(query.delete)
   }
 
+  def deleteAll(ts: Vector[T]): Future[Int] = {
+    val query: Query[Table[_], T, Seq] = findAll(ts)
+    safeDatabase.run(query.delete)
+  }
+
   /** delete all records from the table
     */
   def deleteAll(): Future[Int] =

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -923,4 +923,41 @@ class DLCOracleTest extends DLCOracleFixture {
           dlcOracle.deleteAttestations("test"))
       } yield res
   }
+
+  it must "delete enum attestation" in { dlcOracle: DLCOracle =>
+    val eventName = "test"
+    val createdF =
+      dlcOracle.createNewEvent(eventName, futureTime, testDescriptor)
+    for {
+      _ <- createdF
+      _ <- dlcOracle.signEnumEvent(eventName, EnumAttestation("cloudy"))
+      _ <- dlcOracle.deleteAttestations(eventName)
+      eventOpt <- dlcOracle.findEvent(eventName)
+    } yield {
+      assert(eventOpt.isDefined)
+      assert(eventOpt.get.isInstanceOf[PendingEnumV0OracleEvent])
+    }
+  }
+
+  it must "delete numeric attestations" in { dlcOracle: DLCOracle =>
+    val eventName = "test"
+    val createdF =
+      dlcOracle.createNewDigitDecompEvent(eventName = eventName,
+                                          maturationTime = futureTime,
+                                          base = UInt16(2),
+                                          isSigned = false,
+                                          numDigits = 2,
+                                          unit = "UNIT",
+                                          precision = Int32.zero)
+
+    for {
+      _ <- createdF
+      _ <- dlcOracle.signDigits(eventName, 1)
+      _ <- dlcOracle.deleteAttestations(eventName)
+      eventOpt <- dlcOracle.findEvent(eventName)
+    } yield {
+      assert(eventOpt.isDefined)
+      assert(eventOpt.get.isInstanceOf[PendingDigitDecompositionV0OracleEvent])
+    }
+  }
 }

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -927,7 +927,9 @@ class DLCOracleTest extends DLCOracleFixture {
   it must "delete enum announcements" in { dlcOracle =>
     val eventName = "test"
     val createdF =
-      dlcOracle.createNewEnumEvent(eventName, futureTime, Vector("0", "1", "2"))
+      dlcOracle.createNewEnumAnnouncement(eventName,
+                                          futureTime,
+                                          Vector("0", "1", "2"))
     for {
       c <- createdF
       _ <- dlcOracle.deleteAnnouncement(c)
@@ -941,13 +943,13 @@ class DLCOracleTest extends DLCOracleFixture {
   it must "delete numeric announcements" in { dlcOracle =>
     val eventName = "test"
     val createdF =
-      dlcOracle.createNewDigitDecompEvent(eventName = eventName,
-                                          maturationTime = futureTime,
-                                          base = UInt16.two,
-                                          isSigned = false,
-                                          numDigits = 2,
-                                          unit = "UNIT",
-                                          precision = Int32.zero)
+      dlcOracle.createNewDigitDecompAnnouncement(eventName = eventName,
+                                                 maturationTime = futureTime,
+                                                 base = UInt16.two,
+                                                 isSigned = false,
+                                                 numDigits = 2,
+                                                 unit = "UNIT",
+                                                 precision = Int32.zero)
     for {
       c <- createdF
       _ <- dlcOracle.deleteAnnouncement(c)
@@ -962,13 +964,13 @@ class DLCOracleTest extends DLCOracleFixture {
     dlcOracle =>
       val eventName = "test"
       val createdF =
-        dlcOracle.createNewDigitDecompEvent(eventName = eventName,
-                                            maturationTime = futureTime,
-                                            base = UInt16(2),
-                                            isSigned = false,
-                                            numDigits = 2,
-                                            unit = "UNIT",
-                                            precision = Int32.zero)
+        dlcOracle.createNewDigitDecompAnnouncement(eventName = eventName,
+                                                   maturationTime = futureTime,
+                                                   base = UInt16(2),
+                                                   isSigned = false,
+                                                   numDigits = 2,
+                                                   unit = "UNIT",
+                                                   precision = Int32.zero)
 
       val resultF = for {
         _ <- createdF
@@ -985,10 +987,10 @@ class DLCOracleTest extends DLCOracleFixture {
   it must "delete enum attestation" in { dlcOracle: DLCOracle =>
     val eventName = "test"
     val createdF =
-      dlcOracle.createNewEvent(eventName, futureTime, testDescriptor)
+      dlcOracle.createNewAnnouncement(eventName, futureTime, testDescriptor)
     for {
       _ <- createdF
-      _ <- dlcOracle.signEnumEvent(eventName, EnumAttestation("cloudy"))
+      _ <- dlcOracle.signEnumAnnouncement(eventName, EnumAttestation("cloudy"))
       _ <- dlcOracle.deleteAttestation(eventName)
       eventOpt <- dlcOracle.findEvent(eventName)
     } yield {
@@ -1000,13 +1002,13 @@ class DLCOracleTest extends DLCOracleFixture {
   it must "delete numeric attestations" in { dlcOracle: DLCOracle =>
     val eventName = "test"
     val createdF =
-      dlcOracle.createNewDigitDecompEvent(eventName = eventName,
-                                          maturationTime = futureTime,
-                                          base = UInt16(2),
-                                          isSigned = false,
-                                          numDigits = 2,
-                                          unit = "UNIT",
-                                          precision = Int32.zero)
+      dlcOracle.createNewDigitDecompAnnouncement(eventName = eventName,
+                                                 maturationTime = futureTime,
+                                                 base = UInt16(2),
+                                                 isSigned = false,
+                                                 numDigits = 2,
+                                                 unit = "UNIT",
+                                                 precision = Int32.zero)
 
     for {
       _ <- createdF
@@ -1023,13 +1025,13 @@ class DLCOracleTest extends DLCOracleFixture {
     dlcOracle: DLCOracle =>
       val eventName = "test"
       val createdF =
-        dlcOracle.createNewDigitDecompEvent(eventName = eventName,
-                                            maturationTime = futureTime,
-                                            base = UInt16(2),
-                                            isSigned = false,
-                                            numDigits = 2,
-                                            unit = "UNIT",
-                                            precision = Int32.zero)
+        dlcOracle.createNewDigitDecompAnnouncement(eventName = eventName,
+                                                   maturationTime = futureTime,
+                                                   base = UInt16(2),
+                                                   isSigned = false,
+                                                   numDigits = 2,
+                                                   unit = "UNIT",
+                                                   precision = Int32.zero)
 
       for {
         _ <- createdF

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -843,7 +843,7 @@ class DLCOracleTest extends DLCOracleFixture {
           }
         }
 
-        _ <- dlcOracle.deleteAttestations("test")
+        _ <- dlcOracle.deleteAttestation("test")
         event <- dlcOracle.findEvent("test").map(_.get)
       } yield {
         event match {
@@ -878,7 +878,7 @@ class DLCOracleTest extends DLCOracleFixture {
           }
         }
 
-        _ <- dlcOracle.deleteAttestations("test")
+        _ <- dlcOracle.deleteAttestation("test")
         event <- dlcOracle.findEvent("test").map(_.get)
       } yield {
         event match {
@@ -905,7 +905,7 @@ class DLCOracleTest extends DLCOracleFixture {
           signedEvent.isInstanceOf[PendingDigitDecompositionV0OracleEvent])
 
         res <- recoverToSucceededIf[IllegalArgumentException](
-          dlcOracle.deleteAttestations("test"))
+          dlcOracle.deleteAttestation("test"))
       } yield res
   }
 
@@ -920,7 +920,7 @@ class DLCOracleTest extends DLCOracleFixture {
         _ = assert(signedEvent.isInstanceOf[PendingEnumV0OracleEvent])
 
         res <- recoverToSucceededIf[IllegalArgumentException](
-          dlcOracle.deleteAttestations("test"))
+          dlcOracle.deleteAttestation("test"))
       } yield res
   }
 
@@ -989,7 +989,7 @@ class DLCOracleTest extends DLCOracleFixture {
     for {
       _ <- createdF
       _ <- dlcOracle.signEnumEvent(eventName, EnumAttestation("cloudy"))
-      _ <- dlcOracle.deleteAttestations(eventName)
+      _ <- dlcOracle.deleteAttestation(eventName)
       eventOpt <- dlcOracle.findEvent(eventName)
     } yield {
       assert(eventOpt.isDefined)
@@ -1011,7 +1011,7 @@ class DLCOracleTest extends DLCOracleFixture {
     for {
       _ <- createdF
       _ <- dlcOracle.signDigits(eventName, 1)
-      _ <- dlcOracle.deleteAttestations(eventName)
+      _ <- dlcOracle.deleteAttestation(eventName)
       eventOpt <- dlcOracle.findEvent(eventName)
     } yield {
       assert(eventOpt.isDefined)
@@ -1034,7 +1034,7 @@ class DLCOracleTest extends DLCOracleFixture {
       for {
         _ <- createdF
         _ <- dlcOracle.signDigits(eventName, 1)
-        _ <- dlcOracle.deleteAttestations(eventName)
+        _ <- dlcOracle.deleteAttestation(eventName)
         _ <- dlcOracle.deleteAnnouncement(eventName)
         eventOpt <- dlcOracle.findEvent(eventName)
       } yield {

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -924,6 +924,40 @@ class DLCOracleTest extends DLCOracleFixture {
       } yield res
   }
 
+  it must "delete enum announcements" in { dlcOracle =>
+    val eventName = "test"
+    val createdF =
+      dlcOracle.createNewEnumEvent(eventName, futureTime, Vector("0", "1", "2"))
+    for {
+      c <- createdF
+      _ <- dlcOracle.deleteAnnouncement(c)
+      //make sure we can't find it
+      annOpt <- dlcOracle.findEvent(eventName)
+    } yield {
+      assert(annOpt.isEmpty)
+    }
+  }
+
+  it must "delete numeric announcements" in { dlcOracle =>
+    val eventName = "test"
+    val createdF =
+      dlcOracle.createNewDigitDecompEvent(eventName = eventName,
+                                          maturationTime = futureTime,
+                                          base = UInt16.two,
+                                          isSigned = false,
+                                          numDigits = 2,
+                                          unit = "UNIT",
+                                          precision = Int32.zero)
+    for {
+      c <- createdF
+      _ <- dlcOracle.deleteAnnouncement(c)
+      //make sure we can't find it
+      annOpt <- dlcOracle.findEvent(eventName)
+    } yield {
+      assert(annOpt.isEmpty)
+    }
+  }
+
   it must "delete enum attestation" in { dlcOracle: DLCOracle =>
     val eventName = "test"
     val createdF =

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -414,6 +414,9 @@ case class DLCOracle()(implicit val conf: DLCOracleAppConfig)
                   s"No announcement found by event name $eventName")
       event = eventOpt.get
       eventDbs <- eventDAO.findByOracleEventTLV(event.eventTLV)
+      _ = require(
+        eventDbs.forall(_.attestationOpt.isEmpty),
+        s"Cannot have attesations defined when deleting an announcement, name=$eventName")
       nonces = eventDbs.map(_.nonce)
       rVals <- rValueDAO.findByNonces(nonces)
       outcomeDbs <- eventOutcomeDAO.findByNonces(nonces)

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -437,12 +437,12 @@ case class DLCOracle()(implicit val conf: DLCOracleAppConfig)
     * WARNING: if previous signatures have been made public
     * the oracle private key will be revealed.
     */
-  override def deleteAttestations(eventName: String): Future[OracleEvent] = {
+  override def deleteAttestation(eventName: String): Future[OracleEvent] = {
     for {
       eventOpt <- findEvent(eventName)
       _ = require(eventOpt.isDefined,
                   s"No event found by event name $eventName")
-      res <- deleteAttestations(eventOpt.get.eventTLV)
+      res <- deleteAttestation(eventOpt.get.eventTLV)
     } yield res
   }
 
@@ -451,7 +451,7 @@ case class DLCOracle()(implicit val conf: DLCOracleAppConfig)
     * WARNING: if previous signatures have been made public
     * the oracle private key will be revealed.
     */
-  override def deleteAttestations(
+  override def deleteAttestation(
       oracleEventTLV: OracleEventTLV): Future[OracleEvent] = {
     for {
       eventDbs <- eventDAO.findByOracleEventTLV(oracleEventTLV)

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAO.scala
@@ -46,9 +46,13 @@ case class EventOutcomeDAO()(implicit
   }
 
   def findByNonce(nonce: SchnorrNonce): Future[Vector[EventOutcomeDb]] = {
-    val query = table.filter(_.nonce === nonce)
+    findByNonces(Vector(nonce))
+  }
 
-    safeDatabase.runVec(query.result.transactionally)
+  def findByNonces(
+      nonces: Vector[SchnorrNonce]): Future[Vector[EventOutcomeDb]] = {
+    val action = table.filter(_.nonce.inSet(nonces)).result.transactionally
+    safeDatabase.runVec(action)
   }
 
   def find(

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/RValueDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/RValueDAO.scala
@@ -34,6 +34,16 @@ case class RValueDAO()(implicit
       ts: Vector[RValueDb]): Query[RValueTable, RValueDb, Seq] =
     findByPrimaryKeys(ts.map(_.nonce))
 
+  def findByNonce(nonce: SchnorrNonce): Future[Option[RValueDb]] = {
+    findByNonces(Vector(nonce))
+      .map(_.headOption)
+  }
+
+  def findByNonces(nonces: Vector[SchnorrNonce]): Future[Vector[RValueDb]] = {
+    val action = table.filter(_.nonce.inSet(nonces)).result.transactionally
+    safeDatabase.runVec(action)
+  }
+
   def maxKeyIndex: Future[Option[Int]] = {
     val query = table.map(_.keyIndex).max
 

--- a/docs/oracle/oracle-server.md
+++ b/docs/oracle/oracle-server.md
@@ -34,6 +34,10 @@ checkout [this page](build-oracle-server.md).
   - `unit` - The unit denomination of the outcome value
   - `precision` - The precision of the outcome representing the base exponent by which to multiply the number represented by the composition of the digits to obtain the actual outcome value.
   - `--signed`- Whether the outcomes can be negative
+- `deleteannouncement` `name` - <b>WARNING THIS CAN LEAD TO DLCs NOT SETTLING IF USERS HAVE BUILT DLCS OFF OF THIS ANNOUNCEMENT. USE WITH CARE.</b>
+  - `name` - Name for this event
+- `deleteattestation` `name` - <b>WARNING THIS CAN LEAD TO PRIVATE KEY LEAK IF YOU SIGN ANOTHER ATTESTATION AFTER DELETING A PREVIOUS ONE. USE WITH CARE.</b>
+  - `name` - Name for this event
 - `getannouncement` `event` - Get an event's details
   - `eventName` - The event's name
 - `signannouncement` `event` `outcome` - Signs an event


### PR DESCRIPTION
@user411 requested these endpoints for the bitcoin-s-ts project in https://github.com/bitcoin-s/bitcoin-s-ts/pull/14

I'm not certain why these are needed rather than spinning up ephemeral docker containers to test against. 

This introduces risk into the public endpoints we expose: 

1. This now allows us to delete announcements that we previously may have published. This means DLCs built off of these announcements will never be settled if this endpoint is used incorrectly.
2. This now allows an oracle to delete attestations for announcement. This was originally implemented in the backend api in #2851. This can lead to a user revealing their private key if they delete the attestations, and resign the announcement with a different outcome. The reason for introducing this on the backend was so that we could use it in krystal bull for cases where a user puts a typo in the attestation. See: https://github.com/bitcoin-s/krystal-bull/pull/45

I would like a more detailed writeup of why this is needed in our bitcoin-s-ts repo so we have some written documentation, previously this has just been discussed on calls. 

This PR still needs documentation on the website, with appropriate warnings around the endpoints.

