### PR TITLE
2021 09 30 rename endpoints

### DIFF
--- a/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
+++ b/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
@@ -125,15 +125,15 @@ class OracleRoutesSpec
       }
     }
 
-    "create enum event" in {
+    "create enum announcement" in {
       (mockOracleApi
-        .createNewEnumEvent(_: String, _: Instant, _: Vector[String]))
+        .createNewEnumAnnouncement(_: String, _: Instant, _: Vector[String]))
         .expects("id", Instant.ofEpochSecond(1612396800), Vector("1", "2"))
         .returning(Future.successful(OracleAnnouncementV0TLV.dummy))
 
       val route =
         oracleRoutes.handleCommand(
-          ServerCommand("createenumevent",
+          ServerCommand("createenumannouncement",
                         Arr(Str("id"),
                             Str("2021-02-04T00:00:00Z"),
                             Arr(Str("1"), Str("2")))))
@@ -145,16 +145,16 @@ class OracleRoutesSpec
       }
     }
 
-    "create enum event with just date" in {
+    "create enum announcement with just date" in {
       (mockOracleApi
-        .createNewEnumEvent(_: String, _: Instant, _: Vector[String]))
+        .createNewEnumAnnouncement(_: String, _: Instant, _: Vector[String]))
         .expects("id", Instant.ofEpochSecond(1612396800), Vector("1", "2"))
         .returning(Future.successful(OracleAnnouncementV0TLV.dummy))
 
       val route =
         oracleRoutes.handleCommand(
           ServerCommand(
-            "createenumevent",
+            "createenumannouncement",
             Arr(Str("id"), Str("2021-02-04"), Arr(Str("1"), Str("2")))))
 
       Post() ~> route ~> check {
@@ -164,15 +164,15 @@ class OracleRoutesSpec
       }
     }
 
-    "create numeric event" in {
+    "create numeric announcement" in {
       (mockOracleApi
-        .createNewDigitDecompEvent(_: String,
-                                   _: Instant,
-                                   _: UInt16,
-                                   _: Boolean,
-                                   _: Int,
-                                   _: String,
-                                   _: Int32))
+        .createNewDigitDecompAnnouncement(_: String,
+                                          _: Instant,
+                                          _: UInt16,
+                                          _: Boolean,
+                                          _: Int,
+                                          _: String,
+                                          _: Int32))
         .expects("id",
                  Instant.ofEpochSecond(1612396800),
                  UInt16(2),
@@ -184,7 +184,7 @@ class OracleRoutesSpec
 
       val route =
         oracleRoutes.handleCommand(
-          ServerCommand("createnumericevent",
+          ServerCommand("createnumericannouncement",
                         Arr(Str("id"),
                             Str("2021-02-04T00:00:00Z"),
                             Num(0),
@@ -199,15 +199,15 @@ class OracleRoutesSpec
       }
     }
 
-    "create numeric event with just date" in {
+    "create numeric announcement with just date" in {
       (mockOracleApi
-        .createNewDigitDecompEvent(_: String,
-                                   _: Instant,
-                                   _: UInt16,
-                                   _: Boolean,
-                                   _: Int,
-                                   _: String,
-                                   _: Int32))
+        .createNewDigitDecompAnnouncement(_: String,
+                                          _: Instant,
+                                          _: UInt16,
+                                          _: Boolean,
+                                          _: Int,
+                                          _: String,
+                                          _: Int32))
         .expects("id",
                  Instant.ofEpochSecond(1612396800),
                  UInt16(2),
@@ -219,7 +219,7 @@ class OracleRoutesSpec
 
       val route =
         oracleRoutes.handleCommand(
-          ServerCommand("createnumericevent",
+          ServerCommand("createnumericannouncement",
                         Arr(Str("id"),
                             Str("2021-02-04"),
                             Num(-1),
@@ -234,15 +234,15 @@ class OracleRoutesSpec
       }
     }
 
-    "create digit decomp event" in {
+    "create digit decomp announcement" in {
       (mockOracleApi
-        .createNewDigitDecompEvent(_: String,
-                                   _: Instant,
-                                   _: UInt16,
-                                   _: Boolean,
-                                   _: Int,
-                                   _: String,
-                                   _: Int32))
+        .createNewDigitDecompAnnouncement(_: String,
+                                          _: Instant,
+                                          _: UInt16,
+                                          _: Boolean,
+                                          _: Int,
+                                          _: String,
+                                          _: Int32))
         .expects("id",
                  Instant.ofEpochSecond(1612396800),
                  UInt16(2),
@@ -254,7 +254,7 @@ class OracleRoutesSpec
 
       val route =
         oracleRoutes.handleCommand(
-          ServerCommand("createdigitdecompevent",
+          ServerCommand("createdigitdecompannouncement",
                         Arr(Str("id"),
                             Num(1612396800),
                             Num(2),
@@ -270,15 +270,15 @@ class OracleRoutesSpec
       }
     }
 
-    "sign enum event" in {
+    "sign enum announcement" in {
       (mockOracleApi
-        .signEnumEvent(_: String, _: EnumAttestation))
+        .signEnumAnnouncement(_: String, _: EnumAttestation))
         .expects("id", EnumAttestation("outcome"))
         .returning(Future.successful(dummyEventDb))
 
       val route =
         oracleRoutes.handleCommand(
-          ServerCommand("signevent", Arr(Str("id"), Str("outcome"))))
+          ServerCommand("signannouncement", Arr(Str("id"), Str("outcome"))))
 
       Post() ~> route ~> check {
         assert(contentType == `application/json`)
@@ -287,7 +287,7 @@ class OracleRoutesSpec
       }
     }
 
-    "sign numeric event" in {
+    "sign numeric announcement" in {
       (mockOracleApi
         .signDigits(_: String, _: Long))
         .expects("id", 123)

--- a/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
+++ b/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
@@ -41,9 +41,12 @@ class OracleRoutesSpec
   val testAddressStr = "bc1qvrctqwa6g70z5vtxsyft7xvsyyt749trlm80al"
   val testAddress: Bech32Address = Bech32Address.fromString(testAddressStr)
 
-  val kVal: ECPrivateKey = ECPrivateKey.freshPrivateKey
+  val kVal: ECPrivateKey = ECPrivateKey.fromHex(
+    "447d4457dfff21354d56cb1b62b2ab6e5964c5ef93e6d74ae3b30dc83b89b6a5")
 
-  val dummyPrivKey: ECPrivateKey = ECPrivateKey.freshPrivateKey
+  val dummyPrivKey: ECPrivateKey = ECPrivateKey.fromHex(
+    "f04671ab68f3fefbeaa344c49149748f722287a81b19cd956b2332d07b8f6853")
+
   val dummyKey: ECPublicKey = dummyPrivKey.publicKey
 
   val outcome: NormalizedString = EnumEventDescriptorV0TLV.dummy.outcomes.head
@@ -110,18 +113,61 @@ class OracleRoutesSpec
       }
     }
 
-    "list events" in {
+    "list announcements" in {
       (mockOracleApi.listEvents: () => Future[Vector[OracleEvent]])
         .expects()
         .returning(Future.successful(Vector(dummyOracleEvent)))
 
       val route =
-        oracleRoutes.handleCommand(ServerCommand("listevents", Arr()))
+        oracleRoutes.handleCommand(ServerCommand("listannouncements", Arr()))
 
       Get() ~> route ~> check {
         assert(contentType == `application/json`)
         assert(
           responseAs[String] == s"""{"result":["${dummyOracleEvent.eventName}"],"error":null}""")
+      }
+    }
+
+    "get enum announcement" in {
+      val eventName = "test"
+      (mockOracleApi
+        .findEvent(_: String))
+        .expects(eventName)
+        .returning(Future.successful(Some(dummyOracleEvent)))
+
+      val route = oracleRoutes.handleCommand(
+        ServerCommand("getannouncement", Arr(eventName)))
+
+      val expected =
+        s"""
+           |{"result":
+           |  {
+           |    "nonces":["a0a482a38702146446a1929bebd2c6e15bf9f5e237e58693f457a9405c2b0cb0"],
+           |    "eventName":"id",
+           |    "signingVersion":"DLCOracleV0SigningVersion",
+           |    "maturationTime":"1970-01-01T00:00:00Z",
+           |    "maturationTimeEpoch":0,
+           |    "announcementSignature":"1efe41fa42ea1dcd103a0251929dd2b192d2daece8a4ce4d81f68a183b750d92d6f02d796965dc79adf4e7786e08f861a1ecc897afbba2dab9cff6eb0a81937e",
+           |    "eventDescriptorTLV":"fdd8060800010564756d6d79",
+           |    "eventTLV":"fdd822350001a0a482a38702146446a1929bebd2c6e15bf9f5e237e58693f457a9405c2b0cb000000000fdd8060800010564756d6d79026964",
+           |    "announcementTLV":"fdd824991efe41fa42ea1dcd103a0251929dd2b192d2daece8a4ce4d81f68a183b750d92d6f02d796965dc79adf4e7786e08f861a1ecc897afbba2dab9cff6eb0a81937e9a84ee7378a7de183e98e317cc4c7aebc4a3bab7a6a8e1a8fc3be7dfe429a895fdd822350001a0a482a38702146446a1929bebd2c6e15bf9f5e237e58693f457a9405c2b0cb000000000fdd8060800010564756d6d79026964",
+           |    "attestations":"fdd8686b0269649a84ee7378a7de183e98e317cc4c7aebc4a3bab7a6a8e1a8fc3be7dfe429a8950001a0a482a38702146446a1929bebd2c6e15bf9f5e237e58693f457a9405c2b0cb040135755044f1dabff3344cf56bb0b4926f76f814a3d4946e86570b463ce43ea0564756d6d79",
+           |    "outcomes":["dummy"],
+           |    "signedOutcome":"dummy",
+           |    "announcementTLVsha256":"4c532d1aa1d4f35eaff6c35ddc88e20a3c1adf0b20853b5def4ae6ae703aa555",
+           |    "eventDescriptorTLVsha256":"f51ad245094355b2194d6dfb3fff429c320ba3119ce35b879e5f29c0f402a3fd"
+           |  },
+           |  "error":null
+           |}
+           |""".stripMargin
+          .replaceAll("\\s", "") //strip whitespace
+
+      val expectedJson: ujson.Value = ujson.read(Readable.fromString(expected))
+      Post() ~> route ~> check {
+        assert(contentType == `application/json`)
+        val response = responseAs[String]
+        val actualJson: ujson.Value = ujson.read(Readable.fromString(response))
+        assert(actualJson == expectedJson)
       }
     }
 

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -51,7 +51,7 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
         case Success(CreateEvent(label, maturationTime, outcomes)) =>
           complete {
             oracle
-              .createNewEnumEvent(label, maturationTime, outcomes)
+              .createNewEnumAnnouncement(label, maturationTime, outcomes)
               .map { announcementTLV =>
                 Server.httpSuccess(announcementTLV.hex)
               }
@@ -76,13 +76,13 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
               Math.ceil(Math.log(maxValue.toDouble) / Math.log(2)).toInt
 
             oracle
-              .createNewDigitDecompEvent(eventName,
-                                         maturationTime,
-                                         UInt16(2),
-                                         isSigned,
-                                         numDigits,
-                                         unit,
-                                         Int32(precision))
+              .createNewDigitDecompAnnouncement(eventName,
+                                                maturationTime,
+                                                UInt16(2),
+                                                isSigned,
+                                                numDigits,
+                                                unit,
+                                                Int32(precision))
               .map { announcementTLV =>
                 Server.httpSuccess(announcementTLV.hex)
               }
@@ -103,13 +103,13 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
                                      precision)) =>
           complete {
             oracle
-              .createNewDigitDecompEvent(eventName,
-                                         maturationTime,
-                                         UInt16(base),
-                                         isSigned,
-                                         numDigits,
-                                         unit,
-                                         Int32(precision))
+              .createNewDigitDecompAnnouncement(eventName,
+                                                maturationTime,
+                                                UInt16(base),
+                                                isSigned,
+                                                numDigits,
+                                                unit,
+                                                Int32(precision))
               .map { announcementTLV =>
                 Server.httpSuccess(announcementTLV.hex)
               }
@@ -193,7 +193,7 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
         case Success(SignEvent(eventName, outcome)) =>
           complete {
             oracle
-              .signEnumEvent(eventName, EnumAttestation(outcome))
+              .signEnumAnnouncement(eventName, EnumAttestation(outcome))
               .map { eventDb =>
                 val oracleEvent = OracleEvent.fromEventDbs(Vector(eventDb))
                 oracleEvent match {

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -45,10 +45,10 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
       }
 
     case ServerCommand("createenumevent", arr) =>
-      CreateEvent.fromJsArr(arr) match {
+      CreateAnnouncement.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
-        case Success(CreateEvent(label, maturationTime, outcomes)) =>
+        case Success(CreateAnnouncement(label, maturationTime, outcomes)) =>
           complete {
             oracle
               .createNewEnumAnnouncement(label, maturationTime, outcomes)
@@ -59,16 +59,16 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
       }
 
     case ServerCommand("createnumericevent", arr) =>
-      CreateNumericEvent.fromJsArr(arr) match {
+      CreateNumericAnnouncement.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
         case Success(
-              CreateNumericEvent(eventName,
-                                 maturationTime,
-                                 minValue,
-                                 maxValue,
-                                 unit,
-                                 precision)) =>
+              CreateNumericAnnouncement(eventName,
+                                        maturationTime,
+                                        minValue,
+                                        maxValue,
+                                        unit,
+                                        precision)) =>
           complete {
 
             val isSigned = minValue < 0
@@ -90,17 +90,17 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
       }
 
     case ServerCommand("createdigitdecompevent", arr) =>
-      CreateDigitDecompEvent.fromJsArr(arr) match {
+      CreateDigitDecompAnnouncement.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
         case Success(
-              CreateDigitDecompEvent(eventName,
-                                     maturationTime,
-                                     base,
-                                     isSigned,
-                                     numDigits,
-                                     unit,
-                                     precision)) =>
+              CreateDigitDecompAnnouncement(eventName,
+                                            maturationTime,
+                                            base,
+                                            isSigned,
+                                            numDigits,
+                                            unit,
+                                            precision)) =>
           complete {
             oracle
               .createNewDigitDecompAnnouncement(eventName,
@@ -187,10 +187,10 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
       }
 
     case ServerCommand("signevent", arr) =>
-      SignEvent.fromJsArr(arr) match {
+      SignAnnouncement.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
-        case Success(SignEvent(eventName, outcome)) =>
+        case Success(SignAnnouncement(eventName, outcome)) =>
           complete {
             oracle
               .signEnumAnnouncement(eventName, EnumAttestation(outcome))

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -45,6 +45,9 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
       }
 
     case ServerCommand("createenumevent", arr) =>
+      handleCommand(ServerCommand("createenumannouncement", arr))
+
+    case ServerCommand("createenumannouncement", arr) =>
       CreateAnnouncement.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
@@ -57,8 +60,9 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
               }
           }
       }
-
     case ServerCommand("createnumericevent", arr) =>
+      handleCommand(ServerCommand("createnumericannouncement", arr))
+    case ServerCommand("createnumericannouncement", arr) =>
       CreateNumericAnnouncement.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
@@ -90,6 +94,9 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
       }
 
     case ServerCommand("createdigitdecompevent", arr) =>
+      handleCommand(ServerCommand("createdigitdecompannouncement", arr))
+
+    case ServerCommand("createdigitdecompannouncement", arr) =>
       CreateDigitDecompAnnouncement.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))
@@ -187,6 +194,8 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
       }
 
     case ServerCommand("signevent", arr) =>
+      handleCommand(ServerCommand("signannouncement", arr))
+    case ServerCommand("signannouncement", arr) =>
       SignAnnouncement.fromJsArr(arr) match {
         case Failure(exception) =>
           reject(ValidationRejection("failure", Some(exception)))

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/ServerJsonModels.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/ServerJsonModels.scala
@@ -199,15 +199,15 @@ object SignDigits extends ServerJsonModels {
   }
 }
 
-case class GetEvent(eventName: String)
+case class GetAnnouncement(eventName: String)
 
-object GetEvent extends ServerJsonModels {
+object GetAnnouncement extends ServerJsonModels {
 
-  def fromJsArr(jsArr: ujson.Arr): Try[GetEvent] = {
+  def fromJsArr(jsArr: ujson.Arr): Try[GetAnnouncement] = {
     require(jsArr.arr.size == 1,
             s"Bad number of arguments: ${jsArr.arr.size}. Expected: 1")
     Try {
-      GetEvent(jsArr.arr.head.str)
+      GetAnnouncement(jsArr.arr.head.str)
     }
   }
 }

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/ServerJsonModels.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/ServerJsonModels.scala
@@ -35,14 +35,14 @@ object SignMessage extends ServerJsonModels {
   }
 }
 
-case class CreateEvent(
+case class CreateAnnouncement(
     label: String,
     maturationTime: Instant,
     outcomes: Vector[String])
 
-object CreateEvent extends ServerJsonModels {
+object CreateAnnouncement extends ServerJsonModels {
 
-  def fromJsArr(jsArr: ujson.Arr): Try[CreateEvent] = {
+  def fromJsArr(jsArr: ujson.Arr): Try[CreateAnnouncement] = {
     jsArr.arr.toList match {
       case labelJs :: maturationTimeJs :: outcomesJs :: Nil =>
         Try {
@@ -50,7 +50,7 @@ object CreateEvent extends ServerJsonModels {
           val maturationTime = jsISOtoInstant(maturationTimeJs)
           val outcomes = outcomesJs.arr.map(_.str).toVector
 
-          CreateEvent(label, maturationTime, outcomes)
+          CreateAnnouncement(label, maturationTime, outcomes)
         }
       case Nil =>
         Failure(
@@ -63,7 +63,7 @@ object CreateEvent extends ServerJsonModels {
   }
 }
 
-case class CreateNumericEvent(
+case class CreateNumericAnnouncement(
     eventName: String,
     maturationTime: Instant,
     minValue: Long,
@@ -71,9 +71,9 @@ case class CreateNumericEvent(
     unit: String,
     precision: Int)
 
-object CreateNumericEvent extends ServerJsonModels {
+object CreateNumericAnnouncement extends ServerJsonModels {
 
-  def fromJsArr(jsArr: ujson.Arr): Try[CreateNumericEvent] = {
+  def fromJsArr(jsArr: ujson.Arr): Try[CreateNumericAnnouncement] = {
     jsArr.arr.toList match {
       case labelJs :: maturationTimeJs :: minJs :: maxJs :: unitJs :: precisionJs :: Nil =>
         Try {
@@ -84,12 +84,12 @@ object CreateNumericEvent extends ServerJsonModels {
           val unit = unitJs.str
           val precision = precisionJs.num.toInt
 
-          CreateNumericEvent(label,
-                             maturationTime,
-                             minValue,
-                             maxValue,
-                             unit,
-                             precision)
+          CreateNumericAnnouncement(label,
+                                    maturationTime,
+                                    minValue,
+                                    maxValue,
+                                    unit,
+                                    precision)
         }
       case Nil =>
         Failure(new IllegalArgumentException(
@@ -102,7 +102,7 @@ object CreateNumericEvent extends ServerJsonModels {
   }
 }
 
-case class CreateDigitDecompEvent(
+case class CreateDigitDecompAnnouncement(
     eventName: String,
     maturationTime: Instant,
     base: Int,
@@ -111,9 +111,9 @@ case class CreateDigitDecompEvent(
     unit: String,
     precision: Int)
 
-object CreateDigitDecompEvent extends ServerJsonModels {
+object CreateDigitDecompAnnouncement extends ServerJsonModels {
 
-  def fromJsArr(jsArr: ujson.Arr): Try[CreateDigitDecompEvent] = {
+  def fromJsArr(jsArr: ujson.Arr): Try[CreateDigitDecompAnnouncement] = {
     jsArr.arr.toList match {
       case labelJs :: maturationTimeJs :: baseJs :: isSignedJs :: numDigitsJs :: unitJs :: precisionJs :: Nil =>
         Try {
@@ -126,13 +126,13 @@ object CreateDigitDecompEvent extends ServerJsonModels {
           val unit = unitJs.str
           val precision = precisionJs.num.toInt
 
-          CreateDigitDecompEvent(label,
-                                 maturationTime,
-                                 base,
-                                 isSigned,
-                                 numDigits,
-                                 unit,
-                                 precision)
+          CreateDigitDecompAnnouncement(label,
+                                        maturationTime,
+                                        base,
+                                        isSigned,
+                                        numDigits,
+                                        unit,
+                                        precision)
         }
       case Nil =>
         Failure(new IllegalArgumentException(
@@ -145,17 +145,17 @@ object CreateDigitDecompEvent extends ServerJsonModels {
   }
 }
 
-case class SignEvent(eventName: String, outcome: String)
+case class SignAnnouncement(eventName: String, outcome: String)
 
-object SignEvent extends ServerJsonModels {
+object SignAnnouncement extends ServerJsonModels {
 
-  def fromJsArr(jsArr: ujson.Arr): Try[SignEvent] = {
+  def fromJsArr(jsArr: ujson.Arr): Try[SignAnnouncement] = {
     jsArr.arr.toList match {
       case nameJs :: outcomeJs :: Nil =>
         Try {
           val outcome = outcomeJs.str
 
-          SignEvent(nameJs.str, outcome)
+          SignAnnouncement(nameJs.str, outcome)
         }
       case Nil =>
         Failure(

--- a/core/src/main/scala/org/bitcoins/core/api/dlcoracle/DLCOracleApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlcoracle/DLCOracleApi.scala
@@ -28,7 +28,25 @@ trait DLCOracleApi {
 
   def findEvent(eventName: String): Future[Option[OracleEvent]]
 
+  @deprecated("Call createNewDigitDecompAnnouncement", "2021-09-30")
   def createNewDigitDecompEvent(
+      eventName: String,
+      maturationTime: Instant,
+      base: UInt16,
+      isSigned: Boolean,
+      numDigits: Int,
+      unit: String,
+      precision: Int32): Future[OracleAnnouncementTLV] = {
+    createNewDigitDecompAnnouncement(eventName = eventName,
+                                     maturationTime = maturationTime,
+                                     base = base,
+                                     isSigned = isSigned,
+                                     numDigits = numDigits,
+                                     unit = unit,
+                                     precision = precision)
+  }
+
+  def createNewDigitDecompAnnouncement(
       eventName: String,
       maturationTime: Instant,
       base: UInt16,
@@ -37,27 +55,66 @@ trait DLCOracleApi {
       unit: String,
       precision: Int32): Future[OracleAnnouncementTLV]
 
+  @deprecated("Call createNewEnumAnnouncement", "2021-09-30")
   def createNewEnumEvent(
+      eventName: String,
+      maturationTime: Instant,
+      outcomes: Vector[String]): Future[OracleAnnouncementTLV] = {
+    createNewEnumAnnouncement(eventName, maturationTime, outcomes)
+  }
+
+  def createNewEnumAnnouncement(
       eventName: String,
       maturationTime: Instant,
       outcomes: Vector[String]): Future[OracleAnnouncementTLV]
 
+  @deprecated("Call createNewAnnouncement")
   def createNewEvent(
+      eventName: String,
+      maturationTime: Instant,
+      descriptor: EventDescriptorTLV,
+      signingVersion: SigningVersion = SigningVersion.latest): Future[
+    OracleAnnouncementTLV] = {
+    createNewAnnouncement(eventName, maturationTime, descriptor, signingVersion)
+  }
+
+  def createNewAnnouncement(
       eventName: String,
       maturationTime: Instant,
       descriptor: EventDescriptorTLV,
       signingVersion: SigningVersion = SigningVersion.latest): Future[
     OracleAnnouncementTLV]
 
+  @deprecated("Call signEnumAnnouncement")
   def signEnumEvent(
+      eventName: String,
+      outcome: EnumAttestation): Future[EventDb] = {
+    signEnumAnnouncement(eventName, outcome)
+  }
+
+  def signEnumAnnouncement(
       eventName: String,
       outcome: EnumAttestation): Future[EventDb]
 
+  @deprecated("Call signEnumAnnouncement")
   def signEnumEvent(
+      oracleEventTLV: OracleEventTLV,
+      outcome: EnumAttestation): Future[EventDb] = {
+    signEnumAnnouncement(oracleEventTLV, outcome)
+  }
+
+  def signEnumAnnouncement(
       oracleEventTLV: OracleEventTLV,
       outcome: EnumAttestation): Future[EventDb]
 
+  @deprecated("Call signAnnouncement")
   def signEvent(
+      nonce: SchnorrNonce,
+      outcome: DLCAttestationType): Future[EventDb] = {
+    signAnnouncement(nonce, outcome)
+  }
+
+  def signAnnouncement(
       nonce: SchnorrNonce,
       outcome: DLCAttestationType): Future[EventDb]
 

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -79,9 +79,10 @@ class DLCOracleTest extends DLCOracleFixture {
                                                precision = Int32.zero)
 
       for {
-        announcement <- dlcOracle.createNewEvent(eventName = eventName,
-                                                 maturationTime = futureTime,
-                                                 descriptorTLV)
+        announcement <- dlcOracle.createNewAnnouncement(eventName = eventName,
+                                                        maturationTime =
+                                                          futureTime,
+                                                        descriptorTLV)
 
         // To get around foreign key, won't be needed
         _ <- dlcOracle.eventOutcomeDAO.deleteAll()
@@ -122,12 +123,14 @@ class DLCOracleTest extends DLCOracleFixture {
                                                  precision = Int32.zero)
 
         for {
-          announcementA <- oracleA.createNewEvent(eventName = eventName,
-                                                  maturationTime = futureTime,
-                                                  descriptorTLV)
-          announcementB <- oracleB.createNewEvent(eventName = eventName,
-                                                  maturationTime = futureTime,
-                                                  descriptorTLV)
+          announcementA <- oracleA.createNewAnnouncement(eventName = eventName,
+                                                         maturationTime =
+                                                           futureTime,
+                                                         descriptorTLV)
+          announcementB <- oracleB.createNewAnnouncement(eventName = eventName,
+                                                         maturationTime =
+                                                           futureTime,
+                                                         descriptorTLV)
 
           // Can't compare announcementTLV because different nonces might be used for signature
           _ = assert(announcementA.publicKey == announcementB.publicKey)
@@ -153,7 +156,7 @@ class DLCOracleTest extends DLCOracleFixture {
       val time = futureTime
 
       for {
-        _ <- dlcOracle.createNewEvent("test", time, testDescriptor)
+        _ <- dlcOracle.createNewAnnouncement("test", time, testDescriptor)
         pendingEvents <- dlcOracle.listPendingEventDbs()
       } yield {
         assert(pendingEvents.size == 1)
@@ -166,8 +169,8 @@ class DLCOracleTest extends DLCOracleFixture {
       val time = futureTime
 
       for {
-        _ <- dlcOracle.createNewEvent("test", time, testDescriptor)
-        _ <- dlcOracle.createNewEvent("test2", time, testDescriptor)
+        _ <- dlcOracle.createNewAnnouncement("test", time, testDescriptor)
+        _ <- dlcOracle.createNewAnnouncement("test2", time, testDescriptor)
         events <- dlcOracle.listEvents()
       } yield {
         assert(events.size == 2)
@@ -177,23 +180,23 @@ class DLCOracleTest extends DLCOracleFixture {
 
   it must "create two events and use incrementing key indexes" in {
     dlcOracle: DLCOracle =>
-      val create1F = dlcOracle.createNewDigitDecompEvent(eventName = "test1",
-                                                         maturationTime =
-                                                           futureTime,
-                                                         base = UInt16(10),
-                                                         isSigned = false,
-                                                         numDigits = 3,
-                                                         unit = "units",
-                                                         precision = Int32.zero)
+      val create1F =
+        dlcOracle.createNewDigitDecompAnnouncement(eventName = "test1",
+                                                   maturationTime = futureTime,
+                                                   base = UInt16(10),
+                                                   isSigned = false,
+                                                   numDigits = 3,
+                                                   unit = "units",
+                                                   precision = Int32.zero)
 
-      val create2F = dlcOracle.createNewDigitDecompEvent(eventName = "test2",
-                                                         maturationTime =
-                                                           futureTime,
-                                                         base = UInt16(10),
-                                                         isSigned = false,
-                                                         numDigits = 3,
-                                                         unit = "units",
-                                                         precision = Int32.zero)
+      val create2F =
+        dlcOracle.createNewDigitDecompAnnouncement(eventName = "test2",
+                                                   maturationTime = futureTime,
+                                                   base = UInt16(10),
+                                                   isSigned = false,
+                                                   numDigits = 3,
+                                                   unit = "units",
+                                                   precision = Int32.zero)
 
       for {
         _ <- create1F
@@ -209,9 +212,9 @@ class DLCOracleTest extends DLCOracleFixture {
   it must "fail to create an event with the same name" in {
     dlcOracle: DLCOracle =>
       for {
-        _ <- dlcOracle.createNewEvent("test", futureTime, testDescriptor)
+        _ <- dlcOracle.createNewAnnouncement("test", futureTime, testDescriptor)
         res <- recoverToSucceededIf[IllegalArgumentException](
-          dlcOracle.createNewEvent("test", futureTime, testDescriptor))
+          dlcOracle.createNewAnnouncement("test", futureTime, testDescriptor))
       } yield res
   }
 
@@ -222,7 +225,7 @@ class DLCOracleTest extends DLCOracleFixture {
 
       for {
         announcement <-
-          dlcOracle.createNewEnumEvent(eventName, time, enumOutcomes)
+          dlcOracle.createNewEnumAnnouncement(eventName, time, enumOutcomes)
 
         eventOpt <- dlcOracle.findEvent(announcement.eventTLV)
       } yield {
@@ -270,10 +273,11 @@ class DLCOracleTest extends DLCOracleFixture {
 
     for {
       announcement <-
-        dlcOracle.createNewEvent("test", futureTime, descriptorV0TLV)
+        dlcOracle.createNewAnnouncement("test", futureTime, descriptorV0TLV)
 
       signedEventDb <-
-        dlcOracle.signEnumEvent(announcement.eventTLV, EnumAttestation(outcome))
+        dlcOracle.signEnumAnnouncement(announcement.eventTLV,
+                                       EnumAttestation(outcome))
       eventOpt <- dlcOracle.findEvent(announcement.eventTLV)
     } yield {
       assert(eventOpt.isDefined)
@@ -308,13 +312,13 @@ class DLCOracleTest extends DLCOracleFixture {
 
     for {
       announcement <-
-        dlcOracle.createNewDigitDecompEvent(eventName = "test",
-                                            maturationTime = futureTime,
-                                            base = UInt16(10),
-                                            isSigned = true,
-                                            numDigits = 3,
-                                            unit = "units",
-                                            precision = Int32.zero)
+        dlcOracle.createNewDigitDecompAnnouncement(eventName = "test",
+                                                   maturationTime = futureTime,
+                                                   base = UInt16(10),
+                                                   isSigned = true,
+                                                   numDigits = 3,
+                                                   unit = "units",
+                                                   precision = Int32.zero)
 
       _ = assert(announcement.validateSignature)
 
@@ -385,13 +389,14 @@ class DLCOracleTest extends DLCOracleFixture {
 
       for {
         announcement <-
-          dlcOracle.createNewDigitDecompEvent(eventName = "test",
-                                              maturationTime = futureTime,
-                                              base = UInt16(16),
-                                              isSigned = true,
-                                              numDigits = 3,
-                                              unit = "units",
-                                              precision = Int32.zero)
+          dlcOracle.createNewDigitDecompAnnouncement(eventName = "test",
+                                                     maturationTime =
+                                                       futureTime,
+                                                     base = UInt16(16),
+                                                     isSigned = true,
+                                                     numDigits = 3,
+                                                     unit = "units",
+                                                     precision = Int32.zero)
 
         _ = assert(announcement.validateSignature)
 
@@ -463,13 +468,14 @@ class DLCOracleTest extends DLCOracleFixture {
 
       for {
         announcement <-
-          dlcOracle.createNewDigitDecompEvent(eventName = "test",
-                                              maturationTime = futureTime,
-                                              base = UInt16(2),
-                                              isSigned = false,
-                                              numDigits = 3,
-                                              unit = "units",
-                                              precision = Int32.zero)
+          dlcOracle.createNewDigitDecompAnnouncement(eventName = "test",
+                                                     maturationTime =
+                                                       futureTime,
+                                                     base = UInt16(2),
+                                                     isSigned = false,
+                                                     numDigits = 3,
+                                                     unit = "units",
+                                                     precision = Int32.zero)
 
         _ = assert(announcement.validateSignature)
 
@@ -535,13 +541,14 @@ class DLCOracleTest extends DLCOracleFixture {
       val eventName = "test"
       for {
         announcement <-
-          dlcOracle.createNewDigitDecompEvent(eventName = eventName,
-                                              maturationTime = futureTime,
-                                              base = UInt16(2),
-                                              isSigned = false,
-                                              numDigits = numDigits,
-                                              unit = "units",
-                                              precision = Int32.zero)
+          dlcOracle.createNewDigitDecompAnnouncement(eventName = eventName,
+                                                     maturationTime =
+                                                       futureTime,
+                                                     base = UInt16(2),
+                                                     isSigned = false,
+                                                     numDigits = numDigits,
+                                                     unit = "units",
+                                                     precision = Int32.zero)
 
         _ = assert(announcement.validateSignature)
 
@@ -562,7 +569,7 @@ class DLCOracleTest extends DLCOracleFixture {
     val outcome = enumOutcomes.head
     for {
       announcement <-
-        dlcOracle.createNewEnumEvent("test", futureTime, enumOutcomes)
+        dlcOracle.createNewEnumAnnouncement("test", futureTime, enumOutcomes)
       beforePending <- dlcOracle.listPendingEventDbs()
       beforeEvents <- dlcOracle.listEvents()
       _ = assert(beforePending.size == 1)
@@ -571,7 +578,7 @@ class DLCOracleTest extends DLCOracleFixture {
 
       nonce = announcement.eventTLV.nonces.head
 
-      _ <- dlcOracle.signEvent(nonce, EnumAttestation(outcome))
+      _ <- dlcOracle.signAnnouncement(nonce, EnumAttestation(outcome))
       afterPending <- dlcOracle.listPendingEventDbs()
       afterEvents <- dlcOracle.listEvents()
     } yield {
@@ -585,7 +592,7 @@ class DLCOracleTest extends DLCOracleFixture {
     dlcOracle: DLCOracle =>
       val dummyNonce = SchnorrNonce(ECPublicKey.freshPublicKey.bytes.tail)
       recoverToSucceededIf[RuntimeException](
-        dlcOracle.signEvent(dummyNonce, EnumAttestation("testOutcomes")))
+        dlcOracle.signAnnouncement(dummyNonce, EnumAttestation("testOutcomes")))
   }
 
   it must "fail to sign an enum outcome that doesn't exist" in {
@@ -593,11 +600,14 @@ class DLCOracleTest extends DLCOracleFixture {
       recoverToSucceededIf[RuntimeException] {
         for {
           announcement <-
-            dlcOracle.createNewEnumEvent("test", futureTime, enumOutcomes)
+            dlcOracle.createNewEnumAnnouncement("test",
+                                                futureTime,
+                                                enumOutcomes)
 
           nonce = announcement.eventTLV.nonces.head
 
-          _ <- dlcOracle.signEvent(nonce, EnumAttestation("not a real outcome"))
+          _ <- dlcOracle.signAnnouncement(nonce,
+                                          EnumAttestation("not a real outcome"))
         } yield ()
       }
   }
@@ -606,13 +616,14 @@ class DLCOracleTest extends DLCOracleFixture {
     dlcOracle: DLCOracle =>
       for {
         announcement <-
-          dlcOracle.createNewDigitDecompEvent(eventName = "test",
-                                              maturationTime = futureTime,
-                                              base = UInt16(2),
-                                              isSigned = false,
-                                              numDigits = 3,
-                                              unit = "units",
-                                              precision = Int32.zero)
+          dlcOracle.createNewDigitDecompAnnouncement(eventName = "test",
+                                                     maturationTime =
+                                                       futureTime,
+                                                     base = UInt16(2),
+                                                     isSigned = false,
+                                                     numDigits = 3,
+                                                     unit = "units",
+                                                     precision = Int32.zero)
 
         res <- recoverToSucceededIf[IllegalArgumentException] {
           dlcOracle.signDigits(announcement.eventTLV, -2)
@@ -653,7 +664,7 @@ class DLCOracleTest extends DLCOracleFixture {
       recoverToSucceededIf[IllegalArgumentException] {
         for {
           _ <- setupF
-          _ <- dlcOracle.signEvent(nonce, EnumAttestation(message))
+          _ <- dlcOracle.signAnnouncement(nonce, EnumAttestation(message))
         } yield ()
       }
   }
@@ -672,7 +683,7 @@ class DLCOracleTest extends DLCOracleFixture {
       recoverToSucceededIf[RuntimeException] {
         for {
           _ <- dlcOracle.rValueDAO.create(rValDb)
-          _ <- dlcOracle.signEvent(nonce, EnumAttestation(message))
+          _ <- dlcOracle.signAnnouncement(nonce, EnumAttestation(message))
         } yield ()
       }
   }
@@ -680,7 +691,7 @@ class DLCOracleTest extends DLCOracleFixture {
   it must "fail to create an enum event with no outcomes" in {
     dlcOracle: DLCOracle =>
       assertThrows[IllegalArgumentException] {
-        dlcOracle.createNewEnumEvent("test", futureTime, Vector.empty)
+        dlcOracle.createNewEnumAnnouncement("test", futureTime, Vector.empty)
       }
   }
 
@@ -688,13 +699,13 @@ class DLCOracleTest extends DLCOracleFixture {
     dlcOracle: DLCOracle =>
       val outcomes = enumOutcomes :+ enumOutcomes.head
       assertThrows[IllegalArgumentException] {
-        dlcOracle.createNewEnumEvent("test", futureTime, outcomes)
+        dlcOracle.createNewEnumAnnouncement("test", futureTime, outcomes)
       }
   }
 
   it must "fail to create an event in the past" in { dlcOracle: DLCOracle =>
     assertThrows[IllegalArgumentException] {
-      dlcOracle.createNewEvent("test", Instant.EPOCH, testDescriptor)
+      dlcOracle.createNewAnnouncement("test", Instant.EPOCH, testDescriptor)
     }
   }
 
@@ -710,7 +721,7 @@ class DLCOracleTest extends DLCOracleFixture {
 
       for {
         announcement: OracleAnnouncementTLV <-
-          dlcOracle.createNewEvent(eventName, maturationTime, descriptor)
+          dlcOracle.createNewAnnouncement(eventName, maturationTime, descriptor)
         event <-
           dlcOracle
             .signDigits(announcement.eventTLV, -2)
@@ -739,7 +750,7 @@ class DLCOracleTest extends DLCOracleFixture {
 
       for {
         announcement: OracleAnnouncementTLV <-
-          dlcOracle.createNewEvent(eventName, maturationTime, descriptor)
+          dlcOracle.createNewAnnouncement(eventName, maturationTime, descriptor)
         event <-
           dlcOracle
             .signDigits(announcement.eventTLV, 2)
@@ -769,9 +780,13 @@ class DLCOracleTest extends DLCOracleFixture {
 
       for {
         announcement1: OracleAnnouncementTLV <-
-          dlcOracle.createNewEvent(eventName1, maturationTime, descriptor)
+          dlcOracle.createNewAnnouncement(eventName1,
+                                          maturationTime,
+                                          descriptor)
         announcement2: OracleAnnouncementTLV <-
-          dlcOracle.createNewEvent(eventName2, maturationTime, descriptor)
+          dlcOracle.createNewAnnouncement(eventName2,
+                                          maturationTime,
+                                          descriptor)
         event1 <-
           dlcOracle
             .signDigits(announcement1.eventTLV, 2)
@@ -811,11 +826,11 @@ class DLCOracleTest extends DLCOracleFixture {
 
       for {
         announcement <-
-          dlcOracle.createNewEvent("test", futureTime, descriptorV0TLV)
+          dlcOracle.createNewAnnouncement("test", futureTime, descriptorV0TLV)
 
         _ <-
-          dlcOracle.signEnumEvent(announcement.eventTLV,
-                                  EnumAttestation(outcome))
+          dlcOracle.signEnumAnnouncement(announcement.eventTLV,
+                                         EnumAttestation(outcome))
 
         signedEvent <- dlcOracle.findEvent("test").map(_.get)
         _ = {
@@ -848,7 +863,7 @@ class DLCOracleTest extends DLCOracleFixture {
                                                   Int32(0))
 
       for {
-        _ <- dlcOracle.createNewEvent("test", futureTime, descriptor)
+        _ <- dlcOracle.createNewAnnouncement("test", futureTime, descriptor)
 
         _ <- dlcOracle.signDigits("test", 0)
 
@@ -883,7 +898,7 @@ class DLCOracleTest extends DLCOracleFixture {
                                                   Int32(0))
 
       for {
-        _ <- dlcOracle.createNewEvent("test", futureTime, descriptor)
+        _ <- dlcOracle.createNewAnnouncement("test", futureTime, descriptor)
 
         signedEvent <- dlcOracle.findEvent("test").map(_.get)
         _ = assert(
@@ -899,7 +914,7 @@ class DLCOracleTest extends DLCOracleFixture {
       val descriptor = TLVGen.enumEventDescriptorV0TLV.sampleSome
 
       for {
-        _ <- dlcOracle.createNewEvent("test", futureTime, descriptor)
+        _ <- dlcOracle.createNewAnnouncement("test", futureTime, descriptor)
 
         signedEvent <- dlcOracle.findEvent("test").map(_.get)
         _ = assert(signedEvent.isInstanceOf[PendingEnumV0OracleEvent])

--- a/docs/oracle/oracle-server.md
+++ b/docs/oracle/oracle-server.md
@@ -14,7 +14,7 @@ checkout [this page](build-oracle-server.md).
 
 - `getpublickey` - Get oracle's public key
 - `getstakingaddress` - Get oracle's staking address
-- `listevents` - Lists all event names
+- `listannouncements` - Lists all event names
 - `createenumannouncement` `label` `maturationtime` `outcomes` - Registers an oracle enum event
   - `label` - Label for this event
   - `maturationtime` - The earliest expected time an outcome will be signed, given in ISO 8601 format
@@ -34,7 +34,7 @@ checkout [this page](build-oracle-server.md).
   - `unit` - The unit denomination of the outcome value
   - `precision` - The precision of the outcome representing the base exponent by which to multiply the number represented by the composition of the digits to obtain the actual outcome value.
   - `--signed`- Whether the outcomes can be negative
-- `getevent` `event` - Get an event's details
+- `getannouncement` `event` - Get an event's details
   - `eventName` - The event's name
 - `signannouncement` `event` `outcome` - Signs an event
     - `eventName` - The event's name

--- a/docs/oracle/oracle-server.md
+++ b/docs/oracle/oracle-server.md
@@ -15,18 +15,18 @@ checkout [this page](build-oracle-server.md).
 - `getpublickey` - Get oracle's public key
 - `getstakingaddress` - Get oracle's staking address
 - `listevents` - Lists all event names
-- `createenumevent` `label` `maturationtime` `outcomes` - Registers an oracle enum event
+- `createenumannouncement` `label` `maturationtime` `outcomes` - Registers an oracle enum event
   - `label` - Label for this event
   - `maturationtime` - The earliest expected time an outcome will be signed, given in ISO 8601 format
   - `outcomes` - Possible outcomes for this event
-- `createnumericevent` `name` `maturationtime` `minvalue` `maxvalue` `unit` `precision` - Registers an oracle event that uses digit decomposition when signing the number
+- `createnumericannouncement` `name` `maturationtime` `minvalue` `maxvalue` `unit` `precision` - Registers an oracle event that uses digit decomposition when signing the number
   - `name`- Name for this event
   - `maturationtime` - The earliest expected time an outcome will be signed, given in ISO 8601 format
   - `minvalue` - Minimum value of this event
   - `maxvalue` - Maximum value of this event
   - `unit` - The unit denomination of the outcome value
   - `precision` - The precision of the outcome representing the base exponent by which to multiply the number represented by the composition of the digits to obtain the actual outcome value.
-- `createdigitdecompevent` `name` `maturationtime` `base` `numdigits` `unit` `precision` `[signed]` - Registers an oracle event that uses digit decomposition when signing the number
+- `createdigitdecompannouncement` `name` `maturationtime` `base` `numdigits` `unit` `precision` `[signed]` - Registers an oracle event that uses digit decomposition when signing the number
   - `name`- Name for this event
   - `maturationtime` - The earliest expected time an outcome will be signed, given in epoch second
   - `base` - The base in which the outcome value is decomposed
@@ -36,7 +36,7 @@ checkout [this page](build-oracle-server.md).
   - `--signed`- Whether the outcomes can be negative
 - `getevent` `event` - Get an event's details
   - `eventName` - The event's name
-- `signevent` `event` `outcome` - Signs an event
+- `signannouncement` `event` `outcome` - Signs an event
     - `eventName` - The event's name
     - `outcome`- Outcome to sign for this event
 - `signdigits` `event` `outcome` - Signs an event


### PR DESCRIPTION
This renames endpoints on the oracleServer to be make accurate to what is being created. Previously we used the suffix `event`. This was what we were actually creating or signing, in most cases it was an `announcement`. 

This PR doesn't remove the old endpoints for now, but they will be removed in the next release (1.9) as of this writing.