### PR TITLE
Fixed splitIntoRanges bug for zig-zag payout curve

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/CETCalculatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/CETCalculatorTest.scala
@@ -57,6 +57,30 @@ class CETCalculatorTest extends BitcoinSUnitTest {
     assert(ranges == expected)
   }
 
+  it should "correctly split into ranges when payout is constantly changing" in {
+    val func = DLCPayoutCurve(
+      Vector(
+        OutcomePayoutPoint(0, 1000, isEndpoint = true),
+        OutcomePayoutPoint(1, 0, isEndpoint = true),
+        OutcomePayoutPoint(2, 1000, isEndpoint = true),
+        OutcomePayoutPoint(3, 0, isEndpoint = true),
+        OutcomePayoutPoint(4, 1000, isEndpoint = true),
+        OutcomePayoutPoint(5, 0, isEndpoint = true),
+        OutcomePayoutPoint(6, 1000, isEndpoint = true),
+        OutcomePayoutPoint(7, 0, isEndpoint = true)
+      ))
+
+    val expected = Vector(VariablePayoutRange(0, 7))
+
+    val ranges = CETCalculator.splitIntoRanges(0,
+                                               7,
+                                               Satoshis(10000),
+                                               func,
+                                               RoundingIntervals.noRounding)
+
+    assert(ranges == expected)
+  }
+
   it should "correctly compute front groupings" in {
     val expected = Vector(
       Vector(1, 0, 9, 5),

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/CETCalculator.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/CETCalculator.scala
@@ -81,7 +81,7 @@ object CETCalculator {
     val firstRange = SingletonPayoutRange(from)
 
     val (currentFunc, currentFuncIndex) =
-      if (from == firstFunc.rightEndpoint.outcome && from != to) {
+      if (from + 1 == firstFunc.rightEndpoint.outcome && from + 1 != to) {
         (function.functionComponents(firstFuncIndex + 1), firstFuncIndex + 1)
       } else {
         (firstFunc, firstFuncIndex)


### PR DESCRIPTION
Fixed edge case of numeric range computation where payout(0) > 0 and each point is a new function component on a numeric event. (After and before graphs attached)
<img width="712" alt="Screen Shot 2021-10-01 at 1 11 06 PM" src="https://user-images.githubusercontent.com/22485603/135661819-7047ef9d-9b7a-4dd5-be09-8c30481d1110.png">
<img width="712" alt="Screen Shot 2021-10-01 at 12 32 53 PM" src="https://user-images.githubusercontent.com/22485603/135661824-a2027f37-25e6-4e4c-86dd-2d51702d44a8.png">
