### PR TITLE
2021 10 02 create contract info

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonReaders.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonReaders.scala
@@ -38,6 +38,7 @@ import org.bitcoins.core.script.crypto.HashType
 import org.bitcoins.core.wallet.fee.{BitcoinFeeUnit, SatoshisPerByte}
 import org.bitcoins.crypto._
 import play.api.libs.json._
+import ujson.{Num, Str, Value}
 
 import java.io.File
 import java.net.{InetAddress, InetSocketAddress, URI}
@@ -1406,4 +1407,13 @@ object JsonReaders {
   implicit val walletTransactionReads: Reads[WalletTransaction] =
     Json.reads[WalletTransaction]
 
+  def jsToSatoshis(js: Value): Satoshis =
+    js match {
+      case str: Str =>
+        Satoshis(BigInt(str.value))
+      case num: Num =>
+        Satoshis(num.value.toLong)
+      case _: Value =>
+        throw Value.InvalidData(js, "Expected value in Satoshis")
+    }
 }

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/PicklerKeys.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/PicklerKeys.scala
@@ -7,4 +7,8 @@ object PicklerKeys {
   final val theirPayout: String = "theirPayout"
   final val pnl: String = "pnl"
   final val rateOfReturn: String = "rateOfReturn"
+
+  final val outcomeKey: String = "outcome"
+  final val localPayoutKey: String = "localPayout"
+  final val outcomesKey: String = "outcomes"
 }

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -271,9 +271,8 @@ object Picklers {
   }
 
   private def contractV0Writer(v0: ContractDescriptorV0TLV): Value = {
-    val outcomesJs: Vector[Obj] = v0.outcomes.map { case (outcome, payout) =>
-      Obj(PicklerKeys.outcomeKey -> Str(outcome),
-          PicklerKeys.localPayoutKey -> Num(payout.toLong.toDouble))
+    val outcomesJs: ujson.Obj = v0.outcomes.map { case (outcome, payout) =>
+      outcome -> Num(payout.toLong.toDouble)
     }
     Obj(PicklerKeys.outcomesKey -> outcomesJs)
   }

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -839,21 +839,12 @@ object Picklers {
     readwriter[String].bimap(_.toString, AddressType.fromString)
 
   def parseContractDescriptor(payoutsVal: Value): ContractDescriptorV0TLV = {
-    println(s"ParseContractDescriptor payoutsVal=$payoutsVal")
     val outcomes = payoutsVal(PicklerKeys.outcomesKey)
-    val payouts: Vector[(String, Satoshis)] = outcomes.arr.toVector.map {
-      case mapping: ujson.Obj =>
-        require(mapping.arr.toVector.length == 2,
-                s"Payout must have two values, [payout,outcome], got=$mapping")
-        val outcome = mapping(PicklerKeys.outcomeKey).str
-        val payout = jsToSatoshis(mapping(PicklerKeys.localPayoutKey))
+    val payouts: Vector[(String, Satoshis)] = outcomes.obj.toVector.map {
+      case (outcome, payoutJs) =>
+        val payout = jsToSatoshis(payoutJs.num)
         (outcome, payout)
-      case x @ (_: ujson.Bool | _: ujson.Num | ujson.Null | _: ujson.Arr |
-          _: ujson.Str) =>
-        sys.error(
-          s"Must receive an object for parsing contract descriptor, got=$x")
     }
-    println(s"Done parse contract descriptor")
     ContractDescriptorV0TLV(outcomes = payouts)
   }
 }

--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.cli
 
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.LockUnspentOutputParameter
+import org.bitcoins.commons.serializers.Picklers
 import org.bitcoins.core.api.wallet.CoinSelectionAlgo
 import org.bitcoins.core.config.{NetworkParameters, Networks}
 import org.bitcoins.core.crypto.{ExtPrivateKey, MnemonicCode}
@@ -117,6 +118,17 @@ object CliReaders {
 
       override def reads: String => OracleEventV0TLV = OracleEventV0TLV.fromHex
     }
+
+  implicit val contractDescriptorReads: Read[ContractDescriptorTLV] = {
+    new Read[ContractDescriptorTLV] {
+      override def arity: Int = 1
+      override def reads: String => ContractDescriptorTLV = { str =>
+        val ujsonVal = ujson.read(str)
+        upickle.default.read[ContractDescriptorV0TLV](ujsonVal)(
+          Picklers.contractDescriptorV0)
+      }
+    }
+  }
 
   implicit val instantReads: Read[Instant] =
     new Read[Instant] {

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1136,6 +1136,38 @@ object ConsoleCli {
                 case _: GetDLC => GetDLC(dlcId)
                 case other     => other
               }))),
+      cmd("createcontractinfo")
+        .action((_, conf) => conf.copy(command = CreateContractInfo.empty))
+        .text("Create a contract info from an announcement, total collateral, and contract descriptor")
+        .children(
+          arg[OracleAnnouncementTLV]("announcement")
+            .text("The announcement we are creating a contract info for")
+            .required()
+            .action((ann, conf) =>
+              conf.copy(command = conf.command match {
+                case create: CreateContractInfo =>
+                  create.copy(announcementTLV = ann)
+                case other => other
+              })),
+          arg[Satoshis]("totalCollateral")
+            .text("The total collateral in the DLC. This is your collateral + counterparty collateral")
+            .required()
+            .action((totalCollateral, conf) =>
+              conf.copy(command = conf.command match {
+                case create: CreateContractInfo =>
+                  create.copy(totalCollateral = totalCollateral)
+                case other => other
+              })),
+          arg[ContractDescriptorTLV]("contractDescriptor")
+            .text("The contract descriptor in the DLC. This is expected to be of format [[outcome1, payout1], [outcome2, payout2], ...]")
+            .required()
+            .action((contractDescriptor, conf) =>
+              conf.copy(command = conf.command match {
+                case create: CreateContractInfo =>
+                  create.copy(contractDescriptorTLV = contractDescriptor)
+                case other => other
+              }))
+        ),
       note(sys.props("line.separator") + "=== Network ==="),
       cmd("getpeers")
         .action((_, conf) => conf.copy(command = GetPeers))
@@ -1952,6 +1984,12 @@ object ConsoleCli {
         // skip sending to server and just return version number of cli
         return Success(EnvUtil.getVersion)
 
+      case CreateContractInfo(ann, totalCollateral, contractDescriptor) =>
+        RequestParam("createcontractinfo",
+                     Seq(up.writeJs(ann),
+                         up.writeJs(totalCollateral),
+                         up.writeJs(contractDescriptor)))
+
       case NoCommand => ???
     }
 
@@ -2160,6 +2198,21 @@ object CliCommand {
 
   case object GetDLCs extends AppServerCliCommand
   case class GetDLC(dlcId: Sha256Digest) extends AppServerCliCommand
+
+  case class CreateContractInfo(
+      announcementTLV: OracleAnnouncementTLV,
+      totalCollateral: Satoshis,
+      contractDescriptorTLV: ContractDescriptorTLV)
+      extends AppServerCliCommand
+
+  object CreateContractInfo {
+
+    val empty: CreateContractInfo = {
+      CreateContractInfo(announcementTLV = OracleAnnouncementV0TLV.dummy,
+                         totalCollateral = Satoshis.zero,
+                         contractDescriptorTLV = ContractDescriptorTLV.empty)
+    }
+  }
 
   sealed trait SendCliCommand extends AppServerCliCommand {
     def destination: BitcoinAddress

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1985,10 +1985,10 @@ object ConsoleCli {
         return Success(EnvUtil.getVersion)
 
       case CreateContractInfo(ann, totalCollateral, contractDescriptor) =>
-        RequestParam("createcontractinfo",
-                     Seq(up.writeJs(ann),
-                         up.writeJs(totalCollateral),
-                         up.writeJs(contractDescriptor)))
+        val args = Seq(up.writeJs(ann),
+                       up.writeJs(totalCollateral),
+                       up.writeJs(contractDescriptor))
+        RequestParam("createcontractinfo", args)
 
       case NoCommand => ???
     }

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -2207,7 +2207,7 @@ object CliCommand {
 
   object CreateContractInfo {
 
-    val empty: CreateContractInfo = {
+    lazy val empty: CreateContractInfo = {
       CreateContractInfo(announcementTLV = OracleAnnouncementV0TLV.dummy,
                          totalCollateral = Satoshis.zero,
                          contractDescriptorTLV = ContractDescriptorTLV.empty)

--- a/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
+++ b/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
@@ -7,9 +7,7 @@ import org.bitcoins.core.api.dlcoracle.db.EventDb
 import org.bitcoins.core.config._
 import org.bitcoins.core.number.{Int32, UInt16}
 import org.bitcoins.core.protocol.Bech32Address
-import org.bitcoins.core.protocol.dlc.compute.SigningVersion
 import org.bitcoins.core.protocol.tlv.{
-  EnumEventDescriptorV0TLV,
   NormalizedString,
   OracleAnnouncementV0TLV,
   OracleAttestmentV0TLV
@@ -18,6 +16,7 @@ import org.bitcoins.crypto._
 import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
 import org.bitcoins.server.routes.ServerCommand
 import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkitcore.util.OracleTestUtil
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.wordspec.AnyWordSpec
 import ujson._
@@ -38,45 +37,28 @@ class OracleRoutesSpec
 
   val oracleRoutes: OracleRoutes = OracleRoutes(mockOracleApi)
 
-  val testAddressStr = "bc1qvrctqwa6g70z5vtxsyft7xvsyyt749trlm80al"
-  val testAddress: Bech32Address = Bech32Address.fromString(testAddressStr)
+  val testAddressStr = OracleTestUtil.testAddressStr
+  val testAddress: Bech32Address = OracleTestUtil.testAddress
 
-  val kVal: ECPrivateKey = ECPrivateKey.fromHex(
-    "447d4457dfff21354d56cb1b62b2ab6e5964c5ef93e6d74ae3b30dc83b89b6a5")
+  val kVal: ECPrivateKey = OracleTestUtil.kVal
 
-  val dummyPrivKey: ECPrivateKey = ECPrivateKey.fromHex(
-    "f04671ab68f3fefbeaa344c49149748f722287a81b19cd956b2332d07b8f6853")
+  val dummyPrivKey: ECPrivateKey = OracleTestUtil.dummyPrivKey
 
-  val dummyKey: ECPublicKey = dummyPrivKey.publicKey
+  val dummyKey: ECPublicKey = OracleTestUtil.dummyKey
 
-  val outcome: NormalizedString = EnumEventDescriptorV0TLV.dummy.outcomes.head
+  val outcome: NormalizedString = OracleTestUtil.outcome
 
-  val hash: Sha256Digest = CryptoUtil.sha256DLCAttestation(outcome)
+  val hash: Sha256Digest = OracleTestUtil.hash
 
   val sig: SchnorrDigitalSignature =
-    dummyPrivKey.schnorrSignWithNonce(hash.bytes, kVal)
+    OracleTestUtil.sig
 
-  val dummyEventDb: EventDb = EventDb(
-    nonce = kVal.schnorrNonce,
-    pubkey = dummyKey.schnorrPublicKey,
-    nonceIndex = 0,
-    eventName = "id",
-    numOutcomes = 2,
-    signingVersion = SigningVersion.latest,
-    maturationTime = Instant.ofEpochSecond(0),
-    attestationOpt = Some(sig.sig),
-    outcomeOpt = Some(outcome),
-    announcementSignature = SchnorrDigitalSignature(
-      "1efe41fa42ea1dcd103a0251929dd2b192d2daece8a4ce4d81f68a183b750d92d6f02d796965dc79adf4e7786e08f861a1ecc897afbba2dab9cff6eb0a81937e"),
-    eventDescriptorTLV = EnumEventDescriptorV0TLV.dummy
-  )
+  val dummyEventDb: EventDb = OracleTestUtil.dummyEventDb
 
-  val dummyOracleEvent: CompletedOracleEvent = OracleEvent
-    .fromEventDbs(Vector(dummyEventDb))
-    .asInstanceOf[CompletedOracleEvent]
+  val dummyOracleEvent: CompletedOracleEvent = OracleTestUtil.dummyOracleEvent
 
   val dummyAttestmentTLV: OracleAttestmentV0TLV =
-    dummyOracleEvent.oracleAttestmentV0TLV
+    OracleTestUtil.dummyAttestmentTLV
 
   "The oracle server" must {
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/DLCRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/DLCRoutesSpec.scala
@@ -26,12 +26,13 @@ class DLCRoutesSpec
   //https://test.oracle.suredbits.com/contract/enum/5fbc1d037bacd9ece32ff4b591143bce7fa1c22e0aec2fa8437cc336feb95138
   val expectedContractInfo = ContractInfo.fromHex(
     "fdd82efd01120000000005f5e100fda7103b030e52657075626c6963616e5f77696e00000000000000000c44656d6f637261745f77696e0000000005f5e100056f746865720000000003938700fda712c7fdd824c3988fabec9820690f366271c9ceac00fbec1412075f9b319bb0db1f86460519dd9c61478949f2c00c35aeb8e53a1507616072cb802891e2c189a9fa65a0493de5d3b04a6d7b90c9c43c09ebe5250d583e1c3fc423219b26f6a02ec394a130000afdd8225f0001ae3e30df5a203ad10ee89a909df0c8ccea4836e94e0a5d34c3cdab758fcaee1460189600fdd8062400030e52657075626c6963616e5f77696e0c44656d6f637261745f77696e056f7468657210323032302d75732d656c656374696f6e")
+
   "DLC Routes" should {
     "createcontractinfo" in {
       val totalCollateral = Bitcoins.one
       val payouts: Vector[ujson.Arr] = Vector(
-        ujson.Arr(ujson.Str("Democrat_win"), ujson.Num(100000000)),
         ujson.Arr(ujson.Str("Republican_win"), ujson.Num(0)),
+        ujson.Arr(ujson.Str("Democrat_win"), ujson.Num(100000000)),
         ujson.Arr(ujson.Str("other"), ujson.Num(60000000))
       )
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/DLCRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/DLCRoutesSpec.scala
@@ -1,11 +1,12 @@
 package org.bitcoins.server
 
-import akka.http.scaladsl.model.{ContentTypes}
+import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.bitcoins.commons.serializers.PicklerKeys
 import org.bitcoins.core.api.dlc.node.DLCNodeApi
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.protocol.dlc.models.ContractInfo
-import org.bitcoins.core.protocol.tlv.{OracleAnnouncementTLV}
+import org.bitcoins.core.protocol.tlv.OracleAnnouncementTLV
 import org.bitcoins.server.routes.ServerCommand
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.wordspec.AnyWordSpec
@@ -30,16 +31,19 @@ class DLCRoutesSpec
   "DLC Routes" should {
     "createcontractinfo" in {
       val totalCollateral = Bitcoins.one
-      val payouts: Vector[ujson.Arr] = Vector(
-        ujson.Arr(ujson.Str("Republican_win"), ujson.Num(0)),
-        ujson.Arr(ujson.Str("Democrat_win"), ujson.Num(100000000)),
-        ujson.Arr(ujson.Str("other"), ujson.Num(60000000))
+      val map = Map(
+        "Republican_win" -> ujson.Num(0),
+        "Democrat_win" -> ujson.Num(100000000),
+        "other" -> ujson.Num(60000000)
       )
+      val payouts = ujson.Obj.from(map.toVector)
+
+      val outcomes = ujson.Obj((PicklerKeys.outcomesKey, payouts))
 
       val args = ujson.Arr(
         announcement.hex,
         ujson.Num(totalCollateral.satoshis.toLong.toDouble),
-        ujson.Arr.from(payouts)
+        outcomes
       )
       val route =
         dlcRoutes.handleCommand(ServerCommand("createcontractinfo", args))

--- a/app/server-test/src/test/scala/org/bitcoins/server/DLCRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/DLCRoutesSpec.scala
@@ -1,0 +1,53 @@
+package org.bitcoins.server
+
+import akka.http.scaladsl.model.{ContentTypes}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.bitcoins.core.api.dlc.node.DLCNodeApi
+import org.bitcoins.core.currency.Bitcoins
+import org.bitcoins.core.protocol.dlc.models.ContractInfo
+import org.bitcoins.core.protocol.tlv.{OracleAnnouncementTLV}
+import org.bitcoins.server.routes.ServerCommand
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.wordspec.AnyWordSpec
+
+class DLCRoutesSpec
+    extends AnyWordSpec
+    with ScalatestRouteTest
+    with MockFactory {
+
+  val dlcApi = mock[DLCNodeApi]
+
+  val dlcRoutes = DLCRoutes(dlcApi)
+
+  //https://test.oracle.suredbits.com/announcement/8863cd80e1d37f668e27b84cbfed48541d671b4fed1462b86d547e7f13b5a9e4
+  val announcement = OracleAnnouncementTLV.fromHex(
+    "fdd824c3988fabec9820690f366271c9ceac00fbec1412075f9b319bb0db1f86460519dd9c61478949f2c00c35aeb8e53a1507616072cb802891e2c189a9fa65a0493de5d3b04a6d7b90c9c43c09ebe5250d583e1c3fc423219b26f6a02ec394a130000afdd8225f0001ae3e30df5a203ad10ee89a909df0c8ccea4836e94e0a5d34c3cdab758fcaee1460189600fdd8062400030e52657075626c6963616e5f77696e0c44656d6f637261745f77696e056f7468657210323032302d75732d656c656374696f6e")
+
+  //https://test.oracle.suredbits.com/contract/enum/5fbc1d037bacd9ece32ff4b591143bce7fa1c22e0aec2fa8437cc336feb95138
+  val expectedContractInfo = ContractInfo.fromHex(
+    "fdd82efd01120000000005f5e100fda7103b030e52657075626c6963616e5f77696e00000000000000000c44656d6f637261745f77696e0000000005f5e100056f746865720000000003938700fda712c7fdd824c3988fabec9820690f366271c9ceac00fbec1412075f9b319bb0db1f86460519dd9c61478949f2c00c35aeb8e53a1507616072cb802891e2c189a9fa65a0493de5d3b04a6d7b90c9c43c09ebe5250d583e1c3fc423219b26f6a02ec394a130000afdd8225f0001ae3e30df5a203ad10ee89a909df0c8ccea4836e94e0a5d34c3cdab758fcaee1460189600fdd8062400030e52657075626c6963616e5f77696e0c44656d6f637261745f77696e056f7468657210323032302d75732d656c656374696f6e")
+  "DLC Routes" should {
+    "createcontractinfo" in {
+      val totalCollateral = Bitcoins.one
+      val payouts: Vector[ujson.Arr] = Vector(
+        ujson.Arr(ujson.Str("Democrat_win"), ujson.Num(100000000)),
+        ujson.Arr(ujson.Str("Republican_win"), ujson.Num(0)),
+        ujson.Arr(ujson.Str("other"), ujson.Num(60000000))
+      )
+
+      val args = ujson.Arr(
+        announcement.hex,
+        ujson.Num(totalCollateral.satoshis.toLong.toDouble),
+        ujson.Arr.from(payouts)
+      )
+      val route =
+        dlcRoutes.handleCommand(ServerCommand("createcontractinfo", args))
+
+      Post() ~> route ~> check {
+        assert(contentType == ContentTypes.`application/json`)
+        assert(responseAs[
+          String] == s"""{"result":"${expectedContractInfo.hex}","error":null}""")
+      }
+    }
+  }
+}

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -1204,11 +1204,9 @@ object CreateContractInfo extends ServerJsonModels {
             OracleAnnouncementTLV.fromHex(announcementVal.str)
           val totalCollateral = Satoshis(totalCollateralVal.num.toLong)
           //validate that these are part of the announcement?
-          println(s"Starting contract descriptor, =$payoutsVal")
           val contractDescriptor = upickle.default
             .read[ContractDescriptorV0TLV](payoutsVal)(
               Picklers.contractDescriptorV0)
-          println(s"Done contract descriptor")
           CreateContractInfo(announcementTLV,
                              totalCollateral,
                              contractDescriptor)

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -867,15 +867,18 @@ object OracleAnnouncementV0TLV extends TLVFactory[OracleAnnouncementV0TLV] {
   }
 
   lazy val dummy: OracleAnnouncementV0TLV = {
-    val priv = ECPrivateKey.freshPrivateKey
-    val event = OracleEventV0TLV(OrderedNonces(Vector(priv.schnorrNonce)),
-                                 UInt32.zero,
-                                 EnumEventDescriptorV0TLV.dummy,
-                                 "dummy")
+    val dummyPrivKey: ECPrivateKey = ECPrivateKey.fromHex(
+      "f04671ab68f3fefbeaa344c49149748f722287a81b19cd956b2332d07b8f6853")
+    val event = OracleEventV0TLV(
+      OrderedNonces(Vector(dummyPrivKey.schnorrNonce)),
+      UInt32.zero,
+      EnumEventDescriptorV0TLV.dummy,
+      "dummy")
     val sig =
-      priv.schnorrSign(CryptoUtil.sha256DLCAnnouncement(event.bytes).bytes)
+      dummyPrivKey.schnorrSign(
+        CryptoUtil.sha256DLCAnnouncement(event.bytes).bytes)
 
-    OracleAnnouncementV0TLV(sig, priv.schnorrPublicKey, event)
+    OracleAnnouncementV0TLV(sig, dummyPrivKey.schnorrPublicKey, event)
   }
 
   def dummyForEventsAndKeys(

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -997,6 +997,8 @@ object ContractDescriptorTLV extends TLVParentFactory[ContractDescriptorTLV] {
     Vector(ContractDescriptorV0TLV, ContractDescriptorV1TLV)
 
   override val typeName: String = "ContractDescriptorTLV"
+
+  val empty: ContractDescriptorTLV = ContractDescriptorV0TLV(Vector.empty)
 }
 
 /** @see https://github.com/discreetlogcontracts/dlcspecs/blob/master/Messaging.md#version-0-contract_info */

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -231,6 +231,10 @@ the `-p 9999:9999` port mapping on the docker container to adjust for this.
    - `location` - The locations of the backup file
 
 ### DLC
+ - `createcontractinfo` `announcement` `totalCollateral` `payouts`
+   - the announcement to build the contract info for
+   - the total amount of collateral in the DLC
+   - The payouts in `{ "outcomes" : { "outcome1" : 1, "outcome2": 2, ... }}`. The number is the amount of sats paid to YOU for that outcome.
  - `decodecontractinfo` `contractinfo` - Decodes a contract info into json
    - `contractinfo` - Hex encoded contract info
  - `decodeoffer` `offer` - Decodes an offer message into json

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/OracleTestUtil.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/OracleTestUtil.scala
@@ -1,0 +1,62 @@
+package org.bitcoins.testkitcore.util
+
+import org.bitcoins.core.api.dlcoracle.{CompletedOracleEvent, OracleEvent}
+import org.bitcoins.core.api.dlcoracle.db.EventDb
+import org.bitcoins.core.protocol.Bech32Address
+import org.bitcoins.core.protocol.dlc.compute.SigningVersion
+import org.bitcoins.core.protocol.tlv.{
+  EnumEventDescriptorV0TLV,
+  NormalizedString,
+  OracleAttestmentV0TLV
+}
+import org.bitcoins.crypto.{
+  CryptoUtil,
+  ECPrivateKey,
+  ECPublicKey,
+  SchnorrDigitalSignature,
+  Sha256Digest
+}
+
+import java.time.Instant
+
+object OracleTestUtil {
+  val testAddressStr = "bc1qvrctqwa6g70z5vtxsyft7xvsyyt749trlm80al"
+  val testAddress: Bech32Address = Bech32Address.fromString(testAddressStr)
+
+  val kVal: ECPrivateKey = ECPrivateKey.fromHex(
+    "447d4457dfff21354d56cb1b62b2ab6e5964c5ef93e6d74ae3b30dc83b89b6a5")
+
+  val dummyPrivKey: ECPrivateKey = ECPrivateKey.fromHex(
+    "f04671ab68f3fefbeaa344c49149748f722287a81b19cd956b2332d07b8f6853")
+
+  val dummyKey: ECPublicKey = dummyPrivKey.publicKey
+
+  val outcome: NormalizedString = EnumEventDescriptorV0TLV.dummy.outcomes.head
+
+  val hash: Sha256Digest = CryptoUtil.sha256DLCAttestation(outcome)
+
+  val sig: SchnorrDigitalSignature =
+    dummyPrivKey.schnorrSignWithNonce(hash.bytes, kVal)
+
+  val dummyEventDb: EventDb = EventDb(
+    nonce = kVal.schnorrNonce,
+    pubkey = dummyKey.schnorrPublicKey,
+    nonceIndex = 0,
+    eventName = "id",
+    numOutcomes = 2,
+    signingVersion = SigningVersion.latest,
+    maturationTime = Instant.ofEpochSecond(0),
+    attestationOpt = Some(sig.sig),
+    outcomeOpt = Some(outcome),
+    announcementSignature = SchnorrDigitalSignature(
+      "1efe41fa42ea1dcd103a0251929dd2b192d2daece8a4ce4d81f68a183b750d92d6f02d796965dc79adf4e7786e08f861a1ecc897afbba2dab9cff6eb0a81937e"),
+    eventDescriptorTLV = EnumEventDescriptorV0TLV.dummy
+  )
+
+  val dummyOracleEvent: CompletedOracleEvent = OracleEvent
+    .fromEventDbs(Vector(dummyEventDb))
+    .asInstanceOf[CompletedOracleEvent]
+
+  val dummyAttestmentTLV: OracleAttestmentV0TLV =
+    dummyOracleEvent.oracleAttestmentV0TLV
+}


### PR DESCRIPTION
Adds `createcontractinfo` RPC. This was needed to complete #3631 

Arguments 

1. announcement
2. total collateral
3. contract descriptor, currently in an json object with key `outcomes`

### Example

```
./bitcoin-s-cli createcontractinfo fdd824c3988fabec9820690fceac00fbec1412075f9b319bb0db1f86460519dd9c61478949f2c00c35aeb8e53a1507616072cb802891e2c189a9fa65a0493de5d3b04a6d7b90c9c43c09ebe5250d583e1c3fc423219b26f6a02ec394a130000afdd8225f00
01ae3e30df5a203ad10ee89a909df0c8ccea4836e94e0a5d34c3cdab758fcaee1460189600fdd8062400030e52657075626c6963616e5f77696e0c44656d6f637261745f77696e056f7468657210323032302d75732d656c65
6374696f6e \                                                                                                                                                                      
100000000 \                                                                                                                                                                       
"{\"outcomes\" : { \"Republican_win\" : 0, \"Democrat_win\" : 100000000, \"other\" : 60000000 }}"                                                                                                                                                                                                        
fdd82efd01120000000005f5e100fda7103b030e52657075626c6963616e5f77696e00000000000000000c44656d6f637261745f77696e0000000005f5e100056f746865720000000003938700fda712c7fdd824c3988fabec
9820690f366271c9ceac00fbec1412075f9b319bb0db1f86460519dd9c61478949f2c00c35aeb8e53a1507616072cb802891e2c189a9fa65a0493de5d3b04a6d7b90c9c43c09ebe5250d583e1c3fc423219b26f6a02ec394a1
30000afdd8225f0001ae3e30df5a203ad10ee89a909df0c8ccea4836e94e0a5d34c3cdab758fcaee1460189600fdd8062400030e52657075626c6963616e5f77696e0c44656d6f637261745f77696e056f7468657210323032
302d75732d656c656374696f6e
```