### PR TITLE
disable secp256k1 on native images so we don't run into linking errors

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -9,6 +9,8 @@ on:
   release:
     types: [published]
 jobs:
+  env:
+    DISABLE_SECP256K1: "true"
   unix:
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Found when testing #3713 

```
./bitcoin-s-cli createcontractinfo fdd824c3988fabec9820690f366271c9ceac00fbec1412075f9b319bb0db1f86460519dd9c61478949f2c00c35aeb8e53a1507616072cb802891e2c189a9fa65a0493de5d3b04a6d7b90c9c43c09ebe5250d583e1c3fc423219b26f6a02ec394a130000afdd8225f0001ae3e30df5a203ad10ee89a909df0c8ccea4836e94e0a5d34c3cdab758fcaee1460189600fdd8062400030e52657075626c6963616e5f77696e0c44656d6f637261745f77696e056f7468657210323032302d75732d656c656374696f6e \
100000000 \
"[[\"Republican_win\", 0], [\"Democrat_win\", 100000000], [\"other\", 60000000]]"
Error: Command createcontractinfo failed when given ''. org.bitcoin.NativeSecp256k1.secp256k1_ec_seckey_verify(Ljava/nio/ByteBuffer;J)I [symbol: Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1seckey_1verify or Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1seckey_1verify__Ljava_nio_ByteBuffer_2J]
```