### PR TITLE
Fix bug with unsigned digit decomp events and signing negative outcomes

### DIFF
--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -358,12 +358,7 @@ case class DLCOracle()(implicit val conf: DLCOracleAppConfig)
           createAttestation(oracleEventTLV.nonces.head, signOutcome).map(db =>
             Vector(db))
         case _: UnsignedDigitDecompositionEventDescriptor =>
-          if (num >= 0) {
-            FutureUtil.emptyVec[EventDb]
-          } else {
-            Future.failed(new IllegalArgumentException(
-              s"Cannot sign a negative number for an unsigned event, got $num"))
-          }
+          FutureUtil.emptyVec[EventDb]
       }
 
     val boundedNum = if (num < eventDescriptorTLV.minNum) {


### PR DESCRIPTION
We had incorrect behavior in the oracle for the case where a oracle incorrectly published a digit decomp event. 

#### Hypothetical 

Let's say the oracle is attesting to the temperature of Miami in celsius. Miami does not often see negative temperature in celsius. Due to extreme weather conditions, on the day of the attestation, the temperature of Miami was -5 degrees celsius. 

The oracle is unable to accurately attest to the temperature because he published an unsigned digit decomp announcement. [According to the oracle spec](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Oracle.md#digit-decomposition) the user must attest to the outcome `0` in this case. 

This was not possible previously, because we would throw an exception in `signDigits()`. This removes the exception for this case and adds a test case to make sure we behave correctly.

