### PR TITLE
Add ControlMessageHandler

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -455,6 +455,8 @@ object TransactionMessage extends Factory[TransactionMessage] {
   */
 sealed trait ControlPayload extends NetworkPayload
 
+sealed trait GossipAddrMessage extends ControlPayload
+
 /** The addr (IP address) message relays connection information for peers on the network.
   * Each peer which wants to accept incoming connections creates an addr message providing its
   * connection information and then sends that message to its peers unsolicited.
@@ -463,7 +465,7 @@ sealed trait ControlPayload extends NetworkPayload
   * any program already on the network.
   * @see [[https://bitcoin.org/en/developer-reference#addr]]
   */
-trait AddrMessage extends ControlPayload {
+trait AddrMessage extends GossipAddrMessage {
   def ipCount: CompactSizeUInt
   def addresses: Seq[NetworkIpAddress]
   override def commandName = NetworkPayload.addrCommandName
@@ -500,7 +502,7 @@ object AddrMessage extends Factory[AddrMessage] {
   *
   * @see https://github.com/bitcoin/bips/blob/master/bip-0155.mediawiki
   */
-sealed trait AddrV2Message extends ControlPayload {
+sealed trait AddrV2Message extends GossipAddrMessage {
   def time: UInt32
   def services: CompactSizeUInt
   def networkId: Byte

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -14,7 +14,10 @@ import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
-import org.bitcoins.node.networking.peer.DataMessageHandler
+import org.bitcoins.node.networking.peer.{
+  ControlMessageHandler,
+  DataMessageHandler
+}
 
 import scala.concurrent.Future
 
@@ -36,6 +39,8 @@ case class NeutrinoNode(
   override def chainAppConfig: ChainAppConfig = chainConfig
 
   override val peers: Vector[Peer] = nodePeer
+
+  val controlMessageHandler: ControlMessageHandler = ControlMessageHandler(this)
 
   override def getDataMessageHandler: DataMessageHandler = dataMessageHandler
 

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -22,6 +22,7 @@ import org.bitcoins.node.models.{
 }
 import org.bitcoins.node.networking.P2PClient
 import org.bitcoins.node.networking.peer.{
+  ControlMessageHandler,
   DataMessageHandler,
   PeerMessageReceiver,
   PeerMessageSender
@@ -85,6 +86,8 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     * to make sure we don't corrupt our chainstate cache
     */
   def getDataMessageHandler: DataMessageHandler
+
+  def controlMessageHandler: ControlMessageHandler
 
   def nodeCallbacks: NodeCallbacks = nodeAppConfig.nodeCallbacks
 

--- a/node/src/main/scala/org/bitcoins/node/SpvNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/SpvNode.scala
@@ -11,7 +11,10 @@ import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.util.Mutable
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
-import org.bitcoins.node.networking.peer.DataMessageHandler
+import org.bitcoins.node.networking.peer.{
+  ControlMessageHandler,
+  DataMessageHandler
+}
 
 import scala.concurrent.Future
 
@@ -36,6 +39,8 @@ case class SpvNode(
   private val _bloomFilter = new Mutable(BloomFilter.empty)
 
   def bloomFilter: BloomFilter = _bloomFilter.atomicGet
+
+  val controlMessageHandler = ControlMessageHandler(this)
 
   override def getDataMessageHandler: DataMessageHandler = dataMessageHandler
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/ControlMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/ControlMessageHandler.scala
@@ -1,0 +1,78 @@
+package org.bitcoins.node.networking.peer
+
+import org.bitcoins.core.p2p._
+import org.bitcoins.node.models.Peer
+import org.bitcoins.node.networking.peer.PeerMessageReceiverState._
+import org.bitcoins.node.{Node, P2PLogger}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class ControlMessageHandler(node: Node)(implicit ec: ExecutionContext)
+    extends P2PLogger {
+
+  def handleControlPayload(
+      payload: ControlPayload,
+      sender: PeerMessageSender,
+      peer: Peer,
+      peerMessageReceiver: PeerMessageReceiver): Future[PeerMessageReceiver] = {
+    val state = peerMessageReceiver.state
+    payload match {
+
+      case versionMsg: VersionMessage =>
+        logger.trace(s"Received versionMsg=$versionMsg from peer=$peer")
+
+        state match {
+          case bad @ (_: Disconnected | _: Normal | Preconnection |
+              _: InitializedDisconnect | _: InitializedDisconnectDone) =>
+            Future.failed(
+              new RuntimeException(
+                s"Cannot handle version message while in state=${bad}"))
+
+          case good: Initializing =>
+            val newState = good.withVersionMsg(versionMsg)
+
+            sender.sendVerackMessage()
+            node.setPeerServices(peer, versionMsg.services)
+
+            val newRecv = peerMessageReceiver.toState(newState)
+
+            Future.successful(newRecv)
+
+        }
+
+      case VerAckMessage =>
+        state match {
+          case bad @ (_: Disconnected | _: InitializedDisconnect | _: Normal |
+              _: InitializedDisconnectDone | Preconnection) =>
+            Future.failed(
+              new RuntimeException(
+                s"Cannot handle version message while in state=${bad}"))
+
+          case good: Initializing =>
+            val newState = good.toNormal(VerAckMessage)
+            val newRecv = peerMessageReceiver.toState(newState)
+            Future.successful(newRecv)
+        }
+
+      case ping: PingMessage =>
+        sender.sendPong(ping).map(_ => peerMessageReceiver)
+      case SendHeadersMessage =>
+        //we want peers to just send us headers
+        //we don't want to have to request them manually
+        sender.sendHeadersMessage().map(_ => peerMessageReceiver)
+      case _: GossipAddrMessage =>
+        Future.successful(peerMessageReceiver)
+      case SendAddrV2Message =>
+        sender.sendSendAddrV2Message().map(_ => peerMessageReceiver)
+      case _ @(_: FilterAddMessage | _: FilterLoadMessage |
+          FilterClearMessage) =>
+        Future.successful(peerMessageReceiver)
+      case _ @(GetAddrMessage | _: PongMessage) =>
+        Future.successful(peerMessageReceiver)
+      case _: RejectMessage =>
+        Future.successful(peerMessageReceiver)
+      case _: FeeFilterMessage =>
+        Future.successful(peerMessageReceiver)
+    }
+  }
+}


### PR DESCRIPTION
Refactored existing code to move logic related to handling of `ControlPayload` from `PeerMessageReceiver` to a new `ControlMessageHandler` making it similar to how we deal with `DataPayload` in `DataMessageHandler`.

This would be part 1 of breaking down my previous PR (#3512) into smaller units.