### PR TITLE
Bump logging level back to INFO on http servers

### DIFF
--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -63,7 +63,7 @@ case class Server(
   val route: Route =
     // TODO implement better logging
     DebuggingDirectives.logRequestResult(
-      ("http-rpc-server", Logging.DebugLevel)) {
+      ("http-rpc-server", Logging.InfoLevel)) {
       withErrorHandling {
         pathSingleSlash {
           post {


### PR DESCRIPTION
This reverts #3141 

This is very useful for debugging why there is a disconnect between our proxy server and the backend.


This is what the format looks like atm, definitely think we should figure out how to improve this somehow.
```
2021-10-07T15:29:05UTC INFO [ActorSystemImpl] http-rpc-server: Response for
  Request : HttpRequest(HttpMethod(POST),http://localhost:9998/,List(Timeout-Access: <function1>, sec-fetch-site: same-origin, sec-fetch-mode: cors, sec-fetch-dest: empty, Cookie, Referer, Connection: close, Origin, Accept-Encoding: gzip, deflate, Accept-Language: en-US, en;q=0.5, Accept: application/json, text/plain, */*, User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:92.0) Gecko/20100101 Firefox/92.0, Host),HttpEntity.Strict(application/json,46 bytes total),HttpProtocol(HTTP/1.1))
  Response: Complete(HttpResponse(200 OK,List(Access-Control-Allow-Origin: *, Access-Control-Allow-Credentials: true, Access-Control-Allow-Headers: Authorization, Content-Type, X-Requested-With),HttpEntity.Strict(application/json,250 bytes total),HttpProtocol(HTTP/1.1)))
```