### PR TITLE
Added WitnessScriptPubKeyV1 for sending to Taproot addresses

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -213,7 +213,7 @@ class SignerTest extends BitcoinSUnitTest {
                                  UInt32(idx),
                                  o,
                                  Policy.standardFlags)
-      case _: UnassignedWitnessScriptPubKey => ???
+      case _: UnassignedWitnessScriptPubKey | _: WitnessScriptPubKeyV1 => ???
       case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
           _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
           _: WitnessCommitment | _: CSVScriptPubKey | _: CLTVScriptPubKey |

--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -527,6 +527,8 @@ object BitcoinAddress extends AddressFactory[BitcoinAddress] {
       case p2pkh: P2PKHScriptPubKey      => Success(P2PKHAddress(p2pkh, np))
       case p2sh: P2SHScriptPubKey        => Success(P2SHAddress(p2sh, np))
       case witSPK: WitnessScriptPubKeyV0 => Success(Bech32Address(witSPK, np))
+      case taprootSPK: WitnessScriptPubKeyV1 =>
+        Success(Bech32mAddress(taprootSPK, np))
       case unassigned: UnassignedWitnessScriptPubKey =>
         Success(Bech32mAddress(unassigned, np))
       case x @ (_: P2PKScriptPubKey | _: P2PKWithTimeoutScriptPubKey |

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCFundingInput.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCFundingInput.scala
@@ -72,6 +72,9 @@ object DLCFundingInput {
                   maxWitnessLen == UInt16(107) || maxWitnessLen == UInt16(108),
                   s"P2WPKH max witness length must be 107 or 108, got $maxWitnessLen")
               case _: P2WSHWitnessSPKV0 => ()
+              case spk: WitnessScriptPubKeyV1 =>
+                throw new IllegalArgumentException(
+                  s"Taproot not yet supported: $spk")
               case spk: UnassignedWitnessScriptPubKey =>
                 throw new IllegalArgumentException(
                   s"Unknown segwit version: $spk")
@@ -98,6 +101,8 @@ object DLCFundingInput {
                                prevTxVout,
                                sequence,
                                maxWitnessLen)
+      case spk: WitnessScriptPubKeyV1 =>
+        throw new IllegalArgumentException(s"Taproot not yet supported: $spk")
       case spk: UnassignedWitnessScriptPubKey =>
         throw new IllegalArgumentException(s"Unknown segwit version: $spk")
       case spk: RawScriptPubKey =>

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1159,7 +1159,8 @@ object WitnessScriptPubKey extends ScriptFactory[WitnessScriptPubKey] {
                                                          OP_15,
                                                          OP_16)
 
-  val unassignedWitVersions: Seq[ScriptNumberOperation] = validWitVersions.tail
+  val unassignedWitVersions: Seq[ScriptNumberOperation] =
+    validWitVersions.tail.tail
 
   def apply(asm: Seq[ScriptToken]): WitnessScriptPubKey = fromAsm(asm)
 
@@ -1169,6 +1170,8 @@ object WitnessScriptPubKey extends ScriptFactory[WitnessScriptPubKey] {
         P2WPKHWitnessSPKV0.fromAsm(asm)
       case _ if P2WSHWitnessSPKV0.isValidAsm(asm) =>
         P2WSHWitnessSPKV0.fromAsm(asm)
+      case _ if WitnessScriptPubKeyV1.isValidAsm(asm) =>
+        WitnessScriptPubKeyV1.fromAsm(asm)
       case _ if WitnessScriptPubKey.isValidAsm(asm) =>
         UnassignedWitnessScriptPubKey(asm)
       case _ =>
@@ -1334,6 +1337,27 @@ object P2WSHWitnessSPKV0 extends ScriptFactory[P2WSHWitnessSPKV0] {
     val hash = CryptoUtil.sha256(spk.asmBytes)
     val pushop = BitcoinScriptUtil.calculatePushOp(hash.bytes)
     fromAsm(Seq(OP_0) ++ pushop ++ Seq(ScriptConstant(hash.bytes)))
+  }
+}
+
+case class WitnessScriptPubKeyV1(override val asm: Vector[ScriptToken])
+    extends WitnessScriptPubKey {
+  override def witnessProgram: Seq[ScriptToken] = asm.tail.tail
+  override val scriptType: ScriptType = ScriptType.WITNESS_V1
+}
+
+object WitnessScriptPubKeyV1 extends ScriptFactory[WitnessScriptPubKeyV1] {
+
+  override def fromAsm(asm: Seq[ScriptToken]): WitnessScriptPubKeyV1 = {
+    buildScript(asm.toVector,
+                WitnessScriptPubKeyV1.apply,
+                s"Given asm was not a P2WSHWitnessSPKV0, got $asm")
+  }
+
+  def isValidAsm(asm: Seq[ScriptToken]): Boolean = {
+    val asmBytes = BytesUtil.toByteVector(asm)
+    asm.headOption.contains(OP_1) && WitnessScriptPubKey.isValidAsm(
+      asm) && asmBytes.size == 34
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1319,7 +1319,7 @@ object P2WSHWitnessSPKV0 extends ScriptFactory[P2WSHWitnessSPKV0] {
                 s"Given asm was not a P2WSHWitnessSPKV0, got $asm")
   }
 
-  def isValidAsm(asm: Seq[ScriptToken]): Boolean = {
+  override def isValidAsm(asm: Seq[ScriptToken]): Boolean = {
     val asmBytes = BytesUtil.toByteVector(asm)
     WitnessScriptPubKeyV0.isValidAsm(asm) &&
     asmBytes.size == 34

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -281,6 +281,7 @@ object P2SHScriptSignature extends ScriptFactory[P2SHScriptSignature] {
       case _: P2PKHScriptPubKey | _: MultiSignatureScriptPubKey |
           _: P2PKScriptPubKey | _: P2PKWithTimeoutScriptPubKey |
           _: UnassignedWitnessScriptPubKey | _: WitnessScriptPubKeyV0 |
+          _: WitnessScriptPubKeyV1 |
           _: ConditionalScriptPubKey => // Conditional SPKs are not recursively checked
         true
       case EmptyScriptPubKey => isRecursiveCall // Fine if nested

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/WitnessVersion.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/WitnessVersion.scala
@@ -68,6 +68,17 @@ case object WitnessVersion0 extends WitnessVersion {
   override def version = OP_0
 }
 
+case object WitnessVersion1 extends WitnessVersion {
+
+  override def rebuild(
+      scriptWitness: ScriptWitness,
+      witnessProgram: Seq[ScriptToken]): Try[ScriptPubKey] = {
+    throw new UnsupportedOperationException("Taproot is not yet supported")
+  }
+
+  override def version: ScriptNumberOperation = OP_1
+}
+
 /** The witness version that represents all witnesses that have not been allocated yet */
 case class UnassignedWitness(version: ScriptNumberOperation)
     extends WitnessVersion {
@@ -89,9 +100,9 @@ object WitnessVersion {
   def apply(scriptNumberOp: ScriptNumberOperation): WitnessVersion =
     scriptNumberOp match {
       case OP_0 | OP_FALSE => WitnessVersion0
-      case x @ (OP_1 | OP_TRUE | OP_2 | OP_3 | OP_4 | OP_5 | OP_6 | OP_7 |
-          OP_8 | OP_9 | OP_10 | OP_11 | OP_12 | OP_13 | OP_14 | OP_15 |
-          OP_16) =>
+      case OP_1 | OP_TRUE  => WitnessVersion1
+      case x @ (OP_2 | OP_3 | OP_4 | OP_5 | OP_6 | OP_7 | OP_8 | OP_9 | OP_10 |
+          OP_11 | OP_12 | OP_13 | OP_14 | OP_15 | OP_16) =>
         UnassignedWitness(x)
       case OP_1NEGATE =>
         throw new IllegalArgumentException(

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionWitness.scala
@@ -79,6 +79,8 @@ object EmptyWitness {
 
 object TransactionWitness {
 
+  val empty: EmptyWitness.type = EmptyWitness
+
   private case class TransactionWitnessImpl(witnesses: Vector[ScriptWitness])
       extends TransactionWitness
 

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
@@ -205,6 +205,8 @@ case class InputPSBTMap(elements: Vector[InputPSBTRecord])
   private def missingSigsFromScript(
       spk: ScriptPubKey): Vector[Sha256Hash160Digest] = {
     spk match {
+      case spk: WitnessScriptPubKeyV1 =>
+        throw new IllegalArgumentException(s"Taproot not yet supported: $spk")
       case EmptyScriptPubKey | _: WitnessCommitment |
           _: NonStandardScriptPubKey | _: UnassignedWitnessScriptPubKey =>
         Vector.empty
@@ -606,7 +608,7 @@ case class InputPSBTMap(elements: Vector[InputPSBTRecord])
         val scriptSig = TrivialTrueScriptSignature
         Success(wipeAndAdd(scriptSig))
       case _: NonStandardScriptPubKey | _: UnassignedWitnessScriptPubKey |
-          _: WitnessCommitment =>
+          _: WitnessCommitment | _: WitnessScriptPubKeyV1 =>
         Failure(
           new UnsupportedOperationException(
             s"$spkToSatisfy is not yet supported"))

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptType.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptType.scala
@@ -27,6 +27,7 @@ sealed abstract class ScriptType {
       case NULLDATA                   => "nulldata"
       case WITNESS_V0_KEYHASH         => "witness_v0_keyhash"
       case WITNESS_V0_SCRIPTHASH      => "witness_v0_scripthash"
+      case WITNESS_V1                 => "witness_v1"
       case WITNESS_UNKNOWN            => "witness_unknown"
       case WITNESS_COMMITMENT         => "witness_commitment"
     }
@@ -90,6 +91,7 @@ object ScriptType extends StringFactory[ScriptType] {
   final case object NULLDATA extends ScriptType
   final case object WITNESS_V0_KEYHASH extends ScriptType
   final case object WITNESS_V0_SCRIPTHASH extends ScriptType
+  final case object WITNESS_V1 extends ScriptType
 
   /** Only for Witness versions not already defined */
   final case object WITNESS_UNKNOWN extends ScriptType

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -305,6 +305,9 @@ sealed abstract class ScriptInterpreter {
               //treat the segwit scriptpubkey as any other redeem script
               run(scriptPubKeyExecutedProgram, p2wsh)
             }
+          case spk: WitnessScriptPubKeyV1 =>
+            throw new IllegalArgumentException(
+              s"Taproot not yet supported: $spk")
           case s @ (_: P2SHScriptPubKey | _: P2PKHScriptPubKey |
               _: P2PKWithTimeoutScriptPubKey | _: P2PKScriptPubKey |
               _: MultiSignatureScriptPubKey | _: CLTVScriptPubKey |
@@ -363,6 +366,9 @@ sealed abstract class ScriptInterpreter {
                 Success(
                   scriptPubKeyExecutedProgram.failExecution(
                     ScriptErrorWitnessProgramWitnessEmpty))
+              case WitnessVersion1 =>
+                throw new IllegalArgumentException(
+                  "Taproot is not yet supported")
               case UnassignedWitness(_) =>
                 evaluateUnassignedWitness(b)
             }
@@ -461,6 +467,8 @@ sealed abstract class ScriptInterpreter {
                                                 error = Some(err))
             Success(program)
         }
+      case WitnessVersion1 =>
+        evaluateUnassignedWitness(wTxSigComponent)
       case UnassignedWitness(_) =>
         evaluateUnassignedWitness(wTxSigComponent)
     }

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -611,7 +611,7 @@ trait BitcoinScriptUtil {
       case _: P2PKHScriptPubKey | _: P2SHScriptPubKey | _: P2WPKHWitnessSPKV0 |
           _: P2WSHWitnessSPKV0 | _: UnassignedWitnessScriptPubKey |
           _: NonStandardScriptPubKey | _: WitnessCommitment |
-          EmptyScriptPubKey =>
+          _: WitnessScriptPubKeyV1 | EmptyScriptPubKey =>
         true
 
     }
@@ -653,7 +653,8 @@ trait BitcoinScriptUtil {
                                      UInt32(idx),
                                      o,
                                      Policy.standardFlags)
-          case _: UnassignedWitnessScriptPubKey => ???
+          case _: UnassignedWitnessScriptPubKey | _: WitnessScriptPubKeyV1 =>
+            ???
           case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
               _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
               _: WitnessCommitment | _: CSVScriptPubKey | _: CLTVScriptPubKey |

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -532,6 +532,9 @@ sealed abstract class P2WPKHSigner extends Signer[P2WPKHV0InputInfo] {
 
           val witSPK = output.scriptPubKey match {
             case p2wpkh: P2WPKHWitnessSPKV0 => p2wpkh
+            case spk: WitnessScriptPubKeyV1 =>
+              throw new IllegalArgumentException(
+                s"Taproot not yet supported: $spk")
             case _: UnassignedWitnessScriptPubKey | _: P2WSHWitnessSPKV0 =>
               throw TxBuilderError.WrongSigner.exception
             case _: NonWitnessScriptPubKey =>

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputInfo.scala
@@ -299,6 +299,9 @@ object InputInfo {
                                        hashPreImages)
               case _: P2SHScriptPubKey =>
                 throw new IllegalArgumentException("Cannot have nested P2SH")
+              case _: WitnessScriptPubKeyV1 =>
+                throw new UnsupportedOperationException(
+                  s"Unsupported Taproot ScriptPubKey ${output.scriptPubKey}")
               case _: UnassignedWitnessScriptPubKey =>
                 throw new UnsupportedOperationException(
                   s"Unsupported ScriptPubKey ${output.scriptPubKey}")
@@ -319,11 +322,12 @@ object InputInfo {
                                 witness,
                                 conditionalPath,
                                 hashPreImages)
-      case wspk: UnassignedWitnessScriptPubKey =>
+      case wspk @ (_: UnassignedWitnessScriptPubKey |
+          _: WitnessScriptPubKeyV1) =>
         UnassignedSegwitNativeInputInfo(
           outPoint,
           output.value,
-          wspk,
+          wspk.asInstanceOf[WitnessScriptPubKey],
           scriptWitnessOpt.getOrElse(EmptyScriptWitness),
           conditionalPath,
           Vector.empty)

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CreditingTxGen.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CreditingTxGen.scala
@@ -419,6 +419,9 @@ sealed abstract class CreditingTxGen {
             throw new IllegalArgumentException(
               "Expected P2WSHWitness for P2WSH")
         }
+      case _: WitnessScriptPubKeyV1 =>
+        throw new IllegalArgumentException(
+          s"Unexpected (unsupported) taproot SPK: $spk")
       case _: UnassignedWitnessScriptPubKey =>
         throw new IllegalArgumentException(
           s"Unexpected unassigned witness SPK: $spk")

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -357,6 +357,15 @@ sealed abstract class ScriptGenerators {
   def witnessScriptPubKeyV0: Gen[(WitnessScriptPubKeyV0, Seq[ECPrivateKey])] =
     Gen.oneOf(p2wpkhSPKV0, p2wshSPKV0.map(truncate))
 
+  def witnessScriptPubKeyV1: Gen[(WitnessScriptPubKeyV1, Seq[ECPrivateKey])] = {
+    for {
+      priv <- CryptoGenerators.privateKey
+      pubKey = priv.schnorrPublicKey
+    } yield {
+      (WitnessScriptPubKeyV1.fromPubKey(pubKey), Vector(priv))
+    }
+  }
+
   /** Creates an unassigned witness scriptPubKey.
     * Currently this is any witness script pubkey besides
     * [[org.bitcoins.core.protocol.script.WitnessScriptPubKeyV0 WitnessScriptPubKeyV0]]

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -384,7 +384,7 @@ sealed abstract class ScriptGenerators {
 
   def assignedWitnessScriptPubKey: Gen[
     (WitnessScriptPubKey, Seq[ECPrivateKey])] = {
-    Gen.oneOf(p2wpkhSPKV0, p2wshSPKV0.map(truncate))
+    Gen.oneOf(p2wpkhSPKV0, p2wshSPKV0.map(truncate), witnessScriptPubKeyV1)
   }
 
   def witnessCommitment: Gen[(WitnessCommitment, Seq[ECPrivateKey])] =

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -551,7 +551,8 @@ sealed abstract class ScriptGenerators {
       case EmptyScriptPubKey   => emptyScriptSignature
       case _: CLTVScriptPubKey => cltvScriptSignature
       case _: CSVScriptPubKey  => csvScriptSignature
-      case _: WitnessScriptPubKeyV0 | _: UnassignedWitnessScriptPubKey =>
+      case _: WitnessScriptPubKeyV0 | _: WitnessScriptPubKeyV1 |
+          _: UnassignedWitnessScriptPubKey =>
         emptyScriptSignature
       case x @ (_: P2SHScriptPubKey | _: NonStandardScriptPubKey |
           _: WitnessCommitment) =>

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/TransactionTestUtil.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/TransactionTestUtil.scala
@@ -3,6 +3,7 @@ package org.bitcoins.testkitcore.util
 import org.bitcoins.core.crypto.ECPrivateKeyUtil
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
 import org.bitcoins.core.number.{Int32, UInt32}
+import org.bitcoins.core.protocol.Bech32mAddress
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.psbt.PSBT
@@ -29,6 +30,9 @@ trait TransactionTestUtil {
     * the first input is signed for this tx
     */
   def signedMultiSignatureTx = Transaction(rawSignedMultiSignatureTx)
+
+  def bech32mAddr: Bech32mAddress = Bech32mAddress.fromString(
+    "tb1prp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q98lawz")
 
   /** Mimics this test utility found in bitcoin core
     * https://github.com/bitcoin/bitcoin/blob/605c17844ea32b6d237db6d83871164dc7d59dab/src/test/script_tests.cpp#L57


### PR DESCRIPTION
Not usable for spending from Taproot addresses, just sending.