### PR TITLE
Remove unknown fields from BitGoResult

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/wallet/FeeRateApi.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/wallet/FeeRateApi.scala
@@ -18,8 +18,6 @@ case class BitGoResult(
     feePerKb: SatoshisPerKiloByte,
     cpfpFeePerKb: SatoshisPerKiloByte,
     numBlocks: Int,
-    confidence: Int,
-    multiplier: Double,
     feeByBlockTarget: Map[Int, SatoshisPerKiloByte]
 ) extends FeeRateApiResult
 


### PR DESCRIPTION
Seems like the BitGo api [https://www.bitgo.com/api/v2/btc/tx/fee](https://www.bitgo.com/api/v2/btc/tx/fee) no longer gives `confidence` and `multiplier` in result and this was causing `FeeRateProviderTest` to fail.