### PR TITLE
update oracle explorer client to use v2 of the API

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ExplorerEnv.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ExplorerEnv.scala
@@ -18,18 +18,18 @@ object ExplorerEnv extends StringFactory[ExplorerEnv] {
 
   case object Production extends ExplorerEnv {
     override val siteUrl: String = "https://oracle.suredbits.com/"
-    override val baseUri: String = s"${siteUrl}v1/"
+    override val baseUri: String = s"${siteUrl}v2/"
   }
 
   case object Test extends ExplorerEnv {
     override val siteUrl: String = "https://test.oracle.suredbits.com/"
-    override val baseUri: String = s"${siteUrl}v1/"
+    override val baseUri: String = s"${siteUrl}v2/"
   }
 
   /** For local testing purposes */
   case object Local extends ExplorerEnv {
     override val siteUrl: String = "http://localhost:9000/"
-    override val baseUri: String = s"${siteUrl}v1/"
+    override val baseUri: String = s"${siteUrl}v2/"
   }
 
   val all: Vector[ExplorerEnv] = Vector(Production, Test, Local)


### PR DESCRIPTION
fixes #3742

Updates our oracle explorer client to use v2 of the oracle explorer API: https://gist.github.com/Christewart/a9e55d9ba582ac9a5ceffa96db9d7e1f