### PR TITLE
Make clightning tests execute async

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -555,8 +555,7 @@ lazy val clightningRpcTest = project
   .settings(CommonSettings.testSettings: _*)
   .settings(
     libraryDependencies ++= Deps.clightningRpcTest.value,
-    name := "bitcoin-s-clightning-rpc-test",
-    parallelExecution := false
+    name := "bitcoin-s-clightning-rpc-test"
   )
   .dependsOn(coreJVM % testAndCompile, clightningRpc, testkit)
 


### PR DESCRIPTION
This runs tests asynchronously for clightning. This doesn't address the root cause documented in #3767 , but it does speed things up ~2 minutes locally for me.