### PR TITLE
2021 11 03 protocol version

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -15,6 +15,7 @@ import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
+import org.bitcoins.core.serializers.PicklerKeys
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.core.util.TimeUtil._
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte

--- a/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/WalletGUIModel.scala
@@ -4,8 +4,8 @@ import akka.actor.{ActorSystem, Cancellable}
 import grizzled.slf4j.Logging
 import org.bitcoins.cli.CliCommand._
 import org.bitcoins.cli.ConsoleCli
-import org.bitcoins.commons.serializers.PicklerKeys
 import org.bitcoins.core.dlc.accounting.RateOfReturnUtil
+import org.bitcoins.core.serializers.PicklerKeys
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.gui.dialog._
 import org.bitcoins.gui.dlc.DLCPaneModel

--- a/app/server-test/src/test/scala/org/bitcoins/server/DLCRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/DLCRoutesSpec.scala
@@ -2,11 +2,11 @@ package org.bitcoins.server
 
 import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.bitcoins.commons.serializers.PicklerKeys
 import org.bitcoins.core.api.dlc.node.DLCNodeApi
 import org.bitcoins.core.currency.{Bitcoins, Satoshis}
 import org.bitcoins.core.protocol.dlc.models.ContractInfo
 import org.bitcoins.core.protocol.tlv.OracleAnnouncementTLV
+import org.bitcoins.core.serializers.PicklerKeys
 import org.bitcoins.server.routes.ServerCommand
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.wordspec.AnyWordSpec

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -928,6 +928,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     val contractInfoTLV = contractInfo.toTLV
 
     val offer = DLCOffer(
+      protocolVersionOpt = DLCOfferTLV.currentVersionOpt,
       contractInfo = contractInfo,
       pubKeys = dummyDLCKeys,
       totalCollateral = Satoshis(2500),

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
@@ -10,7 +10,7 @@ import org.bitcoins.core.protocol.dlc.models.DLCMessage.{
   DLCSign
 }
 import org.bitcoins.core.protocol.dlc.models._
-import org.bitcoins.core.protocol.tlv.EnumOutcome
+import org.bitcoins.core.protocol.tlv.{DLCOfferTLV, EnumOutcome}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto._
@@ -47,6 +47,7 @@ class DLCMessageTest extends BitcoinSJvmTest {
   it must "not allow a negative collateral for a DLCOffer" in {
     assertThrows[IllegalArgumentException](
       DLCOffer(
+        protocolVersionOpt = DLCOfferTLV.currentVersionOpt,
         contractInfo = ContractInfo.dummy,
         pubKeys = DLCPublicKeys(dummyPubKey, dummyAddress),
         totalCollateral = Satoshis(-1),
@@ -63,6 +64,7 @@ class DLCMessageTest extends BitcoinSJvmTest {
   it must "not allow same change and fund output serial id for a DLCOffer" in {
     assertThrows[IllegalArgumentException](
       DLCOffer(
+        protocolVersionOpt = DLCOfferTLV.currentVersionOpt,
         contractInfo = ContractInfo.dummy,
         pubKeys = DLCPublicKeys(dummyPubKey, dummyAddress),
         totalCollateral = Satoshis(-1),

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/build/DLCTxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/build/DLCTxBuilder.scala
@@ -28,6 +28,7 @@ import scodec.bits.ByteVector
 case class DLCTxBuilder(offer: DLCOffer, accept: DLCAcceptWithoutSigs) {
 
   val DLCOffer(_,
+               _,
                DLCPublicKeys(offerFundingKey: ECPublicKey,
                              offerFinalAddress: BitcoinAddress),
                offerTotalCollateral: Satoshis,

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
@@ -77,6 +77,7 @@ object DLCMessage {
     * @param timeouts        The set of timeouts for the CETs
     */
   case class DLCOffer(
+      protocolVersionOpt: Option[Int],
       contractInfo: ContractInfo,
       pubKeys: DLCPublicKeys,
       totalCollateral: Satoshis,
@@ -110,9 +111,10 @@ object DLCMessage {
         changeAddress.networkParameters.chainParams.genesisBlock.blockHeader.hash
 
       DLCOfferTLV(
+        protocolVersionOpt = protocolVersionOpt,
         contractFlags = 0x00,
         chainHash = chainHash,
-        contractInfo.toTLV,
+        contractInfo = contractInfo.toTLV,
         fundingPubKey = pubKeys.fundingKey,
         payoutSPK = pubKeys.payoutAddress.scriptPubKey,
         payoutSerialId = payoutSerialId,
@@ -140,6 +142,7 @@ object DLCMessage {
       val contractInfo = ContractInfo.fromTLV(offer.contractInfo)
 
       DLCOffer(
+        protocolVersionOpt = offer.protocolVersionOpt,
         contractInfo = contractInfo,
         pubKeys = DLCPublicKeys(
           offer.fundingPubKey,

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -1507,7 +1507,12 @@ case class DLCOfferTLV(
   override val tpe: BigSizeUInt = DLCOfferTLV.tpe
 
   override val value: ByteVector = {
-    ByteVector(contractFlags) ++
+    val versionBytes = protocolVersionOpt match {
+      case Some(v) => UInt32(v).bytes
+      case None    => ByteVector.empty
+    }
+    versionBytes ++
+      ByteVector(contractFlags) ++
       chainHash.bytes ++
       contractInfo.bytes ++
       fundingPubKey.bytes ++
@@ -1561,7 +1566,7 @@ object DLCOfferTLV extends TLVFactory[DLCOfferTLV] {
       fundingPubKey = fundingPubKey,
       payoutSPK = payoutSPK,
       payoutSerialId = payoutSerialId,
-      offerCollateralSatoshis = totalCollateralSatoshis,
+      totalCollateralSatoshis = totalCollateralSatoshis,
       fundingInputs = fundingInputs,
       changeSPK = changeSPK,
       changeSerialId = changeSerialId,

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -1484,6 +1484,7 @@ object FundingSignaturesV0TLV extends TLVFactory[FundingSignaturesV0TLV] {
 sealed trait DLCSetupTLV extends TLV
 
 case class DLCOfferTLV(
+    protocolVersionOpt: Option[Int],
     contractFlags: Byte,
     chainHash: DoubleSha256Digest,
     contractInfo: ContractInfoV0TLV,
@@ -1524,11 +1525,18 @@ case class DLCOfferTLV(
 }
 
 object DLCOfferTLV extends TLVFactory[DLCOfferTLV] {
+
+  /** No version for now */
+  val currentVersionOpt: Option[Int] = None
+
+  val currentVersionU32: Option[UInt32] = {
+    currentVersionOpt.map(UInt32(_))
+  }
   override val tpe: BigSizeUInt = BigSizeUInt(42778)
 
   override def fromTLVValue(value: ByteVector): DLCOfferTLV = {
     val iter = ValueIterator(value)
-
+    val protocolVersionOpt = None
     val contractFlags = iter.take(1).head
     val chainHash = iter.take(DoubleSha256Digest, 32)
     val contractInfo = iter.take(ContractInfoV0TLV)
@@ -1546,20 +1554,21 @@ object DLCOfferTLV extends TLVFactory[DLCOfferTLV] {
     val contractTimeout = BlockTimeStamp(iter.takeU32())
 
     DLCOfferTLV(
-      contractFlags,
-      chainHash,
-      contractInfo,
-      fundingPubKey,
-      payoutSPK,
-      payoutSerialId,
-      totalCollateralSatoshis,
-      fundingInputs,
-      changeSPK,
-      changeSerialId,
-      fundingOutputSerialId,
-      feeRate,
-      contractMaturityBound,
-      contractTimeout
+      protocolVersionOpt = protocolVersionOpt,
+      contractFlags = contractFlags,
+      chainHash = chainHash,
+      contractInfo = contractInfo,
+      fundingPubKey = fundingPubKey,
+      payoutSPK = payoutSPK,
+      payoutSerialId = payoutSerialId,
+      offerCollateralSatoshis = totalCollateralSatoshis,
+      fundingInputs = fundingInputs,
+      changeSPK = changeSPK,
+      changeSerialId = changeSerialId,
+      fundOutputSerialId = fundingOutputSerialId,
+      feeRate = feeRate,
+      contractMaturityBound = contractMaturityBound,
+      contractTimeout = contractTimeout
     )
   }
 

--- a/core/src/main/scala/org/bitcoins/core/serializers/PicklerKeys.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/PicklerKeys.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.commons.serializers
+package org.bitcoins.core.serializers
 
 object PicklerKeys {
   final val myCollateral: String = "myCollateral"
@@ -17,4 +17,7 @@ object PicklerKeys {
   final val payoutKey: String = "payout"
   final val extraPrecisionKey: String = "extraPrecision"
   final val isEndpointKey: String = "isEndpoint"
+
+  //offers
+  final val protocolVersionKey: String = "protocolVersion"
 }

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCParsingTestVector.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCParsingTestVector.scala
@@ -4,6 +4,7 @@ import org.bitcoins.core.number.{UInt16, UInt64}
 import org.bitcoins.core.protocol.BigSizeUInt
 import org.bitcoins.core.protocol.script.EmptyScriptPubKey
 import org.bitcoins.core.protocol.tlv._
+import org.bitcoins.core.serializers.PicklerKeys
 import org.bitcoins.crypto.{CryptoUtil, NetworkElement}
 import org.bitcoins.dlc.testgen.ByteVectorWrapper._
 import play.api.libs.json._
@@ -285,7 +286,8 @@ object DLCParsingTestVector extends TestVectorParser[DLCParsingTestVector] {
           })
         )
         DLCTLVTestVector(tlv, "funding_signatures_v0", fields)
-      case DLCOfferTLV(contractFlags,
+      case DLCOfferTLV(versionOpt,
+                       contractFlags,
                        chainHash,
                        contractInfo,
                        fundingPubKey,
@@ -300,6 +302,7 @@ object DLCParsingTestVector extends TestVectorParser[DLCParsingTestVector] {
                        contractMaturityBound,
                        contractTimeout) =>
         val fields = Vector(
+          PicklerKeys.protocolVersionKey -> Element(UInt16(versionOpt.get)),
           "tpe" -> Element(UInt16(DLCOfferTLV.tpe.toInt)),
           "contractFlags" -> Element(ByteVector(contractFlags)),
           "chainHash" -> Element(chainHash),

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCParsingTestVector.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCParsingTestVector.scala
@@ -301,8 +301,13 @@ object DLCParsingTestVector extends TestVectorParser[DLCParsingTestVector] {
                        feeRate,
                        contractMaturityBound,
                        contractTimeout) =>
-        val fields = Vector(
-          PicklerKeys.protocolVersionKey -> Element(UInt16(versionOpt.get)),
+        val version = versionOpt match {
+          case Some(version) =>
+            Vector(PicklerKeys.protocolVersionKey -> Element(UInt16(version)))
+          case None =>
+            Vector.empty
+        }
+        val fields = version ++ Vector(
           "tpe" -> Element(UInt16(DLCOfferTLV.tpe.toInt)),
           "contractFlags" -> Element(ByteVector(contractFlags)),
           "chainHash" -> Element(chainHash),

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCTLVGen.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCTLVGen.scala
@@ -229,6 +229,7 @@ object DLCTLVGen {
   }
 
   def dlcOffer(
+      protocolVersionOpt: Option[Int] = DLCOfferTLV.currentVersionOpt,
       contractInfo: ContractInfo = genContractInfo(),
       fundingPubKey: ECPublicKey = ECPublicKey.freshPublicKey,
       payoutAddress: BitcoinAddress = address(),
@@ -242,6 +243,7 @@ object DLCTLVGen {
       contractMaturityBound: BlockTimeStamp = BlockTimeStamp(100),
       contractTimeout: BlockTimeStamp = BlockTimeStamp(200)): DLCOffer = {
     DLCOffer(
+      protocolVersionOpt,
       contractInfo,
       DLCPublicKeys(fundingPubKey, payoutAddress),
       totalCollateral,
@@ -256,6 +258,7 @@ object DLCTLVGen {
   }
 
   def dlcOfferTLV(
+      protocolVersionOpt: Option[Int] = DLCOfferTLV.currentVersionOpt,
       contractInfo: ContractInfo = genContractInfo(),
       fundingPubKey: ECPublicKey = ECPublicKey.freshPublicKey,
       payoutAddress: BitcoinAddress = address(),
@@ -269,6 +272,7 @@ object DLCTLVGen {
       contractMaturityBound: BlockTimeStamp = BlockTimeStamp(100),
       contractTimeout: BlockTimeStamp = BlockTimeStamp(200)): DLCOfferTLV = {
     dlcOffer(
+      protocolVersionOpt,
       contractInfo,
       fundingPubKey,
       payoutAddress,
@@ -285,6 +289,7 @@ object DLCTLVGen {
   }
 
   def dlcOfferParsingTestVector(
+      protocolVersionOpt: Option[Int] = DLCOfferTLV.currentVersionOpt,
       contractInfo: ContractInfo = genContractInfo(),
       fundingPubKey: ECPublicKey = ECPublicKey.freshPublicKey,
       payoutAddress: BitcoinAddress = address(),
@@ -300,6 +305,7 @@ object DLCTLVGen {
         BlockTimeStamp(200)): DLCParsingTestVector = {
     DLCParsingTestVector(
       dlcOfferTLV(
+        protocolVersionOpt,
         contractInfo,
         fundingPubKey,
         payoutAddress,

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCTestVector.scala
@@ -117,6 +117,7 @@ case class DLCPartyParams(
 
   def toOffer(params: DLCParams): DLCOffer = {
     DLCOffer(
+      DLCOfferTLV.currentVersionOpt,
       ContractInfo(
         EnumContractDescriptor(params.contractInfo.map(_.toMapEntry)),
         params.oracleInfo),

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -709,6 +709,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         "fdd824b4caaec7479cc9d37003f5add6504d035054ffeac8637a990305a45cfecc1062044c3f68b45318f57e41c4544a4a950c0744e2a80854349a3426b00ad86da5090b9e942dc6df2ae87f007b45b0ccd63e6c354d92c4545fc099ea3e137e54492d1efdd822500001a6a09c7c83c50b34f9db560a2e14fef2eab5224c15b18c7114331756364bfce65ffe3800fdd8062400030c44656d6f637261745f77696e0e52657075626c6963616e5f77696e056f746865720161"))
 
       val offerData = DLCOffer(
+        DLCOfferTLV.currentVersionOpt,
         ContractInfo(contractDescriptor, oracleInfo),
         dummyDLCKeys,
         Satoshis(5000),

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -372,6 +372,7 @@ abstract class DLCWallet
                              BlockTimeStamp(refundLocktime))
 
       offer = DLCOffer(
+        protocolVersionOpt = DLCOfferTLV.currentVersionOpt,
         contractInfo = contractInfo,
         pubKeys = dlcPubKeys,
         totalCollateral = collateral.satoshis,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDb.scala
@@ -6,6 +6,7 @@ import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.dlc.models.DLCMessage._
 import org.bitcoins.core.protocol.dlc.models._
+import org.bitcoins.core.protocol.tlv.DLCOfferTLV
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto._
 
@@ -39,6 +40,7 @@ case class DLCOfferDb(
       feeRate: SatoshisPerVirtualByte,
       dlcTimeouts: DLCTimeouts): DLCOffer = {
     DLCOffer(
+      protocolVersionOpt = DLCOfferTLV.currentVersionOpt,
       contractInfo = contractInfo,
       pubKeys = dlcPubKeys,
       totalCollateral = collateral.satoshis,

--- a/docs/core/dlc.md
+++ b/docs/core/dlc.md
@@ -174,6 +174,7 @@ Currently, only the most basic Lightning messages are defined (`Ping`, `Pong`, `
 
 ```scala mdoc:to-string
 val offerTLV = DLCOfferTLV(
+    protocolVersionOpt = None,
     contractFlags = 0.toByte,
     chainHash = DoubleSha256Digest.empty,
     contractInfo = contractInfo.toTLV,

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/TestDLCClient.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/TestDLCClient.scala
@@ -15,6 +15,7 @@ import org.bitcoins.core.protocol.dlc.models.DLCMessage.DLCAccept
 import org.bitcoins.core.protocol.dlc.models._
 import org.bitcoins.core.protocol.dlc.sign.DLCTxSigner
 import org.bitcoins.core.protocol.script.ScriptPubKey
+import org.bitcoins.core.protocol.tlv.DLCOfferTLV
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{InputInfo, ScriptSignatureParams}
@@ -208,6 +209,7 @@ object TestDLCClient {
     }
 
     val offer = DLCMessage.DLCOffer(
+      protocolVersionOpt = DLCOfferTLV.currentVersionOpt,
       contractInfo = offerOutcomes,
       pubKeys = offerPubKeys,
       totalCollateral = offerInput.satoshis,

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
@@ -403,6 +403,7 @@ trait TLVGen {
       }
 
       DLCOfferTLV(
+        protocolVersionOpt = None, //TODO: Comeback and change this
         contractFlags = 0.toByte,
         chainHash = chainHash,
         contractInfo = contractInfo,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -147,6 +147,7 @@ object DLCWalletUtil extends Logging {
     DLCMessage.genSerialId(Vector(sampleOfferChangeSerialId))
 
   lazy val sampleDLCOffer: DLCOffer = DLCOffer(
+    protocolVersionOpt = DLCOfferTLV.currentVersionOpt,
     contractInfo = sampleContractInfo,
     pubKeys = dummyDLCKeys,
     totalCollateral = half,


### PR DESCRIPTION
This PR introduces the protocl_version field introduced in this PR on this DLC spec: 

https://github.com/discreetlogcontracts/dlcspecs/pull/163

https://github.com/discreetlogcontracts/dlcspecs/pull/163/files#diff-e0f5b925f91a1c09c6daf26f9a7d28816cb9ff9f08863faca719b7ee0a1cc065R69

I decided to break this out of the branch that I have going to implement the test vectors contained in https://github.com/discreetlogcontracts/dlcspecs/pull/163

This is not intended to change any functionality, but to start incorporating new data structures in to the core module for spec breaking changes.