### PR TITLE
Remove scientific notation from Bitcoins.toString

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/currency/CurrencyUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/currency/CurrencyUnitTest.scala
@@ -213,7 +213,7 @@ class CurrencyUnitTest extends BitcoinSUnitTest {
     }
   }
 
-  it must "convert to and from BigDemimals correctly" in {
+  it must "convert to and from BigDecimals correctly" in {
     forAll(CurrencyUnitGenerator.bitcoins) { num =>
       assert(Bitcoins(num.toBigDecimal) == num)
     }
@@ -223,5 +223,10 @@ class CurrencyUnitTest extends BitcoinSUnitTest {
     forAll(CurrencyUnitGenerator.bitcoins) { num =>
       assert(Satoshis.fromHex(num.hex) == num)
     }
+  }
+
+  it must "correctly print in Bitcoins.toString" in {
+    val btc = Bitcoins(12.3456789)
+    assert(btc.toString == "12.34567890 BTC")
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -140,7 +140,9 @@ object Satoshis
 sealed abstract class Bitcoins extends CurrencyUnit {
   override type A = BigDecimal
 
-  override def toString: String = s"$toBigDecimal BTC"
+  override def toString: String = s"$decimalString BTC"
+
+  def decimalString: String = "%.8f".format(toBigDecimal)
 
   override def toBigDecimal: BigDecimal = underlying
 


### PR DESCRIPTION
this should make parsing by humans and machines easier