### PR TITLE
Make sure exception is caught by Future inside of unmarkUTXOsAsReserved

### DIFF
--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.dlc.wallet
 import com.typesafe.config.ConfigFactory
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil.bip39PasswordOpt
@@ -60,5 +61,31 @@ class MultiWalletDLCTest extends BitcoinSWalletTest {
       assert(dlcsB.isEmpty)
       assert(dlcsA != dlcsB)
     }
+  }
+
+  it must "create an offer, out of band unreserve the utxo, and then cancel the offer" in {
+    fundedWallet: FundedDLCWallet =>
+      //see: https://github.com/bitcoin-s/bitcoin-s/issues/3813#issue-1051117559
+      val wallet = fundedWallet.wallet
+      val offerF = wallet.createDLCOffer(contractInfo = sampleContractInfo,
+                                         collateral = half,
+                                         feeRateOpt =
+                                           Some(SatoshisPerVirtualByte.one),
+                                         locktime = UInt32.zero,
+                                         refundLocktime = UInt32.one)
+
+      //now unreserve the utxo
+      val reservedUtxoF = for {
+        _ <- offerF
+        utxos <- wallet.listUtxos(TxoState.Reserved)
+        _ <- wallet.unmarkUTXOsAsReserved(utxos)
+      } yield ()
+
+      //now cancel the offer
+      for {
+        offer <- offerF
+        _ <- reservedUtxoF
+        _ <- wallet.cancelDLC(offer.dlcId)
+      } yield succeed
   }
 }


### PR DESCRIPTION
fixes parts of #3813 

The requirement was outside of a Future which meant the exception didn't get handled properly by the .recover() inside of `cancelDLC()`