### PR TITLE
Add deleting address tags to to clearAllUtxosAndAddresses()

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -283,6 +283,9 @@ class AddressHandlingTest extends BitcoinSWalletTest {
       for {
         _ <- addressF
         _ <- wallet.clearAllUtxosAndAddresses()
-      } yield succeed
+        tags <- wallet.getAddressTags
+      } yield {
+        assert(tags.isEmpty)
+      }
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -274,4 +274,15 @@ class AddressHandlingTest extends BitcoinSWalletTest {
         res1 <- wallet.isChange(output1)
       } yield assert(res1)
   }
+
+  it must "generate an address with a label, and then clear all addresses in the wallet" in {
+    fundedWallet: FundedWallet =>
+      val wallet = fundedWallet.wallet
+      val tag = AddressLabelTag("test")
+      val addressF = wallet.getNewAddress(Vector(tag))
+      for {
+        _ <- addressF
+        _ <- wallet.clearAllUtxosAndAddresses()
+      } yield succeed
+  }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -258,6 +258,7 @@ abstract class Wallet
 
   override def clearAllUtxosAndAddresses(): Future[Wallet] = {
     val resultedF = for {
+      _ <- addressTagDAO.deleteAll()
       _ <- spendingInfoDAO.deleteAll()
       _ <- addressDAO.deleteAll()
       _ <- scriptPubKeyDAO.deleteAll()


### PR DESCRIPTION
fixes the second half of #3813 

We weren't clearing tags which have database level foreign keys on the address table.