### PR TITLE
Break existing api to get new address to remove the requirement for null label

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -587,14 +587,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     }
 
     "return a new address" in {
-      (mockWalletApi
-        .getNewAddress(_: Vector[AddressTag]))
-        .expects(Vector.empty)
+      (mockWalletApi.getNewAddress: () => Future[BitcoinAddress])
+        .expects()
         .returning(Future.successful(testAddress))
 
       val route =
-        walletRoutes.handleCommand(
-          ServerCommand("getnewaddress", Arr(ujson.Null)))
+        walletRoutes.handleCommand(ServerCommand("getnewaddress", Arr()))
 
       Get() ~> route ~> check {
         assert(contentType == `application/json`)
@@ -1807,6 +1805,5 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         assert(responseAs[String] == s"""{"result":"done","error":null}""")
       }
     }
-
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -31,17 +31,20 @@ case class GetNewAddress(labelOpt: Option[AddressLabelTag])
 object GetNewAddress extends ServerJsonModels {
 
   def fromJsArr(jsArr: ujson.Arr): Try[GetNewAddress] = {
-    require(jsArr.arr.size == 1,
-            s"Bad number of arguments: ${jsArr.arr.size}. Expected: 1")
+    if (jsArr.value.length == 1) {
+      val labelOpt = nullToOpt(jsArr.arr.head).map {
+        case Str(str) =>
+          AddressLabelTag(str)
+        case value: Value =>
+          throw Value.InvalidData(value, "Expected a String")
+      }
 
-    val labelOpt = nullToOpt(jsArr.arr.head).map {
-      case Str(str) =>
-        AddressLabelTag(str)
-      case value: Value =>
-        throw Value.InvalidData(value, "Expected a String")
+      Try(GetNewAddress(labelOpt))
+    } else if (jsArr.value.isEmpty) {
+      Success(GetNewAddress(None))
+    } else {
+      sys.error(s"Too many argumements for GetNewAddress, got=$jsArr")
     }
-
-    Try(GetNewAddress(labelOpt))
   }
 }
 

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -153,10 +153,13 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
       withValidServerCommand(GetNewAddress.fromJsArr(arr)) {
         case GetNewAddress(labelOpt) =>
           complete {
-            val labelVec = Vector(labelOpt).flatten
-            wallet.getNewAddress(labelVec).map { address =>
-              Server.httpSuccess(address)
+            val addressF = labelOpt match {
+              case Some(label) =>
+                wallet.getNewAddress(Vector(label))
+              case None =>
+                wallet.getNewAddress()
             }
+            addressF.map(address => Server.httpSuccess(address))
           }
       }
 


### PR DESCRIPTION
fixes #3801

This removes the requirement to set a label (usually by the empty string) to get a new address. This shouldn't be a requirement to get an address from the wallet. This PR breaks the API and removes that requirement.