### PR TITLE
Remove 'not set' rate of return % sign on wallet

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/GlobalData.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/GlobalData.scala
@@ -13,7 +13,7 @@ object GlobalData {
   val currentTotalBalance: StringProperty = StringProperty("0")
 
   val currentPNL: StringProperty = StringProperty("0")
-  val rateOfReturn: StringProperty = StringProperty("0%")
+  val rateOfReturn: StringProperty = StringProperty("0")
 
   val syncHeight: StringProperty = StringProperty("Syncing headers...")
 


### PR DESCRIPTION
This removes the default '%' on the Wallet Rate of Return zero value.

The bug:
![Screen Shot 2021-11-15 at 4 59 34 PM](https://user-images.githubusercontent.com/22351459/141871608-a8da5212-9c97-439e-a438-2f52a06792fc.png)

