### PR TITLE
Request witness versions of transactions from nodes

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -395,6 +395,8 @@ case class DataMessageHandler(
           case NodeType.BitcoindBackend =>
             throw new RuntimeException("This is impossible")
         }
+      case Inventory(TypeIdentifier.MsgTx, hash) =>
+        Some(Inventory(TypeIdentifier.MsgWitnessTx, hash))
       case other: Inventory => Some(other)
     })
     peerMsgSender.sendMsg(getData).map(_ => this)


### PR DESCRIPTION
When a peer is announcing a tx to us and we want to see it we need to request it with a `GetData`. We were defaulting to use the `MsgTx` version which would give us the non witness version of the tx, meaning the transactions that do have witnesses would be  appear to be unsigned to us. I think this is what #3827 attemptingn to catch. This will fix by requesting the witness version of the transaction.