### PR TITLE
Fix TypeIdentifier fromBytes

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/p2p/TypeIdentifierTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/TypeIdentifierTest.scala
@@ -11,26 +11,39 @@ class TypeIdentifierTest extends BitcoinSUnitTest {
 
   "MsgTx" must "serialize to 01000000" in {
     MsgTx.hex must be("01000000")
+    assert(TypeIdentifier.fromBytes(MsgTx.bytes) == MsgTx)
   }
 
   "MsgWitnessTx" must "serialize to 01000040" in {
     MsgWitnessTx.hex must be("01000040")
+    assert(TypeIdentifier.fromBytes(MsgWitnessTx.bytes) == MsgWitnessTx)
   }
 
   "MsgBlock" must "serialize to 02000000" in {
     MsgBlock.hex must be("02000000")
+    assert(TypeIdentifier.fromBytes(MsgBlock.bytes) == MsgBlock)
   }
 
   "MsgWitnessBlock" must "serialize to 02000040" in {
     MsgWitnessBlock.hex must be("02000040")
+    assert(TypeIdentifier.fromBytes(MsgWitnessBlock.bytes) == MsgWitnessBlock)
   }
 
   "MsgFilteredBlock" must "serialize to 03000000" in {
     MsgFilteredBlock.hex must be("03000000")
+    assert(TypeIdentifier.fromBytes(MsgFilteredBlock.bytes) == MsgFilteredBlock)
   }
 
   "MsgFilteredWitnessBlock" must "serialize to 03000040" in {
     MsgFilteredWitnessBlock.hex must be("03000040")
+    assert(
+      TypeIdentifier.fromBytes(
+        MsgFilteredWitnessBlock.bytes) == MsgFilteredWitnessBlock)
+  }
+
+  "MsgCompactBlock" must "serialize to 04000000" in {
+    MsgCompactBlock.hex must be("04000000")
+    assert(TypeIdentifier.fromBytes(MsgCompactBlock.bytes) == MsgCompactBlock)
   }
 
 }

--- a/core/src/main/scala/org/bitcoins/core/p2p/TypeIdentifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/TypeIdentifier.scala
@@ -63,6 +63,14 @@ object TypeIdentifier extends Factory[TypeIdentifier] {
     val num: UInt32 = MsgFilteredBlock.num | MsgWitnessFlag
   }
 
+  private lazy val assigned = Vector(MsgTx,
+                                     MsgBlock,
+                                     MsgFilteredBlock,
+                                     MsgCompactBlock,
+                                     MsgWitnessTx,
+                                     MsgWitnessBlock,
+                                     MsgFilteredWitnessBlock)
+
   /** from the docs at https://bitcoin.org/en/developer-reference#data-messages
     * These (witness block and tx) are the same as their respective type
     * identifier but with their 30th bit set to indicate witness.
@@ -78,10 +86,5 @@ object TypeIdentifier extends Factory[TypeIdentifier] {
   def apply(num: Long): TypeIdentifier = TypeIdentifier(UInt32(num))
 
   def apply(uInt32: UInt32): TypeIdentifier =
-    uInt32 match {
-      case UInt32.one               => MsgTx
-      case _ if uInt32 == UInt32(2) => MsgBlock
-      case _ if uInt32 == UInt32(3) => MsgFilteredBlock
-      case x: UInt32                => MsgUnassignedImpl(x)
-    }
+    assigned.find(_.num == uInt32).getOrElse(MsgUnassignedImpl(uInt32))
 }


### PR DESCRIPTION
`MsgWitnessTx`, `MsgWitnessBlock`, `MsgFilteredWitnessBlock`, and `MsgCompactBlock` were all missing from the `fromBytes` function