### PR TITLE
Handle TypeIdentifier.MsgWitnessTx messages

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -171,7 +171,7 @@ case class DataMessageHandler(
         getData.inventories.foreach { inv =>
           logger.debug(s"Looking for inv=$inv")
           inv.typeIdentifier match {
-            case TypeIdentifier.MsgTx =>
+            case TypeIdentifier.MsgTx | TypeIdentifier.MsgWitnessTx =>
               txDAO.findByHash(inv.hash).map {
                 case Some(tx) =>
                   peerMsgSender.sendTransactionMessage(tx.transaction)
@@ -183,7 +183,7 @@ case class DataMessageHandler(
                 TypeIdentifier.MsgFilteredBlock |
                 TypeIdentifier.MsgCompactBlock |
                 TypeIdentifier.MsgFilteredWitnessBlock |
-                TypeIdentifier.MsgWitnessBlock | TypeIdentifier.MsgWitnessTx) =>
+                TypeIdentifier.MsgWitnessBlock) =>
               logger.warn(
                 s"Got request to send data type=$other, this is not implemented yet")
 


### PR DESCRIPTION
This is so we handle `MsgWitnessTx` messages if we do ever receive them instead of just dropping them on the floor. This handles them the same way we handle `MsgTx` messages which is fine because we always send the witness serialization of the transaction.