### PR TITLE
Allow lnd remote to work with certificate string

### DIFF
--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/config/LndInstance.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/config/LndInstance.scala
@@ -15,7 +15,8 @@ import scala.util.Properties
 sealed trait LndInstance {
   def rpcUri: URI
   def macaroon: String
-  def certFile: File
+  def certFileOpt: Option[File]
+  def certificateOpt: Option[String]
 }
 
 case class LndInstanceLocal(
@@ -29,6 +30,9 @@ case class LndInstanceLocal(
     zmqConfig: ZmqConfig,
     debugLevel: LogLevel)
     extends LndInstance {
+
+  override val certificateOpt: Option[String] = None
+  override val certFileOpt: Option[File] = Some(certFile)
 
   private var macaroonOpt: Option[String] = None
 
@@ -98,5 +102,26 @@ object LndInstanceLocal
   }
 }
 
-case class LndInstanceRemote(rpcUri: URI, macaroon: String, certFile: File)
+case class LndInstanceRemote(
+    rpcUri: URI,
+    macaroon: String,
+    certFileOpt: Option[File],
+    certificateOpt: Option[String])
     extends LndInstance
+
+object LndInstanceRemote {
+
+  def apply(
+      rpcUri: URI,
+      macaroon: String,
+      certFile: File): LndInstanceRemote = {
+    LndInstanceRemote(rpcUri, macaroon, Some(certFile), None)
+  }
+
+  def apply(
+      rpcUri: URI,
+      macaroon: String,
+      certificate: String): LndInstanceRemote = {
+    LndInstanceRemote(rpcUri, macaroon, None, Some(certificate))
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/LndFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/LndFixture.scala
@@ -7,6 +7,8 @@ import org.bitcoins.testkit.lnd._
 import org.bitcoins.testkit.rpc._
 import org.scalatest.FutureOutcome
 
+import scala.io.Source
+
 /** A trait that is useful if you need Lnd fixtures for your test suite */
 trait LndFixture extends BitcoinSFixture with CachedBitcoindV21 {
 
@@ -82,10 +84,20 @@ trait RemoteLndFixture extends BitcoinSFixture with CachedBitcoindV21 {
           client = LndRpcTestClient.fromSbtDownload(Some(bitcoind))
           lnd <- client.start()
 
+          // get certificate as a string
+          cert = {
+            val file = lnd.instance.certFileOpt.get
+            val source = Source.fromFile(file)
+            val str = source.getLines().toVector.mkString("\n")
+            source.close()
+
+            str
+          }
+
           // create a remote instance and client
           remoteInstance = LndInstanceRemote(lnd.instance.rpcUri,
                                              lnd.instance.macaroon,
-                                             lnd.instance.certFile)
+                                             cert)
           remoteLnd = LndRpcClient(remoteInstance)
         } yield remoteLnd
       },


### PR DESCRIPTION
Instead of needing the certificate on your file system you can now directly input the string. Also allows for no certificate if you have `no-tls-cert` set in your lnd config