### PR TITLE
Fix broadcasting witness vs legacy txs

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/p2p/VersionMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/VersionMessageTest.scala
@@ -27,7 +27,7 @@ class VersionMessageTest extends BitcoinSUnitTest {
     val inet = InetAddress(ipArr)
 
     val versionMessage = VersionMessage(MainNet, inet, inet, relay = false)
-    assert(versionMessage.addressReceiveServices.nodeNone)
+    assert(versionMessage.addressReceiveServices.nodeWitness)
     versionMessage.addressReceiveIpAddress must be(inet)
     versionMessage.addressReceivePort must be(MainNet.port)
 

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1414,9 +1414,9 @@ object VersionMessage extends Factory[VersionMessage] {
     val nonce = UInt64.zero
     VersionMessage(
       version = ProtocolVersion.default,
-      services = ServiceIdentifier.NODE_NONE,
+      services = ServiceIdentifier.NODE_WITNESS,
       timestamp = Int64(java.time.Instant.now.getEpochSecond),
-      addressReceiveServices = ServiceIdentifier.NODE_NONE,
+      addressReceiveServices = ServiceIdentifier.NODE_WITNESS,
       addressReceiveIpAddress = receivingIpAddress,
       addressReceivePort = network.port,
       addressTransServices = ServiceIdentifier.NODE_NETWORK,

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -100,6 +100,10 @@ sealed abstract class Transaction extends NetworkElement {
   }
 
   lazy val totalOutput: CurrencyUnit = outputs.map(_.value).sum
+
+  def toBaseTx: BaseTransaction = {
+    BaseTransaction(version, inputs, outputs, lockTime)
+  }
 }
 
 object Transaction extends Factory[Transaction] {
@@ -176,9 +180,6 @@ case object EmptyTransaction extends NonWitnessTransaction {
   override def inputs: Vector[TransactionInput] = Vector.empty
   override def outputs: Vector[TransactionOutput] = Vector.empty
   override def lockTime: UInt32 = TransactionConstants.lockTime
-
-  def toBaseTx: BaseTransaction =
-    BaseTransaction(version, inputs, outputs, lockTime)
 }
 
 case class WitnessTransaction(
@@ -192,10 +193,6 @@ case class WitnessTransaction(
     inputs.length == witness.length,
     s"Must have same amount of inputs and witnesses in witness tx, inputs=${inputs.length} witnesses=${witness.length}"
   )
-
-  def toBaseTx: BaseTransaction = {
-    BaseTransaction(version, inputs, outputs, lockTime)
-  }
 
   /** The txId for the witness transaction from satoshi's original serialization */
   override def txId: DoubleSha256Digest = {


### PR DESCRIPTION
Reasoning outlined here:

https://bitcoin.stackexchange.com/questions/110775/is-it-okay-to-send-witness-transactions-in-response-to-msg-tx-get-data-message