### PR TITLE
2021 11 23 crud action

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/build/DLCTxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/build/DLCTxBuilder.scala
@@ -92,8 +92,10 @@ case class DLCTxBuilder(offer: DLCOffer, accept: DLCAcceptWithoutSigs) {
   val acceptTotalFunding: CurrencyUnit =
     acceptFundingInputs.map(_.output.value).sum
 
-  require(offer.tempContractId == tempContractId,
-          "Offer and accept (without sigs) must refer to same event")
+  require(
+    offer.tempContractId == tempContractId,
+    s"Offer and accept (without sigs) must refer to same event, offer.tempContractId=${offer.tempContractId.hex} tempContractId=${tempContractId.hex}"
+  )
   require(acceptFinalAddress.networkParameters == network,
           "Offer and accept (without sigs) must be on the same network")
   require(offerChangeAddress.networkParameters == network,

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
@@ -16,9 +16,11 @@ import scala.concurrent.{ExecutionContext, Future}
   * the table and the database you are connecting to.
   */
 abstract class CRUD[T, PrimaryKeyType](implicit
-    private val ec: ExecutionContext,
+    override
+    val ec: ExecutionContext,
     override val appConfig: DbAppConfig)
-    extends JdbcProfileComponent[DbAppConfig] {
+    extends CRUDAction[T, PrimaryKeyType]
+    with JdbcProfileComponent[DbAppConfig] {
 
   val schemaName: Option[String] = appConfig.schemaName
 
@@ -43,9 +45,6 @@ abstract class CRUD[T, PrimaryKeyType](implicit
       tableQuery: TableQuery[SomeT]): TableQuery[SpecificT] = {
     tableQuery.asInstanceOf[TableQuery[SpecificT]]
   }
-
-  /** The table inside our database we are inserting into */
-  val table: profile.api.TableQuery[_ <: profile.api.Table[T]]
 
   /** Binding to the actual database itself, this is what is used to run querys */
   def safeDatabase: SafeDatabase = SafeDatabase(this)

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAction.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAction.scala
@@ -1,0 +1,21 @@
+package org.bitcoins.db
+
+import scala.concurrent.ExecutionContext
+
+abstract class CRUDAction[T, PrimaryKeyType](implicit
+    val ec: ExecutionContext,
+    override val appConfig: DbAppConfig)
+    extends JdbcProfileComponent[DbAppConfig] {
+  import profile.api._
+
+  /** The table inside our database we are inserting into */
+  val table: profile.api.TableQuery[_ <: profile.api.Table[T]]
+
+  def createAllAction(
+      ts: Vector[T]): DBIOAction[Vector[T], NoStream, Effect.Write]
+
+  def createAction(t: T): DBIOAction[T, NoStream, Effect.Write] = {
+    createAllAction(Vector(t))
+      .map(_.head)
+  }
+}

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
@@ -14,16 +14,21 @@ abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](implicit
   /** The table inside our database we are inserting into */
   override val table: profile.api.TableQuery[_ <: TableAutoInc[T]]
 
-  override def createAllAction(ts: Vector[T]): profile.api.DBIOAction[Vector[T], profile.api.NoStream, Effect.Write] = {
-    ???
-  }
-  override def createAll(ts: Vector[T]): Future[Vector[T]] = {
+  override def createAllAction(ts: Vector[T]): profile.api.DBIOAction[
+    Vector[T],
+    profile.api.NoStream,
+    Effect.Write] = {
     val idQuery = table.map(_.id)
     val idAutoInc = table.returning(idQuery)
     val query = {
       idAutoInc.into((t, id) => t.copyWithId(id = id))
     }
     val actions = query.++=(ts)
+    actions.map(_.toVector)
+  }
+
+  override def createAll(ts: Vector[T]): Future[Vector[T]] = {
+    val actions = createAllAction(ts)
     safeDatabase.runVec(actions.transactionally)
   }
 

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
@@ -14,6 +14,9 @@ abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](implicit
   /** The table inside our database we are inserting into */
   override val table: profile.api.TableQuery[_ <: TableAutoInc[T]]
 
+  override def createAllAction(ts: Vector[T]): profile.api.DBIOAction[Vector[T], profile.api.NoStream, Effect.Write] = {
+    ???
+  }
   override def createAll(ts: Vector[T]): Future[Vector[T]] = {
     val idQuery = table.map(_.id)
     val idAutoInc = table.returning(idQuery)

--- a/db-commons/src/main/scala/org/bitcoins/db/SlickUtil.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/SlickUtil.scala
@@ -5,7 +5,22 @@ import slick.jdbc.JdbcProfile
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 
-trait SlickUtil[T, PrimaryKeyType] { _: CRUD[T, PrimaryKeyType] =>
+trait SlickUtilAction[T, PrimaryKeyType] { _: CRUDAction[T, PrimaryKeyType] =>
+
+  def profile: JdbcProfile
+
+  import profile.api._
+
+  def createAllAction(
+      ts: Vector[T]): DBIOAction[Vector[T], NoStream, Effect.Write] = {
+    val fixedSqlAction = table ++= ts
+
+    fixedSqlAction.map(_ => ts)
+  }
+}
+
+trait SlickUtil[T, PrimaryKeyType] extends SlickUtilAction[T, PrimaryKeyType] {
+  _: CRUD[T, PrimaryKeyType] =>
   def profile: JdbcProfile
 
   import profile.api._

--- a/db-commons/src/main/scala/org/bitcoins/db/models/MasterXPubDAO.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/models/MasterXPubDAO.scala
@@ -43,6 +43,16 @@ case class MasterXPubDAO()(implicit
     create(dto)
   }
 
+  override def createAllAction(
+      ts: Vector[ExtPublicKeyDTO]): profile.api.DBIOAction[
+    Vector[ExtPublicKeyDTO],
+    profile.api.NoStream,
+    Effect.Write] = {
+    val fixedSqlAction = table ++= ts
+
+    fixedSqlAction.map(_ => ts)
+  }
+
   override def create(t: ExtPublicKeyDTO): Future[ExtPublicKeyDTO] = {
     val recordCount = table.size.result
 

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventDAO.scala
@@ -16,7 +16,7 @@ import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 
 case class EventDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCOracleAppConfig)
     extends CRUD[EventDb, SchnorrNonce]
     with SlickUtil[EventDb, SchnorrNonce] {

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAO.scala
@@ -10,7 +10,7 @@ import slick.lifted.{ForeignKeyQuery, ProvenShape}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class EventOutcomeDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCOracleAppConfig)
     extends CRUD[EventOutcomeDb, (SchnorrNonce, String)]
     with SlickUtil[EventOutcomeDb, (SchnorrNonce, String)] {

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/RValueDAO.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/storage/RValueDAO.scala
@@ -10,7 +10,7 @@ import slick.lifted.ProvenShape
 import scala.concurrent.{ExecutionContext, Future}
 
 case class RValueDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCOracleAppConfig)
     extends CRUD[RValueDb, SchnorrNonce]
     with SlickUtil[RValueDb, SchnorrNonce] {

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -47,11 +47,11 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
 
       fundingTx <- dlcB.getDLCFundingTx(contractId)
     } yield {
-      assert(offerOpt.isDefined)
-      assert(acceptOpt.isDefined)
+      assert(offerOpt.length == 1)
+      assert(acceptOpt.length == 1)
 
-      val offer = offerOpt.get
-      val accept = acceptOpt.get
+      val offer = offerOpt.head
+      val accept = acceptOpt.head
 
       val comparableInputsA = inputsA
         .sortBy(_.outPoint.hex)

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -47,11 +47,11 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
 
       fundingTx <- dlcB.getDLCFundingTx(contractId)
     } yield {
-      assert(offerOpt.length == 1)
-      assert(acceptOpt.length == 1)
+      assert(offerOpt.isDefined)
+      assert(acceptOpt.isDefined)
 
-      val offer = offerOpt.head
-      val accept = acceptOpt.head
+      val offer = offerOpt.get
+      val accept = acceptOpt.get
 
       val comparableInputsA = inputsA
         .sortBy(_.outPoint.hex)

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -105,11 +105,11 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
     } yield {
       assert(dlcDb.contractIdOpt.get == sign.contractId)
 
-      assert(refundSigsA.length == 1)
-      assert(refundSigsB.length == 1)
-      assert(refundSigsA.head.initiatorSig.isDefined)
-      assert(refundSigsA.head.initiatorSig == refundSigsB.head.initiatorSig)
-      assert(refundSigsA.head.accepterSig == refundSigsB.head.accepterSig)
+      assert(refundSigsA.isDefined)
+      assert(refundSigsB.isDefined)
+      assert(refundSigsA.get.initiatorSig.isDefined)
+      assert(refundSigsA.get.initiatorSig == refundSigsB.get.initiatorSig)
+      assert(refundSigsA.get.accepterSig == refundSigsB.get.accepterSig)
 
       assert(sign.cetSigs.outcomeSigs.forall { case (outcome, sig) =>
         outcomeSigs.exists(dbSig =>
@@ -318,11 +318,11 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       } yield {
         assert(dlcDb.contractIdOpt.get == sign.contractId)
 
-        assert(refundSigsA.length == 1)
-        assert(refundSigsB.length == 1)
-        assert(refundSigsA.head.initiatorSig.isDefined)
-        assert(refundSigsA.head.initiatorSig == refundSigsB.head.initiatorSig)
-        assert(refundSigsA.head.accepterSig == refundSigsB.head.accepterSig)
+        assert(refundSigsA.isDefined)
+        assert(refundSigsB.isDefined)
+        assert(refundSigsA.get.initiatorSig.isDefined)
+        assert(refundSigsA.get.initiatorSig == refundSigsB.get.initiatorSig)
+        assert(refundSigsA.get.accepterSig == refundSigsB.get.accepterSig)
 
         assert(sign.cetSigs.outcomeSigs.forall { case (outcome, sig) =>
           outcomeSigs.exists(dbSig =>
@@ -776,11 +776,11 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         _ = {
           assert(dlcDb.contractIdOpt.get == sign.contractId)
 
-          assert(refundSigsA.length == 1)
-          assert(refundSigsB.length == 1)
-          assert(refundSigsA.head.initiatorSig.isDefined)
-          assert(refundSigsA.head.initiatorSig == refundSigsB.head.initiatorSig)
-          assert(refundSigsA.head.accepterSig == refundSigsB.head.accepterSig)
+          assert(refundSigsA.isDefined)
+          assert(refundSigsB.isDefined)
+          assert(refundSigsA.get.initiatorSig.isDefined)
+          assert(refundSigsA.get.initiatorSig == refundSigsB.get.initiatorSig)
+          assert(refundSigsA.get.accepterSig == refundSigsB.get.accepterSig)
 
           assert(sign.cetSigs.outcomeSigs.forall { case (outcome, sig) =>
             outcomeSigs.exists(dbSig =>

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -105,11 +105,11 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
     } yield {
       assert(dlcDb.contractIdOpt.get == sign.contractId)
 
-      assert(refundSigsA.isDefined)
-      assert(refundSigsB.isDefined)
-      assert(refundSigsA.get.initiatorSig.isDefined)
-      assert(refundSigsA.get.initiatorSig == refundSigsB.get.initiatorSig)
-      assert(refundSigsA.get.accepterSig == refundSigsB.get.accepterSig)
+      assert(refundSigsA.length == 1)
+      assert(refundSigsB.length == 1)
+      assert(refundSigsA.head.initiatorSig.isDefined)
+      assert(refundSigsA.head.initiatorSig == refundSigsB.head.initiatorSig)
+      assert(refundSigsA.head.accepterSig == refundSigsB.head.accepterSig)
 
       assert(sign.cetSigs.outcomeSigs.forall { case (outcome, sig) =>
         outcomeSigs.exists(dbSig =>
@@ -318,11 +318,11 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       } yield {
         assert(dlcDb.contractIdOpt.get == sign.contractId)
 
-        assert(refundSigsA.isDefined)
-        assert(refundSigsB.isDefined)
-        assert(refundSigsA.get.initiatorSig.isDefined)
-        assert(refundSigsA.get.initiatorSig == refundSigsB.get.initiatorSig)
-        assert(refundSigsA.get.accepterSig == refundSigsB.get.accepterSig)
+        assert(refundSigsA.length == 1)
+        assert(refundSigsB.length == 1)
+        assert(refundSigsA.head.initiatorSig.isDefined)
+        assert(refundSigsA.head.initiatorSig == refundSigsB.head.initiatorSig)
+        assert(refundSigsA.head.accepterSig == refundSigsB.head.accepterSig)
 
         assert(sign.cetSigs.outcomeSigs.forall { case (outcome, sig) =>
           outcomeSigs.exists(dbSig =>
@@ -776,11 +776,11 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         _ = {
           assert(dlcDb.contractIdOpt.get == sign.contractId)
 
-          assert(refundSigsA.isDefined)
-          assert(refundSigsB.isDefined)
-          assert(refundSigsA.get.initiatorSig.isDefined)
-          assert(refundSigsA.get.initiatorSig == refundSigsB.get.initiatorSig)
-          assert(refundSigsA.get.accepterSig == refundSigsB.get.accepterSig)
+          assert(refundSigsA.length == 1)
+          assert(refundSigsB.length == 1)
+          assert(refundSigsA.head.initiatorSig.isDefined)
+          assert(refundSigsA.head.initiatorSig == refundSigsB.head.initiatorSig)
+          assert(refundSigsA.head.accepterSig == refundSigsB.head.accepterSig)
 
           assert(sign.cetSigs.outcomeSigs.forall { case (outcome, sig) =>
             outcomeSigs.exists(dbSig =>

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -267,15 +267,7 @@ abstract class DLCWallet
       dbs <- spendingInfoDAO.findByOutPoints(inputs.map(_.outPoint))
       // allow this to fail in the case they have already been unreserved
       _ <- unmarkUTXOsAsReserved(dbs).recover { case _: Throwable => () }
-
-      _ <- dlcSigsDAO.deleteByDLCId(dlcId)
-      _ <- dlcRefundSigDAO.deleteByDLCId(dlcId)
-      _ <- dlcInputsDAO.deleteByDLCId(dlcId)
-      _ <- dlcAcceptDAO.deleteByDLCId(dlcId)
-      _ <- dlcOfferDAO.deleteByDLCId(dlcId)
-      _ <- contractDataDAO.deleteByDLCId(dlcId)
-      _ <- dlcAnnouncementDAO.deleteByDLCId(dlcId)
-      _ <- dlcDAO.deleteByDLCId(dlcId)
+      _ <- deleteDLC(dlcId)
     } yield ()
   }
 
@@ -945,9 +937,9 @@ abstract class DLCWallet
 
           val signatures = refundSigsDb.initiatorSig match {
             case Some(sig) =>
-              CETSignatures(outcomeSigs.toVector, sig)
+              CETSignatures(outcomeSigs, sig)
             case None =>
-              CETSignatures(outcomeSigs.toVector, signer.signRefundTx)
+              CETSignatures(outcomeSigs, signer.signRefundTx)
           }
           Future.successful(signatures)
         }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -508,9 +508,12 @@ abstract class DLCWallet
           }
 
           _ <- writeDLCKeysToAddressDb(account, chainType, nextIndex)
-          writtenDLC <- dlcDAO.create(dlc)
-          _ <- contractDataDAO.create(contractDataDb)
-
+          writtenDLCAction = dlcDAO.createAction(dlc)
+          contractAction = contractDataDAO.createAction(contractDataDb)
+          actions = writtenDLCAction.flatMap { dlcDb =>
+            contractAction.map(_ => dlcDb)
+          }
+          writtenDLC <- contractDataDAO.safeDatabase.run(actions)
           groupedAnnouncements <- groupedAnnouncementsF
           createdDbs <- announcementDAO.createAll(
             groupedAnnouncements.newAnnouncements)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -839,8 +839,9 @@ abstract class DLCWallet
             s"CET Signatures for tempContractId ${accept.tempContractId.hex} were valid, adding to database")
 
           _ <- remoteTxDAO.upsertAll(acceptPrevTxs)
-          _ <- dlcInputsDAO.createAll(acceptInputs)
-          _ <- dlcSigsDAO.createAll(sigsDbs)
+          inputAction = dlcInputsDAO.createAllAction(acceptInputs)
+          sigsAction = dlcSigsDAO.createAllAction(sigsDbs)
+          _ <- safeDatabase.run(DBIO.sequence(Vector(inputAction, sigsAction)))
           _ <- dlcRefundSigDAO.upsert(refundSigsDb)
           _ <- dlcAcceptDAO.upsert(dlcAcceptDb)
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -63,7 +63,7 @@ abstract class DLCWallet
   private[bitcoins] val dlcRefundSigDAO: DLCRefundSigsDAO = DLCRefundSigsDAO()
   private[bitcoins] val remoteTxDAO: DLCRemoteTxDAO = DLCRemoteTxDAO()
 
-  private lazy val actionBuilder: DLCActionBuilder = {
+  protected lazy val actionBuilder: DLCActionBuilder = {
     DLCActionBuilder(
       dlcDAO = dlcDAO,
       contractDataDAO = contractDataDAO,
@@ -283,7 +283,8 @@ abstract class DLCWallet
       dbs <- spendingInfoDAO.findByOutPoints(inputs.map(_.outPoint))
       // allow this to fail in the case they have already been unreserved
       _ <- unmarkUTXOsAsReserved(dbs).recover { case _: Throwable => () }
-      _ <- deleteDLC(dlcId)
+      action = actionBuilder.deleteDLCAction(dlcId)
+      _ <- safeDatabase.run(action)
     } yield ()
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
@@ -670,4 +670,40 @@ private[bitcoins] trait DLCDataManagement { self: DLCWallet =>
     val action = getCetAndRefundSigsAction(dlcId)
     safeDatabase.run(action)
   }
+
+  /** Creates the action to delete the given dlc from our database.
+    * This removes references to the dlc in our various tables
+    */
+  def deleteDLCAction(
+      dlcId: Sha256Digest): DBIOAction[Unit, NoStream, Effect.Write] = {
+    val deleteSigA = dlcSigsDAO.deleteByDLCIdAction(dlcId)
+    val deleteRefundSigA = dlcRefundSigDAO.deleteByDLCIdAction(dlcId)
+    val deleteInputSigA = dlcInputsDAO.deleteByDLCIdAction(dlcId)
+    val deleteAcceptA = dlcAcceptDAO.deleteByDLCIdAction(dlcId)
+    val deleteOfferA = dlcOfferDAO.deleteByDLCIdAction(dlcId)
+    val deleteContractDataA = contractDataDAO.deleteByDLCIdAction(dlcId)
+    val deleteAnnouncementDataA = dlcAnnouncementDAO.deleteByDLCIdAction(dlcId)
+    val deleteDlcA = dlcDAO.deleteByDLCIdAction(dlcId)
+
+    val action = for {
+      _ <- deleteSigA
+      _ <- deleteRefundSigA
+      _ <- deleteInputSigA
+      _ <- deleteAcceptA
+      _ <- deleteOfferA
+      _ <- deleteContractDataA
+      _ <- deleteAnnouncementDataA
+      _ <- deleteDlcA
+    } yield ()
+
+    action
+  }
+
+  /** Deletes the given dlc from our database. This removes
+    * references to the dlc in our various tables
+    */
+  def deleteDLC(dlcId: Sha256Digest): Future[Unit] = {
+    val action = deleteDLCAction(dlcId)
+    safeDatabase.run(action)
+  }
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDAO.scala
@@ -16,7 +16,8 @@ case class DLCAcceptDAO()(implicit
     override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCAcceptDb, Sha256Digest]
-    with SlickUtil[DLCAcceptDb, Sha256Digest] {
+    with SlickUtil[DLCAcceptDb, Sha256Digest]
+    with DLCIdDaoUtil[DLCAcceptDb, Sha256Digest] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._
@@ -44,23 +45,20 @@ case class DLCAcceptDAO()(implicit
       dlcs: Vector[DLCAcceptDb]): Query[DLCAcceptTable, DLCAcceptDb, Seq] =
     findByPrimaryKeys(dlcs.map(_.dlcId))
 
-  def deleteByDLCId(dlcId: Sha256Digest): Future[Int] = {
+  override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Vector[DLCAcceptDb],
+    profile.api.NoStream,
+    profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    safeDatabase.run(q.delete)
+    q.result.map(_.toVector)
   }
 
-  def findByDLCId(dlcId: Sha256Digest): Future[Option[DLCAcceptDb]] = {
+  override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Int,
+    profile.api.NoStream,
+    profile.api.Effect.Write] = {
     val q = table.filter(_.dlcId === dlcId)
-
-    safeDatabase.run(q.result).map {
-      case h +: Vector() =>
-        Some(h)
-      case Vector() =>
-        None
-      case dlcs: Vector[DLCAcceptDb] =>
-        throw new RuntimeException(
-          s"More than one DLCAccept per dlcId ($dlcId), got: $dlcs")
-    }
+    q.delete
   }
 
   class DLCAcceptTable(tag: Tag)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDAO.scala
@@ -13,7 +13,7 @@ import slick.lifted.{ForeignKeyQuery, ProvenShape}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class DLCAcceptDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCAcceptDb, Sha256Digest]
     with SlickUtil[DLCAcceptDb, Sha256Digest] {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDAO.scala
@@ -46,11 +46,11 @@ case class DLCAcceptDAO()(implicit
     findByPrimaryKeys(dlcs.map(_.dlcId))
 
   override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
-    Vector[DLCAcceptDb],
+    Option[DLCAcceptDb],
     profile.api.NoStream,
     profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    q.result.map(_.toVector)
+    q.result.map(_.headOption)
   }
 
   override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAnnouncementDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAnnouncementDAO.scala
@@ -14,7 +14,8 @@ case class DLCAnnouncementDAO()(implicit
     override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCAnnouncementDb, DLCAnnouncementPrimaryKey]
-    with SlickUtil[DLCAnnouncementDb, DLCAnnouncementPrimaryKey] {
+    with SlickUtil[DLCAnnouncementDb, DLCAnnouncementPrimaryKey]
+    with DLCIdDaoUtil[DLCAnnouncementDb, DLCAnnouncementPrimaryKey] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._
@@ -81,15 +82,20 @@ case class DLCAnnouncementDAO()(implicit
     safeDatabase.runVec(query.result)
   }
 
-  def findByDLCId(dlcId: Sha256Digest): Future[Vector[DLCAnnouncementDb]] = {
-    val query = table.filter(_.dlcId === dlcId)
-
-    safeDatabase.runVec(query.result)
+  override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Vector[DLCAnnouncementDb],
+    profile.api.NoStream,
+    profile.api.Effect.Read] = {
+    val q = table.filter(_.dlcId === dlcId)
+    q.result.map(_.toVector)
   }
 
-  def deleteByDLCId(dlcId: Sha256Digest): Future[Int] = {
+  override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Int,
+    profile.api.NoStream,
+    profile.api.Effect.Write] = {
     val q = table.filter(_.dlcId === dlcId)
-    safeDatabase.run(q.delete)
+    q.delete
   }
 
   class DLCAnnouncementTable(tag: Tag)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAnnouncementDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAnnouncementDAO.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class DLCAnnouncementPrimaryKey(dlcId: Sha256Digest, announcementId: Long)
 
 case class DLCAnnouncementDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCAnnouncementDb, DLCAnnouncementPrimaryKey]
     with SlickUtil[DLCAnnouncementDb, DLCAnnouncementPrimaryKey] {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAnnouncementDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAnnouncementDAO.scala
@@ -15,7 +15,7 @@ case class DLCAnnouncementDAO()(implicit
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCAnnouncementDb, DLCAnnouncementPrimaryKey]
     with SlickUtil[DLCAnnouncementDb, DLCAnnouncementPrimaryKey]
-    with DLCIdDaoUtil[DLCAnnouncementDb, DLCAnnouncementPrimaryKey] {
+    with DLCIdDaoUtilNoPK[DLCAnnouncementDb] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignaturesDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignaturesDAO.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class DLCCETSignaturesPrimaryKey(dlcId: Sha256Digest, contractIndex: Long)
 
 case class DLCCETSignaturesDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCCETSignaturesDb, DLCCETSignaturesPrimaryKey]
     with SlickUtil[DLCCETSignaturesDb, DLCCETSignaturesPrimaryKey] {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignaturesDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignaturesDAO.scala
@@ -13,7 +13,8 @@ case class DLCCETSignaturesDAO()(implicit
     override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCCETSignaturesDb, DLCCETSignaturesPrimaryKey]
-    with SlickUtil[DLCCETSignaturesDb, DLCCETSignaturesPrimaryKey] {
+    with SlickUtil[DLCCETSignaturesDb, DLCCETSignaturesPrimaryKey]
+    with DLCIdDaoUtil[DLCCETSignaturesDb, DLCCETSignaturesPrimaryKey] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._
@@ -69,14 +70,20 @@ case class DLCCETSignaturesDAO()(implicit
     findByPrimaryKeys(
       dlcs.map(sig => DLCCETSignaturesPrimaryKey(sig.dlcId, sig.index)))
 
-  def findByDLCId(dlcId: Sha256Digest): Future[Vector[DLCCETSignaturesDb]] = {
+  override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Vector[DLCCETSignaturesDb],
+    profile.api.NoStream,
+    profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    safeDatabase.runVec(q.result)
+    q.result.map(_.toVector)
   }
 
-  def deleteByDLCId(dlcId: Sha256Digest): Future[Int] = {
+  override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Int,
+    profile.api.NoStream,
+    profile.api.Effect.Write] = {
     val q = table.filter(_.dlcId === dlcId)
-    safeDatabase.run(q.delete)
+    q.delete
   }
 
   class DLCCETSignatureTable(tag: Tag)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignaturesDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCCETSignaturesDAO.scala
@@ -14,7 +14,7 @@ case class DLCCETSignaturesDAO()(implicit
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCCETSignaturesDb, DLCCETSignaturesPrimaryKey]
     with SlickUtil[DLCCETSignaturesDb, DLCCETSignaturesPrimaryKey]
-    with DLCIdDaoUtil[DLCCETSignaturesDb, DLCCETSignaturesPrimaryKey] {
+    with DLCIdDaoUtilNoPK[DLCCETSignaturesDb] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCContractDataDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCContractDataDAO.scala
@@ -50,11 +50,11 @@ case class DLCContractDataDAO()(implicit
     findByPrimaryKeys(dlcs.map(_.dlcId))
 
   override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
-    Vector[DLCContractDataDb],
+    Option[DLCContractDataDb],
     profile.api.NoStream,
     profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    q.result.map(_.toVector)
+    q.result.map(_.headOption)
   }
 
   override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCContractDataDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCContractDataDAO.scala
@@ -11,7 +11,7 @@ import slick.lifted._
 import scala.concurrent.{ExecutionContext, Future}
 
 case class DLCContractDataDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCContractDataDb, Sha256Digest]
     with SlickUtil[DLCContractDataDb, Sha256Digest] {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
@@ -16,7 +16,7 @@ import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 
 case class DLCDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCDb, Sha256Digest]
     with SlickUtil[DLCDb, Sha256Digest] {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
@@ -44,11 +44,11 @@ case class DLCDAO()(implicit
     findByPrimaryKeys(dlcs.map(_.dlcId))
 
   override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
-    Vector[DLCDb],
+    Option[DLCDb],
     profile.api.NoStream,
     profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    q.result.map(_.toVector)
+    q.result.map(_.headOption)
   }
 
   override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
@@ -19,7 +19,8 @@ case class DLCDAO()(implicit
     override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCDb, Sha256Digest]
-    with SlickUtil[DLCDb, Sha256Digest] {
+    with SlickUtil[DLCDb, Sha256Digest]
+    with DLCIdDaoUtil[DLCDb, Sha256Digest] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._
@@ -42,9 +43,20 @@ case class DLCDAO()(implicit
   override def findAll(dlcs: Vector[DLCDb]): Query[DLCTable, DLCDb, Seq] =
     findByPrimaryKeys(dlcs.map(_.dlcId))
 
-  def deleteByDLCId(dlcId: Sha256Digest): Future[Int] = {
+  override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Vector[DLCDb],
+    profile.api.NoStream,
+    profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    safeDatabase.run(q.delete)
+    q.result.map(_.toVector)
+  }
+
+  override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Int,
+    profile.api.NoStream,
+    profile.api.Effect.Write] = {
+    val q = table.filter(_.dlcId === dlcId)
+    q.delete
   }
 
   def findByTempContractId(
@@ -77,20 +89,6 @@ case class DLCDAO()(implicit
       case dlcs: Vector[DLCDb] =>
         throw new RuntimeException(
           s"More than one DLC per contractId (${contractId.toHex}), got: $dlcs")
-    }
-  }
-
-  def findByDLCId(dlcId: Sha256Digest): Future[Option[DLCDb]] = {
-    val q = table.filter(_.dlcId === dlcId)
-
-    safeDatabase.run(q.result).map {
-      case h +: Vector() =>
-        Some(h)
-      case Vector() =>
-        None
-      case dlcs: Vector[DLCDb] =>
-        throw new RuntimeException(
-          s"More than one DLC per dlcId (${dlcId.hex}), got: $dlcs")
     }
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDAO.scala
@@ -18,7 +18,8 @@ case class DLCFundingInputDAO()(implicit
     override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCFundingInputDb, TransactionOutPoint]
-    with SlickUtil[DLCFundingInputDb, TransactionOutPoint] {
+    with SlickUtil[DLCFundingInputDb, TransactionOutPoint]
+    with DLCIdDaoUtil[DLCFundingInputDb, TransactionOutPoint] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._
@@ -55,15 +56,20 @@ case class DLCFundingInputDAO()(implicit
     Seq] =
     findByPrimaryKeys(dlcs.map(_.outPoint))
 
-  def deleteByDLCId(dlcId: Sha256Digest): Future[Int] = {
+  override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Vector[DLCFundingInputDb],
+    profile.api.NoStream,
+    profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    safeDatabase.run(q.delete)
+    q.result.map(_.toVector)
   }
 
-  def findByDLCId(dlcId: Sha256Digest): Future[Vector[DLCFundingInputDb]] = {
+  override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Int,
+    profile.api.NoStream,
+    profile.api.Effect.Write] = {
     val q = table.filter(_.dlcId === dlcId)
-
-    safeDatabase.run(q.result).map(_.toVector)
+    q.delete
   }
 
   def findByDLCId(

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDAO.scala
@@ -15,7 +15,7 @@ import slick.lifted.{ForeignKeyQuery, ProvenShape}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class DLCFundingInputDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCFundingInputDb, TransactionOutPoint]
     with SlickUtil[DLCFundingInputDb, TransactionOutPoint] {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCFundingInputDAO.scala
@@ -19,7 +19,7 @@ case class DLCFundingInputDAO()(implicit
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCFundingInputDb, TransactionOutPoint]
     with SlickUtil[DLCFundingInputDb, TransactionOutPoint]
-    with DLCIdDaoUtil[DLCFundingInputDb, TransactionOutPoint] {
+    with DLCIdDaoUtilNoPK[DLCFundingInputDb] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCIdDaoUtil.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCIdDaoUtil.scala
@@ -5,7 +5,33 @@ import org.bitcoins.db.CRUD
 
 import scala.concurrent.Future
 
+/** Helper methods for querying by dlcId whne the dlcId is the primary key on the table */
 trait DLCIdDaoUtil[T, PrimaryKeyType] { _: CRUD[T, PrimaryKeyType] =>
+  import profile.api._
+
+  def findByDLCIdAction(dlcId: Sha256Digest): profile.api.DBIOAction[
+    Option[T],
+    profile.api.NoStream,
+    profile.api.Effect.Read]
+
+  def findByDLCId(dlcId: Sha256Digest): Future[Option[T]] = {
+    safeDatabase.run(findByDLCIdAction(dlcId).transactionally)
+  }
+
+  def deleteByDLCIdAction(dlcId: Sha256Digest): profile.api.DBIOAction[
+    Int,
+    profile.api.NoStream,
+    profile.api.Effect.Write]
+
+  def deleteByDLCId(dlcId: Sha256Digest): Future[Int] = {
+    safeDatabase.run(deleteByDLCIdAction(dlcId).transactionally)
+  }
+}
+
+/** Helper methods for querying by dlcId when the dlcId is not a primary
+  * key on the table
+  */
+trait DLCIdDaoUtilNoPK[T] { _: CRUD[T, _] =>
   import profile.api._
 
   def findByDLCIdAction(dlcId: Sha256Digest): profile.api.DBIOAction[

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCIdDaoUtil.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCIdDaoUtil.scala
@@ -1,0 +1,28 @@
+package org.bitcoins.dlc.wallet.models
+
+import org.bitcoins.crypto.Sha256Digest
+import org.bitcoins.db.CRUD
+
+import scala.concurrent.Future
+
+trait DLCIdDaoUtil[T, PrimaryKeyType] { _: CRUD[T, PrimaryKeyType] =>
+  import profile.api._
+
+  def findByDLCIdAction(dlcId: Sha256Digest): profile.api.DBIOAction[
+    Vector[T],
+    profile.api.NoStream,
+    profile.api.Effect.Read]
+
+  def findByDLCId(dlcId: Sha256Digest): Future[Vector[T]] = {
+    safeDatabase.runVec(findByDLCIdAction(dlcId).transactionally)
+  }
+
+  def deleteByDLCIdAction(dlcId: Sha256Digest): profile.api.DBIOAction[
+    Int,
+    profile.api.NoStream,
+    profile.api.Effect.Write]
+
+  def deleteByDLCId(dlcId: Sha256Digest): Future[Int] = {
+    safeDatabase.run(deleteByDLCIdAction(dlcId).transactionally)
+  }
+}

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDAO.scala
@@ -12,7 +12,7 @@ import slick.lifted.{ForeignKeyQuery, ProvenShape}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class DLCOfferDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCOfferDb, Sha256Digest]
     with SlickUtil[DLCOfferDb, Sha256Digest] {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDAO.scala
@@ -15,7 +15,8 @@ case class DLCOfferDAO()(implicit
     override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCOfferDb, Sha256Digest]
-    with SlickUtil[DLCOfferDb, Sha256Digest] {
+    with SlickUtil[DLCOfferDb, Sha256Digest]
+    with DLCIdDaoUtil[DLCOfferDb, Sha256Digest] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._
@@ -43,23 +44,20 @@ case class DLCOfferDAO()(implicit
       dlcs: Vector[DLCOfferDb]): Query[DLCOfferTable, DLCOfferDb, Seq] =
     findByPrimaryKeys(dlcs.map(_.dlcId))
 
-  def deleteByDLCId(dlcId: Sha256Digest): Future[Int] = {
+  override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Vector[DLCOfferDb],
+    profile.api.NoStream,
+    profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    safeDatabase.run(q.delete)
+    q.result.map(_.toVector)
   }
 
-  def findByDLCId(dlcId: Sha256Digest): Future[Option[DLCOfferDb]] = {
+  override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Int,
+    profile.api.NoStream,
+    profile.api.Effect.Write] = {
     val q = table.filter(_.dlcId === dlcId)
-
-    safeDatabase.run(q.result).map {
-      case h +: Vector() =>
-        Some(h)
-      case Vector() =>
-        None
-      case dlcs: Vector[DLCOfferDb] =>
-        throw new RuntimeException(
-          s"More than one DLCOffer per dlcId ($dlcId), got: $dlcs")
-    }
+    q.delete
   }
 
   class DLCOfferTable(tag: Tag)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDAO.scala
@@ -45,11 +45,11 @@ case class DLCOfferDAO()(implicit
     findByPrimaryKeys(dlcs.map(_.dlcId))
 
   override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
-    Vector[DLCOfferDb],
+    Option[DLCOfferDb],
     profile.api.NoStream,
     profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    q.result.map(_.toVector)
+    q.result.map(_.headOption)
   }
 
   override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigsDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigsDAO.scala
@@ -13,7 +13,8 @@ case class DLCRefundSigsDAO()(implicit
     override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCRefundSigsDb, Sha256Digest]
-    with SlickUtil[DLCRefundSigsDb, Sha256Digest] {
+    with SlickUtil[DLCRefundSigsDb, Sha256Digest]
+    with DLCIdDaoUtil[DLCRefundSigsDb, Sha256Digest] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers._
   import profile.api._
@@ -47,15 +48,20 @@ case class DLCRefundSigsDAO()(implicit
     Seq] =
     findByPrimaryKeys(dlcs.map(_.dlcId))
 
-  def deleteByDLCId(dlcId: Sha256Digest): Future[Int] = {
+  override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Vector[DLCRefundSigsDb],
+    profile.api.NoStream,
+    profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    safeDatabase.run(q.delete)
+    q.result.map(_.toVector)
   }
 
-  def findByDLCId(dlcId: Sha256Digest): Future[Option[DLCRefundSigsDb]] = {
+  override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
+    Int,
+    profile.api.NoStream,
+    profile.api.Effect.Write] = {
     val q = table.filter(_.dlcId === dlcId)
-
-    safeDatabase.runVec(q.result).map(_.headOption)
+    q.delete
   }
 
   class DLCRefundSigTable(tag: Tag)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigsDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigsDAO.scala
@@ -49,11 +49,11 @@ case class DLCRefundSigsDAO()(implicit
     findByPrimaryKeys(dlcs.map(_.dlcId))
 
   override def findByDLCIdAction(dlcId: Sha256Digest): DBIOAction[
-    Vector[DLCRefundSigsDb],
+    Option[DLCRefundSigsDb],
     profile.api.NoStream,
     profile.api.Effect.Read] = {
     val q = table.filter(_.dlcId === dlcId)
-    q.result.map(_.toVector)
+    q.result.map(_.headOption)
   }
 
   override def deleteByDLCIdAction(dlcId: Sha256Digest): DBIOAction[

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigsDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigsDAO.scala
@@ -10,7 +10,7 @@ import slick.lifted.{ForeignKeyQuery, ProvenShape}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class DLCRefundSigsDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[DLCRefundSigsDb, Sha256Digest]
     with SlickUtil[DLCRefundSigsDb, Sha256Digest] {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRemoteTxDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRemoteTxDAO.scala
@@ -12,7 +12,7 @@ import slick.lifted.ProvenShape
 import scala.concurrent.ExecutionContext
 
 case class DLCRemoteTxDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends TxDAO[TransactionDb] {
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleAnnouncementDataDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleAnnouncementDataDAO.scala
@@ -42,6 +42,10 @@ case class OracleAnnouncementDataDAO()(implicit
     safeDatabase.runVec(query.result)
   }
 
+  def findById(id: Long): Future[Option[OracleAnnouncementDataDb]] = {
+    findByIds(Vector(id)).map(_.headOption)
+  }
+
   class OracleAnnouncementsTable(tag: Tag)
       extends TableAutoInc[OracleAnnouncementDataDb](
         tag,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleAnnouncementDataDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleAnnouncementDataDAO.scala
@@ -10,7 +10,7 @@ import slick.lifted.ProvenShape
 import scala.concurrent.{ExecutionContext, Future}
 
 case class OracleAnnouncementDataDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUDAutoInc[OracleAnnouncementDataDb] {
   private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleNonceDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleNonceDAO.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class OracleNoncePrimaryKey(announcementId: Long, index: Long)
 
 case class OracleNonceDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: DLCAppConfig)
     extends CRUD[OracleNonceDb, OracleNoncePrimaryKey]
     with SlickUtil[OracleNonceDb, OracleNoncePrimaryKey] {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.dlc.wallet.util
 
 import org.bitcoins.core.api.dlc.wallet.db.DLCDb
+import org.bitcoins.crypto.Sha256Digest
 import org.bitcoins.dlc.wallet.models.{
   DLCAcceptDAO,
   DLCAcceptDb,
@@ -86,5 +87,59 @@ case class DLCActionBuilder(
       .sequence(actions)
       .map(_ => ())
     allActions
+  }
+
+  /** Creates the action to delete the given dlc from our database.
+    * This removes references to the dlc in our various tables
+    */
+  def deleteDLCAction(dlcId: Sha256Digest)(implicit
+      ec: ExecutionContext): DBIOAction[Unit, NoStream, Effect.Write] = {
+    val deleteSigA = dlcSigsDAO.deleteByDLCIdAction(dlcId)
+    val deleteRefundSigA = dlcRefundSigDAO.deleteByDLCIdAction(dlcId)
+    val deleteInputSigA = dlcInputsDAO.deleteByDLCIdAction(dlcId)
+    val deleteAcceptA = dlcAcceptDAO.deleteByDLCIdAction(dlcId)
+    val deleteOfferA = dlcOfferDAO.deleteByDLCIdAction(dlcId)
+    val deleteContractDataA = contractDataDAO.deleteByDLCIdAction(dlcId)
+    val deleteAnnouncementDataA = dlcAnnouncementDAO.deleteByDLCIdAction(dlcId)
+    val deleteDlcA = dlcDAO.deleteByDLCIdAction(dlcId)
+
+    val action = for {
+      _ <- deleteSigA
+      _ <- deleteRefundSigA
+      _ <- deleteInputSigA
+      _ <- deleteAcceptA
+      _ <- deleteOfferA
+      _ <- deleteContractDataA
+      _ <- deleteAnnouncementDataA
+      _ <- deleteDlcA
+    } yield ()
+
+    action
+  }
+
+  /** Retrieves a DBIOAction that fetches the global dlc db,
+    * the contract, the offer, and funding inputs
+    */
+  def getDLCOfferDataAction(dlcId: Sha256Digest)(implicit
+      ec: ExecutionContext): DBIOAction[
+    (
+        Option[DLCDb],
+        Option[DLCContractDataDb],
+        Option[DLCOfferDb],
+        Vector[DLCFundingInputDb]),
+    NoStream,
+    Effect.Read] = {
+    val dlcDbAction = dlcDAO.findByDLCIdAction(dlcId)
+    val contractDataAction = contractDataDAO.findByDLCIdAction(dlcId)
+    val dlcOfferAction = dlcOfferDAO.findByDLCIdAction(dlcId)
+    val fundingInputsAction = dlcInputsDAO.findByDLCIdAction(dlcId)
+    val combined = for {
+      dlcDb <- dlcDbAction
+      contractData <- contractDataAction
+      offer <- dlcOfferAction
+      inputs <- fundingInputsAction
+    } yield (dlcDb, contractData, offer, inputs)
+
+    combined
   }
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
@@ -1,0 +1,90 @@
+package org.bitcoins.dlc.wallet.util
+
+import org.bitcoins.core.api.dlc.wallet.db.DLCDb
+import org.bitcoins.dlc.wallet.models.{
+  DLCAcceptDAO,
+  DLCAcceptDb,
+  DLCAnnouncementDAO,
+  DLCAnnouncementDb,
+  DLCCETSignaturesDAO,
+  DLCCETSignaturesDb,
+  DLCContractDataDAO,
+  DLCContractDataDb,
+  DLCDAO,
+  DLCFundingInputDAO,
+  DLCFundingInputDb,
+  DLCOfferDAO,
+  DLCOfferDb,
+  DLCRefundSigsDAO,
+  DLCRefundSigsDb
+}
+import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
+
+import scala.concurrent.ExecutionContext
+
+/** Utility class to help build actions to insert things into our DLC tables */
+case class DLCActionBuilder(
+    dlcDAO: DLCDAO,
+    contractDataDAO: DLCContractDataDAO,
+    dlcAnnouncementDAO: DLCAnnouncementDAO,
+    dlcInputsDAO: DLCFundingInputDAO,
+    dlcOfferDAO: DLCOfferDAO,
+    dlcAcceptDAO: DLCAcceptDAO,
+    dlcSigsDAO: DLCCETSignaturesDAO,
+    dlcRefundSigDAO: DLCRefundSigsDAO) {
+
+  /** Builds an offer in our database, adds relevant information to the global table,
+    * contract data, announcements, funding inputs, and the actual offer itself
+    */
+  def buildCreateOfferAction(
+      dlcDb: DLCDb,
+      contractDataDb: DLCContractDataDb,
+      dlcAnnouncementDbs: Vector[DLCAnnouncementDb],
+      dlcInputs: Vector[DLCFundingInputDb],
+      dlcOfferDb: DLCOfferDb)(implicit
+      ec: ExecutionContext): DBIOAction[Unit, NoStream, Effect.Write] = {
+    val globalAction = dlcDAO.createAction(dlcDb)
+    val contractAction = contractDataDAO.createAction(contractDataDb)
+    val announcementAction =
+      dlcAnnouncementDAO.createAllAction(dlcAnnouncementDbs)
+    val inputsAction = dlcInputsDAO.createAllAction(dlcInputs)
+    val offerAction = dlcOfferDAO.createAction(dlcOfferDb)
+    val actions = Vector(globalAction,
+                         contractAction,
+                         announcementAction,
+                         inputsAction,
+                         offerAction)
+    val allActions = DBIO
+      .sequence(actions)
+      .map(_ => ())
+    allActions
+  }
+
+  /** Builds an accept in our database, adds relevant information to the
+    * offer table, accept table, cet sigs table, inputs table, and refund table
+    */
+  def buildCreateAcceptAction(
+      dlcOfferDb: DLCOfferDb,
+      dlcAcceptDb: DLCAcceptDb,
+      offerInputs: Vector[DLCFundingInputDb],
+      acceptInputs: Vector[DLCFundingInputDb],
+      cetSigsDb: Vector[DLCCETSignaturesDb],
+      refundSigsDb: DLCRefundSigsDb)(implicit
+      ec: ExecutionContext): DBIOAction[Unit, NoStream, Effect.Write] = {
+    val inputAction = dlcInputsDAO.createAllAction(offerInputs ++ acceptInputs)
+    val offerAction = dlcOfferDAO.createAction(dlcOfferDb)
+    val acceptAction = dlcAcceptDAO.createAction(dlcAcceptDb)
+    val sigsAction = dlcSigsDAO.createAllAction(cetSigsDb)
+    val refundSigAction = dlcRefundSigDAO.createAction(refundSigsDb)
+    val actions = Vector(inputAction,
+                         offerAction,
+                         acceptAction,
+                         sigsAction,
+                         refundSigAction)
+
+    val allActions = DBIO
+      .sequence(actions)
+      .map(_ => ())
+    allActions
+  }
+}

--- a/node/src/main/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAO.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/BroadcastAbleTransactionDAO.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 final case class BroadcastAbleTransactionDAO()(implicit
     override val appConfig: NodeAppConfig,
-    val ec: ExecutionContext)
+    override val ec: ExecutionContext)
     extends CRUD[BroadcastAbleTransaction, DoubleSha256DigestBE]
     with SlickUtil[BroadcastAbleTransaction, DoubleSha256DigestBE] {
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
@@ -76,7 +76,7 @@ case class TestAppConfig(
 case class TestDb(pk: String, data: ByteVector)
 
 case class TestDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: TestAppConfig)
     extends CRUD[TestDb, String]
     with SlickUtil[TestDb, String] {

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
@@ -10,7 +10,7 @@ import slick.lifted.{PrimaryKey, ProvenShape}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class AccountDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: WalletAppConfig)
     extends CRUD[AccountDb, (HDCoin, Int)]
     with SlickUtil[AccountDb, (HDCoin, Int)] {

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagDAO.scala
@@ -19,7 +19,7 @@ import slick.lifted.{PrimaryKey, ProvenShape}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class AddressTagDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: WalletAppConfig)
     extends CRUD[AddressTagDb, (BitcoinAddress, AddressTagType)]
     with SlickUtil[AddressTagDb, (BitcoinAddress, AddressTagType)] {

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/IncomingTransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/IncomingTransactionDAO.scala
@@ -9,7 +9,7 @@ import slick.lifted.{PrimaryKey, ProvenShape}
 import scala.concurrent.ExecutionContext
 
 case class IncomingTransactionDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: WalletAppConfig)
     extends TxDAO[IncomingTransactionDb] {
   import profile.api._

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/OutgoingTransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/OutgoingTransactionDAO.scala
@@ -10,7 +10,7 @@ import slick.lifted.{PrimaryKey, ProvenShape}
 import scala.concurrent.ExecutionContext
 
 case class OutgoingTransactionDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: WalletAppConfig)
     extends TxDAO[OutgoingTransactionDb] {
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -15,7 +15,7 @@ import java.sql.SQLException
 import scala.concurrent.{ExecutionContext, Future}
 
 case class SpendingInfoDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: WalletAppConfig)
     extends CRUDAutoInc[UTXORecord] {
   import profile.api._

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/TransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/TransactionDAO.scala
@@ -91,7 +91,7 @@ trait TxDAO[DbEntryType <: TxDB]
 }
 
 case class TransactionDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: WalletAppConfig)
     extends TxDAO[TransactionDb] {
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/WalletStateDescriptorDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/WalletStateDescriptorDAO.scala
@@ -20,7 +20,7 @@ case class WalletStateDescriptorDb(
 }
 
 case class WalletStateDescriptorDAO()(implicit
-    val ec: ExecutionContext,
+    override val ec: ExecutionContext,
     override val appConfig: WalletAppConfig)
     extends CRUD[WalletStateDescriptorDb, WalletStateDescriptorType]
     with SlickUtil[WalletStateDescriptorDb, WalletStateDescriptorType] {


### PR DESCRIPTION
This PR begins exposing database actions in our `CRUD` trait. There is now a super trait called `CRUDAction`, and has two methods on it `createAllAction`/`createAction`/`deleteAction`/`deleteAllAction`. I'm not going to implement `upsert`/`upsertAll` on this PR.

For more information on how `DBIOAction` please see this slick documentation: https://scala-slick.org/doc/3.3.3/dbio.html

This PR begins to fix #3844 / #3846 / #3119