### PR TITLE
Use bigendian txids in wallet log messages

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -107,7 +107,7 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
         val utxosStr = utxoSpendingInfos
           .map { utxo =>
             import utxo.outPoint
-            s"${outPoint.txId.hex}:${outPoint.vout.toInt}"
+            s"${outPoint.txIdBE.hex}:${outPoint.vout.toInt}"
           }
           .mkString(", ")
         s"Spending UTXOs: $utxosStr"

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -277,7 +277,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
     } yield {
       val writtenOut = written.outPoint
       logger.info(
-        s"Successfully inserted UTXO ${writtenOut.txId.hex}:${writtenOut.vout.toInt} into DB")
+        s"Successfully inserted UTXO ${writtenOut.txIdBE.hex}:${writtenOut.vout.toInt} into DB")
       logger.debug(s"UTXO details: ${written.output}")
       written
     }
@@ -298,7 +298,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       val output = transaction.outputs(vout.toInt)
       val outPoint = TransactionOutPoint(transaction.txId, vout)
       logger.info(
-        s"Adding UTXO to wallet: ${transaction.txId.hex}:${vout.toInt} amt=${output.value}")
+        s"Adding UTXO to wallet: ${transaction.txIdBE.hex}:${vout.toInt} amt=${output.value}")
       // insert the UTXO into the DB
       val insertedUtxoEF: Either[AddUtxoError, Future[SpendingInfoDb]] = for {
         addressDb <- addressDbE


### PR DESCRIPTION
Fix some annoying logs that were using little endian txids rather than big endian txids.

This helps improving the ergonomics of debugging the wallet.