### PR TITLE
2021 12 10 issue 3891

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -195,7 +195,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
   /** Returns blockchain info, in case of  [[InWarmUp]] exception it retries.
     */
   private def getBlockChainInfo(
-                                 client: BitcoindRpcClient): Future[GetBlockChainInfoResult] = {
+      client: BitcoindRpcClient): Future[GetBlockChainInfoResult] = {
     val promise = Promise[GetBlockChainInfoResult]()
     for {
       _ <- AsyncUtil.retryUntilSatisfiedF(
@@ -221,8 +221,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val tmpWalletF = bitcoindF.flatMap { bitcoind =>
       val feeProvider = getFeeProviderOrElse(bitcoind)
       dlcConf.createDLCWallet(nodeApi = bitcoind,
-        chainQueryApi = bitcoind,
-        feeRateApi = feeProvider)
+                              chainQueryApi = bitcoind,
+                              feeRateApi = feeProvider)
     }
 
     for {

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -17,7 +17,7 @@ import org.bitcoins.core.api.node.{
   NodeApi,
   NodeType
 }
-import org.bitcoins.core.util.NetworkUtil
+import org.bitcoins.core.util.{NetworkUtil, TimeUtil}
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.dlc.node.DLCNode
 import org.bitcoins.dlc.node.config.DLCNodeAppConfig
@@ -55,6 +55,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
 
   override def start(): Future[Unit] = {
     logger.info("Starting appServer")
+    val startTime = TimeUtil.currentEpochMs
     val startedConfigF = conf.start()
 
     logger.info(s"Start on network ${walletConf.network}")
@@ -75,7 +76,11 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
         }
 
       }
-    } yield start
+    } yield {
+      logger.info(
+        s"Done start BitcoinSServerMain, it took=${TimeUtil.currentEpochMs - startTime}ms")
+      start
+    }
   }
 
   override def stop(): Future[Unit] = {

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
@@ -138,18 +138,6 @@ abstract class CRUD[T, PrimaryKeyType](implicit
     }
   }
 
-  /** return all rows that have a certain primary key
-    *
-    * @param id
-    * @return Query object corresponding to the selected rows
-    */
-  protected def findByPrimaryKey(id: PrimaryKeyType): Query[Table[_], T, Seq] =
-    findByPrimaryKeys(Vector(id))
-
-  /** Finds the rows that correlate to the given primary keys */
-  protected def findByPrimaryKeys(
-      ids: Vector[PrimaryKeyType]): Query[Table[T], T, Seq]
-
   /** Finds all elements in the table */
   def findAll(): Future[Vector[T]] =
     safeDatabase.run(table.result).map(_.toVector)

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAction.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAction.scala
@@ -28,6 +28,30 @@ abstract class CRUDAction[T, PrimaryKeyType](implicit
     }
   }
 
+  /** return all rows that have a certain primary key
+    *
+    * @param id
+    * @return Query object corresponding to the selected rows
+    */
+  protected def findByPrimaryKey(id: PrimaryKeyType): Query[Table[_], T, Seq] =
+    findByPrimaryKeys(Vector(id))
+
+  /** Finds the rows that correlate to the given primary keys */
+  protected def findByPrimaryKeys(
+      ids: Vector[PrimaryKeyType]): Query[Table[T], T, Seq]
+
+  protected def findByPrimaryKeysAction(ids: Vector[
+    PrimaryKeyType]): DBIOAction[Vector[T], NoStream, Effect.Read] = {
+    findByPrimaryKeys(ids).result
+      .map(_.toVector)
+  }
+
+  def findByPrimaryKeyAction(
+      id: PrimaryKeyType): DBIOAction[Option[T], NoStream, Effect.Read] = {
+    findByPrimaryKeysAction(Vector(id))
+      .map(_.headOption)
+  }
+
   protected def find(t: T): Query[Table[_], T, Seq] = findAll(Vector(t))
 
   protected def findAll(ts: Vector[T]): Query[Table[_], T, Seq]

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -1079,12 +1079,12 @@ object Wallet extends WalletLogger {
       }
       accounts
     }
-
+    import wallet.accountDAO.profile.api._
     for {
       _ <- createMasterXpubF
       actions = createAccountActions
       accounts <- wallet.accountDAO.safeDatabase.runVec(
-        DBIOAction.sequence(actions))
+        DBIOAction.sequence(actions).transactionally)
       _ = accounts.foreach { a =>
         logger.info(s"Created account=${a} to DB")
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -1007,7 +1007,10 @@ object Wallet extends WalletLogger {
 
   /** Creates the level 0 account for the given HD purpose, if the root account exists do nothing */
   private def createRootAccount(wallet: Wallet, keyManager: BIP39KeyManager)(
-      implicit ec: ExecutionContext): Future[AccountDb] = {
+      implicit ec: ExecutionContext): DBIOAction[
+    AccountDb,
+    NoStream,
+    Effect.Read with Effect.Write] = {
     val coinType = HDUtil.getCoinType(keyManager.kmParams.network)
     val coin =
       HDCoin(purpose = keyManager.kmParams.purpose, coinType = coinType)
@@ -1022,27 +1025,24 @@ object Wallet extends WalletLogger {
     //2. We already have this account in our database, so we do nothing
     //3. We have this account in our database, with a DIFFERENT xpub. This is bad. Fail with an exception
     //   this most likely means that we have a different key manager than we expected
-    wallet.accountDAO.read((account.coin, account.index)).flatMap {
-      case Some(account) =>
-        if (account.xpub != xpub) {
-          val errorMsg =
-            s"Divergent xpubs for account=${account}. Existing database xpub=${account.xpub}, new xpub=${xpub}. " +
-              s"It is possible we have a different key manager being used than expected, keymanager=${keyManager.kmParams.seedPath.toAbsolutePath.toString}"
-          Future.failed(new RuntimeException(errorMsg))
-        } else {
-          logger.debug(
-            s"Account already exists in database, no need to create it, account=${account}")
-          Future.successful(account)
-        }
-      case None =>
-        wallet.accountDAO
-          .create(accountDb)
-          .map { written =>
-            logger.info(s"Created account=${accountDb} to DB")
-            written
+    wallet.accountDAO
+      .findByPrimaryKeyAction((account.coin, account.index))
+      .flatMap {
+        case Some(account) =>
+          if (account.xpub != xpub) {
+            val errorMsg =
+              s"Divergent xpubs for account=${account}. Existing database xpub=${account.xpub}, new xpub=${xpub}. " +
+                s"It is possible we have a different key manager being used than expected, keymanager=${keyManager.kmParams.seedPath.toAbsolutePath.toString}"
+            DBIOAction.failed(new RuntimeException(errorMsg))
+          } else {
+            logger.debug(
+              s"Account already exists in database, no need to create it, account=${account}")
+            DBIOAction.successful(account)
           }
-    }
-
+        case None =>
+          wallet.accountDAO
+            .createAction(accountDb)
+      }
   }
 
   def initialize(wallet: Wallet, bip39PasswordOpt: Option[String])(implicit
@@ -1054,36 +1054,40 @@ object Wallet extends WalletLogger {
     // We want to make sure all level 0 accounts are created,
     // so the user can change the default account kind later
     // and still have their wallet work
-    def createAccountFutures: Future[Vector[Future[AccountDb]]] = {
-      for {
-        _ <- walletAppConfig.start()
-        accounts = HDPurposes.singleSigPurposes.map { purpose =>
-          //we need to create key manager params for each purpose
-          //and then initialize a key manager to derive the correct xpub
-          val kmParams = wallet.keyManager.kmParams.copy(purpose = purpose)
-          val kmE = {
-            BIP39KeyManager.fromParams(kmParams = kmParams,
-                                       passwordOpt = passwordOpt,
-                                       bip39PasswordOpt = bip39PasswordOpt)
-          }
-          kmE match {
-            case Right(km) =>
-              createRootAccount(wallet = wallet, keyManager = km)
-            case Left(err) =>
-              //probably means you haven't initialized the key manager via the
-              //'CreateKeyManagerApi'
-              Future.failed(new RuntimeException(
-                s"Failed to create keymanager with params=$kmParams err=$err"))
-          }
-
+    val createAccountActions: Vector[
+      DBIOAction[AccountDb, NoStream, Effect.Read with Effect.Write]] = {
+      val accounts = HDPurposes.singleSigPurposes.map { purpose =>
+        //we need to create key manager params for each purpose
+        //and then initialize a key manager to derive the correct xpub
+        val kmParams = wallet.keyManager.kmParams.copy(purpose = purpose)
+        val kmE = {
+          BIP39KeyManager.fromParams(kmParams = kmParams,
+                                     passwordOpt = passwordOpt,
+                                     bip39PasswordOpt = bip39PasswordOpt)
         }
-      } yield accounts
+        kmE match {
+          case Right(km) =>
+            createRootAccount(wallet = wallet, keyManager = km)
+          case Left(err) =>
+            //probably means you haven't initialized the key manager via the
+            //'CreateKeyManagerApi'
+            DBIOAction.failed(
+              new RuntimeException(
+                s"Failed to create keymanager with params=$kmParams err=$err"))
+        }
+
+      }
+      accounts
     }
 
     for {
       _ <- createMasterXpubF
-      _ <- createAccountFutures.flatMap(accounts =>
-        FutureUtil.collect(accounts))
+      actions = createAccountActions
+      accounts <- wallet.accountDAO.safeDatabase.runVec(
+        DBIOAction.sequence(actions))
+      _ = accounts.foreach { a =>
+        logger.info(s"Created account=${a} to DB")
+      }
     } yield {
       logger.debug(s"Created root level accounts for wallet")
       wallet

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AccountDAO.scala
@@ -24,7 +24,19 @@ case class AccountDAO()(implicit
     createAllNoAutoInc(ts, safeDatabase)
 
   override protected def findByPrimaryKeys(
-      ids: Vector[(HDCoin, Int)]): Query[AccountTable, AccountDb, Seq] = ???
+      ids: Vector[(HDCoin, Int)]): Query[AccountTable, AccountDb, Seq] = {
+    val queries = ids.map(findByPrimaryKey(_))
+
+    if (queries.isEmpty) {
+      TableQuery.apply[AccountTable]
+    } else if (queries.length == 1) {
+      queries.head
+    } else {
+      queries.tail.foldLeft(queries.head) { case (agg, q) =>
+        agg.union(q)
+      }
+    }
+  }
 
   override def findByPrimaryKey(
       id: (HDCoin, Int)): Query[AccountTable, AccountDb, Seq] = {


### PR DESCRIPTION
Chips away at #3891

This parallelizes the startup logic for our sub modules inside of `BitcoinSAppConfig.start()`

On d060c1c5faa5b6239f81430938fc0a75de5bcf11 it would take this long to startup: 

>2021-12-10T18:29:33UTC INFO [BitcoinSAppConfig] Done starting BitcoinSAppConfig, it took=2685ms

On 003e6a97847f1d186b5f5ee566979397b91baba2 it takes this long to startup:

>2021-12-10T20:04:14UTC INFO [BitcoinSAppConfig] Done starting BitcoinSAppConfig, it took=1618ms

So this cuts a second off of startup time (40% improvement to `BitcoinSAppConfig.start()`). I would assume this would be even larger on the pi, but haven't tested.