### PR TITLE
2021 12 12 wallet doublespend tests

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
@@ -81,7 +81,8 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
           .fundRawTransactionInternal(destinations = Vector(output),
                                       feeRate = feeRate,
                                       fromAccount = account,
-                                      fromTagOpt = Some(exampleTag))
+                                      fromTagOpt = Some(exampleTag),
+                                      markAsReserved = true)
       }
       utx = txBuilder.buildTx()
       signedTx = RawTxSigner.sign(utx, utxoInfos, feeRate)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -492,13 +492,13 @@ class UTXOLifeCycleTest extends BitcoinSWalletTestCachedBitcoindNewest {
         first = utxos.head
         //just reserve this one to start
         reserved <- wallet.markUTXOsAsReserved(Vector(first))
-        //now try to reserve them all
-        //this should fail as the first utxo is reserved
       } yield reserved.head
 
       val reserveFailedF = for {
         utxos <- utxosF
         _ <- reservedUtxoF
+        //now try to reserve them all
+        //this should fail as the first utxo is reserved
         _ <- wallet.markUTXOsAsReserved(utxos)
       } yield ()
 
@@ -509,6 +509,7 @@ class UTXOLifeCycleTest extends BitcoinSWalletTestCachedBitcoindNewest {
         reserved <- reservedUtxoF
         utxos <- wallet.listUtxos(TxoState.Reserved)
       } yield {
+        //make sure only 1 utxo is still reserved
         assert(utxos.length == 1)
         assert(reserved.outPoint == utxos.head.outPoint)
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -744,7 +744,9 @@ abstract class Wallet
         feeRate = feeRate,
         fromAccount = fromAccount,
         coinSelectionAlgo = CoinSelectionAlgo.RandomSelection,
-        fromTagOpt = None)
+        fromTagOpt = None,
+        markAsReserved = true
+      )
       tx <- finishSend(txBuilder,
                        utxoInfos,
                        CurrencyUnits.zero,
@@ -764,7 +766,8 @@ abstract class Wallet
         destinations = outputs,
         feeRate = feeRate,
         fromAccount = fromAccount,
-        fromTagOpt = None)
+        fromTagOpt = None,
+        markAsReserved = true)
       sentAmount = outputs.foldLeft(CurrencyUnits.zero)(_ + _.value)
       tx <- finishSend(txBuilder, utxoInfos, sentAmount, feeRate, newTags)
     } yield tx

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -439,7 +439,6 @@ abstract class Wallet
       signed
     }
 
-
     processedTxF.recoverWith { case _ =>
       //if something fails, we need to unreserve the utxos associated with this tx
       //and then propogate the failed future upwards

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -662,7 +662,8 @@ abstract class Wallet
         feeRate = feeRate,
         fromAccount = fromAccount,
         coinSelectionAlgo = algo,
-        fromTagOpt = None)
+        fromTagOpt = None,
+        markAsReserved = true)
 
       tx <- finishSend(txBuilder, utxoInfos, amount, feeRate, newTags)
     } yield tx

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -53,7 +53,7 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
       fromAccount: AccountDb,
       coinSelectionAlgo: CoinSelectionAlgo = CoinSelectionAlgo.LeastWaste,
       fromTagOpt: Option[AddressTag],
-      markAsReserved: Boolean = false): Future[(
+      markAsReserved: Boolean): Future[(
       RawTxBuilderWithFinalizer[ShufflingNonInteractiveFinalizer],
       Vector[ScriptSignatureParams[InputInfo]])] = {
     val utxosF: Future[Vector[(SpendingInfoDb, Transaction)]] =

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -318,7 +318,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]] = {
     val updated = utxos.map(_.copyWithState(TxoState.Reserved))
     for {
-      utxos <- spendingInfoDAO.updateAllSpendingInfoDb(updated)
+      utxos <- spendingInfoDAO.markAsReserved(updated)
       _ <- walletCallbacks.executeOnReservedUtxos(logger, utxos)
     } yield utxos
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -463,18 +463,23 @@ case class SpendingInfoDAO()(implicit
       ) //must be available to reserve
       .map(_.state)
       .update(TxoState.Reserved)
+      .flatMap { count =>
+        if (count != ts.length) {
+          val exn = new RuntimeException(
+            s"Failed to reserve all utxos, expected=${ts.length} actual=$count")
+          DBIO.failed(exn)
+        } else {
+
+          DBIO.successful(count)
+        }
+      }
+      //this needs to be at the end, to make sure we rollback correctly if
+      //the utxo is already reserved
       .transactionally
 
     safeDatabase
       .run(action)
-      .map { count =>
-        if (count != ts.length) {
-          sys.error(
-            s"Failed to reserve all utxos, expected=${ts.length} actual=$count")
-        } else {
-          ts.map(_.copyWithState(TxoState.Reserved))
-        }
-      }
+      .map(_ => ts.map(_.copyWithState(TxoState.Reserved)))
   }
 
   private def findScriptPubKeys(

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/TransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/TransactionDAO.scala
@@ -58,6 +58,11 @@ trait TxDAO[DbEntryType <: TxDB]
     findByTxId(outPoint.txId)
   }
 
+  def findByOutPoints(
+      outPoints: Vector[TransactionOutPoint]): Future[Vector[DbEntryType]] = {
+    findByTxIds(outPoints.map(_.txIdBE))
+  }
+
   def findByTxIds(
       txIdBEs: Vector[DoubleSha256DigestBE]): Future[Vector[DbEntryType]] = {
     val q = table.filter(_.txIdBE.inSet(txIdBEs))


### PR DESCRIPTION
Related to #3888 and fixes #3890

This PR adds `SpendingInfoDAO.markAsReserved()`. This method should always be used to reserve utxos rather than `SpendingInfoDAO.update()`. 

Previously, we would have a race condition as we didn't check at the _database_ level to see if the utxo was reserved before reserving it. Thus two threads could be trying to reserve utxos, succeed as there wasn't any sychnronization at the databse level.  Now `SpendingInfoDAO.markAsReserved()` transactionally switches a utxo to reserved, and will throw an exception if we couldn't reserve all utxos. 

This PR also removes the default parameter of  `FundTransactionHandling.fundRawTransactionInternal()` `markAsReserved=false`. The caller of `fundRawTransactionInternal()` should be force to specify this. 

