### PR TITLE
Fix bug where we didn't set spendingTxId when transitioning from `Reserved` -> `PendingConfirmationsSpent`

### DIFF
--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -573,10 +573,7 @@ class UTXOLifeCycleTest
         utxos <- wallet
           .listUtxos()
           .map(_.filter(u => TxoState.receivedStates.contains(u.state)))
-        currentReserved <- wallet.listUtxos(TxoState.Reserved)
-        _ = logger.info(s"@@@ current reserved")
-        _ = currentReserved.foreach(c => logger.info(s"c=$c"))
-        _ = logger.info(s"@@@ done current reserved")
+        _ <- wallet.listUtxos(TxoState.Reserved)
         _ <- wallet.markUTXOsAsReserved(utxos)
         blockHash <- bitcoind.generateToAddress(1, bitcoindAdr).map(_.head)
         block <- bitcoind.getBlockRaw(blockHash)
@@ -584,7 +581,7 @@ class UTXOLifeCycleTest
         broadcastSpentUtxo <- wallet.listUtxos(
           TxoState.PendingConfirmationsSpent)
       } yield {
-        assert(broadcastSpentUtxo.length == 1)
+        assert(broadcastSpentUtxo.length == 2)
         assert(broadcastSpentUtxo.head.spendingTxIdOpt.get == txIdBE)
       }
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -539,9 +539,13 @@ class UTXOLifeCycleTest
         utxo = utxos.head
         _ = assert(utxo.txid == txId)
         _ = assert(utxo.state == TxoState.PendingConfirmationsReceived)
-
         //now mark the utxo as reserved
         _ <- wallet.markUTXOsAsReserved(Vector(utxo))
+        //confirm it is reserved
+        _ <- wallet
+          .listUtxos(TxoState.Reserved)
+          .map(utxos =>
+            assert(utxos.contains(utxo.copyWithState(TxoState.Reserved))))
 
         //now process another block
         hashes2 <- bitcoind.generateToAddress(blocks = 1, throwAwayAddr)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -117,9 +117,6 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
           for {
             _ <- acc
             receivedSpendingInfoDbs <- cachedReceivedF
-            //_ = logger.info(s"received spendingInfoDbs")
-            //_ = receivedSpendingInfoDbs.foreach(u => logger.info(s"u=$u"))
-            // _ = logger.info(s"Done with spendingInfoDbs")
             spentSpendingInfo <- cachedSpentF
             processTxResult <- {
               processTransactionImpl(

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -117,6 +117,9 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
           for {
             _ <- acc
             receivedSpendingInfoDbs <- cachedReceivedF
+            _ = logger.info(s"received spendingInfoDbs")
+            _ = receivedSpendingInfoDbs.foreach(u => logger.info(s"u=$u"))
+            _ = logger.info(s"Done with spendingInfoDbs")
             spentSpendingInfo <- cachedSpentF
             processTxResult <- {
               processTransactionImpl(
@@ -323,7 +326,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
       spentSpendingInfoDbsOpt: Option[Vector[SpendingInfoDb]]): Future[
     ProcessTxResult] = {
 
-    logger.debug(
+    logger.info(
       s"Processing transaction=${transaction.txIdBE.hex} with blockHash=${blockHashOpt
         .map(_.hex)}")
 
@@ -356,6 +359,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
     for {
       receivedSpendingInfoDbs <- receivedSpendingInfoDbsF
       receivedStart = TimeUtil.currentEpochMs
+      _ = logger.info(s"receivedSpendingInfoDbs=$receivedSpendingInfoDbs")
       incoming <- processReceivedUtxos(transaction = transaction,
                                        blockHashOpt = blockHashOpt,
                                        spendingInfoDbs =
@@ -487,6 +491,8 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
 
           // If the utxo was marked reserved we want to update it to spent now
           // since it has been included in a block
+          logger.info(
+            s"@@@@@@@@ XXXXXXXXXXXXXXXXXXX @@@@@@@@@@@@@@@ ${foundTxo.state}")
           val unreservedTxo = foundTxo.state match {
             case TxoState.Reserved =>
               foundTxo

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -469,6 +469,8 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
       transaction: Transaction,
       blockHashOpt: Option[DoubleSha256DigestBE],
       foundTxo: SpendingInfoDb): Future[SpendingInfoDb] = {
+    logger.info(
+      s"processExistingReceivedTxo txId=${transaction.txIdBE.hex} foundingTxo.outPoint=${foundTxo.outPoint}")
     if (foundTxo.txid != transaction.txIdBE) {
       val errMsg =
         Seq(
@@ -488,7 +490,6 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
           val unreservedTxo = foundTxo.state match {
             case TxoState.Reserved =>
               foundTxo
-                .copyWithSpendingTxId(transaction.txIdBE)
                 .copyWithState(TxoState.PendingConfirmationsSpent)
             case TxoState.PendingConfirmationsReceived |
                 TxoState.ConfirmedReceived |

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -117,9 +117,9 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
           for {
             _ <- acc
             receivedSpendingInfoDbs <- cachedReceivedF
-            _ = logger.info(s"received spendingInfoDbs")
-            _ = receivedSpendingInfoDbs.foreach(u => logger.info(s"u=$u"))
-            _ = logger.info(s"Done with spendingInfoDbs")
+            //_ = logger.info(s"received spendingInfoDbs")
+            //_ = receivedSpendingInfoDbs.foreach(u => logger.info(s"u=$u"))
+            // _ = logger.info(s"Done with spendingInfoDbs")
             spentSpendingInfo <- cachedSpentF
             processTxResult <- {
               processTransactionImpl(
@@ -359,7 +359,6 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
     for {
       receivedSpendingInfoDbs <- receivedSpendingInfoDbsF
       receivedStart = TimeUtil.currentEpochMs
-      _ = logger.info(s"receivedSpendingInfoDbs=$receivedSpendingInfoDbs")
       incoming <- processReceivedUtxos(transaction = transaction,
                                        blockHashOpt = blockHashOpt,
                                        spendingInfoDbs =
@@ -493,6 +492,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
           val unreservedTxo = foundTxo.state match {
             case TxoState.Reserved =>
               foundTxo
+                .copyWithSpendingTxId(transaction.txIdBE)
                 .copyWithState(TxoState.PendingConfirmationsSpent)
             case TxoState.PendingConfirmationsReceived |
                 TxoState.ConfirmedReceived |

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -412,7 +412,6 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
           out
             .copyWithSpendingTxId(spendingTxId)
             .copyWithState(state = BroadcastSpent)
-
         Some(updated)
       case TxoState.BroadcastSpent =>
         if (!out.spendingTxIdOpt.contains(spendingTxId)) {
@@ -491,8 +490,6 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
 
           // If the utxo was marked reserved we want to update it to spent now
           // since it has been included in a block
-          logger.info(
-            s"@@@@@@@@ XXXXXXXXXXXXXXXXXXX @@@@@@@@@@@@@@@ ${foundTxo.state}")
           val unreservedTxo = foundTxo.state match {
             case TxoState.Reserved =>
               foundTxo

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -487,7 +487,9 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
           // since it has been included in a block
           val unreservedTxo = foundTxo.state match {
             case TxoState.Reserved =>
-              foundTxo.copyWithState(TxoState.PendingConfirmationsSpent)
+              foundTxo
+                .copyWithSpendingTxId(transaction.txIdBE)
+                .copyWithState(TxoState.PendingConfirmationsSpent)
             case TxoState.PendingConfirmationsReceived |
                 TxoState.ConfirmedReceived |
                 TxoState.PendingConfirmationsSpent | TxoState.ConfirmedSpent |

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -315,6 +315,8 @@ private[wallet] trait UtxoHandling extends WalletLogger {
 
   override def markUTXOsAsReserved(
       utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]] = {
+    val outPoints = utxos.map(_.outPoint)
+    logger.info(s"Reserving utxos=$outPoints")
     val updated = utxos.map(_.copyWithState(TxoState.Reserved))
     for {
       utxos <- spendingInfoDAO.markAsReserved(updated)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -329,7 +329,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
       tx: Transaction): Future[Vector[SpendingInfoDb]] = {
     for {
       utxos <- spendingInfoDAO.findOutputsBeingSpent(tx)
-      reserved <- markUTXOsAsReserved(utxos.toVector)
+      reserved <- markUTXOsAsReserved(utxos)
     } yield reserved
   }
 


### PR DESCRIPTION
This PR fixes a bug when we try to transition a `Reserved` utxo to `Spent` inside of `TransactionProcessing.processExistingReceivedTxo()`.

The bug was transition a utxo to spent when we are receiving the utxo. A received utxo doesn't have a `spendingTxId`, thus we will violate the invariant that says every utxo that in a spent state must have a `spendingTxId`