### PR TITLE
Add WalletCallbacks.onBlockProcessed()

### DIFF
--- a/docs/wallet/wallet-callbacks.md
+++ b/docs/wallet/wallet-callbacks.md
@@ -11,6 +11,7 @@ Bitcoin-S support call backs for the following events that happen in the wallet:
 2. onTransactionBroadcast
 3. onReservedUtxos
 4. onNewAddressGenerated
+5. onBlockProcessed
 
 That means every time one of these events happens, we will call your callback
 so that you can be notified of the event. These callbacks will be run after the message has been

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -7,6 +7,7 @@ import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.gcs.BlockFilter
 import org.bitcoins.core.protocol.BlockStamp
+import org.bitcoins.core.protocol.blockchain.RegTestNetChainParams
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.server.BitcoinSAppConfig
@@ -56,10 +57,15 @@ trait BaseWalletTest extends EmbeddedPg { _: Suite with BitcoinSAkkaAsyncTest =>
 
       /** Gets the height of the given block */
       override def getBlockHeight(
-          blockHash: DoubleSha256DigestBE): Future[Option[Int]] =
-        if (blockHash == testBlockHash)
+          blockHash: DoubleSha256DigestBE): Future[Option[Int]] = {
+        if (blockHash == testBlockHash) {
           Future.successful(Some(1))
-        else FutureUtil.none
+        } else if (
+          blockHash == RegTestNetChainParams.genesisBlock.blockHeader.hashBE
+        ) {
+          Future.successful(Some(1))
+        } else FutureUtil.none
+      }
 
       /** Gets the hash of the block that is what we consider "best" */
       override def getBestBlockHash(): Future[DoubleSha256DigestBE] =
@@ -67,10 +73,11 @@ trait BaseWalletTest extends EmbeddedPg { _: Suite with BitcoinSAkkaAsyncTest =>
 
       /** Gets number of confirmations for the given block hash */
       override def getNumberOfConfirmations(
-          blockHash: DoubleSha256DigestBE): Future[Option[Int]] =
-        if (blockHash == testBlockHash)
+          blockHash: DoubleSha256DigestBE): Future[Option[Int]] = {
+        if (blockHash == testBlockHash) {
           Future.successful(Some(6))
-        else FutureUtil.none
+        } else FutureUtil.none
+      }
 
       /** Gets the number of compact filters in the database */
       override def getFilterCount(): Future[Int] = Future.successful(1)


### PR DESCRIPTION
This PR adds a callback for the case after the wallet has processed a block. 

This PR lays the groundwork to add this into #3906 as this is requested on #3910 

