### PR TITLE
Work around for WalletAppConfig.scheduler being blocked by AddressQueueRunnable

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressRequest.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressRequest.scala
@@ -1,0 +1,11 @@
+package org.bitcoins.wallet.internal
+
+import org.bitcoins.core.api.wallet.db.{AccountDb, AddressDb}
+import org.bitcoins.core.hd.HDChainType
+
+import scala.concurrent.Promise
+
+case class AddressRequest(
+    accountDb: AccountDb,
+    chainType: HDChainType,
+    promise: Promise[AddressDb])


### PR DESCRIPTION
This is the smallest workaround for #3916 , this should remove the deadlocks but doesn't address other issues documented there. This is enough to get me unblocked on making progress on #3906 

This makes sure `ArrayBlockingQueue.take()` does NOT block the `WalletAppConfig.scheduler` thread in the case there is no elements in the queue.

