### PR TITLE
Add `getmediantimepast` RPC call

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -87,6 +87,9 @@ object ConsoleCli {
                 case gbh: GetBlockHeader => gbh.copy(hash = hash)
                 case other               => other
               }))),
+      cmd("getmediantimepast")
+        .action((_, conf) => conf.copy(command = GetMedianTimePast))
+        .text(s"Get the median time past"),
       cmd("decoderawtransaction")
         .action((_, conf) =>
           conf.copy(command = DecodeRawTransaction(EmptyTransaction)))
@@ -1706,6 +1709,8 @@ object ConsoleCli {
     val requestParam: RequestParam = command match {
       case GetInfo =>
         RequestParam("getinfo")
+      case GetMedianTimePast =>
+        RequestParam("getmediantimepast")
       case GetUtxos =>
         RequestParam("getutxos")
       case ListReservedUtxos =>
@@ -2357,6 +2362,8 @@ object CliCommand {
 
   case class GetBlockHeader(hash: DoubleSha256DigestBE)
       extends AppServerCliCommand
+
+  case object GetMedianTimePast extends AppServerCliCommand
 
   case class DecodeRawTransaction(transaction: Transaction)
       extends AppServerCliCommand

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -269,6 +269,20 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       }
     }
 
+    "return the median time past" in {
+      (mockChainApi.getMedianTimePast: () => Future[Long])
+        .expects()
+        .returning(Future.successful(1234567890L))
+
+      val route =
+        chainRoutes.handleCommand(ServerCommand("getmediantimepast", Arr()))
+
+      Get() ~> route ~> check {
+        assert(contentType == `application/json`)
+        assert(responseAs[String] == """{"result":1234567890,"error":null}""")
+      }
+    }
+
     "return the wallet's balance" in {
       (mockWalletApi
         .getBalance()(_: ExecutionContext))

--- a/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
@@ -95,6 +95,13 @@ case class ChainRoutes(chain: ChainApi, network: BitcoinNetwork)(implicit
           Server.httpSuccess(info.toJson)
         }
       }
+
+    case ServerCommand("getmediantimepast", _) =>
+      complete {
+        chain.getMedianTimePast().map { mtp =>
+          Server.httpSuccess(mtp)
+        }
+      }
   }
 
 }

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
@@ -236,6 +236,16 @@ class BlockchainRpcTest extends BitcoindFixturesCachedPairV17 {
     }
   }
 
+  it should "calculate median time past" in { nodePair =>
+    val client = nodePair.node1
+    for {
+      medianTime <- client.getMedianTimePast()
+    } yield {
+      val oneHourAgo = (System.currentTimeMillis() / 1000) - 60 * 60
+      assert(medianTime > oneHourAgo)
+    }
+  }
+
   override def afterAll(): Unit = {
     val stoppedF = pruneClientF.flatMap(BitcoindRpcTestUtil.stopServer)
     val _ = Await.result(stoppedF, duration)

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -107,7 +107,8 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
   }
 
   /** Gets the number of compact filters in the database */
-  override def getFilterCount(): Future[Int] = ???
+  override def getFilterCount(): Future[Int] = Future.failed(
+    new UnsupportedOperationException(s"Not implemented: getFilterCount"))
 
   /** Returns the block height of the given block stamp */
   override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] =
@@ -128,6 +129,13 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
   /** Gets the block height of the closest block to the given time */
   override def epochSecondToBlockHeight(time: Long): Future[Int] =
     Future.successful(0)
+
+  override def getMedianTimePast(): Future[Long] = {
+    for {
+      hash <- getBestBlockHash
+      header <- getBlockHeader(hash)
+    } yield header.mediantime.toLong
+  }
 
   // Node Api
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -132,9 +132,8 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
 
   override def getMedianTimePast(): Future[Long] = {
     for {
-      hash <- getBestBlockHash
-      header <- getBlockHeader(hash)
-    } yield header.mediantime.toLong
+      info <- getBlockChainInfo
+    } yield info.mediantime.toLong
   }
 
   // Node Api

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -1013,8 +1013,7 @@ class ChainHandler(
         header.time.toLong
       })
       .map { times =>
-        val (_, upper) = times.sorted.splitAt(times.size / 2)
-        upper.head
+        times.sorted.apply(times.size / 2)
       }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainQueryApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainQueryApi.scala
@@ -41,6 +41,8 @@ trait ChainQueryApi {
   /** Gets the block height of the closest block to the given time */
   def epochSecondToBlockHeight(time: Long): Future[Int]
 
+  /** calculates the median time passed */
+  def getMedianTimePast(): Future[Long]
 }
 
 object ChainQueryApi {

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -150,6 +150,7 @@ the `-p 9999:9999` port mapping on the docker container to adjust for this.
      - `hash` - The block hash
  - `decoderawtransaction` `tx` - `Decode the given raw hex transaction`
      - `tx` - Transaction encoded in hex to decode
+ - `getmediantimepast` - Returns the median time past
 
 ### Wallet
  - `rescan` `[options]` - Rescan for wallet UTXOs

--- a/docs/chain/chain-query-api.md
+++ b/docs/chain/chain-query-api.md
@@ -59,6 +59,8 @@ trait ChainQueryApi {
   def getFiltersBetweenHeights(
       startHeight: Int,
       endHeight: Int): Future[Vector[FilterResponse]]
+      
+  def getMedianTimePast(): Future[Long]
 }
 ```
 
@@ -180,6 +182,8 @@ val chainApi = new ChainQueryApi {
 
       Future.sequence(filterFs)
     }
+    
+    override def getMedianTimePast(): Future[Long] = bitcoind.getMedianTimePast()
   }
 
 // Finally, we can initialize our wallet with our own node api

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -81,6 +81,7 @@ val chainApi = new ChainQueryApi {
     override def getFilterCount(): Future[Int] = Future.successful(0)
     override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] = Future.successful(0)
     override def getFiltersBetweenHeights(startHeight: Int, endHeight: Int): Future[Vector[FilterResponse]] = Future.successful(Vector.empty)
+    override def getMedianTimePast(): Future[Long] = Future.successful(0L)
   }
 ```
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -121,12 +121,16 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         //the send headers message.
         for {
           _ <- NodeTestUtil.awaitSync(node, bitcoind)
-        } yield {
-          val isCancelled = cancellable.cancel()
-          if (!isCancelled) {
-            logger.warn(s"Failed to cancel generating blocks on bitcoind")
+          _ = {
+            val isCancelled = cancellable.cancel()
+            if (!isCancelled) {
+              logger.warn(s"Failed to cancel generating blocks on bitcoind")
+            }
           }
-          succeed
+          mtp1 <- bitcoind.getMedianTimePast()
+          mtp2 <- node.chainApiFromDb().flatMap(_.getMedianTimePast())
+        } yield {
+          assert(mtp1 == mtp2)
         }
       }
   }

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -342,4 +342,7 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
   override def epochSecondToBlockHeight(time: Long): Future[Int] =
     chainApiFromDb().flatMap(_.epochSecondToBlockHeight(time))
 
+  override def getMedianTimePast(): Future[Long] =
+    chainApiFromDb().flatMap(_.getMedianTimePast())
+
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -165,5 +165,9 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
 
     override def epochSecondToBlockHeight(time: Long): Future[Int] =
       Future.successful(0)
+
+    /** calculates the median time passed */
+    override def getMedianTimePast(): Future[Long] =
+      Future.successful(0L)
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -129,6 +129,10 @@ trait BaseWalletTest extends EmbeddedPg { _: Suite with BitcoinSAkkaAsyncTest =>
 
       override def epochSecondToBlockHeight(time: Long): Future[Int] =
         Future.successful(0)
+
+      /** calculates the median time passed */
+      override def getMedianTimePast(): Future[Long] =
+        Future.successful(0L)
     }
 
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -299,6 +299,10 @@ object BitcoinSWalletTest extends WalletLogger {
 
     override def epochSecondToBlockHeight(time: Long): Future[Int] =
       Future.successful(0)
+
+    /** calculates the median time passed */
+    override def getMedianTimePast(): Future[Long] =
+      Future.successful(0L)
   }
 
   private[bitcoins] class RandomFeeProvider extends FeeRateApi {


### PR DESCRIPTION
It's useful to check if a transaction with a specified lock time can be broadcasted to the network.

Bitcoin Core uses `GetMedianTimePast()` to verify  transaction finality: https://github.com/bitcoin/bitcoin/blob/master/src/validation.cpp#L206