### PR TITLE
2021 12 19 dlc callbacks

### DIFF
--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
@@ -1,0 +1,128 @@
+package org.bitcoins.dlc.wallet
+
+import org.bitcoins.core.protocol.dlc.models.{
+  DLCState,
+  DLCStatus,
+  DisjointUnionContractInfo,
+  SingleContractInfo
+}
+import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
+import org.bitcoins.testkit.wallet.{BitcoinSDualWalletTest, DLCWalletUtil}
+import org.bitcoins.testkitcore.gen.CryptoGenerators
+import org.scalatest.FutureOutcome
+
+import scala.concurrent.{Future, Promise}
+
+class DLCWalletCallbackTest extends BitcoinSDualWalletTest {
+  override type FixtureParam = (FundedDLCWallet, FundedDLCWallet)
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    withDualFundedDLCWallets(test)
+  }
+
+  behavior of "DLCWalletCallbackTest"
+
+  it must "verify OnDLCStateChange are executed" in { wallets =>
+    val walletA: DLCWallet = wallets._1.wallet
+    val walletB: DLCWallet = wallets._2.wallet
+    val offerP: Promise[DLCStatus] = Promise()
+    val acceptP: Promise[DLCStatus] = Promise()
+    val signedP: Promise[DLCStatus] = Promise()
+    val broadcastP: Promise[DLCStatus] = Promise()
+
+    //not implemented yet
+    val confirmedP: Promise[DLCStatus] = Promise()
+
+    val claimedP: Promise[DLCStatus] = Promise()
+    val remoteClaimedP: Promise[DLCStatus] = Promise()
+
+    val walletACallback: OnDLCStateChange = { case status: DLCStatus =>
+      status.state match {
+        case DLCState.Offered =>
+          Future.successful(offerP.success(status))
+        case DLCState.Signed =>
+          Future.successful(signedP.success(status))
+        case DLCState.Confirmed =>
+          Future.successful(confirmedP.success(status))
+        case DLCState.Claimed =>
+          Future.successful(claimedP.success(status))
+        case DLCState.Broadcasted =>
+          //ignore broadcast from this wallet
+          Future.unit
+        case x @ (DLCState.Accepted | DLCState.Confirmed |
+            DLCState.RemoteClaimed | DLCState.Refunded) =>
+          sys.error(s"Shouldn't receive state=$x for callback")
+      }
+
+    }
+
+    val walletBCallback: OnDLCStateChange = { case status: DLCStatus =>
+      status.state match {
+        case DLCState.Accepted =>
+          Future.successful(acceptP.success(status))
+        case DLCState.Broadcasted =>
+          Future.successful(broadcastP.success(status))
+        case DLCState.RemoteClaimed =>
+          Future.successful(remoteClaimedP.success(status))
+        case x @ (DLCState.Offered | DLCState.Signed) =>
+          sys.error(s"Shouldn't receive state=$x for callback")
+        case DLCState.Confirmed | DLCState.Claimed | DLCState.Refunded =>
+          //do nothing, we are doing assertions for these on walletACallback
+          Future.unit
+      }
+
+    }
+
+    val walletACallbacks = DLCWalletCallbacks.onDLCStateChange(walletACallback)
+
+    val walletBCallbacks = DLCWalletCallbacks.onDLCStateChange(walletBCallback)
+
+    walletA.dlcConfig.addCallbacks(walletACallbacks)
+    walletB.dlcConfig.addCallbacks(walletBCallbacks)
+
+    //run init DLC and make sure we get the callback hit
+
+    val initF = DLCWalletUtil.initDLC(wallets._1,
+                                      wallets._2,
+                                      DLCWalletUtil.sampleContractInfo)
+    val executeF = for {
+      _ <- initF
+      contractId <- DLCWalletUtil.getContractId(wallets._1.wallet)
+      fundingTx <- walletA.getDLCFundingTx(contractId)
+      _ <- walletA.processTransaction(
+        transaction = fundingTx,
+        blockHashOpt = Some(CryptoGenerators.doubleSha256DigestBE.sample.get))
+      sigs = {
+        DLCWalletUtil.sampleContractInfo match {
+          case single: SingleContractInfo =>
+            DLCWalletUtil.getSigs(single)
+          case disjoint: DisjointUnionContractInfo =>
+            sys.error(
+              s"Cannot retrieve sigs for disjoint union contract, got=$disjoint")
+        }
+      }
+      transaction <- walletA.executeDLC(contractId, sigs._1)
+      _ <- walletB.processTransaction(transaction, None)
+    } yield ()
+
+    for {
+      _ <- initF
+      offer <- offerP.future
+      accept <- acceptP.future
+      sign <- signedP.future
+      broadcast <- broadcastP.future
+      confirmed <- confirmedP.future
+      _ <- executeF
+      claimed <- claimedP.future
+      remoteClaimed <- remoteClaimedP.future
+    } yield {
+      assert(offer.state == DLCState.Offered)
+      assert(accept.state == DLCState.Accepted)
+      assert(sign.state == DLCState.Signed)
+      assert(broadcast.state == DLCState.Broadcasted)
+      assert(confirmed.state == DLCState.Confirmed)
+      assert(claimed.state == DLCState.Claimed)
+      assert(remoteClaimed.state == DLCState.RemoteClaimed)
+    }
+  }
+}

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -5,7 +5,7 @@ import org.bitcoins.commons.config.{AppConfigFactory, ConfigOps}
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
-import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.util.{FutureUtil, Mutable}
 import org.bitcoins.db.DatabaseDriver._
 import org.bitcoins.db._
 import org.bitcoins.wallet.config.WalletAppConfig
@@ -90,6 +90,14 @@ case class DLCAppConfig(private val directory: Path, private val conf: Config*)(
     DLCAppConfig.createDLCWallet(nodeApi = nodeApi,
                                  chainQueryApi = chainQueryApi,
                                  feeRateApi = feeRateApi)(walletConf, this, ec)
+  }
+
+  private val callbacks = new Mutable(DLCWalletCallbacks.empty)
+
+  def walletCallbacks: DLCWalletCallbacks = callbacks.atomicGet
+
+  def addCallbacks(newCallbacks: DLCWalletCallbacks): DLCWalletCallbacks = {
+    callbacks.atomicUpdate(newCallbacks)(_ + _)
   }
 }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1293,7 +1293,8 @@ abstract class DLCWallet
 
       _ <- processTransaction(tx, None)
       dlcStatusOpt <- findDLC(dlcId = dlcDb.dlcId)
-      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, dlcStatusOpt.get)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger,
+                                                             dlcStatusOpt.get)
     } yield tx
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -440,6 +440,8 @@ abstract class DLCWallet
         dlcOfferDb = dlcOfferDb)
 
       _ <- safeDatabase.run(offerActions)
+      status <- findDLC(dlcId)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, status.get)
     } yield offer
   }
 
@@ -588,6 +590,8 @@ abstract class DLCWallet
         case None =>
           createNewDLCAccept(dlc, account, collateral, offer)
       }
+      status <- findDLC(dlcId)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, status.get)
     } yield dlcAccept
   }
 
@@ -917,7 +921,7 @@ abstract class DLCWallet
       (dlc, cetSigsDbs) <- registerDLCAccept(accept)
       // .get should be safe now
       contractId = dlc.contractIdOpt.get
-
+      dlcId = dlc.dlcId
       signer <- signerFromDb(dlc.dlcId)
 
       mySigs <- dlcSigsDAO.findByDLCId(dlc.dlcId)
@@ -967,6 +971,9 @@ abstract class DLCWallet
 
       _ <- updateDLCState(dlc.contractIdOpt.get, DLCState.Signed)
       _ = logger.info(s"DLC ${contractId.toHex} is signed")
+      status <- findDLC(dlcId)
+      _ = println(s"before SIGN state=${status.get.state}")
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, status.get)
     } yield DLCSign(cetSigs, FundingSignatures(sortedSigVec), contractId)
   }
 
@@ -1165,6 +1172,7 @@ abstract class DLCWallet
 
   override def broadcastDLCFundingTx(
       contractId: ByteVector): Future[Transaction] = {
+    logger.info(s"broadcasting $contractId")
     val dlcDbOptF = dlcDAO.findByContractId(contractId)
     val fundingTxF = getDLCFundingTx(contractId)
     for {
@@ -1181,6 +1189,7 @@ abstract class DLCWallet
       _ = logger.info(
         s"Broadcasting funding transaction ${tx.txIdBE.hex} for contract ${contractId.toHex}")
       _ <- broadcastTransaction(tx)
+      _ = logger.info(s"Done broadcast tx ${contractId}")
     } yield tx
   }
 
@@ -1275,7 +1284,7 @@ abstract class DLCWallet
 
       _ <- updateDLCOracleSigs(sigsUsed)
       _ <- updateDLCState(contractId, DLCState.Claimed)
-      _ <- updateClosingTxId(contractId, tx.txIdBE)
+      dlcDb <- updateClosingTxId(contractId, tx.txIdBE)
 
       oracleSigSum =
         OracleSignatures.computeAggregateSignature(outcome, sigsUsed)
@@ -1284,6 +1293,8 @@ abstract class DLCWallet
       _ <- updateAggregateSignature(contractId, aggSig)
 
       _ <- processTransaction(tx, None)
+      dlcDb <- findDLC(dlcId = dlcDb.dlcId)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, dlcDb.get)
     } yield tx
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -972,7 +972,6 @@ abstract class DLCWallet
       _ <- updateDLCState(dlc.contractIdOpt.get, DLCState.Signed)
       _ = logger.info(s"DLC ${contractId.toHex} is signed")
       status <- findDLC(dlcId)
-      _ = println(s"before SIGN state=${status.get.state}")
       _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, status.get)
     } yield DLCSign(cetSigs, FundingSignatures(sortedSigVec), contractId)
   }
@@ -1293,8 +1292,8 @@ abstract class DLCWallet
       _ <- updateAggregateSignature(contractId, aggSig)
 
       _ <- processTransaction(tx, None)
-      dlcDb <- findDLC(dlcId = dlcDb.dlcId)
-      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, dlcDb.get)
+      dlcStatusOpt <- findDLC(dlcId = dlcDb.dlcId)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, dlcStatusOpt.get)
     } yield tx
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWalletCallbacks.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWalletCallbacks.scala
@@ -1,0 +1,44 @@
+package org.bitcoins.dlc.wallet
+
+import grizzled.slf4j.Logger
+import org.bitcoins.core.api.{Callback, CallbackHandler}
+import org.bitcoins.core.protocol.dlc.models.DLCStatus
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class DLCWalletCallbacks(
+    onStateChange: CallbackHandler[DLCStatus, OnDLCStateChange]) {
+
+  def executeOnDLCStateChange(logger: Logger, status: DLCStatus)(implicit
+      ec: ExecutionContext): Future[Unit] = {
+    onStateChange.execute(
+      status,
+      (err: Throwable) =>
+        logger.error(s"${onStateChange.name} Callback failed with error: ",
+                     err))
+  }
+
+  def +(other: DLCWalletCallbacks): DLCWalletCallbacks = {
+    copy(onStateChange = onStateChange ++ other.onStateChange)
+  }
+}
+
+object DLCWalletCallbacks {
+
+  val empty: DLCWalletCallbacks = {
+    DLCWalletCallbacks(
+      CallbackHandler[DLCStatus, OnDLCStateChange]("onDLCStateChange",
+                                                   Vector.empty))
+  }
+
+  def onDLCStateChange(f: OnDLCStateChange): DLCWalletCallbacks = {
+    val handler =
+      CallbackHandler[DLCStatus, OnDLCStateChange]("onDLCStateChange",
+                                                   Vector(f))
+    DLCWalletCallbacks(handler)
+  }
+
+}
+
+/** Triggered when [[DLCStatus.state]] is changed in the database */
+trait OnDLCStateChange extends Callback[DLCStatus]

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
@@ -59,6 +59,11 @@ case class DLCDAO()(implicit
     q.delete
   }
 
+  def findByDLCIds(dlcIds: Vector[Sha256Digest]): Future[Vector[DLCDb]] = {
+    val action = table.filter(_.dlcId.inSet(dlcIds)).result
+    safeDatabase.runVec(action)
+  }
+
   def findByTempContractId(
       tempContractId: Sha256Digest): Future[Option[DLCDb]] = {
     val q = table.filter(_.tempContractId === tempContractId)

--- a/docs/wallet/wallet-callbacks.md
+++ b/docs/wallet/wallet-callbacks.md
@@ -3,7 +3,7 @@ title: Wallet Callbacks
 id: wallet-callbacks
 ---
 
-#### Callbacks
+#### Wallet Callbacks
 
 Bitcoin-S support call backs for the following events that happen in the wallet:
 
@@ -17,6 +17,14 @@ That means every time one of these events happens, we will call your callback
 so that you can be notified of the event. These callbacks will be run after the message has been
 recieved and will execute synchronously. If any of them fail an error log will be output, and the remainder of the callbacks will continue.
 Let's make an easy one:
+
+#### DLC Wallet callbacks
+Bitcoin-s support callbacks for the following events in the DLC wallet: 
+1. onStateChange
+
+That means everytime a DLC's state changes, your callback will be executed so
+that you are notified of the event. For instance, if your DLC transitions from
+`Offered` -> `Accepted`, your callback will be executed.
 
 #### Example
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -251,7 +251,6 @@ object DLCWalletUtil extends Logging {
       accept <- walletB.acceptDLCOffer(offer)
       sigs <- walletA.signDLC(accept)
       _ <- walletB.addDLCSigs(sigs)
-
       tx <- walletB.broadcastDLCFundingTx(sigs.contractId)
       _ <- walletA.processTransaction(tx, None)
     } yield {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -305,7 +305,9 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
         .flatten
       processed <- spendingInfoDAO.updateAllSpendingInfoDb(toBeUpdated)
       _ <- updateUtxoConfirmedStates(processed)
-    } yield processed
+    } yield {
+      processed
+    }
   }
 
   /** Does the grunt work of processing a TX.


### PR DESCRIPTION
This PR adds callbacks to the `dlcWallet` project for state changes for a DLC. Callbacks are currently supported for the states

- Offered
- Accepted
- Signed
- Broadcasted
- Confirmed
- Claimed
- RemoteClaimed


I still need to implement the refund callback, which i'm going to do on another PR for times sake.

The PR that wires these up over the websocket is #3926 