### PR TITLE
2021 12 20 ws dlc callbacks

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ws/WsModels.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ws/WsModels.scala
@@ -3,6 +3,7 @@ package org.bitcoins.commons.jsonmodels.ws
 import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockHeaderResult
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.dlc.models.DLCStatus
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.StringFactory
 
@@ -24,6 +25,7 @@ object WalletWsType extends StringFactory[WalletWsType] {
   case object ReservedUtxos extends WalletWsType
   case object NewAddress extends WalletWsType
   case object BlockProcessed extends WalletWsType
+  case object DLCStateChange extends WalletWsType
 
   private val all =
     Vector(TxProcessed, TxBroadcast, ReservedUtxos, NewAddress, BlockProcessed)
@@ -77,5 +79,10 @@ object WalletNotification {
   case class BlockProcessedNotification(payload: GetBlockHeaderResult)
       extends WalletNotification[GetBlockHeaderResult] {
     override val `type`: WalletWsType = WalletWsType.BlockProcessed
+  }
+
+  case class DLCStateChangeNotification(payload: DLCStatus)
+      extends WalletNotification[DLCStatus] {
+    override val `type`: WalletWsType = WalletWsType.DLCStateChange
   }
 }

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/WsPicklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/WsPicklers.scala
@@ -2,6 +2,7 @@ package org.bitcoins.commons.serializers
 
 import org.bitcoins.commons.jsonmodels.ws.WalletNotification.{
   BlockProcessedNotification,
+  DLCStateChangeNotification,
   NewAddressNotification,
   ReservedUtxosNotification,
   TxBroadcastNotification,
@@ -33,6 +34,8 @@ object WsPicklers {
         ujson.Arr.from(vec)
       case BlockProcessedNotification(block) =>
         upickle.default.writeJs(block)(Picklers.getBlockHeaderResultPickler)
+      case DLCStateChangeNotification(status) =>
+        upickle.default.writeJs(status)(Picklers.dlcStatusW)
     }
 
     val notificationObj = ujson.Obj(
@@ -65,6 +68,9 @@ object WsPicklers {
         val block =
           upickle.default.read(payloadObj)(Picklers.getBlockHeaderResultPickler)
         BlockProcessedNotification(block)
+      case WalletWsType.DLCStateChange =>
+        val status = upickle.default.read(payloadObj)(Picklers.dlcStatusR)
+        DLCStateChangeNotification(status)
     }
   }
 
@@ -101,5 +107,11 @@ object WsPicklers {
       writeWalletNotification(_),
       readWalletNotification(_).asInstanceOf[BlockProcessedNotification]
     )
+  }
+
+  implicit val dlcStateChangePickler: ReadWriter[DLCStateChangeNotification] = {
+    readwriter[ujson.Obj].bimap(
+      writeWalletNotification(_),
+      readWalletNotification(_).asInstanceOf[DLCStateChangeNotification])
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -2,20 +2,20 @@ package org.bitcoins.server
 
 import akka.actor.ActorSystem
 import akka.dispatch.Dispatchers
+import akka.http.scaladsl.model.ws.{Message, TextMessage}
+import akka.stream.scaladsl.SourceQueueWithComplete
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models._
 import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockChainInfoResult
+import org.bitcoins.commons.jsonmodels.ws.WalletNotification
+import org.bitcoins.commons.serializers.WsPicklers
 import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
-import org.bitcoins.core.api.node.{
-  ExternalImplementationNodeType,
-  InternalImplementationNodeType,
-  NodeApi,
-  NodeType
-}
+import org.bitcoins.core.api.node.{ExternalImplementationNodeType, InternalImplementationNodeType, NodeApi, NodeType}
+import org.bitcoins.core.protocol.dlc.models.DLCStatus
 import org.bitcoins.core.util.{NetworkUtil, TimeUtil}
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.dlc.node.DLCNode
@@ -31,12 +31,7 @@ import org.bitcoins.rpc.BitcoindException.InWarmUp
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.config.{BitcoindRpcAppConfig, ZmqConfig}
 import org.bitcoins.server.routes.{BitcoinSServerRunner, CommonRoutes, Server}
-import org.bitcoins.server.util.{
-  BitcoinSAppScalaDaemon,
-  ServerBindings,
-  WebsocketUtil,
-  WsServerConfig
-}
+import org.bitcoins.server.util.{BitcoinSAppScalaDaemon, ServerBindings, WebsocketUtil, WsServerConfig}
 import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.wallet._
 import org.bitcoins.wallet.config.WalletAppConfig
@@ -182,6 +177,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       walletCallbacks = WebsocketUtil.buildWalletCallbacks(server.walletQueue,
                                                            chainApi)
       _ = walletConf.addCallbacks(walletCallbacks)
+      dlcWalletCallbacks = buildDLCWalletCallback(server.walletQueue)
+      _ = dlcConf.addCallbacks(dlcWalletCallbacks)
       _ = {
         logger.info(
           s"Starting ${nodeConf.nodeType.shortName} node sync, it took=${System
@@ -266,6 +263,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       walletCallbacks = WebsocketUtil.buildWalletCallbacks(server.walletQueue,
                                                            bitcoind)
       _ = walletConf.addCallbacks(walletCallbacks)
+      dlcWalletCallbacks = buildDLCWalletCallback(server.walletQueue)
+      _ = dlcConf.addCallbacks(dlcWalletCallbacks)
     } yield {
       logger.info(s"Done starting Main!")
       ()
@@ -517,6 +516,20 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     f
   }
 
+  private def buildDLCWalletCallback(
+      walletQueue: SourceQueueWithComplete[Message]): DLCWalletCallbacks = {
+
+    val onStateChange: OnDLCStateChange = { status: DLCStatus =>
+      val notification = WalletNotification.DLCStateChangeNotification(status)
+      val json =
+        upickle.default.writeJs(notification)(WsPicklers.dlcStateChangePickler)
+      val msg = TextMessage.Strict(json.toString())
+      val offerF = walletQueue.offer(msg)
+      offerF.map(_ => ())
+    }
+
+    DLCWalletCallbacks.onDLCStateChange(onStateChange)
+  }
 }
 
 object BitcoinSServerMain extends BitcoinSAppScalaDaemon {


### PR DESCRIPTION
This PR is built on top of #3906 

This PR is also built on top of #3923 


This PR propagates a state change for a DLC over the websocket. 

You can see in this instance the `"state": "Offered"`. For other states this will change.

```
{"type":"dlcstatechange","payload":{"state":"Offered","dlcId":"1ce529896d6b791adc150802b7adb56d66c288d7df615a91a10a6873f91fbaea","isInitiator":true,"lastUpdated":"2021-12-20T13:48:57.370Z","tempContractId":"dc649999ef58d405f89e01cc723eee2084ebccc83e7bb28612eb3293b79bf4e6","contractInfo":"fdd82efd031600000000000186a0fda7202a0012fda7261e0002010000000000000186a0000001fe0003ffff00000000000000000000fda724020000fda712fd02dafdd824fd02d431acd9596c7d092d7abff4765356ddfcd03cc386122b94973286a899c4ccb4385d73ff699390332cdfbf75ab6e3b008b26d925f0ad7542bf603e5a9c4a3acf7f04ba9838623f02c940d20d7b185d410178cff7990c7fcf19186c7f58c7c4b8defdd822fd026e0012e60f5f053dcbf5548f6a965c3e1c963f95b43f5d608d54b84f8adbd2f5d45f6b5271a8623dc3ac00e3673e0b1618d31d871646728f223c4cfc361542b7aedd7c4b79d4dc0a71ba95db721361459caf21e9b78f40dce71558273155465e029a0032a3bec708e6f1fb65d2bd77a274a0cf44bfd6e558172b42a98e17053c85f4d987c12f2392648a52cdcbe74229828bc7d582c39785c0570e0cf3da4023261d053ac97f88c96f083d6ce575cc9241c18cd02c00158824258165b862cc0c6be27fb2d43729c85e23b35a173c7bf94bea10ff6bcb1f00d76a937d8e131e299b5ebc4a20ac9332c2831a5f22283e2a6eeea1904e968f31a9de8a0add09140853b06713b953d0ba9c6d8972ef2b8c1829e1287f7c7df01dfbcec61abb69d5f801a610e184299b32e53f345df431a25d9321d989cefb62fe6ae2ac663644e6d823b76ec98308251d8c0210438270e2f6dd31c47d3c3d0ebf9e2bb67cb189f67df1a94fefa818d894df7b764882e7dfb931e7dd14db775b2a789cd2e36cdb4370919265d7664cc90dcc96b5ec7a7366143fc66964bb0d28b4a9b9120f2dfacc30ad2e1bf066d99976131f4490a497bd0c5f4fd0ff86c1ba9c1783915ac5c6f2cd25b616b60c40af04c473607fed4858b2907c87a0b75913ccf19b5710527c915306c6e62e190e42d0d0f059b1a6c7a1b23214a6a410f4d1ff8be8f2088fe2c97dec9bbf96b443c284a991ae6c49a7f22b541d2171cdcab1bbbb3fd950426e349b1ae8d16974a71a59f0f6157ef33be11bde8d90dacea2d27671d35bce4fb614d268bf5a61c18980fdd80a100002000642544355534400000000001213446572696269742d4254432d32314445433231","contractMaturity":0,"contractTimeout":1640649600,"feeRate":3,"totalCollateral":100000,"localCollateral":50000,"remoteCollateral":50000}}
```

It should be noted that if you cancel an offered DLC, this doesn't get propagated over the websocket. Do we want this?
