### PR TITLE
Remove `BitcoinSServerMain.startedFP`

### DIFF
--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
@@ -14,7 +14,7 @@ trait BitcoinSRunner extends StartStopAsync[Unit] with Logging {
   implicit lazy val ec: ExecutionContext = system.dispatcher
 
   // start everything!
-  final def run(): Unit = {
+  final def run(): Future[Unit] = {
 
     //We need to set the system property before any logger instances
     //are in instantiated. If we don't do this, we will not log to
@@ -29,6 +29,8 @@ trait BitcoinSRunner extends StartStopAsync[Unit] with Logging {
     runner.failed.foreach { err =>
       logger.error(s"Failed to startup server!", err)
     }(scala.concurrent.ExecutionContext.Implicits.global)
+
+    runner
   }
 }
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTest.scala
@@ -18,8 +18,6 @@ class BitcoinSServerMainBitcoindTest
 
       for {
         _ <- server.start()
-        // Await RPC server started
-        _ <- BitcoinSServer.startedF
 
         info = ConsoleCli.exec(CliCommand.WalletInfo, cliConfig)
         balance = ConsoleCli.exec(CliCommand.GetBalance(isSats = true),
@@ -34,10 +32,5 @@ class BitcoinSServerMainBitcoindTest
         assert(addr.isSuccess)
         assert(blockHash.isSuccess)
       }
-  }
-
-  override def afterAll(): Unit = {
-    super.afterAll()
-    BitcoinSServer.reset()
   }
 }

--- a/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTorTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTorTest.scala
@@ -21,8 +21,6 @@ class BitcoinSServerMainBitcoindTorTest
       for {
         _ <- torF
         _ <- server.start()
-        // Await RPC server started
-        _ <- BitcoinSServer.startedF
 
         info = ConsoleCli.exec(CliCommand.WalletInfo, cliConfig)
         balance = ConsoleCli.exec(CliCommand.GetBalance(isSats = true),
@@ -37,10 +35,5 @@ class BitcoinSServerMainBitcoindTorTest
         assert(addr.isSuccess)
         assert(blockHash.isSuccess)
       }
-  }
-
-  override def afterAll(): Unit = {
-    super.afterAll()
-    BitcoinSServer.reset()
   }
 }


### PR DESCRIPTION
This was causing me a lot of trouble when testing #3906 and i don't really see what it was necessarily if we just return a `Future[Unit]` from `BitcoinSServerMain.run()`