### PR TITLE
Rename database username and password variables

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -38,7 +38,7 @@ trait DbManagement extends Logging {
     // Remove "s needed for config
     val url = appConfig.jdbcUrl.replace("\"", "")
     config
-      .dataSource(url, username, password)
+      .dataSource(url, dbUsername, dbPassword)
       .load
   }
 

--- a/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
@@ -20,9 +20,9 @@ trait JdbcProfileComponent[+ConfigType <: DbAppConfig] extends Logging {
   lazy val profile: JdbcProfile = dbConfig.profile
   import profile.api._
 
-  lazy val username: String = dbConfig.config.getString("db.user")
+  lazy val dbUsername: String = dbConfig.config.getString("db.user")
 
-  lazy val password: String = dbConfig.config.getString("db.password")
+  lazy val dbPassword: String = dbConfig.config.getString("db.password")
 
   lazy val numThreads: Int = dbConfig.config.getInt("db.numThreads")
 


### PR DESCRIPTION
`username` and `password` are likely normal names for variables in an `AppConfig` however these are being used for the database username and password. I renamed them to be specific to the database