### PR TITLE
Call trim on peer address in Accept dialog

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/dialog/AcceptOfferDialog.scala
@@ -21,9 +21,9 @@ class AcceptOfferDialog extends CliCommandProducer[AcceptDLCCliCommand] {
   override def getCliCommand(): AcceptDLCCliCommand = {
     val offerHex = offerTLVTF.text.value
     val offer = LnMessageFactory(DLCOfferTLV).fromHex(offerHex)
-    if (peerAddressTF.text.value.nonEmpty) {
-      val peer =
-        NetworkUtil.parseInetSocketAddress(peerAddressTF.text.value, 2862)
+    val text = peerAddressTF.text.value.trim
+    if (text.nonEmpty) {
+      val peer = NetworkUtil.parseInetSocketAddress(text, 2862)
 
       AcceptDLC(offer, peer)
     } else {


### PR DESCRIPTION
Was having some trouble with testing where there would be a leading space in the string. This should fix that