### PR TITLE
2021 12 28 blockprocessed callback

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ws/WsModels.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ws/WsModels.scala
@@ -13,7 +13,11 @@ sealed trait WsType
 object WsType extends StringFactory[WsType] {
 
   override def fromString(string: String): WsType = {
-    WalletWsType.fromString(string)
+    ChainWsType.fromStringOpt(string) match {
+      case Some(t) => t
+      case None =>
+        WalletWsType.fromString(string)
+    }
   }
 }
 
@@ -52,7 +56,7 @@ object ChainWsType extends StringFactory[ChainWsType] {
 
   override def fromString(string: String): ChainWsType = {
     fromStringOpt(string)
-      .getOrElse(sys.error(s"Cannot find wallet ws type for string=$string"))
+      .getOrElse(sys.error(s"Cannot find chain ws type for string=$string"))
   }
 }
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ws/WsModels.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ws/WsModels.scala
@@ -18,23 +18,39 @@ object WsType extends StringFactory[WsType] {
 }
 
 sealed trait WalletWsType extends WsType
+sealed trait ChainWsType extends WsType
 
 object WalletWsType extends StringFactory[WalletWsType] {
   case object TxProcessed extends WalletWsType
   case object TxBroadcast extends WalletWsType
   case object ReservedUtxos extends WalletWsType
   case object NewAddress extends WalletWsType
-  case object BlockProcessed extends WalletWsType
+
   case object DLCStateChange extends WalletWsType
 
   private val all =
-    Vector(TxProcessed, TxBroadcast, ReservedUtxos, NewAddress, BlockProcessed)
+    Vector(TxProcessed, TxBroadcast, ReservedUtxos, NewAddress)
 
   override def fromStringOpt(string: String): Option[WalletWsType] = {
     all.find(_.toString.toLowerCase() == string.toLowerCase)
   }
 
   override def fromString(string: String): WalletWsType = {
+    fromStringOpt(string)
+      .getOrElse(sys.error(s"Cannot find wallet ws type for string=$string"))
+  }
+}
+
+object ChainWsType extends StringFactory[ChainWsType] {
+  case object BlockProcessed extends ChainWsType
+
+  private val all: Vector[ChainWsType] = Vector(BlockProcessed)
+
+  override def fromStringOpt(string: String): Option[ChainWsType] = {
+    all.find(_.toString.toLowerCase() == string.toLowerCase)
+  }
+
+  override def fromString(string: String): ChainWsType = {
     fromStringOpt(string)
       .getOrElse(sys.error(s"Cannot find wallet ws type for string=$string"))
   }
@@ -48,6 +64,10 @@ object WalletWsType extends StringFactory[WalletWsType] {
 sealed trait WsNotification[T] {
   def `type`: WsType
   def payload: T
+}
+
+sealed trait ChainNotification[T] extends WsNotification[T] {
+  override def `type`: ChainWsType
 }
 
 sealed trait WalletNotification[T] extends WsNotification[T] {
@@ -76,13 +96,16 @@ object WalletNotification {
     override val `type`: WalletWsType = WalletWsType.ReservedUtxos
   }
 
-  case class BlockProcessedNotification(payload: GetBlockHeaderResult)
-      extends WalletNotification[GetBlockHeaderResult] {
-    override val `type`: WalletWsType = WalletWsType.BlockProcessed
-  }
-
   case class DLCStateChangeNotification(payload: DLCStatus)
       extends WalletNotification[DLCStatus] {
     override val `type`: WalletWsType = WalletWsType.DLCStateChange
+  }
+}
+
+object ChainNotification {
+
+  case class BlockProcessedNotification(payload: GetBlockHeaderResult)
+      extends ChainNotification[GetBlockHeaderResult] {
+    override val `type`: ChainWsType = ChainWsType.BlockProcessed
   }
 }

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/WsPicklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/WsPicklers.scala
@@ -131,6 +131,10 @@ object WsPicklers {
     readwriter[ujson.Obj].bimap(writeWalletNotification, readWalletNotification)
   }
 
+  implicit val chainNotificationPickler: ReadWriter[ChainNotification[_]] = {
+    readwriter[ujson.Obj].bimap(writeChainNotification, readChainNotification)
+  }
+
   implicit val blockProcessedPickler: ReadWriter[BlockProcessedNotification] = {
     readwriter[ujson.Obj].bimap(
       writeChainNotification(_),

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.oracle.server
 
 import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
 import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.dlc.oracle.DLCOracle
 import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
@@ -33,13 +34,15 @@ class OracleServerMain(override val serverArgParser: ServerArgParser)(implicit
                  handlers = routes,
                  rpcbindOpt = bindConfOpt,
                  rpcport = rpcport,
-                 None)
+                 None,
+                 Source.empty)
         case None =>
           Server(conf = conf,
                  handlers = routes,
                  rpcbindOpt = bindConfOpt,
                  rpcport = conf.rpcPort,
-                 None)
+                 None,
+                 Source.empty)
       }
 
       _ <- server.start()

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -138,7 +138,7 @@ case class Server(
       .run()
   }
 
-  def walletQueue: SourceQueueWithComplete[Message] = tuple._1
+  def wsQueue: SourceQueueWithComplete[Message] = tuple._1
   def source: Source[Message, NotUsed] = tuple._2
 
   private val eventsRoute = "events"

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -23,7 +23,7 @@ case class Server(
     rpcbindOpt: Option[String],
     rpcport: Int,
     wsConfigOpt: Option[WsServerConfig],
-    source: Source[Message, NotUsed])(implicit system: ActorSystem)
+    wsSource: Source[Message, NotUsed])(implicit system: ActorSystem)
     extends HttpLogger {
 
   import system.dispatcher
@@ -126,7 +126,7 @@ case class Server(
 
   private def wsHandler: Flow[Message, Message, Any] = {
     //we don't allow input, so use Sink.ignore
-    Flow.fromSinkAndSource(Sink.ignore, source)
+    Flow.fromSinkAndSource(Sink.ignore, wsSource)
   }
 
 }

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -9,15 +9,7 @@ import akka.http.scaladsl.model.ws.Message
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.directives.DebuggingDirectives
-import akka.stream.OverflowStrategy
-import akka.stream.scaladsl.{
-  BroadcastHub,
-  Flow,
-  Keep,
-  Sink,
-  Source,
-  SourceQueueWithComplete
-}
+import akka.stream.scaladsl.{Flow, Sink, Source}
 import de.heikoseeberger.akkahttpupickle.UpickleSupport._
 import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.server.util.{ServerBindings, WsServerConfig}
@@ -30,7 +22,8 @@ case class Server(
     handlers: Seq[ServerRoute],
     rpcbindOpt: Option[String],
     rpcport: Int,
-    wsConfigOpt: Option[WsServerConfig])(implicit system: ActorSystem)
+    wsConfigOpt: Option[WsServerConfig],
+    source: Source[Message, NotUsed])(implicit system: ActorSystem)
     extends HttpLogger {
 
   import system.dispatcher
@@ -122,24 +115,6 @@ case class Server(
         Future.successful(None)
     }
   }
-
-  private val maxBufferSize: Int = 25
-
-  /** This will queue [[maxBufferSize]] elements in the queue. Once the buffer size is reached,
-    * we will drop the first element in the buffer
-    */
-  private val tuple = {
-    //from: https://github.com/akka/akka-http/issues/3039#issuecomment-610263181
-    //the BroadcastHub.sink is needed to avoid these errors
-    // 'Websocket handler failed with Processor actor'
-    Source
-      .queue[Message](maxBufferSize, OverflowStrategy.dropHead)
-      .toMat(BroadcastHub.sink)(Keep.both)
-      .run()
-  }
-
-  def wsQueue: SourceQueueWithComplete[Message] = tuple._1
-  def source: Source[Message, NotUsed] = tuple._2
 
   private val eventsRoute = "events"
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
@@ -205,13 +205,13 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
       getBlockHeaderResultStr = ConsoleCli.exec(cmd, cliConfig)
       getBlockHeaderResult = upickle.default.read(getBlockHeaderResultStr.get)(
         Picklers.getBlockHeaderResultPickler)
-      _ <- AkkaUtil.nonBlockingSleep(1500.millis)
+      _ <- AkkaUtil.nonBlockingSleep(2500.millis)
       _ = promise.success(None)
       notifications <- notificationsF
     } yield {
       assert(
-        notifications.exists(
-          _ == BlockProcessedNotification(getBlockHeaderResult)))
+        notifications.count(
+          _ == BlockProcessedNotification(getBlockHeaderResult)) == 1)
     }
   }
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
@@ -197,7 +197,8 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
     val promise = tuple._2._2
 
     val addressF = bitcoind.getNewAddress
-
+    val timeout =
+      15.seconds //any way we can remove this timeout and just check?
     for {
       address <- addressF
       hashes <- bitcoind.generateToAddress(1, address)
@@ -205,9 +206,7 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
       getBlockHeaderResultStr = ConsoleCli.exec(cmd, cliConfig)
       getBlockHeaderResult = upickle.default.read(getBlockHeaderResultStr.get)(
         Picklers.getBlockHeaderResultPickler)
-      _ <- AkkaUtil.nonBlockingSleep(
-        10000.millis
-      ) //anyway we can remove this timeout and just check?
+      _ <- AkkaUtil.nonBlockingSleep(timeout)
       _ = promise.success(None)
       notifications <- notificationsF
     } yield {

--- a/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
@@ -8,7 +8,6 @@ import akka.http.scaladsl.model.ws.{
   WebSocketUpgradeResponse
 }
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.cli.{CliCommand, Config, ConsoleCli}
 import org.bitcoins.commons.jsonmodels.ws.ChainNotification.BlockProcessedNotification
 import org.bitcoins.commons.jsonmodels.ws.WalletNotification.{
@@ -16,7 +15,12 @@ import org.bitcoins.commons.jsonmodels.ws.WalletNotification.{
   TxBroadcastNotification,
   TxProcessedNotification
 }
-import org.bitcoins.commons.jsonmodels.ws.{WalletNotification, WalletWsType}
+import org.bitcoins.commons.jsonmodels.ws.{
+  ChainNotification,
+  WalletNotification,
+  WalletWsType,
+  WsNotification
+}
 import org.bitcoins.commons.serializers.{Picklers, WsPicklers}
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -31,23 +35,27 @@ import org.bitcoins.testkit.util.AkkaUtil
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Future, Promise}
+import scala.util.Try
 
 class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
 
   behavior of "Websocket Tests"
 
-  val endSink: Sink[WalletNotification[_], Future[Seq[WalletNotification[_]]]] =
-    Sink.seq[WalletNotification[_]]
+  val endSink: Sink[WsNotification[_], Future[Seq[WsNotification[_]]]] =
+    Sink.seq[WsNotification[_]]
 
-  val sink: Sink[Message, Future[Seq[WalletNotification[_]]]] = Flow[Message]
+  val sink: Sink[Message, Future[Seq[WsNotification[_]]]] = Flow[Message]
     .map {
       case message: TextMessage.Strict =>
         //we should be able to parse the address message
         val text = message.text
-        val notification: WalletNotification[_] =
+        val walletNotificationOpt: Option[WalletNotification[_]] = Try(
           upickle.default.read[WalletNotification[_]](text)(
-            WsPicklers.walletNotificationPickler)
-        notification
+            WsPicklers.walletNotificationPickler)).toOption
+        val chainNotificationOpt: Option[ChainNotification[_]] = Try(
+          upickle.default.read[ChainNotification[_]](text)(
+            WsPicklers.chainNotificationPickler)).toOption
+        walletNotificationOpt.getOrElse(chainNotificationOpt.get)
       case msg =>
         fail(s"Unexpected msg type received in the sink, msg=$msg")
     }
@@ -60,7 +68,7 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
   val websocketFlow: Flow[
     Message,
     Message,
-    (Future[Seq[WalletNotification[_]]], Promise[Option[Message]])] = {
+    (Future[Seq[WsNotification[_]]], Promise[Option[Message]])] = {
     Flow
       .fromSinkAndSourceCoupledMat(sink, Source.maybe[Message])(Keep.both)
   }
@@ -73,12 +81,12 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
       val req = buildReq(server.conf)
       val notificationsF: (
           Future[WebSocketUpgradeResponse],
-          (Future[Seq[WalletNotification[_]]], Promise[Option[Message]])) = {
+          (Future[Seq[WsNotification[_]]], Promise[Option[Message]])) = {
         Http()
           .singleWebSocketRequest(req, websocketFlow)
       }
 
-      val walletNotificationsF: Future[Seq[WalletNotification[_]]] =
+      val walletNotificationsF: Future[Seq[WsNotification[_]]] =
         notificationsF._2._1
 
       val promise: Promise[Option[Message]] = notificationsF._2._2
@@ -105,7 +113,7 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
       val req = buildReq(server.conf)
       val tuple: (
           Future[WebSocketUpgradeResponse],
-          (Future[Seq[WalletNotification[_]]], Promise[Option[Message]])) = {
+          (Future[Seq[WsNotification[_]]], Promise[Option[Message]])) = {
         Http()
           .singleWebSocketRequest(req, websocketFlow)
       }
@@ -143,7 +151,7 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
       val req = buildReq(server.conf)
       val tuple: (
           Future[WebSocketUpgradeResponse],
-          (Future[Seq[WalletNotification[_]]], Promise[Option[Message]])) = {
+          (Future[Seq[WsNotification[_]]], Promise[Option[Message]])) = {
         Http()
           .singleWebSocketRequest(req, websocketFlow)
       }
@@ -180,7 +188,7 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
     val req = buildReq(server.conf)
     val tuple: (
         Future[WebSocketUpgradeResponse],
-        (Future[Seq[WalletNotification[_]]], Promise[Option[Message]])) = {
+        (Future[Seq[WsNotification[_]]], Promise[Option[Message]])) = {
       Http()
         .singleWebSocketRequest(req, websocketFlow)
     }
@@ -193,15 +201,11 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
     for {
       address <- addressF
       hashes <- bitcoind.generateToAddress(1, address)
-      header <- bitcoind.getBlockHeader(hashes.head)
-      handler = ChainHandler.fromDatabase()(executionContext, server.chainConf)
-      _ <- handler.processHeaders(Vector(header.blockHeader))
-
       cmd = CliCommand.GetBlockHeader(hash = hashes.head)
       getBlockHeaderResultStr = ConsoleCli.exec(cmd, cliConfig)
       getBlockHeaderResult = upickle.default.read(getBlockHeaderResultStr.get)(
         Picklers.getBlockHeaderResultPickler)
-      _ <- AkkaUtil.nonBlockingSleep(500.millis)
+      _ <- AkkaUtil.nonBlockingSleep(1500.millis)
       _ = promise.success(None)
       notifications <- notificationsF
     } yield {
@@ -219,12 +223,12 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
       val req = buildReq(server.conf)
       val tuple: (
           Future[WebSocketUpgradeResponse],
-          (Future[Seq[WalletNotification[_]]], Promise[Option[Message]])) = {
+          (Future[Seq[WsNotification[_]]], Promise[Option[Message]])) = {
         Http()
           .singleWebSocketRequest(req, websocketFlow)
       }
 
-      val notificationsF: Future[Seq[WalletNotification[_]]] = tuple._2._1
+      val notificationsF: Future[Seq[WsNotification[_]]] = tuple._2._1
       val promise = tuple._2._2
 
       //lock all utxos

--- a/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
@@ -205,13 +205,15 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
       getBlockHeaderResultStr = ConsoleCli.exec(cmd, cliConfig)
       getBlockHeaderResult = upickle.default.read(getBlockHeaderResultStr.get)(
         Picklers.getBlockHeaderResultPickler)
-      _ <- AkkaUtil.nonBlockingSleep(2500.millis)
+      _ <- AkkaUtil.nonBlockingSleep(
+        10000.millis
+      ) //anyway we can remove this timeout and just check?
       _ = promise.success(None)
       notifications <- notificationsF
     } yield {
-      assert(
-        notifications.count(
-          _ == BlockProcessedNotification(getBlockHeaderResult)) == 1)
+      val count = notifications.count(
+        _ == BlockProcessedNotification(getBlockHeaderResult))
+      assert(count == 1, s"count=$count")
     }
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -194,6 +194,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
                            dlcNode = dlcNode,
                            serverCmdLineArgs = serverArgParser,
                            wsSource = wsSource)
+      chainCallbacks = WebsocketUtil.buildChainCallbacks(wsQueue, chainApi)
+      _ = chainConf.addCallbacks(chainCallbacks)
       walletCallbacks = WebsocketUtil.buildWalletCallbacks(wsQueue)
       _ = walletConf.addCallbacks(walletCallbacks)
       dlcWalletCallbacks = WebsocketUtil.buildDLCWalletCallbacks(wsQueue)
@@ -260,7 +262,6 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
 
       _ = logger.info("Creating wallet")
       chainCallbacks = WebsocketUtil.buildChainCallbacks(wsQueue, bitcoind)
-      _ = chainConf.addCallbacks(chainCallbacks)
       tmpWallet <- tmpWalletF
       wallet = BitcoindRpcBackendUtil.createDLCWalletWithBitcoindCallbacks(
         bitcoind,

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -179,11 +179,12 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
                                 wallet = wallet,
                                 dlcNode = dlcNode,
                                 serverCmdLineArgs = serverArgParser)
-      walletCallbacks = WebsocketUtil.buildWalletCallbacks(server.walletQueue,
-                                                           chainApi)
+      chainCallbacks = WebsocketUtil.buildChainCallbacks(server.wsQueue,
+                                                         chainApi)
+      _ = chainConf.addCallbacks(chainCallbacks)
+      walletCallbacks = WebsocketUtil.buildWalletCallbacks(server.wsQueue)
       _ = walletConf.addCallbacks(walletCallbacks)
-      dlcWalletCallbacks = WebsocketUtil.buildDLCWalletCallbacks(
-        server.walletQueue)
+      dlcWalletCallbacks = WebsocketUtil.buildDLCWalletCallbacks(server.wsQueue)
       _ = dlcConf.addCallbacks(dlcWalletCallbacks)
       _ = {
         logger.info(
@@ -266,11 +267,12 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
                                 wallet = wallet,
                                 dlcNode = dlcNode,
                                 serverCmdLineArgs = serverArgParser)
-      walletCallbacks = WebsocketUtil.buildWalletCallbacks(server.walletQueue,
-                                                           bitcoind)
+      chainCallbacks = WebsocketUtil.buildChainCallbacks(server.wsQueue,
+                                                         bitcoind)
+      _ = chainConf.addCallbacks(chainCallbacks)
+      walletCallbacks = WebsocketUtil.buildWalletCallbacks(server.wsQueue)
       _ = walletConf.addCallbacks(walletCallbacks)
-      dlcWalletCallbacks = WebsocketUtil.buildDLCWalletCallbacks(
-        server.walletQueue)
+      dlcWalletCallbacks = WebsocketUtil.buildDLCWalletCallbacks(server.wsQueue)
       _ = dlcConf.addCallbacks(dlcWalletCallbacks)
     } yield {
       logger.info(s"Done starting Main!")

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -44,7 +44,7 @@ object BitcoindRpcBackendUtil extends Logging {
             _ <- lastConfirmedOpt match {
               case None =>
                 for {
-                  _ <- doSync(walletHeight = 0,
+                  _ <- doSync(walletHeight = bitcoindHeight - 1,
                               bitcoindHeight = bitcoindHeight,
                               bitcoind = bitcoind,
                               wallet = wallet)

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -86,7 +86,7 @@ object BitcoindRpcBackendUtil extends Logging {
 
       val hasFiltersF = bitcoind
         .getFilter(wallet.walletConfig.chain.genesisHashBE)
-        .map(_ => false)
+        .map(_ => true)
         .recover { case _: Throwable => false }
 
       val blockRange = walletHeight.to(bitcoindHeight).tail
@@ -105,9 +105,9 @@ object BitcoindRpcBackendUtil extends Logging {
         hashes <- hashFs.map(_.toVector)
         hasFilters <- hasFiltersF
         _ <- {
-          if (hasFilters)
+          if (hasFilters) {
             filterSync(hashes, bitcoind.asInstanceOf[V19BlockFilterRpc], wallet)
-          else wallet.nodeApi.downloadBlocks(hashes)
+          } else wallet.nodeApi.downloadBlocks(hashes)
         }
       } yield wallet
     }

--- a/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
@@ -2,6 +2,7 @@ package org.bitcoins.server.util
 
 import akka.http.scaladsl.model.ws.{Message, TextMessage}
 import akka.stream.scaladsl.SourceQueueWithComplete
+import grizzled.slf4j.Logging
 import org.bitcoins.chain.{ChainCallbacks, OnBlockHeaderConnected}
 import org.bitcoins.commons.jsonmodels.ws.{
   ChainNotification,
@@ -23,7 +24,7 @@ import org.bitcoins.wallet.{
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object WebsocketUtil {
+object WebsocketUtil extends Logging {
 
   def buildChainCallbacks(
       queue: SourceQueueWithComplete[Message],

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -235,7 +235,7 @@ object FundWalletUtil extends FundWalletUtil {
 
       wallet = BitcoindRpcBackendUtil.createDLCWalletWithBitcoindCallbacks(
         bitcoind,
-        tmp)
+        tmp)(system, config.chainConf)
 
       funded1 <- fundAccountForWalletWithBitcoind(
         BitcoinSWalletTest.defaultAcctAmts,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -235,7 +235,8 @@ object FundWalletUtil extends FundWalletUtil {
 
       wallet = BitcoindRpcBackendUtil.createDLCWalletWithBitcoindCallbacks(
         bitcoind,
-        tmp)(system, config.chainConf)
+        tmp,
+        None)(system)
 
       funded1 <- fundAccountForWalletWithBitcoind(
         BitcoinSWalletTest.defaultAcctAmts,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -206,7 +206,8 @@ class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
         bip39PasswordOpt = walletAppConfig.bip39PasswordOpt)
     } yield {
       BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(bitcoind,
-                                                               tmpWallet)
+                                                               tmpWallet,
+                                                               None)
     }
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
@@ -27,7 +27,8 @@ class BitcoindBlockPollingTest
           BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind, None)
         wallet =
           BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(bitcoind,
-                                                                   tmpWallet)
+                                                                   tmpWallet,
+                                                                   None)
         // Assert wallet is empty
         isEmpty <- wallet.isEmpty()
         _ = assert(isEmpty)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindZMQBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindZMQBackendTest.scala
@@ -46,8 +46,10 @@ class BitcoindZMQBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
       tmpWallet <-
         BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind, None)
       wallet =
-        BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(bitcoind,
-                                                                 tmpWallet)
+        BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(
+          bitcoind = bitcoind,
+          wallet = tmpWallet,
+          chainCallbacksOpt = None)
       // Assert wallet is empty
       isEmpty <- wallet.isEmpty()
       _ = assert(isEmpty)


### PR DESCRIPTION
This PR changes the semantics of `blockprocessed` callback introduced in #3906 . 

The reason we needed to do this was the divergence in behavior between `neutrino` and `bitcoind` backends. On master, with a `bitcoind` backened, we will execute callbacks everytime a block comes in on the network, whereas our neutrino wallet will only execute `blockprocessed` when a _compact filter matches_, thus requesting the full block from the network. 

Since `blockprocessed` only contains header information, we use `ChainCallbacks.onBlockHeaderConnected` to sent `blockprocessed` over the websocket.

As a by product of this, a few things had to be changed and reordered. I'll comment on them in the PR.

The payload of `blockprocessed` should not be changed.