### PR TITLE
Implement ping every 5 seconds to keep websocket connection alive

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -215,6 +215,10 @@ bitcoin-s {
 
 akka {
 
+  # keep the connection alive in websockets by sending ping every 5 seconds
+  # https://doc.akka.io/docs/akka-http/current/server-side/websocket-support.html#automatic-keep-alive-ping-support
+  http.server.websocket.periodic-keep-alive-max-idle = 5 second
+
   # Let Cli commands take 30 seconds
   http.server.request-timeout = 30s
 


### PR DESCRIPTION
@user411 and I have observed the websocket connection getting closed periodically. This PR implements a ping every 5 seconds sent out by the server to be sure the client is connected to the websocket

https://doc.akka.io/docs/akka-http/current/server-side/websocket-support.html#automatic-keep-alive-ping-support