### PR TITLE
Add MasterXPubTable to list of DLCOracle tables

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -184,7 +184,7 @@ trait DbManagement extends Logging {
     *
     * @see https://flywaydb.org/documentation/command/clean
     */
-  private[bitcoins] def clean(): Unit = {
+  def clean(): Unit = {
     flyway.clean()
   }
 }

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
@@ -165,6 +165,10 @@ case class DLCOracleAppConfig(
 
   private val masterXPubDAO: MasterXPubDAO = MasterXPubDAO()(ec, this)
 
+  private lazy val masterXPubTable: TableQuery[Table[_]] = {
+    masterXPubDAO.table
+  }
+
   private lazy val rValueTable: TableQuery[Table[_]] = {
     RValueDAO()(ec, appConfig).table
   }
@@ -178,7 +182,7 @@ case class DLCOracleAppConfig(
   }
 
   override def allTables: List[TableQuery[Table[_]]] =
-    List(rValueTable, eventTable, eventOutcomeTable)
+    List(masterXPubTable, rValueTable, eventTable, eventOutcomeTable)
 
   /** @param migrations - The number of migrations we have run */
   private def v2V3MigrationWorkaround(migrations: Int): Future[Unit] = {


### PR DESCRIPTION
This was causing an issue where if we called `dlcOracle.conf.dropAll()` the master xpub table would not be dropped. This is particularly a problem in postgres where we can't just delete the file in tests like we do in sqlite. This was not causing a problem in bitcoin-s but it was one of my downstream projects.

Also made it so we can call `clean()` inside of non bitcoin-s app configs, this should also help with the same issue.