### PR TITLE
Patch bug where `zipdatadir` doesn't work if the directory was not created

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/file/FileUtil.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/file/FileUtil.scala
@@ -26,9 +26,6 @@ object FileUtil extends Logging {
     //create directories for target if they DNE
     Files.createDirectories(target.getParent)
 
-    //create the file itself
-    Files.createFile(target)
-
     val zos = new ZipOutputStream(new FileOutputStream(target.toFile))
 
     Files.walkFileTree(

--- a/app-commons/src/main/scala/org/bitcoins/commons/file/FileUtil.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/file/FileUtil.scala
@@ -19,7 +19,18 @@ object FileUtil extends Logging {
       source: Path,
       target: Path,
       fileNameFilter: Vector[Regex] = Vector.empty): Path = {
+    require(
+      !Files.exists(target),
+      s"Cannot overwrite existing target directory=${target.toAbsolutePath}")
+
+    //create directories for target if they DNE
+    Files.createDirectories(target.getParent)
+
+    //create the file itself
+    Files.createFile(target)
+
     val zos = new ZipOutputStream(new FileOutputStream(target.toFile))
+
     Files.walkFileTree(
       source,
       new SimpleFileVisitor[Path]() {

--- a/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSAppConfigTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSAppConfigTest.scala
@@ -1,0 +1,35 @@
+package org.bitcoins.server
+
+import org.bitcoins.testkit.fixtures.BitcoinSAppConfigBitcoinFixtureNotStarted
+import org.bitcoins.testkit.util.FileUtil
+
+import java.nio.file.Files
+import scala.concurrent.Future
+
+class BitcoinSAppConfigTest extends BitcoinSAppConfigBitcoinFixtureNotStarted {
+
+  behavior of "BitcoinSAppConfig"
+
+  it must "zipdatadir if the target directory is not created" in { config =>
+    val startF = config.start()
+
+    val fileName = FileUtil.randomDirName
+    val dir = Files
+      .createTempDirectory("hello")
+
+    //delete it
+    assert(Files.deleteIfExists(dir))
+
+    val target = dir.resolve(fileName)
+
+    assert(!Files.exists(target))
+    assert(!Files.exists(dir))
+
+    for {
+      _ <- startF
+      _ <- Future.fromTry(config.zipDatadir(target))
+    } yield {
+      assert(Files.exists(target))
+    }
+  }
+}


### PR DESCRIPTION
fixes #3958 

We had a bug where if the `target` given as a parameter to `zipdatadir` did not have its parent directories created, we would fail to create the backup. This PR fixes this along with a unit test to verify that the backup occurred. 

Works for me on a0dbdea

![Screenshot from 2022-01-04 10-36-12](https://user-images.githubusercontent.com/3514957/148092325-86129cfd-3230-4484-8c53-533306b90b9c.png)
