### PR TITLE
Make `ContractDescriptorTemplate` an unsealed trait

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractDescriptorTemplate.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractDescriptorTemplate.scala
@@ -4,7 +4,7 @@ import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.dlc.compute.CETCalculator
 import org.bitcoins.core.protocol.tlv.DLCSerializationVersion
 
-sealed trait ContractDescriptorTemplate {
+trait ContractDescriptorTemplate {
   def individualCollateral: CurrencyUnit
 
   def totalCollateral: CurrencyUnit


### PR DESCRIPTION
This doesn't really need to be a `sealed` trait because there really isn't a scenario where we would be matching on it. This should allow for outside libraries to have an easy trait to implement for making templates