### PR TITLE
Reduce polling log to trace when we try to poll bitcoind

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -308,7 +308,7 @@ object BitcoindRpcBackendUtil extends Logging {
         walletSyncState.height)
       system.scheduler.scheduleWithFixedDelay(0.seconds, interval) { () =>
         {
-          logger.info("Polling bitcoind for block count")
+          logger.trace("Polling bitcoind for block count")
           bitcoind.getBlockCount.flatMap { count =>
             val prevCount = atomicPrevCount.get()
             if (prevCount < count) {


### PR DESCRIPTION
This log appears every 10 seconds when we deploy our app, this log isn't that important.