### PR TITLE
Implement recovery for when we cannot receive a fee rate from a FeeRateApi

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -813,7 +813,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
 
     case ServerCommand("estimatefee", _) =>
       complete {
-        val feeRateF = wallet.getFeeRate
+        val feeRateF = wallet
+          .getFeeRate()
           .recover { case scala.util.control.NonFatal(exn) =>
             logger.error(
               s"Failed to fetch fee rate from wallet, returning -1 sats/vbyte",

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -205,6 +205,9 @@ object SatoshisPerVirtualByte extends FeeUnitFactory[SatoshisPerVirtualByte] {
   val zero: SatoshisPerVirtualByte = SatoshisPerVirtualByte(CurrencyUnits.zero)
   val one: SatoshisPerVirtualByte = SatoshisPerVirtualByte(Satoshis.one)
 
+  /** Used to indicate we could not retrieve a fee from a [[org.bitcoins.core.api.feeprovider.FeeRateApi]] */
+  val negativeOne: SatoshisPerVirtualByte = SatoshisPerVirtualByte(Satoshis(-1))
+
   override val unitString: String = "sats/vbyte"
 }
 


### PR DESCRIPTION
fixes #3972

Now we return `-1 sats/vbyte` when we cannot estimate a fee rate. We also log the exception internally so we can diagnose why we aren't getting fee rate estimates from the provider. 

I began implementing some test cases for this, but after discussion with @benthecarman i decided to not handle this at the `BitcoindRpcClient` level as this doesn't solve the problem when other fee providers are down.

This along with #3973 should address @user411 's requests.

![Screenshot from 2022-01-12 10-47-05](https://user-images.githubusercontent.com/3514957/149185212-ffc72873-2149-4313-b26f-811dfcaa229f.png)
