### PR TITLE
2022 01 14 `DLCDataManagement` refactor

### DIFF
--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -32,6 +32,7 @@
         <appender-ref ref="FILE"/>
     </root>
 
+    <logger name="akka" level="DEBUG"/>
     <!-- ╔═══════════════════════╗ -->
     <!-- ║   Bitcoin-S logging   ║-->
     <!-- ╚═══════════════════════╝ -->

--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -32,7 +32,6 @@
         <appender-ref ref="FILE"/>
     </root>
 
-    <logger name="akka" level="DEBUG"/>
     <!-- ╔═══════════════════════╗ -->
     <!-- ║   Bitcoin-S logging   ║-->
     <!-- ╚═══════════════════════╝ -->

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -100,7 +100,6 @@ case class ChainAppConfig(
       logger.info(s"Applied ${numMigrations} to chain project")
       ()
     }
-
   }
 
   override def stop(): Future[Unit] = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/DLCSerializationVersion.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/DLCSerializationVersion.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.core.protocol.tlv
 
+import org.bitcoins.crypto.StringFactory
+
 /** We have various binary serializations in our codebase currently.
   * This is a product of trying to release a DLC wallet before the
   * spec was finalized. Some of the binary level serialization for DLCs
@@ -7,7 +9,7 @@ package org.bitcoins.core.protocol.tlv
   */
 sealed trait DLCSerializationVersion
 
-object DLCSerializationVersion {
+object DLCSerializationVersion extends StringFactory[DLCSerializationVersion] {
 
   /** This format existed in our wallet before we merged support for this PR
     * on the DLC spec repo. See the diff below
@@ -20,4 +22,19 @@ object DLCSerializationVersion {
     * @see [[https://github.com/discreetlogcontracts/dlcspecs/pull/144]]
     */
   case object Beta extends DLCSerializationVersion
+
+  private val all = Vector(Alpha, Beta)
+
+  override def fromString(str: String): DLCSerializationVersion = {
+    fromStringOpt(str) match {
+      case Some(version) => version
+      case None =>
+        sys.error(
+          s"Could not find DLC serialization version associated with str=$str")
+    }
+  }
+
+  override def fromStringOpt(str: String): Option[DLCSerializationVersion] = {
+    all.find(_.toString.toLowerCase == str.toLowerCase)
+  }
 }

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -489,4 +489,11 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
     MappedColumnType.base[ExtKeyPubVersion, String](_.hex,
                                                     ExtKeyPubVersion.fromHex)
   }
+
+  implicit val dlcSerializationVersion: BaseColumnType[
+    DLCSerializationVersion] = {
+    MappedColumnType.base[DLCSerializationVersion, String](
+      _.toString,
+      DLCSerializationVersion.fromString)
+  }
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -41,7 +41,6 @@ import scala.concurrent.{ExecutionContext, Future}
 abstract class DLCWallet
     extends Wallet
     with AnyDLCHDWalletApi
-    with DLCDataManagement
     with DLCTransactionProcessing {
 
   implicit val dlcConfig: DLCAppConfig
@@ -63,18 +62,23 @@ abstract class DLCWallet
   private[bitcoins] val dlcRefundSigDAO: DLCRefundSigsDAO = DLCRefundSigsDAO()
   private[bitcoins] val remoteTxDAO: DLCRemoteTxDAO = DLCRemoteTxDAO()
 
+  private val dlcWalletDAOs = DLCWalletDAOs(
+    dlcDAO,
+    contractDataDAO,
+    dlcAnnouncementDAO,
+    dlcInputsDAO,
+    dlcOfferDAO,
+    dlcAcceptDAO,
+    dlcSigsDAO,
+    dlcRefundSigDAO,
+    oracleNonceDAO,
+    announcementDAO
+  )
+
+  private val dlcDataManagement = DLCDataManagement(dlcWalletDAOs)
+
   protected lazy val actionBuilder: DLCActionBuilder = {
-    DLCActionBuilder(
-      dlcDAO = dlcDAO,
-      contractDataDAO = contractDataDAO,
-      dlcAnnouncementDAO = dlcAnnouncementDAO,
-      dlcInputsDAO = dlcInputsDAO,
-      dlcOfferDAO = dlcOfferDAO,
-      dlcAcceptDAO = dlcAcceptDAO,
-      dlcSigsDAO = dlcSigsDAO,
-      dlcRefundSigDAO = dlcRefundSigDAO,
-      oracleNonceDAO = oracleNonceDAO
-    )
+    DLCActionBuilder(dlcWalletDAOs)
   }
 
   private lazy val safeDatabase: SafeDatabase = dlcDAO.safeDatabase
@@ -578,7 +582,8 @@ abstract class DLCWallet
             outcomeSigsDbs <- dlcSigsDAO.findByDLCId(dlcId)
             refundSigsDb <- dlcRefundSigDAO.read(dlcId)
           } yield {
-            val inputRefs = matchPrevTxsWithInputs(fundingInputs, prevTxs)
+            val inputRefs =
+              dlcDataManagement.matchPrevTxsWithInputs(fundingInputs, prevTxs)
 
             dlcAcceptDb.toDLCAccept(offer.tempContractId,
                                     inputRefs,
@@ -850,19 +855,20 @@ abstract class DLCWallet
             transactionDAO.findByTxIdBEs(offerInputs.map(_.outPoint.txIdBE))
 
           contractData <- contractDataDAO.read(dlcId).map(_.get)
-          (announcements, announcementData, nonceDbs) <- getDLCAnnouncementDbs(
-            dlcId)
+          (announcements, announcementData, nonceDbs) <- dlcDataManagement
+            .getDLCAnnouncementDbs(dlcId)
 
-          contractInfo = getContractInfo(contractData,
-                                         announcements,
-                                         announcementData,
-                                         nonceDbs)
+          contractInfo = dlcDataManagement.getContractInfo(contractData,
+                                                           announcements,
+                                                           announcementData,
+                                                           nonceDbs)
 
           offer =
-            offerDb.toDLCOffer(contractInfo,
-                               matchPrevTxsWithInputs(offerInputs, prevTxs),
-                               dlc,
-                               contractData)
+            offerDb.toDLCOffer(
+              contractInfo,
+              dlcDataManagement.matchPrevTxsWithInputs(offerInputs, prevTxs),
+              dlc,
+              contractData)
 
           dlcDb <- updateDLCContractIds(offer, accept)
 
@@ -904,7 +910,7 @@ abstract class DLCWallet
           Future.failed(new RuntimeException(
             s"No DLC found with corresponding tempContractId ${tempId.hex}, this wallet did not create the corresponding offer"))
       }
-      contractInfo <- getContractInfo(dlcDb.dlcId)
+      contractInfo <- dlcDataManagement.getContractInfo(dlcDb.dlcId)
 
       accept =
         DLCAccept.fromTLV(acceptTLV, walletConfig.network, contractInfo)
@@ -922,7 +928,14 @@ abstract class DLCWallet
       // .get should be safe now
       contractId = dlc.contractIdOpt.get
       dlcId = dlc.dlcId
-      signer <- signerFromDb(dlc.dlcId)
+      fundingInputs <- dlcInputsDAO.findByDLCId(dlcId)
+      scriptSigParams <- getScriptSigParams(dlc, fundingInputs)
+      signer <- dlcDataManagement.signerFromDb(dlcId = dlc.dlcId,
+                                               transactionDAO = transactionDAO,
+                                               remoteTxDAO = remoteTxDAO,
+                                               fundingUtxoScriptSigParams =
+                                                 scriptSigParams,
+                                               keyManager = keyManager)
 
       mySigs <- dlcSigsDAO.findByDLCId(dlc.dlcId)
       refundSigsDb <- dlcRefundSigDAO.findByDLCId(dlc.dlcId).map(_.head)
@@ -977,29 +990,42 @@ abstract class DLCWallet
   }
 
   def verifyCETSigs(accept: DLCAccept): Future[Boolean] = {
-    verifierFromAccept(accept).flatMap(
-      _.verifyCETSigs(accept.cetSigs.indexedOutcomeSigs))
+    val verifierAcceptF =
+      dlcDataManagement.verifierFromAccept(accept, transactionDAO)
+    verifierAcceptF.flatMap(_.verifyCETSigs(accept.cetSigs.indexedOutcomeSigs))
   }
 
   def verifyCETSigs(sign: DLCSign): Future[Boolean] = {
-    verifierFromDb(sign.contractId).flatMap(
-      _.verifyCETSigs(sign.cetSigs.indexedOutcomeSigs))
+    val verifierF = dlcDataManagement.verifierFromDb(sign.contractId,
+                                                     transactionDAO,
+                                                     remoteTxDAO)
+    verifierF.flatMap(_.verifyCETSigs(sign.cetSigs.indexedOutcomeSigs))
   }
 
   def verifyRefundSig(accept: DLCAccept): Future[Boolean] = {
-    verifierFromAccept(accept).map(_.verifyRefundSig(accept.cetSigs.refundSig))
+    val verifierF = dlcDataManagement.verifierFromAccept(accept, transactionDAO)
+
+    verifierF.map(_.verifyRefundSig(accept.cetSigs.refundSig))
   }
 
   def verifyRefundSig(sign: DLCSign): Future[Boolean] = {
-    verifierFromDb(sign.contractId).map(
-      _.verifyRefundSig(sign.cetSigs.refundSig))
+    val verifierF = dlcDataManagement.verifierFromDb(
+      contractId = sign.contractId,
+      transactionDAO = transactionDAO,
+      remoteTxDAO = remoteTxDAO)
+
+    verifierF.map(_.verifyRefundSig(sign.cetSigs.refundSig))
   }
 
   def verifyFundingSigs(
       inputs: Vector[DLCFundingInputDb],
       sign: DLCSign): Future[Boolean] = {
     if (inputs.count(_.isInitiator) == sign.fundingSigs.length) {
-      verifierFromDb(sign.contractId).map { verifier =>
+      val verifierF = dlcDataManagement.verifierFromDb(
+        contractId = sign.contractId,
+        transactionDAO = transactionDAO,
+        remoteTxDAO = remoteTxDAO)
+      verifierF.map { verifier =>
         verifier.verifyRemoteFundingSigs(sign.fundingSigs)
       }
     } else {
@@ -1054,13 +1080,17 @@ abstract class DLCWallet
             s"No DLC found with corresponding contractId ${contractId.toHex}"))
       }
       (_, contractData, dlcOffer, dlcAccept, fundingInputs, contractInfo) <-
-        getDLCFundingData(dlcDb.dlcId)
-      builder <- builderFromDbData(dlcDb,
-                                   contractData,
-                                   dlcOffer,
-                                   dlcAccept,
-                                   fundingInputs,
-                                   contractInfo)
+        dlcDataManagement.getDLCFundingData(dlcDb.dlcId)
+      builder <- dlcDataManagement.builderFromDbData(
+        dlcDb = dlcDb,
+        contractDataDb = contractData,
+        dlcOffer = dlcOffer,
+        dlcAccept = dlcAccept,
+        fundingInputsDb = fundingInputs,
+        contractInfo = contractInfo,
+        transactionDAO = transactionDAO,
+        remoteTxDAO = remoteTxDAO
+      )
 
       sign = DLCSign.fromTLV(signTLV, builder.offer)
       result <- addDLCSigs(sign)
@@ -1127,17 +1157,44 @@ abstract class DLCWallet
     }
   }
 
+  private def getScriptSigParams(
+      dlcDb: DLCDb,
+      fundingInputs: Vector[DLCFundingInputDb]): Future[
+    Vector[ScriptSignatureParams[InputInfo]]] = {
+    val outPoints =
+      fundingInputs.filter(_.isInitiator == dlcDb.isInitiator).map(_.outPoint)
+    val utxosF = listUtxos(outPoints)
+    for {
+      utxos <- utxosF
+      scriptSigParams <-
+        FutureUtil.foldLeftAsync(Vector.empty[ScriptSignatureParams[InputInfo]],
+                                 utxos) { (accum, utxo) =>
+          transactionDAO
+            .findByOutPoint(utxo.outPoint)
+            .map(txOpt =>
+              utxo.toUTXOInfo(keyManager, txOpt.get.transaction) +: accum)
+        }
+    } yield scriptSigParams
+  }
+
   override def getDLCFundingTx(contractId: ByteVector): Future[Transaction] = {
     for {
       (dlcDb, contractData, dlcOffer, dlcAccept, fundingInputs, contractInfo) <-
-        getDLCFundingData(contractId)
+        dlcDataManagement.getDLCFundingData(contractId)
 
-      signer <- signerFromDb(dlcDb,
-                             contractData,
-                             dlcOffer,
-                             dlcAccept,
-                             fundingInputs,
-                             contractInfo)
+      scriptSigParams <- getScriptSigParams(dlcDb, fundingInputs)
+      signer <- dlcDataManagement.signerFromDb(
+        dlcDb = dlcDb,
+        contractDataDb = contractData,
+        dlcOffer = dlcOffer,
+        dlcAccept = dlcAccept,
+        fundingInputsDb = fundingInputs,
+        fundingUtxoScriptSigParams = scriptSigParams,
+        contractInfo = contractInfo,
+        transactionDAO = transactionDAO,
+        remoteTxDAO = remoteTxDAO,
+        keyManager = keyManager
+      )
       fundingTx <-
         if (dlcDb.isInitiator) {
           transactionDAO.findByTxId(signer.builder.buildFundingTx.txIdBE).map {
@@ -1219,12 +1276,13 @@ abstract class DLCWallet
     for {
       dlcDb <- dlcDAO.findByContractId(contractId).map(_.get)
 
-      (announcements, announcementData, nonceDbs) <- getDLCAnnouncementDbs(
-        dlcDb.dlcId)
+      (announcements, announcementData, nonceDbs) <- dlcDataManagement
+        .getDLCAnnouncementDbs(dlcDb.dlcId)
 
-      announcementTLVs = getOracleAnnouncements(announcements,
-                                                announcementData,
-                                                nonceDbs)
+      announcementTLVs = dlcDataManagement.getOracleAnnouncements(
+        announcements,
+        announcementData,
+        nonceDbs)
 
       oracleSigs =
         sigs.foldLeft(Vector.empty[OracleSignatures]) { (acc, sig) =>
@@ -1272,9 +1330,16 @@ abstract class DLCWallet
       contractId: ByteVector,
       oracleSigs: Vector[OracleSignatures]): Future[Transaction] = {
     require(oracleSigs.nonEmpty, "Must provide at least one oracle signature")
-    val executorWithSetupOptF = executorAndSetupFromDb(contractId)
     for {
-      executorWithSetupOpt <- executorWithSetupOptF
+      (dlcDb, _, _, _, fundingInputs, _) <-
+        dlcDataManagement.getDLCFundingData(contractId)
+      scriptSigParams <- getScriptSigParams(dlcDb, fundingInputs)
+      executorWithSetupOpt <- dlcDataManagement.executorAndSetupFromDb(
+        contractId = contractId,
+        transactionDAO = transactionDAO,
+        remoteTxDAO = remoteTxDAO,
+        fundingUtxoScriptSigParams = scriptSigParams,
+        keyManager = keyManager)
       tx <- {
         executorWithSetupOpt match {
           case Some(executorWithSetup) =>
@@ -1359,7 +1424,13 @@ abstract class DLCWallet
             s"Refund transaction is not valid yet, current time: $currentTime, refund valid at time $time")
       }
 
-      executor <- executorFromDb(dlcDb.dlcId)
+      fundingInputs <- dlcInputsDAO.findByDLCId(dlcDb.dlcId)
+      scriptSigParams <- getScriptSigParams(dlcDb, fundingInputs)
+      executor <- dlcDataManagement.executorFromDb(dlcDb.dlcId,
+                                                   transactionDAO,
+                                                   remoteTxDAO,
+                                                   scriptSigParams,
+                                                   keyManager)
       refundSigsDbOpt <- dlcRefundSigDAO.findByDLCId(dlcDb.dlcId)
 
       refundSig =
@@ -1462,18 +1533,20 @@ abstract class DLCWallet
     val aggregatedF: Future[(
         Vector[DLCAnnouncementDb],
         Vector[OracleAnnouncementDataDb],
-        Vector[OracleNonceDb])] = getDLCAnnouncementDbs(dlcDb.dlcId)
+        Vector[OracleNonceDb])] =
+      dlcDataManagement.getDLCAnnouncementDbs(dlcDb.dlcId)
 
     val contractInfoAndAnnouncementsF: Future[
       (ContractInfo, Vector[(OracleAnnouncementV0TLV, Long)])] = {
       aggregatedF.map { case (announcements, announcementData, nonceDbs) =>
-        val contractInfo = getContractInfo(contractData,
-                                           announcements,
-                                           announcementData,
-                                           nonceDbs)
-        val announcementsWithId = getOracleAnnouncementsWithId(announcements,
-                                                               announcementData,
-                                                               nonceDbs)
+        val contractInfo = dlcDataManagement.getContractInfo(contractData,
+                                                             announcements,
+                                                             announcementData,
+                                                             nonceDbs)
+        val announcementsWithId =
+          dlcDataManagement.getOracleAnnouncementsWithId(announcements,
+                                                         announcementData,
+                                                         nonceDbs)
         (contractInfo, announcementsWithId)
       }
     }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
@@ -158,7 +158,7 @@ case class DLCDAO()(implicit
     def aggregateSignatureOpt: Rep[Option[SchnorrDigitalSignature]] = column(
       "aggregate_signature")
 
-    def * : ProvenShape[DLCDb] =
+    override def * : ProvenShape[DLCDb] =
       (dlcId,
        tempContractId,
        contractId,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCWalletDAOs.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCWalletDAOs.scala
@@ -1,0 +1,13 @@
+package org.bitcoins.dlc.wallet.models
+
+case class DLCWalletDAOs(
+    dlcDAO: DLCDAO,
+    contractDataDAO: DLCContractDataDAO,
+    dlcAnnouncementDAO: DLCAnnouncementDAO,
+    dlcInputsDAO: DLCFundingInputDAO,
+    dlcOfferDAO: DLCOfferDAO,
+    dlcAcceptDAO: DLCAcceptDAO,
+    dlcSigsDAO: DLCCETSignaturesDAO,
+    dlcRefundSigDAO: DLCRefundSigsDAO,
+    oracleNonceDAO: OracleNonceDAO,
+    oracleAnnouncementDAO: OracleAnnouncementDataDAO)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
@@ -2,42 +2,25 @@ package org.bitcoins.dlc.wallet.util
 
 import org.bitcoins.core.api.dlc.wallet.db.DLCDb
 import org.bitcoins.crypto.{SchnorrDigitalSignature, SchnorrNonce, Sha256Digest}
-import org.bitcoins.dlc.wallet.models.{
-  DLCAcceptDAO,
-  DLCAcceptDb,
-  DLCAnnouncementDAO,
-  DLCAnnouncementDb,
-  DLCCETSignaturesDAO,
-  DLCCETSignaturesDb,
-  DLCContractDataDAO,
-  DLCContractDataDb,
-  DLCDAO,
-  DLCFundingInputDAO,
-  DLCFundingInputDb,
-  DLCOfferDAO,
-  DLCOfferDb,
-  DLCRefundSigsDAO,
-  DLCRefundSigsDb,
-  OracleNonceDAO,
-  OracleNonceDb
-}
+import org.bitcoins.dlc.wallet.models._
 
 import scala.concurrent.ExecutionContext
 
 /** Utility class to help build actions to insert things into our DLC tables */
-case class DLCActionBuilder(
-    dlcDAO: DLCDAO,
-    contractDataDAO: DLCContractDataDAO,
-    dlcAnnouncementDAO: DLCAnnouncementDAO,
-    dlcInputsDAO: DLCFundingInputDAO,
-    dlcOfferDAO: DLCOfferDAO,
-    dlcAcceptDAO: DLCAcceptDAO,
-    dlcSigsDAO: DLCCETSignaturesDAO,
-    dlcRefundSigDAO: DLCRefundSigsDAO,
-    oracleNonceDAO: OracleNonceDAO) {
+case class DLCActionBuilder(dlcWalletDAOs: DLCWalletDAOs) {
+
+  private val dlcDAO = dlcWalletDAOs.dlcDAO
+  private val dlcAnnouncementDAO = dlcWalletDAOs.dlcAnnouncementDAO
+  private val dlcInputsDAO = dlcWalletDAOs.dlcInputsDAO
+  private val dlcOfferDAO = dlcWalletDAOs.dlcOfferDAO
+  private val contractDataDAO = dlcWalletDAOs.contractDataDAO
+  private val dlcAcceptDAO = dlcWalletDAOs.dlcAcceptDAO
+  private val dlcSigsDAO = dlcWalletDAOs.dlcSigsDAO
+  private val dlcRefundSigDAO = dlcWalletDAOs.dlcRefundSigDAO
+  private val oracleNonceDAO = dlcWalletDAOs.oracleNonceDAO
 
   //idk if it matters which profile api i import, but i need access to transactionally
-  import dlcDAO.profile.api._
+  import dlcWalletDAOs.dlcDAO.profile.api._
 
   /** Builds an offer in our database, adds relevant information to the global table,
     * contract data, announcements, funding inputs, and the actual offer itself

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCTxUtil.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCTxUtil.scala
@@ -1,0 +1,26 @@
+package org.bitcoins.dlc.wallet.util
+
+import org.bitcoins.core.api.wallet.db.TransactionDb
+import org.bitcoins.core.protocol.dlc.models.DLCFundingInput
+import org.bitcoins.dlc.wallet.models.DLCFundingInputDb
+
+object DLCTxUtil {
+
+  /** Takes in a list of inputs to fund DLCs, and pairs them with the full funding transaction for this input
+    * and then converts the input tx pair to a [[DLCFundingInput]]
+    * @throws NoSuchElementException when we have an input we cannot find the funding transaction for
+    */
+  def matchPrevTxsWithInputs(
+      inputs: Vector[DLCFundingInputDb],
+      prevTxs: Vector[TransactionDb]): Vector[DLCFundingInput] = {
+    inputs.sortBy(_.index).map { i =>
+      prevTxs.find(_.txId == i.outPoint.txId) match {
+        case Some(txDb) => i.toFundingInput(txDb.transaction)
+        case None =>
+          throw new NoSuchElementException(
+            s"Could not find previous transaction with txIdBE=${i.outPoint.txId.flip.hex}")
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR refactors `DLCDataManagement` to be a stand alone `case class` rather than a `trait`. This means that `DLCDataManagement` can be used other places if a full blown wallet is not needed to query data from the database. This seems like it will be useful for solving #3969 to query all necessary data from an already existing method in the code base.

This intended to be a move only PR, no functionality is intended to change.