### PR TITLE
Ignore .DS_Store files when making backups

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/DatadirUtil.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DatadirUtil.scala
@@ -22,15 +22,18 @@ object DatadirUtil {
       FileUtil.copyDirectory(
         source = source,
         target = temp,
-        fileNameFilter = Vector(".*.sqlite$".r,
-                                ".*.sqlite-shm$".r,
-                                ".*.sqlite-wal$".r,
-                                ".*bitcoin-s.log$".r,
-                                ".*/seeds/.*".r,
-                                ".*/tor/.*".r,
-                                ".*/binaries/.*".r,
-                                ".*.zip$".r,
-                                tempRE)
+        fileNameFilter = Vector(
+          ".*.sqlite$".r,
+          ".*.sqlite-shm$".r,
+          ".*.sqlite-wal$".r,
+          ".*bitcoin-s.log$".r,
+          ".*/seeds/.*".r,
+          ".*/tor/.*".r,
+          ".*/binaries/.*".r,
+          ".*.zip$".r,
+          ".*.DS_Store".r,
+          tempRE
+        )
       )
 
       SQLiteUtil.backupDirectory(source = source,


### PR DESCRIPTION
I don't think there is any reason we need these Mac specific files in the backup. Saves some log lines.