### PR TITLE
Implement batching of database calls for our chain callback

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -251,13 +251,16 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       (mockChainApi
         .getHeader(_: DoubleSha256DigestBE))
         .expects(blockHeader.hashBE)
-        .twice()
         .returning(Future.successful(Some(blockHeaderDb)))
 
+      (mockChainApi.getBestBlockHeader: () => Future[BlockHeaderDb])
+        .expects()
+        .returning(Future.successful(blockHeaderDb))
+
       (mockChainApi
-        .getNumberOfConfirmations(_: DoubleSha256DigestBE))
-        .expects(blockHeader.hashBE)
-        .returning(Future.successful(Some(1)))
+        .getHeaders(_: Vector[DoubleSha256DigestBE]))
+        .expects(Vector(blockHeader.hashBE))
+        .returning(Future.successful(Vector(Some(blockHeaderDb))))
 
       val route =
         chainRoutes.handleCommand(
@@ -266,7 +269,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       Get() ~> route ~> check {
         assert(contentType == `application/json`)
         assert(responseAs[
-          String] == s"""{"result":{"raw":"${blockHeader.hex}","hash":"${blockHeader.hashBE.hex}","confirmations":1,"height":1899697,"version":${blockHeader.version.toLong},"versionHex":"${blockHeader.version.hex}","merkleroot":"${blockHeader.merkleRootHashBE.hex}","time":${blockHeader.time.toLong},"mediantime":${blockHeaderDb.time.toLong},"nonce":${blockHeader.nonce.toLong},"bits":"${blockHeader.nBits.hex}","difficulty":${blockHeader.difficulty.toDouble},"chainwork":"$chainworkStr","previousblockhash":"${blockHeader.previousBlockHashBE.hex}","nextblockhash":null},"error":null}""")
+          String] == s"""{"result":{"raw":"${blockHeader.hex}","hash":"${blockHeader.hashBE.hex}","confirmations":0,"height":1899697,"version":${blockHeader.version.toLong},"versionHex":"${blockHeader.version.hex}","merkleroot":"${blockHeader.merkleRootHashBE.hex}","time":${blockHeader.time.toLong},"mediantime":${blockHeaderDb.time.toLong},"nonce":${blockHeader.nonce.toLong},"bits":"${blockHeader.nBits.hex}","difficulty":${blockHeader.difficulty.toDouble},"chainwork":"$chainworkStr","previousblockhash":"${blockHeader.previousBlockHashBE.hex}","nextblockhash":null},"error":null}""")
       }
     }
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -258,13 +258,15 @@ object BitcoindRpcBackendUtil extends Logging {
                 val executeCallbackF: Future[Wallet] = blockProcessedF.flatMap {
                   wallet =>
                     chainCallbacksOpt match {
-                      case None => Future.successful(wallet)
+                      case None           => Future.successful(wallet)
                       case Some(callback) =>
+                        //this can be slow as we aren't batching headers at all
+                        val headerWithHeights =
+                          Vector((blockHeaderResult.height, block.blockHeader))
                         val f = callback
                           .executeOnBlockHeaderConnectedCallbacks(
                             logger,
-                            blockHeaderResult.height,
-                            blockHeaderResult.blockHeader)
+                            headerWithHeights)
                         f.map(_ => wallet)
                     }
                 }

--- a/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
@@ -51,11 +51,12 @@ case class ChainRoutes(chain: ChainApi, network: BitcoinNetwork)(implicit
             chain.getHeader(hash).flatMap {
               case None => Future.successful(Server.httpSuccess(ujson.Null))
               case Some(_) =>
-                val resultF = ChainUtil.getBlockHeaderResult(hash, chain)
+                val resultsF =
+                  ChainUtil.getBlockHeaderResult(Vector(hash), chain)
                 for {
-                  result <- resultF
+                  results <- resultsF
                 } yield {
-                  val json = upickle.default.writeJs(result)(
+                  val json = upickle.default.writeJs(results.head)(
                     Picklers.getBlockHeaderResultPickler)
                   Server.httpSuccess(json)
                 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -157,6 +157,15 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
       hash: DoubleSha256DigestBE): Future[Option[BlockHeaderDb]] =
     getBlockHeader(hash).map(header => Some(header.blockHeaderDb))
 
+  override def getHeaders(hashes: Vector[DoubleSha256DigestBE]): Future[
+    Vector[Option[BlockHeaderDb]]] = {
+    //sends a request for every header, i'm not aware of a way to batch these
+    val resultsNested: Vector[Future[Option[BlockHeaderDb]]] =
+      hashes.map(getHeader)
+    Future
+      .sequence(resultsNested)
+  }
+
   override def getHeadersBetween(
       from: BlockHeaderDb,
       to: BlockHeaderDb): Future[Vector[BlockHeaderDb]] = {

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -672,10 +672,12 @@ class ChainHandlerTest extends ChainDbUnitTest {
     chainHandler: ChainHandler =>
       val resultP: Promise[Boolean] = Promise()
 
-      val callback: OnBlockHeaderConnected = (_: Int, _: BlockHeader) => {
-        Future {
-          resultP.success(true)
-          ()
+      val callback: OnBlockHeaderConnected = {
+        case _: Vector[(Int, BlockHeader)] => {
+          Future {
+            resultP.success(true)
+            ()
+          }
         }
       }
 

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -40,6 +40,9 @@ trait ChainApi extends ChainQueryApi {
   /** Gets a [[org.bitcoins.core.api.chain.db.BlockHeaderDb]] from the chain's database */
   def getHeader(hash: DoubleSha256DigestBE): Future[Option[BlockHeaderDb]]
 
+  def getHeaders(hashes: Vector[DoubleSha256DigestBE]): Future[
+    Vector[Option[BlockHeaderDb]]]
+
   /** Gets all [[org.bitcoins.core.api.chain.db.BlockHeaderDb]]s at a given height */
   def getHeadersAtHeight(height: Int): Future[Vector[BlockHeaderDb]]
 

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainQueryApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainQueryApi.scala
@@ -26,7 +26,7 @@ trait ChainQueryApi {
 
   /** Gets number of confirmations for the given block hash */
   def getNumberOfConfirmations(
-      blockHashOpt: DoubleSha256DigestBE): Future[Option[Int]]
+      blockHash: DoubleSha256DigestBE): Future[Option[Int]]
 
   /** Gets the number of compact filters in the database */
   def getFilterCount(): Future[Int]

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -80,6 +80,11 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
         hash: DoubleSha256DigestBE): Future[Option[BlockHeaderDb]] =
       Future.successful(None)
 
+    override def getHeaders(hashes: Vector[DoubleSha256DigestBE]): Future[
+      Vector[Option[BlockHeaderDb]]] = {
+      Future.successful(Vector.fill(hashes.length)(None))
+    }
+
     override def getHeadersAtHeight(
         height: Int): Future[Vector[BlockHeaderDb]] =
       Future.successful(Vector.empty)


### PR DESCRIPTION
fixes #3967 

When we merged #3946 I didn't realize that there was a performance impact for IBD. This happens because _for every block header we receive, we make a database call_. We receive block headers in batches of 2,000 headers, which means we have 2,000 database calls!

https://github.com/bitcoin-s/bitcoin-s/commit/d06b064b6bcd7e383dfe75b184454a71ad59c728#diff-dc390950db2105baa88147c5b8d335fa214be7415b77e2005b6a4f5d9e5dbfbcR34

This PR does a few things 

1. Reworks `ChainCallbacks.OnBlockHeaderConnected` to take a `Vector[(Int,BlockHeaderDb)]` rather than just a single `(Int,BlockHeaderDb)`.
2. Adds a few APIs like `ChainApi.getHeaders()` and `BlockHeaderDAO.findByHashes()`. This allows us to more efficiently query block headers from the database.

Here is what my visualvm `chaindb` thread looks like on da193037ed86303658b71bb13b9694053ca3fae8 . This was pinned at 100% usage before da193037ed86303658b71bb13b9694053ca3fae8

![Screenshot from 2022-01-22 13-53-20](https://user-images.githubusercontent.com/3514957/150653513-400cab1d-326d-47ee-809a-7c884a30e07d.png)
