### PR TITLE
2022 01 22 cetsignatures refactor

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -1010,7 +1010,8 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .fromString(dummyAddress),
       payoutSerialId = UInt64.zero,
       changeSerialId = UInt64.zero,
-      cetSigs = CETSignatures(dummyOutcomeSigs, dummyPartialSig),
+      cetSigs = CETSignatures(dummyOutcomeSigs),
+      refundSig = DLCWalletUtil.dummyPartialSig,
       negotiationFields = DLCAccept.NoNegotiationFields,
       tempContractId = Sha256Digest.empty
     )
@@ -1032,7 +1033,8 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     }
 
     val sign = DLCSign(
-      CETSignatures(dummyOutcomeSigs, dummyPartialSig),
+      CETSignatures(dummyOutcomeSigs),
+      dummyPartialSig,
       FundingSignatures(Vector((EmptyTransactionOutPoint, dummyScriptWitness))),
       paramHash.bytes
     )

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -1011,7 +1011,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       payoutSerialId = UInt64.zero,
       changeSerialId = UInt64.zero,
       cetSigs = CETSignatures(dummyOutcomeSigs),
-      refundSig = DLCWalletUtil.dummyPartialSig,
+      refundSig = DLCWalletUtil.minimalPartialSig,
       negotiationFields = DLCAccept.NoNegotiationFields,
       tempContractId = Sha256Digest.empty
     )

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
@@ -91,8 +91,8 @@ class DLCMessageTest extends BitcoinSJvmTest {
           Vector(
             EnumOracleOutcome(
               Vector(dummyOracle),
-              EnumOutcome(dummyStr)).sigPoint -> ECAdaptorSignature.dummy),
-          dummySig),
+              EnumOutcome(dummyStr)).sigPoint -> ECAdaptorSignature.dummy)),
+        dummySig,
         DLCAccept.NoNegotiationFields,
         Sha256Digest.empty
       )

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
@@ -20,10 +20,12 @@ case class DLCExecutor(signer: DLCTxSigner) {
   /** Constructs the initiator's SetupDLC given the non-initiator's
     * CETSignatures which should arrive in a DLC accept message
     */
-  def setupDLCOffer(cetSigs: CETSignatures): Try[SetupDLC] = {
+  def setupDLCOffer(
+      cetSigs: CETSignatures,
+      refundSig: PartialSignature): Try[SetupDLC] = {
     require(isInitiator, "You should call setupDLCAccept")
 
-    setupDLC(cetSigs, None, None)
+    setupDLC(cetSigs, refundSig, None, None)
   }
 
   /** Constructs the non-initiator's SetupDLC given the initiator's
@@ -32,11 +34,12 @@ case class DLCExecutor(signer: DLCTxSigner) {
     */
   def setupDLCAccept(
       cetSigs: CETSignatures,
+      refundSig: PartialSignature,
       fundingSigs: FundingSignatures,
       cetsOpt: Option[Vector[WitnessTransaction]]): Try[SetupDLC] = {
     require(!isInitiator, "You should call setupDLCOffer")
 
-    setupDLC(cetSigs, Some(fundingSigs), cetsOpt)
+    setupDLC(cetSigs, refundSig, Some(fundingSigs), cetsOpt)
   }
 
   /** Constructs a SetupDLC given the necessary signature information
@@ -44,6 +47,7 @@ case class DLCExecutor(signer: DLCTxSigner) {
     */
   def setupDLC(
       cetSigs: CETSignatures,
+      refundSig: PartialSignature,
       fundingSigsOpt: Option[FundingSignatures],
       cetsOpt: Option[Vector[WitnessTransaction]]): Try[SetupDLC] = {
     if (!isInitiator) {
@@ -51,7 +55,7 @@ case class DLCExecutor(signer: DLCTxSigner) {
               "Accepting party must provide remote funding signatures")
     }
 
-    val CETSignatures(outcomeSigs, refundSig) = cetSigs
+    val CETSignatures(outcomeSigs) = cetSigs
     val msgs = Indexed(outcomeSigs.map(_._1))
     val cets = cetsOpt match {
       case Some(cets) => cets

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
@@ -270,8 +270,7 @@ object DLCMessage {
         changeSPK = changeAddress.scriptPubKey,
         changeSerialId = changeSerialId,
         cetSignatures = CETSignaturesV0TLV(cetSigs.adaptorSigs),
-        refundSignature =
-          ECDigitalSignature.fromFrontOfBytes(refundSig.signature.bytes),
+        refundSignature = refundSig.signature,
         negotiationFields = negotiationFields.toTLV
       )
     }
@@ -375,9 +374,9 @@ object DLCMessage {
         changeSerialId = accept.changeSerialId,
         cetSigs = CETSignatures(outcomeSigs),
         refundSig = PartialSignature(
-          accept.fundingPubKey,
-          ECDigitalSignature(
-            accept.refundSignature.bytes :+ HashType.sigHashAll.byte)),
+          pubKey = accept.fundingPubKey,
+          signature = accept.refundSignature
+        ),
         negotiationFields = NegotiationFields.fromTLV(accept.negotiationFields),
         tempContractId = accept.tempContractId
       )

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
@@ -171,6 +171,35 @@ object DLCMessage {
     }
   }
 
+  /** DLC Accept message that contains refund signatures, but does not contain cet signatures */
+  case class DLCAcceptWithoutCetSigs(
+      totalCollateral: Satoshis,
+      pubKeys: DLCPublicKeys,
+      fundingInputs: Vector[DLCFundingInput],
+      changeAddress: BitcoinAddress,
+      payoutSerialId: UInt64,
+      changeSerialId: UInt64,
+      refundSig: PartialSignature,
+      negotiationFields: DLCAccept.NegotiationFields,
+      tempContractId: Sha256Digest) {
+
+    def withCetSigs(cetSigs: CETSignatures): DLCAccept = {
+      DLCAccept(
+        totalCollateral = totalCollateral,
+        pubKeys = pubKeys,
+        fundingInputs = fundingInputs,
+        changeAddress = changeAddress,
+        payoutSerialId = payoutSerialId,
+        changeSerialId = changeSerialId,
+        cetSigs = cetSigs,
+        refundSig = refundSig,
+        negotiationFields = negotiationFields,
+        tempContractId = tempContractId
+      )
+    }
+  }
+
+  /** DLC accept message that does not contain cet signatures or refund signatures */
   case class DLCAcceptWithoutSigs(
       totalCollateral: Satoshis,
       pubKeys: DLCPublicKeys,
@@ -180,6 +209,20 @@ object DLCMessage {
       changeSerialId: UInt64,
       negotiationFields: DLCAccept.NegotiationFields,
       tempContractId: Sha256Digest) {
+
+    def withRefundSigs(refundSig: PartialSignature): DLCAcceptWithoutCetSigs = {
+      DLCAcceptWithoutCetSigs(
+        totalCollateral = totalCollateral,
+        pubKeys = pubKeys,
+        fundingInputs = fundingInputs,
+        changeAddress = changeAddress,
+        payoutSerialId = payoutSerialId,
+        changeSerialId = changeSerialId,
+        refundSig = refundSig,
+        negotiationFields = negotiationFields,
+        tempContractId = tempContractId
+      )
+    }
 
     def withSigs(
         cetSigs: CETSignatures,
@@ -245,6 +288,20 @@ object DLCMessage {
         changeAddress = changeAddress,
         payoutSerialId = payoutSerialId,
         changeSerialId = changeSerialId,
+        negotiationFields = negotiationFields,
+        tempContractId = tempContractId
+      )
+    }
+
+    def withoutCetSigs: DLCAcceptWithoutCetSigs = {
+      DLCAcceptWithoutCetSigs(
+        totalCollateral = totalCollateral,
+        pubKeys = pubKeys,
+        fundingInputs = fundingInputs,
+        changeAddress = changeAddress,
+        payoutSerialId = payoutSerialId,
+        changeSerialId = changeSerialId,
+        refundSig = refundSig,
         negotiationFields = negotiationFields,
         tempContractId = tempContractId
       )

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
@@ -270,7 +270,8 @@ object DLCMessage {
         changeSPK = changeAddress.scriptPubKey,
         changeSerialId = changeSerialId,
         cetSignatures = CETSignaturesV0TLV(cetSigs.adaptorSigs),
-        refundSignature = refundSig.signature,
+        refundSignature =
+          ECDigitalSignature.fromFrontOfBytes(refundSig.signature.bytes),
         negotiationFields = negotiationFields.toTLV
       )
     }
@@ -360,6 +361,11 @@ object DLCMessage {
           adaptorPoints.zip(sigs)
       }
 
+      //add hashtype
+      val refundSigWithHashType = {
+        ECDigitalSignature.fromBytes(
+          accept.refundSignature.bytes.:+(HashType.sigHashAllByte))
+      }
       DLCAccept(
         totalCollateral = accept.totalCollateralSatoshis,
         pubKeys = DLCPublicKeys(
@@ -375,7 +381,7 @@ object DLCMessage {
         cetSigs = CETSignatures(outcomeSigs),
         refundSig = PartialSignature(
           pubKey = accept.fundingPubKey,
-          signature = accept.refundSignature
+          signature = refundSigWithHashType
         ),
         negotiationFields = NegotiationFields.fromTLV(accept.negotiationFields),
         tempContractId = accept.tempContractId

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCSignatures.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCSignatures.scala
@@ -3,7 +3,6 @@ package org.bitcoins.core.protocol.dlc.models
 import org.bitcoins.core.protocol.script.ScriptWitnessV0
 import org.bitcoins.core.protocol.tlv.FundingSignaturesV0TLV
 import org.bitcoins.core.protocol.transaction.TransactionOutPoint
-import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.util.{Indexed, SeqWrapper}
 import org.bitcoins.crypto.{ECAdaptorSignature, ECPublicKey}
 
@@ -36,9 +35,7 @@ case class FundingSignatures(
   }
 }
 
-case class CETSignatures(
-    outcomeSigs: Vector[(ECPublicKey, ECAdaptorSignature)],
-    refundSig: PartialSignature)
+case class CETSignatures(outcomeSigs: Vector[(ECPublicKey, ECAdaptorSignature)])
     extends DLCSignatures {
 
   require(outcomeSigs.nonEmpty,

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
@@ -202,9 +202,8 @@ case class DLCTxSigner(
   def createCETSigs(): CETSignatures = {
     val adaptorPoints = builder.contractInfo.adaptorPointsIndexed
     val cetSigs = signCETs(adaptorPoints)
-    val refundSig = signRefundTx
 
-    CETSignatures(cetSigs, refundSig)
+    CETSignatures(cetSigs)
   }
 
   /** Creates CET signatures async */
@@ -232,8 +231,7 @@ case class DLCTxSigner(
 
     for {
       cetSigs <- cetSigsF
-      refundSig = signRefundTx
-    } yield CETSignatures(cetSigs, refundSig)
+    } yield CETSignatures(cetSigs)
   }
 
   /** Creates all of this party's CETSignatures */
@@ -241,9 +239,8 @@ case class DLCTxSigner(
     val adaptorPoints = builder.contractInfo.adaptorPointsIndexed
     val cetsAndSigs = buildAndSignCETs(adaptorPoints)
     val (msgs, cets, sigs) = cetsAndSigs.unzip3
-    val refundSig = signRefundTx
 
-    (CETSignatures(msgs.zip(sigs), refundSig), cets)
+    (CETSignatures(msgs.zip(sigs)), cets)
   }
 
   /** The equivalent of [[createCETsAndCETSigs()]] but async */
@@ -264,22 +261,19 @@ case class DLCTxSigner(
         f = fn)
     }
 
-    val refundSig = signRefundTx
-
     for {
       cetsAndSigsNested <- cetsAndSigsF
       cetsAndSigs = cetsAndSigsNested.flatten
       (msgs, cets, sigs) = cetsAndSigs.unzip3
-    } yield (CETSignatures(msgs.zip(sigs), refundSig), cets)
+    } yield (CETSignatures(msgs.zip(sigs)), cets)
   }
 
   /** Creates this party's CETSignatures given the outcomes and their unsigned CETs */
   def createCETSigs(
       outcomesAndCETs: Vector[AdaptorPointCETPair]): CETSignatures = {
     val cetSigs = signGivenCETs(outcomesAndCETs)
-    val refundSig = signRefundTx
 
-    CETSignatures(cetSigs, refundSig)
+    CETSignatures(cetSigs)
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -17,6 +17,7 @@ import org.bitcoins.core.protocol.tlv.TLV.{
 }
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.protocol.{BigSizeUInt, BlockTimeStamp}
+import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.util.sorted.{OrderedAnnouncements, OrderedNonces}
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto._
@@ -1892,6 +1893,10 @@ case class DLCAcceptTLV(
       refundSignature.toRawRS ++
       negotiationFields.bytes
   }
+
+  val refundPartialSignature: PartialSignature = {
+    PartialSignature(fundingPubKey, refundSignature)
+  }
 }
 
 object DLCAcceptTLV extends TLVFactory[DLCAcceptTLV] {
@@ -1944,6 +1949,10 @@ case class DLCSignTLV(
       cetSignatures.bytes ++
       refundSignature.toRawRS ++
       fundingSignatures.bytes
+  }
+
+  def getPartialSignature(fundingPubKey: ECPublicKey): PartialSignature = {
+    PartialSignature(fundingPubKey, refundSignature)
   }
 }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
@@ -130,7 +130,10 @@ object ECDigitalSignature extends Factory[ECDigitalSignature] {
     }
   }
 
-  /** Reads a (DER encoded) ECDigitalSignature from the front of a ByteVector */
+  /** Reads a (DER encoded) ECDigitalSignature from the front of a ByteVector
+    * This method is also useful if you want to parse a ecdsa digital signature
+    * but remove the [[HashType]] that the bitcoin protocol appends to the end of a signature
+    */
   def fromFrontOfBytes(bytes: ByteVector): ECDigitalSignature = {
     val sigWithExtra = fromBytes(bytes)
     val sig = fromRS(sigWithExtra.r, sigWithExtra.s)
@@ -200,6 +203,6 @@ object ECDigitalSignature extends Factory[ECDigitalSignature] {
   /** Minimally encoded zero signature
     * This will NOT be 64 bytes in length, it will be much less
     * due to the DER encoding
-    * */
+    */
   val minimalEncodedZeroSig: ECDigitalSignature = fromRS(0, 0)
 }

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
@@ -196,4 +196,10 @@ object ECDigitalSignature extends Factory[ECDigitalSignature] {
     val bytes = CryptoBytesUtil.decodeHex(hex)
     fromRS(bytes)
   }
+
+  /** Minimally encoded zero signature
+    * This will NOT be 64 bytes in length, it will be much less
+    * due to the DER encoding
+    * */
+  val minimalEncodedZeroSig: ECDigitalSignature = fromRS(0, 0)
 }

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCTxGen.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCTxGen.scala
@@ -256,7 +256,9 @@ object DLCTxGen {
 
       signedFundingTx <- acceptSigner.completeFundingTx(offerFundingSigs)
     } yield {
-      val signedRefundTx = offerSigner.completeRefundTx(acceptCETSigs.refundSig)
+      val offererRefundSig = offerSigner.signRefundTx
+      val acceptRefundSig = acceptSigner.signRefundTx
+      val signedRefundTx = offerSigner.completeRefundTx(acceptRefundSig)
 
       val offerSignedCET = offerSigner.completeCET(
         outcome,
@@ -272,10 +274,11 @@ object DLCTxGen {
           EnumOracleSignature(inputs.params.oracleInfo,
                               inputs.params.oracleSignature)))
 
-      val accept = acceptWithoutSigs.withSigs(acceptCETSigs)
+      val accept = acceptWithoutSigs.withSigs(acceptCETSigs, acceptRefundSig)
 
       val contractId = fundingTx.txIdBE.bytes.xor(accept.tempContractId.bytes)
-      val sign = DLCSign(offerCETSigs, offerFundingSigs, contractId)
+      val sign =
+        DLCSign(offerCETSigs, offererRefundSig, offerFundingSigs, contractId)
 
       SuccessTestVector(
         inputs,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -445,9 +445,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         walletA,
         walletB,
         (sign: DLCSign) =>
-          sign.copy(
-            cetSigs = CETSignatures(DLCWalletUtil.dummyOutcomeSigs,
-                                    sign.cetSigs.refundSig)))
+          sign.copy(cetSigs = CETSignatures(DLCWalletUtil.dummyOutcomeSigs)))
   }
 
   it must "fail to add an invalid dlc refund sig" in {
@@ -458,10 +456,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       testDLCSignVerification[IllegalArgumentException](
         walletA,
         walletB,
-        (sign: DLCSign) =>
-          sign.copy(
-            cetSigs = CETSignatures(sign.cetSigs.outcomeSigs,
-                                    DLCWalletUtil.dummyPartialSig)))
+        (sign: DLCSign) => sign.copy(refundSig = DLCWalletUtil.dummyPartialSig))
   }
 
   it must "fail to sign dlc with cet sigs that are invalid" in {
@@ -473,9 +468,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         walletA,
         walletB,
         (accept: DLCAccept) =>
-          accept.copy(
-            cetSigs = CETSignatures(DLCWalletUtil.dummyOutcomeSigs,
-                                    accept.cetSigs.refundSig)))
+          accept.copy(cetSigs = CETSignatures(DLCWalletUtil.dummyOutcomeSigs)))
   }
 
   it must "fail to sign dlc with an invalid refund sig" in {
@@ -487,9 +480,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         walletA,
         walletB,
         (accept: DLCAccept) =>
-          accept.copy(
-            cetSigs = CETSignatures(accept.cetSigs.outcomeSigs,
-                                    DLCWalletUtil.dummyPartialSig)))
+          accept.copy(refundSig = DLCWalletUtil.dummyPartialSig))
   }
 
   it must "cancel an offered DLC" in {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
@@ -667,11 +667,11 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
       //sometimes we do not have cet signatures, for instance
       //if we have settled a DLC, we prune the cet signatures
       //from the database
-      val cetSigs = CETSignatures(outcomeSigs, refundSig)
+      val cetSigs = CETSignatures(outcomeSigs)
 
       val setupF = if (dlcDb.isInitiator) {
         // Note that the funding tx in this setup is not signed
-        executor.setupDLCOffer(cetSigs)
+        executor.setupDLCOffer(cetSigs, refundSig)
       } else {
         val fundingSigs =
           fundingInputs
@@ -688,7 +688,10 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
                 case None => throw new RuntimeException("")
               }
             }
-        executor.setupDLCAccept(cetSigs, FundingSignatures(fundingSigs), None)
+        executor.setupDLCAccept(cetSigs,
+                                refundSig,
+                                FundingSignatures(fundingSigs),
+                                None)
       }
 
       Future.fromTry(setupF.map(DLCExecutorWithSetup(executor, _)))

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -136,7 +136,7 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
           val fundingInputs = fundingInputDbs.map(input =>
             input.toFundingInput(txs(input.outPoint.txIdBE).head))
 
-          val offerRefundSigOpt = refundSigsDb.map(_.initiatorSig)
+          val offerRefundSigOpt = refundSigsDb.flatMap(_.initiatorSig)
           val acceptRefundSigOpt = refundSigsDb.map(_.accepterSig)
 
           val contractInfo =
@@ -157,8 +157,7 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
           val sign: DLCSign = {
             val cetSigs: CETSignatures =
               CETSignatures(
-                sigDbs.map(dbSig => (dbSig.sigPoint, dbSig.initiatorSig.get)),
-                offerRefundSigOpt.head.get)
+                sigDbs.map(dbSig => (dbSig.sigPoint, dbSig.initiatorSig.get)))
 
             val contractId = dlcDb.contractIdOpt.get
             val fundingSigs =
@@ -179,7 +178,10 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
                   }
                 }
 
-            DLCSign(cetSigs, FundingSignatures(fundingSigs), contractId)
+            DLCSign(cetSigs,
+                    offerRefundSigOpt.get,
+                    FundingSignatures(fundingSigs),
+                    contractId)
           }
 
           DLCStatus.calculateOutcomeAndSig(isInit, offer, accept, sign, cet).get

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDb.scala
@@ -30,7 +30,7 @@ case class DLCAcceptDb(
       refundSig: PartialSignature): DLCAccept = {
     val pubKeys =
       DLCPublicKeys(fundingKey, payoutAddress)
-    val cetSigs = CETSignatures(outcomeSigs, refundSig)
+    val cetSigs = CETSignatures(outcomeSigs)
     DLCAccept(
       totalCollateral = collateral.satoshis,
       pubKeys = pubKeys,
@@ -39,6 +39,7 @@ case class DLCAcceptDb(
       payoutSerialId = payoutSerialId,
       changeSerialId = changeSerialId,
       cetSigs = cetSigs,
+      refundSig = refundSig,
       negotiationFields = negotiationFields,
       tempContractId = tempContractId
     )

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/BytesUtil.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/BytesUtil.scala
@@ -60,11 +60,13 @@ object BytesUtil {
     FundingSignatures(fundingSigs.tail.toVector.+:(firstOutPoint -> badWitness))
   }
 
-  def flipBit(cetSigs: CETSignatures): CETSignatures = {
+  def flipBit(
+      cetSigs: CETSignatures,
+      refundSig: PartialSignature): (CETSignatures, PartialSignature) = {
     val badOutcomeSigs = cetSigs.outcomeSigs.map { case (outcome, sig) =>
       outcome -> flipBit(sig)
     }
-    val badRefundSig = flipBit(cetSigs.refundSig)
-    CETSignatures(badOutcomeSigs, badRefundSig)
+    val badRefundSig = flipBit(refundSig)
+    (CETSignatures(badOutcomeSigs), badRefundSig)
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BytesUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BytesUtil.scala
@@ -60,11 +60,13 @@ object BytesUtil {
     FundingSignatures(fundingSigs.tail.toVector.+:(firstOutPoint -> badWitness))
   }
 
-  def flipBit(cetSigs: CETSignatures): CETSignatures = {
+  def flipBit(
+      cetSigs: CETSignatures,
+      refundSig: PartialSignature): (CETSignatures, PartialSignature) = {
     val badOutcomeSigs = cetSigs.outcomeSigs.map { case (outcome, sig) =>
       outcome -> flipBit(sig)
     }
-    val badRefundSig = flipBit(cetSigs.refundSig)
-    CETSignatures(badOutcomeSigs, badRefundSig)
+    val badRefundSig = flipBit(refundSig)
+    (CETSignatures(badOutcomeSigs), badRefundSig)
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -174,7 +174,7 @@ object DLCWalletUtil extends Logging {
     )
 
   lazy val dummyCETSigs: CETSignatures =
-    CETSignatures(dummyOutcomeSigs, dummyPartialSig)
+    CETSignatures(dummyOutcomeSigs)
 
   lazy val sampleAcceptPayoutSerialId: UInt64 =
     DLCMessage.genSerialId(Vector(sampleOfferPayoutSerialId))
@@ -190,6 +190,7 @@ object DLCWalletUtil extends Logging {
     payoutSerialId = sampleAcceptPayoutSerialId,
     changeSerialId = sampleAcceptChangeSerialId,
     cetSigs = dummyCETSigs,
+    dummyPartialSig,
     negotiationFields = DLCAccept.NoNegotiationFields,
     tempContractId = sampleDLCOffer.tempContractId
   )
@@ -199,7 +200,10 @@ object DLCWalletUtil extends Logging {
       (TransactionOutPoint(dummyBlockHash, UInt32.zero), dummyScriptWitness)))
 
   lazy val sampleDLCSign: DLCSign =
-    DLCSign(dummyCETSigs, dummyFundingSignatures, ByteVector.empty)
+    DLCSign(dummyCETSigs,
+            dummyPartialSig,
+            dummyFundingSignatures,
+            ByteVector.empty)
 
   lazy val sampleDLCDb: DLCDb = DLCDb(
     dlcId = Sha256Digest(

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -110,6 +110,10 @@ object DLCWalletUtil extends Logging {
   lazy val dummyPartialSig: PartialSignature =
     PartialSignature(dummyKey, DummyECDigitalSignature)
 
+  lazy val minimalPartialSig: PartialSignature = {
+    PartialSignature(dummyKey, ECDigitalSignature.minimalEncodedZeroSig)
+  }
+
   lazy val dummyScriptWitness: P2WPKHWitnessV0 = {
     P2WPKHWitnessV0(dummyPartialSig.pubKey, dummyPartialSig.signature)
   }


### PR DESCRIPTION
This PR decouples `CETSignatures` and refund signatures. If you look at the DLC spec they are independent of each other: 

https://github.com/discreetlogcontracts/dlcspecs/blob/master/Protocol.md#the-accept_dlc-message

The reason this is important is because we prune CET signatures in some cases, but we don't prune refund signatures. This leads to awkward handling of this case here: 

https://github.com/bitcoin-s/bitcoin-s/pull/3992/files#diff-6494e9b0259f420e1079197e9ab08ea7e01f9e72226dc1e34ab934afd1994642R342

https://github.com/bitcoin-s/bitcoin-s/pull/3992/files#diff-e5bf7025e11537c8e4821de1c779cfa4405ff18139ad6f08d09b086606465b9eR348