### PR TITLE
Automatically download binaries if they are used in test suite

### DIFF
--- a/.github/workflows/Linux_2.12_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.12_App_Chain_Core_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.12.15 downloadBitcoind coverage chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls cryptoJVM/test cryptoTestJVM/test cryptoJVM/coverageReport cryptoJVM/coverageAggregate cryptoJVM/coveralls coreTestJVM/test dlcTest/test coreJVM/coverageReport coreJVM/coverageAggregate coreJVM/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test oracleServerTest/test
+        run: sbt ++2.12.15 coverage chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls cryptoJVM/test cryptoTestJVM/test cryptoJVM/coverageReport cryptoJVM/coverageAggregate cryptoJVM/coveralls coreTestJVM/test dlcTest/test coreJVM/coverageReport coreJVM/coverageAggregate coreJVM/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test oracleServerTest/test

--- a/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.12_KeyManager_Wallet_DLC_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.12.15 downloadBitcoind keyManagerTest/test feeProviderTest/test walletTest/test dlcWalletTest/test dlcOracleTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test oracleExplorerClient/test
+        run: sbt ++2.12.15 keyManagerTest/test feeProviderTest/test walletTest/test dlcWalletTest/test dlcOracleTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test oracleExplorerClient/test

--- a/.github/workflows/Linux_2.12_Node_Tests.yml
+++ b/.github/workflows/Linux_2.12_Node_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.12.15 downloadBitcoind coverage nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcNodeTest/test
+        run: sbt ++2.12.15 coverage nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcNodeTest/test

--- a/.github/workflows/Linux_2.12_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.12_RPC_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.12.15 downloadBitcoind downloadEclair downloadLnd downloadCLightning coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls lndRpcTest/test clightningRpcTest/test
+        run: sbt ++2.12.15 downloadEclair downloadLnd downloadCLightning coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls lndRpcTest/test clightningRpcTest/test

--- a/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.8 downloadBitcoind coverage chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls cryptoTestJVM/test cryptoJVM/test cryptoJVM/coverageReport cryptoJVM/coverageAggregate cryptoJVM/coveralls coreTestJVM/test dlcTest/test coreJVM/coverageReport coreJVM/coverageAggregate coreJVM/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test oracleServerTest/test
+        run: sbt ++2.13.8 coverage chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls cryptoTestJVM/test cryptoJVM/test cryptoJVM/coverageReport cryptoJVM/coverageAggregate cryptoJVM/coveralls coreTestJVM/test dlcTest/test coreJVM/coverageReport coreJVM/coverageAggregate coreJVM/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test oracleServerTest/test

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.8 downloadBitcoind coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test dlcWalletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test oracleExplorerClient/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls
+        run: sbt ++2.13.8 coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test dlcWalletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test oracleExplorerClient/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls

--- a/.github/workflows/Linux_2.13_Node_Tests.yml
+++ b/.github/workflows/Linux_2.13_Node_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.8 downloadBitcoind coverage nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcNodeTest/test
+        run: sbt ++2.13.8 coverage nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcNodeTest/test

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.8 downloadBitcoind downloadEclair downloadLnd downloadCLightning coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls lndRpcTest/test clightningRpcTest/test
+        run: sbt ++2.13.8 coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls lndRpcTest/test clightningRpcTest/test

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.8 downloadBitcoind downloadEclair downloadLnd coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls lndRpcTest/test
+        run: sbt ++2.13.8 coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls lndRpcTest/test

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -28,4 +28,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.8 downloadBitcoind coverage cryptoTestJVM/test coreTestJVM/test secp256k1jni/test dlcTest/test appCommonsTest/test walletTest/test dlcWalletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcOracleTest/test asyncUtilsTestJVM/test dlcOracle/coverageReport dlcOracle/coveralls dlcNodeTest/test appServerTest/test
+        run: sbt ++2.13.8 coverage cryptoTestJVM/test coreTestJVM/test secp256k1jni/test dlcTest/test appCommonsTest/test walletTest/test dlcWalletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcOracleTest/test asyncUtilsTestJVM/test dlcOracle/coverageReport dlcOracle/coveralls dlcNodeTest/test appServerTest/test

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -30,4 +30,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.7 downloadBitcoind dbCommonsTest/test walletTest/test dlcWalletTest/test chainTest/test nodeTest/test dlcOracle/test
+        run: sbt ++2.13.8 dbCommonsTest/test walletTest/test dlcWalletTest/test chainTest/test nodeTest/test dlcOracle/test

--- a/.github/workflows/TorTests.yml
+++ b/.github/workflows/TorTests.yml
@@ -30,4 +30,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.7 downloadBitcoind torTest/test nodeTest/test dlcNodeTest/test
+        run: sbt ++2.13.8 torTest/test nodeTest/test dlcNodeTest/test

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -31,5 +31,5 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: Windows Crypto, Core, and Database tests
-        run: sbt ++2.13.7 downloadBitcoind cryptoTestJVM/test coreTestJVM/test secp256k1jni/test dlcTest/test appCommonsTest/test dbCommonsTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test appServerTest/test
+        run: sbt ++2.13.8 cryptoTestJVM/test coreTestJVM/test secp256k1jni/test dlcTest/test appCommonsTest/test dbCommonsTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test appServerTest/test
         shell: bash

--- a/chain-test/chain-test.sbt
+++ b/chain-test/chain-test.sbt
@@ -1,7 +1,3 @@
-name := "bitcoin-s-server-test"
-
-publish / skip := true
-
 Test / test := (Test / test dependsOn {
   Projects.bitcoindRpc / TaskKeys.downloadBitcoind
 }).value

--- a/clightning-rpc-test/clightning-rpc-test.sbt
+++ b/clightning-rpc-test/clightning-rpc-test.sbt
@@ -1,3 +1,7 @@
 Test / test := (Test / test dependsOn {
   Projects.clightningRpc / TaskKeys.downloadCLightning
 }).value
+
+Test / test := (Test / test dependsOn {
+  Projects.bitcoindRpc / TaskKeys.downloadBitcoind
+}).value

--- a/dlc-node-test/dlc-node-test.sbt
+++ b/dlc-node-test/dlc-node-test.sbt
@@ -1,7 +1,3 @@
-name := "bitcoin-s-server-test"
-
-publish / skip := true
-
 Test / test := (Test / test dependsOn {
   Projects.bitcoindRpc / TaskKeys.downloadBitcoind
 }).value

--- a/dlc-wallet-test/dlc-wallet-test.sbt
+++ b/dlc-wallet-test/dlc-wallet-test.sbt
@@ -1,7 +1,3 @@
-name := "bitcoin-s-server-test"
-
-publish / skip := true
-
 Test / test := (Test / test dependsOn {
   Projects.bitcoindRpc / TaskKeys.downloadBitcoind
 }).value

--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -75,13 +75,7 @@ git clone --depth 500 --recursive https://github.com/bitcoin-s/bitcoin-s.git
 To run the entire test suite, you need to download all bitcoind instances and eclair instances. This is needed for unit tests
 or binding bitcoin-s to a bitcoind instance if you do not have locally running instances.
 
-```bashrc
-sbt downloadBitcoind
-sbt downloadEclair
-```
-
-If you want to run the entire test suite you can run the following command after you download bitcoind
-and eclair.
+If you want to run the entire test suite you can run the following command.
 
 ```bashrc
 sbt test
@@ -123,9 +117,8 @@ Testnet:
 `bitcoin-s.node.peers = ["neutrino.testnet3.suredbits.com:18333"]`
 
 If you would like to use your own node you can either use the bitcoind backend option or connect to your own compatible node.
-There is no released version of bitcoind that is neutrino compatible, so you will either have to compile the latest `master` yourself, or use the experimental version provided by running `sbt downloadBitcoind`. 
 
-After building your bitcoin-s server, properly configuring it to be in `neutrino` mode you can start your server with:
+After building your bitcoin-s server and properly configuring it to be in `neutrino` mode you can start your server with:
 
 ```bashrc
 ./app/server/target/universal/stage/bin/bitcoin-s-server

--- a/docs/testkit/testkit.md
+++ b/docs/testkit/testkit.md
@@ -26,8 +26,6 @@ import scala.concurrent.duration._
 
 This gives the ability to create and destroy `bitcoind` on the underlying operating system to test against.
 
-Make sure you have run `sbt downloadBitcoind` before running this example, as you need access to the bitcoind binaries.
-
 Our [BitcoindRpcClient](/api/org/bitcoins/rpc/client/common/BitcoindRpcClient) is tested with the functionality provided in the testkit.
 A quick example of a useful utility method is [BitcoindRpcTestUtil.startedBitcoindRpcClient()](/api/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil).
 This spins up a bitcoind regtest instance on machine and generates 101 blocks on that node.

--- a/lnd-rpc-test/lnd-rpc-test.sbt
+++ b/lnd-rpc-test/lnd-rpc-test.sbt
@@ -1,7 +1,7 @@
-name := "bitcoin-s-server-test"
-
-publish / skip := true
-
 Test / test := (Test / test dependsOn {
   Projects.bitcoindRpc / TaskKeys.downloadBitcoind
+}).value
+
+Test / test := (Test / test dependsOn {
+  Projects.lndRpc / TaskKeys.downloadLnd
 }).value

--- a/node-test/node-test.sbt
+++ b/node-test/node-test.sbt
@@ -1,7 +1,3 @@
-name := "bitcoin-s-server-test"
-
-publish / skip := true
-
 Test / test := (Test / test dependsOn {
   Projects.bitcoindRpc / TaskKeys.downloadBitcoind
 }).value

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -5,6 +5,7 @@ object Projects {
   val core = project in file("..") / "core"
   val eclairRpc = project in file("..") / "eclair-rpc"
   val bitcoindRpc = project in file("..") / "bitcoind-rpc"
+  val lndRpc = project in file("..") / "lnd-rpc"
   val clightningRpc = project in file("..") / "clightning-rpc"
   val secp256k1jni = project in file("..") / "secp256k1jni "
 }

--- a/wallet-test/wallet-test.sbt
+++ b/wallet-test/wallet-test.sbt
@@ -1,7 +1,3 @@
-name := "bitcoin-s-server-test"
-
-publish / skip := true
-
 Test / test := (Test / test dependsOn {
   Projects.bitcoindRpc / TaskKeys.downloadBitcoind
 }).value


### PR DESCRIPTION
fixes #3799 

Adds necessary `sbt` scripts to download various binaries if they are used in that projects test suite. This gives a much better developer experience. They no longer need to manually run `downloadBitcoind` or `downloadLnd`, they can just have the build system do it for them.

