### PR TITLE
2022 01 24 rm appconfig varargs

### DIFF
--- a/app-commons-test/src/test/scala/org/bitcoins/commons/config/AppConfigTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/config/AppConfigTest.scala
@@ -77,7 +77,7 @@ class AppConfigTest extends BitcoinSAsyncTest {
 
   it must "fill in typesafe config variables correctly" in {
     val datadir = BitcoinSTestAppConfig.tmpDir()
-    val walletAppConfig = WalletAppConfig(datadir)
+    val walletAppConfig = WalletAppConfig(datadir, Vector.empty)
     for {
       _ <- walletAppConfig.start()
     } yield {
@@ -98,7 +98,7 @@ class AppConfigTest extends BitcoinSAsyncTest {
     ConfigFactory.invalidateCaches()
 
     val walletAppConfig =
-      WalletAppConfig(datadir)
+      WalletAppConfig(datadir, Vector.empty)
     val assertF = for {
       _ <- walletAppConfig.start()
     } yield {

--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -45,7 +45,11 @@ abstract class AppConfig extends StartStopAsync[Unit] with Logging {
   /** List of user-provided configs that should
     * override defaults
     */
-  protected[bitcoins] def configOverrides: List[Config]
+  protected[bitcoins] def configOverrides: Vector[Config]
+
+  def withOverrides(configOverrides: Config): ConfigType = {
+    withOverrides(Vector(configOverrides))
+  }
 
   /** This method returns a new `AppConfig`, where every
     * key under `bitcoin-s` overrides the configuration
@@ -56,13 +60,8 @@ abstract class AppConfig extends StartStopAsync[Unit] with Logging {
     * `bitcoin-s.network`), the latter config overrides the
     * first.
     */
-  def withOverrides(config: Config, configs: Config*): ConfigType = {
-    // the two val assignments below are workarounds
-    // for awkward name resolution in the block below
-    val firstOverride = config
-
-    val numOverrides = configs.length + 1
-
+  def withOverrides(configOverrides: Vector[Config]): ConfigType = {
+    val numOverrides = configOverrides.length
     if (logger.logger.isDebugEnabled()) {
       // force lazy evaluation before we print
       // our lines
@@ -73,7 +72,6 @@ abstract class AppConfig extends StartStopAsync[Unit] with Logging {
       logger.debug(oldConfStr)
     }
 
-    val configOverrides = firstOverride +: configs
     if (logger.logger.isTraceEnabled()) {
       configOverrides.zipWithIndex.foreach { case (c, idx) =>
         logger.trace(s"Override no. $idx: ${c.asReadableJson}")
@@ -177,7 +175,7 @@ object AppConfig extends Logging {
 
   def getBaseConfig(
       baseDatadir: Path,
-      configOverrides: List[Config] = List.empty): Config = {
+      configOverrides: Vector[Config]): Config = {
     val configOptions =
       ConfigParseOptions
         .defaults()

--- a/app-commons/src/main/scala/org/bitcoins/commons/util/DatadirParser.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/DatadirParser.scala
@@ -35,7 +35,7 @@ case class DatadirParser(
     serverArgs.configOpt match {
       case None =>
         AppConfig
-          .getBaseConfig(datadirPath, List(networkConfig))
+          .getBaseConfig(datadirPath, Vector(networkConfig))
           .withFallback(datadirConfig)
           .resolve()
       case Some(config) =>

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
@@ -83,7 +83,7 @@ object OracleServerMain extends BitcoinSAppScalaDaemon {
   System.setProperty("bitcoins.log.location", datadirParser.networkDir.toString)
 
   implicit lazy val conf: DLCOracleAppConfig =
-    DLCOracleAppConfig(datadirParser.datadir, datadirParser.baseConfig)(
+    DLCOracleAppConfig(datadirParser.datadir, Vector(datadirParser.baseConfig))(
       system.dispatcher)
 
   new OracleServerMain(serverCmdLineArgs).run()

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
@@ -20,7 +20,7 @@ class ZipDatadir(override val serverArgParser: ServerArgParser)(implicit
 
     //replace the line below with where you want to zip too
     val path = Paths.get("/tmp", "bitcoin-s.zip")
-    val target = DatadirUtil.zipDatadir(conf.datadir, path)
+    val target = DatadirUtil.zipDatadir(conf.baseDatadir, path)
     logger.info(s"Done zipping to $target!")
     for {
       _ <- system.terminate()
@@ -45,7 +45,8 @@ object Zip extends BitcoinSAppScalaDaemon {
   System.setProperty("bitcoins.log.location", datadirParser.networkDir.toString)
 
   implicit lazy val conf: BitcoinSAppConfig =
-    BitcoinSAppConfig(datadirParser.datadir, datadirParser.baseConfig)(system)
+    BitcoinSAppConfig(datadirParser.datadir, Vector(datadirParser.baseConfig))(
+      system)
 
   new ZipDatadir(serverCmdLineArgs).run()
 }

--- a/app/server-test/src/test/scala/org/bitcoins/server/BitcoindRpcAppConfigTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/BitcoindRpcAppConfigTest.scala
@@ -13,7 +13,7 @@ class BitcoindRpcAppConfigTest extends BitcoinSAsyncTest {
   val tempDir: Path = Files.createTempDirectory("bitcoin-s")
 
   val config: BitcoindRpcAppConfig =
-    BitcoindRpcAppConfig(directory = tempDir)
+    BitcoindRpcAppConfig(baseDatadir = tempDir, Vector.empty)
 
   override def afterAll(): Unit = {
     super.afterAll()
@@ -39,7 +39,7 @@ class BitcoindRpcAppConfigTest extends BitcoinSAsyncTest {
     val overrider =
       ConfigFactory.parseString(s"bitcoin-s.bitcoind-rpc.rpcport = 5555")
 
-    val throughConstructor = BitcoindRpcAppConfig(tempDir, overrider)
+    val throughConstructor = BitcoindRpcAppConfig(tempDir, Vector(overrider))
     val throughWithOverrides = config.withOverrides(overrider)
     assert(throughWithOverrides.rpcPort == 5555)
     assert(throughWithOverrides.rpcPort == throughConstructor.rpcPort)
@@ -69,7 +69,8 @@ class BitcoindRpcAppConfigTest extends BitcoinSAsyncTest {
   it must "be overridable with multiple levels" in {
     val testnet = ConfigFactory.parseString("bitcoin-s.network = testnet3")
     val mainnet = ConfigFactory.parseString("bitcoin-s.network = mainnet")
-    val overriden: BitcoindRpcAppConfig = config.withOverrides(testnet, mainnet)
+    val overriden: BitcoindRpcAppConfig =
+      config.withOverrides(Vector(testnet, mainnet))
     assert(overriden.network == MainNet)
   }
 
@@ -89,7 +90,7 @@ class BitcoindRpcAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig = BitcoindRpcAppConfig(directory = tempDir)
+    val appConfig = BitcoindRpcAppConfig(baseDatadir = tempDir, Vector.empty)
 
     assert(appConfig.datadir == tempDir.resolve("testnet3"))
     assert(appConfig.network == TestNet3)

--- a/app/server-test/src/test/scala/org/bitcoins/server/CommonRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CommonRoutesSpec.scala
@@ -19,7 +19,7 @@ class CommonRoutesSpec
 
   implicit val conf: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getSpvTestConfig()
-  val commonRoutes = CommonRoutes(conf.datadir)
+  val commonRoutes = CommonRoutes(conf.baseDatadir)
 
   "CommonRoutes" should {
     "getversion" in {

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -82,7 +82,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
   val coreRoutes: CoreRoutes = CoreRoutes()
 
-  val commonRoutes: CommonRoutes = CommonRoutes(conf.datadir)
+  val commonRoutes: CommonRoutes = CommonRoutes(conf.baseDatadir)
   "The server" should {
 
     "combine PSBTs" in {

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -386,7 +386,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val chainRoutes = ChainRoutes(chainApi, nodeConf.network)
     val coreRoutes = CoreRoutes()
     val dlcRoutes = DLCRoutes(dlcNode)
-    val commonRoutes = CommonRoutes(conf.datadir)
+    val commonRoutes = CommonRoutes(conf.baseDatadir)
 
     val handlers =
       Seq(walletRoutes,
@@ -584,9 +584,9 @@ object BitcoinSServerMain extends BitcoinSAppScalaDaemon {
   System.setProperty("bitcoins.log.location", datadirParser.networkDir.toString)
 
   implicit lazy val conf: BitcoinSAppConfig =
-    BitcoinSAppConfig(datadirParser.datadir,
-                      datadirParser.baseConfig,
-                      serverCmdLineArgs.toConfig)(system)
+    BitcoinSAppConfig(
+      datadirParser.datadir,
+      Vector(datadirParser.baseConfig, serverCmdLineArgs.toConfig))(system)
 
   new BitcoinSServerMain(serverCmdLineArgs).run()
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -266,7 +266,7 @@ object BitcoindInstanceRemote
     require(file.exists, s"${file.getPath} does not exist!")
     require(file.isFile, s"${file.getPath} is not a file!")
 
-    val conf = BitcoindRpcAppConfig(file.toPath)
+    val conf = BitcoindRpcAppConfig(file.toPath, Vector.empty)
     fromConfig(conf)
   }
 
@@ -293,7 +293,7 @@ object BitcoindInstanceRemote
       system: ActorSystem): BitcoindInstanceRemote = {
     require(dir.exists, s"${dir.getPath} does not exist!")
     require(dir.isDirectory, s"${dir.getPath} is not a directory!")
-    val conf = BitcoindRpcAppConfig(dir.toPath)
+    val conf = BitcoindRpcAppConfig(dir.toPath, Vector.empty)
     fromConfig(conf)
   }
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/config/ChainAppConfigTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/config/ChainAppConfigTest.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Await
 
 class ChainAppConfigTest extends ChainUnitTest {
   val tempDir = Files.createTempDirectory("bitcoin-s")
-  val config = ChainAppConfig(directory = tempDir)
+  val config = ChainAppConfig(baseDatadir = tempDir, Vector.empty)
 
   //if we don't turn off logging here, isInitF a few lines down will
   //produce some nasty error logs since we are testing initialization
@@ -51,7 +51,8 @@ class ChainAppConfigTest extends ChainUnitTest {
   it must "be overridable with multiple levels" in { _ =>
     val testnet = ConfigFactory.parseString("bitcoin-s.network = testnet3")
     val mainnet = ConfigFactory.parseString("bitcoin-s.network = mainnet")
-    val overriden: ChainAppConfig = config.withOverrides(testnet, mainnet)
+    val overriden: ChainAppConfig =
+      config.withOverrides(Vector(testnet, mainnet))
     assert(overriden.network == MainNet)
 
   }
@@ -72,7 +73,7 @@ class ChainAppConfigTest extends ChainUnitTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig = ChainAppConfig(directory = tempDir)
+    val appConfig = ChainAppConfig(baseDatadir = tempDir, Vector.empty)
 
     assert(appConfig.datadir == tempDir.resolve("testnet3"))
     assert(appConfig.network == TestNet3)

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -17,14 +17,11 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param directory The data directory of the module
   * @param confs Optional sequence of configuration overrides
   */
-case class ChainAppConfig(
-    private val directory: Path,
-    private val confs: Config*)(implicit override val ec: ExecutionContext)
+case class ChainAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
+    implicit override val ec: ExecutionContext)
     extends DbAppConfig
     with ChainDbManagement
     with JdbcProfileComponent[ChainAppConfig] {
-
-  override protected[bitcoins] def configOverrides: List[Config] = confs.toList
 
   override protected[bitcoins] def moduleName: String =
     ChainAppConfig.moduleName
@@ -32,8 +29,7 @@ case class ChainAppConfig(
 
   override protected[bitcoins] def newConfigOfType(
       configs: Seq[Config]): ChainAppConfig =
-    ChainAppConfig(directory, configs: _*)
-  protected[bitcoins] def baseDatadir: Path = directory
+    ChainAppConfig(baseDatadir, configs.toVector)
 
   override lazy val appConfig: ChainAppConfig = this
 
@@ -136,5 +132,5 @@ object ChainAppConfig extends AppConfigFactory[ChainAppConfig] {
     */
   override def fromDatadir(datadir: Path, confs: Vector[Config])(implicit
       ec: ExecutionContext): ChainAppConfig =
-    ChainAppConfig(datadir, confs: _*)
+    ChainAppConfig(datadir, confs)
 }

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DBConfigTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DBConfigTest.scala
@@ -23,9 +23,9 @@ class DBConfigTest extends BitcoinSAsyncTest {
                   StandardOpenOption.CREATE_NEW,
                   StandardOpenOption.WRITE)
 
-      val chainConfig = ChainAppConfig(dataDir)
-      val nodeConfig = NodeAppConfig(dataDir)
-      val walletConfig = WalletAppConfig(dataDir)
+      val chainConfig = ChainAppConfig(dataDir, Vector.empty)
+      val nodeConfig = NodeAppConfig(dataDir, Vector.empty)
+      val walletConfig = WalletAppConfig(dataDir, Vector.empty)
 
       val slickChainConfig = chainConfig.slickDbConfig
       assert(slickChainConfig.profileName == "slick.jdbc.SQLiteProfile")
@@ -49,7 +49,7 @@ class DBConfigTest extends BitcoinSAsyncTest {
 
   it should "use sqlite as default database and disable connection pool for tests" in {
     withTempDir { dataDir =>
-      val chainConfig = ChainAppConfig(dataDir)
+      val chainConfig = ChainAppConfig(dataDir, Vector.empty)
       val slickChainConfig = chainConfig.slickDbConfig
       assert(slickChainConfig.profileName == "slick.jdbc.SQLiteProfile")
       assert(slickChainConfig.config.hasPath("db.numThreads"))
@@ -58,7 +58,7 @@ class DBConfigTest extends BitcoinSAsyncTest {
         slickChainConfig.config.getString("db.connectionPool") == "disabled")
       assert(slickChainConfig.config.getInt("db.queueSize") == 5000)
 
-      val nodeConfig = NodeAppConfig(dataDir)
+      val nodeConfig = NodeAppConfig(dataDir, Vector.empty)
       val slickNodeConfig = nodeConfig.slickDbConfig
       assert(slickNodeConfig.profileName == "slick.jdbc.SQLiteProfile")
       assert(slickNodeConfig.config.hasPath("db.numThreads"))
@@ -67,7 +67,7 @@ class DBConfigTest extends BitcoinSAsyncTest {
         slickNodeConfig.config.getString("db.connectionPool") == "disabled")
       assert(slickNodeConfig.config.getInt("db.queueSize") == 5000)
 
-      val walletConfig = WalletAppConfig(dataDir)
+      val walletConfig = WalletAppConfig(dataDir, Vector.empty)
       val slickWalletConfig = walletConfig.slickDbConfig
       assert(slickWalletConfig.profileName == "slick.jdbc.SQLiteProfile")
       assert(slickWalletConfig.config.hasPath("db.numThreads"))

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -54,7 +54,7 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
 
   it must "run migrations for chain db" in {
     val chainAppConfig = ChainAppConfig(BitcoinSTestAppConfig.tmpDir(),
-                                        dbConfig(ProjectType.Chain))
+                                        Vector(dbConfig(ProjectType.Chain)))
     val chainDbManagement = createChainDbManagement(chainAppConfig)
     val result = chainDbManagement.migrate()
     chainAppConfig.driver match {
@@ -77,7 +77,8 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
 
   it must "run migrations for dlc db" in {
     val dlcAppConfig =
-      DLCAppConfig(BitcoinSTestAppConfig.tmpDir(), dbConfig(ProjectType.DLC))
+      DLCAppConfig(BitcoinSTestAppConfig.tmpDir(),
+                   Vector(dbConfig(ProjectType.DLC)))
     val dlcDbManagement = createDLCDbManagement(dlcAppConfig)
     val result = dlcDbManagement.migrate()
     dlcAppConfig.driver match {
@@ -100,7 +101,7 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
 
   it must "run migrations for wallet db" in {
     val walletAppConfig = WalletAppConfig(BitcoinSTestAppConfig.tmpDir(),
-                                          dbConfig(ProjectType.Wallet))
+                                          Vector(dbConfig(ProjectType.Wallet)))
     val walletDbManagement = createWalletDbManagement(walletAppConfig)
     val result = walletDbManagement.migrate()
     walletAppConfig.driver match {
@@ -124,7 +125,8 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
 
   it must "run migrations for node db" in {
     val nodeAppConfig =
-      NodeAppConfig(BitcoinSTestAppConfig.tmpDir(), dbConfig(ProjectType.Node))
+      NodeAppConfig(BitcoinSTestAppConfig.tmpDir(),
+                    Vector(dbConfig(ProjectType.Node)))
     val nodeDbManagement = createNodeDbManagement(nodeAppConfig)
     val result = nodeDbManagement.migrate()
     nodeAppConfig.driver match {
@@ -149,7 +151,7 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
   it must "run migrations for oracle db" in {
     val oracleAppConfig =
       DLCOracleAppConfig(BitcoinSTestAppConfig.tmpDir(),
-                         dbConfig(ProjectType.Oracle))
+                         Vector(dbConfig(ProjectType.Oracle)))
     val result = oracleAppConfig.migrate()
     oracleAppConfig.driver match {
       case SQLite =>

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
@@ -18,11 +18,9 @@ import scala.concurrent._
   * @param directory The data directory of the wallet
   * @param conf      Optional sequence of configuration overrides
   */
-case class DLCNodeAppConfig(
-    private val directory: Path,
-    private val conf: Config*)(implicit ec: ExecutionContext)
+case class DLCNodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
+    implicit ec: ExecutionContext)
     extends AppConfig {
-  override protected[bitcoins] def configOverrides: List[Config] = conf.toList
 
   override protected[bitcoins] def moduleName: String =
     DLCNodeAppConfig.moduleName
@@ -31,9 +29,7 @@ case class DLCNodeAppConfig(
 
   override protected[bitcoins] def newConfigOfType(
       configs: Seq[Config]): DLCNodeAppConfig =
-    DLCNodeAppConfig(directory, configs: _*)
-
-  protected[bitcoins] def baseDatadir: Path = directory
+    DLCNodeAppConfig(baseDatadir, configs.toVector)
 
   override def start(): Future[Unit] = {
     FutureUtil.unit
@@ -42,7 +38,7 @@ case class DLCNodeAppConfig(
   override def stop(): Future[Unit] = Future.unit
 
   lazy val torConf: TorAppConfig =
-    TorAppConfig(directory, Some(moduleName), conf: _*)
+    TorAppConfig(baseDatadir, Some(moduleName), configOverrides)
 
   lazy val socks5ProxyParams: Option[Socks5ProxyParams] =
     torConf.socks5ProxyParams
@@ -76,5 +72,5 @@ object DLCNodeAppConfig extends AppConfigFactory[DLCNodeAppConfig] {
 
   override def fromDatadir(datadir: Path, confs: Vector[Config])(implicit
       ec: ExecutionContext): DLCNodeAppConfig =
-    DLCNodeAppConfig(datadir, confs: _*)
+    DLCNodeAppConfig(datadir, confs)
 }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
@@ -29,7 +29,8 @@ class MultiWalletDLCTest extends BitcoinSWalletTest {
 
     val dir = BitcoinSTestAppConfig.tmpDir()
 
-    val configB = BitcoinSAppConfig(dir, walletNameConfB.withFallback(dbConf))
+    val configB =
+      BitcoinSAppConfig(dir, Vector(walletNameConfB.withFallback(dbConf)))
 
     val walletA = fundedWallet.wallet
 

--- a/docs/chain/chain.md
+++ b/docs/chain/chain.md
@@ -59,7 +59,7 @@ val config = ConfigFactory.parseString {
     |""".stripMargin
 }
 
-implicit val chainConfig = ChainAppConfig(datadir, config)
+implicit val chainConfig = ChainAppConfig(datadir, Vector(config))
 
 // Initialize the needed database tables if they don't exist:
 val chainProjectInitF = chainConfig.start()

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -31,11 +31,11 @@ val defaultConfig = WalletAppConfig.fromDefaultDatadir()
 
 // reads a custom data directory
 val customDirectory = Paths.get(Properties.userHome, "custom-bitcoin-s-directory")
-val configFromCustomDatadir = WalletAppConfig(customDirectory)
+val configFromCustomDatadir = WalletAppConfig(customDirectory, Vector.empty)
 
 // reads a custom data directory and overrides the network to be testnet3
 val customOverride = ConfigFactory.parseString("bitcoin-s.network = testnet3")
-val configFromCustomDirAndOverride = WalletAppConfig(customDirectory, customOverride)
+val configFromCustomDirAndOverride = WalletAppConfig(customDirectory, Vector(customOverride))
 ```
 
 You can pass as many `com.typesafe.config.Config`s as you'd like. If any keys appear multiple times the last one

--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -94,7 +94,7 @@ val config = ConfigFactory.parseString {
     |""".stripMargin
 }
 
-implicit val appConfig = BitcoinSAppConfig(datadir, config)
+implicit val appConfig = BitcoinSAppConfig(datadir, Vector(config))
 implicit val chainConfig = appConfig.chainConf
 implicit val nodeConfig = appConfig.nodeConf
 

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -101,10 +101,10 @@ val config = ConfigFactory.parseString {
 val datadir = Files.createTempDirectory("bitcoin-s-wallet")
 
 
-implicit val walletConfig = WalletAppConfig(datadir, config)
+implicit val walletConfig = WalletAppConfig(datadir, Vector(config))
 
 // we also need to store chain state for syncing purposes
-implicit val chainConfig = ChainAppConfig(datadir, config)
+implicit val chainConfig = ChainAppConfig(datadir, Vector(config))
 
 // when this future completes, we have
 // created the necessary directories and

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
@@ -38,7 +38,7 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
                                                  |}
                                                  |""".stripMargin)
 
-    val throughConstructor = KeyManagerAppConfig(tempDir, overrider)
+    val throughConstructor = KeyManagerAppConfig(tempDir, Vector(overrider))
     val throughWithOverrides = config.withOverrides(overrider)
     assert(throughWithOverrides.network == MainNet)
     assert(throughWithOverrides.network == throughConstructor.network)
@@ -68,7 +68,8 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
   it must "be overridable with multiple levels" in {
     val testnet = ConfigFactory.parseString("bitcoin-s.network = testnet3")
     val mainnet = ConfigFactory.parseString("bitcoin-s.network = mainnet")
-    val overridden: KeyManagerAppConfig = config.withOverrides(testnet, mainnet)
+    val overridden: KeyManagerAppConfig =
+      config.withOverrides(Vector(testnet, mainnet))
     assert(overridden.network == MainNet)
   }
 
@@ -87,7 +88,7 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig = KeyManagerAppConfig(directory = tempDir)
+    val appConfig = KeyManagerAppConfig(baseDatadir = tempDir, Vector.empty)
 
     assert(appConfig.datadir == tempDir.resolve("testnet3"))
     assert(appConfig.network == TestNet3)
@@ -122,8 +123,8 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig1 = KeyManagerAppConfig(directory = tmpDir2)
-    val appConfig2 = KeyManagerAppConfig(directory = tmpDir2)
+    val appConfig1 = KeyManagerAppConfig(baseDatadir = tmpDir2, Vector.empty)
+    val appConfig2 = KeyManagerAppConfig(baseDatadir = tmpDir2, Vector.empty)
     val started1F = appConfig1.start()
     val started2F = appConfig2.start()
     for {
@@ -153,7 +154,7 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig1 = KeyManagerAppConfig(directory = tmpDir2)
+    val appConfig1 = KeyManagerAppConfig(baseDatadir = tmpDir2, Vector.empty)
     appConfig1
       .start()
       .map(_ => succeed)
@@ -171,7 +172,7 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig1 = KeyManagerAppConfig(directory = tmpDir2)
+    val appConfig1 = KeyManagerAppConfig(baseDatadir = tmpDir2, Vector.empty)
 
     assertThrows[RuntimeException] {
       appConfig1.start()
@@ -189,7 +190,7 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig1 = KeyManagerAppConfig(directory = tmpDir2)
+    val appConfig1 = KeyManagerAppConfig(baseDatadir = tmpDir2, Vector.empty)
 
     assertThrows[RuntimeException] {
       appConfig1.start()
@@ -207,7 +208,7 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig1 = KeyManagerAppConfig(directory = tmpDir2)
+    val appConfig1 = KeyManagerAppConfig(baseDatadir = tmpDir2, Vector.empty)
 
     assertThrows[RuntimeException] {
       appConfig1.toBip39KeyManager

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
@@ -16,21 +16,17 @@ import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 
 case class KeyManagerAppConfig(
-    private val directory: Path,
-    private val confs: Config*)(implicit val ec: ExecutionContext)
+    baseDatadir: Path,
+    configOverrides: Vector[Config])(implicit val ec: ExecutionContext)
     extends AppConfig {
-
-  override def configOverrides: List[Config] = confs.toList
 
   override type ConfigType = KeyManagerAppConfig
 
   override def newConfigOfType(
       configOverrides: Seq[Config]): KeyManagerAppConfig =
-    KeyManagerAppConfig(directory, configOverrides: _*)
+    KeyManagerAppConfig(baseDatadir, configOverrides.toVector)
 
   override def moduleName: String = KeyManagerAppConfig.moduleName
-
-  override def baseDatadir: Path = directory
 
   lazy val networkParameters: NetworkParameters = chain.network
 
@@ -212,5 +208,5 @@ object KeyManagerAppConfig extends AppConfigFactory[KeyManagerAppConfig] {
 
   override def fromDatadir(datadir: Path, confs: Vector[Config])(implicit
       ec: ExecutionContext): KeyManagerAppConfig =
-    KeyManagerAppConfig(datadir, confs: _*)
+    KeyManagerAppConfig(datadir, confs)
 }

--- a/node-test/src/test/scala/org/bitcoins/node/NodeAppConfigTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NodeAppConfigTest.scala
@@ -14,7 +14,7 @@ class NodeAppConfigTest extends BitcoinSAsyncTest {
   val tempDir = Files.createTempDirectory("bitcoin-s")
 
   val config: NodeAppConfig =
-    NodeAppConfig(directory = tempDir)
+    NodeAppConfig(baseDatadir = tempDir, Vector.empty)
 
   it must "be overridable" in {
     assert(config.network == RegTest)
@@ -37,7 +37,8 @@ class NodeAppConfigTest extends BitcoinSAsyncTest {
   it must "be overridable with multiple levels" in {
     val testnet = ConfigFactory.parseString("bitcoin-s.network = testnet3")
     val mainnet = ConfigFactory.parseString("bitcoin-s.network = mainnet")
-    val overriden: NodeAppConfig = config.withOverrides(testnet, mainnet)
+    val overriden: NodeAppConfig =
+      config.withOverrides(Vector(testnet, mainnet))
     assert(overriden.network == MainNet)
 
   }
@@ -59,7 +60,7 @@ class NodeAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig = NodeAppConfig(directory = tempDir)
+    val appConfig = NodeAppConfig(baseDatadir = tempDir, Vector.empty)
 
     assert(appConfig.datadir == tempDir.resolve("testnet3"))
     assert(appConfig.network == TestNet3)

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -53,7 +53,7 @@ object BitcoinSTestAppConfig {
          |}
       """.stripMargin
     }
-    BitcoinSAppConfig(tmpDir(), (overrideConf +: config): _*)
+    BitcoinSAppConfig(tmpDir(), (overrideConf +: config).toVector)
   }
 
   def getSpvWithEmbeddedDbTestConfig(
@@ -77,8 +77,7 @@ object BitcoinSTestAppConfig {
 
     BitcoinSAppConfig(
       tmpDir(),
-      (overrideConf +: configWithEmbeddedDb(project = None,
-                                            pgUrl) +: config): _*)
+      (overrideConf +: configWithEmbeddedDb(project = None, pgUrl) +: config))
   }
 
   def getNeutrinoTestConfig(config: Config*)(implicit
@@ -97,7 +96,7 @@ object BitcoinSTestAppConfig {
          |}
       """.stripMargin
     }
-    BitcoinSAppConfig(tmpDir(), (overrideConf +: config): _*)
+    BitcoinSAppConfig(tmpDir(), (overrideConf +: config).toVector)
   }
 
   def getNeutrinoWithEmbeddedDbTestConfig(
@@ -122,7 +121,7 @@ object BitcoinSTestAppConfig {
     BitcoinSAppConfig(
       tmpDir(),
       (overrideConf +: configWithEmbeddedDb(project = None,
-                                            pgUrl) +: config): _*)
+                                            pgUrl) +: config).toVector)
   }
 
   def getDLCOracleAppConfig(config: Config*)(implicit
@@ -138,7 +137,7 @@ object BitcoinSTestAppConfig {
         ConfigFactory.empty()
     }
 
-    DLCOracleAppConfig(tmpDir(), overrideConf +: config: _*)
+    DLCOracleAppConfig(tmpDir(), (overrideConf +: config).toVector)
   }
 
   def getDLCOracleWithEmbeddedDbTestConfig(
@@ -157,7 +156,8 @@ object BitcoinSTestAppConfig {
 
     DLCOracleAppConfig(
       tmpDir(),
-      overrideConf +: configWithEmbeddedDb(project = None, pgUrl) +: config: _*)
+      (overrideConf +: configWithEmbeddedDb(project = None,
+                                            pgUrl) +: config).toVector)
   }
 
   sealed trait ProjectType

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
@@ -41,13 +41,11 @@ trait TestDbManagement extends DbManagement {
 
 }
 
-case class TestAppConfig(
-    private val directory: Path,
-    private val conf: Config*)(implicit override val ec: ExecutionContext)
+case class TestAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
+    implicit override val ec: ExecutionContext)
     extends DbAppConfig
     with TestDbManagement
     with JdbcProfileComponent[TestAppConfig] {
-  override protected[bitcoins] def configOverrides: List[Config] = conf.toList
 
   override protected[bitcoins] def moduleName: String = "test"
 
@@ -55,9 +53,7 @@ case class TestAppConfig(
 
   override protected[bitcoins] def newConfigOfType(
       configs: Seq[Config]): TestAppConfig =
-    TestAppConfig(directory, configs: _*)
-
-  protected[bitcoins] def baseDatadir: Path = directory
+    TestAppConfig(baseDatadir, configOverrides)
 
   override def appConfig: TestAppConfig = this
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/TestAppConfigFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/TestAppConfigFixture.scala
@@ -25,10 +25,11 @@ trait TestAppConfigFixture
   }
 
   def getFreshTestConfig(): Future[TestAppConfig] = {
-    val config = TestAppConfig(
-      BitcoinSTestAppConfig.tmpDir(),
-      BitcoinSTestAppConfig.configWithEmbeddedDb(Some(ProjectType.Test),
-                                                 pgUrl = pgUrl))
+    val configOverride = BitcoinSTestAppConfig.configWithEmbeddedDb(
+      Some(ProjectType.Test),
+      pgUrl = pgUrl)
+    val config =
+      TestAppConfig(BitcoinSTestAppConfig.tmpDir(), Vector(configOverride))
 
     val _ = config.migrate()
     config.start().map { _ =>

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/TestDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/TestDAOFixture.scala
@@ -18,9 +18,11 @@ sealed trait TestDAOFixture
 
   final override type FixtureParam = TestDAO
 
-  implicit private val testConfig: TestAppConfig = TestAppConfig(
-    BitcoinSTestAppConfig.tmpDir(),
-    BitcoinSTestAppConfig.configWithEmbeddedDb(Some(ProjectType.Test), pgUrl))
+  implicit private val testConfig: TestAppConfig = {
+    val configOverrides =
+      BitcoinSTestAppConfig.configWithEmbeddedDb(Some(ProjectType.Test), pgUrl)
+    TestAppConfig(BitcoinSTestAppConfig.tmpDir(), Vector(configOverrides))
+  }
 
   override def beforeAll(): Unit = {
     AppConfig.throwIfDefaultDatadir(testConfig)

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainUtil.scala
@@ -51,7 +51,7 @@ object BitcoinSServerMainUtil {
       system: ActorSystem): BitcoinSAppConfig = {
     val conf = BitcoinSServerMainUtil.buildBitcoindConfig(bitcoind.instance)
     val datadir = FileUtil.tmpDir()
-    BitcoinSAppConfig(datadir.toPath, conf)
+    BitcoinSAppConfig(datadir.toPath, Vector(conf))
   }
 
   def destroyBitcoinSAppConfig(appConfig: BitcoinSAppConfig)(implicit

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -346,7 +346,7 @@ object BitcoinSWalletTest extends WalletLogger {
 
         BitcoinSAppConfig(
           baseConf.baseDatadir,
-          (walletNameOverride +: baseConf.configOverrides): _*).walletConf
+          (walletNameOverride +: baseConf.configOverrides)).walletConf
       case None => baseConf
     }
 
@@ -404,14 +404,14 @@ object BitcoinSWalletTest extends WalletLogger {
 
     val walletConfig = extraConfig match {
       case None    => config
-      case Some(c) => config.withOverrides(c)
+      case Some(c) => config.withOverrides(Vector(c))
     }
 
     val walletConfigWithBip39Pw = bip39PasswordOpt match {
       case Some(pw) =>
         val str = s"""bitcoin-s.keymanager.bip39password="$pw""""
         val bip39Config = ConfigFactory.parseString(str)
-        walletConfig.withOverrides(bip39Config)
+        walletConfig.withOverrides(Vector(bip39Config))
       case None => walletConfig
     }
 

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -20,19 +20,16 @@ import scala.concurrent.{Await, ExecutionContext, Future}
   * @param confs Optional sequence of configuration overrides
   */
 case class TorAppConfig(
-    private val directory: Path,
+    baseDatadir: Path,
     private val subModuleNameOpt: Option[String],
-    private val confs: Config*)(implicit ec: ExecutionContext)
+    configOverrides: Vector[Config])(implicit ec: ExecutionContext)
     extends AppConfig {
-  override protected[bitcoins] def configOverrides: List[Config] = confs.toList
   override protected[bitcoins] def moduleName: String = TorAppConfig.moduleName
   override protected[bitcoins] type ConfigType = TorAppConfig
 
   override protected[bitcoins] def newConfigOfType(
       configs: Seq[Config]): TorAppConfig =
-    TorAppConfig(directory, subModuleNameOpt, configs: _*)
-
-  protected[bitcoins] def baseDatadir: Path = directory
+    TorAppConfig(baseDatadir, subModuleNameOpt, configs.toVector)
 
   private val isStarted: AtomicBoolean = new AtomicBoolean(false)
 
@@ -231,7 +228,7 @@ object TorAppConfig extends AppConfigFactory[TorAppConfig] {
     */
   override def fromDatadir(datadir: Path, confs: Vector[Config])(implicit
       ec: ExecutionContext): TorAppConfig =
-    TorAppConfig(datadir, None, confs: _*)
+    TorAppConfig(datadir, None, confs)
 
   lazy val randomSocks5Port: Int = ports.proxyPort
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/MultiWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/MultiWalletTest.scala
@@ -24,8 +24,10 @@ class MultiWalletTest extends BitcoinSAsyncTest with EmbeddedPg {
 
     val dir = BitcoinSTestAppConfig.tmpDir()
 
-    val configA = BitcoinSAppConfig(dir, walletNameConfA.withFallback(dbConf))
-    val configB = BitcoinSAppConfig(dir, walletNameConfB.withFallback(dbConf))
+    val configA =
+      BitcoinSAppConfig(dir, Vector(walletNameConfA.withFallback(dbConf)))
+    val configB =
+      BitcoinSAppConfig(dir, Vector(walletNameConfB.withFallback(dbConf)))
 
     val walletAF = BitcoinSWalletTest.createDefaultWallet(
       MockNodeApi,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
@@ -15,7 +15,7 @@ class WalletAppConfigTest extends BitcoinSAsyncTest {
   val tempDir = Files.createTempDirectory("bitcoin-s")
 
   val config: WalletAppConfig =
-    WalletAppConfig(directory = tempDir)
+    WalletAppConfig(baseDatadir = tempDir, Vector.empty)
 
   it must "resolve DB connections correctly " in {
     assert(config.dbPath.startsWith(Properties.tmpDir))
@@ -40,7 +40,7 @@ class WalletAppConfigTest extends BitcoinSAsyncTest {
                                                  |}
                                                  |""".stripMargin)
 
-    val throughConstructor = WalletAppConfig(tempDir, overrider)
+    val throughConstructor = WalletAppConfig(tempDir, Vector(overrider))
     val throughWithOverrides = config.withOverrides(overrider)
     assert(throughWithOverrides.network == MainNet)
     assert(throughWithOverrides.network == throughConstructor.network)
@@ -70,7 +70,8 @@ class WalletAppConfigTest extends BitcoinSAsyncTest {
   it must "be overridable with multiple levels" in {
     val testnet = ConfigFactory.parseString("bitcoin-s.network = testnet3")
     val mainnet = ConfigFactory.parseString("bitcoin-s.network = mainnet")
-    val overriden: WalletAppConfig = config.withOverrides(testnet, mainnet)
+    val overriden: WalletAppConfig =
+      config.withOverrides(Vector(testnet, mainnet))
     assert(overriden.network == MainNet)
   }
 
@@ -91,7 +92,7 @@ class WalletAppConfigTest extends BitcoinSAsyncTest {
     """.stripMargin
     val _ = Files.write(tempFile, confStr.getBytes())
 
-    val appConfig = WalletAppConfig(directory = tempDir)
+    val appConfig = WalletAppConfig(baseDatadir = tempDir, Vector.empty)
 
     assert(appConfig.datadir == tempDir.resolve("testnet3"))
     assert(appConfig.network == TestNet3)

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -45,7 +45,7 @@ case class WalletAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
 
   override protected[bitcoins] def newConfigOfType(
       configs: Seq[Config]): WalletAppConfig =
-    WalletAppConfig(baseDatadir, configOverrides)
+    WalletAppConfig(baseDatadir, configs.toVector)
 
   override def appConfig: WalletAppConfig = this
 


### PR DESCRIPTION
When working through a bug with @benthecarman today I thought about a couple of things we could approve with our `AppConfig`s to reduce the likely hood of a bug when passing around in memory configurations. When using varargs, a developer may forget to pass in an argument because the compiler will not warn them that there is a optional parameter. 

This PR

1. Remove the varargs `confs: Config*` and make the developer pass in a `Vector[Config]`, or specify `Vector.empty` if they don't intend to pass any extra configs
2. remove uncessary methods for accessing things. We now just use `baseDatadir` and `configOverrides` and make those parameters public. Previously we would make the arguments `private` for no good reason and then expose the exact same things via a public API. This reduces code complexity.