### PR TITLE
Add log txids inside of inventories in big endian rather than little endian

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/p2p/Inventory.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/Inventory.scala
@@ -15,6 +15,20 @@ case class Inventory(typeIdentifier: TypeIdentifier, hash: DoubleSha256Digest)
     extends NetworkElement {
 
   override def bytes: ByteVector = RawInventorySerializer.write(this)
+
+  override def toString: String = {
+    typeIdentifier match {
+      case TypeIdentifier.MsgTx | TypeIdentifier.MsgWitnessTx =>
+        //want to make a better toString here so it is easier to search txids
+        s"Inventory($typeIdentifier,txIdBE=${hash.flip.hex})"
+      case TypeIdentifier.MsgBlock | TypeIdentifier.MsgCompactBlock |
+          TypeIdentifier.MsgFilteredBlock | TypeIdentifier.MsgFilteredBlock |
+          TypeIdentifier.MsgCompactBlock |
+          TypeIdentifier.MsgFilteredWitnessBlock |
+          TypeIdentifier.MsgWitnessBlock | _: MsgUnassigned =>
+        super.toString
+    }
+  }
 }
 
 object Inventory extends Factory[Inventory] {


### PR DESCRIPTION
When debugging things like #4008 it is super annoying that the txids are little endian. It is hard to search for them on block explorers. This PR logs the txid inventories in big endian rather than little endian for improved debugging ergonomics