### PR TITLE
Fix bugs where we were building internally inconsistent SpendingInfoDb

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/CoinSelectorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/CoinSelectorTest.scala
@@ -8,7 +8,7 @@ import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.wallet.fee._
 import org.bitcoins.core.wallet.utxo.TxoState
-import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPublicKey}
+import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.testkitcore.gen.FeeUnitGen
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 
@@ -124,7 +124,7 @@ class CoinSelectorTest extends BitcoinSUnitTest {
 
   def createSpendingInfoDbs(
       amounts: Vector[CurrencyUnit]): Vector[SpendingInfoDb] = {
-    amounts.map { amt =>
+    val result = amounts.map { amt =>
       val key = ECPublicKey.freshPublicKey
       val spk = P2WPKHWitnessSPKV0(key)
       val output = TransactionOutput(amt, spk)
@@ -139,11 +139,12 @@ class CoinSelectorTest extends BitcoinSUnitTest {
         output = output,
         privKeyPath = path,
         scriptWitness = scriptWitness,
-        txid = DoubleSha256DigestBE.empty,
+        txid = EmptyTransactionOutPoint.txIdBE,
         state = TxoState.ConfirmedReceived,
         spendingTxIdOpt = None
       )
     }
+    result
   }
 
   /** The test assumes feeRate is greater than longTermFeeRate

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
@@ -151,6 +151,10 @@ sealed trait SpendingInfoDb extends DbRowAutoInc[SpendingInfoDb] {
   /** The TXID of the transaction this output was received in */
   def txid: DoubleSha256DigestBE
 
+  require(
+    txid == outPoint.txIdBE,
+    s"Cannot have difference outpoint txId and txIdd outpoint=${outPoint.txIdBE.hex} txid=${txid.hex}")
+
   /** TxId of the transaction that this output was spent by */
   def spendingTxIdOpt: Option[DoubleSha256DigestBE]
 

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
@@ -153,7 +153,7 @@ sealed trait SpendingInfoDb extends DbRowAutoInc[SpendingInfoDb] {
 
   require(
     txid == outPoint.txIdBE,
-    s"Cannot have difference outpoint txId and txIdd outpoint=${outPoint.txIdBE.hex} txid=${txid.hex}")
+    s"Cannot have different outpoint txId and txId outpoint=${outPoint.txIdBE.hex} txId=${txid.hex}")
 
   /** TxId of the transaction that this output was spent by */
   def spendingTxIdOpt: Option[DoubleSha256DigestBE]

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -132,7 +132,7 @@ object WalletTestUtil {
 
     SegwitV0SpendingInfo(
       state = state,
-      txid = randomTXID,
+      txid = outpoint.txIdBE,
       outPoint = outpoint,
       output = output,
       privKeyPath = privkeyPath,
@@ -158,7 +158,7 @@ object WalletTestUtil {
     }
 
     LegacySpendingInfo(state = state,
-                       txid = randomTXID,
+                       txid = outpoint.txIdBE,
                        outPoint = outpoint,
                        output = output,
                        privKeyPath = privKeyPath,
@@ -185,7 +185,7 @@ object WalletTestUtil {
 
     NestedSegwitV0SpendingInfo(
       state = state,
-      txid = randomTXID,
+      txid = outpoint.txIdBE,
       outPoint = outpoint,
       output = output,
       privKeyPath = privkeyPath,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/CoinSelectorTest.scala
@@ -9,11 +9,7 @@ import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerByte}
 import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 import org.bitcoins.testkitcore.Implicits._
-import org.bitcoins.testkitcore.gen.{
-  CryptoGenerators,
-  TransactionGenerators,
-  WitnessGenerators
-}
+import org.bitcoins.testkitcore.gen.{TransactionGenerators, WitnessGenerators}
 import org.scalatest.FutureOutcome
 
 class CoinSelectorTest extends BitcoinSWalletTest {
@@ -33,31 +29,35 @@ class CoinSelectorTest extends BitcoinSWalletTest {
     val output = TransactionOutput(99.sats, ScriptPubKey.empty)
     val feeRate = SatoshisPerByte(CurrencyUnits.zero)
 
+    val outpoint1 = TransactionGenerators.outPoint.sampleSome
     val utxo1 = SegwitV0SpendingInfo(
-      txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
+      txid = outpoint1.txIdBE,
       state = TxoState.DoesNotExist,
       id = Some(1),
-      outPoint = TransactionGenerators.outPoint.sampleSome,
+      outPoint = outpoint1,
       output = TransactionOutput(10.sats, ScriptPubKey.empty),
       privKeyPath = WalletTestUtil.sampleSegwitPath,
       scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
       spendingTxIdOpt = None
     )
+    val outPoint2 = TransactionGenerators.outPoint.sampleSome
     val utxo2 = SegwitV0SpendingInfo(
-      txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
+      txid = outPoint2.txIdBE,
       state = TxoState.DoesNotExist,
       id = Some(2),
-      outPoint = TransactionGenerators.outPoint.sampleSome,
+      outPoint = outPoint2,
       output = TransactionOutput(90.sats, ScriptPubKey.empty),
       privKeyPath = WalletTestUtil.sampleSegwitPath,
       scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
       spendingTxIdOpt = None
     )
+
+    val outPoint3 = TransactionGenerators.outPoint.sampleSome
     val utxo3 = SegwitV0SpendingInfo(
-      txid = CryptoGenerators.doubleSha256Digest.sampleSome.flip,
+      txid = outPoint3.txIdBE,
       state = TxoState.DoesNotExist,
       id = Some(3),
-      outPoint = TransactionGenerators.outPoint.sampleSome,
+      outPoint = outPoint3,
       output = TransactionOutput(20.sats, ScriptPubKey.empty),
       privKeyPath = WalletTestUtil.sampleSegwitPath,
       scriptWitness = WitnessGenerators.scriptWitness.sampleSome,


### PR DESCRIPTION
Found when looking through #3909 

We cannot have the `SpendingInfoDb.outPoint.txIdBE` and `SpendingInfoDb.txid` be different. This means we are internally inconsistent with what we are storing inside of `SpendingInfoDb`

This PR doesn't truly fix the issue IMO, we need to remove the in memory `SpendingInfoDb.txid` parameter. We can still provide this method as we can just define it as 

```scala
def txid: DoubleSha256DigestBE = outPoint.txIdBE
```