### PR TITLE
Add invariant to make sure spendingTxId is different than the txid inside of `SpendingInfoDb`

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDbTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDbTest.scala
@@ -1,0 +1,23 @@
+package org.bitcoins.core.api.wallet.db
+
+import org.bitcoins.crypto.{DoubleSha256DigestBE, ECPrivateKey}
+import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
+
+class SpendingInfoDbTest extends BitcoinSUnitTest {
+
+  behavior of "SpendingInfoDbTest"
+
+  it must "throw an exception if the outpoint txid is different than the txid" in {
+    assertThrows[IllegalArgumentException] {
+      TransactionTestUtil.spendingInfoDb.copy(txid =
+        DoubleSha256DigestBE.fromBytes(ECPrivateKey.freshPrivateKey.bytes))
+    }
+  }
+
+  it must "throw an exception if the spending txid is the same as txid" in {
+    assertThrows[IllegalArgumentException] {
+      TransactionTestUtil.spendingInfoDb.copy(spendingTxIdOpt =
+        Some(DoubleSha256DigestBE.empty))
+    }
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
@@ -158,7 +158,13 @@ sealed trait SpendingInfoDb extends DbRowAutoInc[SpendingInfoDb] {
   /** TxId of the transaction that this output was spent by */
   def spendingTxIdOpt: Option[DoubleSha256DigestBE]
 
+  require(
+    spendingTxIdOpt.map(_ != txid).getOrElse(true),
+    s"txid and the spendingTxId cannot be the same, txid=${txid.hex} spendingTxId=${spendingTxIdOpt.get.hex}"
+  )
+
   /** Converts the UTXO to the canonical `txid:vout` format */
+
   def toHumanReadableString: String =
     s"${outPoint.txId.flip.hex}:${outPoint.vout.toInt}"
 

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/TransactionTestUtil.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/TransactionTestUtil.scala
@@ -13,6 +13,7 @@ import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.crypto.{
   DoubleSha256Digest,
   DoubleSha256DigestBE,
+  ECPrivateKey,
   ECPublicKey,
   ECPublicKeyBytes
 }
@@ -284,7 +285,8 @@ trait TransactionTestUtil {
     scriptWitness = EmptyScriptWitness,
     txid = DoubleSha256DigestBE.empty,
     state = TxoState.PendingConfirmationsSpent,
-    spendingTxIdOpt = Some(DoubleSha256DigestBE.empty)
+    spendingTxIdOpt =
+      Some(DoubleSha256DigestBE.fromBytes(ECPrivateKey.freshPrivateKey.bytes))
   )
 }
 


### PR DESCRIPTION
Follow up on #4016 

This adds test cases and a new invariant to make sure the `spendingTxId` is not the same as `txid`