### PR TITLE
Update flyway to latest version

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -164,7 +164,7 @@ trait DbManagement extends Logging {
         case PostgreSQL =>
           ()
       }
-      flyway.migrate()
+      flyway.migrate().migrationsExecuted
     } catch {
       case err: FlywayException =>
         logger.warn(
@@ -173,7 +173,7 @@ trait DbManagement extends Logging {
         //maybe we have an existing database, so attempt to baseline the existing
         //database and then apply migrations again
         flyway.baseline()
-        flyway.migrate()
+        flyway.migrate().migrationsExecuted
     }
   }
 
@@ -186,5 +186,6 @@ trait DbManagement extends Logging {
     */
   def clean(): Unit = {
     flyway.clean()
+    ()
   }
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -30,7 +30,7 @@ object Deps {
 
     val asyncNewScalaV = "1.0.1"
 
-    val flywayV = "6.4.2"
+    val flywayV = "8.4.3"
     val postgresV = "42.3.1"
     val akkaActorV = akkaStreamv
     val slickV = "3.3.3"


### PR DESCRIPTION
Was getting these logs so updated the flyway dep

```
Flyway upgrade recommended: PostgreSQL 13.4 is newer than this version of Flyway and support has not been tested. The latest supported version of PostgreSQL is 12.
```