### PR TITLE
2022 01 30 optimize processblock

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -334,7 +334,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
     * processing method, which logs and transforms the
     * output fittingly.
     */
-  private def processTransactionImpl(
+  private[internal] def processTransactionImpl(
       transaction: Transaction,
       blockHashOpt: Option[DoubleSha256DigestBE],
       newTags: Vector[AddressTag],

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -125,11 +125,11 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
       val blockInputs = block.transactions.flatMap(_.inputs)
       val wallet: Future[Wallet] = {
         block.transactions.foldLeft(Future.successful(this)) {
-          (acc, transaction) =>
+          (walletF, transaction) =>
             for {
-              _ <- acc
+              wallet <- walletF
               processTxResult <- {
-                processTransactionImpl(
+                wallet.processTransactionImpl(
                   transaction = transaction,
                   blockHashOpt = blockHashOpt,
                   newTags = Vector.empty,


### PR DESCRIPTION
Some small optimzations in the hot path of `processBlockCachedUtxos`. This PR does not intend to change any functionality. Related to #2596

1. Remove allocations of `Some` inside of the parameters to `processTransactionImpl()`
2. Move the `.map()` calls on `cachedReceivedOptF` and `spentSpendingInfoDbsF` out of the `block.transactions.foldLeft()`. This means we only need to call these once rather than `n` times avoiding the `.map()` overhead.
3. Calculate `blockInputs` in advance rather than inside of the inner loop. This should reduce the amount of time to search inputs in the block.