### PR TITLE
Refactor pending receives/spent states into one spot

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/TxoState.scala
@@ -41,12 +41,16 @@ object TxoState extends StringFactory[TxoState] {
   /** Means we have spent this utxo, and it is fully confirmed */
   final case object ConfirmedSpent extends SpentState
 
+  val pendingReceivedStates: Set[TxoState] = {
+    Set(PendingConfirmationsReceived, BroadcastReceived, ImmatureCoinbase)
+  }
+
+  val pendingSpentStates = {
+    Set(BroadcastSpent, PendingConfirmationsSpent)
+  }
+
   val pendingConfStates: Set[TxoState] =
-    Set(BroadcastSpent,
-        BroadcastReceived,
-        ImmatureCoinbase,
-        PendingConfirmationsReceived,
-        PendingConfirmationsSpent)
+    pendingReceivedStates ++ pendingSpentStates
 
   val confirmedStates: Set[TxoState] =
     Set(TxoState.ConfirmedReceived, TxoState.ConfirmedSpent)


### PR DESCRIPTION
Simple refactor. This PR also adds `ImmatureCoinbase` to the pending received states. I don't know what implication this has for things like coin selection. Will this select immature coinbase txs (consensus invalid txs) during coin selection?

