### PR TITLE
Potential fix for 4032

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
@@ -171,6 +171,17 @@ object DLCExecutor {
     val sigsUsed =
       sigsUsedOpt.get // Safe because msgOpt is defined if no throw
 
+    // make sure we have the correct number of oracle signatures
+    // see: https://github.com/bitcoin-s/bitcoin-s/issues/4032
+    msg.oracles.foreach { oracle =>
+      require(
+        sigsUsed.forall(_.size <= oracle.nonces.size),
+        s"Cannot have different oracle signatures and number of nonces, " +
+          s"oracleSignatures.length=${oracleSigs.map(
+            _.sigs.length)} number of nonces=${oracle.nonces.size}"
+      )
+    }
+
     val (fundingMultiSig, _) = DLCTxBuilder.buildFundingSPKs(
       Vector(fundingKey.publicKey, remoteFundingPubKey))
 


### PR DESCRIPTION
Fixes #4032

Alternate to #4037

This doesn't break any tests so I have hope that it is better.

The think is to only check the DLC outcome that we are using and to allow a lesser amount of sigs because of the bits that we rule do not care.
