### PR TITLE
Make newConfigOfType use Vector[Config]

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -40,7 +40,7 @@ abstract class AppConfig extends StartStopAsync[Unit] with Logging {
 
   /** Constructor to make a new instance of this config type */
   protected[bitcoins] def newConfigOfType(
-      configOverrides: Seq[Config]): ConfigType
+      configOverrides: Vector[Config]): ConfigType
 
   /** List of user-provided configs that should
     * override defaults

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
@@ -30,8 +30,8 @@ case class BitcoindRpcAppConfig(
   override protected[bitcoins] type ConfigType = BitcoindRpcAppConfig
 
   override protected[bitcoins] def newConfigOfType(
-      configs: Seq[Config]): BitcoindRpcAppConfig =
-    BitcoindRpcAppConfig(baseDatadir, configs.toVector)
+      configs: Vector[Config]): BitcoindRpcAppConfig =
+    BitcoindRpcAppConfig(baseDatadir, configs)
 
   override def start(): Future[Unit] = Future.unit
 

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -28,8 +28,8 @@ case class ChainAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   override protected[bitcoins] type ConfigType = ChainAppConfig
 
   override protected[bitcoins] def newConfigOfType(
-      configs: Seq[Config]): ChainAppConfig =
-    ChainAppConfig(baseDatadir, configs.toVector)
+      configs: Vector[Config]): ChainAppConfig =
+    ChainAppConfig(baseDatadir, configs)
 
   override lazy val appConfig: ChainAppConfig = this
 

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
@@ -28,8 +28,8 @@ case class DLCNodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   override protected[bitcoins] type ConfigType = DLCNodeAppConfig
 
   override protected[bitcoins] def newConfigOfType(
-      configs: Seq[Config]): DLCNodeAppConfig =
-    DLCNodeAppConfig(baseDatadir, configs.toVector)
+      configs: Vector[Config]): DLCNodeAppConfig =
+    DLCNodeAppConfig(baseDatadir, configs)
 
   override def start(): Future[Unit] = {
     FutureUtil.unit

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
@@ -38,9 +38,8 @@ case class DLCOracleAppConfig(
 
   override type ConfigType = DLCOracleAppConfig
 
-  override def newConfigOfType(
-      configOverrides: Seq[Config]): DLCOracleAppConfig =
-    DLCOracleAppConfig(baseDatadir, configOverrides.toVector)
+  override def newConfigOfType(configs: Vector[Config]): DLCOracleAppConfig =
+    DLCOracleAppConfig(baseDatadir, configs)
 
   /** DLC oracles are not network specific, so just hard code the testnet chain params */
   final override lazy val chain: BitcoinChainParams = TestNetChainParams

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -38,8 +38,8 @@ case class DLCAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   override protected[bitcoins] type ConfigType = DLCAppConfig
 
   override protected[bitcoins] def newConfigOfType(
-      configs: Seq[Config]): DLCAppConfig =
-    DLCAppConfig(baseDatadir, configs.toVector)
+      configs: Vector[Config]): DLCAppConfig =
+    DLCAppConfig(baseDatadir, configs)
 
   override def appConfig: DLCAppConfig = this
 

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
@@ -22,9 +22,8 @@ case class KeyManagerAppConfig(
 
   override type ConfigType = KeyManagerAppConfig
 
-  override def newConfigOfType(
-      configOverrides: Seq[Config]): KeyManagerAppConfig =
-    KeyManagerAppConfig(baseDatadir, configOverrides.toVector)
+  override def newConfigOfType(configs: Vector[Config]): KeyManagerAppConfig =
+    KeyManagerAppConfig(baseDatadir, configs)
 
   override def moduleName: String = KeyManagerAppConfig.moduleName
 

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -37,8 +37,8 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   override protected[bitcoins] type ConfigType = NodeAppConfig
 
   override protected[bitcoins] def newConfigOfType(
-      configs: Seq[Config]): NodeAppConfig =
-    NodeAppConfig(baseDatadir, configs.toVector)
+      configs: Vector[Config]): NodeAppConfig =
+    NodeAppConfig(baseDatadir, configs)
 
   implicit override def ec: ExecutionContext = system.dispatcher
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.testkit.db
 
-import java.nio.file.{Files, Path}
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import org.bitcoins.db._
@@ -8,6 +7,7 @@ import org.bitcoins.db.models.MasterXPubDAO
 import scodec.bits.ByteVector
 import slick.lifted.ProvenShape
 
+import java.nio.file.{Files, Path}
 import scala.concurrent.{ExecutionContext, Future}
 
 object DbTestUtil {
@@ -52,8 +52,8 @@ case class TestAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   override protected[bitcoins] type ConfigType = TestAppConfig
 
   override protected[bitcoins] def newConfigOfType(
-      configs: Seq[Config]): TestAppConfig =
-    TestAppConfig(baseDatadir, configOverrides)
+      configs: Vector[Config]): TestAppConfig =
+    TestAppConfig(baseDatadir, configs)
 
   override def appConfig: TestAppConfig = this
 

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -28,8 +28,8 @@ case class TorAppConfig(
   override protected[bitcoins] type ConfigType = TorAppConfig
 
   override protected[bitcoins] def newConfigOfType(
-      configs: Seq[Config]): TorAppConfig =
-    TorAppConfig(baseDatadir, subModuleNameOpt, configs.toVector)
+      configs: Vector[Config]): TorAppConfig =
+    TorAppConfig(baseDatadir, subModuleNameOpt, configs)
 
   private val isStarted: AtomicBoolean = new AtomicBoolean(false)
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -8,8 +8,8 @@ import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.hd._
 import org.bitcoins.core.util.Mutable
-import org.bitcoins.core.wallet.keymanagement._
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.keymanagement._
 import org.bitcoins.crypto.AesPassword
 import org.bitcoins.db.DatabaseDriver.{PostgreSQL, SQLite}
 import org.bitcoins.db._
@@ -44,8 +44,8 @@ case class WalletAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   override protected[bitcoins] type ConfigType = WalletAppConfig
 
   override protected[bitcoins] def newConfigOfType(
-      configs: Seq[Config]): WalletAppConfig =
-    WalletAppConfig(baseDatadir, configs.toVector)
+      configs: Vector[Config]): WalletAppConfig =
+    WalletAppConfig(baseDatadir, configs)
 
   override def appConfig: WalletAppConfig = this
 


### PR DESCRIPTION
Should make things cleaner.

Also fixed so the `newConfigOfType` impls use the config overrides from the current app config