### PR TITLE
2022 02 03 issue 4032

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -749,7 +749,7 @@ lazy val dlcWalletTest = project
     name := "bitcoin-s-dlc-wallet-test",
     libraryDependencies ++= Deps.dlcWalletTest
   )
-  .dependsOn(coreJVM % testAndCompile, dlcWallet, testkit, dlcTest)
+  .dependsOn(coreJVM % testAndCompile, dlcWallet, testkit, testkitCoreJVM, dlcTest)
 
 lazy val dlcNode = project
   .in(file("dlc-node"))

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCUtil.scala
@@ -206,15 +206,11 @@ object DLCUtil {
       case single: SingleContractInfo =>
         checkSingleContractInfoOracleSigs(single, oracleSigs)
       case disjoint: DisjointUnionContractInfo =>
-        val contractHasMatchingSigs: Vector[Boolean] = {
-          disjoint.contracts.map { single: SingleContractInfo =>
-            checkSingleContractInfoOracleSigs(single, oracleSigs)
-          }
-        }
-
         //at least one disjoint union contract
         //has to have matching signatures
-        contractHasMatchingSigs.exists(_ == true)
+        disjoint.contracts.exists { single: SingleContractInfo =>
+          checkSingleContractInfoOracleSigs(single, oracleSigs)
+        }
     }
   }
 
@@ -276,11 +272,12 @@ object DLCUtil {
             val oracleSig =
               OracleSignatures(SingleOracleInfo(ann), attestment.sigs)
             val isMatch = matchOracleSignaturesForAnnouncements(ann, oracleSig)
-            if (isMatch.isDefined) {
-              acc.:+(isMatch.get)
-            } else {
-              //don't add it, skip it
-              acc
+            isMatch match {
+              case Some(matchedSig) =>
+                acc.:+(matchedSig)
+              case None =>
+                //don't add it, skip it
+                acc
             }
           }.toVector
           r

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCUtil.scala
@@ -8,9 +8,14 @@ import org.bitcoins.core.protocol.dlc.models.DLCMessage.{
   DLCAcceptWithoutSigs,
   DLCOffer
 }
-import org.bitcoins.core.protocol.dlc.models.{ContractInfo, OracleOutcome}
+import org.bitcoins.core.protocol.dlc.models._
 import org.bitcoins.core.protocol.script.P2WSHWitnessV0
+import org.bitcoins.core.protocol.tlv.{
+  OracleAnnouncementTLV,
+  OracleAttestmentTLV
+}
 import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
+import org.bitcoins.core.util.sorted.OrderedAnnouncements
 import org.bitcoins.crypto._
 import scodec.bits.ByteVector
 
@@ -186,5 +191,102 @@ object DLCUtil {
     computeContractId(fundingTx = fundingTx,
                       outputIdx = fundingOutputIdx,
                       tempContractId = offer.tempContractId)
+  }
+
+  /** Checks that the oracles signatures given to us are correct
+    * Things we need to check
+    * 1. We have all the oracle signatures
+    * 2. The oracle signatures are for one of the contracts in the [[ContractInfo]]
+    *  @see https://github.com/bitcoin-s/bitcoin-s/issues/4032
+    */
+  def checkOracleSignaturesAgainstContract(
+      contractInfo: ContractInfo,
+      oracleSigs: Vector[OracleSignatures]): Boolean = {
+    contractInfo match {
+      case single: SingleContractInfo =>
+        checkSingleContractInfoOracleSigs(single, oracleSigs)
+      case disjoint: DisjointUnionContractInfo =>
+        val contractHasMatchingSigs: Vector[Boolean] = {
+          disjoint.contracts.map { single: SingleContractInfo =>
+            checkSingleContractInfoOracleSigs(single, oracleSigs)
+          }
+        }
+
+        //at least one disjoint union contract
+        //has to have matching signatures
+        contractHasMatchingSigs.exists(_ == true)
+    }
+  }
+
+  /** Check if the given [[SingleContractInfo]] has one [[OracleSignatures]]
+    * matches it inside of oracleSignatures.
+    */
+  private def checkSingleContractInfoOracleSigs(
+      contractInfo: SingleContractInfo,
+      oracleSignatures: Vector[OracleSignatures]): Boolean = {
+    require(oracleSignatures.nonEmpty, s"Signatures cannot be empty")
+    matchOracleSignatures(contractInfo, oracleSignatures).isDefined
+  }
+
+  /** Matches a [[SingleContractInfo]] to its oracle's signatures */
+  def matchOracleSignatures(
+      contractInfo: SingleContractInfo,
+      oracleSignatures: Vector[OracleSignatures]): Option[OracleSignatures] = {
+    matchOracleSignatures(contractInfo.announcements, oracleSignatures)
+  }
+
+  def matchOracleSignatures(
+      announcements: Vector[OracleAnnouncementTLV],
+      oracleSignatures: Vector[OracleSignatures]): Option[OracleSignatures] = {
+    val announcementNonces: Vector[Vector[SchnorrNonce]] = {
+      announcements
+        .map(_.eventTLV.nonces)
+        .map(_.vec)
+    }
+    val resultOpt = oracleSignatures.find { case oracleSignature =>
+      val oracleSigNonces: Vector[SchnorrNonce] = oracleSignature.sigs.map(_.rx)
+      announcementNonces.contains(oracleSigNonces)
+    }
+    resultOpt
+  }
+
+  /** Checks to see if the given oracle signatures and announcement have the same nonces */
+  private def matchOracleSignaturesForAnnouncements(
+      announcement: OracleAnnouncementTLV,
+      signature: OracleSignatures): Option[OracleSignatures] = {
+    matchOracleSignatures(
+      Vector(announcement),
+      Vector(signature)
+    )
+  }
+
+  /** Builds a set of oracle signatures from given announcements
+    * and attestations. This method discards attestments
+    * that do not have a matching announcement. Those attestments
+    * are not included in the returned set of [[OracleSignatures]]
+    */
+  def buildOracleSignatures(
+      announcements: OrderedAnnouncements,
+      attestments: Vector[OracleAttestmentTLV]): Vector[OracleSignatures] = {
+    val result: Vector[OracleSignatures] = {
+      val init = Vector.empty[OracleSignatures]
+      attestments
+        .foldLeft(init) { (acc, attestment) =>
+          val r: Vector[OracleSignatures] = announcements.flatMap { ann =>
+            val oracleSig =
+              OracleSignatures(SingleOracleInfo(ann), attestment.sigs)
+            val isMatch = matchOracleSignaturesForAnnouncements(ann, oracleSig)
+            if (isMatch.isDefined) {
+              acc.appended(isMatch.get)
+            } else {
+              //don't add it, skip it
+              acc
+            }
+          }.toVector
+          r
+        }
+    }
+
+    result
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCUtil.scala
@@ -277,7 +277,7 @@ object DLCUtil {
               OracleSignatures(SingleOracleInfo(ann), attestment.sigs)
             val isMatch = matchOracleSignaturesForAnnouncements(ann, oracleSig)
             if (isMatch.isDefined) {
-              acc.appended(isMatch.get)
+              acc.:+(isMatch.get)
             } else {
               //don't add it, skip it
               acc

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
@@ -208,8 +208,7 @@ object DLCExecutor {
         checkSingleContractInfoOracleSigs(single, oracleSigs)
       case disjoint: DisjointUnionContractInfo =>
         val results = disjoint.contracts.map { single: SingleContractInfo =>
-          val matchedSigsOpt = matchOracleSignatures(single, oracleSigs)
-          checkSingleContractInfoOracleSigs(single, matchedSigsOpt.toVector)
+          checkSingleContractInfoOracleSigs(single, oracleSigs)
         }
 
         results.forall(_ == true)

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
@@ -216,18 +216,14 @@ object DLCExecutor {
     }
   }
 
+  /** Check if the given [[SingleContractInfo]] has one [[OracleSignatures]]
+    * matches it inside of oracleSignatures.
+    */
   private def checkSingleContractInfoOracleSigs(
       contractInfo: SingleContractInfo,
       oracleSignatures: Vector[OracleSignatures]): Boolean = {
     require(oracleSignatures.nonEmpty, s"Signatures cannot be empty")
-    contractInfo.contractDescriptor match {
-      case _: EnumContractDescriptor =>
-        val result = oracleSignatures.forall(_.sigs.length == 1)
-        result
-      case numeric: NumericContractDescriptor =>
-        val result = oracleSignatures.forall(_.sigs.length == numeric.numDigits)
-        result
-    }
+    matchOracleSignatures(contractInfo, oracleSignatures).isDefined
   }
 
   /** Matches a [[SingleContractInfo]] to its oracle's signatures */

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
@@ -207,11 +207,15 @@ object DLCExecutor {
       case single: SingleContractInfo =>
         checkSingleContractInfoOracleSigs(single, oracleSigs)
       case disjoint: DisjointUnionContractInfo =>
-        val results = disjoint.contracts.map { single: SingleContractInfo =>
-          checkSingleContractInfoOracleSigs(single, oracleSigs)
+        val contractHasMatchingSigs: Vector[Boolean] = {
+          disjoint.contracts.map { single: SingleContractInfo =>
+            checkSingleContractInfoOracleSigs(single, oracleSigs)
+          }
         }
 
-        results.forall(_ == true)
+        //at least one disjoint union contract
+        //has to have matching signatures
+        contractHasMatchingSigs.exists(_ == true)
     }
   }
 

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DisjointUnionDLCTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DisjointUnionDLCTest.scala
@@ -7,7 +7,7 @@ import org.bitcoins.testkitcore.util.BitcoinSJvmTest
 class DisjointUnionDLCTest extends BitcoinSJvmTest with DLCTest {
   behavior of "Disjoint Union DLC"
 
-  it should "be able to construct and verify with ScriptInterpreter every tx in a double enum contract" ignore {
+  it should "be able to construct and verify with ScriptInterpreter every tx in a double enum contract" in {
     val numDisjoint = 2
     val numOutcomes = 10
     val singleParams = 0.until(numDisjoint).toVector.map { _ =>
@@ -23,7 +23,7 @@ class DisjointUnionDLCTest extends BitcoinSJvmTest with DLCTest {
     executeForCasesInUnion(outcomes, contractParams)
   }
 
-  it should "be able to construct and verify with ScriptInterpreter every tx in a double numeric contract" ignore {
+  it should "be able to construct and verify with ScriptInterpreter every tx in a double numeric contract" in {
     val numDisjoint = 2
     val numDigits = 10
     val singleParams = 0.until(numDisjoint).toVector.map { _ =>
@@ -45,7 +45,7 @@ class DisjointUnionDLCTest extends BitcoinSJvmTest with DLCTest {
     executeForCasesInUnion(outcomes, contractParams)
   }
 
-  it should "be able to construct and verify with ScriptInterpreter every tx in a mixed enum and numeric contract" ignore {
+  it should "be able to construct and verify with ScriptInterpreter every tx in a mixed enum and numeric contract" in {
     val numOutcomes = 10
     val numDigits = 10
     val enumParams =

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DisjointUnionDLCTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DisjointUnionDLCTest.scala
@@ -7,7 +7,7 @@ import org.bitcoins.testkitcore.util.BitcoinSJvmTest
 class DisjointUnionDLCTest extends BitcoinSJvmTest with DLCTest {
   behavior of "Disjoint Union DLC"
 
-  it should "be able to construct and verify with ScriptInterpreter every tx in a double enum contract" in {
+  it should "be able to construct and verify with ScriptInterpreter every tx in a double enum contract" ignore {
     val numDisjoint = 2
     val numOutcomes = 10
     val singleParams = 0.until(numDisjoint).toVector.map { _ =>
@@ -23,7 +23,7 @@ class DisjointUnionDLCTest extends BitcoinSJvmTest with DLCTest {
     executeForCasesInUnion(outcomes, contractParams)
   }
 
-  it should "be able to construct and verify with ScriptInterpreter every tx in a double numeric contract" in {
+  it should "be able to construct and verify with ScriptInterpreter every tx in a double numeric contract" ignore {
     val numDisjoint = 2
     val numDigits = 10
     val singleParams = 0.until(numDisjoint).toVector.map { _ =>
@@ -45,7 +45,7 @@ class DisjointUnionDLCTest extends BitcoinSJvmTest with DLCTest {
     executeForCasesInUnion(outcomes, contractParams)
   }
 
-  it should "be able to construct and verify with ScriptInterpreter every tx in a mixed enum and numeric contract" in {
+  it should "be able to construct and verify with ScriptInterpreter every tx in a mixed enum and numeric contract" ignore {
     val numOutcomes = 10
     val numDigits = 10
     val enumParams =

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DisjointUnionDLCTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DisjointUnionDLCTest.scala
@@ -7,7 +7,7 @@ import org.bitcoins.testkitcore.util.BitcoinSJvmTest
 class DisjointUnionDLCTest extends BitcoinSJvmTest with DLCTest {
   behavior of "Disjoint Union DLC"
 
-  it should "be able to construct and verify with ScriptInterpreter every tx in a double enum contract" in {
+  it should "be able to construct and verify with ScriptInterpreter every tx in a double enum contract" ignore {
     val numDisjoint = 2
     val numOutcomes = 10
     val singleParams = 0.until(numDisjoint).toVector.map { _ =>

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/DisjointUnionDLCTest.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/DisjointUnionDLCTest.scala
@@ -7,7 +7,7 @@ import org.bitcoins.testkitcore.util.BitcoinSJvmTest
 class DisjointUnionDLCTest extends BitcoinSJvmTest with DLCTest {
   behavior of "Disjoint Union DLC"
 
-  it should "be able to construct and verify with ScriptInterpreter every tx in a double enum contract" ignore {
+  it should "be able to construct and verify with ScriptInterpreter every tx in a double enum contract" in {
     val numDisjoint = 2
     val numOutcomes = 10
     val singleParams = 0.until(numDisjoint).toVector.map { _ =>

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -3,15 +3,15 @@ package org.bitcoins.dlc.wallet
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.dlc.models.DLCMessage.DLCOffer
-import org.bitcoins.core.protocol.dlc.models.{
-  DLCState,
-  DisjointUnionContractInfo,
-  SingleContractInfo
-}
 import org.bitcoins.core.protocol.dlc.models.DLCStatus.{
   Claimed,
   Refunded,
   RemoteClaimed
+}
+import org.bitcoins.core.protocol.dlc.models.{
+  DLCState,
+  DisjointUnionContractInfo,
+  SingleContractInfo
 }
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.script.interpreter.ScriptInterpreter

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -416,4 +416,41 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
         _ <- walletA.listDLCs()
       } yield succeed
   }
+
+  it must "throw an exception for a enum contract when do not have all the oracle signatures/outcomes" in {
+    wallets =>
+      val walletA = wallets._1.wallet
+      val resultF = for {
+        contractId <- getContractId(walletA)
+        status <- getDLCStatus(walletA)
+        (goodAttestment, _) = {
+          status.contractInfo match {
+            case single: SingleContractInfo =>
+              DLCWalletUtil.getSigs(single)
+            case disjoint: DisjointUnionContractInfo =>
+              sys.error(
+                s"Cannot retrieve sigs for disjoint union contract, got=$disjoint")
+          }
+        }
+        //purposefully drop these
+        //we cannot drop just a sig, or just an outcome because
+        //of invariants in OracleAttestmentV0TLV
+        badSigs = goodAttestment.sigs.dropRight(1)
+        badOutcomes = goodAttestment.outcomes.dropRight(1)
+        badAttestment = OracleAttestmentV0TLV(eventId = goodAttestment.eventId,
+                                              publicKey =
+                                                goodAttestment.publicKey,
+                                              sigs = badSigs,
+                                              outcomes = badOutcomes)
+        func = (wallet: DLCWallet) =>
+          wallet.executeDLC(contractId, badAttestment)
+
+        result <- dlcExecutionTest(wallets = wallets,
+                                   asInitiator = true,
+                                   func = func,
+                                   expectedOutputs = 1)
+      } yield assert(result)
+
+      recoverToSucceededIf[IllegalArgumentException](resultF)
+  }
 }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
@@ -212,7 +212,7 @@ class DLCMultiOracleExactNumericExecutionTest extends BitcoinSDualWalletTest {
         outcome.oraclesAndOutcomes.find(_._1.publicKey == priv.schnorrPublicKey)
 
       outcomeOpt.map { case (oracleInfo, outcome) =>
-        val neededPadding = kValues.length - outcome.digits.length
+        val neededPadding = numDigits - outcome.digits.length
         val digitsPadded = outcome.digits ++ Vector.fill(neededPadding)(0)
         val sigs = digitsPadded.zip(kValues).map { case (num, kValue) =>
           val hash = CryptoUtil.sha256DLCAttestation(num.toString).bytes

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
@@ -80,7 +80,9 @@ class DLCMultiOracleExactNumericExecutionTest extends BitcoinSDualWalletTest {
           _._1.publicKey == priv.schnorrPublicKey)
 
         outcomeOpt.map { case (oracleInfo, outcome) =>
-          val sigs = outcome.digits.zip(kValues).map { case (num, kValue) =>
+          val neededPadding = kValues.length - outcome.digits.length
+          val digitsPadded = outcome.digits ++ Vector.fill(neededPadding)(0)
+          val sigs = digitsPadded.zip(kValues).map { case (num, kValue) =>
             val hash = CryptoUtil.sha256DLCAttestation(num.toString).bytes
             priv.schnorrSignWithNonce(hash, kValue)
           }
@@ -88,10 +90,13 @@ class DLCMultiOracleExactNumericExecutionTest extends BitcoinSDualWalletTest {
             case v0: OracleEventV0TLV => v0.eventId
           }
 
+          require(
+            kValues.length == sigs.length,
+            s"kValues.length=${kValues.length} sigs.length=${sigs.length}")
           OracleAttestmentV0TLV(eventId,
                                 priv.schnorrPublicKey,
                                 sigs,
-                                outcome.digits.map(_.toString))
+                                digitsPadded.map(_.toString))
         }
       }
 
@@ -120,7 +125,9 @@ class DLCMultiOracleExactNumericExecutionTest extends BitcoinSDualWalletTest {
           _._1.publicKey == priv.schnorrPublicKey)
 
         outcomeOpt.map { case (oracleInfo, outcome) =>
-          val sigs = outcome.digits.zip(kValues).map { case (num, kValue) =>
+          val neededPadding = kValues.length - outcome.digits.length
+          val digitsPadded = outcome.digits ++ Vector.fill(neededPadding)(0)
+          val sigs = digitsPadded.zip(kValues).map { case (num, kValue) =>
             val hash = CryptoUtil.sha256DLCAttestation(num.toString).bytes
             priv.schnorrSignWithNonce(hash, kValue)
           }
@@ -128,10 +135,13 @@ class DLCMultiOracleExactNumericExecutionTest extends BitcoinSDualWalletTest {
             case v0: OracleEventV0TLV => v0.eventId
           }
 
+          require(
+            kValues.length == sigs.length,
+            s"kValues.length=${kValues.length} sigs.length=${sigs.length}")
           OracleAttestmentV0TLV(eventId,
                                 priv.schnorrPublicKey,
                                 sigs,
-                                outcome.digits.map(_.toString))
+                                digitsPadded.map(_.toString))
         }
       }
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
@@ -81,35 +81,7 @@ class DLCMultiOracleNumericExecutionTest
       initiatorWinVec,
       Some(params))
 
-    val initiatorWinSigs =
-      privateKeys.zip(kValues).flatMap { case (priv, kValues) =>
-        val outcomeOpt: Option[(
-            NumericSingleOracleInfo,
-            UnsignedNumericOutcome)] = {
-          initWinOutcomes.oraclesAndOutcomes.find(
-            _._1.publicKey == priv.schnorrPublicKey)
-        }
-
-        outcomeOpt.map { case (oracleInfo, outcome) =>
-          val neededPadding = kValues.length - outcome.digits.length
-          val digitsPadded = outcome.digits ++ Vector.fill(neededPadding)(0)
-          val sigs = digitsPadded.zip(kValues).map { case (num, kValue) =>
-            val hash = CryptoUtil.sha256DLCAttestation(num.toString).bytes
-            priv.schnorrSignWithNonce(hash, kValue)
-          }
-          val eventId = oracleInfo.announcement.eventTLV match {
-            case v0: OracleEventV0TLV => v0.eventId
-          }
-
-          require(
-            kValues.length == sigs.length,
-            s"kValues.length=${kValues.length} sigs.length=${sigs.length}")
-          OracleAttestmentV0TLV(eventId,
-                                priv.schnorrPublicKey,
-                                sigs,
-                                digitsPadded.map(_.toString))
-        }
-      }
+    val initiatorWinSigs = buildAttestments(initWinOutcomes)
 
     val recipientChosenOracles =
       Random.shuffle(oracleIndices).take(oracleInfo.threshold).sorted
@@ -130,31 +102,8 @@ class DLCMultiOracleNumericExecutionTest
       recipientWinVec,
       Some(params))
 
-    val recipientWinSigs =
-      privateKeys.zip(kValues).flatMap { case (priv, kValues) =>
-        val outcomeOpt = recipientWinOutcomes.oraclesAndOutcomes.find(
-          _._1.publicKey == priv.schnorrPublicKey)
-
-        outcomeOpt.map { case (oracleInfo, outcome) =>
-          val neededPadding = kValues.length - outcome.digits.length
-          val digitsPadded = outcome.digits ++ Vector.fill(neededPadding)(0)
-          val sigs = digitsPadded.zip(kValues).map { case (num, kValue) =>
-            val hash = CryptoUtil.sha256DLCAttestation(num.toString).bytes
-            priv.schnorrSignWithNonce(hash, kValue)
-          }
-          val eventId = oracleInfo.announcement.eventTLV match {
-            case v0: OracleEventV0TLV => v0.eventId
-          }
-
-          require(
-            kValues.length == sigs.length,
-            s"kValues.length=${kValues.length} sigs.length=${sigs.length}")
-          OracleAttestmentV0TLV(eventId,
-                                priv.schnorrPublicKey,
-                                sigs,
-                                digitsPadded.map(_.toString))
-        }
-      }
+    val recipientWinSigs: Vector[OracleAttestmentTLV] = buildAttestments(
+      recipientWinOutcomes)
 
     // Shuffle to make sure ordering doesn't matter
     (Random.shuffle(initiatorWinSigs), Random.shuffle(recipientWinSigs))
@@ -261,6 +210,34 @@ class DLCMultiOracleNumericExecutionTest
         val aggregateSignature =
           SchnorrDigitalSignature(aggR, aggS)
         aggregateSignature == statusB.oracleSig
+    }
+  }
+
+  /** Builds an attestment for the given numeric oracle outcome */
+  private def buildAttestments(
+      outcome: NumericOracleOutcome): Vector[OracleAttestmentTLV] = {
+    privateKeys.zip(kValues).flatMap { case (priv, kValues) =>
+      val outcomeOpt =
+        outcome.oraclesAndOutcomes.find(_._1.publicKey == priv.schnorrPublicKey)
+
+      outcomeOpt.map { case (oracleInfo, outcome) =>
+        val neededPadding = kValues.length - outcome.digits.length
+        val digitsPadded = outcome.digits ++ Vector.fill(neededPadding)(0)
+        val sigs = digitsPadded.zip(kValues).map { case (num, kValue) =>
+          val hash = CryptoUtil.sha256DLCAttestation(num.toString).bytes
+          priv.schnorrSignWithNonce(hash, kValue)
+        }
+        val eventId = oracleInfo.announcement.eventTLV match {
+          case v0: OracleEventV0TLV => v0.eventId
+        }
+
+        require(kValues.length == sigs.length,
+                s"kValues.length=${kValues.length} sigs.length=${sigs.length}")
+        OracleAttestmentV0TLV(eventId,
+                              priv.schnorrPublicKey,
+                              sigs,
+                              digitsPadded.map(_.toString))
+      }
     }
   }
 }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
@@ -221,7 +221,7 @@ class DLCMultiOracleNumericExecutionTest
         outcome.oraclesAndOutcomes.find(_._1.publicKey == priv.schnorrPublicKey)
 
       outcomeOpt.map { case (oracleInfo, outcome) =>
-        val neededPadding = kValues.length - outcome.digits.length
+        val neededPadding = numDigits - outcome.digits.length
         val digitsPadded = outcome.digits ++ Vector.fill(neededPadding)(0)
         val sigs = digitsPadded.zip(kValues).map { case (num, kValue) =>
           val hash = CryptoUtil.sha256DLCAttestation(num.toString).bytes

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1355,21 +1355,9 @@ abstract class DLCWallet
         announcementData,
         nonceDbs)
 
-      oracleSigs =
-        sigs.foldLeft(Vector.empty[OracleSignatures]) { (acc, sig) =>
-          // Nonces should be unique so searching for the first nonce should be safe
-          val firstNonce = sig.sigs.head.rx
-          announcementTLVs
-            .find(
-              _.eventTLV.nonces.headOption
-                .contains(firstNonce)) match {
-            case Some(announcement) =>
-              acc :+ OracleSignatures(SingleOracleInfo(announcement), sig.sigs)
-            case None =>
-              throw new RuntimeException(
-                s"Cannot find announcement for associated public key, ${sig.publicKey.hex}")
-          }
-        }
+      oracleSigs = DLCUtil.buildOracleSignatures(announcements =
+                                                   announcementTLVs,
+                                                 attestments = sigs.toVector)
 
       tx <- executeDLC(contractId, oracleSigs)
     } yield tx

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/DLCTest.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/DLCTest.scala
@@ -880,8 +880,11 @@ trait DLCTest {
         .get
         ._2
 
+      val neededPadding =
+        singleOracleInfo.announcement.eventTLV.eventDescriptor.noncesNeeded - digitsToSign.digits.length
+      val paddedDigits = digitsToSign.digits ++ Vector.fill(neededPadding)(0)
       val sigs =
-        computeNumericOracleSignatures(digitsToSign.digits,
+        computeNumericOracleSignatures(paddedDigits,
                                        oraclePrivKeys(index),
                                        preCommittedKsPerOracle(index))
 
@@ -1044,7 +1047,8 @@ trait DLCTest {
       outcomeIndices: Vector[Long],
       contractParams: ContractParams)(implicit
       ec: ExecutionContext): Future[Assertion] = {
-    executeForCasesInUnion(outcomeIndices.map((0, _)), contractParams)
+    executeForCasesInUnion(outcomeIndices = outcomeIndices.map((0, _)),
+                           contractParams = contractParams)
   }
 
   def executeForCasesInUnion(
@@ -1110,12 +1114,14 @@ trait DLCTest {
         (numDigits, true, paramsOpt)
     }
 
-    val oracleSigs = genOracleSignatures(numOutcomes,
-                                         isMultiDigit,
-                                         singleContractInfo,
-                                         possibleOutcomesForContract,
-                                         outcomeIndex,
-                                         paramsOpt)
+    val oracleSigs = genOracleSignatures(
+      numOutcomesOrDigits = numOutcomes,
+      isNumeric = isMultiDigit,
+      contractInfo = singleContractInfo,
+      outcomes = possibleOutcomesForContract,
+      outcomeIndex = outcomeIndex,
+      paramsOpt = paramsOpt
+    )
 
     for {
       offerOutcome <-


### PR DESCRIPTION
Addresses parts of #4032 

This PR adds a check for `ContractInfo` DLCs to make sure we have the entire set of oracle signatures.

This PR also refactors all places we match oracle announcements against oracle signatures into `DLCUtil`. These are now helper methods that can be used from anywhere in the codebase.