### PR TITLE
Reworking/refactoring acceptDLCOffer

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -582,7 +582,7 @@ abstract class DLCWallet
     *
     * This is the first step of the recipient
     */
-    override def acceptDLCOffer(offer: DLCOffer): Future[DLCAccept] = {
+  override def acceptDLCOffer(offer: DLCOffer): Future[DLCAccept] = {
     logger.debug("Calculating relevant wallet data for DLC Accept")
 
     val dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -454,7 +454,7 @@ abstract class DLCWallet
   /** Retrieves the [[DLCDb]] and [[AccountDb]] for the given tempContractId
     * else returns None
     */
-  private def getDlcDbAndAccountDb(tempContractId: Sha256Digest): Future[
+  private def getDlcDbOfferDbAccountDb(tempContractId: Sha256Digest): Future[
     Option[(DLCDb, DLCOfferDb, AccountDb)]] = {
     val result: Future[Option[(DLCDb, DLCOfferDb, AccountDb)]] = for {
       dlcDbOpt <- dlcDAO.findByTempContractId(tempContractId)
@@ -495,7 +495,7 @@ abstract class DLCWallet
       groupByExistingAnnouncements(announcements)
     }
 
-    getDlcDbAndAccountDb(offer.tempContractId).flatMap {
+    getDlcDbOfferDbAccountDb(offer.tempContractId).flatMap {
       case Some((dlcDb, dlcOffer, account)) =>
         Future.successful((dlcDb, dlcOffer, account))
       case None =>

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -454,23 +454,27 @@ abstract class DLCWallet
   /** Retrieves the [[DLCDb]] and [[AccountDb]] for the given tempContractId
     * else returns None
     */
-  private def getDlcDbAndAccountDb(
-      tempContractId: Sha256Digest): Future[Option[(DLCDb, DLCOfferDb, AccountDb)]] = {
-    val resultNested: Future[Option[Future[(DLCDb, AccountDb)]]] = for {
+  private def getDlcDbAndAccountDb(tempContractId: Sha256Digest): Future[
+    Option[(DLCDb, DLCOfferDb, AccountDb)]] = {
+    val result: Future[Option[(DLCDb, DLCOfferDb, AccountDb)]] = for {
       dlcDbOpt <- dlcDAO.findByTempContractId(tempContractId)
-      accountFOpt = dlcDbOpt.map { dlcDb =>
-        accountDAO
-          .findByAccount(dlcDb.account)
-          .map(account => (dlcDb, account.get))
+      dlcOfferDbOpt <- dlcDbOpt match {
+        case Some(dlcDb) => dlcOfferDAO.findByDLCId(dlcDb.dlcId)
+        case None        => Future.successful(None)
+      }
+      accountOpt <- dlcDbOpt match {
+        case Some(dlcDb) => accountDAO.findByAccount(dlcDb.account)
+        case None        => Future.successful(None)
       }
     } yield {
-      accountFOpt
+      for {
+        dlcDb <- dlcDbOpt
+        dlcOfferDb <- dlcOfferDbOpt
+        account <- accountOpt
+      } yield (dlcDb, dlcOfferDb, account)
     }
 
-    resultNested.flatMap {
-      case Some(f) => f.map(Some(_))
-      case None    => Future.successful(None)
-    }
+    result
   }
 
   private def initDLCForAccept(
@@ -479,75 +483,50 @@ abstract class DLCWallet
       s"Initializing DLC from received offer with tempContractId ${offer.tempContractId.hex}")
     val dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))
     val contractInfo = offer.contractInfo
+    val dlcOfferDb = DLCOfferDbHelper.fromDLCOffer(dlcId, offer)
+    val announcements =
+      offer.contractInfo.oracleInfos.head.singleOracleInfos
+        .map(_.announcement)
+
+    val chainType = HDChainType.External
+
+    //filter announcements that we already have in the db
+    val groupedAnnouncementsF: Future[AnnouncementGrouping] = {
+      groupByExistingAnnouncements(announcements)
+    }
+
     getDlcDbAndAccountDb(offer.tempContractId).flatMap {
-      case Some((dlcDb, account)) =>
-        Future.successful((dlcDb, account))
+      case Some((dlcDb, dlcOffer, account)) =>
+        Future.successful((dlcDb, dlcOffer, account))
       case None =>
-        val announcements =
-          offer.contractInfo.oracleInfos.head.singleOracleInfos
-            .map(_.announcement)
-
-        //filter announcements that we already have in the db
-        val groupedAnnouncementsF: Future[AnnouncementGrouping] = {
-          groupByExistingAnnouncements(announcements)
-        }
-
-
-
-        val dlcOfferDb = DLCOfferDbHelper.fromDLCOffer(dlcId, offer)
-
-        val chainType = HDChainType.External
-
         for {
           account <- getDefaultAccountForType(AddressType.SegWit)
           nextIndex <- getNextAvailableIndex(account, chainType)
-          dlc =
-            DLCDb(
-              dlcId = dlcId,
-              tempContractId = offer.tempContractId,
-              contractIdOpt = None,
-              protocolVersion = 0,
-              state = DLCState.Accepted,
-              isInitiator = false,
-              account = account.hdAccount,
-              changeIndex = chainType,
-              keyIndex = nextIndex,
-              feeRate = offer.feeRate,
-              fundOutputSerialId = offer.fundOutputSerialId,
-              lastUpdated = TimeUtil.now,
-              fundingOutPointOpt = None,
-              fundingTxIdOpt = None,
-              closingTxIdOpt = None,
-              aggregateSignatureOpt = None,
-              serializationVersion = contractInfo.serializationVersion
-            )
+          dlc = buildDlcDb(offer,
+                           dlcId,
+                           account,
+                           chainType,
+                           nextIndex,
+                           contractInfo)
 
-          contractDataDb = {
-            val oracleParamsOpt =
-              OracleInfo.getOracleParamsOpt(contractInfo.oracleInfos.head)
-            DLCContractDataDb(
-              dlcId = dlcId,
-              oracleThreshold = contractInfo.oracleInfos.head.threshold,
-              oracleParamsTLVOpt = oracleParamsOpt,
-              contractDescriptorTLV =
-                contractInfo.contractDescriptors.head.toTLV,
-              contractMaturity = offer.timeouts.contractMaturity,
-              contractTimeout = offer.timeouts.contractTimeout,
-              totalCollateral = contractInfo.totalCollateral
-            )
-          }
+          contractDataDb = buildContractDataDb(contractInfo, dlcId, offer)
           _ <- writeDLCKeysToAddressDb(account, chainType, nextIndex)
           groupedAnnouncements <- groupedAnnouncementsF
-          writtenDLCAction = dlcDAO.createAction(dlc)
+          dlcDbAction = dlcDAO.createAction(dlc)
           dlcOfferAction = dlcOfferDAO.createAction(dlcOfferDb)
           contractAction = contractDataDAO.createAction(contractDataDb)
-          createdDbsAction = announcementDAO.createAllAction(
+          createdAnnouncementsAction = announcementDAO.createAllAction(
             groupedAnnouncements.newAnnouncements)
-          zipped = writtenDLCAction.zip(createdDbsAction)
-          actions = zipped.flatMap { dlcDb =>
-            contractAction.map(_ => dlcDb)
+          zipped = {
+            for {
+              dlcDb <- dlcDbAction
+              ann <- createdAnnouncementsAction
+              //we don't need the contract data db, so don't return it
+              _ <- contractAction
+              offer <- dlcOfferAction
+            } yield (dlcDb, ann, offer)
           }
-          (writtenDLC, createdDbs) <- safeDatabase.run(actions)
+          (writtenDLC, createdDbs, offerDb) <- safeDatabase.run(zipped)
           announcementDataDbs =
             createdDbs ++ groupedAnnouncements.existingAnnouncements
 
@@ -577,8 +556,53 @@ abstract class DLCWallet
 
           _ <- safeDatabase.run(
             DBIOAction.seq(createNonceAction, createAnnouncementAction))
-        } yield (writtenDLC, account)
+        } yield (writtenDLC, offerDb, account)
     }
+  }
+
+  private def buildContractDataDb(
+      contractInfo: ContractInfo,
+      dlcId: Sha256Digest,
+      offer: DLCOffer): DLCContractDataDb = {
+    val oracleParamsOpt =
+      OracleInfo.getOracleParamsOpt(contractInfo.oracleInfos.head)
+    DLCContractDataDb(
+      dlcId = dlcId,
+      oracleThreshold = contractInfo.oracleInfos.head.threshold,
+      oracleParamsTLVOpt = oracleParamsOpt,
+      contractDescriptorTLV = contractInfo.contractDescriptors.head.toTLV,
+      contractMaturity = offer.timeouts.contractMaturity,
+      contractTimeout = offer.timeouts.contractTimeout,
+      totalCollateral = contractInfo.totalCollateral
+    )
+  }
+
+  private def buildDlcDb(
+      offer: DLCOffer,
+      dlcId: Sha256Digest,
+      account: AccountDb,
+      chainType: HDChainType,
+      nextIndex: Int,
+      contractInfo: ContractInfo): DLCDb = {
+    DLCDb(
+      dlcId = dlcId,
+      tempContractId = offer.tempContractId,
+      contractIdOpt = None,
+      protocolVersion = 0,
+      state = DLCState.Accepted,
+      isInitiator = false,
+      account = account.hdAccount,
+      changeIndex = chainType,
+      keyIndex = nextIndex,
+      feeRate = offer.feeRate,
+      fundOutputSerialId = offer.fundOutputSerialId,
+      lastUpdated = TimeUtil.now,
+      fundingOutPointOpt = None,
+      fundingTxIdOpt = None,
+      closingTxIdOpt = None,
+      aggregateSignatureOpt = None,
+      serializationVersion = contractInfo.serializationVersion
+    )
   }
 
   /** Creates a DLCAccept from the default Segwit account from a given offer, if one has already been
@@ -656,7 +680,7 @@ abstract class DLCWallet
     val dlcDbAccountDbF: Future[(DLCDb, DLCOfferDb, AccountDb)] =
       initDLCForAccept(offer)
     for {
-      (dlc, dlcOfferDb, account) <- dlcDbAccountDbF
+      (dlc, _, account) <- dlcDbAccountDbF
       (txBuilder, spendingInfos) <- fundRawTransactionInternal(
         destinations = Vector(TransactionOutput(collateral, EmptyScriptPubKey)),
         feeRate = offer.feeRate,
@@ -795,7 +819,6 @@ abstract class DLCWallet
 
       _ <- remoteTxDAO.upsertAll(offerPrevTxs)
       actions = actionBuilder.buildCreateAcceptAction(
-        dlcOfferDb = dlcOfferDb,
         dlcAcceptDb = dlcAcceptDb,
         offerInputs = offerInputs,
         acceptInputs = acceptInputs,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
@@ -56,7 +56,6 @@ case class DLCActionBuilder(dlcWalletDAOs: DLCWalletDAOs) {
     * offer table, accept table, cet sigs table, inputs table, and refund table
     */
   def buildCreateAcceptAction(
-      dlcOfferDb: DLCOfferDb,
       dlcAcceptDb: DLCAcceptDb,
       offerInputs: Vector[DLCFundingInputDb],
       acceptInputs: Vector[DLCFundingInputDb],
@@ -66,15 +65,10 @@ case class DLCActionBuilder(dlcWalletDAOs: DLCWalletDAOs) {
     NoStream,
     Effect.Write with Effect.Transactional] = {
     val inputAction = dlcInputsDAO.createAllAction(offerInputs ++ acceptInputs)
-    val offerAction = dlcOfferDAO.createAction(dlcOfferDb)
     val acceptAction = dlcAcceptDAO.createAction(dlcAcceptDb)
     val sigsAction = dlcSigsDAO.createAllAction(cetSigsDb)
     val refundSigAction = dlcRefundSigDAO.createAction(refundSigsDb)
-    val actions = Vector(inputAction,
-                         offerAction,
-                         acceptAction,
-                         sigsAction,
-                         refundSigAction)
+    val actions = Vector(inputAction, acceptAction, sigsAction, refundSigAction)
 
     val allActions = DBIO
       .sequence(actions)

--- a/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
@@ -39,7 +39,10 @@ trait EmbeddedPg extends BeforeAndAfterAll { this: Suite =>
 
   override def afterAll(): Unit = {
     super.afterAll()
-    val _ = pg.foreach(_.close())
+
+    val _ = pg.foreach { p =>
+      p.close()
+    }
     ()
   }
 


### PR DESCRIPTION
This PR does not intend to change any functionality. Only a refactor.

To achieve #4030 we need to detangle `DLCWallet.acceptDLCOffer()`. 

We want to add a new `DLCState` to represent when adaptor signatures are computing. [See work here](https://github.com/christewart/bitcoin-s-core/tree/2022-01-31-issue-4030)

To do this, we need to make a new state before we are `Accepted`. The problem with implementing this is how `acceptOffer()` creates the `Accepted` state inside of `initDLCForAccept`. This code seems to get called regardless if the DLC was already accepted or not.

This PR

1. Checks if the `Accept` mesage exists as the first step
2. If it does not exist, create it in the database. 