### PR TITLE
2022 02 06 remoteclaimed refactor

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCStatus.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCStatus.scala
@@ -254,6 +254,9 @@ object DLCStatus {
     }
   }
 
+  /** Calculates the outcome and signature for the CET
+    * that was broadcast on chain.
+    */
   def calculateOutcomeAndSig(
       isInitiator: Boolean,
       offer: DLCOffer,
@@ -267,12 +270,14 @@ object DLCStatus {
       accept.cetSigs.outcomeSigs
     }
 
-    DLCUtil.computeOutcome(isInitiator,
-                           offer.pubKeys.fundingKey,
-                           accept.pubKeys.fundingKey,
-                           offer.contractInfo,
-                           localAdaptorSigs,
-                           cet)
+    DLCUtil.computeOutcome(
+      isInitiator = isInitiator,
+      offerFundingKey = offer.pubKeys.fundingKey,
+      acceptFundingKey = accept.pubKeys.fundingKey,
+      contractInfo = offer.contractInfo,
+      localAdaptorSigs = localAdaptorSigs,
+      cet = cet
+    )
   }
 
 }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -125,6 +125,7 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
       _ = {
         (statusAOpt, statusBOpt) match {
           case (Some(statusA: Claimed), Some(statusB: RemoteClaimed)) =>
+            assert(statusA.oracleOutcome == statusB.oracleOutcome)
             assert(statusA.oracleSigs == Vector(statusB.oracleSig))
           case (_, _) => fail()
         }
@@ -172,6 +173,7 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
       _ = {
         (statusAOpt, statusBOpt) match {
           case (Some(statusA: RemoteClaimed), Some(statusB: Claimed)) =>
+            assert(statusA.oracleOutcome == statusB.oracleOutcome)
             assert(Vector(statusA.oracleSig) == statusB.oracleSigs)
           case (_, _) => fail()
         }
@@ -243,6 +245,7 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
       _ = {
         (statusAOpt, statusBOpt) match {
           case (Some(statusA: Claimed), Some(statusB: RemoteClaimed)) =>
+            assert(statusA.oracleOutcome == statusB.oracleOutcome)
             assert(statusA.oracleSigs == Vector(statusB.oracleSig))
           case (_, _) => fail()
         }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
@@ -124,10 +124,10 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
       announcementData: Vector[OracleAnnouncementDataDb],
       nonceDbs: Vector[OracleNonceDb]): Vector[
     (OracleAnnouncementV0TLV, Long)] = {
-    val withIds = nonceDbs
-      .groupBy(_.announcementId)
-      .toVector
-      .map { case (id, nonceDbs) =>
+    val withIds: Vector[(OracleAnnouncementV0TLV, Long)] = {
+      val idNonceVec: Vector[(Long, Vector[OracleNonceDb])] =
+        nonceDbs.groupBy(_.announcementId).toVector
+      idNonceVec.map { case (id, nonceDbs) =>
         announcementData.find(_.id.contains(id)) match {
           case Some(data) =>
             val nonces = nonceDbs.sortBy(_.index).map(_.nonce)
@@ -143,6 +143,7 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
             throw new RuntimeException(s"Error no data for announcement id $id")
         }
       }
+    }
     announcementIds
       .sortBy(_.index)
       .flatMap(a => withIds.find(_._2 == a.announcementId))

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -95,7 +95,9 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
             dlc <- findDLC(dlcDb.dlcId)
             _ = dlcConfig.walletCallbacks.executeOnDLCStateChange(logger,
                                                                   dlc.get)
-          } yield withOutcomeOpt
+          } yield {
+            withOutcomeOpt
+          }
         } else {
           //if the state is RemoteClaimed... we don't want to
           //calculate and set outcome again
@@ -139,6 +141,9 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
     */
   private def calculateAndSetOutcome(dlcDb: DLCDb): Future[Option[DLCDb]] = {
     if (dlcDb.state == DLCState.RemoteClaimed) {
+      logger.info(
+        s"Calculating RemotedClaimed outcome for dlcId=${dlcDb.dlcId.hex} closingTx=${dlcDb.closingTxIdOpt
+          .map(_.hex)}")
       val dlcId = dlcDb.dlcId
 
       for {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -91,8 +91,6 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
         if (dlcDb.state != DLCState.RemoteClaimed) {
           val withState = dlcDb.updateState(DLCState.RemoteClaimed)
           for {
-            // update so we can calculate correct DLCStatus
-            _ <- dlcDAO.update(withState)
             withOutcomeOpt <- calculateAndSetOutcome(withState)
             dlc <- findDLC(dlcDb.dlcId)
             _ = dlcConfig.walletCallbacks.executeOnDLCStateChange(logger,
@@ -211,6 +209,7 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
           }
         }
         updatedDlcDb = dlcDb.copy(aggregateSignatureOpt = Some(sig))
+        //updates the aggregateSignatureOpt along with the state to RemoteClaimed
         updatedDlcDbA = dlcDAO.updateAction(updatedDlcDb)
         updateNonceA = oracleNonceDAO.updateAllAction(updatedNonces)
         updateAnnouncementA = dlcAnnouncementDAO.updateAllAction(

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -228,6 +228,8 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
         }
         updatedDlcDb <- safeDatabase.run(actions.transactionally)
       } yield {
+        logger.info(
+          s"Done calculating RemoteClaimed outcome for dlcId=${dlcId.hex}")
         Some(updatedDlcDb)
       }
     } else {


### PR DESCRIPTION
This PR does not intend to change functionality.

Related to #4050 

This PR intends to refactor the `RemoteClaimed` flow and it make it easier to read. This asserts invariants about the flow that should hold true, and gives more useful error mesages for cases when these are not true.
