### PR TITLE
Limit number of max-connections on oracleServer to 1

### DIFF
--- a/app/oracle-server/src/main/resources/reference.conf
+++ b/app/oracle-server/src/main/resources/reference.conf
@@ -15,4 +15,6 @@ akka {
   http.server.request-timeout = 10s
   http.server.parsing.max-content-length = 8m
   http.client.parsing.max-content-length = 8m
+
+  http.server.max-connections = 1
 }

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -120,7 +120,7 @@ case class Server(
     val httpFut =
       Http()
         .newServerAt(rpchost, rpcport)
-        .bindFlow(route)
+        .bind(route)
     httpFut.foreach { http =>
       logger.info(s"Started Bitcoin-S HTTP server at ${http.localAddress}")
     }


### PR DESCRIPTION
Tries to prevent #4049 from happening again

This PR makes only 1 http connection available to the oracleServer. This is intended to reduce paralellism so we don't have race conditions on the pi as documented here

https://github.com/bitcoin-s/bitcoin-s/issues/4049#issuecomment-1031496481

here is the documentation on this setting from akka

https://doc.akka.io/docs/akka-http/current/server-side/low-level-api.html#controlling-server-parallelism

