### PR TITLE
Change `DLCUtil.buildOracleSignatures`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCUtil.scala
@@ -295,4 +295,24 @@ object DLCUtil {
 
     result
   }
+
+  def buildOracleSignaturesNaive(
+      announcements: OrderedAnnouncements,
+      attestments: Vector[OracleAttestmentTLV]): Vector[OracleSignatures] = {
+
+    attestments.foldLeft(Vector.empty[OracleSignatures]) { (acc, sig) =>
+      // Nonces should be unique so searching for the first nonce should be safe
+      val firstNonce = sig.sigs.head.rx
+      announcements
+        .find(
+          _.eventTLV.nonces.headOption
+            .contains(firstNonce)) match {
+        case Some(announcement) =>
+          acc :+ OracleSignatures(SingleOracleInfo(announcement), sig.sigs)
+        case None =>
+          throw new RuntimeException(
+            s"Cannot find announcement for associated public key, ${sig.publicKey.hex}")
+      }
+    }
+  }
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1355,9 +1355,9 @@ abstract class DLCWallet
         announcementData,
         nonceDbs)
 
-      oracleSigs = DLCUtil.buildOracleSignatures(announcements =
-                                                   announcementTLVs,
-                                                 attestments = sigs.toVector)
+      oracleSigs = DLCUtil.buildOracleSignaturesNaive(
+        announcements = announcementTLVs,
+        attestments = sigs.toVector)
 
       tx <- executeDLC(contractId, oracleSigs)
     } yield tx


### PR DESCRIPTION
Introduced in #4042 , old implementation leads to memory leaks on CI.