### PR TITLE
DLC Mutual Close

### DIFF
--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCPaneModel.scala
@@ -269,7 +269,8 @@ class DLCPaneModel(pane: DLCPane)(implicit ec: ExecutionContext)
               case None | Some(_)      => false
             }
           case DLCState.Broadcasted | DLCState.Confirmed | DLCState.Claimed |
-              DLCState.RemoteClaimed | DLCState.Refunded =>
+              DLCState.RemoteClaimed | DLCState.Refunded |
+              DLCState.MutuallyClosed =>
             new Alert(AlertType.Error) {
               initOwner(owner)
               headerText = "Failed to Cancel DLC"

--- a/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
+++ b/app/gui/src/main/scala/org/bitcoins/gui/dlc/DLCTableView.scala
@@ -222,7 +222,7 @@ class DLCTableView(model: DLCPaneModel) {
                   false
                 case DLCState.Confirmed | DLCState.Broadcasted |
                     DLCState.Claimed | DLCState.Refunded |
-                    DLCState.RemoteClaimed =>
+                    DLCState.RemoteClaimed | DLCState.MutuallyClosed =>
                   true
               }
               val disableRefundExecute = row.item.value.state match {
@@ -230,7 +230,7 @@ class DLCTableView(model: DLCPaneModel) {
                   false
                 case DLCState.Offered | DLCState.Accepted | DLCState.Signed |
                     DLCState.Claimed | DLCState.Refunded |
-                    DLCState.RemoteClaimed =>
+                    DLCState.RemoteClaimed | DLCState.MutuallyClosed =>
                   true
               }
               refundDLCItem.disable = disableRefundExecute

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
@@ -186,6 +186,13 @@ class TLVTest extends BitcoinSUnitTest {
     }
   }
 
+  "DLCMutualCloseTLV" must "have serialization symmetry" in {
+    forAll(TLVGen.dlcMutualCloseTLV) { close =>
+      assert(DLCMutualCloseTLV(close.bytes) == close)
+      assert(TLV(close.bytes) == close)
+    }
+  }
+
   it must "parse a contract info pre 144" in {
     //this was a contract info created before we implemented support for
     //https://github.com/discreetlogcontracts/dlcspecs/pull/144

--- a/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/DLCWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/DLCWalletApi.scala
@@ -2,7 +2,7 @@ package org.bitcoins.core.api.dlc.wallet
 
 import org.bitcoins.core.api.dlc.wallet.db.DLCDb
 import org.bitcoins.core.api.wallet._
-import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.dlc.accounting._
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.dlc.models.DLCMessage._
@@ -86,6 +86,14 @@ trait DLCWalletApi { self: WalletApi =>
 
   /** Creates the refund transaction for the given contractId, does not broadcast it */
   def executeDLCRefund(contractId: ByteVector): Future[Transaction]
+
+  def createMutualClose(
+      contractId: ByteVector,
+      localPayout: CurrencyUnit,
+      remotePayout: CurrencyUnit,
+      closeLocktime: UInt32): Future[DLCMutualCloseTLV]
+
+  def closeDLC(closeTLV: DLCMutualCloseTLV): Future[Transaction]
 
   def listDLCs(): Future[Vector[DLCStatus]]
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCState.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCState.scala
@@ -76,6 +76,12 @@ object DLCState extends StringFactory[DLCState] {
     val order: Int = 6
   }
 
+  /** The state where the DLC has been mutually closed by both parties
+    */
+  final case object MutuallyClosed extends ClosedState {
+    val order: Int = 7
+  }
+
   val all: Vector[DLCState] = Vector(Offered,
                                      Accepted,
                                      Signed,
@@ -83,7 +89,8 @@ object DLCState extends StringFactory[DLCState] {
                                      Confirmed,
                                      Claimed,
                                      RemoteClaimed,
-                                     Refunded)
+                                     Refunded,
+                                     MutuallyClosed)
 
   def fromString(str: String): DLCState = {
     all.find(state => str.toLowerCase() == state.toString.toLowerCase) match {

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCStatus.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCStatus.scala
@@ -217,6 +217,25 @@ object DLCStatus {
     override val state: DLCState.Refunded.type = DLCState.Refunded
   }
 
+  case class MutuallyClosed(
+      dlcId: Sha256Digest,
+      isInitiator: Boolean,
+      lastUpdated: Instant,
+      tempContractId: Sha256Digest,
+      contractId: ByteVector,
+      contractInfo: ContractInfo,
+      timeouts: DLCTimeouts,
+      feeRate: FeeUnit,
+      totalCollateral: CurrencyUnit,
+      localCollateral: CurrencyUnit,
+      fundingTxId: DoubleSha256DigestBE,
+      closingTxId: DoubleSha256DigestBE,
+      myPayout: CurrencyUnit,
+      counterPartyPayout: CurrencyUnit)
+      extends ClosedDLCStatus {
+    override val state: DLCState.MutuallyClosed.type = DLCState.MutuallyClosed
+  }
+
   def getContractId(status: DLCStatus): Option[ByteVector] = {
     status match {
       case status: AcceptedDLCStatus =>
@@ -249,7 +268,8 @@ object DLCStatus {
     status match {
       case claimed: ClaimedDLCStatus =>
         Some(claimed.oracleSigs)
-      case _: Offered | _: Accepted | _: SignedDLCStatus | _: Refunded =>
+      case _: Offered | _: Accepted | _: SignedDLCStatus | _: Refunded |
+          _: MutuallyClosed =>
         None
     }
   }

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCDataHandler.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCDataHandler.scala
@@ -63,6 +63,9 @@ class DLCDataHandler(dlcWalletApi: DLCWalletApi, connectionHandler: ActorRef)
           _ <- dlcWalletApi.broadcastDLCFundingTx(dlcSign.contractId)
         } yield ()
         f
+      case close: DLCMutualCloseTLV =>
+        log.info(s"Received close message for DLC ${close.contractId.toHex}")
+        Future.unit
     }
   }
 }

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCParsingTestVector.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCParsingTestVector.scala
@@ -550,7 +550,8 @@ object DLCParsingTestVector extends TestVectorParser[DLCParsingTestVector] {
         )
 
         DLCMessageTestVector(LnMessage(tlv), "oracle_attestment_v0", fields)
-      case _: UnknownTLV | _: ErrorTLV | _: PingTLV | _: PongTLV | _: InitTLV =>
+      case _: UnknownTLV | _: ErrorTLV | _: PingTLV | _: PongTLV | _: InitTLV |
+          _: DLCMutualCloseTLV =>
         throw new IllegalArgumentException(
           s"DLCParsingTestVector is only defined for DLC messages and TLVs, got $tlv")
     }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
@@ -49,7 +49,7 @@ class DLCWalletCallbackTest extends BitcoinSDualWalletTest {
           //ignore broadcast from this wallet
           Future.unit
         case x @ (DLCState.Accepted | DLCState.RemoteClaimed |
-            DLCState.Refunded) =>
+            DLCState.Refunded | DLCState.MutuallyClosed) =>
           sys.error(s"Shouldn't receive state=$x for callback")
       }
 
@@ -65,7 +65,8 @@ class DLCWalletCallbackTest extends BitcoinSDualWalletTest {
           Future.successful(remoteClaimedP.success(status))
         case x @ (DLCState.Offered | DLCState.Signed) =>
           sys.error(s"Shouldn't receive state=$x for callback")
-        case DLCState.Confirmed | DLCState.Claimed | DLCState.Refunded =>
+        case DLCState.Confirmed | DLCState.Claimed | DLCState.Refunded |
+            DLCState.MutuallyClosed =>
           //do nothing, we are doing assertions for these on walletACallback
           Future.unit
       }
@@ -146,7 +147,7 @@ class DLCWalletCallbackTest extends BitcoinSDualWalletTest {
         case DLCState.Refunded =>
           Future.successful(refundedP.success(status))
         case x @ (DLCState.Claimed | DLCState.Accepted |
-            DLCState.RemoteClaimed | DLCState.Refunded) =>
+            DLCState.RemoteClaimed | DLCState.MutuallyClosed) =>
           sys.error(s"Shouldn't receive state=$x for callback")
       }
 
@@ -160,7 +161,8 @@ class DLCWalletCallbackTest extends BitcoinSDualWalletTest {
           Future.successful(broadcastP.success(status))
         case x @ (DLCState.Refunded | DLCState.Offered | DLCState.Signed) =>
           sys.error(s"Shouldn't receive state=$x for callback")
-        case DLCState.Confirmed | DLCState.Claimed | DLCState.RemoteClaimed =>
+        case DLCState.Confirmed | DLCState.Claimed | DLCState.RemoteClaimed |
+            DLCState.MutuallyClosed =>
           //do nothing, we are doing assertions for these on walletACallback
           Future.unit
       }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1397,7 +1397,8 @@ abstract class DLCWallet
     dlcDb.state match {
       case DLCState.Broadcasted | DLCState.Signed => dlcDb
       case state @ (DLCState.Offered | DLCState.Confirmed | DLCState.Accepted |
-          DLCState.Claimed | DLCState.RemoteClaimed | DLCState.Refunded) =>
+          DLCState.Claimed | DLCState.RemoteClaimed | DLCState.Refunded |
+          DLCState.MutuallyClosed) =>
         sys.error(
           s"Cannot broadcast the dlc when it is in the state=${state} contractId=${dlcDb.contractIdOpt}")
     }
@@ -1592,6 +1593,90 @@ abstract class DLCWallet
                                closingTxOpt)
       _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, status.get)
     } yield refundTx
+  }
+
+  override def createMutualClose(
+      contractId: ByteVector,
+      localPayout: CurrencyUnit,
+      remotePayout: CurrencyUnit,
+      closeLocktime: UInt32): Future[DLCMutualCloseTLV] = {
+    dlcDAO.findByContractId(contractId).flatMap {
+      case None =>
+        Future.failed(
+          new RuntimeException(
+            s"Could not find a DLC with contract id ${contractId.toHex}"))
+      case Some(dlcDb) =>
+        for {
+          fundingInputs <- dlcInputsDAO.findByDLCId(dlcDb.dlcId)
+          scriptSigParams <- getScriptSigParams(dlcDb, fundingInputs)
+          signer <- dlcDataManagement
+            .signerFromDb(dlcId = dlcDb.dlcId,
+                          transactionDAO = transactionDAO,
+                          fundingUtxoScriptSigParams = scriptSigParams,
+                          keyManager = keyManager)
+            .map(_.get)
+
+          (offerPayout, acceptPayout) =
+            if (dlcDb.isInitiator) (localPayout, remotePayout)
+            else (remotePayout, localPayout)
+
+          tlv = signer.createMutualClose(offerPayout,
+                                         acceptPayout,
+                                         Vector.empty,
+                                         closeLocktime)
+
+          _ <- updateDLCState(contractId, DLCState.MutuallyClosed)
+        } yield tlv
+    }
+  }
+
+  override def closeDLC(closeTLV: DLCMutualCloseTLV): Future[Transaction] = {
+    val contractId = closeTLV.contractId
+    dlcDAO.findByContractId(contractId).flatMap {
+      case None =>
+        Future.failed(
+          new RuntimeException(
+            s"Could not find a DLC for contract id ${contractId.toHex}"))
+      case Some(dlcDb) =>
+        val dlcId = dlcDb.dlcId
+
+        for {
+          fundingInputs <- dlcInputsDAO.findByDLCId(dlcId)
+          scriptSigParams <- getScriptSigParams(dlcDb, fundingInputs)
+          signer <- dlcDataManagement
+            .signerFromDb(dlcId = dlcId,
+                          transactionDAO = transactionDAO,
+                          fundingUtxoScriptSigParams = scriptSigParams,
+                          keyManager = keyManager)
+            .map(_.get)
+
+          closeTx = signer.completeMutualClose(closeTLV)
+          _ = logger.info(
+            s"Created DLC close transaction ${closeTx.txIdBE.hex} for contract ${contractId.toHex}")
+
+          _ <- updateDLCState(contractId, DLCState.MutuallyClosed)
+          updatedDlcDb <- updateClosingTxId(contractId, closeTx.txIdBE)
+
+          _ <- processTransaction(closeTx, blockHashOpt = None)
+          closingTxOpt <- getClosingTxOpt(updatedDlcDb)
+          action = {
+            for {
+              contractData <- contractDataDAO.findByDLCIdAction(dlcId)
+              dlcAcceptOpt <- dlcAcceptDAO.findByDLCIdAction(updatedDlcDb.dlcId)
+              offerDbOpt <- dlcOfferDAO.findByDLCIdAction(dlcDb.dlcId)
+            } yield (contractData.get, dlcAcceptOpt, offerDbOpt)
+          }
+          (contractData, dlcAcceptOpt, offerDbOpt) <- dlcDAO.safeDatabase.run(
+            action)
+          status <- buildDLCStatus(updatedDlcDb,
+                                   contractData,
+                                   offerDbOpt.get,
+                                   dlcAcceptOpt,
+                                   closingTxOpt)
+          _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger,
+                                                                 status.get)
+        } yield closeTx
+    }
   }
 
   override def getWalletAccounting(): Future[DLCWalletAccounting] = {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCStatusBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCStatusBuilder.scala
@@ -133,6 +133,24 @@ object DLCStatusBuilder {
       totalCollateral - offerDb.collateral
     }
     val status = dlcDb.state.asInstanceOf[DLCState.ClosedState] match {
+      case DLCState.MutuallyClosed =>
+        // no oracle information in the mutual close case
+        MutuallyClosed(
+          dlcId,
+          dlcDb.isInitiator,
+          dlcDb.lastUpdated,
+          dlcDb.tempContractId,
+          dlcDb.contractIdOpt.get,
+          contractInfo,
+          contractData.dlcTimeouts,
+          dlcDb.feeRate,
+          totalCollateral,
+          localCollateral,
+          dlcDb.fundingTxIdOpt.get,
+          closingTx.txIdBE,
+          myPayout = accounting.myPayout,
+          counterPartyPayout = accounting.theirPayout
+        )
       case DLCState.Refunded =>
         //no oracle information in the refund case
         val refund = Refunded(

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
@@ -528,6 +528,30 @@ trait TLVGen {
     }
   }
 
+  def dlcMutualCloseTLV: Gen[DLCMutualCloseTLV] = {
+    for {
+      contractId <- NumberGenerator.bytevector(32)
+      sig <- CryptoGenerators.digitalSignature
+      payoutOffer <- CurrencyUnitGenerator.positiveRealistic
+      acceptOffer <- CurrencyUnitGenerator.positiveRealistic
+      serialId <- NumberGenerator.uInt64
+      extraInputs <- fundingInputV0TLVs(payoutOffer + acceptOffer)
+      fundingSigs <- fundingSignaturesV0TLV(extraInputs.size)
+      locktime <- NumberGenerator.uInt32s
+    } yield {
+      DLCMutualCloseTLV(
+        contractId = contractId,
+        signature = sig,
+        offerPayoutSatoshis = payoutOffer,
+        acceptPayoutSatoshis = acceptOffer,
+        fundingInputSerialId = serialId,
+        extraInputs = extraInputs,
+        inputSignatures = fundingSigs,
+        closeLocktime = locktime
+      )
+    }
+  }
+
   def dlcSignTLV(offer: DLCOfferTLV, accept: DLCAcceptTLV): Gen[DLCSignTLV] = {
     val contractInfo = ContractInfo.fromTLV(offer.contractInfo)
 
@@ -579,7 +603,8 @@ trait TLVGen {
       fundingSignaturesV0TLV,
       dlcOfferTLV,
       dlcAcceptTLV,
-      dlcSignTLV
+      dlcSignTLV,
+      dlcMutualCloseTLV
     )
   }
 }


### PR DESCRIPTION
impl: https://github.com/discreetlogcontracts/dlcspecs/pull/170

This doesn't have the extraInputs implemented on the create mutual close side, that could be done later

still waiting on a number for the type number of `DLCMutualCloseTLV`