### PR TITLE
Don't call findByPrimaryKeys if ids is empty

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAction.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAction.scala
@@ -42,8 +42,12 @@ abstract class CRUDAction[T, PrimaryKeyType](implicit
 
   protected def findByPrimaryKeysAction(ids: Vector[
     PrimaryKeyType]): DBIOAction[Vector[T], NoStream, Effect.Read] = {
-    findByPrimaryKeys(ids).result
-      .map(_.toVector)
+    if (ids.isEmpty) {
+      DBIO.successful(Vector.empty)
+    } else {
+      findByPrimaryKeys(ids).result
+        .map(_.toVector)
+    }
   }
 
   def findByPrimaryKeyAction(


### PR DESCRIPTION
Was getting errors with postgres where it would fail to query with an empty vector of ids