### PR TITLE
Implement connection timeout for `dlcNode`

### DIFF
--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCClient.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCClient.scala
@@ -10,6 +10,7 @@ import org.bitcoins.tor.{Socks5Connection, Socks5ProxyParams}
 
 import java.io.IOException
 import java.net.InetSocketAddress
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Future, Promise}
 
 class DLCClient(
@@ -36,7 +37,14 @@ class DLCClient(
             remoteAddress
         }
       context.become(connecting(peer))
-      IO(Tcp) ! Tcp.Connect(peerOrProxyAddress)
+
+      //currently our request timeout for requests sent to the backend is 60 seconds
+      //so we need the connection timeout to occur before the request times out
+      //when a user tries to submit an accept to the backend
+      //see: https://github.com/bitcoin-s/bitcoin-s/issues/4080
+      val connectionTimeout = 45.seconds
+      IO(Tcp) ! Tcp.Connect(peerOrProxyAddress,
+                            timeout = Some(connectionTimeout))
   }
 
   def connecting(peer: Peer): Receive = LoggingReceive {
@@ -44,7 +52,6 @@ class DLCClient(
       val ex = c.cause.getOrElse(new IOException("Unknown Error"))
       log.error(s"Cannot connect to ${cmd.remoteAddress} ", ex)
       throw ex
-
     case Tcp.Connected(peerOrProxyAddress, _) =>
       val connection = sender()
       peer.socks5ProxyParams match {


### PR DESCRIPTION
fixes #4080 

If we can't establish a connection with our peers node after 45 seconds, fail.

This timeout is set to less than the request timeout so that we don't have background processes happening after the request times out. The request timeout is set to 60 seconds here: 

https://github.com/bitcoin-s/bitcoin-s/blob/08941206fc0c238aa68046172f9ecb060a75d2cb/db-commons/src/main/resources/reference.conf#L226

This is what the error looks like on the UI. 

![Screenshot from 2022-02-12 06-39-08](https://user-images.githubusercontent.com/3514957/153712410-071d5621-0669-4bc0-ad3e-6bc506b880de.png)
