### PR TITLE
2022 02 12 cleanup example config

### DIFF
--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -98,8 +98,13 @@ to ensure the entire module is initialized correctly.
 
 ```$xslt
 bitcoin-s {
-    datadir = ${HOME}/.bitcoin-s
+    # the network your bitcoin-s node is running on
     network = "testnet3" # regtest, testnet3, mainnet, signet
+
+    # specify what backend you are using with bitcoin-s
+    # by default we do neutrino, but you can also connect
+    # bitcoind with the configuration settings in bitcoin-s.bitcoind-rpc
+    node.mode = neutrino # neutrino, bitcoind
     
     # configurations for connecting to bitcoind
     bitcoind-rpc {
@@ -140,10 +145,6 @@ bitcoin-s {
     
     # settings if you are using a neutrino node in bitcoin-s
     node {
-        # specify what backend you are using with bitcoin-s
-        # by default we do neutrino, but you can also connect
-        # bitcoind with the configuration settings in bitcoin-s.bitcoind-rpc
-        mode = neutrino # neutrino, bitcoind
 
         # a list of peer addresses in form "hostname:portnumber"
         # Port number is optional, the default value is 8333 for mainnet,

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -99,32 +99,9 @@ to ensure the entire module is initialized correctly.
 ```$xslt
 bitcoin-s {
     datadir = ${HOME}/.bitcoin-s
-    network = regtest # regtest, testnet3, mainnet, signet
-    dbDefault = {
-      dataSourceClass = slick.jdbc.DatabaseUrlDataSource
-      profile = "slick.jdbc.SQLiteProfile$"
-  
-      db {
-        # for information on parameters available here see
-        # https://scala-slick.org/doc/3.3.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database
-        path = ${bitcoin-s.datadir}/${bitcoin-s.network}/
-        driver = org.sqlite.JDBC
-        user = ""
-        password = ""
-        host = localhost
-        port = 5432
-  
-        # this needs to be set to 1 for SQLITE as it does not support concurrent database operations
-        # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
-        numThreads = 1
-        queueSize=5000
-        connectionPool = "HikariCP"
-        registerMbeans = true
-      }
-      hikari-logging = false
-      hikari-logging-interval = 10 minute
-    }
+    network = "testnet3" # regtest, testnet3, mainnet, signet
     
+    # configurations for connecting to bitcoind
     bitcoind-rpc {
         # bitcoind rpc username
         rpcuser = user
@@ -160,14 +137,20 @@ bitcoin-s {
         #If you have a bitcoind instance that is running remotely on another machine, you should set it to true
         isRemote = false
     }
-
+    
+    # settings if you are using a neutrino node in bitcoin-s
     node {
-        mode = neutrino # neutrino, spv, bitcoind
+        # specify what backend you are using with bitcoin-s
+        # by default we do neutrino, but you can also connect
+        # bitcoind with the configuration settings in bitcoin-s.bitcoind-rpc
+        mode = neutrino # neutrino, bitcoind
 
-        peers = [] # a list of peer addresses in form "hostname:portnumber"
-        # (e.g. "neutrino.testnet3.suredbits.com:18333")
+        # a list of peer addresses in form "hostname:portnumber"
         # Port number is optional, the default value is 8333 for mainnet,
         # 18333 for testnet and 18444 for regtest.
+        # by default we provide a testnet peer to connect to
+        peers = ["neutrino.testnet3.suredbits.com:18333"] 
+
         
         hikari-logging = true
         hikari-logging-interval = 10 minute
@@ -182,6 +165,7 @@ bitcoin-s {
         socks5 = "127.0.0.1:9050"
     }
 
+    # tor settings
     tor {
         # You can enable Tor for incoming connections
         enabled = false
@@ -207,6 +191,7 @@ bitcoin-s {
         # privateKeyPath = /path/to/priv/key
     }
     
+    # settings for the chain module
     chain {
         force-recalc-chainwork = false
         neutrino {
@@ -268,12 +253,12 @@ bitcoin-s {
         # bip39password = "changeMe"
 
         # Password that your seed is encrypted with
-        aesPassword = changeMe
+        # aesPassword = changeMe
         
         # At least 16 bytes of entropy encoded in hex
         # This will be used as the seed for any
         # project that is dependent on the keymanager
-        entropy = ""
+        # entropy = ""
     }
 
     # Bitcoin-S provides manny different fee providers
@@ -303,7 +288,7 @@ bitcoin-s {
         # The address we are listening on for incoming connections for DLCs
         # Binding to 0.0.0.0 makes us listen to all incoming connections
         # Consider using 127.0.0.1 listen address if Tor is enabled.
-        listen = "0.0.0.0:2862"
+        # listen = "0.0.0.0:2862"
         
         # The address our peers use to connect to our node. 
         # By default it's the same as the listen address, 
@@ -346,6 +331,31 @@ bitcoin-s {
         db {
           path = ${bitcoin-s.datadir}/oracle/
         }
+    }
+    
+    dbDefault = {
+      dataSourceClass = slick.jdbc.DatabaseUrlDataSource
+      profile = "slick.jdbc.SQLiteProfile$"
+  
+      db {
+        # for information on parameters available here see
+        # https://scala-slick.org/doc/3.3.1/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver,ClassLoader):Database
+        path = ${bitcoin-s.datadir}/${bitcoin-s.network}/
+        driver = org.sqlite.JDBC
+        user = ""
+        password = ""
+        host = localhost
+        port = 5432
+  
+        # this needs to be set to 1 for SQLITE as it does not support concurrent database operations
+        # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
+        numThreads = 1
+        queueSize=5000
+        connectionPool = "HikariCP"
+        registerMbeans = true
+      }
+      hikari-logging = false
+      hikari-logging-interval = 10 minute
     }
     
     testkit {

--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -89,7 +89,7 @@ Now that we have the bitcoin-s repo setup, we want to create our application con
 
 First, create a `$HOME/.bitcoin-s` directory via `mkdir` or an equivalent command. 
 
-Next, create a `bitcoin-s.conf` file in `$HOME/.bitcoin-s`. [Here is an example configuration file](config/configuration.md#example-configuration-file). The only thing that you will _need_ to change is the `peers` list to which you will want to add `"localhost:18444"` if you want to run in regtest.
+Next, create a `bitcoin-s.conf` file in `$HOME/.bitcoin-s`. [Here is an example configuration file](config/configuration.md#example-configuration-file).
 
 ## Step 4: Building the Server and Setting Up the CLI
 


### PR DESCRIPTION
This is a common problem that users have when setting up our codebase. They go to our example configuration page, copy the entire configuration, and put it in their `bitcoin-s.conf` file. 

Unfortunately, we had some bad defaults in the configuration file, for instance 

`bitcoin-s.keymanager.entropy = ""`

which leads to an exception being thrown due to no entropy.

![Screenshot from 2022-02-12 07-29-56](https://user-images.githubusercontent.com/3514957/153713361-489a564f-fc0e-4ac0-a231-4d5b24a649f5.png)
