### PR TITLE
2022 02 13 issue 3405

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -67,10 +67,6 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
           case Some(tag) =>
             listUtxos(fromAccount.hdAccount, tag)
         }
-        //real:
-        //https://github.com/bitcoin-s/bitcoin-s/releases/download/1.8.0/bitcoin-s_1.8.0-1_amd64.deb
-        //bad:
-        //https://github.com/bitcoin-s/bitcoin-s/releases/download/1.8.0/bitcoin-s-1.8.0-1_amd64.deb
         utxoWithTxs <- Future.sequence {
           utxos.map { utxo =>
             transactionDAO

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -68,9 +68,9 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
             listUtxos(fromAccount.hdAccount, tag)
         }
         //real:
-        //https://github.com/bitcoin-s/bitcoin-s/releases/download/1.8.0/bitcoin-s-server-1.8.0.zip
+        //https://github.com/bitcoin-s/bitcoin-s/releases/download/1.8.0/bitcoin-s_1.8.0-1_amd64.deb
         //bad:
-        //https://github.com/bitcoin-s/bitcoin-s/releases/download/1.8.0/bitcoin-s-server-1.8.0.tgz
+        //https://github.com/bitcoin-s/bitcoin-s/releases/download/1.8.0/bitcoin-s-1.8.0-1_amd64.deb
         utxoWithTxs <- Future.sequence {
           utxos.map { utxo =>
             transactionDAO

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -67,6 +67,10 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
           case Some(tag) =>
             listUtxos(fromAccount.hdAccount, tag)
         }
+        //real:
+        //https://github.com/bitcoin-s/bitcoin-s/releases/download/1.8.0/bitcoin-s-server-1.8.0.zip
+        //bad:
+        //https://github.com/bitcoin-s/bitcoin-s/releases/download/1.8.0/bitcoin-s-server-1.8.0.tgz
         utxoWithTxs <- Future.sequence {
           utxos.map { utxo =>
             transactionDAO

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -644,6 +644,9 @@
       "version-0.6.0/core/version-0.6.0-addresses": {
         "title": "Generating Addresses"
       },
+      "version-0.6.0/core/version-0.6.0-core-intro": {
+        "title": "Core Module"
+      },
       "version-0.6.0/core/version-0.6.0-dlc": {
         "title": "Discreet Log Contract Data Structures"
       },
@@ -712,6 +715,9 @@
       },
       "version-0.6.0/wallet/version-0.6.0-wallet-rescan": {
         "title": "Wallet Rescans"
+      },
+      "version-0.6.0/wallet/version-0.6.0-wallet-rpc": {
+        "title": "Wallet RPC Examples"
       },
       "version-0.6.0/wallet/version-0.6.0-wallet": {
         "title": "Wallet"

--- a/website/pages/en/download.js
+++ b/website/pages/en/download.js
@@ -41,22 +41,22 @@ function Downloads(props) {
                         <tbody>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server-${latestVersion}.dmg`}>bitcoin-s-server-{latestVersion}.dmg</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-${latestVersion}.dmg`}>bitcoin-s-server-{latestVersion}.dmg</a>
                             </td>
                         </tr>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server-${latestVersion}.zip`}>bitcoin-s-server-{latestVersion}.tgz</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server-${latestVersion}.zip`}>bitcoin-s-server-{latestVersion}.zip</a>
                             </td>
                         </tr>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server.deb`}>bitcoin-s-server.deb</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s_${latestVersion}-1_amd64.deb`}>bitcoin-s-server-amd64.deb</a>
                             </td>
                         </tr>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server.msi`}>bitcoin-s-server.msi</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-bundle.msi`}>bitcoin-s-server.msi</a>
                             </td>
                         </tr>
                         <tr>

--- a/website/pages/en/download.js
+++ b/website/pages/en/download.js
@@ -46,12 +46,7 @@ function Downloads(props) {
                         </tr>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server-${latestVersion}.tgz`}>bitcoin-s-server-{latestVersion}.tgz</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server-docker.zip`}>bitcoin-s-server-docker.zip</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server-${latestVersion}.zip`}>bitcoin-s-server-{latestVersion}.tgz</a>
                             </td>
                         </tr>
                         <tr>

--- a/website/pages/en/download.js
+++ b/website/pages/en/download.js
@@ -27,7 +27,7 @@ function Downloads(props) {
                         <tr>
                             <th>{latestVersion}</th>
                             <td>
-                                <a href={`${releaseUrl}/tag/v${latestVersion}`}>
+                                <a href={`${releaseUrl}/tag/${latestVersion}`}>
                                     Release
                                 </a>
                             </td>
@@ -41,32 +41,32 @@ function Downloads(props) {
                         <tbody>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/v${latestVersion}/bitcoin-s-server-${latestVersion}.dmg`}>bitcoin-s-server-{latestVersion}.dmg</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server-${latestVersion}.dmg`}>bitcoin-s-server-{latestVersion}.dmg</a>
                             </td>
                         </tr>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/v${latestVersion}/bitcoin-s-server-${latestVersion}.tgz`}>bitcoin-s-server-{latestVersion}.tgz</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server-${latestVersion}.tgz`}>bitcoin-s-server-{latestVersion}.tgz</a>
                             </td>
                         </tr>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/v${latestVersion}/bitcoin-s-server-docker.zip`}>bitcoin-s-server-docker.zip</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server-docker.zip`}>bitcoin-s-server-docker.zip</a>
                             </td>
                         </tr>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/v${latestVersion}/bitcoin-s-server.deb`}>bitcoin-s-server.deb</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server.deb`}>bitcoin-s-server.deb</a>
                             </td>
                         </tr>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/v${latestVersion}/bitcoin-s-server.msi`}>bitcoin-s-server.msi</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/bitcoin-s-server.msi`}>bitcoin-s-server.msi</a>
                             </td>
                         </tr>
                         <tr>
                             <td>
-                                <a href={`${releaseUrl}/download/v${latestVersion}/SHA256SUMS.asc`}>SHA256SUMS.asc</a>
+                                <a href={`${releaseUrl}/download/${latestVersion}/SHA256SUMS.asc`}>SHA256SUMS.asc</a>
                             </td>
                         </tr>
                         </tbody>

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -56,7 +56,7 @@ function Versions(props) {
                   <a href={siteConfig.scaladocUrl}>Scaladoc</a>
                 </td>
                 <td>
-                  <a href={`${repoUrl}/releases/tag/v${latestVersion}`}>
+                  <a href={`${repoUrl}/releases/tag/${latestVersion}`}>
                     Release Notes
                   </a>
                 </td>


### PR DESCRIPTION
fixes #3405

Now the download links should with our released artifacts on github. 

Note for the future, anytime we change our tagging scheme (for instance, previously we removed the `v` prefix so our tag is `1.8.0` rather than `v1.8.0`) these download links will break.

<img width="1396" alt="Screen Shot 2022-02-13 at 4 10 50 PM" src="https://user-images.githubusercontent.com/3514957/153777393-94e13af9-8a68-4cd0-982c-bbe970b099bf.png">
