### PR TITLE
Fix SpendingInfoDAO.findOutputsReceived() bug

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -266,7 +266,7 @@ object WalletTestUtil {
   def insertLegacyUTXO(daos: WalletDAOs, state: TxoState)(implicit
       ec: ExecutionContext): Future[LegacySpendingInfo] = {
     for {
-      account <- daos.accountDAO.create(WalletTestUtil.firstAccountDb)
+      account <- daos.accountDAO.upsert(WalletTestUtil.firstAccountDb)
       addr <- daos.addressDAO.create(getAddressDb(account))
       utxo = sampleLegacyUTXO(addr.scriptPubKey, state)
       _ <- insertDummyIncomingTransaction(daos, utxo)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/SpendingInfoDAOTest.scala
@@ -182,14 +182,21 @@ class SpendingInfoDAOTest extends WalletDAOFixture {
     } yield assert(unspent.isEmpty)
   }
 
-  it must "insert a TXO and read it back with through a TXID " in { daos =>
+  it must "insert a TXO that is received and find it" in { daos =>
     val spendingInfoDAO = daos.utxoDAO
 
     for {
-      utxo <- WalletTestUtil.insertLegacyUTXO(daos,
-                                              state = TxoState.DoesNotExist)
-      foundTxos <- spendingInfoDAO.findOutputsReceived(Vector(utxo.txid))
-    } yield assert(foundTxos.contains(utxo))
+      utxo <- WalletTestUtil.insertLegacyUTXO(
+        daos,
+        state = TxoState.PendingConfirmationsReceived)
+      utxo2 <- WalletTestUtil.insertLegacyUTXO(daos,
+                                               state = TxoState.BroadcastSpent)
+      foundTxos <- spendingInfoDAO.findOutputsReceived(
+        Vector(utxo.txid, utxo2.txid))
+    } yield {
+      assert(foundTxos.length == 1)
+      assert(foundTxos.contains(utxo))
+    }
 
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -308,7 +308,9 @@ case class SpendingInfoDAO()(implicit
     */
   def findOutputsReceived(
       txids: Vector[DoubleSha256DigestBE]): Future[Vector[SpendingInfoDb]] = {
-    val filtered = spkJoinQuery.filter(_._1.txid.inSet(txids))
+    val filtered = spkJoinQuery
+      .filter(_._1.state.inSet(TxoState.receivedStates))
+      .filter(_._1.txid.inSet(txids))
     safeDatabase
       .runVec(filtered.result)
       .map(res =>


### PR DESCRIPTION
Found while looking into #3842 

I'm not sure if this is the root cause, but this is definitely a bug.

