### PR TITLE
Segregate updating received utxos and spent utxos

### DIFF
--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
@@ -18,131 +18,156 @@ class UTXOHandlingTest extends BitcoinSWalletTest {
     withNewWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
   }
 
-  it must "correctly update txo state based on confirmations" in { wallet =>
-    val utxo = sampleSegwitUTXO(EmptyScriptPubKey,
-                                state = TxoState.Reserved
-    ) //state doesn't matter here
-    val requiredConfs = 6
-    assert(wallet.walletConfig.requiredConfirmations == requiredConfs)
+  val utxo = sampleSegwitUTXO(EmptyScriptPubKey,
+                              state = TxoState.Reserved
+  ) //state doesn't matter here
+  val requiredConfs = 6
+  val reserved = utxo.copyWithState(Reserved)
 
-    val immatureCoinbase = utxo.copyWithState(ImmatureCoinbase)
-    val pendingConfReceived = utxo.copyWithState(PendingConfirmationsReceived)
-    val spendingTxId = randomTXID
-    val pendingConfSpent = utxo
-      .copyWithSpendingTxId(spendingTxId)
-      .copyWithState(PendingConfirmationsSpent)
-    val confReceived = utxo
-      .copyWithState(ConfirmedReceived)
-    val confSpent = utxo
-      .copyWithSpendingTxId(spendingTxId)
-      .copyWithState(ConfirmedSpent)
-    val reserved = utxo.copyWithState(Reserved)
+  val immatureCoinbase = utxo.copyWithState(ImmatureCoinbase)
 
-    //it must stay reserved if we are receiving confirmations
-    assert(wallet.updateReceivedTxoWithConfs(reserved, 1) == reserved)
-    val withSpendingTxId =
-      reserved.copyWithSpendingTxId(DoubleSha256DigestBE.empty)
+  val confReceived = utxo
+    .copyWithState(ConfirmedReceived)
 
-    //it must transition from reserved to spent
-    assert(
-      wallet
-        .updateSpentTxoWithConfs(withSpendingTxId, 1)
-        .state == TxoState.PendingConfirmationsSpent)
+  val pendingConfReceived = utxo.copyWithState(PendingConfirmationsReceived)
 
-    //it must stay immature coinbase if we don't have > 101 confirmations
-    assert(
-      wallet.updateReceivedTxoWithConfs(immatureCoinbase,
-                                        10) == immatureCoinbase)
-    assert(
-      wallet.updateReceivedTxoWithConfs(immatureCoinbase, 101) == confReceived)
+  it must "correct update receive txo state based on confirmations" in {
+    wallet =>
+      //it must stay reserved if we are receiving confirmations
+      assert(wallet.updateReceivedTxoWithConfs(reserved, 1) == reserved)
 
-    //cannot spend an immature coinbase output
-    assertThrows[RuntimeException] {
-      //cannot have utxo spent from coinbase before 101 blocks
-      wallet.updateSpentTxoWithConfs(immatureCoinbase, 100)
-    }
+      //it must stay immature coinbase if we don't have > 101 confirmations
+      assert(
+        wallet.updateReceivedTxoWithConfs(immatureCoinbase,
+                                          10) == immatureCoinbase)
+      assert(
+        wallet.updateReceivedTxoWithConfs(immatureCoinbase,
+                                          101) == confReceived)
 
-    //we must stay pending confirmations received with only 1 confirmation
-    assert(
-      wallet.updateReceivedTxoWithConfs(pendingConfReceived,
-                                        1) == pendingConfReceived)
+      //we must stay pending confirmations received with only 1 confirmation
+      assert(
+        wallet.updateReceivedTxoWithConfs(pendingConfReceived,
+                                          1) == pendingConfReceived)
 
-    val pendingConfReceivedWithTxId = pendingConfReceived
-      .copyWithSpendingTxId(DoubleSha256DigestBE.empty)
+      //must be able to go back to broadcast received if we don't have confirmations (re-org scenario)
+      assert(
+        wallet
+          .updateReceivedTxoWithConfs(pendingConfReceived, 0)
+          .state == TxoState.BroadcastReceived)
 
-    val expectedConfSpent = pendingConfReceived
-      .copyWithSpendingTxId(DoubleSha256DigestBE.empty)
-      .copyWithState(TxoState.ConfirmedSpent)
+      //it must transition from DoesNotExist -> PendingConfirmationsReceived
+      assert(
+        wallet.updateReceivedTxoWithConfs(dne, 1) == dne.copyWithState(
+          TxoState.PendingConfirmationsReceived))
 
-    val updated =
-      wallet.updateSpentTxoWithConfs(pendingConfReceivedWithTxId, requiredConfs)
-    //it must transition from Pending Confirmation Received -> Pending Confirmation Spent
-    assert(updated == expectedConfSpent)
+      //transition from TxoState.ConfirmedReceived -> TxoState.PendingConfirmationsReceived (reorg scenario)
+      assert(
+        wallet.updateReceivedTxoWithConfs(confReceived, 1) == confReceived
+          .copyWithState(PendingConfirmationsReceived))
 
-    //must stay at pending confirmations spent with only 1 confirmation
-    assert(
-      wallet.updateSpentTxoWithConfs(pendingConfSpent, 1) == pendingConfSpent)
+      //it must stay TxoState.ConfirmedReceived if we keep receiving confirmations
+      assert(
+        wallet.updateReceivedTxoWithConfs(confReceived,
+                                          requiredConfs) == confReceived)
 
-    //must transition from PendingConfirmationsSpent -> ConfirmedSpent
-    assert(
-      wallet.updateSpentTxoWithConfs(pendingConfSpent,
-                                     requiredConfs) == confSpent)
+      //it must stay broadcast received with 0 confirmations
+      val broadcastReceived = utxo
+        .copyWithState(TxoState.BroadcastReceived)
+      assert(
+        wallet.updateReceivedTxoWithConfs(broadcastReceived,
+                                          0) == broadcastReceived)
+  }
 
-    //it must transition from DoesNotExist -> PendingConfirmationsReceived
-    assert(
-      wallet.updateReceivedTxoWithConfs(dne, 1) == dne.copyWithState(
-        TxoState.PendingConfirmationsReceived))
+  it must "correctly update spent txo state based on confirmations" in {
+    wallet =>
+      assert(wallet.walletConfig.requiredConfirmations == requiredConfs)
 
-    val expectedDNEWithTxId =
-      dne.copyWithSpendingTxId(DoubleSha256DigestBE.empty)
-    val expectedDNEConfirmedSpent =
-      expectedDNEWithTxId.copyWithState(TxoState.ConfirmedSpent)
-    //transition from TxoState.DoesNotExist -> TxoState.ConfirmedSpent
-    assert(
-      wallet.updateSpentTxoWithConfs(
-        expectedDNEWithTxId,
-        requiredConfs) == expectedDNEConfirmedSpent)
+      val spendingTxId = randomTXID
+      val pendingConfSpent = utxo
+        .copyWithSpendingTxId(spendingTxId)
+        .copyWithState(PendingConfirmationsSpent)
 
-    //transition form TxoState.ConfirmedSpent -> TxoState.PendingConfirmationSpent (reorg scenario)
-    assert(
-      wallet.updateSpentTxoWithConfs(confSpent, 1) == confSpent.copyWithState(
-        PendingConfirmationsSpent))
+      val confSpent = utxo
+        .copyWithSpendingTxId(spendingTxId)
+        .copyWithState(ConfirmedSpent)
 
-    //stay confirmed if we are already confirmed
-    assert(
-      wallet.updateSpentTxoWithConfs(confSpent, requiredConfs) == confSpent)
+      val withSpendingTxId =
+        reserved.copyWithSpendingTxId(DoubleSha256DigestBE.empty)
 
-    //transition from TxoState.ConfirmedReceived -> TxoState.PendingConfirmationsReceived (reorg scenario)
-    assert(
-      wallet.updateReceivedTxoWithConfs(confReceived, 1) == confReceived
-        .copyWithState(PendingConfirmationsReceived))
+      //it must transition from reserved to broacast spent
+      assert(
+        wallet
+          .updateSpentTxoWithConfs(withSpendingTxId, 0)
+          .state == TxoState.BroadcastSpent)
 
-    //it must stay TxoState.ConfirmedReceived if we keep receiving confirmations
-    assert(
-      wallet.updateReceivedTxoWithConfs(confReceived,
-                                        requiredConfs) == confReceived)
+      //it must transition from reserved to spent
+      assert(
+        wallet
+          .updateSpentTxoWithConfs(withSpendingTxId, 1)
+          .state == TxoState.PendingConfirmationsSpent)
 
-    val expectedConfReceivedWithTxid =
-      confReceived.copyWithSpendingTxId(DoubleSha256DigestBE.empty)
+      //cannot spend an immature coinbase output
+      assertThrows[RuntimeException] {
+        //cannot have utxo spent from coinbase before 101 blocks
+        wallet.updateSpentTxoWithConfs(immatureCoinbase, 100)
+      }
 
-    //TxoState.ConfirmedReceived -> TxoState.ConfirmedSpent
-    assert(
-      wallet.updateSpentTxoWithConfs(
-        expectedConfReceivedWithTxid,
-        requiredConfs) == expectedConfReceivedWithTxid.copyWithState(
-        TxoState.ConfirmedSpent))
+      val pendingConfReceivedWithTxId = pendingConfReceived
+        .copyWithSpendingTxId(DoubleSha256DigestBE.empty)
 
-    //it must stay BroadcastSpent with 0 confirmations
-    val broadcastSpent = utxo
-      .copyWithSpendingTxId(DoubleSha256DigestBE.empty)
-      .copyWithState(TxoState.BroadcastSpent)
-    assert(wallet.updateSpentTxoWithConfs(broadcastSpent, 0) == broadcastSpent)
+      val expectedConfSpent = pendingConfReceived
+        .copyWithSpendingTxId(DoubleSha256DigestBE.empty)
+        .copyWithState(TxoState.ConfirmedSpent)
 
-    //it must stay broadcast received with 0 confirmations
-    val broadcastReceived = utxo
-      .copyWithState(TxoState.BroadcastReceived)
-    assert(
-      wallet.updateReceivedTxoWithConfs(broadcastReceived,
-                                        0) == broadcastReceived)
+      val updated =
+        wallet.updateSpentTxoWithConfs(pendingConfReceivedWithTxId,
+                                       requiredConfs)
+      //it must transition from Pending Confirmation Received -> Pending Confirmation Spent
+      assert(updated == expectedConfSpent)
+
+      //must stay at pending confirmations spent with only 1 confirmation
+      assert(
+        wallet.updateSpentTxoWithConfs(pendingConfSpent, 1) == pendingConfSpent)
+
+      //must transition from PendingConfirmationsSpent -> ConfirmedSpent
+      assert(
+        wallet.updateSpentTxoWithConfs(pendingConfSpent,
+                                       requiredConfs) == confSpent)
+
+      val expectedDNEWithTxId =
+        dne.copyWithSpendingTxId(DoubleSha256DigestBE.empty)
+      val expectedDNEConfirmedSpent =
+        expectedDNEWithTxId.copyWithState(TxoState.ConfirmedSpent)
+      //transition from TxoState.DoesNotExist -> TxoState.ConfirmedSpent
+      assert(
+        wallet.updateSpentTxoWithConfs(
+          expectedDNEWithTxId,
+          requiredConfs) == expectedDNEConfirmedSpent)
+
+      //transition form TxoState.ConfirmedSpent -> TxoState.PendingConfirmationSpent (reorg scenario)
+      assert(
+        wallet.updateSpentTxoWithConfs(confSpent, 1) == confSpent.copyWithState(
+          PendingConfirmationsSpent))
+
+      //stay confirmed if we are already confirmed
+      assert(
+        wallet.updateSpentTxoWithConfs(confSpent, requiredConfs) == confSpent)
+
+      val expectedConfReceivedWithTxid =
+        confReceived.copyWithSpendingTxId(DoubleSha256DigestBE.empty)
+
+      //TxoState.ConfirmedReceived -> TxoState.ConfirmedSpent
+      assert(
+        wallet.updateSpentTxoWithConfs(
+          expectedConfReceivedWithTxid,
+          requiredConfs) == expectedConfReceivedWithTxid.copyWithState(
+          TxoState.ConfirmedSpent))
+
+      //it must stay BroadcastSpent with 0 confirmations
+      val broadcastSpent = utxo
+        .copyWithSpendingTxId(DoubleSha256DigestBE.empty)
+        .copyWithState(TxoState.BroadcastSpent)
+      assert(
+        wallet.updateSpentTxoWithConfs(broadcastSpent, 0) == broadcastSpent)
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
@@ -76,7 +76,7 @@ class UTXOHandlingTest extends BitcoinSWalletTest {
 
     val updated =
       wallet.updateSpentTxoWithConfs(pendingConfReceivedWithTxId, requiredConfs)
-    //it must transition from Pending Confirmation Recieved -> Pending Confirmation Spent
+    //it must transition from Pending Confirmation Received -> Pending Confirmation Spent
     assert(updated == expectedConfSpent)
 
     //must stay at pending confirmations spent with only 1 confirmation
@@ -131,5 +131,18 @@ class UTXOHandlingTest extends BitcoinSWalletTest {
         expectedConfReceivedWithTxid,
         requiredConfs) == expectedConfReceivedWithTxid.copyWithState(
         TxoState.ConfirmedSpent))
+
+    //it must stay BroadcastSpent with 0 confirmations
+    val broadcastSpent = utxo
+      .copyWithSpendingTxId(DoubleSha256DigestBE.empty)
+      .copyWithState(TxoState.BroadcastSpent)
+    assert(wallet.updateSpentTxoWithConfs(broadcastSpent, 0) == broadcastSpent)
+
+    //it must stay broadcast received with 0 confirmations
+    val broadcastReceived = utxo
+      .copyWithState(TxoState.BroadcastReceived)
+    assert(
+      wallet.updateReceivedTxoWithConfs(broadcastReceived,
+                                        0) == broadcastReceived)
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
@@ -55,11 +55,6 @@ class UTXOHandlingTest extends BitcoinSWalletTest {
           .updateReceivedTxoWithConfs(pendingConfReceived, 0)
           .state == TxoState.BroadcastReceived)
 
-      //it must transition from DoesNotExist -> PendingConfirmationsReceived
-      assert(
-        wallet.updateReceivedTxoWithConfs(dne, 1) == dne.copyWithState(
-          TxoState.PendingConfirmationsReceived))
-
       //transition from TxoState.ConfirmedReceived -> TxoState.PendingConfirmationsReceived (reorg scenario)
       assert(
         wallet.updateReceivedTxoWithConfs(confReceived, 1) == confReceived
@@ -133,16 +128,6 @@ class UTXOHandlingTest extends BitcoinSWalletTest {
       assert(
         wallet.updateSpentTxoWithConfs(pendingConfSpent,
                                        requiredConfs) == confSpent)
-
-      val expectedDNEWithTxId =
-        dne.copyWithSpendingTxId(DoubleSha256DigestBE.empty)
-      val expectedDNEConfirmedSpent =
-        expectedDNEWithTxId.copyWithState(TxoState.ConfirmedSpent)
-      //transition from TxoState.DoesNotExist -> TxoState.ConfirmedSpent
-      assert(
-        wallet.updateSpentTxoWithConfs(
-          expectedDNEWithTxId,
-          requiredConfs) == expectedDNEConfirmedSpent)
 
       //transition form TxoState.ConfirmedSpent -> TxoState.PendingConfirmationSpent (reorg scenario)
       assert(

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -323,8 +323,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
       toBeUpdated = outputsBeingSpent
         .map(markAsSpent(_, transaction.txIdBE))
         .flatten
-      processed <- spendingInfoDAO.updateAllSpendingInfoDb(toBeUpdated)
-      _ <- updateUtxoSpentConfirmedStates(processed)
+      processed <- updateUtxoSpentConfirmedStates(toBeUpdated)
     } yield {
       processed
     }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -324,7 +324,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
         .map(markAsSpent(_, transaction.txIdBE))
         .flatten
       processed <- spendingInfoDAO.updateAllSpendingInfoDb(toBeUpdated)
-      _ <- updateUtxoConfirmedStates(processed)
+      _ <- updateUtxoSpentConfirmedStates(processed)
     } yield {
       processed
     }
@@ -503,7 +503,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
 
           // Update Txo State
           updateTxDbF.flatMap(_ =>
-            updateUtxoConfirmedState(foundTxo).flatMap {
+            updateUtxoReceiveConfirmedStates(foundTxo).flatMap {
               case Some(txo) =>
                 logger.debug(
                   s"Updated block_hash of txo=${txo.txid.hex} new block hash=${blockHash.hex}")

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -192,6 +192,8 @@ private[wallet] trait UtxoHandling extends WalletLogger {
 
   /** Updates all the given SpendingInfoDbs to the correct state
     * based on how many confirmations they have received
+    * @param spendingInfoDbs the utxos we need to update
+    * @param fn the function used to transition the [[TxoState]] given a utxo and number of confirmations
     */
   private def updateUtxoStates(
       spendingInfoDbs: Vector[SpendingInfoDb],

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -173,7 +173,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
           else
             txo.copyWithState(TxoState.PendingConfirmationsReceived)
         } else txo
-      case TxoState.PendingConfirmationsReceived | BroadcastReceived =>
+      case TxoState.PendingConfirmationsReceived | BroadcastReceived | TxoState.ConfirmedReceived =>
         if (confs >= walletConfig.requiredConfirmations)
           txo.copyWithState(TxoState.ConfirmedReceived)
         else txo.copyWithState(PendingConfirmationsReceived)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -228,7 +228,7 @@ private[wallet] trait UtxoHandling extends WalletLogger {
         case (None, txos) =>
           logger.debug(
             s"Currently have ${txos.size} transactions in the mempool")
-          Vector.empty
+          txos
       }.toVector
 
       toUpdateFs

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -149,8 +149,8 @@ private[wallet] trait UtxoHandling extends WalletLogger {
           s"Cannot update txo with received state=${TxoState.ImmatureCoinbase}")
       case TxoState.Reserved | TxoState.PendingConfirmationsSpent |
           TxoState.ConfirmedSpent | TxoState.BroadcastSpent |
-          TxoState.DoesNotExist | TxoState.PendingConfirmationsReceived |
-          TxoState.BroadcastReceived | TxoState.ConfirmedReceived =>
+          TxoState.PendingConfirmationsReceived | TxoState.BroadcastReceived |
+          TxoState.ConfirmedReceived =>
         if (confs >= walletConfig.requiredConfirmations) {
           txo.copyWithState(TxoState.ConfirmedSpent)
         } else if (confs == 0) {
@@ -175,7 +175,8 @@ private[wallet] trait UtxoHandling extends WalletLogger {
           else
             txo.copyWithState(TxoState.PendingConfirmationsReceived)
         } else txo
-      case TxoState.PendingConfirmationsReceived | BroadcastReceived | TxoState.ConfirmedReceived =>
+      case TxoState.PendingConfirmationsReceived | BroadcastReceived |
+          TxoState.ConfirmedReceived =>
         if (confs >= walletConfig.requiredConfirmations) {
           txo.copyWithState(TxoState.ConfirmedReceived)
         } else if (confs == 0) {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -153,6 +153,8 @@ private[wallet] trait UtxoHandling extends WalletLogger {
           TxoState.BroadcastReceived | TxoState.ConfirmedReceived =>
         if (confs >= walletConfig.requiredConfirmations) {
           txo.copyWithState(TxoState.ConfirmedSpent)
+        } else if (confs == 0) {
+          txo.copyWithState(TxoState.BroadcastSpent)
         } else {
           txo.copyWithState(TxoState.PendingConfirmationsSpent)
         }
@@ -174,10 +176,13 @@ private[wallet] trait UtxoHandling extends WalletLogger {
             txo.copyWithState(TxoState.PendingConfirmationsReceived)
         } else txo
       case TxoState.PendingConfirmationsReceived | BroadcastReceived | TxoState.ConfirmedReceived =>
-        if (confs >= walletConfig.requiredConfirmations)
+        if (confs >= walletConfig.requiredConfirmations) {
           txo.copyWithState(TxoState.ConfirmedReceived)
-        else txo.copyWithState(PendingConfirmationsReceived)
-      case TxoState.ConfirmedReceived =>
+        } else if (confs == 0) {
+          txo.copyWithState(TxoState.BroadcastReceived)
+        } else txo.copyWithState(PendingConfirmationsReceived)
+      case TxoState.Reserved =>
+        //do nothing if we have reserved the utxo
         txo
       case state: SpentState =>
         sys.error(s"Cannot update spendingInfoDb in spent state=$state")


### PR DESCRIPTION
My attempt at fixing #3842 . I wouldn't be surprised if this is also the cause of #3868 #3864 #3812 et al

This PR also enables some reorg capability in the wallet #2179

The meat and potates of this PR is splitting `updateTxoWithConfs` into two methods

1. `updateUtxoReceiveConfirmedStates`
2. `updateUtxoSpentConfirmedStates` 

As we need to do different things depending on if the utxo is received or confirmed.

I still would like to add more unit tests to this PR to verify the behavior is correct.