### PR TITLE
Remove invoice max amount limit

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePartTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePartTest.scala
@@ -39,11 +39,9 @@ class LnHumanReadablePartTest extends BitcoinSUnitTest {
   }
 
   it must "fail to create hrp from invalid amount" in {
-    val tooBig = Some(MilliBitcoins(LnPolicy.maxAmountMSat.toBigInt + 1))
     val zero = Some(LnCurrencyUnits.zero)
     val tooSmall = Some(MilliBitcoins(-1))
 
-    Try(LnHumanReadablePart(LnBitcoinMainNet, tooBig)).isFailure must be(true)
     Try(LnHumanReadablePart(LnBitcoinMainNet, zero)).isFailure must be(true)
     Try(LnHumanReadablePart(LnBitcoinMainNet, tooSmall)).isFailure must be(true)
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
@@ -559,4 +559,10 @@ class LnInvoiceUnitTest extends BitcoinSUnitTest {
       "lntbs1ps5um52pp562zjpdyec3hjga5sdeh90v09km7ugasretujf3wwj3ueutyujz3sdqqcqzpgxqyz5vqsp5an8lqngrz6w3vd449eqqtvwu2x4v9ltdf9r6hpwxf4x404fhv6zs9qyyssqfdmmsuldkyy7v29kwuuc9egwkthtf3aaf79p3w93ddffq65fs5zs6vys9et89u0yv5kearpnuyttsvufzjnsnup2ehp4nteelz39exqpgd78w8"
     assert(LnInvoice.fromStringT(str).isSuccess)
   }
+
+  it must "create an invoice above the old limit" in {
+    val str =
+      "lntbs42949672960n1p3qavpxpp59mdvu0tw0mzf2kl96ddfcm0597nuxwp42tzsehrn66jrmlg7nu8sdqqcqzpgxqyz5vqsp5y70pg45suf546mses9cp54fk4uke2rmppk9dy4926prhe5v54g4s9qyyssqmtpasu8map7hegdxfzmgusuqnkrssy6m34wcup3lmu0mae3xtht5d49204a3wm9wpklalx49g33cer5gqfractwt79vrc8p7wlpsdlqp296km0"
+    assert(LnInvoice.fromStringT(str).isSuccess)
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePart.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnHumanReadablePart.scala
@@ -13,9 +13,6 @@ import scala.util.{Failure, Success, Try}
 sealed abstract class LnHumanReadablePart extends Bech32HumanReadablePart {
   require(amount.isEmpty || amount.get.toBigInt > 0,
           s"Invoice amount must be greater then 0, got $amount")
-  require(
-    amount.isEmpty || amount.get.toMSat <= LnPolicy.maxAmountMSat,
-    s"Invoice amount must not exceed ${LnPolicy.maxAmountMSat}, got ${amount.get.toMSat}")
 
   def network: LnParams
 


### PR DESCRIPTION
The invoice in the test is generated from lnd so it should be parsable by bitcoin-s