### PR TITLE
2022 02 18 sync since creationtime pt2

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -50,6 +50,7 @@ import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.wallet._
 import org.bitcoins.wallet.config.WalletAppConfig
 
+import java.time.Instant
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
@@ -117,8 +118,12 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val chainApiF = runChainWorkCalc(
       serverArgParser.forceChainWorkRecalc || chainConf.forceRecalcChainWork)
 
+    val creationTimeOpt: Option[Instant] = walletConf.creationTimeOpt
+
     //get a node that isn't started
-    val nodeF = nodeConf.createNode()(chainConf, system)
+    val nodeF = nodeConf.createNode(
+      peers = Vector.empty,
+      walletCreationTimeOpt = creationTimeOpt)(chainConf, system)
 
     val feeProvider = getFeeProviderOrElse(
       MempoolSpaceProvider(HourFeeTarget,

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -118,12 +118,12 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val chainApiF = runChainWorkCalc(
       serverArgParser.forceChainWorkRecalc || chainConf.forceRecalcChainWork)
 
-    val creationTimeOpt: Option[Instant] = walletConf.creationTimeOpt
+    val creationTime: Instant = walletConf.creationTime
 
     //get a node that isn't started
     val nodeF = nodeConf.createNode(
       peers = Vector.empty,
-      walletCreationTimeOpt = creationTimeOpt)(chainConf, system)
+      walletCreationTimeOpt = Some(creationTime))(chainConf, system)
 
     val feeProvider = getFeeProviderOrElse(
       MempoolSpaceProvider(HourFeeTarget,

--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -112,7 +112,9 @@ val nodeF = for {
   chainApi <- chainApiF
   peer <- peerF
 } yield {
-    val dataMessageHandler = DataMessageHandler(chainApi)
+    //you can set this to only sync compact filters after the timestamp
+    val walletCreationTimeOpt = None
+    val dataMessageHandler = DataMessageHandler(chainApi, walletCreationTimeOpt)
     NeutrinoNode(configPeersOverride = Vector(peer),
                dataMessageHandler = dataMessageHandler,
                nodeConfig = nodeConfig,

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
@@ -200,6 +200,13 @@ case class KeyManagerAppConfig(
             s"Failed to initialize mnemonic seed in keymanager with err=$err"))
     }
   }
+
+  /** The creation time of the mnemonic seed
+    * If we cannot decrypt the seed because of invalid passwords, we return None
+    */
+  def creationTime: Instant = {
+    toBip39KeyManager.creationTime
+  }
 }
 
 object KeyManagerAppConfig extends AppConfigFactory[KeyManagerAppConfig] {

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -176,7 +176,7 @@ class P2PClientTest
     val probe = TestProbe()
     val peerMessageReceiverF =
       for {
-        node <- NodeUnitTest.buildNode(peer)
+        node <- NodeUnitTest.buildNode(peer, None)
       } yield PeerMessageReceiver.preConnection(peer, node)
 
     val clientActorF: Future[TestActorRef[P2PClientActor]] =

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -28,7 +28,7 @@ class ReConnectionTest extends BitcoindRpcTest with CachedBitcoinSAppConfig {
   it must "attempt to reconnect if max connections are full" in {
     val peerHandlerF: Future[PeerHandler] = for {
       _ <- cachedConfig.start()
-      peer <- bitcoindPeerF.flatMap(p => NodeUnitTest.buildPeerHandler(p))
+      peer <- bitcoindPeerF.flatMap(p => NodeUnitTest.buildPeerHandler(p, None))
     } yield peer
 
     val connectedF = for {

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerNeutrinoNodesTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerNeutrinoNodesTest.scala
@@ -62,9 +62,9 @@ class DataMessageHandlerNeutrinoNodesTest
         _ = node.nodeAppConfig.addCallbacks(nodeCallbacks)
 
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi)(node.executionContext,
-                                              node.nodeAppConfig,
-                                              node.chainConfig)
+          DataMessageHandler(genesisChainApi, None)(node.executionContext,
+                                                    node.nodeAppConfig,
+                                                    node.chainConfig)
         _ <- dataMessageHandler.handleDataPayload(payload, sender, node)
         result <- resultP.future
       } yield assert(result == tx)

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -36,9 +36,10 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
       val sender = spv.peerMsgSenders(0)
       for {
         chainApi <- spv.chainApiFromDb()
-        dataMessageHandler = DataMessageHandler(chainApi)(spv.executionContext,
-                                                          spv.nodeAppConfig,
-                                                          spv.chainConfig)
+        dataMessageHandler = DataMessageHandler(chainApi, None)(
+          spv.executionContext,
+          spv.nodeAppConfig,
+          spv.chainConfig)
 
         // Use signet genesis block header, this should be invalid for regtest
         invalidPayload =
@@ -81,9 +82,9 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
         _ = spv.nodeAppConfig.addCallbacks(nodeCallbacks)
 
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi)(spv.executionContext,
-                                              spv.nodeAppConfig,
-                                              spv.chainConfig)
+          DataMessageHandler(genesisChainApi, None)(spv.executionContext,
+                                                    spv.nodeAppConfig,
+                                                    spv.chainConfig)
         _ <- dataMessageHandler.handleDataPayload(payload1, sender, spv)
         _ <- dataMessageHandler.handleDataPayload(payload2, sender, spv)
         result <- resultP.future
@@ -114,9 +115,9 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
         _ = spv.nodeAppConfig.addCallbacks(nodeCallbacks)
 
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi)(spv.executionContext,
-                                              spv.nodeAppConfig,
-                                              spv.chainConfig)
+          DataMessageHandler(genesisChainApi, None)(spv.executionContext,
+                                                    spv.nodeAppConfig,
+                                                    spv.chainConfig)
         _ <- dataMessageHandler.handleDataPayload(payload, sender, spv)
         result <- resultP.future
       } yield assert(result == block)
@@ -148,9 +149,9 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
 
         _ = spv.nodeAppConfig.addCallbacks(callbacks)
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi)(spv.executionContext,
-                                              spv.nodeAppConfig,
-                                              spv.chainConfig)
+          DataMessageHandler(genesisChainApi, None)(spv.executionContext,
+                                                    spv.nodeAppConfig,
+                                                    spv.chainConfig)
 
         _ <- dataMessageHandler.handleDataPayload(payload, sender, spv)
         result <- resultP.future
@@ -181,9 +182,9 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
         nodeCallbacks = NodeCallbacks.onCompactFilterReceived(callback)
         _ = spv.nodeAppConfig.addCallbacks(nodeCallbacks)
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi)(spv.executionContext,
-                                              spv.nodeAppConfig,
-                                              spv.chainConfig)
+          DataMessageHandler(genesisChainApi, None)(spv.executionContext,
+                                                    spv.nodeAppConfig,
+                                                    spv.chainConfig)
 
         _ <- dataMessageHandler.handleDataPayload(payload, sender, spv)
         result <- resultP.future

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageHandlerTest.scala
@@ -60,7 +60,7 @@ class PeerMessageHandlerTest
 
   it must "be able to fully initialize a PeerMessageReceiver" in { peer =>
     for {
-      peerHandler <- NodeUnitTest.buildPeerHandler(peer)
+      peerHandler <- NodeUnitTest.buildPeerHandler(peer, None)
       peerMsgSender = peerHandler.peerMsgSender
       p2pClient = peerHandler.p2pClient
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -88,8 +88,9 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
     val nodeWithBitcoindBuilder: () => Future[
       NeutrinoNodeConnectedWithBitcoind] = { () =>
       require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
-      val creationTimeOpt = Some(appConfig.walletConf.creationTime)
       for {
+        _ <- appConfig.walletConf.kmConf.start()
+        creationTimeOpt = Some(appConfig.walletConf.creationTime)
         node <- NodeUnitTest.createNeutrinoNode(bitcoind, creationTimeOpt)(
           system,
           appConfig.chainConf,
@@ -111,8 +112,9 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
     val nodeWithBitcoindBuilder: () => Future[
       NeutrinoNodeConnectedWithBitcoinds] = { () =>
       require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
-      val creationTimeOpt = Some(appConfig.walletConf.creationTime)
       for {
+        _ <- appConfig.walletConf.kmConf.start()
+        creationTimeOpt = Some(appConfig.walletConf.creationTime)
         node <- NodeUnitTest.createNeutrinoNode(bitcoinds, creationTimeOpt)(
           system,
           appConfig.chainConf,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -88,7 +88,7 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
     val nodeWithBitcoindBuilder: () => Future[
       NeutrinoNodeConnectedWithBitcoind] = { () =>
       require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
-      val creationTimeOpt = appConfig.walletConf.creationTimeOpt
+      val creationTimeOpt = Some(appConfig.walletConf.creationTime)
       for {
         node <- NodeUnitTest.createNeutrinoNode(bitcoind, creationTimeOpt)(
           system,
@@ -111,7 +111,7 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
     val nodeWithBitcoindBuilder: () => Future[
       NeutrinoNodeConnectedWithBitcoinds] = { () =>
       require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
-      val creationTimeOpt = appConfig.walletConf.creationTimeOpt
+      val creationTimeOpt = Some(appConfig.walletConf.creationTime)
       for {
         node <- NodeUnitTest.createNeutrinoNode(bitcoinds, creationTimeOpt)(
           system,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -65,9 +65,9 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
         require(appConfig.nodeConf.nodeType == NodeType.SpvNode)
         for {
           peer <- createPeer(bitcoind)
-          node <- NodeUnitTest.createSpvNode(peer)(system,
-                                                   appConfig.chainConf,
-                                                   appConfig.nodeConf)
+          node <- NodeUnitTest.createSpvNode(peer, None)(system,
+                                                         appConfig.chainConf,
+                                                         appConfig.nodeConf)
           started <- node.start()
           _ <- NodeUnitTest.syncSpvNode(started, bitcoind)
         } yield SpvNodeConnectedWithBitcoind(node, bitcoind)
@@ -88,10 +88,12 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
     val nodeWithBitcoindBuilder: () => Future[
       NeutrinoNodeConnectedWithBitcoind] = { () =>
       require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
+      val creationTimeOpt = appConfig.walletConf.creationTimeOpt
       for {
-        node <- NodeUnitTest.createNeutrinoNode(bitcoind)(system,
-                                                          appConfig.chainConf,
-                                                          appConfig.nodeConf)
+        node <- NodeUnitTest.createNeutrinoNode(bitcoind, creationTimeOpt)(
+          system,
+          appConfig.chainConf,
+          appConfig.nodeConf)
       } yield NeutrinoNodeConnectedWithBitcoind(node, bitcoind)
     }
     makeDependentFixture[NeutrinoNodeConnectedWithBitcoind](
@@ -109,10 +111,12 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
     val nodeWithBitcoindBuilder: () => Future[
       NeutrinoNodeConnectedWithBitcoinds] = { () =>
       require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
+      val creationTimeOpt = appConfig.walletConf.creationTimeOpt
       for {
-        node <- NodeUnitTest.createNeutrinoNode(bitcoinds)(system,
-                                                           appConfig.chainConf,
-                                                           appConfig.nodeConf)
+        node <- NodeUnitTest.createNeutrinoNode(bitcoinds, creationTimeOpt)(
+          system,
+          appConfig.chainConf,
+          appConfig.nodeConf)
         startedNode <- node.start()
         syncedNode <- syncNeutrinoNode(startedNode, bitcoinds(0))
       } yield NeutrinoNodeConnectedWithBitcoinds(syncedNode, bitcoinds)
@@ -209,9 +213,9 @@ trait NodeTestWithCachedBitcoindV19
       require(appConfig.nodeConf.nodeType == NodeType.SpvNode)
       for {
         peer <- createPeer(bitcoind)
-        node <- NodeUnitTest.createSpvNode(peer)(system,
-                                                 appConfig.chainConf,
-                                                 appConfig.nodeConf)
+        node <- NodeUnitTest.createSpvNode(peer, None)(system,
+                                                       appConfig.chainConf,
+                                                       appConfig.nodeConf)
         started <- node.start()
         _ <- NodeUnitTest.syncSpvNode(started, bitcoind)
       } yield SpvNodeConnectedWithBitcoindV19(node, bitcoind)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -152,7 +152,7 @@ trait NodeUnitTest extends BaseNodeTest {
     val nodeWithBitcoindBuilder: () => Future[
       NeutrinoNodeConnectedWithBitcoind] = { () =>
       require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
-      val creationTimeOpt = appConfig.walletConf.creationTimeOpt
+      val creationTimeOpt = Some(appConfig.walletConf.creationTime)
       for {
         bitcoind <- BitcoinSFixture.createBitcoind(versionOpt)
         node <- NodeUnitTest.createNeutrinoNode(bitcoind, creationTimeOpt)(
@@ -394,7 +394,7 @@ object NodeUnitTest extends P2PLogger {
     NeutrinoNodeFundedWalletBitcoind] = {
     import system.dispatcher
     require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
-    val creationTimeOpt = appConfig.walletConf.creationTimeOpt
+    val creationTimeOpt = Some(appConfig.walletConf.creationTime)
     for {
       bitcoind <- BitcoinSFixture.createBitcoindWithFunds(versionOpt)
       node <- createNeutrinoNode(bitcoind, creationTimeOpt)(system,
@@ -430,7 +430,7 @@ object NodeUnitTest extends P2PLogger {
     NeutrinoNodeFundedWalletBitcoind] = {
     import system.dispatcher
     require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
-    val creationTimeOpt = appConfig.walletConf.creationTimeOpt
+    val creationTimeOpt = Some(appConfig.walletConf.creationTime)
     for {
       node <- createNeutrinoNode(bitcoind, creationTimeOpt)(system,
                                                             appConfig.chainConf,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -430,8 +430,9 @@ object NodeUnitTest extends P2PLogger {
     NeutrinoNodeFundedWalletBitcoind] = {
     import system.dispatcher
     require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
-    val creationTimeOpt = Some(appConfig.walletConf.creationTime)
     for {
+      _ <- appConfig.walletConf.kmConf.start()
+      creationTimeOpt = Some(appConfig.walletConf.creationTime)
       node <- createNeutrinoNode(bitcoind, creationTimeOpt)(system,
                                                             appConfig.chainConf,
                                                             appConfig.nodeConf)

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -15,7 +15,6 @@ import org.bitcoins.db.DatabaseDriver.{PostgreSQL, SQLite}
 import org.bitcoins.db._
 import org.bitcoins.db.models.MasterXPubDAO
 import org.bitcoins.db.util.{DBMasterXPubApi, MasterXPubUtil}
-import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.keymanager.config.KeyManagerAppConfig
 import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.wallet.config.WalletAppConfig.RebroadcastTransactionsRunnable
@@ -333,13 +332,8 @@ case class WalletAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   /** The creation time of the mnemonic seed
     * If we cannot decrypt the seed because of invalid passwords, we return None
     */
-  def creationTimeOpt: Option[Instant] = {
-    BIP39KeyManager
-      .fromParams(kmParams,
-                  passwordOpt = aesPasswordOpt,
-                  bip39PasswordOpt = bip39PasswordOpt)
-      .map(_.creationTime)
-      .toOption
+  def creationTime: Instant = {
+    kmConf.creationTime
   }
 }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -15,6 +15,7 @@ import org.bitcoins.db.DatabaseDriver.{PostgreSQL, SQLite}
 import org.bitcoins.db._
 import org.bitcoins.db.models.MasterXPubDAO
 import org.bitcoins.db.util.{DBMasterXPubApi, MasterXPubUtil}
+import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.keymanager.config.KeyManagerAppConfig
 import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.wallet.config.WalletAppConfig.RebroadcastTransactionsRunnable
@@ -23,6 +24,7 @@ import org.bitcoins.wallet.models.AccountDAO
 import org.bitcoins.wallet.{Wallet, WalletCallbacks, WalletLogger}
 
 import java.nio.file.{Files, Path, Paths}
+import java.time.Instant
 import java.util.concurrent._
 import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -326,6 +328,18 @@ case class WalletAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
         ()
       case None => ()
     }
+  }
+
+  /** The creation time of the mnemonic seed
+    * If we cannot decrypt the seed because of invalid passwords, we return None
+    */
+  def creationTimeOpt: Option[Instant] = {
+    BIP39KeyManager
+      .fromParams(kmParams,
+                  passwordOpt = aesPasswordOpt,
+                  bip39PasswordOpt = bip39PasswordOpt)
+      .map(_.creationTime)
+      .toOption
   }
 }
 


### PR DESCRIPTION
fixes #1731

replaces #3136 

This syncs compact filters from our key managers `creationTime`. The benefit of this is to reduce initial block download time and save on disk space.

This PR syncs

1. All block headers
2. All compact filter headers
3. Compact filters _after_ `creationTime`. 

This does _not_ sync old compact filters from before the wallet creation time after syncing to tip. We may want to implement this in a separate PR.

### Syncing an existing wallet
When testing on my own local wallet with IBD, ` "creationTime" : 1558799128`  (`May 25, 2019`) it took me ~50 minutes to sync. 

```
2022-02-19T13:25:53UTC INFO [BitcoinSServerMain] version=1.9.0-7-a073f0c1-20220219-0721-SNAPSHOT
...
2022-02-19T14:19:49UTC INFO [DataMessageHandler] We are synced
```

### Syncing a new wallet

When syncing it a fresh wallet with a new seed it took me ~30 minutes on my desktop. This 30 minutes is all block headers + filter header sync.

```
2022-02-19T14:57:33UTC INFO [BitcoinSServerMain] version=1.9.0-7-a073f0c1-20220219-0721-SNAPSHOT
...
2022-02-19T15:31:50UTC INFO [PeerMessageSender] Requesting next compact filter headers from FilterSyncMarker(startHeight=724000, stopBlockHash=00000000000000000004e4ab92fe65a3e98dca855737f4d94084763cb0af97de)
2022-02-19T15:31:51UTC INFO [DataMessageHandler] Done syncing filter headers, beginning to sync filters from startHeightOpt=Some(724044)
2022-02-19T15:31:51UTC INFO [PeerMessageSender] Requesting compact filters from FilterSyncMarker(startHeight=724045, stopBlockHash=00000000000000000004e4ab92fe65a3e98dca855737f4d94084763cb0af97de)
2022-02-19T15:31:51UTC INFO [DataMessageHandler] We are synced
2022-02-19T15:31:51UTC INFO [DataMessageHandler] Processing 1 filters
```

### Disk space savings

The wallet in question was created on `1620073871` (`5/3/2021`) 
The disk space savings with prune filters is 13GB! This wallet was created within the last year, so old wallets won't have as much disk savings. 

<img width="1438" alt="Screen Shot 2022-02-20 at 5 52 29 PM" src="https://user-images.githubusercontent.com/3514957/154870024-0a1fff1d-78f4-42cb-b119-689bdfdc7417.png">

This second wallet was created on ` "creationTime" : 1558799128`  (`May 25, 2019`). This saves 10GB in disk space.

![Screenshot from 2022-02-21 07-44-33](https://user-images.githubusercontent.com/3514957/154971546-9babcbd3-87a0-4bf4-805a-868afced7af3.png)


 