### PR TITLE
Make bitcoind backend work with async scanning of filters and fetching blocks

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -308,7 +308,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
         startHeight = startHeight,
         endHeight = endHeight)
       filtered <- findMatches(filtersResponse, scripts, parallelismLevel)
-      _ = downloadAndProcessBlocks(filtered.map(_.blockHash.flip))
+      _ <- downloadAndProcessBlocks(filtered.map(_.blockHash.flip))
     } yield {
       logger.info(
         s"Found ${filtered.length} matches from start=$startHeight to end=$endHeight")


### PR DESCRIPTION
This PR makes the following async processes

1. Matching of compact filters
2. Requesting and processing of blocks that were matched by a compact filter

### Why is this safe?

This is safe because we can only process one block at a time with our `neutrino` and `bitcoind` backend. This PR reworks the bitcoind backend stream logic to make sure that is the case. Since we can only process one block at a time, we queue up other blocks we have matched so they can be processed immediately once the previous block is done.

### Rescan on master

This is a rescan on took  ~1 hour on cff0e844402a26442fb21808ca505ecb952424c3 

```
2022-02-20T14:34:46UTC INFO [BitcoinSServerMain] version=1.9.0-7-cff0e844-SNAPSHOT
...
2022-02-20T15:31:06UTC INFO [DLCWallet$DLCWalletImpl] Matched 206 blocks on rescan
2022-02-20T15:31:08UTC INFO [DLCWallet$DLCWalletImpl] Finished rescanning the wallet. It took 3370629ms
```

### Rescan with bitcoind backend 

It looks like my rescan with a bitcoind backend took ~25 minutes
```
2022-02-19T22:44:55UTC INFO [DLCWallet$DLCWalletImpl] Starting rescanning the wallet from None to None useCreationTime=true
2022-02-19T22:45:09UTC INFO [DLCWallet$DLCWalletImpl] Beginning to search for matches between 577013:724095 against 447 spks
...
2022-02-19T23:08:01UTC INFO [DLCWallet$DLCWalletImpl] Matched 206 blocks on rescan
2022-02-19T23:08:03UTC INFO [DLCWallet$DLCWalletImpl] Finished rescanning the wallet. It took 1388341ms
```