### PR TITLE
Update release.yml to use openjdk@1.17.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
         with:
-          java-version: zulu@1.11
+          java-version: openjdk@1.17.0
       - uses: olafurpg/setup-gpg@v3
       - run: sbt ci-release docs/publishWebsite
         env:
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: openjdk@1.15.0-2
+          java-version: openjdk@1.17.0
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: openjdk@1.15.0-2
+          java-version: openjdk@1.17.0
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
@@ -169,7 +169,7 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.16.0-1
+          java-version: openjdk@1.17.0
 
       - name: 'Get Previous tag'
         id: previoustag


### PR DESCRIPTION
Same as #4114 but for `release.yml` 

This goal is to test the artifacts produced by our `release.yml` for various platforms. Since `jpackage` is officially released now, hopefully it has better support across platforms than what it had in #3108

