### PR TITLE
Bump heap size on ci-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           java-version: openjdk@1.17.0
       - uses: olafurpg/setup-gpg@v3
-      - run: sbt ci-release docs/publishWebsite
+      - run: sbt -J-Xmx2g ci-release docs/publishWebsite
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
Fixes this: 

https://github.com/bitcoin-s/bitcoin-s/runs/5289215144?check_suite_focus=true#step:5:2432