### PR TITLE
Add a warn log if tor is not enabled and we are booting up DLCServer

### DIFF
--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCNode.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCNode.scala
@@ -24,7 +24,6 @@ case class DLCNode(wallet: DLCWalletApi)(implicit
   private[node] lazy val serverBindF: Future[(InetSocketAddress, ActorRef)] = {
     logger.info(
       s"Binding server to ${config.listenAddress}, with tor hidden service: ${config.torParams.isDefined}")
-
     DLCServer
       .bind(
         wallet,

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCServer.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCServer.scala
@@ -3,6 +3,7 @@ package org.bitcoins.dlc.node
 import akka.actor._
 import akka.event.LoggingReceive
 import akka.io.{IO, Tcp}
+import grizzled.slf4j.Logging
 import org.bitcoins.core.api.dlc.wallet.DLCWalletApi
 import org.bitcoins.tor._
 
@@ -63,7 +64,7 @@ class DLCServer(
 
 }
 
-object DLCServer {
+object DLCServer extends Logging {
 
   case object Disconnect
 
@@ -96,7 +97,10 @@ object DLCServer {
               bindAddress.getPort
             )
             .map(Some(_))
-        case None => Future.successful(None)
+        case None =>
+          logger.warn(
+            s"Tor must be enabled to negotiate a dlc, you can set this with bitcoin-s.tor.enabled=true and bitcoin-s.control.enabled=true in your bitcoin-s.conf")
+          Future.successful(None)
       }
       actorRef = system.actorOf(
         props(dlcWalletApi, bindAddress, Some(promise), dataHandlerFactory))


### PR DESCRIPTION
Spent too much time trying to figure out why my nodes weren't talking. We should probably consider adding some sort of log on the accept flow too if tor is not enabled.