### PR TITLE
Update docker image to jdk 17

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -177,7 +177,7 @@ object CommonSettings {
   lazy val dockerSettings: Seq[Setting[_]] = {
     Vector(
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
-      dockerBaseImage := "openjdk:16-slim",
+      dockerBaseImage := "openjdk:17-slim",
       dockerRepository := Some("bitcoinscala"),
       //set the user to be 'bitcoin-s' rather than
       //the default provided by sbt native packager


### PR DESCRIPTION
Bump base docker image to jdk 17

https://hub.docker.com/layers/openjdk/library/openjdk/17-slim/images/sha256-3a799c8d5639496b9ad390f8e6628409fa108b20dc167d855f2a5e56f41d97a2?context=explore