### PR TITLE
2022 02 24 rm prune addresses after rescan

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -169,9 +169,9 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
         !rescan &&
         balance == BitcoinSWalletTest.expectedDefaultAmt + TestAmount &&
         utxos.size == 4 &&
-        addresses.map(_.scriptPubKey.hex).sorted == utxos
-          .map(_.output.scriptPubKey.hex)
-          .sorted
+        utxos
+          .map(_.output.scriptPubKey)
+          .forall(spk => addresses.exists(_.scriptPubKey == spk))
       }
     }
 

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -51,16 +51,16 @@
     <!-- ╚═════════════════╝ -->
 
     <!-- See incoming message names and the peer it's sent from -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="WARN"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
 
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -302,19 +302,19 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoinV19 {
       val WalletWithBitcoindV19(wallet, _) = fixture
       //do these in parallel on purpose to simulate multiple threads calling rescan
       val startF = wallet.rescanNeutrinoWallet(startOpt = None,
-        endOpt = None,
-        addressBatchSize =
-          DEFAULT_ADDR_BATCH_SIZE,
-        useCreationTime = false)
+                                               endOpt = None,
+                                               addressBatchSize =
+                                                 DEFAULT_ADDR_BATCH_SIZE,
+                                               useCreationTime = false)
 
       //slight delay to make sure other rescan is started
       val alreadyStartedF =
         AsyncUtil.nonBlockingSleep(500.millis).flatMap { _ =>
           wallet.rescanNeutrinoWallet(startOpt = None,
-            endOpt = None,
-            addressBatchSize =
-              DEFAULT_ADDR_BATCH_SIZE,
-            useCreationTime = false)
+                                      endOpt = None,
+                                      addressBatchSize =
+                                        DEFAULT_ADDR_BATCH_SIZE,
+                                      useCreationTime = false)
         }
       for {
         start <- startF
@@ -329,24 +329,18 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoinV19 {
   it must "still receive payments to addresses generated pre-rescan" in {
     fixture: WalletWithBitcoind =>
       val WalletWithBitcoindV19(wallet, bitcoind) = fixture
-      logger.info(s"Beginning test case")
       val addressNoFundsF = wallet.getNewAddress()
 
       //start a rescan without sending payment to that address
       for {
         address <- addressNoFundsF
-        _ = logger.info(s"Beginning test case address=$address")
         _ <- wallet.rescanNeutrinoWallet(startOpt = None,
                                          endOpt = None,
                                          addressBatchSize = 10,
                                          useCreationTime = false)
-        _ <- AsyncUtil.retryUntilSatisfiedF(() => {
-          wallet.isRescanning().map(isRescanning => !isRescanning)
-        })
 
         usedAddresses <- wallet.listFundedAddresses()
 
-        spks <- wallet.listUtxos().map(_.map(_.output.scriptPubKey))
         _ = assert(!usedAddresses.exists(_._1.address == address),
                    s"Address should not be used! address=$address")
         //now send a payment to our wallet

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -4,8 +4,10 @@ import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.currency.{Bitcoins, CurrencyUnits, Satoshis}
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.script.ScriptPubKey
+import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.rescan.RescanState
+import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.wallet.{
@@ -300,19 +302,19 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoinV19 {
       val WalletWithBitcoindV19(wallet, _) = fixture
       //do these in parallel on purpose to simulate multiple threads calling rescan
       val startF = wallet.rescanNeutrinoWallet(startOpt = None,
-                                               endOpt = None,
-                                               addressBatchSize =
-                                                 DEFAULT_ADDR_BATCH_SIZE,
-                                               useCreationTime = false)
+        endOpt = None,
+        addressBatchSize =
+          DEFAULT_ADDR_BATCH_SIZE,
+        useCreationTime = false)
 
       //slight delay to make sure other rescan is started
       val alreadyStartedF =
         AsyncUtil.nonBlockingSleep(500.millis).flatMap { _ =>
           wallet.rescanNeutrinoWallet(startOpt = None,
-                                      endOpt = None,
-                                      addressBatchSize =
-                                        DEFAULT_ADDR_BATCH_SIZE,
-                                      useCreationTime = false)
+            endOpt = None,
+            addressBatchSize =
+              DEFAULT_ADDR_BATCH_SIZE,
+            useCreationTime = false)
         }
       for {
         start <- startF
@@ -321,6 +323,48 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoinV19 {
         alreadyStarted <- alreadyStartedF
       } yield {
         assert(alreadyStarted == RescanState.RescanInProgress)
+      }
+  }
+
+  it must "still receive payments to addresses generated pre-rescan" in {
+    fixture: WalletWithBitcoind =>
+      val WalletWithBitcoindV19(wallet, bitcoind) = fixture
+      logger.info(s"Beginning test case")
+      val addressNoFundsF = wallet.getNewAddress()
+
+      //start a rescan without sending payment to that address
+      for {
+        address <- addressNoFundsF
+        _ = logger.info(s"Beginning test case address=$address")
+        _ <- wallet.rescanNeutrinoWallet(startOpt = None,
+                                         endOpt = None,
+                                         addressBatchSize = 10,
+                                         useCreationTime = false)
+        _ <- AsyncUtil.retryUntilSatisfiedF(() => {
+          wallet.isRescanning().map(isRescanning => !isRescanning)
+        })
+
+        usedAddresses <- wallet.listFundedAddresses()
+
+        spks <- wallet.listUtxos().map(_.map(_.output.scriptPubKey))
+        _ = assert(!usedAddresses.exists(_._1.address == address),
+                   s"Address should not be used! address=$address")
+        //now send a payment to our wallet
+        hashes <- bitcoind.generateToAddress(1, address)
+        block <- bitcoind.getBlockRaw(hashes.head)
+        _ <- wallet.processBlock(block)
+        fundedAddresses <- wallet.listFundedAddresses()
+        utxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
+      } yield {
+
+        //note 25 bitcoin reward from coinbase tx here
+        //if we we move this test case in the future it may need to change
+        val expectedOutput =
+          TransactionOutput(Bitcoins(25), address.scriptPubKey)
+        assert(utxos.exists(_.output == expectedOutput),
+               s"Balance must show up on utxos")
+        val addressExists = fundedAddresses.exists(_._1.address == address)
+        assert(addressExists)
       }
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -156,7 +156,8 @@ private[wallet] trait RescanHandling extends WalletLogger {
         if (
           externalGap >= walletConfig.addressGapLimit && changeGap >= walletConfig.addressGapLimit
         ) {
-          pruneUnusedAddresses()
+          //done rescanning
+          Future.unit
         } else {
           logger.info(
             s"Attempting rescan again with fresh pool of addresses as we had a " +
@@ -164,22 +165,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
           doNeutrinoRescan(account, startOpt, endOpt, addressBatchSize)
         }
     } yield res
-  }
-
-  private def pruneUnusedAddresses(): Future[Unit] = {
-    for {
-      addressDbs <- addressDAO.findAll()
-      _ <- addressDbs.foldLeft(Future.unit) { (prevF, addressDb) =>
-        for {
-          _ <- prevF
-          spendingInfoDbs <-
-            spendingInfoDAO.findByScriptPubKeyId(addressDb.scriptPubKeyId)
-          _ <-
-            if (spendingInfoDbs.isEmpty) addressDAO.delete(addressDb)
-            else Future.unit
-        } yield ()
-      }
-    } yield ()
   }
 
   private def calcAddressGap(


### PR DESCRIPTION
This addresses 2 bugs

1. make sure we can't run multiple rescans at one time
2. Make sure we don't call `pruneAddresses()` after rescan


This is how to trigger the 2nd bug

0. Alice generates address
1. `rescan` started
3. `rescan` finishes (and calls `pruneUnusedAddresses`)
4. Bob sends a payment to Alice's address

Since there were no funds on rescan, we deleted the address. Bob can still pay to the address after the rescan is finisehd and we need to be able to discover funds.