### PR TITLE
Add RescanState, make sure we don't start concurrent rescans

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -36,6 +36,7 @@ import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
+import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto._
 import org.bitcoins.node.Node
@@ -1637,7 +1638,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                               _: Int,
                               _: Boolean)(_: ExecutionContext))
         .expects(None, None, 100, false, executor)
-        .returning(Future.unit)
+        .returning(Future.successful(RescanState.RescanDone))
 
       val route1 =
         walletRoutes.handleCommand(
@@ -1664,7 +1665,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
           100,
           false,
           executor)
-        .returning(Future.unit)
+        .returning(Future.successful(RescanState.RescanDone))
 
       val route2 =
         walletRoutes.handleCommand(
@@ -1691,7 +1692,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                  100,
                  false,
                  executor)
-        .returning(Future.unit)
+        .returning(Future.successful(RescanState.RescanDone))
 
       val route3 =
         walletRoutes.handleCommand(
@@ -1718,7 +1719,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                  100,
                  false,
                  executor)
-        .returning(Future.unit)
+        .returning(Future.successful(RescanState.RescanDone))
 
       val route4 =
         walletRoutes.handleCommand(
@@ -1774,7 +1775,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                               _: Int,
                               _: Boolean)(_: ExecutionContext))
         .expects(None, None, 55, false, executor)
-        .returning(Future.unit)
+        .returning(Future.successful(RescanState.RescanDone))
 
       val route8 =
         walletRoutes.handleCommand(

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
@@ -5,6 +5,7 @@ import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.script.ScriptPubKey
+import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -75,11 +76,12 @@ trait NeutrinoWalletApi { self: WalletApi =>
       startOpt: Option[BlockStamp],
       endOpt: Option[BlockStamp],
       addressBatchSize: Int,
-      useCreationTime: Boolean)(implicit ec: ExecutionContext): Future[Unit]
+      useCreationTime: Boolean)(implicit
+      ec: ExecutionContext): Future[RescanState]
 
   /** Helper method to rescan the ENTIRE blockchain. */
   def fullRescanNeutrinoWallet(addressBatchSize: Int)(implicit
-      ec: ExecutionContext): Future[Unit] =
+      ec: ExecutionContext): Future[RescanState] =
     rescanNeutrinoWallet(startOpt = None,
                          endOpt = None,
                          addressBatchSize = addressBatchSize,

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -1,0 +1,13 @@
+package org.bitcoins.core.wallet.rescan
+
+sealed trait RescanState
+
+object RescanState {
+
+  /** Finished a rescan */
+  case object RescanDone extends RescanState
+
+  /** A rescan has already been started */
+  case object RescanInProgress extends RescanState
+
+}

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -11,6 +11,7 @@ import org.bitcoins.core.protocol.BlockStamp.BlockHeight
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 
@@ -33,15 +34,16 @@ private[wallet] trait RescanHandling extends WalletLogger {
       startOpt: Option[BlockStamp],
       endOpt: Option[BlockStamp],
       addressBatchSize: Int,
-      useCreationTime: Boolean)(implicit ec: ExecutionContext): Future[Unit] = {
+      useCreationTime: Boolean)(implicit
+      ec: ExecutionContext): Future[RescanState] = {
     for {
       account <- getDefaultAccount()
-      _ <- rescanNeutrinoWallet(account.hdAccount,
-                                startOpt,
-                                endOpt,
-                                addressBatchSize,
-                                useCreationTime)
-    } yield ()
+      state <- rescanNeutrinoWallet(account.hdAccount,
+                                    startOpt,
+                                    endOpt,
+                                    addressBatchSize,
+                                    useCreationTime)
+    } yield state
   }
 
   /** @inheritdoc */
@@ -50,37 +52,42 @@ private[wallet] trait RescanHandling extends WalletLogger {
       startOpt: Option[BlockStamp],
       endOpt: Option[BlockStamp],
       addressBatchSize: Int,
-      useCreationTime: Boolean = true): Future[Unit] = {
-
-    rescanning.set(true)
-
-    logger.info(
-      s"Starting rescanning the wallet from ${startOpt} to ${endOpt} useCreationTime=$useCreationTime")
-
-    val start = System.currentTimeMillis()
-    val res = for {
-      start <- (startOpt, useCreationTime) match {
-        case (Some(_), true) =>
-          Future.failed(new IllegalArgumentException(
-            "Cannot define a starting block and use the wallet creation time"))
-        case (Some(value), false) =>
-          Future.successful(Some(value))
-        case (None, true) =>
-          walletCreationBlockHeight.map(Some(_))
-        case (None, false) =>
-          Future.successful(None)
-      }
-      _ <- clearUtxosAndAddresses(account)
-      _ <- doNeutrinoRescan(account, start, endOpt, addressBatchSize)
-    } yield ()
-
-    res.onComplete { _ =>
-      rescanning.set(false)
+      useCreationTime: Boolean = true): Future[RescanState] = {
+    if (rescanning.get()) {
+      logger.warn(
+        s"Rescan already started, ignoring request to start another one")
+      Future.successful(RescanState.RescanInProgress)
+    } else {
+      rescanning.set(true)
       logger.info(
-        s"Finished rescanning the wallet. It took ${System.currentTimeMillis() - start}ms")
-    }
+        s"Starting rescanning the wallet from ${startOpt} to ${endOpt} useCreationTime=$useCreationTime")
+      val start = System.currentTimeMillis()
+      val res = for {
+        start <- (startOpt, useCreationTime) match {
+          case (Some(_), true) =>
+            Future.failed(new IllegalArgumentException(
+              "Cannot define a starting block and use the wallet creation time"))
+          case (Some(value), false) =>
+            Future.successful(Some(value))
+          case (None, true) =>
+            walletCreationBlockHeight.map(Some(_))
+          case (None, false) =>
+            Future.successful(None)
+        }
+        _ <- clearUtxosAndAddresses(account)
+        _ <- doNeutrinoRescan(account, start, endOpt, addressBatchSize)
+      } yield {
+        RescanState.RescanDone
+      }
 
-    res
+      res.onComplete { _ =>
+        rescanning.set(false)
+        logger.info(
+          s"Finished rescanning the wallet. It took ${System.currentTimeMillis() - start}ms")
+      }
+
+      res
+    }
   }
 
   /** @inheritdoc */


### PR DESCRIPTION
Separated this from the wider #4130 PR. 

This PR adds a new `RescanState` trait. This is returned now from our rescan methods to indicate if a rescan is currently ongoing or if its finished. In the future we may want to make rescan asynchronous and add another `RescanState` called `RescanStarted(future: Future[Unit])`. The future inside of `RescanStarted` would be completed when the rescan is done. This imitates the current behavior of `rescanNeutrinoWallet()` which returns a `Future` that isn't completed until the rescan is done. 

The reason this would be useful is because rescans can take awhile on low resource environments like a pi. 

This log gets emitted now if you try to start another rescan when one is already running

![Screenshot from 2022-02-25 04-41-23](https://user-images.githubusercontent.com/3514957/155701459-c498fd59-59f4-4fc4-87ec-3880cb16ccc0.png)
