### PR TITLE
Adjust appconfig logging to INFO

### DIFF
--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -44,9 +44,9 @@
     <logger name="org.bitcoins.db.SafeDatabase" level="WARN"/>
 
     <!-- inspect resolved config -->
-    <logger name="org.bitcoins.chain.config" level="WARN"/>
-    <logger name="org.bitcoins.node.config" level="WARN"/>
-    <logger name="org.bitcoins.wallet.config" level="WARN"/>
+    <logger name="org.bitcoins.chain.config" level="INFO"/>
+    <logger name="org.bitcoins.node.config" level="INFO"/>
+    <logger name="org.bitcoins.wallet.config" level="INFO"/>
 
     <!-- inspect table creation, etc -->
     <logger name="org.bitcoins.chain.db" level="WARN" />
@@ -75,9 +75,9 @@
 
     <!-- See queries received by chain handler, as well as result of  -->
     <!-- connecting new block headers to chain -->
-    <logger name="org.bitcoins.chain.blockchain.ChainHandler" level="WARN"/>
+    <logger name="org.bitcoins.chain.blockchain.ChainHandler" level="INFO"/>
 
-    <logger name="org.bitcoins.chain.validation" level="WARN"/>
+    <logger name="org.bitcoins.chain.validation" level="INFO"/>
 
     <!-- ╔═════════════════════╗ -->
     <!-- ║   Wallet module     ║ -->

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -386,9 +386,8 @@ object WalletAppConfig
 
         _ = {
           if (txs.size > 1)
-            logger.info(s"Rebroadcasting ${txs.size} transactions")
-          else if (txs.size == 1)
-            logger.info(s"Rebroadcasting ${txs.size} transaction")
+            logger.info(
+              s"Rebroadcasting ${txs.size} transactions, txids=${txs.map(_.txIdBE)}")
         }
 
         _ <- wallet.nodeApi.broadcastTransactions(txs)


### PR DESCRIPTION
Helps debug #4138 

There is no reason to have logging level to WARN on `ChainAppConfig`, `WalletAppConfig`, `NodeAppConfig`