### PR TITLE
2022 02 28 Parse both `LnMessage(tlv)` and raw `tlv` in the `acceptdlc` rpc

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -934,8 +934,14 @@ object AcceptDLC extends ServerJsonModels {
         offerJs: Value,
         addrJs: Value,
         payoutAddressJs: Value,
-        changeAddressJs: Value) = Try {
-      val offer = LnMessageFactory(DLCOfferTLV).fromHex(offerJs.str)
+        changeAddressJs: Value): Try[AcceptDLC] = Try {
+      val lnMessageOfferT = LnMessageFactory(DLCOfferTLV)
+        .fromHexT(offerJs.str)
+      val offer: LnMessage[DLCOfferTLV] = lnMessageOfferT match {
+        case Success(o) => o
+        case Failure(_) => LnMessage(DLCOfferTLV.fromHex(offerJs.str))
+      }
+
       val uri = new URI("tcp://" + addrJs.str)
       val peerAddr =
         InetSocketAddress.createUnresolved(uri.getHost, uri.getPort)


### PR DESCRIPTION
Fixes a bug in #4129 where we didn't allow both `LnMessage(DLCOfferTLV)` and `DLCOfferTlv` via the rpc