### PR TITLE
Add jdk version to log

### DIFF
--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
@@ -22,7 +22,8 @@ trait BitcoinSRunner extends StartStopAsync[Unit] with Logging {
     //see: https://github.com/bitcoin-s/bitcoin-s/issues/2496
     //System.setProperty("bitcoins.log.location", usedDir.toAbsolutePath.toString)
 
-    logger.info(s"version=${EnvUtil.getVersion}")
+    logger.info(
+      s"version=${EnvUtil.getVersion} jdkVersion=${EnvUtil.getJdkVersion}")
 
     //logger.info(s"using directory ${usedDir.toAbsolutePath.toString}")
     val runner: Future[Unit] = start()

--- a/core/src/main/scala/org/bitcoins/core/util/EnvUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/EnvUtil.scala
@@ -15,6 +15,8 @@ object EnvUtil {
 
   def getVersion: String = getClass.getPackage.getImplementationVersion
 
+  def getJdkVersion: String = System.getProperty("java.version")
+
   def isNativeSecp256k1Disabled: Boolean = {
     val secpDisabled = System.getenv("DISABLE_SECP256K1")
     secpDisabled != null && (secpDisabled.toLowerCase == "true" || secpDisabled == "1")


### PR DESCRIPTION
Adds the jdk version to the the log. This is useful for debugging purposes.