### PR TITLE
Round `Bitcoins` to nearest `Satoshi`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -6,6 +6,8 @@ import org.bitcoins.core.serializers.RawSatoshisSerializer
 import org.bitcoins.crypto.{Factory, NetworkElement}
 import scodec.bits.ByteVector
 
+import scala.math.BigDecimal.RoundingMode
+import scala.math.BigDecimal.RoundingMode.RoundingMode
 import scala.math.Numeric
 import scala.util.{Failure, Success, Try}
 
@@ -170,7 +172,14 @@ object Bitcoins extends BaseNumbers[Bitcoins] with Bounded[Bitcoins] {
     Bitcoins(b)
   }
 
-  def apply(underlying: BigDecimal): Bitcoins = BitcoinsImpl(underlying)
+  def apply(
+      underlying: BigDecimal,
+      roundingMode: RoundingMode = RoundingMode.DOWN): Bitcoins = {
+    // Bitcoin can't represent amounts lower than a satoshi
+    // so we need to round to the nearest satoshi
+    val rounded = underlying.setScale(8, roundingMode)
+    BitcoinsImpl(rounded)
+  }
 
   private case class BitcoinsImpl(underlying: BigDecimal) extends Bitcoins
 }


### PR DESCRIPTION
This fixes a bug where we would allow having a fraction of a satoshi with `Bitcoins`. This fixes it by rounding it using `setScale` using the default rounding mode `HALF_UP`, curious on thoughts on using `DOWN` so we guarantee there is no extra sats.