### PR TITLE
Fix hardened serialization

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/hd/BIP32Path.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/BIP32Path.scala
@@ -83,7 +83,8 @@ abstract class BIP32Path extends SeqWrapper[BIP32Node] {
   override def toString: String =
     path
       .map { case BIP32Node(index, hardened) =>
-        index.toString + (if (hardened) "'" else "")
+        val isHardened = if (hardened) "'" else ""
+        index.toString + isHardened
       }
       .fold("m")((accum, curr) => accum + "/" + curr)
 


### PR DESCRIPTION
I cannot explain why, but sometime our `HDPath`s get serialized incorrectly in unit test suites. The in memory representation if the path is 

`m/84'/0'/0'/0/0`

however, before this PR this would _sometimes_ get serialized to the database as

`m/84'/0'/0'/0'/0'`

This is an invalid hd path, due to the last two indexes being hardened. We would then write this invalid path to the database. When we go to read the path from the database, we ended up with an error message that looks like this

```
[info]   java.lang.IllegalArgumentException: requirement failed: Expected 49' as the purpose constant, got 84'                                                                    
[info]   at scala.Predef$.require(Predef.scala:337)                                                                                                                               
[info]   at org.bitcoins.core.hd.HDPathFactory.fromString(HDPathFactory.scala:59)
[info]   at org.bitcoins.core.hd.HDPathFactory.fromString$(HDPathFactory.scala:37)
[info]   at org.bitcoins.core.hd.NestedSegWitHDPath$.fromString(NestedSegWitHDPath.scala:7)
[info]   at org.bitcoins.core.hd.NestedSegWitHDPath$.fromString(NestedSegWitHDPath.scala:7)
[info]   at org.bitcoins.crypto.StringFactory.$anonfun$fromStringT$1(StringFactory.scala:18)
[info]   at scala.util.Try$.apply(Try.scala:210)
[info]   at org.bitcoins.crypto.StringFactory.fromStringT(StringFactory.scala:18)
[info]   at org.bitcoins.crypto.StringFactory.fromStringT$(StringFactory.scala:17)
[info]   at org.bitcoins.core.hd.NestedSegWitHDPath$.fromStringT(NestedSegWitHDPath.scala:7)
[info]   at org.bitcoins.core.hd.HDPath$.$anonfun$fromStringT$2(HDPath.scala:64)
[info]   at scala.util.Failure.orElse(Try.scala:221)
[info]   at org.bitcoins.core.hd.HDPath$.fromStringT(HDPath.scala:64)
[info]   at org.bitcoins.core.hd.HDPath$.fromString(HDPath.scala:67)
``` 

The underlying exception is actually hidden due to the implementation of `HDPath.fromString` pre #4159. This would due to the use of `.orElse()` when trying to parse correct paths. You can see from the error message above it looks like we are trying to parse a nested segwit path (`49'`), when in reality the hd path was segwit (`84'`). This is very misleading as the underlying cause of the exception in `SegwitHDPath.fromString()` is due to the fact the last two indexes in the `HDPath` are hardened.  

This is the real exception
![Screenshot from 2022-03-04 08-09-06](https://user-images.githubusercontent.com/3514957/156778147-46fa9911-fff1-44db-a8b6-2ef38cd765cd.png)


I do not understand why this happens with the old code, but with the new code it appears this is fixed. I'm suspicious that this is a `scalac` bug. I cannot deterministically reproduce this bug, but i do see it on my local dev environment once or twice a day when running `walletTest/test` or `dlcWalletTest/test`