### PR TITLE
Move all initialization of accept into initDLCForAccept()

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -504,7 +504,7 @@ abstract class DLCWallet
             DLCPublicKeys)] = nextIndexF.map { nextIndex =>
           DLCAcceptUtil.buildAcceptWithoutSigs(
             keyIndex = nextIndex,
-            changeIndex = chainType,
+            chainType = chainType,
             offer = offer,
             txBuilder = txBuilder,
             spendingInfos = spendingInfos,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/InitializedAccept.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/InitializedAccept.scala
@@ -1,0 +1,24 @@
+package org.bitcoins.dlc.wallet.models
+
+import org.bitcoins.core.api.dlc.wallet.db.DLCDb
+import org.bitcoins.core.protocol.dlc.models.DLCMessage.DLCAcceptWithoutSigs
+import org.bitcoins.core.protocol.dlc.models.DLCPublicKeys
+
+case class InitializedAccept(
+    dlc: DLCDb,
+    offerDb: DLCOfferDb,
+    acceptDb: DLCAcceptDb,
+    fundingInputsDb: Vector[DLCFundingInputDb],
+    pubKeys: DLCPublicKeys,
+    contractDataDb: DLCContractDataDb,
+    acceptWithoutSigs: DLCAcceptWithoutSigs) {
+  require(dlc.dlcId == offerDb.dlcId,
+          s"dlc.dlcId=${dlc.dlcId} offerDb.dlcId=${offerDb.dlcId}")
+  require(dlc.dlcId == acceptDb.dlcId,
+          s"dlc.dlcId=${dlc.dlcId} offerDb.dlcId=${acceptDb.dlcId}")
+  require(dlc.dlcId == contractDataDb.dlcId,
+          s"dlc.dlcId=${dlc.dlcId} offerDb.dlcId=${contractDataDb.dlcId}")
+  require(
+    pubKeys == acceptWithoutSigs.pubKeys,
+    s"pubKeys=${pubKeys} acceptWithoutSigs.pubKeys=${acceptWithoutSigs.pubKeys}")
+}

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCAcceptUtil.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCAcceptUtil.scala
@@ -38,7 +38,7 @@ object DLCAcceptUtil extends Logging {
   /** Builds an [[DLCAcceptWithoutSigs]] message from relevant data inside of the [[DLCWallet]] */
   def buildAcceptWithoutSigs(
       keyIndex: Int,
-      changeIndex: HDChainType,
+      chainType: HDChainType,
       offer: DLCOffer,
       txBuilder: RawTxBuilderWithFinalizer[ShufflingNonInteractiveFinalizer],
       spendingInfos: Vector[ScriptSignatureParams[InputInfo]],
@@ -65,7 +65,7 @@ object DLCAcceptUtil extends Logging {
 
     val dlcPubKeys = DLCUtil.calcDLCPubKeys(
       xpub = account.xpub,
-      chainType = changeIndex,
+      chainType = chainType,
       keyIndex = keyIndex,
       networkParameters = networkParameters,
       externalPayoutAddressOpt = externalPayoutAddressOpt

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCAcceptUtil.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCAcceptUtil.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.HDChainType
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.dlc.compute.DLCUtil
+import org.bitcoins.core.protocol.dlc.models.DLCMessage.DLCAccept.NoNegotiationFields
 import org.bitcoins.core.protocol.dlc.models.DLCMessage.{
   DLCAccept,
   DLCAcceptWithoutSigs,
@@ -22,8 +23,13 @@ import org.bitcoins.core.wallet.builder.{
 }
 import org.bitcoins.core.wallet.utxo.{InputInfo, ScriptSignatureParams}
 import org.bitcoins.crypto.{AdaptorSign, Sha256Digest}
-import org.bitcoins.dlc.wallet.models.{DLCContractDataDb, DLCWalletDAOs}
+import org.bitcoins.dlc.wallet.models.{
+  DLCAcceptDb,
+  DLCContractDataDb,
+  DLCWalletDAOs
+}
 import org.bitcoins.wallet.models.TransactionDAO
+import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -31,7 +37,8 @@ object DLCAcceptUtil extends Logging {
 
   /** Builds an [[DLCAcceptWithoutSigs]] message from relevant data inside of the [[DLCWallet]] */
   def buildAcceptWithoutSigs(
-      dlc: DLCDb,
+      keyIndex: Int,
+      changeIndex: HDChainType,
       offer: DLCOffer,
       txBuilder: RawTxBuilderWithFinalizer[ShufflingNonInteractiveFinalizer],
       spendingInfos: Vector[ScriptSignatureParams[InputInfo]],
@@ -58,8 +65,8 @@ object DLCAcceptUtil extends Logging {
 
     val dlcPubKeys = DLCUtil.calcDLCPubKeys(
       xpub = account.xpub,
-      chainType = dlc.changeIndex,
-      keyIndex = dlc.keyIndex,
+      chainType = changeIndex,
+      keyIndex = keyIndex,
       networkParameters = networkParameters,
       externalPayoutAddressOpt = externalPayoutAddressOpt
     )
@@ -104,6 +111,7 @@ object DLCAcceptUtil extends Logging {
   def buildAcceptDlcDb(
       offer: DLCOffer,
       dlcId: Sha256Digest,
+      contractIdOpt: Option[ByteVector],
       account: AccountDb,
       chainType: HDChainType,
       nextIndex: Int,
@@ -111,7 +119,7 @@ object DLCAcceptUtil extends Logging {
     DLCDb(
       dlcId = dlcId,
       tempContractId = offer.tempContractId,
-      contractIdOpt = None,
+      contractIdOpt = contractIdOpt,
       protocolVersion = 0,
       state = DLCState.AcceptComputingAdaptorSigs,
       isInitiator = false,
@@ -126,6 +134,23 @@ object DLCAcceptUtil extends Logging {
       closingTxIdOpt = None,
       aggregateSignatureOpt = None,
       serializationVersion = contractInfo.serializationVersion
+    )
+  }
+
+  def buildAcceptDb(
+      dlc: DLCDb,
+      acceptWithoutSigs: DLCAcceptWithoutSigs,
+      dlcPubKeys: DLCPublicKeys,
+      collateral: CurrencyUnit): DLCAcceptDb = {
+    DLCAcceptDb(
+      dlcId = dlc.dlcId,
+      fundingKey = dlcPubKeys.fundingKey,
+      payoutAddress = dlcPubKeys.payoutAddress,
+      payoutSerialId = acceptWithoutSigs.payoutSerialId,
+      collateral = collateral,
+      changeAddress = acceptWithoutSigs.changeAddress,
+      changeSerialId = acceptWithoutSigs.changeSerialId,
+      negotiationFieldsTLV = NoNegotiationFields.toTLV
     )
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
@@ -56,24 +56,17 @@ case class DLCActionBuilder(dlcWalletDAOs: DLCWalletDAOs) {
     */
   def buildCreateAcceptAction(
       dlcDb: DLCDb,
-      dlcAcceptDb: DLCAcceptDb,
       offerInputs: Vector[DLCFundingInputDb],
-      acceptInputs: Vector[DLCFundingInputDb],
       cetSigsDb: Vector[DLCCETSignaturesDb],
       refundSigsDb: DLCRefundSigsDb)(implicit ec: ExecutionContext): DBIOAction[
     Unit,
     NoStream,
     Effect.Write with Effect.Transactional] = {
     val dlcDbAction = dlcDAO.updateAction(dlcDb)
-    val inputAction = dlcInputsDAO.createAllAction(offerInputs ++ acceptInputs)
-    val acceptAction = dlcAcceptDAO.createAction(dlcAcceptDb)
+    val inputAction = dlcInputsDAO.createAllAction(offerInputs)
     val sigsAction = dlcSigsDAO.createAllAction(cetSigsDb)
     val refundSigAction = dlcRefundSigDAO.createAction(refundSigsDb)
-    val actions = Vector(dlcDbAction,
-                         inputAction,
-                         acceptAction,
-                         sigsAction,
-                         refundSigAction)
+    val actions = Vector(dlcDbAction, inputAction, sigsAction, refundSigAction)
 
     val allActions = DBIO
       .sequence(actions)


### PR DESCRIPTION
Fixes this comment: https://github.com/bitcoin-s/bitcoin-s/issues/4145#issuecomment-1058399513

When we merged #4066 we did not create all information related to the accept message up front. This means we can have a divergent state in our database if something fails during the adaptor signature computation. This can corrupt a user's database.

This PR inserts all information we have about an accept before starting to compute adaptor signatures.

