### PR TITLE
Fix unit test where coinbase input was sometimes selected

### DIFF
--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TransactionGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TransactionGenerators.scala
@@ -190,7 +190,7 @@ object TransactionGenerators {
               realisiticWitnessTransactionWitnessOut)
 
   /** Generates a transaction where at least one output pays to the given SPK */
-  def transactionTo(spk: ScriptPubKey) =
+  def transactionTo(spk: ScriptPubKey): Gen[Transaction] =
     Gen.oneOf(baseTransactionTo(spk), witnessTransactionTo(spk))
 
   /** Generates a transaction with at least one output */

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -12,6 +12,7 @@ import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
 import org.bitcoins.testkitcore.Implicits._
 import org.bitcoins.testkitcore.gen.TransactionGenerators
+import org.bitcoins.testkitcore.util.TransactionTestUtil
 import org.scalatest.FutureOutcome
 import org.scalatest.compatible.Assertion
 
@@ -56,10 +57,10 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
     wallet =>
       for {
         address <- wallet.getNewAddress()
+        output = TransactionOutput(Bitcoins.one, address.scriptPubKey)
+        outPoint = TransactionGenerators.outPoint.sampleSome
         tx =
-          TransactionGenerators
-            .transactionTo(address.scriptPubKey)
-            .sampleSome
+          TransactionTestUtil.buildTransactionTo(output, outPoint)
 
         _ <- wallet.processTransaction(tx, None)
         oldConfirmed <- wallet.getConfirmedBalance()


### PR DESCRIPTION
fixes #4147 

There was a 1/10 chance we chose a coinbase input in this test case due to this

https://github.com/bitcoin-s/bitcoin-s/blob/7a5c2971dd10f271da44a968e3089d8f9e7383b2/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TransactionGenerators.scala#L135

In #4134 and #4093 we refactored the utxo handling flow to be in a central place. Now we check coinbase inputs correctly and this is an example of a bug in the test suite where we were incorrectly using a coinbase input 1/10 times.