### PR TITLE
Only update wallet's sync height if we don't have a match in `processCompactFilter`

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -207,9 +207,18 @@ abstract class Wallet
       _ <- {
         heightOpt match {
           case Some(height) =>
-            stateDescriptorDAO
-              .updateSyncHeight(hash, height)
-              .map(_ => ())
+            if (blockHashToDownload.isEmpty) {
+              //if we don't have any block hashes
+              //we need to update the wallet's sync height
+              stateDescriptorDAO
+                .updateSyncHeight(hash, height)
+                .map(_ => ())
+            } else {
+              //if we do have a block hash that we matched
+              //we need to let wallet.processBlock()
+              //update the wallet's sync height
+              Future.unit
+            }
           case None =>
             Future.unit
         }


### PR DESCRIPTION
If we do have a match in `processCompactFilter()`, it should be the responsibility of `Wallet.processBlock()` to update the wallet's sync height. 

here is where that happens: 

https://github.com/bitcoin-s/bitcoin-s/blob/f1bd0ea3a56d020a26ede30a6a7924d2eee16825/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala#L76