### PR TITLE
Mark extarnal payout addresses

### DIFF
--- a/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
@@ -4,7 +4,11 @@ import org.bitcoins.commons.serializers.Picklers
 import org.bitcoins.commons.serializers.Picklers._
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.protocol.dlc.models.DLCMessage._
-import org.bitcoins.core.protocol.dlc.models.{DLCState, DLCStatus}
+import org.bitcoins.core.protocol.dlc.models.{
+  DLCState,
+  DLCStatus,
+  PayoutAddress
+}
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.crypto.Sha256Digest
 import org.bitcoins.testkitcore.gen.{CryptoGenerators, NumberGenerator, TLVGen}
@@ -22,16 +26,21 @@ class DLCStatusTest extends BitcoinSJvmTest {
 
         val totalCollateral = offer.contractInfo.max
 
+        val payoutAddress = Option.empty[PayoutAddress]
+
         val status =
-          DLCStatus.Offered(Sha256Digest.empty,
-                            isInit,
-                            TimeUtil.now,
-                            offer.tempContractId,
-                            offer.contractInfo,
-                            offer.timeouts,
-                            offer.feeRate,
-                            totalCollateral,
-                            offer.totalCollateral)
+          DLCStatus.Offered(
+            Sha256Digest.empty,
+            isInit,
+            TimeUtil.now,
+            offer.tempContractId,
+            offer.contractInfo,
+            offer.timeouts,
+            offer.feeRate,
+            totalCollateral,
+            offer.totalCollateral,
+            payoutAddress
+          )
 
         assert(status.state == DLCState.Offered)
         assert(read[DLCStatus](write(status)) == status)
@@ -49,6 +58,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
 
         val totalCollateral = offer.contractInfo.max
 
+        val payoutAddress = Option.empty[PayoutAddress]
+
         val status =
           DLCStatus.Accepted(
             Sha256Digest.empty,
@@ -60,7 +71,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
             offer.timeouts,
             offer.feeRate,
             totalCollateral,
-            offer.totalCollateral
+            offer.totalCollateral,
+            payoutAddress
           )
 
         assert(status.state == DLCState.Accepted)
@@ -80,6 +92,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
 
         val totalCollateral = offer.contractInfo.max
 
+        val payoutAddress = Option.empty[PayoutAddress]
+
         val status =
           DLCStatus.Signed(
             Sha256Digest.empty,
@@ -92,7 +106,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
             offer.feeRate,
             totalCollateral,
             offer.totalCollateral,
-            txId
+            txId,
+            payoutAddress
           )
 
         assert(status.state == DLCState.Signed)
@@ -112,6 +127,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
 
         val totalCollateral = offer.contractInfo.max
 
+        val payoutAddress = Option.empty[PayoutAddress]
+
         val status =
           DLCStatus.Broadcasted(
             Sha256Digest.empty,
@@ -124,7 +141,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
             offer.feeRate,
             totalCollateral,
             offer.totalCollateral,
-            fundingTxId
+            fundingTxId,
+            payoutAddress
           )
 
         assert(status.state == DLCState.Broadcasted)
@@ -144,6 +162,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
 
         val totalCollateral = offer.contractInfo.max
 
+        val payoutAddress = Option.empty[PayoutAddress]
+
         val status =
           DLCStatus.Confirmed(
             Sha256Digest.empty,
@@ -156,7 +176,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
             offer.feeRate,
             totalCollateral,
             offer.totalCollateral,
-            fundingTxId
+            fundingTxId,
+            payoutAddress
           )
 
         assert(status.state == DLCState.Confirmed)
@@ -187,6 +208,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
         scala.util.Random.nextInt(offer.contractInfo.allOutcomes.size)
       val outcome = offer.contractInfo.allOutcomes(rand)
 
+      val payoutAddress = Option.empty[PayoutAddress]
+
       val status =
         DLCStatus.Claimed(
           Sha256Digest.empty,
@@ -204,7 +227,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
           sigs.toVector,
           outcome,
           myPayout = myPayout,
-          counterPartyPayout = theirPayout
+          counterPartyPayout = theirPayout,
+          payoutAddress = payoutAddress
         )
 
       assert(status.state == DLCState.Claimed)
@@ -238,6 +262,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
         scala.util.Random.nextInt(offer.contractInfo.allOutcomes.size)
       val outcome = offer.contractInfo.allOutcomes(rand)
 
+      val payoutAddress = Option.empty[PayoutAddress]
+
       val status =
         DLCStatus.RemoteClaimed(
           Sha256Digest.empty,
@@ -255,7 +281,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
           sig,
           outcome,
           myPayout = myPayout,
-          counterPartyPayout = theirPayout
+          counterPartyPayout = theirPayout,
+          payoutAddress = payoutAddress
         )
 
       assert(status.state == DLCState.RemoteClaimed)
@@ -285,6 +312,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
 
       val theirPayout: CurrencyUnit = totalCollateral - myPayout
 
+      val payoutAddress = Option.empty[PayoutAddress]
+
       val status =
         DLCStatus.Refunded(
           Sha256Digest.empty,
@@ -300,7 +329,8 @@ class DLCStatusTest extends BitcoinSJvmTest {
           fundingTxId,
           closingTxId,
           myPayout = myPayout,
-          counterPartyPayout = theirPayout
+          counterPartyPayout = theirPayout,
+          payoutAddress = payoutAddress
         )
 
       assert(status.state == DLCState.Refunded)

--- a/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.commons
 import org.bitcoins.commons.serializers.Picklers
 import org.bitcoins.commons.serializers.Picklers._
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.dlc.models.DLCMessage._
 import org.bitcoins.core.protocol.dlc.models.{
   DLCState,
@@ -58,7 +59,12 @@ class DLCStatusTest extends BitcoinSJvmTest {
 
         val totalCollateral = offer.contractInfo.max
 
-        val payoutAddress = Option.empty[PayoutAddress]
+        // random testnet address
+        val payoutAddress =
+          Some(
+            PayoutAddress(BitcoinAddress.fromString(
+                            "tb1q4ps6c9ewa7uca5v39fakykq9q6hpgjkxje8gve"),
+                          true))
 
         val status =
           DLCStatus.Accepted(

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -802,6 +802,15 @@ object Picklers {
       )
     }
 
+  implicit val payoutAddressW: Writer[PayoutAddress] = writer[Obj].comapNulls {
+    payoutAddress =>
+      import payoutAddress._
+      Obj(
+        "address" -> Str(address.toString),
+        "isExternal" -> Bool(isExternal)
+      )
+  }
+
   implicit val offeredW: Writer[Offered] =
     writer[Obj].comap { offered =>
       import offered._
@@ -819,7 +828,8 @@ object Picklers {
         "feeRate" -> Num(feeRate.toLong.toDouble),
         "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
         "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
-        "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble)
+        "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
+        "payoutAddress" -> writeJs(payoutAddress)
       )
     }
 
@@ -841,7 +851,8 @@ object Picklers {
       "feeRate" -> Num(feeRate.toLong.toDouble),
       "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
       "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
-      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble)
+      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
+      "payoutAddress" -> writeJs(payoutAddress)
     )
   }
 
@@ -862,7 +873,8 @@ object Picklers {
       "feeRate" -> Num(feeRate.toLong.toDouble),
       "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
       "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
-      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble)
+      "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
+      "payoutAddress" -> writeJs(payoutAddress)
     )
   }
 
@@ -885,7 +897,8 @@ object Picklers {
         "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
         "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
         "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
-        "fundingTxId" -> Str(fundingTxId.hex)
+        "fundingTxId" -> Str(fundingTxId.hex),
+        "payoutAddress" -> writeJs(payoutAddress)
       )
     }
 
@@ -907,7 +920,8 @@ object Picklers {
       "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
       "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
       "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
-      "fundingTxId" -> Str(fundingTxId.hex)
+      "fundingTxId" -> Str(fundingTxId.hex),
+      "payoutAddress" -> writeJs(payoutAddress)
     )
   }
 
@@ -930,7 +944,8 @@ object Picklers {
         "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
         "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
         "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
-        "fundingTxId" -> Str(fundingTxId.hex)
+        "fundingTxId" -> Str(fundingTxId.hex),
+        "payoutAddress" -> writeJs(payoutAddress)
       )
     }
 
@@ -953,7 +968,8 @@ object Picklers {
         "totalCollateral" -> Num(totalCollateral.satoshis.toLong.toDouble),
         "localCollateral" -> Num(localCollateral.satoshis.toLong.toDouble),
         "remoteCollateral" -> Num(remoteCollateral.satoshis.toLong.toDouble),
-        "fundingTxId" -> Str(fundingTxId.hex)
+        "fundingTxId" -> Str(fundingTxId.hex),
+        "payoutAddress" -> writeJs(payoutAddress)
       )
     }
 
@@ -995,7 +1011,8 @@ object Picklers {
       counterPartyPayoutKey -> Num(
         claimed.counterPartyPayout.satoshis.toLong.toDouble),
       PicklerKeys.pnl -> Num(claimed.pnl.satoshis.toLong.toDouble),
-      PicklerKeys.rateOfReturn -> Num(claimed.rateOfReturn.toDouble)
+      PicklerKeys.rateOfReturn -> Num(claimed.rateOfReturn.toDouble),
+      "payoutAddress" -> writeJs(payoutAddress)
     )
   }
 
@@ -1037,7 +1054,8 @@ object Picklers {
         counterPartyPayoutKey -> Num(
           remoteClaimed.counterPartyPayout.satoshis.toLong.toDouble),
         PicklerKeys.pnl -> Num(remoteClaimed.pnl.satoshis.toLong.toDouble),
-        PicklerKeys.rateOfReturn -> Num(remoteClaimed.rateOfReturn.toDouble)
+        PicklerKeys.rateOfReturn -> Num(remoteClaimed.rateOfReturn.toDouble),
+        "payoutAddress" -> writeJs(payoutAddress)
       )
     }
 
@@ -1065,7 +1083,8 @@ object Picklers {
       counterPartyPayoutKey -> Num(
         refunded.counterPartyPayout.satoshis.toLong.toDouble),
       PicklerKeys.pnl -> Num(refunded.pnl.satoshis.toLong.toDouble),
-      PicklerKeys.rateOfReturn -> Num(refunded.rateOfReturn.toDouble)
+      PicklerKeys.rateOfReturn -> Num(refunded.rateOfReturn.toDouble),
+      "payoutAddress" -> writeJs(payoutAddress)
     )
   }
 
@@ -1146,6 +1165,11 @@ object Picklers {
         .map(value => SchnorrDigitalSignature(value.str))
         .toVector
 
+    val payoutAddressJs = obj("payoutAddress")
+    lazy val payoutAddress: Option[PayoutAddress] =
+      payoutAddressJs("address").strOpt.map(a =>
+        PayoutAddress(BitcoinAddress.fromString(a), false))
+
     lazy val outcomesJs = obj("outcomes")
     lazy val outcomes = outcomesJs.strOpt match {
       case Some(value) => Vector(EnumOutcome(value))
@@ -1193,7 +1217,8 @@ object Picklers {
           DLCTimeouts(contractMaturity, contractTimeout),
           feeRate,
           totalCollateral,
-          localCollateral
+          localCollateral,
+          payoutAddress
         )
       case DLCState.AcceptComputingAdaptorSigs =>
         AcceptedComputingAdaptorSigs(
@@ -1206,7 +1231,8 @@ object Picklers {
           DLCTimeouts(contractMaturity, contractTimeout),
           feeRate,
           totalCollateral,
-          localCollateral
+          localCollateral,
+          payoutAddress
         )
       case DLCState.Accepted =>
         Accepted(
@@ -1219,7 +1245,8 @@ object Picklers {
           DLCTimeouts(contractMaturity, contractTimeout),
           feeRate,
           totalCollateral,
-          localCollateral
+          localCollateral,
+          payoutAddress
         )
       case DLCState.SignComputingAdaptorSigs =>
         SignedComputingAdaptorSigs(
@@ -1233,7 +1260,8 @@ object Picklers {
           feeRate,
           totalCollateral,
           localCollateral,
-          fundingTxId
+          fundingTxId,
+          payoutAddress
         )
       case DLCState.Signed =>
         Signed(
@@ -1247,7 +1275,8 @@ object Picklers {
           feeRate,
           totalCollateral,
           localCollateral,
-          fundingTxId
+          fundingTxId,
+          payoutAddress
         )
       case DLCState.Broadcasted =>
         Broadcasted(
@@ -1261,7 +1290,8 @@ object Picklers {
           feeRate,
           totalCollateral,
           localCollateral,
-          fundingTxId
+          fundingTxId,
+          payoutAddress
         )
       case DLCState.Confirmed =>
         Confirmed(
@@ -1275,7 +1305,8 @@ object Picklers {
           feeRate,
           totalCollateral,
           localCollateral,
-          fundingTxId
+          fundingTxId,
+          payoutAddress
         )
       case DLCState.Claimed =>
         Claimed(
@@ -1294,7 +1325,8 @@ object Picklers {
           oracleSigs,
           oracleOutcome,
           myPayout = myPayoutOpt.get,
-          counterPartyPayout = theirPayoutOpt.get
+          counterPartyPayout = theirPayoutOpt.get,
+          payoutAddress
         )
       case DLCState.RemoteClaimed =>
         require(oracleSigs.size == 1,
@@ -1315,7 +1347,8 @@ object Picklers {
           oracleSigs.head,
           oracleOutcome,
           myPayout = myPayoutOpt.get,
-          counterPartyPayout = theirPayoutOpt.get
+          counterPartyPayout = theirPayoutOpt.get,
+          payoutAddress
         )
       case DLCState.Refunded =>
         Refunded(
@@ -1332,7 +1365,8 @@ object Picklers {
           fundingTxId,
           closingTxId,
           myPayout = myPayoutOpt.get,
-          counterPartyPayout = theirPayoutOpt.get
+          counterPartyPayout = theirPayoutOpt.get,
+          payoutAddress
         )
     }
   }

--- a/app/server-test/src/test/scala/org/bitcoins/server/WalletRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WalletRoutesSpec.scala
@@ -74,7 +74,8 @@ class WalletRoutesSpec
         timeouts = null,
         feeRate = null,
         totalCollateral = null,
-        localCollateral = null
+        localCollateral = null,
+        payoutAddress = None
       )
 
       (mockWalletApi.findDLCByTemporaryContractId: Sha256Digest => Future[

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/build/DLCTxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/build/DLCTxBuilder.scala
@@ -39,7 +39,8 @@ case class DLCTxBuilder(offer: DLCOffer, accept: DLCAcceptWithoutSigs) {
                fundOutputSerialId: UInt64,
                feeRate: SatoshisPerVirtualByte,
                DLCTimeouts(contractMaturity: BlockTimeStamp,
-                           contractTimeout: BlockTimeStamp)) = offer
+                           contractTimeout: BlockTimeStamp),
+               _) = offer
 
   val network: BitcoinNetwork = offerFinalAddress.networkParameters match {
     case network: BitcoinNetwork => network

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
@@ -87,7 +87,8 @@ object DLCMessage {
       changeSerialId: UInt64,
       fundOutputSerialId: UInt64,
       feeRate: SatoshisPerVirtualByte,
-      timeouts: DLCTimeouts)
+      timeouts: DLCTimeouts,
+      isExternalAddress: Boolean = false)
       extends DLCSetupMessage {
 
     require(fundingInputs.nonEmpty, s"DLCOffer fundingINnputs cannot be empty")
@@ -251,7 +252,8 @@ object DLCMessage {
       cetSigs: CETSignatures,
       refundSig: PartialSignature,
       negotiationFields: DLCAccept.NegotiationFields,
-      tempContractId: Sha256Digest)
+      tempContractId: Sha256Digest,
+      isExternalAddress: Boolean = false)
       extends DLCSetupMessage {
 
     require(

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCStatusBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCStatusBuilder.scala
@@ -17,7 +17,8 @@ object DLCStatusBuilder {
       dlcDb: DLCDb,
       contractInfo: ContractInfo,
       contractData: DLCContractDataDb,
-      offerDb: DLCOfferDb): DLCStatus = {
+      offerDb: DLCOfferDb,
+      payoutAddress: Option[PayoutAddress]): DLCStatus = {
     require(
       dlcDb.state.isInstanceOf[DLCState.InProgressState],
       s"Cannot have divergent states beteween dlcDb and the parameter state, got= dlcDb.state=${dlcDb.state} state=${dlcDb.state}"
@@ -43,7 +44,8 @@ object DLCStatusBuilder {
           contractData.dlcTimeouts,
           dlcDb.feeRate,
           totalCollateral,
-          localCollateral
+          localCollateral,
+          payoutAddress
         )
       case DLCState.AcceptComputingAdaptorSigs =>
         AcceptedComputingAdaptorSigs(
@@ -56,7 +58,8 @@ object DLCStatusBuilder {
           timeouts = contractData.dlcTimeouts,
           feeRate = dlcDb.feeRate,
           totalCollateral = totalCollateral,
-          localCollateral = localCollateral
+          localCollateral = localCollateral,
+          payoutAddress
         )
       case DLCState.Accepted =>
         Accepted(
@@ -69,7 +72,8 @@ object DLCStatusBuilder {
           contractData.dlcTimeouts,
           dlcDb.feeRate,
           totalCollateral,
-          localCollateral
+          localCollateral,
+          payoutAddress
         )
       case DLCState.SignComputingAdaptorSigs =>
         SignedComputingAdaptorSigs(
@@ -83,7 +87,8 @@ object DLCStatusBuilder {
           feeRate = dlcDb.feeRate,
           totalCollateral = totalCollateral,
           localCollateral = localCollateral,
-          dlcDb.fundingTxIdOpt.get
+          dlcDb.fundingTxIdOpt.get,
+          payoutAddress
         )
       case DLCState.Signed =>
         Signed(
@@ -97,7 +102,8 @@ object DLCStatusBuilder {
           dlcDb.feeRate,
           totalCollateral,
           localCollateral,
-          dlcDb.fundingTxIdOpt.get
+          dlcDb.fundingTxIdOpt.get,
+          payoutAddress
         )
       case DLCState.Broadcasted =>
         Broadcasted(
@@ -111,7 +117,8 @@ object DLCStatusBuilder {
           dlcDb.feeRate,
           totalCollateral,
           localCollateral,
-          dlcDb.fundingTxIdOpt.get
+          dlcDb.fundingTxIdOpt.get,
+          payoutAddress
         )
       case DLCState.Confirmed =>
         Confirmed(
@@ -125,7 +132,8 @@ object DLCStatusBuilder {
           dlcDb.feeRate,
           totalCollateral,
           localCollateral,
-          dlcDb.fundingTxIdOpt.get
+          dlcDb.fundingTxIdOpt.get,
+          payoutAddress
         )
     }
 
@@ -141,7 +149,8 @@ object DLCStatusBuilder {
       announcementIds: Vector[DLCAnnouncementDb],
       offerDb: DLCOfferDb,
       acceptDb: DLCAcceptDb,
-      closingTx: Transaction): ClosedDLCStatus = {
+      closingTx: Transaction,
+      payoutAddress: Option[PayoutAddress]): ClosedDLCStatus = {
     require(
       dlcDb.state.isInstanceOf[DLCState.ClosedState],
       s"Cannot have divergent states beteween dlcDb and the parameter state, got= dlcDb.state=${dlcDb.state} state=${dlcDb.state}"
@@ -176,7 +185,8 @@ object DLCStatusBuilder {
           dlcDb.fundingTxIdOpt.get,
           closingTx.txIdBE,
           myPayout = accounting.myPayout,
-          counterPartyPayout = accounting.theirPayout
+          counterPartyPayout = accounting.theirPayout,
+          payoutAddress = payoutAddress
         )
         refund
       case oracleOutcomeState: DLCState.ClosedViaOracleOutcomeState =>
@@ -203,7 +213,8 @@ object DLCStatusBuilder {
               sigs,
               oracleOutcome,
               myPayout = accounting.myPayout,
-              counterPartyPayout = accounting.theirPayout
+              counterPartyPayout = accounting.theirPayout,
+              payoutAddress = payoutAddress
             )
           case DLCState.RemoteClaimed =>
             RemoteClaimed(
@@ -222,7 +233,8 @@ object DLCStatusBuilder {
               dlcDb.aggregateSignatureOpt.get,
               oracleOutcome,
               myPayout = accounting.myPayout,
-              counterPartyPayout = accounting.theirPayout
+              counterPartyPayout = accounting.theirPayout,
+              payoutAddress = payoutAddress
             )
         }
     }


### PR DESCRIPTION
Fixes https://github.com/bitcoin-s/bitcoin-s/issues/4125

Adds `isExternalAddress` field for `DLCAccept` and and `DLCOffer`. 

Also adds optional `payoutAddress` field (which contains the address and the external flag) to `DLCStatus`.