### PR TITLE
2022 03 08 Publish zip as part of `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "bitcoin-s-server-${{steps.previoustag.outputs.tag}}"
-          path: **/*.zip
+          path: "**/*.zip"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main, "2022-03-08-zip-release"]
+    branches: [master, main]
     tags: ["*"]
   release:
     types: [ published ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "bitcoin-s-server"
-          path: app/server/target/universal/bitcoin-s-server?
+          path: app/server/target/universal/bitcoin-s-server*
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "2022-03-08-zip-release"]
     tags: ["*"]
   release:
     types: [ published ]
@@ -193,4 +193,39 @@ jobs:
           name: windows
           files: "D:\\a\\bitcoin-s\\bitcoin-s\\app\\bundle\\target\\windows\\bitcoin-s-bundle.msi"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  zip:
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v13
+        with:
+          java-version: openjdk@1.17.0
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        with:
+          fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
+      - name: Build zip
+        run: sbt "universal:packageBin"
+      - name: View Artifacts
+        run: ls -l
+      - name: Upload deb
+        uses: actions/upload-artifact@v1
+        env:
+          pkg-version: ${{steps.previoustag.outputs.tag}}
+        with:
+          name: "zip"
+          path: "app/server/target/universal/*.zip"
+      - name: Upload if release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          name: "zip"
+          path: "app/server/target/universal/*.zip"
+        env:
+          pkg-version: ${{steps.previoustag.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,14 +218,14 @@ jobs:
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
-          name: "zip"
+          name: "bitcoin-s-server.zip"
           path: "app/server/target/universal/"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: "zip"
-          path: "app/server/target/universal/*"
+          name: "bitcoin-s-server-${{steps.previoustag.outputs.tag}}.zip"
+          path: "app/server/target/universal/"
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,8 +226,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: "bitcoin-s-server-${{steps.previoustag.outputs.tag}}.zip"
-          path: "app/server/target/universal/"
+          name: "bitcoin-s-server-${{steps.previoustag.outputs.tag}}"
+          files: app/server/target/universal/bitcoin-s-server*
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "zip"
-          path: "app/server/target/universal/bitcoin-s-server*.zip"
+          path: "app/server/target/universal/bitcoin-s-server?/*.zip"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,13 +213,15 @@ jobs:
         run: sbt "universal:packageBin"
       - name: View Artifacts
         run: ls -l app/server/target/universal
+      - name: pwd
+        run: pwd
       - name: Upload zip
         uses: actions/upload-artifact@v1
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
-          name: "bitcoin-s-server-${{steps.previoustag.outputs.tag}}"
-          path: "**/*.zip"
+          name: "bitcoin-s-server"
+          path: app/server/target/universal/bitcoin-s-server*
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,14 +212,14 @@ jobs:
       - name: Build zip
         run: sbt "universal:packageBin"
       - name: View Artifacts
-        run: ls -l
-      - name: Upload deb
+        run: ls -l app/server/target/universal
+      - name: Upload zip
         uses: actions/upload-artifact@v1
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "zip"
-          path: "app/server/target/universal/*.zip"
+          path: "app/server/target/universal/bitcoin-s-server*.zip"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "zip"
-          path: "app/server/target/universal/bitcoin?"
+          path: "app/server/target/universal/"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,8 +218,8 @@ jobs:
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
-          name: "bitcoin-s-server.zip"
-          path: "app/server/target/universal/"
+          name: "bitcoin-s-server"
+          path: app/server/target/universal/bitcoin-s-server?
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,9 +210,9 @@ jobs:
         with:
           fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
       - name: Build zip
-        run: sbt "universal:packageBin"
+        run: sbt "universal:stage"
       - name: View Artifacts
-        run: ls -l app/server/target/universal
+        run: ls -l app/server/target/universal/stage
       - name: pwd
         run: pwd
       - name: Upload zip
@@ -221,13 +221,13 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "bitcoin-s-server"
-          path: app/server/target/universal/bitcoin-s-server*
+          path: app/server/target/universal/stage/
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: "bitcoin-s-server-${{steps.previoustag.outputs.tag}}"
-          files: app/server/target/universal/bitcoin-s-server*
+          files: app/server/target/universal/stage
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "zip"
-          path: "app/server/target/universal/bitcoin-s-server?"
+          path: "bitcoin-s-server?"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,8 +217,8 @@ jobs:
         run: pwd
       - name: chmod startup script
         run: |
-        chmod +x app/server/target/universal/stage/bin/bitcoin-s-server
-        chmod +x app/server/target/universal/stage/bin/bitcoin-s-server.bat
+          chmod +x app/server/target/universal/stage/bin/bitcoin-s-server
+          chmod +x app/server/target/universal/stage/bin/bitcoin-s-server.bat
       - name: Upload zip
         uses: actions/upload-artifact@v3
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,13 +219,13 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "zip"
-          path: "app/server/target/universal/bitcoin-s-server?/*.zip"
+          path: "app/server/target/universal/bitcoin-s-server?/*"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: "zip"
-          path: "app/server/target/universal/*.zip"
+          path: "app/server/target/universal/*"
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,10 @@ jobs:
         run: ls -l app/server/target/universal/stage
       - name: pwd
         run: pwd
+      - name: chmod startup script
+        run: |
+        chmod +x app/server/target/universal/stage/bin/bitcoin-s-server
+        chmod +x app/server/target/universal/stage/bin/bitcoin-s-server.bat
       - name: Upload zip
         uses: actions/upload-artifact@v3
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "zip"
-          path: "app/server/target/universal/bitcoin-s-server*"
+          path: "app/server/target/universal/bitcoin-s-server?"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "zip"
-          path: "app/server/target/universal/bitcoin-s-server?/*"
+          path: "app/server/target/universal/bitcoin-s-server*"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "zip"
-          path: "app/server/target/universal/bitcoin?/*"
+          path: "app/server/target/universal/bitcoin?"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,8 +218,8 @@ jobs:
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
-          name: "bitcoin-s-server"
-          path: app/server/target/universal/bitcoin-s-server*
+          name: "bitcoin-s-server-${{steps.previoustag.outputs.tag}}"
+          path: **/*.zip
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
       - name: pwd
         run: pwd
       - name: Upload zip
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "zip"
-          path: "bitcoin-s-server?"
+          path: "app/server/target/universal/bitcoin?/*"
       - name: Upload if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
This will allow a technical user to `unzip bitcoin-s-server.zip` and then start the backend application with `./bin/bitcoin-s-server`. The purpose it give an easily accessible way for a user to run the backend, in conjunction with the new web frontend. Due to limitations in github actions, the user is required to `chmod +x bin/bitcoin-s-server` to run the script. [See this link for why permissions get lost.](https://github.com/actions/upload-artifact#permission-loss) 

This uses `sbt universal:stage` to create the staged directory, which github actions then zips. You can find more documentation on this [here](https://www.scala-sbt.org/sbt-native-packager/formats/universal.html#)

### Future

Due this limitation in github actions, we decided not to use `sbt universal:packageBin`. This is because this results in a double zip. This requires the unzip one `zip`, and then unzip another zip file. The nice thing about this format, is it preserves executable permissions on `./bin/bitcoin-s-server`. The bad thing is the double zip is confusing. The same principle applies with a tarball, we will have a tarball inside of a zip. Here is what the `zip(zip)` structure looks like: 

![Screenshot from 2022-03-08 17-07-24](https://user-images.githubusercontent.com/3514957/157341073-97d7fa21-9512-4393-b569-7592b1acda19.png)


If you want to test this yourself, try downloading the `bitcoin-s-server` artifact at this link and unzipping it: https://github.com/bitcoin-s/bitcoin-s/actions/runs/1953318068

This is the issue that github needs to fix:

https://github.com/actions/upload-artifact/issues/39

In the future, if this issue gets fixed, we can use this commit to get a native zip file with correct permissions: https://github.com/bitcoin-s/bitcoin-s/commit/406cf137cf4733b815943e5bd55b07c5721900a7