### PR TITLE
2022 03 09 label refactor

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -334,6 +334,9 @@ object ConsoleCli {
                 case other => other
               }))
         ),
+      cmd("getaddresslabels")
+        .action((_, conf) => conf.copy(command = GetAddressLabels))
+        .text("Returns all labels in wallet"),
       cmd("dropaddresslabels")
         .action((_, conf) => conf.copy(command = DropAddressLabels(null)))
         .text("Drop all the labels associated with this address")
@@ -1854,6 +1857,8 @@ object ConsoleCli {
         RequestParam("getaddresstags", Seq(up.writeJs(address)))
       case GetAddressLabel(address) =>
         RequestParam("getaddresslabel", Seq(up.writeJs(address)))
+      case GetAddressLabels =>
+        RequestParam("getaddresslabels")
       case DropAddressLabels(address) =>
         RequestParam("dropaddresslabels", Seq(up.writeJs(address)))
       case Rescan(addressBatchSize,
@@ -2357,6 +2362,8 @@ object CliCommand {
 
   case class GetAddressLabel(address: BitcoinAddress)
       extends AppServerCliCommand
+
+  case object GetAddressLabels extends AppServerCliCommand
 
   case class DropAddressLabels(address: BitcoinAddress)
       extends AppServerCliCommand

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -339,7 +339,7 @@ object ConsoleCli {
         .text("Returns all labels in wallet"),
       cmd("dropaddresslabels")
         .action((_, conf) => conf.copy(command = DropAddressLabels(null)))
-        .text("Drop all the labels associated with this address")
+        .text("Drop the label associated with the address")
         .children(
           arg[BitcoinAddress]("address")
             .text("The address to drop the associated labels of")
@@ -348,6 +348,29 @@ object ConsoleCli {
               conf.copy(command = conf.command match {
                 case dropAddressLabels: DropAddressLabels =>
                   dropAddressLabels.copy(address = addr)
+                case other => other
+              }))
+        ),
+      cmd("dropaddresslabel")
+        .action((_, conf) => conf.copy(command = DropAddressLabel(null, null)))
+        .text("Drop all the labels associated with this address")
+        .children(
+          arg[BitcoinAddress]("address")
+            .text("The address to drop the associated labels of")
+            .required()
+            .action((addr, conf) =>
+              conf.copy(command = conf.command match {
+                case dropAddressLabel: DropAddressLabel =>
+                  dropAddressLabel.copy(address = addr)
+                case other => other
+              })),
+          arg[String]("label")
+            .text("The label to drop")
+            .required()
+            .action((label, conf) =>
+              conf.copy(command = conf.command match {
+                case dropAddressLabel: DropAddressLabel =>
+                  dropAddressLabel.copy(label = label)
                 case other => other
               }))
         ),
@@ -1859,6 +1882,9 @@ object ConsoleCli {
         RequestParam("getaddresslabel", Seq(up.writeJs(address)))
       case GetAddressLabels =>
         RequestParam("getaddresslabels")
+      case DropAddressLabel(address, label) =>
+        RequestParam("dropaddresslabel",
+                     Seq(up.writeJs(address), ujson.Str(label)))
       case DropAddressLabels(address) =>
         RequestParam("dropaddresslabels", Seq(up.writeJs(address)))
       case Rescan(addressBatchSize,
@@ -2364,6 +2390,9 @@ object CliCommand {
       extends AppServerCliCommand
 
   case object GetAddressLabels extends AppServerCliCommand
+
+  case class DropAddressLabel(address: BitcoinAddress, label: String)
+      extends AppServerCliCommand
 
   case class DropAddressLabels(address: BitcoinAddress)
       extends AppServerCliCommand

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -320,8 +320,8 @@ object ConsoleCli {
                 case other => other
               }))
         ),
-      cmd("getaddresslabels")
-        .action((_, conf) => conf.copy(command = GetAddressLabels(null)))
+      cmd("getaddresslabel")
+        .action((_, conf) => conf.copy(command = GetAddressLabel(null)))
         .text("Get all the labels associated with this address")
         .children(
           arg[BitcoinAddress]("address")
@@ -329,7 +329,7 @@ object ConsoleCli {
             .required()
             .action((addr, conf) =>
               conf.copy(command = conf.command match {
-                case getAddressLabels: GetAddressLabels =>
+                case getAddressLabels: GetAddressLabel =>
                   getAddressLabels.copy(address = addr)
                 case other => other
               }))
@@ -1852,8 +1852,8 @@ object ConsoleCli {
                      Seq(up.writeJs(address), up.writeJs(label)))
       case GetAddressTags(address) =>
         RequestParam("getaddresstags", Seq(up.writeJs(address)))
-      case GetAddressLabels(address) =>
-        RequestParam("getaddresslabels", Seq(up.writeJs(address)))
+      case GetAddressLabel(address) =>
+        RequestParam("getaddresslabel", Seq(up.writeJs(address)))
       case DropAddressLabels(address) =>
         RequestParam("dropaddresslabels", Seq(up.writeJs(address)))
       case Rescan(addressBatchSize,
@@ -2355,7 +2355,7 @@ object CliCommand {
 
   case class GetAddressTags(address: BitcoinAddress) extends AppServerCliCommand
 
-  case class GetAddressLabels(address: BitcoinAddress)
+  case class GetAddressLabel(address: BitcoinAddress)
       extends AppServerCliCommand
 
   case class DropAddressLabels(address: BitcoinAddress)

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -134,17 +134,17 @@ object GetAddressLabels extends ServerJsonModels {
   }
 }
 
-case class DropAddressLabels(address: BitcoinAddress)
+case class DropAddressLabel(address: BitcoinAddress)
 
-object DropAddressLabels extends ServerJsonModels {
+object DropAddressLabel extends ServerJsonModels {
 
-  def fromJsArr(jsArr: ujson.Arr): Try[DropAddressLabels] = {
+  def fromJsArr(jsArr: ujson.Arr): Try[DropAddressLabel] = {
     jsArr.arr.toList match {
       case addrJs :: Nil =>
         Try {
           val addr = jsToBitcoinAddress(addrJs)
 
-          DropAddressLabels(addr)
+          DropAddressLabel(addr)
         }
       case other =>
         Failure(

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -114,17 +114,17 @@ object GetAddressTags extends ServerJsonModels {
   }
 }
 
-case class GetAddressLabels(address: BitcoinAddress)
+case class GetAddressLabel(address: BitcoinAddress)
 
-object GetAddressLabels extends ServerJsonModels {
+object GetAddressLabel extends ServerJsonModels {
 
-  def fromJsArr(jsArr: ujson.Arr): Try[GetAddressLabels] = {
+  def fromJsArr(jsArr: ujson.Arr): Try[GetAddressLabel] = {
     jsArr.arr.toList match {
       case addrJs :: Nil =>
         Try {
           val addr = jsToBitcoinAddress(addrJs)
 
-          GetAddressLabels(addr)
+          GetAddressLabel(addr)
         }
       case other =>
         Failure(

--- a/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ServerJsonModels.scala
@@ -134,17 +134,36 @@ object GetAddressLabel extends ServerJsonModels {
   }
 }
 
-case class DropAddressLabel(address: BitcoinAddress)
+case class DropAddressLabel(address: BitcoinAddress, label: String)
 
 object DropAddressLabel extends ServerJsonModels {
 
-  def fromJsArr(jsArr: ujson.Arr): Try[DropAddressLabel] = {
+  def fromJsArr(jsonArr: ujson.Arr): Try[DropAddressLabel] = {
+    jsonArr.arr.toList match {
+      case address :: label :: Nil =>
+        Try {
+          val addr = jsToBitcoinAddress(address)
+          DropAddressLabel(addr, label.str)
+        }
+      case other =>
+        Failure(
+          new IllegalArgumentException(
+            s"Bad number of arguments: ${other.length}. Expected: 2"))
+    }
+  }
+}
+
+case class DropAddressLabels(address: BitcoinAddress)
+
+object DropAddressLabels extends ServerJsonModels {
+
+  def fromJsArr(jsArr: ujson.Arr): Try[DropAddressLabels] = {
     jsArr.arr.toList match {
       case addrJs :: Nil =>
         Try {
           val addr = jsToBitcoinAddress(addrJs)
 
-          DropAddressLabel(addr)
+          DropAddressLabels(addr)
         }
       case other =>
         Failure(

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -246,7 +246,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
 
     case ServerCommand("getaddresslabels", _) =>
       complete {
-        val allTagsF = wallet.getAddressTags
+        val allTagsF = wallet.getAddressTags()
         for {
           allTags <- allTagsF
           grouped = allTags.groupBy(_.address)

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -228,7 +228,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
           }
       }
 
-    case ServerCommand("getaddresslabels", arr) =>
+    case ServerCommand("getaddresslabel", arr) =>
       withValidServerCommand(GetAddressLabels.fromJsArr(arr)) {
         case GetAddressLabels(address) =>
           complete {
@@ -240,8 +240,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
       }
 
     case ServerCommand("dropaddresslabels", arr) =>
-      withValidServerCommand(DropAddressLabels.fromJsArr(arr)) {
-        case DropAddressLabels(address) =>
+      withValidServerCommand(DropAddressLabel.fromJsArr(arr)) {
+        case DropAddressLabel(address) =>
           complete {
             wallet.dropAddressTagType(address, AddressLabelTagType).map {
               numDropped =>

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -229,8 +229,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
       }
 
     case ServerCommand("getaddresslabel", arr) =>
-      withValidServerCommand(GetAddressLabels.fromJsArr(arr)) {
-        case GetAddressLabels(address) =>
+      withValidServerCommand(GetAddressLabel.fromJsArr(arr)) {
+        case GetAddressLabel(address) =>
           complete {
             wallet.getAddressTags(address, AddressLabelTagType).map { tagDbs =>
               val retStr = tagDbs.map(_.tagName.name)

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -17,7 +17,12 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.util.{FutureUtil, StartStopAsync}
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.core.wallet.utxo.{AddressTag, AddressTagType, TxoState}
+import org.bitcoins.core.wallet.utxo.{
+  AddressTag,
+  AddressTagName,
+  AddressTagType,
+  TxoState
+}
 import org.bitcoins.crypto.DoubleSha256DigestBE
 
 import java.time.Instant
@@ -229,6 +234,10 @@ trait WalletApi extends StartStopAsync[WalletApi] {
   def dropAddressTagType(
       address: BitcoinAddress,
       addressTagType: AddressTagType): Future[Int]
+
+  def dropAddressTagName(
+      address: BitcoinAddress,
+      tagName: AddressTagName): Future[Int]
 
   /** Generates a new change address */
   protected[wallet] def getNewChangeAddress()(implicit

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -223,7 +223,7 @@ trait WalletApi extends StartStopAsync[WalletApi] {
       address: BitcoinAddress,
       tagType: AddressTagType): Future[Vector[AddressTagDb]]
 
-  def getAddressTags: Future[Vector[AddressTagDb]]
+  def getAddressTags(): Future[Vector[AddressTagDb]]
 
   def getAddressTags(tagType: AddressTagType): Future[Vector[AddressTagDb]]
 

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -106,13 +106,13 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
     val result = walletDbManagement.migrate()
     walletAppConfig.driver match {
       case SQLite =>
-        val expected = 14
+        val expected = 15
         assert(result == expected)
         val flywayInfo = walletDbManagement.info()
         assert(flywayInfo.applied().length == expected)
         assert(flywayInfo.pending().length == 0)
       case PostgreSQL =>
-        val expected = 12
+        val expected = 13
         assert(result == expected)
         val flywayInfo = walletDbManagement.info()
 

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -306,9 +306,13 @@ the `-p 9999:9999` port mapping on the docker container to adjust for this.
     - `message` - Peer's message or note (optional)
  - `"offer-remove` `hash` - Remove an incoming offer from inbox
     - `hash` - Hash of the offer TLV
-- `offer-send` `offerOrTempContractId` `peerAddress` `message` - Sends an offer to a peer. `offerOrTempContractId` is either an offer TLV or a temporary contract ID.
-- `offers-list` - List all incoming offers from the inbox
-- `getdlcoffer` `tempContractId` - Gets a DLC offer by temporary contract ID.
+ - `offer-send` `offerOrTempContractId` `peerAddress` `message` - Sends an offer to a peer. `offerOrTempContractId` is either an offer TLV or a temporary contract ID.
+ - `offers-list` - List all incoming offers from the inbox
+ - `getdlcoffer` `tempContractId` - Gets a DLC offer by temporary contract ID.
+ - `getaddresslabel` `address` - gets all labels for an address
+ - `getaddresslabels` - returns all addresses with labels in the wallet
+ - `dropaddresslabel` `address` `label` - drops the label for a given address
+ - `dropaddresslabels` `address` - drops all labels for the given address
 
 ### Network
  - `getpeers` - List the connected peers

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -283,7 +283,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
       for {
         _ <- addressF
         _ <- wallet.clearAllUtxosAndAddresses()
-        tags <- wallet.getAddressTags
+        tags <- wallet.getAddressTags()
       } yield {
         assert(tags.isEmpty)
       }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressLabelTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressLabelTest.scala
@@ -5,6 +5,8 @@ import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
 import org.scalatest.FutureOutcome
 
+import java.sql.SQLException
+
 class AddressLabelTest extends BitcoinSWalletTest {
   type FixtureParam = FundedWallet
 
@@ -14,23 +16,40 @@ class AddressLabelTest extends BitcoinSWalletTest {
 
   behavior of "Address tags"
 
-  it must "add two labels to the database" in { fundedWallet =>
+  it must "add two tags to the database" in { fundedWallet =>
     val wallet = fundedWallet.wallet
     val tag1 = UnknownAddressTag("test_tag_name_1", "test_tag_type_1")
     val tag2 = UnknownAddressTag("test_tag_name_2", "test_tag_type_2")
     val addressF = for {
       address <- wallet.getNewAddress(Vector(tag1))
       //add another tag to address
-      tagDb1 <- wallet.tagAddress(address, tag1)
+      tagDb1 <- wallet.getAddressTags(address)
       tagDb2 <- wallet.tagAddress(address, tag2)
     } yield {
-      assert(tagDb1.address == address)
-      assert(tagDb1.tagName == tag1.tagName)
+      assert(tagDb1.head.address == address)
+      assert(tagDb1.head.tagName == tag1.tagName)
 
       assert(tagDb2.tagName == tag2.tagName)
       assert(tagDb2.address == address)
     }
 
     addressF
+  }
+
+  it must "fail if we tag the address with the same tag twice" in {
+    fundedWallet =>
+      val wallet = fundedWallet.wallet
+      val tag1 = UnknownAddressTag(tagName = "test_tag_name_1",
+                                   tagType = "test_tag_type_1")
+      val tag2 = UnknownAddressTag(tagName = "test_tag_name_1",
+                                   tagType = "test_tag_type_2")
+      val resultF = for {
+        address <- wallet.getNewAddress()
+        //add another tag to address
+        _ <- wallet.tagAddress(address, tag1)
+        _ <- wallet.tagAddress(address, tag2)
+      } yield ()
+
+      recoverToSucceededIf[SQLException](resultF)
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/models/AddressTagDAOTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/models/AddressTagDAOTest.scala
@@ -83,4 +83,29 @@ class AddressTagDAOTest extends WalletDAOFixture {
     daos =>
       testInsertion(daos, HotStorage)
   }
+
+  it must "delete a tag by name" in { daos =>
+    val accountDAO = daos.accountDAO
+    val addressDAO = daos.addressDAO
+    val addressTagDAO = daos.addressTagDAO
+    for {
+      createdAccount <- {
+        val account = WalletTestUtil.firstAccountDb
+        accountDAO.create(account)
+      }
+      createdAddress <- {
+        val addressDb = WalletTestUtil.getAddressDb(createdAccount)
+        addressDAO.create(addressDb)
+      }
+      createdAddressTag <- {
+        val tagDb =
+          AddressTagDb(createdAddress.address, exampleTag)
+        addressTagDAO.create(tagDb)
+      }
+      dropped <- addressTagDAO.dropByAddressAndName(createdAddress.address,
+                                                    createdAddressTag.tagName)
+    } yield {
+      assert(dropped == 1)
+    }
+  }
 }

--- a/wallet/src/main/resources/postgresql/wallet/migration/V16__add_tag_name_constraint.sql
+++ b/wallet/src/main/resources/postgresql/wallet/migration/V16__add_tag_name_constraint.sql
@@ -1,0 +1,4 @@
+--changes pk to (address,tag_name) rather than (address,tag_type)
+ALTER TABLE wallet_address_tags DROP CONSTRAINT IF EXISTS "pk_address_tags";
+
+ALTER TABLE wallet_address_tags ADD CONSTRAINT pk_address_tags PRIMARY KEY (address, tag_name);

--- a/wallet/src/main/resources/sqlite/wallet/migration/V15__add_tag_name_constraint.sql
+++ b/wallet/src/main/resources/sqlite/wallet/migration/V15__add_tag_name_constraint.sql
@@ -1,0 +1,7 @@
+-- This changes the primary key to (address, tag_name)
+CREATE TABLE "wallet_address_tags_temp" ("address" VARCHAR(254) NOT NULL,"tag_name" VARCHAR(254) NOT NULL,"tag_type" VARCHAR(254) NOT NULL);
+INSERT INTO "wallet_address_tags_temp" SELECT "address", "tag_name", "tag_type" FROM "wallet_address_tags";
+DROP TABLE "wallet_address_tags";
+CREATE TABLE "wallet_address_tags" ("address" VARCHAR(254) NOT NULL,"tag_name" VARCHAR(254) NOT NULL,"tag_type" VARCHAR(254) NOT NULL,constraint "pk_address_tags" primary key ("address", "tag_name"), constraint "fk_address" foreign key("address") references "addresses"("address") on update NO ACTION on delete NO ACTION);
+INSERT INTO "wallet_address_tags" SELECT "address", "tag_name", "tag_type" FROM "wallet_address_tags_temp";
+DROP TABLE "wallet_address_tags_temp";

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -414,7 +414,7 @@ private[wallet] trait AddressHandling extends WalletLogger {
       address: BitcoinAddress,
       tag: AddressTag): Future[AddressTagDb] = {
     val addressTagDb = AddressTagDb(address, tag)
-    val f = addressTagDAO.upsert(addressTagDb)
+    val f = addressTagDAO.create(addressTagDb)
     f
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -432,7 +432,7 @@ private[wallet] trait AddressHandling extends WalletLogger {
     addressTagDAO.findByAddressAndTag(address, tagType)
   }
 
-  def getAddressTags: Future[Vector[AddressTagDb]] = {
+  def getAddressTags(): Future[Vector[AddressTagDb]] = {
     addressTagDAO.findAll()
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -13,7 +13,11 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutPoint,
   TransactionOutput
 }
-import org.bitcoins.core.wallet.utxo.{AddressTag, AddressTagType}
+import org.bitcoins.core.wallet.utxo.{
+  AddressTag,
+  AddressTagName,
+  AddressTagType
+}
 import org.bitcoins.crypto.ECPublicKey
 import org.bitcoins.wallet._
 
@@ -449,6 +453,12 @@ private[wallet] trait AddressHandling extends WalletLogger {
       address: BitcoinAddress,
       addressTagType: AddressTagType): Future[Int] = {
     addressTagDAO.dropByAddressAndTag(address, addressTagType)
+  }
+
+  override def dropAddressTagName(
+      address: BitcoinAddress,
+      addressTagName: AddressTagName): Future[Int] = {
+    addressTagDAO.dropByAddressAndName(address, addressTagName)
   }
 
   private lazy val addressRequestQueue = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagDAO.scala
@@ -125,6 +125,16 @@ case class AddressTagDAO()(implicit
     safeDatabase.run(query.delete)
   }
 
+  def dropByAddressAndName(
+      address: BitcoinAddress,
+      tagName: AddressTagName): Future[Int] = {
+    val query = table
+      .filter(_.address === address)
+      .filter(_.tagName === tagName)
+
+    safeDatabase.run(query.delete)
+  }
+
   def findTx(
       tx: Transaction,
       network: NetworkParameters): Future[Vector[AddressTagDb]] = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/AddressTagDAO.scala
@@ -201,7 +201,7 @@ case class AddressTagDAO()(implicit
       (address, tagName, tagType).<>(fromTuple, toTuple)
 
     def primaryKey: PrimaryKey =
-      primaryKey("pk_address_tags", sourceColumns = (address, tagType))
+      primaryKey("pk_address_tags", sourceColumns = (address, tagName))
 
     /** All tags must have an associated address */
     def fk_address = {


### PR DESCRIPTION
This reworks the labeling API to be easier to use. 

This PR adds the following RPCs 

- `getaddresslabel` `address` gets all labels for a given address
- `dropaddresslabel` `address` `label` drops the specific label for a given address

This PR modifies these existing RPCs

- `getaddresslabels`  returns all addresses that have labels, and their associated labels
- `dropaddresslabels` `address` this drops all labels for the given addresses.


![Screenshot from 2022-03-09 10-46-51](https://user-images.githubusercontent.com/3514957/157489665-bca633c7-f2e4-47cd-81da-3e6c6904d2b9.png)
