### PR TITLE
Renable tor configuration by default

### DIFF
--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -7,12 +7,12 @@ bitcoin-s {
     }
     proxy {
         # Configure SOCKS5 proxy to use Tor for outgoing connections
-        enabled = false
+        enabled = true
         socks5 = "127.0.0.1:9050"
     }
     tor {
         # Enable Tor for incoming DLC connections
-        enabled = false
+        enabled = true
         control = "127.0.0.1:9051"
     }
 }


### PR DESCRIPTION
Now that we are publishing backend zips that i am sharing with users (#4174 ) we should have the out of box configuration just work :tm: for doing a DLC.