### PR TITLE
Only allow executing a DLC if it is in the Broadcast or Confirmed state

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1431,7 +1431,17 @@ abstract class DLCWallet
 
     for {
       dlcDb <- dlcDAO.findByContractId(contractId).map(_.get)
-
+      _ = dlcDb.state match {
+        case state @ (Offered | AcceptComputingAdaptorSigs | Accepted |
+            SignComputingAdaptorSigs | Signed) =>
+          sys.error(
+            s"Cannot execute DLC before the DLC is broadcast to the blockchain, state=$state")
+        case c: ClosedState =>
+          sys.error(
+            s"Cannot execute a DLC that has already been executed, state=$c")
+        case Broadcasted | Confirmed =>
+        //can continue executing, do nothing
+      }
       (announcements, announcementData, nonceDbs) <- dlcDataManagement
         .getDLCAnnouncementDbs(dlcDb.dlcId)
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1436,10 +1436,7 @@ abstract class DLCWallet
             SignComputingAdaptorSigs | Signed) =>
           sys.error(
             s"Cannot execute DLC before the DLC is broadcast to the blockchain, state=$state")
-        case c: ClosedState =>
-          sys.error(
-            s"Cannot execute a DLC that has already been executed, state=$c")
-        case Broadcasted | Confirmed =>
+        case Broadcasted | Confirmed | _: ClosedState =>
         //can continue executing, do nothing
       }
       (announcements, announcementData, nonceDbs) <- dlcDataManagement


### PR DESCRIPTION
fixes #4184 

This will prevent even more confusion when a DLC funding tx broadcasts. Before this PR we could have the funding tx fail to broadcast, and then the user uses the oracle attestations to settle the DLC, and then tries to broadcast the CET, which also fails because the funding tx doesn't exist onchain. This gives the a user a better error message when that occurs. 