### PR TITLE
Make `buildCreateOfferAction` upsert funding inputs rather than insert

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -563,7 +563,7 @@ abstract class DLCWallet
           dlcDbAction = dlcDAO.createAction(dlc)
           dlcOfferAction = dlcOfferDAO.createAction(dlcOfferDb)
           acceptAction = dlcAcceptDAO.createAction(acceptDb)
-          inputsAction = dlcInputsDAO.createAllAction(acceptInputs)
+          inputsAction = dlcInputsDAO.upsertAllAction(acceptInputs)
           contractAction = contractDataDAO.createAction(contractDataDb)
           createdAnnouncementsAction = announcementDAO.createAllAction(
             groupedAnnouncements.newAnnouncements)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
@@ -33,12 +33,12 @@ case class DLCActionBuilder(dlcWalletDAOs: DLCWalletDAOs) {
       dlcOfferDb: DLCOfferDb)(implicit ec: ExecutionContext): DBIOAction[
     Unit,
     NoStream,
-    Effect.Write with Effect.Transactional] = {
+    Effect.Read with Effect.Write with Effect.Transactional] = {
     val globalAction = dlcDAO.createAction(dlcDb)
     val contractAction = contractDataDAO.createAction(contractDataDb)
     val announcementAction =
       dlcAnnouncementDAO.createAllAction(dlcAnnouncementDbs)
-    val inputsAction = dlcInputsDAO.createAllAction(dlcInputs)
+    val inputsAction = dlcInputsDAO.upsertAllAction(dlcInputs)
     val offerAction = dlcOfferDAO.createAction(dlcOfferDb)
     val actions = Vector(globalAction,
                          contractAction,


### PR DESCRIPTION
fixes #4145

When creating an offer, this PR upserts the dlc funding inputs rather than inserts. This is safe to do as the wallet selects utxos that are not reserved and passes them to `buildCreateOfferAction`.

The reason this is needed is because we have bugs elsewhere in the wallet that can cause DLC negotiation to fail. Since there is no way to gracefully teardown all associated data with a DLC on negotiation fail, we have to expose `Unreserve UTXOs` buttons to the user on the GUI. 

This button unreserves the utxo in the wallet itself, but won't remove it for the `funding_inputs` table. This makes it so next time the wallet selects to utxo to fund a DLC, it will throw an exception when trying to create the offer. This is what happened in #4145
