### PR TITLE
Bind to localhost rather than 127.0.0.1

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -155,11 +155,11 @@ bitcoin-s {
     server {
         # The port we bind our rpc server on
         rpcport = 9999
-        rpcbind = "127.0.0.1"
+        rpcbind = "localhost"
 
         # The port we bind our websocket server on
         wsport = 19999
-        wsbind = "127.0.0.1"
+        wsbind = "localhost"
 
         # The basic auth password. It must me must be non empty.
         password = ""


### PR DESCRIPTION
fixes #4178 

I can node use `node 17.x` locally and it seems to work. I would like others to test this to confirm it works on their machines.