### PR TITLE
Log entire address path when the address is generated

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -228,7 +228,7 @@ private[wallet] trait AddressHandling extends WalletLogger {
         walletCallbacks.executeOnNewAddressGenerated(logger, addressDb.address)
     } yield {
       logger.info(
-        s"Generated new address=${addressDb.address} isChange=${addressDb.isChange} account=$account")
+        s"Generated new address=${addressDb.address} path=${addressDb.path} isChange=${addressDb.isChange}")
       addressDb.address
     }
   }


### PR DESCRIPTION
More improving of logging

>[info] 2022-03-15T12:27:52UTC INFO [DLCWallet$DLCWalletImpl] Generated new address=bc1q5634umttu7v6hcu8a8atk59zexar0xr0ww0n23 path=m/84'/0'/0'/0/228 isChange=false
