### PR TITLE
Rename `clearAllUtxosAndAddresses()` -> `clearAllUtxos()`

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -430,7 +430,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       err)
 
     //clear the entire wallet, then rescan to make sure we get out of a corrupted state
-    val clearedF = wallet.clearAllUtxosAndAddresses()
+    val clearedF = wallet.clearAllUtxos()
     val walletF = for {
       clearedWallet <- clearedF
       _ <- clearedWallet.rescanNeutrinoWallet(startOpt = None,

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
@@ -453,7 +453,7 @@ trait HDWalletApi extends WalletApi {
 
   def listUnusedAddresses(account: HDAccount): Future[Vector[AddressDb]]
 
-  override def clearAllUtxosAndAddresses(): Future[HDWalletApi]
+  override def clearAllUtxos(): Future[HDWalletApi]
 
   def clearUtxosAndAddresses(account: HDAccount): Future[HDWalletApi]
 

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -155,11 +155,11 @@ trait WalletApi extends StartStopAsync[WalletApi] {
   /** Checks if the wallet contains any data */
   def isEmpty(): Future[Boolean]
 
-  /** Removes all utxos and addresses from the wallet.
+  /** Removes all utxos from the wallet.
     * Don't call this unless you are sure you can recover
     * your wallet
     */
-  def clearAllUtxosAndAddresses(): Future[WalletApi]
+  def clearAllUtxos(): Future[WalletApi]
 
   /** Gets a new external address with the specified
     * type.

--- a/core/src/main/scala/org/bitcoins/core/hd/HDCoin.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDCoin.scala
@@ -1,5 +1,9 @@
 package org.bitcoins.core.hd
 
+/** Contains the path
+  * m / purpose' / coin_type' /
+  * @see https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels
+  */
 case class HDCoin(purpose: HDPurpose, coinType: HDCoinType) extends BIP32Path {
 
   override def path: Vector[BIP32Node] =

--- a/docs/wallet/wallet-rescan.md
+++ b/docs/wallet/wallet-rescan.md
@@ -1,3 +1,4 @@
+
 ---
 title: Wallet Rescans
 id: wallet-rescan
@@ -84,7 +85,7 @@ val initBalanceF = for {
 val clearedWalletF = for {
   w <- walletF
   _ <- initBalanceF
-  clearedWallet <- w.clearAllUtxosAndAddresses()
+  clearedWallet <- w.clearAllUtxos()
   zeroBalance <- clearedWallet.getBalance()
 } yield {
   println(s"Balance after clearing utxos: ${zeroBalance}")

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -164,14 +164,14 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
         rescan <- wallet.isRescanning()
         balance <- wallet.getBalance()
         addresses <- wallet.listAddresses()
-        utxos <- wallet.listUtxos()
+        utxos <- wallet.listDefaultAccountUtxos()
+        spks = utxos
+          .map(_.output.scriptPubKey)
       } yield {
         !rescan &&
         balance == BitcoinSWalletTest.expectedDefaultAmt + TestAmount &&
         utxos.size == 4 &&
-        utxos
-          .map(_.output.scriptPubKey)
-          .forall(spk => addresses.exists(_.scriptPubKey == spk))
+        spks.forall(spk => addresses.exists(_.scriptPubKey == spk))
       }
     }
 
@@ -197,10 +197,9 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       _ <- NodeTestUtil.awaitCompactFiltersSync(node, bitcoind)
 
       _ <- wallet.clearAllUtxos()
-
       addresses <- wallet.listAddresses()
       utxos <- wallet.listDefaultAccountUtxos()
-      _ = assert(addresses.isEmpty)
+      _ = assert(addresses.nonEmpty)
       _ = assert(utxos.isEmpty)
 
       rescan <- wallet.isRescanning()

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -196,7 +196,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       _ <- NodeTestUtil.awaitSync(node, bitcoind)
       _ <- NodeTestUtil.awaitCompactFiltersSync(node, bitcoind)
 
-      _ <- wallet.clearAllUtxosAndAddresses()
+      _ <- wallet.clearAllUtxos()
 
       addresses <- wallet.listAddresses()
       utxos <- wallet.listDefaultAccountUtxos()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -275,20 +275,6 @@ class AddressHandlingTest extends BitcoinSWalletTest {
       } yield assert(res1)
   }
 
-  it must "generate an address with a label, and then clear all addresses in the wallet" in {
-    fundedWallet: FundedWallet =>
-      val wallet = fundedWallet.wallet
-      val tag = AddressLabelTag("test")
-      val addressF = wallet.getNewAddress(Vector(tag))
-      for {
-        _ <- addressF
-        _ <- wallet.clearAllUtxosAndAddresses()
-        tags <- wallet.getAddressTags()
-      } yield {
-        assert(tags.isEmpty)
-      }
-  }
-
   it must "create an address and not have an associated utxo until we deposit" in {
     fundedWallet: FundedWallet =>
       val wallet = fundedWallet.wallet

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -265,25 +265,19 @@ abstract class Wallet
       for {
         accountUtxos <- spendingInfoDAO.findAllForAccountAction(account)
         _ <- spendingInfoDAO.deleteSpendingInfoDbAllAction(accountUtxos)
-        accountAddresses <- addressDAO.findAllForAccountAction(account)
-        _ <- addressTagDAO.deleteByAddressesAction(
-          accountAddresses.map(_.address))
-        _ <- addressDAO.deleteAllAction(accountAddresses)
       } yield this
     }
 
     safeDatabase.run(aggregatedActions)
   }
 
-  override def clearAllUtxosAndAddresses(): Future[Wallet] = {
+  override def clearAllUtxos(): Future[Wallet] = {
     val aggregatedActions: DBIOAction[
       Unit,
       NoStream,
       Effect.Write with Effect.Transactional] = for {
-      _ <- addressTagDAO.deleteAllAction()
+
       _ <- spendingInfoDAO.deleteAllAction()
-      _ <- addressDAO.deleteAllAction()
-      _ <- scriptPubKeyDAO.deleteAllAction()
     } yield {
       ()
     }


### PR DESCRIPTION
partially fixes #4192

This was introduced in #4130 

The problem introduced is that if we rescan, we generate a bunch of addresses that may or may not have received payments. The next address generated by a user after the rescan is completed is at the end of all those addresses as we no longer have `pruneUnusedAddresses()`.

If the user rescans again, we will not detect payments to that last address as it is not within the address gap limit. 

The solution to this is not delete addresses when we rescan, only delete utxos. There isn't really a good reason to delete addresses when rescanning. 

This exact same problem exists when restoring from a mnemonic seed. Since we don't have an address list when totally restoring the wallet, the best we can do is generate a bunch of addresses.