### PR TITLE
Make better error message when you cannot connect to bitcoind

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -415,7 +415,12 @@ trait Client
   protected def getPayload(response: HttpResponse): Future[JsValue] = {
     try {
       Unmarshal(response).to[String].map { data =>
-        Json.parse(data)
+        if (data.isEmpty) {
+          throw new IllegalArgumentException(
+            s"Bad authentication credentials supplied, cannot connect to bitcoind rpc")
+        } else {
+          Json.parse(data)
+        }
       }
     } catch {
       case NonFatal(exn) =>


### PR DESCRIPTION
Previously this is the error message we would show. This PR replaces this error message with
<img width="932" alt="Screen Shot 2022-03-19 at 3 23 16 PM" src="https://user-images.githubusercontent.com/3514957/159137720-eceddead-aaa0-4804-9fe9-7c03a8e0ea1c.png">
a more useful error message. I had a user see this error message and ask me what it was.