### PR TITLE
Bump default address gap limit to 100 from 25

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
@@ -87,7 +87,7 @@ trait NeutrinoWalletApi { self: WalletApi =>
                          addressBatchSize = addressBatchSize,
                          useCreationTime = false)
 
-  def discoveryBatchSize(): Int = 25
+  def discoveryBatchSize(): Int
 
 }
 

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -115,7 +115,7 @@ bitcoin-s {
 
       bloomFalsePositiveRate = 0.0001 # percentage
 
-      addressGapLimit = 20
+      addressGapLimit = 100
 
       discoveryBatchSize = 100
 

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -224,8 +224,15 @@ bitcoin-s {
 
         bloomFalsePositiveRate = 0.0001 # percentage
 
-        addressGapLimit = 20
-
+        # the number of consecutive addresses that we do not
+        # discover funds in before we mark as rescan as exhausted
+        # this is needed because we can never truely tell how many addresses
+        # the wallet has used when executing a rescan from a seed
+        addressGapLimit = 100
+        
+        # the number of addresses that get generated everytime
+        # we need to rescan. If a match occurs within the addressGapLimit
+        # we generate another discoveryBatchSize addresses and then rescan again
         discoveryBatchSize = 100
 
         requiredConfirmations = 6

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -156,7 +156,8 @@ private[wallet] trait RescanHandling extends WalletLogger {
         if (
           externalGap >= walletConfig.addressGapLimit && changeGap >= walletConfig.addressGapLimit
         ) {
-          //done rescanning
+          logger.info(
+            s"Did not find any funds within the last ${walletConfig.addressGapLimit} addresses. Stopping our rescan.")
           Future.unit
         } else {
           logger.info(


### PR DESCRIPTION
fixes #3040

and also helps mitigate the bug talked about in #4192. Finally it gives a useful log indicating how many addresses we searched since we last saw funds

```
2022-03-19T22:18:44UTC INFO [DLCWallet$DLCWalletImpl] Did not find any funds within the last 100 addresses. Stopping our rescan.
```