### PR TITLE
Use the set of addresses in the wallet when rescanning rather than generating more

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -310,7 +310,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
       //slight delay to make sure other rescan is started
       val alreadyStartedF =
-        AsyncUtil.nonBlockingSleep(500.millis).flatMap { _ =>
+        AsyncUtil.nonBlockingSleep(100.millis).flatMap { _ =>
           wallet.rescanNeutrinoWallet(startOpt = None,
                                       endOpt = None,
                                       addressBatchSize =


### PR DESCRIPTION
When rescanning a wallet with the addresses already populated, don't generate more addresses. These will not be used and make the address set more fragmented in the future since these addresses aren't being given externally.

This PR still generates the correct set of addresses when running for mnemonic seed.