### PR TITLE
2022 03 22 getrelevantoutputs upfront

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutput.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutput.scala
@@ -27,3 +27,5 @@ object TransactionOutput extends Factory[TransactionOutput] {
     RawTransactionOutputParser.read(bytes)
 
 }
+
+case class OutputWithIndex(output: TransactionOutput, index: Int)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -7,7 +7,11 @@ import org.bitcoins.core.protocol.dlc.models.DLCMessage._
 import org.bitcoins.core.protocol.dlc.models._
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.tlv._
-import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
+import org.bitcoins.core.protocol.transaction.{
+  OutputWithIndex,
+  Transaction,
+  WitnessTransaction
+}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.utxo.AddressTag
@@ -236,9 +240,15 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
       tx: Transaction,
       blockHashOpt: Option[DoubleSha256DigestBE],
       spendingInfoDbs: Vector[SpendingInfoDb],
-      newTags: Vector[AddressTag]): Future[Vector[SpendingInfoDb]] = {
+      newTags: Vector[AddressTag],
+      relevantReceivedOutputs: Vector[OutputWithIndex]): Future[
+    Vector[SpendingInfoDb]] = {
     super
-      .processReceivedUtxos(tx, blockHashOpt, spendingInfoDbs, newTags)
+      .processReceivedUtxos(tx,
+                            blockHashOpt,
+                            spendingInfoDbs,
+                            newTags,
+                            relevantReceivedOutputs)
       .flatMap { res =>
         for {
           dlcDbs <- dlcDAO.findByFundingTxId(tx.txIdBE)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -51,7 +51,6 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
 
       _ <- wallet.processBlock(block)
       utxos <- wallet.listUtxos()
-
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
       syncHeightOpt <- wallet.getSyncDescriptorOpt()


### PR DESCRIPTION
fixes #4220 

This PR optimizes the `processBlock()` method in the wallet to make it faster to process a block. Previously we would need to do a database read for every transaction in the block to determine if an output was relevant to our wallet for us. 

With this PR, we search the entire block up front for outputs that are relevant to us reducing `n` database reads down to `1` database read. 

On my machine, this results in ~3-4 seconds faster block processing time (~25% faster)