### PR TITLE
Don't send websocket events for DLCs while rescanning the wallet

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1692,7 +1692,7 @@ abstract class DLCWallet
     dlcOptF
   }
 
-  private def findDLCStatus(dlcDb: DLCDb) = {
+  private def findDLCStatus(dlcDb: DLCDb): Future[Option[DLCStatus]] = {
     val dlcId = dlcDb.dlcId
     val contractDataOptF = contractDataDAO.read(dlcId)
     val offerDbOptF = dlcOfferDAO.read(dlcId)


### PR DESCRIPTION
fixes #4221

This PR fixes a bug when emitting websocket events when rescanning a wallet. We shouldn't do this because our `dlcdb.sqlite` could have a DLC in a `CLAIMED/REMOTECLAIMED` state, but we don't actually have the closing transaction because we are rescanning the wallet.

This PR adds a guard to make sure we don't send these events while rescanning, only when we are in steady state operations.