### PR TITLE
Allow acceptor to upsert same outpoint multiple times for different offers

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -128,6 +128,7 @@ object Satoshis
   val max = Satoshis(Int64.max)
   val zero = Satoshis(Int64.zero)
   val one = Satoshis(Int64.one)
+  val two = Satoshis(2)
 
   override def fromBytes(bytes: ByteVector): Satoshis =
     RawSatoshisSerializer.read(bytes)

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
@@ -101,9 +101,6 @@ object DLCMessage {
       changeSerialId != fundOutputSerialId,
       s"changeSerialId ($changeSerialId) cannot be equal to fundOutputSerialId ($fundOutputSerialId)")
 
-    require(
-      totalCollateral == contractInfo.totalCollateral,
-      s"total collaterals must be equal, $totalCollateral ${contractInfo.totalCollateral}")
     val oracleInfos: Vector[OracleInfo] = contractInfo.oracleInfos
 
     val contractDescriptors: Vector[ContractDescriptor] =

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
@@ -101,6 +101,9 @@ object DLCMessage {
       changeSerialId != fundOutputSerialId,
       s"changeSerialId ($changeSerialId) cannot be equal to fundOutputSerialId ($fundOutputSerialId)")
 
+    require(
+      totalCollateral == contractInfo.totalCollateral,
+      s"total collaterals must be equal, $totalCollateral ${contractInfo.totalCollateral}")
     val oracleInfos: Vector[OracleInfo] = contractInfo.oracleInfos
 
     val contractDescriptors: Vector[ContractDescriptor] =

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -153,7 +153,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
     fundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
       // construct a contract info that uses many inputs
       val totalCol = Bitcoins(11).satoshis
-      val col = totalCol / Satoshis(2)
+      val col = totalCol / Satoshis.two
 
       val outcomes: Vector[(EnumOutcome, Satoshis)] =
         Vector(EnumOutcome(winStr) -> totalCol,
@@ -897,7 +897,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
     def makeOffer(contractInfo: ContractInfoV0TLV): Future[DLCOffer] = {
       walletA.createDLCOffer(
         contractInfoTLV = contractInfo,
-        collateral = totalCollateral,
+        collateral = (totalCollateral / Satoshis.two).satoshis,
         feeRateOpt = feeRateOpt,
         locktime = UInt32.zero,
         refundLT = UInt32.one,
@@ -928,7 +928,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
     def makeOffer(contractInfo: ContractInfoV0TLV): Future[DLCOffer] = {
       walletA.createDLCOffer(
         contractInfoTLV = contractInfo,
-        collateral = totalCollateral,
+        collateral = (totalCollateral / Satoshis.two).satoshis,
         feeRateOpt = feeRateOpt,
         locktime = UInt32.zero,
         refundLT = UInt32.one,
@@ -1032,7 +1032,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
       val feeRateOpt = Some(SatoshisPerVirtualByte(Satoshis.one))
       val totalCollateral = Satoshis(5000)
-      val feeRateOpt1 = Some(SatoshisPerVirtualByte(Satoshis(2)))
+      val feeRateOpt1 = Some(SatoshisPerVirtualByte(Satoshis.two))
       val totalCollateral1 = Satoshis(10000)
 
       // random testnet addresses
@@ -1104,9 +1104,10 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         _ <- walletB.acceptDLCOffer(offer1.toTLV, None, None)
         //cancel the offer
         _ <- walletA.cancelDLC(dlcId = offer1.dlcId)
+        amt = DLCWalletUtil.half
         offer2 <- walletA.createDLCOffer(
           offerData2.contractInfo,
-          offerData2.totalCollateral,
+          amt,
           Some(offerData2.feeRate),
           offerData2.timeouts.contractMaturity.toUInt32,
           offerData2.timeouts.contractTimeout.toUInt32,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -648,8 +648,7 @@ abstract class DLCWallet
       return Future.failed(InvalidAnnouncementSignature(
         s"Offer ${offer.tempContractId.hex} contains invalid announcement signature(s)"))
     }
-
-    logger.info(s"outpoints=${offer.fundingInputs.map(_.outPoint)}")
+    
     val dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))
 
     val collateral = offer.contractInfo.max - offer.totalCollateral

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -648,11 +648,10 @@ abstract class DLCWallet
       return Future.failed(InvalidAnnouncementSignature(
         s"Offer ${offer.tempContractId.hex} contains invalid announcement signature(s)"))
     }
-    
+
     val dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))
 
     val collateral = offer.contractInfo.max - offer.totalCollateral
-
     logger.debug(s"Checking if Accept (${dlcId.hex}) has already been made")
     for {
       dlcAcceptOpt <- DLCAcceptUtil.findDLCAccept(dlcId = dlcId,
@@ -721,7 +720,6 @@ abstract class DLCWallet
       externalChangeAddressOpt: Option[BitcoinAddress]): Future[DLCAccept] =
     Future {
       DLCWallet.AcceptingOffersLatch.startAccepting(offer.tempContractId)
-
       logger.info(
         s"Creating DLC Accept for tempContractId ${offer.tempContractId.hex}")
       val result = for {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
@@ -61,9 +61,9 @@ case class DLCActionBuilder(dlcWalletDAOs: DLCWalletDAOs) {
       refundSigsDb: DLCRefundSigsDb)(implicit ec: ExecutionContext): DBIOAction[
     Unit,
     NoStream,
-    Effect.Write with Effect.Transactional] = {
+    Effect.Write with Effect.Read with Effect.Transactional] = {
     val dlcDbAction = dlcDAO.updateAction(dlcDb)
-    val inputAction = dlcInputsDAO.createAllAction(offerInputs)
+    val inputAction = dlcInputsDAO.upsertAllAction(offerInputs)
     val sigsAction = dlcSigsDAO.createAllAction(cetSigsDb)
     val refundSigAction = dlcRefundSigDAO.createAction(refundSigsDb)
     val actions = Vector(dlcDbAction, inputAction, sigsAction, refundSigAction)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -86,6 +86,11 @@ object DLCWalletUtil extends Logging {
   lazy val sampleContractInfo: ContractInfo =
     SingleContractInfo(half, sampleContractOraclePair)
 
+  val amt2: Satoshis = Satoshis(100000)
+
+  lazy val sampleContractInfo2: ContractInfo =
+    SingleContractInfo(amt2, sampleContractOraclePair)
+
   lazy val invalidContractInfo: ContractInfo =
     SingleContractInfo(half, invalidContractOraclePair)
 
@@ -171,6 +176,20 @@ object DLCWalletUtil extends Logging {
     contractInfo = sampleContractInfo,
     pubKeys = dummyDLCKeys,
     totalCollateral = half,
+    fundingInputs = Vector(dummyFundingInputs.head),
+    changeAddress = dummyAddress,
+    payoutSerialId = sampleOfferPayoutSerialId,
+    changeSerialId = sampleOfferChangeSerialId,
+    fundOutputSerialId = sampleFundOutputSerialId,
+    feeRate = SatoshisPerVirtualByte(Satoshis(3)),
+    timeouts = dummyTimeouts
+  )
+
+  lazy val sampleDLCOffer2 = DLCOffer(
+    protocolVersionOpt = DLCOfferTLV.currentVersionOpt,
+    contractInfo = sampleContractInfo2,
+    pubKeys = dummyDLCKeys,
+    totalCollateral = sampleContractInfo2.totalCollateral,
     fundingInputs = Vector(dummyFundingInputs.head),
     changeAddress = dummyAddress,
     payoutSerialId = sampleOfferPayoutSerialId,

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -57,7 +57,10 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
       markAsReserved: Boolean): Future[(
       RawTxBuilderWithFinalizer[ShufflingNonInteractiveFinalizer],
       Vector[ScriptSignatureParams[InputInfo]])] = {
-    val amt = destinations.map(_.value).sum
+    val amts = destinations.map(_.value)
+    require(amts.forall(_.satoshis.toBigInt > 0),
+            s"Cannot fund a transaction for a negative amount, got=$amts")
+    val amt = amts.sum
     logger.info(s"Attempting to fund a tx for amt=${amt} with feeRate=$feeRate")
     val utxosF: Future[Vector[(SpendingInfoDb, Transaction)]] =
       for {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -58,7 +58,8 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
       RawTxBuilderWithFinalizer[ShufflingNonInteractiveFinalizer],
       Vector[ScriptSignatureParams[InputInfo]])] = {
     val amts = destinations.map(_.value)
-    require(amts.forall(_.satoshis.toBigInt > 0),
+    //need to allow 0 for OP_RETURN outputs
+    require(amts.forall(_.satoshis.toBigInt >= 0),
             s"Cannot fund a transaction for a negative amount, got=$amts")
     val amt = amts.sum
     logger.info(s"Attempting to fund a tx for amt=${amt} with feeRate=$feeRate")


### PR DESCRIPTION
fixes #4229

In very few cases, there can be a case where Alice the offerer decides not to continue the DLC Bob the acceptor sends the `Sign` message.

The next time Alice sends Bob an offer, if it uses the outpoints in the previous offer she decided not to continue with, this exception will get through at the database level since we are using a `createAllAction()` rather than a `upsertAllAction()`. This PR changes it to `upsertAllAction()` in the method  `buildCreateAcceptAction`