### PR TITLE
Fix unique address tag constraint when process block with tx we broadcast with tag

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -167,7 +167,7 @@ trait BitcoinSWalletTest
       walletAppConfig: WalletAppConfig): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind] = composeBuildersAndWrap(
       builder = { () =>
-        BitcoinSFixture.createBitcoindWithFunds()
+        BitcoinSFixture.createBitcoindWithFunds(Some(BitcoindVersion.newest))
       },
       dependentBuilder = { (bitcoind: BitcoindRpcClient) =>
         createWalletWithBitcoind(bitcoind)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -673,7 +673,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
               .fromScriptPubKey(out.output.scriptPubKey, networkParameters)
             tagsToUse.map(tag => AddressTagDb(address, tag))
           }
-          created <- addressTagDAO.createAll(newTagDbs)
+          created <- addressTagDAO.upsertAll(newTagDbs)
         } yield created
 
         for {


### PR DESCRIPTION
When we broadcast a tx from the wallet, we spending to a tagged address internal to our wallet. When we see this tag in the block when the tx gets confirmed, we could try to create the tag again when it already exists.

This PR uses `upsertAll` to add the tag rather than using `createAll`