### PR TITLE
Async mempool processing

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -10,7 +10,6 @@ import org.bitcoins.core.api.wallet.WalletApi
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.dlc.wallet.DLCWallet
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
@@ -390,19 +389,30 @@ object BitcoindRpcBackendUtil extends Logging {
       {
         if (processing.compareAndSet(false, true)) {
           logger.debug("Polling bitcoind for mempool")
+          val numParallelism = Runtime.getRuntime.availableProcessors()
 
           val res = for {
             mempool <- bitcoind.getRawMemPool
             newTxIds = getDiffAndReplace(mempool.toSet)
             _ = logger.debug(s"Found ${newTxIds.size} new mempool transactions")
-            newTxsOpt <- FutureUtil.sequentially(newTxIds)(
-              bitcoind.getRawTransactionRaw(_).map(Option(_)).recover {
-                case _: Throwable => None
-              })
-            newTxs = newTxsOpt.collect { case Some(tx) =>
-              tx
-            }
-            _ <- FutureUtil.sequentially(newTxs)(processTx)
+            newTxs <- Source(newTxIds)
+              .mapAsync(parallelism = numParallelism) { txid =>
+                bitcoind
+                  .getRawTransactionRaw(txid)
+                  .map(Option(_))
+                  .recover { case _: Throwable =>
+                    None
+                  }
+                  .collect { case Some(tx) =>
+                    tx
+                  }
+              }
+              .toMat(Sink.seq)(Keep.right)
+              .run()
+            _ <- Source(newTxs)
+              .mapAsync(parallelism = numParallelism)(tx => processTx(tx))
+              .toMat(Sink.seq)(Keep.right)
+              .run()
           } yield {
             logger.debug(
               s"Done processing ${newTxIds.size} new mempool transactions")

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -389,7 +389,7 @@ object BitcoindRpcBackendUtil extends Logging {
       {
         if (processing.compareAndSet(false, true)) {
           logger.debug("Polling bitcoind for mempool")
-          val numParallelism = Runtime.getRuntime.availableProcessors()
+          val numParallelism = Runtime.getRuntime.availableProcessors() * 2
 
           //don't want to execute these in parallel
           val processTxFlow = Sink.foreachAsync[Transaction](1)(processTx)


### PR DESCRIPTION
fixes #4242 

this builds ontop of #4244 

This PR adds the last step to the stream where we call `processTx()`. This means we will process transactions while we are fetching them in the mempool. Akka streams will buffer transactions correctly to make sure we are constantly processing them rather 

1. fetching all mempool txs
2. then processing them

This PR fetches txs and processes them concurrently.

With this PR, it takes ~1 minute to process ~6,000 transactions in the mempool. This would take 40 minutes off of 4b964074081dee41686c89522eff946dd57868a7 as documented in #4242 