### PR TITLE
Add SignDbState to fix rescan exception

### DIFF
--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -211,12 +211,7 @@ object Server {
     )
   }
 
-  def httpBadRequest(ex: Throwable): HttpResponse = {
-    httpBadRequest(ex.getMessage)
-  }
-
-  def httpBadRequest(msg: String): HttpResponse = {
-
+  def httpError(msg: String): HttpEntity.Strict = {
     val entity = {
       val response = Response(error = Some(msg))
       HttpEntity(
@@ -224,6 +219,15 @@ object Server {
         up.write(response.toJsonMap)
       )
     }
+    entity
+  }
+
+  def httpBadRequest(ex: Throwable): HttpResponse = {
+    httpBadRequest(ex.getMessage)
+  }
+
+  def httpBadRequest(msg: String): HttpResponse = {
+    val entity = httpError(msg)
     HttpResponse(status = StatusCodes.BadRequest, entity = entity)
   }
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -1175,7 +1175,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       (mockWalletApi
         .executeDLC(_: ByteVector, _: Seq[OracleAttestmentTLV]))
         .expects(contractId, Vector(dummyOracleAttestment))
-        .returning(Future.successful(EmptyTransaction))
+        .returning(Future.successful(Some(EmptyTransaction)))
 
       val route = walletRoutes.handleCommand(
         ServerCommand("executedlc",
@@ -1196,7 +1196,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .executeDLC(_: ByteVector, _: Seq[OracleAttestmentTLV]))
         .expects(contractId,
                  Vector(dummyOracleAttestment, dummyOracleAttestment))
-        .returning(Future.successful(EmptyTransaction))
+        .returning(Future.successful(Some(EmptyTransaction)))
 
       val route = walletRoutes.handleCommand(
         ServerCommand("executedlc",
@@ -1217,7 +1217,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       (mockWalletApi
         .executeDLC(_: ByteVector, _: Seq[OracleAttestmentTLV]))
         .expects(contractId, Vector(dummyOracleAttestment))
-        .returning(Future.successful(EmptyTransaction))
+        .returning(Future.successful(Some(EmptyTransaction)))
 
       (mockWalletApi.broadcastTransaction _)
         .expects(EmptyTransaction)

--- a/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/DLCWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/DLCWalletApi.scala
@@ -86,24 +86,24 @@ trait DLCWalletApi { self: WalletApi =>
   /** Creates the CET for the given contractId and oracle signature, does not broadcast it */
   def executeDLC(
       contractId: ByteVector,
-      oracleSig: OracleAttestmentTLV): Future[Transaction] =
+      oracleSig: OracleAttestmentTLV): Future[Option[Transaction]] =
     executeDLC(contractId, Vector(oracleSig))
 
   /** Creates the CET for the given contractId and oracle signature, does not broadcast it */
   def executeDLC(
       contractId: ByteVector,
-      oracleSigs: Seq[OracleAttestmentTLV]): Future[Transaction]
+      oracleSigs: Seq[OracleAttestmentTLV]): Future[Option[Transaction]]
 
   /** Creates the CET for the given contractId and oracle signature, does not broadcast it */
   def executeDLC(
       contractId: ByteVector,
-      oracleSig: OracleSignatures): Future[Transaction] =
+      oracleSig: OracleSignatures): Future[Option[Transaction]] =
     executeDLC(contractId, Vector(oracleSig))
 
   /** Creates the CET for the given contractId and oracle signature, does not broadcast it */
   def executeDLC(
       contractId: ByteVector,
-      oracleSigs: Vector[OracleSignatures]): Future[Transaction]
+      oracleSigs: Vector[OracleSignatures]): Future[Option[Transaction]]
 
   /** Creates the refund transaction for the given contractId, does not broadcast it */
   def executeDLCRefund(contractId: ByteVector): Future[Transaction]

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionBitcoindBackendTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionBitcoindBackendTest.scala
@@ -74,7 +74,7 @@ class DLCExecutionBitcoindBackendTest
                 s"Cannot retrieve sigs for disjoint union contract, got=$disjoint")
           }
         }
-        closingTx <- dlcB.executeDLC(contractId, oracleSigs)
+        closingTx <- dlcB.executeDLC(contractId, oracleSigs).map(_.get)
         //broadcast the closing tx
         _ <- dlcB.broadcastTransaction(closingTx)
         dlcs <- dlcB

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -108,7 +108,8 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
               s"Cannot retrieve sigs for disjoint union contract, got=$disjoint")
         }
       }
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sig)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sig).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = true,
@@ -153,7 +154,8 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
               s"Cannot retrieve sigs for disjoint union contract, got=$disjoint")
         }
       }
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sig)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sig).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = false,
@@ -225,7 +227,8 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
         }
       }
 
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sig)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sig).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = true,
@@ -406,7 +409,8 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
                 s"Cannot retrieve sigs for disjoint union contract, got=$disjoint")
           }
         }
-        func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sig)
+        func = (wallet: DLCWallet) =>
+          wallet.executeDLC(contractId, sig).map(_.get)
 
         result <- dlcExecutionTest(wallets = wallets,
                                    asInitiator = true,
@@ -452,7 +456,7 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
                                               sigs = badSigs,
                                               outcomes = badOutcomes)
         func = (wallet: DLCWallet) =>
-          wallet.executeDLC(contractId, badAttestment)
+          wallet.executeDLC(contractId, badAttestment).map(_.get)
 
         result <- dlcExecutionTest(wallets = wallets,
                                    asInitiator = true,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleEnumExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleEnumExecutionTest.scala
@@ -112,7 +112,8 @@ class DLCMultiOracleEnumExecutionTest extends BitcoinSDualWalletTest {
       contractId <- getContractId(wallets._1.wallet)
       (sig, _) = getSigs
       status <- getDLCStatus(wallets._2.wallet)
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sig)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sig).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = true,
@@ -151,7 +152,8 @@ class DLCMultiOracleEnumExecutionTest extends BitcoinSDualWalletTest {
       contractId <- getContractId(wallets._1.wallet)
       (_, sig) = getSigs
       status <- getDLCStatus(wallets._2.wallet)
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sig)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sig).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = false,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
@@ -105,7 +105,8 @@ class DLCMultiOracleExactNumericExecutionTest extends BitcoinSDualWalletTest {
       contractId <- getContractId(wallets._1.wallet)
       status <- getDLCStatus(wallets._1.wallet)
       (sigs, _) = getSigs(status.contractInfo)
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sigs)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sigs).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = true,
@@ -144,7 +145,8 @@ class DLCMultiOracleExactNumericExecutionTest extends BitcoinSDualWalletTest {
       contractId <- getContractId(wallets._1.wallet)
       status <- getDLCStatus(wallets._2.wallet)
       (_, sigs) = getSigs(status.contractInfo)
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sigs)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sigs).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = false,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
@@ -114,7 +114,8 @@ class DLCMultiOracleNumericExecutionTest
       contractId <- getContractId(wallets._1.wallet)
       status <- getDLCStatus(wallets._1.wallet)
       (sigs, _) = getSigs(status.contractInfo)
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sigs)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sigs).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = true,
@@ -153,7 +154,8 @@ class DLCMultiOracleNumericExecutionTest
       contractId <- getContractId(wallets._1.wallet)
       status <- getDLCStatus(wallets._2.wallet)
       (_, sigs) = getSigs(status.contractInfo)
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sigs)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sigs).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = false,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCNumericExecutionTest.scala
@@ -91,7 +91,8 @@ class DLCNumericExecutionTest extends BitcoinSDualWalletTest {
       contractId <- getContractId(wallets._1.wallet)
       status <- getDLCStatus(wallets._1.wallet)
       (sigs, _) = getSigs(status.contractInfo)
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sigs)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sigs).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = true,
@@ -130,7 +131,8 @@ class DLCNumericExecutionTest extends BitcoinSDualWalletTest {
       contractId <- getContractId(wallets._1.wallet)
       status <- getDLCStatus(wallets._2.wallet)
       (_, sigs) = getSigs(status.contractInfo)
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sigs)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sigs).map(_.get)
 
       result <- dlcExecutionTest(wallets = wallets,
                                  asInitiator = false,
@@ -181,7 +183,7 @@ class DLCNumericExecutionTest extends BitcoinSDualWalletTest {
                                               sigs = badSigs,
                                               outcomes = badOutcomes)
         func = (wallet: DLCWallet) =>
-          wallet.executeDLC(contractId, badAttestment)
+          wallet.executeDLC(contractId, badAttestment).map(_.get)
 
         result <- dlcExecutionTest(wallets = wallets,
                                    asInitiator = false,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
@@ -106,7 +106,7 @@ class DLCWalletCallbackTest extends BitcoinSDualWalletTest {
               s"Cannot retrieve sigs for disjoint union contract, got=$disjoint")
         }
       }
-      transaction <- walletA.executeDLC(contractId, sigs._1)
+      transaction <- walletA.executeDLC(contractId, sigs._1).map(_.get)
       _ <- walletB.processTransaction(transaction, None)
     } yield ()
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/RescanDLCTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/RescanDLCTest.scala
@@ -40,7 +40,8 @@ class RescanDLCTest extends DualWalletTestCachedBitcoind {
               s"Cannot retrieve sigs for disjoint union contract, got=$disjoint")
         }
       }
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sig)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sig).map(_.get)
 
       result <- dlcExecutionTest(wallets = (walletA, walletB),
                                  asInitiator = true,
@@ -79,7 +80,8 @@ class RescanDLCTest extends DualWalletTestCachedBitcoind {
               s"Cannot retrieve sigs for disjoint union contract, got=$disjoint")
         }
       }
-      func = (wallet: DLCWallet) => wallet.executeDLC(contractId, sig)
+      func = (wallet: DLCWallet) =>
+        wallet.executeDLC(contractId, sig).map(_.get)
 
       result <- dlcExecutionTest(wallets = (walletA, walletB),
                                  asInitiator = true,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -816,7 +816,8 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         tx <- walletB.broadcastDLCFundingTx(sign.contractId)
         _ <- walletA.processTransaction(tx, None)
 
-        func = (wallet: DLCWallet) => wallet.executeDLC(sign.contractId, sig)
+        func = (wallet: DLCWallet) =>
+          wallet.executeDLC(sign.contractId, sig).map(_.get)
         result <- dlcExecutionTest(dlcA = walletA,
                                    dlcB = walletB,
                                    asInitiator = true,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagementTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagementTest.scala
@@ -1,0 +1,50 @@
+package org.bitcoins.dlc.wallet.internal
+
+import org.bitcoins.core.protocol.dlc.models.DLCMessage.DLCOffer
+import org.bitcoins.core.protocol.dlc.models.DLCState
+import org.bitcoins.dlc.wallet.models.SignDbState
+import org.bitcoins.testkit.wallet.{BitcoinSDualWalletTest, DLCWalletUtil}
+import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
+import org.scalatest.FutureOutcome
+
+class DLCDataManagementTest extends BitcoinSDualWalletTest {
+  type FixtureParam = (FundedDLCWallet, FundedDLCWallet)
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    withDualFundedDLCWallets(test)
+  }
+
+  behavior of "DLCDataManagement"
+
+  it must "retrieve a signdb state" in {
+    fundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
+      val walletA = fundedDLCWallets._1.wallet
+      val walletB = fundedDLCWallets._2.wallet
+
+      val offerData: DLCOffer =
+        DLCWalletUtil.sampleDLCOffer
+
+      for {
+        offer1 <- walletA.createDLCOffer(
+          offerData.contractInfo,
+          offerData.collateral,
+          Some(offerData.feeRate),
+          offerData.timeouts.contractMaturity.toUInt32,
+          offerData.timeouts.contractTimeout.toUInt32,
+          None,
+          None
+        )
+        accept <- walletB.acceptDLCOffer(offer1, None, None)
+
+        sign <- walletA.signDLC(accept)
+        signDbStateOpt <- walletA.dlcDataManagement.getDLCFundingData(
+          sign.contractId,
+          walletA.transactionDAO)
+      } yield {
+        assert(signDbStateOpt.isDefined)
+        assert(signDbStateOpt.get.isInstanceOf[SignDbState])
+        assert(signDbStateOpt.get.state == DLCState.Signed)
+      }
+  }
+
+}

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagementTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagementTest.scala
@@ -1,8 +1,9 @@
 package org.bitcoins.dlc.wallet.internal
 
+import org.bitcoins.core.protocol.dlc.compute.DLCUtil
 import org.bitcoins.core.protocol.dlc.models.DLCMessage.DLCOffer
 import org.bitcoins.core.protocol.dlc.models.DLCState
-import org.bitcoins.dlc.wallet.models.SignDbState
+import org.bitcoins.dlc.wallet.models.{AcceptDbState, SignDbState}
 import org.bitcoins.testkit.wallet.{BitcoinSDualWalletTest, DLCWalletUtil}
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
 import org.scalatest.FutureOutcome
@@ -16,7 +17,36 @@ class DLCDataManagementTest extends BitcoinSDualWalletTest {
 
   behavior of "DLCDataManagement"
 
-  it must "retrieve a signdb state" in {
+  it must "retrieve a acceptdb state from getDLCFundingData" in {
+    fundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
+      val walletA = fundedDLCWallets._1.wallet
+      val walletB = fundedDLCWallets._2.wallet
+
+      val offerData: DLCOffer =
+        DLCWalletUtil.sampleDLCOffer
+
+      for {
+        offer1 <- walletA.createDLCOffer(
+          offerData.contractInfo,
+          offerData.collateral,
+          Some(offerData.feeRate),
+          offerData.timeouts.contractMaturity.toUInt32,
+          offerData.timeouts.contractTimeout.toUInt32,
+          None,
+          None
+        )
+        accept <- walletB.acceptDLCOffer(offer1, None, None)
+        contractId = DLCUtil.calcContractId(offer1, accept)
+        acceptDbStateOpt <- walletB.dlcDataManagement.getDLCFundingData(
+          contractId,
+          walletA.transactionDAO)
+      } yield {
+        assert(acceptDbStateOpt.isDefined)
+        assert(acceptDbStateOpt.get.isInstanceOf[AcceptDbState])
+        assert(acceptDbStateOpt.get.state == DLCState.Accepted)
+      }
+  }
+  it must "retrieve a signdb state from getDLCFundingData" in {
     fundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
       val walletA = fundedDLCWallets._1.wallet
       val walletB = fundedDLCWallets._2.wallet
@@ -46,5 +76,4 @@ class DLCDataManagementTest extends BitcoinSDualWalletTest {
         assert(signDbStateOpt.get.state == DLCState.Signed)
       }
   }
-
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -13,9 +13,9 @@ import org.bitcoins.db.DatabaseDriver._
 import org.bitcoins.db._
 import org.bitcoins.dlc.wallet.internal.DLCDataManagement
 import org.bitcoins.dlc.wallet.models.{
-  CompleteSetupDLCDbState,
   DLCSetupDbState,
-  OfferedDbState
+  OfferedDbState,
+  SetupCompleteDLCDbState
 }
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.models.TransactionDAO
@@ -176,7 +176,7 @@ case class DLCAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
       vec: Vector[DLCSetupDbState]): Vector[DLCDb] = {
     vec.map { case state: DLCSetupDbState =>
       val updatedDlcDb: DLCDb = state match {
-        case acceptDbState: CompleteSetupDLCDbState =>
+        case acceptDbState: SetupCompleteDLCDbState =>
           val offer = acceptDbState.offer
           val acceptWithoutSigs = acceptDbState.acceptWithoutSigs
           val dlcDb = acceptDbState.dlcDb

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -13,7 +13,7 @@ import org.bitcoins.db.DatabaseDriver._
 import org.bitcoins.db._
 import org.bitcoins.dlc.wallet.internal.DLCDataManagement
 import org.bitcoins.dlc.wallet.models.{
-  AcceptDbState,
+  CompleteSetupDLCDbState,
   DLCSetupDbState,
   OfferedDbState
 }
@@ -176,7 +176,7 @@ case class DLCAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
       vec: Vector[DLCSetupDbState]): Vector[DLCDb] = {
     vec.map { case state: DLCSetupDbState =>
       val updatedDlcDb: DLCDb = state match {
-        case acceptDbState: AcceptDbState =>
+        case acceptDbState: CompleteSetupDLCDbState =>
           val offer = acceptDbState.offer
           val acceptWithoutSigs = acceptDbState.acceptWithoutSigs
           val dlcDb = acceptDbState.dlcDb

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1335,7 +1335,7 @@ abstract class DLCWallet
           case _: OfferedDbState =>
             sys.error(
               s"Cannot retrieve funding transaction when DLC is in offered state")
-          case complete: CompleteSetupDLCDbState => complete
+          case complete: SetupCompleteDLCDbState => complete
         }.get //bad but going to have to save this refactor for future
       }
       dlcDb = complete.dlcDb
@@ -1497,7 +1497,7 @@ abstract class DLCWallet
             logger.info(
               s"Cannot create execution tx for dlc in state=${o.state}")
             Future.successful(None)
-          case c: CompleteSetupDLCDbState =>
+          case c: SetupCompleteDLCDbState =>
             val dlcDb = c.dlcDb
             val fundingInputs = c.allFundingInputs
             val scriptSigParamsF = getScriptSigParams(dlcDb, fundingInputs)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1540,10 +1540,6 @@ abstract class DLCWallet
                   Some(closingTxOpt.get.transaction)
                 }
             }
-//          case c: ClosedDbStateNoCETSigs =>
-//            logger.info(
-//              s"Cannot create execution tx for dlc that is settled with no cet sigs, state=${c.state}")
-//            Future.successful(None)
         }
     }
   }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -89,7 +89,7 @@ abstract class DLCWallet
     incomingOfferDAO
   )
 
-  private val dlcDataManagement = DLCDataManagement(dlcWalletDAOs)
+  private[wallet] val dlcDataManagement = DLCDataManagement(dlcWalletDAOs)
 
   protected lazy val actionBuilder: DLCActionBuilder = {
     DLCActionBuilder(dlcWalletDAOs)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
@@ -355,7 +355,7 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
           acceptState.state match {
             case _: DLCState.ClosedState =>
               val closedState =
-                DLCClosedDbState.fromAcceptSetupState(acceptState, sigsOpt)
+                DLCClosedDbState.fromCompleteSetupState(acceptState, sigsOpt)
               Some(closedState)
             case _: DLCState.InProgressState =>
               Some(acceptState)
@@ -365,14 +365,13 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
           signState.state match {
             case _: DLCState.ClosedState =>
               val closedState =
-                DLCClosedDbState.fromSignSetupState(signState, sigsOpt)
+                DLCClosedDbState.fromCompleteSetupState(signState, sigsOpt)
               Some(closedState)
             case _: DLCState.InProgressState =>
               Some(signState)
           }
 
         case o: OfferedDbState =>
-          //cannot return a closed state because we haven't seen the accept message
           Some(o)
       }
       closedState

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -30,9 +30,6 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
   self: DLCWallet =>
   private lazy val safeDatabase: SafeDatabase = dlcDAO.safeDatabase
 
-  private lazy val dlcDataManagement: DLCDataManagement = DLCDataManagement(
-    dlcWalletDAOs)
-
   /** Calculates the new state of the DLCDb based on the closing transaction,
     * will delete old CET sigs that are no longer needed after execution
     * @return a DLCDb if we can calculate the state, else None if we cannot calculate the state

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -147,9 +147,9 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
         setupStateOpt <- dlcDataManagement.getDLCFundingData(dlcId,
                                                              txDAO =
                                                                transactionDAO)
-        acceptDbState = {
+        completeDbState = {
           setupStateOpt.get match {
-            case accept: AcceptDbState => accept
+            case c: CompleteSetupDLCDbState => c
             case offered: OfferedDbState =>
               sys.error(
                 s"Cannot calculate and set outcome of dlc that is only offered, id=${offered.dlcDb.dlcId.hex}")
@@ -165,7 +165,7 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
             .map(_.get.transaction.asInstanceOf[WitnessTransaction])
 
         sigAndOutcome = recoverSigAndOutcomeForRemoteClaimed(
-          acceptDbState = acceptDbState,
+          completeDbState = completeDbState,
           cet = cet,
           sigDbs = sigDbs,
           refundSigsDbOpt = refundSigOpt)
@@ -384,25 +384,25 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
     * so we do not necessarily have access to what the [[OracleAttestment]] is
     */
   private def recoverSigAndOutcomeForRemoteClaimed(
-      acceptDbState: AcceptDbState,
+      completeDbState: CompleteSetupDLCDbState,
       cet: WitnessTransaction,
       sigDbs: Vector[DLCCETSignaturesDb],
       refundSigsDbOpt: Option[DLCRefundSigsDb]): (
       SchnorrDigitalSignature,
       OracleOutcome) = {
-    val dlcDb = acceptDbState.dlcDb
+    val dlcDb = completeDbState.dlcDb
     val dlcId = dlcDb.dlcId
     val isInit = dlcDb.isInitiator
 
-    val offer = acceptDbState.offer
+    val offer = completeDbState.offer
 
-    val acceptOpt = acceptDbState.acceptOpt
+    val acceptOpt = completeDbState.acceptOpt
     require(
       acceptOpt.isDefined,
       s"Accept message must still have CET signatures to recover an outcome on chain, dlcId=${dlcId.hex}")
     val accept = acceptOpt.get
 
-    val fundingInputDbs = acceptDbState.allFundingInputs
+    val fundingInputDbs = completeDbState.allFundingInputs
     val offerRefundSigOpt = refundSigsDbOpt.flatMap(_.initiatorSig)
 
     val signOpt: Option[DLCSign] = offerRefundSigOpt.map { refundSig =>

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -146,7 +146,7 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
                                                                transactionDAO)
         completeDbState = {
           setupStateOpt.get match {
-            case c: CompleteSetupDLCDbState => c
+            case c: SetupCompleteDLCDbState => c
             case offered: OfferedDbState =>
               sys.error(
                 s"Cannot calculate and set outcome of dlc that is only offered, id=${offered.dlcDb.dlcId.hex}")
@@ -381,7 +381,7 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
     * so we do not necessarily have access to what the [[OracleAttestment]] is
     */
   private def recoverSigAndOutcomeForRemoteClaimed(
-      completeDbState: CompleteSetupDLCDbState,
+      completeDbState: SetupCompleteDLCDbState,
       cet: WitnessTransaction,
       sigDbs: Vector[DLCCETSignaturesDb],
       refundSigsDbOpt: Option[DLCRefundSigsDb]): (

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDbState.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDbState.scala
@@ -234,70 +234,36 @@ case class ClosedDbStateNoCETSigs(
 
 object DLCClosedDbState {
 
-  def fromAcceptSetupState(
-      acceptState: AcceptDbState,
+  def fromCompleteSetupState(
+      completeState: CompleteSetupDLCDbState,
       cetSigsOpt: Option[Vector[DLCCETSignaturesDb]]): DLCClosedDbState = {
     cetSigsOpt match {
       case Some(cetSigs) =>
         ClosedDbStateWithCETSigs(
-          acceptState.dlcDb,
-          acceptState.contractDataDb,
-          acceptState.contractInfo,
-          acceptState.offerDb,
-          acceptState.acceptDb,
-          acceptState.offerFundingInputsDb,
-          acceptState.offerPrevTxs,
-          acceptState.acceptFundingInputsDb,
-          acceptState.acceptPrevTxs,
-          acceptState.refundSigDb,
+          completeState.dlcDb,
+          completeState.contractDataDb,
+          completeState.contractInfo,
+          completeState.offerDb,
+          completeState.acceptDb,
+          completeState.offerFundingInputsDb,
+          completeState.offerPrevTxs,
+          completeState.acceptFundingInputsDb,
+          completeState.acceptPrevTxs,
+          completeState.refundSigDb,
           cetSigs
         )
       case None =>
         ClosedDbStateNoCETSigs(
-          acceptState.dlcDb,
-          acceptState.contractDataDb,
-          acceptState.contractInfo,
-          acceptState.offerDb,
-          acceptState.acceptDb,
-          acceptState.offerFundingInputsDb,
-          acceptState.offerPrevTxs,
-          acceptState.acceptFundingInputsDb,
-          acceptState.acceptPrevTxs,
-          acceptState.refundSigDb
-        )
-    }
-  }
-
-  def fromSignSetupState(
-      signDbState: SignDbState,
-      cetSigsOpt: Option[Vector[DLCCETSignaturesDb]]): DLCClosedDbState = {
-    cetSigsOpt match {
-      case Some(cetSigs) =>
-        ClosedDbStateWithCETSigs(
-          signDbState.dlcDb,
-          signDbState.contractDataDb,
-          signDbState.contractInfo,
-          signDbState.offerDb,
-          signDbState.acceptDb,
-          signDbState.offerFundingInputsDb,
-          signDbState.offerPrevTxs,
-          signDbState.acceptFundingInputsDb,
-          signDbState.acceptPrevTxs,
-          signDbState.refundSigDb,
-          cetSigs
-        )
-      case None =>
-        ClosedDbStateNoCETSigs(
-          signDbState.dlcDb,
-          signDbState.contractDataDb,
-          signDbState.contractInfo,
-          signDbState.offerDb,
-          signDbState.acceptDb,
-          signDbState.offerFundingInputsDb,
-          signDbState.offerPrevTxs,
-          signDbState.acceptFundingInputsDb,
-          signDbState.acceptPrevTxs,
-          signDbState.refundSigDb
+          completeState.dlcDb,
+          completeState.contractDataDb,
+          completeState.contractInfo,
+          completeState.offerDb,
+          completeState.acceptDb,
+          completeState.offerFundingInputsDb,
+          completeState.offerPrevTxs,
+          completeState.acceptFundingInputsDb,
+          completeState.acceptPrevTxs,
+          completeState.refundSigDb
         )
     }
   }


### PR DESCRIPTION
When rescanning on 1bc3962cfbbbc949eea34b9e18f898fd3c115b50 I get this exception for a DLC that is in the `Confirmed` state.


```
2022-04-06T01:49:28UTC ERROR [DLCWallet$DLCWalletImpl] Error processing of block=00000000000000000006a259c23a3baf12455131a0a995c6d743a701d1f22d48.
java.lang.ClassCastException: class org.bitcoins.core.protocol.dlc.models.DLCState$Confirmed$ cannot be cast to class org.bitcoins.core.protocol.dlc.models.DLCState$ClosedState (org.bitcoins.core.protocol.dlc.models.DLCState$Confirmed$ and org.bitcoins.core.protocol.dlc.models.DLCState$ClosedState are in unnamed module of loader 'app')
	at org.bitcoins.dlc.wallet.models.ClosedDbStateNoCETSigs.<init>(DLCDbState.scala:198)
	at org.bitcoins.dlc.wallet.models.DLCClosedDbState$.fromSetupState(DLCDbState.scala:232)
	at org.bitcoins.dlc.wallet.internal.DLCDataManagement.$anonfun$getAllDLCData$6(DLCDataManagement.scala:360)
	at scala.Option.flatMap(Option.scala:283)
	at org.bitcoins.dlc.wallet.internal.DLCDataManagement.$anonfun$getAllDLCData$5(DLCDataManagement.scala:357)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:63)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:100)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:100)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:49)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
2022-04-06T01:49:28UTC ERROR [DataMessageHandler] onBlockReceived Callback failed with error: 
java.lang.ClassCastException: class org.bitcoins.core.protocol.dlc.models.DLCState$Confirmed$ cannot be cast to class org.bitcoins.core.protocol.dlc.models.DLCState$ClosedState (org.bitcoins.core.protocol.dlc.models.DLCState$Confirmed$ and org.bitcoins.core.protocol.dlc.models.DLCState$ClosedState are in unnamed module of loader 'app')
	at org.bitcoins.dlc.wallet.models.ClosedDbStateNoCETSigs.<init>(DLCDbState.scala:198)
	at org.bitcoins.dlc.wallet.models.DLCClosedDbState$.fromSetupState(DLCDbState.scala:232)
	at org.bitcoins.dlc.wallet.internal.DLCDataManagement.$anonfun$getAllDLCData$6(DLCDataManagement.scala:360)
	at scala.Option.flatMap(Option.scala:283)
	at org.bitcoins.dlc.wallet.internal.DLCDataManagement.$anonfun$getAllDLCData$5(DLCDataManagement.scala:357)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:63)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:100)
```

This PR fixes this exception by removing the cast inside of `ClosedDbStateNoCETSigs`. The DLC is not closed at all (its `Confirmed`). 

This PR adds a new `DLCDbSetupState` called `SignDbState` which means we have received an accept message from our peer with adaptor signatures.

We were previously misclassifying DLCs we were building in `DLCDataManagement.getAllDLCData()` as a `ClosedDbState` when in reality they hadn't been settled onchain yet.