### PR TITLE
Use upsert rather than create as offers can use the same outpoints

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCActionBuilder.scala
@@ -34,12 +34,12 @@ case class DLCActionBuilder(dlcWalletDAOs: DLCWalletDAOs) {
     Unit,
     NoStream,
     Effect.Read with Effect.Write with Effect.Transactional] = {
-    val globalAction = dlcDAO.createAction(dlcDb)
-    val contractAction = contractDataDAO.createAction(contractDataDb)
+    val globalAction = dlcDAO.upsertAction(dlcDb)
+    val contractAction = contractDataDAO.upsertAction(contractDataDb)
     val announcementAction =
-      dlcAnnouncementDAO.createAllAction(dlcAnnouncementDbs)
+      dlcAnnouncementDAO.upsertAllAction(dlcAnnouncementDbs)
     val inputsAction = dlcInputsDAO.upsertAllAction(dlcInputs)
-    val offerAction = dlcOfferDAO.createAction(dlcOfferDb)
+    val offerAction = dlcOfferDAO.upsertAction(dlcOfferDb)
     val actions = Vector(globalAction,
                          contractAction,
                          announcementAction,


### PR DESCRIPTION
During our demos today it was common to have issues with the wallet. One of the common problems was unreserving utxos after a DLC failed to negotiate for whatever reason (likely network issues). 

Since the outpoints were already seen in an offer before, we would through an exception due to unique constraint violation at the database level in the offer logic

<img width="1427" alt="Screen Shot 2022-04-07 at 10 08 09 PM" src="https://user-images.githubusercontent.com/3514957/162355335-42795311-1659-42fd-ab76-943149bfaaa5.png">
