### PR TITLE
Reduce parallelism when fetches txs in mempool for bitcoind backend

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -389,7 +389,7 @@ object BitcoindRpcBackendUtil extends Logging {
       {
         if (processing.compareAndSet(false, true)) {
           logger.debug("Polling bitcoind for mempool")
-          val numParallelism = Runtime.getRuntime.availableProcessors() * 2
+          val numParallelism = Runtime.getRuntime.availableProcessors()
 
           //don't want to execute these in parallel
           val processTxFlow = Sink.foreachAsync[Transaction](1)(processTx)


### PR DESCRIPTION
fixes #4252 



When running on a machine with a lot of cores (16 on my linux desktop), we can constantly be hitting the max number of open requests allowed by akka (32). This can cause rescans to fail when as we need to query blockchain data from bitcoind which leads to this exception: 

```
2022-04-13T11:31:29UTC ERROR [DLCWallet$DLCWalletImpl] Failed to rescan wallet
akka.stream.BufferOverflowException: Exceeded configured max-open-requests value of [32]. This means that the request queue of this pool (HostConnectionPoolSetup(localhost,8332,ConnectionPoolSetup(ConnectionPoolSettings(4,0,5,32,1,Duration.Inf,100 milliseconds,2 minutes,30 seconds,Duration.Inf,ClientConnectionSettings(Some(User-Agent: akka-http/10.2.7),10 seconds,60 seconds,512,None,WebSocketSettings(<function0>,ping,Duration.Inf,akka.http.impl.settings.WebSocketSettingsImpl$$$Lambda$1527/0x000000080124b718@6c11d71a,false),List(),ParserSettings(2048,16,64,64,8192,64,Some(20971520),8388608,256,1048576,5,Strict,RFC6265,true,Set(),Full,Error,Error,Error,HashMap(If-Range -> 0, If-Modified-Since -> 0, If-Unmodified-Since -> 0, default -> 12, If-None-Match -> 0, User-Agent -> 32, Content-MD5 -> 0, Date -> 0, If-Match -> 0),false,false,true,akka.util.ConstantFun$$$Lambda$1517/0x000000080124cec0@5deda9e2,akka.util.ConstantFun$$$Lambda$1517/0x000000080124cec0@5deda9e2,akka.util.ConstantFun$$$Lambda$1518/0x000000080124d270@459e953a),100 milliseconds,None,Http2ClientSettingsImpl(256,65536,10000000,512000,1024,false,0 seconds,0 seconds,0,3 seconds,100 milliseconds,2 minutes,None),TCPTransport),1 second,List()),akka.http.scaladsl.HttpConnectionContext$@27d52394,akka.event.MarkerLoggingAdapter@7c18fc46))) has completely filled up because the pool currently does not process requests fast enough to handle the incoming request load. Please retry the request later. See https://doc.akka.io/docs/akka-http/current/scala/http/client-side/pool-overflow.html for more information.
```