### PR TITLE
Remove staking address from codebase

### DIFF
--- a/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
+++ b/app/oracle-server-test/src/test/scala/org/bitcoins/oracle/server/OracleRoutesSpec.scala
@@ -4,7 +4,6 @@ import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.bitcoins.core.api.dlcoracle._
 import org.bitcoins.core.api.dlcoracle.db.EventDb
-import org.bitcoins.core.config._
 import org.bitcoins.core.number.{Int32, UInt16}
 import org.bitcoins.core.protocol.Bech32Address
 import org.bitcoins.core.protocol.tlv.{
@@ -75,22 +74,6 @@ class OracleRoutesSpec
         assert(contentType == `application/json`)
         assert(
           responseAs[String] == s"""{"result":"${key.hex}","error":null}""")
-      }
-    }
-
-    "get staking address" in {
-      (mockOracleApi
-        .stakingAddress(_: BitcoinNetwork))
-        .expects(MainNet)
-        .returning(testAddress)
-
-      val route =
-        oracleRoutes.handleCommand(ServerCommand("getstakingaddress", Arr()))
-
-      Get() ~> route ~> check {
-        assert(contentType == `application/json`)
-        assert(
-          responseAs[String] == s"""{"result":"$testAddress","error":null}""")
       }
     }
 

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -4,7 +4,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import org.bitcoins.core.api.dlcoracle._
-import org.bitcoins.core.config.MainNet
 import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
@@ -24,13 +23,6 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
     case ServerCommand("getpublickey", _) =>
       complete {
         Server.httpSuccess(oracle.publicKey().hex)
-      }
-
-    case ServerCommand("getstakingaddress", _) =>
-      complete {
-        val address = oracle.stakingAddress(MainNet)
-
-        Server.httpSuccess(address.toString)
       }
 
     case ServerCommand("listevents", arr) =>

--- a/core/src/main/scala/org/bitcoins/core/api/dlcoracle/DLCOracleApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlcoracle/DLCOracleApi.scala
@@ -1,13 +1,12 @@
 package org.bitcoins.core.api.dlcoracle
 
 import org.bitcoins.core.api.dlcoracle.db.EventDb
-import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.number._
-import org.bitcoins.core.protocol.Bech32Address
 import org.bitcoins.core.protocol.dlc.compute.SigningVersion
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.crypto._
 import scodec.bits.ByteVector
+
 import java.time.Instant
 import scala.concurrent.Future
 
@@ -17,8 +16,6 @@ trait DLCOracleApi {
   def oracleName(): Future[Option[String]]
 
   def setOracleName(name: String): Future[Unit]
-
-  def stakingAddress(network: BitcoinNetwork): Bech32Address
 
   def listEventDbs(): Future[Vector[EventDb]]
 

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -5,16 +5,14 @@ import org.bitcoins.core.api.dlcoracle._
 import org.bitcoins.core.api.dlcoracle.db._
 import org.bitcoins.core.hd.{HDCoinType, HDPurpose}
 import org.bitcoins.core.number._
-import org.bitcoins.core.protocol.Bech32Address
 import org.bitcoins.core.protocol.dlc.compute.SigningVersion
-import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.core.util.sorted.OrderedNonces
 import org.bitcoins.crypto._
 import org.bitcoins.testkit.fixtures.DLCOracleFixture
 import org.bitcoins.testkitcore.Implicits._
-import org.bitcoins.testkitcore.gen.{ChainParamsGenerator, TLVGen}
+import org.bitcoins.testkitcore.gen.TLVGen
 
 import java.time.Instant
 
@@ -49,15 +47,6 @@ class DLCOracleTest extends DLCOracleFixture {
     val dummyEvent = TLVGen.oracleEventV0TLV.sampleSome
     dlcOracle.findEvent(dummyEvent).map { eventOpt =>
       assert(eventOpt.isEmpty)
-    }
-  }
-
-  it must "calculate the correct staking address" in { dlcOracle: DLCOracle =>
-    forAllAsync(ChainParamsGenerator.bitcoinNetworkParams) { network =>
-      val expected =
-        Bech32Address(P2WPKHWitnessSPKV0(dlcOracle.publicKey.publicKey),
-                      network)
-      assert(dlcOracle.stakingAddress(network) == expected)
     }
   }
 

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -4,14 +4,11 @@ import com.typesafe.config.Config
 import grizzled.slf4j.Logging
 import org.bitcoins.core.api.dlcoracle._
 import org.bitcoins.core.api.dlcoracle.db._
-import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto.ExtKeyVersion.SegWitTestNet3Priv
 import org.bitcoins.core.crypto.{ExtPrivateKeyHardened, ExtPublicKey}
 import org.bitcoins.core.hd._
 import org.bitcoins.core.number._
-import org.bitcoins.core.protocol.Bech32Address
 import org.bitcoins.core.protocol.dlc.compute.SigningVersion
-import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.util.sorted.OrderedNonces
 import org.bitcoins.core.util.{FutureUtil, NumberUtil, TimeUtil}
@@ -78,9 +75,6 @@ case class DLCOracle()(implicit val conf: DLCOracleAppConfig)
   }
 
   override val publicKey: SchnorrPublicKey = signingKey.schnorrPublicKey
-
-  override def stakingAddress(network: BitcoinNetwork): Bech32Address =
-    Bech32Address(P2WPKHWitnessSPKV0(publicKey.publicKey), network)
 
   protected[bitcoins] val rValueDAO: RValueDAO = RValueDAO()
   protected[bitcoins] val eventDAO: EventDAO = EventDAO()


### PR DESCRIPTION
Remove staking address from codebase. We shouldn't serve an address we can't spend from. Its going to take a bit of logic to implement spending from the staking address, and that is a low priority due to the questionability of how to implement staking addresses that can't trivially be spent from before the oracle lies.

