### PR TITLE
Refactor WalletAppConfig test fixture destructions to stop the config…

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -239,8 +239,9 @@ trait BitcoinSWalletTest
       createWalletAppConfigNotStarted(pgUrl, Vector.empty)
     }
 
-    val destroy: WalletAppConfig => Future[Unit] = walletAppConfig => {
-      destroyWalletAppConfig(walletAppConfig)
+    val destroy: WalletAppConfig => Future[Unit] = _ => {
+      //it might not be started, so don't stop it
+      Future.unit
     }
     makeDependentFixture(builder, destroy = destroy)(test)
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -669,8 +669,6 @@ object BitcoinSWalletTest extends WalletLogger {
   def destroyWallet(wallet: Wallet): Future[Unit] = {
     import wallet.ec
     for {
-      _ <- wallet.walletConfig.dropTable("flyway_schema_history")
-      _ <- wallet.walletConfig.dropAll()
       _ <- wallet.stop()
       _ <- destroyWalletAppConfig(wallet.walletConfig)
     } yield ()
@@ -684,9 +682,13 @@ object BitcoinSWalletTest extends WalletLogger {
     } yield ()
   }
 
-  def destroyWalletAppConfig(walletAppConfig: WalletAppConfig): Future[Unit] = {
-    val stoppedF = walletAppConfig.stop()
-    stoppedF
+  def destroyWalletAppConfig(walletAppConfig: WalletAppConfig)(implicit
+      ec: ExecutionContext): Future[Unit] = {
+    for {
+      _ <- walletAppConfig.dropTable("flyway_schema_history")
+      _ <- walletAppConfig.dropAll()
+      _ <- walletAppConfig.stop()
+    } yield ()
   }
 
   /** Constructs callbacks for the wallet from the node to process blocks and compact filters */

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletAppConfigWithBitcoindFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletAppConfigWithBitcoindFixtures.scala
@@ -49,8 +49,10 @@ trait WalletAppConfigWithBitcoindNewestFixtures
       () => {
         val walletConfig =
           BaseWalletTest.getFreshWalletAppConfig(pgUrl, Vector.empty)
-        val model = WalletAppConfigWithBitcoindRpc(walletConfig, bitcoind)
-        Future.successful(model)
+        for {
+          _ <- walletConfig.start()
+          model = WalletAppConfigWithBitcoindRpc(walletConfig, bitcoind)
+        } yield model
       },
       { case walletAppConfigWithBitcoindRpc =>
         BitcoinSWalletTest.destroyWalletAppConfig(
@@ -59,5 +61,3 @@ trait WalletAppConfigWithBitcoindNewestFixtures
     )(test)
   }
 }
-
-object WalletAppConfigWithBitcoindFixtures {}

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -46,10 +46,6 @@ class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
       syncHeightOpt <- wallet.getSyncDescriptorOpt()
-
-      // clean up
-      _ <- wallet.walletConfig.stop()
-      _ = wallet.walletConfig.clean()
     } yield {
       assert(balance == amountToSend)
       assert(syncHeightOpt.contains(SyncHeightDescriptor(bestHash, height)))
@@ -88,10 +84,6 @@ class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
       _ <- BitcoindRpcBackendUtil.syncWalletToBitcoind(bitcoind, wallet)
 
       utxos <- wallet.listUtxos(TxoState.ConfirmedReceived)
-
-      // clean up
-      _ <- wallet.walletConfig.stop()
-      _ = wallet.walletConfig.clean()
     } yield {
       assert(utxos.size == 1)
       val utxo = utxos.head
@@ -130,10 +122,6 @@ class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
       _ <- wallet.processCompactFilter(header.hash, filter)
 
       balance <- wallet.getBalance()
-
-      // clean up
-      _ <- wallet.walletConfig.stop()
-      _ = wallet.walletConfig.clean()
     } yield {
       assert(balance == amountToSend)
     }
@@ -184,10 +172,6 @@ class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
 
         unconfirmedBalance <- wallet.getUnconfirmedBalance()
         confirmedBalance <- wallet.getConfirmedBalance()
-
-        // clean up
-        _ <- wallet.walletConfig.stop()
-        _ = wallet.walletConfig.clean()
       } yield {
         assert(confirmedBalance == amountToSend)
         assert(unconfirmedBalance == Satoshis.zero)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
@@ -56,8 +56,6 @@ class BitcoindBlockPollingTest
           1.second)
 
         balance <- wallet.getConfirmedBalance()
-        //clean up
-        _ <- wallet.walletConfig.stop()
       } yield assert(balance == amountToSend)
   }
 
@@ -101,9 +99,6 @@ class BitcoindBlockPollingTest
               _.txIdBE == txid2)
           },
           1.second)
-
-        //clean up
-        _ <- wallet.walletConfig.stop()
       } yield succeed
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindZMQBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindZMQBackendTest.scala
@@ -81,9 +81,6 @@ class BitcoindZMQBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
         }
 
       balance <- wallet.getConfirmedBalance()
-
-      // clean up
-      _ <- wallet.walletConfig.stop()
     } yield {
       // use >= because of multiple attempts
       assert(balance >= amountToSend)


### PR DESCRIPTION
fixes #4260

This refactors our test fixtures to stop the database connections in `WalletAppConfig` inside of `destroyWalletAppConfig`. This allows us to clean up a lot of places where we were doing it adhoc in the codebase. This fixes #4260 as well as now the wallet app config is totally self contained to the test fixtures.