### PR TITLE
Reduce what gets tested on tor CI

### DIFF
--- a/.github/workflows/TorTests.yml
+++ b/.github/workflows/TorTests.yml
@@ -30,4 +30,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: run tests
-        run: sbt ++2.13.8 torTest/test nodeTest/test dlcNodeTest/test esploraTest/test
+        run: sbt ++2.13.8 torTest/test


### PR DESCRIPTION
The `tor` test ci matric previously would test `dlcNodeTest`, `nodeTest` and `esploraTest`. This would result in the test suite consistently failing. Reduce what gets tested to just `torTest` so that hopefully it passes consistently on unreliable CI envs