### PR TITLE
Update rolling policies for log files

### DIFF
--- a/app/oracle-server/src/main/resources/logback.xml
+++ b/app/oracle-server/src/main/resources/logback.xml
@@ -14,13 +14,13 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${bitcoins.log.location}/bitcoin-s.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <!-- hourly rollover -->
-            <fileNamePattern>${bitcoins.log.location}/logs/bitcoin-s-%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+            <!-- monthly rollover -->
+            <fileNamePattern>${bitcoins.log.location}/logs/bitcoin-s-%d{yyyy/MM}.%i.log.zip</fileNamePattern>
 
-            <!-- each file should be at most 100MB, keep 2 days of history, and at most 2GB in the archive -->
+            <!-- each file should be at most 100MB, keep 12 months of history, and at most 5GB in the archive -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>48</maxHistory>
-            <totalSizeCap>2GB</totalSizeCap>
+            <maxHistory>12</maxHistory>
+            <totalSizeCap>5GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
             <pattern>%date{yyyy-MM-dd'T'HH:mm:ss,SSXXX, UTC}UTC %level [%logger{0}] %msg%n</pattern>

--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -14,13 +14,13 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${bitcoins.log.location}/bitcoin-s.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <!-- hourly rollover -->
-            <fileNamePattern>${bitcoins.log.location}/logs/bitcoin-s-%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
+            <!-- monthly rollover -->
+            <fileNamePattern>${bitcoins.log.location}/logs/bitcoin-s-%d{yyyy/MM}.%i.log.zip</fileNamePattern>
 
-            <!-- each file should be at most 100MB, keep 2 days of history, and at most 2GB in the archive -->
+            <!-- each file should be at most 100MB, keep 12 months of history, and at most 5GB in the archive -->
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>48</maxHistory>
-            <totalSizeCap>2GB</totalSizeCap>
+            <maxHistory>12</maxHistory>
+            <totalSizeCap>5GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
             <pattern>%date{yyyy-MM-dd'T'HH:mm:ss,SSXXX, UTC}UTC %level [%logger{0}] %msg%n</pattern>


### PR DESCRIPTION
fixes #4051 and related to #4288

https://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy

This PR implements a monthly rolling policy for log files, the max file size for each individual log file is 100MB before we will roll to a new one. Previously we attempting to roll hourly (which didn't work due to the bug fixed in #4288) which seems unnecessary. We keep a maximum of 12 months of log files in the archive. The totalSizeCap is 5GB before we start pruning the archive

(from docs)

>/wombat/%d{yyyy/MM}/foo.txt

This also implements compression of archived log files

>TimeBasedRollingPolicy supports automatic file compression. This feature is enabled if the value of the fileNamePattern option ends with .gz or .zip. 