### PR TITLE
2022 04 26 Startup time of `appServer`

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/BitcoinSServerInfo.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/BitcoinSServerInfo.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.commons.jsonmodels
 
 import org.bitcoins.core.config.{BitcoinNetwork, BitcoinNetworks}
+import org.bitcoins.core.serializers.PicklerKeys
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import ujson._
 
@@ -8,13 +9,15 @@ import ujson._
 case class BitcoinSServerInfo(
     network: BitcoinNetwork,
     blockHeight: Int,
-    blockHash: DoubleSha256DigestBE) {
+    blockHash: DoubleSha256DigestBE,
+    torStarted: Boolean) {
 
   lazy val toJson: Value = {
     Obj(
-      "network" -> Str(network.name),
-      "blockHeight" -> Num(blockHeight),
-      "blockHash" -> Str(blockHash.hex)
+      PicklerKeys.networkKey -> Str(network.name),
+      PicklerKeys.blockHeightKey -> Num(blockHeight),
+      PicklerKeys.blockHashKey -> Str(blockHash.hex),
+      PicklerKeys.torStartedKey -> Bool(torStarted)
     )
   }
 }
@@ -24,10 +27,14 @@ object BitcoinSServerInfo {
   def fromJson(json: Value): BitcoinSServerInfo = {
     val obj = json.obj
 
-    val network = BitcoinNetworks.fromString(obj("network").str)
-    val height = obj("blockHeight").num.toInt
-    val blockHash = DoubleSha256DigestBE(obj("blockHash").str)
+    val network = BitcoinNetworks.fromString(obj(PicklerKeys.networkKey).str)
+    val height = obj(PicklerKeys.blockHeightKey).num.toInt
+    val blockHash = DoubleSha256DigestBE(obj(PicklerKeys.blockHashKey).str)
+    val torStarted = obj(PicklerKeys.torStartedKey).bool
 
-    BitcoinSServerInfo(network, height, blockHash)
+    BitcoinSServerInfo(network = network,
+                       blockHeight = height,
+                       blockHash = blockHash,
+                       torStarted = torStarted)
   }
 }

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
@@ -27,11 +27,11 @@ class OracleServerMain(override val serverArgParser: ServerArgParser)(implicit
     for {
       _ <- conf.start()
       oracle = new DLCOracle()
-      routes = Seq(OracleRoutes(oracle), commonRoutes)
+      routes = Seq(OracleRoutes(oracle), commonRoutes).map(Future.successful)
       server = serverArgParser.rpcPortOpt match {
         case Some(rpcport) =>
           Server(conf = conf,
-                 handlers = routes,
+                 handlersF = routes,
                  rpcbindOpt = bindConfOpt,
                  rpcport = rpcport,
                  rpcPassword = conf.rpcPassword,
@@ -39,7 +39,7 @@ class OracleServerMain(override val serverArgParser: ServerArgParser)(implicit
                  Source.empty)
         case None =>
           Server(conf = conf,
-                 handlers = routes,
+                 handlersF = routes,
                  rpcbindOpt = bindConfOpt,
                  rpcport = conf.rpcPort,
                  rpcPassword = conf.rpcPassword,

--- a/app/server-routes/src/main/scala/org/bitcoins/server/util/AppConfigMarker.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/util/AppConfigMarker.scala
@@ -1,0 +1,16 @@
+package org.bitcoins.server.util
+
+import scala.concurrent.Future
+
+/** A trait used to indicated when different parts of [[BitcoinSAppConfig]] are started */
+sealed trait AppConfigMarker
+
+/** This class represents when BitcoinSAppConfig modules are started
+  * @param torStartedF this future is completed when all tor dependent modules are fully started
+  *                   the reason this is needed is because tor startup time is so variable
+  * @see https://github.com/bitcoin-s/bitcoin-s/issues/4210
+  */
+case class StartedBitcoinSAppConfig(torStartedF: Future[Unit])
+    extends AppConfigMarker
+
+case object StoppedBitcoinSAppConfig extends AppConfigMarker

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -67,7 +67,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
   val mockNode = mock[Node]
 
-  val chainRoutes = ChainRoutes(mockChainApi, RegTest)
+  val chainRoutes = ChainRoutes(mockChainApi, RegTest, Future.unit)
 
   val nodeRoutes = NodeRoutes(mockNode)
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -77,13 +77,12 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     }
 
     for {
-      _ <- startedConfigF
       start <- {
         nodeConf.nodeType match {
           case _: InternalImplementationNodeType =>
-            startBitcoinSBackend()
+            startBitcoinSBackend(startedConfigF)
           case NodeType.BitcoindBackend =>
-            startBitcoindBackend()
+            startBitcoindBackend(startedConfigF)
         }
       }
     } yield {
@@ -107,7 +106,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     }
   }
 
-  def startBitcoinSBackend(): Future[Unit] = {
+  def startBitcoinSBackend(startedConfigF: Future[Unit]): Future[Unit] = {
     logger.info(s"startBitcoinSBackend()")
     val start = System.currentTimeMillis()
 
@@ -174,18 +173,14 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val startedDLCNodeF = dlcNodeF
       .flatMap(_.start())
       .flatMap(_ => dlcNodeF)
+
+    val chainApi = ChainHandler.fromDatabase()
     //start our http server now that we are synced
     for {
-      wallet <- configuredWalletF
-      node <- startedNodeF
-      _ <- startedWalletF
-      cachedChainApi <- node.chainApiFromDb()
-      chainApi = ChainHandler.fromChainHandlerCached(cachedChainApi)
-      dlcNode <- startedDLCNodeF
-      _ <- startHttpServer(nodeApi = node,
+      _ <- startHttpServer(nodeApiF = startedNodeF,
                            chainApi = chainApi,
-                           wallet = wallet,
-                           dlcNode = dlcNode,
+                           walletF = configuredWalletF,
+                           dlcNodeF = startedDLCNodeF,
                            serverCmdLineArgs = serverArgParser,
                            wsSource = wsSource)
       _ = {
@@ -193,8 +188,11 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
           s"Starting ${nodeConf.nodeType.shortName} node sync, it took=${System
             .currentTimeMillis() - start}ms")
       }
+      _ <- startedWalletF
       //make sure callbacks are registered before we start sync
       _ <- callbacksF
+      node <- startedNodeF
+      _ <- startedConfigF
       _ <- node.sync()
     } yield {
       logger.info(
@@ -235,14 +233,18 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     } yield info
   }
 
-  def startBitcoindBackend(): Future[Unit] = {
+  def startBitcoindBackend(startedConfigF: Future[Unit]): Future[Unit] = {
     logger.info(s"startBitcoindBackend()")
     val bitcoindF = for {
       client <- bitcoindRpcConf.clientF
       _ <- client.start()
     } yield client
 
-    val tmpWalletF = bitcoindF.flatMap { bitcoind =>
+    val tuple = buildWsSource
+    val wsQueue: SourceQueueWithComplete[Message] = tuple._1
+    val wsSource: Source[Message, NotUsed] = tuple._2
+
+    val walletF = bitcoindF.flatMap { bitcoind =>
       val feeProvider = FeeProviderFactory.getFeeProviderOrElse(
         bitcoind,
         feeProviderNameStrOpt = walletConf.feeProviderNameOpt,
@@ -250,14 +252,38 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
         proxyParamsOpt = walletConf.torConf.socks5ProxyParams,
         network = walletConf.network
       )
-      dlcConf.createDLCWallet(nodeApi = bitcoind,
-                              chainQueryApi = bitcoind,
-                              feeRateApi = feeProvider)
+      logger.info("Creating wallet")
+      val tmpWalletF = dlcConf.createDLCWallet(nodeApi = bitcoind,
+                                               chainQueryApi = bitcoind,
+                                               feeRateApi = feeProvider)
+      val chainCallbacks = WebsocketUtil.buildChainCallbacks(wsQueue, bitcoind)
+      for {
+        tmpWallet <- tmpWalletF
+        wallet = BitcoindRpcBackendUtil.createDLCWalletWithBitcoindCallbacks(
+          bitcoind,
+          tmpWallet,
+          Some(chainCallbacks))
+        nodeCallbacks <- CallbackUtil.createBitcoindNodeCallbacksForWallet(
+          wallet)
+        _ = nodeConf.addCallbacks(nodeCallbacks)
+        _ = logger.info("Starting wallet")
+        _ <- wallet.start().recoverWith {
+          //https://github.com/bitcoin-s/bitcoin-s/issues/2917
+          //https://github.com/bitcoin-s/bitcoin-s/pull/2918
+          case err: IllegalArgumentException
+              if err.getMessage.contains("If we have spent a spendinginfodb") =>
+            handleMissingSpendingInfoDb(err, wallet)
+        }
+      } yield wallet
     }
 
-    val tuple = buildWsSource
-    val wsQueue: SourceQueueWithComplete[Message] = tuple._1
-    val wsSource: Source[Message, NotUsed] = tuple._2
+    val dlcNodeF = {
+      for {
+        wallet <- walletF
+        dlcNode = dlcNodeConf.createDLCNode(wallet)
+        _ <- dlcNode.start()
+      } yield dlcNode
+    }
 
     for {
       _ <- bitcoindRpcConf.start()
@@ -268,42 +294,23 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       _ = require(
         bitcoindNetwork == walletConf.network,
         s"bitcoind ($bitcoindNetwork) on different network than wallet (${walletConf.network})")
-
-      _ = logger.info("Creating wallet")
-      chainCallbacks = WebsocketUtil.buildChainCallbacks(wsQueue, bitcoind)
-      tmpWallet <- tmpWalletF
-      wallet = BitcoindRpcBackendUtil.createDLCWalletWithBitcoindCallbacks(
-        bitcoind,
-        tmpWallet,
-        Some(chainCallbacks))
-      nodeCallbacks <- CallbackUtil.createBitcoindNodeCallbacksForWallet(wallet)
-      _ = nodeConf.addCallbacks(nodeCallbacks)
-      _ = logger.info("Starting wallet")
-      _ <- wallet.start().recoverWith {
-        //https://github.com/bitcoin-s/bitcoin-s/issues/2917
-        //https://github.com/bitcoin-s/bitcoin-s/pull/2918
-        case err: IllegalArgumentException
-            if err.getMessage.contains("If we have spent a spendinginfodb") =>
-          handleMissingSpendingInfoDb(err, wallet)
-      }
-
-      dlcNode = dlcNodeConf.createDLCNode(wallet)
-      _ <- dlcNode.start()
-      _ <- startHttpServer(nodeApi = bitcoind,
+      _ <- startHttpServer(nodeApiF = Future.successful(bitcoind),
                            chainApi = bitcoind,
-                           wallet = wallet,
-                           dlcNode = dlcNode,
+                           walletF = walletF,
+                           dlcNodeF = dlcNodeF,
                            serverCmdLineArgs = serverArgParser,
                            wsSource = wsSource)
       walletCallbacks = WebsocketUtil.buildWalletCallbacks(wsQueue)
       _ = walletConf.addCallbacks(walletCallbacks)
 
+      wallet <- walletF
       //intentionally doesn't map on this otherwise we
       //wait until we are done syncing the entire wallet
       //which could take 1 hour
       _ = syncWalletWithBitcoindAndStartPolling(bitcoind, wallet)
       dlcWalletCallbacks = WebsocketUtil.buildDLCWalletCallbacks(wsQueue)
       _ = dlcConf.addCallbacks(dlcWalletCallbacks)
+      _ <- startedConfigF
     } yield {
       logger.info(s"Done starting Main!")
       ()
@@ -351,10 +358,10 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
   private var serverBindingsOpt: Option[ServerBindings] = None
 
   private def startHttpServer(
-      nodeApi: NodeApi,
+      nodeApiF: Future[NodeApi],
       chainApi: ChainApi,
-      wallet: DLCWallet,
-      dlcNode: DLCNode,
+      walletF: Future[DLCWallet],
+      dlcNodeF: Future[DLCNode],
       serverCmdLineArgs: ServerArgParser,
       wsSource: Source[Message, NotUsed])(implicit
       system: ActorSystem,
@@ -362,20 +369,20 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     implicit val nodeConf: NodeAppConfig = conf.nodeConf
     implicit val walletConf: WalletAppConfig = conf.walletConf
 
-    val walletRoutes = WalletRoutes(wallet)
-    val nodeRoutes = NodeRoutes(nodeApi)
+    val walletRoutesF = walletF.map(WalletRoutes(_))
+    val nodeRoutesF = nodeApiF.map(NodeRoutes(_))
     val chainRoutes = ChainRoutes(chainApi, nodeConf.network)
     val coreRoutes = CoreRoutes()
-    val dlcRoutes = DLCRoutes(dlcNode)
+    val dlcRoutesF = dlcNodeF.map(DLCRoutes(_))
     val commonRoutes = CommonRoutes(conf.baseDatadir)
 
     val handlers =
-      Seq(walletRoutes,
-          nodeRoutes,
-          chainRoutes,
-          coreRoutes,
-          dlcRoutes,
-          commonRoutes)
+      Seq(walletRoutesF,
+          nodeRoutesF,
+          Future.successful(chainRoutes),
+          Future.successful(coreRoutes),
+          dlcRoutesF,
+          Future.successful(commonRoutes))
 
     val rpcBindConfOpt = serverCmdLineArgs.rpcBindOpt match {
       case Some(rpcbind) => Some(rpcbind)
@@ -399,7 +406,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       serverCmdLineArgs.rpcPortOpt match {
         case Some(rpcport) =>
           Server(conf = nodeConf,
-                 handlers = handlers,
+                 handlersF = handlers,
                  rpcbindOpt = rpcBindConfOpt,
                  rpcport = rpcport,
                  rpcPassword = conf.rpcPassword,
@@ -408,7 +415,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
         case None =>
           Server(
             conf = nodeConf,
-            handlers = handlers,
+            handlersF = handlers,
             rpcbindOpt = rpcBindConfOpt,
             rpcport = conf.rpcPort,
             rpcPassword = conf.rpcPassword,

--- a/core/src/main/scala/org/bitcoins/core/serializers/PicklerKeys.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/PicklerKeys.scala
@@ -32,6 +32,8 @@ object PicklerKeys {
   final val chainworkKey: String = "chainwork"
   final val previousblockhashKey: String = "previousblockhash"
   final val nextblockhashKey: String = "nextblockhash"
+  final val blockHashKey: String = "blockHash"
+  final val blockHeightKey: String = "blockHeight"
   final val myCollateral: String = "myCollateral"
   final val theirCollateral: String = "theirCollateral"
   final val myPayout: String = "myPayout"
@@ -39,9 +41,13 @@ object PicklerKeys {
   final val pnl: String = "pnl"
   final val rateOfReturn: String = "rateOfReturn"
 
+  final val networkKey: String = "network"
+
   final val outcomeKey: String = "outcome"
   final val localPayoutKey: String = "localPayout"
   final val outcomesKey: String = "outcomes"
+
+  final val torStartedKey: String = "torStarted"
 
   //tlv points
   final val pointsKey = "points"

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/CachedAppConfig.scala
@@ -39,6 +39,7 @@ trait CachedBitcoinSAppConfig { _: BitcoinSAkkaAsyncTest =>
 
   override def afterAll(): Unit = {
     Await.result(cachedConfig.stop(), duration)
+    ()
   }
 }
 


### PR DESCRIPTION
fixes #4210 

The purpose of this PR is to decouple the starting of our tor binary with the binding of our rpc server.

Previously, we would startup everything in a very synchronous manner. That meant having tor started (along with other heavyweight things) before binding our rpc server. This meant it could be 5 seconds to startup the rpc server on a good machine, and even slower on a lower resource device like a raspberry pi.

For instance, this is a log from a pi on how long it took to start up. A little over 2 minutes!

>2022-04-05T13:54:53UTC INFO [BitcoinSServerMain] Done start BitcoinSServerMain, it took=122719ms

The `getinfo` rpc endpoint has been modified to return `torStarted` which is a boolean flag indicating if tor has started or not

![Screenshot from 2022-04-26 16-47-36](https://user-images.githubusercontent.com/3514957/165398670-b872c2b3-bf21-465e-ad9c-94893396d809.png)

Modules that are dependent on tor (`dlcNode`,`dlcWallet`, `bitcoindRpcConf`) will not be able to make progress until tor is started.