### PR TITLE
2022 04 29 issue 4302

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main, "2022-04-29-issue-4302"]
+    branches: [master, main]
     tags: ["*"]
   release:
     types: [ published ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,13 @@ jobs:
         with:
           name: "bitcoin-s-oracle-server"
           path: app/oracle-server/target/universal/stage/
+      - name: Upload bitcoin-s-cli zip
+        uses: actions/upload-artifact@v3
+        env:
+          pkg-version: ${{steps.previoustag.outputs.tag}}
+        with:
+          name: "bitcoin-s-cli"
+          path: app/cli/target/universal/stage/
       - name: Upload bitcoin-s-server if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -246,8 +253,15 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: "bitcoin-s-server-${{steps.previoustag.outputs.tag}}"
+          name: "bitcoin-s-oracle-server-${{steps.previoustag.outputs.tag}}"
           files: app/oracle-server/target/universal/*.zip
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload bitcoin-s-cli if release
+        uses: actions/upload-artifact@v3
+        env:
+          pkg-version: ${{steps.previoustag.outputs.tag}}
+        with:
+          name: "bitcoin-s-cli-${{steps.previoustag.outputs.tag}}"
+          path: app/cli/target/universal/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "2022-04-29-issue-4302"]
     tags: ["*"]
   release:
     types: [ published ]
@@ -219,19 +219,35 @@ jobs:
         run: |
           chmod +x app/server/target/universal/stage/bin/bitcoin-s-server
           chmod +x app/server/target/universal/stage/bin/bitcoin-s-server.bat
-      - name: Upload zip
+      - name: Upload bitcoin-s-server zip
         uses: actions/upload-artifact@v3
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
           name: "bitcoin-s-server"
           path: app/server/target/universal/stage/
-      - name: Upload if release
+      - name: Upload bitcoin-s-oracle-server zip
+        uses: actions/upload-artifact@v3
+        env:
+          pkg-version: ${{steps.previoustag.outputs.tag}}
+        with:
+          name: "bitcoin-s-oracle-server"
+          path: app/oracle-server/target/universal/stage/
+      - name: Upload bitcoin-s-server if release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: "bitcoin-s-server-${{steps.previoustag.outputs.tag}}"
           files: app/server/target/universal/*.zip
+        env:
+          pkg-version: ${{steps.previoustag.outputs.tag}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload bitcoin-s-oracle-server if release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          name: "bitcoin-s-server-${{steps.previoustag.outputs.tag}}"
+          files: app/oracle-server/target/universal/*.zip
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,9 +259,11 @@ jobs:
           pkg-version: ${{steps.previoustag.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload bitcoin-s-cli if release
-        uses: actions/upload-artifact@v3
-        env:
-          pkg-version: ${{steps.previoustag.outputs.tag}}
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           name: "bitcoin-s-cli-${{steps.previoustag.outputs.tag}}"
-          path: app/cli/target/universal/*.zip
+          files: app/cli/target/universal/*.zip
+        env:
+          pkg-version: ${{steps.previoustag.outputs.tag}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fixes #4302 and #4272

We now publish `bitcoin-s-oracle-server.zip` and `bitcoin-s-cli.zip` everytime we merge to master now.