### PR TITLE
Reduce rescan threadpool size to just be number of available processors

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -65,7 +65,7 @@ case class WalletAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
 
   /** Threads for rescanning the wallet */
   private[wallet] lazy val rescanThreadPool: ExecutorService =
-    Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors() * 2,
+    Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors(),
                                  rescanThreadFactory)
 
   private val callbacks = new Mutable(WalletCallbacks.empty)


### PR DESCRIPTION
When looking at thread usage in visualvm while rescanning, no single thread gets > 50% cpu utilization. Thus we should reduce the threadpool size to get better cpu utilization and reduce threadpool overhead. 