### PR TITLE
Segregate handling of Tcp.ErrorClosed command from the rest of Tcp.ConnectionClosed

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -290,6 +290,11 @@ case class P2PClientActor(
         context.become(awaitNetworkRequest(peerConnection, unalignedBytes))
         unalignedBytes
 
+      case Tcp.ErrorClosed(cause) =>
+        logger.error(
+          s"An error occurred in our connection with $peer, cause=$cause state=${currentPeerMsgHandlerRecv.state}")
+        currentPeerMsgHandlerRecv = currentPeerMsgHandlerRecv.disconnect()
+        unalignedBytes
       case closeCmd @ (Tcp.ConfirmedClosed | Tcp.Closed | Tcp.Aborted |
           Tcp.PeerClosed | Tcp.ErrorClosed(_)) =>
         logger.info(

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -296,7 +296,7 @@ case class P2PClientActor(
         currentPeerMsgHandlerRecv = currentPeerMsgHandlerRecv.disconnect()
         unalignedBytes
       case closeCmd @ (Tcp.ConfirmedClosed | Tcp.Closed | Tcp.Aborted |
-          Tcp.PeerClosed | Tcp.ErrorClosed(_)) =>
+          Tcp.PeerClosed) =>
         logger.info(
           s"We've been disconnected by $peer command=${closeCmd} state=${currentPeerMsgHandlerRecv.state}")
         currentPeerMsgHandlerRecv = currentPeerMsgHandlerRecv.disconnect()


### PR DESCRIPTION
This case is different than the rest of the `Tcp.ConnectionClosed` type hierarchy. In this case, an internal IO error occurred. We need to log that specific error so we can debug what is happening. 

https://doc.akka.io/docs/akka/current/io-tcp.html#closing-connections

I needed this when debugging errors in #4112