### PR TITLE
2022 05 03 oracle server jlink build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -371,6 +371,7 @@ lazy val oracleServer = project
   .settings(CommonSettings.dockerSettings: _*)
   .settings(CommonSettings.dockerBuildxSettings: _*)
   .settings(jlinkModules ++= CommonSettings.jlinkModules)
+  .settings(jlinkModules --= CommonSettings.rmJlinkModules)
   .settings(jlinkOptions ++= CommonSettings.jlinkOptions)
   .settings(jlinkIgnoreMissingDependency := CommonSettings.oracleServerJlinkIgnore)
   .dependsOn(

--- a/build.sbt
+++ b/build.sbt
@@ -370,11 +370,14 @@ lazy val oracleServer = project
   .settings(CommonSettings.appSettings: _*)
   .settings(CommonSettings.dockerSettings: _*)
   .settings(CommonSettings.dockerBuildxSettings: _*)
+  .settings(jlinkModules ++= CommonSettings.jlinkModules)
+  .settings(jlinkOptions ++= CommonSettings.jlinkOptions)
+  .settings(jlinkIgnoreMissingDependency := CommonSettings.oracleServerJlinkIgnore)
   .dependsOn(
     dlcOracle,
     serverRoutes
   )
-  .enablePlugins(JavaAppPackaging, DockerPlugin)
+  .enablePlugins(JavaAppPackaging, DockerPlugin, JlinkPlugin)
 
 lazy val oracleServerTest = project
   .in(file("app/oracle-server-test"))

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -96,6 +96,17 @@ object CommonSettings {
     "jdk.unsupported"
   )
 
+  //these are java modules we do not need
+  //our artifacts do not use java.desktop
+  //there may be others we don't need
+  //but this is the most obvious and reduces
+  //artifact size by 15MB
+  //do 'show jlinkModules' in the module
+  //to see what ones are used
+  lazy val rmJlinkModules = Seq(
+    "java.desktop"
+  )
+
   lazy val jlinkOptions = Seq(
     "--no-header-files",
     "--no-man-pages",

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -3,15 +3,8 @@ import com.typesafe.sbt.SbtNativePackager.Docker
 import com.typesafe.sbt.SbtNativePackager.autoImport.packageName
 
 import java.nio.file.Paths
-import com.typesafe.sbt.packager.Keys.{
-  daemonUser,
-  daemonUserUid,
-  dockerAlias,
-  dockerAliases,
-  dockerRepository,
-  dockerUpdateLatest,
-  maintainer
-}
+import com.typesafe.sbt.packager.Keys.{daemonUser, daemonUserUid, dockerAlias, dockerAliases, dockerRepository, dockerUpdateLatest, maintainer}
+import com.typesafe.sbt.packager.archetypes.jlink.JlinkPlugin.autoImport.JlinkIgnore
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerBaseImage
 import sbt._
 import sbt.Keys._
@@ -96,6 +89,17 @@ object CommonSettings {
       //https://github.com/eclipse/jetty.project/issues/3244#issuecomment-495322586
       Seq("--release", "8")
     }
+  )
+
+  lazy val jlinkModules = Seq(
+    "jdk.crypto.ec",
+    "jdk.unsupported"
+  )
+
+  lazy val jlinkOptions = Seq(
+    "--no-header-files",
+    "--no-man-pages",
+    "--compress=2"
   )
 
   private val commonCompilerOpts = {
@@ -237,4 +241,60 @@ object CommonSettings {
 
   lazy val binariesPath =
     Paths.get(Properties.userHome, ".bitcoin-s", "binaries")
+
+  lazy val oracleServerJlinkIgnore = {
+    JlinkIgnore.byPackagePrefix(
+      "java.xml" -> "java.activation",
+      "ch.qos.logback.core.net" -> "javax.mail",
+      "ch.qos.logback.core.net" -> "javax.mail.internet",
+      "org.flywaydb.core.api.android" -> "android.content",
+      "org.flywaydb.core.internal.logging.android" -> "android.util",
+
+      //we don't use android
+      "org.flywaydb.core.internal.resource.android" -> "android.content.res",
+      "org.flywaydb.core.internal.scanner.android" -> "android.content",
+      "org.flywaydb.core.internal.scanner.android" -> "android.content.pm",
+      "org.flywaydb.core.internal.scanner.android" -> "android.content.res",
+      "org.flywaydb.core.internal.scanner.android" -> "dalvik.system",
+
+      //we don't use hibernate
+      "com.zaxxer.hikari.hibernate" -> "org.hibernate",
+
+      //we don't ship with support for any aws products
+      "org.flywaydb.core.internal.resource.s3" -> "software.amazon.awssdk.awscore.exception",
+      "org.flywaydb.core.internal.resource.s3" -> "software.amazon.awssdk.core",
+      "org.flywaydb.core.internal.resource.s3" -> "software.amazon.awssdk.services.s3",
+      "org.flywaydb.core.internal.resource.s3" -> "software.amazon.awssdk.services.s3.model",
+      "org.flywaydb.core.internal.scanner.cloud.s3" -> "software.amazon.awssdk.core.exception",
+      "org.flywaydb.core.internal.scanner.cloud.s3" -> "software.amazon.awssdk.services.s3",
+      "org.flywaydb.core.internal.scanner.cloud.s3" -> "software.amazon.awssdk.services.s3.model",
+      "org.flywaydb.core.api.configuration" -> "software.amazon.awssdk.services.s3",
+
+      //we don't use oracle database products
+      "org.flywaydb.core.internal.database.oracle" -> "oracle.jdbc",
+
+      //we don't use jboss
+      "org.flywaydb.core.internal.scanner.classpath.jboss" -> "org.jboss.vfs",
+
+      "org.flywaydb.core.internal.logging.log4j2" -> "org.apache.logging.log4j",
+
+      "slick.jdbc" -> "javax.xml.bind",
+
+      "com.github.benmanes.caffeine" -> "javax.annotation",
+      "com.github.benmanes.caffeine.cache" -> "javax.annotation",
+      "com.github.benmanes.caffeine.cache.stats" -> "javax.annotation",
+
+      "com.zaxxer.hikari.metrics.micrometer" -> "io.micrometer.core.instrument",
+      "com.zaxxer.hikari.pool" -> "io.micrometer.core.instrument",
+
+      "waffle.jaas" -> "java.security.acl",
+
+      "org.apache.log4j.jmx" -> "com.sun.jdmk.comm",
+      //optional
+      "org.codehaus.janino" -> "org.apache.tools.ant",
+      "com.zaxxer.hikari.metrics.prometheus" -> "io.prometheus.client",
+      "com.zaxxer.hikari.util" -> "javassist",
+      "com.zaxxer.hikari.util" -> "javassist.bytecode"
+    )
+  }
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -6,7 +6,12 @@ object Deps {
   object V {
     val bouncyCastle = "1.70"
     val dropwizardMetricsV = "4.2.9" //https://github.com/dropwizard/metrics
+
     val logback = "1.2.11"
+    val log4jV = "1.2.17"
+    val logkitV = "1.0.1"
+    val avalonLoggingV = "4.1.5"
+
     val grizzledSlf4j = "1.3.4"
     val scalacheck = "1.15.4"
     val scalaTest = "3.2.10"
@@ -31,7 +36,7 @@ object Deps {
     val asyncNewScalaV = "1.0.1"
 
     val flywayV = "8.5.9"
-    val postgresV = "42.3.3"
+    val postgresV = "42.3.4"
     val akkaActorV = akkaStreamv
     val slickV = "3.3.3"
     val sqliteV = "3.36.0.3"
@@ -46,6 +51,10 @@ object Deps {
     val newMicroPickleV = "1.3.8"
     val newMicroJsonV = newMicroPickleV
 
+    val osgiFrameworkV = "1.10.0"
+    val osgiJdbcV = "1.0.1"
+    val osgiCoreV = "8.0.0"
+
     // akka-http-upickle is not yet published
     // to Maven central. There's a PR for adding
     // suport, https://github.com/hseeberger/akka-http-json/pull/314.
@@ -59,11 +68,19 @@ object Deps {
     // CLI deps
     val scoptV = "4.0.1"
     val sttpV = "1.7.2"
-    val codehausV = "3.1.6"
+    val codehausV = "3.1.7"
     val scalaJsTimeV = "2.3.0"
     val zxingV = "3.4.1"
 
     val monixV = "3.4.0"
+
+    val javaxServletV = "4.0.1"
+    val javaxJmsV = "2.0.1"
+    val javaxMailV = "1.4.7"
+
+    val gsonV = "2.9.0"
+    val jnaV = "5.11.0"
+    val waffleJnaV = "1.9.1"
   }
 
   object Compile {
@@ -101,6 +118,8 @@ object Deps {
 
     val akkaTestkit =
       "com.typesafe.akka" %% "akka-testkit" % V.akkaActorV withSources () withJavadoc ()
+
+    val gson = "com.google.code.gson" % "gson" % V.gsonV //https://github.com/google/gson
 
     val jUnixSocket =
       "com.kohlschutter.junixsocket" % "junixsocket-core" % V.jUnixSocketV
@@ -140,6 +159,14 @@ object Deps {
     lazy val javaFxDeps =
       List(javaFxBase, javaFxControls, javaFxGraphics, javaFxMedia)
 
+    val javaxServlet = "javax.servlet" % "javax.servlet-api" % V.javaxServletV // https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api
+    val javaxJms = "javax.jms" % "javax.jms-api" % V.javaxJmsV // https://mvnrepository.com/artifact/javax.jms/javax.jms-api
+    val javaxMail = "javax.mail" % "mail" % V.javaxMailV // https://mvnrepository.com/artifact/javax.mail/mail
+
+
+    val jna = "net.java.dev.jna" % "jna" % V.jnaV
+    val waffleJna = "com.github.waffle" % "waffle-jna" % V.waffleJnaV
+
     val breezeViz =
       ("org.scalanlp" %% "breeze-viz" % V.breezeV withSources () withJavadoc ())
         .exclude("bouncycastle", "bcprov-jdk14")
@@ -152,6 +179,10 @@ object Deps {
 
     val logback =
       "ch.qos.logback" % "logback-classic" % V.logback withSources () withJavadoc ()
+
+    val log4j = "log4j" % "log4j" % V.log4jV //https://github.com/apache/commons-logging/blob/0d4f2604ada038fd95e714d504d2278f1bd5814a/pom.xml#L486
+    val logkit = "logkit" % "logkit" % V.logkitV //https://github.com/apache/commons-logging/blob/0d4f2604ada038fd95e714d504d2278f1bd5814a/pom.xml#L492
+    val avalonLogging = "avalon-framework" % "avalon-framework" % V.avalonLoggingV //https://github.com/apache/commons-logging/blob/0d4f2604ada038fd95e714d504d2278f1bd5814a/pom.xml#L498
 
     val grizzledSlf4j =
       "org.clapper" %% "grizzled-slf4j" % V.grizzledSlf4j withSources () withJavadoc ()
@@ -174,6 +205,10 @@ object Deps {
 
     val newMicroPickle =
       Def.setting("com.lihaoyi" %%% "upickle" % V.newMicroPickleV)
+
+    val osgiFramework = "org.osgi" % "org.osgi.framework" % V.osgiFrameworkV // https://mvnrepository.com/artifact/org.osgi/org.osgi.framework,
+    val osgiJdbc = "org.osgi" % "org.osgi.service.jdbc" % V.osgiJdbcV // https://mvnrepository.com/artifact/org.osgi/org.osgi.service.jdbc
+    val osgiCore = "org.osgi" % "osgi.core" % V.osgiCoreV // https://mvnrepository.com/artifact/org.osgi/osgi.core,
 
     // parsing of CLI opts and args
     val scopt = "com.github.scopt" %% "scopt" % V.scoptV
@@ -205,8 +240,11 @@ object Deps {
     val pgEmbedded =
       "com.opentable.components" % "otj-pg-embedded" % V.pgEmbeddedV withSources () withJavadoc ()
 
-    val dropwizardMetrics =
+    val dropwizardMetricsCore =
       "io.dropwizard.metrics" % "metrics-core" % V.dropwizardMetricsV withSources () withJavadoc ()
+
+    val dropwizardMetricsHealthChecks = "io.dropwizard.metrics" % "metrics-healthchecks" % V.dropwizardMetricsV
+    val dropwizardMetricsJvm = "io.dropwizard.metrics" % "metrics-jvm" % V.dropwizardMetricsV // https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-jvm
 
     val zxingCore =
       "com.google.zxing" % "core" % V.zxingV withSources () withJavadoc ()
@@ -399,7 +437,7 @@ object Deps {
 
   def dbCommons = Def.setting {
     List(
-      Compile.dropwizardMetrics,
+      Compile.dropwizardMetricsCore,
       Compile.flyway,
       Compile.slick,
       Compile.logback,
@@ -442,14 +480,41 @@ object Deps {
     )
   }
 
+  /** Transitive dependencies needed for the oracleServer to build properly with jlink */
+  private val oracleServerTransitiveDeps = Vector(
+    //transitive deps needed for jlink
+    Compile.codehaus,
+    Compile.gson,
+
+    Compile.dropwizardMetricsHealthChecks,
+    Compile.dropwizardMetricsJvm,
+
+    //postgres transitive deps
+    Compile.jna,
+    Compile.waffleJna,
+    Compile.osgiCore,
+    Compile.osgiJdbc,
+    Compile.osgiFramework,
+
+    //logging transitive deps
+    Compile.log4j,
+    Compile.avalonLogging,
+    Compile.logkit,
+
+    //transitive javax deps
+    Compile.javaxServlet,
+    Compile.javaxMail,
+    Compile.javaxJms
+  )
+
   val oracleServer = Def.setting {
-    List(
+    Vector(
       Compile.newMicroPickle.value,
       Compile.logback,
       Compile.akkaActor,
       Compile.akkaHttp,
-      Compile.akkaSlf4j
-    )
+      Compile.akkaSlf4j,
+    ) ++ oracleServerTransitiveDeps
   }
 
   val eclairRpc = List(


### PR DESCRIPTION
This PR implements embedding a JRE in our `bitcoin-s-oracle-server.zip` artifact we build in #4304. This uses the [jlink](https://docs.oracle.com/en/java/javase/11/tools/jlink.html) to embed the JRE. This means a user will no longer have to manually install a JRE if they are running the artifact on their desktop. This provides a better UX for the end user, and allows us to control the runtime that the user is running on (i.e. we don't need to worry about ancient versions of java). 

As a by product of this, I had to manually go through our transitive dependencies and figure out which ones we need. I added the ones I believe we need into a `Deps.oracleServerTransitiveDeps`. 

There is also a new field called `Deps.oracleServerJlinkIgnore`. These are the transitive dependencies I'm ignoring for now. You'll see a lot of amazon related dependencies, and some other ones i'm unsure of what they do. The do not seem to affect running of the `bitcoin-s-oracle-server`

#### Resources

- [Jlink JEP](http://openjdk.java.net/jeps/282)
- [Sbt native packager jlink integration](https://www.scala-sbt.org/sbt-native-packager/archetypes/jlink_plugin.html?highlight=jdk#jlink-plugin)
- [Useful tutorial using jlink/sbt for a play app](https://dkovalenko.net/scala-sbt-jlink/)

