### PR TITLE
Remove explicit inclusion of jdk.unsupported

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -92,8 +92,7 @@ object CommonSettings {
   )
 
   lazy val jlinkModules = Seq(
-    "jdk.crypto.ec",
-    "jdk.unsupported"
+    "jdk.crypto.ec"
   )
 
   //these are java modules we do not need


### PR DESCRIPTION
This was fixed in the sbt native packager release 1.9.9 (#4317 )

https://github.com/sbt/sbt-native-packager/issues/1446