### PR TITLE
Add ProcessLogger to ProcessBuilder so that we capture logs from binaries

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/util/NativeProcessFactory.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/NativeProcessFactory.scala
@@ -4,7 +4,7 @@ import grizzled.slf4j.Logging
 
 import java.io.File
 import scala.concurrent.{ExecutionContext, Future}
-import scala.sys.process.{Process, ProcessBuilder}
+import scala.sys.process.{Process, ProcessBuilder, ProcessLogger}
 
 /** A trait that helps start bitcoind/eclair when it is started via bitcoin-s */
 trait NativeProcessFactory extends Logging {
@@ -35,7 +35,7 @@ trait NativeProcessFactory extends Logging {
         ()
       case None =>
         if (cmd.nonEmpty) {
-          val started = process.run()
+          val started = process.run(NativeProcessFactory.processLogger)
           processOpt = Some(started)
         } else {
           logger.warn("cmd not set, no binary started")
@@ -65,7 +65,10 @@ trait NativeProcessFactory extends Logging {
 
 }
 
-object NativeProcessFactory {
+object NativeProcessFactory extends Logging {
+
+  val processLogger: ProcessLogger =
+    ProcessLogger(logger.info(_), logger.error(_))
 
   def findExecutableOnPath(name: String): Option[File] =
     sys.env

--- a/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
@@ -55,7 +55,7 @@ class TorClient()(implicit
   private lazy val executable = TorClient.torBinaryFromResource(conf.torDir)
 
   /** The command to start the daemon on the underlying OS */
-  lazy val cmd: String = {
+  override lazy val cmd: String = {
 
     val args = Vector(
       "--ExitRelay 0", // ensure we aren't an exit relay


### PR DESCRIPTION
This will put logs from things like `tor` into `bitcoin-s.log`

That way we can get some observability for the binaries we are managing. 

```
[info] May 10 13:03:47.952 [notice] Tor 0.4.6.9 (git-ea2ada6d1459f829) running on Linux with Libevent 2.1.12-stable, OpenSSL 1.1.1m, Zlib 1.2.11, Liblzma N/A, Libzstd N/A and Glibc 2.31 as libc.
[info] May 10 13:03:47.952 [notice] Tor can't help you if you use it wrong! Learn how to be safe at https://www.torproject.org/download/download#warning
[info] May 10 13:03:47.952 [notice] Configuration file "/var/tmp/dist/tor/etc/tor/torrc" not present, using reasonable defaults.
[info] May 10 13:03:47.956 [notice] Opening Socks listener on 127.0.0.1:39798
[info] May 10 13:03:47.956 [notice] Opened Socks listener connection (ready) on 127.0.0.1:39798
[info] May 10 13:03:47.956 [notice] Opening Control listener on 127.0.0.1:29278
[info] May 10 13:03:47.956 [notice] Opened Control listener connection (ready) on 127.0.0.1:29278
```