### PR TITLE
Make all uint64 types from lnd a UInt64

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/lnd/LndModels.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/lnd/LndModels.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.commons.jsonmodels.lnd
 
 import org.bitcoins.core.currency.CurrencyUnit
+import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.ln.LnInvoice
 import org.bitcoins.core.protocol.ln.LnTag.PaymentHashTag
@@ -14,7 +15,7 @@ sealed abstract class LndModel
 case class AddInvoiceResult(
     rHash: PaymentHashTag,
     invoice: LnInvoice,
-    addIndex: Long,
+    addIndex: UInt64,
     paymentAddr: ByteVector)
     extends LndModel
 

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -393,6 +393,10 @@ object UInt32
     UInt32(bytes.toLong(signed = false, ordering = ByteOrdering.BigEndian))
   }
 
+  def apply(int: Int): UInt32 = {
+    apply(int.toLong)
+  }
+
   def apply(long: Long): UInt32 = {
     checkCached(long)
   }

--- a/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRemoteClientTest.scala
+++ b/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRemoteClientTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.lnd.rpc
 
 import lnrpc.Invoice.InvoiceState
 import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.ln.LnInvoice
 import org.bitcoins.core.protocol.ln.currency._
 import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
@@ -14,7 +15,7 @@ class LndRemoteClientTest extends RemoteLndFixture {
   it must "get info from lnd" in { lnd =>
     for {
       info <- lnd.getInfo
-    } yield assert(info.blockHeight >= 0)
+    } yield assert(info.blockHeight >= UInt32.zero)
   }
 
   it must "create an invoice using sats" in { lnd =>

--- a/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRpcClientPairTest.scala
+++ b/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRpcClientPairTest.scala
@@ -31,8 +31,8 @@ class LndRpcClientPairTest extends DualLndFixture {
       infoB <- lndB.getInfo
     } yield {
       assert(infoA.identityPubkey != infoB.identityPubkey)
-      assert(infoA.blockHeight >= 0)
-      assert(infoB.blockHeight >= 0)
+      assert(infoA.blockHeight >= UInt32.zero)
+      assert(infoB.blockHeight >= UInt32.zero)
     }
   }
 

--- a/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRpcClientTest.scala
+++ b/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRpcClientTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.lnd.rpc
 
 import lnrpc.Invoice.InvoiceState
 import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.ln.LnInvoice
 import org.bitcoins.core.protocol.ln.currency._
 import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
@@ -15,7 +16,7 @@ class LndRpcClientTest extends LndFixture {
   it must "get info from lnd" in { lnd =>
     for {
       info <- lnd.getInfo
-    } yield assert(info.blockHeight >= 0)
+    } yield assert(info.blockHeight >= UInt32.zero)
   }
 
   it must "create an invoice using sats" in { lnd =>

--- a/lnd-rpc/lnd-rpc.sbt
+++ b/lnd-rpc/lnd-rpc.sbt
@@ -10,10 +10,19 @@ CommonSettings.prodSettings
 
 enablePlugins(AkkaGrpcPlugin)
 
-// Disable deprecation warning otherwise protobuf deprecation warnings will cause errors
-Compile / scalacOptions += {
-  "-Wconf:cat=deprecation:site=lnrpc\\..*:silent,cat=deprecation:site=signrpc\\..*:silent,cat=deprecation:site=walletrpc\\..*:silent,cat=deprecation:site=routerrpc\\..*:silent,cat=deprecation:site=invoicesrpc\\..*:silent"
-}
+// Disable deprecation and unused imports warning otherwise generated files will cause errors
+Compile / scalacOptions ++= Seq(
+  "-Wconf:cat=deprecation:site=lnrpc\\..*:silent",
+  "-Wconf:cat=deprecation:site=signrpc\\..*:silent",
+  "-Wconf:cat=deprecation:site=walletrpc\\..*:silent",
+  "-Wconf:cat=deprecation:site=routerrpc\\..*:silent",
+  "-Wconf:cat=deprecation:site=invoicesrpc\\..*:silent",
+  "-Wconf:cat=unused-imports:site=lnrpc:silent",
+  "-Wconf:cat=unused-imports:site=signrpc:silent",
+  "-Wconf:cat=unused-imports:site=walletrpc:silent",
+  "-Wconf:cat=unused-imports:site=routerrpc:silent",
+  "-Wconf:cat=unused-imports:site=invoicesrpc:silent"
+)
 
 TaskKeys.downloadLnd := {
   val logger = streams.value.log

--- a/lnd-rpc/src/main/protobuf/invoicesrpc/invoices.proto
+++ b/lnd-rpc/src/main/protobuf/invoicesrpc/invoices.proto
@@ -6,6 +6,21 @@ package invoicesrpc;
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/invoicesrpc";
 
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  import: "org.bitcoins.lnd.rpc.LndUtils._"
+  scope: PACKAGE
+  field_transformations : [
+    {
+      when : {
+        type: TYPE_UINT64
+      }
+      set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt64' }}
+    }
+  ]
+};
+
 // Invoices is a service that can be used to create, accept, settle and cancel
 // invoices.
 service Invoices {

--- a/lnd-rpc/src/main/protobuf/invoicesrpc/invoices.proto
+++ b/lnd-rpc/src/main/protobuf/invoicesrpc/invoices.proto
@@ -17,6 +17,12 @@ option (scalapb.options) = {
         type: TYPE_UINT64
       }
       set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt64' }}
+    },
+    {
+      when : {
+        type: TYPE_UINT32
+      }
+      set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt32' }}
     }
   ]
 };

--- a/lnd-rpc/src/main/protobuf/lightning.proto
+++ b/lnd-rpc/src/main/protobuf/lightning.proto
@@ -4,6 +4,21 @@ package lnrpc;
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc";
 
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+    import: "org.bitcoins.lnd.rpc.LndUtils._"
+    scope: PACKAGE
+    field_transformations : [
+        {
+            when : {
+                type: TYPE_UINT64
+            }
+            set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt64' }}
+        }
+    ]
+};
+
 /*
  * Comments in this file will be directly parsed into the API
  * Documentation as descriptions of the associated method, message, or field.

--- a/lnd-rpc/src/main/protobuf/lightning.proto
+++ b/lnd-rpc/src/main/protobuf/lightning.proto
@@ -15,6 +15,12 @@ option (scalapb.options) = {
                 type: TYPE_UINT64
             }
             set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt64' }}
+        },
+        {
+            when : {
+                type: TYPE_UINT32
+            }
+            set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt32' }}
         }
     ]
 };

--- a/lnd-rpc/src/main/protobuf/routerrpc/router.proto
+++ b/lnd-rpc/src/main/protobuf/routerrpc/router.proto
@@ -17,6 +17,12 @@ option (scalapb.options) = {
         type: TYPE_UINT64
       }
       set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt64' }}
+    },
+    {
+      when : {
+        type: TYPE_UINT32
+      }
+      set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt32' }}
     }
   ]
 };

--- a/lnd-rpc/src/main/protobuf/routerrpc/router.proto
+++ b/lnd-rpc/src/main/protobuf/routerrpc/router.proto
@@ -6,6 +6,21 @@ package routerrpc;
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/routerrpc";
 
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  import: "org.bitcoins.lnd.rpc.LndUtils._"
+  scope: PACKAGE
+  field_transformations : [
+    {
+      when : {
+        type: TYPE_UINT64
+      }
+      set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt64' }}
+    }
+  ]
+};
+
 // Router is a service that offers advanced interaction with the router
 // subsystem of the daemon.
 service Router {

--- a/lnd-rpc/src/main/protobuf/signrpc/signer.proto
+++ b/lnd-rpc/src/main/protobuf/signrpc/signer.proto
@@ -4,6 +4,21 @@ package signrpc;
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/signrpc";
 
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  import: "org.bitcoins.lnd.rpc.LndUtils._"
+  scope: PACKAGE
+  field_transformations : [
+    {
+      when : {
+        type: TYPE_UINT64
+      }
+      set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt64' }}
+    }
+  ]
+};
+
 // Signer is a service that gives access to the signing functionality of the
 // daemon's wallet.
 service Signer {

--- a/lnd-rpc/src/main/protobuf/signrpc/signer.proto
+++ b/lnd-rpc/src/main/protobuf/signrpc/signer.proto
@@ -15,6 +15,12 @@ option (scalapb.options) = {
         type: TYPE_UINT64
       }
       set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt64' }}
+    },
+    {
+      when : {
+        type: TYPE_UINT32
+      }
+      set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt32' }}
     }
   ]
 };

--- a/lnd-rpc/src/main/protobuf/walletrpc/walletkit.proto
+++ b/lnd-rpc/src/main/protobuf/walletrpc/walletkit.proto
@@ -7,6 +7,21 @@ package walletrpc;
 
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/walletrpc";
 
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  import: "org.bitcoins.lnd.rpc.LndUtils._"
+  scope: PACKAGE
+  field_transformations : [
+    {
+      when : {
+        type: TYPE_UINT64
+      }
+      set : {[scalapb.field] {type : 'org.bitcoins.core.number.UInt64' }}
+    }
+  ]
+};
+
 // WalletKit is a service that gives access to the core functionalities of the
 // daemon's wallet.
 service WalletKit {

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndUtils.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndUtils.scala
@@ -5,11 +5,12 @@ import lnrpc.ChannelPoint.FundingTxid.FundingTxidBytes
 import lnrpc.{ChannelPoint, OutPoint}
 import org.bitcoins.commons.jsonmodels.lnd.TxDetails
 import org.bitcoins.core.currency.Satoshis
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.crypto._
+import scalapb.TypeMapper
 import scodec.bits._
 import signrpc.TxOut
 
@@ -90,6 +91,9 @@ trait LndUtils {
       label = details.label
     )
   }
+
+  implicit val uint64Mapper: TypeMapper[Long, UInt64] =
+    TypeMapper[Long, UInt64](UInt64.apply)(_.toBigInt.longValue)
 }
 
 object LndUtils extends LndUtils

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndUtils.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndUtils.scala
@@ -32,11 +32,10 @@ trait LndUtils {
                       ScriptPubKey.fromAsmBytes(txOut.pkScript))
 
   implicit def outpointToTxOutPoint(op: OutPoint): TransactionOutPoint =
-    TransactionOutPoint(DoubleSha256DigestBE(op.txidStr),
-                        UInt32(op.outputIndex))
+    TransactionOutPoint(DoubleSha256DigestBE(op.txidStr), op.outputIndex)
 
   implicit def txOutpointToOutpoint(outpoint: TransactionOutPoint): OutPoint =
-    OutPoint(outpoint.txId.bytes, outpoint.txIdBE.hex, outpoint.vout.toInt)
+    OutPoint(outpoint.txId.bytes, outpoint.txIdBE.hex, outpoint.vout)
 
   // If other kinds of Iterables are needed, there's a fancy thing to do
   // that is done all over the Seq code using params and an implicit CanBuildFrom
@@ -59,14 +58,13 @@ trait LndUtils {
   implicit def channelPointToOutpoint(
       channelPoint: ChannelPoint): TransactionOutPoint = {
     val txIdBytes = channelPoint.fundingTxid.fundingTxidBytes.get
-    TransactionOutPoint(DoubleSha256Digest(txIdBytes),
-                        UInt32(channelPoint.outputIndex))
+    TransactionOutPoint(DoubleSha256Digest(txIdBytes), channelPoint.outputIndex)
   }
 
   implicit def outPointToChannelPoint(
       outPoint: TransactionOutPoint): ChannelPoint = {
     val txId = FundingTxidBytes(outPoint.txId.bytes)
-    ChannelPoint(txId, outPoint.vout.toInt)
+    ChannelPoint(txId, outPoint.vout)
   }
 
   implicit def LndTransactionToTxDetails(
@@ -94,6 +92,9 @@ trait LndUtils {
 
   implicit val uint64Mapper: TypeMapper[Long, UInt64] =
     TypeMapper[Long, UInt64](UInt64.apply)(_.toBigInt.longValue)
+
+  implicit val uint32Mapper: TypeMapper[Int, UInt32] =
+    TypeMapper[Int, UInt32](UInt32.apply)(_.toBigInt.intValue)
 }
 
 object LndUtils extends LndUtils

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/internal/LndRouterClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/internal/LndRouterClient.scala
@@ -30,7 +30,7 @@ trait LndRouterClient { self: LndRpcClient =>
       routeHints: Vector[LnRoute]): Future[QueryRoutesResponse] = {
     val hopHints = routeHints.map { hint =>
       HopHint(hint.pubkey.hex,
-              hint.shortChannelID.u64.toLong,
+              hint.shortChannelID.u64,
               hint.feeBaseMsat.msat.toLong.toInt,
               hint.feePropMilli.u32.toInt,
               hint.cltvExpiryDelta)

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/internal/LndRouterClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/internal/LndRouterClient.scala
@@ -11,6 +11,7 @@ import lnrpc.{
   RouteHint
 }
 import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.ln.LnInvoice
 import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
 import org.bitcoins.core.protocol.ln.node.NodeId
@@ -31,9 +32,9 @@ trait LndRouterClient { self: LndRpcClient =>
     val hopHints = routeHints.map { hint =>
       HopHint(hint.pubkey.hex,
               hint.shortChannelID.u64,
-              hint.feeBaseMsat.msat.toLong.toInt,
-              hint.feePropMilli.u32.toInt,
-              hint.cltvExpiryDelta)
+              UInt32(hint.feeBaseMsat.msat.toLong),
+              hint.feePropMilli.u32,
+              UInt32(hint.cltvExpiryDelta))
     }
     val request =
       QueryRoutesRequest(pubKey = node.pubKey.hex,

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -21,6 +21,7 @@ object Deps {
     val slf4j = "1.7.36"
     val spray = "1.3.6"
     val zeromq = "0.5.2"
+    val scalapb = "0.11.10"
     val akkav = "10.2.9"
     val playv = "2.9.2"
     val akkaStreamv = "2.6.19"
@@ -97,6 +98,9 @@ object Deps {
 
     val zeromq =
       "org.zeromq" % "jeromq" % V.zeromq withSources () withJavadoc ()
+
+    val scalapb =
+      "com.thesamet.scalapb" %% "scalapb-runtime" % V.scalapb % "protobuf"
 
     val akkaHttp =
       "com.typesafe.akka" %% "akka-http" % V.akkav withSources () withJavadoc ()
@@ -549,6 +553,7 @@ object Deps {
   }
 
   val lndRpc = List(
+    Compile.scalapb,
     Compile.akkaHttp,
     Compile.akkaHttp2,
     Compile.akkaStream,

--- a/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestUtil.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit, Satoshis}
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.core.protocol.transaction.TransactionOutPoint
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
@@ -139,7 +140,7 @@ trait LndRpcTestUtil extends Logging {
     for {
       blockCount <- bitcoind.getBlockCount
       info <- client.getInfo
-    } yield info.blockHeight == blockCount
+    } yield info.blockHeight == UInt32(blockCount)
 
   /** Shuts down an lnd daemon and the bitcoind daemon it is associated with
     */


### PR DESCRIPTION
This makes it so any uint64 from the lnd rpc is converted into a bitcoin-s `UInt64` instead of a `Long`. The encoding would still work fine previously (https://github.com/scalapb/ScalaPB/issues/1368) but sometimes the actual number wasn't useful. This also fixes some potential errors where we would call `longExact` on some values and it couldn't be converted into a `Long` and thus throw an error.