### PR TITLE
2022 05 11 tor race condition

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/util/NativeProcessFactory.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/NativeProcessFactory.scala
@@ -29,9 +29,9 @@ trait NativeProcessFactory extends Logging {
   /** Starts the binary by spinning up a new process */
   def startBinary(): Future[Unit] = Future {
     processOpt match {
-      case Some(_) =>
+      case Some(p) =>
         //don't do anything as it is already started
-        logger.debug(s"Binary was already started!")
+        logger.info(s"Binary was already started! process=$p")
         ()
       case None =>
         if (cmd.nonEmpty) {

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -169,7 +169,14 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val callbacksF =
       chainApiF.map(chainApi => buildNeutrinoCallbacks(wsQueue, chainApi))
 
-    val startedNodeF = configuredNodeF.flatMap(_.start())
+    val startedNodeF = {
+      //can't start connecting to peers until tor is done starting
+      for {
+        _ <- startedTorConfigF
+        started <- configuredNodeF.flatMap(_.start())
+      } yield started
+    }
+
     val startedWalletF = configuredWalletF.flatMap(_.start())
     val startedDLCNodeF = dlcNodeF
       .flatMap(_.start())

--- a/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
@@ -127,7 +127,12 @@ object TorClient extends Logging {
       //set files as executable
       torBundle.executables.foreach { f =>
         val executable = datadir.resolve(f)
-        executable.toFile.setExecutable(true)
+        logger.info(s"executable=${executable.toAbsolutePath}")
+        val isExecutable = executable.toFile.setExecutable(true)
+        if (!isExecutable) {
+          sys.error(
+            s"Could not make file=${executable.toAbsolutePath} executable")
+        }
       }
 
       // write geoip files
@@ -139,7 +144,6 @@ object TorClient extends Logging {
 
       logger.info(
         s"Using prepackaged Tor from bitcoin-s resources, $executableFileName")
-
       executableFileName
     }
   }

--- a/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
@@ -127,7 +127,6 @@ object TorClient extends Logging {
       //set files as executable
       torBundle.executables.foreach { f =>
         val executable = datadir.resolve(f)
-        logger.info(s"executable=${executable.toAbsolutePath}")
         val isExecutable = executable.toFile.setExecutable(true)
         if (!isExecutable) {
           sys.error(

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -121,7 +121,7 @@ case class TorAppConfig(
           torLogFile.toFile.delete()
         }
         val client = createClient
-        Thread.sleep(10000)
+
         for {
           _ <- client.startBinary()
           _ = Runtime.getRuntime.addShutdownHook(new Thread() {

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -105,7 +105,7 @@ case class TorAppConfig(
     * place for our node.
     */
   override def start(): Future[Unit] = {
-    if (torProvided) {
+    val f = if (torProvided) {
       logger.info(s"Tor provided to us, skipping start")
       Future.unit
     } else {
@@ -121,6 +121,7 @@ case class TorAppConfig(
           torLogFile.toFile.delete()
         }
         val client = createClient
+        Thread.sleep(10000)
         for {
           _ <- client.startBinary()
           _ = Runtime.getRuntime.addShutdownHook(new Thread() {
@@ -147,6 +148,8 @@ case class TorAppConfig(
         Future.unit
       }
     }
+    f.failed.foreach(err => logger.error("Error starting TorAppConfig", err))
+    f
   }
 
   override def stop(): Future[Unit] = {


### PR DESCRIPTION
Fixes a race condition between starting tor and starting our node. We weren't waiting until tor was fully started before we tried connecting to peers. This lead to errors that looked like this when starting with tor. This bug was introduced on #4294 

```
2022-05-10T23:56:58UTC ERROR [TorController] Cannot connect to Tor control address localhost/127.0.0.1:6368
java.net.ConnectException: Connection refused
	at java.base/sun.nio.ch.Net.pollConnect(Native Method)
	at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:672)
	at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:946)
	at akka.io.TcpOutgoingConnection$$anonfun$connecting$1.$anonfun$applyOrElse$4(TcpOutgoingConnection.scala:111)
	at akka.io.TcpOutgoingConnection.akka$io$TcpOutgoingConnection$$reportConnectFailure(TcpOutgoingConnection.scala:53)
	at akka.io.TcpOutgoingConnection$$anonfun$connecting$1.applyOrElse(TcpOutgoingConnection.scala:111)
	at akka.actor.Actor.aroundReceive(Actor.scala:537)
	at akka.actor.Actor.aroundReceive$(Actor.scala:535)
	at akka.io.TcpConnection.aroundReceive(TcpConnection.scala:33)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:580)
	at akka.actor.ActorCell.invoke(ActorCell.scala:548)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
```