### PR TITLE
Validate `bitcoin-s.wallet.walletName` config option

### DIFF
--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
@@ -214,4 +214,18 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
       appConfig1.toBip39KeyManager
     }
   }
+
+  it must "validate a wallet name" in {
+    assert(KeyManagerAppConfig.validateWalletName(""))
+    assert(KeyManagerAppConfig.validateWalletName("old-wallet"))
+
+    //weird whitespace
+    assert(!KeyManagerAppConfig.validateWalletName("       "))
+    assert(!KeyManagerAppConfig.validateWalletName(" old-wallet"))
+
+    //no non alpha-numeric
+    assert(!KeyManagerAppConfig.validateWalletName("@@@"))
+    assert(!KeyManagerAppConfig.validateWalletName("old-wallet."))
+
+  }
 }

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
@@ -30,7 +30,10 @@ case class KeyManagerAppConfig(
   lazy val networkParameters: NetworkParameters = chain.network
 
   lazy val walletNameOpt: Option[String] = {
-    config.getStringOrNone(s"bitcoin-s.wallet.walletName")
+    val nameOpt = config.getStringOrNone(s"bitcoin-s.wallet.walletName")
+    require(nameOpt.map(KeyManagerAppConfig.validateWalletName).getOrElse(true),
+            s"Invalid wallet name, only alphanumeric with _, got=$nameOpt")
+    nameOpt
   }
 
   lazy val seedFolder: Path = baseDatadir
@@ -215,4 +218,10 @@ object KeyManagerAppConfig extends AppConfigFactory[KeyManagerAppConfig] {
   override def fromDatadir(datadir: Path, confs: Vector[Config])(implicit
       ec: ExecutionContext): KeyManagerAppConfig =
     KeyManagerAppConfig(datadir, confs)
+
+  def validateWalletName(walletName: String): Boolean = {
+    walletName.forall { char =>
+      char.isLetterOrDigit || char == '-' || char == '_'
+    }
+  }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -404,5 +404,4 @@ object WalletAppConfig
       ()
     }
   }
-
 }


### PR DESCRIPTION
This came up in #4323 . This makes sure that the walletName is alpha numeric and only contains `-` or `_`

https://github.com/bitcoin-s/bitcoin-s/pull/4323#issuecomment-1121402512