### PR TITLE
Enable LauncherJarPlugin on oracleServer/appServer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, "2022-05-17-launcher-jar-plugin"]
     tags: ["*"]
   release:
     types: [ published ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main, "2022-05-17-launcher-jar-plugin"]
+    branches: [master, main]
     tags: ["*"]
   release:
     types: [ published ]

--- a/build.sbt
+++ b/build.sbt
@@ -393,7 +393,9 @@ lazy val oracleServer = project
     dlcOracle,
     serverRoutes
   )
-  .enablePlugins(JavaAppPackaging, DockerPlugin, JlinkPlugin)
+  .enablePlugins(JavaAppPackaging, DockerPlugin, JlinkPlugin, 
+    //needed for windows, else we have the 'The input line is too long` on windows OS
+    LauncherJarPlugin)
 
 lazy val oracleServerTest = project
   .in(file("app/oracle-server-test"))
@@ -433,7 +435,9 @@ lazy val appServer = project
     feeProvider,
     zmq
   )
-  .enablePlugins(JavaAppPackaging, DockerPlugin, JlinkPlugin)
+  .enablePlugins(JavaAppPackaging, DockerPlugin, JlinkPlugin,
+    //needed for windows, else we have the 'The input line is too long` on windows OS
+    LauncherJarPlugin)
 
 lazy val appServerTest = project
   .in(file("app/server-test"))


### PR DESCRIPTION
This fixes bugs on windows for `oracleServer`/`appServer` where the classpath is too long resulting in errors that look like this

>“The input line is too long. The syntax of the command is incorrect.”

This PR adds the `LauncherJarPlugin` to `oracleServer`/`appServer` to fix this.

https://www.scala-sbt.org/sbt-native-packager/recipes/longclasspath.html