### PR TITLE
Upgrade sttp to 3.6.1

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -2167,11 +2167,11 @@ object ConsoleCli {
     }
 
     Try {
-      import com.softwaremill.sttp._
-      implicit val backend: SttpBackend[Id, Nothing] =
+      import sttp.client3._
+      implicit val backend: SttpBackend[Identity, Any] =
         HttpURLConnectionBackend()
       val request =
-        sttp
+        basicRequest
           .post(uri"http://$host:${config.rpcPort}/")
           .contentType("application/json")
           .auth
@@ -2184,7 +2184,7 @@ object ConsoleCli {
             up.write(paramsWithID)
           }
       debug(s"HTTP request: $request")
-      val response = request.send()
+      val response = request.send(backend)
 
       debug(s"HTTP response:")
       debug(response)

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -68,7 +68,7 @@ object Deps {
     val scalaJsStubsV = "1.1.0"
     // CLI deps
     val scoptV = "4.0.1"
-    val sttpV = "1.7.2"
+    val sttpV = "3.6.1"
     val codehausV = "3.1.7"
     val scalaJsTimeV = "2.3.0"
     val zxingV = "3.4.1"
@@ -218,7 +218,7 @@ object Deps {
     val scopt = "com.github.scopt" %% "scopt" % V.scoptV
 
     // HTTP client lib
-    val sttp = "com.softwaremill.sttp" %% "core" % V.sttpV
+    val sttp = "com.softwaremill.sttp.client3" %% "core" % V.sttpV
 
     val scalaCollectionCompat =
       "org.scala-lang.modules" %% "scala-collection-compat" % V.scalaCollectionCompatV


### PR DESCRIPTION
https://github.com/softwaremill/sttp/releases/tag/v3.6.1

In this release notes it does say 

>sttp-client now requires at least Java 11

Since we do ship by default with java 17 (#4316 ) with `bitcoin-s-cli` i think this should be ok 