### PR TITLE
Upgrade to slick to 3.4.0-M1

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -39,7 +39,7 @@ object Deps {
     val flywayV = "8.5.9"
     val postgresV = "42.3.4"
     val akkaActorV = akkaStreamv
-    val slickV = "3.3.3"
+    val slickV = "3.4.0-M1"
     val sqliteV = "3.36.0.3"
 
     val scalameterV = "0.17"


### PR DESCRIPTION
This gives us access to slick compiled with Scala 2.13.7. This should fix android issues detailed on the Scala 2.13.7 release

- https://github.com/slick/slick/blob/main/project/Dependencies.scala#L9
- https://github.com/scala/scala/releases/tag/v2.13.7

