### PR TITLE
Downgrade slick to fix jlink build

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -39,7 +39,7 @@ object Deps {
     val flywayV = "8.5.9"
     val postgresV = "42.3.4"
     val akkaActorV = akkaStreamv
-    val slickV = "3.4.0-M1"
+    val slickV = "3.3.3"
     val sqliteV = "3.36.0.3"
 
     val scalameterV = "0.17"


### PR DESCRIPTION
This undoes #4342 because we can't get jlink to work until we have access to java 18 on CI (#4344 )