### PR TITLE
Remove exception when we have zero relevant outputs

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -566,9 +566,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
       transaction: Transaction,
       blockHashOpt: Option[DoubleSha256DigestBE]): Future[
     Seq[SpendingInfoDb]] = {
-    require(
-      outputsWithIndex.nonEmpty,
-      s"Cannot add utxos to wallet if we have none! got=${outputsWithIndex}")
+
     val spks = outputsWithIndex.map(_.output.scriptPubKey).toVector
 
     val addressDbsF: Future[Vector[AddressDb]] = {


### PR DESCRIPTION
fixes #4351 

I'm not sure why this `require()` was added in #4219 