### PR TITLE
Add isStandard to Address

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32mTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/Bech32mTest.scala
@@ -210,6 +210,21 @@ class Bech32mTest extends BitcoinSUnitTest {
     }
   }
 
+  it must "validate addresses as non standard" in {
+    // Taproot address with invalid x-only pubkey
+    assert(
+      !Bech32mAddress
+        .fromString(
+          "bc1pvkpqgqe7g6sl4rxwhpqp8nlz6dmv5uk47k2nr9yhh9ds32ny49cqdcghmx")
+        .isStandard)
+
+    // segwit v2 address
+    assert(
+      !Bech32mAddress
+        .fromString("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs")
+        .isStandard)
+  }
+
   @tailrec
   private def pickReplacementChar(oldChar: Char): Char = {
     val rand = Math.abs(Random.nextInt())


### PR DESCRIPTION
This should help give warning to users if they are providing an address that is currently anyone-can-spend or invalid. 