### PR TITLE
Switch base docker image to ubuntu to get docker working again

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -201,7 +201,7 @@ object CommonSettings {
   lazy val dockerSettings: Seq[Setting[_]] = {
     Vector(
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
-      dockerBaseImage := "openjdk:17-slim",
+      dockerBaseImage := "ubuntu",
       dockerRepository := Some("bitcoinscala"),
       //set the user to be 'bitcoin-s' rather than
       //the default provided by sbt native packager


### PR DESCRIPTION
fixes #4366 

For some reason, it appears a combination of #4338 / #4332 broke our docker builds on the backend. This means our `Dockerfile` in our main repo wasn't working anymore as reported by a user. 

We don't need to specify a docker image that contains a jre anymore (we were previously using `openjdk:17-slim`) since we now bring our own jre to the party.

I spent a considerable amount of time trying to get an `alpine` image working, but failed to do so https://github.com/sbt/sbt-native-packager/issues/1506

This does shave ~100mb off of our base docker image size.

Locally built `bitcoin-s-server`

![Screenshot from 2022-06-04 17-49-23](https://user-images.githubusercontent.com/3514957/172027805-eb82bc80-008f-4fb0-b546-e5dc211175be.png)

Last image pushed to dockerhub for `bitcoin-s-server`

![Screenshot from 2022-06-04 17-50-14](https://user-images.githubusercontent.com/3514957/172027816-955172f6-8a9a-41fc-9409-c7a332a286b6.png)

Image built pre-jlink

![Screenshot from 2022-06-04 17-51-09](https://user-images.githubusercontent.com/3514957/172027856-8991318e-2dbe-4f0a-9ddf-13d03227b34e.png)

This PR shaves ~50mb off of our initial docker image size _before_ we incorporated the jlink plugin.