### PR TITLE
Make flyway protected so other apps can access it

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -15,7 +15,7 @@ trait DbManagement extends Logging {
 
   import scala.language.implicitConversions
 
-  private lazy val flyway: Flyway = {
+  protected lazy val flyway: Flyway = {
     val module = appConfig.moduleName
 
     val driverName = appConfig.driver match {


### PR DESCRIPTION
This would be nice for TBC, as well as makes sure anyone can use the various functions that flyway lets us do