### PR TITLE
Revert docker image, implement workarounds for arm64 machines and java

### DIFF
--- a/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
+++ b/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
@@ -6,3 +6,42 @@ if [[ "$OS" == "OSX" ]]; then
 fi
 
 chmod +x jre/bin/java #make sure java is executable
+
+
+if [[ "$OS" == "OSX" ]]; then
+  #mac doesn't allow random binaries to be executable
+  #remove the quarantine attribute so java is executable on mac
+  xattr -d com.apple.quarantine jre/bin/java
+fi
+chmod +x jre/bin/java #make sure java is executable
+
+chip=$(uname -m)
+
+if [[ $chip == "arm64" || $chip == "aarch64" ]]; then
+  # This is needed as a hack for now
+  # This replaces overrides how sbt native packager finds java
+  # on users machines when the user is running arm64.
+  # This is needed because we don't have access to a CI environment with arm64
+  # and the jlink jre we ship is broken because its built against x86
+  # this simply copies the 'get_java` bash function and removes the first
+  # check to see if there is a bundled_jvm built by jlink if the detected
+  # computer arch is arm64 or aarch64. This means a user if they are running
+  # arm64 / aarch64 will need to provide their own jre
+  # see https://github.com/bitcoin-s/bitcoin-s/issues/4369!
+  echo "Removing ARM jre as its not linked correctly, see https://github.com/bitcoin-s/bitcoin-s/issues/4369!"
+  get_java_no_jlink() {
+    if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+      echo "$JAVA_HOME/bin/java"
+    else
+      echo "java"
+    fi
+  }
+
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi

--- a/app/server/src/universal/wallet-server-extra-startup-script.sh
+++ b/app/server/src/universal/wallet-server-extra-startup-script.sh
@@ -4,5 +4,34 @@ if [[ "$OS" == "OSX" ]]; then
   #remove the quarantine attribute so java is executable on mac
   xattr -d com.apple.quarantine jre/bin/java
 fi
-
 chmod +x jre/bin/java #make sure java is executable
+
+chip=$(uname -m)
+
+if [[ $chip == "arm64" || $chip == "aarch64" ]]; then
+  # This is needed as a hack for now
+  # This replaces overrides how sbt native packager finds java
+  # on users machines when the user is running arm64.
+  # This is needed because we don't have access to a CI environment with arm64
+  # and the jlink jre we ship is broken because its built against x86
+  # this simply copies the 'get_java` bash function and removes the first
+  # check to see if there is a bundled_jvm built by jlink if the detected
+  # computer arch is arm64 or aarch64. This means a user if they are running
+  # arm64 / aarch64 will need to provide their own jre
+  echo "Removing ARM jre as its not linked correctly, see https://github.com/bitcoin-s/bitcoin-s/issues/4369!"
+  get_java_no_jlink() {
+    if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+      echo "$JAVA_HOME/bin/java"
+    else
+      echo "java"
+    fi
+  }
+
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -201,7 +201,7 @@ object CommonSettings {
   lazy val dockerSettings: Seq[Setting[_]] = {
     Vector(
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
-      dockerBaseImage := "ubuntu",
+      dockerBaseImage := "openjdk:17-slim",
       dockerRepository := Some("bitcoinscala"),
       //set the user to be 'bitcoin-s' rather than
       //the default provided by sbt native packager


### PR DESCRIPTION
This is a workaround for #4369 

When introducing `jlink` in #4322 we broke arm64 related builds that are produced on github actions. This is because `jlink` builds a `jre` that is OS _and_ architecture specific to the host machine.

As documented in #4369, `jlink` expects an `x86` linker to be available when attempting to run `java`. Since this is not available on `arm64` platforms, java fails to start.

This PR implements a work around by modifying the `bitcoin-s-server` and `bitcoin-s-oracle-server` bash startup scripts. 

If we detect the user is running on `arm64` or `aarch64`, we define a new bash function called `get_java_no_jlink`. This function is equivalent to the bash script that sbt native packager generates with one exception, it removes the `jlink` check.

This is the function that is generated by sbt native packagers startup script by default:

```bash
# Detect if we should use JAVA_HOME or just try PATH.
get_java_cmd() {
  # High-priority override for Jlink images
  if [[ -n "$bundled_jvm" ]];  then
    echo "$bundled_jvm/bin/java"
  elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
    echo "$JAVA_HOME/bin/java"
  else
    echo "java"
  fi
}
```

My PR removes these two lines in the new `get_java_no_jlink` function 

```bash
  # High-priority override for Jlink images
  if [[ -n "$bundled_jvm" ]];  then
    echo "$bundled_jvm/bin/java"
```

As a by product, this PR also reverts #4367 and reverts our base docker image to be `openjdk:17-slim`. This way our docker containers can just work :tm: out of the box. This is because the docker container provides java, so we don't need to rely on our `jre` built by `jlink`.

The only thing that still isn't working on this PR is users that have an m1 mac and do not have a pre-existing java installed on their system. They will fail to run servers. The best we can do at this time is to ask them to install java out of band. As discussed with @rorp , in this case i think the only thing we can do is install an arm64 java manually on CI and package with our `bitcoin-s-server-mac` zips that we ship. We would need to now make a `bitcoin-s-server-mac-x86` build and `bitcoin-s-server-mac-arm64` build and equivalents for the `bitcoin-s-oracle-server`. 