### PR TITLE
Add TLVs defined in BOLT 4

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/LnMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/LnMessageTest.scala
@@ -39,7 +39,7 @@ class LnMessageTest extends BitcoinSUnitTest {
       Try(LnMessageFactory(InitTLV)(hex"00100000000001012a030104")).isSuccess)
 
     assert(Try(LnMessageFactory(InitTLV)(hex"00100000000001")).isFailure)
-    assert(Try(LnMessageFactory(InitTLV)(hex"00100000000002012a")).isFailure)
+    assert(Try(LnMessageFactory(InitTLV)(hex"001000000000ca012a")).isFailure)
     assert(
       Try(LnMessageFactory(InitTLV)(hex"001000000000010101010102")).isFailure)
   }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
@@ -47,6 +47,34 @@ class TLVTest extends BitcoinSUnitTest {
     }
   }
 
+  "AmtToForwardTLV" must "have serialization symmetry" in {
+    forAll(TLVGen.amtToForwardTLV) { tlv =>
+      assert(AmtToForwardTLV(tlv.bytes) == tlv)
+      assert(TLV(tlv.bytes) == tlv)
+    }
+  }
+
+  "OutgoingCLTVValueTLV" must "have serialization symmetry" in {
+    forAll(TLVGen.outgoingCLTVValueTLV) { tlv =>
+      assert(OutgoingCLTVValueTLV(tlv.bytes) == tlv)
+      assert(TLV(tlv.bytes) == tlv)
+    }
+  }
+
+  "ShortChannelIdTLV" must "have serialization symmetry" in {
+    forAll(TLVGen.shortChannelIdTLV) { tlv =>
+      assert(ShortChannelIdTLV(tlv.bytes) == tlv)
+      assert(TLV(tlv.bytes) == tlv)
+    }
+  }
+
+  "PaymentDataTLV" must "have serialization symmetry" in {
+    forAll(TLVGen.paymentDataTLV) { tlv =>
+      assert(PaymentDataTLV(tlv.bytes) == tlv)
+      assert(TLV(tlv.bytes) == tlv)
+    }
+  }
+
   "PingTLV" must "have serialization symmetry" in {
     forAll(TLVGen.pingTLV) { ping =>
       assert(PingTLV(ping.bytes) == ping)

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -66,6 +66,7 @@ sealed abstract class Number[T <: Number[T]]
   def &(num: T): T = apply(underlying & num.underlying)
   def unary_- : T = apply(-underlying)
 
+  def truncatedBytes: ByteVector = bytes.dropWhile(_ == 0x00)
 }
 
 /** Represents a signed number in our number system
@@ -349,6 +350,10 @@ object UInt16
     UInt16(bytes.toLong(signed = false, ordering = ByteOrdering.BigEndian))
   }
 
+  def fromTruncatedBytes(bytes: ByteVector): UInt16 = {
+    fromBytes(bytes.padLeft(2))
+  }
+
   def apply(long: Long): UInt16 = {
     checkCached(long)
   }
@@ -391,6 +396,10 @@ object UInt32
       bytes.size <= 4,
       "UInt32 byte array was too large, got: " + BytesUtil.encodeHex(bytes))
     UInt32(bytes.toLong(signed = false, ordering = ByteOrdering.BigEndian))
+  }
+
+  def fromTruncatedBytes(bytes: ByteVector): UInt32 = {
+    fromBytes(bytes.padLeft(4))
   }
 
   def apply(int: Int): UInt32 = {
@@ -438,6 +447,10 @@ object UInt64
   override def fromBytes(bytes: ByteVector): UInt64 = {
     require(bytes.size <= 8)
     UInt64(NumberUtil.toUnsignedInt(bytes))
+  }
+
+  def fromTruncatedBytes(bytes: ByteVector): UInt64 = {
+    fromBytes(bytes.padLeft(8))
   }
 
   def apply(long: Long): UInt64 = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/LnMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/LnMessage.scala
@@ -43,7 +43,8 @@ object LnMessage extends Factory[LnMessage[TLV]] {
         throw new IllegalArgumentException(s"Parsed unknown TLV $unknown")
       case _: DLCSetupTLV | _: DLCSetupPieceTLV | _: InitTLV | _: DLCOracleTLV |
           _: ErrorTLV | _: PingTLV | _: PongTLV | _: ContractInfoV0TLV |
-          _: ContractInfoV1TLV | _: PayoutCurvePieceTLV =>
+          _: ContractInfoV1TLV | _: PayoutCurvePieceTLV | _: AmtToForwardTLV |
+          _: OutgoingCLTVValueTLV | _: ShortChannelIdTLV | _: PaymentDataTLV =>
         ()
     }
 

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCDataHandler.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCDataHandler.scala
@@ -32,7 +32,9 @@ class DLCDataHandler(dlcWalletApi: DLCWalletApi, connectionHandler: ActorRef)
 
   private def handleTLVMessage(lnMessage: LnMessage[TLV]): Future[Unit] = {
     lnMessage.tlv match {
-      case msg @ (_: UnknownTLV | _: DLCOracleTLV | _: DLCSetupPieceTLV) =>
+      case msg @ (_: UnknownTLV | _: DLCOracleTLV | _: DLCSetupPieceTLV |
+          _: ShortChannelIdTLV | _: OutgoingCLTVValueTLV | _: AmtToForwardTLV |
+          _: PaymentDataTLV) =>
         log.error(s"Received unhandled message $msg")
         Future.unit
       case _: InitTLV =>

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCParsingTestVector.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCParsingTestVector.scala
@@ -551,7 +551,8 @@ object DLCParsingTestVector extends TestVectorParser[DLCParsingTestVector] {
 
         DLCMessageTestVector(LnMessage(tlv), "oracle_attestment_v0", fields)
       case _: UnknownTLV | _: ErrorTLV | _: PingTLV | _: PongTLV | _: InitTLV |
-          _: SendOfferTLV =>
+          _: SendOfferTLV | _: AmtToForwardTLV | _: OutgoingCLTVValueTLV |
+          _: PaymentDataTLV | _: ShortChannelIdTLV =>
         throw new IllegalArgumentException(
           s"DLCParsingTestVector is only defined for DLC messages and TLVs, got $tlv")
     }

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
@@ -13,6 +13,7 @@ import org.bitcoins.core.util.sorted._
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto.ECPrivateKey
 import org.bitcoins.testkitcore.dlc.DLCTestUtil
+import org.bitcoins.testkitcore.gen.ln._
 import org.scalacheck.Gen
 
 trait TLVGen {
@@ -50,6 +51,39 @@ trait TLVGen {
       data <- NumberGenerator.bytevector
     } yield {
       ErrorTLV(id, data)
+    }
+  }
+
+  def amtToForwardTLV: Gen[AmtToForwardTLV] = {
+    for {
+      msat <- LnCurrencyUnitGen.milliSatoshis
+    } yield {
+      AmtToForwardTLV(msat)
+    }
+  }
+
+  def outgoingCLTVValueTLV: Gen[OutgoingCLTVValueTLV] = {
+    for {
+      uint32 <- NumberGenerator.uInt32s
+    } yield {
+      OutgoingCLTVValueTLV(uint32)
+    }
+  }
+
+  def shortChannelIdTLV: Gen[ShortChannelIdTLV] = {
+    for {
+      scid <- LnRouteGen.shortChannelId
+    } yield {
+      ShortChannelIdTLV(scid)
+    }
+  }
+
+  def paymentDataTLV: Gen[PaymentDataTLV] = {
+    for {
+      secretTag <- LnInvoiceGen.secret
+      msat <- LnCurrencyUnitGen.milliSatoshis
+    } yield {
+      PaymentDataTLV(secretTag.secret, msat)
     }
   }
 
@@ -568,6 +602,10 @@ trait TLVGen {
       errorTLV,
       pingTLV,
       pongTLV,
+      amtToForwardTLV,
+      outgoingCLTVValueTLV,
+      shortChannelIdTLV,
+      paymentDataTLV,
       oracleEventV0TLV,
       eventDescriptorTLV,
       oracleAnnouncementV0TLV,


### PR DESCRIPTION
This adds the `AmtToForwardTLV` `OutgoingCLTVValueTLV` `ShortChannelIdTLV` and `PaymentDataTLV` tlvs defined in BOLT 4

https://github.com/lightning/bolts/blob/master/04-onion-routing.md