### PR TITLE
Refactor `WitnessVersion.rebuild()` to be `Either[ScriptError,ScriptPubKey]`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -415,9 +415,10 @@ sealed abstract class ScriptInterpreter {
           if (witness.stack.size != 2) {
             Left(ScriptErrorWitnessProgramMisMatch)
           } else {
-            Right(
-              (witness.stack.map(ScriptConstant(_)),
-               WitnessVersion0.rebuild(witness, program).get))
+            for {
+              rebuilt <- WitnessVersion0.rebuild(witness, program)
+              r <- Right((witness.stack.map(ScriptConstant(_)), rebuilt))
+            } yield r
           }
         case 32 =>
           //p2wsh
@@ -425,10 +426,9 @@ sealed abstract class ScriptInterpreter {
             Left(ScriptErrorWitnessProgramWitnessEmpty)
           else {
             WitnessVersion0.rebuild(witness, program) match {
-              case Success(rebuilt) =>
+              case Right(rebuilt) =>
                 Right((witness.stack.tail.map(ScriptConstant(_)), rebuilt))
-              case Failure(_) =>
-                Left(ScriptErrorWitnessProgramMisMatch)
+              case Left(err) => Left(err)
             }
           }
         case _ =>


### PR DESCRIPTION
This makes the Taproot implementation for `WitenssVersion1.rebuild()` easier in #3769  This is because Taproot has many more validation steps to check, and different error codes that can be returned if a certain piece of validation fails.

With segwit v0, there were only a few ways validation can fail.

Changing the return type on this method allows us to be much more expressive of _why_ validation failed for rebuild a witness program.

