### PR TITLE
Remove carve out for protoc on aarch64 now that the akka grpc plugin has been updated

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -56,17 +56,6 @@ object CommonSettings {
     Test / console / scalacOptions ++= (Compile / console / scalacOptions).value,
     Test / scalacOptions ++= testCompilerOpts(scalaVersion.value),
     licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
-    //you need to build protoc manually to get it working on the new
-    //mac m1 chip. For instructions on how to do so see
-    //see: https://github.com/scalapb/ScalaPB/issues/1024
-    PB.protocExecutable := (
-      if (protocbridge.SystemDetector.detectedClassifier() == "osx-aarch_64")
-        file(
-          "/usr/local/bin/protoc"
-        ) // to change if needed, this is where protobuf manual compilation put it for me
-      else
-        PB.protocExecutable.value
-    ),
     assembly / test := {}
   )
 


### PR DESCRIPTION
Reverts #3013 as this is now supported natively.

Would like confirmation from @GreyMcCarthy that his intellij can compile now with this change