### PR TITLE
2022 06 13 taprootspk xonlypubkey

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
@@ -41,7 +41,7 @@ class ScriptPubKeyTest extends BitcoinSUnitTest {
   }
 
   it must "construct valid witness spk v1 for taproot" in {
-    val pubKey = CryptoGenerators.schnorrPublicKey.sample.get.toXOnly
+    val pubKey = CryptoGenerators.xOnlyPubKey.sample.get
     val witSPKV1 = TaprootScriptPubKey.fromPubKey(pubKey)
     assert(witSPKV1.pubKey == pubKey)
   }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
@@ -41,7 +41,7 @@ class ScriptPubKeyTest extends BitcoinSUnitTest {
   }
 
   it must "construct valid witness spk v1 for taproot" in {
-    val pubKey = CryptoGenerators.schnorrPublicKey.sample.get
+    val pubKey = CryptoGenerators.schnorrPublicKey.sample.get.toXOnly
     val witSPKV1 = TaprootScriptPubKey.fromPubKey(pubKey)
     assert(witSPKV1.pubKey == pubKey)
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1347,7 +1347,7 @@ case class TaprootScriptPubKey(override val asm: Vector[ScriptToken])
   override def witnessProgram: Seq[ScriptToken] = asm.tail.tail
   override val scriptType: ScriptType = ScriptType.WITNESS_V1_TAPROOT
 
-  val pubKey: SchnorrPublicKey = SchnorrPublicKey.fromBytes(asm(2).bytes)
+  val pubKey: XOnlyPubKey = XOnlyPubKey.fromBytes(asm(2).bytes)
 }
 
 object TaprootScriptPubKey extends ScriptFactory[TaprootScriptPubKey] {
@@ -1358,13 +1358,13 @@ object TaprootScriptPubKey extends ScriptFactory[TaprootScriptPubKey] {
                 s"Given asm was not a P2WSHWitnessSPKV0, got $asm")
   }
 
-  def apply(schnorrPubKey: SchnorrPublicKey): TaprootScriptPubKey = {
+  def apply(schnorrPubKey: XOnlyPubKey): TaprootScriptPubKey = {
     fromPubKey(schnorrPubKey)
   }
 
-  def fromPubKey(schnorrPubKey: SchnorrPublicKey): TaprootScriptPubKey = {
-    val pushOp = BitcoinScriptUtil.calculatePushOp(schnorrPubKey.bytes)
-    val asm = OP_1 +: (pushOp ++ Vector(ScriptConstant(schnorrPubKey.bytes)))
+  def fromPubKey(xOnlyPubKey: XOnlyPubKey): TaprootScriptPubKey = {
+    val pushOp = BitcoinScriptUtil.calculatePushOp(xOnlyPubKey.bytes)
+    val asm = OP_1 +: (pushOp ++ Vector(ScriptConstant(xOnlyPubKey.bytes)))
     fromAsm(asm)
   }
 
@@ -1375,7 +1375,7 @@ object TaprootScriptPubKey extends ScriptFactory[TaprootScriptPubKey] {
     WitnessScriptPubKey.isValidAsm(asm) &&
     asmBytes.size == 34 &&
     //have to make sure we have a valid xonly pubkey, not just 32 bytes
-    SchnorrPublicKey.fromBytesT(asm(2).bytes).isSuccess
+    XOnlyPubKey.fromBytesT(asm(2).bytes).isSuccess
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1358,14 +1358,18 @@ object TaprootScriptPubKey extends ScriptFactory[TaprootScriptPubKey] {
                 s"Given asm was not a P2WSHWitnessSPKV0, got $asm")
   }
 
-  def apply(schnorrPubKey: XOnlyPubKey): TaprootScriptPubKey = {
-    fromPubKey(schnorrPubKey)
+  def apply(xOnlyPubKey: XOnlyPubKey): TaprootScriptPubKey = {
+    fromPubKey(xOnlyPubKey)
   }
 
   def fromPubKey(xOnlyPubKey: XOnlyPubKey): TaprootScriptPubKey = {
     val pushOp = BitcoinScriptUtil.calculatePushOp(xOnlyPubKey.bytes)
     val asm = OP_1 +: (pushOp ++ Vector(ScriptConstant(xOnlyPubKey.bytes)))
     fromAsm(asm)
+  }
+
+  def fromPubKey(schnorrPublicKey: SchnorrPublicKey): TaprootScriptPubKey = {
+    fromPubKey(schnorrPublicKey.toXOnly)
   }
 
   def isValidAsm(asm: Seq[ScriptToken]): Boolean = {

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
@@ -238,6 +238,8 @@ case class ECPrivateKey(bytes: ByteVector)
     SchnorrPublicKey(publicKey.bytes)
   }
 
+  def toXOnly: XOnlyPubKey = schnorrPublicKey.toXOnly
+
   def schnorrNonce: SchnorrNonce = {
     SchnorrNonce(publicKey.bytes)
   }

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
@@ -23,7 +23,8 @@ import org.bitcoins.crypto.{
   Sha256Digest,
   Sha256DigestBE,
   Sha256Hash160Digest,
-  SipHashKey
+  SipHashKey,
+  XOnlyPubKey
 }
 import org.scalacheck.Gen
 import scodec.bits.{BitVector, ByteVector}
@@ -157,6 +158,8 @@ sealed abstract class CryptoGenerators {
 
   def schnorrPublicKey: Gen[SchnorrPublicKey] =
     publicKey.map(_.schnorrPublicKey)
+
+  def xOnlyPubKey: Gen[XOnlyPubKey] = publicKey.map(_.toXOnly)
 
   /** Generate a sequence of private keys
     * @param num maximum number of keys to generate

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -360,7 +360,7 @@ sealed abstract class ScriptGenerators {
   def witnessScriptPubKeyV1: Gen[(TaprootScriptPubKey, Seq[ECPrivateKey])] = {
     for {
       priv <- CryptoGenerators.privateKey
-      pubKey = priv.schnorrPublicKey.toXOnly
+      pubKey = priv.toXOnly
     } yield {
       (TaprootScriptPubKey.fromPubKey(pubKey), Vector(priv))
     }

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -360,7 +360,7 @@ sealed abstract class ScriptGenerators {
   def witnessScriptPubKeyV1: Gen[(TaprootScriptPubKey, Seq[ECPrivateKey])] = {
     for {
       priv <- CryptoGenerators.privateKey
-      pubKey = priv.schnorrPublicKey
+      pubKey = priv.schnorrPublicKey.toXOnly
     } yield {
       (TaprootScriptPubKey.fromPubKey(pubKey), Vector(priv))
     }


### PR DESCRIPTION
Adds ontop of #4387 

Modifies `TaprootScriptPubKey.pubkey` to return `XOnlyPubKey`

Also adds `ECPrivateKey.toXOnly`

The equivalent data structure in bitcoin core

https://github.com/bitcoin/bitcoin/blob/66e3b16b8b1033414f843058f360e22b725d89c5/src/script/standard.h#L119