### PR TITLE
Add `TaprootWitness`, new methods to `XOnlyPubKey`

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/SerializedTransaction.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/SerializedTransaction.scala
@@ -85,6 +85,10 @@ object SerializedTransaction {
                                        pubKey = None,
                                        signature = None,
                                        stack = Some(p2wsh.stack.toVector.tail)))
+
+      case taprootWitness: TaprootWitness =>
+        throw new UnsupportedOperationException(
+          s"Taproot not supported, got=$taprootWitness")
     }
   }
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -10,7 +10,8 @@ import org.bitcoins.core.protocol.script.{
   EmptyScriptWitness,
   P2WPKHWitnessV0,
   P2WSHWitnessV0,
-  ScriptSignature
+  ScriptSignature,
+  TaprootWitness
 }
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.protocol.{Bech32Address, BitcoinAddress, P2PKHAddress}
@@ -643,7 +644,7 @@ class WalletRpcTest extends BitcoindFixturesCachedPairV21 {
               case p2wpkh: P2WPKHWitnessV0 =>
                 assert(p2wpkh.pubKey == partialSig.pubKey)
                 assert(p2wpkh.signature == partialSig.signature)
-              case _: P2WSHWitnessV0 | EmptyScriptWitness =>
+              case _: P2WSHWitnessV0 | EmptyScriptWitness | _: TaprootWitness =>
                 fail("Expected P2WPKH")
             }
         }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/TaprootWitnessTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/TaprootWitnessTest.scala
@@ -1,0 +1,74 @@
+package org.bitcoins.core.protocol.script
+
+import org.bitcoins.crypto.{Sha256Digest, XOnlyPubKey}
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+
+class TaprootWitnessTest extends BitcoinSUnitTest {
+
+  behavior of "TaprootWitness"
+
+  //from this test case in script_assets.json with this comment 'tapscript/input80limit'
+  //in script_assets.json
+  val controlBlockHex =
+    "c1a7957acbaaf7b444c53d9e0c9436e8a8a3247fd515095d66ddf6201918b40a3668f9a4ccdffcf778da624dca2dd" +
+      "a0b08e763ec52fd4ad403ec7563a3504d0cc168b9a77a410029e01dac89567c9b2e6cd726e840351df3f2f58fefe976200a19244150d04153" +
+      "909f660184d656ee95fa7bf8e1d4ec83da1fca34f64bc279b76d257ec623e08baba2cfa4ea9e99646e88f1eb1668c00c0f15b7443c8ab8348" +
+      "1611cc3ae85eb89a7bfc40067eb1d2e6354a32426d0ce710e88bc4cc0718b99c325509c9d02a6a980d675a8969be10ee9bef82cafee2fc913" +
+      "475667ccda37b1bc7f13f64e56c449c532658ba8481631c02ead979754c809584a875951619cec8fb040c33f06468ae0266cd8693d6a64cea" +
+      "5912be32d8de95a6da6300b0c50fdcd6001ea41126e7b7e5280d455054a816560028f5ca53c9a50ee52f10e15c5337315bad1f5277acb109a" +
+      "1418649dc6ead2fe14699742fee7182f2f15e54279c7d932ed2799d01d73c97e68bbc94d6f7f56ee0a80efd7c76e3169e10d1a1ba3b5f1eb0" +
+      "2369dc43af687461c7a2a3344d13eb5485dca29a67f16b4cb988923060fd3b65d0f0352bb634bcc44f2fe668836dcd0f604150049835135dc" +
+      "4b4fbf90fb334b3938a1f137eb32f047c65b85e6c1173b890b6d0162b48b186d1f1af8521945924ac8ac8efec321bf34f1d4b3d4a304a1031" +
+      "3052c652d53f6ecb8a55586614e8950cde9ab6fe8e22802e93b3b9139112250b80ebc589aba231af535bb20f7eeec2e412f698c17f3fdc0a2" +
+      "e20924a5e38b21a628a9e3b2a61e35958e60c7f5087c"
+
+  val controlBlock = ControlBlock.fromHex(controlBlockHex)
+
+  val merkleRootHex =
+    "c5c62d7fc595ba5fbe61602eb1a29e2e4763408fe1e2b161beb7cb3c71ebcad9"
+
+  val merkleRoot = Sha256Digest.fromHex(merkleRootHex)
+
+  val tapLeafHash = Sha256Digest.fromHex(
+    "8d76c657582b87b087f36579a9ea78816d7e2a94098bc3e3c6113ed4b6315bb4")
+
+  val taprootSPK = TaprootScriptPubKey.fromHex(
+    "2251201ebe8b90363bd097aa9f352c8b21914e1886bc09fe9e70c09f33ef2d2abdf4bc")
+
+  val internalPubKey: XOnlyPubKey = XOnlyPubKey.fromHex(
+    "a7957acbaaf7b444c53d9e0c9436e8a8a3247fd515095d66ddf6201918b40a36")
+  it must "compute a tap leaf hash correctly" in {
+    //from this test case in script_assets.json with this comment 'tapscript/input80limit'
+    val expected =
+      "8d76c657582b87b087f36579a9ea78816d7e2a94098bc3e3c6113ed4b6315bb4"
+    val asmHex =
+      "7520c7b5db9562078049719228db2ac80cb9643ec96c8055aa3b29c2c03d4d99edb0ac"
+    val spk = ScriptPubKey.fromAsmHex(asmHex)
+    assert(asmHex == spk.asmHex)
+    val hash = TaprootScriptPath.computeTapleafHash(0xc0.toByte, spk)
+    assert(hash.hex == expected)
+  }
+
+  it must "compute a merkle root for a tapscript tree" in {
+    //expected from the 'compute a tap leaf hash correctly' test case referenced above
+
+    val merkleRoot =
+      TaprootScriptPath.computeTaprootMerkleRoot(controlBlock, tapLeafHash)
+    assert(merkleRoot.hex == merkleRootHex)
+  }
+
+  it must "compute a tap tweak correctly" in {
+    val expected =
+      "4680a8777b651ac25f6da13f97f2bf530341b637da3f6295f2893e9d41b281aa"
+    val tapTweakHash = internalPubKey.computeTapTweakHash(Some(merkleRoot))
+    assert(tapTweakHash.hex == expected)
+  }
+  it must "verify a taproot commitment" in {
+    val result =
+      TaprootScriptPath.verifyTaprootCommitment(controlBlock = controlBlock,
+                                                program = taprootSPK,
+                                                tapLeafHash = tapLeafHash)
+    assert(result)
+  }
+
+}

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
@@ -344,6 +344,10 @@ class RawTxSignerTest extends BitcoinSUnitTest {
                   p2wpkh.signature == LowRDummyECDigitalSignature
                 case EmptyScriptWitness =>
                   true
+
+                case taprootWitness: TaprootWitness =>
+                  throw new UnsupportedOperationException(
+                    s"Taproot not supported, got=$taprootWitness")
               }
             )
         }

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -135,6 +135,9 @@ class SignerTest extends BitcoinSUnitTest {
                 case p2wpkh: P2WPKHWitnessV0 => Vector(p2wpkh.signature)
                 case p2wsh: P2WSHWitnessV0   => p2wsh.signatures
                 case EmptyScriptWitness      => Vector.empty
+                case taprootWitness: TaprootWitness =>
+                  throw new UnsupportedOperationException(
+                    s"Taproot not supported, got=$taprootWitness")
               }
             }
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
@@ -78,6 +78,9 @@ object TxSigComponent {
         }
       case _: ScriptWitnessV0 =>
         unsignedWtx
+      case t: TaprootWitness =>
+        throw new UnsupportedOperationException(
+          s"Taproot not supported, got=$t")
     }
   }
 
@@ -201,14 +204,15 @@ object TxSigComponent {
   }
 
   def getScriptWitness(
-      txSigComponent: TxSigComponent): Option[ScriptWitnessV0] = {
+      txSigComponent: TxSigComponent): Option[ScriptWitness] = {
     txSigComponent.transaction match {
       case _: NonWitnessTransaction => None
       case wtx: WitnessTransaction =>
         val witness = wtx.witness.witnesses(txSigComponent.inputIndex.toInt)
         witness match {
-          case EmptyScriptWitness       => None
-          case witness: ScriptWitnessV0 => Some(witness)
+          case EmptyScriptWitness             => None
+          case witness: ScriptWitnessV0       => Some(witness)
+          case taprootWitness: TaprootWitness => Some(taprootWitness)
         }
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
@@ -1,0 +1,39 @@
+package org.bitcoins.core.protocol.script
+
+import org.bitcoins.crypto.{Factory, NetworkElement, XOnlyPubKey}
+import scodec.bits.ByteVector
+
+/** Control block as defined by BIP341
+  *
+  * The last stack element is called the control block c, and must have length 33 + 32m,
+  * for a value of m that is an integer between 0 and 128[6], inclusive. Fail if it does not have such a length.
+  *
+  * @see https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules
+  */
+case class ControlBlock(bytes: ByteVector) extends NetworkElement {
+  //invariants from: https://github.com/bitcoin/bitcoin/blob/37633d2f61697fc719390767aae740ece978b074/src/script/interpreter.cpp#L1835
+  require(bytes.size >= TaprootScriptPath.TAPROOT_CONTROL_BASE_SIZE)
+  require(bytes.size <= TaprootScriptPath.TAPROOT_CONTROL_MAX_SIZE)
+  require(
+    (bytes.size - TaprootScriptPath.TAPROOT_CONTROL_BASE_SIZE) % TaprootScriptPath.TAPROOT_CONTROL_NODE_SIZE == 0)
+
+  /** Let p = c[1:33] and let P = lift_x(int(p)) where lift_x and [:] are defined as in BIP340. Fail if this point is not on the curve.
+    */
+  def p: XOnlyPubKey = {
+    XOnlyPubKey.fromBytes(bytes.slice(1, 33))
+  }
+
+  val leafVersion: Byte =
+    (bytes.head & TaprootScriptPath.TAPROOT_LEAF_MASK).toByte
+
+  val isTapLeafMask: Boolean = {
+    (bytes.head & TaprootScriptPath.TAPROOT_LEAF_MASK).toByte == TaprootScriptPath.TAPROOT_LEAF_TAPSCRIPT
+  }
+}
+
+object ControlBlock extends Factory[ControlBlock] {
+
+  override def fromBytes(bytes: ByteVector): ControlBlock = {
+    new ControlBlock(bytes)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -7,15 +7,7 @@ import org.bitcoins.core.serializers.script.{
   ScriptParser
 }
 import org.bitcoins.core.util.{BitcoinScriptUtil, BytesUtil}
-import org.bitcoins.crypto.{
-  CryptoUtil,
-  ECDigitalSignature,
-  ECPublicKey,
-  ECPublicKeyBytes,
-  EmptyDigitalSignature,
-  Factory,
-  NetworkElement
-}
+import org.bitcoins.crypto._
 import scodec.bits.ByteVector
 
 /** Created by chris on 11/10/16.
@@ -173,6 +165,8 @@ object P2WSHWitnessV0 {
 
 object ScriptWitness extends Factory[ScriptWitness] {
 
+  val empty: EmptyScriptWitness.type = EmptyScriptWitness
+
   override def fromBytes(bytes: ByteVector): ScriptWitness = {
     RawScriptWitnessParser.read(bytes)
   }
@@ -206,5 +200,215 @@ object ScriptWitness extends Factory[ScriptWitness] {
           P2WSHWitnessV0(spk, t)
       }
     }
+  }
+}
+
+sealed trait TaprootWitness extends ScriptWitness {
+  override def bytes: ByteVector = RawScriptWitnessParser.write(this)
+}
+
+object TaprootWitness {
+
+  def fromStack(stack: Vector[ByteVector]): TaprootWitness = {
+    if (stack.length == 1) TaprootKeyPath.fromStack(stack)
+    else TaprootScriptPath(stack)
+  }
+}
+
+/** Spending a taproot output via the key path spend */
+case class TaprootKeyPath(
+    signature: SchnorrDigitalSignature,
+    hashType: HashType)
+    extends TaprootWitness {
+  override val stack: Vector[ByteVector] = Vector(signature.bytes)
+}
+
+object TaprootKeyPath {
+
+  def fromStack(vec: Vector[ByteVector]): TaprootKeyPath = {
+    require(
+      vec.length == 1,
+      s"Taproot keypath can only have one stack element, got=${vec.length}")
+
+    val sigBytes = vec.head
+
+    val keyPath = if (sigBytes.length == 64) {
+      //means SIGHASH_ALL is implicitly encoded
+      //see: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#Common_signature_message
+      val sig = SchnorrDigitalSignature.fromBytes(sigBytes)
+      TaprootKeyPath(sig, HashType.sigHashAll)
+    } else if (sigBytes.length == 65) {
+      val sig = SchnorrDigitalSignature.fromBytes(sigBytes.dropRight(1))
+      val hashType = HashType.fromByte(sigBytes.last)
+      TaprootKeyPath(sig, hashType)
+    } else {
+      sys.error(
+        s"Unknown sig bytes length, should be 64 or 65, got=${sigBytes.length}")
+    }
+
+    keyPath
+  }
+
+  def isValid(stack: Vector[ByteVector]): Boolean = {
+    stack.length == 1 && (stack.length == 64 || stack.head.length == 65)
+  }
+}
+
+/** Spending a taproot output via the script path */
+case class TaprootScriptPath(stack: Vector[ByteVector]) extends TaprootWitness {
+  require(TaprootScriptPath.isValid(stack),
+          s"Invalid witness stack for TaprootScriptPath, got=$stack")
+
+  val controlBlock: ControlBlock = {
+    if (stack.headOption.map(_.head) == TaprootScriptPath.annexOpt) {
+      //If there are at least two witness elements, and the first byte of the last element is 0x50[4],
+      // this last element is called annex a[5] and is removed from the witness stack.
+      // The annex (or the lack of thereof) is always covered by the signature and contributes to transaction weight,
+      // but is otherwise ignored during taproot validation.
+      //see: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules
+      ControlBlock.fromBytes(stack(1))
+    } else {
+      ControlBlock.fromBytes(stack.head)
+    }
+  }
+
+  //  require(
+  //    controlBlock.length >= 33 && controlBlock.length < 33 + (32 * 128),
+  //    s"Control block length is wrong, got=${controlBlock.length}, max=${33 + (32 * 128)}")
+
+  /** If there are at least two witness elements, and the first byte of the last element is 0x50[4],
+    * this last element is called annex a[5] and is removed from the witness stack.
+    * The annex (or the lack of thereof) is always covered by the signature and contributes to transaction weight,
+    * but is otherwise ignored during taproot validation.
+    */
+  def annexOpt: Option[ByteVector] = {
+    if (stack.headOption.map(_.head) == TaprootScriptPath.annexOpt) {
+      Some(stack.head)
+    } else {
+      None
+    }
+  }
+
+  /** Call the second-to-last stack element s, the script
+    */
+  def script: ScriptPubKey = {
+    annexOpt match {
+      case Some(_) =>
+        ScriptPubKey.fromAsmBytes(stack(1))
+      case None =>
+        val spk = ScriptPubKey.fromAsmBytes(stack(1))
+        spk
+    }
+
+  }
+
+  /** Let p = c[1:33] and let P = lift_x(int(p)) where lift_x and [:] are defined as in BIP340. Fail if this point is not on the curve.
+    */
+  def p: XOnlyPubKey = controlBlock.p
+}
+
+object TaprootScriptPath {
+
+  final val annex: Byte = 0x50
+
+  final val annexOpt: Option[Byte] = Some(annex)
+
+  final val TAPROOT_CONTROL_BASE_SIZE: Byte = 33
+  final val TAPROOT_CONTROL_NODE_SIZE: Byte = 32
+  final val TAPROOT_CONTROL_MAX_NODE_COUNT: Int = 128
+
+  final val TAPROOT_CONTROL_MAX_SIZE: Int = {
+    TAPROOT_CONTROL_BASE_SIZE + TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT
+  }
+
+  final val TAPROOT_LEAF_MASK: Byte = 0xfe.toByte
+  final val TAPROOT_LEAF_TAPSCRIPT: Byte = 0xc0.toByte
+
+  def isValid(stack: Vector[ByteVector]): Boolean = {
+    if (stack.length >= 2) {
+      val controlBlock = {
+        if (stack.headOption.map(_.head) == annexOpt) {
+          //If there are at least two witness elements, and the first byte of the last element is 0x50[4],
+          // this last element is called annex a[5] and is removed from the witness stack.
+          // The annex (or the lack of thereof) is always covered by the signature and contributes to transaction weight,
+          // but is otherwise ignored during taproot validation.
+          //see: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules
+          stack(1)
+        } else {
+          stack.head
+        }
+      }
+
+      val m = controlBlock.drop(33).length / 32.0
+      if (m >= 0 && m <= 128) {
+        val pubKeyBytes = controlBlock.slice(1, 33)
+        // if not whole, we do not have correct # of bytes for control block
+        m.isWhole && SchnorrPublicKey.fromBytesOpt(pubKeyBytes).isDefined
+      } else {
+        false
+      }
+    } else {
+      false
+    }
+  }
+
+  def fromStack(stack: Vector[ByteVector]): TaprootScriptPath =
+    TaprootScriptPath(stack)
+
+  def verifyTaprootCommitment(
+      controlBlock: ControlBlock,
+      program: TaprootScriptPubKey,
+      tapLeafHash: Sha256Digest): Boolean = {
+    val internalPubKey = controlBlock.p
+    val merkleRoot = computeTaprootMerkleRoot(controlBlock, tapLeafHash)
+
+    val parity = (controlBlock.bytes.head & 1) == 1
+    program.pubKey.checkTapTweak(internal = internalPubKey,
+                                 merkleRootOpt = Some(merkleRoot),
+                                 parity = parity)
+  }
+
+  /** Computes the hash of the script that is a leaf in the tapscript tree
+    * @param leafVersion
+    * @param spk
+    * @see https://github.com/bitcoin/bitcoin/blob/37633d2f61697fc719390767aae740ece978b074/src/script/interpreter.cpp#L1828
+    * @return
+    */
+  def computeTapleafHash(leafVersion: Byte, spk: ScriptPubKey): Sha256Digest = {
+    val bytes =
+      ByteVector.fromByte(leafVersion) ++ spk.bytes
+    CryptoUtil.taggedSha256(bytes, "TapLeaf")
+  }
+
+  /** Computes the merkle root of a tapscript tree
+    * @param controlBlock
+    * @param tapLeafHash
+    * @see https://github.com/bitcoin/bitcoin/blob/37633d2f61697fc719390767aae740ece978b074/src/script/interpreter.cpp#L1833
+    * @return
+    */
+  def computeTaprootMerkleRoot(
+      controlBlock: ControlBlock,
+      tapLeafHash: Sha256Digest): Sha256Digest = {
+    val pathLen =
+      (controlBlock.bytes.size - TaprootScriptPath.TAPROOT_CONTROL_BASE_SIZE) / TaprootScriptPath.TAPROOT_CONTROL_NODE_SIZE
+    var k = tapLeafHash
+    var i = 0
+    while (i < pathLen) {
+      val startIdx =
+        TaprootScriptPath.TAPROOT_CONTROL_BASE_SIZE + (TaprootScriptPath.TAPROOT_CONTROL_NODE_SIZE * i)
+      val endIdx = startIdx + TaprootScriptPath.TAPROOT_CONTROL_NODE_SIZE
+      val node = controlBlock.bytes.slice(startIdx, endIdx)
+      if (k.hex.compareTo(node.toHex) < 0) {
+        k = hashTapBranch(k.bytes ++ node)
+      } else {
+        k = hashTapBranch(node ++ k.bytes)
+      }
+      i += 1
+    }
+    k
+  }
+
+  private def hashTapBranch(bytes: ByteVector): Sha256Digest = {
+    CryptoUtil.taggedSha256(bytes, "TapBranch")
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -1771,6 +1771,9 @@ object FundingSignaturesV0TLV extends TLVFactory[FundingSignaturesV0TLV] {
         case EmptyScriptWitness =>
           throw new IllegalArgumentException(s"Invalid witness: $stack")
         case witness: ScriptWitnessV0 => witness
+        case taprootWitness: TaprootWitness =>
+          throw new IllegalArgumentException(
+            s"Invalid witness, taproot not supported in DLC spec, got=$taprootWitness")
       }
     }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
@@ -194,6 +194,9 @@ object TxUtil {
             wtx.witness.witnesses(index) match {
               case EmptyScriptWitness   => None
               case wit: ScriptWitnessV0 => Some(wit)
+              case taprootWitness: TaprootWitness =>
+                throw new UnsupportedOperationException(
+                  s"Taproot not supported, got=$taprootWitness")
             }
         }
 

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -418,6 +418,9 @@ case class PSBT(
       case p2wsh: P2WSHWitnessV0 =>
         val newElement = InputPSBTRecord.WitnessScript(p2wsh.redeemScript)
         InputPSBTMap(previousElements :+ newElement)
+      case taprootWitness: TaprootWitness =>
+        throw new UnsupportedOperationException(
+          s"Taproot not supported, got=$taprootWitness")
       case EmptyScriptWitness =>
         throw new IllegalArgumentException(
           s"Invalid scriptWitness given, got: $scriptWitness")
@@ -523,6 +526,9 @@ case class PSBT(
         OutputPSBTMap(
           outputMap.filterRecords(PSBTOutputKeyId.WitnessScriptKeyId) :+
             OutputPSBTRecord.WitnessScript(p2wsh.redeemScript))
+      case taprootWitness: TaprootWitness =>
+        throw new UnsupportedOperationException(
+          s"Taproot not supported, got=$taprootWitness")
       case EmptyScriptWitness =>
         throw new IllegalArgumentException(
           s"Invalid scriptWitness given, got: $scriptWitness")

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -295,7 +295,8 @@ object BitcoinSigner extends SignerUtils {
                   case None      => wtx
                 }
 
-              case _: P2WPKHWitnessV0 | _: P2WSHWitnessV0 => wtx
+              case _: P2WPKHWitnessV0 | _: P2WSHWitnessV0 | _: TaprootWitness =>
+                wtx
             }
         }
       case _: ScriptPubKey => tx

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputInfo.scala
@@ -164,6 +164,9 @@ object InputInfo {
             getPreImagesAndCondPath(p2wsh.scriptSignature)
           case EmptyScriptWitness =>
             getPreImagesAndCondPath(txIn.scriptSignature)
+          case taprootWitness: TaprootWitness =>
+            throw new UnsupportedOperationException(
+              s"Taproot not supported, got=$taprootWitness")
         }
     }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/KeyParity.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/KeyParity.scala
@@ -2,7 +2,10 @@ package org.bitcoins.crypto
 
 import scodec.bits.ByteVector
 
-sealed trait KeyParity extends NetworkElement
+sealed trait KeyParity extends NetworkElement {
+  def isOdd: Boolean = this == OddParity
+  def isEven: Boolean = this == EvenParity
+}
 
 object KeyParity extends Factory[KeyParity] {
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/XOnlyPubKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/XOnlyPubKey.scala
@@ -22,7 +22,49 @@ case class XOnlyPubKey(bytes: ByteVector) extends NetworkElement {
     SchnorrPublicKey(bytes)
   }
 
+  def publicKey: ECPublicKey = schnorrPublicKey.publicKey
+
   def coord: CurveCoordinate = CurveCoordinate(bytes)
+
+  /** @see https://github.com/bitcoin/bitcoin/blob/3340d46cd363e568ce842b2a9930e30902d150ca/src/pubkey.cpp#L227
+    * @see https://github.com/bitcoin-core/secp256k1/blob/9a5a87e0f1276e0284446af1172056ea4693737f/src/modules/extrakeys/main_impl.h#L151
+    * @param pubKey the internal tapscript pubkey
+    * @param merkleRootOpt the merkle root of the tapscript tree, if empty means we have no scripts in the tapscript tree
+    * @param parity the expected parity of the public key reproduced
+    * @return
+    */
+  def checkTapTweak(
+      internal: XOnlyPubKey,
+      merkleRootOpt: Option[Sha256Digest],
+      parity: Boolean): Boolean = {
+    // Q = point_add(lift_x(pubkey), point_mul(G, t))
+    val tweaked = internal.computeTapTweakHash(merkleRootOpt)
+    val fe = FieldElement.fromBytes(tweaked.bytes)
+    val multi = CryptoParams.getG.multiply(fe)
+    val add = internal.publicKey.add(multi)
+    this == add.toXOnly && add.parity.isOdd == parity
+  }
+
+  /** @see https://github.com/bitcoin/bitcoin/blob/5174a139c92c1238f9700d06e362dc628d81a0a9/src/pubkey.cpp#L216
+    * @param merkleRootOpt if merkle root is empty we have no scripts.
+    * The actual tweak does not matter, but follow BIP341 here to
+    *
+    * @return
+    */
+  def computeTapTweakHash(merkleRootOpt: Option[Sha256Digest]): Sha256Digest = {
+    merkleRootOpt match {
+      case Some(merkleRoot) =>
+        tapTweakHash(bytes ++ merkleRoot.bytes)
+      case None =>
+        // We have no scripts. The actual tweak does not matter, but follow BIP341 here to
+        // allow for reproducible tweaking.
+        tapTweakHash(bytes)
+    }
+  }
+
+  private def tapTweakHash(bytes: ByteVector): Sha256Digest = {
+    CryptoUtil.taggedSha256(bytes, "TapTweak")
+  }
 }
 
 object XOnlyPubKey extends Factory[XOnlyPubKey] {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1419,6 +1419,9 @@ abstract class DLCWallet
                       case EmptyScriptWitness =>
                         throw new RuntimeException(
                           "Script witness cannot be empty")
+                      case taprootWitness: TaprootWitness =>
+                        throw new UnsupportedOperationException(
+                          s"Taproot not supported, got=$taprootWitness")
                       case witness: ScriptWitnessV0 => (input.outPoint, witness)
                     }
                   case None => throw new RuntimeException("")

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
@@ -719,6 +719,9 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
                       case EmptyScriptWitness =>
                         throw new RuntimeException(
                           "Script witness cannot be empty")
+                      case taprootWitness: TaprootWitness =>
+                        throw new UnsupportedOperationException(
+                          s"Taproot not supported, got=$taprootWitness")
                       case witness: ScriptWitnessV0 => (input.outPoint, witness)
                     }
                   case None => throw new RuntimeException("")

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -371,6 +371,9 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
                 witnessScript match {
                   case EmptyScriptWitness =>
                     throw new RuntimeException("Script witness cannot be empty")
+                  case taprootWitness: TaprootWitness =>
+                    throw new UnsupportedOperationException(
+                      s"Taproot not supported, got=$taprootWitness")
                   case witness: ScriptWitnessV0 =>
                     (input.outPoint, witness)
                 }


### PR DESCRIPTION
Pulls `TaprootWitness`, and various other methods from #3769 with the hope that this will make #3769 easier to review when it is time to merge.

There are many places in the codebase where we had pattern match exhaustiveness errors, I will go back and correct these when I start to implement signing. For now i'm just trying to implement verification of a taproot output.

The methods tested in `TaprootWitnessTest` are tested against a special branch of bitcoin core where i print out bitcoin core's results, so I'm pretty certain they are correct: https://github.com/christewart/bitcoin/tree/2022-06-12-taproot-sig-serialization

The hard coded values in `TaprootWitnessTest` are taken from the `script_assets.json`, namely this test case since it is verifying a tapscript script.

```
[  {"tx": "26dc279d02d8b1a203b653fc4e0f27f408432f3f540136d33f8f930eaeba655910095142980402000000fd697cd4eb5278f1e34545cd57b6670df806fa3a0a064fd8e385a19f1a53d9ce8d8971a30f02000000378d5fb502335dbe02000000001976a9140053a23441c8478caac4c6b769c51f8476cd4b4b88ac58020000000000001976a914f2aae94a43e0d173354201d7832b46c5269c8a2488ac4a08671e", "prevouts": ["91ca4c010000000017a9145658b58602cdf7b7e962cfe44e024cb0e366f27087", "cb127401000000002251201ebe8b90363bd097aa9f352c8b21914e1886bc09fe9e70c09f33ef2d2abdf4bc"], "index": 1,

  "success": {"scriptSig": "", "witness": ["9675a9982c6398ea9d441cb7a943bcd6ff033cc3a2e01a0178a7d3be4575be863871c6bf3eef5ecd34721c784259385ca9101c3a313e010ac942c99de05aaaa602",
  "5799cf4b193b730fb99580b186f7477c2cca4d28957326f6f1a5d14116438530e7ec0ce1cd465ad96968ae8a6a09d4d37a060a115919f56fcfebe7b2277cc2df5cc08fb6cda9105ee2512b2e22635aba",
  "7520c7b5db9562078049719228db2ac80cb9643ec96c8055aa3b29c2c03d4d99edb0ac",
  "c1a7957acbaaf7b444c53d9e0c9436e8a8a3247fd515095d66ddf6201918b40a3668f9a4ccdffcf778da624dca2dda0b08e763ec52fd4ad403ec7563a3504d0cc168b9a77a410029e01dac89567c9b2e6cd726e840351df3f2f58fefe976200a19244150d04153909f660184d656ee95fa7bf8e1d4ec83da1fca34f64bc279b76d257ec623e08baba2cfa4ea9e99646e88f1eb1668c00c0f15b7443c8ab83481611cc3ae85eb89a7bfc40067eb1d2e6354a32426d0ce710e88bc4cc0718b99c325509c9d02a6a980d675a8969be10ee9bef82cafee2fc913475667ccda37b1bc7f13f64e56c449c532658ba8481631c02ead979754c809584a875951619cec8fb040c33f06468ae0266cd8693d6a64cea5912be32d8de95a6da6300b0c50fdcd6001ea41126e7b7e5280d455054a816560028f5ca53c9a50ee52f10e15c5337315bad1f5277acb109a1418649dc6ead2fe14699742fee7182f2f15e54279c7d932ed2799d01d73c97e68bbc94d6f7f56ee0a80efd7c76e3169e10d1a1ba3b5f1eb02369dc43af687461c7a2a3344d13eb5485dca29a67f16b4cb988923060fd3b65d0f0352bb634bcc44f2fe668836dcd0f604150049835135dc4b4fbf90fb334b3938a1f137eb32f047c65b85e6c1173b890b6d0162b48b186d1f1af8521945924ac8ac8efec321bf34f1d4b3d4a304a10313052c652d53f6ecb8a55586614e8950cde9ab6fe8e22802e93b3b9139112250b80ebc589aba231af535bb20f7eeec2e412f698c17f3fdc0a2e20924a5e38b21a628a9e3b2a61e35958e60c7f5087c"]},

  "flags": "P2SH,DERSIG,CHECKLOCKTIMEVERIFY,CHECKSEQUENCEVERIFY,WITNESS,NULLDUMMY,TAPROOT",
  "final": true, "comment": "tapscript/input80limit"}
```