### PR TITLE
Add platform specific name to bitcoin-s artifacts

### DIFF
--- a/app/cli/cli.sbt
+++ b/app/cli/cli.sbt
@@ -1,4 +1,4 @@
-name := "bitcoin-s-cli"
+name := s"bitcoin-s-cli-${System.getProperty("os.name")}"
 
 libraryDependencies ++= Deps.cli.value
 

--- a/app/cli/cli.sbt
+++ b/app/cli/cli.sbt
@@ -1,4 +1,6 @@
-name := s"bitcoin-s-cli-${System.getProperty("os.name")}"
+name := s"bitcoin-s-cli"
+
+Universal / packageName := CommonSettings.buildPackageName((Universal /packageName).value)
 
 libraryDependencies ++= Deps.cli.value
 

--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -1,6 +1,6 @@
 import com.typesafe.sbt.packager.docker.DockerChmodType
 
-name := "bitcoin-s-oracle-server"
+name := s"bitcoin-s-oracle-server-${System.getProperty("os.name")}"
 
 // Ensure actor system is shut down
 // when server is quit

--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -1,8 +1,10 @@
 import com.typesafe.sbt.packager.docker.DockerChmodType
 
-name := s"bitcoin-s-oracle-server-${System.getProperty("os.name")}"
+name := "bitcoin-s-oracle-server"
 
-// Ensure actor system is shut down
+Universal / packageName := CommonSettings.buildPackageName((Universal /packageName).value)
+
+  // Ensure actor system is shut down
 // when server is quit
 Compile / fork := true
 

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -1,4 +1,4 @@
-name := "bitcoin-s-server"
+name := s"bitcoin-s-server-${System.getProperty("os.name")}"
 
 // Ensure actor system is shut down
 // when server is quit

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -1,4 +1,9 @@
-name := s"bitcoin-s-server-${System.getProperty("os.name")}"
+name := s"bitcoin-s-server"
+
+Universal / packageName := {
+  val old = (Universal / packageName).value
+  CommonSettings.buildPackageName(old)
+}
 
 // Ensure actor system is shut down
 // when server is quit

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -335,4 +335,15 @@ object CommonSettings {
 
     JlinkIgnore.byPackagePrefix(cliIgnore:_*)
   }
+
+  def buildPackageName(packageName: String): String = {
+    //bitcoin-s-server-1.9.2-1-59aaf330-20220616-1614-SNAPSHOT -> bitcoin-s-server-linux-1.9.2-1-59aaf330-20220616-1614-SNAPSHOT
+    //bitcoin-s-cli-1.9.2-1-59aaf330-20220616-1614-SNAPSHOT.zip -> bitcoin-s-cli-linux-1.9.2-1-59aaf330-20220616-1614-SNAPSHOT.zip
+
+    val osName = System.getProperty("os.name").toLowerCase()
+    val split = packageName.split("-")
+    val versionIdx = split.zipWithIndex.find(_._1.count(_ =='.') > 1).get._2
+    val insertedOSName = split.take(versionIdx) ++ Vector(osName) ++ split.drop(versionIdx)
+    insertedOSName.mkString("-")
+  }
 }


### PR DESCRIPTION
This PR appends the OS name to the aritfact name generated by bitcoin-s

This is needed because when publishing OS specific releases on a tag, the artifacts overwrite each other as they are named the same across platforms. This is needed for the 1.9.2 release because our backend binaries are now platform specific due to `jlink`

![Screenshot from 2022-06-16 16-05-39](https://user-images.githubusercontent.com/3514957/174164075-17f39171-8dea-4e78-b5dc-1cb2c363dd4c.png)
![Screenshot from 2022-06-16 16-05-27](https://user-images.githubusercontent.com/3514957/174164080-b574a8c1-2876-4d1d-99e8-67cb02518cee.png)

Now the artifact names will show up as `bitcoin-s-server-mac` and `bitcoin-s-server-linux` rather than just `bitcoin-s-server`. This should allow us to publish all of our releases on the artifacts page.

Here is examples of what locally built binaries look like, the only difference here is the fact that the OS name is included in the artifact name, in this case its `linux`

![Screenshot from 2022-06-16 16-49-56](https://user-images.githubusercontent.com/3514957/174171868-2111225b-128e-4da0-8b93-69575045007b.png)
