### PR TITLE
Default to suredbits node if peers field is left empty

### DIFF
--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -2,7 +2,7 @@ bitcoin-s {
     network = mainnet
     node {
         mode = neutrino # neutrino, spv, bitcoind
-        peers = ["neutrino.suredbits.com:8333"]
+        #peers = ["neutrino.suredbits.com:8333"]
         relay = true
     }
     proxy {

--- a/app/server/src/universal/docker-application.conf
+++ b/app/server/src/universal/docker-application.conf
@@ -3,7 +3,7 @@ bitcoin-s.network = ${?BITCOIN_S_NETWORK}
 
 bitcoin-s.node.mode = neutrino
 bitcoin-s.node.mode = ${?BITCOIN_S_NODE_MODE}
-bitcoin-s.node.peers = ["neutrino.suredbits.com:8333"]
+bitcoin-s.node.peers = [${?BITCOIN_S_NODE_PEERS}]
 
 # need to bind to all interfaces so we can
 # have host machine forward requests to the docker container

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -30,7 +30,7 @@ bitcoin-s {
   node = ${bitcoin-s.dbDefault}
 
   node {
-    peers = ["localhost"] # a list of peer addresses in form "hostname:portnumber"
+    peers = [] # a list of peer addresses in form "hostname:portnumber"
                           # (e.g. "neutrino.testnet3.suredbits.com:18333")
                           # Port number is optional, the default value is 8333 for mainnet,
                           # 18333 for testnet and 18444 for regtest.

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -103,7 +103,6 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     */
   lazy val peers: Vector[String] = {
     val list = config.getStringList("bitcoin-s.node.peers")
-    logger.info(s"peers.list=$list")
     val strs = 0
       .until(list.size())
       .foldLeft(Vector.empty[String])((acc, i) => acc :+ list.get(i))


### PR DESCRIPTION
Undoes part of #4282 . The problem with #4282 is it doesn't allow the `BITCOIN_S_NETWORK` environment var to work on any network other than `mainnet`. This is because `bitcoin-s.node.peers` was hardcoded to the mainnet node in `docker-application.conf`

This brings back the `BITCOIN_S_NODE_PEERS` setting in the `docker-application.conf` and now allows `bitcoin-s.node.peers = []`. This allows us to set a custom peer in a docker environment. 

In the case that `bitcoin-s.node.peers = []` in the config file, we default to the suredbits neutrino node on the appropriate bitcoin network.