### PR TITLE
Move lastCodeSeparator to StartedScriptProgram

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -126,7 +126,9 @@ object PreExecutionScriptProgram {
 }
 
 /** This represents any ScriptProgram that is not PreExecution */
-sealed trait StartedScriptProgram extends ScriptProgram
+sealed trait StartedScriptProgram extends ScriptProgram {
+  def lastCodeSeparator: Option[Int]
+}
 
 /** Implements the counting required for O(1) handling of conditionals in Bitcoin Script.
   * @see [[https://github.com/bitcoin/bitcoin/pull/16902]]
@@ -236,6 +238,7 @@ case class ExecutionInProgressScriptProgram(
       originalScript,
       altStack,
       flags,
+      lastCodeSeparator,
       errorOpt
     )
   }
@@ -348,6 +351,7 @@ case class ExecutedScriptProgram(
     originalScript: List[ScriptToken],
     altStack: List[ScriptToken],
     flags: Seq[ScriptFlag],
+    lastCodeSeparator: Option[Int],
     error: Option[ScriptError])
     extends StartedScriptProgram {
 

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -461,14 +461,16 @@ sealed abstract class ScriptInterpreter {
             val evaluated = newProgram.map(executeProgram)
             evaluated.map(e => postSegWitProgramChecks(e))
           case Left(err) =>
-            val program = ExecutedScriptProgram(txSignatureComponent =
-                                                  wTxSigComponent,
-                                                stack = Nil,
-                                                script = Nil,
-                                                originalScript = Nil,
-                                                altStack = Nil,
-                                                flags = wTxSigComponent.flags,
-                                                error = Some(err))
+            val program = ExecutedScriptProgram(
+              txSignatureComponent = wTxSigComponent,
+              stack = Nil,
+              script = Nil,
+              originalScript = Nil,
+              altStack = Nil,
+              flags = wTxSigComponent.flags,
+              lastCodeSeparator = None,
+              error = Some(err)
+            )
             Success(program)
         }
       case WitnessVersion1 =>
@@ -1196,7 +1198,8 @@ sealed abstract class ScriptInterpreter {
         script = Nil,
         originalScript = txSigComponent.scriptPubKey.asm.toList,
         altStack = Nil,
-        flags,
+        flags = flags,
+        lastCodeSeparator = None,
         error = Some(ScriptErrorDiscourageUpgradeableWitnessProgram)
       )
       Success(executed)


### PR DESCRIPTION
In some cases it is useful to access lastCodeSeparator from an `ExecutedScriptProgam`