### PR TITLE
Fix out of bounds issues with lnd mappers

### DIFF
--- a/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRpcClientTest.scala
+++ b/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRpcClientTest.scala
@@ -1,8 +1,9 @@
 package org.bitcoins.lnd.rpc
 
 import lnrpc.Invoice.InvoiceState
+import lnrpc.{HopHint, Invoice, RouteHint}
 import org.bitcoins.core.currency.Satoshis
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.ln.LnInvoice
 import org.bitcoins.core.protocol.ln.currency._
 import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
@@ -142,5 +143,28 @@ class LndRpcClientTest extends LndFixture {
 
       leases <- lnd.listLeases()
     } yield assert(leases.isEmpty)
+  }
+
+  it must "correctly handle UInt64 & UInt32 converters" in { lnd =>
+    val hopHint = HopHint(
+      nodeId =
+        "037c862ec724bc85462aaeb804dd0941cd77dc4521cabd05edf3d0f23ed6b01f09",
+      chanId = UInt64.max - UInt64.twentyTwo,
+      feeBaseMsat = UInt32.zero,
+      feeProportionalMillionths = UInt32.max,
+      cltvExpiryDelta = UInt32.zero
+    )
+
+    val invoice = Invoice("memo",
+                          value = 100000,
+                          expiry = 1000,
+                          routeHints = Vector(RouteHint(Vector(hopHint))))
+
+    for {
+      res <- lnd.addInvoice(invoice)
+      lookup <- lnd.lookupInvoice(res.rHash)
+    } yield {
+      assert(lookup.routeHints == invoice.routeHints)
+    }
   }
 }

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndUtils.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndUtils.scala
@@ -14,6 +14,8 @@ import scalapb.TypeMapper
 import scodec.bits._
 import signrpc.TxOut
 
+import java.lang.Long.toUnsignedString
+import java.math.BigInteger
 import scala.language.implicitConversions
 
 trait LndUtils {
@@ -91,10 +93,15 @@ trait LndUtils {
   }
 
   implicit val uint64Mapper: TypeMapper[Long, UInt64] =
-    TypeMapper[Long, UInt64](UInt64.apply)(_.toBigInt.longValue)
+    TypeMapper[Long, UInt64] { l =>
+      val bigInt = new BigInteger(toUnsignedString(l))
+      UInt64(bigInt)
+    }(_.toBigInt.longValue)
 
   implicit val uint32Mapper: TypeMapper[Int, UInt32] =
-    TypeMapper[Int, UInt32](UInt32.apply)(_.toBigInt.intValue)
+    TypeMapper[Int, UInt32] { i =>
+      UInt32(Integer.toUnsignedLong(i))
+    }(_.toBigInt.intValue)
 }
 
 object LndUtils extends LndUtils


### PR DESCRIPTION
Protobuf encodes the final bit of a unsigned `uint64` or `uint32` as the sign. This would cause issues where previously numbers that require the sign bit would fail