### PR TITLE
Implement `DISABLE_JLINK` env variable to disable jlink jre's usage at runtime

### DIFF
--- a/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
+++ b/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
@@ -15,6 +15,26 @@ if [[ "$OS" == "OSX" ]]; then
 fi
 chmod +x jre/bin/java #make sure java is executable
 
+get_java_no_jlink() {
+  if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+    echo "$JAVA_HOME/bin/java"
+  else
+    echo "java"
+  fi
+}
+
+if [[ -n "$DISABLE_JLINK" ]]; then
+  echo "jlink disabled by the DISABLE_JLINK environment variable, defaulting to JAVA_HOME for java"
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi
+
+
 chip=$(uname -m)
 
 if [[ $chip == "arm64" || $chip == "aarch64" ]]; then
@@ -29,13 +49,7 @@ if [[ $chip == "arm64" || $chip == "aarch64" ]]; then
   # arm64 / aarch64 will need to provide their own jre
   # see https://github.com/bitcoin-s/bitcoin-s/issues/4369!
   echo "Removing ARM jre as its not linked correctly, see https://github.com/bitcoin-s/bitcoin-s/issues/4369!"
-  get_java_no_jlink() {
-    if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
-      echo "$JAVA_HOME/bin/java"
-    else
-      echo "java"
-    fi
-  }
+
 
   # java_cmd is overrode in process_args when -java-home is used
   declare java_cmd=$(get_java_no_jlink)


### PR DESCRIPTION
fixes #4422 by allowing jlink to be disabled at runtime with the `DISABLE_JLINK` environment variable. This means we can fallback to our systems default `JAVA_HOME` and be able to use visualvm to inspect resource usage of the jvm.

