### PR TITLE
lnd: Add needed param for taproot compute input script

### DIFF
--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -752,6 +752,26 @@ class LndRpcClient(val instance: LndInstance, binaryOpt: Option[File] = None)(
   def computeInputScript(
       tx: Tx,
       inputIdx: Int,
+      hashType: HashType,
+      output: TransactionOutput,
+      signMethod: SignMethod,
+      prevOuts: Vector[TransactionOutput]): Future[
+    (ScriptSignature, ScriptWitness)] = {
+    val signDescriptor =
+      SignDescriptor(output = Some(output),
+                     sighash = UInt32(hashType.num),
+                     inputIndex = inputIdx,
+                     signMethod = signMethod)
+
+    val request: SignReq =
+      SignReq(tx.bytes, Vector(signDescriptor), prevOuts)
+
+    computeInputScript(request).map(_.head)
+  }
+
+  def computeInputScript(
+      tx: Tx,
+      inputIdx: Int,
       output: TransactionOutput): Future[(ScriptSignature, ScriptWitness)] = {
     val signDescriptor =
       SignDescriptor(output = Some(output),


### PR DESCRIPTION
Because of the new signing algo we need `prevOuts: Vector[TransactionOutput]`