### PR TITLE
lnd: Add needed param for taproot compute input script

### DIFF
--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -752,6 +752,26 @@ class LndRpcClient(val instance: LndInstance, binaryOpt: Option[File] = None)(
   def computeInputScript(
       tx: Tx,
       inputIdx: Int,
+      hashType: HashType,
+      output: TransactionOutput,
+      signMethod: SignMethod,
+      prevOuts: Vector[TransactionOutput]): Future[
+    (ScriptSignature, ScriptWitness)] = {
+    val signDescriptor =
+      SignDescriptor(output = Some(output),
+                     sighash = UInt32(hashType.num),
+                     inputIndex = inputIdx,
+                     signMethod = signMethod)
+
+    val request: SignReq =
+      SignReq(tx.bytes, Vector(signDescriptor), prevOuts)
+
+    computeInputScript(request).map(_.head)
+  }
+
+  def computeInputScript(
+      tx: Tx,
+      inputIdx: Int,
       output: TransactionOutput): Future[(ScriptSignature, ScriptWitness)] = {
     val signDescriptor =
       SignDescriptor(output = Some(output),

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -749,14 +749,13 @@ class LndRpcClient(val instance: LndInstance, binaryOpt: Option[File] = None)(
     computeInputScript(tx, Vector(signDescriptor)).map(_.head)
   }
 
-  def computeInputScript(
+  def signOutputRaw(
       tx: Tx,
       inputIdx: Int,
       hashType: HashType,
       output: TransactionOutput,
       signMethod: SignMethod,
-      prevOuts: Vector[TransactionOutput]): Future[
-    (ScriptSignature, ScriptWitness)] = {
+      prevOuts: Vector[TransactionOutput]): Future[ByteVector] = {
     val signDescriptor =
       SignDescriptor(output = Some(output),
                      sighash = UInt32(hashType.num),
@@ -766,7 +765,7 @@ class LndRpcClient(val instance: LndInstance, binaryOpt: Option[File] = None)(
     val request: SignReq =
       SignReq(tx.bytes, Vector(signDescriptor), prevOuts)
 
-    computeInputScript(request).map(_.head)
+    signer.signOutputRaw(request).map(_.rawSigs.head)
   }
 
   def computeInputScript(

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/LndFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/LndFixture.scala
@@ -2,7 +2,7 @@ package org.bitcoins.testkit.fixtures
 
 import org.bitcoins.lnd.rpc.LndRpcClient
 import org.bitcoins.lnd.rpc.config.LndInstanceRemote
-import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.rpc.client.v23.BitcoindV23RpcClient
 import org.bitcoins.testkit.lnd._
 import org.bitcoins.testkit.rpc._
 import org.scalatest.FutureOutcome
@@ -38,9 +38,10 @@ trait LndFixture extends BitcoinSFixture with CachedBitcoindV21 {
 }
 
 /** A trait that is useful if you need Lnd fixtures for your test suite */
-trait DualLndFixture extends BitcoinSFixture with CachedBitcoindV21 {
+trait DualLndFixture extends BitcoinSFixture with CachedBitcoindV23 {
 
-  override type FixtureParam = (BitcoindRpcClient, LndRpcClient, LndRpcClient)
+  override type FixtureParam =
+    (BitcoindV23RpcClient, LndRpcClient, LndRpcClient)
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     withDualLnd(test)


### PR DESCRIPTION
Because of the new signing algo we need `prevOuts: Vector[TransactionOutput]`