### PR TITLE
Get a SIGHASH_SINGLE test case working

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -95,7 +95,6 @@ trait TransactionSignatureChecker {
       TransactionSignatureSerializer.hashForSignature(txSigComponent,
                                                       hashType,
                                                       taprootOptions)
-
     val result = pubKey.verify(hash, schnorrSignature)
     if (result) ScriptOk else ScriptErrorSchnorrSig
   }

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -283,7 +283,7 @@ sealed abstract class TransactionSignatureSerializer {
           }
         }
         val sequenceHash: ByteVector =
-          if (isNotAnyoneCanPay && isNotSigHashSingle) {
+          if (isNotAnyoneCanPay) {
             val sequences = spendingTransaction.inputs.map(_.sequence)
             val littleEndianSeq =
               sequences.foldLeft(ByteVector.empty)(_ ++ _.bytes.reverse)
@@ -298,7 +298,7 @@ sealed abstract class TransactionSignatureSerializer {
           } else {
             ByteVector.empty
           }
-
+        println(s"sequenceHash=$sequenceHash")
         val outputHash: ByteVector =
           if (isNotSigHashSingle && isNotSigHashNone) {
             val outputs = spendingTransaction.outputs
@@ -309,12 +309,12 @@ sealed abstract class TransactionSignatureSerializer {
             inputIndex < UInt32(spendingTransaction.outputs.size)
           ) {
             val output = spendingTransaction.outputs(inputIndex.toInt)
-            val bytes = CryptoUtil
-              .sha256(RawTransactionOutputParser.write(output))
+            val hash = CryptoUtil
+              .sha256(output.bytes)
               .bytes
-            bytes
+            hash
           } else ByteVector.empty
-
+        println(s"outputHash=$outputHash")
         val haveAnnex: Boolean = taprootOptions.haveAnnex
         val annexByte = if (haveAnnex) 1.toByte else 0.toByte
 
@@ -343,12 +343,22 @@ sealed abstract class TransactionSignatureSerializer {
         }
         val result = {
           if (isNotAnyoneCanPay) {
-            epoch ++ ByteVector.fromByte(
-              hashType.byte) ++ version ++ locktimeBytes ++
-              outPointHash ++ amounts ++ spentSPKs ++
-              sequenceHash ++ outputHash ++
-              ByteVector.fromByte(spendType) ++
-              inputIndexBytes ++ annexBytes ++ tapScriptBytes
+            if (!isNotSigHashSingle) {
+              epoch ++ ByteVector.fromByte(
+                hashType.byte) ++ version ++ locktimeBytes ++
+                outPointHash ++ amounts ++ spentSPKs ++
+                sequenceHash ++ ByteVector.fromByte(
+                  spendType) ++ inputIndexBytes ++ outputHash ++
+                annexBytes ++ tapScriptBytes
+            } else {
+              epoch ++ ByteVector.fromByte(
+                hashType.byte) ++ version ++ locktimeBytes ++
+                outPointHash ++ amounts ++ spentSPKs ++
+                sequenceHash ++ outputHash ++
+                ByteVector.fromByte(spendType) ++
+                inputIndexBytes ++ annexBytes ++ tapScriptBytes
+            }
+
           } else {
             //different ordering if we use SIGHASH_ANYONECANPAY
             epoch ++ ByteVector.fromByte(

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -298,7 +298,7 @@ sealed abstract class TransactionSignatureSerializer {
           } else {
             ByteVector.empty
           }
-        println(s"sequenceHash=$sequenceHash")
+
         val outputHash: ByteVector =
           if (isNotSigHashSingle && isNotSigHashNone) {
             val outputs = spendingTransaction.outputs
@@ -314,7 +314,7 @@ sealed abstract class TransactionSignatureSerializer {
               .bytes
             hash
           } else ByteVector.empty
-        println(s"outputHash=$outputHash")
+
         val haveAnnex: Boolean = taprootOptions.haveAnnex
         val annexByte = if (haveAnnex) 1.toByte else 0.toByte
 


### PR DESCRIPTION
Fixes some bugs in the `SIGHASH_SINGLE` implementation for taproot with a test case. This is pulled off of #3769