### PR TITLE
Remove map on tor to allow access to `getdlchostaddress` endpoint before tor is fully started

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -181,7 +181,6 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val startedDLCNodeF = {
       for {
         dlcNode <- dlcNodeF
-        _ <- startedTorConfigF
         _ <- dlcNode.start()
       } yield dlcNode
     }


### PR DESCRIPTION
Fixes this error on startup

<img width="508" alt="Screen Shot 2022-06-28 at 10 41 16 AM" src="https://user-images.githubusercontent.com/3514957/176249616-05586afa-7210-49ae-9600-528aa41ffba8.png">
