### PR TITLE
Fix lnd OutputDetails for outputs that dont have an address

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/lnd/LndModels.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/lnd/LndModels.scala
@@ -43,7 +43,7 @@ case class ChannelBalances(
 ) extends LndModel
 
 case class OutputDetails(
-    address: BitcoinAddress,
+    addressOpt: Option[BitcoinAddress],
     spk: ScriptPubKey,
     outputIndex: Long,
     amount: CurrencyUnit,

--- a/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRpcClientPairTest.scala
+++ b/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRpcClientPairTest.scala
@@ -197,7 +197,7 @@ class LndRpcClientPairTest extends DualLndFixture {
 
       assert(details.tx == tx)
       assert(details.txId == tx.txIdBE)
-      assert(details.outputDetails.map(_.address).contains(addr))
+      assert(details.outputDetails.flatMap(_.addressOpt).contains(addr))
       assert(details.amount == sendAmt)
     }
   }

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndUtils.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndUtils.scala
@@ -72,7 +72,7 @@ trait LndUtils {
   implicit def lndOutputDetailToOutputDetails(
       detail: lnrpc.OutputDetail): OutputDetails = {
     OutputDetails(
-      address = BitcoinAddress.fromString(detail.address),
+      addressOpt = BitcoinAddress.fromStringOpt(detail.address),
       spk = ScriptPubKey.fromAsmHex(detail.pkScript),
       outputIndex = detail.outputIndex,
       amount = Satoshis(detail.amount),


### PR DESCRIPTION
Bug I found with op_return bot. When we haven an output that doesn't have an assiocated address (op_returns) it will return an empty string.