### PR TITLE
2022 06 30 `OP_CODESEPARATOR` impl compatible with taproot

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
@@ -73,7 +73,7 @@ class ScriptProgramFactoryTest extends BitcoinSUnitTest {
         altStack = Nil,
         flags = Nil,
         lastCodeSeparator = None,
-        codeSeparatorIdx = None,
+        codeSeparatorTapscriptIdx = None,
         conditionalCounter = ConditionalCounter.empty
       )
     inProgress.stack must be(stack)

--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptProgramFactoryTest.scala
@@ -73,6 +73,7 @@ class ScriptProgramFactoryTest extends BitcoinSUnitTest {
         altStack = Nil,
         flags = Nil,
         lastCodeSeparator = None,
+        codeSeparatorIdx = None,
         conditionalCounter = ConditionalCounter.empty
       )
     inProgress.stack must be(stack)

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -75,7 +75,7 @@ case class PreExecutionScriptProgram(
       altStack = altStack,
       flags = flags,
       lastCodeSeparator = None,
-      codeSeparatorIdx = None,
+      codeSeparatorTapscriptIdx = None,
       conditionalCounter = ConditionalCounter.empty
     )
   }
@@ -222,7 +222,7 @@ case class ExecutionInProgressScriptProgram(
     altStack: List[ScriptToken],
     flags: Seq[ScriptFlag],
     lastCodeSeparator: Option[Int],
-    codeSeparatorIdx: Option[Int],
+    codeSeparatorTapscriptIdx: Option[Int],
     conditionalCounter: ConditionalCounter)
     extends StartedScriptProgram {
 
@@ -241,7 +241,7 @@ case class ExecutionInProgressScriptProgram(
       altStack,
       flags,
       lastCodeSeparator,
-      codeSeparatorIdx,
+      codeSeparatorTapscriptIdx,
       errorOpt
     )
   }
@@ -339,8 +339,9 @@ case class ExecutionInProgressScriptProgram(
     this.copy(lastCodeSeparator = Some(newLastCodeSeparator))
   }
 
-  def updateCodeSeparatorIdx(newIdx: Int): ExecutionInProgressScriptProgram = {
-    this.copy(codeSeparatorIdx = Some(newIdx))
+  def updateTapscriptCodeSeparatorIdx(
+      newIdx: Int): ExecutionInProgressScriptProgram = {
+    this.copy(codeSeparatorTapscriptIdx = Some(newIdx))
   }
 }
 
@@ -359,7 +360,7 @@ case class ExecutedScriptProgram(
     altStack: List[ScriptToken],
     flags: Seq[ScriptFlag],
     lastCodeSeparator: Option[Int],
-    codeSeparatorIdx: Option[Int],
+    codeSeparatorTapscriptIdx: Option[Int],
     error: Option[ScriptError])
     extends StartedScriptProgram {
 

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -75,6 +75,7 @@ case class PreExecutionScriptProgram(
       altStack = altStack,
       flags = flags,
       lastCodeSeparator = None,
+      codeSeparatorIdx = None,
       conditionalCounter = ConditionalCounter.empty
     )
   }
@@ -221,8 +222,15 @@ case class ExecutionInProgressScriptProgram(
     altStack: List[ScriptToken],
     flags: Seq[ScriptFlag],
     lastCodeSeparator: Option[Int],
+    codeSeparatorIdx: Option[Int],
     conditionalCounter: ConditionalCounter)
     extends StartedScriptProgram {
+
+  def taprootSerializationOptions: TaprootSerializationOptions = {
+    TaprootSerializationOptions(tapLeafHashOpt,
+                                getAnnexHashOpt,
+                                codeSeparatorIdx.map(UInt32(_)))
+  }
 
   def toExecutedProgram: ExecutedScriptProgram = {
     val errorOpt = if (conditionalCounter.totalDepth > 0) {
@@ -239,6 +247,7 @@ case class ExecutionInProgressScriptProgram(
       altStack,
       flags,
       lastCodeSeparator,
+      codeSeparatorIdx,
       errorOpt
     )
   }
@@ -335,6 +344,10 @@ case class ExecutionInProgressScriptProgram(
       newLastCodeSeparator: Int): ExecutionInProgressScriptProgram = {
     this.copy(lastCodeSeparator = Some(newLastCodeSeparator))
   }
+
+  def updateCodeSeparatorIdx(newIdx: Int): ExecutionInProgressScriptProgram = {
+    this.copy(codeSeparatorIdx = Some(newIdx))
+  }
 }
 
 /** Type for a [[org.bitcoins.core.script.ScriptProgram ScriptProgram]] that has been
@@ -352,8 +365,15 @@ case class ExecutedScriptProgram(
     altStack: List[ScriptToken],
     flags: Seq[ScriptFlag],
     lastCodeSeparator: Option[Int],
+    codeSeparatorIdx: Option[Int],
     error: Option[ScriptError])
     extends StartedScriptProgram {
+
+  def taprootSerializationOptions: TaprootSerializationOptions = {
+    TaprootSerializationOptions(tapLeafHashOpt,
+                                getAnnexHashOpt,
+                                codeSeparatorIdx.map(UInt32(_)))
+  }
 
   override def failExecution(error: ScriptError): ExecutedScriptProgram = {
     this.copy(error = Some(error))

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -226,12 +226,6 @@ case class ExecutionInProgressScriptProgram(
     conditionalCounter: ConditionalCounter)
     extends StartedScriptProgram {
 
-  def taprootSerializationOptions: TaprootSerializationOptions = {
-    TaprootSerializationOptions(tapLeafHashOpt,
-                                getAnnexHashOpt,
-                                codeSeparatorIdx.map(UInt32(_)))
-  }
-
   def toExecutedProgram: ExecutedScriptProgram = {
     val errorOpt = if (conditionalCounter.totalDepth > 0) {
       Some(ScriptErrorUnbalancedConditional)
@@ -368,12 +362,6 @@ case class ExecutedScriptProgram(
     codeSeparatorIdx: Option[Int],
     error: Option[ScriptError])
     extends StartedScriptProgram {
-
-  def taprootSerializationOptions: TaprootSerializationOptions = {
-    TaprootSerializationOptions(tapLeafHashOpt,
-                                getAnnexHashOpt,
-                                codeSeparatorIdx.map(UInt32(_)))
-  }
 
   override def failExecution(error: ScriptError): ExecutedScriptProgram = {
     this.copy(error = Some(error))

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
@@ -138,7 +138,7 @@ sealed abstract class CryptoInterpreter {
     program
       .updateScript(program.script.tail)
       .updateLastCodeSeparator(indexOfOpCodeSeparator)
-      .updateCodeSeparatorIdx(indexOfOpCodeSeparator - constants)
+      .updateTapscriptCodeSeparatorIdx(indexOfOpCodeSeparator - constants)
   }
 
   /** Compares the first signature against each public key until it finds an ECDSA match.

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
@@ -124,12 +124,21 @@ sealed abstract class CryptoInterpreter {
     require(program.script.headOption.contains(OP_CODESEPARATOR),
             "Script top must be OP_CODESEPARATOR")
 
+    // Filter out the constants for Tapscript OP_CODESEPARATORs
+    // because we only count op codes
+    val constants =
+      program.originalScript.dropRight(program.script.size).count {
+        case _: ScriptOperation => false
+        case _: ScriptConstant  => true
+      }
+
     val indexOfOpCodeSeparator =
       program.originalScript.size - program.script.size
 
     program
       .updateScript(program.script.tail)
       .updateLastCodeSeparator(indexOfOpCodeSeparator)
+      .updateCodeSeparatorIdx(indexOfOpCodeSeparator - constants)
   }
 
   /** Compares the first signature against each public key until it finds an ECDSA match.

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -469,6 +469,7 @@ sealed abstract class ScriptInterpreter {
               altStack = Nil,
               flags = wTxSigComponent.flags,
               lastCodeSeparator = None,
+              codeSeparatorIdx = None,
               error = Some(err)
             )
             Success(program)
@@ -1203,6 +1204,7 @@ sealed abstract class ScriptInterpreter {
         altStack = Nil,
         flags = flags,
         lastCodeSeparator = None,
+        codeSeparatorIdx = None,
         error = Some(ScriptErrorDiscourageUpgradeableWitnessProgram)
       )
       Success(executed)

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -469,7 +469,7 @@ sealed abstract class ScriptInterpreter {
               altStack = Nil,
               flags = wTxSigComponent.flags,
               lastCodeSeparator = None,
-              codeSeparatorIdx = None,
+              codeSeparatorTapscriptIdx = None,
               error = Some(err)
             )
             Success(program)
@@ -1204,7 +1204,7 @@ sealed abstract class ScriptInterpreter {
         altStack = Nil,
         flags = flags,
         lastCodeSeparator = None,
-        codeSeparatorIdx = None,
+        codeSeparatorTapscriptIdx = None,
         error = Some(ScriptErrorDiscourageUpgradeableWitnessProgram)
       )
       Success(executed)


### PR DESCRIPTION
Pulled from @benthecarman 's branch to implement `OP_CODESEPARATOR` in  way that is compatible with taproot. I thought this was worth pulling out, and we might want to figure out better variable names. `lastCodeSeparator` and `codeSeparatorIdx` aren't very descriptive, but i don't really have great proposals either

https://github.com/Christewart/bitcoin-s-core/pull/35