### PR TITLE
Fix Taproot keyspend serialization

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -237,7 +237,12 @@ case class TaprootKeyPath(
     hashType: HashType,
     annexOpt: Option[ByteVector])
     extends TaprootWitness {
-  override val stack: Vector[ByteVector] = Vector(signature.bytes)
+
+  override val stack: Vector[ByteVector] = {
+    if (hashType == HashType.sigHashDefault) {
+      Vector(signature.bytes)
+    } else Vector(signature.bytes :+ hashType.byte)
+  }
 }
 
 object TaprootKeyPath {


### PR DESCRIPTION
Without this change we cannot parse https://mempool.space/tx/66cc4de192001d970244ffe32896282a1994fef80f01d35b216033aeacac1651

on #3769