### PR TITLE
Fix TaprootKeyPath.isValid for 64 byte sigs

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -281,7 +281,7 @@ object TaprootKeyPath {
   }
 
   def isValid(stack: Vector[ByteVector]): Boolean = {
-    stack.length == 1 && (stack.length == 64 || stack.head.length == 65)
+    stack.length == 1 && (stack.head.length == 64 || stack.head.length == 65)
   }
 }
 


### PR DESCRIPTION
checking the size of the stack not the element