### PR TITLE
Allow creation of TaprootTxSigComponent

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
@@ -228,6 +228,7 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
       WitnessTxSigComponent(transaction = p2wshTx,
                             inputIndex = UInt32.zero,
                             output = p2wshOutput,
+                            Map.empty,
                             Policy.standardFlags)
 
     val result1 =
@@ -560,6 +561,7 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
       WitnessTxSigComponent(transaction = p2wshTx,
                             inputIndex = UInt32.zero,
                             output = p2wshOutput,
+                            Map.empty,
                             Policy.standardFlags)
 
     val result1 =
@@ -599,6 +601,7 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
       WitnessTxSigComponent(transaction = p2wshTx,
                             inputIndex = UInt32.zero,
                             output = p2wshOutput,
+                            Map.empty,
                             Policy.standardFlags)
 
     val result1 =

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.protocol.script.{
 }
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.ScriptToken
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.crypto.{ECDigitalSignature, ECPublicKey, ECPublicKeyBytes}
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 
@@ -228,7 +229,7 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
       WitnessTxSigComponent(transaction = p2wshTx,
                             inputIndex = UInt32.zero,
                             output = p2wshOutput,
-                            Map.empty,
+                            PreviousOutputMap.empty,
                             Policy.standardFlags)
 
     val result1 =
@@ -561,7 +562,7 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
       WitnessTxSigComponent(transaction = p2wshTx,
                             inputIndex = UInt32.zero,
                             output = p2wshOutput,
-                            Map.empty,
+                            PreviousOutputMap.empty,
                             Policy.standardFlags)
 
     val result1 =
@@ -601,7 +602,7 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
       WitnessTxSigComponent(transaction = p2wshTx,
                             inputIndex = UInt32.zero,
                             output = p2wshOutput,
-                            Map.empty,
+                            PreviousOutputMap.empty,
                             Policy.standardFlags)
 
     val result1 =

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.result.ScriptOk
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.wallet.builder.StandardNonInteractiveFinalizer
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{ECSignatureParams, P2PKHInputInfo}
@@ -122,7 +123,6 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
   }
 
   it should "have old and new createSig functions agree" in {
-
     forAll(CreditingTxGen.inputsAndOutputs(), ScriptGenerators.scriptPubKey) {
       case ((creditingTxsInfo, destinations), (changeSPK, _)) =>
         val fee = SatoshisPerVirtualByte(Satoshis(100))
@@ -133,9 +133,8 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
                   feeRate = fee,
                   changeSPK = changeSPK)
 
-        val prevOutMap = creditingTxsInfo.map { info =>
-          info.outPoint -> info.inputInfo.output
-        }.toMap
+        val prevOutMap =
+          PreviousOutputMap.fromScriptSignatureParams(creditingTxsInfo)
 
         val correctSigs =
           creditingTxsInfo.flatMap { signInfo =>

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
@@ -133,11 +133,15 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
                   feeRate = fee,
                   changeSPK = changeSPK)
 
+        val prevOutMap = creditingTxsInfo.map { info =>
+          info.outPoint -> info.inputInfo.output
+        }.toMap
+
         val correctSigs =
           creditingTxsInfo.flatMap { signInfo =>
             signInfo.signers.map { signer =>
               val txSignatureComponent =
-                TxSigComponent(signInfo.inputInfo, spendingTx)
+                TxSigComponent(signInfo.inputInfo, spendingTx, prevOutMap)
 
               val oldSig =
                 TransactionSignatureCreator.createSig(txSignatureComponent,

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
@@ -442,11 +442,15 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
                   feeRate = fee,
                   changeSPK = changeSPK)
 
+        val prevOutMap = creditingTxsInfo.map { info =>
+          info.outPoint -> info.inputInfo.output
+        }.toMap
+
         val correctScripts =
           creditingTxsInfo.flatMap { signInfo =>
             signInfo.signers.map { _ =>
               val txSigComponent =
-                TxSigComponent(signInfo.inputInfo, spendingTx)
+                TxSigComponent(signInfo.inputInfo, spendingTx, prevOutMap)
 
               val oldBytes =
                 TransactionSignatureSerializer.serializeForSignature(
@@ -480,11 +484,15 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
                   feeRate = fee,
                   changeSPK = changeSPK)
 
+        val prevOutMap = creditingTxsInfo.map { info =>
+          info.outPoint -> info.inputInfo.output
+        }.toMap
+
         val correctHashes =
           creditingTxsInfo.flatMap { signInfo =>
             signInfo.signers.map { _ =>
               val txSigComponent =
-                TxSigComponent(signInfo.inputInfo, spendingTx)
+                TxSigComponent(signInfo.inputInfo, spendingTx, prevOutMap)
 
               val oldHash =
                 TransactionSignatureSerializer.hashForSignature(
@@ -518,11 +526,15 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
                   feeRate = fee,
                   changeSPK = changeSPK)
 
+        val prevOutMap = creditingTxsInfo.map { info =>
+          info.outPoint -> info.inputInfo.output
+        }.toMap
+
         val correctScripts =
           creditingTxsInfo.flatMap { signInfo =>
             signInfo.signers.map { _ =>
               val txSigComponent =
-                TxSigComponent(signInfo.inputInfo, spendingTx)
+                TxSigComponent(signInfo.inputInfo, spendingTx, prevOutMap)
 
               val oldScript =
                 BitcoinScriptUtil.calculateScriptForSigning(

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
@@ -5,6 +5,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.serializers.script.ScriptParser
 import org.bitcoins.core.util._
 import org.bitcoins.core.wallet.builder.StandardNonInteractiveFinalizer
@@ -442,9 +443,8 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
                   feeRate = fee,
                   changeSPK = changeSPK)
 
-        val prevOutMap = creditingTxsInfo.map { info =>
-          info.outPoint -> info.inputInfo.output
-        }.toMap
+        val prevOutMap =
+          PreviousOutputMap.fromScriptSignatureParams(creditingTxsInfo)
 
         val correctScripts =
           creditingTxsInfo.flatMap { signInfo =>
@@ -484,9 +484,8 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
                   feeRate = fee,
                   changeSPK = changeSPK)
 
-        val prevOutMap = creditingTxsInfo.map { info =>
-          info.outPoint -> info.inputInfo.output
-        }.toMap
+        val prevOutMap =
+          PreviousOutputMap.fromScriptSignatureParams(creditingTxsInfo)
 
         val correctHashes =
           creditingTxsInfo.flatMap { signInfo =>
@@ -526,9 +525,8 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
                   feeRate = fee,
                   changeSPK = changeSPK)
 
-        val prevOutMap = creditingTxsInfo.map { info =>
-          info.outPoint -> info.inputInfo.output
-        }.toMap
+        val prevOutMap =
+          PreviousOutputMap.fromScriptSignatureParams(creditingTxsInfo)
 
         val correctScripts =
           creditingTxsInfo.flatMap { signInfo =>
@@ -571,8 +569,10 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
     val witnessTx =
       WitnessTransaction.toWitnessTx(spendingTx).updateWitness(0, witness)
 
-    val outputMap: Map[TransactionOutPoint, TransactionOutput] =
-      spendingTx.inputs.map(_.previousOutput).zip(Vector(prevOutput)).toMap
+    val outputMap: PreviousOutputMap =
+      PreviousOutputMap(
+        spendingTx.inputs.map(_.previousOutput).zip(Vector(prevOutput)).toMap)
+
     val taprootTxSigComponent = TaprootTxSigComponent(witnessTx,
                                                       inputIndex,
                                                       outputMap,
@@ -625,8 +625,9 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
         .toWitnessTx(spendingTx)
         .updateWitness(inputIndex.toInt, witness)
 
-    val outputMap: Map[TransactionOutPoint, TransactionOutput] =
-      spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap
+    val outputMap: PreviousOutputMap =
+      PreviousOutputMap(
+        spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap)
 
     val taprootTxSigComponent = TaprootTxSigComponent(witnessTx,
                                                       inputIndex,
@@ -660,8 +661,9 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
     val prevout = TransactionOutput.fromHex(
       "5ba3440100000000225120325901f5659ff9031572e5f790166d9efbc9c693daa47d4acd2ba873176d7879")
     val prevOutputs = Vector(prevout)
-    val outputMap: Map[TransactionOutPoint, TransactionOutput] =
-      spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap
+    val outputMap: PreviousOutputMap =
+      PreviousOutputMap(
+        spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap)
 
     val witnessStackHex = Vector(
       "de7950201305f38c82b1f9743b1cecbc0dda2ea4557c1ff22b769666e12539302a0988cd0e1489b8123c1181e275b576fe8ea7c4a997d332bcf90a5dc6604a2701",
@@ -724,8 +726,9 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
     val prevout = TransactionOutput.fromHex(
       "0aab5f01000000002251204aeed300fcf09260e6c44f6680f5f0eff387e6c4594700358dae78e695aafbe0")
     val prevOutputs = Vector(prevout)
-    val outputMap: Map[TransactionOutPoint, TransactionOutput] =
-      spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap
+    val outputMap: PreviousOutputMap =
+      PreviousOutputMap(
+        spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap)
 
     val witnessStackHex = Vector(
       "ce51561684cec9066e9a4f336fcf7d8a5e6386be8196bbbd283ff95f8a6dc3a3c06468b66640b0d46d2a03836250d23dff5286a98b9d7db760754289238b181701",
@@ -776,8 +779,9 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
     val prevout = TransactionOutput.fromHex(
       "5e6aae010000000022512045cad6b20c81a782892f064caeab47cad9c276a917bed28ac30435e343a82188")
     val prevOutputs = Vector(prevout)
-    val outputMap: Map[TransactionOutPoint, TransactionOutput] =
-      spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap
+    val outputMap: PreviousOutputMap =
+      PreviousOutputMap(
+        spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap)
 
     val witnessStackHex = Vector(
       "2c6347f19bd72e40ff0d3ffcb872973ead3100bd0dc39d2dc48d31bb039e0f281f24c963404922771ef28ec09ec6f3875dca076f8ebc0c59d99cfa3e0eafdf0483",
@@ -823,8 +827,9 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
     val prevout = TransactionOutput.fromHex(
       "5e6aae010000000022512045cad6b20c81a782892f064caeab47cad9c276a917bed28ac30435e343a82188")
     val prevOutputs = Vector(prevout)
-    val outputMap: Map[TransactionOutPoint, TransactionOutput] =
-      spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap
+    val outputMap: PreviousOutputMap =
+      PreviousOutputMap(
+        spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap)
 
     val witnessStackHex = Vector(
       "2c6347f19bd72e40ff0d3ffcb872973ead3100bd0dc39d2dc48d31bb039e0f281f24c963404922771ef28ec09ec6f3875dca076f8ebc0c59d99cfa3e0eafdf0483",
@@ -918,8 +923,9 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
       "8d30780100000000225120db51afd5ed217d7a33c04dd0f8b5bb41f78a138d3aec6a6bfc2a03e266334c89"
     )
       .map(TransactionOutput.fromHex)
-    val outputMap: Map[TransactionOutPoint, TransactionOutput] =
-      spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap
+    val outputMap: PreviousOutputMap =
+      PreviousOutputMap(
+        spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap)
 
     val witnessStackHex = Vector(
       "85b5c1a31fda48328459aec83811bfd5754a24110c3fb7026500561e4880f313fbdb44125ca7e06f3a37490e1fcd0d9383ff970ff7b7f724a9df7dca8cf17d4d03")
@@ -958,8 +964,9 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
     val prevout = TransactionOutput.fromHex(
       "bd2897010000000022512088ffcb569bf1dc1a9e0b22b8cb164c31bcf65e6e95fa113ddbdbbead6e85fedf")
     val prevOutputs = Vector(prevout)
-    val outputMap: Map[TransactionOutPoint, TransactionOutput] =
-      spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap
+    val outputMap: PreviousOutputMap =
+      PreviousOutputMap(
+        spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap)
     val witnessStackHex = Vector(
       "f14afc2bf9b4a9f8e4b5e8503e396de9ad12aacf7726fd53dc147978f52bf9435d658cb326f533b39c57af2c8406f5177120eda69e51f52e0fd076040c7d831d83",
       "50d8"
@@ -1004,8 +1011,9 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
     val prevout = TransactionOutput.fromHex(
       "94037f010000000022512057c1162a56ec9db80a8eb342634f613c8d990bf305925df7ddb85b356ce8f0bb")
     val prevOutputs = Vector(prevout)
-    val outputMap: Map[TransactionOutPoint, TransactionOutput] =
-      spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap
+    val outputMap: PreviousOutputMap =
+      PreviousOutputMap(
+        spendingTx.inputs.map(_.previousOutput).zip(prevOutputs).toMap)
     val witnessStackHex = Vector(
       "228187c314a903fe94c1c8260c243e0949a3233d404a58f90cd991a44f5dad4d89bd5763525b437a10a973abd8eb99adcfec9e2865fa235fa4d6af82c427f17a81")
     val witnessStack = witnessStackHex.map(w => ByteVector.fromValidHex(w))

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureTest.scala
@@ -135,9 +135,12 @@ class ScriptSignatureTest extends BitcoinSJvmTest {
                              output,
                              Policy.standardFlags)
         case wtx: WitnessTransaction =>
+          val outPoint = wtx.inputs(testCase.inputIndex.toInt).previousOutput
+          val outputMap = Map(outPoint -> output)
           WitnessTxSigComponent(wtx,
                                 inputIndex = testCase.inputIndex,
                                 output,
+                                outputMap,
                                 Policy.standardFlags)
       }
       val hashForSig =

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptSignatureTest.scala
@@ -10,6 +10,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput,
   WitnessTransaction
 }
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.serializers.script.RawScriptSignatureParser
 import org.bitcoins.core.util.BytesUtil
 import org.bitcoins.crypto._
@@ -136,7 +137,7 @@ class ScriptSignatureTest extends BitcoinSJvmTest {
                              Policy.standardFlags)
         case wtx: WitnessTransaction =>
           val outPoint = wtx.inputs(testCase.inputIndex.toInt).previousOutput
-          val outputMap = Map(outPoint -> output)
+          val outputMap = PreviousOutputMap(Map(outPoint -> output))
           WitnessTxSigComponent(wtx,
                                 inputIndex = testCase.inputIndex,
                                 output,

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -16,6 +16,7 @@ import org.bitcoins.core.protocol.transaction.{
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.flag.ScriptFlagFactory
 import org.bitcoins.core.script.interpreter.testprotocol.CoreTestCase
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
 import upickle.default._
 
@@ -109,7 +110,9 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
     // safe to use EmptyTransactionOutPoint because non-taproot
     assert(
       ScriptInterpreter
-        .verifyTransaction(p2shWitTx, Map(EmptyTransactionOutPoint -> prevOut)))
+        .verifyTransaction(
+          p2shWitTx,
+          PreviousOutputMap(Map(EmptyTransactionOutPoint -> prevOut))))
   }
 
   it must "evaluate a witness transaction as valid" in {
@@ -121,7 +124,9 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
     // safe to use EmptyTransactionOutPoint because non-taproot
     assert(
       ScriptInterpreter
-        .verifyTransaction(wtx, Map(EmptyTransactionOutPoint -> prevOut)))
+        .verifyTransaction(
+          wtx,
+          PreviousOutputMap(Map(EmptyTransactionOutPoint -> prevOut))))
   }
 
   it must "evaluate a base transaction as valid" in {
@@ -133,7 +138,9 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
     // safe to use EmptyTransactionOutPoint because non-taproot
     assert(
       ScriptInterpreter
-        .verifyTransaction(tx, Map(EmptyTransactionOutPoint -> prevOut)))
+        .verifyTransaction(
+          tx,
+          PreviousOutputMap(Map(EmptyTransactionOutPoint -> prevOut))))
   }
 }
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.crypto.{
 import org.bitcoins.core.currency.CurrencyUnits
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction.{
+  EmptyTransactionOutPoint,
   Transaction,
   TransactionOutput,
   WitnessTransaction
@@ -105,7 +106,10 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
     val prevOut = TransactionOutput(
       "48677bda0100000017a914885437151ad21f21c5c714ddffdf67e56fcd63ea87")
 
-    ScriptInterpreter.verifyTransaction(p2shWitTx, Vector(prevOut))
+    // safe to use EmptyTransactionOutPoint because non-taproot
+    assert(
+      ScriptInterpreter
+        .verifyTransaction(p2shWitTx, Map(EmptyTransactionOutPoint -> prevOut)))
   }
 
   it must "evaluate a witness transaction as valid" in {
@@ -114,7 +118,10 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
     val prevOut = TransactionOutput(
       "b82a0000000000002200202d501d0b2df21825d3dca7dc2bdaeea2c484c552b4ccbf687ffa887ae47e42c2")
 
-    ScriptInterpreter.verifyTransaction(wtx, Vector(prevOut))
+    // safe to use EmptyTransactionOutPoint because non-taproot
+    assert(
+      ScriptInterpreter
+        .verifyTransaction(wtx, Map(EmptyTransactionOutPoint -> prevOut)))
   }
 
   it must "evaluate a base transaction as valid" in {
@@ -123,7 +130,10 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
     val prevOut = TransactionOutput(
       "37733ba40b0000001976a914741423cca440e7dc81d3468b832433e4db3c924288ac")
 
-    ScriptInterpreter.verifyTransaction(tx, Vector(prevOut))
+    // safe to use EmptyTransactionOutPoint because non-taproot
+    assert(
+      ScriptInterpreter
+        .verifyTransaction(tx, Map(EmptyTransactionOutPoint -> prevOut)))
   }
 }
 

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -15,6 +15,7 @@ import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.wallet.builder.{
   RawTxSigner,
   StandardNonInteractiveFinalizer
@@ -160,9 +161,8 @@ class SignerTest extends BitcoinSUnitTest {
                   feeRate = fee,
                   changeSPK = changeSPK)
 
-        val prevOutMap = creditingTxsInfo.map { info =>
-          info.outPoint -> info.inputInfo.output
-        }.toMap
+        val prevOutMap =
+          PreviousOutputMap.fromScriptSignatureParams(creditingTxsInfo)
 
         val correctSigs =
           creditingTxsInfo.flatMap { signInfo =>

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -160,11 +160,15 @@ class SignerTest extends BitcoinSUnitTest {
                   feeRate = fee,
                   changeSPK = changeSPK)
 
+        val prevOutMap = creditingTxsInfo.map { info =>
+          info.outPoint -> info.inputInfo.output
+        }.toMap
+
         val correctSigs =
           creditingTxsInfo.flatMap { signInfo =>
             signInfo.signers.map { signer =>
               val txSignatureComponent =
-                TxSigComponent(signInfo.inputInfo, spendingTx)
+                TxSigComponent(signInfo.inputInfo, spendingTx, prevOutMap)
               @nowarn val oldSig = BitcoinSigner.doSign(txSignatureComponent,
                                                         signer.sign,
                                                         signInfo.hashType,

--- a/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
@@ -6,6 +6,7 @@ import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.flag.ScriptFlag
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.wallet.utxo._
 
 import scala.util.{Failure, Success, Try}
@@ -48,7 +49,7 @@ object TxSigComponent {
   def apply(
       inputInfo: InputInfo,
       unsignedTx: Transaction,
-      outputMap: Map[TransactionOutPoint, TransactionOutput],
+      outputMap: PreviousOutputMap,
       flags: Seq[ScriptFlag] = Policy.standardFlags): TxSigComponent = {
     inputInfo match {
       case segwit: SegwitV0NativeInputInfo =>
@@ -101,7 +102,7 @@ object TxSigComponent {
   def fromWitnessInput(
       inputInfo: UnassignedSegwitNativeInputInfo,
       unsignedTx: Transaction,
-      outputMap: Map[TransactionOutPoint, TransactionOutput],
+      outputMap: PreviousOutputMap,
       flags: Seq[ScriptFlag]): TxSigComponent = {
     val idx = TxUtil.inputIndex(inputInfo, unsignedTx)
     val wtx = setTransactionWitness(inputInfo, unsignedTx)
@@ -179,7 +180,7 @@ object TxSigComponent {
       transaction: Transaction,
       inputIndex: UInt32,
       output: TransactionOutput,
-      outputMap: Map[TransactionOutPoint, TransactionOutput],
+      outputMap: PreviousOutputMap,
       flags: Seq[ScriptFlag]): TxSigComponent = {
     val scriptSig = transaction.inputs(inputIndex.toInt).scriptSignature
     output.scriptPubKey match {
@@ -390,7 +391,7 @@ sealed abstract class WitnessTxSigComponentRebuilt extends TxSigComponent {
 case class TaprootTxSigComponent(
     transaction: WitnessTransaction,
     inputIndex: UInt32,
-    outputMap: Map[TransactionOutPoint, TransactionOutput],
+    outputMap: PreviousOutputMap,
     flags: Seq[ScriptFlag])
     extends WitnessTxSigComponent {
   require(
@@ -475,7 +476,7 @@ object WitnessTxSigComponent {
       transaction: WitnessTransaction,
       inputIndex: UInt32,
       output: TransactionOutput,
-      outputMap: Map[TransactionOutPoint, TransactionOutput],
+      outputMap: PreviousOutputMap,
       flags: Seq[ScriptFlag]): WitnessTxSigComponent =
     output.scriptPubKey match {
       case _: WitnessScriptPubKeyV0 | _: UnassignedWitnessScriptPubKey =>

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -7,6 +7,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.util.BitcoinScriptUtil
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.signer.BitcoinSigner
@@ -678,10 +679,8 @@ case class PSBT(
     PSBT(globalMap, newInputMaps, outputMaps)
   }
 
-  protected def getPrevOutputMap(): Map[
-    TransactionOutPoint,
-    TransactionOutput] = {
-    transaction.inputs
+  def getPrevOutputMap(): PreviousOutputMap = {
+    val map = transaction.inputs
       .zip(inputMaps)
       .map { case (input, inputMap) =>
         val prevTxOpt = inputMap.nonWitnessOrUnknownUTXOOpt
@@ -701,6 +700,8 @@ case class PSBT(
         input.previousOutput -> output
       }
       .toMap
+
+    PreviousOutputMap(map)
   }
 
   def verifyFinalizedInput(index: Int): Boolean = {
@@ -755,7 +756,7 @@ case class PSBT(
 
             val outputMap = output.scriptPubKey match {
               case _: NonWitnessScriptPubKey | _: WitnessScriptPubKeyV0 =>
-                Map.empty[TransactionOutPoint, TransactionOutput]
+                PreviousOutputMap.empty
               case _: TaprootScriptPubKey | _: UnassignedWitnessScriptPubKey =>
                 getPrevOutputMap()
             }
@@ -773,7 +774,7 @@ case class PSBT(
 
             val outputMap = output.scriptPubKey match {
               case _: NonWitnessScriptPubKey | _: WitnessScriptPubKeyV0 =>
-                Map.empty[TransactionOutPoint, TransactionOutput]
+                PreviousOutputMap.empty
               case _: TaprootScriptPubKey | _: UnassignedWitnessScriptPubKey =>
                 getPrevOutputMap()
             }

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -171,11 +171,13 @@ sealed abstract class ScriptInterpreter {
   def verifyInputScript(
       transaction: Transaction,
       inputIndex: Long,
+      outputMap: Map[TransactionOutPoint, TransactionOutput],
       prevOut: TransactionOutput): Boolean = {
     val sigComponent = TxSigComponent(
       transaction,
       UInt32(inputIndex),
       prevOut,
+      outputMap,
       Policy.standardFlags
     )
     ScriptInterpreter.runVerify(PreExecutionScriptProgram(sigComponent))
@@ -183,13 +185,13 @@ sealed abstract class ScriptInterpreter {
 
   def verifyTransaction(
       transaction: Transaction,
-      prevOuts: Vector[TransactionOutput]): Boolean = {
+      outputMap: Map[TransactionOutPoint, TransactionOutput]): Boolean = {
     require(
-      transaction.inputs.size == prevOuts.size,
-      s"There must be a prevOut for every input in the transaction, got ${prevOuts.size}")
+      transaction.inputs.size == outputMap.size,
+      s"There must be a prevOut for every input in the transaction, got ${outputMap.size}")
 
-    prevOuts.zipWithIndex.forall { case (prevOut, index) =>
-      verifyInputScript(transaction, index, prevOut)
+    outputMap.zipWithIndex.forall { case ((_, prevOut), index) =>
+      verifyInputScript(transaction, index, outputMap, prevOut)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -24,6 +24,7 @@ import org.bitcoins.core.script.reserved._
 import org.bitcoins.core.script.result._
 import org.bitcoins.core.script.splice._
 import org.bitcoins.core.script.stack._
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.util._
 
 import scala.annotation.tailrec
@@ -171,7 +172,7 @@ sealed abstract class ScriptInterpreter {
   def verifyInputScript(
       transaction: Transaction,
       inputIndex: Long,
-      outputMap: Map[TransactionOutPoint, TransactionOutput],
+      outputMap: PreviousOutputMap,
       prevOut: TransactionOutput): Boolean = {
     val sigComponent = TxSigComponent(
       transaction,
@@ -185,7 +186,7 @@ sealed abstract class ScriptInterpreter {
 
   def verifyTransaction(
       transaction: Transaction,
-      outputMap: Map[TransactionOutPoint, TransactionOutput]): Boolean = {
+      outputMap: PreviousOutputMap): Boolean = {
     require(
       transaction.inputs.size == outputMap.size,
       s"There must be a prevOut for every input in the transaction, got ${outputMap.size}")

--- a/core/src/main/scala/org/bitcoins/core/script/util/PreviousOutputMap.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/util/PreviousOutputMap.scala
@@ -1,0 +1,31 @@
+package org.bitcoins.core.script.util
+
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.util.MapWrapper
+import org.bitcoins.core.wallet.utxo._
+
+case class PreviousOutputMap(
+    outputMap: Map[TransactionOutPoint, TransactionOutput])
+    extends MapWrapper[TransactionOutPoint, TransactionOutput] {
+
+  override protected val wrapped: Map[TransactionOutPoint, TransactionOutput] =
+    outputMap
+}
+
+object PreviousOutputMap {
+
+  val empty: PreviousOutputMap = PreviousOutputMap(Map.empty)
+
+  def fromScriptSignatureParams(
+      inputInfos: Seq[ScriptSignatureParams[InputInfo]]): PreviousOutputMap = {
+    fromInputInfos(inputInfos.map(_.inputInfo))
+  }
+
+  def fromInputInfos(inputInfos: Seq[InputInfo]): PreviousOutputMap = {
+    val inputMap = inputInfos.map { inputInfo =>
+      inputInfo.outPoint -> inputInfo.output
+    }.toMap
+
+    PreviousOutputMap(inputMap)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -695,6 +695,7 @@ trait BitcoinScriptUtil {
       tx: Transaction,
       inputMap: InputPSBTMap,
       index: Int,
+      outputMap: Map[TransactionOutPoint, TransactionOutput],
       flags: Seq[ScriptFlag] = Policy.standardFlags): Try[Transaction] = {
 
     val txIn = tx.inputs(index)
@@ -706,7 +707,7 @@ trait BitcoinScriptUtil {
                                          conditionalPath = condPath,
                                          preImages = preImages)
 
-    val txSigComponent = TxSigComponent(inputInfo, tx, flags)
+    val txSigComponent = TxSigComponent(inputInfo, tx, outputMap, flags)
 
     val inputResult =
       ScriptInterpreter.run(PreExecutionScriptProgram(txSigComponent))

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -29,6 +29,7 @@ import org.bitcoins.core.script.result.{
   ScriptErrorWitnessPubKeyType,
   ScriptOk
 }
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.script.{
   ExecutionInProgressScriptProgram,
   PreExecutionScriptProgram
@@ -695,7 +696,7 @@ trait BitcoinScriptUtil {
       tx: Transaction,
       inputMap: InputPSBTMap,
       index: Int,
-      outputMap: Map[TransactionOutPoint, TransactionOutput],
+      outputMap: PreviousOutputMap,
       flags: Seq[ScriptFlag] = Policy.standardFlags): Try[Transaction] = {
 
     val txIn = tx.inputs(index)

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -15,6 +15,7 @@ import org.bitcoins.core.protocol.dlc.models.{
 }
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.testkit.wallet.DLCWalletUtil._
 import org.bitcoins.testkit.wallet.{BitcoinSDualWalletTest, DLCWalletUtil}
@@ -84,7 +85,8 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
         .map(_.toOutputReference)
 
       val prevOutputMap =
-        fundingTxPrevOutputRefs.map(ref => ref.outPoint -> ref.output).toMap
+        PreviousOutputMap(
+          fundingTxPrevOutputRefs.map(ref => ref.outPoint -> ref.output).toMap)
 
       val fundingTxVerify = fundingTx.inputs.zipWithIndex.forall {
         case (input, index) =>

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -83,13 +83,16 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
       val fundingTxPrevOutputRefs = inputsA.map(_.toOutputReference) ++ inputsB
         .map(_.toOutputReference)
 
+      val prevOutputMap =
+        fundingTxPrevOutputRefs.map(ref => ref.outPoint -> ref.output).toMap
+
       val fundingTxVerify = fundingTx.inputs.zipWithIndex.forall {
         case (input, index) =>
           val output = fundingTxPrevOutputRefs
             .find(_.outPoint == input.previousOutput)
             .get
             .output
-          verifyInput(fundingTx, index, output)
+          verifyInput(fundingTx, index, output, prevOutputMap)
       }
       assert(fundingTxVerify)
     }

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TransactionGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TransactionGenerators.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.script.locktime.LockTimeInterpreter
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.crypto.ECPrivateKey
 import org.bitcoins.testkitcore.Implicits._
 import org.scalacheck.Gen
@@ -494,7 +495,7 @@ object TransactionGenerators {
         signedTx,
         inputIndex,
         output,
-        Map.empty,
+        PreviousOutputMap.empty,
         Policy.standardScriptVerifyFlags)
     } yield (signedTxSignatureComponent, privKeys)
 
@@ -536,7 +537,7 @@ object TransactionGenerators {
         signedTx,
         inputIndex,
         output,
-        Map.empty,
+        PreviousOutputMap.empty,
         Policy.standardScriptVerifyFlags)
     } yield (signedTxSignatureComponent, privKeys)
 

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TransactionGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TransactionGenerators.scala
@@ -494,6 +494,7 @@ object TransactionGenerators {
         signedTx,
         inputIndex,
         output,
+        Map.empty,
         Policy.standardScriptVerifyFlags)
     } yield (signedTxSignatureComponent, privKeys)
 
@@ -535,6 +536,7 @@ object TransactionGenerators {
         signedTx,
         inputIndex,
         output,
+        Map.empty,
         Policy.standardScriptVerifyFlags)
     } yield (signedTxSignatureComponent, privKeys)
 

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/WitnessGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/WitnessGenerators.scala
@@ -227,11 +227,13 @@ sealed abstract class WitnessGenerators {
         WitnessTxSigComponent(signedSpendingTx,
                               unsignedWTxComponent.inputIndex,
                               wtxP2SH.output,
+                              Map.empty,
                               unsignedWTxComponent.flags)
       case wtxRaw: WitnessTxSigComponentRaw =>
         WitnessTxSigComponent(signedSpendingTx,
                               unsignedWTxComponent.inputIndex,
                               wtxRaw.output,
+                              Map.empty,
                               unsignedWTxComponent.flags)
       case _: TaprootTxSigComponent =>
         sys.error(s"Cannot build signed taproot sig component yet")

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/WitnessGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/WitnessGenerators.scala
@@ -6,6 +6,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.crypto.{ECPrivateKey, HashType}
 import org.scalacheck.Gen
 
@@ -227,13 +228,13 @@ sealed abstract class WitnessGenerators {
         WitnessTxSigComponent(signedSpendingTx,
                               unsignedWTxComponent.inputIndex,
                               wtxP2SH.output,
-                              Map.empty,
+                              PreviousOutputMap.empty,
                               unsignedWTxComponent.flags)
       case wtxRaw: WitnessTxSigComponentRaw =>
         WitnessTxSigComponent(signedSpendingTx,
                               unsignedWTxComponent.inputIndex,
                               wtxRaw.output,
-                              Map.empty,
+                              PreviousOutputMap.empty,
                               unsignedWTxComponent.flags)
       case _: TaprootTxSigComponent =>
         sys.error(s"Cannot build signed taproot sig component yet")

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -20,6 +20,7 @@ import org.bitcoins.core.protocol.{BitcoinAddress, BlockTimeStamp}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto._
 import org.bitcoins.dlc.wallet.DLCWallet
@@ -355,7 +356,7 @@ object DLCWalletUtil extends Logging {
       transaction: Transaction,
       inputIndex: Long,
       prevOut: TransactionOutput,
-      outputMap: Map[TransactionOutPoint, TransactionOutput]): Boolean = {
+      outputMap: PreviousOutputMap): Boolean = {
     val sigComponent = WitnessTxSigComponent(
       transaction.asInstanceOf[WitnessTransaction],
       UInt32(inputIndex),
@@ -410,7 +411,7 @@ object DLCWalletUtil extends Logging {
       val fundingOutPoint =
         TransactionOutPoint(fundingTx.txId, UInt32(fundOutputIndex))
 
-      val outputMap = Map(fundingOutPoint -> fundingOutput)
+      val outputMap = PreviousOutputMap(Map(fundingOutPoint -> fundingOutput))
 
       verifyInput(tx, 0, fundingOutput, outputMap)
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -354,11 +354,13 @@ object DLCWalletUtil extends Logging {
   def verifyInput(
       transaction: Transaction,
       inputIndex: Long,
-      prevOut: TransactionOutput): Boolean = {
+      prevOut: TransactionOutput,
+      outputMap: Map[TransactionOutPoint, TransactionOutput]): Boolean = {
     val sigComponent = WitnessTxSigComponent(
       transaction.asInstanceOf[WitnessTransaction],
       UInt32(inputIndex),
       prevOut,
+      outputMap,
       Policy.standardFlags
     )
     ScriptInterpreter.runVerify(PreExecutionScriptProgram(sigComponent))
@@ -405,8 +407,12 @@ object DLCWalletUtil extends Logging {
 
       val fundOutputIndex = dlcDb.get.fundingOutPointOpt.get.vout.toInt
       val fundingOutput = fundingTx.outputs(fundOutputIndex)
+      val fundingOutPoint =
+        TransactionOutPoint(fundingTx.txId, UInt32(fundOutputIndex))
 
-      verifyInput(tx, 0, fundingOutput)
+      val outputMap = Map(fundingOutPoint -> fundingOutput)
+
+      verifyInput(tx, 0, fundingOutput, outputMap)
     }
   }
 


### PR DESCRIPTION
For verifying a taproot txs we need a `Map[TransactionOutPoint, TransactionOutput]`. This adds it to the all the `TxSigComponent` creation functions