### PR TITLE
Fix test logging

### DIFF
--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -6,7 +6,7 @@
     <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
 
 
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/application.log</file>
         <encoder>
             <!-- UTC ISO8601 date format -->
@@ -85,16 +85,16 @@
     <!-- ╚═════════════════════════╝ -->
 
     <!-- see how long statements took to execute by setting to DEBUG -->
-    <logger name="slick.jdbc.JdbcBackend.benchmark" level="INFO"/>
+    <logger name="slick.jdbc.JdbcBackend.benchmark" level="OFF"/>
 
     <!-- see what statements are executed by setting to DEBUG -->
-    <logger name="slick.jdbc.JdbcBackend.statement" level="INFO"/>
+    <logger name="slick.jdbc.JdbcBackend.statement" level="OFF"/>
 
     <!-- see what slick is compiling to in sql -->
-    <logger name="slick.compiler" level="INFO"/>
+    <logger name="slick.compiler" level="OFF"/>
 
     <!-- see what's returned by Slick -->
-    <logger name="slick.jdbc.StatementInvoker.result" level="INFO"/>
+    <logger name="slick.jdbc.StatementInvoker.result" level="OFF"/>
 
     <!-- Get rid of messages like this:
     Connection attempt failed. Backing off new connection


### PR DESCRIPTION
It appears we need to define a trigger policy for a `RollingFileAppender` which wasn't defined in #4288 and caused test logging to fail. This reverts our test framework logging to just use a simple `FileAppender` 

