### PR TITLE
2022 07 05 `UnknownControlBlock`

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptWitnessSpec.scala
@@ -1,28 +1,32 @@
 package org.bitcoins.core.protocol.script
 
 import org.bitcoins.testkitcore.gen.{ScriptGenerators, WitnessGenerators}
-import org.scalacheck.{Prop, Properties}
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 
-class ScriptWitnessSpec extends Properties("ScriptWitnessSpec") {
+class ScriptWitnessSpec extends BitcoinSUnitTest {
 
-  property("serialization symmetry") = {
-    Prop.forAll(WitnessGenerators.scriptWitness) { scriptWit =>
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    generatorDrivenConfigNewCode
+  it must "have serialization symmetry" in {
+    forAll(WitnessGenerators.scriptWitness) { scriptWit =>
       val x = ScriptWitness(scriptWit.stack)
-      scriptWit == x
+      val fromBytes = ScriptWitness.fromBytes(scriptWit.bytes)
+      assert(scriptWit == x)
+      assert(fromBytes == scriptWit)
     }
   }
 
-  property("pull redeem script out of p2wsh witness") = {
-    Prop.forAll(ScriptGenerators.rawScriptPubKey) { case (spk, _) =>
-      P2WSHWitnessV0(spk).redeemScript == spk
+  it must "pull redeem script out of p2wsh witness" in {
+    forAll(ScriptGenerators.rawScriptPubKey) { case (spk, _) =>
+      assert(P2WSHWitnessV0(spk).redeemScript == spk)
     }
   }
 
-  property("pull script signature out of p2wsh witness") = {
-    Prop.forAll(ScriptGenerators.rawScriptPubKey,
-                ScriptGenerators.rawScriptSignature) {
-      case ((spk, _), scriptSig) =>
-        P2WSHWitnessV0(spk, scriptSig).scriptSignature == scriptSig
+  it must "pull script signature out of p2wsh witness" in {
+    forAll(ScriptGenerators.rawScriptPubKey,
+           ScriptGenerators.rawScriptSignature) { case ((spk, _), scriptSig) =>
+      assert(P2WSHWitnessV0(spk, scriptSig).scriptSignature == scriptSig)
     }
   }
+
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
@@ -417,8 +417,8 @@ case class TaprootTxSigComponent(
 
   override def sigVersion: SigVersionTaproot = {
     witness match {
-      case _: TaprootKeyPath    => SigVersionTaprootKeySpend
-      case _: TaprootScriptPath => SigVersionTapscript
+      case _: TaprootKeyPath                            => SigVersionTaprootKeySpend
+      case _: TaprootScriptPath | _: TaprootUnknownPath => SigVersionTapscript
     }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
@@ -3,8 +3,6 @@ package org.bitcoins.core.protocol.script
 import org.bitcoins.crypto.{Factory, NetworkElement, XOnlyPubKey}
 import scodec.bits.ByteVector
 
-import scala.util.Try
-
 /** Control block as defined by BIP341
   *
   * The last stack element is called the control block c, and must have length 33 + 32m,
@@ -46,7 +44,7 @@ case class UnknownControlBlock(bytes: ByteVector) extends ControlBlock {
 object ControlBlock extends Factory[ControlBlock] {
 
   override def fromBytes(bytes: ByteVector): ControlBlock = {
-    Try(TapscriptControlBlock(bytes)).getOrElse(UnknownControlBlock(bytes))
+    TapscriptControlBlock(bytes)
   }
 
   /** invariants from: https://github.com/bitcoin/bitcoin/blob/37633d2f61697fc719390767aae740ece978b074/src/script/interpreter.cpp#L1835
@@ -70,9 +68,13 @@ object TapscriptControlBlock extends Factory[TapscriptControlBlock] {
   /** invariants from: https://github.com/bitcoin/bitcoin/blob/37633d2f61697fc719390767aae740ece978b074/src/script/interpreter.cpp#L1835
     */
   def isValid(bytes: ByteVector): Boolean = {
-    ControlBlock.isValid(bytes) &&
-    knownLeafVersions.contains(bytes.head) &&
-    XOnlyPubKey.fromBytesT(bytes.slice(1, 33)).isSuccess
+    if (bytes.isEmpty) {
+      false
+    } else {
+      knownLeafVersions.contains(bytes.head) &&
+      ControlBlock.isValid(bytes) &&
+      XOnlyPubKey.fromBytesT(bytes.slice(1, 33)).isSuccess
+    }
   }
 
   override def fromBytes(bytes: ByteVector): TapscriptControlBlock = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
@@ -10,7 +10,7 @@ import scodec.bits.ByteVector
   *
   * @see https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules
   */
-sealed trait ControlBlock extends NetworkElement {
+sealed abstract class ControlBlock extends NetworkElement {
   require(ControlBlock.isValid(bytes), s"Bytes for control block are not valid")
 
   /** Let p = c[1:33] and let P = lift_x(int(p)) where lift_x and [:] are defined as in BIP340. Fail if this point is not on the curve.
@@ -36,10 +36,7 @@ case class TapscriptControlBlock(bytes: ByteVector) extends ControlBlock {
   * This is needed for future soft fork compatability where we introduce new leaf versions
   * to correspond to new spending rules
   */
-case class UnknownControlBlock(bytes: ByteVector) extends ControlBlock {
-  require(ControlBlock.isValid(bytes),
-          s"Unknown control block didn't have correct format, got=$bytes")
-}
+case class UnknownControlBlock(bytes: ByteVector) extends ControlBlock
 
 object ControlBlock extends Factory[ControlBlock] {
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -189,7 +189,6 @@ object ScriptWitness extends Factory[ScriptWitness] {
       P2WPKHWitnessV0(pubKey)
     } else if (TaprootScriptPath.isValid(stack.toVector)) {
       TaprootScriptPath.fromStack(stack.toVector)
-
     } else if (isPubKey && stack.size == 2) {
       val pubKey = ECPublicKeyBytes(stack.head)
       val sig = ECDigitalSignature(stack(1))
@@ -377,7 +376,6 @@ object TaprootScriptPath {
           stack.head
         }
       }
-
       TapscriptControlBlock.isValid(controlBlock)
     } else {
       false
@@ -442,7 +440,9 @@ object TaprootScriptPath {
 
   /** Checks the witness stack has an annex in it */
   def hasAnnex(stack: Vector[ByteVector]): Boolean = {
-    stack.headOption.map(_.head) == annexOpt
+    stack.headOption
+      .map(_.headOption == annexOpt)
+      .getOrElse(false)
   }
 
   private def hashTapBranch(bytes: ByteVector): Sha256Digest = {
@@ -452,8 +452,6 @@ object TaprootScriptPath {
 
 case class TaprootUnknownPath(stack: Vector[ByteVector])
     extends TaprootWitness {
-  require(TaprootUnknownPath.isValid(bytes),
-          s"Invalid bytes given to TaprootUnknownPath, got=$bytes")
 
   val controlBlock: UnknownControlBlock = {
     if (TaprootScriptPath.hasAnnex(stack)) {
@@ -474,12 +472,5 @@ case class TaprootUnknownPath(stack: Vector[ByteVector])
     } else {
       None
     }
-  }
-}
-
-object TaprootUnknownPath {
-
-  def isValid(bytes: ByteVector): Boolean = {
-    true //any things we need to check here?
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -278,7 +278,7 @@ object TaprootKeyPath {
     }
 
     val keyPath = if (sigBytes.length == 64) {
-      //means SIGHASH_ALL is implicitly encoded
+      //means SIGHASH_DEFAULT is implicitly encoded
       //see: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#Common_signature_message
       val sig = SchnorrDigitalSignature.fromBytes(sigBytes)
       TaprootKeyPath(sig, HashType.sigHashDefault, annexOpt)

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -179,6 +179,7 @@ object ScriptWitness extends Factory[ScriptWitness] {
         || (stack.head.size == 65 && stack.head.head == 0x04 && CryptoUtil
           .isValidPubKey(ECPublicKeyBytes(stack.head))))
     }
+
     if (stack.isEmpty) {
       EmptyScriptWitness
     } else if (TaprootKeyPath.isValid(stack.toVector)) {
@@ -189,6 +190,7 @@ object ScriptWitness extends Factory[ScriptWitness] {
       P2WPKHWitnessV0(pubKey)
     } else if (TaprootScriptPath.isValid(stack.toVector)) {
       TaprootScriptPath.fromStack(stack.toVector)
+
     } else if (isPubKey && stack.size == 2) {
       val pubKey = ECPublicKeyBytes(stack.head)
       val sig = ECDigitalSignature(stack(1))
@@ -279,7 +281,7 @@ object TaprootKeyPath {
       //means SIGHASH_ALL is implicitly encoded
       //see: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#Common_signature_message
       val sig = SchnorrDigitalSignature.fromBytes(sigBytes)
-      TaprootKeyPath(sig, HashType.sigHashAll, annexOpt)
+      TaprootKeyPath(sig, HashType.sigHashDefault, annexOpt)
     } else if (sigBytes.length == 65) {
       val sig = SchnorrDigitalSignature.fromBytes(sigBytes.dropRight(1))
       val hashType = HashType.fromByte(sigBytes.last)

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/WitnessVersion.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/WitnessVersion.scala
@@ -86,6 +86,8 @@ case object WitnessVersion1 extends WitnessVersion {
               Right(witnessSPK)
             case sp: TaprootScriptPath =>
               Right(sp.script)
+            case _: TaprootUnknownPath =>
+              Right(witnessSPK)
             case w @ (EmptyScriptWitness | _: P2WPKHWitnessV0 |
                 _: P2WSHWitnessV0) =>
               sys.error(

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -387,7 +387,6 @@ sealed abstract class ScriptInterpreter {
     }
   }
 
-
   /** Verifies a segregated witness program by running it through the interpreter
     * [[https://github.com/bitcoin/bitcoin/blob/f8528134fc188abc5c7175a19680206964a8fade/src/script/interpreter.cpp#L1302]]
     */

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -387,6 +387,7 @@ sealed abstract class ScriptInterpreter {
     }
   }
 
+
   /** Verifies a segregated witness program by running it through the interpreter
     * [[https://github.com/bitcoin/bitcoin/blob/f8528134fc188abc5c7175a19680206964a8fade/src/script/interpreter.cpp#L1302]]
     */


### PR DESCRIPTION
Adds new data structures 

1. `UnknownControlBlock` - needed to represent a control block that does not have a known leaf version
2. `TapscriptControlBlock` - represents a taproot script path with a leaf version defined in [BIP341/BIP342 (`0xc0`,`0xc1`)](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#rationale)
3. `TaprootUnknownPath` - a taproot script path that corresponds to `UnknownControlBlock`

The reason this is needed is because the static test vectors in #3769 have unknown leaf versions to make sure we maintain future soft fork compatability. 

