### PR TITLE
Allow creating input info of simple OP_TRUE script pub key

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputInfo.scala
@@ -5,7 +5,7 @@ import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
-import org.bitcoins.core.script.constant.ScriptConstant
+import org.bitcoins.core.script.constant.{OP_TRUE, ScriptConstant}
 import org.bitcoins.core.util.{BitcoinScriptUtil, BytesUtil}
 import org.bitcoins.crypto.{
   ECPublicKey,
@@ -401,9 +401,13 @@ object RawInputInfo {
                           hashPreImages)
       case EmptyScriptPubKey =>
         EmptyInputInfo(outPoint, amount)
-      case _: NonStandardScriptPubKey | _: WitnessCommitment =>
-        throw new UnsupportedOperationException(
-          s"Currently unsupported ScriptPubKey $scriptPubKey")
+      case spk @ (_: NonStandardScriptPubKey | _: WitnessCommitment) =>
+        if (spk == ScriptPubKey.fromAsm(Vector(OP_TRUE))) {
+          EmptyInputInfo(outPoint, amount)
+        } else {
+          throw new UnsupportedOperationException(
+            s"Currently unsupported ScriptPubKey $scriptPubKey")
+        }
     }
   }
 }


### PR DESCRIPTION
Extracted from #3823

Let's us create a simple input info for trivial true spks. Nice for creating dummy transactions