### PR TITLE
Remove `.map()` and use .foreach() with buffer in `CryptoBytesUtil.toByteVector`

### DIFF
--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
@@ -36,7 +36,7 @@ class ScanBitcoind()(implicit
       bitcoind <- bitcoindF
       endHeight <- endHeightF
       //_ <- countWitV1MempoolTxs(bitcoind)
-      _ <- countTaprootTxsInBlocks(endHeight, 10000, bitcoind)
+      _ <- countTaprootTxsInBlocks(endHeight, 250000, bitcoind)
     } yield ()
     f.failed.foreach(err =>
       logger.error(s"Failed to count witness v1 mempool txs", err))

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoBytesUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoBytesUtil.scala
@@ -2,7 +2,7 @@ package org.bitcoins.crypto
 
 import scodec.bits.{BitVector, ByteVector}
 
-import scala.math.BigInt
+import java.io.ByteArrayOutputStream
 
 /** Created by chris on 2/26/16.
   */
@@ -97,7 +97,11 @@ trait CryptoBytesUtil {
 
   @inline
   final def toByteVector[T <: NetworkElement](h: Seq[T]): ByteVector = {
-    ByteVector.concat(h.map(_.bytes))
+    val outputStream = new ByteArrayOutputStream()
+    h.foreach { ne =>
+      outputStream.write(ne.bytes.toArray)
+    }
+    ByteVector(outputStream.toByteArray)
   }
 }
 


### PR DESCRIPTION
This seems to be a common hot spot in #3769 when testing

Attempt to improve performance by removing the `.concat()`/`.map()` call and use a Buffer

![Screenshot from 2022-07-06 16-15-22](https://user-images.githubusercontent.com/3514957/177645283-5bbb21c8-5497-45cb-9f4a-02bc177816f1.png)

It seems to reduce the amount of CPU used:

![Screenshot from 2022-07-06 16-25-34](https://user-images.githubusercontent.com/3514957/177646268-155b9f6f-f18c-4fd4-ba89-f4aee0478538.png)
