### PR TITLE
Header sync validation

### DIFF
--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -112,14 +112,12 @@ val nodeF = for {
   chainApi <- chainApiF
   peer <- peerF
 } yield {
-    //you can set this to only sync compact filters after the timestamp
-    val walletCreationTimeOpt = None
-    val dataMessageHandler = DataMessageHandler(chainApi, walletCreationTimeOpt)
-    NeutrinoNode(paramPeers = Vector(peer),
-               dataMessageHandler = dataMessageHandler,
-               nodeConfig = nodeConfig,
-               chainConfig = chainConfig,
-               actorSystem = system)
+    NeutrinoNode(chainApi = chainApi,
+        walletCreationTimeOpt = None, //you can set this to only sync compact filters after the timestamp
+        paramPeers = Vector(peer),
+        nodeConfig = nodeConfig,
+        chainConfig = chainConfig,
+        actorSystem = system)
 }
 
 //let's start it

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -13,7 +13,7 @@ import org.bitcoins.testkit.node.{
   NodeTestWithCachedBitcoindPair,
   NodeUnitTest
 }
-import org.bitcoins.testkit.util.TorUtil
+import org.bitcoins.testkit.util.{AkkaUtil, TorUtil}
 import org.scalatest.{Assertion, FutureOutcome, Outcome}
 
 import scala.concurrent.Future
@@ -108,7 +108,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         _ <- bothOurs
         _ <- allConnected
         _ <- allInitialized
-        _ = peers.map(peerManager.removePeer)
+        _ <- Future.sequence(peers.map(peerManager.removePeer))
         _ <- allDisconn
       } yield {
         succeed
@@ -264,6 +264,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
 
       for {
         _ <- NodeUnitTest.syncNeutrinoNode(node, bitcoind)
+        _ <- AkkaUtil.nonBlockingSleep(3.seconds)
         _ <- bitcoind.generateToAddress(2, junkAddress)
         _ <- NodeTestUtil.awaitAllSync(node, bitcoind)
       } yield {

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -1,7 +1,8 @@
 package org.bitcoins.node
 
+import com.typesafe.config.ConfigFactory
 import org.bitcoins.asyncutil.AsyncUtil
-import org.bitcoins.core.p2p.GetHeadersMessage
+import org.bitcoins.core.p2p.{GetHeadersMessage, HeadersMessage}
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.P2PClient.ExpectResponseCommand
 import org.bitcoins.server.BitcoinSAppConfig
@@ -20,7 +21,9 @@ import scala.concurrent.{Await, Future}
 class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
 
   lazy val bitcoindsF =
-    BitcoindRpcTestUtil.createNodePair().map(p => Vector(p._1, p._2))
+    BitcoindRpcTestUtil
+      .createUnconnectedNodePairWithBlocks()
+      .map(p => Vector(p._1, p._2))
 
   lazy val bitcoinPeersF: Future[Vector[Peer]] = {
     bitcoindsF.flatMap { bitcoinds =>
@@ -30,7 +33,11 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
   }
 
   override protected def getFreshConfig: BitcoinSAppConfig = {
-    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    val configs = ConfigFactory.parseString("""
+                                              | peer-discovery-timeout = 5s
+                                              |""".stripMargin)
+    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                                       configs)
   }
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoinds
@@ -82,6 +89,99 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         peer2 = bitcoindPeers(1)
       } yield {
         assert(newSyncPeer == peer2)
+      }
+  }
+
+  it must "have the best header chain post sync from all peers" in {
+    nodeConnectedWithBitcoinds =>
+      val node = nodeConnectedWithBitcoinds.node
+      val bitcoinds = nodeConnectedWithBitcoinds.bitcoinds
+      val peerManager = node.peerManager
+
+      def peers = peerManager.peers
+
+      for {
+        _ <- AsyncUtil.retryUntilSatisfied(peers.size == 2)
+        _ <- bitcoinds(1).generateToAddress(1, junkAddress)
+        h1 <- bitcoinds(0).getBestHashBlockHeight()
+        h2 <- bitcoinds(1).getBestHashBlockHeight()
+        //out of sync by 1 block, h2 ahead
+        _ = assert(h2 - h1 == 1)
+        _ <- node.sync()
+        _ <- NodeTestUtil.awaitSync(node, bitcoinds(1))
+      } yield {
+        succeed
+      }
+  }
+  //note: now bitcoinds(1) is ahead by 1 block compared to bitcoinds(0)
+
+  it must "re-query in case invalid headers are sent" in {
+    nodeConnectedWithBitcoinds =>
+      val node = nodeConnectedWithBitcoinds.node
+      val bitcoinds = nodeConnectedWithBitcoinds.bitcoinds
+
+      for {
+        _ <- AsyncUtil.retryUntilSatisfied(node.peerManager.peers.size == 2)
+        peers <- bitcoinPeersF
+        peer = peers.head
+        _ = node.updateDataMessageHandler(
+          node.getDataMessageHandler.copy(syncPeer = Some(peer))(
+            executionContext,
+            node.nodeConfig,
+            node.chainConfig))
+
+        invalidHeader = node.chainAppConfig.chain.genesisBlock.blockHeader
+        invalidHeaderMessage = HeadersMessage(headers = Vector(invalidHeader))
+        sender <- node.peerManager.peerData(peer).peerMessageSender
+        _ <- node.getDataMessageHandler.addToStream(invalidHeaderMessage,
+                                                    sender,
+                                                    peer)
+        bestChain = bitcoinds(1)
+        _ <- NodeTestUtil.awaitSync(node, bestChain)
+      } yield {
+        succeed
+      }
+  }
+
+  it must "must disconnect a peer that keeps sending invalid headers" in {
+    nodeConnectedWithBitcoinds =>
+      val node = nodeConnectedWithBitcoinds.node
+      val peerManager = node.peerManager
+
+      def sendInvalidHeaders(peer: Peer): Future[Unit] = {
+        val invalidHeader = node.chainAppConfig.chain.genesisBlock.blockHeader
+        val invalidHeaderMessage =
+          HeadersMessage(headers = Vector(invalidHeader))
+        val senderF = node.peerManager.peerData(peer).peerMessageSender
+
+        for {
+          sender <- senderF
+          sendFs = 1
+            .to(node.nodeConfig.maxInvalidResponsesAllowed + 1)
+            .map(_ =>
+              node.getDataMessageHandler.addToStream(invalidHeaderMessage,
+                                                     sender,
+                                                     peer))
+          _ <- Future.sequence(sendFs)
+        } yield ()
+      }
+
+      for {
+        _ <- AsyncUtil.retryUntilSatisfied(peerManager.peers.size == 2)
+        peers <- bitcoinPeersF
+        peer = peers(0)
+        _ <- node.peerManager.isConnected(peer).map(assert(_))
+        _ = node.updateDataMessageHandler(
+          node.getDataMessageHandler.copy(syncPeer = Some(peer))(
+            executionContext,
+            node.nodeConfig,
+            node.chainConfig))
+
+        _ <- sendInvalidHeaders(peer)
+        _ <- AsyncUtil.retryUntilSatisfied(
+          !node.peerManager.peers.contains(peer))
+      } yield {
+        succeed
       }
   }
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.node
 
-import com.typesafe.config.ConfigFactory
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.p2p.{GetHeadersMessage, HeadersMessage}
 import org.bitcoins.node.models.Peer
@@ -33,11 +32,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
   }
 
   override protected def getFreshConfig: BitcoinSAppConfig = {
-    val configs = ConfigFactory.parseString("""
-                                              | peer-discovery-timeout = 5s
-                                              |""".stripMargin)
-    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(pgUrl,
-                                                                       configs)
+    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(pgUrl)
   }
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoinds

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -39,6 +39,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
         chainApi <- node.chainApiFromDb()
         dataMessageHandler = DataMessageHandler(chainApi,
                                                 None,
+                                                node,
                                                 syncPeer = Some(peer))(
           node.executionContext,
           node.nodeAppConfig,
@@ -83,10 +84,12 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
         _ = node.nodeAppConfig.addCallbacks(nodeCallbacks)
 
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi, None, syncPeer = Some(peer))(
-            node.executionContext,
-            node.nodeAppConfig,
-            node.chainConfig)
+          DataMessageHandler(genesisChainApi,
+                             None,
+                             node,
+                             syncPeer = Some(peer))(node.executionContext,
+                                                    node.nodeAppConfig,
+                                                    node.chainConfig)
         sender <- senderF
         _ <- dataMessageHandler.handleDataPayload(payload, sender, peer)
         result <- resultP.future
@@ -120,10 +123,12 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
 
         _ = node.nodeAppConfig.addCallbacks(callbacks)
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi, None, syncPeer = Some(peer))(
-            node.executionContext,
-            node.nodeAppConfig,
-            node.chainConfig)
+          DataMessageHandler(genesisChainApi,
+                             None,
+                             node,
+                             syncPeer = Some(peer))(node.executionContext,
+                                                    node.nodeAppConfig,
+                                                    node.chainConfig)
         sender <- senderF
         _ <- dataMessageHandler.handleDataPayload(payload, sender, peer)
         result <- resultP.future
@@ -155,10 +160,12 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
         nodeCallbacks = NodeCallbacks.onCompactFilterReceived(callback)
         _ = node.nodeAppConfig.addCallbacks(nodeCallbacks)
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi, None, syncPeer = Some(peer))(
-            node.executionContext,
-            node.nodeAppConfig,
-            node.chainConfig)
+          DataMessageHandler(genesisChainApi,
+                             None,
+                             node,
+                             syncPeer = Some(peer))(node.executionContext,
+                                                    node.nodeAppConfig,
+                                                    node.chainConfig)
         sender <- senderF
         _ <- dataMessageHandler.handleDataPayload(payload, sender, peer)
         result <- resultP.future
@@ -191,10 +198,12 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
         _ = node.nodeAppConfig.addCallbacks(nodeCallbacks)
 
         dataMessageHandler =
-          DataMessageHandler(genesisChainApi, None, syncPeer = Some(peer))(
-            node.executionContext,
-            node.nodeAppConfig,
-            node.chainConfig)
+          DataMessageHandler(genesisChainApi,
+                             None,
+                             node,
+                             syncPeer = Some(peer))(node.executionContext,
+                                                    node.nodeAppConfig,
+                                                    node.chainConfig)
         sender <- senderF
         _ <- dataMessageHandler.handleDataPayload(payload, sender, peer)
         result <- resultP.future

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -9,6 +9,7 @@ import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.node._
+import org.bitcoins.node.networking.peer.DataMessageHandlerState.HeaderSync
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.node.NodeUnitTest
@@ -40,6 +41,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
         dataMessageHandler = DataMessageHandler(chainApi,
                                                 None,
                                                 node,
+                                                HeaderSync,
                                                 syncPeer = Some(peer))(
           node.executionContext,
           node.nodeAppConfig,
@@ -87,6 +89,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
           DataMessageHandler(genesisChainApi,
                              None,
                              node,
+                             HeaderSync,
                              syncPeer = Some(peer))(node.executionContext,
                                                     node.nodeAppConfig,
                                                     node.chainConfig)
@@ -126,6 +129,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
           DataMessageHandler(genesisChainApi,
                              None,
                              node,
+                             HeaderSync,
                              syncPeer = Some(peer))(node.executionContext,
                                                     node.nodeAppConfig,
                                                     node.chainConfig)
@@ -163,6 +167,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
           DataMessageHandler(genesisChainApi,
                              None,
                              node,
+                             HeaderSync,
                              syncPeer = Some(peer))(node.executionContext,
                                                     node.nodeAppConfig,
                                                     node.chainConfig)
@@ -201,6 +206,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
           DataMessageHandler(genesisChainApi,
                              None,
                              node,
+                             HeaderSync,
                              syncPeer = Some(peer))(node.executionContext,
                                                     node.nodeAppConfig,
                                                     node.chainConfig)

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -20,10 +20,12 @@ import org.bitcoins.node.networking.peer.{
   DataMessageHandler
 }
 
+import java.time.Instant
 import scala.concurrent.Future
 
 case class NeutrinoNode(
-    private var dataMessageHandler: DataMessageHandler,
+    chainApi: ChainApi,
+    walletCreationTimeOpt: Option[Instant],
     nodeConfig: NodeAppConfig,
     chainConfig: ChainAppConfig,
     actorSystem: ActorSystem,
@@ -40,6 +42,9 @@ case class NeutrinoNode(
   implicit override def chainAppConfig: ChainAppConfig = chainConfig
 
   val controlMessageHandler: ControlMessageHandler = ControlMessageHandler(this)
+
+  private var dataMessageHandler: DataMessageHandler =
+    DataMessageHandler(chainApi, walletCreationTimeOpt, this)
 
   override def getDataMessageHandler: DataMessageHandler = dataMessageHandler
 

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -15,6 +15,7 @@ import org.bitcoins.core.p2p.ServiceIdentifier
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
+import org.bitcoins.node.networking.peer.DataMessageHandlerState.HeaderSync
 import org.bitcoins.node.networking.peer.{
   ControlMessageHandler,
   DataMessageHandler
@@ -44,7 +45,7 @@ case class NeutrinoNode(
   val controlMessageHandler: ControlMessageHandler = ControlMessageHandler(this)
 
   private var dataMessageHandler: DataMessageHandler =
-    DataMessageHandler(chainApi, walletCreationTimeOpt, this)
+    DataMessageHandler(chainApi, walletCreationTimeOpt, this, HeaderSync)
 
   override def getDataMessageHandler: DataMessageHandler = dataMessageHandler
 

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -51,6 +51,12 @@ case class PeerData(
     _serviceIdentifier = Some(serviceIdentifier)
   }
 
+  private var _invalidMessagesCount: Int = 0
+
+  def updateInvalidMessageCount(): Unit = {
+    _invalidMessagesCount += 1
+  }
+
   private var lastTimedOut: Long = 0
 
   def updateLastFailureTime(): Unit = {
@@ -62,5 +68,9 @@ case class PeerData(
   def hasFailedRecently: Boolean = {
     val timePast = System.currentTimeMillis() - lastTimedOut
     timePast < 30.minutes.toMillis
+  }
+
+  def exceededMaxInvalidMessages: Boolean = {
+    _invalidMessagesCount > nodeAppConfig.maxInvalidResponsesAllowed
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -539,7 +539,7 @@ case class P2PClientActor(
     require(
       msg.isInstanceOf[ExpectsResponse],
       s"Tried to wait for response to message which is not a query, got=$msg")
-    logger.info(s"Expecting response for ${msg.commandName} for $peer")
+    logger.debug(s"Expecting response for ${msg.commandName} for $peer")
     currentPeerMsgHandlerRecv.handleExpectResponse(msg).map { newReceiver =>
       currentPeerMsgHandlerRecv = newReceiver
     }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -31,13 +31,13 @@ case class DataMessageHandler(
     chainApi: ChainApi,
     walletCreationTimeOpt: Option[Instant],
     node: Node,
+    state: DataMessageHandlerState,
     initialSyncDone: Option[Promise[Done]] = None,
     currentFilterBatch: Vector[CompactFilterMessage] = Vector.empty,
     filterHeaderHeightOpt: Option[Int] = None,
     filterHeightOpt: Option[Int] = None,
     syncing: Boolean = false,
-    syncPeer: Option[Peer] = None,
-    state: DataMessageHandlerState = HeaderSync)(implicit
+    syncPeer: Option[Peer] = None)(implicit
     ec: ExecutionContext,
     appConfig: NodeAppConfig,
     chainConfig: ChainAppConfig)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandlerState.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandlerState.scala
@@ -2,8 +2,6 @@ package org.bitcoins.node.networking.peer
 
 import org.bitcoins.node.models.Peer
 
-import scala.collection.mutable
-
 sealed abstract class DataMessageHandlerState
 
 object DataMessageHandlerState {
@@ -11,8 +9,8 @@ object DataMessageHandlerState {
   final case object HeaderSync extends DataMessageHandlerState
 
   case class ValidatingHeaders(
-      inSyncWith: mutable.Set[Peer],
-      failedCheck: mutable.Set[Peer],
+      inSyncWith: Set[Peer],
+      failedCheck: Set[Peer],
       verifyingWith: Set[Peer]
   ) extends DataMessageHandlerState {
     def validated: Boolean = inSyncWith ++ failedCheck == verifyingWith

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandlerState.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandlerState.scala
@@ -1,0 +1,22 @@
+package org.bitcoins.node.networking.peer
+
+import org.bitcoins.node.models.Peer
+
+import scala.collection.mutable
+
+sealed abstract class DataMessageHandlerState
+
+object DataMessageHandlerState {
+
+  final case object HeaderSync extends DataMessageHandlerState
+
+  case class ValidatingHeaders(
+      inSyncWith: mutable.Set[Peer],
+      failedCheck: mutable.Set[Peer],
+      verifyingWith: Set[Peer]
+  ) extends DataMessageHandlerState {
+    def validated: Boolean = inSyncWith ++ failedCheck == verifyingWith
+  }
+
+  final case object PostHeaderSync extends DataMessageHandlerState
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -506,7 +506,7 @@ object NodeUnitTest extends P2PLogger {
   def syncNeutrinoNode(node: NeutrinoNode, bitcoind: BitcoindRpcClient)(implicit
       system: ActorSystem): Future[NeutrinoNode] = {
     import system.dispatcher
-    val x = for {
+    for {
       syncing <- node.chainApiFromDb().flatMap(_.isSyncing())
       _ = assert(!syncing)
       _ <- node.sync()
@@ -523,17 +523,6 @@ object NodeUnitTest extends P2PLogger {
         interval = 1.second,
         maxTries = 5)
     } yield node
-
-    x.recoverWith { case e: Throwable =>
-      for {
-        peer <- createPeer(bitcoind)
-      } yield {
-        println(s"SYNC FAIL WITH $peer")
-        throw e
-      }
-    }
-
-    x
   }
 
   /** This is needed for postgres, we do not drop tables in between individual tests with postgres

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -790,6 +790,24 @@ trait BitcoindRpcTestUtil extends Logging {
     createNodePairInternal(version)
   }
 
+  /** Returns a pair of [[org.bitcoins.rpc.client.common.BitcoindRpcClient BitcoindRpcClient]]
+    * that are not connected but have the same blocks in the chain
+    */
+  def createUnconnectedNodePairWithBlocks[T <: BitcoindRpcClient](
+      clientAccum: RpcClientAccum = Vector.newBuilder)(implicit
+      system: ActorSystem): Future[(BitcoindRpcClient, BitcoindRpcClient)] = {
+    import system.dispatcher
+    for {
+      (first, second) <- createNodePair(clientAccum)
+      _ <- first.addNode(second.getDaemon.uri, AddNodeArgument.Remove)
+      _ <- first.disconnectNode(second.getDaemon.uri)
+      _ <- awaitDisconnected(first, second)
+      _ <- awaitDisconnected(second, first)
+    } yield {
+      (first, second)
+    }
+  }
+
   /** Returns a pair of [[org.bitcoins.rpc.client.v17.BitcoindV17RpcClient BitcoindV17RpcClient]]
     * that are connected with some blocks in the chain
     */


### PR DESCRIPTION
Multiple changes related to header sync in case of multiple peers:
- [x] Post header sync, query all peers for headers once and sync if a better chain exists.
- [x] Test for ^
- [x] Re-query in case invalid headers are sent
- [x] Test for ^
- [x] Disconnect and use another peer if current one keeps sending invalid headers.
- [x] Test for ^ 
- [ ] ~Start syncing headers from non filter peers while waiting for filter peers.~ The test suite peers show support for `NODE_COMPACT_FILTERS` but not `NODE_NETWORK` so seeing where the issue lies at.
- [ ] ~Test for ^~

Put this up for some review. Personally I think this should be merged after the existing issues wrt node tests are dealt with. 