### PR TITLE
Have `FutureUtil.makeAsync` handle thrown exceptions

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/util/FutureUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/FutureUtilTest.scala
@@ -109,4 +109,11 @@ class FutureUtilTest extends BitcoinSJvmTest {
     }
   }
 
+  it must "properly handle an exception in makeAsync" in {
+    val f = FutureUtil.makeAsync { () =>
+      throw new RuntimeException("test")
+    }
+
+    recoverToSucceededIf[RuntimeException](f)
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.core.util
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.Try
 
 object FutureUtil {
 
@@ -100,8 +101,8 @@ object FutureUtil {
     val resultP = Promise[T]()
 
     ec.execute { () =>
-      val result = func()
-      resultP.success(result)
+      val resultT = Try(func())
+      resultP.complete(resultT)
     }
 
     resultP.future


### PR DESCRIPTION
Previously if `func()` failed  `FutureUtil.makeAsync` would just hang forever. This will now return the expected failed future