### PR TITLE
Add `imported` flag to the seed JSON

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -1017,7 +1017,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
             "hdPath" -> Str(accountDb.hdAccount.toString),
             "height" -> Num(walletState.height),
             "blockHash" -> Str(walletState.blockHash.hex),
-            "rescan" -> rescan
+            "rescan" -> rescan,
+            "imported" -> wallet.keyManager.imported
           )
       )
     }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -871,10 +871,16 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
 
             val mnemonicState = passwordOpt match {
               case Some(pass) =>
-                DecryptedMnemonic(mnemonic, creationTime, backupTimeOpt = None)
+                DecryptedMnemonic(mnemonic,
+                                  creationTime,
+                                  backupTimeOpt = None,
+                                  imported = true)
                   .encrypt(pass)
               case None =>
-                DecryptedMnemonic(mnemonic, creationTime, backupTimeOpt = None)
+                DecryptedMnemonic(mnemonic,
+                                  creationTime,
+                                  backupTimeOpt = None,
+                                  imported = true)
             }
 
             WalletStorage.writeSeedToDisk(seedPath, mnemonicState)
@@ -936,10 +942,16 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
 
             val mnemonicState = passwordOpt match {
               case Some(pass) =>
-                DecryptedExtPrivKey(xprv, creationTime, backupTimeOpt = None)
+                DecryptedExtPrivKey(xprv,
+                                    creationTime,
+                                    backupTimeOpt = None,
+                                    imported = true)
                   .encrypt(pass)
               case None =>
-                DecryptedExtPrivKey(xprv, creationTime, backupTimeOpt = None)
+                DecryptedExtPrivKey(xprv,
+                                    creationTime,
+                                    backupTimeOpt = None,
+                                    imported = true)
             }
 
             WalletStorage.writeSeedToDisk(seedPath, mnemonicState)

--- a/core/src/main/scala/org/bitcoins/core/api/keymanager/KeyManagerApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/keymanager/KeyManagerApi.scala
@@ -14,4 +14,5 @@ trait BIP39KeyManagerApi extends KeyManagerApi {
   def deriveXPub(account: HDAccount): Try[ExtPublicKey]
   def getRootXPub: ExtPublicKey
   def kmParams: KeyManagerParams
+  def imported: Boolean
 }

--- a/docs/key-manager/key-manager.md
+++ b/docs/key-manager/key-manager.md
@@ -110,7 +110,7 @@ again after initializing it once. You can use the same `mnemonic` for different 
 val mainnetKmParams = KeyManagerParams(seedPath, HDPurposes.SegWit, MainNet)
 
 //we do not need to all `initializeWithMnemonic()` again as we have saved the seed to dis
-val mainnetKeyManager = BIP39KeyManager.fromMnemonic(mnemonic, mainnetKmParams, None, Instant.now)
+val mainnetKeyManager = BIP39KeyManager.fromMnemonic(mnemonic, mainnetKmParams, None, Instant.now, false)
 
 val mainnetXpub = mainnetKeyManager.getRootXPub
 

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
@@ -37,7 +37,8 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
 
   def getAndWriteMnemonic(walletConf: WalletAppConfig): DecryptedMnemonic = {
     val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
-    val decryptedMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None)
+    val decryptedMnemonic =
+      DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
     val encrypted = decryptedMnemonic.encrypt(passphrase.get)
     val seedPath = getSeedPath(walletConf)
     WalletStorage.writeSeedToDisk(seedPath, encrypted)
@@ -46,7 +47,8 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
 
   def getAndWriteXprv(walletConf: WalletAppConfig): DecryptedExtPrivKey = {
     val xprv = CryptoGenerators.extPrivateKey.sampleSome
-    val decryptedExtPrivKey = DecryptedExtPrivKey(xprv, TimeUtil.now, None)
+    val decryptedExtPrivKey =
+      DecryptedExtPrivKey(xprv, TimeUtil.now, None, false)
     val encrypted = decryptedExtPrivKey.encrypt(passphrase.get)
     val seedPath = getSeedPath(walletConf)
     WalletStorage.writeSeedToDisk(seedPath, encrypted)
@@ -106,7 +108,8 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
     walletConf: WalletAppConfig =>
       assert(!walletConf.kmConf.seedExists())
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
-      val writtenMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None)
+      val writtenMnemonic =
+        DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
       val seedPath = getSeedPath(walletConf)
       WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
 
@@ -131,7 +134,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
     walletConf: WalletAppConfig =>
       assert(!walletConf.kmConf.seedExists())
       val xprv = CryptoGenerators.extPrivateKey.sampleSome
-      val writtenXprv = DecryptedExtPrivKey(xprv, TimeUtil.now, None)
+      val writtenXprv = DecryptedExtPrivKey(xprv, TimeUtil.now, None, false)
       val seedPath = getSeedPath(walletConf)
       WalletStorage.writeSeedToDisk(seedPath, writtenXprv)
 
@@ -184,7 +187,8 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
     walletConf: WalletAppConfig =>
       assert(!walletConf.kmConf.seedExists())
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
-      val writtenMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None)
+      val writtenMnemonic =
+        DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
       val seedPath = getSeedPath(walletConf)
       WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
 
@@ -271,7 +275,8 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
     walletConf: WalletAppConfig =>
       assert(!walletConf.kmConf.seedExists())
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
-      val writtenMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None)
+      val writtenMnemonic =
+        DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
       val seedPath = getSeedPath(walletConf)
       WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
 
@@ -622,7 +627,8 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
     walletConf: WalletAppConfig =>
       assert(!walletConf.kmConf.seedExists())
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
-      val writtenMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None)
+      val writtenMnemonic =
+        DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
       val seedPath = getSeedPath(walletConf)
       WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
 
@@ -698,7 +704,8 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   it must "backup an unencrypted seed" in { walletConf: WalletAppConfig =>
     assert(!walletConf.kmConf.seedExists())
     val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
-    val writtenMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None)
+    val writtenMnemonic =
+      DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
     val seedPath = getSeedPath(walletConf)
     WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
     assert(walletConf.kmConf.seedExists())
@@ -725,8 +732,9 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   it must "backup an encrypted seed" in { walletConf: WalletAppConfig =>
     assert(!walletConf.kmConf.seedExists())
     val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
-    val writtenMnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None)
-      .encrypt(passphrase.get)
+    val writtenMnemonic =
+      DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
+        .encrypt(passphrase.get)
     val seedPath = getSeedPath(walletConf)
     WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
     assert(walletConf.kmConf.seedExists())
@@ -750,4 +758,60 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
         .get)
   }
 
+  it must "set imported flag for an encrypted seed" in {
+    walletConf: WalletAppConfig =>
+      assert(!walletConf.kmConf.seedExists())
+      val seedPath = getSeedPath(walletConf)
+      val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
+
+      val writtenMnemonic = DecryptedMnemonic(mnemonicCode,
+                                              TimeUtil.now,
+                                              None,
+                                              false).encrypt(passphrase.get)
+
+      WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
+      WalletStorage.decryptSeedFromDisk(walletConf.seedPath, passphrase) match {
+        case Right(seed) => assert(!seed.imported)
+        case Left(err)   => fail(err.toString)
+      }
+
+      seedPath.toFile.delete()
+
+      val importedWrittenMnemonic =
+        DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, true).encrypt(
+          passphrase.get)
+
+      WalletStorage.writeSeedToDisk(seedPath, importedWrittenMnemonic)
+      WalletStorage.decryptSeedFromDisk(walletConf.seedPath, passphrase) match {
+        case Right(seed) => assert(seed.imported)
+        case Left(err)   => fail(err.toString)
+      }
+  }
+
+  it must "set imported flag for an unencrypted seed" in {
+    walletConf: WalletAppConfig =>
+      assert(!walletConf.kmConf.seedExists())
+      val seedPath = getSeedPath(walletConf)
+      val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
+
+      val writtenMnemonic =
+        DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
+
+      WalletStorage.writeSeedToDisk(seedPath, writtenMnemonic)
+      WalletStorage.decryptSeedFromDisk(walletConf.seedPath, None) match {
+        case Right(seed) => assert(!seed.imported)
+        case Left(err)   => fail(err.toString)
+      }
+
+      seedPath.toFile.delete()
+
+      val importedWrittenMnemonic =
+        DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, true)
+
+      WalletStorage.writeSeedToDisk(seedPath, importedWrittenMnemonic)
+      WalletStorage.decryptSeedFromDisk(walletConf.seedPath, None) match {
+        case Right(seed) => assert(seed.imported)
+        case Left(err)   => fail(err.toString)
+      }
+  }
 }

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
@@ -85,7 +85,11 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
   it must "initialize a key manager to the same xpub if we call constructor directly or use CreateKeyManagerApi" in {
     val kmParams = buildParams()
     val direct =
-      BIP39KeyManager.fromMnemonic(mnemonic, kmParams, None, TimeUtil.now)
+      BIP39KeyManager.fromMnemonic(mnemonic,
+                                   kmParams,
+                                   None,
+                                   TimeUtil.now,
+                                   false)
 
     val directXpub = direct.getRootXPub
 
@@ -112,7 +116,8 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
       BIP39KeyManager.fromMnemonic(mnemonic,
                                    kmParams,
                                    Some(bip39Pw),
-                                   TimeUtil.now)
+                                   TimeUtil.now,
+                                   false)
 
     val directXpub = direct.getRootXPub
 
@@ -139,7 +144,8 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
       BIP39KeyManager.fromMnemonic(mnemonic,
                                    kmParams,
                                    Some(bip39Pw),
-                                   TimeUtil.now)
+                                   TimeUtil.now,
+                                   false)
 
     val decryptedMnemonic =
       DecryptedMnemonic(mnemonic, direct.creationTime, None, false)
@@ -170,7 +176,8 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
       BIP39KeyManager.fromMnemonic(mnemonic,
                                    kmParams,
                                    Some(bip39Pw),
-                                   TimeUtil.now)
+                                   TimeUtil.now,
+                                   false)
     val seed = BIP39Seed.fromMnemonic(mnemonic, Some(bip39Pw))
     val privVersion = HDUtil.getXprivVersion(kmParams.purpose, kmParams.network)
     val rootExtPrivKey = seed.toExtPrivateKey(privVersion)
@@ -203,7 +210,8 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
       BIP39KeyManager.fromMnemonic(mnemonic,
                                    kmParams,
                                    Some(bip39Pw),
-                                   TimeUtil.now)
+                                   TimeUtil.now,
+                                   false)
 
     val directXpub = direct.getRootXPub
 
@@ -232,11 +240,16 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
       BIP39KeyManager.fromMnemonic(mnemonic,
                                    kmParams,
                                    Some(bip39Pw),
-                                   TimeUtil.now)
+                                   TimeUtil.now,
+                                   false)
     val withPasswordXpub = withPassword.getRootXPub
 
     val noPassword =
-      BIP39KeyManager.fromMnemonic(mnemonic, kmParams, None, TimeUtil.now)
+      BIP39KeyManager.fromMnemonic(mnemonic,
+                                   kmParams,
+                                   None,
+                                   TimeUtil.now,
+                                   false)
 
     val noPwXpub = noPassword.getRootXPub
 

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/bip39/BIP39KeyManagerApiTest.scala
@@ -142,7 +142,7 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
                                    TimeUtil.now)
 
     val decryptedMnemonic =
-      DecryptedMnemonic(mnemonic, direct.creationTime, None)
+      DecryptedMnemonic(mnemonic, direct.creationTime, None, false)
     val password = AesPassword.fromNonEmptyString("password")
     WalletStorage.writeSeedToDisk(kmParams.seedPath,
                                   decryptedMnemonic.encrypt(password))
@@ -176,7 +176,7 @@ class BIP39KeyManagerApiTest extends KeyManagerApiUnitTest {
     val rootExtPrivKey = seed.toExtPrivateKey(privVersion)
 
     val decryptedXprv =
-      DecryptedExtPrivKey(rootExtPrivKey, direct.creationTime, None)
+      DecryptedExtPrivKey(rootExtPrivKey, direct.creationTime, None, false)
     val password = AesPassword.fromNonEmptyString("password")
     WalletStorage.writeSeedToDisk(kmParams.seedPath,
                                   decryptedXprv.encrypt(password))

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
@@ -97,7 +97,7 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
   it must "move an old seed into the seeds folder" in {
     // generate and write mnemonic
     val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
-    val mnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None)
+    val mnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
     val seedPath = tempDir.resolve(WalletStorage.ENCRYPTED_SEED_FILE_NAME)
     WalletStorage.writeSeedToDisk(seedPath, mnemonic)
 

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/EncryptedMnemonic.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/EncryptedMnemonic.scala
@@ -10,6 +10,7 @@ import scala.util.{Failure, Success, Try}
 sealed trait SeedState {
   def creationTime: Instant
   def backupTimeOpt: Option[Instant]
+  def imported: Boolean
   def withBackupTime(backupTime: Instant): SeedState
 }
 
@@ -22,14 +23,15 @@ sealed trait DecryptedSeedState extends SeedState {
 
     val encrypted = AesCrypt.encrypt(clearText, key)
 
-    EncryptedSeed(encrypted, salt, creationTime, backupTimeOpt)
+    EncryptedSeed(encrypted, salt, creationTime, backupTimeOpt, imported)
   }
 }
 
 case class DecryptedMnemonic(
     private[keymanager] val mnemonicCode: MnemonicCode,
     creationTime: Instant,
-    backupTimeOpt: Option[Instant])
+    backupTimeOpt: Option[Instant],
+    imported: Boolean)
     extends DecryptedSeedState {
   override protected val strToEncrypt: String = mnemonicCode.words.mkString(" ")
 
@@ -41,7 +43,8 @@ case class DecryptedMnemonic(
 case class DecryptedExtPrivKey(
     private[keymanager] val xprv: ExtPrivateKey,
     creationTime: Instant,
-    backupTimeOpt: Option[Instant])
+    backupTimeOpt: Option[Instant],
+    imported: Boolean)
     extends DecryptedSeedState {
   override protected val strToEncrypt: String = xprv.toStringSensitive
 
@@ -54,7 +57,8 @@ case class EncryptedSeed(
     value: AesEncryptedData,
     salt: AesSalt,
     creationTime: Instant,
-    backupTimeOpt: Option[Instant])
+    backupTimeOpt: Option[Instant],
+    imported: Boolean)
     extends SeedState {
 
   private def decryptStr(password: AesPassword): Try[String] = {

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -33,7 +33,8 @@ import scala.util.{Failure, Success, Try}
 class BIP39KeyManager(
     private[this] val rootExtPrivKey: ExtPrivateKey,
     val kmParams: KeyManagerParams,
-    val creationTime: Instant)
+    val creationTime: Instant,
+    val imported: Boolean)
     extends BIP39KeyManagerApi
     with KeyManagerLogger {
 
@@ -75,12 +76,13 @@ object BIP39KeyManager
       mnemonic: MnemonicCode,
       kmParams: KeyManagerParams,
       bip39PasswordOpt: Option[String],
-      creationTime: Instant
+      creationTime: Instant,
+      imported: Boolean
   ): BIP39KeyManager = {
     val seed = BIP39Seed.fromMnemonic(mnemonic, bip39PasswordOpt)
     val privVersion = HDUtil.getXprivVersion(kmParams.purpose, kmParams.network)
     val rootExtPrivKey = seed.toExtPrivateKey(privVersion)
-    new BIP39KeyManager(rootExtPrivKey, kmParams, creationTime)
+    new BIP39KeyManager(rootExtPrivKey, kmParams, creationTime, imported)
   }
 
   val badPassphrase: AesPassword = AesPassword.fromString("changeMe")
@@ -140,7 +142,8 @@ object BIP39KeyManager
           fromMnemonic(mnemonic = mnemonic,
                        kmParams = kmParams,
                        bip39PasswordOpt = bip39PasswordOpt,
-                       creationTime = time)
+                       creationTime = time,
+                       imported = writable.imported)
         }
       } else {
         logger.info(
@@ -153,9 +156,13 @@ object BIP39KeyManager
               fromMnemonic(mnemonic = mnemonic.mnemonicCode,
                            kmParams = kmParams,
                            bip39PasswordOpt = bip39PasswordOpt,
-                           creationTime = mnemonic.creationTime))
+                           creationTime = mnemonic.creationTime,
+                           imported = mnemonic.imported))
           case Right(xprv: DecryptedExtPrivKey) =>
-            val km = new BIP39KeyManager(xprv.xprv, kmParams, xprv.creationTime)
+            val km = new BIP39KeyManager(xprv.xprv,
+                                         kmParams,
+                                         xprv.creationTime,
+                                         xprv.imported)
             Right(km)
           case Left(err) =>
             Left(
@@ -215,9 +222,13 @@ object BIP39KeyManager
           fromMnemonic(mnemonic.mnemonicCode,
                        kmParams,
                        bip39PasswordOpt,
-                       mnemonic.creationTime))
+                       mnemonic.creationTime,
+                       mnemonic.imported))
       case Right(xprv: DecryptedExtPrivKey) =>
-        val km = new BIP39KeyManager(xprv.xprv, kmParams, xprv.creationTime)
+        val km = new BIP39KeyManager(xprv.xprv,
+                                     kmParams,
+                                     xprv.creationTime,
+                                     xprv.imported)
         Right(km)
       case Left(v) => Left(v)
     }

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39KeyManager.scala
@@ -118,7 +118,10 @@ object BIP39KeyManager
         val writableMnemonicE: Either[KeyManagerInitializeError, SeedState] =
           mnemonicE.map { mnemonic =>
             val decryptedMnemonic =
-              DecryptedMnemonic(mnemonic, time, backupTimeOpt = None)
+              DecryptedMnemonic(mnemonic,
+                                time,
+                                backupTimeOpt = None,
+                                imported = false)
             aesPasswordOpt match {
               case Some(aesPassword) => decryptedMnemonic.encrypt(aesPassword)
               case None =>

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/bip39/BIP39LockedKeyManager.scala
@@ -34,10 +34,14 @@ object BIP39LockedKeyManager extends Logging {
           BIP39KeyManager.fromMnemonic(mnemonic.mnemonicCode,
                                        kmParams,
                                        bip39PasswordOpt,
-                                       mnemonic.creationTime))
+                                       mnemonic.creationTime,
+                                       mnemonic.imported))
 
       case Right(xprv: DecryptedExtPrivKey) =>
-        val km = new BIP39KeyManager(xprv.xprv, kmParams, xprv.creationTime)
+        val km = new BIP39KeyManager(xprv.xprv,
+                                     kmParams,
+                                     xprv.creationTime,
+                                     xprv.imported)
         Right(km)
 
       case Left(result) =>

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
@@ -112,7 +112,8 @@ case class KeyManagerAppConfig(
         .fromMnemonic(mnemonic = mnemonicEntropy,
                       kmParams = kmParams,
                       bip39PasswordOpt = bip39PasswordOpt,
-                      creationTime = Instant.now)
+                      creationTime = Instant.now,
+                      imported = false)
       val kmRootXpub = toBip39KeyManager.getRootXPub
       require(
         kmEntropy.getRootXPub == kmRootXpub,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/EncryptedMnemonicTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/EncryptedMnemonicTest.scala
@@ -17,7 +17,7 @@ class EncryptedMnemonicTest extends BitcoinSUnitTest {
     val badPassword = AesPassword.fromNonEmptyString("bad")
 
     val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
-    val mnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None)
+    val mnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
     val encrypted = mnemonic.encrypt(password)
 
     val decrypted = encrypted.toMnemonic(badPassword)
@@ -28,7 +28,7 @@ class EncryptedMnemonicTest extends BitcoinSUnitTest {
   it must "have encryption/decryption symmetry" in {
     forAll(CryptoGenerators.mnemonicCode, CryptoGenerators.aesPassword) {
       (mnemonicCode, password) =>
-        val mnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None)
+        val mnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
         val encrypted = mnemonic.encrypt(password)
         val decrypted = encrypted.toMnemonic(password) match {
           case Success(clear) => clear

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/EncryptedMnemonicTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/EncryptedMnemonicTest.scala
@@ -28,7 +28,8 @@ class EncryptedMnemonicTest extends BitcoinSUnitTest {
   it must "have encryption/decryption symmetry" in {
     forAll(CryptoGenerators.mnemonicCode, CryptoGenerators.aesPassword) {
       (mnemonicCode, password) =>
-        val mnemonic = DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
+        val mnemonic =
+          DecryptedMnemonic(mnemonicCode, TimeUtil.now, None, false)
         val encrypted = mnemonic.encrypt(password)
         val decrypted = encrypted.toMnemonic(password) match {
           case Success(clear) => clear


### PR DESCRIPTION
All seeds created using `importseed` RPC will have this flag set to `true`. Automatically genarted seeds (ex. the default wallet) will have it set to `false`.