### PR TITLE
Fix filter sync if headers received while syncing

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -13,7 +13,7 @@ import org.bitcoins.testkit.node.{
   NodeTestWithCachedBitcoindPair,
   NodeUnitTest
 }
-import org.bitcoins.testkit.util.{AkkaUtil, TorUtil}
+import org.bitcoins.testkit.util.TorUtil
 import org.scalatest.{Assertion, FutureOutcome, Outcome}
 
 import scala.concurrent.Future
@@ -44,7 +44,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
 
   behavior of "NeutrinoNode"
 
-  ignore must "be able to sync" in { nodeConnectedWithBitcoinds =>
+  it must "be able to sync" in { nodeConnectedWithBitcoinds =>
     val node = nodeConnectedWithBitcoinds.node
     val bitcoinds = nodeConnectedWithBitcoinds.bitcoinds
     val peerManager = node.peerManager
@@ -69,7 +69,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
     }
   }
 
-  ignore must "be able to connect, initialize and then disconnect from all peers" in {
+  it must "be able to connect, initialize and then disconnect from all peers" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoind.node
       def peerManager = node.peerManager
@@ -113,7 +113,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       }
   }
 
-  ignore must "store peers after successful initialization" in {
+  it must "store peers after successful initialization" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoind.node
       val peerManager = node.peerManager
@@ -167,7 +167,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       }
   }
 
-  ignore must "receive notification that a block occurred on the p2p network for neutrino" in {
+  it must "receive notification that a block occurred on the p2p network for neutrino" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoind.node
       val bitcoind = nodeConnectedWithBitcoind.bitcoinds(0)
@@ -204,7 +204,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       }
   }
 
-  ignore must "stay in sync with a bitcoind instance for neutrino" in {
+  it must "stay in sync with a bitcoind instance for neutrino" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoind.node
       val bitcoind = nodeConnectedWithBitcoind.bitcoinds(0)
@@ -263,12 +263,6 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       for {
         _ <- NodeUnitTest.syncNeutrinoNode(node, bitcoind)
         _ <- bitcoind.generateToAddress(2, junkAddress)
-        _ <- AkkaUtil.nonBlockingSleep(3.seconds)
-        chain <- node.chainApiFromDb()
-        h1 <- chain.getBestHashBlockHeight()
-        h2 <- chain.getFilterHeaderCount()
-        h3 <- chain.getFilterCount()
-        _ = println(s"STATUS $h1 $h2 $h3")
         _ <- NodeTestUtil.awaitAllSync(node, bitcoind)
       } yield {
         succeed

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -13,7 +13,7 @@ import org.bitcoins.testkit.node.{
   NodeTestWithCachedBitcoindPair,
   NodeUnitTest
 }
-import org.bitcoins.testkit.util.TorUtil
+import org.bitcoins.testkit.util.{AkkaUtil, TorUtil}
 import org.scalatest.{Assertion, FutureOutcome, Outcome}
 
 import scala.concurrent.Future
@@ -44,7 +44,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
 
   behavior of "NeutrinoNode"
 
-  it must "be able to sync" in { nodeConnectedWithBitcoinds =>
+  ignore must "be able to sync" in { nodeConnectedWithBitcoinds =>
     val node = nodeConnectedWithBitcoinds.node
     val bitcoinds = nodeConnectedWithBitcoinds.bitcoinds
     val peerManager = node.peerManager
@@ -69,7 +69,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
     }
   }
 
-  it must "be able to connect, initialize and then disconnect from all peers" in {
+  ignore must "be able to connect, initialize and then disconnect from all peers" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoind.node
       def peerManager = node.peerManager
@@ -113,7 +113,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       }
   }
 
-  it must "store peers after successful initialization" in {
+  ignore must "store peers after successful initialization" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoind.node
       val peerManager = node.peerManager
@@ -167,7 +167,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       }
   }
 
-  it must "receive notification that a block occurred on the p2p network for neutrino" in {
+  ignore must "receive notification that a block occurred on the p2p network for neutrino" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoind.node
       val bitcoind = nodeConnectedWithBitcoind.bitcoinds(0)
@@ -204,7 +204,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       }
   }
 
-  it must "stay in sync with a bitcoind instance for neutrino" in {
+  ignore must "stay in sync with a bitcoind instance for neutrino" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoind.node
       val bitcoind = nodeConnectedWithBitcoind.bitcoinds(0)
@@ -251,6 +251,27 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         } yield {
           assert(mtp1 == mtp2)
         }
+      }
+  }
+
+  //intended for test fixtures
+  it must "sync filters when multiple header messages are sent in succession" in {
+    nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
+      val node = nodeConnectedWithBitcoind.node
+      val bitcoind = nodeConnectedWithBitcoind.bitcoinds(0)
+
+      for {
+        _ <- NodeUnitTest.syncNeutrinoNode(node, bitcoind)
+        _ <- bitcoind.generateToAddress(2, junkAddress)
+        _ <- AkkaUtil.nonBlockingSleep(3.seconds)
+        chain <- node.chainApiFromDb()
+        h1 <- chain.getBestHashBlockHeight()
+        h2 <- chain.getFilterHeaderCount()
+        h3 <- chain.getFilterCount()
+        _ = println(s"STATUS $h1 $h2 $h3")
+        _ <- NodeTestUtil.awaitAllSync(node, bitcoind)
+      } yield {
+        succeed
       }
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -150,7 +150,7 @@ case class DataMessageHandler(
             if (!newSyncing) {
               syncIfHeadersAhead(peerMsgSender)
             } else {
-              Future.successful(syncing)
+              Future.successful(newSyncing)
             }
           }
         } yield {

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -119,7 +119,6 @@ case class DataMessageHandler(
             } else {
               val syncing = newFilterHeight < newFilterHeaderHeight
               if (!syncing) {
-                logger.info(s"We are synced")
                 Try(initialSyncDone.map(_.success(Done)))
               }
               syncing
@@ -147,11 +146,18 @@ case class DataMessageHandler(
                 s"Received maximum amount of filters in one batch. This means we are not synced, requesting more")
               sendNextGetCompactFilterCommand(peerMsgSender, newFilterHeight)
             } else Future.unit
+          newSyncing2 <- {
+            if (!newSyncing) {
+              syncIfHeadersAhead(peerMsgSender)
+            } else {
+              Future.successful(syncing)
+            }
+          }
         } yield {
           this.copy(
             chainApi = newChainApi,
             currentFilterBatch = newBatch,
-            syncing = newSyncing,
+            syncing = newSyncing2,
             filterHeaderHeightOpt = Some(newFilterHeaderHeight),
             filterHeightOpt = Some(newFilterHeight)
           )
@@ -333,6 +339,34 @@ case class DataMessageHandler(
       }
 
     }
+  }
+
+  /** syncs filter headers in case the header chain is still ahead post filter sync */
+  def syncIfHeadersAhead(
+      peerMessageSender: PeerMessageSender): Future[Boolean] = {
+    for {
+      headerHeight <- chainApi.getBestHashBlockHeight()
+      filterHeaderCount <- chainApi.getFilterHeaderCount()
+      filterCount <- chainApi.getFilterCount()
+      syncing <- {
+        assert(headerHeight >= Math.max(filterHeaderCount, filterCount),
+               "Header chain cannot be behind filter or filter header chain")
+        assert(
+          filterHeaderCount >= filterCount,
+          s"Filter header height $filterHeaderCount must be atleast filter height $filterCount")
+        if (headerHeight > filterHeaderCount) {
+          logger.info(
+            s"Starting to fetch filter headers in data message handler")
+          sendFirstGetCompactFilterHeadersCommand(peerMessageSender)
+        } else {
+          assert(
+            headerHeight == filterHeaderCount && headerHeight == filterCount)
+          logger.info(s"We are synced")
+          Try(initialSyncDone.map(_.success(Done)))
+          Future.successful(false)
+        }
+      }
+    } yield syncing
   }
 
   private def sendNextGetCompactFilterHeadersCommand(


### PR DESCRIPTION
If headers are received when the node is still syncing filters or filter headers, then no queries to fetch filers are made for the received headers.

In tests, when node receives header messages one after the other, it makes a request for filters for the first header message and sets `syncing` as true which is back again to false after filters are received. Any headers received in between them are processed but query for filter would not be made.
Haven't verified it, but this should also happen for any headers received during the node IBD on mainnet as the filters for the headers received while node is syncing filter headers and filters are not queried for. In such a case, we would still have a fully synced chain once we receive any header post IBD.

This adds a simple check after a compact filter sync to ensure that the filters and filter headers are actually in sync with headers, and if not, it tries to sync.