### PR TITLE
Validate max ScriptNumber bytes in OP_CHECKSIGADD

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
@@ -455,8 +455,7 @@ sealed abstract class CryptoInterpreter {
           val numT = ScriptNumber(updatedProgram.stack(1).bytes, requireMinimal)
 
           if (numT.isFailure || numT.get.byteSize > 4) {
-            // not sure what error to throw here
-            updatedProgram.failExecution(ScriptErrorInvalidStackOperation)
+            updatedProgram.failExecution(ScriptErrorUnknownError)
           } else {
             val restOfStack =
               updatedProgram.stack.tail.tail.tail //remove signature, num, pubkey


### PR DESCRIPTION
Gets the `tapscript/checksigaddoversize` failure cases passing.

From BIP 341

> For OP_CHECKSIGADD, the public key (top element), a CScriptNum n (second to top element), and a signature (third to top element) are popped from the stack.
> - If fewer than 3 elements are on the stack, the script MUST fail and terminate immediately.
> - If n is larger than 4 bytes, the script MUST fail and terminate immediately.
