### PR TITLE
Fix hashtype check to correctly handle scala's conversion

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
@@ -231,15 +231,19 @@ sealed abstract class CryptoInterpreter {
       }
       helperE match {
         case Right(helper) =>
-          val result = TransactionSignatureChecker.checkSigTapscript(
-            txSignatureComponent = program.txSignatureComponent,
-            pubKey = helper.pubKey.schnorrPublicKey,
-            signature = helper.signature,
-            hashType = helper.hashType,
-            taprootOptions = program.taprootSerializationOptions,
-            flags = program.flags
-          )
-          Right(result)
+          val validHashType =
+            TransactionSignatureChecker.checkTaprootHashType(helper.hashType)
+          if (validHashType) {
+            val result = TransactionSignatureChecker.checkSigTapscript(
+              txSignatureComponent = program.txSignatureComponent,
+              pubKey = helper.pubKey.schnorrPublicKey,
+              signature = helper.signature,
+              hashType = helper.hashType,
+              taprootOptions = program.taprootSerializationOptions,
+              flags = program.flags
+            )
+            Right(result)
+          } else Left(ScriptErrorSchnorrSigHashType)
         case Left(err) => Left(err)
       }
     }


### PR DESCRIPTION
This fixes the remaining of the hash type failure cases.

The previous check did not correctly work because scala would evulate the bytes as an int (ie `0xe1` would be evalutated as `-31`). So instead I just created a vector of all the valid hash types
```
    val invalidHashType = {
      !(hashType.byte <= 0x03.toByte || (hashType.byte >= 0x81.toByte && hashType.byte <= 0x83.toByte))
    }
```