### PR TITLE
Fix `chmod: jre/bin/java: No such file or directory` errors

### DIFF
--- a/app/cli/src/universal/cli-extra-startup-script.sh
+++ b/app/cli/src/universal/cli-extra-startup-script.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 if [[ "$OS" == "OSX" ]]; then
   #mac doesn't allow random binaries to be executable
@@ -5,4 +6,10 @@ if [[ "$OS" == "OSX" ]]; then
   xattr -d com.apple.quarantine jre/bin/java
 fi
 
-chmod +x jre/bin/java #make sure java is executable
+if test -f "jre/bin/java"; then
+  chmod +x jre/bin/java #make sure java is executable
+fi
+
+if test -f "../jre/bin/java" ; then
+  chmod +x ../jre/bin/java #make sure java is executable
+fi

--- a/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
+++ b/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 if [[ "$OS" == "OSX" ]]; then
   #mac doesn't allow random binaries to be executable
@@ -5,7 +6,14 @@ if [[ "$OS" == "OSX" ]]; then
   xattr -d com.apple.quarantine jre/bin/java
 fi
 
-chmod +x jre/bin/java #make sure java is executable
+if test -f "jre/bin/java"; then
+  chmod +x jre/bin/java #make sure java is executable
+fi
+
+if test -f "../jre/bin/java" ; then
+  chmod +x ../jre/bin/java #make sure java is executable
+fi
+
 
 
 if [[ "$OS" == "OSX" ]]; then
@@ -13,7 +21,7 @@ if [[ "$OS" == "OSX" ]]; then
   #remove the quarantine attribute so java is executable on mac
   xattr -d com.apple.quarantine jre/bin/java
 fi
-chmod +x jre/bin/java #make sure java is executable
+
 
 get_java_no_jlink() {
   if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then

--- a/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
+++ b/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
@@ -14,15 +14,6 @@ if test -f "../jre/bin/java" ; then
   chmod +x ../jre/bin/java #make sure java is executable
 fi
 
-
-
-if [[ "$OS" == "OSX" ]]; then
-  #mac doesn't allow random binaries to be executable
-  #remove the quarantine attribute so java is executable on mac
-  xattr -d com.apple.quarantine jre/bin/java
-fi
-
-
 get_java_no_jlink() {
   if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
     echo "$JAVA_HOME/bin/java"

--- a/app/server/src/universal/wallet-server-extra-startup-script.sh
+++ b/app/server/src/universal/wallet-server-extra-startup-script.sh
@@ -7,12 +7,10 @@ if [[ "$OS" == "OSX" ]]; then
 fi
 
 if test -f "jre/bin/java"; then
-  echo "TOPLEVELJAVA";
   chmod +x jre/bin/java #make sure java is executable
 fi
 
 if test -f "../jre/bin/java" ; then
-  echo "NESTED JAVA";
   chmod +x ../jre/bin/java #make sure java is executable
 fi
 

--- a/app/server/src/universal/wallet-server-extra-startup-script.sh
+++ b/app/server/src/universal/wallet-server-extra-startup-script.sh
@@ -1,10 +1,21 @@
+#!/bin/bash
+
 if [[ "$OS" == "OSX" ]]; then
   #mac doesn't allow random binaries to be executable
   #remove the quarantine attribute so java is executable on mac
   xattr -d com.apple.quarantine jre/bin/java
 fi
 
-chmod +x jre/bin/java #make sure java is executable
+if test -f "jre/bin/java"; then
+  echo "TOPLEVELJAVA";
+  chmod +x jre/bin/java #make sure java is executable
+fi
+
+if test -f "../jre/bin/java" ; then
+  echo "NESTED JAVA";
+  chmod +x ../jre/bin/java #make sure java is executable
+fi
+
 
 chip=$(uname -m)
 


### PR DESCRIPTION
fixes #4492 

Now you should be able to run `{bitcoin-s-cli,bitcoin-s-server,bitcoin-s-oracle-server}` from `./bin/bitcoin-s-server` OR `cd bin && ./bitcoin-s-server` 

You use to get error messages that looked like

```
chmod: jre/bin/java: No such file or directory
```