### PR TITLE
Refactor coin selection to be not be bitcoin-s specific

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/CoinSelectorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/CoinSelectorTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.wallet
 
-import org.bitcoins.core.api.wallet.CoinSelector
+import org.bitcoins.core.api.wallet.{CoinSelector, CoinSelectorUtxo}
 import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.currency._
 import org.bitcoins.core.hd._
@@ -16,9 +16,10 @@ class CoinSelectorTest extends BitcoinSUnitTest {
 
   behavior of "CoinSelector"
 
-  val utxos: Vector[SpendingInfoDb] =
+  val utxos: Vector[CoinSelectorUtxo] =
     createSpendingInfoDbs(Vector(Bitcoins(1), Bitcoins(2)))
-  val inAmt: CurrencyUnit = utxos.map(_.output.value).sum
+      .map(CoinSelectorUtxo.fromSpendingInfoDb)
+  val inAmt: CurrencyUnit = utxos.map(_.prevOut.value).sum
   val target: Bitcoins = Bitcoins(2)
   val changeCost: Satoshis = Satoshis.one
 

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelectorUtxo.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelectorUtxo.scala
@@ -1,0 +1,21 @@
+package org.bitcoins.core.api.wallet
+
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
+import org.bitcoins.core.protocol.script._
+import org.bitcoins.core.protocol.transaction._
+
+case class CoinSelectorUtxo(
+    prevOut: TransactionOutput,
+    outPoint: TransactionOutPoint,
+    redeemScriptOpt: Option[ScriptPubKey],
+    scriptWitnessOpt: Option[ScriptWitness])
+
+object CoinSelectorUtxo {
+
+  def fromSpendingInfoDb(db: SpendingInfoDb): CoinSelectorUtxo = {
+    CoinSelectorUtxo(db.output,
+                     db.outPoint,
+                     db.redeemScriptOpt,
+                     db.scriptWitnessOpt)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/db/SpendingInfoDb.scala
@@ -2,6 +2,7 @@ package org.bitcoins.core.api.wallet.db
 
 import org.bitcoins.core.api.db.DbRowAutoInc
 import org.bitcoins.core.api.keymanager.BIP39KeyManagerApi
+import org.bitcoins.core.api.wallet.CoinSelectorUtxo
 import org.bitcoins.core.hd._
 import org.bitcoins.core.protocol.script.{
   P2SHScriptPubKey,
@@ -194,6 +195,10 @@ sealed trait SpendingInfoDb extends DbRowAutoInc[SpendingInfoDb] {
       Vector(sign),
       hashType
     )
+  }
+
+  def toCoinSelectorUtxo: CoinSelectorUtxo = {
+    CoinSelectorUtxo.fromSpendingInfoDb(this)
   }
 }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/CoinSelectorTest.scala
@@ -1,13 +1,11 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.core.api.wallet.CoinSelector
-import org.bitcoins.core.api.wallet.db.{SegwitV0SpendingInfo, SpendingInfoDb}
+import org.bitcoins.core.api.wallet.{CoinSelector, CoinSelectorUtxo}
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerByte}
-import org.bitcoins.core.wallet.utxo.TxoState
-import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
+import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkitcore.Implicits._
 import org.bitcoins.testkitcore.gen.{TransactionGenerators, WitnessGenerators}
 import org.scalatest.FutureOutcome
@@ -17,10 +15,12 @@ class CoinSelectorTest extends BitcoinSWalletTest {
   case class CoinSelectionFixture(
       output: TransactionOutput,
       feeRate: FeeUnit,
-      utxo1: SpendingInfoDb,
-      utxo2: SpendingInfoDb,
-      utxo3: SpendingInfoDb) {
-    val utxoSet: Vector[SpendingInfoDb] = Vector(utxo1, utxo2, utxo3)
+      utxo1: CoinSelectorUtxo,
+      utxo2: CoinSelectorUtxo,
+      utxo3: CoinSelectorUtxo) {
+
+    val utxoSet: Vector[CoinSelectorUtxo] = Vector(utxo1, utxo2, utxo3)
+
   }
 
   override type FixtureParam = CoinSelectionFixture
@@ -30,35 +30,26 @@ class CoinSelectorTest extends BitcoinSWalletTest {
     val feeRate = SatoshisPerByte(CurrencyUnits.zero)
 
     val outpoint1 = TransactionGenerators.outPoint.sampleSome
-    val utxo1 = SegwitV0SpendingInfo(
-      state = TxoState.PendingConfirmationsReceived,
-      id = Some(1),
+    val utxo1 = CoinSelectorUtxo(
       outPoint = outpoint1,
-      output = TransactionOutput(10.sats, ScriptPubKey.empty),
-      privKeyPath = WalletTestUtil.sampleSegwitPath,
-      scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
-      spendingTxIdOpt = None
+      prevOut = TransactionOutput(10.sats, ScriptPubKey.empty),
+      scriptWitnessOpt = Some(WitnessGenerators.scriptWitness.sampleSome),
+      redeemScriptOpt = None
     )
     val outPoint2 = TransactionGenerators.outPoint.sampleSome
-    val utxo2 = SegwitV0SpendingInfo(
-      state = TxoState.ConfirmedReceived,
-      id = Some(2),
+    val utxo2 = CoinSelectorUtxo(
       outPoint = outPoint2,
-      output = TransactionOutput(90.sats, ScriptPubKey.empty),
-      privKeyPath = WalletTestUtil.sampleSegwitPath,
-      scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
-      spendingTxIdOpt = None
+      prevOut = TransactionOutput(90.sats, ScriptPubKey.empty),
+      scriptWitnessOpt = Some(WitnessGenerators.scriptWitness.sampleSome),
+      redeemScriptOpt = None
     )
 
     val outPoint3 = TransactionGenerators.outPoint.sampleSome
-    val utxo3 = SegwitV0SpendingInfo(
-      state = TxoState.ConfirmedReceived,
-      id = Some(3),
+    val utxo3 = CoinSelectorUtxo(
       outPoint = outPoint3,
-      output = TransactionOutput(20.sats, ScriptPubKey.empty),
-      privKeyPath = WalletTestUtil.sampleSegwitPath,
-      scriptWitness = WitnessGenerators.scriptWitness.sampleSome,
-      spendingTxIdOpt = None
+      prevOut = TransactionOutput(20.sats, ScriptPubKey.empty),
+      scriptWitnessOpt = Some(WitnessGenerators.scriptWitness.sampleSome),
+      redeemScriptOpt = None
     )
 
     test(CoinSelectionFixture(output, feeRate, utxo1, utxo2, utxo3))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.core.api.wallet.{CoinSelectionAlgo, CoinSelector}
+import org.bitcoins.core.api.wallet._
 import org.bitcoins.core.currency._
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -464,7 +464,10 @@ class WalletSendingTest extends BitcoinSWalletTest {
     for {
       account <- wallet.getDefaultAccount()
       feeRate <- wallet.getFeeRate()
-      allUtxos <- wallet.listUtxos(account.hdAccount)
+      allUtxos <- wallet
+        .listUtxos(account.hdAccount)
+        .map(_.map(CoinSelectorUtxo.fromSpendingInfoDb))
+
       output = TransactionOutput(amountToSend, testAddress.scriptPubKey)
       expectedUtxos =
         CoinSelector.selectByAlgo(algo, allUtxos, Vector(output), feeRate)


### PR DESCRIPTION
Previously coin selection used `SpendingInfoDb` which is specific to the bitcoin-s wallet. To make it more general I created a `CoinSelectorUtxo` which just has the necessary data required for coin selection.

Also added size calculations for taproot scripts