### PR TITLE
2022 07 12 server startup cleanup

### DIFF
--- a/app-commons-test/src/test/scala/org/bitcoins/commons/config/AppConfigTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/config/AppConfigTest.scala
@@ -72,7 +72,6 @@ class AppConfigTest extends BitcoinSAsyncTest {
     val appConfig = BitcoinSAppConfig.fromClassPathConfig()
     assert(appConfig.nodeConf.network == RegTest)
     assert(appConfig.walletConf.requiredConfirmations == 6)
-    assert(!appConfig.chainConf.forceRecalcChainWork)
   }
 
   it must "fill in typesafe config variables correctly" in {

--- a/app-commons-test/src/test/scala/org/bitcoins/commons/util/ServerArgParserTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/util/ServerArgParserTest.scala
@@ -27,7 +27,6 @@ class ServerArgParserTest extends BitcoinSUnitTest {
       "my.cool.site.com",
       "--datadir",
       s"${datadirString}",
-      "--force-recalc-chainwork",
       "--wsbind",
       "ws.my.cool.site.com",
       "--wsport",
@@ -42,7 +41,6 @@ class ServerArgParserTest extends BitcoinSUnitTest {
     assert(config.hasPath(datadirPathConfigKey))
     assert(config.hasPath(s"bitcoin-s.server.rpcbind"))
     assert(config.hasPath(s"bitcoin-s.server.rpcport"))
-    assert(config.hasPath(s"bitcoin-s.chain.force-recalc-chainwork"))
     assert(config.hasPath("bitcoin-s.server.wsport"))
     assert(config.hasPath("bitcoin-s.server.wsbind"))
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/util/ServerArgParser.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/ServerArgParser.scala
@@ -91,9 +91,6 @@ case class ServerArgParser(commandLineArgs: Vector[String]) {
     }
   }
 
-  lazy val forceChainWorkRecalc: Boolean =
-    commandLineArgs.exists(_.toLowerCase == "--force-recalc-chainwork")
-
   /** Converts the given command line args into a Config object.
     * There is one exclusion to this, we cannot write the --conf
     * flag to the config file as that is self referential
@@ -117,12 +114,6 @@ case class ServerArgParser(commandLineArgs: Vector[String]) {
       case None => s""
     }
 
-    val forceChainWorkRecalcString = if (forceChainWorkRecalc) {
-      s"bitcoin-s.chain.force-recalc-chainwork=$forceChainWorkRecalc\n"
-    } else {
-      ""
-    }
-
     val wsBindString = wsBindOpt match {
       case Some(wsBind) =>
         s"bitcoin-s.server.wsbind=$wsBind\n"
@@ -141,7 +132,6 @@ case class ServerArgParser(commandLineArgs: Vector[String]) {
       rpcPortString +
         rpcBindString +
         datadirString +
-        forceChainWorkRecalcString +
         wsBindString +
         wsPortString
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -162,8 +162,9 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val wsSource: Source[Message, NotUsed] = tuple._2
     val _ = buildNeutrinoCallbacks(wsQueue, chainApi)
 
-    val torCallbacks = WebsocketUtil.buildTorCallbacks(wsQueue)
-    val _ = torConf.addCallbacks(torCallbacks)
+    val torCallbacks =
+    torConf.addCallbacks(torCallbacks)
+
     val isTorStartedF = if (torConf.torProvided) {
       //if tor is provided we need to execute the tor started callback immediately
       torConf.callBacks.executeOnTorStarted()
@@ -224,11 +225,16 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       chainApi: ChainApi): Unit = {
     val chainCallbacks = WebsocketUtil.buildChainCallbacks(wsQueue, chainApi)
     chainConf.addCallbacks(chainCallbacks)
+
     val walletCallbacks =
       WebsocketUtil.buildWalletCallbacks(wsQueue, walletConf.walletNameOpt)
     walletConf.addCallbacks(walletCallbacks)
+
     val dlcWalletCallbacks = WebsocketUtil.buildDLCWalletCallbacks(wsQueue)
     dlcConf.addCallbacks(dlcWalletCallbacks)
+
+    val torCallbacks = WebsocketUtil.buildTorCallbacks(wsQueue)
+    torConf.addCallbacks(torCallbacks)
 
     ()
   }

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -161,8 +161,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val wsQueue: SourceQueueWithComplete[Message] = tuple._1
     val wsSource: Source[Message, NotUsed] = tuple._2
     val _ = buildNeutrinoCallbacks(wsQueue, chainApi)
-
-    val torCallbacks =
+    val torCallbacks = WebsocketUtil.buildTorCallbacks(wsQueue)
     torConf.addCallbacks(torCallbacks)
 
     val isTorStartedF = if (torConf.torProvided) {

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -5,7 +5,7 @@ import org.bitcoins.chain.ChainCallbacks
 import org.bitcoins.chain.db.ChainDbManagement
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.chain.pow.Pow
-import org.bitcoins.commons.config.{AppConfigFactory, ConfigOps}
+import org.bitcoins.commons.config.AppConfigFactory
 import org.bitcoins.core.api.CallbackConfig
 import org.bitcoins.core.api.chain.db.BlockHeaderDbHelper
 import org.bitcoins.core.util.Mutable
@@ -120,9 +120,6 @@ case class ChainAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   lazy val filterBatchSize: Int =
     config.getInt(s"bitcoin-s.${moduleName}.neutrino.filter-batch-size")
 
-  lazy val forceRecalcChainWork: Boolean =
-    config.getBooleanOrElse(s"bitcoin-s.$moduleName.force-recalc-chainwork",
-                            default = false)
 }
 
 object ChainAppConfig extends AppConfigFactory[ChainAppConfig] {

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -213,7 +213,6 @@ bitcoin-s {
     
     # settings for the chain module
     chain {
-        force-recalc-chainwork = false
         neutrino {
             filter-header-batch-size.default = 2000
             filter-header-batch-size.regtest = 10


### PR DESCRIPTION
This reverts #2918 and #1518

The purpose for reverting these is to simplify server startup logic to make PRs like #4417 easier to implement. 

Both these PRs were bug fixes for ancient versions of the wallet. If somehow a user comes along and needs these bug fixes we can ask them to download and run any release pre-2.0