### PR TITLE
Implement a timeout on fee rate requests

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -31,6 +31,7 @@ import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.dlc.node.DLCNode
 import org.bitcoins.dlc.node.config.DLCNodeAppConfig
 import org.bitcoins.dlc.wallet._
+import org.bitcoins.feeprovider.MempoolSpaceTarget.HourFeeTarget
 import org.bitcoins.feeprovider._
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.rpc.BitcoindException.InWarmUp
@@ -123,8 +124,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       walletCreationTimeOpt = Some(creationTime))(chainConf, system)
 
     val defaultApi =
-      BitGoFeeRateProvider(Some(walletConf.requiredConfirmations),
-                           //walletConf.network, bitgo doesn't have segregated networks?
+      MempoolSpaceProvider(HourFeeTarget,
+                           walletConf.network,
                            walletConf.torConf.socks5ProxyParams)
     val feeProvider = FeeProviderFactory.getFeeProviderOrElse(
       defaultApi,

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -31,7 +31,6 @@ import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.dlc.node.DLCNode
 import org.bitcoins.dlc.node.config.DLCNodeAppConfig
 import org.bitcoins.dlc.wallet._
-import org.bitcoins.feeprovider.MempoolSpaceTarget.HourFeeTarget
 import org.bitcoins.feeprovider._
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.rpc.BitcoindException.InWarmUp
@@ -124,8 +123,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       walletCreationTimeOpt = Some(creationTime))(chainConf, system)
 
     val defaultApi =
-      MempoolSpaceProvider(HourFeeTarget,
-                           walletConf.network,
+      BitGoFeeRateProvider(Some(walletConf.requiredConfirmations),
+                           //walletConf.network, bitgo doesn't have segregated networks?
                            walletConf.torConf.socks5ProxyParams)
     val feeProvider = FeeProviderFactory.getFeeProviderOrElse(
       defaultApi,


### PR DESCRIPTION
This fixes the variable latency from retrieving a fee rate by introducing a 1 second timeout. If the request hasn't completed in 1 second, we timeout the request and return -1. 

Since we cache fee rates internally, the next time you call `estimatefee` you should get the correctly cached fee rate (assuming the original request completed).

Discussion: 
https://github.com/bitcoin-s/bitcoin-s/issues/4460#issuecomment-1182325014