### PR TITLE
Remove assertion after syncing in NodeUnitTest

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -50,6 +50,21 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
 
   behavior of "NeutrinoNode"
 
+  it must "have not syncing status after sync" in {
+    nodeConnectedWithBitcoinds =>
+      val node = nodeConnectedWithBitcoinds.node
+      val bitcoind = nodeConnectedWithBitcoinds.bitcoinds(0)
+
+      for {
+        _ <- AsyncUtil.retryUntilSatisfied(node.peerManager.peers.size == 2)
+        _ <- NodeUnitTest.syncNeutrinoNode(node, bitcoind)
+        syncing <- node.chainApiFromDb().flatMap(_.isSyncing())
+        syncing2 = node.getDataMessageHandler.syncing
+      } yield {
+        assert(!syncing && !syncing2)
+      }
+  }
+
   it must "switch to different peer and sync if current is unavailable" in {
     nodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoinds.node

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -519,8 +519,6 @@ object NodeUnitTest extends P2PLogger {
       _ <- NodeTestUtil.awaitSync(node, bitcoind)
       _ <- NodeTestUtil.awaitCompactFilterHeadersSync(node, bitcoind)
       _ <- NodeTestUtil.awaitCompactFiltersSync(node, bitcoind)
-      syncing <- node.chainApiFromDb().flatMap(_.isSyncing())
-      _ = assert(!syncing)
 
     } yield node
   }


### PR DESCRIPTION
Was seeing this assertion fail occasionally.
* Removed assertion to check not syncing status after sync as this may not necessarily be true in a parallel setting. Example: after node is synced, some other test using the same cached bitcoind may produce another block right at that time which may change status to syncing again and hence this assertion fails.
* Added this check separately in another test that would not be affected by parallel execution.