### PR TITLE
Set syncing flag to true on startup

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -75,6 +75,10 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
 
     for {
       startedConfig <- startedConfigF
+      chainApi = ChainHandler.fromDatabase()
+      //on server startup we assume we are out of sync with the bitcoin network
+      //so we set this flag to true.
+      _ <- chainApi.setSyncing(true)
       start <- {
         nodeConf.nodeType match {
           case _: InternalImplementationNodeType =>
@@ -273,7 +277,6 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       client <- bitcoindRpcConf.clientF
       _ <- client.start()
     } yield client
-
     val tuple = buildWsSource
     val wsQueue: SourceQueueWithComplete[Message] = tuple._1
     val wsSource: Source[Message, NotUsed] = tuple._2


### PR DESCRIPTION
Follow up on #4452 to set the `syncing` flag to true on start by default. This occur before the http server is bound so that there is not a race condition.