### PR TITLE
Make KeyManagerAppConfig.walletName return `String` rather than `Option[String]`

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -230,7 +230,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     chainConf.addCallbacks(chainCallbacks)
 
     val walletCallbacks =
-      WebsocketUtil.buildWalletCallbacks(wsQueue, walletConf.walletNameOpt)
+      WebsocketUtil.buildWalletCallbacks(wsQueue, walletConf.walletName)
     walletConf.addCallbacks(walletCallbacks)
 
     val dlcWalletCallbacks = WebsocketUtil.buildDLCWalletCallbacks(wsQueue)
@@ -341,7 +341,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
 
       walletCallbacks = WebsocketUtil.buildWalletCallbacks(
         wsQueue,
-        walletConf.walletNameOpt)
+        walletConf.walletName)
       _ = walletConf.addCallbacks(walletCallbacks)
 
       (wallet, chainCallbacks) <- walletF

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -1011,7 +1011,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
             KeyManagerAppConfig.moduleName -> Obj(
               "rootXpub" -> Str(wallet.keyManager.getRootXPub.toString)
             ),
-            "walletName" -> Str(walletConf.walletNameOpt.getOrElse("")),
+            "walletName" -> Str(walletConf.walletName),
             "xpub" -> Str(accountDb.xpub.toString),
             "hdPath" -> Str(accountDb.hdAccount.toString),
             "height" -> Num(walletState.height),

--- a/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
@@ -84,8 +84,7 @@ object WebsocketUtil extends Logging {
   /** Builds websocket callbacks for the wallet */
   def buildWalletCallbacks(
       walletQueue: SourceQueueWithComplete[Message],
-      walletNameOpt: Option[String])(implicit
-      ec: ExecutionContext): WalletCallbacks = {
+      walletName: String)(implicit ec: ExecutionContext): WalletCallbacks = {
     val onAddressCreated: OnNewAddressGenerated = { addr =>
       val notification = WalletNotification.NewAddressNotification(addr)
       val json =
@@ -118,9 +117,7 @@ object WebsocketUtil extends Logging {
     }
 
     val onRescanComplete: OnRescanComplete = { _ =>
-      val name =
-        walletNameOpt.getOrElse("") // default name empty string on the wallet
-      val notification = WalletNotification.RescanComplete(name)
+      val notification = WalletNotification.RescanComplete(walletName)
       val notificationJson =
         upickle.default.writeJs(notification)(WsPicklers.rescanPickler)
       val msg = TextMessage.Strict(notificationJson.toString())

--- a/db-commons/src/main/scala/org/bitcoins/db/PostgresUtil.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/PostgresUtil.scala
@@ -1,0 +1,14 @@
+package org.bitcoins.db
+
+import org.bitcoins.keymanager.config.KeyManagerAppConfig
+
+object PostgresUtil {
+
+  def getSchemaName(moduleName: String, walletName: String): String = {
+    if (walletName == KeyManagerAppConfig.DEFAULT_WALLET_NAME) {
+      moduleName
+    } else {
+      s"${moduleName}_$walletName"
+    }
+  }
+}

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -17,6 +17,7 @@ import org.bitcoins.dlc.wallet.models.{
   OfferedDbState,
   SetupCompleteDLCDbState
 }
+import org.bitcoins.keymanager.config.KeyManagerAppConfig
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.models.TransactionDAO
 import org.bitcoins.wallet.{Wallet, WalletLogger}
@@ -75,28 +76,30 @@ case class DLCAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   lazy val walletConf: WalletAppConfig =
     WalletAppConfig(baseDatadir, configOverrides)
 
-  lazy val walletNameOpt: Option[String] = walletConf.walletNameOpt
+  lazy val walletName: String = walletConf.walletName
 
   override lazy val dbPath: Path = {
     val pathStrOpt =
       config.getStringOrNone(s"bitcoin-s.$moduleName.db.path")
-    (pathStrOpt, walletNameOpt) match {
-      case (Some(pathStr), Some(walletName)) =>
-        Paths.get(pathStr).resolve(walletName)
-      case (Some(pathStr), None) =>
-        Paths.get(pathStr)
-      case (None, Some(_)) | (None, None) =>
+    pathStrOpt match {
+      case Some(pathStr) =>
+        if (walletName == KeyManagerAppConfig.DEFAULT_WALLET_NAME) {
+          Paths.get(pathStr)
+        } else {
+          Paths.get(pathStr).resolve(walletName)
+        }
+      case None =>
         sys.error(s"Could not find dbPath for $moduleName.db.path")
     }
   }
 
   override lazy val schemaName: Option[String] = {
-    (driver, walletNameOpt) match {
-      case (PostgreSQL, Some(walletName)) =>
-        Some(s"${moduleName}_$walletName")
-      case (PostgreSQL, None) =>
-        Some(moduleName)
-      case (SQLite, None) | (SQLite, Some(_)) =>
+    driver match {
+      case PostgreSQL =>
+        val schema = PostgresUtil.getSchemaName(moduleName = moduleName,
+                                                walletName = walletName)
+        Some(schema)
+      case SQLite =>
         None
     }
   }

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
@@ -670,7 +670,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       assert(walletConfA.kmConf.seedExists())
 
       val otherWalletName = StringGenerators.genNonEmptyString
-        .suchThat(_ != walletConfA.walletNameOpt.getOrElse(""))
+        .suchThat(_ != walletConfA.walletName)
         .sampleSome
 
       val walletConfB = walletConfA.withOverrides(


### PR DESCRIPTION
fixes #4498

Every wallet has a name, the default wallet's name is the empty string (`""`).

This refactor simplifies the codebase to reflect this reality.

