### PR TITLE
Move OSX check inside of jre path check

### DIFF
--- a/app/cli/src/universal/cli-extra-startup-script.sh
+++ b/app/cli/src/universal/cli-extra-startup-script.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
-if [[ "$OS" == "OSX" ]]; then
-  #mac doesn't allow random binaries to be executable
-  #remove the quarantine attribute so java is executable on mac
-  xattr -d com.apple.quarantine jre/bin/java
-fi
-
 if test -f "jre/bin/java"; then
+  if [[ "$OS" == "OSX" ]]; then
+    #mac doesn't allow random binaries to be executable
+    #remove the quarantine attribute so java is executable on mac
+    xattr -d com.apple.quarantine jre/bin/java
+  fi
   chmod +x jre/bin/java #make sure java is executable
 fi
 
 if test -f "../jre/bin/java" ; then
+  if [[ "$OS" == "OSX" ]]; then
+    #mac doesn't allow random binaries to be executable
+    #remove the quarantine attribute so java is executable on mac
+    xattr -d com.apple.quarantine ../jre/bin/java
+  fi
   chmod +x ../jre/bin/java #make sure java is executable
 fi

--- a/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
+++ b/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
-if [[ "$OS" == "OSX" ]]; then
-  #mac doesn't allow random binaries to be executable
-  #remove the quarantine attribute so java is executable on mac
-  xattr -d com.apple.quarantine jre/bin/java
-fi
-
 if test -f "jre/bin/java"; then
+  if [[ "$OS" == "OSX" ]]; then
+    #mac doesn't allow random binaries to be executable
+    #remove the quarantine attribute so java is executable on mac
+    xattr -d com.apple.quarantine jre/bin/java
+  fi
   chmod +x jre/bin/java #make sure java is executable
 fi
 
 if test -f "../jre/bin/java" ; then
+  if [[ "$OS" == "OSX" ]]; then
+    #mac doesn't allow random binaries to be executable
+    #remove the quarantine attribute so java is executable on mac
+    xattr -d com.apple.quarantine ../jre/bin/java
+  fi
   chmod +x ../jre/bin/java #make sure java is executable
 fi
 

--- a/app/server/src/universal/wallet-server-extra-startup-script.sh
+++ b/app/server/src/universal/wallet-server-extra-startup-script.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
-if [[ "$OS" == "OSX" ]]; then
-  #mac doesn't allow random binaries to be executable
-  #remove the quarantine attribute so java is executable on mac
-  xattr -d com.apple.quarantine jre/bin/java
-fi
-
 if test -f "jre/bin/java"; then
+  if [[ "$OS" == "OSX" ]]; then
+    #mac doesn't allow random binaries to be executable
+    #remove the quarantine attribute so java is executable on mac
+    xattr -d com.apple.quarantine jre/bin/java
+  fi
   chmod +x jre/bin/java #make sure java is executable
 fi
 
 if test -f "../jre/bin/java" ; then
+  if [[ "$OS" == "OSX" ]]; then
+    #mac doesn't allow random binaries to be executable
+    #remove the quarantine attribute so java is executable on mac
+    xattr -d com.apple.quarantine ../jre/bin/java
+  fi
   chmod +x ../jre/bin/java #make sure java is executable
 fi
 


### PR DESCRIPTION
This also fixes a small bug introduced in #4493 where we won't remove the quarantine attribute on the jre if we are in the same directory as `{bitcoin-s-server,bitcoin-s-oracle-server,bitcoin-s-cli}`