### PR TITLE
Add P2PClientSupervisor

### DIFF
--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -73,6 +73,9 @@
     <!-- inspect TCP details -->
     <logger name="org.bitcoins.node.networking.P2PClientActor" level="INFO"/>
 
+    <!-- See exceptions thrown in actor-->
+    <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
+
     <!-- See peer details -->
     <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
 

--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -73,9 +73,6 @@
     <!-- inspect TCP details -->
     <logger name="org.bitcoins.node.networking.P2PClientActor" level="INFO"/>
 
-    <!-- See exceptions thrown in actor-->
-    <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
-
     <!-- See peer details -->
     <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -52,12 +52,14 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
 
     val connAndInit = for {
       _ <- AsyncUtil
-        .retryUntilSatisfied(peers.size == 2, interval = 1.second, maxTries = 5)
+        .retryUntilSatisfied(peers.size == 2,
+                             maxTries = 30,
+                             interval = 1.second)
       _ <- Future
         .sequence(peers.map(peerManager.isConnected))
         .flatMap(p => assert(p.forall(_ == true)))
       res <- Future
-        .sequence(peers.map(peerManager.isConnected))
+        .sequence(peers.map(peerManager.isInitialized))
         .flatMap(p => assert(p.forall(_ == true)))
     } yield res
 
@@ -80,7 +82,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       def has2Peers: Future[Unit] =
         AsyncUtil.retryUntilSatisfied(peers.size == 2,
                                       interval = 1.second,
-                                      maxTries = 5)
+                                      maxTries = 30)
       def bothOurs: Future[Assertion] = ourPeersF.map { ours =>
         assert(ours.map(peers.contains(_)).forall(_ == true))
       }
@@ -144,7 +146,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         _ <- AsyncUtil
           .retryUntilSatisfied(peers.size == 2,
                                interval = 1.second,
-                               maxTries = 5)
+                               maxTries = 30)
         _ <- Future
           .sequence(peers.map(peerManager.isConnected))
           .flatMap(p => assert(p.forall(_ == true)))
@@ -178,7 +180,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         _ <- AsyncUtil
           .retryUntilSatisfied(peers.size == 2,
                                interval = 1.second,
-                               maxTries = 5)
+                               maxTries = 30)
         _ <- NodeUnitTest.syncNeutrinoNode(node, bitcoind)
         _ <- Future
           .sequence(peers.map(peerManager.isConnected))

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -18,6 +18,7 @@ import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 
 class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
 
@@ -113,7 +114,9 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       _ <- NodeTestUtil.awaitSync(node, bitcoind)
       _ <- NodeTestUtil.awaitCompactFilterHeadersSync(node, bitcoind)
       _ <- NodeTestUtil.awaitCompactFiltersSync(node, bitcoind)
-      _ <- TestAsyncUtil.awaitConditionF(condition2)
+      _ <- TestAsyncUtil.awaitConditionF(condition2,
+                                         interval = 1.second,
+                                         maxTries = 30)
       // assert we got the full tx with witness data
       txs <- wallet.listTransactions()
     } yield assert(txs.exists(_.transaction == expectedTx))

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -34,7 +34,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
       val NeutrinoNodeConnectedWithBitcoindV22(node, _) = param
       val peer = node.peerManager.peers.head
 
-      val sender = node.peerMsgSenders(0)
+      val senderF = node.peerMsgSenders(0)
       for {
         chainApi <- node.chainApiFromDb()
         dataMessageHandler = DataMessageHandler(chainApi,
@@ -52,6 +52,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
         _ <- recoverToSucceededIf[RuntimeException](
           chainApi.processHeaders(invalidPayload.headers))
 
+        sender <- senderF
         // Verify we handle the payload correctly
         _ <- dataMessageHandler.handleDataPayload(invalidPayload, sender, peer)
       } yield succeed
@@ -70,7 +71,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
           ()
         }
       }
-      val sender = node.peerMsgSenders(0)
+      val senderF = node.peerMsgSenders(0)
 
       for {
         hash <- bitcoind.generateToAddress(blocks = 1, junkAddress).map(_.head)
@@ -86,6 +87,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
             node.executionContext,
             node.nodeAppConfig,
             node.chainConfig)
+        sender <- senderF
         _ <- dataMessageHandler.handleDataPayload(payload, sender, peer)
         result <- resultP.future
       } yield assert(result == block)
@@ -107,7 +109,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
         }
       }
 
-      val sender = node.peerMsgSenders(0)
+      val senderF = node.peerMsgSenders(0)
       for {
         hash <- bitcoind.generateToAddress(blocks = 1, junkAddress).map(_.head)
         header <- bitcoind.getBlockHeaderRaw(hash)
@@ -122,7 +124,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
             node.executionContext,
             node.nodeAppConfig,
             node.chainConfig)
-
+        sender <- senderF
         _ <- dataMessageHandler.handleDataPayload(payload, sender, peer)
         result <- resultP.future
       } yield assert(result == Vector(header))
@@ -142,7 +144,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
             ()
           }
       }
-      val sender = node.peerMsgSenders(0)
+      val senderF = node.peerMsgSenders(0)
       for {
         hash <- bitcoind.generateToAddress(blocks = 1, junkAddress).map(_.head)
         filter <- bitcoind.getBlockFilter(hash, FilterType.Basic)
@@ -157,7 +159,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
             node.executionContext,
             node.nodeAppConfig,
             node.chainConfig)
-
+        sender <- senderF
         _ <- dataMessageHandler.handleDataPayload(payload, sender, peer)
         result <- resultP.future
       } yield assert(result == Vector((hash.flip, filter.filter)))
@@ -176,7 +178,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
           ()
         }
       }
-      val sender = node.peerMsgSenders(0)
+      val senderF = node.peerMsgSenders(0)
 
       for {
 
@@ -193,6 +195,7 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
             node.executionContext,
             node.nodeAppConfig,
             node.chainConfig)
+        sender <- senderF
         _ <- dataMessageHandler.handleDataPayload(payload, sender, peer)
         result <- resultP.future
       } yield assert(result == tx)

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverTest.scala
@@ -72,12 +72,15 @@ class PeerMessageReceiverTest extends NodeTestWithCachedBitcoindNewest {
       val peerMsgReceiver =
         PeerMessageReceiver(normal, node, peer)(system, node.nodeAppConfig)
 
-      val newMsgReceiver = peerMsgReceiver.disconnect()
+      val newMsgReceiverF = peerMsgReceiver.disconnect()
 
-      assert(
-        newMsgReceiver.state
-          .isInstanceOf[PeerMessageReceiverState.Disconnected])
-      assert(newMsgReceiver.isDisconnected)
+      newMsgReceiverF.map { newMsgReceiver =>
+        assert(
+          newMsgReceiver.state
+            .isInstanceOf[PeerMessageReceiverState.Disconnected])
+        assert(newMsgReceiver.isDisconnected)
+      }
+
   }
 
   it must "change a peer message receiver to be initializing disconnect" in {
@@ -118,12 +121,12 @@ class PeerMessageReceiverTest extends NodeTestWithCachedBitcoindNewest {
           .isInstanceOf[PeerMessageReceiverState.InitializedDisconnect])
       assert(!newMsgReceiver.isDisconnected)
 
-      val disconnectRecv = newMsgReceiver.disconnect()
-
-      assert(
-        disconnectRecv.state
-          .isInstanceOf[PeerMessageReceiverState.InitializedDisconnectDone])
-      assert(disconnectRecv.isDisconnected)
-      assert(disconnectRecv.state.clientDisconnectP.isCompleted)
+      newMsgReceiver.disconnect().map { disconnectRecv =>
+        assert(
+          disconnectRecv.state
+            .isInstanceOf[PeerMessageReceiverState.InitializedDisconnectDone])
+        assert(disconnectRecv.isDisconnected)
+        assert(disconnectRecv.state.clientDisconnectP.isCompleted)
+      }
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.node
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorRef, ActorSystem}
 import org.bitcoins.core.p2p.ServiceIdentifier
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
@@ -16,7 +16,8 @@ import scala.concurrent.duration.DurationInt
   */
 case class PeerData(
     peer: Peer,
-    node: Node
+    node: Node,
+    supervisor: ActorRef
 )(implicit system: ActorSystem, nodeAppConfig: NodeAppConfig) {
 
   lazy val peerMessageSender: PeerMessageSender = PeerMessageSender(client)
@@ -25,12 +26,12 @@ case class PeerData(
     val peerMessageReceiver =
       PeerMessageReceiver.newReceiver(node = node, peer = peer)
     P2PClient(
-      context = system,
       peer = peer,
       peerMessageReceiver = peerMessageReceiver,
       onReconnect = node.peerManager.onReconnect,
       onStop = node.peerManager.onP2PClientStopped,
-      maxReconnectionTries = 4
+      maxReconnectionTries = 4,
+      supervisor = supervisor
     )
   }
 

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -10,6 +10,7 @@ import org.bitcoins.node.networking.peer.{
   PeerMessageSender
 }
 
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 /** PeerData contains objects specific to a peer associated together
@@ -19,10 +20,13 @@ case class PeerData(
     node: Node,
     supervisor: ActorRef
 )(implicit system: ActorSystem, nodeAppConfig: NodeAppConfig) {
+  import system.dispatcher
 
-  lazy val peerMessageSender: PeerMessageSender = PeerMessageSender(client)
+  lazy val peerMessageSender: Future[PeerMessageSender] = {
+    client.map(PeerMessageSender(_))
+  }
 
-  lazy val client: P2PClient = {
+  lazy val client: Future[P2PClient] = {
     val peerMessageReceiver =
       PeerMessageReceiver.newReceiver(node = node, peer = peer)
     P2PClient(

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.node
 
-import akka.actor.{ActorSystem, Cancellable}
+import akka.actor.{ActorRef, ActorSystem, Cancellable}
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.p2p.ServiceIdentifier
 import org.bitcoins.core.util.{NetworkUtil, StartStopAsync}
@@ -17,7 +17,8 @@ import scala.util.Random
 case class PeerFinder(
     paramPeers: Vector[Peer],
     node: NeutrinoNode,
-    skipPeers: () => Vector[Peer])(implicit
+    skipPeers: () => Vector[Peer],
+    supervisor: ActorRef)(implicit
     ec: ExecutionContext,
     system: ActorSystem,
     nodeAppConfig: NodeAppConfig)
@@ -177,7 +178,7 @@ case class PeerFinder(
 
   /** creates and initialises a new test peer */
   def tryPeer(peer: Peer): Unit = {
-    _peerData.put(peer, PeerData(peer, node))
+    _peerData.put(peer, PeerData(peer, node, supervisor))
     _peerData(peer).peerMessageSender.connect()
   }
 

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -516,8 +516,9 @@ case class P2PClientActor(
     * Currently, such a situation is not meant to happen.
     */
   def handleExpectResponse(msg: NetworkPayload): Future[Unit] = {
-    require(msg.isInstanceOf[ExpectsResponse],
-            "Tried to wait for response to message which is not a query.")
+    require(
+      msg.isInstanceOf[ExpectsResponse],
+      s"Tried to wait for response to message which is not a query, got=$msg")
     logger.info(s"Expecting response for ${msg.commandName} for $peer")
     currentPeerMsgHandlerRecv.handleExpectResponse(msg).map { newReceiver =>
       currentPeerMsgHandlerRecv = newReceiver

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClientSupervisor.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClientSupervisor.scala
@@ -1,0 +1,23 @@
+package org.bitcoins.node.networking
+
+import akka.actor.SupervisorStrategy._
+import akka.actor.{Actor, OneForOneStrategy, Props}
+import org.bitcoins.node.P2PLogger
+import org.bitcoins.node.util.BitcoinSNodeUtil
+
+class P2PClientSupervisor extends Actor with P2PLogger {
+
+  override val supervisorStrategy: OneForOneStrategy =
+    OneForOneStrategy() { case e: Throwable =>
+      logger.error("Error while processing messages", e)
+      Stop
+    }
+
+  def receive: Receive = { case props: Props =>
+    /* actors to be supervised need to built withing this context this creates an actor using props and sends back
+    the ActorRef */
+    sender() ! context.actorOf(props,
+                               name =
+                                 BitcoinSNodeUtil.createActorName(getClass))
+  }
+}

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -9,7 +9,8 @@ import org.bitcoins.node.networking.P2PClient
 import org.bitcoins.node.networking.peer.PeerMessageReceiverState._
 import org.bitcoins.node.{Node, P2PLogger}
 
-import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
 
 /** Responsible for receiving messages from a peer on the
   * p2p network. This is called by [[org.bitcoins.rpc.client.common.Client Client]] when doing the p2p
@@ -46,7 +47,7 @@ class PeerMessageReceiver(
 
         val timeout =
           system.scheduler.scheduleOnce(nodeAppConfig.initializationTimeout)(
-            onInitTimeout())
+            Await.result(onInitTimeout(), 10.seconds))
 
         val newState = Preconnection.toInitializing(client, timeout)
 
@@ -91,7 +92,6 @@ class PeerMessageReceiver(
                                              state.verackMsgP)
         toState(newState)
       case state: Waiting =>
-        onResponseTimeout(state.responseFor)
         val newState = InitializedDisconnect(state.clientConnectP,
                                              state.clientDisconnectP,
                                              state.versionMsgP,
@@ -121,7 +121,7 @@ class PeerMessageReceiver(
     }
   }
 
-  protected[networking] def disconnect(): PeerMessageReceiver = {
+  protected[networking] def disconnect(): Future[PeerMessageReceiver] = {
     logger.trace(s"Disconnecting with internalstate=${state}")
     state match {
       case bad @ (_: Disconnected | Preconnection |
@@ -134,15 +134,19 @@ class PeerMessageReceiver(
           clientDisconnectP = good.clientDisconnectP.success(()),
           versionMsgP = good.versionMsgP,
           verackMsgP = good.verackMsgP)
-        new PeerMessageReceiver(node, newState, peer)
+        val newReceiver = new PeerMessageReceiver(node, newState, peer)
+        Future.successful(newReceiver)
       case good @ (_: Initializing | _: Normal | _: Waiting) =>
-        good match {
+        val handleF: Future[Unit] = good match {
           case wait: Waiting =>
-            onResponseTimeout(wait.responseFor)
-            wait.timeout.cancel()
+            onResponseTimeout(wait.responseFor).map { _ =>
+              wait.timeout.cancel()
+              ()
+            }
           case wait: Initializing =>
             wait.timeout.cancel()
-          case _ =>
+            Future.unit
+          case _ => Future.unit
         }
 
         logger.debug(s"Disconnected bitcoin peer=${peer}")
@@ -153,7 +157,8 @@ class PeerMessageReceiver(
           verackMsgP = good.verackMsgP
         )
 
-        new PeerMessageReceiver(node, newState, peer)
+        val newReceiver = new PeerMessageReceiver(node, newState, peer)
+        handleF.map(_ => newReceiver)
     }
   }
 
@@ -253,12 +258,12 @@ class PeerMessageReceiver(
       .handleControlPayload(payload, sender, peer, curReceiver)
   }
 
-  def onInitTimeout(): Unit = {
+  def onInitTimeout(): Future[Unit] = {
     logger.debug(s"Init timeout for peer $peer")
     node.peerManager.onInitializationTimeout(peer)
   }
 
-  def onResponseTimeout(networkPayload: NetworkPayload): Unit = {
+  def onResponseTimeout(networkPayload: NetworkPayload): Future[Unit] = {
     assert(networkPayload.isInstanceOf[ExpectsResponse])
     logger.debug(s"Handling response timeout for ${networkPayload.commandName}")
 
@@ -271,21 +276,22 @@ class PeerMessageReceiver(
     networkPayload match {
       case payload: ExpectsResponse =>
         logger.debug(
-          s"Response for ${payload.commandName} from $peer timed out.")
-        node.peerManager.onQueryTimeout(payload, peer).foreach(_ => ())
+          s"Response for ${payload.commandName} from $peer timed out in state $state")
+        node.peerManager.onQueryTimeout(payload, peer)
       case _ =>
         logger.error(
           s"onResponseTimeout called for ${networkPayload.commandName} which does not expect response")
+        Future.unit
     }
   }
 
-  def handleExpectResponse(msg: NetworkPayload): PeerMessageReceiver = {
+  def handleExpectResponse(msg: NetworkPayload): Future[PeerMessageReceiver] = {
     state match {
       case good: Normal =>
         logger.debug(s"Handling expected response for ${msg.commandName}")
         val timeout =
           system.scheduler.scheduleOnce(nodeAppConfig.queryWaitTime)(
-            onResponseTimeout(msg))
+            Await.result(onResponseTimeout(msg), 10.seconds))
         val newState = Waiting(
           clientConnectP = good.clientConnectP,
           clientDisconnectP = good.clientDisconnectP,
@@ -295,11 +301,11 @@ class PeerMessageReceiver(
           waitingSince = System.currentTimeMillis(),
           timeout = timeout
         )
-        toState(newState)
+        Future.successful(toState(newState))
       case state: Waiting =>
         logger.debug(
           s"Waiting for response to ${state.responseFor.commandName}. Ignoring next request for ${msg.commandName}")
-        this
+        Future.successful(this)
       case bad @ (_: InitializedDisconnect | _: InitializedDisconnectDone |
           _: StoppedReconnect) =>
         throw new RuntimeException(
@@ -307,9 +313,7 @@ class PeerMessageReceiver(
       case Preconnection | _: Initializing | _: Disconnected =>
         //so we sent a message when things were good, but not we are back to connecting?
         //can happen when can happen where once we initialize the remote peer immediately disconnects us
-        onResponseTimeout(msg)
-        this
-
+        onResponseTimeout(msg).flatMap(_ => Future.successful(this))
     }
   }
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -16,7 +16,6 @@ import org.bitcoins.node.P2PLogger
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.constant.NodeConstants
 import org.bitcoins.node.networking.P2PClient
-import org.bitcoins.node.networking.P2PClient.ExpectResponseCommand
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
@@ -244,14 +243,6 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
     val networkMsg = NetworkMessage(conf.network, msg)
     client.actor ! networkMsg
-
-    msg match {
-      case _: ExpectsResponse =>
-        logger.debug(s"${msg.commandName} expects response")
-        client.actor ! ExpectResponseCommand(msg)
-      case _ =>
-    }
-
     Future.unit
   }
 }

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -62,6 +62,9 @@
     <!-- inspect TCP details -->
     <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
 
+    <!-- See exceptions thrown in actor-->
+    <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
+
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->
     <!-- ╚════════════════════╝ -->

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -22,8 +22,9 @@ abstract class NodeTestUtil extends P2PLogger {
       peer: Peer,
       peerMsgReceiver: PeerMessageReceiver,
       supervisor: ActorRef)(implicit
-      conf: NodeAppConfig
-  ): P2PClient = {
+      conf: NodeAppConfig,
+      system: ActorSystem
+  ): Future[P2PClient] = {
     P2PClient.apply(peer,
                     peerMsgReceiver,
                     (_: Peer) => Future.unit,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.testkit.node
 
-import akka.actor.{ActorRefFactory, ActorSystem}
+import akka.actor.{ActorRef, ActorSystem}
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
@@ -18,16 +18,18 @@ import scala.concurrent.{ExecutionContext, Future}
 
 abstract class NodeTestUtil extends P2PLogger {
 
-  def client(peer: Peer, peerMsgReceiver: PeerMessageReceiver)(implicit
-      ref: ActorRefFactory,
+  def client(
+      peer: Peer,
+      peerMsgReceiver: PeerMessageReceiver,
+      supervisor: ActorRef)(implicit
       conf: NodeAppConfig
   ): P2PClient = {
-    P2PClient.apply(ref,
-                    peer,
+    P2PClient.apply(peer,
                     peerMsgReceiver,
                     (_: Peer) => Future.unit,
                     (_: Peer) => Future.unit,
-                    16)
+                    16,
+                    supervisor)
   }
 
   /** Helper method to get the [[java.net.InetSocketAddress]]

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -227,7 +227,7 @@ object NodeUnitTest extends P2PLogger {
       node <- nodeF
       peerMsgReceiver = PeerMessageReceiver.preConnection(peer, node)
       supervisor = node.peerManager.supervisor
-      client = NodeTestUtil.client(peer, peerMsgReceiver, supervisor)
+      client <- NodeTestUtil.client(peer, peerMsgReceiver, supervisor)
       peerMsgSender = PeerMessageSender(client)
     } yield PeerHandler(client, peerMsgSender)
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -221,14 +221,13 @@ object NodeUnitTest extends P2PLogger {
       system: ActorSystem): Future[PeerHandler] = {
     import system.dispatcher
     val nodeF = buildNode(peer, walletCreationTimeOpt)
-    val peerMsgReceiverF = nodeF.map { node =>
-      PeerMessageReceiver.preConnection(peer, node)
-    }
     //the problem here is the 'self', this needs to be an ordinary peer message handler
     //that can handle the handshake
     val peerHandlerF = for {
-      peerMsgReceiver <- peerMsgReceiverF
-      client = NodeTestUtil.client(peer, peerMsgReceiver)
+      node <- nodeF
+      peerMsgReceiver = PeerMessageReceiver.preConnection(peer, node)
+      supervisor = node.peerManager.supervisor
+      client = NodeTestUtil.client(peer, peerMsgReceiver, supervisor)
       peerMsgSender = PeerMessageSender(client)
     } yield PeerHandler(client, peerMsgSender)
 


### PR DESCRIPTION
 -  Fixes logging for errors thrown in `P2PClientActor`.
 - The way P2PClient awaits response for a message like getheaders is that I send an ExpectResponseCommand to the node. So, in the case of headers, 2 messages would be sent consecutively, first getheaders then an ExpectResponseCommand that schedules a timeout function to be executed sometime in the future. Problem here was that sometimes a response from the peer may be received in between these 2 messages that we send. I noticed that, especially in the case of tests, sometimes response for getheaders is sent before the ExpectResponseCommand is sent. This is fixed now, the timer is started before even sending a getheaders so no messages are missed.
 - Second was with disconnecting peers, so that now we ignore messages once we have started disconnecting a peer.
 - Third would be the use of Await at some places. I had a quite big misunderstanding wrt foreach that cleared up with your earlier comments on this. Now I'm following the function signatures properly. So Await was introduced in postStop of Actor as that returned a Unit and schedulers or runnables that I'm using as they too expect a function with a Unit return type.