### PR TITLE
Add abillity to clear callbacks

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/ChainCallbacks.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/ChainCallbacks.scala
@@ -1,12 +1,13 @@
 package org.bitcoins.chain
 
 import grizzled.slf4j.Logger
+import org.bitcoins.core.api.callback.{CallbackFactory, ModuleCallbacks}
 import org.bitcoins.core.api.{Callback, CallbackHandler}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait ChainCallbacks {
+trait ChainCallbacks extends ModuleCallbacks[ChainCallbacks] {
 
   def onBlockHeaderConnected: CallbackHandler[
     Vector[(Int, BlockHeader)],
@@ -14,7 +15,7 @@ trait ChainCallbacks {
 
   def onSyncFlagChanged: CallbackHandler[Boolean, OnSyncFlagChanged]
 
-  def +(other: ChainCallbacks): ChainCallbacks
+  override def +(other: ChainCallbacks): ChainCallbacks
 
   def executeOnBlockHeaderConnectedCallbacks(
       logger: Logger,
@@ -45,7 +46,7 @@ trait OnBlockHeaderConnected extends Callback[Vector[(Int, BlockHeader)]]
 
 trait OnSyncFlagChanged extends Callback[Boolean]
 
-object ChainCallbacks {
+object ChainCallbacks extends CallbackFactory[ChainCallbacks] {
 
   private case class ChainCallbacksImpl(
       onBlockHeaderConnected: CallbackHandler[
@@ -67,7 +68,7 @@ object ChainCallbacks {
   def onOnSyncFlagChanged(f: OnSyncFlagChanged): ChainCallbacks =
     ChainCallbacks(onSyncFlagChanged = Vector(f))
 
-  lazy val empty: ChainCallbacks =
+  override val empty: ChainCallbacks =
     ChainCallbacks(onBlockHeaderConnected = Vector.empty)
 
   def apply(

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -8,7 +8,6 @@ import org.bitcoins.chain.pow.Pow
 import org.bitcoins.commons.config.AppConfigFactory
 import org.bitcoins.core.api.CallbackConfig
 import org.bitcoins.core.api.chain.db.BlockHeaderDbHelper
-import org.bitcoins.core.util.Mutable
 import org.bitcoins.db._
 
 import java.nio.file.Path
@@ -35,13 +34,7 @@ case class ChainAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
 
   override lazy val appConfig: ChainAppConfig = this
 
-  private val callbacks = new Mutable(ChainCallbacks.empty)
-
-  override def callBacks: ChainCallbacks = callbacks.atomicGet
-
-  override def addCallbacks(newCallbacks: ChainCallbacks): ChainCallbacks = {
-    callbacks.atomicUpdate(newCallbacks)(_ + _)
-  }
+  override lazy val callbackFactory: ChainCallbacks.type = ChainCallbacks
 
   /** Checks whether or not the chain project is initialized by
     * trying to read the genesis block header from our block
@@ -102,6 +95,7 @@ case class ChainAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
 
   override def stop(): Future[Unit] = {
     val _ = stopHikariLogger()
+    clearCallbacks()
     super.stop()
   }
 

--- a/core/src/main/scala/org/bitcoins/core/api/callback/CallbackFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/callback/CallbackFactory.scala
@@ -1,0 +1,5 @@
+package org.bitcoins.core.api.callback
+
+trait CallbackFactory[T] {
+  def empty: T
+}

--- a/core/src/main/scala/org/bitcoins/core/api/callback/ModuleCallbacks.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/callback/ModuleCallbacks.scala
@@ -1,0 +1,6 @@
+package org.bitcoins.core.api.callback
+
+/** A data structure to represent all callbacks for a specific module */
+trait ModuleCallbacks[T <: ModuleCallbacks[T]] {
+  def +(other: T): T
+}

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -13,7 +13,7 @@ import org.bitcoins.chain.models.{
 import org.bitcoins.core.api.CallbackConfig
 import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.core.config.{MainNet, RegTest, SigNet, TestNet3}
-import org.bitcoins.core.util.{Mutable, TimeUtil}
+import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.db.{DbAppConfig, JdbcProfileComponent}
 import org.bitcoins.node._
 import org.bitcoins.node.db.NodeDbManagement
@@ -50,13 +50,7 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
 
   override def appConfig: NodeAppConfig = this
 
-  private val callbacks = new Mutable(NodeCallbacks.empty)
-
-  override def callBacks: NodeCallbacks = callbacks.atomicGet
-
-  override def addCallbacks(newCallbacks: NodeCallbacks): NodeCallbacks = {
-    callbacks.atomicUpdate(newCallbacks)(_ + _)
-  }
+  override lazy val callbackFactory: NodeCallbacks.type = NodeCallbacks
 
   /** Ensures correct tables and other required information is in
     * place for our node.
@@ -96,6 +90,7 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   }
 
   override def stop(): Future[Unit] = {
+    clearCallbacks()
     val _ = stopHikariLogger()
     super.stop()
   }

--- a/tor/src/main/scala/org/bitcoins/tor/TorCallbacks.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/TorCallbacks.scala
@@ -1,13 +1,14 @@
 package org.bitcoins.tor
 
 import grizzled.slf4j.Logging
+import org.bitcoins.core.api.callback.{CallbackFactory, ModuleCallbacks}
 import org.bitcoins.core.api.{Callback, CallbackHandler}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait OnTorStarted extends Callback[Unit]
 
-trait TorCallbacks extends Logging {
+trait TorCallbacks extends ModuleCallbacks[TorCallbacks] with Logging {
   def onTorStarted: CallbackHandler[Unit, OnTorStarted]
 
   def executeOnTorStarted()(implicit ec: ExecutionContext): Future[Unit] = {
@@ -20,7 +21,7 @@ trait TorCallbacks extends Logging {
   def +(other: TorCallbacks): TorCallbacks
 }
 
-object TorCallbacks {
+object TorCallbacks extends CallbackFactory[TorCallbacks] {
 
   private case class TorCallbacksImpl(
       onTorStarted: CallbackHandler[Unit, OnTorStarted]
@@ -31,7 +32,7 @@ object TorCallbacks {
     }
   }
 
-  val empty = apply(Vector.empty)
+  override val empty: TorCallbacks = apply(Vector.empty)
 
   def apply(onTorStarted: OnTorStarted): TorCallbacks = {
     apply(Vector(onTorStarted))

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletCallbacks.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletCallbacks.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.wallet
 
 import grizzled.slf4j.Logger
+import org.bitcoins.core.api.callback.{CallbackFactory, ModuleCallbacks}
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.api.{Callback, CallbackHandler}
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -13,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * The appropriate callback is executed whenever the wallet finishes,
   * the corresponding function.
   */
-trait WalletCallbacks {
+trait WalletCallbacks extends ModuleCallbacks[WalletCallbacks] {
 
   def onTransactionProcessed: CallbackHandler[
     Transaction,
@@ -107,7 +108,7 @@ trait OnBlockProcessed extends Callback[Block]
 /** Triggered when a rescan is */
 trait OnRescanComplete extends Callback[Unit]
 
-object WalletCallbacks {
+object WalletCallbacks extends CallbackFactory[WalletCallbacks] {
 
   private case class WalletCallbacksImpl(
       onTransactionProcessed: CallbackHandler[
@@ -159,7 +160,7 @@ object WalletCallbacks {
   }
 
   /** Empty callbacks that does nothing with the received data */
-  val empty: WalletCallbacks =
+  override val empty: WalletCallbacks =
     apply(Vector.empty,
           Vector.empty,
           Vector.empty,

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -8,7 +8,6 @@ import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.hd._
-import org.bitcoins.core.util.Mutable
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.keymanagement._
 import org.bitcoins.crypto.AesPassword
@@ -70,13 +69,7 @@ case class WalletAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors(),
                                  rescanThreadFactory)
 
-  private val callbacks = new Mutable(WalletCallbacks.empty)
-
-  override def callBacks: WalletCallbacks = callbacks.atomicGet
-
-  override def addCallbacks(newCallbacks: WalletCallbacks): WalletCallbacks = {
-    callbacks.atomicUpdate(newCallbacks)(_ + _)
-  }
+  override lazy val callbackFactory: WalletCallbacks.type = WalletCallbacks
 
   lazy val kmConf: KeyManagerAppConfig =
     KeyManagerAppConfig(baseDatadir, configOverrides)
@@ -219,6 +212,7 @@ case class WalletAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
       stopHikariLogger()
     }
 
+    clearCallbacks()
     stopRebroadcastTxsScheduler()
     //this eagerly shuts down all scheduled tasks on the scheduler
     //in the future, we should actually cancel all things that are scheduled


### PR DESCRIPTION
Related to #1752 

This PR adds the ability to remove all callbacks in a `CallbackConfig` 

We clear all callbacks when a `CallbackConfig` is stopped. Examples of this is `TorAppConfig`, `WalletAppConfig`, `NodeAppConfig`, `ChainAppConfig`. 

Finally this PR introduces some new abstractions so we can move implementations of callbacks into traits.

- `ModuleCallbacks` - contains all possible types of callbacks for a module
- `CallbackFactory` - a factory for creating a callback

