### PR TITLE
2022 07 18 node callback stream manager

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
@@ -44,12 +44,12 @@ class CallBackUtilTest extends BitcoinSWalletTest {
         tx2 <- tx2F
         callbacks <- callbacksF
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx1)
-        _ <- AsyncUtil.nonBlockingSleep(1000.millis)
+        _ <- AsyncUtil.nonBlockingSleep(500.millis)
         initBalance <- initBalanceF
         balance2 <- wallet.getBalance()
         _ = killSwitch.shutdown()
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
-        _ <- AsyncUtil.nonBlockingSleep(1000.millis)
+        _ <- AsyncUtil.nonBlockingSleep(500.millis)
         balance3 <- wallet.getBalance()
       } yield {
         assert(balance2 > initBalance)
@@ -81,12 +81,12 @@ class CallBackUtilTest extends BitcoinSWalletTest {
         tx2 <- tx2F
         callbacks <- callbacksF
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx1)
-        _ <- AsyncUtil.nonBlockingSleep(1000.millis)
+        _ <- AsyncUtil.nonBlockingSleep(500.millis)
         initBalance <- initBalanceF
         balance2 <- wallet.getBalance()
         _ = killSwitch.shutdown()
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
-        _ <- AsyncUtil.nonBlockingSleep(1000.millis)
+        _ <- AsyncUtil.nonBlockingSleep(500.millis)
         balance3 <- wallet.getBalance()
       } yield {
         assert(balance2 > initBalance)

--- a/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
@@ -44,12 +44,12 @@ class CallBackUtilTest extends BitcoinSWalletTest {
         tx2 <- tx2F
         callbacks <- callbacksF
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx1)
-        _ <- AsyncUtil.nonBlockingSleep(500.millis)
+        _ <- AsyncUtil.nonBlockingSleep(1000.millis)
         initBalance <- initBalanceF
         balance2 <- wallet.getBalance()
         _ = killSwitch.shutdown()
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
-        _ <- AsyncUtil.nonBlockingSleep(500.millis)
+        _ <- AsyncUtil.nonBlockingSleep(1000.millis)
         balance3 <- wallet.getBalance()
       } yield {
         assert(balance2 > initBalance)
@@ -81,12 +81,12 @@ class CallBackUtilTest extends BitcoinSWalletTest {
         tx2 <- tx2F
         callbacks <- callbacksF
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx1)
-        _ <- AsyncUtil.nonBlockingSleep(500.millis)
+        _ <- AsyncUtil.nonBlockingSleep(1000.millis)
         initBalance <- initBalanceF
         balance2 <- wallet.getBalance()
         _ = killSwitch.shutdown()
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
-        _ <- AsyncUtil.nonBlockingSleep(500.millis)
+        _ <- AsyncUtil.nonBlockingSleep(1000.millis)
         balance3 <- wallet.getBalance()
       } yield {
         assert(balance2 > initBalance)

--- a/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.server
 
-import akka.stream.KillSwitches
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.server.util.CallbackUtil
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
@@ -36,9 +35,8 @@ class CallBackUtilTest extends BitcoinSWalletTest {
           .sampleSome
       }
 
-      val killSwitch = KillSwitches.shared("callbackutil-test-killswitch")
       val callbacksF =
-        CallbackUtil.createBitcoindNodeCallbacksForWallet(wallet, killSwitch)
+        CallbackUtil.createBitcoindNodeCallbacksForWallet(wallet)
       for {
         tx1 <- tx1F
         tx2 <- tx2F
@@ -47,11 +45,9 @@ class CallBackUtilTest extends BitcoinSWalletTest {
         _ <- AsyncUtil.nonBlockingSleep(1000.millis)
         initBalance <- initBalanceF
         balance2 <- wallet.getBalance()
-        _ = killSwitch.shutdown()
-        _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
-        _ <- AsyncUtil.nonBlockingSleep(1000.millis)
-        balance3 <- wallet.getBalance()
         _ <- callbacks.stop()
+        _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
+        balance3 <- wallet.getBalance()
       } yield {
         assert(balance2 > initBalance)
         assert(balance3 == balance2)
@@ -74,9 +70,8 @@ class CallBackUtilTest extends BitcoinSWalletTest {
           .sampleSome
       }
 
-      val killSwitch = KillSwitches.shared("callbackutil-test2-killswitch")
       val callbacksF =
-        CallbackUtil.createNeutrinoNodeCallbacksForWallet(wallet, killSwitch)
+        CallbackUtil.createNeutrinoNodeCallbacksForWallet(wallet)
       for {
         tx1 <- tx1F
         tx2 <- tx2F
@@ -85,11 +80,9 @@ class CallBackUtilTest extends BitcoinSWalletTest {
         _ <- AsyncUtil.nonBlockingSleep(1000.millis)
         initBalance <- initBalanceF
         balance2 <- wallet.getBalance()
-        _ = killSwitch.shutdown()
-        _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
-        _ <- AsyncUtil.nonBlockingSleep(1000.millis)
-        balance3 <- wallet.getBalance()
         _ <- callbacks.stop()
+        _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
+        balance3 <- wallet.getBalance()
       } yield {
         assert(balance2 > initBalance)
         assert(balance3 == balance2)

--- a/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
@@ -51,6 +51,7 @@ class CallBackUtilTest extends BitcoinSWalletTest {
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
         _ <- AsyncUtil.nonBlockingSleep(1000.millis)
         balance3 <- wallet.getBalance()
+        _ <- callbacks.stop()
       } yield {
         assert(balance2 > initBalance)
         assert(balance3 == balance2)
@@ -88,6 +89,7 @@ class CallBackUtilTest extends BitcoinSWalletTest {
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
         _ <- AsyncUtil.nonBlockingSleep(1000.millis)
         balance3 <- wallet.getBalance()
+        _ <- callbacks.stop()
       } yield {
         assert(balance2 > initBalance)
         assert(balance3 == balance2)

--- a/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
@@ -1,0 +1,205 @@
+package org.bitcoins.node.callback
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.BoundedSourceQueue
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import grizzled.slf4j.{Logger, Logging}
+import org.bitcoins.core.api.CallbackHandler
+import org.bitcoins.core.gcs.GolombFilter
+import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader, MerkleBlock}
+import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.core.util.StartStopAsync
+import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.node.{
+  NodeCallbacks,
+  OnBlockHeadersReceived,
+  OnBlockReceived,
+  OnCompactFiltersReceived,
+  OnMerkleBlockReceived,
+  OnTxReceived
+}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Creates a wrapper around the give node callbacks with a stream */
+case class NodeCallbackStreamManager(callbacks: NodeCallbacks)(implicit
+    system: ActorSystem)
+    extends NodeCallbacks
+    with StartStopAsync[Unit]
+    with Logging {
+  import system.dispatcher
+  private val maxBufferSize: Int = 25
+
+  private val filterQueueSource: Source[
+    Vector[(DoubleSha256Digest, GolombFilter)],
+    BoundedSourceQueue[Vector[(DoubleSha256Digest, GolombFilter)]]] = {
+    Source.queue(maxBufferSize)
+  }
+
+  private val filterSink: Sink[
+    Vector[(DoubleSha256Digest, GolombFilter)],
+    Future[Done]] = {
+    Sink.foreachAsync(1) { case vec =>
+      callbacks.executeOnCompactFiltersReceivedCallbacks(logger, vec)
+    }
+  }
+
+  private val (filterQueue, filterSinkCompleteF) =
+    matSourceAndQueue(filterQueueSource, filterSink)
+
+  private val txQueueSource: Source[
+    Transaction,
+    BoundedSourceQueue[Transaction]] = {
+    Source.queue(maxBufferSize)
+  }
+
+  private val txSink: Sink[Transaction, Future[Done]] = {
+    Sink.foreachAsync(1) { case tx =>
+      callbacks.executeOnTxReceivedCallbacks(logger, tx)
+    }
+  }
+
+  private val (txQueue, txSinkCompleteF) =
+    matSourceAndQueue(txQueueSource, txSink)
+
+  private val headerQueueSource: Source[
+    Vector[BlockHeader],
+    BoundedSourceQueue[Vector[BlockHeader]]] = {
+    Source.queue(maxBufferSize)
+  }
+
+  private val headerSink: Sink[Vector[BlockHeader], Future[Done]] = {
+    Sink.foreachAsync(1) { case headers =>
+      callbacks.executeOnBlockHeadersReceivedCallbacks(logger, headers)
+    }
+  }
+
+  private val (headerQueue, headerSinkCompleteF) =
+    matSourceAndQueue(headerQueueSource, headerSink)
+
+  private val blockQueueSource: Source[Block, BoundedSourceQueue[Block]] = {
+    Source.queue(maxBufferSize)
+  }
+
+  private val blockSink: Sink[Block, Future[Done]] = {
+    Sink.foreachAsync(1) { case block =>
+      callbacks.executeOnBlockReceivedCallbacks(logger, block)
+    }
+  }
+
+  private val (blockQueue, blockSinkCompleteF) =
+    matSourceAndQueue(blockQueueSource, blockSink)
+
+  private val merkleBlockQueueSource: Source[
+    (MerkleBlock, Vector[Transaction]),
+    BoundedSourceQueue[(MerkleBlock, Vector[Transaction])]] = {
+    Source.queue(maxBufferSize)
+  }
+
+  private val merkleBlockSink: Sink[
+    (MerkleBlock, Vector[Transaction]),
+    Future[Done]] = {
+    Sink.foreachAsync(1) { case tuple =>
+      callbacks.executeOnMerkleBlockReceivedCallbacks(logger = logger,
+                                                      merkleBlock = tuple._1,
+                                                      txs = tuple._2)
+    }
+  }
+
+  private val (merkleBlockQueue, merkleBlockCompleteF) =
+    matSourceAndQueue(merkleBlockQueueSource, merkleBlockSink)
+
+  override def start(): Future[Unit] = Future.unit
+
+  /** Completes all streams and waits until they are fully drained */
+  override def stop(): Future[Unit] = {
+    val start = System.currentTimeMillis()
+    //complete all queues
+    filterQueue.complete()
+    txQueue.complete()
+    headerQueue.complete()
+    merkleBlockQueue.complete()
+    blockQueue.complete()
+
+    for {
+      _ <- filterSinkCompleteF
+      _ <- txSinkCompleteF
+      _ <- headerSinkCompleteF
+      _ <- merkleBlockCompleteF
+      _ <- blockSinkCompleteF
+    } yield {
+      logger.info(s"Done draining akka streams for NodeCallbackStreamManager, it took=${System.currentTimeMillis() - start}ms")
+      ()
+    }
+  }
+
+  private def matSourceAndQueue[T](
+      source: Source[T, BoundedSourceQueue[T]],
+      sink: Sink[T, Future[Done]]): (BoundedSourceQueue[T], Future[Done]) = {
+    source
+      .toMat(sink)(Keep.both)
+      .run()
+  }
+
+  override def onCompactFiltersReceived: CallbackHandler[
+    Vector[(DoubleSha256Digest, GolombFilter)],
+    OnCompactFiltersReceived] = {
+    callbacks.onCompactFiltersReceived
+  }
+
+  override def onTxReceived: CallbackHandler[Transaction, OnTxReceived] = {
+    callbacks.onTxReceived
+  }
+
+  override def onBlockReceived: CallbackHandler[Block, OnBlockReceived] =
+    callbacks.onBlockReceived
+
+  override def onMerkleBlockReceived: CallbackHandler[
+    (MerkleBlock, Vector[Transaction]),
+    OnMerkleBlockReceived] = callbacks.onMerkleBlockReceived
+
+  override def onBlockHeadersReceived: CallbackHandler[
+    Vector[BlockHeader],
+    OnBlockHeadersReceived] = callbacks.onBlockHeadersReceived
+
+  override def executeOnTxReceivedCallbacks(logger: Logger, tx: Transaction)(
+      implicit ec: ExecutionContext): Future[Unit] = {
+    txQueue.offer(tx)
+    Future.unit
+  }
+
+  override def executeOnBlockReceivedCallbacks(logger: Logger, block: Block)(
+      implicit ec: ExecutionContext): Future[Unit] = {
+    blockQueue.offer(block)
+    Future.unit
+  }
+
+  override def executeOnCompactFiltersReceivedCallbacks(
+      logger: Logger,
+      blockFilters: Vector[(DoubleSha256Digest, GolombFilter)])(implicit
+      ec: ExecutionContext): Future[Unit] = {
+    filterQueue.offer(blockFilters)
+    Future.unit
+  }
+
+  override def executeOnMerkleBlockReceivedCallbacks(
+      logger: Logger,
+      merkleBlock: MerkleBlock,
+      txs: Vector[Transaction])(implicit ec: ExecutionContext): Future[Unit] = {
+    merkleBlockQueue.offer((merkleBlock, txs))
+    Future.unit
+  }
+
+  override def executeOnBlockHeadersReceivedCallbacks(
+      logger: Logger,
+      headers: Vector[BlockHeader])(implicit
+      ec: ExecutionContext): Future[Unit] = {
+    headerQueue.offer(headers)
+    Future.unit
+  }
+
+  override def +(other: NodeCallbacks): NodeCallbacks = {
+    ???
+  }
+}

--- a/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
@@ -201,7 +201,12 @@ case class NodeCallbackStreamManager(callbacks: NodeCallbacks)(implicit
     Future.unit
   }
 
+  /** Consider calling [[stop()]] before creating a new instance of callbacks
+    * this is because the previous stream will keep running and a new stream
+    * will be created
+    */
   override def +(other: NodeCallbacks): NodeCallbacks = {
-    ???
+    val newCallbacks = other.+(this)
+    NodeCallbackStreamManager(newCallbacks)
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
@@ -129,7 +129,9 @@ case class NodeCallbackStreamManager(callbacks: NodeCallbacks)(implicit
       _ <- merkleBlockCompleteF
       _ <- blockSinkCompleteF
     } yield {
-      logger.info(s"Done draining akka streams for NodeCallbackStreamManager, it took=${System.currentTimeMillis() - start}ms")
+      logger.info(
+        s"Done draining akka streams for NodeCallbackStreamManager, it took=${System
+          .currentTimeMillis() - start}ms")
       ()
     }
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.testkit.wallet
 
 import akka.actor.ActorSystem
-import akka.stream.{KillSwitches, SharedKillSwitch}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.config.AppConfig
@@ -645,11 +644,8 @@ object BitcoinSWalletTest extends WalletLogger {
         chainQueryApi = chainQueryApi,
         bip39PasswordOpt = bip39PasswordOpt)(config.walletConf, system)
       //add callbacks for wallet
-      killSwitch = KillSwitches.shared("fundedWalletAndBitcoind-killswitch")
       nodeCallbacks <-
-        BitcoinSWalletTest.createNeutrinoNodeCallbacksForWallet(
-          wallet,
-          killSwitch)(system)
+        BitcoinSWalletTest.createNeutrinoNodeCallbacksForWallet(wallet)(system)
       _ = config.nodeConf.addCallbacks(nodeCallbacks)
       withBitcoind <- createWalletWithBitcoind(wallet, bitcoindRpcClient)
       funded <- FundWalletUtil.fundWalletWithBitcoind(withBitcoind)
@@ -694,11 +690,9 @@ object BitcoinSWalletTest extends WalletLogger {
   }
 
   /** Constructs callbacks for the wallet from the node to process blocks and compact filters */
-  def createNeutrinoNodeCallbacksForWallet(
-      wallet: Wallet,
-      killSwitch: SharedKillSwitch)(implicit
+  def createNeutrinoNodeCallbacksForWallet(wallet: Wallet)(implicit
       system: ActorSystem): Future[NodeCallbacks] = {
-    CallbackUtil.createNeutrinoNodeCallbacksForWallet(wallet, killSwitch)
+    CallbackUtil.createNeutrinoNodeCallbacksForWallet(wallet)
   }
 
   /** Makes sure our wallet is fully funded with the default amounts specified in


### PR DESCRIPTION
Built ontop of #4516 

This adds `NodeCallbackStreamManager`. This is because #4516 doesn't expose a graceful way to terminate a stream. When testing out `loadwallet` (#4417) with only #4516 there ends up being a race condition when shutting down and processing callbacks.

Now with `NodeCallbackStreamManager.stop()` this gives us access to the `Future`'s that are completed when the stream is terminated. We should :tm: be able to map on these and not load the new wallet until the previous stream is completed. 