### PR TITLE
Add guard for calling NodeCallbackStreamManager.stop()

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
@@ -129,7 +129,8 @@ case class NodeCallbackStreamManager(callbacks: NodeCallbacks)(implicit
       blockQueue.complete()
       isStopped.set(true)
     } else {
-      logger.warn(s"Already stopped all queues associated with this NodeCallBackStreamManager")
+      logger.warn(
+        s"Already stopped all queues associated with this NodeCallBackStreamManager")
     }
 
     for {


### PR DESCRIPTION
If you called `NodeCallbackStreamMananger.stop()` twice it would failed with an exception because the queues have already been completed.

This PR adds a flag to determine if `.stop()` has already been called, if it has, don't try to complete the queues.