### PR TITLE
2022 07 21 Modify helper methods in `BitcoindRpcBackendUtil` to not materialize streams eagerly.

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -25,7 +25,8 @@ import org.bitcoins.core.api.node.{
   NodeApi,
   NodeType
 }
-import org.bitcoins.core.api.wallet.{NeutrinoWalletApi, WalletApi}
+import org.bitcoins.core.api.wallet.NeutrinoHDWalletApi
+
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.dlc.node.DLCNode
@@ -525,7 +526,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     */
   private def syncWalletWithBitcoindAndStartPolling(
       bitcoind: BitcoindRpcClient,
-      wallet: WalletApi with NeutrinoWalletApi,
+      wallet: NeutrinoHDWalletApi,
       chainCallbacksOpt: Option[ChainCallbacks]): Future[
     BitcoindPollingCancellabe] = {
     val f = for {

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
@@ -11,12 +11,12 @@ trait NeutrinoWalletApi { self: WalletApi =>
 
   def processCompactFilter(
       blockHash: DoubleSha256Digest,
-      blockFilter: GolombFilter): Future[WalletApi with NeutrinoWalletApi] =
+      blockFilter: GolombFilter): Future[NeutrinoHDWalletApi] =
     processCompactFilters(Vector((blockHash, blockFilter)))
 
   def processCompactFilters(
       blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
-    WalletApi with NeutrinoWalletApi]
+    NeutrinoHDWalletApi]
 
   /** Recreates the account using BIP-157 approach
     *

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -114,8 +114,9 @@ class WalletHolder(implicit ec: ExecutionContext)
 
   override def processCompactFilters(
       blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
-    WalletApi with NeutrinoWalletApi] = delegate(
-    _.processCompactFilters(blockFilters))
+    NeutrinoHDWalletApi] = {
+    delegate(_.processCompactFilters(blockFilters))
+  }
 
   override def rescanNeutrinoWallet(
       startOpt: Option[BlockStamp],
@@ -709,7 +710,7 @@ class WalletHolder(implicit ec: ExecutionContext)
 
   override def processCompactFilter(
       blockHash: DoubleSha256Digest,
-      blockFilter: GolombFilter): Future[WalletApi with NeutrinoWalletApi] =
+      blockFilter: GolombFilter): Future[NeutrinoHDWalletApi] =
     delegate(_.processCompactFilter(blockHash, blockFilter))
 
   override def fullRescanNeutrinoWallet(addressBatchSize: Int, force: Boolean)(


### PR DESCRIPTION
This re-implements internals helper methods of `BitcoindRpcBackendUtil` to allow us to connect stream pieces together rather than materializing streams inside of the helper method.

This gives will give us more control over eventually materializing streams and completing the stream as is needed in #4499 