### PR TITLE
Pull over infrastructure changes from `loadwallet` branch

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
@@ -3,7 +3,7 @@ package org.bitcoins.server
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.server.util.CallbackUtil
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
+import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
 import org.bitcoins.testkitcore.Implicits.GeneratorOps
 import org.bitcoins.testkitcore.gen.TransactionGenerators
 import org.scalatest.FutureOutcome
@@ -14,10 +14,10 @@ class CallBackUtilTest extends BitcoinSWalletTest {
 
   behavior of "CallBackUtil"
 
-  override type FixtureParam = FundedWallet
+  override type FixtureParam = FundedDLCWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withFundedWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
+    withFundedDLCWallet(test, getBIP39PasswordOpt())(getFreshConfig)
 
   it must "have the kill switch kill messages to the createBitcoindNodeCallbacksForWallet callback" in {
     fundedWallet =>

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -1,0 +1,172 @@
+package org.bitcoins.server
+
+import akka.actor.ActorSystem
+import grizzled.slf4j.Logging
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.dlc.wallet.AnyDLCHDWalletApi
+import org.bitcoins.core.api.feeprovider.FeeRateApi
+import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.crypto.AesPassword
+import org.bitcoins.dlc.wallet.DLCAppConfig
+import org.bitcoins.node.NodeCallbacks
+import org.bitcoins.node.callback.NodeCallbackStreamManager
+import org.bitcoins.node.models.NodeStateDescriptorDAO
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.server.util.CallbackUtil
+import org.bitcoins.wallet.WalletHolder
+import org.bitcoins.wallet.config.WalletAppConfig
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** A trait used to help load a different load and discard the current wallet in memory
+  * This trait encapsulates the heavy lifting done in the 'loadwallet' RPC command
+  */
+sealed trait DLCWalletLoaderApi extends Logging {
+
+  protected def conf: BitcoinSAppConfig
+
+  implicit protected def system: ActorSystem
+
+  def load(
+      walletNameOpt: Option[String],
+      aesPasswordOpt: Option[AesPassword]): Future[
+    (WalletHolder, WalletAppConfig, DLCAppConfig)]
+
+  protected def loadWallet(
+      walletHolder: WalletHolder,
+      chainQueryApi: ChainQueryApi,
+      nodeApi: NodeApi,
+      feeProviderApi: FeeRateApi,
+      walletNameOpt: Option[String],
+      aesPasswordOpt: Option[AesPassword])(implicit
+      ec: ExecutionContext): Future[
+    (AnyDLCHDWalletApi, WalletAppConfig, DLCAppConfig)] = {
+    logger.info(
+      s"Loading wallet with bitcoind backend, walletName=${walletNameOpt.getOrElse("DEFAULT")}")
+    val stoppedCallbacksF = conf.nodeConf.callBacks match {
+      case manager: NodeCallbackStreamManager =>
+        manager.stop()
+      case _: NodeCallbacks =>
+        Future.unit
+    }
+    val walletName =
+      walletNameOpt.getOrElse(WalletAppConfig.DEFAULT_WALLET_NAME)
+
+    for {
+      _ <- stoppedCallbacksF
+      (walletConfig, dlcConfig) <- updateWalletConfigs(walletName,
+                                                       Some(aesPasswordOpt))
+        .recover { case _: Throwable => (conf.walletConf, conf.dlcConf) }
+      _ <- {
+        if (walletHolder.isInitialized) {
+          walletHolder
+            .stop()
+            .map(_ => ())
+        } else {
+          Future.unit
+        }
+      }
+      _ <- walletConfig.start()
+      _ <- dlcConfig.start()
+      dlcWallet <- dlcConfig.createDLCWallet(
+        nodeApi = nodeApi,
+        chainQueryApi = chainQueryApi,
+        feeRateApi = feeProviderApi
+      )(walletConfig, ec)
+    } yield (dlcWallet, walletConfig, dlcConfig)
+  }
+
+  protected def updateWalletConfigs(
+      walletName: String,
+      aesPasswordOpt: Option[Option[AesPassword]])(implicit
+      ec: ExecutionContext): Future[(WalletAppConfig, DLCAppConfig)] = {
+    val kmConfigF = Future.successful(
+      conf.walletConf.kmConf.copy(walletNameOverride = Some(walletName),
+                                  aesPasswordOverride = aesPasswordOpt))
+
+    (for {
+      kmConfig <- kmConfigF
+      _ = if (!kmConfig.seedExists())
+        throw new RuntimeException(s"Wallet `${walletName}` does not exist")
+
+      // First thing start the key manager to be able to fail fast if the password is invalid
+      _ <- kmConfig.start()
+
+      walletConfig = conf.walletConf.copy(kmConfOpt = Some(kmConfig))
+      dlcConfig = conf.dlcConf.copy(walletConfigOpt = Some(walletConfig))
+    } yield (walletConfig, dlcConfig))
+  }
+
+  protected def updateWalletName(walletNameOpt: Option[String])(implicit
+      ec: ExecutionContext): Future[Unit] = {
+    val nodeStateDAO: NodeStateDescriptorDAO =
+      NodeStateDescriptorDAO()(ec, conf.nodeConf)
+    nodeStateDAO.updateWalletName(walletNameOpt)
+  }
+}
+
+case class DLCWalletNeutrinoBackendLoader(
+    walletHolder: WalletHolder,
+    chainQueryApi: ChainQueryApi,
+    nodeApi: NodeApi,
+    feeRateApi: FeeRateApi)(implicit
+    override val conf: BitcoinSAppConfig,
+    override val system: ActorSystem)
+    extends DLCWalletLoaderApi {
+  import system.dispatcher
+  implicit private val nodeConf = conf.nodeConf
+
+  override def load(
+      walletNameOpt: Option[String],
+      aesPasswordOpt: Option[AesPassword]): Future[
+    (WalletHolder, WalletAppConfig, DLCAppConfig)] = {
+
+    for {
+      (dlcWallet, walletConfig, dlcConfig) <- loadWallet(
+        walletHolder = walletHolder,
+        chainQueryApi = chainQueryApi,
+        nodeApi = nodeApi,
+        feeProviderApi = feeRateApi,
+        walletNameOpt = walletNameOpt,
+        aesPasswordOpt = aesPasswordOpt
+      )
+      _ <- walletHolder.replaceWallet(dlcWallet)
+      nodeCallbacks <-
+        CallbackUtil.createNeutrinoNodeCallbacksForWallet(walletHolder)
+      _ = nodeConf.replaceCallbacks(nodeCallbacks)
+      _ <- updateWalletName(walletNameOpt)
+    } yield (walletHolder, walletConfig, dlcConfig)
+  }
+}
+
+case class DLCWalletBitcoindBackendLoader(
+    walletHolder: WalletHolder,
+    bitcoind: BitcoindRpcClient,
+    nodeApi: NodeApi,
+    feeProvider: FeeRateApi)(implicit
+    override val conf: BitcoinSAppConfig,
+    override val system: ActorSystem)
+    extends DLCWalletLoaderApi {
+  import system.dispatcher
+  implicit private val nodeConf = conf.nodeConf
+
+  override def load(
+      walletNameOpt: Option[String],
+      aesPasswordOpt: Option[AesPassword]): Future[
+    (WalletHolder, WalletAppConfig, DLCAppConfig)] = {
+    for {
+      (dlcWallet, walletConfig, dlcConfig) <- loadWallet(
+        walletHolder = walletHolder,
+        chainQueryApi = bitcoind,
+        nodeApi = nodeApi,
+        feeProviderApi = feeProvider,
+        walletNameOpt = walletNameOpt,
+        aesPasswordOpt = aesPasswordOpt)
+
+      nodeCallbacks <- CallbackUtil.createBitcoindNodeCallbacksForWallet(
+        walletHolder)
+      _ = nodeConf.addCallbacks(nodeCallbacks)
+      _ <- walletHolder.replaceWallet(dlcWallet)
+    } yield (walletHolder, walletConfig, dlcConfig)
+  }
+}

--- a/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
@@ -3,25 +3,28 @@ package org.bitcoins.server.util
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Sink, Source}
 import grizzled.slf4j.Logging
+import org.bitcoins.core.api.dlc.wallet.AnyDLCHDWalletApi
+import org.bitcoins.core.api.wallet.{NeutrinoWalletApi, WalletApi}
 import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.DoubleSha256Digest
-import org.bitcoins.node.callback.NodeCallbackStreamManager
 import org.bitcoins.node._
-import org.bitcoins.wallet.Wallet
+import org.bitcoins.node.callback.NodeCallbackStreamManager
+import org.bitcoins.wallet.WalletNotInitialized
 
 import scala.concurrent.Future
 
 object CallbackUtil extends Logging {
 
-  def createNeutrinoNodeCallbacksForWallet(wallet: Wallet)(implicit
+  def createNeutrinoNodeCallbacksForWallet(
+      wallet: WalletApi with NeutrinoWalletApi)(implicit
       system: ActorSystem): Future[NodeCallbackStreamManager] = {
     import system.dispatcher
     val txSink = Sink.foreachAsync[Transaction](1) { case tx: Transaction =>
       logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")
       wallet
-        .processTransaction(tx, blockHashOpt = None)
+        .processTransaction(tx, blockHash = None)
         .map(_ => ())
     }
 
@@ -67,6 +70,7 @@ object CallbackUtil extends Logging {
         .single(blockFilters)
         .runWith(compactFilterSink)
         .map(_ => ())
+        .recover { case _: WalletNotInitialized => () }
     }
     lazy val onBlock: OnBlockReceived = { block =>
       Source
@@ -91,13 +95,13 @@ object CallbackUtil extends Logging {
     Future.successful(streamManager)
   }
 
-  def createBitcoindNodeCallbacksForWallet(wallet: Wallet)(implicit
+  def createBitcoindNodeCallbacksForWallet(wallet: AnyDLCHDWalletApi)(implicit
       system: ActorSystem): Future[NodeCallbackStreamManager] = {
     import system.dispatcher
     val txSink = Sink.foreachAsync[Transaction](1) { case tx: Transaction =>
       logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")
       wallet
-        .processTransaction(tx, blockHashOpt = None)
+        .processTransaction(tx, blockHash = None)
         .map(_ => ())
     }
     val onTx: OnTxReceived = { tx =>

--- a/core/src/main/scala/org/bitcoins/core/api/CallbackConfig.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/CallbackConfig.scala
@@ -17,6 +17,11 @@ trait CallbackConfig[T <: ModuleCallbacks[T]] {
     }
   }
 
+  def replaceCallbacks(newCallbacks: T): T = {
+    atomicCallbacks.atomicSet(newCallbacks)
+    newCallbacks
+  }
+
   def callBacks: T = atomicCallbacks.atomicGet
 
   /** Clears all callbacks */

--- a/core/src/main/scala/org/bitcoins/core/api/node/NodeStateDescriptor.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/NodeStateDescriptor.scala
@@ -1,0 +1,66 @@
+package org.bitcoins.core.api.node
+
+import org.bitcoins.crypto.StringFactory
+
+sealed abstract class NodeStateDescriptorType
+
+object NodeStateDescriptorType extends StringFactory[NodeStateDescriptorType] {
+
+  final case object WalletName extends NodeStateDescriptorType
+
+  val all: Vector[NodeStateDescriptorType] = Vector(WalletName)
+
+  override def fromStringOpt(str: String): Option[NodeStateDescriptorType] = {
+    all.find(state => str.toLowerCase() == state.toString.toLowerCase)
+  }
+
+  override def fromString(string: String): NodeStateDescriptorType = {
+    fromStringOpt(string) match {
+      case Some(state) => state
+      case None =>
+        sys.error(s"Could not find NodeStateDescriptorType for string=$string")
+    }
+  }
+}
+
+sealed abstract class NodeStateDescriptor {
+  def descriptorType: NodeStateDescriptorType
+}
+
+sealed trait NodeStateDescriptorFactory[T <: NodeStateDescriptor]
+    extends StringFactory[T] {
+  def tpe: NodeStateDescriptorType
+}
+
+object NodeStateDescriptor extends StringFactory[NodeStateDescriptor] {
+
+  val all: Vector[StringFactory[NodeStateDescriptor]] =
+    Vector(WalletNameDescriptor)
+
+  override def fromString(string: String): NodeStateDescriptor = {
+    all.find(f => f.fromStringT(string).isSuccess) match {
+      case Some(factory) => factory.fromString(string)
+      case None =>
+        sys.error(s"Could not find NodeStateDescriptor for string=$string")
+    }
+  }
+}
+
+case class WalletNameDescriptor(walletName: String)
+    extends NodeStateDescriptor {
+
+  override val descriptorType: NodeStateDescriptorType =
+    NodeStateDescriptorType.WalletName
+  override val toString: String = walletName
+}
+
+object WalletNameDescriptor
+    extends NodeStateDescriptorFactory[WalletNameDescriptor] {
+
+  override val tpe: NodeStateDescriptorType =
+    NodeStateDescriptorType.WalletName
+
+  override def fromString(string: String): WalletNameDescriptor = {
+    WalletNameDescriptor(string)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
@@ -45,8 +45,7 @@ trait HDWalletApi extends WalletApi {
   def getUnconfirmedBalance(account: HDAccount): Future[CurrencyUnit]
 
   /** Generates a new change address */
-  protected[wallet] def getNewChangeAddress(
-      account: AccountDb): Future[BitcoinAddress]
+  def getNewChangeAddress(account: AccountDb): Future[BitcoinAddress]
 
   override def getNewChangeAddress()(implicit
       ec: ExecutionContext): Future[BitcoinAddress] = {
@@ -64,8 +63,7 @@ trait HDWalletApi extends WalletApi {
   /** Fetches the default account for the given address/account kind
     * @param addressType
     */
-  protected[wallet] def getDefaultAccountForType(
-      addressType: AddressType): Future[AccountDb]
+  def getDefaultAccountForType(addressType: AddressType): Future[AccountDb]
 
   def sendWithAlgo(
       address: BitcoinAddress,

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
@@ -15,16 +15,16 @@ trait NeutrinoWalletApi { self: WalletApi =>
   /** Processes the give block, updating our DB state if it's relevant to us.
     * @param block The block we're processing
     */
-  def processBlock(block: Block): Future[WalletApi]
+  def processBlock(block: Block): Future[WalletApi with NeutrinoWalletApi]
 
   def processCompactFilter(
       blockHash: DoubleSha256Digest,
-      blockFilter: GolombFilter): Future[WalletApi] =
+      blockFilter: GolombFilter): Future[WalletApi with NeutrinoWalletApi] =
     processCompactFilters(Vector((blockHash, blockFilter)))
 
   def processCompactFilters(
       blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
-    WalletApi]
+    WalletApi with NeutrinoWalletApi]
 
   /** Iterates over the block filters in order to find filters that match to the given addresses
     *

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -6,8 +6,9 @@ import org.bitcoins.core.api.keymanager.KeyManagerApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.currency.CurrencyUnit
-import org.bitcoins.core.hd.AddressType
+import org.bitcoins.core.hd.{AddressType, HDAccount}
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.transaction.{
@@ -413,7 +414,23 @@ trait WalletApi extends StartStopAsync[WalletApi] {
   def getSyncState(): Future[BlockSyncState]
 
   def isRescanning(): Future[Boolean]
+
+  def getSyncDescriptorOpt(): Future[Option[SyncHeightDescriptor]]
+
+  def getWalletName(): Future[String]
+
+  def getInfo(): Future[WalletInfo]
 }
+
+case class WalletInfo(
+    walletName: String,
+    rootXpub: ExtPublicKey,
+    xpub: ExtPublicKey,
+    hdAccount: HDAccount,
+    height: Int,
+    blockHash: DoubleSha256DigestBE,
+    rescan: Boolean,
+    imported: Boolean)
 
 /** An HDWallet that uses Neutrino to sync */
 trait NeutrinoHDWalletApi extends HDWalletApi with NeutrinoWalletApi

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletStateDescriptor.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletStateDescriptor.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.commons.jsonmodels.wallet
+package org.bitcoins.core.api.wallet
 
 import org.bitcoins.crypto.{DoubleSha256DigestBE, StringFactory}
 

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -131,14 +131,14 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
     val result = nodeDbManagement.migrate()
     nodeAppConfig.driver match {
       case SQLite =>
-        val expected = 4
+        val expected = 5
         assert(result.migrationsExecuted == expected)
         val flywayInfo = nodeDbManagement.info()
 
         assert(flywayInfo.applied().length == expected)
         assert(flywayInfo.pending().length == 0)
       case PostgreSQL =>
-        val expected = 4
+        val expected = 5
         assert(result.migrationsExecuted == expected)
         val flywayInfo = nodeDbManagement.info()
 

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.db
 
-import org.bitcoins.commons.jsonmodels.wallet.{
+import org.bitcoins.core.api.node.{NodeStateDescriptor, NodeStateDescriptorType}
+import org.bitcoins.core.api.wallet.{
   WalletStateDescriptor,
   WalletStateDescriptorType
 }
@@ -530,4 +531,16 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
 
   implicit val MilliSatoshisMapper: BaseColumnType[MilliSatoshis] =
     MappedColumnType.base[MilliSatoshis, Long](_.toLong, MilliSatoshis.apply(_))
+
+  implicit val nodeStateDescriptorTypeMapper: BaseColumnType[
+    NodeStateDescriptorType] =
+    MappedColumnType.base[NodeStateDescriptorType, String](
+      _.toString,
+      NodeStateDescriptorType.fromString)
+
+  implicit val nodeStateDescriptorMapper: BaseColumnType[NodeStateDescriptor] =
+    MappedColumnType.base[NodeStateDescriptor, String](
+      _.toString,
+      NodeStateDescriptor.fromString)
+
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -30,8 +30,11 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param directory The data directory of the wallet
   * @param conf Optional sequence of configuration overrides
   */
-case class DLCAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
-    implicit override val ec: ExecutionContext)
+case class DLCAppConfig(
+    baseDatadir: Path,
+    configOverrides: Vector[Config],
+    walletConfigOpt: Option[WalletAppConfig] = None)(implicit
+    override val ec: ExecutionContext)
     extends DbAppConfig
     with DLCDbManagement
     with JdbcProfileComponent[DLCAppConfig] {
@@ -74,7 +77,7 @@ case class DLCAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   }
 
   lazy val walletConf: WalletAppConfig =
-    WalletAppConfig(baseDatadir, configOverrides)
+    walletConfigOpt.getOrElse(WalletAppConfig(baseDatadir, configOverrides))
 
   lazy val walletName: String = walletConf.walletName
 

--- a/node/src/main/resources/postgresql/node/migration/V5__state_descriptor_table.sql
+++ b/node/src/main/resources/postgresql/node/migration/V5__state_descriptor_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE "state_descriptors" (
+    "type" VARCHAR(254) PRIMARY KEY NOT NULL,
+    "descriptor" VARCHAR(1024) NOT NULL
+);

--- a/node/src/main/resources/sqlite/node/migration/V5__state_descriptor_table.sql
+++ b/node/src/main/resources/sqlite/node/migration/V5__state_descriptor_table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE "state_descriptors" (
+    "type" VARCHAR(254) PRIMARY KEY NOT NULL,
+    "descriptor" VARCHAR(1024) NOT NULL
+);

--- a/node/src/main/scala/org/bitcoins/node/models/NodeStateDescriptorDAO.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/NodeStateDescriptorDAO.scala
@@ -1,0 +1,95 @@
+package org.bitcoins.node.models
+
+import org.bitcoins.core.api.node.NodeStateDescriptorType.WalletName
+import org.bitcoins.core.api.node.{
+  NodeStateDescriptor,
+  NodeStateDescriptorType,
+  WalletNameDescriptor
+}
+import org.bitcoins.db.{CRUD, SlickUtil}
+import org.bitcoins.node.config.NodeAppConfig
+import slick.lifted.ProvenShape
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class NodeStateDescriptorDb(
+    tpe: NodeStateDescriptorType,
+    descriptor: NodeStateDescriptor) {
+  require(descriptor.descriptorType == tpe)
+}
+
+case class NodeStateDescriptorDAO()(implicit
+    override val ec: ExecutionContext,
+    override val appConfig: NodeAppConfig)
+    extends CRUD[NodeStateDescriptorDb, NodeStateDescriptorType]
+    with SlickUtil[NodeStateDescriptorDb, NodeStateDescriptorType] {
+  import profile.api._
+  private val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
+  import mappers._
+
+  override val table: profile.api.TableQuery[NodeStateDescriptorTable] =
+    TableQuery[NodeStateDescriptorTable]
+
+  override def createAll(ts: Vector[NodeStateDescriptorDb]): Future[
+    Vector[NodeStateDescriptorDb]] =
+    createAllNoAutoInc(ts, safeDatabase)
+
+  override def findByPrimaryKeys(ids: Vector[NodeStateDescriptorType]): Query[
+    NodeStateDescriptorTable,
+    NodeStateDescriptorDb,
+    Seq] = {
+    table.filter(_.tpe.inSet(ids))
+  }
+
+  override def findByPrimaryKey(id: NodeStateDescriptorType): Query[
+    Table[_],
+    NodeStateDescriptorDb,
+    Seq] = {
+    table.filter(_.tpe === id)
+  }
+
+  override def findAll(ts: Vector[NodeStateDescriptorDb]): Query[
+    Table[_],
+    NodeStateDescriptorDb,
+    Seq] =
+    findByPrimaryKeys(ts.map(_.tpe))
+
+//  def setWalletName(walletName: Option[String]): Future[Unit] = {
+//
+//  }
+
+  def getWalletName(): Future[Option[WalletNameDescriptor]] = {
+    read(WalletName).map {
+      case Some(db) =>
+        val desc = WalletNameDescriptor.fromString(db.descriptor.toString)
+        Some(desc)
+      case None => None
+    }
+  }
+
+  def updateWalletName(walletNameOpt: Option[String]): Future[Unit] = {
+    val tpe: NodeStateDescriptorType = WalletName
+    walletNameOpt match {
+      case Some(walletName) =>
+        val descriptor = WalletNameDescriptor(walletName)
+        val newDb = NodeStateDescriptorDb(tpe, descriptor)
+        upsert(newDb).map(_ => ())
+      case None =>
+        val query = table.filter(_.tpe === tpe)
+        safeDatabase.run(query.delete).map(_ => ())
+    }
+  }
+
+  class NodeStateDescriptorTable(t: Tag)
+      extends Table[NodeStateDescriptorDb](t, schemaName, "state_descriptors") {
+
+    def tpe: Rep[NodeStateDescriptorType] = column("type", O.PrimaryKey)
+
+    def descriptor: Rep[NodeStateDescriptor] = column("descriptor")
+
+    override def * : ProvenShape[NodeStateDescriptorDb] =
+      (tpe, descriptor).<>(NodeStateDescriptorDb.tupled,
+                           NodeStateDescriptorDb.unapply)
+
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
@@ -32,7 +32,9 @@ trait BitcoinSServerMainBitcoindFixture
         server = new BitcoinSServerMain(ServerArgParser.empty)(system, config)
         _ <- server.start()
         //need to create account 2 to use FundWalletUtil.fundWalletWithBitcoind
-        wallet <- server.walletConf.createHDWallet(bitcoind, bitcoind, bitcoind)
+        wallet <- server.conf.walletConf.createHDWallet(bitcoind,
+                                                        bitcoind,
+                                                        bitcoind)
         _ <- wallet.start()
         account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -2,7 +2,7 @@ package org.bitcoins.wallet
 
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.{ChainCallbacks, OnSyncFlagChanged}
-import org.bitcoins.commons.jsonmodels.wallet.SyncHeightDescriptor
+import org.bitcoins.core.api.wallet.SyncHeightDescriptor
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.wallet.utxo.TxoState

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.commons.jsonmodels.wallet.SyncHeightDescriptor
+import org.bitcoins.core.api.wallet.SyncHeightDescriptor
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.hd.{HDCoin, LegacyHDPath}

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -1,0 +1,944 @@
+package org.bitcoins.wallet
+
+import grizzled.slf4j.Logging
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.dlc.wallet.AnyDLCHDWalletApi
+import org.bitcoins.core.api.dlc.wallet.db.{
+  DLCContactDb,
+  DLCDb,
+  IncomingDLCOfferDb
+}
+import org.bitcoins.core.api.feeprovider.FeeRateApi
+import org.bitcoins.core.api.keymanager.BIP39KeyManagerApi
+import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.wallet._
+import org.bitcoins.core.api.wallet.db._
+import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
+import org.bitcoins.core.dlc.accounting.DLCWalletAccounting
+import org.bitcoins.core.gcs.GolombFilter
+import org.bitcoins.core.hd.{AddressType, HDAccount, HDChainType, HDPurpose}
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.blockchain.Block
+import org.bitcoins.core.protocol.dlc.models.{
+  ContractInfo,
+  DLCMessage,
+  DLCStatus,
+  OracleSignatures
+}
+import org.bitcoins.core.protocol.script.ScriptPubKey
+import org.bitcoins.core.protocol.tlv._
+import org.bitcoins.core.protocol.transaction.{
+  Transaction,
+  TransactionOutPoint,
+  TransactionOutput
+}
+import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
+import org.bitcoins.core.psbt.PSBT
+import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
+import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
+import org.bitcoins.core.wallet.rescan.RescanState
+import org.bitcoins.core.wallet.utxo.{
+  AddressTag,
+  AddressTagName,
+  AddressTagType,
+  TxoState
+}
+import org.bitcoins.crypto.{
+  DoubleSha256Digest,
+  DoubleSha256DigestBE,
+  Sha256Digest
+}
+import scodec.bits.ByteVector
+
+import java.net.InetSocketAddress
+import java.time.Instant
+import scala.concurrent.{ExecutionContext, Future}
+
+class WalletNotInitialized extends Exception("The wallet is not initialized")
+
+class WalletHolder(implicit ec: ExecutionContext)
+    extends AnyDLCHDWalletApi
+    with Logging {
+
+  @volatile private var walletOpt: Option[AnyDLCHDWalletApi] = None
+
+  private def wallet: AnyDLCHDWalletApi = synchronized {
+    walletOpt match {
+      case Some(wallet) => wallet
+      case None =>
+        throw new WalletNotInitialized
+    }
+  }
+
+  def isInitialized: Boolean = synchronized {
+    walletOpt.isDefined
+  }
+
+  def replaceWallet(newWallet: AnyDLCHDWalletApi): Future[AnyDLCHDWalletApi] =
+    synchronized {
+      val oldWalletOpt = walletOpt
+      walletOpt = None
+      val res = for {
+        _ <- {
+          oldWalletOpt match {
+            case Some(oldWallet) => oldWallet.stop()
+            case None            => Future.unit
+          }
+        }
+        _ <- newWallet.start()
+      } yield {
+        synchronized {
+          walletOpt = Some(newWallet)
+          newWallet
+        }
+      }
+
+      res.failed.foreach(ex => logger.error("Cannot start wallet ", ex))
+
+      res
+    }
+
+  private def delegate[T]: (AnyDLCHDWalletApi => Future[T]) => Future[T] = {
+    Future(wallet).flatMap[T](_)
+  }
+
+  override def processBlock(
+      block: Block): Future[WalletApi with NeutrinoWalletApi] =
+    delegate(_.processBlock(block))
+
+  override def processCompactFilters(
+      blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
+    WalletApi with NeutrinoWalletApi] = delegate(
+    _.processCompactFilters(blockFilters))
+
+  override def getMatchingBlocks(
+      scripts: Vector[ScriptPubKey],
+      startOpt: Option[BlockStamp],
+      endOpt: Option[BlockStamp],
+      batchSize: Int,
+      parallelismLevel: Int)(implicit ec: ExecutionContext): Future[
+    Vector[NeutrinoWalletApi.BlockMatchingResponse]] = delegate(
+    _.getMatchingBlocks(scripts, startOpt, endOpt, batchSize, parallelismLevel))
+
+  override def rescanNeutrinoWallet(
+      startOpt: Option[BlockStamp],
+      endOpt: Option[BlockStamp],
+      addressBatchSize: Int,
+      useCreationTime: Boolean,
+      force: Boolean)(implicit ec: ExecutionContext): Future[RescanState] =
+    delegate(
+      _.rescanNeutrinoWallet(startOpt,
+                             endOpt,
+                             addressBatchSize,
+                             useCreationTime,
+                             force))
+
+  override def discoveryBatchSize(): Int = wallet.discoveryBatchSize()
+
+  override lazy val nodeApi: NodeApi = wallet.nodeApi
+  override lazy val chainQueryApi: ChainQueryApi = wallet.chainQueryApi
+  override lazy val feeRateApi: FeeRateApi = wallet.feeRateApi
+  override lazy val creationTime: Instant = wallet.creationTime
+
+  override def start(): Future[WalletApi] = delegate(_.start())
+
+  override def stop(): Future[WalletApi] = {
+    val res = delegate(_.stop())
+
+    res.onComplete { _ =>
+      synchronized {
+        walletOpt = None
+      }
+    }
+
+    res
+  }
+
+  override def processTransaction(
+      transaction: Transaction,
+      blockHash: Option[DoubleSha256DigestBE]): Future[WalletApi] = delegate(
+    _.processTransaction(transaction, blockHash))
+
+  override def findTransaction(
+      txId: DoubleSha256DigestBE): Future[Option[TransactionDb]] = delegate(
+    _.findTransaction(txId))
+
+  override def fundRawTransaction(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromTagOpt: Option[AddressTag],
+      markAsReserved: Boolean): Future[Transaction] = delegate(
+    _.fundRawTransaction(destinations, feeRate, fromTagOpt, markAsReserved))
+
+  override def listTransactions(): Future[Vector[TransactionDb]] = delegate(
+    _.listTransactions())
+
+  override def updateUtxoPendingStates(): Future[Vector[SpendingInfoDb]] =
+    delegate(_.updateUtxoPendingStates())
+
+  override def getConfirmedBalance(): Future[CurrencyUnit] = delegate(
+    _.getConfirmedBalance())
+
+  override def getConfirmedBalance(tag: AddressTag): Future[CurrencyUnit] =
+    delegate(_.getConfirmedBalance(tag))
+
+  override def getUnconfirmedBalance(): Future[CurrencyUnit] = delegate(
+    _.getUnconfirmedBalance())
+
+  override def getUnconfirmedBalance(tag: AddressTag): Future[CurrencyUnit] =
+    delegate(_.getUnconfirmedBalance(tag))
+
+  override def listUtxos(): Future[Vector[SpendingInfoDb]] = delegate(
+    _.listUtxos())
+
+  override def listUtxos(tag: AddressTag): Future[Vector[SpendingInfoDb]] =
+    delegate(_.listUtxos(tag))
+
+  override def listUtxos(state: TxoState): Future[Vector[SpendingInfoDb]] =
+    delegate(_.listUtxos(state))
+
+  override def listAddresses(): Future[Vector[AddressDb]] = delegate(
+    _.listAddresses())
+
+  override def listSpentAddresses(): Future[Vector[AddressDb]] = delegate(
+    _.listSpentAddresses())
+
+  override def listFundedAddresses(): Future[
+    Vector[(AddressDb, CurrencyUnit)]] = delegate(_.listFundedAddresses())
+
+  override def listUnusedAddresses(): Future[Vector[AddressDb]] = delegate(
+    _.listUnusedAddresses())
+
+  override def listScriptPubKeys(): Future[Vector[ScriptPubKeyDb]] = delegate(
+    _.listScriptPubKeys())
+
+  override def watchScriptPubKey(
+      scriptPubKey: ScriptPubKey): Future[ScriptPubKeyDb] = delegate(
+    _.watchScriptPubKey(scriptPubKey))
+
+  override def markUTXOsAsReserved(
+      utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]] = delegate(
+    _.markUTXOsAsReserved(utxos))
+
+  override def markUTXOsAsReserved(
+      tx: Transaction): Future[Vector[SpendingInfoDb]] = delegate(
+    _.markUTXOsAsReserved(tx))
+
+  override def unmarkUTXOsAsReserved(
+      utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]] = delegate(
+    _.unmarkUTXOsAsReserved(utxos))
+
+  override def unmarkUTXOsAsReserved(
+      tx: Transaction): Future[Vector[SpendingInfoDb]] = delegate(
+    _.unmarkUTXOsAsReserved(tx))
+
+  override def isEmpty(): Future[Boolean] = delegate(_.isEmpty())
+
+  override def getNewAddress(addressType: AddressType): Future[BitcoinAddress] =
+    delegate(_.getNewAddress(addressType))
+
+  override def getNewAddress(): Future[BitcoinAddress] = delegate(
+    _.getNewAddress())
+
+  override def getNewAddress(
+      addressType: AddressType,
+      tags: Vector[AddressTag]): Future[BitcoinAddress] = delegate(
+    _.getNewAddress(addressType, tags))
+
+  override def getNewAddress(tags: Vector[AddressTag]): Future[BitcoinAddress] =
+    delegate(_.getNewAddress(tags))
+
+  override def getUnusedAddress(
+      addressType: AddressType): Future[BitcoinAddress] = delegate(
+    _.getUnusedAddress(addressType))
+
+  override def getUnusedAddress: Future[BitcoinAddress] = delegate(
+    _.getUnusedAddress)
+
+  override def getAddressInfo(
+      address: BitcoinAddress): Future[Option[AddressInfo]] = delegate(
+    _.getAddressInfo(address))
+
+  override def tagAddress(
+      address: BitcoinAddress,
+      tag: AddressTag): Future[AddressTagDb] = delegate(
+    _.tagAddress(address, tag))
+
+  override def getAddressTags(
+      address: BitcoinAddress): Future[Vector[AddressTagDb]] = delegate(
+    _.getAddressTags(address))
+
+  override def getAddressTags(
+      address: BitcoinAddress,
+      tagType: AddressTagType): Future[Vector[AddressTagDb]] = delegate(
+    _.getAddressTags(address, tagType))
+
+  override def getAddressTags(): Future[Vector[AddressTagDb]] = delegate(
+    _.getAddressTags())
+
+  override def getAddressTags(
+      tagType: AddressTagType): Future[Vector[AddressTagDb]] = delegate(
+    _.getAddressTags(tagType))
+
+  override def dropAddressTag(addressTagDb: AddressTagDb): Future[Int] =
+    delegate(_.dropAddressTag(addressTagDb))
+
+  override def dropAddressTagType(addressTagType: AddressTagType): Future[Int] =
+    delegate(_.dropAddressTagType(addressTagType))
+
+  override def dropAddressTagType(
+      address: BitcoinAddress,
+      addressTagType: AddressTagType): Future[Int] = delegate(
+    _.dropAddressTagType(address, addressTagType))
+
+  override def dropAddressTagName(
+      address: BitcoinAddress,
+      tagName: AddressTagName): Future[Int] = delegate(
+    _.dropAddressTagName(address, tagName))
+
+  override def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      feeRate: FeeUnit)(implicit ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendFromOutPoints(outPoints, address, feeRate))
+
+  override def sweepWallet(address: BitcoinAddress, feeRate: FeeUnit)(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sweepWallet(address, feeRate))
+
+  override def bumpFeeRBF(
+      txId: DoubleSha256DigestBE,
+      newFeeRate: FeeUnit): Future[Transaction] = delegate(
+    _.bumpFeeRBF(txId, newFeeRate))
+
+  override def bumpFeeCPFP(
+      txId: DoubleSha256DigestBE,
+      feeRate: FeeUnit): Future[Transaction] = delegate(
+    _.bumpFeeCPFP(txId, feeRate))
+
+  override def isChange(output: TransactionOutput): Future[Boolean] = delegate(
+    _.isChange(output))
+
+  override def getSyncState(): Future[BlockSyncState] = delegate(
+    _.getSyncState())
+
+  override def isRescanning(): Future[Boolean] = delegate(_.isRescanning())
+
+  override def createDLCOffer(
+      contractInfo: ContractInfo,
+      collateral: Satoshis,
+      feeRateOpt: Option[SatoshisPerVirtualByte],
+      refundLT: UInt32,
+      peerAddressOpt: Option[InetSocketAddress],
+      externalPayoutAddressOpt: Option[BitcoinAddress],
+      externalChangeAddressOpt: Option[BitcoinAddress]): Future[
+    DLCMessage.DLCOffer] = delegate(
+    _.createDLCOffer(contractInfo,
+                     collateral,
+                     feeRateOpt,
+                     refundLT,
+                     peerAddressOpt,
+                     externalPayoutAddressOpt,
+                     externalChangeAddressOpt))
+
+  override def createDLCOffer(
+      contractInfo: ContractInfo,
+      collateral: Satoshis,
+      feeRateOpt: Option[SatoshisPerVirtualByte],
+      locktime: UInt32,
+      refundLT: UInt32,
+      peerAddressOpt: Option[InetSocketAddress],
+      externalPayoutAddressOpt: Option[BitcoinAddress],
+      externalChangeAddressOpt: Option[BitcoinAddress]): Future[
+    DLCMessage.DLCOffer] = delegate(
+    _.createDLCOffer(contractInfo,
+                     collateral,
+                     feeRateOpt,
+                     locktime,
+                     refundLT,
+                     peerAddressOpt,
+                     externalPayoutAddressOpt,
+                     externalChangeAddressOpt))
+
+  override def acceptDLCOffer(
+      dlcOffer: DLCMessage.DLCOffer,
+      peerAddress: Option[InetSocketAddress],
+      externalPayoutAddressOpt: Option[BitcoinAddress],
+      externalChangeAddressOpt: Option[BitcoinAddress]): Future[
+    DLCMessage.DLCAccept] = delegate(
+    _.acceptDLCOffer(dlcOffer,
+                     peerAddress,
+                     externalPayoutAddressOpt,
+                     externalChangeAddressOpt))
+
+  override def signDLC(acceptTLV: DLCAcceptTLV): Future[DLCMessage.DLCSign] =
+    delegate(_.signDLC(acceptTLV))
+
+  override def signDLC(
+      accept: DLCMessage.DLCAccept): Future[DLCMessage.DLCSign] = delegate(
+    _.signDLC(accept))
+
+  override def addDLCSigs(signTLV: DLCSignTLV): Future[DLCDb] = delegate(
+    _.addDLCSigs(signTLV))
+
+  override def addDLCSigs(sigs: DLCMessage.DLCSign): Future[DLCDb] = delegate(
+    _.addDLCSigs(sigs))
+
+  override def getDLCFundingTx(contractId: ByteVector): Future[Transaction] =
+    delegate(_.getDLCFundingTx(contractId))
+
+  override def broadcastDLCFundingTx(
+      contractId: ByteVector): Future[Transaction] = delegate(
+    _.broadcastDLCFundingTx(contractId))
+
+  override def executeDLC(
+      contractId: ByteVector,
+      oracleSigs: Seq[OracleAttestmentTLV]): Future[Option[Transaction]] =
+    delegate(_.executeDLC(contractId, oracleSigs))
+
+  override def executeDLC(
+      contractId: ByteVector,
+      oracleSigs: Vector[OracleSignatures]): Future[Option[Transaction]] =
+    delegate(_.executeDLC(contractId, oracleSigs))
+
+  override def executeDLCRefund(contractId: ByteVector): Future[Transaction] =
+    delegate(_.executeDLCRefund(contractId))
+
+  override def listDLCs(): Future[Vector[DLCStatus]] = delegate(_.listDLCs())
+
+  override def findDLC(dlcId: Sha256Digest): Future[Option[DLCStatus]] =
+    delegate(_.findDLC(dlcId))
+
+  override def findDLCByTemporaryContractId(
+      tempContractId: Sha256Digest): Future[Option[DLCStatus]] = delegate(
+    _.findDLCByTemporaryContractId(tempContractId))
+
+  override def cancelDLC(dlcId: Sha256Digest): Future[Unit] = delegate(
+    _.cancelDLC(dlcId))
+
+  override def getDLCOffer(
+      dlcId: Sha256Digest): Future[Option[DLCMessage.DLCOffer]] = delegate(
+    _.getDLCOffer(dlcId))
+
+  override def getWalletAccounting(): Future[DLCWalletAccounting] = delegate(
+    _.getWalletAccounting())
+
+  override def registerIncomingDLCOffer(
+      offerTLV: DLCOfferTLV,
+      peer: Option[String],
+      message: Option[String]): Future[Sha256Digest] = delegate(
+    _.registerIncomingDLCOffer(offerTLV, peer, message))
+
+  override def listIncomingDLCOffers(): Future[Vector[IncomingDLCOfferDb]] =
+    delegate(_.listIncomingDLCOffers())
+
+  override def rejectIncomingDLCOffer(offerHash: Sha256Digest): Future[Unit] =
+    delegate(_.rejectIncomingDLCOffer(offerHash))
+
+  override def findIncomingDLCOffer(
+      offerHash: Sha256Digest): Future[Option[IncomingDLCOfferDb]] = delegate(
+    _.findIncomingDLCOffer(offerHash))
+
+  override def listDLCContacts(): Future[Vector[DLCContactDb]] = delegate(
+    _.listDLCContacts())
+
+  override def addDLCContact(contact: DLCContactDb): Future[Unit] = delegate(
+    _.addDLCContact(contact))
+
+  override def removeDLCContact(address: InetSocketAddress): Future[Unit] =
+    delegate(_.removeDLCContact(address))
+
+  override def findDLCContacts(alias: String): Future[Vector[DLCContactDb]] =
+    delegate(_.findDLCContacts(alias))
+
+  override def addDLCContactMapping(
+      dlcId: Sha256Digest,
+      contactId: InetSocketAddress): Future[Unit] = delegate(
+    _.addDLCContactMapping(dlcId, contactId))
+
+  override def removeDLCContactMapping(dlcId: Sha256Digest): Future[Unit] =
+    delegate(_.removeDLCContactMapping(dlcId))
+
+  override def listDLCsByContact(
+      address: InetSocketAddress): Future[Vector[DLCStatus]] = delegate(
+    _.listDLCsByContact(address))
+
+  override def keyManager: BIP39KeyManagerApi = wallet.keyManager
+
+  override def getConfirmedBalance(account: HDAccount): Future[CurrencyUnit] =
+    delegate(_.getConfirmedBalance(account))
+
+  override def getUnconfirmedBalance(account: HDAccount): Future[CurrencyUnit] =
+    delegate(_.getUnconfirmedBalance(account))
+
+  override def getNewChangeAddress(account: AccountDb): Future[BitcoinAddress] =
+    delegate(_.getNewChangeAddress(account))
+
+  override def getDefaultAccount(): Future[AccountDb] = delegate(
+    _.getDefaultAccount())
+
+  override def getDefaultAccountForType(
+      addressType: AddressType): Future[AccountDb] = delegate(
+    _.getDefaultAccountForType(addressType))
+
+  override def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      algo: CoinSelectionAlgo,
+      fromAccount: AccountDb,
+      newTags: Vector[AddressTag])(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendWithAlgo(address, amount, feeRate, algo, fromAccount, newTags))
+
+  override def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      newTags: Vector[AddressTag])(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendFromOutPoints(outPoints,
+                        address,
+                        amount,
+                        feeRate,
+                        fromAccount,
+                        newTags))
+
+  override def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      newTags: Vector[AddressTag])(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendToAddress(address, amount, feeRate, fromAccount, newTags))
+
+  override def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      newTags: Vector[AddressTag])(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendToAddresses(addresses, amounts, feeRate, fromAccount, newTags))
+
+  override def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      newTags: Vector[AddressTag])(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendToOutputs(outputs, feeRate, fromAccount, newTags))
+
+  override def signPSBT(psbt: PSBT)(implicit
+      ec: ExecutionContext): Future[PSBT] = delegate(_.signPSBT(psbt))
+
+  override def makeOpReturnCommitment(
+      message: String,
+      hashMessage: Boolean,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.makeOpReturnCommitment(message, hashMessage, feeRate, fromAccount))
+
+  override def listDefaultAccountUtxos(): Future[Vector[SpendingInfoDb]] =
+    delegate(_.listDefaultAccountUtxos())
+
+  override def listUtxos(account: HDAccount): Future[Vector[SpendingInfoDb]] =
+    delegate(_.listUtxos(account))
+
+  override def listUtxos(
+      hdAccount: HDAccount,
+      tag: AddressTag): Future[Vector[SpendingInfoDb]] = delegate(
+    _.listUtxos(hdAccount))
+
+  override def listUtxos(
+      hdAccount: HDAccount,
+      state: TxoState): Future[Vector[SpendingInfoDb]] = delegate(
+    _.listUtxos(hdAccount, state))
+
+  override def listAddresses(account: HDAccount): Future[Vector[AddressDb]] =
+    delegate(_.listAddresses(account))
+
+  override def listSpentAddresses(
+      account: HDAccount): Future[Vector[AddressDb]] = delegate(
+    _.listSpentAddresses(account))
+
+  override def listFundedAddresses(
+      account: HDAccount): Future[Vector[(AddressDb, CurrencyUnit)]] = delegate(
+    _.listFundedAddresses(account))
+
+  override def listUnusedAddresses(
+      account: HDAccount): Future[Vector[AddressDb]] = delegate(
+    _.listUnusedAddresses(account))
+
+  override def clearAllUtxos(): Future[HDWalletApi] = delegate(
+    _.clearAllUtxos())
+
+  override def clearUtxos(account: HDAccount): Future[HDWalletApi] = delegate(
+    _.clearUtxos(account))
+
+  override def getAddress(
+      account: AccountDb,
+      chainType: HDChainType,
+      addressIndex: Int): Future[AddressDb] = delegate(
+    _.getAddress(account, chainType, addressIndex))
+
+  override def listAccounts(): Future[Vector[AccountDb]] = delegate(
+    _.listAccounts())
+
+  override def createNewAccount(
+      keyManagerParams: KeyManagerParams): Future[HDWalletApi] = delegate(
+    _.createNewAccount(keyManagerParams))
+
+  override def createNewAccount(
+      hdAccount: HDAccount,
+      keyManagerParams: KeyManagerParams): Future[HDWalletApi] = delegate(
+    _.createNewAccount(hdAccount, keyManagerParams))
+
+  override def getSyncDescriptorOpt(): Future[Option[SyncHeightDescriptor]] =
+    delegate(_.getSyncDescriptorOpt())
+
+  override def getWalletName(): Future[String] = delegate(_.getWalletName())
+
+  override def getInfo(): Future[WalletInfo] = delegate(_.getInfo())
+
+  override def broadcastTransaction(transaction: Transaction): Future[Unit] =
+    delegate(_.broadcastTransaction(transaction))
+
+  override def getFeeRate(): Future[FeeUnit] = delegate(_.getFeeRate())
+
+  override def processTransactions(
+      transactions: Vector[Transaction],
+      blockHash: Option[DoubleSha256DigestBE])(implicit
+      ec: ExecutionContext): Future[WalletApi] = delegate(
+    _.processTransactions(transactions, blockHash))
+
+  override def getBalance()(implicit
+      ec: ExecutionContext): Future[CurrencyUnit] = delegate(_.getBalance())
+
+  override def getBalance(tag: AddressTag)(implicit
+      ec: ExecutionContext): Future[CurrencyUnit] = delegate(_.getBalance(tag))
+
+  override def getAddressInfo(
+      spendingInfoDb: SpendingInfoDb,
+      networkParameters: NetworkParameters): Future[Option[AddressInfo]] =
+    delegate(_.getAddressInfo(spendingInfoDb, networkParameters))
+
+  override def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit]
+  )(implicit ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendFromOutPoints(outPoints, address, amount, feeRateOpt))
+
+  override def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      feeRateOpt: Option[FeeUnit]
+  )(implicit ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendFromOutPoints(outPoints, address, feeRateOpt))
+
+  override def sweepWallet(address: BitcoinAddress)(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sweepWallet(address))
+
+  override def sweepWallet(
+      address: BitcoinAddress,
+      feeRateOpt: Option[FeeUnit])(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sweepWallet(address, feeRateOpt))
+
+  override def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit],
+      algo: CoinSelectionAlgo
+  )(implicit ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendWithAlgo(address, amount, feeRateOpt, algo))
+
+  override def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit]
+  )(implicit ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendToAddress(address, amount, feeRateOpt))
+
+  override def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRateOpt: Option[FeeUnit])(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendToOutputs(outputs, feeRateOpt))
+
+  override def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRateOpt: Option[FeeUnit])(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.sendToAddresses(addresses, amounts, feeRateOpt))
+
+  override def makeOpReturnCommitment(
+      message: String,
+      hashMessage: Boolean,
+      feeRateOpt: Option[FeeUnit])(implicit
+      ec: ExecutionContext): Future[Transaction] = delegate(
+    _.makeOpReturnCommitment(message, hashMessage, feeRateOpt))
+
+  override def getBalance(account: HDAccount)(implicit
+      ec: ExecutionContext): Future[CurrencyUnit] = delegate(
+    _.getBalance(account))
+
+  override def processCompactFilter(
+      blockHash: DoubleSha256Digest,
+      blockFilter: GolombFilter): Future[WalletApi with NeutrinoWalletApi] =
+    delegate(_.processCompactFilter(blockHash, blockFilter))
+
+  override def fullRescanNeutrinoWallet(addressBatchSize: Int, force: Boolean)(
+      implicit ec: ExecutionContext): Future[RescanState] = delegate(
+    _.fullRescanNeutrinoWallet(addressBatchSize, force))
+
+  override def getNewChangeAddress()(implicit
+      ec: ExecutionContext): Future[BitcoinAddress] =
+    delegate(_.getNewChangeAddress())
+
+  override def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      algo: CoinSelectionAlgo,
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendWithAlgo(address, amount, feeRate, algo, fromAccount))
+
+  override def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit],
+      algo: CoinSelectionAlgo,
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendWithAlgo(address, amount, feeRateOpt, algo, fromAccount))
+
+  override def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      algo: CoinSelectionAlgo)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendWithAlgo(address, amount, feeRate, algo))
+
+  override def sendWithAlgo(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      algo: CoinSelectionAlgo,
+      newTags: Vector[AddressTag])(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendWithAlgo(address, amount, feeRate, algo, newTags))
+
+  override def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(
+      _.sendFromOutPoints(outPoints, address, amount, feeRate, fromAccount))
+
+  override def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit],
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(
+      _.sendFromOutPoints(outPoints, address, amount, feeRateOpt, fromAccount))
+
+  override def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit)(implicit ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendFromOutPoints(outPoints, address, amount, feeRate))
+
+  override def sendFromOutPoints(
+      outPoints: Vector[TransactionOutPoint],
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      newTags: Vector[AddressTag])(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendFromOutPoints(outPoints, address, amount, feeRate, newTags))
+
+  override def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToAddress(address, amount, feeRate, fromAccount))
+
+  override def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRateOpt: Option[FeeUnit],
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToAddress(address, amount, feeRateOpt, fromAccount))
+
+  override def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit)(implicit ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToAddress(address, amount, feeRate))
+
+  override def sendToAddress(
+      address: BitcoinAddress,
+      amount: CurrencyUnit,
+      feeRate: FeeUnit,
+      newTags: Vector[AddressTag])(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToAddress(address, amount, feeRate, newTags))
+
+  override def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToAddresses(addresses, amounts, feeRate, fromAccount))
+
+  override def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRateOpt: Option[FeeUnit],
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToAddresses(addresses, amounts, feeRateOpt, fromAccount))
+
+  override def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRate: FeeUnit)(implicit ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToAddresses(addresses, amounts, feeRate))
+
+  override def sendToAddresses(
+      addresses: Vector[BitcoinAddress],
+      amounts: Vector[CurrencyUnit],
+      feeRate: FeeUnit,
+      newTags: Vector[AddressTag])(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToAddresses(addresses, amounts, feeRate, newTags))
+
+  override def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToOutputs(outputs, feeRate, fromAccount))
+
+  override def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRateOpt: Option[FeeUnit],
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToOutputs(outputs, feeRateOpt, fromAccount))
+
+  override def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      newTags: Vector[AddressTag])(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToOutputs(outputs, feeRate, newTags))
+
+  override def sendToOutputs(
+      outputs: Vector[TransactionOutput],
+      feeRate: FeeUnit)(implicit ec: ExecutionContext): Future[Transaction] =
+    delegate(_.sendToOutputs(outputs, feeRate))
+
+  override def makeOpReturnCommitment(
+      message: String,
+      hashMessage: Boolean,
+      feeRateOpt: Option[FeeUnit],
+      fromAccount: AccountDb)(implicit
+      ec: ExecutionContext): Future[Transaction] =
+    delegate(
+      _.makeOpReturnCommitment(message, hashMessage, feeRateOpt, fromAccount))
+
+  override def makeOpReturnCommitment(
+      message: String,
+      hashMessage: Boolean,
+      feeRate: FeeUnit)(implicit ec: ExecutionContext): Future[Transaction] =
+    delegate(_.makeOpReturnCommitment(message, hashMessage, feeRate))
+
+  override def getAddress(chainType: HDChainType, addressIndex: Int)(implicit
+      ec: ExecutionContext): Future[AddressDb] =
+    delegate(_.getAddress(chainType, addressIndex))
+
+  override def listAccounts(purpose: HDPurpose)(implicit
+      ec: ExecutionContext): Future[Vector[AccountDb]] =
+    delegate(_.listAccounts(purpose))
+
+  override def createDLCOffer(
+      contractInfoTLV: ContractInfoTLV,
+      collateral: Satoshis,
+      feeRateOpt: Option[SatoshisPerVirtualByte],
+      refundLT: UInt32,
+      peerAddressOpt: Option[InetSocketAddress],
+      externalPayoutAddressOpt: Option[BitcoinAddress],
+      externalChangeAddressOpt: Option[BitcoinAddress]): Future[
+    DLCMessage.DLCOffer] = delegate(
+    _.createDLCOffer(contractInfoTLV,
+                     collateral,
+                     feeRateOpt,
+                     refundLT,
+                     peerAddressOpt,
+                     externalPayoutAddressOpt,
+                     externalChangeAddressOpt))
+
+  override def createDLCOffer(
+      contractInfoTLV: ContractInfoTLV,
+      collateral: Satoshis,
+      feeRateOpt: Option[SatoshisPerVirtualByte],
+      locktime: UInt32,
+      refundLT: UInt32,
+      peerAddressOpt: Option[InetSocketAddress],
+      externalPayoutAddressOpt: Option[BitcoinAddress],
+      externalChangeAddressOpt: Option[BitcoinAddress]): Future[
+    DLCMessage.DLCOffer] = delegate(
+    _.createDLCOffer(contractInfoTLV,
+                     collateral,
+                     feeRateOpt,
+                     locktime,
+                     refundLT,
+                     peerAddressOpt,
+                     externalPayoutAddressOpt,
+                     externalChangeAddressOpt))
+
+  override def acceptDLCOffer(
+      dlcOfferTLV: DLCOfferTLV,
+      peerAddress: Option[InetSocketAddress],
+      externalPayoutAddressOpt: Option[BitcoinAddress],
+      externalChangeAddressOpt: Option[BitcoinAddress]): Future[
+    DLCMessage.DLCAccept] = delegate(
+    _.acceptDLCOffer(dlcOfferTLV,
+                     peerAddress,
+                     externalPayoutAddressOpt,
+                     externalChangeAddressOpt))
+
+  override def executeDLC(
+      contractId: ByteVector,
+      oracleSig: OracleAttestmentTLV): Future[Option[Transaction]] =
+    delegate(_.executeDLC(contractId, oracleSig))
+
+  override def executeDLC(
+      contractId: ByteVector,
+      oracleSig: OracleSignatures): Future[Option[Transaction]] =
+    delegate(_.executeDLC(contractId, oracleSig))
+}

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -37,8 +37,11 @@ import scala.concurrent.{Await, ExecutionContext, Future}
   * @param directory The data directory of the wallet
   * @param conf Optional sequence of configuration overrides
   */
-case class WalletAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
-    implicit override val ec: ExecutionContext)
+case class WalletAppConfig(
+    baseDatadir: Path,
+    configOverrides: Vector[Config],
+    kmConfOpt: Option[KeyManagerAppConfig] = None)(implicit
+    override val ec: ExecutionContext)
     extends DbAppConfig
     with WalletDbManagement
     with JdbcProfileComponent[WalletAppConfig]
@@ -77,7 +80,7 @@ case class WalletAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   override lazy val callbackFactory: WalletCallbacks.type = WalletCallbacks
 
   lazy val kmConf: KeyManagerAppConfig =
-    KeyManagerAppConfig(baseDatadir, configOverrides)
+    kmConfOpt.getOrElse(KeyManagerAppConfig(baseDatadir, configOverrides))
 
   lazy val defaultAccountKind: HDPurpose =
     config.getString("bitcoin-s.wallet.defaultAccountType") match {
@@ -347,6 +350,9 @@ case class WalletAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
 object WalletAppConfig
     extends AppConfigFactory[WalletAppConfig]
     with WalletLogger {
+
+  final val DEFAULT_WALLET_NAME: String =
+    KeyManagerAppConfig.DEFAULT_WALLET_NAME
 
   val moduleName: String = "wallet"
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/WalletStateDescriptorDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/WalletStateDescriptorDAO.scala
@@ -1,7 +1,10 @@
 package org.bitcoins.wallet.models
 
-import org.bitcoins.commons.jsonmodels.wallet.WalletStateDescriptorType._
-import org.bitcoins.commons.jsonmodels.wallet.{
+import org.bitcoins.core.api.wallet.WalletStateDescriptorType.{
+  Rescan,
+  SyncHeight
+}
+import org.bitcoins.core.api.wallet.{
   RescanDescriptor,
   SyncHeightDescriptor,
   WalletStateDescriptor,


### PR DESCRIPTION
Pulls over changes from #4499 

This PR intends to not change any behavior on server startup logic. This PR does NOT include the `loadwallet` RPC introduced in #4499 . 

The intention of the PR is to start introducing parts of the infrastructure needed to merge #4449. So this PR includes 

- `DLCWalletLoaderApi`
- `WalletHolder`
- `NodeStateDescriptor`

This PR modifies the `BitcoinSServerMain` startup logic to use the `DLCWalletLoaderApi` on server startup. This way we can test this code without introducing more complicated changes.