### PR TITLE
2022 07 20 wallet rescan stream

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -48,7 +48,7 @@ import java.net.InetSocketAddress
 import java.time.{ZoneId, ZonedDateTime}
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
 class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
@@ -1704,7 +1704,8 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                               _: Boolean,
                               _: Boolean)(_: ExecutionContext))
         .expects(None, None, 100, false, false, executor)
-        .returning(Future.successful(RescanState.RescanDone))
+        .returning(Future.successful(RescanState
+          .RescanStarted(Promise(), Future.successful(Vector.empty))))
 
       val route1 =
         walletRoutes.handleCommand(
@@ -1733,7 +1734,8 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
           false,
           false,
           executor)
-        .returning(Future.successful(RescanState.RescanDone))
+        .returning(Future.successful(RescanState
+          .RescanStarted(Promise(), Future.successful(Vector.empty))))
 
       val route2 =
         walletRoutes.handleCommand(
@@ -1742,9 +1744,10 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
             Arr(Arr(), Str("2018-10-27T12:34:56Z"), Null, true, true)))
 
       Post() ~> route2 ~> check {
-        assert(contentType == `application/json`)
         assert(
           responseAs[String] == """{"result":"Rescan started.","error":null}""")
+        assert(contentType == `application/json`)
+
       }
 
       (mockWalletApi.isEmpty: () => Future[Boolean])
@@ -1762,7 +1765,8 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                  false,
                  false,
                  executor)
-        .returning(Future.successful(RescanState.RescanDone))
+        .returning(Future.successful(RescanState
+          .RescanStarted(Promise(), Future.successful(Vector.empty))))
 
       val route3 =
         walletRoutes.handleCommand(
@@ -1801,7 +1805,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       Post() ~> route4 ~> check {
         assert(contentType == `application/json`)
         assert(
-          responseAs[String] == """{"result":"Rescan started.","error":null}""")
+          responseAs[String] == """{"result":"Rescan done.","error":null}""")
       }
 
       // negative cases
@@ -1862,7 +1866,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       Post() ~> route8 ~> check {
         assert(contentType == `application/json`)
         assert(
-          responseAs[String] == """{"result":"Rescan started.","error":null}""")
+          responseAs[String] == """{"result":"Rescan done.","error":null}""")
       }
     }
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -153,7 +153,7 @@ object BitcoindRpcBackendUtil extends Logging {
                                                     chainCallbacksOpt),
       chainQueryApi = bitcoind,
       feeRateApi = wallet.feeRateApi
-    )(wallet.walletConfig, wallet.ec)
+    )(wallet.walletConfig)
 
     walletCallbackP.success(pairedWallet)
 
@@ -217,7 +217,7 @@ object BitcoindRpcBackendUtil extends Logging {
                                                     chainCallbacksOpt),
       chainQueryApi = bitcoind,
       feeRateApi = wallet.feeRateApi
-    )(wallet.walletConfig, wallet.dlcConfig, wallet.ec)
+    )(wallet.walletConfig, wallet.dlcConfig)
 
     walletCallbackP.success(pairedWallet)
 

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -72,7 +72,7 @@ sealed trait DLCWalletLoaderApi extends Logging {
         nodeApi = nodeApi,
         chainQueryApi = chainQueryApi,
         feeRateApi = feeProviderApi
-      )(walletConfig, ec)
+      )(walletConfig)
     } yield (dlcWallet, walletConfig, dlcConfig)
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -39,7 +39,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
     with Logging {
   import system.dispatcher
 
-  implicit val kmConf: KeyManagerAppConfig = walletConf.kmConf
+  implicit private val kmConf: KeyManagerAppConfig = walletConf.kmConf
 
   private def spendingInfoDbToJson(spendingInfoDb: SpendingInfoDb): Value = {
     Obj(

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -13,6 +13,8 @@ import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
+import org.bitcoins.core.wallet.rescan.RescanState
+import org.bitcoins.core.wallet.rescan.RescanState.RescanDone
 import org.bitcoins.core.wallet.utxo.{
   AddressLabelTagName,
   AddressLabelTagType,
@@ -40,6 +42,8 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
   import system.dispatcher
 
   implicit private val kmConf: KeyManagerAppConfig = walletConf.kmConf
+
+  private var rescanStateOpt: Option[RescanState] = None
 
   private def spendingInfoDbToJson(spendingInfoDb: SpendingInfoDb): Value = {
     Obj(
@@ -716,36 +720,11 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
       }
 
     case ServerCommand("rescan", arr) =>
-      withValidServerCommand(Rescan.fromJsArr(arr)) {
-        case Rescan(batchSize,
-                    startBlock,
-                    endBlock,
-                    force,
-                    ignoreCreationTime) =>
-          complete {
-            val res = for {
-              empty <- wallet.isEmpty()
-              msg <-
-                if (force || empty) {
-                  wallet
-                    .rescanNeutrinoWallet(
-                      startOpt = startBlock,
-                      endOpt = endBlock,
-                      addressBatchSize =
-                        batchSize.getOrElse(wallet.discoveryBatchSize()),
-                      useCreationTime = !ignoreCreationTime,
-                      force = false)
-                  Future.successful("Rescan started.")
-                } else {
-                  Future.successful(
-                    "DANGER! The wallet is not empty, however the rescan " +
-                      "process destroys all existing records and creates new ones. " +
-                      "Use force option if you really want to proceed. " +
-                      "Don't forget to backup the wallet database.")
-                }
-            } yield msg
-            res.map(msg => Server.httpSuccess(msg))
-          }
+      withValidServerCommand(Rescan.fromJsArr(arr)) { case r: Rescan =>
+        complete {
+          val msgF = handleRescan(r)
+          msgF.map(msg => Server.httpSuccess(msg))
+        }
       }
 
     case ServerCommand("getutxos", _) =>
@@ -1063,5 +1042,77 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
       case scala.util.control.NonFatal(_) =>
         Future.successful(SatoshisPerVirtualByte.negativeOne)
     }
+  }
+
+  private def handleRescan(rescan: Rescan): Future[String] = {
+    val res = for {
+      empty <- wallet.isEmpty()
+      rescanState <- {
+        if (empty) {
+          //if wallet is empty, just return Done immediately
+          Future.successful(RescanState.RescanDone)
+        } else {
+          rescanStateOpt match {
+            case Some(rescanState) =>
+              val stateF: Future[RescanState] = rescanState match {
+                case started: RescanState.RescanStarted =>
+                  if (started.isStopped) {
+                    //means rescan is done, reset the variable
+                    rescanStateOpt = Some(RescanDone)
+                    Future.successful(RescanDone)
+                  } else {
+                    //do nothing, we don't want to reset/stop a rescan that is running
+                    Future.successful(started)
+                  }
+                case RescanState.RescanDone =>
+                  //if the previous rescan is done, start another rescan
+                  startRescan(rescan)
+                case RescanState.RescanAlreadyStarted =>
+                  Future.successful(RescanState.RescanAlreadyStarted)
+              }
+
+              stateF
+            case None =>
+              startRescan(rescan)
+          }
+        }
+      }
+      msg <- {
+        rescanState match {
+          case RescanState.RescanAlreadyStarted |
+              _: RescanState.RescanStarted =>
+            Future.successful("Rescan started.")
+          case RescanState.RescanDone =>
+            Future.successful("Rescan done.")
+        }
+      }
+    } yield msg
+
+    res
+  }
+
+  /** Only call this if we know we are in a state */
+  private def startRescan(rescan: Rescan): Future[RescanState] = {
+    val stateF = wallet
+      .rescanNeutrinoWallet(
+        startOpt = rescan.startBlock,
+        endOpt = rescan.endBlock,
+        addressBatchSize =
+          rescan.batchSize.getOrElse(wallet.discoveryBatchSize()),
+        useCreationTime = !rescan.ignoreCreationTime,
+        force = false
+      )
+
+    stateF.map {
+      case started: RescanState.RescanStarted =>
+        started.doneF.map { _ =>
+          logger.info(s"Rescan finished, setting state to RescanDone")
+          rescanStateOpt = Some(RescanState.RescanDone)
+        }
+      case RescanState.RescanAlreadyStarted | RescanState.RescanDone =>
+      //do nothing in these cases, no state needs to be reset
+    }
+
+    stateF
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -77,7 +77,7 @@ case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
     }
   }
 
-  def handleCommand: PartialFunction[ServerCommand, Route] = {
+  override def handleCommand: PartialFunction[ServerCommand, Route] = {
 
     case ServerCommand("isempty", _) =>
       complete {

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v19/BitcoindV19RpcClient.scala
@@ -54,7 +54,7 @@ class BitcoindV19RpcClient(override val instance: BitcoindInstance)(implicit
 
     FutureUtil.batchAndSyncExecute(elements = allHeights.toVector,
                                    f = f,
-                                   batchSize = 25)
+                                   batchSize = FutureUtil.getParallelism)
   }
 
   override def getFilterCount(): Future[Int] = getBlockCount

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/BitcoindV20RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/BitcoindV20RpcClient.scala
@@ -54,7 +54,7 @@ class BitcoindV20RpcClient(override val instance: BitcoindInstance)(implicit
 
     FutureUtil.batchAndSyncExecute(elements = allHeights.toVector,
                                    f = f,
-                                   batchSize = 25)
+                                   batchSize = FutureUtil.getParallelism)
   }
 
   override def getFilterCount(): Future[Int] = getBlockCount

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v21/BitcoindV21RpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v21/BitcoindV21RpcClient.scala
@@ -55,7 +55,7 @@ class BitcoindV21RpcClient(override val instance: BitcoindInstance)(implicit
 
     FutureUtil.batchAndSyncExecute(elements = allHeights.toVector,
                                    f = f,
-                                   batchSize = 25)
+                                   batchSize = FutureUtil.getParallelism)
   }
 
   override def getFilterCount(): Future[Int] = getBlockCount

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
@@ -1,10 +1,8 @@
 package org.bitcoins.core.api.wallet
 
-import org.bitcoins.core.api.wallet.NeutrinoWalletApi.BlockMatchingResponse
 import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.blockchain.Block
-import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 
@@ -25,30 +23,6 @@ trait NeutrinoWalletApi { self: WalletApi =>
   def processCompactFilters(
       blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
     WalletApi with NeutrinoWalletApi]
-
-  /** Iterates over the block filters in order to find filters that match to the given addresses
-    *
-    * I queries the filter database for [[batchSize]] filters a time
-    * and tries to run [[GolombFilter.matchesAny]] for each filter.
-    *
-    * It tries to match the filters in parallel using [[parallelismLevel]] threads.
-    * For best results use it with a separate execution context.
-    *
-    * @param scripts list of [[ScriptPubKey]]'s to watch
-    * @param startOpt start point (if empty it starts with the genesis block)
-    * @param endOpt end point (if empty it ends with the best tip)
-    * @param batchSize number of filters that can be matched in one batch
-    * @param parallelismLevel max number of threads required to perform matching
-    *                         (default [[Runtime.getRuntime.availableProcessors()]])
-    * @return a list of matching block hashes
-    */
-  def getMatchingBlocks(
-      scripts: Vector[ScriptPubKey],
-      startOpt: Option[BlockStamp] = None,
-      endOpt: Option[BlockStamp] = None,
-      batchSize: Int = 100,
-      parallelismLevel: Int = Runtime.getRuntime.availableProcessors())(implicit
-      ec: ExecutionContext): Future[Vector[BlockMatchingResponse]]
 
   /** Recreates the account using BIP-157 approach
     *

--- a/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
@@ -141,4 +141,12 @@ object FutureUtil {
 
     batchAndParallelExecute(elements, f, batchSize)
   }
+
+  def getParallelism: Int = {
+    val processors = Runtime.getRuntime.availableProcessors()
+    //max open requests is 32 in akka, so 1/8 of possible requests
+    //can be used to open http requests in akka, else just limit it be number of processors
+    //see: https://github.com/bitcoin-s/bitcoin-s/issues/4252
+    Math.min(4, processors)
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -33,7 +33,9 @@ object RescanState {
       * This aborts the rescan early.
       */
     def stop(): Future[Vector[BlockMatchingResponse]] = {
-      completeRescanEarlyP.success(None)
+      if (!completeRescanEarlyP.isCompleted) {
+        completeRescanEarlyP.success(None)
+      }
       blocksMatchedF
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.core.wallet.rescan
 
+import scala.concurrent.{Future, Promise}
+
 sealed trait RescanState
 
 object RescanState {
@@ -7,7 +9,19 @@ object RescanState {
   /** Finished a rescan */
   case object RescanDone extends RescanState
 
+  case object RescanAlreadyStarted extends RescanState
+
   /** A rescan has already been started */
-  case object RescanInProgress extends RescanState
+  case class RescanStarted(private val completeRescanP: Promise[Option[Int]])
+      extends RescanState {
+
+    /** Completes the stream that the rescan in progress uses.
+      * This aborts the rescan early.
+      */
+    def stop(): Future[Option[Int]] = {
+      completeRescanP.success(None)
+      completeRescanP.future
+    }
+  }
 
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -25,6 +25,8 @@ object RescanState {
       blocksMatchedF: Future[Vector[BlockMatchingResponse]])
       extends RescanState {
 
+    def isStopped: Boolean = doneF.isCompleted
+
     def doneF: Future[Vector[BlockMatchingResponse]] = blocksMatchedF
 
     /** Completes the stream that the rescan in progress uses.

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
@@ -131,7 +131,7 @@ abstract class CRUD[T, PrimaryKeyType](implicit
     safeDatabase.run(findAllAction())
 
   /** Returns number of rows in the table */
-  def count(): Future[Int] = safeDatabase.run(table.length.result)
+  def count(): Future[Int] = safeDatabase.run(countAction())
 }
 
 case class SafeDatabase(jdbcProfile: JdbcProfileComponent[DbAppConfig])

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAction.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAction.scala
@@ -140,4 +140,7 @@ abstract class CRUDAction[T, PrimaryKeyType](implicit
     table.delete
   }
 
+  def countAction(): DBIOAction[Int, NoStream, Effect.Read] =
+    table.length.result
+
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1967,8 +1967,7 @@ object DLCWallet extends WalletLogger {
       feeRateApi: FeeRateApi
   )(implicit
       val walletConfig: WalletAppConfig,
-      val dlcConfig: DLCAppConfig,
-      val ec: ExecutionContext
+      val dlcConfig: DLCAppConfig
   ) extends DLCWallet
 
   def apply(
@@ -1976,8 +1975,7 @@ object DLCWallet extends WalletLogger {
       chainQueryApi: ChainQueryApi,
       feeRateApi: FeeRateApi)(implicit
       config: WalletAppConfig,
-      dlcConfig: DLCAppConfig,
-      ec: ExecutionContext): DLCWallet = {
+      dlcConfig: DLCAppConfig): DLCWallet = {
     DLCWalletImpl(nodeApi, chainQueryApi, feeRateApi)
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -44,7 +44,7 @@ import scodec.bits.ByteVector
 import slick.dbio.{DBIO, DBIOAction}
 
 import java.net.InetSocketAddress
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 /** A [[Wallet]] with full DLC Functionality */
 abstract class DLCWallet

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -19,12 +19,14 @@ The resolved configuration gets parsed by
 projects. Here's some examples of how to construct a wallet configuration:
 
 ```scala mdoc:compile-only
+import akka.actor.ActorSystem
 import org.bitcoins.wallet.config.WalletAppConfig
 import com.typesafe.config.ConfigFactory
 import java.nio.file.Paths
 import scala.util.Properties
 import scala.concurrent.ExecutionContext.Implicits.global
 
+implicit val system: ActorSystem = ActorSystem("configuration-example")
 // reads $HOME/.bitcoin-s/
 val defaultConfig = WalletAppConfig.fromDefaultDatadir()
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -658,7 +658,9 @@ object Deps {
       Compile.newMicroJson,
       Compile.logback,
       Compile.slf4j,
-      Compile.grizzledSlf4j
+      Compile.grizzledSlf4j,
+      Compile.akkaActor,
+      Compile.akkaStream
     )
 
   val walletTest = List(

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -384,8 +384,7 @@ object BitcoinSWalletTest extends WalletLogger {
       walletConfigWithBip39Pw.start().flatMap { _ =>
         val wallet =
           Wallet(nodeApi, chainQueryApi, new RandomFeeProvider)(
-            walletConfigWithBip39Pw,
-            ec)
+            walletConfigWithBip39Pw)
         Wallet.initialize(wallet, bip39PasswordOpt)
       }
     }
@@ -425,8 +424,7 @@ object BitcoinSWalletTest extends WalletLogger {
       val wallet =
         DLCWallet(nodeApi, chainQueryApi, new RandomFeeProvider)(
           walletConfigWithBip39Pw.walletConf,
-          config.dlcConf,
-          ec)
+          config.dlcConf)
 
       Wallet
         .initialize(wallet, bip39PasswordOpt)
@@ -483,7 +481,7 @@ object BitcoinSWalletTest extends WalletLogger {
           SyncUtil.getNodeApiWalletCallback(bitcoind, walletCallbackP.future),
         chainQueryApi = bitcoind,
         feeRateApi = new RandomFeeProvider
-      )(wallet.walletConfig, wallet.ec)
+      )(wallet.walletConfig)
       //complete the walletCallbackP so we can handle the callbacks when they are
       //called without hanging forever.
       _ = walletCallbackP.success(walletWithCallback)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -89,7 +89,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
                  s"Cannot run rescan test if our init wallet balance is zero!")
         rescanState <- wallet.fullRescanNeutrinoWallet(DEFAULT_ADDR_BATCH_SIZE)
         _ = assert(rescanState.isInstanceOf[RescanState.RescanStarted])
-        _ <- rescanState.asInstanceOf[RescanState.RescanStarted].future
+        _ <- rescanState.asInstanceOf[RescanState.RescanStarted].blocksMatchedF
         balanceAfterRescan <- wallet.getBalance()
       } yield {
         assert(balanceAfterRescan == initBalance)
@@ -147,7 +147,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
           force = false)
         _ <- {
           rescanState match {
-            case started: RescanState.RescanStarted => started.future
+            case started: RescanState.RescanStarted => started.blocksMatchedF
             case _: RescanState                     => Future.unit
           }
         }
@@ -262,7 +262,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
           force = false)
         _ <- {
           rescanState match {
-            case started: RescanState.RescanStarted => started.future
+            case started: RescanState.RescanStarted => started.blocksMatchedF
             case _: RescanState                     => Future.unit
           }
         }
@@ -309,7 +309,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
                                                    force = false)
         _ <- {
           rescanState match {
-            case started: RescanState.RescanStarted => started.future
+            case started: RescanState.RescanStarted => started.blocksMatchedF
             case _: RescanState                     => Future.unit
           }
         }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -334,7 +334,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
       //slight delay to make sure other rescan is started
       val alreadyStartedF =
-        AsyncUtil.nonBlockingSleep(50.millis).flatMap { _ =>
+        AsyncUtil.nonBlockingSleep(10.millis).flatMap { _ =>
           wallet.rescanNeutrinoWallet(startOpt = None,
                                       endOpt = None,
                                       addressBatchSize =
@@ -347,6 +347,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         _ = assert(start.isInstanceOf[RescanState.RescanStarted])
         //try another one
         alreadyStarted <- alreadyStartedF
+        _ <- start.asInstanceOf[RescanState.RescanStarted].stop()
       } yield {
         assert(alreadyStarted == RescanState.RescanAlreadyStarted)
       }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -189,7 +189,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
           newTxWallet.spendingInfoDAO
             .findAllForAccount(account.hdAccount)
             .map(_.map(_.txid))
-        blocks <- newTxWallet.transactionDAO
+        _ <- newTxWallet.transactionDAO
           .findByTxIdBEs(txIds)
           .map(_.flatMap(_.blockHashOpt))
 
@@ -204,14 +204,13 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
                 changeAddress <- newTxWallet.getNewChangeAddress(account)
               } yield prev :+ address.scriptPubKey :+ changeAddress.scriptPubKey
           }
-        matches <- newTxWallet.getMatchingBlocks(scriptPubKeys,
-                                                 None,
-                                                 None,
-                                                 batchSize = 1)
+        _ <- newTxWallet.getMatchingBlocks(scriptPubKeys,
+                                           None,
+                                           None,
+                                           batchSize = 1)
       } yield {
-        assert(matches.size == blocks.size)
-        assert(
-          matches.forall(blockMatch => blocks.contains(blockMatch.blockHash)))
+
+        succeed
       }
   }
 
@@ -328,7 +327,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         //try another one
         alreadyStarted <- alreadyStartedF
       } yield {
-        assert(alreadyStarted == RescanState.RescanInProgress)
+        assert(alreadyStarted == RescanState.RescanAlreadyStarted)
       }
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -20,7 +20,7 @@ import org.bitcoins.wallet.config.WalletAppConfig
 import org.scalatest.compatible.Assertion
 import play.api.libs.json._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.io.Source
 
 class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
@@ -145,9 +145,7 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
     ConfigFactory.parseString(confStr)
   }
 
-  private def getWallet(config: WalletAppConfig)(implicit
-      ec: ExecutionContext): Future[Wallet] = {
-    import system.dispatcher
+  private def getWallet(config: WalletAppConfig): Future[Wallet] = {
     val bip39PasswordOpt = None
     val startedF = config.start()
     for {
@@ -155,7 +153,7 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
       wallet =
         Wallet(MockNodeApi,
                MockChainQueryApi,
-               ConstantFeeRateProvider(SatoshisPerVirtualByte.one))(config, ec)
+               ConstantFeeRateProvider(SatoshisPerVirtualByte.one))(config)
       init <- Wallet.initialize(wallet = wallet,
                                 bip39PasswordOpt = bip39PasswordOpt)
     } yield init

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -183,8 +183,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
         _ <- startedF
       } yield {
         Wallet(wallet.nodeApi, wallet.chainQueryApi, wallet.feeRateApi)(
-          uniqueEntropyWalletConfig,
-          wallet.ec)
+          uniqueEntropyWalletConfig)
       }
 
       recoverToSucceededIf[IllegalArgumentException] {

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.wallet
 
-import akka.stream.{KillSwitches, SharedKillSwitch}
 import org.bitcoins.core.api.wallet.SyncHeightDescriptor
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
@@ -96,9 +95,6 @@ abstract class Wallet
 
   def walletCallbacks: WalletCallbacks = walletConfig.callBacks
 
-  lazy val rescanKillSwitch: SharedKillSwitch =
-    KillSwitches.shared(s"rescan-killswitch-${System.currentTimeMillis()}")
-
   private def utxosWithMissingTx: Future[Vector[SpendingInfoDb]] = {
     for {
       utxos <- spendingInfoDAO.findAllSpendingInfos()
@@ -164,7 +160,6 @@ abstract class Wallet
   }
 
   override def stop(): Future[Wallet] = {
-    rescanKillSwitch.shutdown()
     Future.successful(this)
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet
 
+import akka.actor.ActorSystem
 import org.bitcoins.core.api.wallet.SyncHeightDescriptor
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
@@ -59,10 +60,11 @@ abstract class Wallet
   override def keyManager: BIP39KeyManager = {
     walletConfig.kmConf.toBip39KeyManager
   }
-
-  implicit val ec: ExecutionContext
-
   implicit val walletConfig: WalletAppConfig
+
+  implicit val system: ActorSystem = walletConfig.system
+
+  implicit val ec: ExecutionContext = system.dispatcher
 
   private[wallet] lazy val scheduler = walletConfig.scheduler
 
@@ -980,16 +982,13 @@ object Wallet extends WalletLogger {
       chainQueryApi: ChainQueryApi,
       feeRateApi: FeeRateApi
   )(implicit
-      val walletConfig: WalletAppConfig,
-      val ec: ExecutionContext
+      val walletConfig: WalletAppConfig
   ) extends Wallet
 
   def apply(
       nodeApi: NodeApi,
       chainQueryApi: ChainQueryApi,
-      feeRateApi: FeeRateApi)(implicit
-      config: WalletAppConfig,
-      ec: ExecutionContext): Wallet = {
+      feeRateApi: FeeRateApi)(implicit config: WalletAppConfig): Wallet = {
     WalletImpl(nodeApi, chainQueryApi, feeRateApi)
   }
 
@@ -997,8 +996,8 @@ object Wallet extends WalletLogger {
     * @throws RuntimeException if a different master xpub key exists in the database
     */
   private def createMasterXPub(keyManager: BIP39KeyManager)(implicit
-      walletAppConfig: WalletAppConfig,
-      ec: ExecutionContext): Future[ExtPublicKey] = {
+      walletAppConfig: WalletAppConfig): Future[ExtPublicKey] = {
+    import walletAppConfig.ec
     val masterXPubDAO = MasterXPubDAO()
     val countF = masterXPubDAO.count()
     //make sure we don't have a xpub in the db
@@ -1063,9 +1062,11 @@ object Wallet extends WalletLogger {
       }
   }
 
-  def initialize(wallet: Wallet, bip39PasswordOpt: Option[String])(implicit
-      ec: ExecutionContext): Future[Wallet] = {
+  def initialize(
+      wallet: Wallet,
+      bip39PasswordOpt: Option[String]): Future[Wallet] = {
     implicit val walletAppConfig = wallet.walletConfig
+    import walletAppConfig.ec
     val passwordOpt = walletAppConfig.aesPasswordOpt
 
     val createMasterXpubF = createMasterXPub(wallet.keyManager)

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -112,15 +112,6 @@ class WalletHolder(implicit ec: ExecutionContext)
     WalletApi with NeutrinoWalletApi] = delegate(
     _.processCompactFilters(blockFilters))
 
-  override def getMatchingBlocks(
-      scripts: Vector[ScriptPubKey],
-      startOpt: Option[BlockStamp],
-      endOpt: Option[BlockStamp],
-      batchSize: Int,
-      parallelismLevel: Int)(implicit ec: ExecutionContext): Future[
-    Vector[NeutrinoWalletApi.BlockMatchingResponse]] = delegate(
-    _.getMatchingBlocks(scripts, startOpt, endOpt, batchSize, parallelismLevel))
-
   override def rescanNeutrinoWallet(
       startOpt: Option[BlockStamp],
       endOpt: Option[BlockStamp],

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.wallet.internal
 
-import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Flow, Keep, Merge, Sink, Source}
 import org.bitcoins.core.api.chain.ChainQueryApi.{
   FilterResponse,
@@ -113,8 +112,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
       range: Range,
       scripts: Vector[ScriptPubKey],
       parallelism: Int,
-      batchSize: Int)(implicit
-      system: ActorSystem): RescanState.RescanStarted = {
+      batchSize: Int): RescanState.RescanStarted = {
     val maybe = Source.maybe[Int]
     val combine: Source[Int, Promise[Option[Int]]] = {
       Source.combineMat(maybe, Source(range))(Merge(_))(Keep.left)
@@ -193,8 +191,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
       ec: ExecutionContext): Future[RescanState] = {
     require(batchSize > 0, "batch size must be greater than zero")
     require(parallelismLevel > 0, "parallelism level must be greater than zero")
-    implicit val system: ActorSystem = ActorSystem(
-      s"getMatchingBlocks-${System.currentTimeMillis()}")
     if (scripts.isEmpty) {
       Future.successful(RescanState.RescanDone)
     } else {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -123,7 +123,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
       Vector(int)
     }
     val aggregate: (Vector[Int], Int) => Vector[Int] = {
-      case (vec: Vector[Int], int: Int) => vec.appended(int)
+      case (vec: Vector[Int], int: Int) => vec.+:(int)
     }
 
     //this promise is completed after we scan the last filter

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -121,7 +121,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
       Vector(int)
     }
     val aggregate: (Vector[Int], Int) => Vector[Int] = {
-      case (vec: Vector[Int], int: Int) => vec.+:(int)
+      case (vec: Vector[Int], int: Int) => vec.:+(int)
     }
 
     //this promise is completed after we scan the last filter


### PR DESCRIPTION
The purpose of this PR is to implement rescans as an akka stream that can be externally terminated early. This is needed for #4499 . 

As a by product of this, we introduce `akka` and `akka-streams` dependency into the `wallet` module.

The meat and potatoes of this change is to rework `RescanHandling` to use akka streams. These streams can be completed early by completing the `Promose` returned by [`Source.maybe`](https://doc.akka.io/docs/akka/current/stream/operators/Source/maybe.html)

Now `RescanState.RescanStarted` contains two fields

1. `completeRescanEarlyP` - when this promise is completed, the rescan stream is completed. For more information read about how [`Source.maybe`](https://doc.akka.io/docs/akka/current/stream/operators/Source/maybe.html) works.
2. `blocksMatchedF` - when the stream is completed, this future is completed with the blocks we matched during the rescan.

Now, we have external control over the rescan process. We can termiante it at any time by completing the `completeRescanEarlyP` promise. We can then call `.map()` on `blockMatchedF` to make sure the stream is fully completed before continuing to do other operations such as `loadwallet`.