### PR TITLE
Remove hard coded values for embedded pg config

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -2,13 +2,18 @@ package org.bitcoins.testkit
 
 import akka.actor.ActorSystem
 import com.typesafe.config._
+import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
+import org.bitcoins.dlc.wallet.DLCAppConfig
+import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.db.TestAppConfig
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
 import org.bitcoins.testkit.util.FileUtil
 import org.bitcoins.testkit.util.TorUtil.torEnabled
 import org.bitcoins.testkitcore.Implicits.GeneratorOps
 import org.bitcoins.testkitcore.gen.{NumberGenerator, StringGenerators}
+import org.bitcoins.wallet.config.WalletAppConfig
 
 import java.nio.file._
 import scala.concurrent.ExecutionContext
@@ -168,7 +173,6 @@ object BitcoinSTestAppConfig {
       pgUrl: () => Option[String]): Config = {
 
     def pgConfigForProject(project: ProjectType): String = {
-      val name = project.toString.toLowerCase()
       val url = pgUrl().getOrElse(
         throw new RuntimeException(s"Cannot get db url for $project"))
       val parts = url.split(":")
@@ -178,20 +182,20 @@ object BitcoinSTestAppConfig {
       val endOfPortStr = str.indexOf('/')
       val (port, _) = str.splitAt(endOfPortStr)
       val projectString = project match {
-        case ProjectType.Wallet               => "wallet"
-        case ProjectType.Chain                => "chain"
-        case ProjectType.Node                 => "node"
-        case ProjectType.Oracle               => "oracle"
-        case ProjectType.DLC                  => "dlc"
-        case ProjectType.Test                 => "test"
+        case ProjectType.Wallet               => WalletAppConfig.moduleName
+        case ProjectType.Chain                => ChainAppConfig.moduleName
+        case ProjectType.Node                 => NodeAppConfig.moduleName
+        case ProjectType.Oracle               => DLCOracleAppConfig.moduleName
+        case ProjectType.DLC                  => DLCAppConfig.moduleName
+        case ProjectType.Test                 => TestAppConfig.moduleName
         case ProjectType.Unknown(projectName) => projectName
       }
 
       val poolName =
         s"bitcoin-s-$projectString-pool-${System.currentTimeMillis()}"
 
-      s""" $name.profile = "slick.jdbc.PostgresProfile$$"
-         | $name.db {
+      s""" $projectString.profile = "slick.jdbc.PostgresProfile$$"
+         | $projectString.db {
          |   driverName = postgres
          |   name = postgres
          |   url = "$url"

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
@@ -47,7 +47,7 @@ case class TestAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     with TestDbManagement
     with JdbcProfileComponent[TestAppConfig] {
 
-  override protected[bitcoins] def moduleName: String = "test"
+  override protected[bitcoins] def moduleName: String = TestAppConfig.moduleName
 
   override protected[bitcoins] type ConfigType = TestAppConfig
 
@@ -67,6 +67,10 @@ case class TestAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
       _ <- createTable(TestDAO()(ec, this).table)
     } yield ()
   }
+}
+
+object TestAppConfig {
+  val moduleName: String = "test"
 }
 
 case class TestDb(pk: String, data: ByteVector)


### PR DESCRIPTION
Cleans up so we use the actual module name from the app config instead of having it hard coded in 2 different places