### PR TITLE
Implement ability to cancel bitcoind polling jobs

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -147,11 +147,12 @@ object BitcoindRpcBackendUtil extends Logging {
     // so we don't lose the internal state of the wallet
     val walletCallbackP = Promise[Wallet]()
 
+    val nodeApi = BitcoindRpcBackendUtil.buildBitcoindNodeApi(
+      bitcoind,
+      walletCallbackP.future,
+      chainCallbacksOpt)
     val pairedWallet = Wallet(
-      nodeApi =
-        BitcoindRpcBackendUtil.buildBitcoindNodeApi(bitcoind,
-                                                    walletCallbackP.future,
-                                                    chainCallbacksOpt),
+      nodeApi = nodeApi,
       chainQueryApi = bitcoind,
       feeRateApi = wallet.feeRateApi
     )(wallet.walletConfig)

--- a/app/server/src/main/scala/org/bitcoins/server/util/BitcoindPollingCancellabe.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/BitcoindPollingCancellabe.scala
@@ -1,0 +1,22 @@
+package org.bitcoins.server.util
+
+import akka.actor.Cancellable
+
+case class BitcoindPollingCancellabe(
+    blockPollingCancellable: Cancellable,
+    mempoolPollingCancelable: Cancellable)
+    extends Cancellable {
+
+  override def cancel(): Boolean =
+    blockPollingCancellable.cancel() && mempoolPollingCancelable.cancel()
+
+  override def isCancelled: Boolean =
+    blockPollingCancellable.isCancelled && mempoolPollingCancelable.cancel()
+}
+
+object BitcoindPollingCancellabe {
+
+  val none: BitcoindPollingCancellabe = BitcoindPollingCancellabe(
+    Cancellable.alreadyCancelled,
+    Cancellable.alreadyCancelled)
+}

--- a/app/server/src/main/scala/org/bitcoins/server/util/BitcoindPollingCancellabe.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/BitcoindPollingCancellabe.scala
@@ -1,14 +1,18 @@
 package org.bitcoins.server.util
 
 import akka.actor.Cancellable
+import grizzled.slf4j.Logging
 
 case class BitcoindPollingCancellabe(
     blockPollingCancellable: Cancellable,
     mempoolPollingCancelable: Cancellable)
-    extends Cancellable {
+    extends Cancellable
+    with Logging {
 
-  override def cancel(): Boolean =
+  override def cancel(): Boolean = {
+    logger.info(s"Cancelling bitcoind polling jobs")
     blockPollingCancellable.cancel() && mempoolPollingCancelable.cancel()
+  }
 
   override def isCancelled: Boolean =
     blockPollingCancellable.isCancelled && mempoolPollingCancelable.cancel()

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -83,9 +83,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
             _ <- stateDescriptorDAO.updateRescanning(false)
             _ <- walletCallbacks.executeOnRescanComplete(logger)
           } yield {
-            logger.info(s"Finished rescanning the wallet. It took ${System
-              .currentTimeMillis() - startTime}ms")
-
             state
           }
 
@@ -94,6 +91,15 @@ private[wallet] trait RescanHandling extends WalletLogger {
             stateDescriptorDAO
               .updateRescanning(false)
               .flatMap(_ => Future.failed(err))
+          }
+
+          res.map {
+            case r: RescanState.RescanStarted =>
+              r.doneF.map(_ =>
+                logger.info(s"Finished rescanning the wallet. It took ${System
+                  .currentTimeMillis() - startTime}ms"))
+            case RescanState.RescanDone | RescanState.RescanAlreadyStarted =>
+            //nothing to log
           }
 
           res


### PR DESCRIPTION
Fixes bugs in the `appServerTest/test` suite where polling jobs were not stopped after a test was completed. This now cancels all polling jobs against bitcoind when `BItcoinSServerMain.stop()` is called.