### PR TITLE
Create a helper case class called `FundRawTxHelper`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -18,7 +18,10 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.util.{FutureUtil, StartStopAsync}
-import org.bitcoins.core.wallet.builder.FundRawTxHelper
+import org.bitcoins.core.wallet.builder.{
+  FundRawTxHelper,
+  ShufflingNonInteractiveFinalizer
+}
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.{
   AddressTag,
@@ -86,7 +89,8 @@ trait WalletApi extends StartStopAsync[WalletApi] {
       destinations: Vector[TransactionOutput],
       feeRate: FeeUnit,
       fromTagOpt: Option[AddressTag],
-      markAsReserved: Boolean): Future[FundRawTxHelper[_]]
+      markAsReserved: Boolean): Future[
+    FundRawTxHelper[ShufflingNonInteractiveFinalizer]]
 
   def listTransactions(): Future[Vector[TransactionDb]]
 

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -18,6 +18,7 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.util.{FutureUtil, StartStopAsync}
+import org.bitcoins.core.wallet.builder.FundRawTxHelper
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.{
   AddressTag,
@@ -85,7 +86,7 @@ trait WalletApi extends StartStopAsync[WalletApi] {
       destinations: Vector[TransactionOutput],
       feeRate: FeeUnit,
       fromTagOpt: Option[AddressTag],
-      markAsReserved: Boolean): Future[Transaction]
+      markAsReserved: Boolean): Future[FundRawTxHelper[_]]
 
   def listTransactions(): Future[Vector[TransactionDb]]
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/FundRawTxHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/FundRawTxHelper.scala
@@ -13,7 +13,7 @@ case class FundRawTxHelper[T <: RawTxFinalizer](
   def unsignedTx: Transaction = txBuilderWithFinalizer.buildTx()
 
   /** Produces a signed bitcoin transaction with the given fee rate */
-  def signedTx: Transaction = {
+  lazy val signedTx: Transaction = {
     RawTxSigner.sign(unsignedTx, scriptSigParams, feeRate)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/FundRawTxHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/FundRawTxHelper.scala
@@ -1,0 +1,19 @@
+package org.bitcoins.core.wallet.builder
+
+import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.utxo.{InputInfo, ScriptSignatureParams}
+
+case class FundRawTxHelper[T <: RawTxFinalizer](
+    txBuilderWithFinalizer: RawTxBuilderWithFinalizer[T],
+    scriptSigParams: Vector[ScriptSignatureParams[InputInfo]],
+    feeRate: FeeUnit) {
+
+  /** Produces the unsigned transaction built by fundrawtransaction */
+  def unsignedTx: Transaction = txBuilderWithFinalizer.buildTx()
+
+  /** Produces a signed bitcoin transaction with the given fee rate */
+  def signedTx: Transaction = {
+    RawTxSigner.sign(unsignedTx, scriptSigParams, feeRate)
+  }
+}

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCAcceptUtil.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCAcceptUtil.scala
@@ -18,10 +18,9 @@ import org.bitcoins.core.protocol.dlc.models._
 import org.bitcoins.core.protocol.transaction.TransactionConstants
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.core.wallet.builder.{
-  RawTxBuilderWithFinalizer,
+  FundRawTxHelper,
   ShufflingNonInteractiveFinalizer
 }
-import org.bitcoins.core.wallet.utxo.{InputInfo, ScriptSignatureParams}
 import org.bitcoins.crypto.{AdaptorSign, Sha256Digest}
 import org.bitcoins.dlc.wallet.models.{
   DLCAcceptDb,
@@ -40,8 +39,7 @@ object DLCAcceptUtil extends Logging {
       keyIndex: Int,
       chainType: HDChainType,
       offer: DLCOffer,
-      txBuilder: RawTxBuilderWithFinalizer[ShufflingNonInteractiveFinalizer],
-      spendingInfos: Vector[ScriptSignatureParams[InputInfo]],
+      fundRawTxHelper: FundRawTxHelper[ShufflingNonInteractiveFinalizer],
       account: AccountDb,
       fundingPrivKey: AdaptorSign,
       collateral: CurrencyUnit,
@@ -50,6 +48,8 @@ object DLCAcceptUtil extends Logging {
       externalChangeAddressOpt: Option[BitcoinAddress]): (
       DLCAcceptWithoutSigs,
       DLCPublicKeys) = {
+    val spendingInfos = fundRawTxHelper.scriptSigParams
+    val txBuilder = fundRawTxHelper.txBuilderWithFinalizer
     val serialIds = DLCMessage.genSerialIds(
       spendingInfos.size,
       offer.fundingInputs.map(_.inputSerialId))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -180,14 +180,14 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
         wallet <- processedFundingTxF
         destinations = Vector(
           TransactionOutput(amount, receivingAddress.scriptPubKey))
-        spendingTx <- wallet.fundRawTransaction(
+        rawTxHelper <- wallet.fundRawTransaction(
           destinations = destinations,
           feeRate = SatoshisPerByte.one,
           fromTagOpt = None,
           markAsReserved = true
         )
         processedSpendingTx <- wallet.processTransaction(transaction =
-                                                           spendingTx,
+                                                           rawTxHelper.signedTx,
                                                          blockHash = None)
         balance <- processedSpendingTx.getBalance()
       } yield assert(balance == amount)

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -35,7 +35,10 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.psbt.PSBT
-import org.bitcoins.core.wallet.builder.FundRawTxHelper
+import org.bitcoins.core.wallet.builder.{
+  FundRawTxHelper,
+  ShufflingNonInteractiveFinalizer
+}
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.core.wallet.rescan.RescanState
@@ -159,7 +162,8 @@ class WalletHolder(implicit ec: ExecutionContext)
       destinations: Vector[TransactionOutput],
       feeRate: FeeUnit,
       fromTagOpt: Option[AddressTag],
-      markAsReserved: Boolean): Future[FundRawTxHelper[_]] = delegate(
+      markAsReserved: Boolean): Future[
+    FundRawTxHelper[ShufflingNonInteractiveFinalizer]] = delegate(
     _.fundRawTransaction(destinations, feeRate, fromTagOpt, markAsReserved))
 
   override def listTransactions(): Future[Vector[TransactionDb]] = delegate(

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -35,6 +35,7 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.psbt.PSBT
+import org.bitcoins.core.wallet.builder.FundRawTxHelper
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.core.wallet.rescan.RescanState
@@ -158,7 +159,7 @@ class WalletHolder(implicit ec: ExecutionContext)
       destinations: Vector[TransactionOutput],
       feeRate: FeeUnit,
       fromTagOpt: Option[AddressTag],
-      markAsReserved: Boolean): Future[Transaction] = delegate(
+      markAsReserved: Boolean): Future[FundRawTxHelper[_]] = delegate(
     _.fundRawTransaction(destinations, feeRate, fromTagOpt, markAsReserved))
 
   override def listTransactions(): Future[Vector[TransactionDb]] = delegate(

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -18,7 +18,8 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
       destinations: Vector[TransactionOutput],
       feeRate: FeeUnit,
       fromTagOpt: Option[AddressTag],
-      markAsReserved: Boolean): Future[FundRawTxHelper[_]] = {
+      markAsReserved: Boolean): Future[
+    FundRawTxHelper[ShufflingNonInteractiveFinalizer]] = {
     for {
       account <- getDefaultAccount()
       funded <- fundRawTransaction(destinations = destinations,
@@ -34,7 +35,8 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
       feeRate: FeeUnit,
       fromAccount: AccountDb,
       fromTagOpt: Option[AddressTag] = None,
-      markAsReserved: Boolean = false): Future[FundRawTxHelper[_]] = {
+      markAsReserved: Boolean = false): Future[
+    FundRawTxHelper[ShufflingNonInteractiveFinalizer]] = {
     fundRawTransactionInternal(destinations = destinations,
                                feeRate = feeRate,
                                fromAccount = fromAccount,

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -18,7 +18,7 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
       destinations: Vector[TransactionOutput],
       feeRate: FeeUnit,
       fromTagOpt: Option[AddressTag],
-      markAsReserved: Boolean): Future[Transaction] = {
+      markAsReserved: Boolean): Future[FundRawTxHelper[_]] = {
     for {
       account <- getDefaultAccount()
       funded <- fundRawTransaction(destinations = destinations,
@@ -34,13 +34,12 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
       feeRate: FeeUnit,
       fromAccount: AccountDb,
       fromTagOpt: Option[AddressTag] = None,
-      markAsReserved: Boolean = false): Future[Transaction] = {
+      markAsReserved: Boolean = false): Future[FundRawTxHelper[_]] = {
     fundRawTransactionInternal(destinations = destinations,
                                feeRate = feeRate,
                                fromAccount = fromAccount,
                                fromTagOpt = fromTagOpt,
                                markAsReserved = markAsReserved)
-      .map(_._1.buildTx())
   }
 
   /** This returns a [[RawTxBuilder]] that can be used to generate an unsigned transaction with [[RawTxBuilder.result()]]
@@ -54,9 +53,8 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
       fromAccount: AccountDb,
       coinSelectionAlgo: CoinSelectionAlgo = CoinSelectionAlgo.LeastWaste,
       fromTagOpt: Option[AddressTag],
-      markAsReserved: Boolean): Future[(
-      RawTxBuilderWithFinalizer[ShufflingNonInteractiveFinalizer],
-      Vector[ScriptSignatureParams[InputInfo]])] = {
+      markAsReserved: Boolean): Future[
+    FundRawTxHelper[ShufflingNonInteractiveFinalizer]] = {
     val amts = destinations.map(_.value)
     //need to allow 0 for OP_RETURN outputs
     require(amts.forall(_.satoshis.toBigInt >= 0),
@@ -133,7 +131,9 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
                                                        feeRate,
                                                        change.scriptPubKey)
 
-      (txBuilder, utxoSpendingInfos)
+      FundRawTxHelper(txBuilderWithFinalizer = txBuilder,
+                      scriptSigParams = utxoSpendingInfos,
+                      feeRate)
     }
 
     resultF.recoverWith { case NonFatal(error) =>


### PR DESCRIPTION
The purpose of this class is to encapsulate the values returned by `fundRawTransactionInternal`. This makes it easier to work with `fundRawTransactionInternal` when refactoring code for #4539 

