### PR TITLE
2022 07 25 wallet api refactor

### DIFF
--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{Await, Future}
 class OracleServerMain(override val serverArgParser: ServerArgParser)(implicit
     override val system: ActorSystem,
     conf: DLCOracleAppConfig)
-    extends BitcoinSServerRunner {
+    extends BitcoinSServerRunner[Unit] {
 
   override def start(): Future[Unit] = {
 

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Future
 class ScanBitcoind()(implicit
     override val system: ActorSystem,
     rpcAppConfig: BitcoindRpcAppConfig)
-    extends BitcoinSRunner {
+    extends BitcoinSRunner[Unit] {
 
   override def start(): Future[Unit] = {
 

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ZipDatadir.scala
@@ -14,7 +14,7 @@ import scala.concurrent.Future
 class ZipDatadir(override val serverArgParser: ServerArgParser)(implicit
     override val system: ActorSystem,
     conf: BitcoinSAppConfig)
-    extends BitcoinSServerRunner {
+    extends BitcoinSServerRunner[Unit] {
 
   override def start(): Future[Unit] = {
 

--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/BitcoinSRunner.scala
@@ -7,14 +7,14 @@ import org.bitcoins.core.util.{EnvUtil, StartStopAsync}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait BitcoinSRunner extends StartStopAsync[Unit] with Logging {
+trait BitcoinSRunner[T] extends StartStopAsync[T] with Logging {
 
   implicit def system: ActorSystem
 
   implicit lazy val ec: ExecutionContext = system.dispatcher
 
   // start everything!
-  final def run(): Future[Unit] = {
+  final def run(): Future[T] = {
 
     //We need to set the system property before any logger instances
     //are in instantiated. If we don't do this, we will not log to
@@ -26,7 +26,7 @@ trait BitcoinSRunner extends StartStopAsync[Unit] with Logging {
       s"version=${EnvUtil.getVersion} jdkVersion=${EnvUtil.getJdkVersion}")
 
     //logger.info(s"using directory ${usedDir.toAbsolutePath.toString}")
-    val runner: Future[Unit] = start()
+    val runner: Future[T] = start()
     runner.failed.foreach { err =>
       logger.error(s"Failed to startup server!", err)
     }(scala.concurrent.ExecutionContext.Implicits.global)
@@ -35,6 +35,6 @@ trait BitcoinSRunner extends StartStopAsync[Unit] with Logging {
   }
 }
 
-trait BitcoinSServerRunner extends BitcoinSRunner {
+trait BitcoinSServerRunner[T] extends BitcoinSRunner[T] {
   protected def serverArgParser: ServerArgParser
 }

--- a/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
@@ -41,9 +41,9 @@ class CallBackUtilTest extends BitcoinSWalletTest {
         tx1 <- tx1F
         tx2 <- tx2F
         callbacks <- callbacksF
+        initBalance <- initBalanceF
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx1)
         _ <- AsyncUtil.nonBlockingSleep(5000.millis)
-        initBalance <- initBalanceF
         balance2 <- wallet.getBalance()
         _ <- callbacks.stop()
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)
@@ -76,9 +76,9 @@ class CallBackUtilTest extends BitcoinSWalletTest {
         tx1 <- tx1F
         tx2 <- tx2F
         callbacks <- callbacksF
+        initBalance <- initBalanceF
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx1)
         _ <- AsyncUtil.nonBlockingSleep(5000.millis)
-        initBalance <- initBalanceF
         balance2 <- wallet.getBalance()
         _ <- callbacks.stop()
         _ <- callbacks.executeOnTxReceivedCallbacks(logger, tx2)

--- a/app/server-test/src/test/scala/org/bitcoins/wallet/MockWalletApi.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/wallet/MockWalletApi.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.core.api.dlc.wallet.AnyDLCHDWalletApi
+import org.bitcoins.core.api.dlc.wallet.DLCNeutrinoHDWalletApi
 import org.bitcoins.core.api.wallet.db.AccountDb
 import org.bitcoins.core.hd.AddressType
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 /** ScalaMock cannot stub traits with protected methods,
   * so we need to stub them manually.
   */
-abstract class MockWalletApi extends AnyDLCHDWalletApi {
+abstract class MockWalletApi extends DLCNeutrinoHDWalletApi {
 
   override def getNewChangeAddress(account: AccountDb): Future[BitcoinAddress] =
     stub

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -604,8 +604,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
   }
 
   private def handleDuplicateSpendingInfoDb(
-                                             wallet: DLCNeutrinoHDWalletApi,
-                                             walletConfig: WalletAppConfig): Future[Unit] = {
+      wallet: DLCNeutrinoHDWalletApi,
+      walletConfig: WalletAppConfig): Future[Unit] = {
     val spendingInfoDAO = SpendingInfoDAO()(ec, walletConfig)
     for {
       rescanNeeded <- spendingInfoDAO.hasDuplicates()

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -53,7 +53,7 @@ import scala.concurrent.{Await, Future, Promise}
 class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     override val system: ActorSystem,
     val conf: BitcoinSAppConfig)
-    extends BitcoinSServerRunner {
+    extends BitcoinSServerRunner[WalletHolder] {
 
   implicit lazy val nodeConf: NodeAppConfig = conf.nodeConf
   implicit lazy val chainConf: ChainAppConfig = conf.chainConf
@@ -62,7 +62,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
   implicit lazy val torConf: TorAppConfig = conf.torConf
   lazy val network = conf.walletConf.network
 
-  override def start(): Future[Unit] = {
+  override def start(): Future[WalletHolder] = {
     logger.info("Starting appServer")
     val startTime = TimeUtil.currentEpochMs
     val startedConfigF = conf.start()
@@ -95,7 +95,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     }
   }
 
-  override def stop(): Future[Unit] = {
+  override def stop(): Future[WalletHolder] = {
     logger.error(s"Exiting process")
     mempoolPollingCancellableOpt.foreach(_.cancel())
     for {
@@ -106,7 +106,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       }
       _ = logger.info(s"Stopped ${nodeConf.nodeType.shortName} node")
     } yield {
-      ()
+      //return empty wallet holder
+      new WalletHolder()
     }
   }
 
@@ -114,7 +115,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     * @param startedTorConfigF a future that is completed when tor is fully started
     * @return
     */
-  def startBitcoinSBackend(startedTorConfigF: Future[Unit]): Future[Unit] = {
+  def startBitcoinSBackend(
+      startedTorConfigF: Future[Unit]): Future[WalletHolder] = {
     logger.info(s"startBitcoinSBackend()")
     val start = System.currentTimeMillis()
 
@@ -207,7 +209,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     }
 
     //start our http server now that we are synced
-    for {
+    val startedF = for {
       _ <- neutrinoWalletLoaderF
       _ <- startHttpServer(
         nodeApiF = startedNodeF,
@@ -236,6 +238,11 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
         s"Done starting Main! It took ${System.currentTimeMillis() - start}ms")
       ()
     }
+
+    for {
+      _ <- startedF
+      walletHolder <- configuredWalletF.map(_._1)
+    } yield walletHolder
   }
 
   private def buildNeutrinoCallbacks(
@@ -288,7 +295,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     * @param startedTorConfigF a future that is completed when tor is fully started
     * @return
     */
-  def startBitcoindBackend(startedTorConfigF: Future[Unit]): Future[Unit] = {
+  def startBitcoindBackend(
+      startedTorConfigF: Future[Unit]): Future[WalletHolder] = {
     logger.info(s"startBitcoindBackend()")
     val bitcoindF = for {
       client <- bitcoindRpcConf.clientF
@@ -416,7 +424,10 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       _.map(c => mempoolPollingCancellableOpt = Some(c)))
 
     //don't return the Future that represents the full syncing of the wallet with bitcoind
-    pollingCancellableNestedF.map(_ => ())
+    for {
+      _ <- pollingCancellableNestedF //drop nested Future here
+      walletHolder <- walletF.map(_._1)
+    } yield walletHolder
   }
 
   private var serverBindingsOpt: Option[ServerBindings] = None
@@ -676,5 +687,6 @@ object BitcoinSServerMain extends BitcoinSAppScalaDaemon {
     logger.info(
       s"@@@@@@@@@@@@@@@@@@@@@ Shutting down ${getClass.getSimpleName} @@@@@@@@@@@@@@@@@@@@@")
     Await.result(m.stop(), 10.seconds)
+    ()
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -19,7 +19,7 @@ import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockChainInfoResult
 import org.bitcoins.commons.jsonmodels.ws.WsNotification
 import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.core.api.chain.ChainApi
-import org.bitcoins.core.api.dlc.wallet.AnyDLCHDWalletApi
+import org.bitcoins.core.api.dlc.wallet.DLCNeutrinoHDWalletApi
 import org.bitcoins.core.api.node.{
   InternalImplementationNodeType,
   NodeApi,
@@ -604,8 +604,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
   }
 
   private def handleDuplicateSpendingInfoDb(
-      wallet: AnyDLCHDWalletApi,
-      walletConfig: WalletAppConfig): Future[Unit] = {
+                                             wallet: DLCNeutrinoHDWalletApi,
+                                             walletConfig: WalletAppConfig): Future[Unit] = {
     val spendingInfoDAO = SpendingInfoDAO()(ec, walletConfig)
     for {
       rescanNeeded <- spendingInfoDAO.hasDuplicates()
@@ -632,7 +632,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
   }
 
   private def restartRescanIfNeeded(
-      wallet: AnyDLCHDWalletApi): Future[RescanState] = {
+      wallet: DLCNeutrinoHDWalletApi): Future[RescanState] = {
     for {
       isRescanning <- wallet.isRescanning()
       res <-

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -3,7 +3,7 @@ package org.bitcoins.server
 import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
 import org.bitcoins.core.api.chain.ChainQueryApi
-import org.bitcoins.core.api.dlc.wallet.AnyDLCHDWalletApi
+import org.bitcoins.core.api.dlc.wallet.DLCNeutrinoHDWalletApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.crypto.AesPassword
@@ -40,7 +40,7 @@ sealed trait DLCWalletLoaderApi extends Logging {
       walletNameOpt: Option[String],
       aesPasswordOpt: Option[AesPassword])(implicit
       ec: ExecutionContext): Future[
-    (AnyDLCHDWalletApi, WalletAppConfig, DLCAppConfig)] = {
+    (DLCNeutrinoHDWalletApi, WalletAppConfig, DLCAppConfig)] = {
     logger.info(
       s"Loading wallet with bitcoind backend, walletName=${walletNameOpt.getOrElse("DEFAULT")}")
     val stoppedCallbacksF = conf.nodeConf.callBacks match {

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -35,8 +35,8 @@ import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
 
 case class WalletRoutes(wallet: DLCNeutrinoHDWalletApi)(implicit
-                                                        system: ActorSystem,
-                                                        walletConf: WalletAppConfig)
+    system: ActorSystem,
+    walletConf: WalletAppConfig)
     extends ServerRoute
     with Logging {
   import system.dispatcher

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.server._
 import akka.stream.Materializer
 import grizzled.slf4j.Logging
 import org.bitcoins.commons.serializers.Picklers._
-import org.bitcoins.core.api.dlc.wallet.AnyDLCHDWalletApi
+import org.bitcoins.core.api.dlc.wallet.DLCNeutrinoHDWalletApi
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.tlv._
@@ -34,9 +34,9 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
 
-case class WalletRoutes(wallet: AnyDLCHDWalletApi)(implicit
-    system: ActorSystem,
-    walletConf: WalletAppConfig)
+case class WalletRoutes(wallet: DLCNeutrinoHDWalletApi)(implicit
+                                                        system: ActorSystem,
+                                                        walletConf: WalletAppConfig)
     extends ServerRoute
     with Logging {
   import system.dispatcher

--- a/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
@@ -3,7 +3,7 @@ package org.bitcoins.server.util
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Sink, Source}
 import grizzled.slf4j.Logging
-import org.bitcoins.core.api.dlc.wallet.AnyDLCHDWalletApi
+import org.bitcoins.core.api.dlc.wallet.DLCNeutrinoHDWalletApi
 import org.bitcoins.core.api.wallet.{NeutrinoWalletApi, WalletApi}
 import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
@@ -95,8 +95,8 @@ object CallbackUtil extends Logging {
     Future.successful(streamManager)
   }
 
-  def createBitcoindNodeCallbacksForWallet(wallet: AnyDLCHDWalletApi)(implicit
-      system: ActorSystem): Future[NodeCallbackStreamManager] = {
+  def createBitcoindNodeCallbacksForWallet(wallet: DLCNeutrinoHDWalletApi)(implicit
+                                                                           system: ActorSystem): Future[NodeCallbackStreamManager] = {
     import system.dispatcher
     val txSink = Sink.foreachAsync[Transaction](1) { case tx: Transaction =>
       logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")

--- a/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
@@ -95,8 +95,8 @@ object CallbackUtil extends Logging {
     Future.successful(streamManager)
   }
 
-  def createBitcoindNodeCallbacksForWallet(wallet: DLCNeutrinoHDWalletApi)(implicit
-                                                                           system: ActorSystem): Future[NodeCallbackStreamManager] = {
+  def createBitcoindNodeCallbacksForWallet(wallet: DLCNeutrinoHDWalletApi)(
+      implicit system: ActorSystem): Future[NodeCallbackStreamManager] = {
     import system.dispatcher
     val txSink = Sink.foreachAsync[Transaction](1) { case tx: Transaction =>
       logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")

--- a/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
@@ -24,7 +24,7 @@ object CallbackUtil extends Logging {
     val txSink = Sink.foreachAsync[Transaction](1) { case tx: Transaction =>
       logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")
       wallet
-        .processTransaction(tx, blockHash = None)
+        .processTransaction(tx, blockHashOpt = None)
         .map(_ => ())
     }
 
@@ -101,7 +101,7 @@ object CallbackUtil extends Logging {
     val txSink = Sink.foreachAsync[Transaction](1) { case tx: Transaction =>
       logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")
       wallet
-        .processTransaction(tx, blockHash = None)
+        .processTransaction(tx, blockHashOpt = None)
         .map(_ => ())
     }
     val onTx: OnTxReceived = { tx =>

--- a/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/DLCWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/DLCWalletApi.scala
@@ -178,7 +178,4 @@ trait DLCWalletApi { self: WalletApi =>
 }
 
 /** An HDWallet that supports DLCs and Neutrino method of syncing */
-trait AnyDLCHDWalletApi
-    extends HDWalletApi
-    with DLCWalletApi
-    with NeutrinoWalletApi
+trait AnyDLCHDWalletApi extends NeutrinoHDWalletApi with DLCWalletApi

--- a/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/DLCWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/DLCWalletApi.scala
@@ -178,4 +178,4 @@ trait DLCWalletApi { self: WalletApi =>
 }
 
 /** An HDWallet that supports DLCs and Neutrino method of syncing */
-trait AnyDLCHDWalletApi extends NeutrinoHDWalletApi with DLCWalletApi
+trait DLCNeutrinoHDWalletApi extends NeutrinoHDWalletApi with DLCWalletApi

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
@@ -5,9 +5,16 @@ import org.bitcoins.core.api.wallet.db.{AccountDb, AddressDb, SpendingInfoDb}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.{AddressType, HDAccount, HDChainType, HDPurpose}
 import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint, TransactionOutput}
+import org.bitcoins.core.protocol.transaction.{
+  Transaction,
+  TransactionOutPoint,
+  TransactionOutput
+}
 import org.bitcoins.core.psbt.PSBT
-import org.bitcoins.core.wallet.builder.{FundRawTxHelper, ShufflingNonInteractiveFinalizer}
+import org.bitcoins.core.wallet.builder.{
+  FundRawTxHelper,
+  ShufflingNonInteractiveFinalizer
+}
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
@@ -505,5 +512,6 @@ trait HDWalletApi extends WalletApi {
       destinations: Vector[TransactionOutput],
       feeRate: FeeUnit,
       fromAccount: AccountDb,
-      markAsReserved: Boolean): Future[FundRawTxHelper[ShufflingNonInteractiveFinalizer]]
+      markAsReserved: Boolean): Future[
+    FundRawTxHelper[ShufflingNonInteractiveFinalizer]]
 }

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
@@ -5,12 +5,9 @@ import org.bitcoins.core.api.wallet.db.{AccountDb, AddressDb, SpendingInfoDb}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.{AddressType, HDAccount, HDChainType, HDPurpose}
 import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionOutPoint,
-  TransactionOutput
-}
+import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint, TransactionOutput}
 import org.bitcoins.core.psbt.PSBT
+import org.bitcoins.core.wallet.builder.{FundRawTxHelper, ShufflingNonInteractiveFinalizer}
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
@@ -503,4 +500,10 @@ trait HDWalletApi extends WalletApi {
       keyManagerParams: KeyManagerParams): Future[HDWalletApi]
 
   def findAccount(account: HDAccount): Future[Option[AccountDb]]
+
+  def fundRawTransaction(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      markAsReserved: Boolean): Future[FundRawTxHelper[ShufflingNonInteractiveFinalizer]]
 }

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
@@ -46,6 +46,8 @@ trait HDWalletApi extends WalletApi {
 
   def getNewAddress(account: HDAccount): Future[BitcoinAddress]
 
+  def getNewAddress(account: AccountDb): Future[BitcoinAddress]
+
   /** Generates a new change address */
   def getNewChangeAddress(account: AccountDb): Future[BitcoinAddress]
 
@@ -500,4 +502,5 @@ trait HDWalletApi extends WalletApi {
       hdAccount: HDAccount,
       keyManagerParams: KeyManagerParams): Future[HDWalletApi]
 
+  def findAccount(account: HDAccount): Future[Option[AccountDb]]
 }

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/ProcessTxResult.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/ProcessTxResult.scala
@@ -1,0 +1,7 @@
+package org.bitcoins.core.api.wallet
+
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
+
+case class ProcessTxResult(
+    updatedIncoming: Vector[SpendingInfoDb],
+    updatedOutgoing: Vector[SpendingInfoDb])

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -29,7 +29,7 @@ import org.bitcoins.core.wallet.utxo.{
   AddressTagType,
   TxoState
 }
-import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
@@ -432,6 +432,23 @@ trait WalletApi extends StartStopAsync[WalletApi] {
   def getWalletName(): Future[String]
 
   def getInfo(): Future[WalletInfo]
+
+  def findByOutPoints(
+      outPoints: Vector[TransactionOutPoint]): Future[Vector[SpendingInfoDb]]
+
+  def findByOutPoint(outPoint: TransactionOutPoint)(implicit
+      ec: ExecutionContext): Future[Option[SpendingInfoDb]] = {
+    findByOutPoints(Vector(outPoint)).map(_.headOption)
+  }
+
+  def findByTxId(txIdBE: DoubleSha256DigestBE): Future[Option[TransactionDb]]
+
+  def findByTxId(txId: DoubleSha256Digest): Future[Option[TransactionDb]] = {
+    findByTxId(txId.flip)
+  }
+
+  /** Finds all the outputs in our wallet being spent in the given transaction */
+  def findOutputsBeingSpent(tx: Transaction): Future[Vector[SpendingInfoDb]]
 }
 
 case class WalletInfo(

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -458,6 +458,7 @@ trait WalletApi extends StartStopAsync[WalletApi] {
 
   /** Finds all the outputs in our wallet being spent in the given transaction */
   def findOutputsBeingSpent(tx: Transaction): Future[Vector[SpendingInfoDb]]
+
 }
 
 case class WalletInfo(

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -74,6 +74,18 @@ trait WalletApi extends StartStopAsync[WalletApi] {
     }
   }
 
+  /** Processes TXs originating from our wallet.
+    * This is called right after we've signed a TX,
+    * updating our UTXO state.
+    */
+  def processOurTransaction(
+      transaction: Transaction,
+      feeRate: FeeUnit,
+      inputAmount: CurrencyUnit,
+      sentAmount: CurrencyUnit,
+      blockHashOpt: Option[DoubleSha256DigestBE],
+      newTags: Vector[AddressTag]): Future[ProcessTxResult]
+
   /** Processes the give block, updating our DB state if it's relevant to us.
     *
     * @param block The block we're processing

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -174,6 +174,8 @@ trait WalletApi extends StartStopAsync[WalletApi] {
     */
   def clearAllUtxos(): Future[WalletApi]
 
+  def clearAllAddresses(): Future[WalletApi]
+
   /** Gets a new external address with the specified
     * type.
     *  @param addressType
@@ -441,9 +443,16 @@ trait WalletApi extends StartStopAsync[WalletApi] {
     findByOutPoints(Vector(outPoint)).map(_.headOption)
   }
 
-  def findByTxId(txIdBE: DoubleSha256DigestBE): Future[Option[TransactionDb]]
+  def findByTxIds(
+      txIds: Vector[DoubleSha256DigestBE]): Future[Vector[TransactionDb]]
 
-  def findByTxId(txId: DoubleSha256Digest): Future[Option[TransactionDb]] = {
+  def findByTxId(txId: DoubleSha256DigestBE)(implicit
+      ec: ExecutionContext): Future[Option[TransactionDb]] = {
+    findByTxIds(Vector(txId)).map(_.headOption)
+  }
+
+  def findByTxId(txId: DoubleSha256Digest)(implicit
+      ec: ExecutionContext): Future[Option[TransactionDb]] = {
     findByTxId(txId.flip)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -459,6 +459,8 @@ trait WalletApi extends StartStopAsync[WalletApi] {
   /** Finds all the outputs in our wallet being spent in the given transaction */
   def findOutputsBeingSpent(tx: Transaction): Future[Vector[SpendingInfoDb]]
 
+  def findByScriptPubKey(
+      scriptPubKey: ScriptPubKey): Future[Vector[SpendingInfoDb]]
 }
 
 case class WalletInfo(

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -63,14 +63,14 @@ trait WalletApi extends StartStopAsync[WalletApi] {
     */
   def processTransaction(
       transaction: Transaction,
-      blockHash: Option[DoubleSha256DigestBE]): Future[WalletApi]
+      blockHashOpt: Option[DoubleSha256DigestBE]): Future[WalletApi]
 
   def processTransactions(
       transactions: Vector[Transaction],
-      blockHash: Option[DoubleSha256DigestBE])(implicit
+      blockHashOpt: Option[DoubleSha256DigestBE])(implicit
       ec: ExecutionContext): Future[WalletApi] = {
     transactions.foldLeft(Future.successful(this)) { case (wallet, tx) =>
-      wallet.flatMap(_.processTransaction(tx, blockHash))
+      wallet.flatMap(_.processTransaction(tx, blockHashOpt))
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -487,6 +487,3 @@ case class WalletInfo(
 
 /** An HDWallet that uses Neutrino to sync */
 trait NeutrinoHDWalletApi extends HDWalletApi with NeutrinoWalletApi
-
-/** An HDWallet that supports Neutrino method of syncing */
-trait AnyHDWalletApi extends HDWalletApi with NeutrinoWalletApi

--- a/core/src/main/scala/org/bitcoins/core/hd/HDPath.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDPath.scala
@@ -47,9 +47,13 @@ trait HDPath extends BIP32Path {
 
   def coin: HDCoin = address.coin
 
+  def coinType: HDCoinType = coin.coinType
   def chain: HDChain = address.chain
 
+  def chainType: HDChainType = chain.chainType
   def address: HDAddress
+
+  def accountIdx: Int = address.account.index
 
   override val path: Vector[BIP32Node] = address.path
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.dlc.wallet
 
 import org.bitcoins.core.api.chain.ChainQueryApi
-import org.bitcoins.core.api.dlc.wallet.AnyDLCHDWalletApi
+import org.bitcoins.core.api.dlc.wallet.DLCNeutrinoHDWalletApi
 import org.bitcoins.core.api.dlc.wallet.db.DLCDb
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
@@ -49,7 +49,7 @@ import scala.concurrent.Future
 /** A [[Wallet]] with full DLC Functionality */
 abstract class DLCWallet
     extends Wallet
-    with AnyDLCHDWalletApi
+    with DLCNeutrinoHDWalletApi
     with DLCTransactionProcessing
     with IncomingDLCOffersHandling {
 

--- a/docs/wallet/wallet-rescan.md
+++ b/docs/wallet/wallet-rescan.md
@@ -68,7 +68,6 @@ val walletWithBitcoindF = for {
   walletWithBitcoind <- BitcoinSWalletTest.fundedWalletAndBitcoind(
   Some(BitcoindVersion.newest),
   MockNodeApi,
-  None,
   MockChainQueryApi,
   WalletCallbacks.empty)
 } yield walletWithBitcoind

--- a/docs/wallet/wallet-rescan.md
+++ b/docs/wallet/wallet-rescan.md
@@ -41,11 +41,15 @@ To run this example you need to make sure you have access to a bitcoind binary.
 You can download this with bitcoin-s by doing `sbt downloadBitcoind`
 
 ```scala mdoc:invisible
+import org.bitcoins.testkit.chain.MockChainQueryApi
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.fixtures._
 import org.bitcoins.testkit.wallet._
+import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.wallet.config.WalletAppConfig
+import org.bitcoins.wallet.WalletCallbacks
+import org.bitcoins.testkit.node.MockNodeApi
 import akka.actor.ActorSystem
 import scala.concurrent._
 import scala.concurrent.duration.DurationInt
@@ -61,8 +65,12 @@ implicit val walletAppConfig: WalletAppConfig = appConfig.walletConf
 
 //ok now let's spin up a bitcoind and a bitcoin-s wallet with funds in it
 val walletWithBitcoindF = for {
-  bitcoind <- BitcoinSFixture.createBitcoindWithFunds()
-  walletWithBitcoind <- BitcoinSWalletTest.createWalletWithBitcoindCallbacks(bitcoind)
+  walletWithBitcoind <- BitcoinSWalletTest.fundedWalletAndBitcoind(
+  Some(BitcoindVersion.newest),
+  MockNodeApi,
+  None,
+  MockChainQueryApi,
+  WalletCallbacks.empty)
 } yield walletWithBitcoind
 
 val walletF = walletWithBitcoindF.map(_.wallet)
@@ -99,7 +107,8 @@ val clearedWalletF = for {
 val addrBatchSize = 100
 //ok now that we have a cleared wallet, we need to rescan and find our fudns again!
 val rescannedBalanceF = for {
-  w <- clearedWalletF
+  _ <- clearedWalletF
+  w <- walletF
   _ <- w.fullRescanNeutrinoWallet(addrBatchSize)
   balanceAfterRescan <- w.getBalance()
 } yield {

--- a/docs/wallet/wallet-sync.md
+++ b/docs/wallet/wallet-sync.md
@@ -112,6 +112,8 @@ val getBlockHeaderFunc = { hash: DoubleSha256DigestBE => bitcoind.getBlockHeader
 
 val getBlockFunc = {hash: DoubleSha256DigestBE => bitcoind.getBlockRaw(hash) }
 
+val genesisHashBEF = bitcoind.getBlockHash(0)
+
 //yay! We are now all setup. Using our 3 functions above and a wallet, we can now sync
 //a fresh wallet
 implicit val walletAppConfig = WalletAppConfig.fromDefaultDatadir()
@@ -120,8 +122,11 @@ val feeRateProvider: FeeRateApi = MempoolSpaceProvider.fromBlockTarget(6, proxyP
 val wallet = Wallet(bitcoind, bitcoind, feeRateProvider)
 
 //yay! we have a synced wallet
-val syncedWalletF = WalletSync.syncFullBlocks(wallet,
-                                                  getBlockHeaderFunc,
-                                                  getBestBlockHashFunc,
-                                                  getBlockFunc)
+val syncedWalletF = genesisHashBEF.flatMap { genesisHash => 
+  WalletSync.syncFullBlocks(wallet,
+      getBlockHeaderFunc,
+      getBestBlockHashFunc,
+      getBlockFunc, 
+      genesisHash)
+}
 ```

--- a/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
@@ -30,7 +30,7 @@ case class NodeCallbackStreamManager(callbacks: NodeCallbacks)(implicit
     with StartStopAsync[Unit]
     with Logging {
   import system.dispatcher
-  private val maxBufferSize: Int = 25
+  private val maxBufferSize: Int = 1000
 
   private val filterQueueSource: Source[
     Vector[(DoubleSha256Digest, GolombFilter)],

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeFundedWalletBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeFundedWalletBitcoind.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.testkit.node
 
-import org.bitcoins.core.api.wallet.HDWalletApi
+import org.bitcoins.core.api.wallet.NeutrinoHDWalletApi
 import org.bitcoins.node.{NeutrinoNode, Node}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.node.fixture.{
@@ -16,7 +16,7 @@ import org.bitcoins.testkit.node.fixture.{
   */
 trait NodeFundedWalletBitcoind {
   def node: Node
-  def wallet: HDWalletApi
+  def wallet: NeutrinoHDWalletApi
   def bitcoindRpc: BitcoindRpcClient
 
   /** Helper method to convert from this to a [[NodeConnectedWithBitcoind]] */
@@ -25,7 +25,7 @@ trait NodeFundedWalletBitcoind {
 
 case class NeutrinoNodeFundedWalletBitcoind(
     node: NeutrinoNode,
-    wallet: HDWalletApi,
+    wallet: NeutrinoHDWalletApi,
     bitcoindRpc: BitcoindRpcClient)
     extends NodeFundedWalletBitcoind {
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeFundedWalletBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeFundedWalletBitcoind.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.testkit.node
 
+import org.bitcoins.core.api.wallet.HDWalletApi
 import org.bitcoins.node.{NeutrinoNode, Node}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.node.fixture.{
   NeutrinoNodeConnectedWithBitcoind,
   NodeConnectedWithBitcoind
 }
-import org.bitcoins.wallet.Wallet
 
 /** Creates
   * 1. a funded bitcoind wallet
@@ -16,7 +16,7 @@ import org.bitcoins.wallet.Wallet
   */
 trait NodeFundedWalletBitcoind {
   def node: Node
-  def wallet: Wallet
+  def wallet: HDWalletApi
   def bitcoindRpc: BitcoindRpcClient
 
   /** Helper method to convert from this to a [[NodeConnectedWithBitcoind]] */
@@ -25,7 +25,7 @@ trait NodeFundedWalletBitcoind {
 
 case class NeutrinoNodeFundedWalletBitcoind(
     node: NeutrinoNode,
-    wallet: Wallet,
+    wallet: HDWalletApi,
     bitcoindRpc: BitcoindRpcClient)
     extends NodeFundedWalletBitcoind {
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -359,7 +359,8 @@ object NodeUnitTest extends P2PLogger {
     import system.dispatcher
     val walletWithBitcoind = {
       WalletWithBitcoindRpc(fundedWalletBitcoind.wallet,
-                            fundedWalletBitcoind.bitcoindRpc)
+                            fundedWalletBitcoind.bitcoindRpc,
+                            appConfig.walletConf)
     }
 
     //these need to be done in order, as the spv node needs to be

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -366,7 +366,7 @@ object NodeUnitTest extends P2PLogger {
     //these need to be done in order, as the spv node needs to be
     //stopped before the bitcoind node is stopped
     val destroyedF = for {
-      _ <- BitcoinSWalletTest.destroyWallet(walletWithBitcoind.wallet)
+      _ <- BitcoinSWalletTest.destroyWallet(walletWithBitcoind)
       _ <- destroyNodeConnectedWithBitcoind(
         fundedWalletBitcoind.toNodeConnectedWithBitcoind)
     } yield ()

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -366,7 +366,8 @@ object NodeUnitTest extends P2PLogger {
     //these need to be done in order, as the spv node needs to be
     //stopped before the bitcoind node is stopped
     val destroyedF = for {
-      _ <- BitcoinSWalletTest.destroyWallet(walletWithBitcoind)
+      _ <- BitcoinSWalletTest.destroyOnlyWalletWithBitcoindCached(
+        walletWithBitcoind)
       _ <- destroyNodeConnectedWithBitcoind(
         fundedWalletBitcoind.toNodeConnectedWithBitcoind)
     } yield ()

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
@@ -37,9 +37,10 @@ trait BitcoinSServerMainBitcoindFixture
         _ <- walletHolder.createNewAccount(hdAccount = account1,
                                            keyManagerParams =
                                              walletHolder.keyManager.kmParams)
-
-        _ <- FundWalletUtil.fundWalletWithBitcoind(
-          WalletWithBitcoindRpc(walletHolder, bitcoind))
+        walletWithBitcoind = WalletWithBitcoindRpc(walletHolder,
+                                                   bitcoind,
+                                                   config.walletConf)
+        _ <- FundWalletUtil.fundWalletWithBitcoind(walletWithBitcoind)
       } yield {
         ServerWithBitcoind(bitcoind, server)
       }

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
@@ -30,20 +30,16 @@ trait BitcoinSServerMainBitcoindFixture
         bitcoind <- cachedBitcoindWithFundsF
         config = BitcoinSServerMainUtil.buildBitcoindBitcoinSAppConfig(bitcoind)
         server = new BitcoinSServerMain(ServerArgParser.empty)(system, config)
-        _ <- server.start()
-        //need to create account 2 to use FundWalletUtil.fundWalletWithBitcoind
-        wallet <- server.conf.walletConf.createHDWallet(bitcoind,
-                                                        bitcoind,
-                                                        bitcoind)
-        _ <- wallet.start()
-        account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
+        walletHolder <- server.start()
+        account1 = WalletTestUtil.getHdAccount1(config.walletConf)
 
         //needed for fundWalletWithBitcoind
-        _ <- wallet.createNewAccount(hdAccount = account1,
-                                     kmParams = wallet.keyManager.kmParams)
+        _ <- walletHolder.createNewAccount(hdAccount = account1,
+                                           keyManagerParams =
+                                             walletHolder.keyManager.kmParams)
 
         _ <- FundWalletUtil.fundWalletWithBitcoind(
-          WalletWithBitcoindRpc(wallet, bitcoind))
+          WalletWithBitcoindRpc(walletHolder, bitcoind))
       } yield {
         ServerWithBitcoind(bitcoind, server)
       }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -24,6 +24,7 @@ trait BaseWalletTest extends EmbeddedPg { _: Suite with BitcoinSAkkaAsyncTest =>
     super[EmbeddedPg].afterAll()
   }
 
+
   /** Wallet config with data directory set to user temp directory */
   protected def getFreshConfig: BitcoinSAppConfig = {
     val bipPasswordOpt = KeyManagerTestUtil.bip39PasswordOpt

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -24,7 +24,6 @@ trait BaseWalletTest extends EmbeddedPg { _: Suite with BitcoinSAkkaAsyncTest =>
     super[EmbeddedPg].afterAll()
   }
 
-
   /** Wallet config with data directory set to user temp directory */
   protected def getFreshConfig: BitcoinSAppConfig = {
     val bipPasswordOpt = KeyManagerTestUtil.bip39PasswordOpt

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -144,10 +144,15 @@ trait BitcoinSWalletTest
   /** Fixture for a wallet with default configuration with no funds in it */
   def withNewWallet(test: OneArgAsyncTest)(implicit
       walletAppConfig: WalletAppConfig): FutureOutcome = {
-    makeDependentFixture(build = { () =>
+    makeDependentFixture[Wallet](build = { () =>
                            createDefaultWallet(nodeApi, chainQueryApi)
                          },
-                         destroy = destroyWallet)(test)
+                         destroy = { wallet =>
+                           for {
+                             _ <- destroyWallet(wallet)
+                             _ <- destroyWalletAppConfig(walletAppConfig)
+                           } yield ()
+                         })(test)
   }
 
   def withNewWallet2Accounts(test: OneArgAsyncTest)(implicit

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -582,6 +582,7 @@ object BitcoinSWalletTest extends WalletLogger {
     import wallet.ec
     for {
       _ <- destroyWallet(wallet)
+      _ <- destroyWalletAppConfig(wallet.walletConfig)
       _ <- wallet.dlcConfig.stop()
     } yield ()
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -144,15 +144,17 @@ trait BitcoinSWalletTest
   /** Fixture for a wallet with default configuration with no funds in it */
   def withNewWallet(test: OneArgAsyncTest)(implicit
       walletAppConfig: WalletAppConfig): FutureOutcome = {
-    makeDependentFixture[Wallet](build = { () =>
-                           createDefaultWallet(nodeApi, chainQueryApi)
-                         },
-                         destroy = { wallet =>
-                           for {
-                             _ <- destroyWallet(wallet)
-                             _ <- destroyWalletAppConfig(walletAppConfig)
-                           } yield ()
-                         })(test)
+    makeDependentFixture[Wallet](
+      build = { () =>
+        createDefaultWallet(nodeApi, chainQueryApi)
+      },
+      destroy = { wallet =>
+        for {
+          _ <- destroyWallet(wallet)
+          _ <- destroyWalletAppConfig(walletAppConfig)
+        } yield ()
+      }
+    )(test)
   }
 
   def withNewWallet2Accounts(test: OneArgAsyncTest)(implicit

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -179,8 +179,10 @@ trait BitcoinSWalletTestCachedBitcoinV19
       for {
         walletWithBitcoind <- createWalletWithBitcoindCallbacks(
           bitcoind = bitcoind)
-        walletWithBitcoindV19 = WalletWithBitcoindV19(walletWithBitcoind.wallet,
-                                                      bitcoind)
+        walletWithBitcoindV19 = WalletWithBitcoindV19(
+          walletWithBitcoind.wallet,
+          bitcoind,
+          walletWithBitcoind.walletConfig)
         fundedWallet <- FundWalletUtil
           .fundWalletWithBitcoind(walletWithBitcoindV19)
         _ <- SyncUtil.syncWalletFullBlocks(wallet = fundedWallet.wallet,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -59,7 +59,7 @@ trait BitcoinSWalletTestCachedBitcoind
     makeDependentFixture[WalletWithBitcoind[_]](
       builder,
       { case walletWithBitcoind: WalletWithBitcoind[_] =>
-        destroyWallet(walletWithBitcoind.wallet)
+        destroyWallet(walletWithBitcoind)
       })(test)
   }
 
@@ -83,7 +83,7 @@ trait BitcoinSWalletTestCachedBitcoind
     makeDependentFixture[WalletWithBitcoind[_]](
       builder,
       { case walletWithBitcoind: WalletWithBitcoind[_] =>
-        destroyWallet(walletWithBitcoind.wallet)
+        destroyWallet(walletWithBitcoind)
       })(test)
   }
 
@@ -194,7 +194,7 @@ trait BitcoinSWalletTestCachedBitcoinV19
     makeDependentFixture[WalletWithBitcoind[_]](
       builder,
       destroy = { case walletWithBitcoind: WalletWithBitcoind[_] =>
-        destroyWallet(walletWithBitcoind.wallet)
+        destroyWallet(walletWithBitcoind)
       })(test)
   }
 
@@ -218,7 +218,7 @@ trait BitcoinSWalletTestCachedBitcoinV19
     makeDependentFixture[WalletWithBitcoind[_]](
       builder,
       { case walletWithBitcoind: WalletWithBitcoind[_] =>
-        destroyWallet(walletWithBitcoind.wallet)
+        destroyWallet(walletWithBitcoind)
       })(test)
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -15,7 +15,7 @@ import org.bitcoins.testkit.rpc.{
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest.{
   createWalletWithBitcoind,
   createWalletWithBitcoindCallbacks,
-  destroyWallet
+  destroyOnlyWalletWithBitcoindCached
 }
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.scalatest.{FutureOutcome, Outcome}
@@ -59,7 +59,7 @@ trait BitcoinSWalletTestCachedBitcoind
     makeDependentFixture[WalletWithBitcoind[_]](
       builder,
       { case walletWithBitcoind: WalletWithBitcoind[_] =>
-        destroyWallet(walletWithBitcoind)
+        destroyOnlyWalletWithBitcoindCached(walletWithBitcoind)
       })(test)
   }
 
@@ -83,7 +83,7 @@ trait BitcoinSWalletTestCachedBitcoind
     makeDependentFixture[WalletWithBitcoind[_]](
       builder,
       { case walletWithBitcoind: WalletWithBitcoind[_] =>
-        destroyWallet(walletWithBitcoind)
+        destroyOnlyWalletWithBitcoindCached(walletWithBitcoind)
       })(test)
   }
 
@@ -194,7 +194,7 @@ trait BitcoinSWalletTestCachedBitcoinV19
     makeDependentFixture[WalletWithBitcoind[_]](
       builder,
       destroy = { case walletWithBitcoind: WalletWithBitcoind[_] =>
-        destroyWallet(walletWithBitcoind)
+        destroyOnlyWalletWithBitcoindCached(walletWithBitcoind)
       })(test)
   }
 
@@ -218,7 +218,7 @@ trait BitcoinSWalletTestCachedBitcoinV19
     makeDependentFixture[WalletWithBitcoind[_]](
       builder,
       { case walletWithBitcoind: WalletWithBitcoind[_] =>
-        destroyWallet(walletWithBitcoind)
+        destroyOnlyWalletWithBitcoindCached(walletWithBitcoind)
       })(test)
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.wallet.HDWalletApi
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -33,7 +34,7 @@ trait FundWalletUtil extends Logging {
       pair: T)(implicit ec: ExecutionContext): Future[T] = {
     val (wallet, bitcoind) = (pair.wallet, pair.bitcoind)
 
-    val defaultAccount = wallet.walletConfig.defaultAccount
+    val defaultAccount = pair.walletConfig.defaultAccount
     val fundedDefaultAccountWalletF =
       FundWalletUtil.fundAccountForWalletWithBitcoind(
         amts = defaultAcctAmts,
@@ -42,7 +43,7 @@ trait FundWalletUtil extends Logging {
         bitcoind = bitcoind
       )
 
-    val hdAccount1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
+    val hdAccount1 = WalletTestUtil.getHdAccount1(pair.walletConfig)
     val fundedAccount1WalletF = for {
       fundedDefaultAcct <- fundedDefaultAccountWalletF
 
@@ -89,9 +90,9 @@ trait FundWalletUtil extends Logging {
   def fundAccountForWalletWithBitcoind(
       amts: Vector[CurrencyUnit],
       account: HDAccount,
-      wallet: Wallet,
+      wallet: HDWalletApi,
       bitcoind: BitcoindRpcClient)(implicit
-      ec: ExecutionContext): Future[Wallet] = {
+      ec: ExecutionContext): Future[HDWalletApi] = {
 
     val addressesF: Future[Vector[BitcoinAddress]] = Future.sequence {
       Vector.fill(3)(wallet.getNewAddress(account))

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletWithBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletWithBitcoind.scala
@@ -1,19 +1,24 @@
 package org.bitcoins.testkit.wallet
 
+import org.bitcoins.core.api.wallet.HDWalletApi
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.wallet.Wallet
 
 sealed trait WalletWithBitcoind[T <: BitcoindRpcClient] {
-  def wallet: Wallet
+  def wallet: HDWalletApi
   def bitcoind: T
 }
 
 /** General pairing of a wallet with a bitcoind rpc. If you don't care about
   * the version of bitcoind, you should use this.
   */
-case class WalletWithBitcoindRpc(wallet: Wallet, bitcoind: BitcoindRpcClient)
+case class WalletWithBitcoindRpc(
+    wallet: HDWalletApi,
+    bitcoind: BitcoindRpcClient)
     extends WalletWithBitcoind[BitcoindRpcClient]
 
-case class WalletWithBitcoindV19(wallet: Wallet, bitcoind: BitcoindV19RpcClient)
+case class WalletWithBitcoindV19(
+    wallet: HDWalletApi,
+    bitcoind: BitcoindV19RpcClient)
     extends WalletWithBitcoind[BitcoindV19RpcClient]

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletWithBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletWithBitcoind.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.testkit.wallet
 
-import org.bitcoins.core.api.wallet.HDWalletApi
+import org.bitcoins.core.api.wallet.NeutrinoHDWalletApi
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.wallet.config.WalletAppConfig
 
 sealed trait WalletWithBitcoind[T <: BitcoindRpcClient] {
-  def wallet: HDWalletApi
+  def wallet: NeutrinoHDWalletApi
   def bitcoind: T
 
   def walletConfig: WalletAppConfig
@@ -16,13 +16,13 @@ sealed trait WalletWithBitcoind[T <: BitcoindRpcClient] {
   * the version of bitcoind, you should use this.
   */
 case class WalletWithBitcoindRpc(
-    wallet: HDWalletApi,
+    wallet: NeutrinoHDWalletApi,
     bitcoind: BitcoindRpcClient,
     walletConfig: WalletAppConfig)
     extends WalletWithBitcoind[BitcoindRpcClient]
 
 case class WalletWithBitcoindV19(
-    wallet: HDWalletApi,
+    wallet: NeutrinoHDWalletApi,
     bitcoind: BitcoindV19RpcClient,
     walletConfig: WalletAppConfig)
     extends WalletWithBitcoind[BitcoindV19RpcClient]

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletWithBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletWithBitcoind.scala
@@ -3,11 +3,13 @@ package org.bitcoins.testkit.wallet
 import org.bitcoins.core.api.wallet.HDWalletApi
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
-import org.bitcoins.wallet.Wallet
+import org.bitcoins.wallet.config.WalletAppConfig
 
 sealed trait WalletWithBitcoind[T <: BitcoindRpcClient] {
   def wallet: HDWalletApi
   def bitcoind: T
+
+  def walletConfig: WalletAppConfig
 }
 
 /** General pairing of a wallet with a bitcoind rpc. If you don't care about
@@ -15,10 +17,12 @@ sealed trait WalletWithBitcoind[T <: BitcoindRpcClient] {
   */
 case class WalletWithBitcoindRpc(
     wallet: HDWalletApi,
-    bitcoind: BitcoindRpcClient)
+    bitcoind: BitcoindRpcClient,
+    walletConfig: WalletAppConfig)
     extends WalletWithBitcoind[BitcoindRpcClient]
 
 case class WalletWithBitcoindV19(
     wallet: HDWalletApi,
-    bitcoind: BitcoindV19RpcClient)
+    bitcoind: BitcoindV19RpcClient,
+    walletConfig: WalletAppConfig)
     extends WalletWithBitcoind[BitcoindV19RpcClient]

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
@@ -28,7 +28,7 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
   val exampleTag: InternalAddressTag = StorageLocationTag.HotStorage
 
   it should "correctly keep tagged utxos separated" in { walletWithBitcoind =>
-    val WalletWithBitcoindRpc(wallet, bitcoind) = walletWithBitcoind
+    val WalletWithBitcoindRpc(wallet, bitcoind, _) = walletWithBitcoind
     // the amount we're receiving from bitcoind
     val valueFromBitcoind = Bitcoins.one
 
@@ -119,7 +119,7 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
   it must "process a tagged tx correctly when we broadcast it and receive it in a block" in {
     walletWithBitcoind =>
       //see: https://github.com/bitcoin-s/bitcoin-s/issues/4238
-      val WalletWithBitcoindRpc(wallet, bitcoind) = walletWithBitcoind
+      val WalletWithBitcoindRpc(wallet, bitcoind, _) = walletWithBitcoind
 
       val bitcoindAddrF = bitcoind.getNewAddress
       val walletAddr1F = wallet.getNewAddress()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
@@ -78,7 +78,6 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
           .getUnconfirmedBalance(exampleTag)
           .map(unconfirmed => assert(unconfirmed == valueFromBitcoind))
 
-      account <- wallet.getDefaultAccount()
       feeRate <- wallet.getFeeRate()
       rawTxHelper <- bitcoind.getNewAddress.flatMap { addr =>
         val output = TransactionOutput(valueToBitcoind, addr.scriptPubKey)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -257,10 +257,9 @@ class FundTransactionHandlingTest
       expectedUtxos <- wallet.listUtxos(account.hdAccount, tag)
       fundRawTxHelper <-
         wallet
-          .fundRawTransactionInternal(
+          .fundRawTransaction(
             destinations = Vector(destination),
             feeRate = feeRate,
-            fromAccount = account,
             fromTagOpt = Some(tag),
             markAsReserved = true
           )

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -148,8 +148,9 @@ class FundTransactionHandlingTest
       val amt = Bitcoins(0.1)
       val newDestination = destination.copy(value = amt)
       val wallet = fundedWallet.wallet
-      val account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
-      val account1DbF = wallet.accountDAO.findByAccount(account1)
+      val walletConfig = fundedWallet.walletConfig
+      val account1 = WalletTestUtil.getHdAccount1(walletConfig)
+      val account1DbF = wallet.findAccount(account1)
       for {
         feeRate <- wallet.getFeeRate()
         account1DbOpt <- account1DbF
@@ -170,8 +171,9 @@ class FundTransactionHandlingTest
       val amt = Bitcoins(1.1)
       val newDestination = destination.copy(value = amt)
       val wallet = fundedWallet.wallet
-      val account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
-      val account1DbF = wallet.accountDAO.findByAccount(account1)
+      val walletConfig = fundedWallet.walletConfig
+      val account1 = WalletTestUtil.getHdAccount1(walletConfig)
+      val account1DbF = wallet.findAccount(account1)
       val fundedTxF = for {
         feeRate <- wallet.getFeeRate()
         account1DbOpt <- account1DbF
@@ -192,7 +194,7 @@ class FundTransactionHandlingTest
       val fundedTxF = for {
         feeRate <- wallet.getFeeRate()
         _ <- wallet.createNewAccount(wallet.keyManager.kmParams)
-        accounts <- wallet.accountDAO.findAll()
+        accounts <- wallet.listAccounts()
         account2 = accounts.find(_.hdAccount.index == 2).get
 
         addr <- wallet.getNewAddress(account2)
@@ -224,9 +226,8 @@ class FundTransactionHandlingTest
                                                      fromTagOpt = None,
                                                      markAsReserved = true)
 
-        spendingInfos <- wallet.spendingInfoDAO.findOutputsBeingSpent(
-          fundRawTxHelper.unsignedTx)
-        reserved <- wallet.spendingInfoDAO.findByTxoState(TxoState.Reserved)
+        spendingInfos <- wallet.findOutputsBeingSpent(fundRawTxHelper.unsignedTx)
+        reserved <- wallet.listUtxos(TxoState.Reserved)
       } yield {
         assert(spendingInfos.exists(_.state == TxoState.Reserved))
         assert(reserved.size == spendingInfos.size)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -158,7 +158,7 @@ class FundTransactionHandlingTest
         fundRawTxHelper <- wallet.fundRawTransaction(Vector(newDestination),
                                                      feeRate,
                                                      account1DbOpt.get,
-  markAsReserved = true)
+                                                     markAsReserved = true)
       } yield {
         val fundedTx = fundRawTxHelper.unsignedTx
         assert(fundedTx.inputs.nonEmpty)
@@ -233,7 +233,8 @@ class FundTransactionHandlingTest
                                                      fromTagOpt = None,
                                                      markAsReserved = true)
 
-        spendingInfos <- wallet.findOutputsBeingSpent(fundRawTxHelper.unsignedTx)
+        spendingInfos <- wallet.findOutputsBeingSpent(
+          fundRawTxHelper.unsignedTx)
         reserved <- wallet.listUtxos(TxoState.Reserved)
       } yield {
         assert(spendingInfos.exists(_.state == TxoState.Reserved))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -3,7 +3,7 @@ package org.bitcoins.wallet
 import org.bitcoins.core.api.wallet.SyncHeightDescriptor
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.FilterType
-import org.bitcoins.core.hd.{HDCoin, LegacyHDPath}
+import org.bitcoins.core.hd.LegacyHDPath
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.script.EmptyScriptSignature
 import org.bitcoins.core.protocol.transaction._

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -33,7 +33,8 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
   }
 
   it must "process a block" in { param =>
-    val WalletWithBitcoindV19(wallet, bitcoind) = param
+    val wallet = param.wallet
+    val bitcoind = param.bitcoind
 
     for {
       startingUtxos <- wallet.listUtxos()
@@ -66,7 +67,8 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
   }
 
   it must "process coinbase txs" in { param =>
-    val WalletWithBitcoindV19(wallet, bitcoind) = param
+    val wallet = param.wallet
+    val bitcoind = param.bitcoind
     for {
       startingUtxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
       startingBalance <- wallet.getBalance()
@@ -91,7 +93,8 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
   }
 
   it must "process coinbase txs using filters" in { param =>
-    val WalletWithBitcoindV19(wallet, bitcoind) = param
+    val wallet = param.wallet
+    val bitcoind = param.bitcoind
 
     for {
       startingUtxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
@@ -119,7 +122,8 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
   }
 
   it must "receive and spend funds in the same block" in { param =>
-    val WalletWithBitcoindV19(wallet, bitcoind) = param
+    val wallet = param.wallet
+    val bitcoind = param.bitcoind
     val recvAmount = Bitcoins.one
     val sendAmount = Bitcoins(0.5)
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -188,7 +188,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
         )
         processedSpendingTx <- wallet.processTransaction(transaction =
                                                            rawTxHelper.signedTx,
-                                                         blockHash = None)
+                                                         blockHashOpt = None)
         balance <- processedSpendingTx.getBalance()
       } yield assert(balance == amount)
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -71,7 +71,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
   val DEFAULT_ADDR_BATCH_SIZE = 10
   it must "be able to discover funds that belong to the wallet using WalletApi.rescanNeutrinoWallet" in {
     fixture: WalletWithBitcoindRpc =>
-      val WalletWithBitcoindRpc(wallet, _) = fixture
+      val wallet = fixture.wallet
 
       val initBalanceF = wallet.getBalance()
 
@@ -93,7 +93,8 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   it must "be able to discover funds that occurred within a certain range" in {
     fixture: WalletWithBitcoindRpc =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = fixture
+      val wallet = fixture.wallet
+      val bitcoind = fixture.bitcoind
 
       val amt = Bitcoins.one
       val numBlocks = 1
@@ -154,7 +155,8 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   it must "be able to discover funds using multiple batches" in {
     fixture: WalletWithBitcoindRpc =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = fixture
+      val wallet = fixture.wallet
+      val bitcoind = fixture.bitcoind
 
       val amt = Bitcoins.one
       val numBlocks = 1
@@ -217,7 +219,8 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   it must "be able to discover funds that occurred from the wallet creation time" in {
     fixture: WalletWithBitcoindRpc =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = fixture
+      val wallet = fixture.wallet
+      val bitcoind = fixture.bitcoind
 
       val amt = Bitcoins.one
       val numBlocks = 1
@@ -269,7 +272,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   it must "NOT discover funds that happened OUTSIDE of a certain range of block hashes" in {
     fixture: WalletWithBitcoindRpc =>
-      val WalletWithBitcoindRpc(wallet, _) = fixture
+      val wallet = fixture.wallet
 
       val initBalanceF = wallet.getBalance()
 
@@ -316,7 +319,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   it must "acknowledge that a rescan is already in progress" in {
     fixture: WalletWithBitcoindRpc =>
-      val WalletWithBitcoindRpc(wallet, _) = fixture
+      val wallet = fixture.wallet
       //do these in parallel on purpose to simulate multiple threads calling rescan
       val startF = wallet.rescanNeutrinoWallet(startOpt = None,
                                                endOpt = None,
@@ -348,7 +351,8 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   it must "still receive payments to addresses generated pre-rescan" in {
     fixture: WalletWithBitcoindRpc =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = fixture
+      val wallet = fixture.wallet
+      val bitcoind = fixture.bitcoind
       val addressNoFundsF = wallet.getNewAddress()
 
       //start a rescan without sending payment to that address
@@ -384,7 +388,8 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   it must "discover funds after rescanning twice" in {
     fixture: WalletWithBitcoindRpc =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = fixture
+      val wallet = fixture.wallet
+      val bitcoind = fixture.bitcoind
       val amt = Bitcoins.one
       for {
         _ <- wallet.rescanNeutrinoWallet(startOpt = None,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -244,7 +244,7 @@ class UTXOLifeCycleTest
       _ <- wallet.processTransaction(tx, Some(hash))
 
       pendingCoins <-
-        wallet.spendingInfoDAO.findByScriptPubKey(addr.scriptPubKey)
+        wallet.findByScriptPubKey(addr.scriptPubKey)
     } yield {
       assert(
         pendingCoins.forall(_.state == TxoState.PendingConfirmationsReceived))
@@ -275,7 +275,7 @@ class UTXOLifeCycleTest
       )
 
       updatedCoin <-
-        wallet.spendingInfoDAO.findByScriptPubKey(addr.scriptPubKey)
+        wallet.findByScriptPubKey(addr.scriptPubKey)
       newTransactions <- wallet.listTransactions()
       _ = assert(updatedCoin.forall(_.state == PendingConfirmationsReceived))
       _ = assert(!oldTransactions.map(_.transaction).contains(tx))
@@ -287,7 +287,7 @@ class UTXOLifeCycleTest
       // Need to call this to actually update the state, normally a node callback would do this
       _ <- wallet.updateUtxoPendingStates()
       confirmedCoins <-
-        wallet.spendingInfoDAO.findByScriptPubKey(addr.scriptPubKey)
+        wallet.findByScriptPubKey(addr.scriptPubKey)
     } yield assert(confirmedCoins.forall(_.state == ConfirmedReceived))
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -207,7 +207,7 @@ class UTXOLifeCycleTest
                                         newTags = Vector.empty)
 
       updatedCoin <-
-        wallet.spendingInfoDAO.findByScriptPubKey(addr.scriptPubKey)
+        wallet.findByScriptPubKey(addr.scriptPubKey)
       newTransactions <- wallet.listTransactions()
     } yield {
       assert(updatedCoin.forall(_.state == TxoState.BroadcastReceived))
@@ -234,7 +234,7 @@ class UTXOLifeCycleTest
                                         newTags = Vector.empty)
 
       updatedCoin <-
-        wallet.spendingInfoDAO.findByScriptPubKey(addr.scriptPubKey)
+        wallet.findByScriptPubKey(addr.scriptPubKey)
       newTransactions <- wallet.listTransactions()
       _ = assert(updatedCoin.forall(_.state == TxoState.BroadcastReceived))
 
@@ -389,11 +389,10 @@ class UTXOLifeCycleTest
       for {
         oldTransactions <- wallet.listTransactions()
         account <- accountF
-        rawTxHelper <- wallet.fundRawTransactionInternal(
+        rawTxHelper <- wallet.fundRawTransaction(
           destinations = Vector(dummyOutput),
           feeRate = SatoshisPerVirtualByte.one,
           fromAccount = account,
-          fromTagOpt = None,
           markAsReserved = true
         )
         builderResult = rawTxHelper.txBuilderWithFinalizer.builder.result()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -45,7 +45,7 @@ class UTXOLifeCycleTest
       .fromString("bcrt1qlhctylgvdsvaanv539rg7hyn0sjkdm23y70kgq")
 
   it should "track a utxo state change to broadcast spent" in { param =>
-    val WalletWithBitcoindRpc(wallet, _) = param
+    val wallet = param.wallet
 
     for {
       oldTransactions <- wallet.listTransactions()
@@ -62,8 +62,8 @@ class UTXOLifeCycleTest
   }
 
   it should "track a utxo state change to confirmed spent" in { param =>
-    val WalletWithBitcoindRpc(wallet, bitcoind) = param
-
+    val wallet = param.wallet
+    val bitcoind = param.bitcoind
     for {
       oldTransactions <- wallet.listTransactions()
       tx <- wallet.sendToAddress(testAddr, Satoshis(3000), None)
@@ -96,7 +96,7 @@ class UTXOLifeCycleTest
   }
 
   it should "handle an RBF transaction on unconfirmed coins" in { param =>
-    val WalletWithBitcoindRpc(wallet, _) = param
+    val wallet = param.wallet
 
     for {
       tx <- wallet.sendToAddress(testAddr,
@@ -117,7 +117,7 @@ class UTXOLifeCycleTest
   }
 
   it should "handle attempting to spend an immature coinbase" in { param =>
-    val WalletWithBitcoindRpc(wallet, _) = param
+    val wallet = param.wallet
 
     for {
       tx <- wallet.sendToAddress(testAddr, Satoshis(3000), None)
@@ -141,7 +141,8 @@ class UTXOLifeCycleTest
   }
 
   it should "handle processing a new spending tx for a spent utxo" in { param =>
-    val WalletWithBitcoindRpc(wallet, bitcoind) = param
+    val wallet = param.wallet
+    val bitcoind = param.bitcoind
 
     for {
       oldTransactions <- wallet.listTransactions()
@@ -187,7 +188,8 @@ class UTXOLifeCycleTest
   }
 
   it should "track a utxo state change to broadcast received" in { param =>
-    val WalletWithBitcoindRpc(wallet, bitcoind) = param
+    val wallet = param.wallet
+    val bitcoind = param.bitcoind
 
     for {
       oldTransactions <- wallet.listTransactions()
@@ -213,7 +215,8 @@ class UTXOLifeCycleTest
   }
 
   it should "track a utxo state change to pending received" in { param =>
-    val WalletWithBitcoindRpc(wallet, bitcoind) = param
+    val wallet = param.wallet
+    val bitcoind = param.bitcoind
 
     for {
       oldTransactions <- wallet.listTransactions()
@@ -249,7 +252,8 @@ class UTXOLifeCycleTest
   }
 
   it should "track a utxo state change to confirmed received" in { param =>
-    val WalletWithBitcoindRpc(wallet, bitcoind) = param
+    val wallet = param.wallet
+    val bitcoind = param.bitcoind
 
     for {
       oldTransactions <- wallet.listTransactions()
@@ -287,7 +291,7 @@ class UTXOLifeCycleTest
   }
 
   it should "track a utxo state change to reserved" in { param =>
-    val WalletWithBitcoindRpc(wallet, _) = param
+    val wallet = param.wallet
 
     val dummyOutput = TransactionOutput(Satoshis(3000), EmptyScriptPubKey)
 
@@ -314,7 +318,7 @@ class UTXOLifeCycleTest
 
   it should "track a utxo state change to reserved and then to unreserved" in {
     param =>
-      val WalletWithBitcoindRpc(wallet, _) = param
+      val wallet = param.wallet
 
       val dummyOutput = TransactionOutput(Satoshis(3000), EmptyScriptPubKey)
 
@@ -345,7 +349,7 @@ class UTXOLifeCycleTest
 
   it should "track a utxo state change to reserved and then to unreserved using the transaction the utxo was included in" in {
     param =>
-      val WalletWithBitcoindRpc(wallet, _) = param
+      val wallet = param.wallet
 
       val dummyOutput = TransactionOutput(Satoshis(3000), EmptyScriptPubKey)
 
@@ -375,7 +379,7 @@ class UTXOLifeCycleTest
 
   it should "track a utxo state change to reserved and then to unreserved using a block" in {
     param =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = param
+      val wallet = param.wallet
 
       val dummyOutput =
         TransactionOutput(Satoshis(100000),
@@ -421,7 +425,8 @@ class UTXOLifeCycleTest
 
   it should "handle a utxo being spent from a tx outside the wallet" in {
     param =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = param
+      val wallet = param.wallet
+      val bitcoind = param.bitcoind
 
       for {
         utxo <- wallet.listUtxos().map(_.head)
@@ -466,7 +471,7 @@ class UTXOLifeCycleTest
 
   it must "fail to mark utxos as reserved if one of the utxos is already reserved" in {
     param =>
-      val WalletWithBitcoindRpc(wallet, _) = param
+      val wallet = param.wallet
       val utxosF = wallet.listUtxos()
 
       val reservedUtxoF: Future[SpendingInfoDb] = for {
@@ -499,7 +504,8 @@ class UTXOLifeCycleTest
 
   it must "mark a utxo as reserved that is still receiving confirmations and not unreserve the utxo" in {
     param =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = param
+      val wallet = param.wallet
+      val bitcoind = param.bitcoind
       val addressF = wallet.getNewAddress()
       val txIdF =
         addressF.flatMap(addr => bitcoind.sendToAddress(addr, Bitcoins.one))
@@ -542,7 +548,8 @@ class UTXOLifeCycleTest
 
   it must "transition a reserved utxo to spent when we are offline" in {
     param =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = param
+      val wallet = param.wallet
+      val bitcoind = param.bitcoind
       val bitcoindAddrF = bitcoind.getNewAddress
       val amt = Satoshis(100000)
       val utxoCountF = wallet.listUtxos()
@@ -589,7 +596,8 @@ class UTXOLifeCycleTest
 
   it should "track a utxo state change to broadcast spent and then to pending confirmations received (the spend transaction gets confirmed together with the receive transaction))" in {
     param =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = param
+      val wallet = param.wallet
+      val bitcoind = param.bitcoind
 
       val receiveValue = Bitcoins(8)
       val sendValue = Bitcoins(4)
@@ -643,7 +651,8 @@ class UTXOLifeCycleTest
 
   it should "track a utxo state change to broadcast spent and then to pending confirmations received (the spend transaction gets confirmed after the receive transaction))" in {
     param =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = param
+      val wallet = param.wallet
+      val bitcoind = param.bitcoind
 
       val receiveValue = Bitcoins(8)
       val sendValue = Bitcoins(4)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -15,6 +15,10 @@ import org.bitcoins.testkit.wallet.{
   WalletTestUtil,
   WalletWithBitcoindRpc
 }
+import org.bitcoins.wallet.models.{
+  IncomingTransactionDAO,
+  OutgoingTransactionDAO
+}
 import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
@@ -45,8 +49,12 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
   it should ("create an address, receive funds to it from bitcoind, import the"
     + " UTXO and construct a valid, signed transaction that's"
     + " broadcast and confirmed by bitcoind") in { walletWithBitcoind =>
-    val WalletWithBitcoindRpc(wallet, bitcoind) = walletWithBitcoind
+    val wallet = walletWithBitcoind.wallet
+    val bitcoind = walletWithBitcoind.bitcoind
+    val walletConfig = walletWithBitcoind.walletConfig
 
+    val incomingDAO = IncomingTransactionDAO()(system.dispatcher, walletConfig)
+    val outgoingDAO = OutgoingTransactionDAO()(system.dispatcher, walletConfig)
     for {
       addr <- wallet.getNewAddress()
       txId <- bitcoind.sendToAddress(addr, valueFromBitcoind)
@@ -75,7 +83,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
         wallet
           .getUnconfirmedBalance()
           .map(unconfirmed => assert(unconfirmed == valueFromBitcoind))
-      incomingTx <- wallet.incomingTxDAO.findByTxId(tx.txIdBE)
+      incomingTx <- incomingDAO.findByTxId(tx.txIdBE)
       _ = assert(incomingTx.isDefined)
       _ = assert(incomingTx.get.incomingAmount == valueFromBitcoind)
 
@@ -124,7 +132,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
         case other => fail(s"Found ${other.length} utxos!")
       }
 
-      outgoingTx <- wallet.outgoingTxDAO.findByTxId(txid)
+      outgoingTx <- outgoingDAO.findByTxId(txid)
       _ = assert(outgoingTx.isDefined)
       _ = assert(outgoingTx.get.inputAmount == valueFromBitcoind)
       _ = assert(outgoingTx.get.sentAmount == valueToBitcoind)
@@ -155,7 +163,9 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
   }
 
   it should "correctly bump fees with RBF" in { walletWithBitcoind =>
-    val WalletWithBitcoindRpc(wallet, bitcoind) = walletWithBitcoind
+    val wallet = walletWithBitcoind.wallet
+    val bitcoind = walletWithBitcoind.bitcoind
+    val walletConfig = walletWithBitcoind.walletConfig
 
     for {
       // Fund wallet
@@ -207,7 +217,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
       replacementInfo <- bitcoind.getRawTransaction(replacementTx.txIdBE)
 
-      utxos <- wallet.spendingInfoDAO.findOutputsBeingSpent(replacementTx)
+      utxos <- wallet.findOutputsBeingSpent(replacementTx)
     } yield {
       assert(utxos.forall(_.spendingTxIdOpt.contains(replacementTx.txIdBE)))
       // Check correct one was confirmed
@@ -216,7 +226,8 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
   }
 
   it should "fail to RBF a confirmed transaction" in { walletWithBitcoind =>
-    val WalletWithBitcoindRpc(wallet, bitcoind) = walletWithBitcoind
+    val wallet = walletWithBitcoind.wallet
+    val bitcoind = walletWithBitcoind.bitcoind
 
     for {
       // Fund wallet
@@ -250,7 +261,8 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
   }
 
   it should "correctly bump fees with CPFP" in { walletWithBitcoind =>
-    val WalletWithBitcoindRpc(wallet, bitcoind) = walletWithBitcoind
+    val wallet = walletWithBitcoind.wallet
+    val bitcoind = walletWithBitcoind.bitcoind
 
     for {
       // Fund wallet
@@ -291,7 +303,8 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   it should "correctly handle spending coinbase utxos" in {
     walletWithBitcoind =>
-      val WalletWithBitcoindRpc(wallet, bitcoind) = walletWithBitcoind
+      val wallet = walletWithBitcoind.wallet
+      val bitcoind = walletWithBitcoind.bitcoind
 
       // Makes fee rate for tx ~5 sat/vbyte
       val amountToSend = Bitcoins(49.99999000)
@@ -310,7 +323,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
         _ <- wallet.processBlock(block)
 
         // Verify we funded the wallet
-        allUtxos <- wallet.spendingInfoDAO.findAllSpendingInfos()
+        allUtxos <- wallet.listUtxos()
         _ = assert(allUtxos.size == 1)
         utxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
         _ = assert(utxos.size == 1)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -165,8 +165,6 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
   it should "correctly bump fees with RBF" in { walletWithBitcoind =>
     val wallet = walletWithBitcoind.wallet
     val bitcoind = walletWithBitcoind.bitcoind
-    val walletConfig = walletWithBitcoind.walletConfig
-
     for {
       // Fund wallet
       addr <- wallet.getNewAddress()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/sync/WalletSyncTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/sync/WalletSyncTest.scala
@@ -15,16 +15,23 @@ class WalletSyncTest extends BitcoinSWalletTestCachedBitcoinV19 {
   it must "sync a wallet with bitcoind" in { param =>
     val wallet = param.wallet
     val bitcoind = param.bitcoind
+    val genesisBlockHashF = bitcoind.getBlockHash(0)
     //first we need to implement the 'getBestBlockHashFunc' and 'getBlockHeaderFunc' functions
     val getBestBlockHashFunc = SyncUtil.getBestBlockHashFunc(bitcoind)
 
     val getBlockHeaderFunc = SyncUtil.getBlockHeaderFunc(bitcoind)
 
     val getBlockFunc = SyncUtil.getBlockFunc(bitcoind)
-    val syncedWalletF = WalletSync.syncFullBlocks(wallet,
-                                                  getBlockHeaderFunc,
-                                                  getBestBlockHashFunc,
-                                                  getBlockFunc)
+    val syncedWalletF = {
+      for {
+        genesisBlockHash <- genesisBlockHashF
+        synced <- WalletSync.syncFullBlocks(wallet,
+                                            getBlockHeaderFunc,
+                                            getBestBlockHashFunc,
+                                            getBlockFunc,
+                                            genesisBlockHash)
+      } yield synced
+    }
 
     val bitcoindBestHeaderF = bitcoind.getBestBlockHeader()
     for {

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -1,7 +1,13 @@
 package org.bitcoins.wallet
 
 import akka.actor.ActorSystem
-import org.bitcoins.core.api.wallet.SyncHeightDescriptor
+import org.bitcoins.core.api.wallet.{
+  BlockSyncState,
+  CoinSelectionAlgo,
+  NeutrinoHDWalletApi,
+  SyncHeightDescriptor,
+  WalletInfo
+}
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
@@ -9,12 +15,6 @@ import org.bitcoins.core.api.wallet.db.{
   AccountDb,
   SpendingInfoDb,
   TransactionDb
-}
-import org.bitcoins.core.api.wallet.{
-  AnyHDWalletApi,
-  BlockSyncState,
-  CoinSelectionAlgo,
-  WalletInfo
 }
 import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.crypto.ExtPublicKey
@@ -52,7 +52,7 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Random, Success}
 
 abstract class Wallet
-    extends AnyHDWalletApi
+    extends NeutrinoHDWalletApi
     with UtxoHandling
     with AddressHandling
     with AccountHandling

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -5,7 +5,11 @@ import org.bitcoins.core.api.wallet.SyncHeightDescriptor
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
-import org.bitcoins.core.api.wallet.db.{AccountDb, SpendingInfoDb}
+import org.bitcoins.core.api.wallet.db.{
+  AccountDb,
+  SpendingInfoDb,
+  TransactionDb
+}
 import org.bitcoins.core.api.wallet.{
   AnyHDWalletApi,
   BlockSyncState,
@@ -375,6 +379,21 @@ abstract class Wallet
         TxoState.pendingReceivedStates.contains(utxo.state))
       confirmed.foldLeft(CurrencyUnits.zero)(_ + _.output.value)
     }
+  }
+
+  override def findByOutPoints(outPoints: Vector[TransactionOutPoint]): Future[
+    Vector[SpendingInfoDb]] = {
+    spendingInfoDAO.findByOutPoints(outPoints)
+  }
+
+  override def findByTxId(
+      txIdBE: DoubleSha256DigestBE): Future[Option[TransactionDb]] = {
+    transactionDAO.findByTxId(txIdBE)
+  }
+
+  override def findOutputsBeingSpent(
+      tx: Transaction): Future[Vector[SpendingInfoDb]] = {
+    spendingInfoDAO.findOutputsBeingSpent(tx)
   }
 
   /** Enumerates all the TX outpoints in the wallet */

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -968,6 +968,11 @@ abstract class Wallet
     }
   }
 
+  override def findByScriptPubKey(
+      scriptPubKey: ScriptPubKey): Future[Vector[SpendingInfoDb]] = {
+    spendingInfoDAO.findByScriptPubKey(scriptPubKey)
+  }
+
   def startFeeRateCallbackScheduler(): Unit = {
     val feeRateChangedRunnable = new Runnable {
       override def run(): Unit = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -580,6 +580,10 @@ class WalletHolder(implicit ec: ExecutionContext)
   override def clearUtxos(account: HDAccount): Future[HDWalletApi] = delegate(
     _.clearUtxos(account))
 
+  override def clearAllAddresses(): Future[WalletApi] = {
+    delegate(_.clearAllAddresses())
+  }
+
   override def getAddress(
       account: AccountDb,
       chainType: HDChainType,
@@ -946,13 +950,21 @@ class WalletHolder(implicit ec: ExecutionContext)
     delegate(_.findByOutPoints(outPoints))
   }
 
-  override def findByTxId(
-      txIdBE: DoubleSha256DigestBE): Future[Option[TransactionDb]] = {
-    delegate(_.findByTxId(txIdBE))
+  override def findByTxIds(
+      txIds: Vector[DoubleSha256DigestBE]): Future[Vector[TransactionDb]] = {
+    delegate(_.findByTxIds(txIds))
   }
 
   override def findOutputsBeingSpent(
       tx: Transaction): Future[Vector[SpendingInfoDb]] = {
     delegate(_.findOutputsBeingSpent(tx))
+  }
+
+  override def findAccount(account: HDAccount): Future[Option[AccountDb]] = {
+    delegate(_.findAccount(account))
+  }
+
+  override def getNewAddress(account: AccountDb): Future[BitcoinAddress] = {
+    delegate(_.getNewAddress(account))
   }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -79,7 +79,8 @@ class WalletHolder(implicit ec: ExecutionContext)
     walletOpt.isDefined
   }
 
-  def replaceWallet(newWallet: DLCNeutrinoHDWalletApi): Future[DLCNeutrinoHDWalletApi] =
+  def replaceWallet(
+      newWallet: DLCNeutrinoHDWalletApi): Future[DLCNeutrinoHDWalletApi] =
     synchronized {
       val oldWalletOpt = walletOpt
       walletOpt = None
@@ -103,7 +104,8 @@ class WalletHolder(implicit ec: ExecutionContext)
       res
     }
 
-  private def delegate[T]: (DLCNeutrinoHDWalletApi => Future[T]) => Future[T] = {
+  private def delegate[T]: (
+      DLCNeutrinoHDWalletApi => Future[T]) => Future[T] = {
     Future(wallet).flatMap[T](_)
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -2,7 +2,7 @@ package org.bitcoins.wallet
 
 import grizzled.slf4j.Logging
 import org.bitcoins.core.api.chain.ChainQueryApi
-import org.bitcoins.core.api.dlc.wallet.AnyDLCHDWalletApi
+import org.bitcoins.core.api.dlc.wallet.DLCNeutrinoHDWalletApi
 import org.bitcoins.core.api.dlc.wallet.db.{
   DLCContactDb,
   DLCDb,
@@ -62,12 +62,12 @@ import scala.concurrent.{ExecutionContext, Future}
 class WalletNotInitialized extends Exception("The wallet is not initialized")
 
 class WalletHolder(implicit ec: ExecutionContext)
-    extends AnyDLCHDWalletApi
+    extends DLCNeutrinoHDWalletApi
     with Logging {
 
-  @volatile private var walletOpt: Option[AnyDLCHDWalletApi] = None
+  @volatile private var walletOpt: Option[DLCNeutrinoHDWalletApi] = None
 
-  private def wallet: AnyDLCHDWalletApi = synchronized {
+  private def wallet: DLCNeutrinoHDWalletApi = synchronized {
     walletOpt match {
       case Some(wallet) => wallet
       case None =>
@@ -79,7 +79,7 @@ class WalletHolder(implicit ec: ExecutionContext)
     walletOpt.isDefined
   }
 
-  def replaceWallet(newWallet: AnyDLCHDWalletApi): Future[AnyDLCHDWalletApi] =
+  def replaceWallet(newWallet: DLCNeutrinoHDWalletApi): Future[DLCNeutrinoHDWalletApi] =
     synchronized {
       val oldWalletOpt = walletOpt
       walletOpt = None
@@ -103,7 +103,7 @@ class WalletHolder(implicit ec: ExecutionContext)
       res
     }
 
-  private def delegate[T]: (AnyDLCHDWalletApi => Future[T]) => Future[T] = {
+  private def delegate[T]: (DLCNeutrinoHDWalletApi => Future[T]) => Future[T] = {
     Future(wallet).flatMap[T](_)
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -170,7 +170,8 @@ class WalletHolder(implicit ec: ExecutionContext)
       destinations: Vector[TransactionOutput],
       feeRate: FeeUnit,
       fromAccount: AccountDb,
-      markAsReserved: Boolean): Future[FundRawTxHelper[ShufflingNonInteractiveFinalizer]] = {
+      markAsReserved: Boolean): Future[
+    FundRawTxHelper[ShufflingNonInteractiveFinalizer]] = {
     delegate(
       _.fundRawTransaction(destinations, feeRate, fromAccount, markAsReserved))
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -976,4 +976,9 @@ class WalletHolder(implicit ec: ExecutionContext)
   override def getNewAddress(account: AccountDb): Future[BitcoinAddress] = {
     delegate(_.getNewAddress(account))
   }
+
+  override def findByScriptPubKey(
+      scriptPubKey: ScriptPubKey): Future[Vector[SpendingInfoDb]] = {
+    delegate(_.findByScriptPubKey(scriptPubKey))
+  }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -940,4 +940,19 @@ class WalletHolder(implicit ec: ExecutionContext)
       contractId: ByteVector,
       oracleSig: OracleSignatures): Future[Option[Transaction]] =
     delegate(_.executeDLC(contractId, oracleSig))
+
+  override def findByOutPoints(outPoints: Vector[TransactionOutPoint]): Future[
+    Vector[SpendingInfoDb]] = {
+    delegate(_.findByOutPoints(outPoints))
+  }
+
+  override def findByTxId(
+      txIdBE: DoubleSha256DigestBE): Future[Option[TransactionDb]] = {
+    delegate(_.findByTxId(txIdBE))
+  }
+
+  override def findOutputsBeingSpent(
+      tx: Transaction): Future[Vector[SpendingInfoDb]] = {
+    delegate(_.findOutputsBeingSpent(tx))
+  }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -982,4 +982,20 @@ class WalletHolder(implicit ec: ExecutionContext)
       scriptPubKey: ScriptPubKey): Future[Vector[SpendingInfoDb]] = {
     delegate(_.findByScriptPubKey(scriptPubKey))
   }
+
+  override def processOurTransaction(
+      transaction: Transaction,
+      feeRate: FeeUnit,
+      inputAmount: CurrencyUnit,
+      sentAmount: CurrencyUnit,
+      blockHashOpt: Option[DoubleSha256DigestBE],
+      newTags: Vector[AddressTag]): Future[ProcessTxResult] = {
+    delegate(
+      _.processOurTransaction(transaction = transaction,
+                              feeRate = feeRate,
+                              inputAmount = inputAmount,
+                              sentAmount = sentAmount,
+                              blockHashOpt = blockHashOpt,
+                              newTags = newTags))
+  }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -166,6 +166,15 @@ class WalletHolder(implicit ec: ExecutionContext)
     FundRawTxHelper[ShufflingNonInteractiveFinalizer]] = delegate(
     _.fundRawTransaction(destinations, feeRate, fromTagOpt, markAsReserved))
 
+  override def fundRawTransaction(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      markAsReserved: Boolean): Future[FundRawTxHelper[ShufflingNonInteractiveFinalizer]] = {
+    delegate(
+      _.fundRawTransaction(destinations, feeRate, fromAccount, markAsReserved))
+  }
+
   override def listTransactions(): Future[Vector[TransactionDb]] = delegate(
     _.listTransactions())
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -359,7 +359,7 @@ private[wallet] trait AddressHandling extends WalletLogger {
     } yield address
   }
 
-  def findAccount(account: HDAccount): Future[Option[AccountDb]] = {
+  override def findAccount(account: HDAccount): Future[Option[AccountDb]] = {
     accountDAO.findByAccount(account)
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -49,7 +49,8 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
       destinations: Vector[TransactionOutput],
       feeRate: FeeUnit,
       fromAccount: AccountDb,
-      markAsReserved: Boolean): Future[Transaction] = {
+      markAsReserved: Boolean): Future[
+    FundRawTxHelper[ShufflingNonInteractiveFinalizer]] = {
     fundRawTransaction(destinations = destinations,
                        feeRate = feeRate,
                        fromAccount = fromAccount,

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/FundTransactionHandling.scala
@@ -44,6 +44,19 @@ trait FundTransactionHandling extends WalletLogger { self: Wallet =>
                                markAsReserved = markAsReserved)
   }
 
+  /** Funds an unsigned transaction from the specified account */
+  def fundRawTransaction(
+      destinations: Vector[TransactionOutput],
+      feeRate: FeeUnit,
+      fromAccount: AccountDb,
+      markAsReserved: Boolean): Future[Transaction] = {
+    fundRawTransaction(destinations = destinations,
+                       feeRate = feeRate,
+                       fromAccount = fromAccount,
+                       fromTagOpt = None,
+                       markAsReserved = markAsReserved)
+  }
+
   /** This returns a [[RawTxBuilder]] that can be used to generate an unsigned transaction with [[RawTxBuilder.result()]]
     * which can be signed with the returned [[ScriptSignatureParams]].
     *

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet.internal
 
+import org.bitcoins.core.api.wallet.ProcessTxResult
 import org.bitcoins.core.api.wallet.db._
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.UInt32
@@ -199,10 +200,6 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
   override def listTransactions(): Future[Vector[TransactionDb]] =
     transactionDAO.findAll()
 
-  private[wallet] case class ProcessTxResult(
-      updatedIncoming: Vector[SpendingInfoDb],
-      updatedOutgoing: Vector[SpendingInfoDb])
-
   /////////////////////
   // Internal wallet API
 
@@ -235,7 +232,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
     * This is called right after we've signed a TX,
     * updating our UTXO state.
     */
-  private[wallet] def processOurTransaction(
+  override def processOurTransaction(
       transaction: Transaction,
       feeRate: FeeUnit,
       inputAmount: CurrencyUnit,


### PR DESCRIPTION
The purpose of this PR is to use our wallet apis (`WalletApi`, `HDWallletApi`, `NeutrinoHDWalletApi`) in our `walletTest` test suite.

This PR does not intend to change any functionality, just refactor.

The reason for doing this is to make it easier to refactor the test suite in the future. Previously we would be reaching into internal implementation details (i.e. accessing `wallet.spendingInfoDAO`) rather than using equivalent methods available to us in the `WalletApi` such as `listUtxos()`. 

This adds the following new methods to `WalletApi` to make it easier to use

- `processOurTransaction`
- `clearAllAddresses`
- `findByOutPoints`
- `findByTxIds`
- `findOutputsBeingSpent`
- `findByScriptPubKey`


Now in out `WalletWithBitcoind` test datastructures are typed as `WalletApi`/`HDWalletApi` rather than `Wallet`. The reason this is needed is to solve the resource issues talked about in #4539 