### PR TITLE
Add branch and bound coin selection

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/wallet/BranchAndBoundTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/BranchAndBoundTest.scala
@@ -1,0 +1,136 @@
+package org.bitcoins.core.wallet
+
+import org.bitcoins.core.api.wallet._
+import org.bitcoins.core.currency._
+import org.bitcoins.core.number._
+import org.bitcoins.core.protocol.script._
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.wallet.fee._
+import org.bitcoins.crypto._
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+
+import scala.util.Random
+
+class BranchAndBoundTest extends BitcoinSUnitTest {
+
+  behavior of "CoinSelector"
+
+  val rand = new Random(System.currentTimeMillis())
+
+  // tests copied from https://github.com/bitcoindevkit/bdk/blob/6bae52e6f2843a371ec2a6e293ea7ab0ba96aff4/src/wallet/coin_selection.rs#L1322
+
+  private def buildTestUtxo(value: CurrencyUnit, idx: Int): CoinSelectorUtxo = {
+    val output = TransactionOutput(
+      value = value,
+      scriptPubKey = P2WPKHWitnessSPKV0(ECPublicKey.dummy)
+    )
+    val prevOut = TransactionOutPoint(DoubleSha256Digest.empty, UInt32(idx))
+    CoinSelectorUtxo(output, prevOut, None, None)
+  }
+
+  val testUtxos: Vector[CoinSelectorUtxo] = {
+    Vector(buildTestUtxo(Satoshis(100000), 0),
+           buildTestUtxo(Satoshis(10), 1),
+           buildTestUtxo(Satoshis(200000), 2))
+  }
+
+  def generateSameValueUtxos(
+      value: CurrencyUnit,
+      numUtxos: Int): Vector[CoinSelectorUtxo] = {
+    0.until(numUtxos).toVector.map { int =>
+      buildTestUtxo(value, int)
+    }
+  }
+
+  def generateRandomUtxos(numUtxos: Int): Vector[CoinSelectorUtxo] = {
+    0.until(numUtxos).toVector.map { int =>
+      val value = Satoshis(Math.abs(rand.nextLong() % 200000000L))
+      buildTestUtxo(value, int)
+    }
+  }
+
+  def sumRandomUtxos(utxos: Vector[CoinSelectorUtxo]): CurrencyUnit = {
+    // select between 2 and utxos.size/2 utxos
+    val num = Math.max(2, rand.nextInt(utxos.size / 2))
+    rand.shuffle(utxos).take(num).map(_.value).sum
+  }
+
+  it must "correctly select exact coins" in {
+    0.until(200).foreach { _ =>
+      val utxos = generateRandomUtxos(16)
+      val target = sumRandomUtxos(utxos)
+      val targetUtxo = TransactionOutput(target, EmptyScriptPubKey)
+
+      val selection = CoinSelector.branchAndBound(utxos,
+                                                  Vector(targetUtxo),
+                                                  Satoshis.zero,
+                                                  SatoshisPerVirtualByte.zero)
+
+      val selectedAmt = selection.map(_.value).sum
+      assert(selectedAmt == target)
+    }
+  }
+
+  it must "correctly select exact coins with more utxos" in {
+    0.until(200).foreach { _ =>
+      val utxos = generateRandomUtxos(40)
+      val target = Vector(utxos(3).prevOut, utxos(23).prevOut)
+
+      val selection = CoinSelector.branchAndBound(utxos,
+                                                  target,
+                                                  Satoshis.zero,
+                                                  SatoshisPerVirtualByte.zero)
+
+      val selectedAmt = selection.map(_.value).sum
+      assert(selectedAmt == target.map(_.value).sum)
+    }
+  }
+
+  it must "have an exact match with fees" in {
+    val feeRate = SatoshisPerVirtualByte.fromLong(1)
+    val utxos = generateSameValueUtxos(Satoshis(50000), 10)
+
+    val changeCost = feeRate * 31
+    val dummyUtxo = TransactionOutput(Satoshis.zero, EmptyScriptPubKey)
+
+    val nonInputFees = feeRate * (dummyUtxo.byteSize + 10)
+
+    // 2*(value of 1 utxo)  - 2*(1 utxo fees with 1.0sat/vbyte fee rate) -
+    // changeCost + 5 - output cost
+    val targetAmount =
+      (2 * 50000) - (2 * 67) - changeCost.satoshis.toLong + 5 - nonInputFees.satoshis.toLong
+
+    val target = TransactionOutput(Satoshis(targetAmount), EmptyScriptPubKey)
+
+    val selection = CoinSelector
+      .branchAndBound(utxos, Vector(target), changeCost, feeRate)
+
+    val selectedAmt = selection.map(_.value).sum
+    assert(selectedAmt == Satoshis(100000))
+  }
+
+  it must "fail to find a match" in {
+    val feeRate = SatoshisPerVirtualByte.fromLong(10)
+    val target = buildTestUtxo(Satoshis(20000), 0)
+    val changeCost = feeRate * 31
+
+    val error = intercept[RuntimeException](
+      CoinSelector
+        .branchAndBound(testUtxos, Vector(target.prevOut), changeCost, feeRate))
+
+    assert(error.getMessage == "No solution found for the given parameters")
+  }
+
+  it must "have max tries exceeded" in {
+    val feeRate = SatoshisPerVirtualByte.fromLong(10)
+    val utxos = generateSameValueUtxos(Satoshis(100000), 100000)
+    val target = buildTestUtxo(Satoshis(20000), 0)
+    val changeCost = feeRate * 31
+
+    val error = intercept[RuntimeException](
+      CoinSelector
+        .branchAndBound(utxos, Vector(target.prevOut), changeCost, feeRate))
+
+    assert(error.getMessage == "Could not find a bnb solution")
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelectionAlgo.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelectionAlgo.scala
@@ -30,12 +30,15 @@ object CoinSelectionAlgo extends StringFactory[CoinSelectionAlgo] {
   /** Tries all coin selection algos and uses the one with the least waste */
   case object LeastWaste extends CoinSelectionAlgo
 
+  case object BranchAndBound extends CoinSelectionAlgo
+
   case class SelectedUtxos(outPoints: Set[(DoubleSha256Digest, Int)])
       extends CoinSelectionAlgo
 
   /** Coin selection algos that don't call other ones */
   val independentAlgos: Vector[CoinSelectionAlgo] =
     Vector(RandomSelection,
+           BranchAndBound,
            AccumulateLargest,
            AccumulateSmallestViable,
            StandardAccumulate)

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelector.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelector.scala
@@ -4,13 +4,126 @@ import org.bitcoins.core.api.wallet.CoinSelectionAlgo._
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
-import org.bitcoins.core.wallet.fee.FeeUnit
+import org.bitcoins.core.wallet.fee._
 
 import scala.annotation.tailrec
+import scala.util.control.Breaks._
 import scala.util.{Random, Try}
 
 /** Implements algorithms for selecting from a UTXO set to spend to an output set at a given fee rate. */
 trait CoinSelector {
+
+  private val BNB_MAX_TRIES = 100000
+
+  /** Selects coins using the branch and bound algorithm.
+    * TODO this isn't very scala-y, could be refactored.
+    * @see https://github.com/bitcoindevkit/bdk/blob/6bae52e6f2843a371ec2a6e293ea7ab0ba96aff4/src/wallet/coin_selection.rs#L529
+    */
+  def branchAndBound(
+      walletUtxos: Vector[CoinSelectorUtxo],
+      outputs: Vector[TransactionOutput],
+      changeCost: CurrencyUnit,
+      feeRate: FeeUnit): Vector[CoinSelectorUtxo] = {
+    // target is the total of the outputs we are trying to spend
+    // plus the 10 overhead bytes of the transaction and size of the outputs
+    val nonInputFees = feeRate * (outputs.map(_.byteSize).sum + 10)
+    val target =
+      outputs.foldLeft(CurrencyUnits.zero)(_ + _.value) + nonInputFees
+
+    if (target <= CurrencyUnits.zero)
+      throw new IllegalArgumentException(
+        "Target amount must be greater than zero")
+
+    // Filter dust coins
+    val usableUtxos =
+      walletUtxos
+        .filter(_.effectiveValue(feeRate) > CurrencyUnits.zero)
+        .sortBy(_.value)(Ordering[CurrencyUnit].reverse)
+
+    var currentAvailValue =
+      usableUtxos.foldLeft(CurrencyUnits.zero)(_ + _.effectiveValue(feeRate))
+
+    // Note that currentSelection.size could be less than
+    // usableUtxos.size, it just means that we still haven't decided if we should keep
+    // certain usableUtxos or not.
+    var currentSelection: Vector[Boolean] = Vector.empty
+    var currentSelectionValue = CurrencyUnits.zero
+
+    var bestSelection: Vector[Boolean] = Vector.empty
+    var bestSelectionValue: Option[CurrencyUnit] = None
+
+    breakable {
+      0.until(BNB_MAX_TRIES).foreach { _ =>
+        val backtrack =
+          if (
+            currentSelectionValue + currentAvailValue < target
+            || currentSelectionValue > target + changeCost
+          ) {
+            true
+          } else if (currentSelectionValue >= target) {
+            // If we found a solution better than the previous one, or if there wasn't previous
+            // solution, update the best solution
+            if (
+              bestSelectionValue.isEmpty || currentSelectionValue < bestSelectionValue.get
+            ) {
+              bestSelection = currentSelection
+              bestSelectionValue = Some(currentSelectionValue)
+            }
+
+            // If we found a perfect match, break here
+            if (currentSelectionValue == target) {
+              break()
+            }
+
+            // Selected value is within range, there's no point in going forward. Start
+            // backtracking
+            true
+          } else false
+
+        if (backtrack) {
+          while (currentSelection.lastOption.contains(false)) {
+            currentSelection = currentSelection.dropRight(1)
+            currentAvailValue += usableUtxos(currentSelection.size)
+              .effectiveValue(feeRate)
+          }
+
+          if (currentSelection.lastOption.isEmpty) {
+            // We have walked back to the first utxo and no branch is untraversed. All solutions searched
+            // If best selection is empty, then there's no exact match
+            if (bestSelectionValue.isEmpty) {
+              throw new RuntimeException(
+                "No solution found for the given parameters")
+            } else break()
+          }
+
+          if (currentSelection.lastOption.contains(true)) {
+            // Output was included on previous iterations, try excluding now.
+            currentSelection = currentSelection.dropRight(1) :+ false
+          }
+
+          val utxo = usableUtxos(currentSelection.size - 1)
+          currentSelectionValue -= utxo.effectiveValue(feeRate)
+        } else {
+          // Moving forwards, continuing down this branch
+          val utxo = usableUtxos(currentSelection.size)
+
+          // Remove this utxo from the curr_available_value utxo amount
+          currentAvailValue -= utxo.effectiveValue(feeRate)
+
+          // Inclusion branch first (Largest First Exploration)
+          currentSelection = currentSelection :+ true
+          currentSelectionValue += utxo.effectiveValue(feeRate)
+        }
+      }
+    }
+
+    if (bestSelection.isEmpty)
+      throw new RuntimeException("Could not find a bnb solution")
+
+    usableUtxos.zip(bestSelection).flatMap { case (utxo, keep) =>
+      if (keep) Some(utxo) else None
+    }
+  }
 
   /** Randomly selects utxos until it has enough to fund the desired amount,
     * should only be used for research purposes
@@ -64,40 +177,51 @@ trait CoinSelector {
     def addUtxos(
         alreadyAdded: Vector[CoinSelectorUtxo],
         valueSoFar: CurrencyUnit,
-        bytesSoFar: Long,
+        feeSoFar: CurrencyUnit,
         utxosLeft: Vector[CoinSelectorUtxo]): Vector[CoinSelectorUtxo] = {
-      val fee = feeRate * bytesSoFar
-      if (valueSoFar > totalValue + fee) {
+      if (valueSoFar > totalValue + feeSoFar) {
         alreadyAdded
       } else if (utxosLeft.isEmpty) {
         throw new RuntimeException(
-          s"Not enough value in given outputs ($valueSoFar) to make transaction spending $totalValue plus fees $fee")
+          s"Not enough value in given outputs ($valueSoFar) to make transaction spending $totalValue plus fees $feeSoFar")
       } else {
         val nextUtxo = utxosLeft.head
         val effectiveValue = calcEffectiveValue(nextUtxo, feeRate)
         if (effectiveValue <= Satoshis.zero) {
-          addUtxos(alreadyAdded, valueSoFar, bytesSoFar, utxosLeft.tail)
+          addUtxos(alreadyAdded, valueSoFar, feeSoFar, utxosLeft.tail)
         } else {
           val newAdded = alreadyAdded.:+(nextUtxo)
           val newValue = valueSoFar + nextUtxo.prevOut.value
-          val approxUtxoSize = CoinSelector.approximateUtxoSize(nextUtxo)
+          val utxoFee = calculateUtxoFee(nextUtxo, feeRate)
 
-          addUtxos(newAdded,
-                   newValue,
-                   bytesSoFar + approxUtxoSize,
-                   utxosLeft.tail)
+          addUtxos(newAdded, newValue, feeSoFar + utxoFee, utxosLeft.tail)
         }
       }
     }
 
-    addUtxos(Vector.empty, CurrencyUnits.zero, bytesSoFar = 0L, walletUtxos)
+    val nonInputFees = feeRate * (outputs.map(_.byteSize).sum + 10)
+
+    addUtxos(alreadyAdded = Vector.empty,
+             valueSoFar = CurrencyUnits.zero,
+             feeSoFar = nonInputFees,
+             utxosLeft = walletUtxos)
   }
 
   def calculateUtxoFee(
       utxo: CoinSelectorUtxo,
       feeRate: FeeUnit): CurrencyUnit = {
-    val approxUtxoSize = CoinSelector.approximateUtxoSize(utxo)
-    feeRate * approxUtxoSize
+    val size = feeRate match {
+      case _: SatoshisPerByte =>
+        CoinSelector.approximateUtxoBytesSize(utxo)
+      case _: SatoshisPerKiloByte =>
+        CoinSelector.approximateUtxoBytesSize(utxo)
+      case _: SatoshisPerVirtualByte =>
+        CoinSelector.approximateUtxoVBytesSize(utxo)
+      case _: SatoshisPerKW =>
+        CoinSelector.approximateUtxoWeight(utxo)
+    }
+
+    feeRate * size
   }
 
   def calcEffectiveValue(
@@ -111,10 +235,50 @@ trait CoinSelector {
 object CoinSelector extends CoinSelector {
 
   /** Cribbed from [[https://github.com/bitcoinjs/coinselect/blob/master/utils.js]] */
-  def approximateUtxoSize(utxo: CoinSelectorUtxo): Long = {
+  def approximateUtxoBytesSize(utxo: CoinSelectorUtxo): Long = {
     val inputBase = 32 + 4 + 1 + 4
     val scriptSize = utxo.redeemScriptOpt match {
       case Some(script) => script.bytes.length
+      case None =>
+        utxo.scriptWitnessOpt match {
+          case Some(script) => script.bytes.length
+          case None =>
+            utxo.prevOut.scriptPubKey match {
+              case _: NonWitnessScriptPubKey        => 107 // P2PKH
+              case _: WitnessScriptPubKeyV0         => 107 // P2WPKH
+              case _: TaprootScriptPubKey           => 64 // Single Schnorr signature
+              case _: UnassignedWitnessScriptPubKey => 0 // unknown
+            }
+        }
+    }
+
+    inputBase + scriptSize
+  }
+
+  def approximateUtxoVBytesSize(utxo: CoinSelectorUtxo): Long = {
+    val inputBase = 32 + 4 + 1 + 4
+    val scriptSize = utxo.redeemScriptOpt match {
+      case Some(script) => script.bytes.length
+      case None =>
+        utxo.scriptWitnessOpt match {
+          case Some(script) => script.bytes.length
+          case None =>
+            utxo.prevOut.scriptPubKey match {
+              case _: NonWitnessScriptPubKey        => 107 // P2PKH
+              case _: WitnessScriptPubKeyV0         => 26 // P2WPKH
+              case _: TaprootScriptPubKey           => 17 // Single Schnorr signature
+              case _: UnassignedWitnessScriptPubKey => 0 // unknown
+            }
+        }
+    }
+
+    inputBase + scriptSize
+  }
+
+  def approximateUtxoWeight(utxo: CoinSelectorUtxo): Long = {
+    val inputBase = (32 + 4 + 1 + 4) * 3
+    val scriptSize = utxo.redeemScriptOpt match {
+      case Some(script) => script.bytes.length * 3
       case None =>
         utxo.scriptWitnessOpt match {
           case Some(script) => script.bytes.length
@@ -136,6 +300,7 @@ object CoinSelector extends CoinSelector {
       walletUtxos: Vector[CoinSelectorUtxo],
       outputs: Vector[TransactionOutput],
       feeRate: FeeUnit,
+      changeCostOpt: Option[CurrencyUnit],
       longTermFeeRateOpt: Option[FeeUnit] = None): Vector[CoinSelectorUtxo] =
     coinSelectionAlgo match {
       case RandomSelection =>
@@ -146,13 +311,25 @@ object CoinSelector extends CoinSelector {
         accumulateSmallestViable(walletUtxos, outputs, feeRate)
       case StandardAccumulate =>
         accumulate(walletUtxos, outputs, feeRate)
-      case LeastWaste =>
-        longTermFeeRateOpt match {
-          case Some(longTermFeeRate) =>
-            selectByLeastWaste(walletUtxos, outputs, feeRate, longTermFeeRate)
+      case BranchAndBound =>
+        changeCostOpt match {
+          case Some(changeCost) =>
+            branchAndBound(walletUtxos, outputs, changeCost, feeRate)
           case None =>
             throw new IllegalArgumentException(
-              "longTermFeeRateOpt must be defined for LeastWaste")
+              "changeCostOpt must be defined for BranchAndBound")
+        }
+      case LeastWaste =>
+        (longTermFeeRateOpt, changeCostOpt) match {
+          case (Some(longTermFeeRate), Some(changeCost)) =>
+            selectByLeastWaste(walletUtxos,
+                               outputs,
+                               feeRate,
+                               changeCost,
+                               longTermFeeRate)
+          case (None, None) | (Some(_), None) | (None, Some(_)) =>
+            throw new IllegalArgumentException(
+              "longTermFeeRateOpt and changeCostOpt must be defined for LeastWaste")
         }
       case SelectedUtxos(outPoints) =>
         val result = walletUtxos.foldLeft(Vector.empty[CoinSelectorUtxo]) {
@@ -192,6 +369,7 @@ object CoinSelector extends CoinSelector {
       walletUtxos: Vector[CoinSelectorUtxo],
       outputs: Vector[TransactionOutput],
       feeRate: FeeUnit,
+      changeCost: CurrencyUnit,
       longTermFeeRate: FeeUnit
   ): Vector[CoinSelectorUtxo] = {
     val target = outputs.map(_.value).sum
@@ -203,14 +381,11 @@ object CoinSelector extends CoinSelector {
                        walletUtxos,
                        outputs,
                        feeRate,
+                       Some(changeCost),
                        Some(longTermFeeRate))
 
-        // todo for now just use 1 sat, when we have more complex selection algos
-        // that just don't result in change (Branch and Bound), this will need to be calculated
-        val changeCostOpt = Some(Satoshis.one)
-
         val waste = calculateSelectionWaste(selection,
-                                            changeCostOpt,
+                                            Some(changeCost),
                                             target,
                                             feeRate,
                                             longTermFeeRate)

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelectorUtxo.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/CoinSelectorUtxo.scala
@@ -1,14 +1,26 @@
 package org.bitcoins.core.api.wallet
 
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
+import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.wallet.fee.FeeUnit
 
 case class CoinSelectorUtxo(
     prevOut: TransactionOutput,
     outPoint: TransactionOutPoint,
     redeemScriptOpt: Option[ScriptPubKey],
-    scriptWitnessOpt: Option[ScriptWitness])
+    scriptWitnessOpt: Option[ScriptWitness]) {
+  val value: CurrencyUnit = prevOut.value
+
+  def fee(feeUnit: FeeUnit): CurrencyUnit = {
+    CoinSelector.calculateUtxoFee(this, feeUnit)
+  }
+
+  def effectiveValue(feeUnit: FeeUnit): CurrencyUnit = {
+    value - fee(feeUnit)
+  }
+}
 
 object CoinSelectorUtxo {
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/CoinSelectorTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/CoinSelectorTest.scala
@@ -97,13 +97,27 @@ class CoinSelectorTest extends BitcoinSWalletTest {
     assert(selections.exists(_ != first))
   }
 
+  it must "select by branch and bound" in { fixture =>
+    val selection = CoinSelector.branchAndBound(walletUtxos = fixture.utxoSet,
+                                                outputs =
+                                                  Vector(fixture.output),
+                                                feeRate = fixture.feeRate,
+                                                changeCost = Satoshis(1))
+
+    val expected = Vector(fixture.utxo1, fixture.utxo2).sortBy(_.value)
+
+    assert(selection.sortBy(_.value) == expected)
+  }
+
   it must "select the least wasteful outputs" in { fixture =>
     val selection =
-      CoinSelector.selectByLeastWaste(walletUtxos = fixture.utxoSet,
-                                      outputs = Vector(fixture.output),
-                                      feeRate = fixture.feeRate,
-                                      longTermFeeRate =
-                                        SatoshisPerByte.fromLong(10))
+      CoinSelector.selectByLeastWaste(
+        walletUtxos = fixture.utxoSet,
+        outputs = Vector(fixture.output),
+        feeRate = fixture.feeRate,
+        changeCost = Satoshis.one,
+        longTermFeeRate = SatoshisPerByte.fromLong(10)
+      )
 
     // Need to sort as ordering will be different sometimes
     val sortedSelection = selection.sortBy(_.outPoint.hex)
@@ -121,8 +135,8 @@ class CoinSelectorTest extends BitcoinSWalletTest {
     val expected3 =
       32 + 4 + 1 + 4 + fixture.utxo3.scriptWitnessOpt.get.bytes.length
 
-    assert(CoinSelector.approximateUtxoSize(fixture.utxo1) == expected1)
-    assert(CoinSelector.approximateUtxoSize(fixture.utxo2) == expected2)
-    assert(CoinSelector.approximateUtxoSize(fixture.utxo3) == expected3)
+    assert(CoinSelector.approximateUtxoBytesSize(fixture.utxo1) == expected1)
+    assert(CoinSelector.approximateUtxoBytesSize(fixture.utxo2) == expected2)
+    assert(CoinSelector.approximateUtxoBytesSize(fixture.utxo3) == expected3)
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -150,7 +150,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
       val receivingAddressF = wallet.getNewAddress()
       val amount = Bitcoins.one
 
-      val amtWithFee = amount + Satoshis(175) //for fee
+      val amtWithFee = amount + Satoshis(200) //for fee
 
       //build funding tx
       val fundingTxF: Future[(Transaction, UInt32)] = for {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -469,8 +469,13 @@ class WalletSendingTest extends BitcoinSWalletTest {
         .map(_.map(CoinSelectorUtxo.fromSpendingInfoDb))
 
       output = TransactionOutput(amountToSend, testAddress.scriptPubKey)
+      changeCost = wallet.changeCost(feeRate)
       expectedUtxos =
-        CoinSelector.selectByAlgo(algo, allUtxos, Vector(output), feeRate)
+        CoinSelector.selectByAlgo(coinSelectionAlgo = algo,
+                                  walletUtxos = allUtxos,
+                                  outputs = Vector(output),
+                                  feeRate = feeRate,
+                                  changeCostOpt = Some(changeCost))
       tx <- wallet.sendWithAlgo(testAddress, amountToSend, feeRate, algo)
     } yield {
       val diff =


### PR DESCRIPTION
Closes #1650

This required a small refactor because I found a bug in our utxo size approximation which would only return in bytes instead of the unit we needed for the `FeeUnit`

The implementation of branch of bound is a translation from the implementation in BDK. It could be made to be more scala-y but left that as a `// todo`