### PR TITLE
Refactor so we don't create multiple WalletAppConfig in testkit

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CallBackUtilTest.scala
@@ -17,7 +17,7 @@ class CallBackUtilTest extends BitcoinSWalletTest {
   override type FixtureParam = FundedDLCWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withFundedDLCWallet(test, getBIP39PasswordOpt())(getFreshConfig)
+    withFundedDLCWallet(test)(getFreshConfig)
 
   it must "have the kill switch kill messages to the createBitcoindNodeCallbacksForWallet callback" in {
     fundedWallet =>

--- a/dlc-node-test/src/test/scala/org/bitcoins/dlc/node/DLCServerTest.scala
+++ b/dlc-node-test/src/test/scala/org/bitcoins/dlc/node/DLCServerTest.scala
@@ -20,7 +20,7 @@ class DLCServerTest extends BitcoinSActorFixtureWithDLCWallet {
   override type FixtureParam = FundedDLCWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedDLCWallet(test, getBIP39PasswordOpt())(getFreshConfig)
+    withFundedDLCWallet(test)(getFreshConfig)
   }
 
   it must "send/receive Ping and Pong TLVs over clearnet" in { dlcWalletApi =>

--- a/dlc-node-test/src/test/scala/org/bitcoins/dlc/node/DLCServerTorTest.scala
+++ b/dlc-node-test/src/test/scala/org/bitcoins/dlc/node/DLCServerTorTest.scala
@@ -32,7 +32,7 @@ class DLCServerTorTest
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     if (TorUtil.torEnabled) {
-      withFundedDLCWallet(test, getBIP39PasswordOpt())
+      withFundedDLCWallet(test)
     } else FutureOutcome.succeeded
   }
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionBitcoindBackendTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionBitcoindBackendTest.scala
@@ -97,7 +97,7 @@ class DLCExecutionBitcoindBackendTest
   }
 
   override def afterAll(): Unit = {
-    super[BitcoinSDualWalletTest].afterAll()
     super[CachedBitcoindNewest].afterAll()
+    super[BitcoinSDualWalletTest].afterAll()
   }
 }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionBitcoindBackendTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionBitcoindBackendTest.scala
@@ -95,4 +95,9 @@ class DLCExecutionBitcoindBackendTest
       }
       executedF
   }
+
+  override def afterAll(): Unit = {
+    super[BitcoinSDualWalletTest].afterAll()
+    super[CachedBitcoindNewest].afterAll()
+  }
 }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
@@ -7,7 +7,6 @@ import org.bitcoins.core.wallet.utxo.TxoState
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.chain.MockChainQueryApi
-import org.bitcoins.testkit.keymanager.KeyManagerTestUtil.bip39PasswordOpt
 import org.bitcoins.testkit.node.MockNodeApi
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest._
@@ -19,8 +18,12 @@ class MultiWalletDLCTest extends BitcoinSWalletTest {
 
   override type FixtureParam = FundedDLCWallet
 
+  override def getFreshConfig: BitcoinSAppConfig = {
+    BitcoinSWalletTest.getSegwitWalletConfigWithBip39PasswordOpt(pgUrl())
+  }
+
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withFundedDLCWallet(test, getBIP39PasswordOpt())(getFreshConfig)
+    withFundedDLCWallet(test)(getFreshConfig)
 
   it must "create 2 different dlc wallets" in { fundedWallet =>
     val walletNameConfB =
@@ -38,8 +41,7 @@ class MultiWalletDLCTest extends BitcoinSWalletTest {
 
     val walletBF = BitcoinSWalletTest.createDLCWallet2Accounts(
       MockNodeApi,
-      MockChainQueryApi,
-      bip39PasswordOpt)(configB, system)
+      MockChainQueryApi)(configB, system)
 
     for {
       accountA <- walletA.getDefaultAccount()

--- a/docs/wallet/wallet-rescan.md
+++ b/docs/wallet/wallet-rescan.md
@@ -59,11 +59,10 @@ implicit val ec: ExecutionContext = system.dispatcher
 implicit val appConfig: BitcoinSAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig()
 implicit val walletAppConfig: WalletAppConfig = appConfig.walletConf
 
-val bip39PasswordOpt = None
 //ok now let's spin up a bitcoind and a bitcoin-s wallet with funds in it
 val walletWithBitcoindF = for {
   bitcoind <- BitcoinSFixture.createBitcoindWithFunds()
-  walletWithBitcoind <- BitcoinSWalletTest.createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
+  walletWithBitcoind <- BitcoinSWalletTest.createWalletWithBitcoindCallbacks(bitcoind)
 } yield walletWithBitcoind
 
 val walletF = walletWithBitcoindF.map(_.wallet)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -32,7 +32,6 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       bitcoind <- cachedBitcoindWithFundsF
       outcome = withNeutrinoNodeFundedWalletBitcoind(
         test = test,
-        bip39PasswordOpt = getBIP39PasswordOpt(),
         bitcoind = bitcoind
       )(system, getFreshConfig)
       f <- outcome.toFuture
@@ -46,7 +45,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
   val TestFees: Satoshis = 2220.sats
 
   it must "receive information about received payments" in { param =>
-    val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind, _) = param
+    val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind) = param
 
     def condition(
         expectedBalance: CurrencyUnit,
@@ -121,7 +120,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
   }
 
   it must "watch an arbitrary SPK" in { param =>
-    val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind, _) = param
+    val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind) = param
 
     def generateBlock() =
       for {
@@ -157,7 +156,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
   }
 
   it must "rescan information about received payments" in { param =>
-    val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind, _) = param
+    val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind) = param
 
     def condition(): Future[Boolean] = {
       for {
@@ -212,7 +211,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
 
   it must "receive funds while the node is offline when we restart" in {
     param =>
-      val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind, _) = param
+      val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind) = param
 
       val initBalanceF = wallet.getBalance()
       val receivedAddrF = wallet.getNewAddress()
@@ -249,7 +248,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
   it must "recognize funds were spent while we were offline" in { param =>
     //useful test for the case where we are in a DLC
     //and the counterparty broadcasts the funding tx or a CET
-    val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind, _) = param
+    val NeutrinoNodeFundedWalletBitcoind(node, wallet, bitcoind) = param
     val initBalanceF = wallet.getBalance()
     val bitcoindAddrF = bitcoind.getNewAddress
     val sendAmt = Bitcoins.one

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
@@ -38,7 +38,6 @@ trait EmbeddedPg extends BeforeAndAfterAll { this: Suite =>
     pg.map(_.getJdbcUrl(userName = "postgres", dbName = "postgres"))
 
   override def afterAll(): Unit = {
-    println(s"EmbeddedPg.afterAll()")
     super.afterAll()
 
     val _ = pg.foreach { p =>

--- a/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/EmbeddedPg.scala
@@ -38,6 +38,7 @@ trait EmbeddedPg extends BeforeAndAfterAll { this: Suite =>
     pg.map(_.getJdbcUrl(userName = "postgres", dbName = "postgres"))
 
   override def afterAll(): Unit = {
+    println(s"EmbeddedPg.afterAll()")
     super.afterAll()
 
     val _ = pg.foreach { p =>

--- a/testkit/src/main/scala/org/bitcoins/testkit/dlc/BitcoinSDLCNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/dlc/BitcoinSDLCNodeTest.scala
@@ -19,10 +19,7 @@ trait BitcoinSDLCNodeTest extends BitcoinSWalletTest with CachedTor {
         s"""bitcoin-s.dlcnode.listen = "127.0.0.1:${RpcUtil.randomPort}" """)
       .withFallback(BaseWalletTest.segwitWalletConf)
 
-    val extraConfig = BitcoinSWalletTest.buildBip39PasswordWithExtraConfig(
-      bip39PasswordOpt = getBIP39PasswordOpt(),
-      extraConfig = Some(dlcListenWithSegwitWallet))
-    BaseWalletTest.getFreshConfig(pgUrl, Vector(extraConfig))
+    BaseWalletTest.getFreshConfig(pgUrl, Vector(dlcListenWithSegwitWallet))
   }
 
   /** Creates two DLC nodes with wallets that are funded with some bitcoin,

--- a/testkit/src/main/scala/org/bitcoins/testkit/dlc/BitcoinSDLCNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/dlc/BitcoinSDLCNodeTest.scala
@@ -14,9 +14,15 @@ trait BitcoinSDLCNodeTest extends BitcoinSWalletTest with CachedTor {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig = {
-    val dlcListen = ConfigFactory.parseString(
-      s"""bitcoin-s.dlcnode.listen = "127.0.0.1:${RpcUtil.randomPort}" """)
-    BaseWalletTest.getFreshConfig(pgUrl, Vector(dlcListen))
+    val dlcListenWithSegwitWallet = ConfigFactory
+      .parseString(
+        s"""bitcoin-s.dlcnode.listen = "127.0.0.1:${RpcUtil.randomPort}" """)
+      .withFallback(BaseWalletTest.segwitWalletConf)
+
+    val extraConfig = BitcoinSWalletTest.buildBip39PasswordWithExtraConfig(
+      bip39PasswordOpt = getBIP39PasswordOpt(),
+      extraConfig = Some(dlcListenWithSegwitWallet))
+    BaseWalletTest.getFreshConfig(pgUrl, Vector(extraConfig))
   }
 
   /** Creates two DLC nodes with wallets that are funded with some bitcoin,
@@ -34,16 +40,12 @@ trait BitcoinSDLCNodeTest extends BitcoinSWalletTest with CachedTor {
 
         for {
           walletA <-
-            FundWalletUtil.createFundedDLCWallet(
-              nodeApi,
-              chainQueryApi,
-              getBIP39PasswordOpt(),
-              Some(BaseWalletTest.segwitWalletConf))(configA, system)
+            FundWalletUtil.createFundedDLCWallet(nodeApi, chainQueryApi)(
+              configA,
+              system)
           walletB <- FundWalletUtil.createFundedDLCWallet(
             nodeApi,
-            chainQueryApi,
-            getBIP39PasswordOpt(),
-            Some(BaseWalletTest.segwitWalletConf))(configB, system)
+            chainQueryApi)(configB, system)
 
           nodeA = configA.dlcNodeConf.createDLCNode(walletA.wallet)
           nodeB = configB.dlcNodeConf.createDLCNode(walletB.wallet)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeFundedWalletBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeFundedWalletBitcoind.scala
@@ -18,7 +18,6 @@ trait NodeFundedWalletBitcoind {
   def node: Node
   def wallet: Wallet
   def bitcoindRpc: BitcoindRpcClient
-  def bip39PasswordOpt: Option[String]
 
   /** Helper method to convert from this to a [[NodeConnectedWithBitcoind]] */
   def toNodeConnectedWithBitcoind: NodeConnectedWithBitcoind
@@ -27,8 +26,7 @@ trait NodeFundedWalletBitcoind {
 case class NeutrinoNodeFundedWalletBitcoind(
     node: NeutrinoNode,
     wallet: Wallet,
-    bitcoindRpc: BitcoindRpcClient,
-    bip39PasswordOpt: Option[String])
+    bitcoindRpc: BitcoindRpcClient)
     extends NodeFundedWalletBitcoind {
 
   override def toNodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoind = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -154,7 +154,6 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
 
   def withNeutrinoNodeFundedWalletBitcoind(
       test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String],
       bitcoind: BitcoindRpcClient,
       walletCallbacks: WalletCallbacks = WalletCallbacks.empty)(implicit
       system: ActorSystem,
@@ -163,7 +162,6 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
       build = () =>
         NodeUnitTest
           .createNeutrinoNodeFundedWalletFromBitcoind(
-            bip39PasswordOpt = bip39PasswordOpt,
             bitcoind,
             walletCallbacks = walletCallbacks)(system, appConfig),
       { x: NeutrinoNodeFundedWalletBitcoind =>

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -140,23 +140,18 @@ trait NodeUnitTest extends BaseNodeTest {
 
   def withNeutrinoNodeFundedWalletBitcoind(
       test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String],
-      appConfig: BitcoinSAppConfig,
       versionOpt: Option[BitcoindVersion] = None,
       walletCallbacks: WalletCallbacks = WalletCallbacks.empty)(implicit
-      system: ActorSystem): FutureOutcome = {
-    val bip39PwConfig =
-      BitcoinSWalletTest.buildBip39PasswordConfig(bip39PasswordOpt)
-    implicit val appConfigBip39Pw =
-      appConfig.withOverrides(Vector(bip39PwConfig))
+      system: ActorSystem,
+      appConfig: BitcoinSAppConfig): FutureOutcome = {
     makeDependentFixture(
       build = () =>
         NodeUnitTest
           .createNeutrinoNodeFundedWalletBitcoind(
             versionOpt = versionOpt,
-            walletCallbacks = walletCallbacks)(system, appConfigBip39Pw),
+            walletCallbacks = walletCallbacks)(system, appConfig),
       destroy = NodeUnitTest.destroyNodeFundedWalletBitcoind(
-        _: NodeFundedWalletBitcoind)(system, appConfigBip39Pw)
+        _: NodeFundedWalletBitcoind)(system, appConfig)
     )(test)
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -88,7 +88,10 @@ trait CachedBitcoindFunded[T <: BitcoindRpcClient] extends CachedBitcoind[T] {
       val stoppedF = for {
         cachedBitcoind <- cachedBitcoindWithFundsF
         _ <- BitcoindRpcTestUtil.stopServer(cachedBitcoind)
-      } yield ()
+      } yield {
+        isBitcoindUsed.set(false)
+        ()
+      }
 
       Await.result(stoppedF, duration)
     } else {

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -25,8 +25,12 @@ trait BaseWalletTest extends EmbeddedPg { _: Suite with BitcoinSAkkaAsyncTest =>
   }
 
   /** Wallet config with data directory set to user temp directory */
-  protected def getFreshConfig: BitcoinSAppConfig =
-    BaseWalletTest.getFreshConfig(pgUrl, Vector.empty)
+  protected def getFreshConfig: BitcoinSAppConfig = {
+    val bipPasswordOpt = KeyManagerTestUtil.bip39PasswordOpt
+    val bip39Config =
+      BitcoinSWalletTest.buildBip39PasswordConfig(bipPasswordOpt)
+    BaseWalletTest.getFreshConfig(pgUrl, Vector(bip39Config))
+  }
 
   protected def getFreshWalletAppConfig: WalletAppConfig = {
     getFreshConfig.walletConf

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.testkit.wallet
 
+import com.typesafe.config.ConfigFactory
 import org.bitcoins.commons.config.AppConfig
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.node.NodeApi
@@ -26,8 +27,13 @@ trait BitcoinSDualWalletTest extends BitcoinSWalletTest {
     BitcoinSWalletTest.getSegwitWalletConfigWithBip39PasswordOpt(pgUrl())
   }
 
-  implicit protected def config2: BitcoinSAppConfig =
-    getFreshConfig
+  /** Enables external payout addresses which is needed for some unit tests */
+  implicit protected def config2: BitcoinSAppConfig = {
+    val externalPayoutConfig =
+      "bitcoin-s.wallet.allowExternalDLCAddresses = true"
+    val extraConfig = ConfigFactory.parseString(externalPayoutConfig)
+    getFreshConfig.withOverrides(Vector(extraConfig))
+  }
 
   implicit protected def wallet2AppConfig: WalletAppConfig = {
     config2.walletConf

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSDualWalletTest.scala
@@ -12,6 +12,7 @@ import org.bitcoins.core.protocol.dlc.models.{
 import org.bitcoins.dlc.wallet.{DLCAppConfig, DLCWallet}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.wallet.DLCWalletUtil.InitializedDLCWallet
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
 import org.bitcoins.wallet.config.WalletAppConfig
@@ -24,7 +25,8 @@ trait BitcoinSDualWalletTest extends BitcoinSWalletTest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig = {
-    BitcoinSWalletTest.getSegwitWalletConfigWithBip39PasswordOpt(pgUrl())
+    val segwitConfig = BaseWalletTest.segwitWalletConf
+    BitcoinSTestAppConfig.getNeutrinoTestConfig(segwitConfig)
   }
 
   /** Enables external payout addresses which is needed for some unit tests */

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -554,7 +554,7 @@ object BitcoinSWalletTest extends WalletLogger {
       _ <- walletAppConfig.dropTable("flyway_schema_history")
       _ <- walletAppConfig.dropAll()
       _ <- walletAppConfig.stop()
-    } yield ()
+    } yield {}
   }
 
   /** Constructs callbacks for the wallet from the node to process blocks and compact filters */

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -82,30 +82,20 @@ trait BitcoinSWalletTest
     * peered with a bitcoind so the funds in the wallet are not tied to an
     * underlying blockchain
     */
-  def withFundedWallet(test: OneArgAsyncTest, bip39PasswordOpt: Option[String])(
-      implicit walletAppConfig: WalletAppConfig): FutureOutcome = {
+  def withFundedWallet(test: OneArgAsyncTest)(implicit
+      walletAppConfig: WalletAppConfig): FutureOutcome = {
     makeDependentFixture(
-      build = () =>
-        FundWalletUtil.createFundedWallet(nodeApi,
-                                          chainQueryApi,
-                                          bip39PasswordOpt),
+      build = () => FundWalletUtil.createFundedWallet(nodeApi, chainQueryApi),
       destroy = { funded: FundedWallet =>
         destroyWallet(funded.wallet)
       }
     )(test)
   }
 
-  def withFundedSegwitWallet(
-      test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String])(implicit
+  def withFundedSegwitWallet(test: OneArgAsyncTest)(implicit
       walletAppConfig: WalletAppConfig): FutureOutcome = {
     makeDependentFixture(
-      build = () =>
-        FundWalletUtil.createFundedWallet(
-          nodeApi,
-          chainQueryApi,
-          bip39PasswordOpt,
-          Some(BaseWalletTest.segwitWalletConf)),
+      build = () => FundWalletUtil.createFundedWallet(nodeApi, chainQueryApi),
       destroy = { funded: FundedWallet =>
         destroyWallet(funded.wallet)
       }
@@ -116,15 +106,11 @@ trait BitcoinSWalletTest
     * peered with a bitcoind so the funds in the wallet are not tied to an
     * underlying blockchain
     */
-  def withFundedDLCWallet(
-      test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String])(implicit
+  def withFundedDLCWallet(test: OneArgAsyncTest)(implicit
       config: BitcoinSAppConfig): FutureOutcome = {
     makeDependentFixture(
-      build = () =>
-        FundWalletUtil.createFundedDLCWallet(nodeApi,
-                                             chainQueryApi,
-                                             bip39PasswordOpt),
+      build =
+        () => FundWalletUtil.createFundedDLCWallet(nodeApi, chainQueryApi),
       destroy = { funded: FundedDLCWallet =>
         for {
           _ <- destroyDLCWallet(funded.wallet)
@@ -144,23 +130,20 @@ trait BitcoinSWalletTest
   }
 
   /** Fixture for a wallet with default configuration with no funds in it */
-  def withNewWallet(test: OneArgAsyncTest, bip39PasswordOpt: Option[String])(
-      implicit walletAppConfig: WalletAppConfig): FutureOutcome =
-    makeDependentFixture(
-      build = { () =>
-        createDefaultWallet(nodeApi, chainQueryApi, bip39PasswordOpt)
-      },
-      destroy = destroyWallet)(test)
-
-  def withNewWallet2Accounts(
-      test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String])(implicit
+  def withNewWallet(test: OneArgAsyncTest)(implicit
       walletAppConfig: WalletAppConfig): FutureOutcome = {
-    makeDependentFixture(
-      build = { () =>
-        createWallet2Accounts(nodeApi, chainQueryApi, bip39PasswordOpt)
-      },
-      destroy = destroyWallet)(test)
+    makeDependentFixture(build = { () =>
+                           createDefaultWallet(nodeApi, chainQueryApi)
+                         },
+                         destroy = destroyWallet)(test)
+  }
+
+  def withNewWallet2Accounts(test: OneArgAsyncTest)(implicit
+      walletAppConfig: WalletAppConfig): FutureOutcome = {
+    makeDependentFixture(build = { () =>
+                           createWallet2Accounts(nodeApi, chainQueryApi)
+                         },
+                         destroy = destroyWallet)(test)
   }
 
   def withNewWalletAndBitcoind(test: OneArgAsyncTest)(implicit
@@ -183,9 +166,7 @@ trait BitcoinSWalletTest
       destroy = destroyWalletWithBitcoind(_: WalletWithBitcoindRpc))(test)
   }
 
-  def withNewWalletAndBitcoindV19(
-      test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String])(implicit
+  def withNewWalletAndBitcoindV19(test: OneArgAsyncTest)(implicit
       walletAppConfig: WalletAppConfig): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoindV19] =
       BitcoinSFixture.composeBuildersAndWrap(
@@ -195,7 +176,7 @@ trait BitcoinSWalletTest
             .map(_.asInstanceOf[BitcoindV19RpcClient])
         },
         dependentBuilder = { (bitcoind: BitcoindV19RpcClient) =>
-          createWalletWithBitcoindV19(bitcoind, bip39PasswordOpt)
+          createWalletWithBitcoindV19(bitcoind)
         },
         wrap = (
             _: BitcoindV19RpcClient,
@@ -207,9 +188,7 @@ trait BitcoinSWalletTest
       destroy = destroyWalletWithBitcoind(_: WalletWithBitcoindV19))(test)
   }
 
-  def withFundedWalletAndBitcoindV19(
-      test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String])(implicit
+  def withFundedWalletAndBitcoindV19(test: OneArgAsyncTest)(implicit
       walletAppConfig: WalletAppConfig): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoindV19] = { () =>
       for {
@@ -217,7 +196,7 @@ trait BitcoinSWalletTest
           BitcoinSFixture
             .createBitcoindWithFunds(Some(BitcoindVersion.V19))
             .map(_.asInstanceOf[BitcoindV19RpcClient])
-        wallet <- createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
+        wallet <- createWalletWithBitcoindCallbacks(bitcoind)
         fundedWallet <- FundWalletUtil.fundWalletWithBitcoind(wallet)
         _ <- SyncUtil.syncWalletFullBlocks(wallet = fundedWallet.wallet,
                                            bitcoind = bitcoind)
@@ -340,75 +319,45 @@ object BitcoinSWalletTest extends WalletLogger {
     }
   }
 
-  private def createDLCWallet(
-      bip39PasswordOpt: Option[String],
-      extraConfig: Option[Config],
-      nodeApi: NodeApi,
-      chainQueryApi: ChainQueryApi)(implicit
+  private def createDLCWallet(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)(
+      implicit
       config: BitcoinSAppConfig,
       ec: ExecutionContext): Future[DLCWallet] = {
 
-    val walletConfig = extraConfig match {
-      case None    => config
-      case Some(c) => config.withOverrides(Vector(c))
-    }
-
-    val walletConfigWithBip39Pw = bip39PasswordOpt match {
-      case Some(pw) =>
-        val str = s"""bitcoin-s.keymanager.bip39password="$pw""""
-        val bip39Config = ConfigFactory.parseString(str)
-        walletConfig.withOverrides(Vector(bip39Config))
-      case None => walletConfig
-    }
-
     // we want to check we're not overwriting
     // any user data
-    AppConfig.throwIfDefaultDatadir(walletConfigWithBip39Pw.walletConf)
+    AppConfig.throwIfDefaultDatadir(config.walletConf)
 
     val initConfs = for {
-      _ <- walletConfigWithBip39Pw.walletConf.start()
+      _ <- config.walletConf.start()
       _ <- config.dlcConf.start()
     } yield ()
 
     initConfs.flatMap { _ =>
       val wallet =
         DLCWallet(nodeApi, chainQueryApi, new RandomFeeProvider)(
-          walletConfigWithBip39Pw.walletConf,
+          config.walletConf,
           config.dlcConf)
 
       Wallet
-        .initialize(wallet, bip39PasswordOpt)
+        .initialize(wallet, config.walletConf.bip39PasswordOpt)
         .map(_.asInstanceOf[DLCWallet])
     }
   }
 
   /** Creates a wallet with the default configuration */
-  def createDefaultWallet(
-      nodeApi: NodeApi,
-      chainQueryApi: ChainQueryApi,
-      bip39PasswordOpt: Option[String],
-      extraConfig: Option[Config] = None)(implicit
-      config: WalletAppConfig): Future[Wallet] = {
-    val bip39PasswordConfig =
-      BitcoinSWalletTest.buildBip39PasswordConfig(bip39PasswordOpt)
-
-    val merged = bip39PasswordConfig.withFallback(
-      extraConfig.getOrElse(ConfigFactory.empty))
-
-    val newWalletConf = config.withOverrides(merged)
+  def createDefaultWallet(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)(
+      implicit walletAppConfig: WalletAppConfig): Future[Wallet] = {
     createNewWallet(nodeApi = nodeApi, chainQueryApi = chainQueryApi)(
-      newWalletConf
+      walletAppConfig
     )() // get the standard config
   }
 
   /** Creates a default wallet with bitcoind where the [[ChainQueryApi]] fed to the wallet
     * is implemented by bitcoind
     */
-  def createWalletWithBitcoindCallbacks(
-      bitcoind: BitcoindRpcClient,
-      bip39PasswordOpt: Option[String],
-      extraConfig: Option[Config] = None)(implicit
-      config: WalletAppConfig,
+  def createWalletWithBitcoindCallbacks(bitcoind: BitcoindRpcClient)(implicit
+      walletAppConfig: WalletAppConfig,
       system: ActorSystem): Future[WalletWithBitcoindRpc] = {
     import system.dispatcher
     //we need to create a promise so we can inject the wallet with the callback
@@ -416,11 +365,7 @@ object BitcoinSWalletTest extends WalletLogger {
     //so we don't lose the internal state of the wallet
     val walletCallbackP = Promise[Wallet]()
     val walletWithBitcoindF = for {
-      wallet <- BitcoinSWalletTest.createWallet2Accounts(bitcoind,
-                                                         bitcoind,
-                                                         bip39PasswordOpt =
-                                                           bip39PasswordOpt,
-                                                         extraConfig)
+      wallet <- BitcoinSWalletTest.createWallet2Accounts(bitcoind, bitcoind)
       //create the wallet with the appropriate callbacks now that
       //we have them
       walletWithCallback = Wallet(
@@ -439,17 +384,14 @@ object BitcoinSWalletTest extends WalletLogger {
     walletWithBitcoindF
   }
 
-  def createWallet2Accounts(
-      nodeApi: NodeApi,
-      chainQueryApi: ChainQueryApi,
-      bip39PasswordOpt: Option[String],
-      extraConfig: Option[Config] = None)(implicit
+  def createWallet2Accounts(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)(
+      implicit
       config: WalletAppConfig,
       system: ActorSystem): Future[Wallet] = {
     implicit val ec: ExecutionContextExecutor = system.dispatcher
 
     val defaultWalletF =
-      createDefaultWallet(nodeApi, chainQueryApi, bip39PasswordOpt, extraConfig)
+      createDefaultWallet(nodeApi, chainQueryApi)
     for {
       wallet <- defaultWalletF
       account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
@@ -460,18 +402,13 @@ object BitcoinSWalletTest extends WalletLogger {
 
   }
 
-  def createDLCWallet2Accounts(
-      nodeApi: NodeApi,
-      chainQueryApi: ChainQueryApi,
-      bip39PasswordOpt: Option[String],
-      extraConfig: Option[Config] = None)(implicit
+  def createDLCWallet2Accounts(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)(
+      implicit
       config: BitcoinSAppConfig,
       system: ActorSystem): Future[DLCWallet] = {
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     for {
-      wallet <- createDLCWallet(bip39PasswordOpt = bip39PasswordOpt,
-                                extraConfig = extraConfig,
-                                nodeApi = nodeApi,
+      wallet <- createDLCWallet(nodeApi = nodeApi,
                                 chainQueryApi = chainQueryApi)
       account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
       newAccountWallet <- wallet.createNewAccount(hdAccount = account1,
@@ -501,7 +438,18 @@ object BitcoinSWalletTest extends WalletLogger {
   def createWalletWithBitcoind(bitcoind: BitcoindRpcClient)(implicit
       system: ActorSystem,
       config: WalletAppConfig): Future[WalletWithBitcoindRpc] = {
-    createWalletWithBitcoindCallbacks(bitcoind, None)
+    createWalletWithBitcoindCallbacks(bitcoind)
+  }
+
+  def createWalletWithBitcoindV19(bitcoind: BitcoindV19RpcClient)(implicit
+      system: ActorSystem,
+      config: WalletAppConfig): Future[WalletWithBitcoindV19] = {
+    import system.dispatcher
+    val resultF = createWalletWithBitcoindCallbacks(bitcoind)
+    resultF.map { result =>
+      WalletWithBitcoindV19(result.wallet, bitcoind)
+    }
+
   }
 
   def createWalletWithBitcoindV19(wallet: Wallet)(implicit
@@ -516,28 +464,6 @@ object BitcoinSWalletTest extends WalletLogger {
       created.bitcoind.asInstanceOf[BitcoindV19RpcClient])
   }
 
-  def createWalletWithBitcoindV19(
-      bitcoind: BitcoindV19RpcClient,
-      bip39PasswordOpt: Option[String])(implicit
-      system: ActorSystem,
-      config: WalletAppConfig): Future[WalletWithBitcoindV19] = {
-    import system.dispatcher
-    for {
-      created <- createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
-    } yield WalletWithBitcoindV19(created.wallet, bitcoind)
-  }
-
-  def createWalletWithBitcoind(
-      bitcoind: BitcoindRpcClient,
-      bip39PasswordOpt: Option[String])(implicit
-      system: ActorSystem,
-      config: WalletAppConfig): Future[WalletWithBitcoindRpc] = {
-    import system.dispatcher
-    for {
-      created <- createWalletWithBitcoindCallbacks(bitcoind, bip39PasswordOpt)
-    } yield WalletWithBitcoindRpc(created.wallet, bitcoind)
-  }
-
   def createWalletWithBitcoind(
       wallet: Wallet,
       bitcoindRpcClient: BitcoindRpcClient
@@ -549,7 +475,6 @@ object BitcoinSWalletTest extends WalletLogger {
   def fundedWalletAndBitcoind(
       versionOpt: Option[BitcoindVersion],
       nodeApi: NodeApi,
-      bip39PasswordOpt: Option[String],
       chainQueryApi: ChainQueryApi,
       walletCallbacks: WalletCallbacks)(implicit
       config: BitcoinSAppConfig,
@@ -559,8 +484,7 @@ object BitcoinSWalletTest extends WalletLogger {
     for {
       wallet <- BitcoinSWalletTest.createWallet2Accounts(
         nodeApi,
-        chainQueryApi,
-        bip39PasswordOpt)(config.walletConf, system)
+        chainQueryApi)(config.walletConf, system)
       withBitcoind <- createWalletWithBitcoind(wallet, versionOpt)
       funded <- FundWalletUtil.fundWalletWithBitcoind(withBitcoind)
     } yield funded
@@ -577,7 +501,6 @@ object BitcoinSWalletTest extends WalletLogger {
       bitcoindRpcClient: BitcoindRpcClient,
       nodeApi: NodeApi,
       chainQueryApi: ChainQueryApi,
-      bip39PasswordOpt: Option[String],
       walletCallbacks: WalletCallbacks)(implicit
       config: BitcoinSAppConfig,
       system: ActorSystem): Future[WalletWithBitcoindRpc] = {
@@ -586,8 +509,7 @@ object BitcoinSWalletTest extends WalletLogger {
     for {
       wallet <- BitcoinSWalletTest.createWallet2Accounts(
         nodeApi = nodeApi,
-        chainQueryApi = chainQueryApi,
-        bip39PasswordOpt = bip39PasswordOpt)(config.walletConf, system)
+        chainQueryApi = chainQueryApi)(config.walletConf, system)
       //add callbacks for wallet
       nodeCallbacks <-
         BitcoinSWalletTest.createNeutrinoNodeCallbacksForWallet(wallet)(system)
@@ -675,10 +597,36 @@ object BitcoinSWalletTest extends WalletLogger {
   def buildBip39PasswordConfig(bip39PasswordOpt: Option[String]): Config = {
     bip39PasswordOpt match {
       case Some(bip39Password) =>
-        val str = s"""bitcoin-s.keymanager.bip39password=$bip39Password"""
-        ConfigFactory.parseString(str)
+        if (bip39Password == "") {
+          ConfigFactory.empty
+        } else {
+          val str = s"""bitcoin-s.keymanager.bip39password=$bip39Password"""
+          ConfigFactory.parseString(str)
+        }
       case None =>
         ConfigFactory.empty
     }
+  }
+
+  def buildBip39PasswordWithExtraConfig(
+      bip39PasswordOpt: Option[String],
+      extraConfig: Option[Config]): Config = {
+    val bip39PasswordConfig =
+      BitcoinSWalletTest.buildBip39PasswordConfig(bip39PasswordOpt)
+
+    val merged = bip39PasswordConfig.withFallback(
+      extraConfig.getOrElse(ConfigFactory.empty))
+
+    merged
+  }
+
+  def getSegwitWalletConfigWithBip39PasswordOpt(pgUrl: Option[String])(implicit
+      system: ActorSystem): BitcoinSAppConfig = {
+    val segwitConfig = BaseWalletTest.segwitWalletConf
+
+    val extraConfig = BitcoinSWalletTest.buildBip39PasswordWithExtraConfig(
+      bip39PasswordOpt = KeyManagerTestUtil.bip39PasswordOpt,
+      extraConfig = Some(segwitConfig))
+    BaseWalletTest.getFreshConfig(() => pgUrl, Vector(extraConfig))
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -65,15 +65,8 @@ trait BitcoinSWalletTestCachedBitcoind
 
   def withNewWalletAndBitcoindCached(
       test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String],
-      bitcoind: BitcoindRpcClient,
+      bitcoind: BitcoindRpcClient)(implicit
       walletAppConfig: WalletAppConfig): FutureOutcome = {
-    val bip39PasswordConfig: Config =
-      BitcoinSWalletTest.buildBip39PasswordConfig(bip39PasswordOpt)
-
-    implicit val newWalletConf =
-      walletAppConfig.withOverrides(bip39PasswordConfig)
-
     val builder: () => Future[WalletWithBitcoind[_]] =
       BitcoinSFixture.composeBuildersAndWrap(
         builder = { () =>

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTestCachedBitcoind.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.testkit.wallet
 
+import com.typesafe.config.Config
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
 import org.bitcoins.testkit.EmbeddedPg
@@ -41,14 +42,12 @@ trait BitcoinSWalletTestCachedBitcoind
     */
   def withFundedWalletAndBitcoindCached(
       test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String],
       bitcoind: BitcoindRpcClient)(implicit
       walletAppConfig: WalletAppConfig): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind[_]] = { () =>
       for {
         walletWithBitcoind <- createWalletWithBitcoindCallbacks(
-          bitcoind = bitcoind,
-          bip39PasswordOpt = bip39PasswordOpt)
+          bitcoind = bitcoind)
         fundedWallet <- FundWalletUtil.fundWalletWithBitcoind(
           walletWithBitcoind)
         _ <- SyncUtil.syncWalletFullBlocks(wallet = fundedWallet.wallet,
@@ -67,15 +66,21 @@ trait BitcoinSWalletTestCachedBitcoind
   def withNewWalletAndBitcoindCached(
       test: OneArgAsyncTest,
       bip39PasswordOpt: Option[String],
-      bitcoind: BitcoindRpcClient)(implicit
+      bitcoind: BitcoindRpcClient,
       walletAppConfig: WalletAppConfig): FutureOutcome = {
+    val bip39PasswordConfig: Config =
+      BitcoinSWalletTest.buildBip39PasswordConfig(bip39PasswordOpt)
+
+    implicit val newWalletConf =
+      walletAppConfig.withOverrides(bip39PasswordConfig)
+
     val builder: () => Future[WalletWithBitcoind[_]] =
       BitcoinSFixture.composeBuildersAndWrap(
         builder = { () =>
           Future.successful(bitcoind)
         },
         dependentBuilder = { (bitcoind: BitcoindRpcClient) =>
-          createWalletWithBitcoind(bitcoind, bip39PasswordOpt)
+          createWalletWithBitcoind(bitcoind)
         },
         wrap =
           (_: BitcoindRpcClient, walletWithBitcoind: WalletWithBitcoind[_]) =>
@@ -89,9 +94,7 @@ trait BitcoinSWalletTestCachedBitcoind
       })(test)
   }
 
-  def withFundedWalletAndBitcoind(
-      test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String])(implicit
+  def withFundedWalletAndBitcoind(test: OneArgAsyncTest)(implicit
       walletAppConfig: WalletAppConfig): FutureOutcome = {
     val bitcoindF = BitcoinSFixture
       .createBitcoindWithFunds(None)
@@ -100,9 +103,8 @@ trait BitcoinSWalletTestCachedBitcoind
     //so we can re-use code in withFundedWalletBitcoindCached
     val resultF = for {
       bitcoind <- bitcoindF
-      outcome = withFundedWalletAndBitcoindCached(test,
-                                                  bip39PasswordOpt,
-                                                  bitcoind)
+      outcome = withFundedWalletAndBitcoindCached(test = test,
+                                                  bitcoind = bitcoind)
       f <- outcome.toFuture
     } yield f
 
@@ -142,10 +144,8 @@ trait BitcoinSWalletTestCachedBitcoindNewest
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withFundedWalletAndBitcoindCached(
-        test,
-        getBIP39PasswordOpt(),
-        bitcoind)(getFreshWalletAppConfig)
+      futOutcome = withFundedWalletAndBitcoindCached(test, bitcoind)(
+        getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)
@@ -175,13 +175,17 @@ trait BitcoinSWalletTestCachedBitcoinV19
   def withFundedWalletAndBitcoindCachedV19(
       test: OneArgAsyncTest,
       bip39PasswordOpt: Option[String],
-      bitcoind: BitcoindV19RpcClient)(implicit
+      bitcoind: BitcoindV19RpcClient,
       walletAppConfig: WalletAppConfig): FutureOutcome = {
+    val bip39PasswordConfig: Config =
+      BitcoinSWalletTest.buildBip39PasswordConfig(bip39PasswordOpt)
+
+    implicit val newWalletConf =
+      walletAppConfig.withOverrides(bip39PasswordConfig)
     val builder: () => Future[WalletWithBitcoindV19] = { () =>
       for {
         walletWithBitcoind <- createWalletWithBitcoindCallbacks(
-          bitcoind = bitcoind,
-          bip39PasswordOpt = bip39PasswordOpt)
+          bitcoind = bitcoind)
         walletWithBitcoindV19 = WalletWithBitcoindV19(walletWithBitcoind.wallet,
                                                       bitcoind)
         fundedWallet <- FundWalletUtil
@@ -201,7 +205,6 @@ trait BitcoinSWalletTestCachedBitcoinV19
 
   def withNewWalletAndBitcoindCachedV19(
       test: OneArgAsyncTest,
-      bip39PasswordOpt: Option[String],
       bitcoind: BitcoindV19RpcClient)(implicit
       walletAppConfig: WalletAppConfig): FutureOutcome = {
     val builder: () => Future[WalletWithBitcoind[_]] =
@@ -210,8 +213,7 @@ trait BitcoinSWalletTestCachedBitcoinV19
           Future.successful(bitcoind)
         },
         dependentBuilder = { (bitcoind: BitcoindV19RpcClient) =>
-          BitcoinSWalletTest.createWalletWithBitcoindV19(bitcoind,
-                                                         bip39PasswordOpt)
+          BitcoinSWalletTest.createWalletWithBitcoindV19(bitcoind)
         },
         wrap =
           (_: BitcoindRpcClient, walletWithBitcoind: WalletWithBitcoindV19) =>
@@ -228,10 +230,10 @@ trait BitcoinSWalletTestCachedBitcoinV19
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withFundedWalletAndBitcoindCachedV19(
-        test,
-        getBIP39PasswordOpt(),
-        bitcoind)(getFreshWalletAppConfig)
+      futOutcome = withFundedWalletAndBitcoindCachedV19(test,
+                                                        getBIP39PasswordOpt(),
+                                                        bitcoind,
+                                                        getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DualWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DualWalletTestCachedBitcoind.scala
@@ -17,9 +17,6 @@ trait DualWalletTestCachedBitcoind
     extends BitcoinSWalletTestCachedBitcoindNewest {
   import BitcoinSWalletTest._
 
-  override def getFreshConfig: BitcoinSAppConfig = {
-    BitcoinSWalletTest.getSegwitWalletConfigWithBip39PasswordOpt(pgUrl())
-  }
   implicit protected def config2: BitcoinSAppConfig = getFreshConfig
 
   implicit protected def wallet2AppConfig: WalletAppConfig = {

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DualWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DualWalletTestCachedBitcoind.scala
@@ -8,6 +8,7 @@ import org.bitcoins.core.protocol.dlc.models.{
 }
 import org.bitcoins.dlc.wallet.DLCAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.wallet.DLCWalletUtil.InitializedDLCWallet
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
 import org.bitcoins.wallet.config.WalletAppConfig
@@ -17,7 +18,12 @@ trait DualWalletTestCachedBitcoind
     extends BitcoinSWalletTestCachedBitcoindNewest {
   import BitcoinSWalletTest._
 
-  implicit protected def config2: BitcoinSAppConfig = getFreshConfig
+  implicit protected def config2: BitcoinSAppConfig = {
+    val config = BitcoinSWalletTest.buildBip39PasswordWithExtraConfig(
+      getBIP39PasswordOpt(),
+      Some(BaseWalletTest.segwitWalletConf))
+    BitcoinSTestAppConfig.getNeutrinoTestConfig(config)
+  }
 
   implicit protected def wallet2AppConfig: WalletAppConfig = {
     config2.walletConf

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DualWalletTestCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DualWalletTestCachedBitcoind.scala
@@ -8,7 +8,6 @@ import org.bitcoins.core.protocol.dlc.models.{
 }
 import org.bitcoins.dlc.wallet.DLCAppConfig
 import org.bitcoins.server.BitcoinSAppConfig
-import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.wallet.DLCWalletUtil.InitializedDLCWallet
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
 import org.bitcoins.wallet.config.WalletAppConfig
@@ -18,8 +17,10 @@ trait DualWalletTestCachedBitcoind
     extends BitcoinSWalletTestCachedBitcoindNewest {
   import BitcoinSWalletTest._
 
-  implicit protected def config2: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoTestConfig()
+  override def getFreshConfig: BitcoinSAppConfig = {
+    BitcoinSWalletTest.getSegwitWalletConfigWithBip39PasswordOpt(pgUrl())
+  }
+  implicit protected def config2: BitcoinSAppConfig = getFreshConfig
 
   implicit protected def wallet2AppConfig: WalletAppConfig = {
     config2.walletConf
@@ -43,19 +44,15 @@ trait DualWalletTestCachedBitcoind
     */
   def withDualFundedDLCWallets(test: OneArgAsyncTest): FutureOutcome = {
     makeDependentFixture(
-      build = () =>
-        for {
-          bitcoind <- cachedBitcoindWithFundsF
-          walletA <-
-            FundWalletUtil.createFundedDLCWalletWithBitcoind(
-              bitcoind,
-              getBIP39PasswordOpt(),
-              Some(BaseWalletTest.segwitWalletConf))
-          walletB <- FundWalletUtil.createFundedDLCWalletWithBitcoind(
-            bitcoind,
-            getBIP39PasswordOpt(),
-            Some(BaseWalletTest.segwitWalletConf))(config2, system)
-        } yield (walletA, walletB, bitcoind),
+      build =
+        () =>
+          for {
+            bitcoind <- cachedBitcoindWithFundsF
+            walletA <-
+              FundWalletUtil.createFundedDLCWalletWithBitcoind(bitcoind)
+            walletB <- FundWalletUtil.createFundedDLCWalletWithBitcoind(
+              bitcoind)(config2, system)
+          } yield (walletA, walletB, bitcoind),
       destroy = { fundedWallets: (FundedDLCWallet, FundedDLCWallet, _) =>
         for {
           _ <- destroyDLCWallet(fundedWallets._1.wallet)
@@ -70,37 +67,33 @@ trait DualWalletTestCachedBitcoind
       test: OneArgAsyncTest,
       contractOraclePair: ContractOraclePair): FutureOutcome = {
     makeDependentFixture(
-      build = () => {
-        val bitcoindF = cachedBitcoindWithFundsF
+      build =
+        () => {
+          val bitcoindF = cachedBitcoindWithFundsF
 
-        val walletAF = bitcoindF.flatMap { bitcoind =>
-          FundWalletUtil.createFundedDLCWalletWithBitcoind(
-            bitcoind,
-            getBIP39PasswordOpt(),
-            Some(BaseWalletTest.segwitWalletConf))
-        }
-        val walletBF = for {
-          bitcoind <- bitcoindF
+          val walletAF = bitcoindF.flatMap { bitcoind =>
+            FundWalletUtil.createFundedDLCWalletWithBitcoind(bitcoind)
+          }
+          val walletBF = for {
+            bitcoind <- bitcoindF
 
-          //its important to map on this otherwise we generate blocks in parallel
-          //causing a reorg inside of createFundedDLCWallet
-          _ <- walletAF
-          walletB <- FundWalletUtil.createFundedDLCWalletWithBitcoind(
-            bitcoind,
-            getBIP39PasswordOpt(),
-            Some(BaseWalletTest.segwitWalletConf))(config2, system)
-        } yield { walletB }
+            //its important to map on this otherwise we generate blocks in parallel
+            //causing a reorg inside of createFundedDLCWallet
+            _ <- walletAF
+            walletB <- FundWalletUtil.createFundedDLCWalletWithBitcoind(
+              bitcoind)(config2, system)
+          } yield { walletB }
 
-        for {
-          walletA <- walletAF
-          walletB <- walletBF
-          amt = expectedDefaultAmt / Satoshis(2)
-          contractInfo = SingleContractInfo(amt.satoshis, contractOraclePair)
-          (dlcWalletA, dlcWalletB) <-
-            DLCWalletUtil.initDLC(walletA, walletB, contractInfo)
-          bitcoind <- bitcoindF
-        } yield (dlcWalletA, dlcWalletB, bitcoind)
-      },
+          for {
+            walletA <- walletAF
+            walletB <- walletBF
+            amt = expectedDefaultAmt / Satoshis(2)
+            contractInfo = SingleContractInfo(amt.satoshis, contractOraclePair)
+            (dlcWalletA, dlcWalletB) <-
+              DLCWalletUtil.initDLC(walletA, walletB, contractInfo)
+            bitcoind <- bitcoindF
+          } yield (dlcWalletA, dlcWalletB, bitcoind)
+        },
       destroy = { dlcWallets: (InitializedDLCWallet, InitializedDLCWallet, _) =>
         for {
           _ <- destroyDLCWallet(dlcWallets._1.wallet)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.testkit.wallet
 
 import akka.actor.ActorSystem
-import com.typesafe.config.Config
 import grizzled.slf4j.Logging
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.node.NodeApi
@@ -181,58 +180,42 @@ object FundWalletUtil extends FundWalletUtil {
     * Account 0 (default account) has utxos of 1,2,3 bitcoin in it (6 btc total)
     * Account 1 has a utxos of 0.2,0.3,0.5 bitcoin in it (1 btc total)
     */
-  def createFundedWallet(
-      nodeApi: NodeApi,
-      chainQueryApi: ChainQueryApi,
-      bip39PasswordOpt: Option[String],
-      extraConfig: Option[Config] = None)(implicit
+  def createFundedWallet(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)(
+      implicit
       config: WalletAppConfig,
       system: ActorSystem): Future[FundedWallet] = {
-
     import system.dispatcher
     for {
-      wallet <- BitcoinSWalletTest.createWallet2Accounts(
-        nodeApi = nodeApi,
-        chainQueryApi = chainQueryApi,
-        bip39PasswordOpt = bip39PasswordOpt,
-        extraConfig = extraConfig)
+      wallet <- BitcoinSWalletTest.createWallet2Accounts(nodeApi = nodeApi,
+                                                         chainQueryApi =
+                                                           chainQueryApi)
       funded <- FundWalletUtil.fundWallet(wallet)
     } yield FundedWallet(funded.wallet)
   }
 
-  def createFundedDLCWallet(
-      nodeApi: NodeApi,
-      chainQueryApi: ChainQueryApi,
-      bip39PasswordOpt: Option[String],
-      extraConfig: Option[Config] = None)(implicit
+  def createFundedDLCWallet(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)(
+      implicit
       config: BitcoinSAppConfig,
       system: ActorSystem): Future[FundedDLCWallet] = {
     import system.dispatcher
     for {
-      wallet <- BitcoinSWalletTest.createDLCWallet2Accounts(
-        nodeApi = nodeApi,
-        chainQueryApi = chainQueryApi,
-        bip39PasswordOpt = bip39PasswordOpt,
-        extraConfig = extraConfig)
+      wallet <- BitcoinSWalletTest.createDLCWallet2Accounts(nodeApi = nodeApi,
+                                                            chainQueryApi =
+                                                              chainQueryApi)
       funded <- FundWalletUtil.fundWallet(wallet)
     } yield {
       FundedDLCWallet(funded.wallet.asInstanceOf[DLCWallet])
     }
   }
 
-  def createFundedDLCWalletWithBitcoind(
-      bitcoind: BitcoindRpcClient,
-      bip39PasswordOpt: Option[String],
-      extraConfig: Option[Config] = None)(implicit
+  def createFundedDLCWalletWithBitcoind(bitcoind: BitcoindRpcClient)(implicit
       config: BitcoinSAppConfig,
       system: ActorSystem): Future[FundedDLCWallet] = {
     import system.dispatcher
     for {
-      tmp <- BitcoinSWalletTest.createDLCWallet2Accounts(
-        nodeApi = bitcoind,
-        chainQueryApi = bitcoind,
-        bip39PasswordOpt = bip39PasswordOpt,
-        extraConfig = extraConfig)
+      tmp <- BitcoinSWalletTest.createDLCWallet2Accounts(nodeApi = bitcoind,
+                                                         chainQueryApi =
+                                                           bitcoind)
       wallet = BitcoindRpcBackendUtil.createDLCWalletWithBitcoindCallbacks(
         bitcoind,
         tmp,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -21,7 +21,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
   type FixtureParam = FundedWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
+    withFundedWallet(test)(getFreshWalletAppConfig)
   }
 
   behavior of "AddressHandling"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressLabelTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressLabelTest.scala
@@ -11,7 +11,7 @@ class AddressLabelTest extends BitcoinSWalletTest {
   type FixtureParam = FundedWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
+    withFundedWallet(test)(getFreshWalletAppConfig)
   }
 
   behavior of "Address tags"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -205,10 +205,9 @@ class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
     implicit val walletAppConfig: WalletAppConfig = params.walletAppConfig
 
     for {
-      tmpWallet <- BitcoinSWalletTest.createDefaultWallet(
-        nodeApi = bitcoind,
-        chainQueryApi = bitcoind,
-        bip39PasswordOpt = walletAppConfig.bip39PasswordOpt)
+      tmpWallet <- BitcoinSWalletTest.createDefaultWallet(nodeApi = bitcoind,
+                                                          chainQueryApi =
+                                                            bitcoind)
     } yield {
       BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(bitcoind,
                                                                tmpWallet,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
@@ -27,7 +27,7 @@ class BitcoindBlockPollingTest
       for {
         // Setup wallet
         tmpWallet <-
-          BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind, None)
+          BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind)
         wallet =
           BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(bitcoind,
                                                                    tmpWallet,
@@ -72,7 +72,7 @@ class BitcoindBlockPollingTest
       for {
         // Setup wallet
         tmpWallet <-
-          BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind, None)
+          BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind)
         wallet =
           BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(bitcoind,
                                                                    tmpWallet,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindZMQBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindZMQBackendTest.scala
@@ -44,7 +44,7 @@ class BitcoindZMQBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
     for {
       // Setup wallet
       tmpWallet <-
-        BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind, None)
+        BitcoinSWalletTest.createDefaultWallet(bitcoind, bitcoind)
       wallet =
         BitcoindRpcBackendUtil.createWalletWithBitcoindCallbacks(
           bitcoind = bitcoind,

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -22,10 +22,8 @@ class FundTransactionHandlingTest
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withFundedWalletAndBitcoindCached(
-        test,
-        getBIP39PasswordOpt(),
-        bitcoind)(getFreshWalletAppConfig)
+      futOutcome = withFundedWalletAndBitcoindCached(test, bitcoind)(
+        getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/MultiWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/MultiWalletTest.scala
@@ -3,7 +3,6 @@ package org.bitcoins.wallet
 import com.typesafe.config.ConfigFactory
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.chain.MockChainQueryApi
-import org.bitcoins.testkit.keymanager.KeyManagerTestUtil.bip39PasswordOpt
 import org.bitcoins.testkit.node.MockNodeApi
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
@@ -30,15 +29,13 @@ class MultiWalletTest extends BitcoinSAsyncTest with EmbeddedPg {
     val configB =
       BitcoinSAppConfig(dir, Vector(walletNameConfB.withFallback(dbConf)))
 
-    val walletAF = BitcoinSWalletTest.createDefaultWallet(
-      MockNodeApi,
-      MockChainQueryApi,
-      bip39PasswordOpt)(configA.walletConf)
+    val walletAF =
+      BitcoinSWalletTest.createDefaultWallet(MockNodeApi, MockChainQueryApi)(
+        configA.walletConf)
 
-    val walletBF = BitcoinSWalletTest.createDefaultWallet(
-      MockNodeApi,
-      MockChainQueryApi,
-      bip39PasswordOpt)(configB.walletConf)
+    val walletBF =
+      BitcoinSWalletTest.createDefaultWallet(MockNodeApi, MockChainQueryApi)(
+        configB.walletConf)
 
     val assertionF: Future[Assertion] = for {
       walletA <- walletAF

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/MultiWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/MultiWalletTest.scala
@@ -33,12 +33,12 @@ class MultiWalletTest extends BitcoinSAsyncTest with EmbeddedPg {
     val walletAF = BitcoinSWalletTest.createDefaultWallet(
       MockNodeApi,
       MockChainQueryApi,
-      bip39PasswordOpt)(configA.walletConf, system.dispatcher)
+      bip39PasswordOpt)(configA.walletConf)
 
     val walletBF = BitcoinSWalletTest.createDefaultWallet(
       MockNodeApi,
       MockChainQueryApi,
-      bip39PasswordOpt)(configB.walletConf, system.dispatcher)
+      bip39PasswordOpt)(configB.walletConf)
 
     val assertionF: Future[Assertion] = for {
       walletA <- walletAF

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -25,10 +25,8 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withNewWalletAndBitcoindCachedV19(
-        test,
-        getBIP39PasswordOpt(),
-        bitcoind)(getFreshWalletAppConfig)
+      futOutcome = withNewWalletAndBitcoindCachedV19(test, bitcoind)(
+        getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -23,7 +23,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
   override type FixtureParam = Wallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withNewWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
+    withNewWallet(test)(getFreshWalletAppConfig)
   }
 
   behavior of "Wallet.processTransaction"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -8,8 +8,6 @@ import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.core.wallet.utxo.TxoState
-import org.bitcoins.server.BitcoinSAppConfig
-import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.wallet.{
   BitcoinSWalletTestCachedBitcoindNewest,
   WalletWithBitcoindRpc
@@ -19,10 +17,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
-
-  /** Wallet config with data directory set to user temp directory */
-  override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
 
   override type FixtureParam = WalletWithBitcoindRpc
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOLifeCycleTest.scala
@@ -33,10 +33,8 @@ class UTXOLifeCycleTest
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withFundedWalletAndBitcoindCached(
-        test,
-        getBIP39PasswordOpt(),
-        bitcoind)(getFreshWalletAppConfig)
+      futOutcome = withFundedWalletAndBitcoindCached(test, bitcoind)(
+        getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
@@ -17,7 +17,7 @@ class WalletCallbackTest extends BitcoinSWalletTest {
   type FixtureParam = FundedWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    withFundedWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
+    withFundedWallet(test)(getFreshWalletAppConfig)
   }
 
   behavior of "WalletCallbacks"

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -27,9 +27,10 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
       futOutcome = withNewWalletAndBitcoindCached(
-        test,
-        getBIP39PasswordOpt(),
-        bitcoind)(getFreshWalletAppConfig)
+        test = test,
+        bip39PasswordOpt = getBIP39PasswordOpt(),
+        bitcoind = bitcoind,
+        walletAppConfig = getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -28,9 +28,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       bitcoind <- cachedBitcoindWithFundsF
       futOutcome = withNewWalletAndBitcoindCached(
         test = test,
-        bip39PasswordOpt = getBIP39PasswordOpt(),
-        bitcoind = bitcoind,
-        walletAppConfig = getFreshWalletAppConfig)
+        bitcoind = bitcoind)(getFreshWalletAppConfig)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -27,7 +27,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
   override type FixtureParam = FundedWallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withFundedWallet(test, getBIP39PasswordOpt())(getFreshWalletAppConfig)
+    withFundedWallet(test)(getFreshWalletAppConfig)
 
   behavior of "Wallet"
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -19,12 +19,11 @@ import java.nio.file.Files
 import scala.concurrent.Future
 
 class WalletUnitTest extends BitcoinSWalletTest {
-  private val bip39PasswordOpt: Option[String] = getBIP39PasswordOpt()
 
   override type FixtureParam = Wallet
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withNewWallet(test, bip39PasswordOpt)(getFreshWalletAppConfig)
+    withNewWallet(test)(getFreshWalletAppConfig)
 
   behavior of "Wallet - unit test"
 
@@ -149,6 +148,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
   it must "be able to call initialize twice without throwing an exception if we have the same key manager" in {
     wallet: Wallet =>
+      val bip39PasswordOpt = wallet.walletConfig.bip39PasswordOpt
       val twiceF = Wallet
         .initialize(wallet, bip39PasswordOpt)
         .flatMap { _ =>
@@ -161,6 +161,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
   it must "be able to detect an incompatible key manager with a wallet" in {
     wallet: Wallet =>
+      val bip39PasswordOpt = wallet.walletConfig.bip39PasswordOpt
       recoverToSucceededIf[RuntimeException] {
         Wallet
           .initialize(wallet, bip39PasswordOpt)
@@ -190,7 +191,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
       recoverToSucceededIf[IllegalArgumentException] {
         walletDiffKeyManagerF.flatMap { walletDiffKeyManager =>
-          Wallet.initialize(walletDiffKeyManager, bip39PasswordOpt)
+          Wallet.initialize(walletDiffKeyManager, None)
         }
       }
   }


### PR DESCRIPTION
Make sure we don't create multiple `WalletAppConfig` in the testkit harness so we avoid resource leaks. This is needed to fix #4539 

a6868ce - this commit removes the `bip39PasswordOpt` parameter everywhere in test fixtures and consolidates it to be set into one place -- `BaseWalletTest.getFreshConfig`.