### PR TITLE
Fix rescan batch boundary bug

### DIFF
--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -155,7 +155,6 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   it must "be able to discover funds using multiple batches" in {
     fixture: WalletWithBitcoindRpc =>
-      //  700,000,000 sats did not equal 300,000,000 sats
       val wallet = fixture.wallet
       val bitcoind = fixture.bitcoind
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -155,6 +155,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
   it must "be able to discover funds using multiple batches" in {
     fixture: WalletWithBitcoindRpc =>
+      //  700,000,000 sats did not equal 300,000,000 sats
       val wallet = fixture.wallet
       val bitcoind = fixture.bitcoind
 
@@ -170,6 +171,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         addr <- addrF
         _ <- initBalanceF
         txid <- bitcoind.sendToAddress(addr, amt)
+        _ = logger.info(s"rescan.address=$addr rescan.txid=$txid")
         tx <- bitcoind.getRawTransactionRaw(txid)
         bitcoindAddr <- bitcoindAddrF
         blockHashes <-
@@ -205,10 +207,11 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         balanceAfterClear <- wallet.getBalance()
         rescanState <- wallet.fullRescanNeutrinoWallet(1, true)
         _ <- RescanState.awaitRescanDone(rescanState)
+        _ <- AsyncUtil.nonBlockingSleep(5.second)
         balanceAfterRescan <- wallet.getBalance()
       } yield {
         assert(balanceAfterClear == CurrencyUnits.zero)
-        assert(balanceAfterPayment1 == balanceAfterRescan)
+        assert(balanceAfterRescan == balanceAfterPayment1)
       }
   }
 
@@ -494,6 +497,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         balanceAfterClear <- wallet.getBalance()
         rescanState <- wallet.fullRescanNeutrinoWallet(1, true)
         _ <- RescanState.awaitRescanDone(rescanState)
+        _ <- AsyncUtil.nonBlockingSleep(5.second)
         balanceAfterRescan <- wallet.getBalance()
       } yield {
         assert(balanceAfterClear == CurrencyUnits.zero)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -171,7 +171,6 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         addr <- addrF
         _ <- initBalanceF
         txid <- bitcoind.sendToAddress(addr, amt)
-        _ = logger.info(s"rescan.address=$addr rescan.txid=$txid")
         tx <- bitcoind.getRawTransactionRaw(txid)
         bitcoindAddr <- bitcoindAddrF
         blockHashes <-
@@ -501,7 +500,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         balanceAfterRescan <- wallet.getBalance()
       } yield {
         assert(balanceAfterClear == CurrencyUnits.zero)
-        assert(balanceAfterPayment1 == balanceAfterRescan)
+        assert(balanceAfterRescan == balanceAfterPayment1)
       }
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -81,7 +81,11 @@ private[wallet] trait RescanHandling extends WalletLogger {
                 Future.successful(None)
             }
             _ <- clearUtxos(account)
-            state <- doNeutrinoRescan(account, start, endOpt, addressBatchSize)
+            state <- doNeutrinoRescan(account = account,
+                                      startOpt = start,
+                                      endOpt = endOpt,
+                                      addressBatchSize = addressBatchSize,
+                                      forceGenerateSpks = false)
             //purposefully don't map on this Future as it won't be completed until
             //the rescan is completely done.
             _ = RescanState.awaitRescanComplete(state).map { _ =>
@@ -139,8 +143,11 @@ private[wallet] trait RescanHandling extends WalletLogger {
       addressBatchSize: Int,
       range: Range,
       parallelism: Int,
-      filterBatchSize: Int): RescanState.RescanStarted = {
-    val scriptsF = generateScriptPubKeys(account, addressBatchSize)
+      filterBatchSize: Int,
+      forceGenerateSpks: Boolean): RescanState.RescanStarted = {
+    val scriptsF = generateScriptPubKeys(account = account,
+                                         addressBatchSize = addressBatchSize,
+                                         forceGenerateSpks = forceGenerateSpks)
     //by completing the promise returned by this sink
     //we will be able to arbitrarily terminate the stream
     //see: https://doc.akka.io/docs/akka/current/stream/operators/Source/maybe.html
@@ -230,6 +237,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
       endOpt: Option[BlockStamp],
       addressBatchSize: Int,
       account: HDAccount,
+      forceGenerateSpks: Boolean,
       parallelismLevel: Int = Runtime.getRuntime.availableProcessors())(implicit
       ec: ExecutionContext): Future[RescanState] = {
     require(addressBatchSize > 0, "batch size must be greater than zero")
@@ -248,11 +256,14 @@ private[wallet] trait RescanHandling extends WalletLogger {
         s"Beginning to search for matches between ${startHeight}:${endHeight}")
       range = startHeight.to(endHeight)
 
-      rescanStarted = buildRescanFlow(account = account,
-                                      addressBatchSize = addressBatchSize,
-                                      range = range,
-                                      parallelism = parallelismLevel,
-                                      filterBatchSize = addressBatchSize)
+      rescanStarted = buildRescanFlow(
+        account = account,
+        addressBatchSize = addressBatchSize,
+        range = range,
+        parallelism = parallelismLevel,
+        filterBatchSize = addressBatchSize,
+        forceGenerateSpks = forceGenerateSpks
+      )
     } yield {
       rescanStarted
     }
@@ -265,13 +276,15 @@ private[wallet] trait RescanHandling extends WalletLogger {
       account: HDAccount,
       startOpt: Option[BlockStamp],
       endOpt: Option[BlockStamp],
-      addressBatchSize: Int): Future[RescanState] = {
+      addressBatchSize: Int,
+      forceGenerateSpks: Boolean): Future[RescanState] = {
     for {
       addressCount <- addressDAO.count()
       inProgress <- matchBlocks(endOpt = endOpt,
                                 startOpt = startOpt,
                                 account = account,
-                                addressBatchSize = addressBatchSize)
+                                addressBatchSize = addressBatchSize,
+                                forceGenerateSpks)
       _ = recursiveRescan(prevState = inProgress,
                           startOpt = startOpt,
                           endOpt = endOpt,
@@ -322,7 +335,11 @@ private[wallet] trait RescanHandling extends WalletLogger {
           logger.info(
             s"Attempting rescan again with fresh pool of addresses as we had a " +
               s"match within our address gap limit of ${walletConfig.addressGapLimit}")
-          doNeutrinoRescan(account, startOpt, endOpt, addressBatchSize)
+          doNeutrinoRescan(account = account,
+                           startOpt = startOpt,
+                           endOpt = endOpt,
+                           addressBatchSize = addressBatchSize,
+                           forceGenerateSpks = true)
         }
       }
     } yield ()
@@ -372,12 +389,14 @@ private[wallet] trait RescanHandling extends WalletLogger {
       endOpt: Option[BlockStamp],
       startOpt: Option[BlockStamp],
       account: HDAccount,
-      addressBatchSize: Int): Future[RescanState] = {
+      addressBatchSize: Int,
+      forceGenerateSpks: Boolean): Future[RescanState] = {
     val rescanStateF = for {
       rescanState <- getMatchingBlocks(startOpt = startOpt,
                                        endOpt = endOpt,
                                        addressBatchSize = addressBatchSize,
-                                       account = account)(
+                                       account = account,
+                                       forceGenerateSpks = forceGenerateSpks)(
         ExecutionContext.fromExecutor(walletConfig.rescanThreadPool))
     } yield {
       rescanState
@@ -388,7 +407,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
 
   private def generateAddressesForRescanAction(
       account: HDAccount,
-      count: Int): DBIOAction[
+      addressBatchSize: Int): DBIOAction[
     Vector[BitcoinAddress],
     NoStream,
     Effect.Read with Effect.Write with Effect.Transactional] = {
@@ -397,7 +416,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
       NoStream,
       Effect.Read with Effect.Write with Effect.Transactional] = {
       DBIOAction.sequence {
-        1.to(count)
+        1.to(addressBatchSize)
           .map(_ => getNewAddressAction(account))
       }
     }.map(_.toVector)
@@ -407,7 +426,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
       NoStream,
       Effect.Read with Effect.Write with Effect.Transactional] = {
       DBIOAction.sequence {
-        1.to(count)
+        1.to(addressBatchSize)
           .map(_ => getNewAddressAction(account))
       }
     }.map(_.toVector)
@@ -418,19 +437,22 @@ private[wallet] trait RescanHandling extends WalletLogger {
     } yield receiveAddresses ++ changeAddresses
   }
 
+  /** If forceGeneratSpks is true or addressCount == 0 we generate a new pool of scriptpubkeys */
   private def generateScriptPubKeysAction(
       account: HDAccount,
-      count: Int): DBIOAction[
+      addressBatchSize: Int,
+      forceGenerateSpks: Boolean): DBIOAction[
     Vector[ScriptPubKey],
     NoStream,
     Effect.Read with Effect.Write with Effect.Transactional] = {
-    logger.info(s"addressCount=$count")
     val addressCountA = addressDAO.countAction
     for {
       addressCount <- addressCountA
       addresses <- {
-        if (addressCount == 0) {
-          generateAddressesForRescanAction(account, count)
+        if (forceGenerateSpks || addressCount == 0) {
+          logger.info(
+            s"Generating $addressBatchSize fresh addresses for the rescan")
+          generateAddressesForRescanAction(account, addressBatchSize)
         } else {
           //we don't want to continously generate addresses
           //if our wallet already has them, so just use what is in the
@@ -468,8 +490,12 @@ private[wallet] trait RescanHandling extends WalletLogger {
 
   private def generateScriptPubKeys(
       account: HDAccount,
-      count: Int): Future[Vector[ScriptPubKey]] = {
-    val action = generateScriptPubKeysAction(account, count)
+      addressBatchSize: Int,
+      forceGenerateSpks: Boolean): Future[Vector[ScriptPubKey]] = {
+    val action = generateScriptPubKeysAction(
+      account = account,
+      addressBatchSize = addressBatchSize,
+      forceGenerateSpks = forceGenerateSpks)
     safeDatabase.run(action)
   }
 


### PR DESCRIPTION
Fixes bug in rescan logic where a single transaction pays to `address1` and `address2` in your wallet. If `address1` and `address2` were found in _different_ rescan batches, `address2` would not be discovered by the wallet.