### PR TITLE
Implement cleanup of dlcWallet/wallet DbAppConfig threadpools

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -153,7 +153,6 @@ case class DLCWalletNeutrinoBackendLoader(
       _ <- stopOldWalletAppConfig(walletConfig)
       _ <- stopOldDLCAppConfig(dlcConfig)
       _ <- walletHolder.replaceWallet(dlcWallet)
-      _ <- walletHolder.start()
       nodeCallbacks <-
         CallbackUtil.createNeutrinoNodeCallbacksForWallet(walletHolder)
       _ = nodeConf.replaceCallbacks(nodeCallbacks)

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -248,7 +248,6 @@ case class DLCWalletBitcoindBackendLoader(
         walletHolder)
       _ = nodeConf.addCallbacks(nodeCallbacks)
       _ <- walletHolder.replaceWallet(dlcWallet)
-      _ <- walletHolder.start()
     } yield (walletHolder, walletConfig, dlcConfig)
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -6,6 +6,7 @@ import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.dlc.wallet.DLCNeutrinoHDWalletApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.util.StartStopAsync
 import org.bitcoins.crypto.AesPassword
 import org.bitcoins.dlc.wallet.DLCAppConfig
 import org.bitcoins.node.NodeCallbacks
@@ -21,8 +22,9 @@ import scala.concurrent.{ExecutionContext, Future}
 /** A trait used to help load a different load and discard the current wallet in memory
   * This trait encapsulates the heavy lifting done in the 'loadwallet' RPC command
   */
-sealed trait DLCWalletLoaderApi extends Logging {
+sealed trait DLCWalletLoaderApi extends Logging with StartStopAsync[Unit] {
 
+  override def start(): Future[Unit] = Future.unit
   protected def conf: BitcoinSAppConfig
 
   implicit protected def system: ActorSystem
@@ -56,7 +58,6 @@ sealed trait DLCWalletLoaderApi extends Logging {
       _ <- stoppedCallbacksF
       (walletConfig, dlcConfig) <- updateWalletConfigs(walletName,
                                                        Some(aesPasswordOpt))
-        .recover { case _: Throwable => (conf.walletConf, conf.dlcConf) }
       _ <- {
         if (walletHolder.isInitialized) {
           walletHolder
@@ -116,6 +117,25 @@ case class DLCWalletNeutrinoBackendLoader(
   import system.dispatcher
   implicit private val nodeConf = conf.nodeConf
 
+  private[this] var currentWalletAppConfigOpt: Option[WalletAppConfig] = None
+  private[this] var currentDLCAppConfigOpt: Option[DLCAppConfig] = None
+
+  override def stop(): Future[Unit] = {
+    val walletStopF = currentWalletAppConfigOpt match {
+      case Some(w) => w.stop()
+      case None    => Future.unit
+    }
+    val dlcStopF = currentDLCAppConfigOpt match {
+      case Some(d) => d.stop()
+      case None    => Future.unit
+    }
+
+    for {
+      _ <- walletStopF
+      _ <- dlcStopF
+    } yield ()
+  }
+
   override def load(
       walletNameOpt: Option[String],
       aesPasswordOpt: Option[AesPassword]): Future[
@@ -130,12 +150,52 @@ case class DLCWalletNeutrinoBackendLoader(
         walletNameOpt = walletNameOpt,
         aesPasswordOpt = aesPasswordOpt
       )
+      _ <- stopOldWalletAppConfig(walletConfig)
+      _ <- stopOldDLCAppConfig(dlcConfig)
       _ <- walletHolder.replaceWallet(dlcWallet)
+      _ <- walletHolder.start()
       nodeCallbacks <-
         CallbackUtil.createNeutrinoNodeCallbacksForWallet(walletHolder)
       _ = nodeConf.replaceCallbacks(nodeCallbacks)
       _ <- updateWalletName(walletNameOpt)
     } yield (walletHolder, walletConfig, dlcConfig)
+  }
+
+  private def stopOldWalletAppConfig(
+      newWalletConfig: WalletAppConfig): Future[Unit] = {
+    currentWalletAppConfigOpt match {
+      case Some(current) =>
+        //stop the old config
+        current
+          .stop()
+          .map(_ => {
+            currentWalletAppConfigOpt = Some(newWalletConfig)
+          })
+      case None =>
+        for {
+          _ <- conf.walletConf.stop()
+        } yield {
+          currentWalletAppConfigOpt = Some(newWalletConfig)
+        }
+    }
+  }
+
+  private def stopOldDLCAppConfig(newDlcConfig: DLCAppConfig): Future[Unit] = {
+    currentDLCAppConfigOpt match {
+      case Some(current) =>
+        //stop the old config
+        current
+          .stop()
+          .map(_ => {
+            currentDLCAppConfigOpt = Some(newDlcConfig)
+          })
+      case None =>
+        for {
+          _ <- conf.walletConf.stop()
+        } yield {
+          currentDLCAppConfigOpt = Some(newDlcConfig)
+        }
+    }
   }
 }
 
@@ -150,6 +210,26 @@ case class DLCWalletBitcoindBackendLoader(
   import system.dispatcher
   implicit private val nodeConf = conf.nodeConf
 
+  private[this] var currentWalletAppConfigOpt: Option[WalletAppConfig] = None
+
+  private[this] var currentDLCAppConfigOpt: Option[DLCAppConfig] = None
+
+  override def stop(): Future[Unit] = {
+    val walletStopF = currentWalletAppConfigOpt match {
+      case Some(w) => w.stop()
+      case None    => Future.unit
+    }
+    val dlcStopF = currentDLCAppConfigOpt match {
+      case Some(d) => d.stop()
+      case None    => Future.unit
+    }
+
+    for {
+      _ <- walletStopF
+      _ <- dlcStopF
+    } yield ()
+  }
+
   override def load(
       walletNameOpt: Option[String],
       aesPasswordOpt: Option[AesPassword]): Future[
@@ -163,10 +243,50 @@ case class DLCWalletBitcoindBackendLoader(
         walletNameOpt = walletNameOpt,
         aesPasswordOpt = aesPasswordOpt)
 
+      _ <- stopOldWalletAppConfig(walletConfig)
+      _ <- stopOldDLCAppConfig(dlcConfig)
       nodeCallbacks <- CallbackUtil.createBitcoindNodeCallbacksForWallet(
         walletHolder)
       _ = nodeConf.addCallbacks(nodeCallbacks)
       _ <- walletHolder.replaceWallet(dlcWallet)
+      _ <- walletHolder.start()
     } yield (walletHolder, walletConfig, dlcConfig)
+  }
+
+  private def stopOldWalletAppConfig(
+      newWalletConfig: WalletAppConfig): Future[Unit] = {
+    currentWalletAppConfigOpt match {
+      case Some(current) =>
+        //stop the old config
+        current
+          .stop()
+          .map(_ => {
+            currentWalletAppConfigOpt = Some(newWalletConfig)
+          })
+      case None =>
+        for {
+          _ <- conf.walletConf.stop()
+        } yield {
+          currentWalletAppConfigOpt = Some(newWalletConfig)
+        }
+    }
+  }
+
+  private def stopOldDLCAppConfig(newDlcConfig: DLCAppConfig): Future[Unit] = {
+    currentDLCAppConfigOpt match {
+      case Some(current) =>
+        //stop the old config
+        current
+          .stop()
+          .map(_ => {
+            currentDLCAppConfigOpt = Some(newDlcConfig)
+          })
+      case None =>
+        for {
+          _ <- conf.walletConf.stop()
+        } yield {
+          currentDLCAppConfigOpt = Some(newDlcConfig)
+        }
+    }
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
@@ -42,7 +42,6 @@ trait BitcoinSServerMainBitcoindFixture
                                                    config.walletConf)
         _ <- FundWalletUtil.fundWalletWithBitcoind(walletWithBitcoind)
       } yield {
-        logger.info(s"Done setting up fixture")
         ServerWithBitcoind(bitcoind, server)
       }
     }
@@ -54,7 +53,6 @@ trait BitcoinSServerMainBitcoindFixture
         _ <- BitcoinSServerMainUtil
           .destroyBitcoinSAppConfig(serverWithBitcoind.server.conf)
       } yield {
-        logger.info(s"Done tearing down fixture")
         ()
       }
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
@@ -42,6 +42,7 @@ trait BitcoinSServerMainBitcoindFixture
                                                    config.walletConf)
         _ <- FundWalletUtil.fundWalletWithBitcoind(walletWithBitcoind)
       } yield {
+        logger.info(s"Done setting up fixture")
         ServerWithBitcoind(bitcoind, server)
       }
     }
@@ -53,6 +54,7 @@ trait BitcoinSServerMainBitcoindFixture
         _ <- BitcoinSServerMainUtil
           .destroyBitcoinSAppConfig(serverWithBitcoind.server.conf)
       } yield {
+        logger.info(s"Done tearing down fixture")
         ()
       }
     }


### PR DESCRIPTION
fixes #4539 

This implements the ability to call `DLCWalletLoaderApi.stop()` to free resources allocated by the currently loaded `WalletAppConfig`/`DLCAppConfig`. 

In #4527 when we integrated `DLCWalletLoaderApi`, there was no way to clean up after the newly created `WalletAppConfig`/`DLCAppConfig`. 

Now they new configs are cached inside of `DLCWalletLoaderApi` and freed when `stop()` is called. This then requires caching of the `DLCWalletLoaderApi` instance in `BitcoinSServerMain` and then calling `walletLoaderApi.stop()` when `BitcoinSServerMain.stop()` is called.