### PR TITLE
Refactor to not use filterThenSum() when calculating balances

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet
 
+import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.wallet.SyncHeightDescriptor
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.FilterType
@@ -108,6 +109,8 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
         bitcoind.getBlockFilter(_, FilterType.Basic))
       filtersWithBlockHash = hashes.map(_.flip).zip(filters.map(_.filter))
       _ <- wallet.processCompactFilters(filtersWithBlockHash)
+      _ <- AsyncUtil.retryUntilSatisfiedF(() =>
+        wallet.getConfirmedBalance().map(_ == Bitcoins(100)))
       utxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
       balance <- wallet.getConfirmedBalance()
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.wallet.SyncHeightDescriptor
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.FilterType
@@ -57,14 +56,13 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
       syncHeightOpt <- wallet.getSyncDescriptorOpt()
       txDbOpt <- wallet.findByTxId(txId)
     } yield {
+      assert(syncHeightOpt.contains(SyncHeightDescriptor(bestHash, height)))
       assert(txDbOpt.isDefined)
       assert(txDbOpt.get.blockHashOpt.contains(hash))
       assert(utxos.size == 1)
       assert(utxos.head.output.scriptPubKey == addr.scriptPubKey)
       assert(utxos.head.output.value == 1.bitcoin)
       assert(utxos.head.txid == txId)
-
-      assert(syncHeightOpt.contains(SyncHeightDescriptor(bestHash, height)))
     }
   }
 
@@ -80,17 +78,22 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
       hashes <- bitcoind.generateToAddress(101, addr)
       blocks <- FutureUtil.sequentially(hashes)(bitcoind.getBlockRaw)
       _ <- FutureUtil.sequentially(blocks)(wallet.processBlock)
-      utxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
+      coinbaseUtxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
+      confirmedUtxos <- wallet.listUtxos(TxoState.ConfirmedReceived)
       balance <- wallet.getConfirmedBalance()
 
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
       syncHeightOpt <- wallet.getSyncDescriptorOpt()
     } yield {
-      assert(utxos.size == 100)
-      assert(balance == Bitcoins(50))
-
+      assert(syncHeightOpt.isDefined)
       assert(syncHeightOpt.contains(SyncHeightDescriptor(bestHash, height)))
+
+      // note: 100 because the very first coinbase utxo is now confirmed
+      assert(coinbaseUtxos.size == 100)
+      //block reward is still 50 bitcoin per block
+      assert(balance == Bitcoins(50))
+      assert(confirmedUtxos.length == 1)
     }
   }
 
@@ -109,19 +112,26 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
         bitcoind.getBlockFilter(_, FilterType.Basic))
       filtersWithBlockHash = hashes.map(_.flip).zip(filters.map(_.filter))
       _ <- wallet.processCompactFilters(filtersWithBlockHash)
-      _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-        wallet.getConfirmedBalance().map(_ == Bitcoins(100)))
-      utxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
+      coinbaseUtxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
+      confirmedUtxos <- wallet.listUtxos(TxoState.ConfirmedReceived)
       balance <- wallet.getConfirmedBalance()
 
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
       syncHeightOpt <- wallet.getSyncDescriptorOpt()
     } yield {
-      assert(utxos.size == 100)
-      assert(balance == Bitcoins(100))
 
+      assert(syncHeightOpt.isDefined)
       assert(syncHeightOpt.contains(SyncHeightDescriptor(bestHash, height)))
+
+      // note: 100 because the very first coinbase utxo is now confirmed
+      assert(coinbaseUtxos.size == 100)
+
+      //note: This is 50 bitcoins because the block reward on regtest
+      //is now 25 bitcoin per block due to blocks being mined
+      //in prior test cases in this test suite.
+      assert(balance == Bitcoins(50))
+      assert(confirmedUtxos.length == 2)
     }
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -80,7 +80,7 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
       blocks <- FutureUtil.sequentially(hashes)(bitcoind.getBlockRaw)
       _ <- FutureUtil.sequentially(blocks)(wallet.processBlock)
       utxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
-      balance <- wallet.getBalance()
+      balance <- wallet.getConfirmedBalance()
 
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
@@ -109,14 +109,14 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoinV19 {
       filtersWithBlockHash = hashes.map(_.flip).zip(filters.map(_.filter))
       _ <- wallet.processCompactFilters(filtersWithBlockHash)
       utxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
-      balance <- wallet.getBalance()
+      balance <- wallet.getConfirmedBalance()
 
       height <- bitcoind.getBlockCount
       bestHash <- bitcoind.getBestBlockHash
       syncHeightOpt <- wallet.getSyncDescriptorOpt()
     } yield {
       assert(utxos.size == 100)
-      assert(balance == Bitcoins(50))
+      assert(balance == Bitcoins(100))
 
       assert(syncHeightOpt.contains(SyncHeightDescriptor(bestHash, height)))
     }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -416,7 +416,9 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
       )
       _ = if (incoming.nonEmpty) {
         logger.info(
-          s"Finished processing ${incoming.length} received outputs, it took=${TimeUtil.currentEpochMs - receivedStart}ms")
+          s"Finished processing ${incoming.length} received outputs, balance=${incoming
+            .map(_.output.value)
+            .sum} it took=${TimeUtil.currentEpochMs - receivedStart}ms")
       }
 
       spentSpendingInfoDbs <- spentSpendingInfoDbsF


### PR DESCRIPTION
Refactor `getBalance()` to use `getBalance(account`) so our implementation is internally consistent rather than `getBalance()` having a different implementation than `getBalance(account)`. This should reduce the possibility for bugs.

On another note, this seems to fix `CallBackUtilTest` intermittent test failures, although i'm not sure why.

