### PR TITLE
Refactor `WalletRoutes` to take `DLCWalletLoaderApi` as a paramete

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/DLCWalletBitcoindBackendLoaderTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/DLCWalletBitcoindBackendLoaderTest.scala
@@ -42,6 +42,7 @@ class DLCWalletBitcoindBackendLoaderTest extends WalletLoaderFixtures {
 
     //as a hack, set rescanning to true, so next time we load it starts a rescan
     val setRescanF = for {
+      _ <- blocksF
       walletConfig <- walletConfigF
       descriptorDAO = WalletStateDescriptorDAO()(system.dispatcher,
                                                  walletConfig)
@@ -51,7 +52,6 @@ class DLCWalletBitcoindBackendLoaderTest extends WalletLoaderFixtures {
     //now that we have set rescanning, we should see a rescan next time we load wallet
     for {
       _ <- setRescanF
-      _ <- blocksF
       (loadWallet2, _, _) <- loader.load(
         walletNameOpt = None,
         aesPasswordOpt = None

--- a/app/server-test/src/test/scala/org/bitcoins/server/DLCWalletBitcoindBackendLoaderTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/DLCWalletBitcoindBackendLoaderTest.scala
@@ -34,7 +34,7 @@ class DLCWalletBitcoindBackendLoaderTest extends WalletLoaderFixtures {
     val bitcoind = walletHolderWithLoader.bitcoind
     //need some blocks to make rescans last longer for the test case
     val blocksF = bitcoind.getNewAddress.flatMap(addr =>
-      bitcoind.generateToAddress(500, addr))
+      bitcoind.generateToAddress(250, addr))
 
     val loadedWalletF = loader.load(walletNameOpt = None, aesPasswordOpt = None)
 

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -32,8 +32,10 @@ sealed trait DLCWalletLoaderApi extends Logging with StartStopAsync[Unit] {
   implicit protected def system: ActorSystem
   implicit private def ec: ExecutionContext = system.dispatcher
 
+  def walletHolder: WalletHolder
+
   /** Determine if a wallet has been loaded */
-  def isWalletLoaded: Boolean
+  def isWalletLoaded: Boolean = walletHolder.isInitialized
 
   def load(
       walletNameOpt: Option[String],
@@ -337,7 +339,6 @@ case class DLCWalletBitcoindBackendLoader(
     extends DLCWalletLoaderApi {
   import system.dispatcher
   implicit private val nodeConf = conf.nodeConf
-  override def isWalletLoaded: Boolean = walletHolder.isInitialized
 
   override def load(
       walletNameOpt: Option[String],

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -8,7 +8,6 @@ import akka.stream.Materializer
 import grizzled.slf4j.Logging
 import org.bitcoins.commons.rpc._
 import org.bitcoins.commons.serializers.Picklers._
-import org.bitcoins.core.api.dlc.wallet.DLCNeutrinoHDWalletApi
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.tlv._
@@ -25,6 +24,7 @@ import org.bitcoins.crypto.NetworkElement
 import org.bitcoins.keymanager._
 import org.bitcoins.keymanager.config.KeyManagerAppConfig
 import org.bitcoins.server.routes.{Server, ServerCommand, ServerRoute}
+import org.bitcoins.wallet.WalletHolder
 import org.bitcoins.wallet.config.WalletAppConfig
 import ujson._
 import upickle.default._
@@ -35,12 +35,15 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
 
-case class WalletRoutes(wallet: DLCNeutrinoHDWalletApi)(implicit
+case class WalletRoutes(loader: DLCWalletLoaderApi)(implicit
     system: ActorSystem,
     walletConf: WalletAppConfig)
     extends ServerRoute
     with Logging {
   import system.dispatcher
+
+  /** The loaded wallet that requests should be directed against */
+  private[this] val wallet: WalletHolder = loader.walletHolder
 
   implicit private val kmConf: KeyManagerAppConfig = walletConf.kmConf
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -71,7 +71,7 @@ object RescanState {
     }
   }
 
-  /** Returns a Future that is compelted when a rescan is fully executed.
+  /** Returns a Future that is completed when a rescan is fully executed.
     * This means that the rescan was NOT terminated externally by completing
     * the akka stream that underlies the rescan logic.
     */

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/WalletLoaderFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/WalletLoaderFixtures.scala
@@ -26,7 +26,7 @@ trait WalletLoaderFixtures
                                               chainQueryApi = bitcoind,
                                               feeRateApi = bitcoind)
 
-        walletHolder = new WalletHolder()
+        walletHolder = WalletHolder.empty
         loader = DLCWalletBitcoindBackendLoader(
           walletHolder = walletHolder,
           bitcoind = bitcoind,

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -61,11 +61,13 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class WalletNotInitialized extends Exception("The wallet is not initialized")
 
-class WalletHolder(implicit ec: ExecutionContext)
+class WalletHolder(initWalletOpt: Option[DLCNeutrinoHDWalletApi])(implicit
+    ec: ExecutionContext)
     extends DLCNeutrinoHDWalletApi
     with Logging {
 
-  @volatile private var walletOpt: Option[DLCNeutrinoHDWalletApi] = None
+  @volatile private var walletOpt: Option[DLCNeutrinoHDWalletApi] =
+    initWalletOpt
 
   private def wallet: DLCNeutrinoHDWalletApi = synchronized {
     walletOpt match {
@@ -1001,4 +1003,10 @@ class WalletHolder(implicit ec: ExecutionContext)
                               blockHashOpt = blockHashOpt,
                               newTags = newTags))
   }
+}
+
+object WalletHolder {
+
+  def empty(implicit ec: ExecutionContext): WalletHolder = new WalletHolder(
+    None)
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -97,7 +97,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
                 logger.error(s"Failed to reset rescan state", err))
             }
           } yield {
-            logger.info(s"7")
             state
           }
 
@@ -129,7 +128,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
         }
 
     } yield {
-      logger.info("8")
       rescanState
     }
   }
@@ -145,9 +143,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
       range: Range,
       parallelism: Int,
       filterBatchSize: Int): RescanState.RescanStarted = {
-    logger.info(s"1")
     val scriptsF = generateScriptPubKeys(account, addressBatchSize)
-    logger.info(s"2")
     //by completing the promise returned by this sink
     //we will be able to arbitrarily terminate the stream
     //see: https://doc.akka.io/docs/akka/current/stream/operators/Source/maybe.html
@@ -213,7 +209,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
 
     //return RescanStarted with access to the ability to complete the rescan early
     //via the completeRescanEarlyP promise.
-    logger.info(s"3")
     RescanState.RescanStarted(completeRescanEarlyP, flatten)
   }
 
@@ -262,7 +257,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
                                       parallelism = parallelismLevel,
                                       filterBatchSize = addressBatchSize)
     } yield {
-      logger.info(s"4")
       rescanStarted
     }
   }
@@ -280,18 +274,22 @@ private[wallet] trait RescanHandling extends WalletLogger {
       inProgress <- matchBlocks(endOpt = endOpt,
                                 startOpt = startOpt,
                                 account = account)
-      _ <- recursiveRescan(prevState = inProgress,
-                           startOpt = startOpt,
-                           endOpt = endOpt,
-                           addressBatchSize = addressBatchSize,
-                           addressCount = addressCount,
-                           account = account)
+      _ = recursiveRescan(prevState = inProgress,
+                          startOpt = startOpt,
+                          endOpt = endOpt,
+                          addressBatchSize = addressBatchSize,
+                          addressCount = addressCount,
+                          account = account)
     } yield {
-      logger.info(s"6")
       inProgress
     }
   }
 
+  /** Used to call a recursive rescan after the previous rescan is complete.
+    * The [[prevState]] parameter is what represents the previous rescan.
+    * We wait for this rescan to complete, and then check if we need to
+    * do another rescan
+    */
   private def recursiveRescan(
       prevState: RescanState,
       startOpt: Option[BlockStamp],

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -102,6 +102,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
 
           res.recoverWith {
             case _: RejectedExecutionException =>
+              println(s"Caught rejected execution exception")
               Future.unit //don't do anything if its from the threadpool shutting down
             case err: Throwable =>
               logger.error(s"Failed to rescan wallet", err)


### PR DESCRIPTION
Makes it easier to manage wallet state (such as `RescanState`) in conjunction with `loadwallet` RPC calls. Now they are in a single place and can be shutdown simultaneously when a `loadwallet` RPC call is made.