### PR TITLE
Add rescanState variable to DLCWalletLoaderApi

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -37,6 +37,8 @@ sealed trait DLCWalletLoaderApi extends Logging with StartStopAsync[Unit] {
   def setRescanState(rescanState: RescanState): Unit
   def clearRescanState(): Unit
 
+  def isRescanStateEmpty: Boolean
+
   def load(
       walletNameOpt: Option[String],
       aesPasswordOpt: Option[AesPassword]): Future[
@@ -290,7 +292,7 @@ case class DLCWalletNeutrinoBackendLoader(
         }
     }
   }
-
+  override def isRescanStateEmpty: Boolean = rescanStateOpt.isEmpty
   override def clearRescanState(): Unit = {
     rescanStateOpt = None
     ()
@@ -435,4 +437,6 @@ case class DLCWalletBitcoindBackendLoader(
     rescanStateOpt = None
     ()
   }
+
+  override def isRescanStateEmpty: Boolean = rescanStateOpt.isEmpty
 }

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -293,6 +293,7 @@ case class DLCWalletNeutrinoBackendLoader(
     }
   }
   override def isRescanStateEmpty: Boolean = rescanStateOpt.isEmpty
+
   override def clearRescanState(): Unit = {
     rescanStateOpt = None
     ()


### PR DESCRIPTION
This allows us to track rescan state accurately through the lifecycle of a wallet. 