### PR TITLE
Add unit tests for loader rescans

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/DLCWalletBitcoindBackendLoaderTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/DLCWalletBitcoindBackendLoaderTest.scala
@@ -1,0 +1,70 @@
+package org.bitcoins.server
+
+import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.server.util.WalletHolderWithBitcoindLoaderApi
+import org.bitcoins.testkit.server.WalletLoaderFixtures
+import org.bitcoins.wallet.models.WalletStateDescriptorDAO
+import org.scalatest.FutureOutcome
+
+class DLCWalletBitcoindBackendLoaderTest extends WalletLoaderFixtures {
+
+  override type FixtureParam = WalletHolderWithBitcoindLoaderApi
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    withBitcoindBackendLoader(test)
+  }
+
+  behavior of "DLCWalletBitcoindBackendLoader"
+
+  it must "load a wallet" in { walletHolderWithLoader =>
+    val loader = walletHolderWithLoader.loaderApi
+    assert(!loader.isWalletLoaded)
+
+    val loadedWalletF = loader.load(
+      walletNameOpt = None,
+      aesPasswordOpt = None
+    )
+    loadedWalletF.map { _ =>
+      assert(loader.isWalletLoaded)
+    }
+  }
+
+  it must "track rescan state accurately" in { walletHolderWithLoader =>
+    val loader = walletHolderWithLoader.loaderApi
+    val bitcoind = walletHolderWithLoader.bitcoind
+    //need some blocks to make rescans last longer for the test case
+    val blocksF = bitcoind.getNewAddress.flatMap(addr =>
+      bitcoind.generateToAddress(500, addr))
+
+    val loadedWalletF = loader.load(walletNameOpt = None, aesPasswordOpt = None)
+
+    val walletConfigF = loadedWalletF.map(_._2)
+
+    //as a hack, set rescanning to true, so next time we load it starts a rescan
+    val setRescanF = for {
+      walletConfig <- walletConfigF
+      descriptorDAO = WalletStateDescriptorDAO()(system.dispatcher,
+                                                 walletConfig)
+      set <- descriptorDAO.compareAndSetRescanning(false, true)
+    } yield assert(set)
+
+    //now that we have set rescanning, we should see a rescan next time we load wallet
+    for {
+      _ <- setRescanF
+      _ <- blocksF
+      (loadWallet2, _, _) <- loader.load(
+        walletNameOpt = None,
+        aesPasswordOpt = None
+      ) //load wallet again
+      isRescanning <- loadWallet2.isRescanning()
+      _ = assert(isRescanning)
+      _ = assert(loader.isRescanStateDefined)
+      //wait until rescanning is done
+      _ <- AsyncUtil.retryUntilSatisfiedF { () =>
+        loadWallet2.isRescanning().map(isRescanning => isRescanning == false)
+      }
+    } yield {
+      assert(loader.isRescanStateEmpty)
+    }
+  }
+}

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -30,18 +30,10 @@ sealed trait DLCWalletLoaderApi extends Logging with StartStopAsync[Unit] {
   def conf: BitcoinSAppConfig
 
   implicit protected def system: ActorSystem
+  implicit private def ec: ExecutionContext = system.dispatcher
 
   /** Determine if a wallet has been loaded */
   def isWalletLoaded: Boolean
-
-  /** Sets rescan state in the loader, we need this to be able to
-    * cleanly shutdown a wallet in the middle of a rescan
-    */
-  def setRescanState(rescanState: RescanState): Unit
-  def clearRescanState(): Unit
-
-  def isRescanStateEmpty: Boolean
-  def isRescanStateDefined: Boolean = !isRescanStateEmpty
 
   def load(
       walletNameOpt: Option[String],
@@ -164,23 +156,103 @@ sealed trait DLCWalletLoaderApi extends Logging with StartStopAsync[Unit] {
     } yield res
   }
 
-}
+  /** Store a rescan state for the wallet that is currently loaded
+    * This is needed because we don't save rescan state anywhere else.
+    */
+  @volatile private[this] var rescanStateOpt: Option[
+    RescanState.RescanStarted] = None
 
-case class DLCWalletNeutrinoBackendLoader(
-    walletHolder: WalletHolder,
-    chainQueryApi: ChainQueryApi,
-    nodeApi: NodeApi,
-    feeRateApi: FeeRateApi)(implicit
-    override val conf: BitcoinSAppConfig,
-    override val system: ActorSystem)
-    extends DLCWalletLoaderApi {
-  import system.dispatcher
-  implicit private val nodeConf = conf.nodeConf
+  def setRescanState(rescanState: RescanState): Unit = {
+    rescanState match {
+      case RescanState.RescanAlreadyStarted =>
+      //do nothing in this case, we don't need to keep these states around
+      //don't overwrite the existing reference to RescanStarted
+      case RescanState.RescanDone =>
+        //rescan is done, reset state
+        rescanStateOpt = None
+      case started: RescanState.RescanStarted =>
+        if (rescanStateOpt.isEmpty) {
+          //add callback to reset state when the rescan is done
+          val resetStateCallbackF = started.doneF.map { _ =>
+            rescanStateOpt = None
+          }
+          resetStateCallbackF.failed.foreach(err =>
+            logger.error(s"Failed to reset rescanState", err))
+          rescanStateOpt = Some(started)
+        } else {
+          sys.error(
+            s"Cannot run multiple rescans at the same time, got=$started have=$rescanStateOpt")
+        }
+    }
+  }
+
+  protected def stopRescan()(implicit ec: ExecutionContext): Future[Unit] = {
+    rescanStateOpt match {
+      case Some(state) => state.stop().map(_ => ()) //stop the rescan
+      case None        => Future.unit
+    }
+  }
+
+  def isRescanStateEmpty: Boolean = rescanStateOpt.isEmpty
+
+  def isRescanStateDefined: Boolean = !isRescanStateEmpty
+
+  def clearRescanState(): Unit = {
+    rescanStateOpt = None
+    ()
+  }
 
   private[this] var currentWalletAppConfigOpt: Option[WalletAppConfig] = None
+
+  protected def setWalletAppConfig(walletAppConfig: WalletAppConfig): Unit = {
+    currentWalletAppConfigOpt = Some(walletAppConfig)
+    ()
+  }
+
+  protected def setDlcAppConfig(dlcAppConfig: DLCAppConfig): Unit = {
+    currentDLCAppConfigOpt = Some(dlcAppConfig)
+    ()
+  }
+
   private[this] var currentDLCAppConfigOpt: Option[DLCAppConfig] = None
 
-  override def isWalletLoaded: Boolean = walletHolder.isInitialized
+  protected def stopOldWalletAppConfig(
+      newWalletConfig: WalletAppConfig): Future[Unit] = {
+    currentWalletAppConfigOpt match {
+      case Some(current) =>
+        //stop the old config
+        current
+          .stop()
+          .map(_ => {
+            currentWalletAppConfigOpt = Some(newWalletConfig)
+          })
+      case None =>
+        for {
+          _ <- conf.walletConf.stop()
+        } yield {
+          currentWalletAppConfigOpt = Some(newWalletConfig)
+        }
+    }
+  }
+
+  protected def stopOldDLCAppConfig(
+      newDlcConfig: DLCAppConfig): Future[Unit] = {
+    currentDLCAppConfigOpt match {
+      case Some(current) =>
+        //stop the old config
+        current
+          .stop()
+          .map(_ => {
+            currentDLCAppConfigOpt = Some(newDlcConfig)
+          })
+      case None =>
+        for {
+          _ <- conf.walletConf.stop()
+        } yield {
+          currentDLCAppConfigOpt = Some(newDlcConfig)
+        }
+    }
+  }
 
   override def stop(): Future[Unit] = {
     val rescanStopF = rescanStateOpt match {
@@ -207,17 +279,28 @@ case class DLCWalletNeutrinoBackendLoader(
       _ <- dlcStopF
     } yield ()
   }
+}
+
+case class DLCWalletNeutrinoBackendLoader(
+    walletHolder: WalletHolder,
+    chainQueryApi: ChainQueryApi,
+    nodeApi: NodeApi,
+    feeRateApi: FeeRateApi)(implicit
+    override val conf: BitcoinSAppConfig,
+    override val system: ActorSystem)
+    extends DLCWalletLoaderApi {
+  import system.dispatcher
+  implicit private val nodeConf = conf.nodeConf
+
+  override def isWalletLoaded: Boolean = walletHolder.isInitialized
 
   override def load(
       walletNameOpt: Option[String],
       aesPasswordOpt: Option[AesPassword]): Future[
     (WalletHolder, WalletAppConfig, DLCAppConfig)] = {
-    val stopRescanFOpt = rescanStateOpt match {
-      case Some(state) => state.stop() //stop the rescan
-      case None        => Future.unit
-    }
+    val stopRescanF = stopRescan()
     for {
-      _ <- stopRescanFOpt
+      _ <- stopRescanF
       (dlcWallet, walletConfig, dlcConfig) <- loadWallet(
         walletHolder = walletHolder,
         chainQueryApi = chainQueryApi,
@@ -242,78 +325,6 @@ case class DLCWalletNeutrinoBackendLoader(
     }
   }
 
-  private def stopOldWalletAppConfig(
-      newWalletConfig: WalletAppConfig): Future[Unit] = {
-    currentWalletAppConfigOpt match {
-      case Some(current) =>
-        //stop the old config
-        current
-          .stop()
-          .map(_ => {
-            currentWalletAppConfigOpt = Some(newWalletConfig)
-          })
-      case None =>
-        for {
-          _ <- conf.walletConf.stop()
-        } yield {
-          currentWalletAppConfigOpt = Some(newWalletConfig)
-        }
-    }
-  }
-
-  private def stopOldDLCAppConfig(newDlcConfig: DLCAppConfig): Future[Unit] = {
-    currentDLCAppConfigOpt match {
-      case Some(current) =>
-        //stop the old config
-        current
-          .stop()
-          .map(_ => {
-            currentDLCAppConfigOpt = Some(newDlcConfig)
-          })
-      case None =>
-        for {
-          _ <- conf.walletConf.stop()
-        } yield {
-          currentDLCAppConfigOpt = Some(newDlcConfig)
-        }
-    }
-  }
-
-  /** Store a rescan state for the wallet that is currently loaded
-    * This is needed because we don't save rescan state anywhere else.
-    */
-  @volatile private[this] var rescanStateOpt: Option[
-    RescanState.RescanStarted] = None
-
-  override def setRescanState(rescanState: RescanState): Unit = {
-    rescanState match {
-      case RescanState.RescanAlreadyStarted =>
-      //do nothing in this case, we don't need to keep these states around
-      //don't overwrite the existing reference to RescanStarted
-      case RescanState.RescanDone =>
-        //rescan is done, reset state
-        rescanStateOpt = None
-      case started: RescanState.RescanStarted =>
-        if (rescanStateOpt.isEmpty) {
-          //add callback to reset state when the rescan is done
-          val resetStateCallbackF = started.doneF.map { _ =>
-            rescanStateOpt = None
-          }
-          resetStateCallbackF.failed.foreach(err =>
-            logger.error(s"Failed to reset rescanState", err))
-          rescanStateOpt = Some(started)
-        } else {
-          sys.error(
-            s"Cannot run multiple rescans at the same time, got=$started have=$rescanStateOpt")
-        }
-    }
-  }
-  override def isRescanStateEmpty: Boolean = rescanStateOpt.isEmpty
-
-  override def clearRescanState(): Unit = {
-    rescanStateOpt = None
-    ()
-  }
 }
 
 case class DLCWalletBitcoindBackendLoader(
@@ -326,48 +337,15 @@ case class DLCWalletBitcoindBackendLoader(
     extends DLCWalletLoaderApi {
   import system.dispatcher
   implicit private val nodeConf = conf.nodeConf
-
-  private[this] var currentWalletAppConfigOpt: Option[WalletAppConfig] = None
-
-  private[this] var currentDLCAppConfigOpt: Option[DLCAppConfig] = None
   override def isWalletLoaded: Boolean = walletHolder.isInitialized
-
-  override def stop(): Future[Unit] = {
-    val rescanStopF = rescanStateOpt match {
-      case Some(rescanState) => rescanState.stop()
-      case None              => Future.unit
-    }
-
-    val walletStopF = rescanStopF.flatMap { _ =>
-      currentWalletAppConfigOpt match {
-        case Some(w) => w.stop()
-        case None    => Future.unit
-      }
-    }
-    val dlcStopF = rescanStopF.flatMap { _ =>
-      currentDLCAppConfigOpt match {
-        case Some(d) => d.stop()
-        case None    => Future.unit
-      }
-    }
-
-    for {
-      _ <- rescanStopF
-      _ <- walletStopF
-      _ <- dlcStopF
-    } yield ()
-  }
 
   override def load(
       walletNameOpt: Option[String],
       aesPasswordOpt: Option[AesPassword]): Future[
     (WalletHolder, WalletAppConfig, DLCAppConfig)] = {
-    val stopRescanFOpt = rescanStateOpt match {
-      case Some(state) => state.stop() //stop the rescan
-      case None        => Future.unit
-    }
+    val stopRescanF = stopRescan()
     for {
-      _ <- stopRescanFOpt
+      _ <- stopRescanF
       (dlcWallet, walletConfig, dlcConfig) <- loadWallet(
         walletHolder = walletHolder,
         chainQueryApi = bitcoind,
@@ -391,77 +369,4 @@ case class DLCWalletBitcoindBackendLoader(
       (walletHolder, walletConfig, dlcConfig)
     }
   }
-
-  private def stopOldWalletAppConfig(
-      newWalletConfig: WalletAppConfig): Future[Unit] = {
-    currentWalletAppConfigOpt match {
-      case Some(current) =>
-        //stop the old config
-        current
-          .stop()
-          .map(_ => {
-            currentWalletAppConfigOpt = Some(newWalletConfig)
-          })
-      case None =>
-        for {
-          _ <- conf.walletConf.stop()
-        } yield {
-          currentWalletAppConfigOpt = Some(newWalletConfig)
-        }
-    }
-  }
-
-  private def stopOldDLCAppConfig(newDlcConfig: DLCAppConfig): Future[Unit] = {
-    currentDLCAppConfigOpt match {
-      case Some(current) =>
-        //stop the old config
-        current
-          .stop()
-          .map(_ => {
-            currentDLCAppConfigOpt = Some(newDlcConfig)
-          })
-      case None =>
-        for {
-          _ <- conf.walletConf.stop()
-        } yield {
-          currentDLCAppConfigOpt = Some(newDlcConfig)
-        }
-    }
-  }
-
-  /** Store a rescan state for the wallet that is currently loaded
-    * This is needed because we don't save rescan state anywhere else.
-    */
-  private[this] var rescanStateOpt: Option[RescanState.RescanStarted] = None
-
-  override def setRescanState(rescanState: RescanState): Unit = {
-    rescanState match {
-      case RescanState.RescanAlreadyStarted =>
-      //do nothing in this case, we don't need to keep these states around
-      //don't overwrite the existing reference to RescanStarted
-      case RescanState.RescanDone =>
-        //rescan is done, reset state
-        rescanStateOpt = None
-      case started: RescanState.RescanStarted =>
-        if (rescanStateOpt.isEmpty) {
-          //add callback to reset state when the rescan is done
-          val resetStateCallbackF = started.doneF.map { _ =>
-            rescanStateOpt = None
-          }
-          resetStateCallbackF.failed.foreach(err =>
-            logger.error(s"Failed to reset rescanState", err))
-          rescanStateOpt = Some(started)
-        } else {
-          sys.error(
-            s"Cannot run multiple rescans at the same time, got=$started have=$rescanStateOpt")
-        }
-    }
-  }
-
-  override def clearRescanState(): Unit = {
-    rescanStateOpt = None
-    ()
-  }
-
-  override def isRescanStateEmpty: Boolean = rescanStateOpt.isEmpty
 }

--- a/app/server/src/main/scala/org/bitcoins/server/util/WalletHolderWithLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WalletHolderWithLoaderApi.scala
@@ -1,0 +1,26 @@
+package org.bitcoins.server.util
+
+import org.bitcoins.rpc.client.common.BitcoindRpcClient
+import org.bitcoins.server.{
+  DLCWalletBitcoindBackendLoader,
+  DLCWalletLoaderApi,
+  DLCWalletNeutrinoBackendLoader
+}
+import org.bitcoins.wallet.WalletHolder
+
+sealed trait WalletHolderWithLoaderApi {
+  def walletHolder: WalletHolder
+  def loaderApi: DLCWalletLoaderApi
+}
+
+case class WalletHolderWithNeutrinoLoaderApi(
+    walletHolder: WalletHolder,
+    loaderApi: DLCWalletNeutrinoBackendLoader)
+    extends WalletHolderWithLoaderApi
+
+case class WalletHolderWithBitcoindLoaderApi(
+    walletHolder: WalletHolder,
+    loaderApi: DLCWalletBitcoindBackendLoader)
+    extends WalletHolderWithLoaderApi {
+  val bitcoind: BitcoindRpcClient = loaderApi.bitcoind
+}

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -2,6 +2,7 @@ package org.bitcoins.core.wallet.rescan
 
 import org.bitcoins.core.api.wallet.NeutrinoWalletApi.BlockMatchingResponse
 
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
 sealed trait RescanState
@@ -22,8 +23,23 @@ object RescanState {
     */
   case class RescanStarted(
       private val completeRescanEarlyP: Promise[Option[Int]],
-      blocksMatchedF: Future[Vector[BlockMatchingResponse]])
+      blocksMatchedF: Future[Vector[BlockMatchingResponse]])(implicit
+      ec: ExecutionContext)
       extends RescanState {
+
+    private val _isCompletedEarly: AtomicBoolean = new AtomicBoolean(false)
+    //the promise returned by Source.maybe completes with None
+    //if the stream terminated because the rescan was complete.
+    completeRescanEarlyP.future.map {
+      case None    => //do nothing, this means the stream terminated normally
+      case Some(_) => _isCompletedEarly.set(true)
+    }
+
+    /** Useful for determining if the rescan was completed
+      * externally by the promise to terminate the stream
+      * or was completed because the rescan was fully executed
+      */
+    def isCompletedEarly: Boolean = _isCompletedEarly.get
 
     def isStopped: Boolean = doneF.isCompleted
 
@@ -40,7 +56,11 @@ object RescanState {
     }
   }
 
-  /** Returns a Future for all rescan states that will be complete when the rescan is done */
+  /** Returns a Future for all rescan states that will be complete when the rescan is done.
+    * This can be because the stream was externally termianted early, or the rescan completes.
+    * If you are interested in just the stream completing beacuse the rescan was fully executed,
+    * use [[awaitComplete())]]
+    */
   def awaitRescanDone(rescanState: RescanState)(implicit
       ec: ExecutionContext): Future[Unit] = {
     rescanState match {
@@ -48,6 +68,28 @@ object RescanState {
         Future.unit
       case started: RescanState.RescanStarted =>
         started.doneF.map(_ => ())
+    }
+  }
+
+  /** Returns a Future that is compelted when a rescan is fully executed.
+    * This means that the rescan was NOT terminated externally by completing
+    * the akka stream that underlies the rescan logic.
+    */
+  def awaitRescanComplete(rescanState: RescanState)(implicit
+      ec: ExecutionContext): Future[Unit] = {
+    rescanState match {
+      case RescanState.RescanDone | RescanState.RescanAlreadyStarted =>
+        Future.unit
+      case started: RescanState.RescanStarted =>
+        started.doneF.flatMap { _ =>
+          if (started.isCompletedEarly) {
+            Future.failed(
+              new RuntimeException(
+                s"Rescan was completed early, so cannot fulfill this request"))
+          } else {
+            Future.unit
+          }
+        }
     }
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/WalletLoaderFixtures.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/WalletLoaderFixtures.scala
@@ -1,0 +1,56 @@
+package org.bitcoins.testkit.server
+
+import org.bitcoins.server.DLCWalletBitcoindBackendLoader
+import org.bitcoins.server.util.WalletHolderWithBitcoindLoaderApi
+import org.bitcoins.testkit.EmbeddedPg
+import org.bitcoins.testkit.fixtures.BitcoinSFixture
+import org.bitcoins.testkit.rpc.CachedBitcoindNewest
+import org.bitcoins.wallet.WalletHolder
+import org.scalatest.FutureOutcome
+
+import scala.concurrent.Future
+
+trait WalletLoaderFixtures
+    extends BitcoinSFixture
+    with EmbeddedPg
+    with CachedBitcoindNewest {
+
+  def withBitcoindBackendLoader(test: OneArgAsyncTest): FutureOutcome = {
+    val builder: () => Future[WalletHolderWithBitcoindLoaderApi] = { () =>
+      for {
+        bitcoind <- cachedBitcoindWithFundsF
+        config = BitcoinSServerMainUtil.buildBitcoindBitcoinSAppConfig(bitcoind)
+        _ <- config.start()
+        //initialize the default wallet so it can be used in tests
+        _ <- config.walletConf.createHDWallet(nodeApi = bitcoind,
+                                              chainQueryApi = bitcoind,
+                                              feeRateApi = bitcoind)
+
+        walletHolder = new WalletHolder()
+        loader = DLCWalletBitcoindBackendLoader(
+          walletHolder = walletHolder,
+          bitcoind = bitcoind,
+          nodeApi = bitcoind,
+          feeProvider = bitcoind)(config, system)
+      } yield WalletHolderWithBitcoindLoaderApi(walletHolder, loader)
+    }
+
+    val destroy: WalletHolderWithBitcoindLoaderApi => Future[Unit] = {
+      walletHolderWithLoaderApi =>
+        val loader = walletHolderWithLoaderApi.loaderApi
+        val stopF = loader.stop()
+        for {
+          _ <- stopF
+          _ <- BitcoinSServerMainUtil.destroyBitcoinSAppConfig(loader.conf)
+        } yield ()
+    }
+
+    makeDependentFixture(builder, destroy)(test)
+  }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindNewest].afterAll()
+    super[EmbeddedPg].afterAll()
+    super[BitcoinSFixture].afterAll()
+  }
+}

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -38,6 +38,7 @@ import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto._
 import org.bitcoins.db.SafeDatabase
 import org.bitcoins.db.models.MasterXPubDAO
+import org.bitcoins.keymanager.WalletStorage
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.internal._
@@ -1064,6 +1065,9 @@ object Wallet extends WalletLogger {
     import walletAppConfig.ec
     val passwordOpt = walletAppConfig.aesPasswordOpt
 
+    if (!WalletStorage.seedExists(wallet.walletConfig.datadir)) {
+      WalletStorage
+    }
     val createMasterXpubF = createMasterXPub(wallet.keyManager)
     // We want to make sure all level 0 accounts are created,
     // so the user can change the default account kind later

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -38,7 +38,6 @@ import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto._
 import org.bitcoins.db.SafeDatabase
 import org.bitcoins.db.models.MasterXPubDAO
-import org.bitcoins.keymanager.WalletStorage
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.internal._
@@ -1065,9 +1064,6 @@ object Wallet extends WalletLogger {
     import walletAppConfig.ec
     val passwordOpt = walletAppConfig.aesPasswordOpt
 
-    if (!WalletStorage.seedExists(wallet.walletConfig.datadir)) {
-      WalletStorage
-    }
     val createMasterXpubF = createMasterXPub(wallet.keyManager)
     // We want to make sure all level 0 accounts are created,
     // so the user can change the default account kind later

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -85,7 +85,9 @@ private[wallet] trait RescanHandling extends WalletLogger {
             state <- doNeutrinoRescan(account, start, endOpt, addressBatchSize)
             //purposefully don't map on this Future as it won't be completed until
             //the rescan is completely done.
-            _ = RescanState.awaitRescanDone(state).map { _ =>
+            _ = RescanState.awaitRescanComplete(state).map { _ =>
+              logger.info(
+                s"Rescan is complete, resetting rescan state to false")
               val f = for {
                 _ <- stateDescriptorDAO.updateRescanning(false)
                 _ <- walletCallbacks.executeOnRescanComplete(logger)


### PR DESCRIPTION
Adds a unit test for functionality added in #4568

This also segregates

- `RescanState.awaitRescanDone` - this future always completes when the rescan is done regardless if it was terminated early
- `RescanState.awaitRescanComplete`- this future completes when a rescan was fully executed and not terminated early.

