### PR TITLE
Implement `RescanTerminatedEarly` exception to terminate the stream, implement `ArgumentSource`

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/DLCWalletBitcoindBackendLoaderTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/DLCWalletBitcoindBackendLoaderTest.scala
@@ -6,6 +6,8 @@ import org.bitcoins.testkit.server.WalletLoaderFixtures
 import org.bitcoins.wallet.models.WalletStateDescriptorDAO
 import org.scalatest.FutureOutcome
 
+import scala.concurrent.duration.DurationInt
+
 class DLCWalletBitcoindBackendLoaderTest extends WalletLoaderFixtures {
 
   override type FixtureParam = WalletHolderWithBitcoindLoaderApi
@@ -60,9 +62,11 @@ class DLCWalletBitcoindBackendLoaderTest extends WalletLoaderFixtures {
       _ = assert(isRescanning)
       _ = assert(loader.isRescanStateDefined)
       //wait until rescanning is done
-      _ <- AsyncUtil.retryUntilSatisfiedF { () =>
-        loadWallet2.isRescanning().map(isRescanning => isRescanning == false)
-      }
+      _ <- AsyncUtil.retryUntilSatisfiedF(
+        { () =>
+          loadWallet2.isRescanning().map(isRescanning => isRescanning == false)
+        },
+        250.millis)
     } yield {
       assert(loader.isRescanStateEmpty)
     }

--- a/core/src/main/scala/org/bitcoins/core/api/commons/ArgumentSource.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/commons/ArgumentSource.scala
@@ -1,0 +1,12 @@
+package org.bitcoins.core.api.commons
+
+/** A trait to indicate where an argument came from */
+sealed trait ArgumentSource[+T]
+
+object ArgumentSource {
+
+  /** Means this argument was passed via the rpc */
+  case class RpcArgument[T](arg: T) extends ArgumentSource[T]
+
+  case object NoArgument extends ArgumentSource[Nothing]
+}

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -9,6 +9,9 @@ sealed trait RescanState
 
 object RescanState {
 
+  case object RescanTerminatedEarly
+      extends RuntimeException(s"Rescan terminated early")
+
   /** Finished a rescan */
   case object RescanDone extends RescanState
 
@@ -30,9 +33,12 @@ object RescanState {
     private val _isCompletedEarly: AtomicBoolean = new AtomicBoolean(false)
     //the promise returned by Source.maybe completes with None
     //if the stream terminated because the rescan was complete.
-    completeRescanEarlyP.future.map {
-      case None    => //do nothing, this means the stream terminated normally
-      case Some(_) => _isCompletedEarly.set(true)
+    completeRescanEarlyP.future.map { _ =>
+      _isCompletedEarly.set(false)
+    }
+
+    completeRescanEarlyP.future.failed.foreach { case RescanTerminatedEarly =>
+      _isCompletedEarly.set(true)
     }
 
     /** Useful for determining if the rescan was completed
@@ -50,9 +56,17 @@ object RescanState {
       */
     def stop(): Future[Vector[BlockMatchingResponse]] = {
       if (!completeRescanEarlyP.isCompleted) {
-        completeRescanEarlyP.success(None)
+        completeRescanEarlyP.failure(RescanTerminatedEarly)
       }
-      blocksMatchedF
+      blocksMatchedF.recoverWith {
+        case RescanTerminatedEarly =>
+          println(s"Caught rescan terminated early")
+          //this means this was purposefully terminated early
+          //don't propagate the exception
+          Future.successful(Vector.empty)
+        case err =>
+          throw err
+      }
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -60,7 +60,6 @@ object RescanState {
       }
       blocksMatchedF.recoverWith {
         case RescanTerminatedEarly =>
-          println(s"Caught rescan terminated early")
           //this means this was purposefully terminated early
           //don't propagate the exception
           Future.successful(Vector.empty)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -102,7 +102,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
 
           res.recoverWith {
             case _: RejectedExecutionException =>
-              println(s"Caught rejected execution exception")
               Future.unit //don't do anything if its from the threadpool shutting down
             case err: Throwable =>
               logger.error(s"Failed to rescan wallet", err)


### PR DESCRIPTION
This PR addresses two issues 

1. In #4530 I implemented termination of the stream by passing `None` into the stream. This is incorrect because I misinterpreted what the word `complete` means in the reactive manifesto. [See the definition here](https://doc.akka.io/docs/akka/current/stream/operators/Source/maybe.html#reactive-streams-semantics)
2. This adds a class called `ArgumentSource` so we can track where an argument came from like an `RpcArugment`, a `ConfigurationFileArgument` etc. This fixes a bug I introduced in #4564 because I didn't understand why we had an `Option[Option[]]`. One of the `Option` represented the fact that `aesPassword` as an RPC argument.