### PR TITLE
Make fundRawTransactionInternal use DBIOActions

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/FundRawTxHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/FundRawTxHelper.scala
@@ -4,10 +4,13 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.{InputInfo, ScriptSignatureParams}
 
+import scala.concurrent.Future
+
 case class FundRawTxHelper[T <: RawTxFinalizer](
     txBuilderWithFinalizer: RawTxBuilderWithFinalizer[T],
     scriptSigParams: Vector[ScriptSignatureParams[InputInfo]],
-    feeRate: FeeUnit) {
+    feeRate: FeeUnit,
+    reservedUTXOsCallbackF: Future[Unit]) {
 
   /** Produces the unsigned transaction built by fundrawtransaction */
   def unsignedTx: Transaction = txBuilderWithFinalizer.buildTx()

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -32,7 +32,7 @@ import scala.concurrent._
   */
 private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
   self: DLCWallet =>
-  private lazy val safeDatabase: SafeDatabase = dlcDAO.safeDatabase
+  private lazy val safeDLCDatabase: SafeDatabase = dlcDAO.safeDatabase
 
   /** Calculates the new state of the DLCDb based on the closing transaction,
     * will delete old CET sigs that are no longer needed after execution
@@ -224,7 +224,7 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
             _ <- updateAnnouncementA
           } yield updatedDlcDb
         }
-        updatedDlcDb <- safeDatabase.run(actions)
+        updatedDlcDb <- safeDLCDatabase.run(actions)
       } yield {
         logger.info(
           s"Done calculating RemoteClaimed outcome for dlcId=${dlcId.hex}")

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -525,7 +525,8 @@ class WalletSendingTest extends BitcoinSWalletTest {
         recoverToExceptionIf[RuntimeException](failedTx)
 
       exnF.map(err =>
-        assert(err.getMessage.contains("Failed to reserve all utxos")))
+        assert(err.getMessage.contains(
+          "Not enough value in given outputs to make transaction spending 599500000 sats plus fees")))
 
   }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -447,7 +447,7 @@ abstract class Wallet
       _ = require(
         tmp.outputs.size == 1,
         s"Created tx is not as expected, does not have 1 output, got $tmp")
-      rawTxHelper = FundRawTxHelper(withFinalizer, utxos, feeRate)
+      rawTxHelper = FundRawTxHelper(withFinalizer, utxos, feeRate, Future.unit)
       tx <- finishSend(rawTxHelper,
                        tmp.outputs.head.value,
                        feeRate,
@@ -495,7 +495,7 @@ abstract class Wallet
         utxos,
         feeRate,
         changeAddr.scriptPubKey)
-      rawTxHelper = FundRawTxHelper(txBuilder, utxos, feeRate)
+      rawTxHelper = FundRawTxHelper(txBuilder, utxos, feeRate, Future.unit)
       tx <- finishSend(rawTxHelper, amount, feeRate, newTags)
     } yield tx
   }
@@ -596,7 +596,10 @@ abstract class Wallet
                                                                 sequence)
 
       amount = outputs.foldLeft(CurrencyUnits.zero)(_ + _.value)
-      rawTxHelper = FundRawTxHelper(txBuilder, spendingInfos, newFeeRate)
+      rawTxHelper = FundRawTxHelper(txBuilder,
+                                    spendingInfos,
+                                    newFeeRate,
+                                    Future.unit)
       tx <-
         finishSend(rawTxHelper, amount, newFeeRate, Vector.empty)
     } yield tx

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -94,7 +94,7 @@ abstract class Wallet
   private[bitcoins] val stateDescriptorDAO: WalletStateDescriptorDAO =
     WalletStateDescriptorDAO()
 
-  private val safeDatabase: SafeDatabase = spendingInfoDAO.safeDatabase
+  protected lazy val safeDatabase: SafeDatabase = spendingInfoDAO.safeDatabase
   val nodeApi: NodeApi
   val chainQueryApi: ChainQueryApi
   val creationTime: Instant = keyManager.creationTime

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -19,7 +19,6 @@ import org.bitcoins.core.wallet.utxo.{
   AddressTagType
 }
 import org.bitcoins.crypto.ECPublicKey
-import org.bitcoins.db.SafeDatabase
 import org.bitcoins.wallet._
 import slick.dbio.{DBIOAction, Effect, NoStream}
 
@@ -31,8 +30,6 @@ import scala.util.{Failure, Success}
   */
 private[wallet] trait AddressHandling extends WalletLogger {
   self: Wallet =>
-
-  private lazy val safeDatabase: SafeDatabase = addressDAO.safeDatabase
 
   def contains(
       address: BitcoinAddress,
@@ -293,6 +290,13 @@ private[wallet] trait AddressHandling extends WalletLogger {
     NoStream,
     Effect.Read with Effect.Write with Effect.Transactional] = {
     getNewAddressHelperAction(account, HDChainType.External)
+  }
+
+  def getNewChangeAddressAction(account: AccountDb): DBIOAction[
+    BitcoinAddress,
+    NoStream,
+    Effect.Read with Effect.Write with Effect.Transactional] = {
+    getNewAddressHelperAction(account, HDChainType.Change)
   }
 
   def getNewAddress(account: AccountDb): Future[BitcoinAddress] = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -15,7 +15,6 @@ import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.crypto.DoubleSha256Digest
-import org.bitcoins.db.SafeDatabase
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 import slick.dbio.{DBIOAction, Effect, NoStream}
 
@@ -29,7 +28,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
   /////////////////////
   // Public facing API
 
-  private lazy val safeDatabase: SafeDatabase = addressDAO.safeDatabase
   override def isRescanning(): Future[Boolean] = stateDescriptorDAO.isRescanning
 
   /** @inheritdoc */

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -17,7 +17,6 @@ import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.TxoState._
 import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
-import org.bitcoins.db.SafeDatabase
 import org.bitcoins.wallet._
 
 import scala.concurrent.{Future, Promise}
@@ -32,8 +31,6 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
   self: Wallet =>
 
   import walletConfig.profile.api._
-
-  private lazy val safeDatabase: SafeDatabase = transactionDAO.safeDatabase
 
   /////////////////////
   // Public facing API


### PR DESCRIPTION
Changes `fundRawTransactionInternal` to use a single DBIOAction. This should improve speed and reliability. One notable improvement this does make is help prevent failures like we previously needed to here:

```scala
    resultF.recoverWith { case NonFatal(error) =>
      logger.error(
        s"Failed to reserve utxos for amount=${amt} feeRate=$feeRate, unreserving the selected utxos")
      // un-reserve utxos since we failed to create valid spending infos
      if (markAsReserved) {
        for {
          utxos <- selectedUtxosF
          _ <- unmarkUTXOsAsReserved(utxos.map(_._1))
        } yield error
      } else Future.failed(error)
    }
```

However, this does remove is a call to `walletCallbacks.executeOnReservedUtxos(logger, utxos)` when reserving through this. This could be added by instead making `fundRawTransactionInternalAction`  return a `DBIOAction[(FundRawTxHelper[ShufflingNonInteractiveFinalizer], Future[Unit])]` this is kind of an ugly way around it, otherwise not sure the best course of action (maybe just drop the future on the floor?)


Also made `safeDatabase` `protected` so it required a small refactor