### PR TITLE
Replace `BoundedSourceQueueWithComplete` with `SourceQueueWithComplete`

### DIFF
--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
When using `SourceQueueWithComplete.offer`, we get a `Future` returned. This allows us to propagate error failures easily when we fail to put things into a queue. 

see: https://doc.akka.io/docs/akka/current/stream/operators/Source/queue.html#source-queue