### PR TITLE
Dafault to the latest Bitcoin Core version

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.rpc.client.common
 
 import akka.actor.ActorSystem
+import grizzled.slf4j.Logging
 import org.bitcoins.core.api.chain.db.{
   BlockHeaderDb,
   CompactFilterDb,
@@ -359,7 +360,7 @@ object BitcoindRpcClient {
 
 sealed trait BitcoindVersion
 
-object BitcoindVersion extends StringFactory[BitcoindVersion] {
+object BitcoindVersion extends StringFactory[BitcoindVersion] with Logging {
 
   /** The newest version of `bitcoind` we support */
   val newest: BitcoindVersion = V23
@@ -435,7 +436,10 @@ object BitcoindVersion extends StringFactory[BitcoindVersion] {
       case "21" => V21
       case "22" => V22
       case "23" => V23
-      case _    => Unknown
+      case _ =>
+        logger.warn(
+          s"Unsupported Bitcoin Core version: $int. The latest supported version is ${BitcoindVersion.newest}")
+        newest
     }
   }
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -74,7 +74,10 @@ sealed trait BitcoindInstanceLocal extends BitcoindInstance {
         BitcoindVersion.V22
       case _: String if foundVersion.startsWith(BitcoindVersion.V23.toString) =>
         BitcoindVersion.V23
-      case _: String => BitcoindVersion.Unknown
+      case _: String =>
+        logger.warn(
+          s"Unsupported Bitcoin Core version: $foundVersion. The latest supported version is ${BitcoindVersion.newest}")
+        BitcoindVersion.newest
     }
   }
 }


### PR DESCRIPTION
Now when a user starts bitcoind, we will do our best to support the newer rpc version. As `bitcoind` gets more stable, hopefully they break the API less and we can mostly function across new versions even if we don't officially support the RPC.