### PR TITLE
Disable Akka HTTP idle timeouts

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -226,6 +226,8 @@ bitcoin-s {
 }
 
 akka {
+  # disable idle timeouts
+  http.host-connection-pool.client.idle-timeout = infinite
 
   # keep the connection alive in websockets by sending ping every 5 seconds
   # https://doc.akka.io/docs/akka-http/current/server-side/websocket-support.html#automatic-keep-alive-ping-support


### PR DESCRIPTION
Prevents `akka.stream.scaladsl.TcpIdleTimeoutException` when bitcoind is syncing, reindexing or rescanning.