### PR TITLE
Fix Mac `NeutrinoNodeWithWalletTest` failures

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -14,6 +14,7 @@ import org.bitcoins.testkit.node.{
   NodeTestUtil,
   NodeTestWithCachedBitcoindNewest
 }
+import org.bitcoins.testkit.util.AkkaUtil
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.scalatest.{FutureOutcome, Outcome}
 
@@ -233,6 +234,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
         _ <- bitcoind.sendToAddress(receiveAddr, sendAmt)
         //generate a block to confirm the tx
         _ <- bitcoind.generateToAddress(1, bitcoindAddr)
+        _ <- AkkaUtil.nonBlockingSleep(3.seconds)
         //restart the node now that we have received funds
         startedNode <- stoppedNode.start()
         _ <- startedNode.sync()
@@ -270,6 +272,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       //broadcast tx
       _ <- bitcoind.sendRawTransaction(tx)
       _ <- bitcoind.generateToAddress(6, bitcoindAddr)
+      _ <- AkkaUtil.nonBlockingSleep(3.seconds)
 
       //bring node back online
       startedNode <- stoppedNode.start()


### PR DESCRIPTION
Fixes the occasional mac failures happening with `NeutrinoNodeWithWalletTest` on ci.

```
_ <- bitcoind.generateToAddress(1, bitcoindAddr)
startedNode <- stoppedNode.start()
```
* Note that the `generateToAddress` future completes when the rpc call completes, blocks are actually generated sometime in the future. What I observed in the logs is that sometimes, the node is already started by the time the blocks were generated, which is not something we want to simulate in this test. So added a delay of `3.seconds` here.

* In the case mentioned above, generating blocks led to the node receiving a `BlockMessage` for which it processes the header associated with the block but does not try to fetch cf headers and filters for it. When we get the subsequent header match then that too will fail as that header would already be present from the block.

With this there should not be any failures on ci as far as `node` is concerned so do ping me if any still show up.