### PR TITLE
Drop support for the experimental bitcoind version

### DIFF
--- a/bitcoind-rpc/bitcoind-rpc.sbt
+++ b/bitcoind-rpc/bitcoind-rpc.sbt
@@ -22,9 +22,6 @@ TaskKeys.downloadBitcoind := {
     Files.createDirectories(binaryDir)
   }
 
-  val experimentalVersion =
-    "0.18.99" // TODO: change this when new version compiled on suredbits server
-
   val versions =
     List("23.0",
          "22.0",
@@ -33,8 +30,7 @@ TaskKeys.downloadBitcoind := {
          "0.19.0.1",
          "0.18.1",
          "0.17.0.1",
-         "0.16.3",
-         experimentalVersion)
+         "0.16.3")
 
   logger.debug(
     s"(Maybe) downloading Bitcoin Core binaries for versions: ${versions.mkString(",")}")
@@ -55,9 +51,7 @@ TaskKeys.downloadBitcoind := {
     val (platform, suffix) = getPlatformAndSuffix(version)
     val archiveLocation = binaryDir resolve s"$version.$suffix"
     val location =
-      if (version == experimentalVersion)
-        s"https://s3-us-west-1.amazonaws.com/suredbits.com/bitcoin-core-$version/bitcoin-$version-$platform.$suffix"
-      else if (version.init.endsWith("rc")) { // if it is a release candidate
+      if (version.init.endsWith("rc")) { // if it is a release candidate
         val (base, rc) = version.splitAt(version.length - 3)
         s"https://bitcoincore.org/bin/bitcoin-core-$base/test.$rc/bitcoin-$version-$platform.$suffix"
       } else
@@ -113,8 +107,7 @@ TaskKeys.downloadBitcoind := {
               "0.19.0.1" -> "732cc96ae2e5e25603edf76b8c8af976fe518dd925f7e674710c6c8ee5189204",
               "0.18.1" -> "600d1db5e751fa85903e935a01a74f5cc57e1e7473c15fd3e17ed21e202cfe5a",
               "0.17.0.1" -> "6ccc675ee91522eee5785457e922d8a155e4eb7d5524bd130eb0ef0f0c4a6008",
-              "0.16.3" -> "5d422a9d544742bc0df12427383f9c2517433ce7b58cf672b9a9b17c2ef51e4f",
-              experimentalVersion -> "f8b1a0ded648249e5e8c14fca3e11a733da8172b05523922c87557ea5eaaa4c5"
+              "0.16.3" -> "5d422a9d544742bc0df12427383f9c2517433ce7b58cf672b9a9b17c2ef51e4f"
             )
           else if (Properties.isMac)
             Map(
@@ -125,8 +118,7 @@ TaskKeys.downloadBitcoind := {
               "0.19.0.1" -> "a64e4174e400f3a389abd76f4d6b1853788730013ab1dedc0e64b0a0025a0923",
               "0.18.1" -> "b7bbcee7a7540f711b171d6981f939ca8482005fde22689bc016596d80548bb1",
               "0.17.0.1" -> "3b1fb3dd596edb656bbc0c11630392e201c1a4483a0e1a9f5dd22b6556cbae12",
-              "0.16.3" -> "78c3bff3b619a19aed575961ea43cc9e142959218835cf51aede7f0b764fc25d",
-              experimentalVersion -> "cfd4ed0b8db08fb1355aca44ca282b1de31e83b5862efaac527e3952b0987e55"
+              "0.16.3" -> "78c3bff3b619a19aed575961ea43cc9e142959218835cf51aede7f0b764fc25d"
             )
           else if (Properties.isWin)
             Map(
@@ -137,8 +129,7 @@ TaskKeys.downloadBitcoind := {
               "0.19.0.1" -> "7706593de727d893e4b1e750dc296ea682ccee79acdd08bbc81eaacf3b3173cf",
               "0.18.1" -> "b0f94ab43c068bac9c10a59cb3f1b595817256a00b84f0b724f8504b44e1314f",
               "0.17.0.1" -> "2d0a0aafe5a963beb965b7645f70f973a17f4fa4ddf245b61d532f2a58449f3e",
-              "0.16.3" -> "52469c56222c1b5344065ef2d3ce6fc58ae42939a7b80643a7e3ee75ec237da9",
-              experimentalVersion -> "b7ad8e6c0b91adf820499bf891f22f590e969b834980d4910efac5b082d83c49"
+              "0.16.3" -> "52469c56222c1b5344065ef2d3ce6fc58ae42939a7b80643a7e3ee75ec237da9"
             )
           else sys.error(s"Unsupported OS: ${Properties.osName}")
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -341,8 +341,6 @@ object BitcoindRpcClient {
       case BitcoindVersion.V21 => BitcoindV21RpcClient.withActorSystem(instance)
       case BitcoindVersion.V22 => BitcoindV22RpcClient.withActorSystem(instance)
       case BitcoindVersion.V23 => BitcoindV23RpcClient.withActorSystem(instance)
-      case BitcoindVersion.Experimental =>
-        BitcoindV18RpcClient.withActorSystem(instance)
       case BitcoindVersion.Unknown =>
         sys.error(
           s"Cannot create a Bitcoin Core RPC client: unsupported version")
@@ -368,7 +366,7 @@ object BitcoindVersion extends StringFactory[BitcoindVersion] with Logging {
   val standard: Vector[BitcoindVersion] =
     Vector(V16, V17, V18, V19, V20, V21, V22, V23)
 
-  val known: Vector[BitcoindVersion] = standard :+ Experimental
+  val known: Vector[BitcoindVersion] = standard
 
   case object V16 extends BitcoindVersion {
     override def toString: String = "v0.16"
@@ -402,10 +400,6 @@ object BitcoindVersion extends StringFactory[BitcoindVersion] with Logging {
     override def toString: String = "v23"
   }
 
-  case object Experimental extends BitcoindVersion {
-    override def toString: String = "v0.18.99"
-  }
-
   case object Unknown extends BitcoindVersion {
     override def toString: String = "Unknown"
   }
@@ -426,11 +420,7 @@ object BitcoindVersion extends StringFactory[BitcoindVersion] with Logging {
     int.toString.substring(0, 2) match {
       case "16" => V16
       case "17" => V17
-      case "18" =>
-        int.toString.substring(2, 4) match {
-          case "99" => Experimental
-          case _    => V18
-        }
+      case "18" => V18
       case "19" => V19
       case "20" => V20
       case "21" => V21

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BlockchainRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BlockchainRpc.scala
@@ -33,7 +33,7 @@ trait BlockchainRpc { self: Client =>
         bitcoindCall[GetBlockChainInfoResultPreV19]("getblockchaininfo")
       case V22 | V21 | V20 | V19 =>
         bitcoindCall[GetBlockChainInfoResultPostV19]("getblockchaininfo")
-      case V23 | Experimental | Unknown =>
+      case V23 | Unknown =>
         bitcoindCall[GetBlockChainInfoResultPostV23]("getblockchaininfo")
     }
   }
@@ -85,7 +85,7 @@ trait BlockchainRpc { self: Client =>
           "getblock",
           List(JsString(headerHash.hex), isVerboseJsonObject))
 
-      case V16 | V17 | V18 | V19 | V20 | V21 | Experimental =>
+      case V16 | V17 | V18 | V19 | V20 | V21 =>
         bitcoindCall[GetBlockWithTransactionsResultPreV22](
           "getblock",
           List(JsString(headerHash.hex), isVerboseJsonObject))

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MempoolRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MempoolRpc.scala
@@ -32,11 +32,11 @@ trait MempoolRpc { self: Client =>
     Map[DoubleSha256DigestBE, GetMemPoolResult]] = {
 
     self.version.flatMap {
-      case V23 | Experimental | Unknown =>
+      case V23 | Unknown =>
         bitcoindCall[Map[DoubleSha256DigestBE, GetMemPoolResultPostV23]](
           "getmempoolancestors",
           List(JsString(txid.hex), JsBoolean(true)))
-      case V22 | V21 | V20 | V19 | Experimental | Unknown =>
+      case V22 | V21 | V20 | V19 | Unknown =>
         bitcoindCall[Map[DoubleSha256DigestBE, GetMemPoolResultPostV19]](
           "getmempoolancestors",
           List(JsString(txid.hex), JsBoolean(true)))
@@ -67,11 +67,11 @@ trait MempoolRpc { self: Client =>
   def getMemPoolDescendantsVerbose(txid: DoubleSha256DigestBE): Future[
     Map[DoubleSha256DigestBE, GetMemPoolResult]] = {
     self.version.flatMap {
-      case V23 | Experimental | Unknown =>
+      case V23 | Unknown =>
         bitcoindCall[Map[DoubleSha256DigestBE, GetMemPoolResultPostV23]](
           "getmempooldescendants",
           List(JsString(txid.hex), JsBoolean(true)))
-      case V22 | V21 | V20 | V19 | Experimental | Unknown =>
+      case V22 | V21 | V20 | V19 | Unknown =>
         bitcoindCall[Map[DoubleSha256DigestBE, GetMemPoolResultPostV19]](
           "getmempooldescendants",
           List(JsString(txid.hex), JsBoolean(true)))
@@ -91,10 +91,10 @@ trait MempoolRpc { self: Client =>
       txid: DoubleSha256DigestBE): Future[GetMemPoolEntryResult] = {
 
     self.version.flatMap {
-      case V23 | Experimental | Unknown =>
+      case V23 | Unknown =>
         bitcoindCall[GetMemPoolEntryResultPostV23]("getmempoolentry",
                                                    List(JsString(txid.hex)))
-      case V22 | V21 | V20 | V19 | Experimental | Unknown =>
+      case V22 | V21 | V20 | V19 | Unknown =>
         bitcoindCall[GetMemPoolEntryResultPostV19]("getmempoolentry",
                                                    List(JsString(txid.hex)))
       case V16 | V17 | V18 =>
@@ -136,11 +136,11 @@ trait MempoolRpc { self: Client =>
     Map[DoubleSha256DigestBE, GetMemPoolResult]] = {
 
     self.version.flatMap {
-      case V23 | Experimental | Unknown =>
+      case V23 | Unknown =>
         bitcoindCall[Map[DoubleSha256DigestBE, GetMemPoolResultPostV23]](
           "getrawmempool",
           List(JsBoolean(true)))
-      case V22 | V21 | V20 | V19 | Experimental | Unknown =>
+      case V22 | V21 | V20 | V19 | Unknown =>
         bitcoindCall[Map[DoubleSha256DigestBE, GetMemPoolResultPostV19]](
           "getrawmempool",
           List(JsBoolean(true)))

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MultisigRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MultisigRpc.scala
@@ -46,7 +46,7 @@ trait MultisigRpc { self: Client =>
           "addmultisigaddress",
           params,
           uriExtensionOpt = walletNameOpt.map(walletExtension))
-      case V16 | V17 | V18 | V19 | Experimental =>
+      case V16 | V17 | V18 | V19 =>
         bitcoindCall[MultiSigResultPreV20]("addmultisigaddress",
                                            params,
                                            uriExtensionOpt =
@@ -88,7 +88,7 @@ trait MultisigRpc { self: Client =>
           "createmultisig",
           List(JsNumber(minSignatures), Json.toJson(keys.map(_.hex))),
           uriExtensionOpt = walletNameOpt.map(walletExtension))
-      case V16 | V17 | V18 | V19 | Experimental =>
+      case V16 | V17 | V18 | V19 =>
         bitcoindCall[MultiSigResultPreV20](
           "createmultisig",
           List(JsNumber(minSignatures), Json.toJson(keys.map(_.hex))),

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/P2PRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/P2PRpc.scala
@@ -68,7 +68,7 @@ trait P2PRpc { self: Client =>
         bitcoindCall[Vector[PeerPostV21]]("getpeerinfo")
       case V20 =>
         bitcoindCall[Vector[PeerV20]]("getpeerinfo")
-      case V16 | V17 | V18 | V19 | Experimental =>
+      case V16 | V17 | V18 | V19 =>
         bitcoindCall[Vector[PeerPreV20]]("getpeerinfo")
     }
   }
@@ -79,7 +79,7 @@ trait P2PRpc { self: Client =>
         bitcoindCall[Vector[NodeBanPostV22]]("listbanned")
       case V21 | V20 =>
         bitcoindCall[Vector[NodeBanPostV20]]("listbanned")
-      case V16 | V17 | V18 | V19 | Experimental =>
+      case V16 | V17 | V18 | V19 =>
         bitcoindCall[Vector[NodeBanPreV20]]("listbanned")
     }
   }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/PsbtRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/PsbtRpc.scala
@@ -14,7 +14,6 @@ import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionInput}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.rpc.client.common.BitcoindVersion.{
-  Experimental,
   Unknown,
   V16,
   V17,
@@ -99,7 +98,7 @@ trait PsbtRpc {
     self.version.flatMap {
       case V22 | V23 | Unknown =>
         bitcoindCall[DecodePsbtResultV22]("decodepsbt", List(Json.toJson(psbt)))
-      case V16 | V17 | V18 | V19 | V20 | V21 | Experimental =>
+      case V16 | V17 | V18 | V19 | V20 | V21 =>
         bitcoindCall[DecodePsbtResultPreV22]("decodepsbt",
                                              List(Json.toJson(psbt)))
     }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/RawTransactionRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/RawTransactionRpc.scala
@@ -47,7 +47,7 @@ trait RawTransactionRpc { self: Client =>
         bitcoindCall[RpcTransactionV22]("decoderawtransaction",
                                         List(JsString(transaction.hex)))
 
-      case V16 | V17 | V18 | V19 | V20 | V21 | Experimental =>
+      case V16 | V17 | V18 | V19 | V20 | V21 =>
         bitcoindCall[RpcTransactionPreV22]("decoderawtransaction",
                                            List(JsString(transaction.hex)))
     }
@@ -104,7 +104,7 @@ trait RawTransactionRpc { self: Client =>
     self.version.flatMap {
       case V22 | V23 | Unknown =>
         bitcoindCall[GetRawTransactionResultV22]("getrawtransaction", params)
-      case V16 | V17 | V18 | V19 | V20 | V21 | Experimental =>
+      case V16 | V17 | V18 | V19 | V20 | V21 =>
         bitcoindCall[GetRawTransactionResultPreV22]("getrawtransaction", params)
     }
 
@@ -129,7 +129,7 @@ trait RawTransactionRpc { self: Client =>
       maxfeerate: Double = 0.10): Future[DoubleSha256DigestBE] = {
 
     val feeParameterF = self.version.map {
-      case V23 | V22 | V21 | V20 | V19 | Experimental | Unknown =>
+      case V23 | V22 | V21 | V20 | V19 | Unknown =>
         JsNumber(maxfeerate)
       case V16 | V17 | V18 =>
         JsBoolean(maxfeerate == 0)

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/TransactionRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/TransactionRpc.scala
@@ -7,7 +7,6 @@ import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.protocol.blockchain.MerkleBlock
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.rpc.client.common.BitcoindVersion.{
-  Experimental,
   Unknown,
   V16,
   V17,
@@ -97,7 +96,7 @@ trait TransactionRpc { self: Client =>
           "gettxout",
           List(JsString(txid.hex), JsNumber(vout), JsBoolean(includeMemPool)))
 
-      case V16 | V17 | V18 | V19 | V20 | V21 | Experimental =>
+      case V16 | V17 | V18 | V19 | V20 | V21 =>
         bitcoindCall[GetTxOutResultPreV22](
           "gettxout",
           List(JsString(txid.hex), JsNumber(vout), JsBoolean(includeMemPool)))

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/UtilRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/UtilRpc.scala
@@ -25,7 +25,7 @@ trait UtilRpc { self: Client =>
       case V22 | V23 | Unknown =>
         bitcoindCall[DecodeScriptResultV22]("decodescript",
                                             List(Json.toJson(script)))
-      case V16 | V17 | V18 | V19 | V20 | V21 | Experimental =>
+      case V16 | V17 | V18 | V19 | V20 | V21 =>
         bitcoindCall[DecodeScriptResultPreV22]("decodescript",
                                                List(Json.toJson(script)))
     }
@@ -36,7 +36,7 @@ trait UtilRpc { self: Client =>
     version.flatMap {
       case V23 | V22 | V21 | Unknown =>
         bitcoindCall[Map[String, IndexInfoResult]]("getindexinfo")
-      case V16 | V17 | V18 | V19 | V20 | Experimental =>
+      case V16 | V17 | V18 | V19 | V20 =>
         Future.failed(
           new RuntimeException(
             s"getIndexInfo is only for version V21+, got $version"))
@@ -49,7 +49,7 @@ trait UtilRpc { self: Client =>
         bitcoindCall[Map[String, IndexInfoResult]](
           "getindexinfo",
           List(JsString(indexName))).map(_.head._2)
-      case V16 | V17 | V18 | V19 | V20 | Experimental =>
+      case V16 | V17 | V18 | V19 | V20 =>
         Future.failed(
           new RuntimeException(
             s"getIndexInfo is only for version V21+, got $version"))

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/WalletRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/WalletRpc.scala
@@ -170,8 +170,7 @@ trait WalletRpc { self: Client =>
           "getwalletinfo",
           uriExtensionOpt = walletName.map(walletExtension))
       case BitcoindVersion.V16 | BitcoindVersion.V17 | BitcoindVersion.V18 |
-          BitcoindVersion.V19 | BitcoindVersion.V20 | BitcoindVersion.V21 |
-          BitcoindVersion.Experimental =>
+          BitcoindVersion.V19 | BitcoindVersion.V20 | BitcoindVersion.V21 =>
         bitcoindCall[GetWalletInfoResultPreV22](
           "getwalletinfo",
           uriExtensionOpt = walletName.map(walletExtension))
@@ -318,7 +317,7 @@ trait WalletRpc { self: Client =>
   ): Future[SetWalletFlagResult] = {
 
     self.version.flatMap {
-      case V23 | V22 | V21 | V20 | V19 | Experimental | Unknown =>
+      case V23 | V22 | V21 | V20 | V19 | Unknown =>
         bitcoindCall[SetWalletFlagResult](
           "setwalletflag",
           List(JsString(flag.toString), Json.toJson(value)),
@@ -332,7 +331,7 @@ trait WalletRpc { self: Client =>
 
   def getBalances: Future[GetBalancesResult] = {
     self.version.flatMap {
-      case V23 | V22 | V21 | V20 | V19 | Experimental | Unknown =>
+      case V23 | V22 | V21 | V20 | V19 | Unknown =>
         bitcoindCall[GetBalancesResult]("getbalances")
       case V16 | V17 | V18 =>
         Future.failed(
@@ -343,7 +342,7 @@ trait WalletRpc { self: Client =>
 
   def getBalances(walletName: String): Future[GetBalancesResult] = {
     self.version.flatMap {
-      case V23 | V22 | V21 | V20 | V19 | Experimental | Unknown =>
+      case V23 | V22 | V21 | V20 | V19 | Unknown =>
         bitcoindCall[GetBalancesResult]("getbalances",
                                         uriExtensionOpt =
                                           Some(walletExtension(walletName)))
@@ -428,7 +427,7 @@ trait WalletRpc { self: Client =>
                JsBoolean(avoidReuse),
                JsBoolean(descriptors))
         )
-      case V21 | V20 | V19 | Unknown | Experimental =>
+      case V21 | V20 | V19 | Unknown =>
         bitcoindCall[CreateWalletResult](
           "createwallet",
           List(JsString(walletName),
@@ -454,7 +453,7 @@ trait WalletRpc { self: Client =>
           "getaddressinfo",
           List(JsString(address.value)),
           uriExtensionOpt = walletNameOpt.map(walletExtension))
-      case V18 | V19 | V20 | Experimental | Unknown =>
+      case V18 | V19 | V20 | Unknown =>
         bitcoindCall[AddressInfoResultPostV18](
           "getaddressinfo",
           List(JsString(address.value)),

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v18/V18AssortedRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v18/V18AssortedRpc.scala
@@ -34,8 +34,7 @@ trait V18AssortedRpc {
           "getnodeaddresses",
           List(Json.toJson(count)))
       case BitcoindVersion.V16 | BitcoindVersion.V17 | BitcoindVersion.V18 |
-          BitcoindVersion.V19 | BitcoindVersion.V20 | BitcoindVersion.V21 |
-          BitcoindVersion.Experimental =>
+          BitcoindVersion.V19 | BitcoindVersion.V20 | BitcoindVersion.V21 =>
         bitcoindCall[Vector[GetNodeAddressesResultPreV22]](
           "getnodeaddresses",
           List(Json.toJson(count)))

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/V20MultisigRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/v20/V20MultisigRpc.scala
@@ -39,7 +39,7 @@ trait V20MultisigRpc extends MultisigRpc { self: Client =>
     self.version.flatMap {
       case V20 | V21 | V22 | V23 | Unknown =>
         bitcoindCall[MultiSigResultPostV20]("addmultisigaddress", params)
-      case version @ (V16 | V17 | V18 | V19 | Experimental) =>
+      case version @ (V16 | V17 | V18 | V19) =>
         throw new RuntimeException(
           s"Cannot use v20MultisigRpc on an older version, got $version")
     }
@@ -80,7 +80,7 @@ trait V20MultisigRpc extends MultisigRpc { self: Client =>
           "createmultisig",
           List(JsNumber(minSignatures), Json.toJson(keys.map(_.hex))),
           uriExtensionOpt = walletNameOpt.map(walletExtension))
-      case version @ (V16 | V17 | V18 | V19 | Experimental) =>
+      case version @ (V16 | V17 | V18 | V19) =>
         throw new RuntimeException(
           s"Cannot use v20MultisigRpc on an older version, got $version")
     }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -55,9 +55,6 @@ sealed trait BitcoindInstanceLocal extends BitcoindInstance {
         .last
 
     foundVersion match {
-      case _: String
-          if foundVersion.equals(BitcoindVersion.Experimental.toString) =>
-        BitcoindVersion.Experimental
       case _: String if foundVersion.startsWith(BitcoindVersion.V16.toString) =>
         BitcoindVersion.V16
       case _: String if foundVersion.startsWith(BitcoindVersion.V17.toString) =>

--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -65,7 +65,7 @@ implicit val ec = system.dispatcher
 
 //we also require a bitcoind instance to connect to
 //so let's start one (make sure you ran 'sbt downloadBitcoind')
-val instance = BitcoindRpcTestUtil.instance(versionOpt = Some(BitcoindVersion.Experimental))
+val instance = BitcoindRpcTestUtil.instance(versionOpt = Some(BitcoindVersion.newest))
 val p2pPort = instance.p2pPort
 val bitcoindF = BitcoindRpcTestUtil.startedBitcoindRpcClient(Some(instance), Vector.newBuilder)
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -9,8 +9,6 @@ import org.scalatest._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-object UsesExperimentalBitcoind extends Tag("UsesExperimentalBitcoind")
-
 trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
 
   /** Given functions to build and destroy a fixture, returns a OneArgAsyncTest => FutureOutcome


### PR DESCRIPTION
We used a custom built 0.18.99 version for the Neutrino wallet tests before the official support for BIP-137/BIP-138 had been released. It's not used anymore.