### PR TITLE
Implement `listDLCs(state)`, use it in `getWalletAccounting()`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/DLCWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/DLCWalletApi.scala
@@ -134,6 +134,9 @@ trait DLCWalletApi { self: WalletApi =>
   /** Creates the refund transaction for the given contractId, does not broadcast it */
   def executeDLCRefund(contractId: ByteVector): Future[Transaction]
 
+  /** Fetches all DLCs with the given set of states */
+  def listDLCs(states: Vector[DLCState]): Future[Vector[DLCStatus]]
+
   def listDLCs(): Future[Vector[DLCStatus]]
 
   def findDLC(dlcId: Sha256Digest): Future[Option[DLCStatus]]

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCState.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCState.scala
@@ -110,6 +110,12 @@ object DLCState extends StringFactory[DLCState] {
     Signed
   )
 
+  val closedStates: Vector[ClosedState] = Vector(
+    Claimed,
+    RemoteClaimed,
+    Refunded
+  )
+
   override def fromString(str: String): DLCState = {
     all.find(state => str.toLowerCase() == state.toString.toLowerCase) match {
       case Some(state) => state

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
@@ -133,6 +133,22 @@ case class DLCDAO()(implicit
     table.filter(_.peerOpt === peer).result.map(_.toVector)
   }
 
+  def findByStateAction(
+      state: DLCState): DBIOAction[Vector[DLCDb], NoStream, Effect.Read] = {
+    table.filter(_.state === state).result.map(_.toVector)
+  }
+
+  def findByStatesAction(states: Vector[DLCState]): DBIOAction[
+    Vector[DLCDb],
+    NoStream,
+    Effect.Read] = {
+    table.filter(_.state.inSet(states)).result.map(_.toVector)
+  }
+
+  def findByState(state: DLCState): Future[Vector[DLCDb]] = {
+    safeDatabase.run(findByStateAction(state))
+  }
+
   def updateDLCContactMapping(
       dlcId: Sha256Digest,
       contcatId: InetSocketAddress): Future[Unit] = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -23,6 +23,7 @@ import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.dlc.models.{
   ContractInfo,
   DLCMessage,
+  DLCState,
   DLCStatus,
   OracleSignatures
 }
@@ -419,6 +420,9 @@ class WalletHolder(initWalletOpt: Option[DLCNeutrinoHDWalletApi])(implicit
   override def executeDLCRefund(contractId: ByteVector): Future[Transaction] =
     delegate(_.executeDLCRefund(contractId))
 
+  override def listDLCs(states: Vector[DLCState]): Future[Vector[DLCStatus]] = {
+    delegate(_.listDLCs(states))
+  }
   override def listDLCs(): Future[Vector[DLCStatus]] = delegate(_.listDLCs())
 
   override def findDLC(dlcId: Sha256Digest): Future[Option[DLCStatus]] =


### PR DESCRIPTION
This is an optimization. 

When fetching wallet accounting, we only do accoutnign for DLCs in closed states. 

There is no point in fetching wallet accounting for DLCs in progress, so don't do it.
