### PR TITLE
Implement small optimization to not query for DLCDb twice

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1742,8 +1742,7 @@ abstract class DLCWallet
             contactId.getHostString + ":" + contactId.getPort)
         case None => dlcDAO.findAllAction()
       }
-      ids = dlcs.map(_.dlcId)
-      dlcFs = ids.map(findDLCAction)
+      dlcFs = dlcs.map(d => findDLCAction(d))
       dlcs <- DBIO.sequence(dlcFs)
     } yield {
       dlcs.collect { case Some(dlc) =>
@@ -1827,6 +1826,14 @@ abstract class DLCWallet
     } yield (closingTxOpt, payoutAddress)
   }
 
+
+  private def findDLCAction(dlcDb: DLCDb): DBIOAction[
+    Option[IntermediaryDLCStatus],
+    NoStream,
+    Effect.Read] = {
+    findDLCStatusAction(dlcDb)
+  }
+
   private def findDLCAction(dlcId: Sha256Digest): DBIOAction[
     Option[IntermediaryDLCStatus],
     NoStream,
@@ -1837,7 +1844,7 @@ abstract class DLCWallet
       dlcDbOpt <- dlcDAO.findByPrimaryKeyAction(dlcId)
       dlcStatusOpt <- dlcDbOpt match {
         case None        => DBIO.successful(None)
-        case Some(dlcDb) => findDLCStatusAction(dlcDb)
+        case Some(dlcDb) => findDLCAction(dlcDb)
       }
     } yield dlcStatusOpt
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDAO.scala
@@ -31,7 +31,7 @@ case class DLCAcceptDAO()(implicit
   override def createAll(ts: Vector[DLCAcceptDb]): Future[Vector[DLCAcceptDb]] =
     createAllNoAutoInc(ts, safeDatabase)
 
-  override protected def findByPrimaryKeys(
+  override def findByPrimaryKeys(
       ids: Vector[Sha256Digest]): Query[DLCAcceptTable, DLCAcceptDb, Seq] =
     table.filter(_.dlcId.inSet(ids))
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCContractDataDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCContractDataDAO.scala
@@ -31,7 +31,7 @@ case class DLCContractDataDAO()(implicit
       ts: Vector[DLCContractDataDb]): Future[Vector[DLCContractDataDb]] =
     createAllNoAutoInc(ts, safeDatabase)
 
-  override protected def findByPrimaryKeys(ids: Vector[Sha256Digest]): Query[
+  override def findByPrimaryKeys(ids: Vector[Sha256Digest]): Query[
     DLCContractDataTable,
     DLCContractDataDb,
     Seq] =

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCOfferDAO.scala
@@ -30,7 +30,7 @@ case class DLCOfferDAO()(implicit
   override def createAll(ts: Vector[DLCOfferDb]): Future[Vector[DLCOfferDb]] =
     createAllNoAutoInc(ts, safeDatabase)
 
-  override protected def findByPrimaryKeys(
+  override def findByPrimaryKeys(
       ids: Vector[Sha256Digest]): Query[DLCOfferTable, DLCOfferDb, Seq] =
     table.filter(_.dlcId.inSet(ids))
 


### PR DESCRIPTION
Implement a optimization to make the `getdlcs` endpoint faster. This is the slowest RPC we provide at the moment, especially on large DLC wallets.