### PR TITLE
2022 08 11 issue 4600 and only emit `syncing` ws event when we are actually syncing

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -399,7 +399,9 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val bitcoindSyncStateF: Future[BitcoindSyncState] = {
       for {
         bitcoind <- bitcoindF
-        bitcoindNetwork <- getBlockChainInfo(bitcoind).map(_.chain)
+        blockchainInfo <- getBlockChainInfo(bitcoind)
+        _ <- bitcoind.setSyncing(blockchainInfo.initialblockdownload)
+        bitcoindNetwork = blockchainInfo.chain
         _ = require(
           bitcoindNetwork == network,
           s"bitcoind ($bitcoindNetwork) on different network than wallet ($network)")

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -368,10 +368,10 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
         nodeApi <- nodeApiF
         feeProvider <- feeProviderF
       } yield {
-        val l = DLCWalletBitcoindBackendLoader(walletHolder,
-                                               bitcoind,
-                                               nodeApi,
-                                               feeProvider)
+        val l = DLCWalletBitcoindBackendLoader(walletHolder = walletHolder,
+                                               bitcoind = bitcoind,
+                                               nodeApi = nodeApi,
+                                               feeProvider = feeProvider)
 
         walletLoaderApiOpt = Some(l)
         l

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -111,7 +111,7 @@ object BitcoindRpcBackendUtil extends Logging {
       bitcoind: BitcoindRpcClient,
       chainCallbacksOpt: Option[ChainCallbacks])(implicit
       ec: ExecutionContext): Future[Unit] = {
-    logger.debug(s"Setting bitcoind syncing flag to $syncing")
+    logger.info(s"Setting bitcoind syncing flag to $syncing")
     for {
       _ <- bitcoind.setSyncing(syncing)
     } yield {


### PR DESCRIPTION
This PR fixes #4600 . Now if bitcoind is syncing, we will also return `"syncing":true` in response to our `getinfo` endpoint.

This PR also addresses some issues around emitting websocket events for sync flags changing with `bitcoind` introduced in #4452 . Previously when we we polled bitcoind this sequence of events would occur

1. Polling bitcoind starts
2. We set syncing flag to true
3. We emit a websocket event saying the syncing flag is true
4. We check if bitcoind as any new blocks
5. If it does, we sync the blocks.
6. When we are done syncing, set the syncing flag to false.
7. We emit the websocket event event saying sync is false.

The new flow is 

1. Polling bitcoind starts
2. Check if bitcoind has any new blocks
3. If there are new blocks, emit a websocket event saying the syncing flag is true. If there are not new blocks, emit no event.
4. When bitcoind is done syncing blocks (if there are any), emit the websocket event event saying sync is false.


The key difference is there will be _no_ events emitted if our wallet and bitcoind are in sync when we poll bitcoind. This was not the case previously.

[5bb25ee](https://github.com/bitcoin-s/bitcoin-s/pull/4604/commits/5bb25eed89912d91db15ed17f85a61b616febab7) also introduces changes where we will only emit websocket events when sync state is actually changed when `bitcoin-s.node.mode=neutrino`.