### PR TITLE
Add min & max functions for CurrencyUnits

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
+++ b/core/src/main/scala/org/bitcoins/core/currency/CurrencyUnits.scala
@@ -268,6 +268,14 @@ object CurrencyUnits extends Numeric[CurrencyUnit] {
     }
   }
 
+  def max(a: CurrencyUnit, b: CurrencyUnit): CurrencyUnit = {
+    if (a > b) a else b
+  }
+
+  def min(a: CurrencyUnit, b: CurrencyUnit): CurrencyUnit = {
+    if (a < b) a else b
+  }
+
   /** The number you need to multiply BTC by to get it's satoshis */
   val btcToSatoshiScalar: Long = 100000000
   val satoshisToBTCScalar: BigDecimal = BigDecimal(1.0) / btcToSatoshiScalar


### PR DESCRIPTION
I find myself using Math.min or Math.max with CurrencyUnits and having to turn it into a double, and then back into a Satoshis which is pretty ugly, this should allow some cleanup