### PR TITLE
Implement `exportstakingaddresswif`

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1525,6 +1525,9 @@ object ConsoleCli {
       cmd("getstakingaddress")
         .action((_, conf) => conf.copy(command = GetStakingAddress))
         .text(s"Get oracle's staking address"),
+      cmd("exportstakingaddresswif")
+        .action((_, conf) => conf.copy(command = ExportStakingAddressWif))
+        .text(s"Export the private key for the wallet's staking address"),
       cmd("listannouncements")
         .action((_, conf) => conf.copy(command = ListAnnouncements))
         .text(s"Lists all announcement names"),
@@ -2227,6 +2230,8 @@ object ConsoleCli {
         RequestParam("setoraclename", Seq(up.writeJs(oracleName)))
       case GetStakingAddress =>
         RequestParam("getstakingaddress")
+      case ExportStakingAddressWif =>
+        RequestParam("exportstakingaddresswif")
       case ListAnnouncements =>
         RequestParam("listannouncements")
       case GetAnnouncement(eventName) =>
@@ -2507,6 +2512,8 @@ object CliCommand {
   // Oracle
   case object GetPublicKey extends OracleServerCliCommand
   case object GetStakingAddress extends OracleServerCliCommand
+
+  case object ExportStakingAddressWif extends OracleServerCliCommand
   case object ListAnnouncements extends OracleServerCliCommand
 
   case class GetAnnouncement(eventName: String) extends OracleServerCliCommand

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleRoutes.scala
@@ -326,5 +326,10 @@ case class OracleRoutes(oracle: DLCOracleApi)(implicit
           Server.httpSuccess(name)
         }
       }
+    case ServerCommand("exportstakingaddresswif", _) =>
+      complete {
+        val wif = oracle.exportSigningKeyWIF
+        Server.httpSuccess(wif)
+      }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/api/dlcoracle/DLCOracleApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlcoracle/DLCOracleApi.scala
@@ -117,4 +117,9 @@ trait DLCOracleApi {
 
   /** Signs the SHA256 hash of the given bytes using the oracle's signing key */
   def signMessage(message: ByteVector): SchnorrDigitalSignature
+
+  /** Returns the staking address private key in wallet import format
+    * so a user can take it an recover the funds in another wallet
+    */
+  def exportSigningKeyWIF: String
 }

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.dlc.oracle
 import com.typesafe.config.ConfigFactory
 import org.bitcoins.core.api.dlcoracle._
 import org.bitcoins.core.api.dlcoracle.db._
+import org.bitcoins.core.crypto.ECPrivateKeyUtil
 import org.bitcoins.core.hd.{HDCoinType, HDPurpose}
 import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.Bech32Address
@@ -1058,5 +1059,12 @@ class DLCOracleTest extends DLCOracleFixture {
       assert(emptyNameOpt.isEmpty)
       assert(testNameOpt.contains("test name"))
     }
+  }
+
+  it must "export staking address wif" in { dlcOracle: DLCOracle =>
+    val pubKey = dlcOracle.publicKey
+    val wif = dlcOracle.exportSigningKeyWIF
+    val privKey = ECPrivateKeyUtil.fromWIFToPrivateKey(wif)
+    assert(privKey.toPrivateKey.schnorrPublicKey == pubKey)
   }
 }

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -4,9 +4,13 @@ import com.typesafe.config.Config
 import grizzled.slf4j.Logging
 import org.bitcoins.core.api.dlcoracle._
 import org.bitcoins.core.api.dlcoracle.db._
-import org.bitcoins.core.config.BitcoinNetwork
+import org.bitcoins.core.config.{BitcoinNetwork, MainNet}
 import org.bitcoins.core.crypto.ExtKeyVersion.SegWitTestNet3Priv
-import org.bitcoins.core.crypto.{ExtPrivateKeyHardened, ExtPublicKey}
+import org.bitcoins.core.crypto.{
+  ECPrivateKeyUtil,
+  ExtPrivateKeyHardened,
+  ExtPublicKey
+}
 import org.bitcoins.core.hd._
 import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.Bech32Address
@@ -73,7 +77,6 @@ case class DLCOracle()(implicit val conf: DLCOracleAppConfig)
 
     val path = BIP32Path.fromHardenedString(
       s"m/${purpose.constant}'/${coin.coinType.toInt}'/${account.index}'/${chain.index}'/$index'")
-
     extPrivateKey.deriveChildPrivKey(path).key
   }
 
@@ -514,6 +517,11 @@ case class DLCOracle()(implicit val conf: DLCOracleAppConfig)
 
   override def setOracleName(name: String): Future[Unit] = {
     masterXpubDAO.updateName(name)
+  }
+
+  override def exportSigningKeyWIF: String = {
+    ECPrivateKeyUtil.toWIF(privKey = signingKey.toPrivateKeyBytes(false),
+                           network = MainNet)
   }
 }
 

--- a/docs/oracle/oracle-server.md
+++ b/docs/oracle/oracle-server.md
@@ -56,6 +56,7 @@ Make sure you don't back the seed file to a place that is not safe.
   - `message` - Message to hash and sign
 - `setoraclename` `oraclename` Sets the oracle name in the database
 - `getoraclename` gets the oraclename for the database
+- `exportstakingaddresswif` exports the staking addresses private key so it can be recovered in another wallet.
   
 ### Create Event Example
 
@@ -208,4 +209,12 @@ You can retrieve the oracle name with
 ```
 curl --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getoraclename", "params" : []}' -H "Content-Type: application/json" http://127.0.0.1:9998/
 {"result":"MY_ORACLE_NAME","error":null}
+```
+
+
+### Exporting the staking address
+
+```
+curl --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "exportstakingaddresswif", "params": []}' -H "Content-Type: application/json" http://127.0.0.1:9998/
+{"result":"5Kcx1CqW6soAFAvDd32T4932BPZPUqYHmXzSxydhfVBKHoWxF1C","error":null}
 ```


### PR DESCRIPTION
fixes #4267

Now a user can take this WIF, import it into another wallet, and recover funds in the staking address.

Example: 

```
 curl --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "exportstakingaddresswif", "params": []}' -H "Content-Type: application/json" http://127.0.0.1:9998/
{"result":"5Kcx1CqW6soAFAvDd32T4932BPZPUqYHmXzSxydhfVBKHoWxF1C","error":null}
```