### PR TITLE
More lazy initialization for `BitcoinSServerMain`

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -235,14 +235,14 @@ object AppConfig extends Logging {
     * TODO: use different directories on Windows and Mac,
     * should probably mimic what Bitcoin Core does
     */
-  private[bitcoins] val DEFAULT_BITCOIN_S_DATADIR: Path =
+  private[bitcoins] lazy val DEFAULT_BITCOIN_S_DATADIR: Path =
     Paths.get(Properties.userHome, ".bitcoin-s")
 
   /** Matches the default data directory location
     * with a network appended,
     * both with and without a trailing `/`
     */
-  private val defaultDatadirRegex: Regex = {
+  private lazy val defaultDatadirRegex: Regex = {
     // Fix for windows
     val home = Properties.userHome.replace('\\', '/')
 


### PR DESCRIPTION
I saw this error on umbrel when trying to get #4601 working on umbrel. I'm not sure if this is the root cause, but it doesn't seem like it would hurt to change these to be lazily evaluated.

```
Exception in thread "main" java.lang.ExceptionInInitializerError
        at org.bitcoins.commons.util.DatadirParser.datadirConfig$lzycompute(DatadirParser.scala:25)
        at org.bitcoins.commons.util.DatadirParser.datadirConfig(DatadirParser.scala:23)
        at org.bitcoins.commons.util.DatadirParser.baseConfig$lzycompute(DatadirParser.scala:44)
        at org.bitcoins.commons.util.DatadirParser.baseConfig(DatadirParser.scala:34)
        at org.bitcoins.commons.util.DatadirParser.datadir$lzycompute(DatadirParser.scala:54)
        at org.bitcoins.commons.util.DatadirParser.datadir(DatadirParser.scala:53)
        at org.bitcoins.commons.util.DatadirParser.networkDir(DatadirParser.scala:63)
        at org.bitcoins.server.BitcoinSServerMain$.delayedEndpoint$org$bitcoins$server$BitcoinSServerMain$1(BitcoinSServerMain.scala:660)
        at org.bitcoins.server.BitcoinSServerMain$delayedInit$body.apply(BitcoinSServerMain.scala:647)
        at scala.Function0.apply$mcV$sp(Function0.scala:39)
        at scala.Function0.apply$mcV$sp$(Function0.scala:39)
        at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
        at scala.App.$anonfun$main$1(App.scala:76)
        at scala.App.$anonfun$main$1$adapted(App.scala:76)
        at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
        at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
        at scala.App.main(App.scala:76)
        at scala.App.main$(App.scala:74)
        at org.bitcoins.server.BitcoinSServerMain$.main(BitcoinSServerMain.scala:647)
        at org.bitcoins.server.BitcoinSServerMain.main(BitcoinSServerMain.scala)
Caused by: java.util.regex.PatternSyntaxException: Dangling meta character '?' near index 0
?/.bitcoin-s/(testnet3|mainnet|regtest)/?$
^
        at java.base/java.util.regex.Pattern.error(Pattern.java:2028)
        at java.base/java.util.regex.Pattern.sequence(Pattern.java:2203)
        at java.base/java.util.regex.Pattern.expr(Pattern.java:2069)
        at java.base/java.util.regex.Pattern.compile(Pattern.java:1783)
        at java.base/java.util.regex.Pattern.<init>(Pattern.java:1430)
        at java.base/java.util.regex.Pattern.compile(Pattern.java:1069)
        at scala.util.matching.Regex.<init>(Regex.scala:234)
        at scala.collection.StringOps$.r$extension(StringOps.scala:857)
        at org.bitcoins.commons.config.AppConfig$.<clinit>(AppConfig.scala:249)
        ... 21 more
```