### PR TITLE
Adjust bash script permissions so they can be run by any user

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -5,7 +5,8 @@ import com.typesafe.sbt.SbtNativePackager.autoImport.packageName
 import java.nio.file.Paths
 import com.typesafe.sbt.packager.Keys.{daemonUser, daemonUserUid, dockerAlias, dockerAliases, dockerRepository, dockerUpdateLatest, maintainer}
 import com.typesafe.sbt.packager.archetypes.jlink.JlinkPlugin.autoImport.JlinkIgnore
-import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.dockerBaseImage
+import com.typesafe.sbt.packager.docker.DockerChmodType
+import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.{dockerAdditionalPermissions, dockerBaseImage}
 import sbt._
 import sbt.Keys._
 import sbtprotoc.ProtocPlugin.autoImport.PB
@@ -192,6 +193,7 @@ object CommonSettings {
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
       dockerBaseImage := "openjdk:17-slim",
       dockerRepository := Some("bitcoinscala"),
+      dockerAdditionalPermissions += (DockerChmodType.Custom("a=rx"),"/opt/docker/bin/bitcoin-s-server"),
       Docker / packageName := packageName.value,
       Docker / version := version.value,
       dockerUpdateLatest := isSnapshot.value


### PR DESCRIPTION
This adjusts permission so they should be executable by any user, thus getting rid of this error message. This hopefully fixes bugs introduced in the umbrel platform by #4601 

![Screenshot from 2022-08-17 14-40-35](https://user-images.githubusercontent.com/3514957/185239007-ee4f1140-3016-453c-aad8-4d5c73eb5184.png)


```
root@c63c2f6f6fe3:/opt/docker# ls -l /opt/docker/bin/bitcoin-s-server
-r-xr-xr-x 1 demiourgos728 root 11987 Aug 17 20:33 /opt/docker/bin/bitcoin-s-server
```