### PR TITLE
Fix bug where we weren't specify the bash script for each project 

### DIFF
--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -20,6 +20,9 @@ dockerExposedPorts ++= Seq(9998)
 
 dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-oracle-server")
 
+//so the server can be read and executed by all users
+dockerAdditionalPermissions += (DockerChmodType.Custom("a=rx"),"/opt/docker/bin/bitcoin-s-oracle-server")
+
 //make it so all users can execute the startup script
 //for the oracle server
 //this is needed for umbrel

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -1,3 +1,4 @@
+import com.typesafe.sbt.packager.docker.DockerChmodType
 name := s"bitcoin-s-server"
 
 Universal / packageName := {
@@ -22,8 +23,13 @@ dockerExposedPorts ++= Seq(9999, 19999)
 
 dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-server")
 
+//so the server can be read and executed by all users
+dockerAdditionalPermissions += (DockerChmodType.Custom("a=rx"),"/opt/docker/bin/bitcoin-s-server")
+
 //this passes in our default configuration for docker
 //you can override this by passing in a custom configuration
 //when the docker container is started by using bind mount
 //https://docs.docker.com/storage/bind-mounts/#start-a-container-with-a-bind-mount
 dockerCmd ++= Seq("--conf", "/opt/docker/docker-application.conf")
+
+

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -193,7 +193,6 @@ object CommonSettings {
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
       dockerBaseImage := "openjdk:17-slim",
       dockerRepository := Some("bitcoinscala"),
-      dockerAdditionalPermissions += (DockerChmodType.Custom("a=rx"),"/opt/docker/bin/bitcoin-s-server"),
       Docker / packageName := packageName.value,
       Docker / version := version.value,
       dockerUpdateLatest := isSnapshot.value


### PR DESCRIPTION
Fixes bug in #4624

This was failing builds in master because when we tried to publish the `oracleServer` docker image it would failed because there is no bash script called `bitcoin-s-server`