### PR TITLE
2022 08 18 Add configuration to only emit websocket events when IBD is done

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/BitcoinSServerInfo.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/BitcoinSServerInfo.scala
@@ -11,7 +11,8 @@ case class BitcoinSServerInfo(
     blockHeight: Int,
     blockHash: DoubleSha256DigestBE,
     torStarted: Boolean,
-    syncing: Boolean) {
+    syncing: Boolean,
+    isInitialBlockDownload: Boolean) {
 
   lazy val toJson: Value = {
     Obj(
@@ -19,7 +20,8 @@ case class BitcoinSServerInfo(
       PicklerKeys.blockHeightKey -> Num(blockHeight),
       PicklerKeys.blockHashKey -> Str(blockHash.hex),
       PicklerKeys.torStartedKey -> Bool(torStarted),
-      PicklerKeys.syncKey -> Bool(syncing)
+      PicklerKeys.syncKey -> Bool(syncing),
+      PicklerKeys.isInitialBlockDownload -> Bool(isInitialBlockDownload)
     )
   }
 }
@@ -34,11 +36,13 @@ object BitcoinSServerInfo {
     val blockHash = DoubleSha256DigestBE(obj(PicklerKeys.blockHashKey).str)
     val torStarted = obj(PicklerKeys.torStartedKey).bool
     val sync = obj(PicklerKeys.syncKey).bool
+    val isIBD = obj(PicklerKeys.isInitialBlockDownload).bool
 
     BitcoinSServerInfo(network = network,
                        blockHeight = height,
                        blockHash = blockHash,
                        torStarted = torStarted,
-                       syncing = sync)
+                       syncing = sync,
+                       isInitialBlockDownload = isIBD)
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
@@ -72,13 +72,16 @@ case class ChainRoutes(
         for {
           header <- chain.getBestBlockHeader()
           syncing <- chain.isSyncing()
+          isIBD <- chain.isIBD()
         } yield {
-          val info = BitcoinSServerInfo(network = network,
-                                        blockHeight = header.height,
-                                        blockHash = header.hashBE,
-                                        torStarted =
-                                          startedTorConfigF.isCompleted,
-                                        syncing = syncing)
+          val info = BitcoinSServerInfo(
+            network = network,
+            blockHeight = header.height,
+            blockHash = header.hashBE,
+            torStarted = startedTorConfigF.isCompleted,
+            syncing = syncing,
+            isInitialBlockDownload = isIBD
+          )
           Server.httpSuccess(info.toJson)
         }
       }

--- a/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
@@ -51,7 +51,7 @@ object WebsocketUtil extends Logging {
         val emitBlockProccessedWhileIBDOnGoing =
           chainAppConfig.ibdBlockProcessedEvents
         isIBDF.flatMap { isIBD =>
-          if (isIBD && emitBlockProccessedWhileIBDOnGoing) {
+          if (isIBD && !emitBlockProccessedWhileIBDOnGoing) {
             //do nothing, don't emit events until IBD is complete
             Future.unit
           } else {
@@ -61,7 +61,6 @@ object WebsocketUtil extends Logging {
                 results.map(result =>
                   ChainNotification.BlockProcessedNotification(result))
               _ <- FutureUtil.sequentially(notifications) { case msg =>
-                logger.info(s"buildChainCallbacks.msg=$msg")
                 val x: Future[Unit] = queue
                   .offer(msg)
                   .map(_ => ())

--- a/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
@@ -44,6 +44,8 @@ object WebsocketUtil extends Logging {
           headersWithHeight.map(_._2.hashBE)
         val resultsF =
           ChainUtil.getBlockHeaderResult(hashes, chainApi)
+
+        //val isIBD = chainApi.isSyncing()
         val f = for {
           results <- resultsF
           notifications =

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -281,6 +281,10 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
 
   override def isSyncing(): Future[Boolean] = Future.successful(syncing.get())
 
+  override def isIBD(): Future[Boolean] = {
+    getBlockChainInfo.map(_.initialblockdownload)
+  }
+
   override def setSyncing(value: Boolean): Future[ChainApi] = {
     syncing.set(value)
     Future.successful(this)

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -289,6 +289,11 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
     syncing.set(value)
     Future.successful(this)
   }
+
+  override def setIBD(value: Boolean): Future[ChainApi] = {
+    logger.warn(s"Cannot set IBD of BitcoindRpcClient, this is a noop")
+    Future.successful(this)
+  }
 }
 
 object BitcoindRpcClient {

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/ChainStateDescriptorDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/ChainStateDescriptorDAOTest.scala
@@ -46,7 +46,7 @@ class ChainStateDescriptorDAOTest extends ChainDbUnitTest {
     for {
       read <- dao.read(IsInitialBlockDownload.tpe)
       _ = assert(read.isEmpty)
-      isIBDDone <- dao.isIBDDone
+      isIBDDone <- dao.isIBD
       _ = assert(!isIBDDone)
 
       _ <- dao.updateIsIbd(false)
@@ -54,7 +54,7 @@ class ChainStateDescriptorDAOTest extends ChainDbUnitTest {
       _ = assert(
         read == Some(ChainStateDescriptorDb(IsInitialBlockDownload.tpe,
                                             IsInitialBlockDownload(false))))
-      sync <- dao.isSyncing
+      sync <- dao.isIBD
       _ = assert(!sync)
 
       _ <- dao.updateIsIbd(true)
@@ -63,7 +63,7 @@ class ChainStateDescriptorDAOTest extends ChainDbUnitTest {
       _ = assert(
         read == Some(ChainStateDescriptorDb(IsInitialBlockDownload.tpe,
                                             IsInitialBlockDownload(true))))
-      isIBDone2 <- dao.isIBDDone
+      isIBDone2 <- dao.isIBD
       _ = assert(isIBDone2)
     } yield succeed
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/ChainStateDescriptorDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/ChainStateDescriptorDAOTest.scala
@@ -42,4 +42,31 @@ class ChainStateDescriptorDAOTest extends ChainDbUnitTest {
 
   }
 
+  it should "set and get ibd flag" in { dao: ChainStateDescriptorDAO =>
+    for {
+      read <- dao.read(IsInitialBlockDownloadDone.tpe)
+      _ = assert(read.isEmpty)
+      isIBDDone <- dao.isIBDDone
+      _ = assert(!isIBDDone)
+
+      _ <- dao.updateIsIbdDone(false)
+      read <- dao.read(ChainStateDescriptorType.IsInitialBlockDownloadDone)
+      _ = assert(
+        read == Some(ChainStateDescriptorDb(IsInitialBlockDownloadDone.tpe,
+                                            IsInitialBlockDownloadDone(false))))
+      sync <- dao.isSyncing
+      _ = assert(!sync)
+
+      _ <- dao.updateIsIbdDone(true)
+
+      read <- dao.read(IsInitialBlockDownloadDone.tpe)
+      _ = assert(
+        read == Some(ChainStateDescriptorDb(IsInitialBlockDownloadDone.tpe,
+                                            IsInitialBlockDownloadDone(true))))
+      isIBDone2 <- dao.isIBDDone
+      _ = assert(isIBDone2)
+    } yield succeed
+
+  }
+
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/ChainStateDescriptorDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/ChainStateDescriptorDAOTest.scala
@@ -44,25 +44,25 @@ class ChainStateDescriptorDAOTest extends ChainDbUnitTest {
 
   it should "set and get ibd flag" in { dao: ChainStateDescriptorDAO =>
     for {
-      read <- dao.read(IsInitialBlockDownloadDone.tpe)
+      read <- dao.read(IsInitialBlockDownload.tpe)
       _ = assert(read.isEmpty)
       isIBDDone <- dao.isIBDDone
       _ = assert(!isIBDDone)
 
-      _ <- dao.updateIsIbdDone(false)
-      read <- dao.read(ChainStateDescriptorType.IsInitialBlockDownloadDone)
+      _ <- dao.updateIsIbd(false)
+      read <- dao.read(ChainStateDescriptorType.IsInitialBlockDownload)
       _ = assert(
-        read == Some(ChainStateDescriptorDb(IsInitialBlockDownloadDone.tpe,
-                                            IsInitialBlockDownloadDone(false))))
+        read == Some(ChainStateDescriptorDb(IsInitialBlockDownload.tpe,
+                                            IsInitialBlockDownload(false))))
       sync <- dao.isSyncing
       _ = assert(!sync)
 
-      _ <- dao.updateIsIbdDone(true)
+      _ <- dao.updateIsIbd(true)
 
-      read <- dao.read(IsInitialBlockDownloadDone.tpe)
+      read <- dao.read(IsInitialBlockDownload.tpe)
       _ = assert(
-        read == Some(ChainStateDescriptorDb(IsInitialBlockDownloadDone.tpe,
-                                            IsInitialBlockDownloadDone(true))))
+        read == Some(ChainStateDescriptorDb(IsInitialBlockDownload.tpe,
+                                            IsInitialBlockDownload(true))))
       isIBDone2 <- dao.isIBDDone
       _ = assert(isIBDone2)
     } yield succeed

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -1040,6 +1040,27 @@ class ChainHandler(
     }
   }
 
+  def setIBD(value: Boolean): Future[ChainApi] = {
+    val isIBDF = stateDAO.isIBD
+    for {
+      isIBD <- isIBDF
+      _ <- {
+        if (isIBD == value) {
+          //do nothing as we are already at this state
+          Future.unit
+        } else if (!isIBD && value) {
+          logger.warn(
+            s"Can only do IBD once, cannot set flag to true when database flag is false.")
+          Future.unit
+        } else {
+          stateDAO.updateIsIbd(value)
+        }
+      }
+    } yield {
+      this
+    }
+  }
+
   private def updateSyncingAndExecuteCallback(value: Boolean): Future[Unit] = {
     for {
       changed <- stateDAO.updateSyncing(value)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -1019,6 +1019,10 @@ class ChainHandler(
     stateDAO.isSyncing
   }
 
+  override def isIBD(): Future[Boolean] = {
+    stateDAO.isIBD
+  }
+
   override def setSyncing(value: Boolean): Future[ChainApi] = {
     val isSyncingF = stateDAO.isSyncing
     for {

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -114,6 +114,14 @@ case class ChainAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   lazy val filterBatchSize: Int =
     config.getInt(s"bitcoin-s.${moduleName}.neutrino.filter-batch-size")
 
+  /** Whether we should emit block processed events during IBD or not.
+    * This is because websocket events can overwhelm UIs during IBD.
+    * If this is set, we won't emit blockprocessed event until ibd is complete.
+    */
+  lazy val ibdBlockProcessedEvents: Boolean = {
+    config.getBoolean(s"bitcoin-s.${moduleName}.websocket.block-processed-ibd")
+  }
+
 }
 
 object ChainAppConfig extends AppConfigFactory[ChainAppConfig] {

--- a/chain/src/main/scala/org/bitcoins/chain/models/ChainStateDescriptor.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/ChainStateDescriptor.scala
@@ -71,12 +71,12 @@ object SyncDescriptor extends ChainStateDescriptorFactory[SyncDescriptor] {
   }
 }
 
-case class IsInitialBlockDownload(isComplete: Boolean)
+case class IsInitialBlockDownload(isIBDRunning: Boolean)
     extends ChainStateDescriptor {
 
   override val descriptorType: ChainStateDescriptorType =
     ChainStateDescriptorType.IsInitialBlockDownload
-  override val toString = s"${IsInitialBlockDownload.prefix} $isComplete"
+  override val toString = s"${IsInitialBlockDownload.prefix} $isIBDRunning"
 }
 
 object IsInitialBlockDownload

--- a/chain/src/main/scala/org/bitcoins/chain/models/ChainStateDescriptor.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/ChainStateDescriptor.scala
@@ -9,10 +9,15 @@ object ChainStateDescriptorType
 
   final case object Syncing extends ChainStateDescriptorType
 
-  val all: Vector[ChainStateDescriptorType] = Vector(Syncing)
+  final case object IsInitialBlockDownloadDone extends ChainStateDescriptorType
+
+  val all: Vector[ChainStateDescriptorType] =
+    Vector(IsInitialBlockDownloadDone, Syncing)
 
   override def fromStringOpt(str: String): Option[ChainStateDescriptorType] = {
-    all.find(state => str.toLowerCase() == state.toString.toLowerCase)
+    val result =
+      all.find(state => str.toLowerCase() == state.toString.toLowerCase)
+    result
   }
 
   override def fromString(string: String): ChainStateDescriptorType = {
@@ -36,7 +41,7 @@ sealed trait ChainStateDescriptorFactory[T <: ChainStateDescriptor]
 object ChainStateDescriptor extends StringFactory[ChainStateDescriptor] {
 
   val all: Vector[StringFactory[ChainStateDescriptor]] =
-    Vector(SyncDescriptor)
+    Vector(IsInitialBlockDownloadDone, SyncDescriptor)
 
   override def fromString(string: String): ChainStateDescriptor = {
     all.find(f => f.fromStringT(string).isSuccess) match {
@@ -63,5 +68,42 @@ object SyncDescriptor extends ChainStateDescriptorFactory[SyncDescriptor] {
   override def fromString(string: String): SyncDescriptor = {
     val rescanning = java.lang.Boolean.parseBoolean(string)
     SyncDescriptor(rescanning)
+  }
+}
+
+case class IsInitialBlockDownloadDone(isComplete: Boolean)
+    extends ChainStateDescriptor {
+
+  override val descriptorType: ChainStateDescriptorType =
+    ChainStateDescriptorType.IsInitialBlockDownloadDone
+  override val toString = s"${IsInitialBlockDownloadDone.prefix} $isComplete"
+}
+
+object IsInitialBlockDownloadDone
+    extends ChainStateDescriptorFactory[IsInitialBlockDownloadDone] {
+  val prefix: String = "IsInitialBlockDownload".toLowerCase()
+
+  override val tpe: ChainStateDescriptorType =
+    ChainStateDescriptorType.IsInitialBlockDownloadDone
+
+  override def fromString(string: String): IsInitialBlockDownloadDone = {
+    fromStringOpt(string) match {
+      case Some(ibd) => ibd
+      case None =>
+        sys.error(s"$string could not be parsed to InitialBlockDownload")
+    }
+  }
+
+  override def fromStringOpt(
+      string: String): Option[IsInitialBlockDownloadDone] = {
+    val arr = string.split(' ').take(2)
+
+    if (arr(0).toLowerCase == prefix) {
+      val isBool: Boolean = java.lang.Boolean.parseBoolean(arr(1))
+      val result = IsInitialBlockDownloadDone(isBool)
+      Some(result)
+    } else {
+      None
+    }
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/models/ChainStateDescriptor.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/ChainStateDescriptor.scala
@@ -9,10 +9,10 @@ object ChainStateDescriptorType
 
   final case object Syncing extends ChainStateDescriptorType
 
-  final case object IsInitialBlockDownloadDone extends ChainStateDescriptorType
+  final case object IsInitialBlockDownload extends ChainStateDescriptorType
 
   val all: Vector[ChainStateDescriptorType] =
-    Vector(IsInitialBlockDownloadDone, Syncing)
+    Vector(IsInitialBlockDownload, Syncing)
 
   override def fromStringOpt(str: String): Option[ChainStateDescriptorType] = {
     val result =
@@ -41,7 +41,7 @@ sealed trait ChainStateDescriptorFactory[T <: ChainStateDescriptor]
 object ChainStateDescriptor extends StringFactory[ChainStateDescriptor] {
 
   val all: Vector[StringFactory[ChainStateDescriptor]] =
-    Vector(IsInitialBlockDownloadDone, SyncDescriptor)
+    Vector(IsInitialBlockDownload, SyncDescriptor)
 
   override def fromString(string: String): ChainStateDescriptor = {
     all.find(f => f.fromStringT(string).isSuccess) match {
@@ -71,22 +71,22 @@ object SyncDescriptor extends ChainStateDescriptorFactory[SyncDescriptor] {
   }
 }
 
-case class IsInitialBlockDownloadDone(isComplete: Boolean)
+case class IsInitialBlockDownload(isComplete: Boolean)
     extends ChainStateDescriptor {
 
   override val descriptorType: ChainStateDescriptorType =
-    ChainStateDescriptorType.IsInitialBlockDownloadDone
-  override val toString = s"${IsInitialBlockDownloadDone.prefix} $isComplete"
+    ChainStateDescriptorType.IsInitialBlockDownload
+  override val toString = s"${IsInitialBlockDownload.prefix} $isComplete"
 }
 
-object IsInitialBlockDownloadDone
-    extends ChainStateDescriptorFactory[IsInitialBlockDownloadDone] {
+object IsInitialBlockDownload
+    extends ChainStateDescriptorFactory[IsInitialBlockDownload] {
   val prefix: String = "IsInitialBlockDownload".toLowerCase()
 
   override val tpe: ChainStateDescriptorType =
-    ChainStateDescriptorType.IsInitialBlockDownloadDone
+    ChainStateDescriptorType.IsInitialBlockDownload
 
-  override def fromString(string: String): IsInitialBlockDownloadDone = {
+  override def fromString(string: String): IsInitialBlockDownload = {
     fromStringOpt(string) match {
       case Some(ibd) => ibd
       case None =>
@@ -94,13 +94,12 @@ object IsInitialBlockDownloadDone
     }
   }
 
-  override def fromStringOpt(
-      string: String): Option[IsInitialBlockDownloadDone] = {
+  override def fromStringOpt(string: String): Option[IsInitialBlockDownload] = {
     val arr = string.split(' ').take(2)
 
     if (arr(0).toLowerCase == prefix) {
       val isBool: Boolean = java.lang.Boolean.parseBoolean(arr(1))
-      val result = IsInitialBlockDownloadDone(isBool)
+      val result = IsInitialBlockDownload(isBool)
       Some(result)
     } else {
       None

--- a/chain/src/main/scala/org/bitcoins/chain/models/ChainStateDescriptorDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/ChainStateDescriptorDAO.scala
@@ -69,7 +69,7 @@ case class ChainStateDescriptorDAO()(implicit
     }
   }
 
-  def getIsIBDDone(): Future[Option[IsInitialBlockDownload]] = {
+  def getIsIBD(): Future[Option[IsInitialBlockDownload]] = {
     read(IsInitialBlockDownload.tpe).map {
       case Some(db) =>
         val desc = IsInitialBlockDownload.fromString(db.descriptor.toString)
@@ -80,7 +80,7 @@ case class ChainStateDescriptorDAO()(implicit
 
   def isSyncing: Future[Boolean] = getSync().map(_.exists(_.syncing))
 
-  def isIBDDone: Future[Boolean] = getIsIBDDone().map(_.exists(_.isComplete))
+  def isIBD: Future[Boolean] = getIsIBD().map(_.exists(_.isComplete))
 
   def updateSyncing(syncing: Boolean): Future[Boolean] = {
     val tpe: ChainStateDescriptorType = Syncing

--- a/chain/src/main/scala/org/bitcoins/chain/models/ChainStateDescriptorDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/ChainStateDescriptorDAO.scala
@@ -69,10 +69,10 @@ case class ChainStateDescriptorDAO()(implicit
     }
   }
 
-  def getIsIBDDone(): Future[Option[IsInitialBlockDownloadDone]] = {
-    read(IsInitialBlockDownloadDone.tpe).map {
+  def getIsIBDDone(): Future[Option[IsInitialBlockDownload]] = {
+    read(IsInitialBlockDownload.tpe).map {
       case Some(db) =>
-        val desc = IsInitialBlockDownloadDone.fromString(db.descriptor.toString)
+        val desc = IsInitialBlockDownload.fromString(db.descriptor.toString)
         Some(desc)
       case None => None
     }
@@ -107,21 +107,21 @@ case class ChainStateDescriptorDAO()(implicit
     safeDatabase.run(actions)
   }
 
-  def updateIsIbdDone(isIbdDone: Boolean): Future[Boolean] = {
-    val tpe: ChainStateDescriptorType = IsInitialBlockDownloadDone.tpe
+  def updateIsIbd(isIbdDone: Boolean): Future[Boolean] = {
+    val tpe: ChainStateDescriptorType = IsInitialBlockDownload.tpe
     val query = table.filter(_.tpe === tpe)
     val actions = for {
       dbs <- query.result
       res <- dbs.headOption match {
         case None =>
-          val desc = IsInitialBlockDownloadDone(isIbdDone)
+          val desc = IsInitialBlockDownload(isIbdDone)
           val db = ChainStateDescriptorDb(tpe, desc)
           (table += db).map(_ => isIbdDone)
         case Some(db) =>
           val oldDesc =
-            IsInitialBlockDownloadDone.fromString(db.descriptor.toString)
+            IsInitialBlockDownload.fromString(db.descriptor.toString)
           if (oldDesc.isComplete != isIbdDone) {
-            val newDesc = IsInitialBlockDownloadDone(isIbdDone)
+            val newDesc = IsInitialBlockDownload(isIbdDone)
             val newDb = ChainStateDescriptorDb(tpe, newDesc)
             query.update(newDb).map(_ => true)
           } else {

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -152,5 +152,7 @@ trait ChainApi extends ChainQueryApi {
 
   def isSyncing(): Future[Boolean]
 
+  def isIBD(): Future[Boolean]
+
   def setSyncing(value: Boolean): Future[ChainApi]
 }

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -155,4 +155,6 @@ trait ChainApi extends ChainQueryApi {
   def isIBD(): Future[Boolean]
 
   def setSyncing(value: Boolean): Future[ChainApi]
+
+  def setIBD(value: Boolean): Future[ChainApi]
 }

--- a/core/src/main/scala/org/bitcoins/core/serializers/PicklerKeys.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/PicklerKeys.scala
@@ -50,6 +50,7 @@ object PicklerKeys {
 
   final val torStartedKey: String = "torStarted"
   final val syncKey: String = "syncing"
+  final val isInitialBlockDownload: String = "isinitialblockdownload"
 
   //tlv points
   final val pointsKey = "points"

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -93,6 +93,8 @@ bitcoin-s {
       # so it does not exceed the chain size.
 
       filter-batch-size = 1000
+
+
     }
     # this config key is read by Slick
     db {
@@ -106,6 +108,14 @@ bitcoin-s {
     #   user = postgres
     #   password = ""
     # }
+
+    websocket {
+        # don't emit block processed events over the websocket
+        # until IBD is complete. This is an optimization for the
+        # the UI so it doesn't have to handle hundreds of thousands of
+        # events while IBD is going on.
+        block-processed-ibd = false
+    }
   }
 
   wallet = ${bitcoin-s.dbDefault}

--- a/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUD.scala
@@ -66,7 +66,6 @@ abstract class CRUD[T, PrimaryKeyType](implicit
     * @return Option[T] - the record if found, else none
     */
   def read(id: PrimaryKeyType): Future[Option[T]] = {
-    logger.trace(s"Reading from DB with config: ${appConfig}")
     val query = findByPrimaryKey(id)
     val rows: Future[Seq[T]] = safeDatabase.run(query.result)
     rows.map(_.headOption)

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -159,6 +159,7 @@ the `-p 9999:9999` port mapping on the docker container to adjust for this.
  - `decoderawtransaction` `tx` - `Decode the given raw hex transaction`
      - `tx` - Transaction encoded in hex to decode
  - `getmediantimepast` - Returns the median time past
+ - `getinfo` returns general information about our blockchain state
 
 ### Wallet
  - `rescan` `[options]` - Rescan for wallet UTXOs
@@ -366,6 +367,13 @@ the `-p 9999:9999` port mapping on the docker container to adjust for this.
     - `keys` - The hex-encoded public keys.
     - `address_type` -The address type to use. Options are "legacy", "p2sh-segwit", and "bech32"
  - `estimatefee` - Returns the recommended fee rate using the fee provider
+
+## getinfo
+
+```bash
+curl --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getinfo", "params": []}' -H "Content-Type: application/json" http://127.0.0.1:9999/
+{"result":{"network":"main","blockHeight":750129,"blockHash":"00000000000000000002f7d39ca6c914329a8d87010215ef6466c17ffaba0a1f","torStarted":true,"syncing":false,"isinitialblockdownload":false},"error":null}
+```
 
 ## Sign PSBT with Wallet Example
 

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -229,6 +229,14 @@ bitcoin-s {
         
         hikari-logging = true
         hikari-logging-interval = 10 minute
+        
+        websocket {
+          # don't emit block processed events over the websocket
+          # until IBD is complete. This is an optimization for the
+          # the UI so it doesn't have to handle hundreds of thousands of 
+          # events while IBD is going on.
+          block-processed-ibd = false
+      }
     }
 
     # settings for wallet module

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -155,6 +155,7 @@ case class DataMessageHandler(
             }
           }
           newChainApi <- newChainApi.setSyncing(newSyncing2)
+          _ <- newChainApi.setIBD(newSyncing)
         } yield {
           this.copy(
             chainApi = newChainApi,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -181,5 +181,9 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
 
     override def setSyncing(value: Boolean): Future[ChainApi] =
       Future.successful(this)
+
+    override def setIBD(value: Boolean): Future[ChainApi] = {
+      Future.successful(this)
+    }
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -177,6 +177,8 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
 
     override def isSyncing(): Future[Boolean] = Future.successful(false)
 
+    override def isIBD(): Future[Boolean] = Future.successful(false)
+
     override def setSyncing(value: Boolean): Future[ChainApi] =
       Future.successful(this)
   }


### PR DESCRIPTION
This PR adds the ability to configure when bitcoin-s will emit `blockprocessed` websocket events we introduced in #3906. There has been a request from the UI to only emit websocket events after initial block download is finished. This is because hundreds of thousands of websocket events degrades performance on the UI while our neutrino node is syncing.

This setting can be controlled with the `bitcoin-s.chain.websocket.block-processed-ibd` flag. It is set to `false` by default, so `blockprocessed` events will only get emitted when IBD is finished. You can set this flag to `true` to get the old behavior where every time we process a block header during IBD, we will emit a websocket event.

I've added a field on the `getinfo` endpoint that you can poll to see if `bitcoin-s` is in initial block download state.

```
{
  "network": "main",
  "blockHeight": 4000,
  "blockHash": "00000000922e2aa9e84a474350a3555f49f06061fd49df50a9352f156692a842",
  "torStarted": true,
  "syncing": true,
  "isinitialblockdownload": true
}
```