### PR TITLE
Fix bug where we were not generating change addresses during a rescan

### DIFF
--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -511,8 +511,8 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         //need to clear all utxos / addresses to test this
         //otherwise the wallet will see we already have addresses and not generate
         //a fresh pool of addresses
-        _ <- wallet.clearAllAddresses()
         _ <- wallet.clearAllUtxos()
+        _ <- wallet.clearAllAddresses()
         rescanState <- wallet.fullRescanNeutrinoWallet(DEFAULT_ADDR_BATCH_SIZE)
         _ = assert(rescanState.isInstanceOf[RescanState.RescanStarted])
         _ <- RescanState.awaitRescanDone(rescanState)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -515,6 +515,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         _ <- wallet.clearAllUtxos()
         rescanState <- wallet.fullRescanNeutrinoWallet(DEFAULT_ADDR_BATCH_SIZE)
         _ = assert(rescanState.isInstanceOf[RescanState.RescanStarted])
+        _ <- RescanState.awaitRescanDone(rescanState)
         addresses <- wallet.listAddresses()
       } yield {
         assert(addresses.exists(_.isChange))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -503,4 +503,25 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
       }
   }
 
+  it must "generate addresses for a rescan that are both external and change addresses" in {
+    fixture =>
+      val wallet = fixture.wallet
+
+      val rescanF = for {
+        //need to clear all utxos / addresses to test this
+        //otherwise the wallet will see we already have addresses and not generate
+        //a fresh pool of addresses
+        _ <- wallet.clearAllAddresses()
+        _ <- wallet.clearAllUtxos()
+        rescanState <- wallet.fullRescanNeutrinoWallet(DEFAULT_ADDR_BATCH_SIZE)
+        _ = assert(rescanState.isInstanceOf[RescanState.RescanStarted])
+        addresses <- wallet.listAddresses()
+      } yield {
+        assert(addresses.exists(_.isChange))
+        assert(addresses.exists(!_.isChange))
+      }
+
+      rescanF
+  }
+
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -274,6 +274,20 @@ private[wallet] trait AddressHandling extends WalletLogger {
     }
   }
 
+  def getNewChangeAddressAction(account: HDAccount): DBIOAction[
+    BitcoinAddress,
+    NoStream,
+    Effect.Read with Effect.Write with Effect.Transactional] = {
+    val accountDbOptA = findAccountAction(account)
+    accountDbOptA.flatMap {
+      case Some(accountDb) => getNewChangeAddressAction(accountDb)
+      case None =>
+        DBIOAction.failed(
+          new RuntimeException(
+            s"No account found for given hdaccount=${account}"))
+    }
+  }
+
   def getNewAddress(account: HDAccount): Future[BitcoinAddress] = {
     val accountDbOptF = findAccount(account)
     accountDbOptF.flatMap {


### PR DESCRIPTION
fixes #4629 

This bug was introduced in #4524 . I use the `getNewAddressAction` rather than `getNewChangeAddressAction` when refactoring code.

Since we never generated a change address, this predicate `changeGap >= walletConfig.addressGapLimit` would always evaulate to false since `0` is never less than the `addressGapLimit`. This in turn starts a recursive rescan.


