### PR TITLE
Fix bug where it prevented us from rescanning an empty wallet

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -1706,9 +1706,6 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .expects()
         .returning(100)
         .atLeastOnce()
-      (mockWalletApi.isEmpty: () => Future[Boolean])
-        .expects()
-        .returning(Future.successful(false))
       (mockWalletApi
         .rescanNeutrinoWallet(_: Option[BlockStamp],
                               _: Option[BlockStamp],
@@ -1729,9 +1726,6 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
           responseAs[String] == """{"result":"Rescan started.","error":null}""")
       }
 
-      (mockWalletApi.isEmpty: () => Future[Boolean])
-        .expects()
-        .returning(Future.successful(false))
       (mockWalletApi
         .rescanNeutrinoWallet(_: Option[BlockStamp],
                               _: Option[BlockStamp],
@@ -1762,9 +1756,6 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
       }
 
-      (mockWalletApi.isEmpty: () => Future[Boolean])
-        .expects()
-        .returning(Future.successful(false))
       (mockWalletApi
         .rescanNeutrinoWallet(_: Option[BlockStamp],
                               _: Option[BlockStamp],
@@ -1792,9 +1783,6 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
           responseAs[String] == """{"result":"Rescan started.","error":null}""")
       }
 
-      (mockWalletApi.isEmpty: () => Future[Boolean])
-        .expects()
-        .returning(Future.successful(false))
       (mockWalletApi
         .rescanNeutrinoWallet(_: Option[BlockStamp],
                               _: Option[BlockStamp],
@@ -1858,9 +1846,6 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
           responseAs[String] == s"""{"result":null,"error":"Expected a positive integer (data: -1)"}""")
       }
 
-      (mockWalletApi.isEmpty: () => Future[Boolean])
-        .expects()
-        .returning(Future.successful(false))
       (mockWalletApi
         .rescanNeutrinoWallet(_: Option[BlockStamp],
                               _: Option[BlockStamp],

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -1084,29 +1084,29 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
     if (loadWalletApi.isRescanStateEmpty) {
       val res = for {
         rescanState <- {
-            rescanStateOpt match {
-              case Some(rescanState) =>
-                val stateF: Future[RescanState] = rescanState match {
-                  case started: RescanState.RescanStarted =>
-                    if (started.isStopped) {
-                      //means rescan is done, reset the variable
-                      rescanStateOpt = Some(RescanDone)
-                      Future.successful(RescanDone)
-                    } else {
-                      //do nothing, we don't want to reset/stop a rescan that is running
-                      Future.successful(started)
-                    }
-                  case RescanState.RescanDone =>
-                    //if the previous rescan is done, start another rescan
-                    startRescan(rescan)
-                  case RescanState.RescanAlreadyStarted =>
-                    Future.successful(RescanState.RescanAlreadyStarted)
-                }
+          rescanStateOpt match {
+            case Some(rescanState) =>
+              val stateF: Future[RescanState] = rescanState match {
+                case started: RescanState.RescanStarted =>
+                  if (started.isStopped) {
+                    //means rescan is done, reset the variable
+                    rescanStateOpt = Some(RescanDone)
+                    Future.successful(RescanDone)
+                  } else {
+                    //do nothing, we don't want to reset/stop a rescan that is running
+                    Future.successful(started)
+                  }
+                case RescanState.RescanDone =>
+                  //if the previous rescan is done, start another rescan
+                  startRescan(rescan)
+                case RescanState.RescanAlreadyStarted =>
+                  Future.successful(RescanState.RescanAlreadyStarted)
+              }
 
-                stateF
-              case None =>
-                startRescan(rescan)
-            }
+              stateF
+            case None =>
+              startRescan(rescan)
+          }
         }
         _ = loadWalletApi.setRescanState(rescanState)
         msg = getRescanMsg(rescanState)

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -1083,12 +1083,7 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
   private def handleRescan(rescan: Rescan): Future[String] = {
     if (loadWalletApi.isRescanStateEmpty) {
       val res = for {
-        empty <- wallet.isEmpty()
         rescanState <- {
-          if (empty) {
-            //if wallet is empty, just return Done immediately
-            Future.successful(RescanState.RescanDone)
-          } else {
             rescanStateOpt match {
               case Some(rescanState) =>
                 val stateF: Future[RescanState] = rescanState match {
@@ -1112,7 +1107,6 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
               case None =>
                 startRescan(rescan)
             }
-          }
         }
         _ = loadWalletApi.setRescanState(rescanState)
         msg = getRescanMsg(rescanState)


### PR DESCRIPTION
This piece of logic prevented us from rescanning an empty wallet with a mnemonic seed via the rpc. Prior to this bug fix, we could only rescan wallets with addresses/utxos already in them.  This bug was introduced in #4417.