### PR TITLE
Only build native `bitcoin-s-cli` on tags or merges to master

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -5,9 +5,8 @@ env:
   DISABLE_SECP256K1: "true"
 on:
   push:
-    branches: [master, main, adaptor-dlc]
+    branches: [master, main]
     tags: ["*"]
-  pull_request:
   release:
     types: [published]
 jobs:


### PR DESCRIPTION
Building on the theme of #4633 , get rid of the PR builds for the native `bitcoin-s-cli` . This only needs to get built when merged to master. 