### PR TITLE
Configure scalafmt to preserve line endings

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,6 +2,7 @@ version = "2.7.5"
 # See Documentation at https://scalameta.org/scalafmt/#Configuration
 trailingCommas = never
 maxColumn = 80
+lineEndings = preserve
 docstrings = ScalaDoc
 continuationIndent {
     callSite = 2


### PR DESCRIPTION
scalafmt changes line endings in all source files to CRLF under Windows, which makes developments under Windows almost impossible. 