### PR TITLE
Bump rescan test timeouts from 5 -> 10 seconds

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -205,7 +205,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         balanceAfterClear <- wallet.getBalance()
         rescanState <- wallet.fullRescanNeutrinoWallet(1, true)
         _ <- RescanState.awaitRescanDone(rescanState)
-        _ <- AsyncUtil.nonBlockingSleep(5.second)
+        _ <- AsyncUtil.nonBlockingSleep(10.second)
         balanceAfterRescan <- wallet.getBalance()
       } yield {
         assert(balanceAfterClear == CurrencyUnits.zero)
@@ -495,7 +495,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         balanceAfterClear <- wallet.getBalance()
         rescanState <- wallet.fullRescanNeutrinoWallet(1, true)
         _ <- RescanState.awaitRescanDone(rescanState)
-        _ <- AsyncUtil.nonBlockingSleep(5.second)
+        _ <- AsyncUtil.nonBlockingSleep(10.second)
         balanceAfterRescan <- wallet.getBalance()
       } yield {
         assert(balanceAfterClear == CurrencyUnits.zero)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -205,7 +205,9 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         balanceAfterClear <- wallet.getBalance()
         rescanState <- wallet.fullRescanNeutrinoWallet(1, true)
         _ <- RescanState.awaitRescanDone(rescanState)
-        _ <- AsyncUtil.nonBlockingSleep(10.second)
+        _ <- AsyncUtil.awaitConditionF(
+          () => wallet.getBalance().map(_ == balanceAfterPayment1),
+          maxTries = 100)
         balanceAfterRescan <- wallet.getBalance()
       } yield {
         assert(balanceAfterClear == CurrencyUnits.zero)
@@ -495,7 +497,9 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         balanceAfterClear <- wallet.getBalance()
         rescanState <- wallet.fullRescanNeutrinoWallet(1, true)
         _ <- RescanState.awaitRescanDone(rescanState)
-        _ <- AsyncUtil.nonBlockingSleep(10.second)
+        _ <- AsyncUtil.awaitConditionF(
+          () => wallet.getBalance().map(_ == balanceAfterPayment1),
+          maxTries = 100)
         balanceAfterRescan <- wallet.getBalance()
       } yield {
         assert(balanceAfterClear == CurrencyUnits.zero)


### PR DESCRIPTION
Until #4563 gets solved we don't have a good way to synchronize state based on the _full_ rescan completing, not just the first recursion