### PR TITLE
Fix some bugs around resetting rescan state when a rescan fails

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -183,7 +183,10 @@ sealed trait DLCWalletLoaderApi extends Logging with StartStopAsync[Unit] {
             case RescanState.RescanTerminatedEarly =>
               rescanStateOpt = None
             case scala.util.control.NonFatal(exn) =>
-              logger.error(s"Failed to reset rescanState in wallet loader", exn)
+              logger.error(
+                s"Failed to reset rescanState in wallet loader. Resetting rescan state",
+                exn)
+              rescanStateOpt = None
           }
           rescanStateOpt = Some(started)
         } else {

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -51,6 +51,11 @@ object RescanState {
 
     def doneF: Future[Vector[BlockMatchingResponse]] = blocksMatchedF
 
+    /** Fails a rescan with the given exception */
+    def fail(err: Throwable): Unit = {
+      completeRescanEarlyP.failure(err)
+    }
+
     /** Completes the stream that the rescan in progress uses.
       * This aborts the rescan early.
       */

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -61,7 +61,7 @@ object RescanState {
       */
     def stop(): Future[Vector[BlockMatchingResponse]] = {
       if (!completeRescanEarlyP.isCompleted) {
-        completeRescanEarlyP.failure(RescanTerminatedEarly)
+        fail(RescanTerminatedEarly)
       }
       blocksMatchedF.recoverWith {
         case RescanTerminatedEarly =>

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -67,7 +67,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
           logger.info(
             s"Starting rescanning the wallet=${walletConfig.walletName} from ${startOpt} to ${endOpt} useCreationTime=$useCreationTime")
           val startTime = System.currentTimeMillis()
-          val res = for {
+          val resF: Future[RescanState] = for {
             start <- (startOpt, useCreationTime) match {
               case (Some(_), true) =>
                 Future.failed(new IllegalArgumentException(
@@ -103,15 +103,10 @@ private[wallet] trait RescanHandling extends WalletLogger {
             state
           }
 
-          res.recoverWith { case err: Throwable =>
-            logger.error(s"Failed to rescan wallet=${walletConfig.walletName}",
-                         err)
-            stateDescriptorDAO
-              .updateRescanning(false)
-              .flatMap(_ => Future.failed(err))
-          }
+          //register callbacks for resetting rescan flag in case of failure
+          val _ = handleRescanFailure(resF)
 
-          res.map {
+          resF.map {
             case r: RescanState.RescanStarted =>
               r.doneF.map(_ =>
                 logger.info(s"Finished rescanning the wallet. It took ${System
@@ -120,7 +115,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
             //nothing to log
           }
 
-          res
+          resF
         } else {
           logger.warn(
             s"Rescan already started for wallet=${walletConfig.walletName}, ignoring request to start another one")
@@ -130,6 +125,32 @@ private[wallet] trait RescanHandling extends WalletLogger {
     } yield {
       rescanState
     }
+  }
+
+  /** Register callbacks to reset rescan flag in the database if there is a rescan failure */
+  private def handleRescanFailure(
+      rescanStateF: Future[RescanState]): Future[Unit] = {
+    //handle the case where there is a top level rescan failure when _starting_ the rescan
+    rescanStateF.recoverWith { case err: Throwable =>
+      logger.error(s"Failed to rescan wallet=${walletConfig.walletName}", err)
+      stateDescriptorDAO
+        .updateRescanning(false)
+        .flatMap(_ => Future.failed(err))
+    }
+
+    //handle the case where the rescan fails while the rescan is in progress
+    for {
+      rescanState <- rescanStateF
+      _ <- RescanState.awaitRescanDone(rescanState).recoverWith {
+        case err: Throwable =>
+          logger.error(s"Failed to rescan wallet=${walletConfig.walletName}",
+                       err)
+          stateDescriptorDAO
+            .updateRescanning(false)
+            .flatMap(_ => Future.failed(err))
+
+      }
+    } yield ()
   }
 
   lazy val walletCreationBlockHeight: Future[BlockHeight] =


### PR DESCRIPTION
This should fix #4641 for bugs introduced in #4530 

Previously we never reset `RescanState` if a generic exception occurred. 

We also didn't update the failure handling code to account to reset the `rescanning` flag in the database if the rescan fails for whatever reason.