### PR TITLE
If `DISABLE_JLINK` set, don't try to chmod `jre/bin/java`

### DIFF
--- a/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
+++ b/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 
-if test -f "jre/bin/java"; then
-  if [[ "$OS" == "OSX" ]]; then
-    #mac doesn't allow random binaries to be executable
-    #remove the quarantine attribute so java is executable on mac
-    xattr -d com.apple.quarantine jre/bin/java
+if [[ -z "$DISABLE_JLINK" ]]; then
+  if test -f "jre/bin/java"; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine jre/bin/java
+    fi
+    chmod +x jre/bin/java #make sure java is executable
   fi
-  chmod +x jre/bin/java #make sure java is executable
-fi
 
-if test -f "../jre/bin/java" ; then
-  if [[ "$OS" == "OSX" ]]; then
-    #mac doesn't allow random binaries to be executable
-    #remove the quarantine attribute so java is executable on mac
-    xattr -d com.apple.quarantine ../jre/bin/java
+
+  if test -f "../jre/bin/java" ; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine ../jre/bin/java
+    fi
+    chmod +x ../jre/bin/java #make sure java is executable
   fi
-  chmod +x ../jre/bin/java #make sure java is executable
 fi
 
 get_java_no_jlink() {

--- a/app/server/src/universal/wallet-server-extra-startup-script.sh
+++ b/app/server/src/universal/wallet-server-extra-startup-script.sh
@@ -1,26 +1,27 @@
 #!/bin/bash
 
-if test -f "jre/bin/java"; then
-  if [[ "$OS" == "OSX" ]]; then
-    #mac doesn't allow random binaries to be executable
-    #remove the quarantine attribute so java is executable on mac
-    xattr -d com.apple.quarantine jre/bin/java
-  fi
-  chmod +x jre/bin/java #make sure java is executable
-fi
 
-if test -f "../jre/bin/java" ; then
-  if [[ "$OS" == "OSX" ]]; then
-    #mac doesn't allow random binaries to be executable
-    #remove the quarantine attribute so java is executable on mac
-    xattr -d com.apple.quarantine ../jre/bin/java
+if [[ -z "$DISABLE_JLINK" ]]; then
+  if test -f "jre/bin/java"; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine jre/bin/java
+    fi
+    chmod +x jre/bin/java #make sure java is executable
   fi
-  chmod +x ../jre/bin/java #make sure java is executable
-fi
 
+  if test -f "../jre/bin/java" ; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine ../jre/bin/java
+    fi
+    chmod +x ../jre/bin/java #make sure java is executable
+  fi
+fi
 
 chip=$(uname -m)
-
 
 get_java_no_jlink() {
   if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then


### PR DESCRIPTION
This issue was seen when trying to run our docker images on umbrel from _fresh_ installs.

![Screenshot from 2022-08-23 12-43-39](https://user-images.githubusercontent.com/3514957/186228222-f17f482c-ff11-4ed6-8949-2c82007bcdc7.png)

Because of #4369 / #4377 we now ship with java inside of the docker image. This means we don't need access to the `jlink`'d jre. 

So to work around if the `DISABLE_JLINK` is set, don't try to do anything with `chmod` on the jlink'd jre.

