### PR TITLE
Adds logic to make sure we create network directories

### DIFF
--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
@@ -82,14 +82,14 @@ object OracleServerMain extends BitcoinSAppScalaDaemon {
 
   val serverCmdLineArgs = ServerArgParser(args.toVector)
 
-  if (Files.notExists(datadirParser.networkDir)) {
-    Files.createDirectories(datadirParser.networkDir)
-  }
-
   val datadirParser =
     DatadirParser(serverCmdLineArgs, customFinalDirOpt)
 
   System.setProperty("bitcoins.log.location", datadirParser.networkDir.toString)
+
+  if (Files.notExists(datadirParser.networkDir)) {
+    Files.createDirectories(datadirParser.networkDir)
+  }
 
   implicit lazy val conf: DLCOracleAppConfig =
     DLCOracleAppConfig(datadirParser.datadir, Vector(datadirParser.baseConfig))(

--- a/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
+++ b/app/oracle-server/src/main/scala/org/bitcoins/oracle/server/OracleServerMain.scala
@@ -8,6 +8,7 @@ import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
 import org.bitcoins.server.routes.{BitcoinSServerRunner, CommonRoutes, Server}
 import org.bitcoins.server.util.{BitcoinSAppScalaDaemon, ServerBindings}
 
+import java.nio.file.Files
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 
@@ -80,6 +81,10 @@ object OracleServerMain extends BitcoinSAppScalaDaemon {
   override val customFinalDirOpt: Option[String] = Some("oracle")
 
   val serverCmdLineArgs = ServerArgParser(args.toVector)
+
+  if (Files.notExists(datadirParser.networkDir)) {
+    Files.createDirectories(datadirParser.networkDir)
+  }
 
   val datadirParser =
     DatadirParser(serverCmdLineArgs, customFinalDirOpt)

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -43,7 +43,7 @@ import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.wallet.WalletHolder
 import org.bitcoins.wallet.config.WalletAppConfig
 
-import java.nio.file.{Files, Path}
+import java.nio.file.Files
 import java.sql.SQLException
 import java.time.Instant
 import scala.concurrent.duration.DurationInt
@@ -685,11 +685,11 @@ object BitcoinSServerMain extends BitcoinSAppScalaDaemon {
   val datadirParser =
     DatadirParser(serverCmdLineArgs, customFinalDirOpt)
 
+  System.setProperty("bitcoins.log.location", datadirParser.networkDir.toString)
+
   if (Files.notExists(datadirParser.networkDir)) {
     Files.createDirectories(datadirParser.networkDir)
   }
-
-  System.setProperty("bitcoins.log.location", datadirParser.networkDir.toString)
 
   implicit lazy val conf: BitcoinSAppConfig =
     BitcoinSAppConfig(

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -43,6 +43,7 @@ import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.wallet.WalletHolder
 import org.bitcoins.wallet.config.WalletAppConfig
 
+import java.nio.file.{Files, Path}
 import java.sql.SQLException
 import java.time.Instant
 import scala.concurrent.duration.DurationInt
@@ -683,6 +684,10 @@ object BitcoinSServerMain extends BitcoinSAppScalaDaemon {
 
   val datadirParser =
     DatadirParser(serverCmdLineArgs, customFinalDirOpt)
+
+  if (Files.notExists(datadirParser.networkDir)) {
+    Files.createDirectories(datadirParser.networkDir)
+  }
 
   System.setProperty("bitcoins.log.location", datadirParser.networkDir.toString)
 


### PR DESCRIPTION
When we changed out docker logic in #4601 it appears our startup logic will no longer create the directories we are specifying in the docker entrypoint with the `--datadir` flag. Now the USER we are running under doesn't necessarily correspond to the path we are specifying in `--datadir`. 

