### PR TITLE
Partially revert #4601 and re-add `daemonUser := bitcoin-s`

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -1,14 +1,8 @@
 package org.bitcoins.server
 
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.{
-  BroadcastHub,
-  Keep,
-  Sink,
-  Source,
-  SourceQueueWithComplete
-}
 import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{BroadcastHub, Keep, Sink, Source, SourceQueueWithComplete}
 import akka.{Done, NotUsed}
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.asyncutil.AsyncUtil.Exponential
@@ -19,11 +13,7 @@ import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockChainInfoResult
 import org.bitcoins.commons.jsonmodels.ws.WsNotification
 import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.core.api.chain.ChainApi
-import org.bitcoins.core.api.node.{
-  InternalImplementationNodeType,
-  NodeApi,
-  NodeType
-}
+import org.bitcoins.core.api.node.{InternalImplementationNodeType, NodeApi, NodeType}
 import org.bitcoins.core.api.wallet.{NeutrinoHDWalletApi, WalletApi}
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.dlc.node.DLCNode

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -2,7 +2,13 @@ package org.bitcoins.server
 
 import akka.actor.ActorSystem
 import akka.stream.OverflowStrategy
-import akka.stream.scaladsl.{BroadcastHub, Keep, Sink, Source, SourceQueueWithComplete}
+import akka.stream.scaladsl.{
+  BroadcastHub,
+  Keep,
+  Sink,
+  Source,
+  SourceQueueWithComplete
+}
 import akka.{Done, NotUsed}
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.asyncutil.AsyncUtil.Exponential
@@ -13,7 +19,11 @@ import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockChainInfoResult
 import org.bitcoins.commons.jsonmodels.ws.WsNotification
 import org.bitcoins.commons.util.{DatadirParser, ServerArgParser}
 import org.bitcoins.core.api.chain.ChainApi
-import org.bitcoins.core.api.node.{InternalImplementationNodeType, NodeApi, NodeType}
+import org.bitcoins.core.api.node.{
+  InternalImplementationNodeType,
+  NodeApi,
+  NodeType
+}
 import org.bitcoins.core.api.wallet.{NeutrinoHDWalletApi, WalletApi}
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.dlc.node.DLCNode

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -193,6 +193,7 @@ object CommonSettings {
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
       dockerBaseImage := "openjdk:17-slim",
       dockerRepository := Some("bitcoinscala"),
+      Docker / daemonUser := "bitcoin-s",
       Docker / packageName := packageName.value,
       Docker / version := version.value,
       dockerUpdateLatest := isSnapshot.value


### PR DESCRIPTION
Partially revert #4601 and re-add `Docker / daemonUser := "bitcoin-s"` so we are compatible with existing umbrel environments