### PR TITLE
Change default DLC peer alias

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/db/DLCContactDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlc/wallet/db/DLCContactDb.scala
@@ -11,7 +11,7 @@ object DLCContactDbHelper {
 
   def fromPeerAddress(peerAddress: String): DLCContactDb =
     DLCContactDb(
-      alias = "",
+      alias = peerAddress.take(8),
       address =
         NetworkUtil.parseInetSocketAddress(peerAddress, DLC.DefaultPort),
       memo = ""


### PR DESCRIPTION
Currently it an empty string. This PR uses 8 first characters of the peer address as peer's alias. It fixes `A UNIQUE constraint failed (UNIQUE constraint failed: contacts.alias)` exception.

See https://github.com/bitcoin-s/bitcoin-s/issues/4661