### PR TITLE
Revert #4601 / #4624 so that docker works on umbrel again

### DIFF
--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -20,16 +20,6 @@ dockerExposedPorts ++= Seq(9998)
 
 dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-oracle-server")
 
-//so the server can be read and executed by all users
-dockerAdditionalPermissions += (DockerChmodType.Custom("a=rx"),"/opt/docker/bin/bitcoin-s-oracle-server")
-
-//make it so all users can execute the startup script
-//for the oracle server
-//this is needed for umbrel
-//https://linuxize.com/post/chmod-command-in-linux/#symbolic-text-method
-dockerAdditionalPermissions += (DockerChmodType.Custom(
-  "a=rx"), "/opt/docker/bin/bitcoin-s-oracle-server")
-
 //this passes in our default configuration for docker
 //you can override this by passing in a custom conf file
 //when the docker container is started by using bind mount

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -23,9 +23,6 @@ dockerExposedPorts ++= Seq(9999, 19999)
 
 dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-server")
 
-//so the server can be read and executed by all users
-dockerAdditionalPermissions += (DockerChmodType.Custom("a=rx"),"/opt/docker/bin/bitcoin-s-server")
-
 //this passes in our default configuration for docker
 //you can override this by passing in a custom configuration
 //when the docker container is started by using bind mount

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -194,6 +194,10 @@ object CommonSettings {
       dockerBaseImage := "openjdk:17-slim",
       dockerRepository := Some("bitcoinscala"),
       Docker / daemonUser := "bitcoin-s",
+      //needed for umbrel environment, container uids and host uids must matchup so we can
+      //properly write to volumes on the host machine
+      //see: https://medium.com/@mccode/understanding-how-uid-and-gid-work-in-docker-containers-c37a01d01cf
+      daemonUserUid := Some("1000"),
       Docker / packageName := packageName.value,
       Docker / version := version.value,
       dockerUpdateLatest := isSnapshot.value

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -197,7 +197,7 @@ object CommonSettings {
       //needed for umbrel environment, container uids and host uids must matchup so we can
       //properly write to volumes on the host machine
       //see: https://medium.com/@mccode/understanding-how-uid-and-gid-work-in-docker-containers-c37a01d01cf
-      daemonUserUid := Some("1000"),
+      Docker / daemonUserUid := Some("1000"),
       Docker / packageName := packageName.value,
       Docker / version := version.value,
       dockerUpdateLatest := isSnapshot.value


### PR DESCRIPTION
reverts #4601. Now that our `uid` is the same as umbrel's host's `uid`, we don't know the startup script permissions stuff as the users are identical. 