### PR TITLE
Fix infinite invalid header loop

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainException.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainException.scala
@@ -28,3 +28,5 @@ case class DuplicateFilters(message: String) extends ChainException(message)
 case class InvalidBlockRange(message: String) extends ChainException(message)
 
 case class InvalidBlockHeader(message: String) extends ChainException(message)
+
+case class DuplicateHeaders(message: String) extends ChainException(message)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -119,6 +119,10 @@ class ChainHandler(
       val filteredHeaders = headers.filterNot(h =>
         headersWeAlreadyHave.exists(_.hashBE == h.hashBE))
 
+      if (filteredHeaders.isEmpty) {
+        return Future.failed(DuplicateHeaders(s"Received duplicate headers."))
+      }
+
       val blockchainUpdates: Vector[BlockchainUpdate] = {
         Blockchain.connectHeadersToChains(headers = filteredHeaders,
                                           blockchains = blockchains)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.node
 
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.p2p.{GetHeadersMessage, HeadersMessage}
+import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.P2PClient.ExpectResponseCommand
 import org.bitcoins.server.BitcoinSAppConfig
@@ -30,6 +31,9 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
       Future.sequence(peersF)
     }
   }
+
+  lazy val invalidHeader = BlockHeader.fromHex(
+    s"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f2003000000")
 
   override protected def getFreshConfig: BitcoinSAppConfig = {
     BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(pgUrl)
@@ -125,7 +129,6 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
             node.nodeConfig,
             node.chainConfig))
 
-        invalidHeader = node.chainAppConfig.chain.genesisBlock.blockHeader
         invalidHeaderMessage = HeadersMessage(headers = Vector(invalidHeader))
         sender <- node.peerManager.peerData(peer).peerMessageSender
         _ <- node.getDataMessageHandler.addToStream(invalidHeaderMessage,
@@ -144,7 +147,6 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
       val peerManager = node.peerManager
 
       def sendInvalidHeaders(peer: Peer): Future[Unit] = {
-        val invalidHeader = node.chainAppConfig.chain.genesisBlock.blockHeader
         val invalidHeaderMessage =
           HeadersMessage(headers = Vector(invalidHeader))
         val senderF = node.peerManager.peerData(peer).peerMessageSender

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -368,6 +368,17 @@ case class PeerManager(
     Future.unit
   }
 
+  def sendResponseTimeout(peer: Peer, payload: NetworkPayload): Future[Unit] = {
+    logger.debug(
+      s"Sending response timeout for ${payload.commandName} to $peer")
+    if (peerData.contains(peer)) {
+      peerData(peer).client.map(_.actor ! ResponseTimeout(payload))
+    } else {
+      logger.debug(s"Requested to send response timeout for unknown $peer")
+      Future.unit
+    }
+  }
+
   def syncFromNewPeer(): Future[DataMessageHandler] = {
     logger.debug(s"Trying to sync from new peer")
     val newNode =
@@ -407,3 +418,5 @@ case class PeerManager(
   val dataMessageStream: SourceQueueWithComplete[StreamDataMessageWrapper] =
     dataMessageStreamSource.to(dataMessageStreamSink).run()
 }
+
+case class ResponseTimeout(payload: NetworkPayload)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -384,11 +384,11 @@ case class DataMessageHandler(
 
         getHeadersF.recoverWith {
           case _: DuplicateHeaders =>
-            logger.debug(
+            logger.warn(
               s"Received duplicate headers from ${syncPeer.get} in state=$state")
             Future.successful(this)
           case _: InvalidBlockHeader =>
-            logger.debug(
+            logger.warn(
               s"Invalid headers of count $count sent from ${syncPeer.get} in state=$state")
             recoverInvalidHeader(peer, peerMsgSender)
           case e: Throwable => throw e


### PR DESCRIPTION
@Christewart @nkohen 

How it re-queries headers is that we make a request, and ask again if we don't get a response in 10 seconds.
I have tested the laptop sleep issue and it works for that on my end.

A new issue that I noticed while testing this is that if the internet goes down, every 10 second we send a `getheaders` and when we get back online, all of those messages are sent at once.

So the first response that we send would give us the valid headers, for the remaining we will get a duplicate exception, and rest should proceed fine. This behavior I suppose needs to change, instead of continuous request, maybe try `ping` . As for this PR, I believe everything here is a strict improvement.