### PR TITLE
Add default exposed volume of `/bitcoin-s` so we can always write data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,11 +23,11 @@ services:
       - walletserver
   walletserver:
     image: bitcoinscala/bitcoin-s-server:latest
-    entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/wallet", "--conf", "/opt/docker/docker-application.conf"]
+    entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
     user: "0:1000"
     restart: on-failure
     volumes:
-      - ./data/wallet:/wallet
+      - ./data/wallet:/bitcoin-s
     environment:
       BITCOIN_S_NODE_MODE: "neutrino"
       BITCOIN_S_NODE_PEERS: "neutrino.suredbits.com:8333"

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtNativePackager.Docker
 import com.typesafe.sbt.SbtNativePackager.autoImport.packageName
 
 import java.nio.file.Paths
-import com.typesafe.sbt.packager.Keys.{daemonUser, daemonUserUid, dockerAlias, dockerAliases, dockerCommands, dockerRepository, dockerUpdateLatest, maintainer}
+import com.typesafe.sbt.packager.Keys.{daemonUser, daemonUserUid, dockerAlias, dockerAliases, dockerCommands, dockerExposedVolumes, dockerRepository, dockerUpdateLatest, maintainer}
 import com.typesafe.sbt.packager.archetypes.jlink.JlinkPlugin.autoImport.JlinkIgnore
 import com.typesafe.sbt.packager.docker.{Cmd, DockerChmodType}
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.{dockerAdditionalPermissions, dockerBaseImage}
@@ -200,9 +200,8 @@ object CommonSettings {
       Docker / daemonUserUid := Some("1000"),
       Docker / packageName := packageName.value,
       Docker / version := version.value,
-      dockerCommands ++= Seq(
-        Cmd("RUN", "mkdir", "/wallet")
-      ),
+      //add a default exposed volume of /bitcoin-s so we can always write data here
+      dockerExposedVolumes += "/bitcoin-s",
       dockerUpdateLatest := isSnapshot.value
     )
   }


### PR DESCRIPTION
This is a native way to support volumes with sbt native packager. This replaces #4666 . H/T to @user411 for advocating for the need for this.

Now when using docker, the `--datadir /bitcoin-s` should always be set on a container's entrypoint so we can safely write data. This volume will be available on both the `oracle-server` and `app-server` images.

Its probably worth asking if we should set these on the default entrypoints we provide for containers in these two spots: 

- https://github.com/bitcoin-s/bitcoin-s/blob/ac24bfb23019f16210bed5aa46606d6751e8666e/app/server/server.sbt#L24
- https://github.com/bitcoin-s/bitcoin-s/blob/ac24bfb23019f16210bed5aa46606d6751e8666e/app/oracle-server/oracle-server.sbt#L21

I don't see why not as this would be the safest place to write data IMO