### PR TITLE
Use findByPrimaryKey query in findByPrimaryKeyAction

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAction.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAction.scala
@@ -54,8 +54,7 @@ abstract class CRUDAction[T, PrimaryKeyType](implicit
 
   def findByPrimaryKeyAction(
       id: PrimaryKeyType): DBIOAction[Option[T], NoStream, Effect.Read] = {
-    findByPrimaryKeysAction(Vector(id))
-      .map(_.headOption)
+    findByPrimaryKey(id).result.map(_.headOption)
   }
 
   protected def find(t: T): Query[Table[T], T, Seq] = findAll(Vector(t))


### PR DESCRIPTION
This should make it more explict so if you override `findByPrimaryKey` then `findByPrimaryKeyAction` and `read` correctly use the updated query