### PR TITLE
Add `BITCOIN_S_UID`, explicit volume in `docker-compose.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For a complete guide on how to get started with Bitcoin-S, see our website at [B
 In this repo, you can just run
 
 ```
-APP_PASSWORD=topsecret docker-compose up
+APP_PASSWORD=topsecret BITCOIN_S_UID="$(id -u):$(id -g)" docker-compose up
 ```
 
 which will spin up a docker environment that starts syncing the backend and will allow you to visit

--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -20,6 +20,9 @@ dockerExposedPorts ++= Seq(9998)
 
 dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-oracle-server")
 
+//so the server can be read and executed by all users
+dockerAdditionalPermissions += (DockerChmodType.Custom("a=rx"),"/opt/docker/bin/bitcoin-s-oracle-server")
+
 //this passes in our default configuration for docker
 //you can override this by passing in a custom conf file
 //when the docker container is started by using bind mount

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -6,10 +6,6 @@ Universal / packageName := {
   CommonSettings.buildPackageName(old)
 }
 
-// Ensure actor system is shut down
-// when server is quit
-Compile / fork := true
-
 libraryDependencies ++= Deps.server.value
 
 mainClass := Some("org.bitcoins.server.BitcoinSServerMain")
@@ -22,6 +18,9 @@ packageDescription := "Runs a Bitcoin neutrino node and wallet, has functionalit
 dockerExposedPorts ++= Seq(9999, 19999)
 
 dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-server")
+
+//so the server can be read and executed by all users
+dockerAdditionalPermissions += (DockerChmodType.Custom("a=rx"),"/opt/docker/bin/bitcoin-s-server")
 
 //this passes in our default configuration for docker
 //you can override this by passing in a custom configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: on-failure
     stop_grace_period: 1m
     volumes:
-      - bitcoin-s-datadir:/bitcoin-s
+      - bitcoin-s-frontend-log:/bitcoin-s
     environment:
       LOG_PATH: "/bitcoin-s/log/"
       BITCOIN_S_HOME: "/bitcoin-s/"
@@ -26,7 +26,7 @@ services:
     user: $BITCOIN_S_UID
     restart: on-failure
     volumes:
-      - bitcoin-s-datadir:/bitcoin-s
+      - bitcoin-s-backend-datadir:/bitcoin-s
     environment:
       BITCOIN_S_NODE_MODE: "neutrino"
       BITCOIN_S_NODE_PEERS: "neutrino.suredbits.com:8333"
@@ -50,11 +50,19 @@ services:
     restart: on-failure
 
 volumes:
-  bitcoin-s-datadir:
-    name: "bitcoin-s"
+  bitcoin-s-backend-datadir:
+    name: "bitcoin-s-backend-datadir"
     driver: local
     external: false
     driver_opts:
       o: bind
       type: none
-      device: ${PWD}
+      device: ${PWD}/data/wallet
+  bitcoin-s-frontend-log:
+    name: "bitcoin-s-frontend-log"
+    driver: local
+    external: false
+    driver_opts:
+      o: bind
+      type: none
+      device: ${PWD}/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,13 @@ version: "3.7"
 services:
   web:
     image: bitcoinscala/wallet-server-ui:latest
-    user: "0:1000"
+    user: $BITCOIN_S_UID
     restart: on-failure
     stop_grace_period: 1m
     volumes:
-      - ./data/wallet:/bitcoin-s
-      - ./data/log:/log
+      - bitcoin-s-datadir:/bitcoin-s
     environment:
-      LOG_PATH: "/log/"
+      LOG_PATH: "/bitcoin-s/log/"
       BITCOIN_S_HOME: "/bitcoin-s/"
       MEMPOOL_API_URL: "http://mempool.space/api"
       WALLET_SERVER_API_URL: "http://walletserver:9999/"
@@ -24,10 +23,10 @@ services:
   walletserver:
     image: bitcoinscala/bitcoin-s-server:latest
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
-    user: "0:1000"
+    user: $BITCOIN_S_UID
     restart: on-failure
     volumes:
-      - ./data/wallet:/bitcoin-s
+      - bitcoin-s-datadir:/bitcoin-s
     environment:
       BITCOIN_S_NODE_MODE: "neutrino"
       BITCOIN_S_NODE_PEERS: "neutrino.suredbits.com:8333"
@@ -40,6 +39,7 @@ services:
       BITCOIN_S_DLCNODE_TOR_CONTROL: "tor:9051"
       BITCOIN_S_DLCNODE_TOR_PASSWORD: "topsecret"
       BITCOIN_S_SERVER_RPC_PASSWORD: $APP_PASSWORD
+      DISABLE_JLINK: "1"
     ports:
       - "9999:9999"
     depends_on:
@@ -48,3 +48,13 @@ services:
     image:  bitcoinscala/tor:latest
     entrypoint: ["/tor", "--ExitRelay", "0", "--BridgeRelay",  "0", "--SOCKSPort", "0.0.0.0:9050", "--ControlPort", "0.0.0.0:9051", "--HashedControlPassword", "16:EF3A794FD6F30EF76049147EF252111809E7D51C049FEB353B547C1553"]
     restart: on-failure
+
+volumes:
+  bitcoin-s-datadir:
+    name: "bitcoin-s"
+    driver: local
+    external: false
+    driver_opts:
+      o: bind
+      type: none
+      device: ${PWD}


### PR DESCRIPTION
This makes our `docker-compose.yml` flexible with the `uid` that the docker containers get run as. Now the `uid` on the host machine will be what runs the containers. You can run the `docker-compose.yml` with 

```
APP_PASSWORD=topsecret BITCOIN_S_UID="$(id -u):$(id -g)" docker-compose up
```

Currently this PR does not write to the old volume location in `data/wallet`. For some reason i can't seem to create child directories for volumes inside of `$(pwd)`. I'm hoping someone answers this question: https://stackoverflow.com/questions/73520753/failure-to-mount-local-volume-when-the-volume-is-a-child-directory-of-pwd\


If you ran our `docker-compose.yml` before this PR is merged, you will need to run 

```
id -u
sudo chown -R [id-output-from-id-u] data/
```
to give permissions over the `data/` directory to the correct user.