### PR TITLE
Set entrypoint scripts so they are executable by anyone, revert `daemonUserId`

### DIFF
--- a/app/oracle-server/oracle-server.sbt
+++ b/app/oracle-server/oracle-server.sbt
@@ -20,6 +20,9 @@ dockerExposedPorts ++= Seq(9998)
 
 dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-oracle-server")
 
+//so the server can be read and executed by all users
+dockerAdditionalPermissions += (DockerChmodType.Custom("a=rx"),"/opt/docker/bin/bitcoin-s-oracle-server")
+
 //this passes in our default configuration for docker
 //you can override this by passing in a custom conf file
 //when the docker container is started by using bind mount

--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -6,10 +6,6 @@ Universal / packageName := {
   CommonSettings.buildPackageName(old)
 }
 
-// Ensure actor system is shut down
-// when server is quit
-Compile / fork := true
-
 libraryDependencies ++= Deps.server.value
 
 mainClass := Some("org.bitcoins.server.BitcoinSServerMain")
@@ -22,6 +18,9 @@ packageDescription := "Runs a Bitcoin neutrino node and wallet, has functionalit
 dockerExposedPorts ++= Seq(9999, 19999)
 
 dockerEntrypoint := Seq("/opt/docker/bin/bitcoin-s-server")
+
+//so the server can be read and executed by all users
+dockerAdditionalPermissions += (DockerChmodType.Custom("a=rx"),"/opt/docker/bin/bitcoin-s-server")
 
 //this passes in our default configuration for docker
 //you can override this by passing in a custom configuration

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -197,7 +197,7 @@ object CommonSettings {
       //needed for umbrel environment, container uids and host uids must matchup so we can
       //properly write to volumes on the host machine
       //see: https://medium.com/@mccode/understanding-how-uid-and-gid-work-in-docker-containers-c37a01d01cf
-      Docker / daemonUserUid := Some("1000"),
+      //Docker / daemonUserUid := Some("1000"),
       Docker / packageName := packageName.value,
       Docker / version := version.value,
       //add a default exposed volume of /bitcoin-s so we can always write data here


### PR DESCRIPTION
Pulled the script permissions from #4677. Since we are dynamically passing teh `uid` in #4677 the scripts need to be executable by anyone.

The second change reverts the `daemonUserId` to the default `1001` setting again. I need this to not be `1000` so I can test on umbrel. Umbrel happens to run under the user `1000` so if we are set the same things will always just work.