### PR TITLE
use real docker volumes rather than bind mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,13 @@ version: "3.7"
 services:
   web:
     image: bitcoinscala/wallet-server-ui:latest
-    user: "0:1000"
+    user: 1000:1000
     restart: on-failure
     stop_grace_period: 1m
     volumes:
-      - ./data/wallet:/bitcoin-s
-      - ./data/log:/log
+      - bitcoin-s:/bitcoin-s
     environment:
-      LOG_PATH: "/log/"
+      LOG_PATH: "/bitcoin-s/log/"
       BITCOIN_S_HOME: "/bitcoin-s/"
       MEMPOOL_API_URL: "http://mempool.space/api"
       WALLET_SERVER_API_URL: "http://walletserver:9999/"
@@ -24,10 +23,10 @@ services:
   walletserver:
     image: bitcoinscala/bitcoin-s-server:latest
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
-    user: "0:1000"
+    user: 1000:1000
     restart: on-failure
     volumes:
-      - ./data/wallet:/bitcoin-s
+      - bitcoin-s:/bitcoin-s
     environment:
       BITCOIN_S_NODE_MODE: "neutrino"
       BITCOIN_S_NODE_PEERS: "neutrino.suredbits.com:8333"
@@ -40,6 +39,7 @@ services:
       BITCOIN_S_DLCNODE_TOR_CONTROL: "tor:9051"
       BITCOIN_S_DLCNODE_TOR_PASSWORD: "topsecret"
       BITCOIN_S_SERVER_RPC_PASSWORD: $APP_PASSWORD
+      DISABLE_JLINK: "1"
     ports:
       - "9999:9999"
     depends_on:
@@ -48,3 +48,6 @@ services:
     image:  bitcoinscala/tor:latest
     entrypoint: ["/tor", "--ExitRelay", "0", "--BridgeRelay",  "0", "--SOCKSPort", "0.0.0.0:9050", "--ControlPort", "0.0.0.0:9051", "--HashedControlPassword", "16:EF3A794FD6F30EF76049147EF252111809E7D51C049FEB353B547C1553"]
     restart: on-failure
+
+volumes:
+  bitcoin-s:


### PR DESCRIPTION
This is an alternative to #4677 

This uses real docker volumes rather than bind mounts for our `docker-compose.yml`. Here are the advantages of using volumes [according to docker's own site](https://docs.docker.com/storage/volumes/#use-a-volume-with-docker-compose).

![Screenshot from 2022-08-29 13-35-33](https://user-images.githubusercontent.com/3514957/187273523-579a29a1-bef1-429e-9060-ecd7cb636833.png)

This makes us less sensitive to host specific configurations. 

### Migrating an existing bind mount into a volume

This is only needed if you have an existing datadir you would like to migrate. If you are a new user this is not necessary.

```
 $ docker volume create bitcoin-s_bitcoin-s
bitcoin-s_bitcoin-s
#copy contents of existing bind mount into volume 
$ sudo cp -R data/wallet/* /var/lib/docker/volumes/bitcoin-s_bitcoin-s/_data/
# get your user ids, so we can switch permissions correctly. My uid is 1001. Yours might be different.
$ id -u 
1001
$ id -g 
1001
# use ids from your machine rather than my machines id of 1001:1001
sudo chown -R 1001:1001  /var/lib/docker/volumes/bitcoin-s/_data/
```

and now startup your service with 

>APP_PASSWORD=topsecret BITCOIN_S_UID="$(id -u):$(id -g)" docker-compose up

and all your old information should show up in your new docker volume! :tada: 