### PR TITLE
Allow LnMessage(tlv) & raw tlv to be used in `DLCRoutes`

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/rpc/Command.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/rpc/Command.scala
@@ -1004,8 +1004,10 @@ object AcceptDLCOffer extends ServerJsonModels {
         offerJs: Value,
         payoutAddressJs: Value,
         changeAddressJs: Value,
-        peerAddressJs: Value) = Try {
-      val offer = LnMessageFactory(DLCOfferTLV).fromHex(offerJs.str)
+        peerAddressJs: Value): Try[AcceptDLCOffer] = Try {
+      val offer = LnMessageFactory(DLCOfferTLV)
+        .fromHexT(offerJs.str)
+        .getOrElse(LnMessage(DLCOfferTLV.fromHex(offerJs.str)))
       val payoutAddressJsOpt = nullToOpt(payoutAddressJs)
       val payoutAddressOpt =
         payoutAddressJsOpt.map(js => jsToBitcoinAddress(js))

--- a/app-commons/src/main/scala/org/bitcoins/commons/rpc/Command.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/rpc/Command.scala
@@ -1109,7 +1109,9 @@ object SignDLC extends ServerJsonModels {
     jsArr.arr.toList match {
       case acceptJs :: Nil =>
         Try {
-          val accept = LnMessageFactory(DLCAcceptTLV).fromHex(acceptJs.str)
+          val accept = LnMessageFactory(DLCAcceptTLV)
+            .fromHexT(acceptJs.str)
+            .getOrElse(LnMessage(DLCAcceptTLV.fromHex(acceptJs.str)))
           SignDLC(accept)
         }
       case Nil =>
@@ -1132,7 +1134,10 @@ object AddDLCSigs extends ServerJsonModels {
     jsArr.arr.toList match {
       case sigsJs :: Nil =>
         Try {
-          val sigs = LnMessageFactory(DLCSignTLV).fromHex(sigsJs.str)
+          val sigs = LnMessageFactory(DLCSignTLV)
+            .fromHexT(sigsJs.str)
+            .getOrElse(LnMessage(DLCSignTLV.fromHex(sigsJs.str)))
+
           AddDLCSigs(sigs)
         }
       case Nil =>

--- a/app/server-test/src/test/scala/org/bitcoins/server/WalletRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WalletRoutesSpec.scala
@@ -3,19 +3,22 @@ package org.bitcoins.server
 import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.bitcoins.core.api.chain.ChainApi
-import org.bitcoins.core.protocol.dlc.models.DLCMessage.DLCOffer
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.dlc.models.DLCMessage.{DLCAccept, DLCOffer}
 import org.bitcoins.core.protocol.dlc.models.DLCStatus
-import org.bitcoins.core.protocol.tlv.{DLCOfferTLV, LnMessageFactory}
+import org.bitcoins.core.protocol.tlv.{DLCOfferTLV, LnMessage, LnMessageFactory}
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.crypto.Sha256Digest
 import org.bitcoins.feeprovider.ConstantFeeRateProvider
 import org.bitcoins.node.Node
 import org.bitcoins.server.routes.ServerCommand
 import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkitcore.gen.TLVGen
 import org.bitcoins.wallet.{MockWalletApi, WalletHolder}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.wordspec.AnyWordSpec
 
+import java.net.InetSocketAddress
 import scala.concurrent.Future
 
 class WalletRoutesSpec
@@ -111,6 +114,35 @@ class WalletRoutesSpec
       Get() ~> route ~> check {
         assert(contentType == `application/json`)
         assert(responseAs[String] == s"""{"result":"$hex","error":null}""")
+      }
+    }
+
+    "acceptdlcoffer" in {
+      val tlv =
+        "fda71afd03e7006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000fdd82efd010f0000000000004e20fda7102903035245440000000000004e2005475245454e0000000000000000054f544845520000000000002710fda712d6fdd824d226ad9030250e65edcf06b56bb32cf9dfdbd22a51170388ced303ba232e209baccf3933efec093ef8597601be11e4c5f629595dcfc0324450c2a79be1c2a00483929a56f9131bd0efe55d75eeddeb3ad989102c7a4ac1228e9fa15df2d6fa4b9cfdd8226e0001d4a1d0746a64b44a05ef46dd9513f92dd2e379bfe1b98b177daaf566eda431f1630db570fdd8061200030352454405475245454e054f5448455231436f6c6f72206f6620424242592063616e646c65206f6e2074686520636c6f7365206f6e204175672033302c203230323202ce1182702c45fe82d778e38a5963c6e7e6957d437bb08df9a8018cfed76818a400160014a8c34b3b872c55a5477570fdb91a014d0e93b5b7a7be83ec1c74529700000000000027100001fda714fd022802332f7b1ea63664021202000000000103844fc6700dbef77bdbf556fec43ef78427eb850f3b7c0798902df72b5d92cd840100000000fdfffffff9de6f0b00bb154455b866c01708d455cb55f0502797dddf4aab1592ba5b43f10000000000fdffffff2e41f6e2d73167986dfc5072f2b887007de904f044100c1708dc8b27176ab75e0200000000fdffffff02f289010000000000220020a5f698268debfea4f5a9684f9ec5f15773f5b021ae1dc71609296479489c78ec7c2f0100000000001600146d2cf34c182a41ac51c9f80ddb6505a1ea8b40b00247304402205320b6ed396d89c6571b94b1b955e5bd124b372df1961bc0a6baf3aa68fca40a0220274e1cb6f8e1d58882a7c31f347ef7ef3d7450ab60553e15b762652d8d8e0494012102970b2ff8def2718c9ad3592cb01d905c564105eb5b26a5df2af2df2707450f230247304402203319c99742c06d382eef2736a7a40852e435c0a933f9bfd2c1e84d6005225a9a02200ff06bb796096890b2682a0022516f011458be17ad31dea053ee31c465ad1f7b012103d116cbb7868d31f487ae53b56efe5b63dba59cfc56900359cfd8cf12f61a8ac60247304402207d3a005c278644c2699693807692067350ed6fb26948cd4387e1c2a8d70f9f0002205e9ee1e92ecd4dcbacc1da63f13beecfc3dfb196ba8a204464e5697329c7bf920121027c8028c521db4392039df71dbf07af523cc34d6e29ffc77bdc26f655601450aa0000000000000001fffffffd006b000000160014b49fd0410361b8bd9f176d7d448881ec65186b3e25d399d45c997297757a2fc8e6d3101f000000000000000b630db5706316eff0"
+      val expectedTlv = DLCOfferTLV.fromHex(tlv)
+      val offer = DLCOffer.fromTLV(expectedTlv)
+      val dummyAcceptLnMsg =
+        LnMessage(TLVGen.dlcAcceptTLV(offer.toTLV).sample.get)
+      val acceptTLV = DLCAccept.fromTLV(dummyAcceptLnMsg.tlv, offer)
+      (mockWalletApi
+        .acceptDLCOffer(_: DLCOfferTLV,
+                        _: Option[InetSocketAddress],
+                        _: Option[BitcoinAddress],
+                        _: Option[BitcoinAddress]))
+        .expects(expectedTlv, None, None, None)
+        .returning(Future.successful(acceptTLV))
+
+      val cmd = ServerCommand(
+        "acceptdlcoffer",
+        ujson.Arr(ujson.Str(tlv), ujson.Null, ujson.Null, ujson.Null))
+      val route = walletRoutes.handleCommand(cmd)
+
+      Get() ~> route ~> check {
+        assert(contentType == `application/json`)
+        assert(
+          responseAs[
+            String] == s"""{"result":"${dummyAcceptLnMsg.hex}","error":null}""")
       }
     }
   }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -440,7 +440,8 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
 
             val hex = Files.readAllLines(path).get(0)
 
-            val offerMessage = LnMessageFactory(DLCOfferTLV).fromHexT(hex)
+            val offerMessage = LnMessageFactory(DLCOfferTLV)
+              .fromHexT(hex)
               .getOrElse(LnMessage(DLCOfferTLV.fromHex(hex)))
 
             wallet
@@ -478,7 +479,8 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
 
             val hex = Files.readAllLines(path).get(0)
 
-            val acceptMessage = LnMessageFactory(DLCAcceptTLV).fromHexT(hex)
+            val acceptMessage = LnMessageFactory(DLCAcceptTLV)
+              .fromHexT(hex)
               .getOrElse(LnMessage(DLCAcceptTLV.fromHex(hex)))
 
             wallet
@@ -512,7 +514,8 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
 
             val hex = Files.readAllLines(path).get(0)
 
-            val signMessage = LnMessageFactory(DLCSignTLV).fromHexT(hex)
+            val signMessage = LnMessageFactory(DLCSignTLV)
+              .fromHexT(hex)
               .getOrElse(LnMessage(DLCSignTLV.fromHex(hex)))
 
             wallet.addDLCSigs(signMessage.tlv).map { db =>
@@ -542,7 +545,8 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
         case Success(DLCDataFromFile(path, _, _, _)) =>
           val hex = Files.readAllLines(path).get(0)
 
-          val signMessage = LnMessageFactory(DLCSignTLV).fromHexT(hex)
+          val signMessage = LnMessageFactory(DLCSignTLV)
+            .fromHexT(hex)
             .getOrElse(LnMessage(DLCSignTLV.fromHex(hex)))
           complete {
             for {

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -440,7 +440,8 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
 
             val hex = Files.readAllLines(path).get(0)
 
-            val offerMessage = LnMessageFactory(DLCOfferTLV).fromHex(hex)
+            val offerMessage = LnMessageFactory(DLCOfferTLV).fromHexT(hex)
+              .getOrElse(LnMessage(DLCOfferTLV.fromHex(hex)))
 
             wallet
               .acceptDLCOffer(offerMessage.tlv,
@@ -477,7 +478,8 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
 
             val hex = Files.readAllLines(path).get(0)
 
-            val acceptMessage = LnMessageFactory(DLCAcceptTLV).fromHex(hex)
+            val acceptMessage = LnMessageFactory(DLCAcceptTLV).fromHexT(hex)
+              .getOrElse(LnMessage(DLCAcceptTLV.fromHex(hex)))
 
             wallet
               .signDLC(acceptMessage.tlv)
@@ -510,7 +512,8 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
 
             val hex = Files.readAllLines(path).get(0)
 
-            val signMessage = LnMessageFactory(DLCSignTLV).fromHex(hex)
+            val signMessage = LnMessageFactory(DLCSignTLV).fromHexT(hex)
+              .getOrElse(LnMessage(DLCSignTLV.fromHex(hex)))
 
             wallet.addDLCSigs(signMessage.tlv).map { db =>
               Server.httpSuccess(
@@ -539,7 +542,8 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
         case Success(DLCDataFromFile(path, _, _, _)) =>
           val hex = Files.readAllLines(path).get(0)
 
-          val signMessage = LnMessageFactory(DLCSignTLV).fromHex(hex)
+          val signMessage = LnMessageFactory(DLCSignTLV).fromHexT(hex)
+            .getOrElse(LnMessage(DLCSignTLV.fromHex(hex)))
           complete {
             for {
               _ <- wallet.addDLCSigs(signMessage.tlv)

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
fixes #4681 , now allows both types via the rpc to avoid errors. We do this in other places through the RPC. Lets do it everywhere.