### PR TITLE
Remove javafx from official release

### DIFF
--- a/.github/workflows/javafx.yml
+++ b/.github/workflows/javafx.yml
@@ -3,9 +3,6 @@ name: JavaFX Desktop Apps
 on:
   push:
     branches: [master, main]
-    tags: ["*"]
-  release:
-    types: [ published ]
 
 env:
   pkg-assembly: 'bitcoin-s-bundle.jar'


### PR DESCRIPTION
Keep the code in master for now, but don't publish an official release.

Now that we have our electron app in #4434 we should encourage users to move there and not use the old desktop app.