### PR TITLE
revert docker-compose user again as its impossible to create mounted direcotry as non root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For a complete guide on how to get started with Bitcoin-S, see our website at [B
 In this repo, you can just run
 
 ```
-APP_PASSWORD=topsecret BITCOIN_S_UID="$(id -u):$(id -g)" docker-compose up
+APP_PASSWORD=topsecret docker-compose up
 ```
 
 which will spin up a docker environment that starts syncing the backend and will allow you to visit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   web:
     image: bitcoinscala/wallet-server-ui:latest
-    user: $BITCOIN_S_UID
+    user: 0:1000
     restart: on-failure
     stop_grace_period: 1m
     volumes:
@@ -24,7 +24,7 @@ services:
   walletserver:
     image: bitcoinscala/bitcoin-s-server:latest
     entrypoint: ["/opt/docker/bin/bitcoin-s-server", "--datadir", "/bitcoin-s", "--conf", "/opt/docker/docker-application.conf"]
-    user: $BITCOIN_S_UID
+    user: 0:1000
     restart: on-failure
     volumes:
       - ./data/wallet:/bitcoin-s


### PR DESCRIPTION
From this issue: https://github.com/moby/moby/issues/2259

Unfortunately we will have to keep running as root user if we are using bind mounts. This is a fundamental limitation of docker right now as far as I can tell.

The last PR #4680 introduced a bug where new users could not run `docker-compose up` because of permissions issues.