### PR TITLE
Fixes for force closes or failure to close lnd channel

### DIFF
--- a/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRpcClientPairTest.scala
+++ b/lnd-rpc-test/src/test/scala/org/bitcoins/lnd/rpc/LndRpcClientPairTest.scala
@@ -106,9 +106,9 @@ class LndRpcClientPairTest extends DualLndFixture {
       vout = UInt32(voutStr.tail.toLong)
       channelPoint = TransactionOutPoint(txId, vout)
 
-      outPoint <- lnd.closeChannel(channelPoint)
+      txIdBE <- lnd.closeChannel(channelPoint)
       _ <- bitcoind.getNewAddress.flatMap(bitcoind.generateToAddress(6, _))
-      tx <- bitcoind.getRawTransaction(outPoint.txIdBE)
+      tx <- bitcoind.getRawTransaction(txIdBE)
       find <- lnd.findChannel(channelPoint)
     } yield {
       assert(tx.confirmations.isDefined)


### PR DESCRIPTION
In #4688 the CI timed out because a channel failed to close. This fixes the close channel function to handle if the channel is force closed or if the channel fails to close instead of just hanging forever.