### PR TITLE
Switch base docker image to `eclipse-temurin:17`

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -191,7 +191,7 @@ object CommonSettings {
   lazy val dockerSettings: Seq[Setting[_]] = {
     Vector(
       //https://sbt-native-packager.readthedocs.io/en/latest/formats/docker.html
-      dockerBaseImage := "openjdk:17-slim",
+      dockerBaseImage := "eclipse-temurin:17",
       dockerRepository := Some("bitcoinscala"),
       Docker / daemonUser := "bitcoin-s",
       //needed for umbrel environment, container uids and host uids must matchup so we can


### PR DESCRIPTION
fixes #4675 

Our old image was at `17.0.2` which i guess has security issues: https://github.com/docker-library/openjdk/pull/495#issuecomment-1112708993 . This updates the jre runtime to `17.0.4.1`