### PR TITLE
ignore jakarta dependnecy in logback

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -302,6 +302,15 @@ object CommonSettings {
       "ch.qos.logback.core.net" -> "javax.mail",
       "ch.qos.logback.core.net" -> "javax.mail.internet",
       "org.apache.log4j.jmx" -> "com.sun.jdmk.comm",
+      "ch.qos.logback.classic" -> "jakarta.servlet.http",
+      "ch.qos.logback.classic.helpers" -> "jakarta.servlet",
+      "ch.qos.logback.classic.helpers" -> "jakarta.servlet.http",
+      "ch.qos.logback.classic.selector.servlet" -> "jakarta.servlet",
+      "ch.qos.logback.classic.servlet" -> "jakarta.servlet",
+      "ch.qos.logback.core.net" -> "jakarta.mail",
+      "ch.qos.logback.core.net" -> "jakarta.mail.internet",
+      "ch.qos.logback.core.status" -> "jakarta.servlet",
+      "ch.qos.logback.core.status" -> "jakarta.servlet.http"
     )
   }
 


### PR DESCRIPTION
missed in #4705 as i didn't publish the artifacts locally. It looks like logback took a new dependency in jakarta for the `2.0.0` release.