### PR TITLE
Allow for custom config file name

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -115,8 +115,11 @@ abstract class AppConfig extends StartStopAsync[Unit] with Logging {
   /** The blockchain network we're on */
   lazy val network: BitcoinNetwork = chain.network
 
+  def configFileName: String = AppConfig.DEFAULT_BITCOIN_S_CONF_FILE
+
   protected lazy val config: Config = {
-    val finalConfig = AppConfig.getBaseConfig(baseDatadir, configOverrides)
+    val finalConfig =
+      AppConfig.getBaseConfig(baseDatadir, configFileName, configOverrides)
 
     logger.trace(s"Resolved bitcoin-s config:")
     logger.trace(finalConfig.asReadableJson)
@@ -175,13 +178,14 @@ object AppConfig extends Logging {
 
   def getBaseConfig(
       baseDatadir: Path,
+      configFileName: String,
       configOverrides: Vector[Config]): Config = {
     val configOptions =
       ConfigParseOptions
         .defaults()
         .setClassLoader(getClass().getClassLoader())
     val datadirConfig = {
-      val file = baseDatadir.resolve("bitcoin-s.conf")
+      val file = baseDatadir.resolve(configFileName)
       val config = if (Files.isReadable(file)) {
         ConfigFactory.parseFile(file.toFile, configOptions)
       } else {
@@ -237,6 +241,9 @@ object AppConfig extends Logging {
     */
   private[bitcoins] lazy val DEFAULT_BITCOIN_S_DATADIR: Path =
     Paths.get(Properties.userHome, ".bitcoin-s")
+
+  private[bitcoins] lazy val DEFAULT_BITCOIN_S_CONF_FILE: String =
+    "bitcoin-s.conf"
 
   /** Matches the default data directory location
     * with a network appended,

--- a/app-commons/src/main/scala/org/bitcoins/commons/util/DatadirParser.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/DatadirParser.scala
@@ -35,7 +35,9 @@ case class DatadirParser(
     serverArgs.configOpt match {
       case None =>
         AppConfig
-          .getBaseConfig(datadirPath, Vector(networkConfig))
+          .getBaseConfig(datadirPath,
+                         AppConfig.DEFAULT_BITCOIN_S_CONF_FILE,
+                         Vector(networkConfig))
           .withFallback(datadirConfig)
           .resolve()
       case Some(config) =>

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import com.typesafe.config.{Config, ConfigFactory}
 import grizzled.slf4j.Logging
 import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.commons.config.AppConfig.DEFAULT_BITCOIN_S_CONF_FILE
 import org.bitcoins.commons.config.{AppConfig, ConfigOps}
 import org.bitcoins.commons.util.ServerArgParser
 import org.bitcoins.core.config.NetworkParameters
@@ -121,7 +122,9 @@ case class BitcoinSAppConfig(
   /** The underlying config the result of our fields derive from */
   lazy val config: Config = {
     val finalConfig =
-      AppConfig.getBaseConfig(baseDatadir = baseDatadir, configOverrides)
+      AppConfig.getBaseConfig(baseDatadir = baseDatadir,
+                              DEFAULT_BITCOIN_S_CONF_FILE,
+                              configOverrides)
     val resolved = finalConfig.resolve()
 
     resolved.checkValid(ConfigFactory.defaultReference(), "bitcoin-s")


### PR DESCRIPTION
This way 3rd party apps can use a different file name ie (`krystal-bull.conf` instead of `bitcoin-s.conf`)