### PR TITLE
Add [regtest] section to fixture config

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -105,6 +105,7 @@ trait BitcoindRpcTestUtil extends Logging {
                   |regtest=1
                   |server=1
                   |daemon=$isDaemon
+                  |[regtest]
                   |rpcuser=$username
                   |rpcpassword=$pass
                   |rpcport=${rpcUri.getPort}


### PR DESCRIPTION
It seems something changed in bitcoind since this was originally made, I tried running an instance of the regtest node that was used during a test and got this error

```
ben@ben-thinkpad: /tmp/GRRVj 
$ bitcoind --regtest -datadir=`pwd`
Error: Config setting for -port only applied on regtest network when in [regtest] section.
Config setting for -rpcport only applied on regtest network when in [regtest] section.
```

seems this could have potentially been causing problems with overlapping instances of bitcoind.