### PR TITLE
Make docker publish use java 18 to avoid slick 3.4.0 issues

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,12 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
+      - name: Setup Scala
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '18'
+          cache: 'sbt'
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
fixes #4344 

This popped up again after merging #4620 . Now that we have #4466 we can specify java 18.