### PR TITLE
DLC connection checks and notifications

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ws/WsModels.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/ws/WsModels.scala
@@ -97,10 +97,13 @@ object TorWsType extends StringFactory[TorWsType] {
 }
 
 object DLCNodeWsType extends StringFactory[DLCNodeWsType] {
+  case object DLCConnectionInitiated extends DLCNodeWsType
   case object DLCConnectionEstablished extends DLCNodeWsType
   case object DLCConnectionFailed extends DLCNodeWsType
 
-  private val all = Vector(DLCConnectionEstablished, DLCConnectionFailed)
+  private val all = Vector(DLCConnectionInitiated,
+                           DLCConnectionEstablished,
+                           DLCConnectionFailed)
 
   override def fromStringOpt(string: String): Option[DLCNodeWsType] = {
     all.find(_.toString.toLowerCase() == string.toLowerCase)
@@ -258,6 +261,14 @@ object TorNotification {
 
 object DLCNodeNotification {
 
+  case class DLCNodeConnectionInitiated(payload: InetSocketAddress)
+      extends DLCNodeNotification[InetSocketAddress] {
+    override def `type`: DLCNodeWsType = DLCNodeWsType.DLCConnectionInitiated
+
+    override def json: Value = upickle.default.writeJs(this)(
+      WsPicklers.dlcNodeConnectionInitiatedPickler)
+  }
+
   case class DLCNodeConnectionEstablished(payload: InetSocketAddress)
       extends DLCNodeNotification[InetSocketAddress] {
     override def `type`: DLCNodeWsType = DLCNodeWsType.DLCConnectionEstablished
@@ -266,8 +277,8 @@ object DLCNodeNotification {
       WsPicklers.dlcNodeConnectionEstablishedPickler)
   }
 
-  case class DLCNodeConnectionFailed(payload: (InetSocketAddress, String))
-      extends DLCNodeNotification[(InetSocketAddress, String)] {
+  case class DLCNodeConnectionFailed(payload: InetSocketAddress)
+      extends DLCNodeNotification[InetSocketAddress] {
     override def `type`: DLCNodeWsType = DLCNodeWsType.DLCConnectionFailed
 
     override def json: Value =

--- a/app-commons/src/main/scala/org/bitcoins/commons/rpc/Command.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/rpc/Command.scala
@@ -1599,6 +1599,31 @@ object DLCContactRemove {
   }
 }
 
+case class DLCCheckConnection(address: InetSocketAddress)
+    extends CommandRpc
+    with AppServerCliCommand
+    with ServerJsonModels
+
+object DLCCheckConnection {
+
+  def fromJsArr(arr: ujson.Arr): Try[DLCCheckConnection] = {
+    arr.arr.toList match {
+      case addressJs :: Nil =>
+        Try {
+          val address = {
+            val uri = new URI(s"tcp://${addressJs.str}")
+            InetSocketAddress.createUnresolved(uri.getHost, uri.getPort)
+          }
+          DLCCheckConnection(address)
+        }
+      case other =>
+        val exn = new IllegalArgumentException(
+          s"Bad number or arguments to checkconnection, got=${other.length} expected=1")
+        Failure(exn)
+    }
+  }
+}
+
 case class LoadWallet(
     walletNameOpt: Option[String],
     passwordOpt: Option[AesPassword],

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -298,6 +298,9 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val torCallbacks = WebsocketUtil.buildTorCallbacks(wsQueue)
     torConf.addCallbacks(torCallbacks)
 
+    val dlcNodeCallbacks = WebsocketUtil.buildDLCNodeCallbacks(wsQueue)
+    dlcNodeConf.addCallbacks(dlcNodeCallbacks)
+
     ()
   }
 
@@ -459,6 +462,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
         }
         dlcWalletCallbacks = WebsocketUtil.buildDLCWalletCallbacks(wsQueue)
         _ = dlcConfig.addCallbacks(dlcWalletCallbacks)
+        dlcNodeCallbacks = WebsocketUtil.buildDLCNodeCallbacks(wsQueue)
+        _ = dlcNodeConf.addCallbacks(dlcNodeCallbacks)
         _ <- startedTorConfigF
       } yield {
         logger.info(s"Done starting Main!")

--- a/app/server/src/main/scala/org/bitcoins/server/DLCRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCRoutes.scala
@@ -186,5 +186,13 @@ case class DLCRoutes(dlcNode: DLCNodeApi)(implicit system: ActorSystem)
           }
       }
 
+    case ServerCommand("checkconnection", arr) =>
+      withValidServerCommand(DLCCheckConnection.fromJsArr(arr)) { addr =>
+        complete {
+          dlcNode.checkPeerConnection(addr.address).map { _ =>
+            Server.httpSuccess("initiated")
+          }
+        }
+      }
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/DLCRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCRoutes.scala
@@ -7,18 +7,13 @@ import org.bitcoins.commons.rpc._
 import org.bitcoins.commons.serializers.Picklers
 import org.bitcoins.core.api.dlc.node.DLCNodeApi
 import org.bitcoins.core.api.dlc.wallet.db.IncomingDLCOfferDb
-import org.bitcoins.core.protocol.dlc.models.{
-  EnumSingleOracleInfo,
-  NumericSingleOracleInfo,
-  SingleContractInfo
-}
-import org.bitcoins.core.protocol.tlv.{
-  EnumEventDescriptorV0TLV,
-  NumericEventDescriptorTLV
-}
+import org.bitcoins.core.protocol.dlc.models.{EnumSingleOracleInfo, NumericSingleOracleInfo, SingleContractInfo}
+import org.bitcoins.core.protocol.tlv.{EnumEventDescriptorV0TLV, NumericEventDescriptorTLV}
 import org.bitcoins.server.routes._
 import ujson._
 import upickle.default._
+
+import scala.concurrent.Future
 
 case class DLCRoutes(dlcNode: DLCNodeApi)(implicit system: ActorSystem)
     extends ServerRoute {
@@ -189,7 +184,7 @@ case class DLCRoutes(dlcNode: DLCNodeApi)(implicit system: ActorSystem)
     case ServerCommand("checkconnection", arr) =>
       withValidServerCommand(DLCCheckConnection.fromJsArr(arr)) { addr =>
         complete {
-          dlcNode.checkPeerConnection(addr.address).map { _ =>
+          Future(dlcNode.checkPeerConnection(addr.address)).map { _ =>
             Server.httpSuccess("initiated")
           }
         }

--- a/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
@@ -11,6 +11,7 @@ import org.bitcoins.chain.{
 import org.bitcoins.commons.jsonmodels.ws.TorNotification.TorStartedNotification
 import org.bitcoins.commons.jsonmodels.ws.{
   ChainNotification,
+  DLCNodeNotification,
   WalletNotification,
   WalletWsType,
   WsNotification
@@ -22,6 +23,11 @@ import org.bitcoins.core.protocol.dlc.models.DLCStatus
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.{DoubleSha256DigestBE, Sha256Digest}
+import org.bitcoins.dlc.node.{
+  DLCNodeCallbacks,
+  OnPeerConnectionEstablished,
+  OnPeerConnectionFailed
+}
 import org.bitcoins.dlc.wallet.{
   DLCWalletCallbacks,
   OnDLCOfferAdd,
@@ -195,5 +201,28 @@ object WebsocketUtil extends Logging {
 
     onDLCStateChange(onStateChange) + onDLCOfferAdd(
       onOfferAdd) + onDLCOfferRemove(onOfferRemove)
+  }
+
+  def buildDLCNodeCallbacks(
+      walletQueue: SourceQueueWithComplete[WsNotification[_]])(implicit
+      ec: ExecutionContext): DLCNodeCallbacks = {
+
+    val onConnectionEstablished: OnPeerConnectionEstablished = { payload =>
+      val notification =
+        DLCNodeNotification.DLCNodeConnectionEstablished(payload)
+      val offerF = walletQueue.offer(notification)
+      offerF.map(_ => ())
+    }
+
+    val onConnectionFailed: OnPeerConnectionFailed = { payload =>
+      val notification = DLCNodeNotification.DLCNodeConnectionFailed(payload)
+      val offerF = walletQueue.offer(notification)
+      offerF.map(_ => ())
+    }
+
+    import DLCNodeCallbacks._
+
+    onPeerConnectionEstablished(
+      onConnectionEstablished) + onPeerConnectionFailed(onConnectionFailed)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/api/dlc/node/DLCNodeApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlc/node/DLCNodeApi.scala
@@ -31,5 +31,7 @@ trait DLCNodeApi extends StartStopAsync[Unit] {
       message: String,
       tempContractId: Sha256Digest): Future[Sha256Digest]
 
+  def checkPeerConnection(peerAddress: InetSocketAddress): Future[Unit]
+
   def getHostAddress: Future[InetSocketAddress]
 }

--- a/dlc-node-test/src/test/scala/org/bitcoins/dlc/node/DLCNodeTest.scala
+++ b/dlc-node-test/src/test/scala/org/bitcoins/dlc/node/DLCNodeTest.scala
@@ -2,12 +2,15 @@ package org.bitcoins.dlc.node
 
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.dlc.models.DLCState
+import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.testkit.async.TestAsyncUtil
 import org.bitcoins.testkit.dlc.BitcoinSDLCNodeTest
 import org.bitcoins.testkit.wallet.DLCWalletUtil._
 import org.scalatest.FutureOutcome
 
+import java.net.InetSocketAddress
+import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration.DurationInt
 
 class DLCNodeTest extends BitcoinSDLCNodeTest {
@@ -15,6 +18,50 @@ class DLCNodeTest extends BitcoinSDLCNodeTest {
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     witTwoFundedDLCNodes(test)
+  }
+
+  it must "check a connection" in { nodes: (DLCNode, DLCNode) =>
+    val nodeA = nodes._1
+    val nodeB = nodes._2
+
+    val configA = nodeA.config
+
+    val errorMessageP = Promise[String]()
+    val failure =
+      DLCNodeCallbacks.onPeerConnectionFailed(new OnPeerConnectionFailed {
+        override def apply(param: (InetSocketAddress, String)): Future[Unit] = {
+          errorMessageP.success(param._2)
+          Future.unit
+        }
+      })
+    configA.addCallbacks(failure)
+
+    val okP = Promise[Boolean]()
+    val established = DLCNodeCallbacks.onPeerConnectionEstablished(
+      new OnPeerConnectionEstablished {
+        override def apply(param: InetSocketAddress): Future[Unit] = {
+          okP.success(true)
+          Future.unit
+        }
+      })
+    configA.addCallbacks(established)
+
+    for {
+      (addrB, _) <- nodeB.serverBindF
+      _ = assert(!errorMessageP.isCompleted)
+      _ = assert(!okP.isCompleted)
+      _ <- nodeA.checkPeerConnection(addrB)
+      ok <- okP.future
+      _ = assert(ok)
+      _ = assert(!errorMessageP.isCompleted)
+      invalidAddr = InetSocketAddress.createUnresolved(addrB.getHostString,
+                                                       NetworkUtil.randomPort())
+      _ <- recoverToSucceededIf[java.net.ConnectException](
+        nodeA.checkPeerConnection(invalidAddr))
+      errorMessage <- errorMessageP.future
+    } yield {
+      assert(errorMessage.nonEmpty)
+    }
   }
 
   it must "setup a DLC" in { nodes: (DLCNode, DLCNode) =>

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCClient.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCClient.scala
@@ -51,6 +51,7 @@ class DLCClient(
     case c @ Tcp.CommandFailed(cmd: Tcp.Connect) =>
       val ex = c.cause.getOrElse(new IOException("Unknown Error"))
       log.error(s"Cannot connect to ${cmd.remoteAddress} ", ex)
+      connectedAddress.foreach(_.failure(ex))
       throw ex
     case Tcp.Connected(peerOrProxyAddress, _) =>
       val connection = sender()

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCNode.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCNode.scala
@@ -13,6 +13,7 @@ import org.bitcoins.dlc.node.peer.Peer
 
 import java.net.InetSocketAddress
 import scala.concurrent._
+import scala.util.{Failure, Success}
 
 case class DLCNode(wallet: DLCWalletApi)(implicit
     system: ActorSystem,
@@ -111,15 +112,34 @@ case class DLCNode(wallet: DLCWalletApi)(implicit
     } yield res
   }
 
+  override def checkPeerConnection(
+      peerAddress: InetSocketAddress): Future[Unit] = {
+    for {
+      handler <- connectToPeer(peerAddress)
+    } yield {
+      handler ! DLCConnectionHandler.CloseConnection
+    }
+  }
+
   private def connectToPeer(
       peerAddress: InetSocketAddress): Future[ActorRef] = {
     val peer =
       Peer(socket = peerAddress, socks5ProxyParams = config.socks5ProxyParams)
 
     val handlerP = Promise[ActorRef]()
-    for {
+
+    val f = for {
       _ <- DLCClient.connect(peer, wallet, Some(handlerP))
       handler <- handlerP.future
     } yield handler
+
+    f.onComplete {
+      case Success(_) =>
+        config.callBacks.executeOnPeerConnectionEstablished(peerAddress)
+      case Failure(ex) =>
+        config.callBacks.executeOnPeerConnectionFailed(peerAddress, ex)
+    }
+
+    f
   }
 }

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCNode.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCNode.scala
@@ -123,6 +123,7 @@ case class DLCNode(wallet: DLCWalletApi)(implicit
 
   private def connectToPeer(
       peerAddress: InetSocketAddress): Future[ActorRef] = {
+    config.callBacks.executeOnPeerConnectionInitiated(peerAddress)
     val peer =
       Peer(socket = peerAddress, socks5ProxyParams = config.socks5ProxyParams)
 
@@ -136,8 +137,8 @@ case class DLCNode(wallet: DLCWalletApi)(implicit
     f.onComplete {
       case Success(_) =>
         config.callBacks.executeOnPeerConnectionEstablished(peerAddress)
-      case Failure(ex) =>
-        config.callBacks.executeOnPeerConnectionFailed(peerAddress, ex)
+      case Failure(_) =>
+        config.callBacks.executeOnPeerConnectionFailed(peerAddress)
     }
 
     f

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCNodeCallbacks.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCNodeCallbacks.scala
@@ -1,0 +1,98 @@
+package org.bitcoins.dlc.node
+
+import grizzled.slf4j.Logging
+import org.bitcoins.core.api.callback.{CallbackFactory, ModuleCallbacks}
+import org.bitcoins.core.api.{Callback, CallbackHandler}
+
+import java.net.InetSocketAddress
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Callbacks for responding to events in the DLC node. */
+trait DLCNodeCallbacks extends ModuleCallbacks[DLCNodeCallbacks] with Logging {
+
+  def onPeerConnectionEstablished: CallbackHandler[
+    InetSocketAddress,
+    OnPeerConnectionEstablished]
+
+  def onPeerConnectionFailed: CallbackHandler[
+    (InetSocketAddress, String),
+    OnPeerConnectionFailed]
+
+  override def +(other: DLCNodeCallbacks): DLCNodeCallbacks
+
+  def executeOnPeerConnectionEstablished(peerAddress: InetSocketAddress)(
+      implicit ec: ExecutionContext): Future[Unit] = {
+    onPeerConnectionEstablished.execute(
+      peerAddress,
+      (err: Throwable) =>
+        logger.error(
+          s"${onPeerConnectionEstablished.name} Callback failed with error: ",
+          err))
+  }
+
+  def executeOnPeerConnectionFailed(
+      peerAddress: InetSocketAddress,
+      ex: Throwable)(implicit ec: ExecutionContext): Future[Unit] = {
+    onPeerConnectionFailed.execute(
+      (peerAddress, ex.getMessage),
+      (err: Throwable) =>
+        logger.error(
+          s"${onPeerConnectionFailed.name} Callback failed with error: ",
+          err))
+  }
+}
+
+trait OnPeerConnectionEstablished extends Callback[InetSocketAddress]
+
+trait OnPeerConnectionFailed extends Callback[(InetSocketAddress, String)]
+
+object DLCNodeCallbacks extends CallbackFactory[DLCNodeCallbacks] {
+
+  // Use Impl pattern here to enforce the correct names on the CallbackHandlers
+  private case class DLCNodeCallbacksImpl(
+      onPeerConnectionEstablished: CallbackHandler[
+        InetSocketAddress,
+        OnPeerConnectionEstablished],
+      onPeerConnectionFailed: CallbackHandler[
+        (InetSocketAddress, String),
+        OnPeerConnectionFailed])
+      extends DLCNodeCallbacks {
+
+    override def +(other: DLCNodeCallbacks): DLCNodeCallbacks =
+      copy(
+        onPeerConnectionEstablished =
+          onPeerConnectionEstablished ++ other.onPeerConnectionEstablished,
+        onPeerConnectionFailed =
+          onPeerConnectionFailed ++ other.onPeerConnectionFailed
+      )
+  }
+
+  /** Constructs a set of callbacks that only acts on TX received */
+  def onPeerConnectionEstablished(
+      f: OnPeerConnectionEstablished): DLCNodeCallbacks =
+    DLCNodeCallbacks(onPeerConnectionEstablished = Vector(f))
+
+  def onPeerConnectionFailed(f: OnPeerConnectionFailed): DLCNodeCallbacks =
+    DLCNodeCallbacks(onPeerConnectionFailed = Vector(f))
+
+  /** Empty callbacks that does nothing with the received data */
+  override val empty: DLCNodeCallbacks =
+    DLCNodeCallbacks(Vector.empty, Vector.empty)
+
+  def apply(
+      onPeerConnectionEstablished: Vector[OnPeerConnectionEstablished] =
+        Vector.empty,
+      onPeerConnectionFailed: Vector[OnPeerConnectionFailed] =
+        Vector.empty): DLCNodeCallbacks = {
+    DLCNodeCallbacksImpl(
+      onPeerConnectionEstablished =
+        CallbackHandler[InetSocketAddress, OnPeerConnectionEstablished](
+          "onPeerConnectionEstablished",
+          onPeerConnectionEstablished),
+      onPeerConnectionFailed =
+        CallbackHandler[(InetSocketAddress, String), OnPeerConnectionFailed](
+          "onPeerConnectionFailed",
+          onPeerConnectionFailed)
+    )
+  }
+}

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
@@ -3,9 +3,10 @@ package org.bitcoins.dlc.node.config
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import org.bitcoins.commons.config.{AppConfig, AppConfigFactory}
+import org.bitcoins.core.api.CallbackConfig
 import org.bitcoins.core.api.dlc.wallet.DLCWalletApi
 import org.bitcoins.core.util.{FutureUtil, NetworkUtil}
-import org.bitcoins.dlc.node.DLCNode
+import org.bitcoins.dlc.node.{DLCNode, DLCNodeCallbacks}
 import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.tor.{Socks5ProxyParams, TorParams}
 
@@ -20,7 +21,8 @@ import scala.concurrent._
   */
 case class DLCNodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     implicit ec: ExecutionContext)
-    extends AppConfig {
+    extends AppConfig
+    with CallbackConfig[DLCNodeCallbacks] {
 
   override protected[bitcoins] def moduleName: String =
     DLCNodeAppConfig.moduleName
@@ -36,6 +38,8 @@ case class DLCNodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   }
 
   override def stop(): Future[Unit] = Future.unit
+
+  override lazy val callbackFactory: DLCNodeCallbacks.type = DLCNodeCallbacks
 
   lazy val torConf: TorAppConfig =
     TorAppConfig(baseDatadir, Some(moduleName), configOverrides)


### PR DESCRIPTION
Examples of Websocket payloads:

Init message:

```json
  {
    "type": "dlcconnectioninitiated",
    "payload": "localhost:12345"
  }
```

Success message:

```json
  {
    "type": "dlcconnectionestablished",
    "payload": "localhost:12345"
  }
```

Failure message:

```json
  {
    "type": "dlcconnectionfailed",
    "payload":  "localhost:12345"
  }
```

