### PR TITLE
Fix bug where no exception was thrown if the acceptor did not have enough money

### DIFF
--- a/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
+++ b/app-commons-test/src/test/scala/org/bitcoins/commons/DLCStatusTest.scala
@@ -25,7 +25,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
       case (isInit, offerTLV) =>
         val offer = DLCOffer.fromTLV(offerTLV)
 
-        val totalCollateral = offer.contractInfo.max
+        val totalCollateral = offer.contractInfo.totalCollateral
 
         val payoutAddress = Option.empty[PayoutAddress]
 
@@ -60,7 +60,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
       case (isInit, offerTLV, contractId) =>
         val offer = DLCOffer.fromTLV(offerTLV)
 
-        val totalCollateral = offer.contractInfo.max
+        val totalCollateral = offer.contractInfo.totalCollateral
 
         // random testnet address
         val payoutAddress =
@@ -102,7 +102,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
       case (isInit, offerTLV, contractId, txId) =>
         val offer = DLCOffer.fromTLV(offerTLV)
 
-        val totalCollateral = offer.contractInfo.max
+        val totalCollateral = offer.contractInfo.totalCollateral
 
         val payoutAddress = Option.empty[PayoutAddress]
 
@@ -140,7 +140,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
       case (isInit, offerTLV, contractId, fundingTxId) =>
         val offer = DLCOffer.fromTLV(offerTLV)
 
-        val totalCollateral = offer.contractInfo.max
+        val totalCollateral = offer.contractInfo.totalCollateral
 
         val payoutAddress = Option.empty[PayoutAddress]
 
@@ -178,7 +178,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
       case (isInit, offerTLV, contractId, fundingTxId) =>
         val offer = DLCOffer.fromTLV(offerTLV)
 
-        val totalCollateral = offer.contractInfo.max
+        val totalCollateral = offer.contractInfo.totalCollateral
 
         val payoutAddress = Option.empty[PayoutAddress]
 
@@ -219,7 +219,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
     ) { case (isInit, offerTLV, contractId, fundingTxId, closingTxId, sigs) =>
       val offer = DLCOffer.fromTLV(offerTLV)
 
-      val totalCollateral = offer.contractInfo.max
+      val totalCollateral = offer.contractInfo.totalCollateral
       val randomMyPayout =
         Math.abs(scala.util.Random.nextLong() % totalCollateral.toLong)
       val myPayout: CurrencyUnit = Satoshis(randomMyPayout)
@@ -274,7 +274,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
     ) { case (isInit, offerTLV, contractId, fundingTxId, closingTxId, sig) =>
       val offer = DLCOffer.fromTLV(offerTLV)
 
-      val totalCollateral = offer.contractInfo.max
+      val totalCollateral = offer.contractInfo.totalCollateral
 
       val randomMyPayout =
         Math.abs(scala.util.Random.nextLong() % totalCollateral.toLong)
@@ -330,7 +330,7 @@ class DLCStatusTest extends BitcoinSJvmTest {
     ) { case (isInit, offerTLV, contractId, fundingTxId, closingTxId) =>
       val offer = DLCOffer.fromTLV(offerTLV)
 
-      val totalCollateral = offer.contractInfo.max
+      val totalCollateral = offer.contractInfo.totalCollateral
 
       val randomMyPayout =
         Math.abs(scala.util.Random.nextLong() % totalCollateral.toLong)

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/build/DLCTxBuilder.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/build/DLCTxBuilder.scala
@@ -103,8 +103,10 @@ case class DLCTxBuilder(offer: DLCOffer, accept: DLCAcceptWithoutSigs) {
           "Offer change address must have same network as final address")
   require(acceptChangeAddress.networkParameters == network,
           "Accept change address must have same network as final address")
-  require(totalInput >= contractInfo.max,
-          "Total collateral must add up to max winnings")
+  require(
+    totalInput >= contractInfo.totalCollateral,
+    s"Total collateral must add up to max winnings, totalInput=${totalInput} contractInfo.totalCollateral=${contractInfo.totalCollateral}"
+  )
   require(
     offerTotalFunding >= offerTotalCollateral,
     "Offer funding inputs must add up to at least offer's total collateral")

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractInfo.scala
@@ -42,7 +42,7 @@ sealed trait ContractInfo extends TLVSerializable[ContractInfoTLV] {
   def contractDescriptors: Vector[ContractDescriptor]
 
   /** Returns the maximum payout the offerer could win from this contract */
-  def max: Satoshis
+  def maxOffererPayout: Satoshis
 
   /** Computes the CET set and their corresponding payouts using CETCalculator. */
   def allOutcomesAndPayouts: Vector[(OracleOutcome, Satoshis)]
@@ -220,7 +220,7 @@ case class SingleContractInfo(
   }
 
   /** @inheritdoc */
-  override val max: Satoshis = {
+  override val maxOffererPayout: Satoshis = {
     contractDescriptor match {
       case descriptor: EnumContractDescriptor =>
         descriptor.values.maxBy(_.toLong)
@@ -406,7 +406,8 @@ case class DisjointUnionContractInfo(contracts: Vector[SingleContractInfo])
   }
 
   /** @inheritdoc */
-  override val max: Satoshis = contracts.map(_.max).max
+  override val maxOffererPayout: Satoshis =
+    contracts.map(_.maxOffererPayout).max
 
   /** @inheritdoc */
   override lazy val allOutcomesAndPayouts: Vector[(OracleOutcome, Satoshis)] = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractInfo.scala
@@ -220,7 +220,14 @@ case class SingleContractInfo(
   }
 
   /** @inheritdoc */
-  override val max: Satoshis = totalCollateral
+  override val max: Satoshis = {
+    contractDescriptor match {
+      case descriptor: EnumContractDescriptor =>
+        descriptor.values.maxBy(_.toLong)
+      case _: NumericContractDescriptor =>
+        totalCollateral
+    }
+  }
 
   /** @inheritdoc */
   override lazy val allOutcomesAndPayouts: Vector[(OracleOutcome, Satoshis)] = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/ContractInfo.scala
@@ -220,11 +220,7 @@ case class SingleContractInfo(
   }
 
   /** @inheritdoc */
-  override val max: Satoshis = contractDescriptor match {
-    case descriptor: EnumContractDescriptor =>
-      descriptor.values.maxBy(_.toLong)
-    case _: NumericContractDescriptor => totalCollateral
-  }
+  override val max: Satoshis = totalCollateral
 
   /** @inheritdoc */
   override lazy val allOutcomesAndPayouts: Vector[(OracleOutcome, Satoshis)] = {

--- a/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCTLVGen.scala
+++ b/dlc-test/src/test/scala/org/bitcoins/dlc/testgen/DLCTLVGen.scala
@@ -405,7 +405,7 @@ object DLCTLVGen {
       changeAddress: BitcoinAddress = address(),
       changeSerialId: UInt64 = DLCMessage.genSerialId()): DLCAccept = {
     val totalCollateral =
-      offer.contractInfo.max - offer.collateral + overCollateral
+      offer.contractInfo.maxOffererPayout - offer.collateral + overCollateral
 
     val cetSignatures =
       cetSigs(

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
@@ -3,7 +3,6 @@ package org.bitcoins.dlc.wallet
 import org.bitcoins.core.protocol.dlc.models.{
   DLCState,
   DLCStatus,
-  DisjointUnionContractInfo,
   SingleContractInfo
 }
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
@@ -101,9 +100,6 @@ class DLCWalletCallbackTest extends BitcoinSDualWalletTest {
         DLCWalletUtil.sampleContractInfo match {
           case single: SingleContractInfo =>
             DLCWalletUtil.getSigs(single)
-          case disjoint: DisjointUnionContractInfo =>
-            sys.error(
-              s"Cannot retrieve sigs for disjoint union contract, got=$disjoint")
         }
       }
       transaction <- walletA.executeDLC(contractId, sigs._1).map(_.get)

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -76,7 +76,8 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
           accept.fundingInputs
             .map(_.output.value)
             .sum >= accept.collateral)
-        assert(accept.collateral == offer.contractInfo.max - offer.collateral)
+        assert(
+          accept.collateral == offer.contractInfo.totalCollateral - offer.collateral)
         assert(accept.changeAddress.value.nonEmpty)
       }
 
@@ -141,6 +142,12 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
   it must "correctly negotiate a dlc" in {
     fundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
       testNegotiate(fundedDLCWallets, DLCWalletUtil.sampleDLCOffer)
+  }
+
+  it must "correctly negotiate a non winner take all dlc" in {
+    fundedDLCWallets: (FundedDLCWallet, FundedDLCWallet) =>
+      testNegotiate(fundedDLCWallets,
+                    DLCWalletUtil.sampleDLCOfferNonWinnerTakeAll)
   }
 
   it must "correctly negotiate a dlc with a multi-nonce oracle info" in {

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -317,7 +317,8 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
             accept.fundingInputs
               .map(_.output.value)
               .sum >= accept.collateral)
-          assert(accept.collateral == offer.contractInfo.max - offer.collateral)
+          assert(
+            accept.collateral == offer.contractInfo.totalCollateral - offer.collateral)
           assert(accept.changeAddress.value.nonEmpty)
         }
 
@@ -790,7 +791,8 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         accept <- walletB.acceptDLCOffer(offer, None, None, None)
         _ = {
           assert(accept.fundingInputs.nonEmpty)
-          assert(accept.collateral == offer.contractInfo.max - offer.collateral)
+          assert(
+            accept.collateral == offer.contractInfo.maxOffererPayout - offer.collateral)
           assert(accept.changeAddress.value.nonEmpty)
         }
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -982,6 +982,30 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
     } yield res
   }
 
+  it must "fail to accept an offer when you do not have enough money in the wallet" in {
+    wallets =>
+      val walletA = wallets._1.wallet
+      val walletB = wallets._2.wallet
+
+      val offerData: DLCOffer =
+        DLCWalletUtil.buildDLCOffer(totalCollateral = Bitcoins(100))
+      //val walletBBalanceF = walletB.getBalance()
+      for {
+        offer <- walletA.createDLCOffer(
+          contractInfo = offerData.contractInfo,
+          collateral = offerData.collateral,
+          feeRateOpt = Some(offerData.feeRate),
+          locktime = offerData.timeouts.contractMaturity.toUInt32,
+          refundLocktime = UInt32.max,
+          peerAddressOpt = None,
+          externalPayoutAddressOpt = None,
+          externalChangeAddressOpt = None
+        )
+        _ <- recoverToSucceededIf[RuntimeException](
+          walletB.acceptDLCOffer(offer, None, None, None))
+      } yield succeed
+  }
+
   it must "fail to create an offer with an invalid announcement signature" in {
     wallets =>
       val walletA = wallets._1.wallet

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -989,7 +989,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
       val offerData: DLCOffer =
         DLCWalletUtil.buildDLCOffer(totalCollateral = Bitcoins(100))
-      //val walletBBalanceF = walletB.getBalance()
+
       for {
         offer <- walletA.createDLCOffer(
           contractInfo = offerData.contractInfo,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -693,7 +693,6 @@ abstract class DLCWallet
     val dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))
 
     val collateral = offer.contractInfo.max - offer.collateral
-
     logger.debug(s"Checking if Accept (${dlcId.hex}) has already been made")
     for {
       dlcAcceptOpt <- DLCAcceptUtil.findDLCAccept(dlcId = dlcId,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -692,7 +692,7 @@ abstract class DLCWallet
 
     val dlcId = calcDLCId(offer.fundingInputs.map(_.outPoint))
 
-    val collateral = offer.contractInfo.max - offer.collateral
+    val collateral = offer.contractInfo.totalCollateral - offer.collateral
     logger.debug(s"Checking if Accept (${dlcId.hex}) has already been made")
     for {
       dlcAcceptOpt <- DLCAcceptUtil.findDLCAccept(dlcId = dlcId,

--- a/docs/core/dlc.md
+++ b/docs/core/dlc.md
@@ -152,7 +152,7 @@ val oracleInfo = NumericMultiOracleInfo(
 )
 
 val contractInfo = SingleContractInfo(totalCollateral, ContractOraclePair.NumericPair(descriptor, oracleInfo))
-contractInfo.max
+contractInfo.totalCollateral
 contractInfo.allOutcomes.length
 
 val signingOracles = oracleInfo.singleOracleInfos.take(3)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -84,7 +84,7 @@ object DLCWalletUtil extends Logging {
   lazy val invalidContractOraclePair: ContractOraclePair.EnumPair =
     ContractOraclePair.EnumPair(sampleContractDescriptor, invalidOracleInfo)
 
-  lazy val sampleContractInfo: ContractInfo =
+  lazy val sampleContractInfo: SingleContractInfo =
     SingleContractInfo(half, sampleContractOraclePair)
 
   val amt2: Satoshis = Satoshis(100000)
@@ -185,6 +185,11 @@ object DLCWalletUtil extends Logging {
     feeRate = SatoshisPerVirtualByte(Satoshis(3)),
     timeouts = dummyTimeouts
   )
+
+  def buildDLCOffer(totalCollateral: CurrencyUnit): DLCOffer = {
+    val ci = sampleContractInfo.copy(totalCollateral = totalCollateral.satoshis)
+    sampleDLCOffer.copy(contractInfo = ci)
+  }
 
   lazy val sampleDLCOffer2 = DLCOffer(
     protocolVersionOpt = DLCOfferTLV.currentVersionOpt,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -56,9 +56,8 @@ object DLCWalletUtil extends Logging {
   val total: Satoshis = (expectedDefaultAmt / Satoshis(2)).satoshis
   val half: Satoshis = (total / Satoshis(2)).satoshis
 
-  val sampleOutcomes: Vector[(EnumOutcome, Satoshis)] = Vector(
-    EnumOutcome(winStr) -> (expectedDefaultAmt / Satoshis(2)).satoshis,
-    EnumOutcome(loseStr) -> Satoshis.zero)
+  val sampleOutcomes: Vector[(EnumOutcome, Satoshis)] =
+    Vector(EnumOutcome(winStr) -> total, EnumOutcome(loseStr) -> Satoshis.zero)
 
   lazy val sampleContractDescriptor: EnumContractDescriptor =
     EnumContractDescriptor(sampleOutcomes)
@@ -85,7 +84,8 @@ object DLCWalletUtil extends Logging {
     ContractOraclePair.EnumPair(sampleContractDescriptor, invalidOracleInfo)
 
   lazy val sampleContractInfo: SingleContractInfo =
-    SingleContractInfo(half, sampleContractOraclePair)
+    SingleContractInfo(totalCollateral = total,
+                       contractOraclePair = sampleContractOraclePair)
 
   val amt2: Satoshis = Satoshis(100000)
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -59,13 +59,31 @@ object DLCWalletUtil extends Logging {
   val sampleOutcomes: Vector[(EnumOutcome, Satoshis)] =
     Vector(EnumOutcome(winStr) -> total, EnumOutcome(loseStr) -> Satoshis.zero)
 
+  val nonWinnerTakeAllOutcomes: Vector[(EnumOutcome, Satoshis)] = {
+    val offset = Satoshis(10000)
+    Vector(
+      EnumOutcome(winStr) -> (total.satoshis - offset).satoshis,
+      EnumOutcome(loseStr) -> offset
+    )
+  }
+
   lazy val sampleContractDescriptor: EnumContractDescriptor =
     EnumContractDescriptor(sampleOutcomes)
+
+  lazy val sampleContractDescriptorNonWinnerTakeAll: EnumContractDescriptor = {
+    EnumContractDescriptor(nonWinnerTakeAllOutcomes)
+  }
 
   lazy val sampleOracleInfo: EnumSingleOracleInfo =
     EnumSingleOracleInfo.dummyForKeys(oraclePrivKey,
                                       rValue,
                                       sampleOutcomes.map(_._1))
+
+  lazy val sampleOracleInfoNonWinnerTakeAll: EnumSingleOracleInfo = {
+    EnumSingleOracleInfo.dummyForKeys(oraclePrivKey,
+                                      rValue,
+                                      nonWinnerTakeAllOutcomes.map(_._1))
+  }
 
   lazy val invalidOracleInfo: EnumSingleOracleInfo = {
     val info = EnumSingleOracleInfo.dummyForKeys(oraclePrivKey,
@@ -80,12 +98,21 @@ object DLCWalletUtil extends Logging {
   lazy val sampleContractOraclePair: ContractOraclePair.EnumPair =
     ContractOraclePair.EnumPair(sampleContractDescriptor, sampleOracleInfo)
 
+  lazy val sampleContractOraclePairNonWinnerTakeAll: ContractOraclePair.EnumPair = {
+    ContractOraclePair.EnumPair(sampleContractDescriptorNonWinnerTakeAll,
+                                sampleOracleInfoNonWinnerTakeAll)
+  }
+
   lazy val invalidContractOraclePair: ContractOraclePair.EnumPair =
     ContractOraclePair.EnumPair(sampleContractDescriptor, invalidOracleInfo)
 
   lazy val sampleContractInfo: SingleContractInfo =
     SingleContractInfo(totalCollateral = total,
                        contractOraclePair = sampleContractOraclePair)
+
+  lazy val sampleContractInfoNonWinnerTakeAll: SingleContractInfo = {
+    SingleContractInfo(total, sampleContractOraclePairNonWinnerTakeAll)
+  }
 
   val amt2: Satoshis = Satoshis(100000)
 
@@ -185,6 +212,9 @@ object DLCWalletUtil extends Logging {
     feeRate = SatoshisPerVirtualByte(Satoshis(3)),
     timeouts = dummyTimeouts
   )
+
+  lazy val sampleDLCOfferNonWinnerTakeAll: DLCOffer =
+    sampleDLCOffer.copy(contractInfo = sampleContractInfoNonWinnerTakeAll)
 
   def buildDLCOffer(totalCollateral: CurrencyUnit): DLCOffer = {
     val ci = sampleContractInfo.copy(totalCollateral = totalCollateral.satoshis)


### PR DESCRIPTION
fixes #4727

This fixes an interesting bug in the wallet for enum contracts.

Previously, we would require that the `max` value in the contract be the most amount of paid to one counterparty. 

This doesn't make sense, because we should always have the total collateral assigned in the enum contract. I.e.

```
total_collateral = offer_collateral + accept_collateral
```

before this PR, for enum contracts, we had

```
max_payout = offer_collateral + accept_collateral
```

but `max_payout == total_collateral` is not necessarily true. For instance, imagine i'm doing a coinflip bet with an enum contract for `1BTC` where the payouts are

- Heads Alice receives `0.75BTC`, Bob receives `0.25BTC`
- Tails Bob receives `0.75BTC`, Alice receives `0.25BTC`.

The `max_payout=0.75BTC`, but the total collateral is `1BTC`. 

