### PR TITLE
Add handling so test lnd clients can be reached by docker

### DIFF
--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -131,8 +131,12 @@ class LndRpcClient(val instance: LndInstance, binaryOpt: Option[File] = None)(
       case None         => None
     }
 
+    val host =
+      if (instance.rpcUri.getHost == "0.0.0.0") "localhost"
+      else instance.rpcUri.getHost
+
     val client = GrpcClientSettings
-      .connectToServiceAt(instance.rpcUri.getHost, instance.rpcUri.getPort)
+      .connectToServiceAt(host, instance.rpcUri.getPort)
       .withCallCredentials(callCredentials)
 
     trustManagerOpt match {

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -131,12 +131,8 @@ class LndRpcClient(val instance: LndInstance, binaryOpt: Option[File] = None)(
       case None         => None
     }
 
-    val host =
-      if (instance.rpcUri.getHost == "0.0.0.0") "localhost"
-      else instance.rpcUri.getHost
-
     val client = GrpcClientSettings
-      .connectToServiceAt(host, instance.rpcUri.getPort)
+      .connectToServiceAt(instance.rpcUri.getHost, instance.rpcUri.getPort)
       .withCallCredentials(callCredentials)
 
     trustManagerOpt match {

--- a/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestUtil.scala
@@ -79,7 +79,12 @@ trait LndRpcTestUtil extends Logging {
        |historicalsyncinterval=1s
        |trickledelay=1000
        |listen=127.0.0.1:$port
-       |rpclisten=127.0.0.1:$rpcPort
+       |
+       |# allow requests from docker containers
+       |tlsextradomain=host.docker.internal
+       |tlsextradomain=host-gateway
+       |rpclisten=0.0.0.0:$rpcPort
+       |
        |externalip=127.0.0.1
        |maxpendingchannels=10
        |bitcoind.rpcuser = ${bitcoindInstance.authCredentials


### PR DESCRIPTION
To access the lnd rpc from a docker container we need to be bound to `0.0.0.0`, this makes it so our default test ones do that, as well as adds the tls domain to allow requests from it.