### PR TITLE
re-add `Compile / fork` in server.sbt so we can run `appServer` from sbt

### DIFF
--- a/app/server/server.sbt
+++ b/app/server/server.sbt
@@ -6,6 +6,8 @@ Universal / packageName := {
   CommonSettings.buildPackageName(old)
 }
 
+Compile / fork := true
+
 libraryDependencies ++= Deps.server.value
 
 mainClass := Some("org.bitcoins.server.BitcoinSServerMain")


### PR DESCRIPTION
This was removed in #4678 , i didn't realize that wouldn't allow us to shutdown `appServer/run` without shutting down sbt as well.