### PR TITLE
Bump `bitcoin-s.node.query-wait-time=120 seconds`

### DIFF
--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -172,7 +172,7 @@ bitcoin-s {
         try-peers-interval = 12s
         
         # wait time for queries like getheaders etc before switching to another
-        query-wait-time = 15s
+        query-wait-time = 120s
         
         hikari-logging = true
         hikari-logging-interval = 10 minute

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -194,7 +194,7 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     if (config.hasPath("bitcoin-s.node.query-wait-time")) {
       val duration = config.getDuration("bitcoin-s.node.query-wait-time")
       TimeUtil.durationToFiniteDuration(duration)
-    } else 15.seconds
+    } else 120.seconds
   }
 
   /** maximum consecutive number of invalid responses allowed from the same peer */

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -392,7 +392,7 @@ case class P2PClientActor(
         unalignedBytes
       case closeCmd @ (Tcp.ConfirmedClosed | Tcp.Closed | Tcp.Aborted |
           Tcp.PeerClosed) =>
-        logger.debug(
+        logger.info(
           s"We've been disconnected by $peer command=${closeCmd} state=${currentPeerMsgHandlerRecv.state}")
         currentPeerMsgHandlerRecv =
           Await.result(currentPeerMsgHandlerRecv.disconnect(), timeout)

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -505,7 +505,7 @@ case class P2PClientActor(
       case P2PClient.CloseCommand =>
         peerConnectionOpt match {
           case Some(peerConnection) =>
-            logger.debug(s"Disconnecting from peer $peer")
+            logger.info(s"Disconnecting from peer $peer")
             context become ignoreNetworkMessages(Some(peerConnection),
                                                  ByteVector.empty)
             currentPeerMsgHandlerRecv =
@@ -516,7 +516,7 @@ case class P2PClientActor(
               s"Attempting to disconnect peer that was not connected!")
         }
       case P2PClient.CloseAnyStateCommand =>
-        logger.debug(s"Received close any state for $peer")
+        logger.info(s"Received close any state for $peer")
         peerConnectionOpt match {
           case Some(peerConnection) =>
             context become ignoreNetworkMessages(Some(peerConnection),


### PR DESCRIPTION
I think this would be the simplest work around for #4715 , i also wonder how a 10 second timeout would perform for compact filter batches. Tor is also known to have highly variable latency. It seems like 10 seconds is a bit aggressive. Thoughts @shreyanshyad ?