### PR TITLE
Implement retry of fetching bitcoind version when calling `clientF`

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -70,7 +70,7 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
 
   private val syncing = new AtomicBoolean(false)
 
-  override lazy val version: Future[BitcoindVersion] = {
+  override def version: Future[BitcoindVersion] = {
     instance match {
       case _: BitcoindInstanceRemote =>
         getNetworkInfo.map(info =>

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -156,7 +156,7 @@ trait Client
     *         cannot be started
     */
   override def start(): Future[BitcoindRpcClient] = {
-
+    logger.info(s"Client.start() instance=$instance")
     // if we're doing cookie based authentication, we might attempt
     // to read the cookie file before it's written. this ensures
     // we avoid that


### PR DESCRIPTION
fixes #4618

When calling `BitcoinSServerMain.startBitcoindBackend()` we call `BitcoindRpcAppConfig.clientF` to get an rpc client. Inside of this, we fetch the [`version`](https://github.com/bitcoin-s/bitcoin-s/blob/075b90c930c565073a509ebc45077f16d713f248/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala#L176) which can lead to an exception if the bitcoind instance is still warming up.

<img width="1440" alt="Screen Shot 2022-09-10 at 10 32 20 AM" src="https://user-images.githubusercontent.com/3514957/189490464-97714e75-d4b2-4e69-a57f-83f83355e916.png">
