### PR TITLE
Attempt to reduce redundant work on startup to speed up start up time

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -76,14 +76,14 @@ case class BitcoinSAppConfig(
     val start = TimeUtil.currentEpochMs
     //configurations that don't depend on tor startup
     //start these in parallel as an optimization
-    val nonTorConfigs = Vector(kmConf, chainConf, walletConf)
+    val nonTorConfigs = Vector(kmConf, chainConf, walletConf, dlcConf)
 
     val torConfig = torConf.start()
     val torDependentConfigs =
-      Vector(nodeConf, bitcoindRpcConf, dlcConf, dlcNodeConf)
+      Vector(nodeConf, bitcoindRpcConf, dlcNodeConf)
 
     val dbConfigsDependentOnTor: Vector[DbManagement] =
-      Vector(nodeConf, dlcConf)
+      Vector(nodeConf)
 
     //run migrations here to avoid issues like: https://github.com/bitcoin-s/bitcoin-s/issues/4606
     //since we don't require tor dependent configs


### PR DESCRIPTION
This PR attempts to reduce redundant work on startup to decrease startup time.

This does this by reducing redundant calls to `.migrate()`. Now we just call `.migrate()` on `*AppConfig`'s that are dependent on tor. This is because when we return from `BitcoinSAppConfig.start()`, the configs that are guaranteed to be fully started are non tor configs (`WalletAppConfig`, `KeyManagerAppConfig`, `ChainAppConfig`).

Related to #4606 / #4607