### PR TITLE
Use postrgres when flagged in TrezorAddressTest

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -284,7 +284,10 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
     }
 
     assertionsF.flatMap { _ =>
-      conf.stop().map(_ => succeed)
+      for {
+        _ <- conf.dropAll()
+        _ = conf.clean()
+      } yield succeed
     }
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -220,7 +220,9 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
   private def testAccountType(purpose: HDPurpose): Future[Assertion] = {
     val confOverride = configForPurposeAndSeed(purpose)
     implicit val conf: WalletAppConfig =
-      BitcoinSTestAppConfig.getNeutrinoTestConfig(confOverride).walletConf
+      BitcoinSTestAppConfig
+        .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl(), confOverride)
+        .walletConf
 
     val testVectors = purpose match {
       case HDPurposes.Legacy       => legacyVectors


### PR DESCRIPTION
Noticed in #4758 that this test was using sqlite when we meant to test postgres