### PR TITLE
Implement `contract_id` column in `accept_dlc_data` table

### DIFF
--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -83,13 +83,13 @@ class DbManagementTest extends BitcoinSAsyncTest with EmbeddedPg {
     val result = dlcDbManagement.migrate()
     dlcAppConfig.driver match {
       case SQLite =>
-        val expected = 8
+        val expected = 9
         assert(result.migrationsExecuted == expected)
         val flywayInfo = dlcAppConfig.info()
         assert(flywayInfo.applied().length == expected)
         assert(flywayInfo.pending().length == 0)
       case PostgreSQL =>
-        val expected = 9
+        val expected = 10
         assert(result.migrationsExecuted == expected)
         val flywayInfo = dlcAppConfig.info()
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCDAOTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCDAOTest.scala
@@ -17,10 +17,12 @@ import org.bitcoins.testkit.chain.MockChainQueryApi
 import org.bitcoins.testkit.fixtures.DLCDAOFixture
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, DLCWalletUtil}
 import org.scalatest.Assertion
+import scodec.bits.ByteVector
 
 import java.net.InetSocketAddress
 import java.sql.SQLException
 import scala.concurrent.Future
+import scala.util.Random
 
 class DLCDAOTest extends BitcoinSWalletTest with DLCDAOFixture {
 
@@ -64,8 +66,11 @@ class DLCDAOTest extends BitcoinSWalletTest with DLCDAOFixture {
     val dlcDAO = daos.dlcDAO
     val acceptDAO = daos.dlcAcceptDAO
 
+    val contractId = ByteVector(Random.nextBytes(32))
     val acceptDb =
-      DLCAcceptDbHelper.fromDLCAccept(dlcId, DLCWalletUtil.sampleDLCAccept)
+      DLCAcceptDbHelper.fromDLCAccept(dlcId,
+                                      DLCWalletUtil.sampleDLCAccept,
+                                      contractId)
 
     verifyDatabaseInsertion(acceptDb, dlcId, acceptDAO, dlcDAO)
   }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -1190,7 +1190,8 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
       val walletA = fundedDLCWallets._1.wallet
       val walletB = fundedDLCWallets._2.wallet
 
-      val offerData = DLCWalletUtil.sampleDLCOffer
+      //needs to be 4 BTC to select all utxos to make sure dlcId is identical
+      val offerData = DLCWalletUtil.buildDLCOffer(Bitcoins(3))
       for {
         offer1 <- walletA.createDLCOffer(
           offerData.contractInfo,
@@ -1208,7 +1209,6 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
         //cancel the offer
         _ <- walletA.cancelDLC(offer1.dlcId)
-
         //reoffer it
         offer2 <- walletA.createDLCOffer(
           offerData.contractInfo,

--- a/dlc-wallet/src/main/resources/postgresql/dlc/migration/V10__add_accept_contractid.sql
+++ b/dlc-wallet/src/main/resources/postgresql/dlc/migration/V10__add_accept_contractid.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "accept_dlc_data" ADD COLUMN "contract_id" VARCHAR(32);

--- a/dlc-wallet/src/main/resources/sqlite/dlc/migration/V9__add_accept_contractid.sql
+++ b/dlc-wallet/src/main/resources/sqlite/dlc/migration/V9__add_accept_contractid.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "accept_dlc_data" ADD COLUMN "contract_id" VARCHAR(32);
+
+
+

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDAO.scala
@@ -46,12 +46,17 @@ case class DLCAcceptDAO()(implicit
       dlcs: Vector[DLCAcceptDb]): Query[DLCAcceptTable, DLCAcceptDb, Seq] =
     findByPrimaryKeys(dlcs.map(_.dlcId))
 
-  def findByContractId(contractId: ByteVector): DBIOAction[
+  def findByContractIdAction(contractId: ByteVector): DBIOAction[
     Option[DLCAcceptDb],
     NoStream,
     Effect.Read] = {
     val query = table.filter(_.contractId === contractId)
     query.result.map(_.headOption)
+  }
+
+  def findByContractId(contractId: ByteVector): Future[Option[DLCAcceptDb]] = {
+    val action = findByContractIdAction(contractId)
+    safeDatabase.run(action)
   }
 
   override def findByDLCIdsAction(dlcIds: Vector[Sha256Digest]): DBIOAction[

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDb.scala
@@ -9,6 +9,7 @@ import org.bitcoins.core.protocol.dlc.models._
 import org.bitcoins.core.protocol.tlv.NegotiationFieldsTLV
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.crypto._
+import scodec.bits.ByteVector
 
 case class DLCAcceptDb(
     dlcId: Sha256Digest,
@@ -18,7 +19,8 @@ case class DLCAcceptDb(
     collateral: CurrencyUnit,
     changeAddress: BitcoinAddress,
     changeSerialId: UInt64,
-    negotiationFieldsTLV: NegotiationFieldsTLV) {
+    negotiationFieldsTLV: NegotiationFieldsTLV,
+    contractId: ByteVector) {
 
   lazy val negotiationFields: NegotiationFields =
     NegotiationFields.fromTLV(negotiationFieldsTLV)
@@ -66,7 +68,10 @@ case class DLCAcceptDb(
 
 object DLCAcceptDbHelper {
 
-  def fromDLCAccept(id: Sha256Digest, accept: DLCAccept): DLCAcceptDb = {
+  def fromDLCAccept(
+      id: Sha256Digest,
+      accept: DLCAccept,
+      contractId: ByteVector): DLCAcceptDb = {
     DLCAcceptDb(
       id,
       accept.pubKeys.fundingKey,
@@ -75,7 +80,8 @@ object DLCAcceptDbHelper {
       accept.collateral,
       accept.changeAddress,
       accept.changeSerialId,
-      accept.negotiationFields.toTLV
+      accept.negotiationFields.toTLV,
+      contractId = contractId
     )
   }
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCAcceptUtil.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/util/DLCAcceptUtil.scala
@@ -143,7 +143,8 @@ object DLCAcceptUtil extends Logging {
       dlc: DLCDb,
       acceptWithoutSigs: DLCAcceptWithoutSigs,
       dlcPubKeys: DLCPublicKeys,
-      collateral: CurrencyUnit): DLCAcceptDb = {
+      collateral: CurrencyUnit,
+      contractId: ByteVector): DLCAcceptDb = {
     DLCAcceptDb(
       dlcId = dlc.dlcId,
       fundingKey = dlcPubKeys.fundingKey,
@@ -152,7 +153,8 @@ object DLCAcceptUtil extends Logging {
       collateral = collateral,
       changeAddress = acceptWithoutSigs.changeAddress,
       changeSerialId = acceptWithoutSigs.changeSerialId,
-      negotiationFieldsTLV = NoNegotiationFields.toTLV
+      negotiationFieldsTLV = NoNegotiationFields.toTLV,
+      contractId = contractId
     )
   }
 
@@ -167,7 +169,7 @@ object DLCAcceptUtil extends Logging {
       dlcAcceptDbs <- dlcWalletDAOs.dlcAcceptDAO.findByDLCId(dlcId)
       dlcAcceptFOpt = {
         dlcAcceptDbs.headOption.map { case dlcAcceptDb =>
-          logger.debug(
+          logger.info(
             s"DLC Accept (${dlcId.hex}) has already been made, returning accept")
           for {
             fundingInputs <-


### PR DESCRIPTION
fixes #4772

because utxos may correspond to cancelled offers, using `dlcId` as the stable identifier for accept messages doesn't work. We need to use `(dlcId, contractId)` since the contractId contains guaranteed unique information (via sha256)