### PR TITLE
Add support for mac m1 lnd rpc

### DIFF
--- a/lnd-rpc/lnd-rpc.sbt
+++ b/lnd-rpc/lnd-rpc.sbt
@@ -43,6 +43,8 @@ TaskKeys.downloadLnd := {
 
   val (platform, suffix) =
     if (Properties.isLinux) ("linux-amd64", "tar.gz")
+    else if (Properties.isMac && System.getProperty("os.arch") == "aarch64")
+      ("darwin-arm64", "tar.gz")
     else if (Properties.isMac) ("darwin-amd64", "tar.gz")
     else if (Properties.isWin) ("windows-amd64", "zip")
     else sys.error(s"Unsupported OS: ${Properties.osName}")
@@ -73,6 +75,8 @@ TaskKeys.downloadLnd := {
     val expectedHash =
       if (Properties.isLinux)
         "60511b4717a82c303e164f7d1048fd52f965c5fcb7aefaa11678be48e81a9dcc"
+      else if (Properties.isMac && System.getProperty("os.arch") == "aarch64")
+        "c1e1452dd2f4cf6bca248cc6b63d2f1b8f64b82ae0f81dcf669575bc4b359f84"
       else if (Properties.isMac)
         "eacf6e8f19de942fb23f481c85541342d3248bd545616822a172da3d23c03c9d"
       else if (Properties.isWin)

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -4,6 +4,7 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.grpc.{GrpcClientSettings, SSLContextUtils}
 import akka.stream.scaladsl.{Sink, Source}
+import chainrpc._
 import com.google.protobuf.ByteString
 import grizzled.slf4j.Logging
 import invoicesrpc.LookupInvoiceMsg.InvoiceRef
@@ -12,7 +13,6 @@ import io.grpc.{CallCredentials, Metadata}
 import lnrpc.ChannelPoint.FundingTxid.FundingTxidBytes
 import lnrpc.CloseStatusUpdate.Update.{ChanClose, ClosePending}
 import lnrpc._
-import chainrpc._
 import org.bitcoins.commons.jsonmodels.lnd._
 import org.bitcoins.commons.util.NativeProcessFactory
 import org.bitcoins.core.currency._
@@ -33,7 +33,7 @@ import org.bitcoins.core.protocol.transaction.{
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.util.StartStopAsync
 import org.bitcoins.core.wallet.fee.{SatoshisPerKW, SatoshisPerVirtualByte}
-import org.bitcoins.crypto.{HashType, _}
+import org.bitcoins.crypto._
 import org.bitcoins.lnd.rpc.LndRpcClient._
 import org.bitcoins.lnd.rpc.LndUtils._
 import org.bitcoins.lnd.rpc.config._
@@ -58,7 +58,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 /** @param binaryOpt Path to lnd executable
   */

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -1011,11 +1011,11 @@ class LndRpcClient(val instance: LndInstance, binaryOpt: Option[File] = None)(
       val state = Await.result(getStateF, 5.seconds)
 
       state.state match {
-        case WalletState.RPC_ACTIVE | WalletState.SERVER_ACTIVE =>
+        case WalletState.SERVER_ACTIVE =>
           p.trySuccess(true)
         case _: WalletState.Unrecognized | WalletState.WAITING_TO_START |
             WalletState.UNLOCKED | WalletState.LOCKED |
-            WalletState.NON_EXISTING =>
+            WalletState.NON_EXISTING | WalletState.RPC_ACTIVE =>
           p.trySuccess(false)
       }
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestClient.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestClient.scala
@@ -57,9 +57,6 @@ case class LndRpcTestClient(
             lnd <- lndRpcClientF
 
             _ <- lnd.start()
-            // Sleep to make sure lnd is ready for RPC requests
-            _ <- TestAsyncUtil.nonBlockingSleep(1.second)
-
             // Wait for it to be ready
             _ <- TestAsyncUtil.awaitConditionF(() => lnd.isStarted,
                                                interval = 500.milliseconds,

--- a/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestClient.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/lnd/LndRpcTestClient.scala
@@ -131,6 +131,8 @@ object LndRpcTestClient extends SbtBinaryFactory {
 
     val platform =
       if (Properties.isLinux) "linux-amd64"
+      else if (Properties.isMac && System.getProperty("os.arch") == "aarch64")
+        "darwin-arm64"
       else if (Properties.isMac) "darwin-amd64"
       else if (Properties.isWin) "windows-amd64"
       else sys.error(s"Unsupported OS: ${Properties.osName}")


### PR DESCRIPTION
Fixes #3878
Previously we were downloading the wrong lnd for m1 macs. I don't have an m1 mac so if someone could test that it previously didn't work (`sbt lndRpcTest/test`) but now does, that would be greatly appreciated 