### PR TITLE
Set db auth in slick db config

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -19,6 +19,12 @@ abstract class DbAppConfig extends AppConfig {
     Future.successful(slickDbConfig.db.close())
   }
 
+  lazy val dbUsername: String =
+    config.getString(s"bitcoin-s.$moduleName.db.user")
+
+  lazy val dbPassword: String =
+    config.getString(s"bitcoin-s.$moduleName.db.password")
+
   lazy val driver: DatabaseDriver = {
     val driverStr =
       getConfigString(s"bitcoin-s.$moduleName.db.driver").toLowerCase
@@ -98,6 +104,8 @@ abstract class DbAppConfig extends AppConfig {
          |     db {
          |        path = ${AppConfig.safePathToString(dbPath)}
          |        name = $dbName
+         |        user = "$dbUsername"
+         |        password = "$dbPassword"
          |        url = $jdbcUrl
          |     }
          |  }

--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -49,7 +49,7 @@ trait DbManagement extends Logging {
     // Remove "s needed for config
     val url = appConfig.jdbcUrl.replace("\"", "")
     config
-      .dataSource(url, dbUsername, dbPassword)
+      .dataSource(url, appConfig.dbUsername, appConfig.dbPassword)
       .load
   }
 

--- a/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
@@ -20,10 +20,6 @@ trait JdbcProfileComponent[+ConfigType <: DbAppConfig] extends Logging {
   lazy val profile: JdbcProfile = dbConfig.profile
   import profile.api._
 
-  lazy val dbUsername: String = dbConfig.config.getString("db.user")
-
-  lazy val dbPassword: String = dbConfig.config.getString("db.password")
-
   lazy val numThreads: Int = dbConfig.config.getInt("db.numThreads")
 
   /** The database we are connecting to */


### PR DESCRIPTION
This lets us set the db credentials from a source (aws secrets) other than the actual config by overriding `dbUsername` and `dbPassword`.