### PR TITLE
Remove event descriptor parameter from `SigningVersion.calcOutcomeHash()`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/dlcoracle/OracleEvent.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlcoracle/OracleEvent.scala
@@ -282,7 +282,7 @@ object OracleEvent {
           enum.outcomes.exists { outcome =>
             val attestationType = EnumAttestation(outcome)
             val hash =
-              signingVersion.calcOutcomeHash(enum, attestationType.bytes)
+              signingVersion.calcOutcomeHash(attestationType.bytes)
             announcement.publicKey.verify(hash,
                                           sig) && outcome == tlvOutcomes.head
           }
@@ -299,7 +299,7 @@ object OracleEvent {
 
                 val validSign = signOutcomes.exists { attestationType =>
                   val hash =
-                    signingVersion.calcOutcomeHash(dd, attestationType.bytes)
+                    signingVersion.calcOutcomeHash(attestationType.bytes)
                   announcement.publicKey.verify(
                     hash,
                     attestations.head) && tlvOutcomes.head.toString == attestationType.outcomeString
@@ -319,7 +319,7 @@ object OracleEvent {
               case (sig, outcome) =>
                 digitOutcomes.exists { attestationType =>
                   val hash =
-                    signingVersion.calcOutcomeHash(dd, attestationType.bytes)
+                    signingVersion.calcOutcomeHash(attestationType.bytes)
                   announcement.publicKey.verify(
                     hash,
                     sig) && attestationType.outcomeString == outcome.toString

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/SigningVersion.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/SigningVersion.scala
@@ -13,15 +13,11 @@ sealed abstract class SigningVersion {
   def calcAnnouncementHash(eventTLV: OracleEventTLV): ByteVector
 
   /** Calculates the bytes to sign for an event outcome */
-  def calcOutcomeHash(
-      descriptor: EventDescriptorTLV,
-      bytes: ByteVector): ByteVector
+  def calcOutcomeHash(bytes: ByteVector): ByteVector
 
   /** Calculates the bytes to sign for an event outcome */
-  final def calcOutcomeHash(
-      descriptor: EventDescriptorTLV,
-      string: String): ByteVector = {
-    calcOutcomeHash(descriptor, CryptoUtil.serializeForHash(string))
+  final def calcOutcomeHash(string: String): ByteVector = {
+    calcOutcomeHash(CryptoUtil.serializeForHash(string))
   }
 }
 
@@ -41,9 +37,7 @@ object SigningVersion extends StringFactory[SigningVersion] {
     override def calcAnnouncementHash(eventTLV: OracleEventTLV): ByteVector =
       CryptoUtil.taggedSha256(eventTLV.bytes, "DLCv0/Announcement").bytes
 
-    override def calcOutcomeHash(
-        descriptor: EventDescriptorTLV,
-        byteVector: ByteVector): ByteVector =
+    override def calcOutcomeHash(byteVector: ByteVector): ByteVector =
       CryptoUtil.taggedSha256(byteVector, "DLCv0/Outcome").bytes
   }
 
@@ -61,14 +55,8 @@ object SigningVersion extends StringFactory[SigningVersion] {
     override def calcAnnouncementHash(eventTLV: OracleEventTLV): ByteVector =
       CryptoUtil.sha256(eventTLV.bytes).bytes
 
-    override def calcOutcomeHash(
-        descriptor: EventDescriptorTLV,
-        byteVector: ByteVector): ByteVector = {
-      descriptor match {
-        case _: EnumEventDescriptorV0TLV |
-            _: DigitDecompositionEventDescriptorV0TLV =>
-          CryptoUtil.sha256(byteVector).bytes
-      }
+    override def calcOutcomeHash(byteVector: ByteVector): ByteVector = {
+      CryptoUtil.sha256(byteVector).bytes
     }
   }
 
@@ -86,14 +74,8 @@ object SigningVersion extends StringFactory[SigningVersion] {
     override def calcAnnouncementHash(eventTLV: OracleEventTLV): ByteVector =
       CryptoUtil.sha256DLCAnnouncement(eventTLV.bytes).bytes
 
-    override def calcOutcomeHash(
-        descriptor: EventDescriptorTLV,
-        byteVector: ByteVector): ByteVector = {
-      descriptor match {
-        case _: EnumEventDescriptorV0TLV |
-            _: DigitDecompositionEventDescriptorV0TLV =>
-          CryptoUtil.sha256DLCAttestation(byteVector).bytes
-      }
+    override def calcOutcomeHash(byteVector: ByteVector): ByteVector = {
+      CryptoUtil.sha256DLCAttestation(byteVector).bytes
     }
   }
 

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -289,8 +289,7 @@ class DLCOracleTest extends DLCOracleFixture {
           assert(completedEvent.attestation == sig.sig)
           assert(completedEvent.outcomes == Vector(EnumAttestation(outcome)))
 
-          val descriptor = completedEvent.eventDescriptorTLV
-          val hash = SigningVersion.latest.calcOutcomeHash(descriptor, outcome)
+          val hash = SigningVersion.latest.calcOutcomeHash(outcome)
 
           assert(dlcOracle.publicKey.verify(hash, sig))
           assert(
@@ -334,10 +333,8 @@ class DLCOracleTest extends DLCOracleFixture {
                                      DigitDecompositionAttestation(1))
           assert(completedEvent.outcomes == signOutcome +: digitOutcomes)
 
-          val descriptor = completedEvent.eventDescriptorTLV
-
           // Sign Signature Check
-          val signHash = SigningVersion.latest.calcOutcomeHash(descriptor, "-")
+          val signHash = SigningVersion.latest.calcOutcomeHash("-")
           val signSig = completedEvent.signatures.head
           assert(dlcOracle.publicKey.verify(signHash, signSig))
           assert(
@@ -348,7 +345,6 @@ class DLCOracleTest extends DLCOracleFixture {
           // 100s Place signature Check
           val hash100 =
             SigningVersion.latest.calcOutcomeHash(
-              descriptor,
               DigitDecompositionAttestation(3).bytes)
           val sig100 = completedEvent.signatures(1)
           assert(dlcOracle.publicKey.verify(hash100, sig100))
@@ -359,7 +355,6 @@ class DLCOracleTest extends DLCOracleFixture {
           // 10s Place signature Check
           val hash10 =
             SigningVersion.latest.calcOutcomeHash(
-              descriptor,
               DigitDecompositionAttestation(2).bytes)
           val sig10 = completedEvent.signatures(2)
           assert(dlcOracle.publicKey.verify(hash10, sig10))
@@ -370,7 +365,6 @@ class DLCOracleTest extends DLCOracleFixture {
           // 1s Place signature Check
           val hash1 =
             SigningVersion.latest.calcOutcomeHash(
-              descriptor,
               DigitDecompositionAttestation(1).bytes)
           val sig1 = completedEvent.signatures(3)
           assert(dlcOracle.publicKey.verify(hash1, sig1))
@@ -412,11 +406,9 @@ class DLCOracleTest extends DLCOracleFixture {
                                        DigitDecompositionAttestation(11))
             assert(completedEvent.outcomes == signOutcome +: digitOutcomes)
 
-            val descriptor = completedEvent.eventDescriptorTLV
-
             // Sign Signature Check
             val signHash =
-              SigningVersion.latest.calcOutcomeHash(descriptor, "-")
+              SigningVersion.latest.calcOutcomeHash("-")
             val signSig = completedEvent.signatures.head
             assert(dlcOracle.publicKey.verify(signHash, signSig))
             assert(
@@ -427,7 +419,6 @@ class DLCOracleTest extends DLCOracleFixture {
             // 100s Place signature Check
             val hash100 =
               SigningVersion.latest.calcOutcomeHash(
-                descriptor,
                 DigitDecompositionAttestation(7).bytes)
             val sig100 = completedEvent.signatures(1)
             assert(dlcOracle.publicKey.verify(hash100, sig100))
@@ -438,7 +429,6 @@ class DLCOracleTest extends DLCOracleFixture {
             // 10s Place signature Check
             val hash10 =
               SigningVersion.latest.calcOutcomeHash(
-                descriptor,
                 DigitDecompositionAttestation(8).bytes)
             val sig10 = completedEvent.signatures(2)
             assert(dlcOracle.publicKey.verify(hash10, sig10))
@@ -449,7 +439,6 @@ class DLCOracleTest extends DLCOracleFixture {
             // 1s Place signature Check
             val hash1 =
               SigningVersion.latest.calcOutcomeHash(
-                descriptor,
                 DigitDecompositionAttestation(11).bytes)
             val sig1 = completedEvent.signatures(3)
             assert(dlcOracle.publicKey.verify(hash1, sig1))
@@ -490,12 +479,9 @@ class DLCOracleTest extends DLCOracleFixture {
                                        DigitDecompositionAttestation(0))
             assert(completedEvent.outcomes == digitOutcomes)
 
-            val descriptor = completedEvent.eventDescriptorTLV
-
             // 100s Place signature Check
             val hash100 =
               SigningVersion.latest.calcOutcomeHash(
-                descriptor,
                 DigitDecompositionAttestation(0).bytes)
             val sig100 = completedEvent.signatures.head
             assert(dlcOracle.publicKey.verify(hash100, sig100))
@@ -507,7 +493,6 @@ class DLCOracleTest extends DLCOracleFixture {
             // 10s Place signature Check
             val hash10 =
               SigningVersion.latest.calcOutcomeHash(
-                descriptor,
                 DigitDecompositionAttestation(1).bytes)
             val sig10 = completedEvent.signatures(1)
             assert(dlcOracle.publicKey.verify(hash10, sig10))
@@ -518,7 +503,6 @@ class DLCOracleTest extends DLCOracleFixture {
             // 1s Place signature Check
             val hash1 =
               SigningVersion.latest.calcOutcomeHash(
-                descriptor,
                 DigitDecompositionAttestation(0).bytes)
             val sig1 = completedEvent.signatures(2)
             assert(dlcOracle.publicKey.verify(hash1, sig1))

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/DLCOracle.scala
@@ -334,8 +334,8 @@ case class DLCOracle()(implicit val conf: DLCOracleAppConfig)
               s"No event saved with nonce ${nonce.hex} $outcome"))
       }
 
-      hash = eventDb.signingVersion.calcOutcomeHash(eventDb.eventDescriptorTLV,
-                                                    outcome.outcomeString)
+      hash = eventDb.signingVersion
+        .calcOutcomeHash(outcome.outcomeString)
       eventOutcomeOpt <- eventOutcomeDAO.find(nonce, hash)
       eventOutcomeDb <- eventOutcomeOpt match {
         case Some(value) => Future.successful(value)

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/util/EventDbUtil.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/util/EventDbUtil.scala
@@ -22,14 +22,14 @@ trait EventDbUtil {
         enum.outcomes.map { outcome =>
           val attestationType = EnumAttestation(outcome)
           val hash =
-            signingVersion.calcOutcomeHash(enum, attestationType.bytes)
+            signingVersion.calcOutcomeHash(attestationType.bytes)
           EventOutcomeDb(nonce, outcome, hash)
         }
       case decomp: DigitDecompositionEventDescriptorV0TLV =>
         val signDbs = decomp match {
           case _: SignedDigitDecompositionEventDescriptor =>
-            val plusHash = signingVersion.calcOutcomeHash(decomp, "+")
-            val minusHash = signingVersion.calcOutcomeHash(decomp, "-")
+            val plusHash = signingVersion.calcOutcomeHash("+")
+            val minusHash = signingVersion.calcOutcomeHash("-")
             Vector(EventOutcomeDb(nonces.head, "+", plusHash),
                    EventOutcomeDb(nonces.head, "-", minusHash))
           case _: UnsignedDigitDecompositionEventDescriptor =>
@@ -47,7 +47,7 @@ trait EventDbUtil {
           0.until(decomp.base.toInt).map { num =>
             val attestationType = DigitDecompositionAttestation(num)
             val hash =
-              signingVersion.calcOutcomeHash(decomp, attestationType.bytes)
+              signingVersion.calcOutcomeHash(attestationType.bytes)
             EventOutcomeDb(nonce, num.toString, hash)
           }
         }


### PR DESCRIPTION
This is uncessary and simplifies some things on #4790