### PR TITLE
2022 09 29 handle unordered sigs

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -936,7 +936,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     val dummyOracleAttestment =
       OracleAttestmentV0TLV("eventId",
                             dummyPubKey.schnorrPublicKey,
-                            OrderedSchnorrSignatures(dummyOracleSig),
+                            OrderedSchnorrSignatures(dummyOracleSig).toVector,
                             Vector("outcome"))
 
     lazy val winStr: String = "WIN"

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCAdaptorPointComputer.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCAdaptorPointComputer.scala
@@ -7,6 +7,7 @@ import org.bitcoins.core.protocol.dlc.models.{
 }
 import org.bitcoins.core.protocol.tlv.{
   EnumOutcome,
+  OracleEventV0TLV,
   SignedNumericOutcome,
   UnsignedNumericOutcome
 }
@@ -137,7 +138,10 @@ object DLCAdaptorPointComputer {
       contractInfo.oracleInfo.singleOracleInfos.map { info =>
         val announcement = info.announcement
         val pubKey = announcement.publicKey
-        val nonces = announcement.eventTLV.nonces.toVector.map(_.publicKey)
+        val nonces = announcement.eventTLV match {
+          case v0: OracleEventV0TLV =>
+            v0.nonces.map(_.publicKey)
+        }
 
         nonces.map { nonce =>
           possibleOutcomes.map { outcome =>

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
@@ -138,8 +138,7 @@ object DLCExecutor {
   ): ExecutedDLCOutcome = {
     require(
       DLCUtil.checkOracleSignaturesAgainstContract(contractInfo, oracleSigs),
-      s"Incorrect oracle signatures and contract combination, got=${oracleSigs} contractInfo.announcement=${contractInfo.oracleInfos
-        .map(_.singleOracleInfos.map(_.announcement.eventTLV.nonces))}"
+      s"Incorrect oracle signatures and contract combination, got=${oracleSigs}"
     )
     val sigOracles = oracleSigs.map(_.oracle)
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/OracleInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/OracleInfo.scala
@@ -69,7 +69,12 @@ sealed trait SingleOracleInfo
   def publicKey: SchnorrPublicKey = announcement.publicKey
 
   /** The oracle's pre-committed nonces, in the correct order */
-  def nonces: OrderedNonces = announcement.eventTLV.nonces
+  def nonces: OrderedNonces = {
+    announcement.eventTLV match {
+      case v0: OracleEventV0TLV =>
+        OrderedNonces(v0.nonces)
+    }
+  }
 
   /** The order of the given sigs should correspond to the given outcome. */
   def verifySigs(outcome: DLCOutcomeType, sigs: OracleSignatures): Boolean
@@ -125,7 +130,12 @@ case class EnumSingleOracleInfo(announcement: OracleAnnouncementTLV)
             .isInstanceOf[EnumEventDescriptorV0TLV],
           s"Enum OracleInfo requires EnumEventDescriptor, $announcement")
 
-  val nonce: SchnorrNonce = announcement.eventTLV.nonces.head
+  val nonce: SchnorrNonce = {
+    announcement.eventTLV match {
+      case v0: OracleEventV0TLV =>
+        v0.nonces.head
+    }
+  }
 
   /** @inheritdoc */
   override def verifySigs(

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/AttestationVerificationTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/AttestationVerificationTest.scala
@@ -132,4 +132,35 @@ class AttestationVerificationTest extends BitcoinSUnitTest {
                                       invalidSignedDigitDecompAttestation1,
                                       signingVersion))
   }
+
+  it must "validate announcement/attesation with out of order nonces" in {
+    val annHex =
+      "fdd824fd01661aabd9bbcae0207aff9510f05099295f32ff72290cf5c494d3869f582f8c4a6cf1b7d832562047f68ce607eb39" +
+        "dcd7ec8ce64432dc51a8853dc5a3acd96a8bc5545aa0024da81c3fec63e56e07ee141cbefbd2c6e7d4dede124fe856ea453a85fdd822fd010" +
+        "000070652285e89487dc8ce816a81234082394d9602263d35a7322b77299082257767b559c622def4bba15a2ad7fc336edd71ace9b4c366b9" +
+        "eaba22b73df00589e74b7ca5b6c7301ef7dc62aeae1823018107868d8956677421e11ffd8f125f2fedf4a527003355640ee9333cda6c37a92" +
+        "d4989c6ab96eddc9266f0ddce0e2a3ffb77aa9eefa1fe40eddd0fa63f501e9b368eed6ab0cc0d2e5e6da1baa570ed9e857134bbc8a15dd594" +
+        "9eb1203b1d15ae701fe4b04707a1ea54c10fef16308bf806f2aa0b17f8673fe785f6b9ff0718e55b621c8e9d92839759a98b88bd6590a0ff8" +
+        "56011fe80fdd80a0f00020105756e697473000000000006067369676e6564"
+
+    val annV0 = OracleAnnouncementV0TLV.fromHex(annHex)
+    val attestationHex =
+      "fdd868fd01f7067369676e6564545aa0024da81c3fec63e56e07ee141cbefbd2c6e7d4dede124fe856ea453a8500" +
+        "070652285e89487dc8ce816a81234082394d9602263d35a7322b772990822577670ab288b31d99f56d18d4f34be875c0a4d73aae135c4f503" +
+        "49a1014b686d69841b559c622def4bba15a2ad7fc336edd71ace9b4c366b9eaba22b73df00589e74ba7b82eef2041bf6af1511016cadabe9d" +
+        "52e64d875caf5bfef85903dbc4fc00737ca5b6c7301ef7dc62aeae1823018107868d8956677421e11ffd8f125f2fedf469f40edbb7846274f" +
+        "46a973f5442ece91b5a6e450a8cdcef272058a27176dabba527003355640ee9333cda6c37a92d4989c6ab96eddc9266f0ddce0e2a3ffb7762" +
+        "f10e09f79273ab04d1549c1d60054738fe903575aa732760bd2668530459e9aa9eefa1fe40eddd0fa63f501e9b368eed6ab0cc0d2e5e6da1b" +
+        "aa570ed9e857188bae5c59c9ac89bec3fa00c8e1b725789e1af15f7b256ae7f169edfe7f3ef8834bbc8a15dd5949eb1203b1d15ae701fe4b0" +
+        "4707a1ea54c10fef16308bf806f2144d3e7aa63705924da607162f59bff757490469c2c8d4e62a1aa0bf27323bcdaa0b17f8673fe785f6b9f" +
+        "f0718e55b621c8e9d92839759a98b88bd6590a0ff85e072b65d258bbfdc653444b08714c2be395b7e645caa214567b22916ffb7ebeb012d01" +
+        "3001310130013101300130"
+    val attestationV0 = OracleAttestmentV0TLV.fromHex(attestationHex)
+
+    val result = OracleEvent.verifyAttestations(annV0,
+                                                attestationV0,
+                                                SigningVersion.latest)
+
+    assert(result)
+  }
 }

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/AttestationVerificationTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/AttestationVerificationTest.scala
@@ -25,8 +25,7 @@ class AttestationVerificationTest extends BitcoinSUnitTest {
 
   val invalidEnumAttestation: OracleAttestmentV0TLV = {
     val unsorted = validEnumAttestation.sigs.map(_.copy(sig = FieldElement.one))
-    validEnumAttestation.copy(sigs =
-      OrderedSchnorrSignatures.fromUnsorted(unsorted.toVector))
+    validEnumAttestation.copy(unsortedSignatures = unsorted.toVector)
   }
 
   val unsignedDigitDecompAnnouncement: OracleAnnouncementV0TLV =
@@ -42,7 +41,8 @@ class AttestationVerificationTest extends BitcoinSUnitTest {
     val unsorted = validUnsignedDigitDecompAttestation.sigs.map(
       _.copy(sig = FieldElement.one))
     val sorted = OrderedSchnorrSignatures.fromUnsorted(unsorted.toVector)
-    validUnsignedDigitDecompAttestation.copy(sigs = sorted)
+    validUnsignedDigitDecompAttestation.copy(unsortedSignatures =
+      sorted.toVector)
   }
 
   // this one was generated with a different public key
@@ -62,7 +62,7 @@ class AttestationVerificationTest extends BitcoinSUnitTest {
     val unsorted =
       validSignedDigitDecompAttestation.sigs.map(_.copy(sig = FieldElement.one))
     val sorted = OrderedSchnorrSignatures.fromUnsorted(unsorted.toVector)
-    validSignedDigitDecompAttestation.copy(sigs = sorted)
+    validSignedDigitDecompAttestation.copy(unsortedSignatures = sorted.toVector)
   }
 
   val invalidSignedDigitDecompAttestation1: OracleAttestmentV0TLV =

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/util/EventDbUtil.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/util/EventDbUtil.scala
@@ -2,9 +2,9 @@ package org.bitcoins.dlc.oracle.util
 
 import org.bitcoins.core.api.dlcoracle._
 import org.bitcoins.core.api.dlcoracle.db._
-import org.bitcoins.core.protocol.dlc.compute.SigningVersion
 import org.bitcoins.core.protocol.tlv._
-import org.bitcoins.core.util.sorted.OrderedNonces
+import org.bitcoins.crypto.SchnorrNonce
+import org.bitcoins.core.protocol.dlc.compute.SigningVersion
 
 trait EventDbUtil {
 
@@ -13,7 +13,9 @@ trait EventDbUtil {
     */
   def toEventOutcomeDbs(
       descriptor: EventDescriptorTLV,
-      nonces: OrderedNonces,
+      nonces: Vector[
+        SchnorrNonce
+      ], //ugh, can we enforce some sort of invariant here? can i make this method private?
       signingVersion: SigningVersion): Vector[EventOutcomeDb] = {
     descriptor match {
       case enum: EnumEventDescriptorV0TLV =>
@@ -59,9 +61,12 @@ trait EventDbUtil {
       oracleAnnouncementV0TLV: OracleAnnouncementV0TLV,
       signingVersion: SigningVersion = SigningVersion.latest): Vector[
     EventOutcomeDb] = {
+    val oracleEventV0 = oracleAnnouncementV0TLV.eventTLV match {
+      case v0: OracleEventV0TLV => v0
+    }
     toEventOutcomeDbs(descriptor =
                         oracleAnnouncementV0TLV.eventTLV.eventDescriptor,
-                      nonces = oracleAnnouncementV0TLV.eventTLV.nonces,
+                      nonces = oracleEventV0.nonces,
                       signingVersion = signingVersion)
   }
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCExecutionTest.scala
@@ -16,7 +16,6 @@ import org.bitcoins.core.protocol.dlc.models.{
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.util.PreviousOutputMap
-import org.bitcoins.core.util.sorted.OrderedSchnorrSignatures
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.testkit.wallet.DLCWalletUtil._
 import org.bitcoins.testkit.wallet.{BitcoinSDualWalletTest, DLCWalletUtil}
@@ -458,11 +457,12 @@ class DLCExecutionTest extends BitcoinSDualWalletTest {
         //of invariants in OracleAttestmentV0TLV
         badSigs = goodAttestment.sigs.dropRight(1)
         badOutcomes = goodAttestment.outcomes.dropRight(1)
-        badAttestment = OracleAttestmentV0TLV(
-          eventId = goodAttestment.eventId,
-          publicKey = goodAttestment.publicKey,
-          sigs = OrderedSchnorrSignatures.fromUnsorted(badSigs.toVector),
-          outcomes = badOutcomes)
+        badAttestment = OracleAttestmentV0TLV(eventId = goodAttestment.eventId,
+                                              publicKey =
+                                                goodAttestment.publicKey,
+                                              unsortedSignatures =
+                                                badSigs.toVector,
+                                              outcomes = badOutcomes)
         func = (wallet: DLCWallet) =>
           wallet.executeDLC(contractId, badAttestment).map(_.get)
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleEnumExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleEnumExecutionTest.scala
@@ -80,7 +80,7 @@ class DLCMultiOracleEnumExecutionTest extends BitcoinSDualWalletTest {
       val initiatorWinSig = priv.schnorrSignWithNonce(hash, kValue)
       OracleAttestmentV0TLV(eventId,
                             priv.schnorrPublicKey,
-                            OrderedSchnorrSignatures(initiatorWinSig),
+                            OrderedSchnorrSignatures(initiatorWinSig).toVector,
                             Vector(initiatorWinStr))
     }
 
@@ -101,7 +101,7 @@ class DLCMultiOracleEnumExecutionTest extends BitcoinSDualWalletTest {
       val recipientWinSig = priv.schnorrSignWithNonce(hash, kValue)
       OracleAttestmentV0TLV(eventId,
                             priv.schnorrPublicKey,
-                            OrderedSchnorrSignatures(recipientWinSig),
+                            OrderedSchnorrSignatures(recipientWinSig).toVector,
                             Vector(recipientWinStr))
     }
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
@@ -243,10 +243,11 @@ class DLCMultiOracleExactNumericExecutionTest extends BitcoinSDualWalletTest {
 
         require(kValues.length == sigs.length,
                 s"kValues.length=${kValues.length} sigs.length=${sigs.length}")
-        OracleAttestmentV0TLV(eventId,
-                              priv.schnorrPublicKey,
-                              OrderedSchnorrSignatures.fromUnsorted(sigs),
-                              digitsPadded.map(_.toString))
+        OracleAttestmentV0TLV(
+          eventId,
+          priv.schnorrPublicKey,
+          OrderedSchnorrSignatures.fromUnsorted(sigs).toVector,
+          digitsPadded.map(_.toString))
       }
     }
   }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
@@ -253,10 +253,11 @@ class DLCMultiOracleNumericExecutionTest
 
         require(kValues.length == sigs.length,
                 s"kValues.length=${kValues.length} sigs.length=${sigs.length}")
-        OracleAttestmentV0TLV(eventId,
-                              priv.schnorrPublicKey,
-                              OrderedSchnorrSignatures.fromUnsorted(sigs),
-                              digitsPadded.map(_.toString))
+        OracleAttestmentV0TLV(
+          eventId,
+          priv.schnorrPublicKey,
+          OrderedSchnorrSignatures.fromUnsorted(sigs).toVector,
+          digitsPadded.map(_.toString))
       }
     }
   }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCNumericExecutionTest.scala
@@ -79,11 +79,11 @@ class DLCNumericExecutionTest extends BitcoinSDualWalletTest {
 
     (OracleAttestmentV0TLV(eventId,
                            publicKey,
-                           OrderedSchnorrSignatures(initiatorWinSigs),
+                           OrderedSchnorrSignatures(initiatorWinSigs).toVector,
                            initiatorWinVec.map(_.toString)),
      OracleAttestmentV0TLV(eventId,
                            publicKey,
-                           OrderedSchnorrSignatures(recipientWinSigs),
+                           OrderedSchnorrSignatures(recipientWinSigs).toVector,
                            recipientWinVec.map(_.toString)))
   }
 
@@ -182,7 +182,8 @@ class DLCNumericExecutionTest extends BitcoinSDualWalletTest {
         badAttestment = OracleAttestmentV0TLV(eventId = goodAttestment.eventId,
                                               publicKey =
                                                 goodAttestment.publicKey,
-                                              sigs = badSigs,
+                                              unsortedSignatures =
+                                                badSigs.toVector,
                                               outcomes = badOutcomes)
         func = (wallet: DLCWallet) =>
           wallet.executeDLC(contractId, badAttestment).map(_.get)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
@@ -12,7 +12,7 @@ import org.bitcoins.core.protocol.dlc.sign.DLCTxSigner
 import org.bitcoins.core.protocol.dlc.verify.DLCSignatureVerifier
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.tlv._
-import org.bitcoins.core.util.sorted.{OrderedAnnouncements, OrderedNonces}
+import org.bitcoins.core.util.sorted.{OrderedAnnouncements}
 import org.bitcoins.core.wallet.utxo._
 import org.bitcoins.crypto.Sha256Digest
 import org.bitcoins.db.SafeDatabase
@@ -111,7 +111,7 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
             if (used) {
               val nonces = nonceDbs.sortBy(_.index).map(_.nonce)
               val eventTLV =
-                OracleEventV0TLV(OrderedNonces.fromUnsorted(nonces),
+                OracleEventV0TLV(nonces,
                                  data.eventMaturity,
                                  data.eventDescriptor,
                                  data.eventId)
@@ -152,7 +152,7 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
         announcementData.find(_.id.contains(id)) match {
           case Some(data) =>
             val nonces = nonceDbs.sortBy(_.index).map(_.nonce)
-            val eventTLV = OracleEventV0TLV(OrderedNonces.fromUnsorted(nonces),
+            val eventTLV = OracleEventV0TLV(nonces,
                                             data.eventMaturity,
                                             data.eventDescriptor,
                                             data.eventId)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleNonceDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleNonceDb.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.dlc.wallet.models
 
-import org.bitcoins.core.protocol.tlv.OracleAnnouncementTLV
+import org.bitcoins.core.protocol.tlv.{OracleAnnouncementTLV, OracleEventV0TLV}
 import org.bitcoins.crypto._
 
 case class OracleNonceDb(
@@ -17,8 +17,16 @@ object OracleNonceDbHelper {
   def fromAnnouncement(
       id: Long,
       tlv: OracleAnnouncementTLV): Vector[OracleNonceDb] = {
-    tlv.eventTLV.nonces.toVector.zipWithIndex.map { case (nonce, index) =>
-      OracleNonceDb(id, index, SchnorrDigitalSignature.dummy, nonce, None, None)
+    tlv.eventTLV match {
+      case v0: OracleEventV0TLV =>
+        v0.nonces.zipWithIndex.map { case (nonce, index) =>
+          OracleNonceDb(id,
+                        index,
+                        SchnorrDigitalSignature.dummy,
+                        nonce,
+                        None,
+                        None)
+        }
     }
   }
 

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
@@ -134,7 +134,7 @@ trait TLVGen {
         Gen
           .listOfN(desc.noncesNeeded, CryptoGenerators.schnorrNonce)
           .map(_.toVector)
-    } yield OracleEventV0TLV(OrderedNonces.fromUnsorted(nonces),
+    } yield OracleEventV0TLV(OrderedNonces.fromUnsorted(nonces).toVector,
                              maturity,
                              desc,
                              uri)
@@ -162,7 +162,7 @@ trait TLVGen {
         Gen
           .listOfN(numSigs, StringGenerators.genUTF8String)
           .map(_.toVector)
-    } yield OracleAttestmentV0TLV(eventId, pubkey, sigs, outcomes)
+    } yield OracleAttestmentV0TLV(eventId, pubkey, sigs.toVector, outcomes)
   }
 
   def contractDescriptorV0TLVWithTotalCollateral: Gen[

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -21,7 +21,7 @@ import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.util.PreviousOutputMap
-import org.bitcoins.core.util.sorted.{OrderedNonces, OrderedSchnorrSignatures}
+import org.bitcoins.core.util.sorted.OrderedNonces
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto._
 import org.bitcoins.dlc.wallet.DLCWallet
@@ -514,11 +514,11 @@ object DLCWalletUtil extends Logging {
 
     (OracleAttestmentV0TLV(eventId,
                            publicKey,
-                           OrderedSchnorrSignatures(initiatorWinSig),
+                           Vector(initiatorWinSig),
                            Vector(initiatorWinStr)),
      OracleAttestmentV0TLV(eventId,
                            publicKey,
-                           OrderedSchnorrSignatures(recipientWinSig),
+                           Vector(recipientWinSig),
                            Vector(recipientWinStr)))
   }
 


### PR DESCRIPTION
In #4803 we added the requirement that nonces/signatures are ordered by their nonce.

Unfortunately, prior announcements have been published with unordered nonces/attestations. We need to have the ability to correctly parse and verify announcements/attestations with out of order nonces. This PR adds support for that.

Now we will publish _new_ announcmeents with ordered nonces, but we can still use old `v0` announcements with out of order nonces.