### PR TITLE
re-order RPC command order to have commands first that do not depend on tor

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -506,12 +506,15 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
     val commonRoutes = CommonRoutes(conf.baseDatadir)
 
     val handlers =
-      Seq(walletRoutesF,
-          nodeRoutesF,
-          Future.successful(chainRoutes),
-          Future.successful(coreRoutes),
-          dlcRoutesF,
-          Future.successful(commonRoutes))
+      Seq(
+        Future.successful(commonRoutes),
+        Future.successful(coreRoutes),
+        Future.successful(chainRoutes),
+        //dependent on tor, slow start up
+        walletRoutesF,
+        nodeRoutesF,
+        dlcRoutesF
+      )
 
     val rpcBindConfOpt = serverCmdLineArgs.rpcBindOpt match {
       case Some(rpcbind) => Some(rpcbind)


### PR DESCRIPTION
This means we will not block RPC requests that are not dependent on tor before tor is started.