### PR TITLE
Use `ByteVector.compare` rather than rolling our own

### DIFF
--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoOrdering.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoOrdering.scala
@@ -2,8 +2,6 @@ package org.bitcoins.crypto
 
 import scodec.bits.ByteVector
 
-import scala.annotation.tailrec
-
 object CryptoOrdering {
 
   val nonceOrdering: Ordering[SchnorrNonce] = {
@@ -17,19 +15,8 @@ object CryptoOrdering {
   val byteVectorOrdering: Ordering[ByteVector] =
     new Ordering[ByteVector] {
 
-      @tailrec
       override def compare(x: ByteVector, y: ByteVector): Int = {
-        if (x == y) {
-          0
-        } else if (x.isEmpty) {
-          -1
-        } else if (y.isEmpty) {
-          1
-        } else if (x.head != y.head) {
-          x.head.compare(y.head)
-        } else {
-          compare(x.tail, y.tail)
-        }
+        x.compare(y)
       }
     }
 }


### PR DESCRIPTION
The old implementation doesn't work for anything past the first byte.