### PR TITLE
2022 10 05 Delete legacy `DLCSerializationVersion.Alpha` DLCs for a cleaner upgrade to v0 spec

### DIFF
--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCDAOTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCDAOTest.scala
@@ -5,6 +5,7 @@ import org.bitcoins.core.api.wallet.db.TransactionDbHelper
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.{UInt32, UInt64}
 import org.bitcoins.core.protocol.script.EmptyScriptPubKey
+import org.bitcoins.core.protocol.tlv.DLCSerializationVersion
 import org.bitcoins.core.protocol.transaction.{
   TransactionConstants,
   TransactionOutPoint,
@@ -259,6 +260,18 @@ class DLCDAOTest extends BitcoinSWalletTest with DLCDAOFixture {
       assert(created.peerOpt.isEmpty)
       assert(updated.get.peerOpt == Some("127.0.0.1:1"))
       assert(deleted.get.peerOpt.isEmpty)
+    }
+  }
+
+  it must "read an alpha version of a DLC from the database" in { daos =>
+    val alphaDLCDb =
+      dlcDb.copy(serializationVersion = DLCSerializationVersion.Alpha)
+    for {
+      _ <- daos.dlcDAO.create(alphaDLCDb)
+      foundOpt <- daos.dlcDAO.findByDLCSerializationVersion(
+        DLCSerializationVersion.Alpha)
+    } yield {
+      assert(foundOpt.nonEmpty)
     }
   }
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -4,23 +4,20 @@ import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import org.bitcoins.commons.config.{AppConfigFactoryBase, ConfigOps}
 import org.bitcoins.core.api.chain.ChainQueryApi
-import org.bitcoins.core.api.dlc.wallet.db.DLCDb
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
-import org.bitcoins.core.protocol.dlc.compute.DLCUtil
+import org.bitcoins.core.protocol.dlc.models.DLCState
+import org.bitcoins.core.protocol.dlc.models.DLCState.{
+  AdaptorSigComputationState,
+  ClosedState
+}
 import org.bitcoins.core.protocol.tlv.DLCSerializationVersion
 import org.bitcoins.core.util.Mutable
 import org.bitcoins.db.DatabaseDriver._
 import org.bitcoins.db._
 import org.bitcoins.dlc.wallet.internal.DLCDataManagement
-import org.bitcoins.dlc.wallet.models.{
-  DLCSetupDbState,
-  OfferedDbState,
-  SetupCompleteDLCDbState
-}
 import org.bitcoins.keymanager.config.KeyManagerAppConfig
 import org.bitcoins.wallet.config.WalletAppConfig
-import org.bitcoins.wallet.models.TransactionDAO
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 
 import java.nio.file._
@@ -63,10 +60,10 @@ case class DLCAppConfig(
       migrate()
     }
 
-    val f = if (initMigrations != 0 && initMigrations <= 5) {
+    val f = if (initMigrations != 0 && initMigrations <= 8) {
       //means we have an old wallet that we need to migrate
-      logger.info(s"Running serialization version migration code")
-      serializationVersionMigration()
+      logger.info(s"Deleting alpha version DLCs")
+      deleteAlphaVersionDLCs()
     } else {
       //the wallet is new enough where we cannot have any old
       //DLCs in the database with a broken contractId
@@ -127,84 +124,26 @@ case class DLCAppConfig(
     callbacks.atomicUpdate(newCallbacks)(_ + _)
   }
 
-  /** Correctly populates the serialization version for existing DLCs
-    * in our wallet database
-    */
-  private def serializationVersionMigration(): Future[Unit] = {
+  /** Delete alpha version DLCs, these are old protocol format DLCs that cannot be safely updated to the new protocol version of DLCs */
+  private def deleteAlphaVersionDLCs(): Future[Unit] = {
     val dlcManagement = DLCDataManagement.fromDbAppConfig()(this, ec)
     val dlcDAO = dlcManagement.dlcDAO
-    //read all existing DLCs
-    val allDlcsF = dlcDAO.findAll()
-
-    //ugh, this is kinda nasty, idk how to make better though
-    val walletAppConfig =
-      WalletAppConfig(baseDatadir, configOverrides)
-    val txDAO: TransactionDAO =
-      TransactionDAO()(ec = ec, appConfig = walletAppConfig)
-    //get the offers so we can figure out what the serialization version is
-    val dlcDbContractInfoOfferF: Future[Vector[DLCSetupDbState]] = {
-      for {
-        allDlcs <- allDlcsF
-        //only DLC with the alpha version need to be migrated
-        alphaVersionDLCs = allDlcs.filter(
-          _.serializationVersion == DLCSerializationVersion.Alpha)
-        nestedOfferAndAccept = alphaVersionDLCs.map { a =>
-          val setupDbOptF =
-            dlcManagement.getDLCFundingData(a.dlcId, txDAO = txDAO)
-
-          setupDbOptF.foreach {
-            case Some(_) => //happy path, do nothing
-            case None =>
-              logger.warn(s"Corrupted dlcId=${a.dlcId.hex} state=${a.state}, " +
-                s"this is likely because of issue 4001 https://github.com/bitcoin-s/bitcoin-s/issues/4001 . " +
-                s"This DLC will not have its contractId migrated to DLSerializationVersion.Beta")
-          }
-          setupDbOptF
+    val alphaDLCsF =
+      dlcDAO.findByDLCSerializationVersion(DLCSerializationVersion.Alpha)
+    for {
+      alphaDLCs <- alphaDLCsF
+      _ <- Future.traverse(alphaDLCs) { dlc =>
+        dlc.state match {
+          case _: ClosedState | DLCState.Offered | DLCState.Accepted |
+              _: AdaptorSigComputationState | DLCState.Signed =>
+            logger.info(s"Deleting alpha version of a dlc=$dlc")
+            dlcManagement.deleteByDLCId(dlc.dlcId)
+          case DLCState.Broadcasted | DLCState.Confirmed =>
+            sys.error(
+              s"Cannot upgrade our DLC wallet as we have DLCs in progress using an ancient format of DLCs, dlcId=${dlc.dlcId.hex}")
         }
-        offerAndAccepts <- Future.sequence(nestedOfferAndAccept)
-      } yield {
-        offerAndAccepts.flatten
       }
-    }
-
-    //now we need to insert the serialization type
-    //into global_dlc_data
-    val updatedDLCDbsF = for {
-      dlcDbContractInfoOffer <- dlcDbContractInfoOfferF
-    } yield setSerializationVersions(dlcDbContractInfoOffer)
-
-    val updatedInDbF = updatedDLCDbsF.flatMap(dlcDAO.updateAll)
-
-    updatedInDbF.map(_ => ())
-  }
-
-  /** Sets serialization versions on [[DLCDb]] based on the corresponding [[ContractInfo]] */
-  private def setSerializationVersions(
-      vec: Vector[DLCSetupDbState]): Vector[DLCDb] = {
-    vec.map { case state: DLCSetupDbState =>
-      val updatedDlcDb: DLCDb = state match {
-        case acceptDbState: SetupCompleteDLCDbState =>
-          val offer = acceptDbState.offer
-          val acceptWithoutSigs = acceptDbState.acceptWithoutSigs
-          val dlcDb = acceptDbState.dlcDb
-          val contractId = DLCUtil.calcContractId(offer, acceptWithoutSigs)
-          logger.info(
-            s"Updating contractId for dlcId=${dlcDb.dlcId.hex} old contractId=${dlcDb.contractIdOpt
-              .map(_.toHex)} new contractId=${contractId.toHex}")
-          dlcDb.copy(tempContractId = offer.tempContractId,
-                     contractIdOpt = Some(contractId),
-                     serializationVersion = DLCSerializationVersion.Beta)
-        case offerDbState: OfferedDbState =>
-          //if we don't have an accept message, we can only calculate tempContractId
-          val dlcDb = offerDbState.dlcDb
-          val offer = offerDbState.offer
-          logger.info(
-            s"Updating tempContractId for dlcId=${dlcDb.dlcId.hex} old tempContractId=${dlcDb.tempContractId.hex} new contractId=${offer.tempContractId.hex}")
-          dlcDb.copy(tempContractId = offer.tempContractId,
-                     serializationVersion = DLCSerializationVersion.Beta)
-      }
-      updatedDlcDb
-    }
+    } yield ()
   }
 }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
@@ -775,6 +775,11 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
     safeDatabase.run(action)
   }
 
+  def deleteByDLCId(dlcId: Sha256Digest): Future[Unit] = {
+    val action = actionBuilder.deleteDLCAction(dlcId)
+    safeDatabase.run(action)
+  }
+
   /** Retrieves the transaction(s) used to fund the offer message */
   private def getOfferPrevTxs(
       dlcDb: DLCDb,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCDAO.scala
@@ -173,7 +173,12 @@ case class DLCDAO()(implicit
     safeDatabase.run(action).map(_ => ())
   }
 
-  private def updatePeerAction(dlcId: Sha256Digest, peerOpt: Option[String]) = {
+  private def updatePeerAction(
+      dlcId: Sha256Digest,
+      peerOpt: Option[String]): DBIOAction[
+    Int,
+    NoStream,
+    Effect.Read with Effect.Write] = {
     val dlcQuery = table.filter(_.dlcId === dlcId)
 
     for {
@@ -184,6 +189,14 @@ case class DLCDAO()(implicit
           dlcQuery.update(dlc.copy(peerOpt = peerOpt))
       }
     } yield res
+  }
+
+  def findByDLCSerializationVersion(
+      version: DLCSerializationVersion): Future[Vector[DLCDb]] = {
+    val action = table.filter(_.serializationVersion === version).result
+    safeDatabase
+      .run(action)
+      .map(_.toVector)
   }
 
   class DLCTable(tag: Tag)


### PR DESCRIPTION
This PR deletes `DLCSerializationVersion.Alpha` DLCs in the wallet. This serialization version was introduced in #3854 and was needed to fix a bug we had in our initial implementation of DLCs. See https://github.com/discreetlogcontracts/dlcspecs/pull/144 for more information about fixes to serialization.

The reason why its necessary to get rid of these is because of ambiguity between the legacy format DLCs and the v0 format in https://github.com/discreetlogcontracts/dlcspecs/pull/163 and https://github.com/discreetlogcontracts/dlcspecs/pull/167 . If we remove these old format DLCs, we can cleanly upgrade from `DLCSerializationVersion.Beta` -> `DLCSerializationVersion.Gamma`. 

In my personal wallets, I have 3 DLCs in my wallet with alpha version. I think its very unlikely that many deployed wallets have `Alpha` DLCs. If the user has an ongoing `Alpha` version `DLC` (`DLCState.Confirmed` or `DLCState.Broadcasted`) we throw an exception on wallet startup and don't delete the ongoing DLC. If they DLC is in any other state, we delete it.

 