### PR TITLE
2022 10 14 v19 testkit refactor

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/FilterSyncTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/sync/FilterSyncTest.scala
@@ -6,18 +6,18 @@ import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.testkit.chain.SyncUtil
 import org.bitcoins.testkit.chain.fixture.{
-  BitcoindV19ChainHandler,
-  ChainWithBitcoindV19CachedUnitTest
+  BitcoindBlockFilterRpcChainHandler,
+  ChainWithBitcoindBlockFilterRpcCachedUnitTest
 }
 
 import scala.concurrent.Future
 
-class FilterSyncTest extends ChainWithBitcoindV19CachedUnitTest {
+class FilterSyncTest extends ChainWithBitcoindBlockFilterRpcCachedUnitTest {
 
   behavior of "FilterSync"
 
   it must "sync 1 filter header from an external data source" in { fixture =>
-    val BitcoindV19ChainHandler(bitcoind, chainHandler) = fixture
+    val BitcoindBlockFilterRpcChainHandler(bitcoind, chainHandler) = fixture
 
     val initFilterCountF = chainHandler.getFilterCount()
     val initFilterHeaderCountF = chainHandler.getFilterHeaderCount()
@@ -56,7 +56,7 @@ class FilterSyncTest extends ChainWithBitcoindV19CachedUnitTest {
 
   it must "sync a bunch of filter headers from an external data source" in {
     fixture =>
-      val BitcoindV19ChainHandler(bitcoind, _) = fixture
+      val BitcoindBlockFilterRpcChainHandler(bitcoind, _) = fixture
 
       val numBlocks = 100
       val generatedBlocksF = for {
@@ -79,7 +79,7 @@ class FilterSyncTest extends ChainWithBitcoindV19CachedUnitTest {
 
   it must "be able to call filterSync() and not fail when nothing has happened" in {
     fixture =>
-      val BitcoindV19ChainHandler(bitcoind, _) = fixture
+      val BitcoindBlockFilterRpcChainHandler(bitcoind, _) = fixture
 
       val generated1BlockF = for {
         addr <- bitcoind.getNewAddress
@@ -105,9 +105,10 @@ class FilterSyncTest extends ChainWithBitcoindV19CachedUnitTest {
   }
 
   private def syncHelper(
-      bitcoindV19ChainHandler: BitcoindV19ChainHandler): Future[ChainApi] = {
+      bitcoindV19ChainHandler: BitcoindBlockFilterRpcChainHandler): Future[
+    ChainApi] = {
     val filterType = FilterType.Basic
-    val BitcoindV19ChainHandler(bitcoind, chainHandler) =
+    val BitcoindBlockFilterRpcChainHandler(bitcoind, chainHandler) =
       bitcoindV19ChainHandler
     val getBestBlockHashFunc = SyncUtil.getBestBlockHashFunc(bitcoind)
     val getBlockHeaderFunc = SyncUtil.getBlockHeaderFunc(bitcoind)

--- a/docs/chain/filter-sync.md
+++ b/docs/chain/filter-sync.md
@@ -30,7 +30,7 @@ import org.bitcoins.chain.blockchain.sync._
 
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.chain._
-import org.bitcoins.testkit.chain.fixture.BitcoindV19ChainHandler
+import org.bitcoins.testkit.chain.fixture.BitcoindBlockFilterRpcChainHandler
 
 ```
 
@@ -57,7 +57,7 @@ implicit val chainAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig().chai
 
 //let's use a helper method to get a v19 bitcoind
 //instance and a chainApi
-val bitcoindWithChainApiF: Future[BitcoindV19ChainHandler] = {
+val bitcoindWithChainApiF: Future[BitcoindBlockFilterRpcChainHandler] = {
   ChainUnitTest.createBitcoindV19ChainHandler()
 }
 val bitcoindF = bitcoindWithChainApiF.map(_.bitcoindRpc)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoUnsupportedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoUnsupportedPeerTest.scala
@@ -3,14 +3,15 @@ package org.bitcoins.node
 import com.typesafe.config.ConfigFactory
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
-import org.bitcoins.testkit.node.NodeTestWithCachedBitcoindV19
+import org.bitcoins.testkit.node.{NodeTestWithCachedBitcoindNoP2pBlockFilters}
 import org.bitcoins.testkit.node.fixture.NeutrinoNodeConnectedWithBitcoind
 import org.bitcoins.testkit.util.TorUtil
 import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
 
-class NeutrinoUnsupportedPeerTest extends NodeTestWithCachedBitcoindV19 {
+class NeutrinoUnsupportedPeerTest
+    extends NodeTestWithCachedBitcoindNoP2pBlockFilters {
 
   override protected def getFreshConfig: BitcoinSAppConfig = {
     val config = ConfigFactory.parseString(

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
@@ -18,11 +18,11 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.rpc.client.v19.V19BlockFilterRpc
 import org.bitcoins.testkit.chain.fixture.{
   BitcoindBaseVersionChainHandlerViaRpc,
-  BitcoindChainHandlerViaRpc,
-  BitcoindV19ChainHandler
+  BitcoindBlockFilterRpcChainHandler,
+  BitcoindChainHandlerViaRpc
 }
 import org.bitcoins.wallet.Wallet
 import org.bitcoins.wallet.sync.WalletSync
@@ -47,7 +47,7 @@ abstract class SyncUtil extends Logging {
 
   /** Creates a function that you can pass a block header to and it's return's it's [[GolombFilter]] */
   def getFilterFunc(
-      bitcoind: BitcoindV19RpcClient,
+      bitcoind: V19BlockFilterRpc,
       filterType: FilterType)(implicit
       ec: ExecutionContext): BlockHeader => Future[FilterWithHeaderHash] = {
     case header: BlockHeader =>
@@ -220,9 +220,10 @@ abstract class SyncUtil extends Logging {
     * since we know a bitcoind v19 node has block filter capability
     */
   def syncBitcoindV19WithChainHandler(
-      bitcoindWithChainHandler: BitcoindV19ChainHandler)(implicit
+      bitcoindWithChainHandler: BitcoindBlockFilterRpcChainHandler)(implicit
       ec: ExecutionContext,
-      chainAppConfig: ChainAppConfig): Future[BitcoindV19ChainHandler] = {
+      chainAppConfig: ChainAppConfig): Future[
+    BitcoindBlockFilterRpcChainHandler] = {
     val bitcoindV19 = bitcoindWithChainHandler.bitcoindRpc
     val chainApiF = syncBitcoindWithChainHandler(bitcoindWithChainHandler)
       .map(_.chainHandler)
@@ -240,7 +241,7 @@ abstract class SyncUtil extends Logging {
         bestBlockHash == ourBestFilter.get.blockHashBE,
         s"We did not sync filter's in our fixture bitcoindBestBlockHash=$bestBlockHash our best filter's blockHash=${ourBestFilter.get.blockHashBE}"
       )
-    } yield BitcoindV19ChainHandler(
+    } yield BitcoindBlockFilterRpcChainHandler(
       bitcoindRpc = bitcoindWithChainHandler.bitcoindRpc,
       chainHandler = filterSyncChainApi.asInstanceOf[ChainHandler])
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/BitcoindChainHandlerViaRpc.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/BitcoindChainHandlerViaRpc.scala
@@ -2,7 +2,7 @@ package org.bitcoins.testkit.chain.fixture
 
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.rpc.client.v19.{V19BlockFilterRpc}
 
 sealed trait BitcoindChainHandlerViaRpc {
   def bitcoindRpc: BitcoindRpcClient
@@ -18,7 +18,7 @@ case class BitcoindBaseVersionChainHandlerViaRpc(
     chainHandler: ChainHandler)
     extends BitcoindChainHandlerViaRpc
 
-case class BitcoindV19ChainHandler(
-    override val bitcoindRpc: BitcoindV19RpcClient,
+case class BitcoindBlockFilterRpcChainHandler(
+    override val bitcoindRpc: BitcoindRpcClient with V19BlockFilterRpc,
     chainHandler: ChainHandler)
     extends BitcoindChainHandlerViaRpc

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.testkit.chain.fixture
 
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
-import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.rpc.client.v19.V19BlockFilterRpc
 import org.bitcoins.testkit.chain.{ChainDbUnitTest, ChainUnitTest}
 import org.bitcoins.testkit.rpc.{
   CachedBitcoind,
-  CachedBitcoindNewest,
-  CachedBitcoindV19
+  CachedBitcoindBlockFilterRpcNewest,
+  CachedBitcoindNewest
 }
 import org.scalatest.{FutureOutcome, Outcome}
 
@@ -53,37 +53,38 @@ trait ChainWithBitcoindNewestCachedUnitTest
 }
 
 /** Chain Unit test suite that has a cached bitcoind v19 instance */
-trait ChainWithBitcoindV19CachedUnitTest
+trait ChainWithBitcoindBlockFilterRpcCachedUnitTest
     extends ChainWithBitcoindUnitTest
-    with CachedBitcoindV19 {
+    with CachedBitcoindBlockFilterRpcNewest {
 
-  override type FixtureParam = BitcoindV19ChainHandler
+  override type FixtureParam = BitcoindBlockFilterRpcChainHandler
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val f: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
-      futOutcome = withBitcoindV19ChainHandlerViaRpc(test, bitcoind)
+      futOutcome = withBitcoindBlockFilterRpcChainHandlerViaRpc(test, bitcoind)
       fut <- futOutcome.toFuture
     } yield fut
     new FutureOutcome(f)
   }
 
-  def withBitcoindV19ChainHandlerViaRpc(
+  def withBitcoindBlockFilterRpcChainHandlerViaRpc(
       test: OneArgAsyncTest,
-      bitcoindV19RpcClient: BitcoindV19RpcClient): FutureOutcome = {
-    val builder: () => Future[BitcoindV19ChainHandler] = { () =>
-      ChainUnitTest.createBitcoindV19ChainHandler(bitcoindV19RpcClient)
+      bitcoindRpcClient: BitcoindRpcClient
+        with V19BlockFilterRpc): FutureOutcome = {
+    val builder: () => Future[BitcoindBlockFilterRpcChainHandler] = { () =>
+      ChainUnitTest.createBitcoindBlockFilterRpcChainHandler(bitcoindRpcClient)
     }
 
-    val destroy: BitcoindV19ChainHandler => Future[Unit] = {
-      case _: BitcoindV19ChainHandler =>
+    val destroy: BitcoindBlockFilterRpcChainHandler => Future[Unit] = {
+      case _: BitcoindBlockFilterRpcChainHandler =>
         ChainUnitTest.destroyChainApi()
     }
     makeDependentFixture(builder, destroy)(test)
   }
 
   override def afterAll(): Unit = {
-    super[CachedBitcoindV19].afterAll()
+    super[CachedBitcoindBlockFilterRpcNewest].afterAll()
     super[ChainWithBitcoindUnitTest].afterAll()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -106,11 +106,17 @@ object BitcoinSFixture {
     } yield bitcoind.asInstanceOf[BitcoindRpcClient with V19BlockFilterRpc]
   }
 
-  /** Creates a new bitcoind instance */
-  def createBitcoind(versionOpt: Option[BitcoindVersion] = None)(implicit
+  /** Creates a new bitcoind instance
+    * @param versionOpt the version of bitcoind ot use
+    * @param enableNeutrinoOpt whether neutrino should be enabled or not, if param not given it is default enabled
+    */
+  def createBitcoind(
+      versionOpt: Option[BitcoindVersion] = None,
+      enableNeutrino: Boolean = true)(implicit
       system: ActorSystem): Future[BitcoindRpcClient] = {
     import system.dispatcher
-    val instance = BitcoindRpcTestUtil.instance(versionOpt = versionOpt)
+    val instance = BitcoindRpcTestUtil.instance(versionOpt = versionOpt,
+                                                enableNeutrino = enableNeutrino)
     val bitcoind = versionOpt match {
       case Some(v) => BitcoindRpcClient.fromVersion(v, instance)
       case None    => new BitcoindRpcClient(instance)

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -2,6 +2,7 @@ package org.bitcoins.testkit.fixtures
 
 import akka.actor.ActorSystem
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
+import org.bitcoins.rpc.client.v19.V19BlockFilterRpc
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkit.util.BitcoinSAsyncFixtureTest
 import org.scalatest._
@@ -91,6 +92,18 @@ object BitcoinSFixture {
       address <- bitcoind.getNewAddress
       _ <- bitcoind.generateToAddress(blocks = 101, address)
     } yield bitcoind
+  }
+
+  def createBitcoindBlockFilterRpcWithFunds(
+      versionOpt: Option[BitcoindVersion] = None)(implicit
+      system: ActorSystem): Future[BitcoindRpcClient with V19BlockFilterRpc] = {
+    import system.dispatcher
+    for {
+      bitcoind <- createBitcoindWithFunds(versionOpt)
+      _ = require(
+        bitcoind.isInstanceOf[V19BlockFilterRpc],
+        s"Given version does not support block filter rpc, got=$versionOpt")
+    } yield bitcoind.asInstanceOf[BitcoindRpcClient with V19BlockFilterRpc]
   }
 
   /** Creates a new bitcoind instance */

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -14,6 +14,7 @@ import org.bitcoins.testkit.node.fixture.{
 import org.bitcoins.testkit.rpc.{
   CachedBitcoind,
   CachedBitcoindNewest,
+  CachedBitcoindNewestNoP2pBlockFilters,
   CachedBitcoindPairNewest,
   CachedBitcoindV19
 }
@@ -230,6 +231,16 @@ trait NodeTestWithCachedBitcoindV19
 
   override def afterAll(): Unit = {
     super[CachedBitcoindV19].afterAll()
+    super[NodeTestWithCachedBitcoind].afterAll()
+  }
+}
+
+trait NodeTestWithCachedBitcoindNoP2pBlockFilters
+    extends NodeTestWithCachedBitcoind
+    with CachedBitcoindNewestNoP2pBlockFilters {
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindNewestNoP2pBlockFilters].afterAll()
     super[NodeTestWithCachedBitcoind].afterAll()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -208,16 +208,26 @@ trait BitcoindRpcTestUtil extends Logging {
       zmqConfig: ZmqConfig = RpcUtil.zmqConfig,
       pruneMode: Boolean = false,
       versionOpt: Option[BitcoindVersion] = None,
-      binaryDirectory: Path = BitcoindRpcTestClient.sbtBinaryDirectory)(implicit
+      binaryDirectory: Path = BitcoindRpcTestClient.sbtBinaryDirectory,
+      enableNeutrino: Boolean = true)(implicit
       system: ActorSystem): BitcoindInstanceLocal = {
     val uri = new URI("http://localhost:" + port)
     val rpcUri = new URI("http://localhost:" + rpcPort)
-    val hasNeutrinoSupport = versionOpt match {
-      case Some(V17) | Some(V18) =>
+    val hasNeutrinoSupport = {
+      if (enableNeutrino == false) {
+        logger.warn(s"Neutrino is disabled")
+        //don't enable neutrino, this is useful for certain test cases
+        //like NeutrinoUnsupportedPeerTest
         false
-      case Some(V19) | Some(V20) | Some(V21) | Some(V22) | Some(V23) | Some(
-            Unknown) | None =>
-        true
+      } else {
+        versionOpt match {
+          case Some(V17) | Some(V18) =>
+            false
+          case Some(V19) | Some(V20) | Some(V21) | Some(V22) | Some(V23) | Some(
+                Unknown) | None =>
+            true
+        }
+      }
     }
     val configFile =
       writtenConfig(uri,

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -3,7 +3,7 @@ package org.bitcoins.testkit.rpc
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.client.v17.BitcoindV17RpcClient
 import org.bitcoins.rpc.client.v18.BitcoindV18RpcClient
-import org.bitcoins.rpc.client.v19.BitcoindV19RpcClient
+import org.bitcoins.rpc.client.v19.{BitcoindV19RpcClient, V19BlockFilterRpc}
 import org.bitcoins.rpc.client.v20.BitcoindV20RpcClient
 import org.bitcoins.rpc.client.v21.BitcoindV21RpcClient
 import org.bitcoins.rpc.client.v22.BitcoindV22RpcClient
@@ -108,6 +108,18 @@ trait CachedBitcoindNewest extends CachedBitcoindFunded[BitcoindRpcClient] {
     val _ = isBitcoindUsed.set(true)
     BitcoinSFixture
       .createBitcoindWithFunds(Some(BitcoindVersion.newest))
+  }
+}
+
+trait CachedBitcoindBlockFilterRpcNewest
+    extends CachedBitcoindFunded[BitcoindRpcClient with V19BlockFilterRpc] {
+  _: BitcoinSAkkaAsyncTest =>
+
+  override protected lazy val cachedBitcoindWithFundsF: Future[
+    BitcoindRpcClient with V19BlockFilterRpc] = {
+    val _ = isBitcoindUsed.set(true)
+    BitcoinSFixture
+      .createBitcoindBlockFilterRpcWithFunds(Some(BitcoindVersion.newest))
   }
 }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/CachedBitcoind.scala
@@ -111,6 +111,17 @@ trait CachedBitcoindNewest extends CachedBitcoindFunded[BitcoindRpcClient] {
   }
 }
 
+trait CachedBitcoindNewestNoP2pBlockFilters extends CachedBitcoindNewest {
+  _: BitcoinSAkkaAsyncTest =>
+
+  override protected lazy val cachedBitcoindWithFundsF: Future[
+    BitcoindRpcClient] = {
+    val _ = isBitcoindUsed.set(true)
+    BitcoinSFixture
+      .createBitcoind(Some(BitcoindVersion.newest), enableNeutrino = false)
+  }
+}
+
 trait CachedBitcoindBlockFilterRpcNewest
     extends CachedBitcoindFunded[BitcoindRpcClient with V19BlockFilterRpc] {
   _: BitcoinSAkkaAsyncTest =>


### PR DESCRIPTION
As part of #4587 this tries to move `nodeTest` test cases away from `v19` bitcoind. The reason lots of these test cases were on v19 is because that is when block filters were introduced into bitcoind.