### PR TITLE
Adjust period of time we query for peers on the p2p network

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -48,6 +48,8 @@ bitcoin-s {
     #   password = ""
     # }
 
+    # time interval for trying next set of peers in peer discovery
+    try-peers-interval = 1 hour
   }
 
   # You can configure SOCKS5 proxy to use Tor for outgoing connections

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -169,7 +169,7 @@ bitcoin-s {
         # initialization timeout once connected, reconnections resets this
         initialization-timeout = 10s
         # time interval for trying next set of peers in peer discovery
-        try-peers-interval = 12s
+        try-peers-interval = 1 hour
         
         # wait time for queries like getheaders etc before switching to another
         query-wait-time = 120s

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -186,7 +186,7 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     if (config.hasPath("bitcoin-s.node.try-peers-interval")) {
       val duration = config.getDuration("bitcoin-s.node.try-peers-interval")
       TimeUtil.durationToFiniteDuration(duration)
-    } else 12.seconds
+    } else 1.hour
   }
 
   /** timeout to wait for response the messages extend [[org.bitcoins.core.p2p.ExpectsResponse]] */


### PR DESCRIPTION
Addresses part of #4826

This bumps the `try-peers-interval` from `12 seconds` -> `1 hour`. 

This way we aren't _constantly_ querying the p2p network if you have 

```
bitcoin-s.node.enable-peer-discovery = true
```

in your `bitcoin-s.conf`

