### PR TITLE
Rework `tor` exceptions to be more useful

### DIFF
--- a/tor/src/main/scala/org/bitcoins/tor/TorConnectionError.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/TorConnectionError.scala
@@ -1,0 +1,86 @@
+package org.bitcoins.tor
+
+sealed trait TorConnectionError {
+  def prefix: Byte
+
+  def exn: RuntimeException = new RuntimeException(toString)
+}
+
+object TorConnectionError {
+
+  val connectErrors: Map[Byte, String] = Map[Byte, String](
+    (0x00, "Request granted"),
+    (0x01, "General failure"),
+    (0x02, "Connection not allowed by ruleset"),
+    (0x03, "Network unreachable"),
+    (0x04, "Host unreachable"),
+    (0x05, "Connection refused by destination host"),
+    (0x06, "TTL expired"),
+    (0x07, "Command not supported / protocol error"),
+    (0x08, "Address type not supported")
+  )
+
+  private val all: Vector[TorConnectionError] = Vector(
+    RequestGranted,
+    GeneralFailure,
+    ConnectionNotAllowed,
+    NetworkUnreachable,
+    HostUnreachable,
+    ConnectionRefusedByDestination,
+    TTLExpired,
+    CommandNotSupportedOrProtocolError,
+    AddressTypeNotSupported
+  )
+
+  def fromByte(byte: Byte): TorConnectionError = {
+    fromByteOpt(byte) match {
+      case Some(err) => err
+      case None =>
+        sys.error(s"Could not find tor connection error by prefix=$byte")
+    }
+  }
+
+  def fromByteOpt(byte: Byte): Option[TorConnectionError] = {
+    all.find(_.prefix == byte)
+  }
+
+  case object RequestGranted extends TorConnectionError {
+    override val prefix: Byte = 0.toByte
+  }
+
+  case object GeneralFailure extends TorConnectionError {
+    override val prefix: Byte = 1.toByte
+
+    override def toString: String =
+      s"General failure, this likely means tor timed out when trying to connect. Try using telnet to reproduce error."
+  }
+
+  case object ConnectionNotAllowed extends TorConnectionError {
+    override val prefix: Byte = 0x02.toByte
+    override val toString: String = "Connection not allowed by ruleset"
+  }
+
+  case object NetworkUnreachable extends TorConnectionError {
+    override val prefix: Byte = 0x03.toByte
+  }
+
+  case object HostUnreachable extends TorConnectionError {
+    override val prefix: Byte = 0x04.toByte
+  }
+
+  case object ConnectionRefusedByDestination extends TorConnectionError {
+    override val prefix: Byte = 0x05.toByte
+  }
+
+  case object TTLExpired extends TorConnectionError {
+    override val prefix: Byte = 0x06.toByte
+  }
+
+  case object CommandNotSupportedOrProtocolError extends TorConnectionError {
+    override val prefix: Byte = 0x07.toByte
+  }
+
+  case object AddressTypeNotSupported extends TorConnectionError {
+    override val prefix: Byte = 0x08.toByte
+  }
+}


### PR DESCRIPTION
fixes #4825 

In our previous implementation of a socks5 client for tor we throw extremely unhelpful error messages. These error messages could be thrown for a variety of reasons (connection timeout, connection refused, peer offline etc). 

This is extremely unhelpful when querying peers over the p2p network as documented in #4825 as we have no clue what the state of the peers are in the p2p network. We end up with our logs getting spammed with exception stack traces that look like this 

```
2022-10-13 15:35:34,432UTC ERROR [OneForOneStrategy] General failure
org.bitcoins.tor.Socks5Connection$Socks5Error: General failure
	at org.bitcoins.tor.Socks5Connection$.parseConnectedAddress(Socks5Connection.scala:213)
	at org.bitcoins.tor.Socks5Connection$$anonfun$connectionRequest$1.applyOrElse(Socks5Connection.scala:65)
	at akka.actor.Actor.aroundReceive(Actor.scala:537)
	at akka.actor.Actor.aroundReceive$(Actor.scala:535)
	at org.bitcoins.tor.Socks5Connection.aroundReceive(Socks5Connection.scala:19)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)
	at akka.actor.ActorCell.invoke(ActorCell.scala:547)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1311)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1840)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
2022-10-13 15:35:35,888UTC ERROR [OneForOneStrategy] General failure
org.bitcoins.tor.Socks5Connection$Socks5Error: General failure
	at org.bitcoins.tor.Socks5Connection$.parseConnectedAddress(Socks5Connection.scala:213)
	at org.bitcoins.tor.Socks5Connection$$anonfun$connectionRequest$1.applyOrElse(Socks5Connection.scala:65)
	at akka.actor.Actor.aroundReceive(Actor.scala:537)
	at akka.actor.Actor.aroundReceive$(Actor.scala:535)
	at org.bitcoins.tor.Socks5Connection.aroundReceive(Socks5Connection.scala:19)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)
	at akka.actor.ActorCell.invoke(ActorCell.scala:547)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1311)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1840)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
2022-10-13 15:35:36,899UTC ERROR [OneForOneStrategy] General failure
org.bitcoins.tor.Socks5Connection$Socks5Error: General failure
	at org.bitcoins.tor.Socks5Connection$.parseConnectedAddress(Socks5Connection.scala:213)
	at org.bitcoins.tor.Socks5Connection$$anonfun$connectionRequest$1.applyOrElse(Socks5Connection.scala:65)
	at akka.actor.Actor.aroundReceive(Actor.scala:537)
	at akka.actor.Actor.aroundReceive$(Actor.scala:535)
	at org.bitcoins.tor.Socks5Connection.aroundReceive(Socks5Connection.scala:19)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)
	at akka.actor.ActorCell.invoke(ActorCell.scala:547)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1311)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1840)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```


Now with this PR, when we query peers over the p2p network, the errors will look like this

```
2022-10-22 15:01:18,608UTC ERROR [Socks5Connection] Tor connection request failed to Socks5Connect(103.139.171.114/<unresolved>:18333) errMsg=java.lang.RuntimeException: ConnectionRefusedByDestination
2022-10-22 15:01:19,241UTC ERROR [Socks5Connection] Tor connection request failed to Socks5Connect(68.183.179.219/<unresolved>:18333) errMsg=java.lang.RuntimeException: ConnectionRefusedByDestination
```