### PR TITLE
Enable peer discovery by default

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -48,6 +48,9 @@ bitcoin-s {
     #   password = ""
     # }
 
+    # enable peer discovery on the p2p network by default
+    enable-peer-discovery = true
+
     # time interval for trying next set of peers in peer discovery
     try-peers-interval = 1 hour
   }

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -158,7 +158,7 @@ bitcoin-s {
         use-default-peers = true
         
         # try to connect to peers from dns seeds, database, addr messages etc
-        enable-peer-discovery = false
+        enable-peer-discovery = true
         
         # number of persistent peer connections to maintain for node use
         maxConnectedPeers = 1


### PR DESCRIPTION
This PR switches `bitcoin-s.node.enable-peer-discovery=true` by default in our configuration. This configuration option was added in #4408 

This will mean if `bitcoin-s.node.mode=neutrino` is set, we will query for peers on the p2p network and store them in `nodedb.sqlite`. After our nodes store a diverse set of peers, we can eventually bump to `bitcoin-s.node.maxConnectedPeers` and not have our nodes connect to suredbits run nodes by default. 

This PR will query for peers on the p2p network every 1 hour. The logs will look something like this

```
2022-10-25 15:11:08,262UTC INFO [PeerFinder] Querying p2p network for peers...
2022-10-25 15:11:09,443UTC INFO [Socks5Connection] Tor connection request succeeded. target=Socks5Connect(193.178.170.232/<unresolved>:8333) connectedAddress=/0.0.0.0:0
2022-10-25 15:11:09,446UTC INFO [P2PClientActor] We've been disconnected by Peer(193.178.170.232:8333) command=PeerClosed state=Initializing
2022-10-25 15:11:11,601UTC INFO [Socks5Connection] Tor connection request succeeded. target=Socks5Connect(38.141.134.140/<unresolved>:8333) connectedAddress=/0.0.0.0:0
2022-10-25 15:11:11,735UTC INFO [Socks5Connection] Tor connection request succeeded. target=Socks5Connect(84.75.28.247/<unresolved>:8333) connectedAddress=/0.0.0.0:0
```

```
sqlite3 ~/.bitcoin-s/mainnet/nodedb.sqlite
-- Loading resources from /Users/chris/.sqliterc
SQLite version 3.37.0 2021-12-09 01:34:53
Enter ".help" for usage hints.
sqlite> select COUNT(*) from peers ;
COUNT(*)
9
sqlite> .quit
```