### PR TITLE
Upgrade sbt ci release to 1.5.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import com.typesafe.sbt.SbtGit.GitKeys._
 import sbt.Keys.{publish, publishLocal}
 
 import scala.util.Properties
@@ -306,7 +305,6 @@ lazy val `bitcoin-s` = project
   )
   .settings(
     name := "bitcoin-s",
-    gitRemoteRepo := "git@github.com:bitcoin-s/bitcoin-s-core.git",
     publish / skip := true
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import com.github.sbt.git.SbtGit.GitKeys._
 import sbt.Keys.{publish, publishLocal}
 
 import scala.util.Properties
@@ -305,6 +306,7 @@ lazy val `bitcoin-s` = project
   )
   .settings(
     name := "bitcoin-s",
+    gitRemoteRepo := "git@github.com:bitcoin-s/bitcoin-s-core.git",
     publish / skip := true
   )
 

--- a/inThisBuild.sbt
+++ b/inThisBuild.sbt
@@ -14,8 +14,7 @@ ThisBuild / crossScalaVersions := List(scala2_13)
 //https://github.com/bitcoin-s/bitcoin-s/pull/2194
 Global / excludeLintKeys ++= Set(
   com.typesafe.sbt.packager.Keys.maintainer,
-  Keys.mainClass,
-  com.typesafe.sbt.SbtGit.GitKeys.gitRemoteRepo
+  Keys.mainClass
 )
 
 //needed so that we can use our versions with docker

--- a/inThisBuild.sbt
+++ b/inThisBuild.sbt
@@ -14,7 +14,8 @@ ThisBuild / crossScalaVersions := List(scala2_13)
 //https://github.com/bitcoin-s/bitcoin-s/pull/2194
 Global / excludeLintKeys ++= Set(
   com.typesafe.sbt.packager.Keys.maintainer,
-  Keys.mainClass
+  Keys.mainClass,
+  com.github.sbt.git.SbtGit.GitKeys.gitRemoteRepo
 )
 
 //needed so that we can use our versions with docker

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,7 +29,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.4")
 
 //tool to publish snapshots to sonatype after CI builds finish
 //https://github.com/olafurpg/sbt-ci-release
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 
 // write markdown files with type-checked Scala
 //https://github.com/scalameta/mdoc


### PR DESCRIPTION
Supersedes #4856 , it seems that `sbt-git` is no longer bundled with sbt ci release so I needed to remove usage of `SbtGit` keys.