### PR TITLE
Fix race condition in websocket tests for dlc node updates

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
@@ -460,6 +460,7 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
         .singleWebSocketRequest(req, websocketFlow)
     }
 
+    val setupF = notificationsF._1
     val walletNotificationsF: Future[Seq[WsNotification[_]]] =
       notificationsF._2._1
 
@@ -468,13 +469,15 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
     val peerAddr =
       InetSocketAddress.createUnresolved("127.0.0.1", NetworkUtil.randomPort())
 
-    exec(AcceptDLC(offer = offer,
-                   externalPayoutAddressOpt = None,
-                   externalChangeAddressOpt = None,
-                   peerAddr = peerAddr),
-         cliConfig)
-
+    val acceptMsg = {
+      AcceptDLC(offer = offer,
+                externalPayoutAddressOpt = None,
+                externalChangeAddressOpt = None,
+                peerAddr = peerAddr)
+    }
     for {
+      _ <- setupF
+      _ = ConsoleCli.exec(acceptMsg, cliConfig)
       _ <- AkkaUtil.nonBlockingSleep(500.millis)
       _ = promise.success(None)
       notifications <- walletNotificationsF


### PR DESCRIPTION
Fixes a race condition in 

```
"receive dlc node updates"
```

unit test. There was a race condition between setting up the websocket connection and adding elements to the queue. Sometimes the connection initiated message would get pushed onto the queue before the websocket got connected. This caused the message to be discarded was we don't keep messages queued until someone connects. Perhaps we want to look into changing this behavior in the future, here is where it is implemented i believe: 

https://github.com/bitcoin-s/bitcoin-s/blob/73200b64bfbb04592842b1cb179480cdf4c51484/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala#L664