### PR TITLE
Add OrderedTLVPoints as this is an invariant in the codebase

### DIFF
--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/dlc/testgen/DLCParsingTestVector.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/dlc/testgen/DLCParsingTestVector.scala
@@ -149,7 +149,7 @@ object DLCParsingTestVector extends TestVectorParser[DLCParsingTestVector] {
           "length" -> Element(tlv.length),
           "numPieces" -> Element(UInt16(pieces.length)),
           "endpointsAndPieces" -> MultiElement(
-            endpoints
+            endpoints.toVector
               .zip(pieces)
               .flatMap { case (leftEndpoint, piece) =>
                 Vector(leftEndpoint, piece)

--- a/core/src/main/scala/org/bitcoins/core/package.scala
+++ b/core/src/main/scala/org/bitcoins/core/package.scala
@@ -1,5 +1,6 @@
 package org.bitcoins
 
+import org.bitcoins.core.protocol.tlv.TLVPoint
 import org.bitcoins.core.protocol.transaction.{
   TransactionInput,
   TransactionOutput
@@ -85,6 +86,14 @@ package object core {
           x: SchnorrDigitalSignature,
           y: SchnorrDigitalSignature): Int = {
         nonceOrdering.compare(x.rx, y.rx)
+      }
+    }
+  }
+
+  implicit val tlvPointOrdering: Ordering[TLVPoint] = {
+    new Ordering[TLVPoint] {
+      override def compare(point1: TLVPoint, point2: TLVPoint): Int = {
+        point1.outcome.compare(point2.outcome)
       }
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCPayoutCurve.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCPayoutCurve.scala
@@ -2,6 +2,7 @@ package org.bitcoins.core.protocol.dlc.models
 
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.protocol.tlv._
+import org.bitcoins.core.util.sorted.OrderedTLVPoints
 import org.bitcoins.core.util.{Indexed, NumberUtil}
 
 import scala.math.BigDecimal.RoundingMode
@@ -22,9 +23,10 @@ case class DLCPayoutCurve(
 
   override def toTLV: PayoutFunctionV0TLV = {
     val tlvEndpoints = endpoints.map(_.toTLVPoint)
+    val orderedTlvPoints = OrderedTLVPoints(tlvEndpoints)
     val tlvPieces = pieces.map(_.toTLV)
 
-    PayoutFunctionV0TLV(tlvEndpoints, tlvPieces, serializationVersion)
+    PayoutFunctionV0TLV(orderedTlvPoints, tlvPieces, serializationVersion)
   }
 
   private lazy val endpointOutcomes = endpoints.map(_.outcome)
@@ -84,7 +86,7 @@ object DLCPayoutCurve
 
   override def fromTLV(tlv: PayoutFunctionV0TLV): DLCPayoutCurve = {
     val pieces =
-      tlv.endpoints.init.zip(tlv.endpoints.tail).zip(tlv.pieces).map {
+      tlv.endpoints.toVector.init.zip(tlv.endpoints.tail).zip(tlv.pieces).map {
         case ((leftEndpoint, rightEndpoint), tlvPiece) =>
           DLCPayoutCurvePiece.fromTLV(leftEndpoint, tlvPiece, rightEndpoint)
       }

--- a/core/src/main/scala/org/bitcoins/core/util/sorted/OrderedTLVPoints.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/sorted/OrderedTLVPoints.scala
@@ -1,0 +1,19 @@
+package org.bitcoins.core.util.sorted
+
+import org.bitcoins.core.protocol.tlv.TLVPoint
+
+case class OrderedTLVPoints(private val vec: Vector[TLVPoint])
+    extends SortedVec[TLVPoint, TLVPoint](vec,
+                                          org.bitcoins.core.tlvPointOrdering)
+
+object OrderedTLVPoints extends SortedVecFactory[TLVPoint, OrderedTLVPoints] {
+
+  override def apply(point: TLVPoint): OrderedTLVPoints = {
+    OrderedTLVPoints(Vector(point))
+  }
+
+  override def fromUnsorted(vec: Vector[TLVPoint]): OrderedTLVPoints = {
+    val sorted = vec.sorted(org.bitcoins.core.tlvPointOrdering)
+    OrderedTLVPoints(sorted)
+  }
+}


### PR DESCRIPTION
This is an invariant enforced in DLCPayoutCurve, we might as well add type for it 

https://github.com/bitcoin-s/bitcoin-s/blob/8857af2b66e8d493814d0bb7b817d8d46579709d/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCPayoutCurve.scala#L389

I'm running into issues with firing up my wallet on #4790 because of this error message: 

```
java.lang.IllegalArgumentException: requirement failed: Points must be ascending: OutcomePayoutLine(OutcomePayoutPoint(outcome=1,payout=0),OutcomePayoutPoint(outcome=0,payout=1.52587890625))
	at scala.Predef$.require(Predef.scala:337)
	at org.bitcoins.core.protocol.dlc.models.DLCPayoutCurvePiece.$init$(DLCPayoutCurve.scala:250)
	at org.bitcoins.core.protocol.dlc.models.OutcomePayoutLine.<init>(DLCPayoutCurve.scala:474)
	at org.bitcoins.core.protocol.dlc.models.DLCPolynomialPayoutCurvePiece$.apply(DLCPayoutCurve.scala:431)
	at org.bitcoins.core.protocol.dlc.models.DLCPolynomialPayoutCurvePiece$.fromTLV(DLCPayoutCurve.scala:453)
	at org.bitcoins.core.protocol.dlc.models.DLCPayoutCurvePiece$.fromTLV(DLCPayoutCurve.scala:289)
	at org.bitcoins.core.protocol.dlc.models.DLCPayoutCurve$.$anonfun$fromSubType$1(DLCPayoutCurve.scala:89)
	at scala.collection.immutable.Vector1.map(Vector.scala:1872)
	at scala.collection.immutable.Vector1.map(Vector.scala:375)
```

This PR should make this easiy to diagnose the source the bug, and make it impossible to make this bug in the future :crossed_fingers: 