### PR TITLE
Add `OrderedDLCPayoutCurvePieces`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/package.scala
+++ b/core/src/main/scala/org/bitcoins/core/package.scala
@@ -1,5 +1,9 @@
 package org.bitcoins
 
+import org.bitcoins.core.protocol.dlc.models.{
+  DLCPayoutCurvePiece,
+  OutcomePayoutPoint
+}
 import org.bitcoins.core.protocol.tlv.TLVPoint
 import org.bitcoins.core.protocol.transaction.{
   TransactionInput,
@@ -94,6 +98,26 @@ package object core {
     new Ordering[TLVPoint] {
       override def compare(point1: TLVPoint, point2: TLVPoint): Int = {
         point1.outcome.compare(point2.outcome)
+      }
+    }
+  }
+
+  implicit val outcomePayoutPointOrdering: Ordering[OutcomePayoutPoint] = {
+    new Ordering[OutcomePayoutPoint] {
+      override def compare(
+          x: OutcomePayoutPoint,
+          y: OutcomePayoutPoint): Int = {
+        x.outcome.compare(y.outcome)
+      }
+    }
+  }
+
+  implicit val dlcPayoutCurvePieceOrdering: Ordering[DLCPayoutCurvePiece] = {
+    new Ordering[DLCPayoutCurvePiece] {
+      override def compare(
+          x: DLCPayoutCurvePiece,
+          y: DLCPayoutCurvePiece): Int = {
+        outcomePayoutPointOrdering.compare(x.leftEndpoint, y.leftEndpoint)
       }
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/util/sorted/OrderedDLCPayoutCurvePieces.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/sorted/OrderedDLCPayoutCurvePieces.scala
@@ -1,0 +1,24 @@
+package org.bitcoins.core.util.sorted
+
+import org.bitcoins.core.protocol.dlc.models.DLCPayoutCurvePiece
+
+case class OrderedDLCPayoutCurvePieces(
+    private val vec: Vector[DLCPayoutCurvePiece])
+    extends SortedVec[DLCPayoutCurvePiece, DLCPayoutCurvePiece](
+      vec,
+      org.bitcoins.core.dlcPayoutCurvePieceOrdering)
+
+object OrderedDLCPayoutCurvePieces
+    extends SortedVecFactory[DLCPayoutCurvePiece, OrderedDLCPayoutCurvePieces] {
+
+  override def apply(
+      piece: DLCPayoutCurvePiece): OrderedDLCPayoutCurvePieces = {
+    OrderedDLCPayoutCurvePieces(Vector(piece))
+  }
+
+  override def fromUnsorted(
+      vec: Vector[DLCPayoutCurvePiece]): OrderedDLCPayoutCurvePieces = {
+    val sorted = vec.sorted(org.bitcoins.core.dlcPayoutCurvePieceOrdering)
+    OrderedDLCPayoutCurvePieces(sorted)
+  }
+}


### PR DESCRIPTION
Follow up on #4874 

We should make sure that our curve pieces are ordered by endpoint from left to right as well. Previously it would be possible to have curve pieces that are out of order.