### PR TITLE
Support bip32 paths with 'h' instead of an apostrophe

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/bip32/BIP32PathTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/bip32/BIP32PathTest.scala
@@ -90,6 +90,12 @@ class BIP32PathTest extends BitcoinSUnitTest {
     assert(fromString.path.head.toUInt32 == ExtKey.hardenedIdx)
   }
 
+  it must "parse a hardened path without an apostrophe" in {
+    val fromString = BIP32Path.fromString("m/0h")
+    assert(fromString.path.length == 1)
+    assert(fromString.path.head.toUInt32 == ExtKey.hardenedIdx)
+  }
+
   it must "parse a hardened path from bytes" in {
     val fromString = BIP32Path.fromBytes(hex"0x80000000")
     assert(fromString.path.length == 1)

--- a/core/src/main/scala/org/bitcoins/core/hd/BIP32Path.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/BIP32Path.scala
@@ -136,7 +136,7 @@ object BIP32Path extends Factory[BIP32Path] with StringFactory[BIP32Path] {
 
     val path = rest.map { str =>
       val (index: String, hardened: Boolean) =
-        if (str.endsWith("'")) {
+        if (str.endsWith("'") || str.endsWith("h")) {
           (str.dropRight(1), true)
         } else {
           (str, false)


### PR DESCRIPTION
Seems to be something people are moving towards: https://github.com/bitcoin/bitcoin/pull/26076