### PR TITLE
Delay querying for peers for 30 minutes

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -113,7 +113,7 @@ case class PeerFinder(
 
   val maxPeerSearchCount: Int = 1000
 
-  private val initialDelay: FiniteDuration = 1.minute
+  private val initialDelay: FiniteDuration = 30.minute
 
   private val isConnectionSchedulerRunning = AtomicBoolean(false)
 


### PR DESCRIPTION
Follow up on #4847 

This delays the time for querying for peers from `1.minute` -> `30.minute`. This is nice because often i startup my node and get logs spammed almost immediately with querying peers.

