### PR TITLE
Add generateblock bitcoind rpc

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/OtherResult.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/OtherResult.scala
@@ -66,6 +66,8 @@ case class GetMiningInfoResult(
 
 case class GetMemoryInfoResult(locked: MemoryManager) extends OtherResult
 
+case class GenerateBlockResult(hash: DoubleSha256DigestBE) extends OtherResult
+
 case class MemoryManager(
     used: Int,
     free: Int,

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
@@ -581,6 +581,9 @@ object JsonSerializers {
   implicit val getMemoryInfoResultReads: Reads[GetMemoryInfoResult] =
     Json.reads[GetMemoryInfoResult]
 
+  implicit val GenerateBlockResultReads: Reads[GenerateBlockResult] =
+    Json.reads[GenerateBlockResult]
+
   implicit val validateAddressResultReads: Reads[ValidateAddressResultImpl] =
     Json.reads[ValidateAddressResultImpl]
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MiningRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MiningRpc.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.rpc.client.common
 
 import org.bitcoins.commons.jsonmodels.bitcoind.{
+  GenerateBlockResult,
   GetBlockTemplateResult,
   GetMiningInfoResult,
   RpcOpts
@@ -9,8 +10,9 @@ import org.bitcoins.commons.serializers.JsonReaders._
 import org.bitcoins.commons.serializers.JsonSerializers._
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
-import play.api.libs.json.{JsNumber, JsString, Json}
+import play.api.libs.json.{JsArray, JsNumber, JsString, Json}
 
 import scala.concurrent.Future
 
@@ -25,6 +27,16 @@ trait MiningRpc { self: Client =>
     bitcoindCall[Vector[DoubleSha256DigestBE]](
       "generatetoaddress",
       List(JsNumber(blocks), JsString(address.toString), JsNumber(maxTries)))
+  }
+
+  def generateBlock(
+      address: BitcoinAddress,
+      transactions: Vector[Transaction]
+  ): Future[DoubleSha256DigestBE] = {
+    val txsJs = JsArray(transactions.map(t => JsString(t.hex)))
+    bitcoindCall[GenerateBlockResult](
+      "generateblock",
+      List(JsString(address.toString), txsJs)).map(_.hash)
   }
 
   def getBlockTemplate(request: Option[RpcOpts.BlockTemplateRequest] =


### PR DESCRIPTION
This lets us generate a block with a transaction without having to broadcast to the mempool first, useful for testing non-standard txs as well as wallets without mempool support