### PR TITLE
Fix synced flag but in `DataMessageHandler` bug

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -107,7 +107,7 @@ case class DataMessageHandler(
                   peerMsgSender,
                   startHeightOpt).map { synced =>
                   if (!synced) logger.info("We are synced")
-                  syncing
+                  synced
                 }
               } yield (syncing, startHeightOpt)
             }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -105,9 +105,9 @@ case class DataMessageHandler(
                   s"Done syncing filter headers, beginning to sync filters from startHeightOpt=$startHeightOpt")
                 syncing <- sendFirstGetCompactFilterCommand(
                   peerMsgSender,
-                  startHeightOpt).map { synced =>
-                  if (!synced) logger.info("We are synced")
-                  synced
+                  startHeightOpt).map { syncing =>
+                  if (!syncing) logger.info("We are synced")
+                  syncing
                 }
               } yield (syncing, startHeightOpt)
             }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -196,6 +196,8 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     sendMsg(message)
   }
 
+  /** @return a flag indicating if we are syncing or not
+    */
   private[node] def sendNextGetCompactFilterCommand(
       chainApi: ChainApi,
       filterBatchSize: Int,


### PR DESCRIPTION
This was introduced in #1969

https://github.com/bitcoin-s/bitcoin-s/pull/1969/files#diff-61413f0a707d1e3e49431ad34fcb1af04b4fa36148e75c7abc692bebc07822b7R72

It seems we renamed the local scoped variable from `syncing` -> `synced`. We didn't replace the return value.