### PR TITLE
Call `handleDataPayloadHelper` explicitly on `DataMessageHandlerState`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -126,7 +126,7 @@ case class DataMessageHandler(
           this.copy(chainApi = newChainApi)
         }
       case filterHeader: CompactFilterHeadersMessage =>
-        logger.info(
+        logger.debug(
           s"Got ${filterHeader.filterHashes.size} compact filter header hashes")
         val filterHeaders = filterHeader.filterHeaders
         for {
@@ -168,7 +168,7 @@ case class DataMessageHandler(
                     filterHeightOpt = startFilterHeightOpt)
         }
       case filter: CompactFilterMessage =>
-        logger.trace(s"Received ${filter.commandName}, $filter")
+        logger.debug(s"Received ${filter.commandName}, $filter")
         val batchSizeFull: Boolean =
           currentFilterBatch.size == chainConfig.filterBatchSize - 1
         for {
@@ -327,7 +327,7 @@ case class DataMessageHandler(
                   }
 
                 } else {
-                  logger.info(
+                  logger.debug(
                     List(s"Received headers=${count.toInt} in one message,",
                          "which is less than max. This means we are synced,",
                          s"not requesting more. state=$state")

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -70,8 +70,51 @@ case class DataMessageHandler(
       payload: DataPayload,
       peerMsgSender: PeerMessageSender,
       peer: Peer): Future[DataMessageHandler] = {
+    state match {
+      case _: ValidatingHeaders =>
+        val resultF = handleDataPayloadValidState(payload, peerMsgSender, peer)
+        //process messages from all peers
+        resultF.failed.foreach { err =>
+          logger.error(s"Failed to handle data payload=${payload} from $peer",
+                       err)
+        }
+        resultF.recoverWith { case NonFatal(_) =>
+          Future.successful(this)
+        }
+      case HeaderSync =>
+        if (syncPeer.isEmpty || peer != syncPeer.get) {
+          //ignore message from peers that we aren't syncing with during IBD
+          logger.warn(
+            s"Ignoring message ${payload.commandName} from $peer because we are syncing with this peer currently. syncPeer=$syncPeer")
+          Future.successful(this)
+        } else {
+          val resultF =
+            handleDataPayloadValidState(payload, peerMsgSender, peer)
+          resultF.failed.foreach { err =>
+            logger.error(s"Failed to handle data payload=${payload} from $peer",
+                         err)
+          }
+          resultF.recoverWith { case NonFatal(_) =>
+            Future.successful(this)
+          }
+        }
+      case PostHeaderSync =>
+        val resultF = handleDataPayloadValidState(payload, peerMsgSender, peer)
+        resultF.recoverWith { case NonFatal(_) =>
+          Future.successful(this)
+        }
+    }
 
-    lazy val resultF = payload match {
+  }
+
+  /** Processes a [[DataPayload]] if our [[DataMessageHandlerState]] is valid.
+    * We ignore messages from certain peers when we are in initial block download.
+    */
+  private def handleDataPayloadValidState(
+      payload: DataPayload,
+      peerMsgSender: PeerMessageSender,
+      peer: Peer): Future[DataMessageHandler] = {
+    payload match {
       case checkpoint: CompactFilterCheckPointMessage =>
         logger.debug(
           s"Got ${checkpoint.filterHeaders.size} checkpoints ${checkpoint} from $peer")
@@ -83,7 +126,7 @@ case class DataMessageHandler(
           this.copy(chainApi = newChainApi)
         }
       case filterHeader: CompactFilterHeadersMessage =>
-        logger.debug(
+        logger.info(
           s"Got ${filterHeader.filterHashes.size} compact filter header hashes")
         val filterHeaders = filterHeader.filterHeaders
         for {
@@ -119,13 +162,18 @@ case class DataMessageHandler(
           }
           newChainApi <- newChainApi.setSyncing(newSyncing)
         } yield {
+          val syncPeerOpt = if (newSyncing) {
+            syncPeer
+          } else {
+            None
+          }
           this.copy(chainApi = newChainApi,
-                    syncing = newSyncing,
                     filterHeaderHeightOpt = Some(newFilterHeaderHeight),
-                    filterHeightOpt = startFilterHeightOpt)
+                    filterHeightOpt = startFilterHeightOpt,
+                    syncPeer = syncPeerOpt)
         }
       case filter: CompactFilterMessage =>
-        logger.debug(s"Received ${filter.commandName}, $filter")
+        logger.trace(s"Received ${filter.commandName}, $filter")
         val batchSizeFull: Boolean =
           currentFilterBatch.size == chainConfig.filterBatchSize - 1
         for {
@@ -174,12 +222,17 @@ case class DataMessageHandler(
           newChainApi <- newChainApi.setSyncing(newSyncing2)
           _ <- checkIBD(newChainApi)
         } yield {
+          val syncPeerOpt = if (newSyncing2) {
+            syncPeer
+          } else {
+            None
+          }
           this.copy(
             chainApi = newChainApi,
             currentFilterBatch = newBatch,
-            syncing = newSyncing2,
             filterHeaderHeightOpt = Some(newFilterHeaderHeight),
-            filterHeightOpt = Some(newFilterHeight)
+            filterHeightOpt = Some(newFilterHeight),
+            syncPeer = syncPeerOpt
           )
         }
       case notHandling @ (MemPoolMessage | _: GetHeadersMessage |
@@ -227,8 +280,6 @@ case class DataMessageHandler(
       case HeadersMessage(count, headers) =>
         logger.info(
           s"Received headers message with ${count.toInt} headers from $peer")
-        logger.trace(
-          s"Received headers=${headers.map(_.hashBE.hex).mkString("[", ",", "]")}")
         val chainApiHeaderProcessF: Future[DataMessageHandler] = for {
           newChainApi <- chainApi.setSyncing(count.toInt > 0)
           processed <- newChainApi.processHeaders(headers)
@@ -275,19 +326,24 @@ case class DataMessageHandler(
                       for {
                         _ <- Future.sequence(removeFs)
                         newSyncing <- askF
-                      } yield newDmh.copy(syncing = newSyncing,
-                                          state = HeaderSync,
-                                          syncPeer = newSyncPeer)
+                      } yield {
+                        val syncPeerOpt = if (newSyncing) {
+                          newSyncPeer
+                        } else {
+                          None
+                        }
+                        newDmh.copy(state = HeaderSync, syncPeer = syncPeerOpt)
+                      }
 
                     case _: DataMessageHandlerState =>
                       Future.successful(newDmh)
                   }
 
                 } else {
-                  logger.debug(
+                  logger.info(
                     List(s"Received headers=${count.toInt} in one message,",
                          "which is less than max. This means we are synced,",
-                         "not requesting more.")
+                         s"not requesting more. state=$state")
                       .mkString(" "))
                   // If we are in neutrino mode, we might need to start fetching filters and their headers
                   // if we are syncing we should do this, however, sometimes syncing isn't a good enough check,
@@ -344,6 +400,8 @@ case class DataMessageHandler(
 
                     case PostHeaderSync =>
                       //send further requests to the same one that sent this
+                      logger.info(
+                        s"!syncing=${!syncing} filterHeaderHeightOpt=${filterHeaderHeightOpt.isEmpty} filterHeight=${filterHeightOpt}")
                       if (
                         !syncing ||
                         (filterHeaderHeightOpt.isEmpty &&
@@ -353,8 +411,14 @@ case class DataMessageHandler(
                           s"Starting to fetch filter headers in data message handler")
                         val newSyncingF =
                           sendFirstGetCompactFilterHeadersCommand(peerMsgSender)
-                        newSyncingF.map(newSyncing =>
-                          newDmh.copy(syncing = newSyncing))
+                        newSyncingF.map { newSyncing =>
+                          val syncPeerOpt = if (newSyncing) {
+                            syncPeer
+                          } else {
+                            None
+                          }
+                          newDmh.copy(syncPeer = syncPeerOpt)
+                        }
                       } else {
                         Try(initialSyncDone.map(_.success(Done)))
                         Future.successful(newDmh)
@@ -456,30 +520,6 @@ case class DataMessageHandler(
         Future.successful(this)
       case invMsg: InventoryMessage =>
         handleInventoryMsg(invMsg = invMsg, peerMsgSender = peerMsgSender)
-    }
-
-    if (state.isInstanceOf[ValidatingHeaders]) {
-      //process messages from all peers
-      resultF.failed.foreach { err =>
-        logger.error(s"Failed to handle data payload=${payload} from $peer",
-                     err)
-      }
-      resultF.recoverWith { case NonFatal(_) =>
-        Future.successful(this)
-      }
-    } else if (syncPeer.isEmpty || peer != syncPeer.get) {
-      //in other states, process messages only from syncPeer
-      logger.debug(s"Ignoring ${payload.commandName} from $peer")
-      Future.successful(this)
-    } else {
-      resultF.failed.foreach { err =>
-        logger.error(s"Failed to handle data payload=${payload} from $peer",
-                     err)
-      }
-      resultF.recoverWith { case NonFatal(_) =>
-        Future.successful(this)
-      }
-
     }
   }
 


### PR DESCRIPTION
In #4456 we introduced `DataMessageHandlerState`. 

As part of this, we may not process certain p2p messages based on `DataMessageHandlerState`. For instance, if we are doing IBD with a _specific_ peer, we should ignore messages from _other_ peers while we are doing IBD. 

This PR refactors this logic to be more explicit based on `DataMessageHandlerState`. 

I suspect this might fix/be related to #4894 too.