### PR TITLE
Download blocks from random peer if we aren't in IBD

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -183,6 +183,21 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     if (blockHashes.isEmpty) {
       Future.unit
     } else {
+      for {
+        chainApi <- chainApiFromDb()
+        isIBD <- chainApi.isIBD()
+        _ <- downloadBlocksBasedOnIBD(isIBD, blockHashes)
+      } yield ()
+    }
+  }
+
+  /** Helper method to download blocks.
+    * If our node is in IBD, we will only download only from our peer we are doing IBD with.
+    * If we are not in IBD, we will download from a random peer. */
+  private def downloadBlocksBasedOnIBD(
+      isIBD: Boolean,
+      blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = {
+    if (isIBD) {
       val syncPeerOpt = getDataMessageHandler.syncPeer
       syncPeerOpt match {
         case Some(peer) =>
@@ -195,6 +210,11 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
           throw new RuntimeException(
             "IBD not started yet. Cannot query for blocks.")
       }
+    } else {
+      val peerMsgSenderF = peerManager.randomPeerMsgSenderWithService(
+        ServiceIdentifier.NODE_NETWORK)
+      peerMsgSenderF.flatMap(
+        _.sendGetDataMessage(TypeIdentifier.MsgWitnessBlock, blockHashes: _*))
     }
   }
 

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -193,7 +193,8 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
 
   /** Helper method to download blocks.
     * If our node is in IBD, we will only download only from our peer we are doing IBD with.
-    * If we are not in IBD, we will download from a random peer. */
+    * If we are not in IBD, we will download from a random peer.
+    */
   private def downloadBlocksBasedOnIBD(
       isIBD: Boolean,
       blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = {


### PR DESCRIPTION
This fixes this comment on #4522 https://github.com/bitcoin-s/bitcoin-s/pull/4522/files#r924895166

In #4627 we added a flag to track IBD state. We use this flag to select what peer to request blocks from. If we are in IBD, we only request from the peer we are syncing with. If we aren't in IBD, we select a random peer.