### PR TITLE
Stop P2PClientActor when we receive closed command

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -389,6 +389,7 @@ case class P2PClientActor(
           s"An error occurred in our connection with $peer, cause=$cause state=${currentPeerMsgHandlerRecv.state}")
         currentPeerMsgHandlerRecv =
           Await.result(currentPeerMsgHandlerRecv.disconnect(), timeout)
+        context.stop(self)
         unalignedBytes
       case closeCmd @ (Tcp.ConfirmedClosed | Tcp.Closed | Tcp.Aborted |
           Tcp.PeerClosed) =>
@@ -396,6 +397,8 @@ case class P2PClientActor(
           s"We've been disconnected by $peer command=${closeCmd} state=${currentPeerMsgHandlerRecv.state}")
         currentPeerMsgHandlerRecv =
           Await.result(currentPeerMsgHandlerRecv.disconnect(), timeout)
+
+        context.stop(self)
         unalignedBytes
 
       case Tcp.Received(byteString: ByteString) =>


### PR DESCRIPTION
Stop `P2PClientActor` when we receive `Tcp.{ErrorClosed,ConfirmedClosed,Closed,Aborted,PeerClosed}`commands. These commands indicate that the TCP connection has been stopped. We should shutdown the actor corresponding to the Tcp connection as well and force the developer to start another one. This prevents the possibility of having corrupt state. 

I'm not sure how this plays with Reconnection logic. The tests seem to be passing. It might be contextual on why we are reconnecting. For instance, if `PeerClosed`, we may want to reconnect and not terminate the `P2PClientActor`?