### PR TITLE
Refactor `NodeTestUtil.awaitSync()` to check compact filters

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -112,7 +112,8 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         //out of sync by 1 block, h2 ahead
         _ = assert(h2 - h1 == 1)
         _ <- node.sync()
-        _ <- NodeTestUtil.awaitSync(node, bitcoinds(1))
+        bestHash <- bitcoinds(1).getBestBlockHash
+        _ <- NodeTestUtil.awaitBestHash(bestHash, node)
       } yield {
         succeed
       }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -138,13 +138,9 @@ abstract class NodeTestUtil extends P2PLogger {
   private val syncTries: Int = 15
 
   /** Awaits sync between the given node and bitcoind client */
-  def awaitSync(node: Node, rpc: BitcoindRpcClient)(implicit
+  def awaitSync(node: NeutrinoNode, rpc: BitcoindRpcClient)(implicit
       sys: ActorSystem): Future[Unit] = {
-    import sys.dispatcher
-    TestAsyncUtil
-      .retryUntilSatisfiedF(() => isSameBestHash(node, rpc),
-                            1.second,
-                            maxTries = syncTries)
+    awaitAllSync(node, rpc)
   }
 
   /** Awaits sync between the given node and bitcoind client */
@@ -185,7 +181,8 @@ abstract class NodeTestUtil extends P2PLogger {
       system: ActorSystem): Future[Unit] = {
     import system.dispatcher
     for {
-      _ <- NodeTestUtil.awaitSync(node, bitcoind)
+      bitcoindBestHash <- bitcoind.getBestBlockHash
+      _ <- NodeTestUtil.awaitBestHash(bitcoindBestHash, node)
       _ <- NodeTestUtil.awaitCompactFilterHeadersSync(node, bitcoind)
       _ <- NodeTestUtil.awaitCompactFiltersSync(node, bitcoind)
     } yield ()


### PR DESCRIPTION
We removed SPV node code in #4356 so our default `awaitSync()` method should await _full_ sychnornization of a neutrino node. This avoids the footgun of writing test cases and using `NodeTestUtil.awaitSync()` thinking it checks blockheader _and_ compact filter sync.