### PR TITLE
Rework logging so that stack traces in `DataMessageHandler`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -78,8 +78,8 @@ case class DataMessageHandler(
         val resultF = handleDataPayloadValidState(payload, peerMsgSender, peer)
         //process messages from all peers
         resultF.failed.foreach { err =>
-          logger.error(s"Failed to handle data payload=${payload} from $peer",
-                       err)
+          logger.error(
+            s"Failed to handle data payload=${payload} from $peer errMsg=${err.getMessage}")
         }
         resultF.recoverWith { case NonFatal(_) =>
           Future.successful(this)
@@ -94,8 +94,8 @@ case class DataMessageHandler(
           val resultF =
             handleDataPayloadValidState(payload, peerMsgSender, peer)
           resultF.failed.foreach { err =>
-            logger.error(s"Failed to handle data payload=${payload} from $peer",
-                         err)
+            logger.error(
+              s"Failed to handle data payload=${payload} from $peer errMsg=${err.getMessage}")
           }
           resultF.recoverWith { case NonFatal(_) =>
             Future.successful(this)
@@ -451,7 +451,8 @@ case class DataMessageHandler(
         }
 
         getHeadersF.failed.map { err =>
-          logger.error(s"Error when processing headers message", err)
+          logger.error(
+            s"Error when processing headers message: ${err.getMessage}")
         }
 
         for {


### PR DESCRIPTION
Now the logs will look like this rather than also including the stack trace which ends up being very spammy in logs. We may want to think of more effective logs for this stuff in the future.

```
2022-12-30 18:25:55,935UTC ERROR DataMessageHandler - Failed to handle data payload=HeadersMessage(CompactSizeUInt(1),00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6..00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6 from Peer(localhost:14532) errMsg=Failed to connect any headers to our internal chain state, failures=Vector(Failed(BaseBlockchain(tip=BlockHeaderDb(height=101,hashBE=3ebd55f2e10a940d6ba0dbc1cb271888d10eb44d911e770768e80071d7ed9868,version=Int32Impl(536870912),prevBlockHashBE=7f82b91c2ce691740523889384b6c264f1b243d4e020171f27672c3130114697merkleRootHashBE=91c7b4c44c8c15cfb2f99056afbe85fb010f8e5ae0ec9a9a5511d399e0aac694,time=UInt32Impl(1672424752),nBits=UInt32Impl(545259519),nonce=UInt32Impl(1),chainWork=204),last=BlockHeaderDb(height=0,hashBE=0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206,version=Int32Impl(1),prevBlockHashBE=0000000000000000000000000000000000000000000000000000000000000000merkleRootHashBE=4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b,time=UInt32Impl(1296688602),nBits=UInt32Impl(545259519),nonce=UInt32Impl(2),chainWork=2),length=102),Vector(),BlockHeader(hashBE=00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6,version=Int32Impl(1),prevBlockHashBE=0000000000000000000000000000000000000000000000000000000000000000,merkleRootHashBE=4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b,time=UInt32Impl(1598918400),nBits=UInt32Impl(503543726),nonce=UInt32Impl(52613770)),BadPreviousBlockHash(hash=DoubleSha256BDigestBE(00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6), previous=DoubleSha256BDigestBE(0000000000000000000000000000000000000000000000000000000000000000))))
2022-12-30 18:25:55,937UTC ERROR DataMessageHandler - Error when processing headers message: Failed to connect any headers to our internal chain state, failures=Vector(Failed(BaseBlockchain(tip=BlockHeaderDb(height=101,hashBE=3ebd55f2e10a940d6ba0dbc1cb271888d10eb44d911e770768e80071d7ed9868,version=Int32Impl(536870912),prevBlockHashBE=7f82b91c2ce691740523889384b6c264f1b243d4e020171f27672c3130114697merkleRootHashBE=91c7b4c44c8c15cfb2f99056afbe85fb010f8e5ae0ec9a9a5511d399e0aac694,time=UInt32Impl(1672424752),nBits=UInt32Impl(545259519),nonce=UInt32Impl(1),chainWork=204),last=BlockHeaderDb(height=0,hashBE=0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206,version=Int32Impl(1),prevBlockHashBE=0000000000000000000000000000000000000000000000000000000000000000merkleRootHashBE=4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b,time=UInt32Impl(1296688602),nBits=UInt32Impl(545259519),nonce=UInt32Impl(2),chainWork=2),length=102),Vector(),BlockHeader(hashBE=00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6,version=Int32Impl(1),prevBlockHashBE=0000000000000000000000000000000000000000000000000000000000000000,merkleRootHashBE=4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b,time=UInt32Impl(1598918400),nBits=UInt32Impl(503543726),nonce=UInt32Impl(52613770)),BadPreviousBlockHash(hash=DoubleSha256BDigestBE(00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6), previous=DoubleSha256BDigestBE(0000000000000000000000000000000000000000000000000000000000000000))))
```