### PR TITLE
Implement ability to cancel background task for querying peer with specific services

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -148,6 +148,7 @@ case class PeerManager(
     //remove the cancellable from the peerServicesQueries
     //when our promise is completed from the scheduled job
     promise.future.onComplete { _ =>
+      val _: Boolean = cancellable.cancel()
       val idx = peerServicesQueries.indexOf(cancellable)
       if (idx >= 0) {
         peerServicesQueries = peerServicesQueries.zipWithIndex


### PR DESCRIPTION
In #4408 we implemented the ability to wait until we have a peer with a specific service. We weren't able to stop this task based until the job timed out. This PR implements the ability to stop this task when `PeerManager.stop()` is called.

