### PR TITLE
Catch non `RescanTerminatedEarly` errors when rescan is terminated early

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -37,8 +37,9 @@ object RescanState {
       _isCompletedEarly.set(false)
     }
 
-    completeRescanEarlyP.future.failed.foreach { case RescanTerminatedEarly =>
-      _isCompletedEarly.set(true)
+    completeRescanEarlyP.future.failed.foreach {
+      case RescanTerminatedEarly          => _isCompletedEarly.set(true)
+      case scala.util.control.NonFatal(_) => //do nothing
     }
 
     /** Useful for determining if the rescan was completed


### PR DESCRIPTION
Fixes this exception that gets thrown when shutting down actor system's while a rescan is ongoing 

```
[ERROR] [01/05/2023 10:42:35.642] [NeutrinoNodeWithWalletTest-1672936939580-akka.actor.default-dispatcher-7] [akka.dispatch.Dispatcher] akka.stream.AbruptStageTerminationException: GraphStage [akka.stream.impl.MaybeSource$$anon$1-MaybeSource] terminated abruptly, caused by for example materializer or actor system termination. (of class akka.stream.AbruptStageTerminationException)
scala.MatchError: akka.stream.AbruptStageTerminationException: GraphStage [akka.stream.impl.MaybeSource$$anon$1-MaybeSource] terminated abruptly, caused by for example materializer or actor system termination. (of class akka.stream.AbruptStageTerminationException)
        at org.bitcoins.core.wallet.rescan.RescanState$RescanStarted.$anonfun$new$2(RescanState.scala:40)
        at org.bitcoins.core.wallet.rescan.RescanState$RescanStarted.$anonfun$new$2$adapted(RescanState.scala:40)
        at scala.util.Success.foreach(Try.scala:260)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:481)
        at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:63)
        at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:100)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
        at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
        at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:100)
        at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:49)
        at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1311)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1840)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```