### PR TITLE
Encapsulate `PeerData.client`

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -78,7 +78,10 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         expectHeaders = ExpectResponseCommand(
           GetHeadersMessage(node.chainConfig.chain.genesisHash))
         //waiting for response to header query now
-        client <- peerManager.peerData(bitcoindPeers(0)).client
+        client <- peerManager
+          .peerData(bitcoindPeers(0))
+          .peerMessageSender
+          .map(_.client)
         _ = client.actor ! expectHeaders
         nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoinds(0))
         _ <- bitcoinds(0).disconnectNode(nodeUri)

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -16,7 +16,6 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models._
-import org.bitcoins.node.networking.P2PClient
 import org.bitcoins.node.networking.peer.{
   ControlMessageHandler,
   DataMessageHandler,
@@ -67,12 +66,6 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
                                     CompactFilterDAO(),
                                     ChainStateDescriptorDAO())
   }
-
-  /** Unlike our chain api, this is cached inside our node
-    * object. Internally in [[org.bitcoins.node.networking.P2PClient p2p client]] you will see that
-    * the [[ChainApi chain api]] is updated inside of the p2p client
-    */
-  def clients: Vector[Future[P2PClient]] = peerManager.clients
 
   def peerMsgSenders: Vector[Future[PeerMessageSender]] =
     peerManager.peerMsgSenders

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -26,7 +26,7 @@ case class PeerData(
     client.map(PeerMessageSender(_))
   }
 
-  lazy val client: Future[P2PClient] = {
+  private lazy val client: Future[P2PClient] = {
     val peerMessageReceiver =
       PeerMessageReceiver.newReceiver(node = node, peer = peer)
     P2PClient(
@@ -39,6 +39,9 @@ case class PeerData(
     )
   }
 
+  def stop(): Future[Unit] = {
+    client.map(_.close())
+  }
   private var _serviceIdentifier: Option[ServiceIdentifier] = None
 
   def serviceIdentifier: ServiceIdentifier = {

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -184,7 +184,7 @@ case class PeerFinder(
     //delete try queue
     _peersToTry.clear()
 
-    val closeFs = _peerData.map(_._2.client.map(_.close()))
+    val closeFs = _peerData.map(_._2.stop())
     val closeF = Future.sequence(closeFs)
 
     val waitStopF = AsyncUtil

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -650,7 +650,6 @@ object P2PClient extends P2PLogger {
       supervisor: ActorRef)(implicit
       config: NodeAppConfig,
       system: ActorSystem): Future[P2PClient] = {
-
     val clientProps = props(peer,
                             peerMessageReceiver,
                             onReconnect,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -25,12 +25,14 @@ abstract class NodeTestUtil extends P2PLogger {
       conf: NodeAppConfig,
       system: ActorSystem
   ): Future[P2PClient] = {
-    P2PClient.apply(peer,
-                    peerMsgReceiver,
-                    (_: Peer) => Future.unit,
-                    (_: Peer) => Future.unit,
-                    16,
-                    supervisor)
+    P2PClient.apply(
+      peer = peer,
+      peerMessageReceiver = peerMsgReceiver,
+      onReconnect = (_: Peer) => Future.unit,
+      onStop = (_: Peer) => Future.unit,
+      maxReconnectionTries = 16,
+      supervisor = supervisor
+    )
   }
 
   /** Helper method to get the [[java.net.InetSocketAddress]]


### PR DESCRIPTION
Enapsulate `PeerData.client` so its easier to manage the actor lifecycle stored inside of `P2PClient`.