### PR TITLE
Remove `Await.result()`in `initializationTimeoutCancellable`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -244,8 +244,8 @@ case class PeerManager(
   }
 
   def onInitializationTimeout(peer: Peer): Future[Unit] = {
-    assert(!finder.hasPeer(peer) || !peerData.contains(peer),
-           s"$peer cannot be both a test and a persistent peer")
+    require(!finder.hasPeer(peer) || !peerData.contains(peer),
+            s"$peer cannot be both a test and a persistent peer")
 
     if (finder.hasPeer(peer)) {
       //one of the peers that we tried, failed to init within time, disconnect


### PR DESCRIPTION
This is related to #4955 

Try to remove the blocking on the callback, just add a log for failure in case the call to `onInitTimeout()` fails.