### PR TITLE
2023 01 24 small changes from pr 4950

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -546,11 +546,7 @@ class ChainHandler(
 
   /** @inheritdoc */
   override def getFilterHeaderCount(): Future[Int] = {
-    logger.debug(s"Querying for filter header count")
-    filterHeaderDAO.getBestFilterHeaderHeight.map { height =>
-      logger.debug(s"getFilterHeaderCount result: count=$height")
-      height
-    }
+    filterHeaderDAO.getBestFilterHeaderHeight
   }
 
   /** @inheritdoc */
@@ -659,11 +655,7 @@ class ChainHandler(
 
   /** @inheritdoc */
   override def getFilterCount(): Future[Int] = {
-    logger.debug(s"Querying for filter count")
-    filterDAO.getBestFilterHeight.map { height =>
-      logger.debug(s"getFilterCount result: count=$height")
-      height
-    }
+    filterDAO.getBestFilterHeight
   }
 
   /** @inheritdoc */

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientTest.scala
@@ -217,14 +217,12 @@ class P2PClientTest
     * remote node and bind our local
     * connection to the specified port
     */
-  def connectAndDisconnect(p2pClient: P2PClient): Future[Assertion] = {
+  private def connectAndDisconnect(p2pClient: P2PClient): Future[Assertion] = {
 
     p2pClient.actor ! ConnectCommand
 
     val isConnectedF = for {
-      isConnected <- TestAsyncUtil.retryUntilSatisfiedF(p2pClient.isConnected,
-                                                        interval = 1.second,
-                                                        maxTries = 100)
+      isConnected <- TestAsyncUtil.retryUntilSatisfiedF(p2pClient.isConnected)
     } yield isConnected
 
     isConnectedF.flatMap { _ =>

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -228,7 +228,8 @@ case class PeerFinder(
   }
 
   def getData(peer: Peer): PeerData = {
-    require(hasPeer(peer), s"finder.getData called without any data on peer=$peer")
+    require(hasPeer(peer),
+            s"finder.getData called without any data on peer=$peer")
     _peerData(peer)
   }
 

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -141,7 +141,7 @@ case class PeerFinder(
               isConnectionSchedulerRunning.set(false)
             case Failure(err) =>
               isConnectionSchedulerRunning.set(false)
-              logger.error(s"Failed to connect to peers", err)
+              logger.error(s"Failed to connect to peers=$peers", err)
           }
         } else {
           logger.warn(
@@ -153,8 +153,8 @@ case class PeerFinder(
   override def start(): Future[PeerFinder] = {
     logger.debug(s"Starting PeerFinder")
 
-    val initPeerF = Future.sequence(
-      (getPeersFromParam ++ getPeersFromConfig).distinct.map(tryPeer))
+    val peersToTry = (getPeersFromParam ++ getPeersFromConfig).distinct
+    val initPeerF = Future.traverse(peersToTry)(tryPeer)
 
     val peerDiscoveryF = if (nodeAppConfig.enablePeerDiscovery) {
       val startedF = for {
@@ -228,7 +228,7 @@ case class PeerFinder(
   }
 
   def getData(peer: Peer): PeerData = {
-    assert(hasPeer(peer), "finder.getData called without any data on peer")
+    require(hasPeer(peer), s"finder.getData called without any data on peer=$peer")
     _peerData(peer)
   }
 

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -49,6 +49,9 @@ case class PeerManager(
 
   def connectedPeerCount: Int = _peerData.size
 
+  def addPeerToTry(peers: Vector[Peer], priority: Int = 0): Unit = {
+    finder.addToTry(peers, priority)
+  }
   def addPeer(peer: Peer): Future[Unit] = {
     require(finder.hasPeer(peer), s"Unknown $peer marked as usable")
     val curPeerData = finder.popFromCache(peer).get
@@ -80,7 +83,7 @@ case class PeerManager(
           .filter(p => p._2.serviceIdentifier.hasServicesOf(services))
           .keys
           .toVector
-      assert(filteredPeers.nonEmpty)
+      require(filteredPeers.nonEmpty)
       val (good, failedRecently) =
         filteredPeers.partition(p => !peerData(p).hasFailedRecently)
 

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -52,6 +52,7 @@ case class PeerManager(
   def addPeerToTry(peers: Vector[Peer], priority: Int = 0): Unit = {
     finder.addToTry(peers, priority)
   }
+
   def addPeer(peer: Peer): Future[Unit] = {
     require(finder.hasPeer(peer), s"Unknown $peer marked as usable")
     val curPeerData = finder.popFromCache(peer).get

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -94,7 +94,7 @@ case class P2PClientActor(
     */
   private val network: NetworkParameters = config.network
 
-  private val timeout = 1000.seconds
+  private val timeout = 60.seconds
 
   /** The manager is an actor that handles the underlying low level I/O resources (selectors, channels)
     * and instantiates workers for specific tasks, such as listening to incoming connections.

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/ControlMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/ControlMessageHandler.scala
@@ -95,7 +95,7 @@ case class ControlMessageHandler(node: Node)(implicit ec: ExecutionContext)
           val peer = Peer.fromSocket(socket = inetAddress,
                                      socks5ProxyParams =
                                        node.nodeAppConfig.socks5ProxyParams)
-          node.peerManager.finder.addToTry(Vector(peer), 0)
+          node.peerManager.addPeerToTry(Vector(peer), 0)
         }
       case addr: AddrV2Message =>
         val bytes = addr.bytes
@@ -109,10 +109,10 @@ case class ControlMessageHandler(node: Node)(implicit ec: ExecutionContext)
         val priority = if (services.nodeCompactFilters) 1 else 0
         addr match {
           case IPv4AddrV2Message(_, _, _, _) | IPv6AddrV2Message(_, _, _, _) =>
-            node.peerManager.finder.addToTry(Vector(peer), priority = priority)
+            node.peerManager.addPeerToTry(Vector(peer), priority = priority)
           case TorV3AddrV2Message(_, _, _, _) =>
             if (node.nodeAppConfig.torConf.enabled)
-              node.peerManager.finder.addToTry(Vector(peer), priority)
+              node.peerManager.addPeerToTry(Vector(peer), priority)
           case _ => logger.debug(s"Unsupported network. Skipping.")
         }
     }


### PR DESCRIPTION
Pulls over changes from #4950 that should not make the node module worse.

This PR

- reduces noisy logs
- adds more information to error message such as what peer caused the error
- renames misleading methods
- reduces timeouts in `P2PClientActor`