### PR TITLE
Add check we have more than 1 peer before we try to `syncFromNewPeer()`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -358,10 +358,12 @@ case class PeerManager(
       val syncPeer = node.getDataMessageHandler.syncPeer
       if (peers.length > 1 && syncPeer.isDefined && syncPeer.get == peer) {
         syncFromNewPeer().map(_ => ())
-      } else {
-        logger.error(
-          s"No new peers to sync from, cannot start new sync. Terminated sync with syncPeer=$syncPeer")
+      } else if (syncPeer.isEmpty) {
         Future.unit
+      } else {
+        val exn = new RuntimeException(
+          s"No new peers to sync from, cannot start new sync. Terminated sync with syncPeer=$syncPeer")
+        Future.failed(exn)
       }
     } else if (waitingForDeletion.contains(peer)) {
       //a peer we wanted to disconnect has remove has stopped the client actor, finally mark this as deleted

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -356,10 +356,13 @@ case class PeerManager(
       //reconnection tries exceeding the max limit in which the client was stopped to disconnect from it, remove it
       _peerData.remove(peer)
       val syncPeer = node.getDataMessageHandler.syncPeer
-      if (syncPeer.isDefined && syncPeer.get == peer) {
-
+      if (peers.length > 1 && syncPeer.isDefined && syncPeer.get == peer) {
         syncFromNewPeer().map(_ => ())
-      } else Future.unit
+      } else {
+        logger.error(
+          s"No new peers to sync from, cannot start new sync. Terminated sync with syncPeer=$syncPeer")
+        Future.unit
+      }
     } else if (waitingForDeletion.contains(peer)) {
       //a peer we wanted to disconnect has remove has stopped the client actor, finally mark this as deleted
       _waitingForDeletion.remove(peer)
@@ -371,13 +374,13 @@ case class PeerManager(
   }
 
   def onVersionMessage(peer: Peer, versionMsg: VersionMessage): Unit = {
-    assert(!finder.hasPeer(peer) || !peerData.contains(peer),
-           s"$peer cannot be both a test and a persistent peer")
+    require(!finder.hasPeer(peer) || !peerData.contains(peer),
+            s"$peer cannot be both a test and a persistent peer")
 
     if (finder.hasPeer(peer)) {
       finder.getData(peer).setServiceIdentifier(versionMsg.services)
     } else if (peerData.contains(peer)) {
-      assert(
+      require(
         peerData(peer).serviceIdentifier.bytes == versionMsg.services.bytes)
     } else {
       logger.warn(s"onVersionMessage called for unknown $peer")

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -65,6 +65,7 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
+    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->
     <!-- ╚════════════════════╝ -->


### PR DESCRIPTION
Fixes deadlock that can happen where we try to sync from another peer when we only have 1 peer in our `PeerManager`. 

This could lead to the future returned by `PeerManager.syncFromNewPeer()` to not complete inside of `P2PClientActor.postStop()`. This leads to the `Await.result(onStop(peer), timeout)` inside of `P2PClientActor.postStop()` to fail to stop, leading to a exception that fails to the test case.

<img width="1187" alt="Screen Shot 2023-02-01 at 5 58 14 PM" src="https://user-images.githubusercontent.com/3514957/216196332-7cedfa13-2c56-4c74-a828-96e306561c92.png">
