### PR TITLE
Refactor to not throw an exception is node is already syncing

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -520,13 +520,13 @@ object NodeUnitTest extends P2PLogger {
             s"Node is already syncing, skipping initiating a new sync.")
           Future.successful(node)
         } else {
-          startNeutrinoNodeSync(node, bitcoind)
+          neutrinoNodeSyncHelper(node, bitcoind)
         }
       }
     } yield newNode
   }
 
-  private def startNeutrinoNodeSync(
+  private def neutrinoNodeSyncHelper(
       node: NeutrinoNode,
       bitcoind: BitcoindRpcClient)(implicit
       system: ActorSystem): Future[NeutrinoNode] = {


### PR DESCRIPTION
Fixes this exception being thrown inside of `NodeUnitTest.syncNeutrinoNode`. Now we just log a message. In the future we may want to get rid of the log as well.



```
ScalaTest can't report this exception because another preceded it, so printing its stack trace:
java.lang.IllegalArgumentException: requirement failed: Cannot start syncing neutrino node when previous sync is ongoing
  | => oat scala.Predef$.require(Predef.scala:337)geHandlerTest 256s
  | => oat org.bitcoins.testkit.node.NodeUnitTest$.$anonfun$syncNeutrinoNode$2(NodeUnitTest.scala:518)
  | => oat org.bitcoins.testkit.node.NodeUnitTest$.$anonfun$syncNeutrinoNode$2$adapted(NodeUnitTest.scala:515)
  | => oat scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
        at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:63)
        at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:100)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
        at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
        at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:100)
        at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:49)
        at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1311)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1840)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```