### PR TITLE
Segregate handling of exceptions in fixtures

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -30,7 +30,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 
-  def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val outcomeF: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
       outcome = withNeutrinoNodeFundedWalletBitcoind(
@@ -39,7 +39,6 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       )(system, getFreshConfig)
       f <- outcome.toFuture
     } yield f
-
     new FutureOutcome(outcomeF)
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -45,6 +45,7 @@ trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
           case Failure(fixtureExn) =>
             //means setting up the fixture, NOT the test case, failed
             //since the fixture failed, we cannot destroy the fixture
+            logger.error(s"Failed to setup test fixture", fixtureExn)
             Future.failed(fixtureExn)
         }
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSFixture.scala
@@ -29,9 +29,6 @@ trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
       .flatMap { fixture =>
         test(fixture.asInstanceOf[FixtureParam]).toFuture
       }
-      .recoverWith { case err =>
-        FutureOutcome.failed(err).toFuture
-      }
 
     val destructedF: Future[Outcome] = outcomeF.transformWith {
       case Success(o) =>
@@ -40,11 +37,15 @@ trait BitcoinSFixture extends BitcoinSAsyncFixtureTest {
           _ <- destroy(t)
         } yield o
       case Failure(exn) =>
-        for {
-          t <- fixtureF
-          _ <- destroy(t)
-        } yield {
-          throw exn
+        fixtureF.transformWith {
+          case Success(t) =>
+            //means fixture setup successfully, something in test case code failed
+            //so we should destroy the fixture
+            destroy(t).flatMap(_ => Future.failed(exn))
+          case Failure(fixtureExn) =>
+            //means setting up the fixture, NOT the test case, failed
+            //since the fixture failed, we cannot destroy the fixture
+            Future.failed(fixtureExn)
         }
     }
     new FutureOutcome(destructedF)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -173,9 +173,11 @@ abstract class NodeTestUtil extends P2PLogger {
       node.chainApiFromDb().flatMap(_.getBestBlockHash())
     }
     TestAsyncUtil.retryUntilSatisfiedF(() =>
-      bestHashF.map { case bestHash =>
-        bestHash == hash
-      })
+                                         bestHashF.map { case bestHash =>
+                                           bestHash == hash
+                                         },
+                                       interval = 1.second,
+                                       maxTries = syncTries)
   }
 
   /** Awaits header, filter header and filter sync between the neutrino node and rpc client */


### PR DESCRIPTION
Creates two separate paths for two different scenarios failure paths in `makeDependentFixture`

The two different scenarios are 

1. The _fixture_ fails to setup an exception
2. The _test case_ fails with an exception

We want to do different things in these two cases. Namely we want to destroy the fixture if it was successfully setup. If the fixture failed to setup correctly, we cannot destroy it. 