### PR TITLE
Refactor `NodeTestUtil.awaitBestHash()` to take a reference to `bitcoind`

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -224,9 +224,9 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       //as they happen with the 'sendheaders' message
       //both our spv node and our bitcoind node _should_ both be at the genesis block (regtest)
       //at this point so no actual syncing is happening
-      val initSyncF = gen1F.flatMap { hashes =>
+      val initSyncF = gen1F.flatMap { _ =>
         for {
-          _ <- NodeTestUtil.awaitBestHash(hashes.head, node)
+          _ <- NodeTestUtil.awaitBestHash(node, bitcoind)
         } yield ()
       }
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -115,8 +115,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         //out of sync by 1 block, h2 ahead
         _ = assert(h2 - h1 == 1)
         _ <- node.sync()
-        bestHash <- bitcoinds(1).getBestBlockHash
-        _ <- NodeTestUtil.awaitBestHash(bestHash, node)
+        _ <- NodeTestUtil.awaitBestHash(node, bitcoinds(1))
       } yield {
         succeed
       }


### PR DESCRIPTION
This avoids problems where else where a `bitcoind.generate()` could be called, thus making the parameter for `NodeTestUtil.awaitBestHash()` becoming stale, which means the `Future` returned will fail with a timeout.

This refactor should make the method usage much more robust and safe.