### PR TITLE
Segregate `P2PClientTest` and `P2PClientActorTest`

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -20,7 +20,8 @@ class BroadcastTransactionTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
@@ -10,7 +10,8 @@ import org.scalatest.FutureOutcome
 class DisconnectedPeerTest extends NodeUnitTest {
 
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   override type FixtureParam = NeutrinoNode
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -24,7 +24,9 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig = {
-    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(
+      pgUrl,
+      Vector.empty)
   }
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoinds

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -36,7 +36,9 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
     s"0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4adae5494dffff7f2003000000")
 
   override protected def getFreshConfig: BitcoinSAppConfig = {
-    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(
+      pgUrl,
+      Vector.empty)
   }
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoinds

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -26,7 +26,8 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   override type FixtureParam = NeutrinoNodeFundedWalletBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoUnsupportedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoUnsupportedPeerTest.scala
@@ -19,7 +19,8 @@ class NeutrinoUnsupportedPeerTest
         |bitcoin-s.node.peer-discovery-timeout = 10s
       """.stripMargin
     )
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl, config)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector(config))
   }
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoind

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -17,7 +17,9 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig = {
-    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(
+      pgUrl,
+      Vector.empty)
   }
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoind

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
@@ -43,6 +43,12 @@ class P2PClientActorTest
   }
 
   lazy val probe: TestProbe = TestProbe()
+
+  override def afterAll(): Unit = {
+    super[BitcoindRpcBaseTest].afterAll()
+    super[BitcoinSAppConfigBitcoinFixtureStarted].afterAll()
+  }
+
   behavior of "P2PClientActorTest"
 
   it must "establish a tcp connection with a bitcoin node" in { tuple =>

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
@@ -70,17 +70,12 @@ class P2PClientActorTest
 
     val try2 = for {
       peer <- bitcoindPeer2F
-      _ <-
-        try1 //wait for the first node to get connected to avoid a race condition
       client <- buildP2PClient(peer)(tuple._2.chainConf, tuple._2.nodeConf)
       res <- connectAndDisconnect(client)
     } yield res
 
     try1.flatMap { _ =>
-      try2.map { a =>
-        logger.error(s"Done with connect to two nodes")
-        a
-      }
+      try2
     }
   }
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
@@ -1,0 +1,146 @@
+package org.bitcoins.node.networking
+
+import akka.testkit.{TestActorRef, TestProbe}
+import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.node.config.NodeAppConfig
+import org.bitcoins.node.models.Peer
+import org.bitcoins.node.networking.P2PClient.ConnectCommand
+import org.bitcoins.node.networking.peer.PeerMessageReceiver
+import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.async.TestAsyncUtil
+import org.bitcoins.testkit.fixtures.BitcoinSAppConfigBitcoinFixtureStarted
+import org.bitcoins.testkit.node.{NodeTestUtil, NodeUnitTest}
+import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
+import org.bitcoins.testkit.tor.CachedTor
+import org.bitcoins.testkit.util.BitcoindRpcBaseTest
+import org.scalatest.{Assertion, FutureOutcome}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+
+class P2PClientActorTest
+    extends BitcoinSAppConfigBitcoinFixtureStarted
+    with BitcoindRpcBaseTest
+    with CachedTor {
+
+  override type FixtureParam = (BitcoinSAppConfig, BitcoinSAppConfig)
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+    withTwoBitcoinSAppConfigNotStarted(test)
+
+  lazy val bitcoindRpcF =
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
+
+  lazy val bitcoindPeerF = bitcoindRpcF.flatMap { bitcoind =>
+    NodeTestUtil.getBitcoindPeer(bitcoind)
+  }
+
+  lazy val bitcoindRpc2F =
+    BitcoindRpcTestUtil.startedBitcoindRpcClient(clientAccum = clientAccum)
+
+  lazy val bitcoindPeer2F = bitcoindRpcF.flatMap { bitcoind =>
+    NodeTestUtil.getBitcoindPeer(bitcoind)
+  }
+
+  lazy val probe: TestProbe = TestProbe()
+  behavior of "P2PClientActorTest"
+
+  it must "establish a tcp connection with a bitcoin node" in { tuple =>
+    implicit val chainConf = tuple._1.chainConf
+    implicit val nodeConf = tuple._1.nodeConf
+    for {
+      peer <- bitcoindPeerF
+      client <- buildP2PClient(peer)
+      res <- connectAndDisconnect(client)
+    } yield res
+  }
+
+  it must "connect to two nodes" in { tuple =>
+    val try1 = for {
+      peer <- bitcoindPeerF
+      client <- buildP2PClient(peer)(tuple._1.chainConf, tuple._1.nodeConf)
+      res <- connectAndDisconnect(client)
+    } yield res
+
+    val try2 = for {
+      peer <- bitcoindPeer2F
+      _ <-
+        try1 //wait for the first node to get connected to avoid a race condition
+      client <- buildP2PClient(peer)(tuple._2.chainConf, tuple._2.nodeConf)
+      res <- connectAndDisconnect(client)
+    } yield res
+
+    try1.flatMap { _ =>
+      try2.map { a =>
+        logger.error(s"Done with connect to two nodes")
+        a
+      }
+    }
+  }
+
+  it must "close actor on disconnect" in { tuple =>
+    for {
+      peer <- bitcoindPeerF
+      client <- buildP2PClient(peer)(tuple._1.chainConf, tuple._1.nodeConf)
+      _ = probe.watch(client.actor)
+      _ <- connectAndDisconnect(client)
+      term = probe.expectTerminated(client.actor)
+    } yield {
+      assert(term.actor == client.actor)
+    }
+  }
+
+  def buildP2PClient(peer: Peer)(implicit
+      chainAppConfig: ChainAppConfig,
+      nodeAppConfig: NodeAppConfig): Future[P2PClient] = {
+    val peerMessageReceiverF =
+      for {
+        node <- NodeUnitTest.buildNode(peer, None)
+      } yield PeerMessageReceiver.preConnection(peer, node)
+
+    val clientActorF: Future[TestActorRef[P2PClientActor]] =
+      peerMessageReceiverF.map { peerMsgRecv =>
+        TestActorRef(
+          P2PClient.props(peer = peer,
+                          peerMsgHandlerReceiver = peerMsgRecv,
+                          onReconnect = (_: Peer) => Future.unit,
+                          onStop = (_: Peer) => Future.unit,
+                          maxReconnectionTries = 16),
+          probe.ref
+        )
+      }
+    val p2pClientF: Future[P2PClient] = clientActorF.map {
+      client: TestActorRef[P2PClientActor] =>
+        P2PClient(client, peer)
+    }
+    p2pClientF
+  }
+
+  /** Helper method to connect to the
+    * remote node and bind our local
+    * connection to the specified port
+    */
+  private def connectAndDisconnect(p2pClient: P2PClient): Future[Assertion] = {
+    p2pClient.actor ! ConnectCommand
+
+    val isConnectedF = for {
+      isConnected <- TestAsyncUtil.retryUntilSatisfiedF(p2pClient.isConnected,
+                                                        1.second,
+                                                        10)
+    } yield isConnected
+
+    isConnectedF.flatMap { _ =>
+      p2pClient.actor ! P2PClient.CloseCommand
+      val isDisconnectedF = for {
+        isDisconnected <-
+          TestAsyncUtil.retryUntilSatisfiedF(p2pClient.isDisconnected,
+                                             interval = 1.second,
+                                             maxTries = 100)
+      } yield isDisconnected
+
+      isDisconnectedF.map { _ =>
+        succeed
+      }
+    }
+  }
+}

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -19,7 +19,8 @@ import scala.concurrent.duration.DurationInt
 class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
 
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoind
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -25,7 +25,8 @@ class DataMessageHandlerTest extends NodeUnitTest with CachedTor {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoindV22
 

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverTest.scala
@@ -21,7 +21,9 @@ class PeerMessageReceiverTest extends NodeTestWithCachedBitcoindNewest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(
+      pgUrl,
+      Vector.empty)
 
   override type FixtureParam = NeutrinoNodeConnectedWithBitcoind
 

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -35,7 +35,7 @@ case class NeutrinoNode(
     extends Node {
   require(
     nodeConfig.nodeType == NodeType.NeutrinoNode,
-    s"We need our Neutrino mode enabled to be able to construct a Neutrino node!")
+    s"We need our Neutrino mode enabled to be able to construct a Neutrino node, got=${nodeConfig.nodeType}!")
 
   implicit override def system: ActorSystem = actorSystem
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -24,10 +24,11 @@ object BitcoinSTestAppConfig {
   /** Generates a temp directory with the prefix 'bitcoin-s- */
   def tmpDir(): Path = Files.createTempDirectory("bitcoin-s-")
 
-  def genWalletNameConf: Config = {
-    val walletNameOpt = if (NumberGenerator.bool.sampleSome) {
-      Some(UUID.randomUUID().toString.replace("-", ""))
-    } else None
+  def genWalletNameConf(forceNamedWallet: Boolean): Config = {
+    val walletNameOpt =
+      if (forceNamedWallet || NumberGenerator.bool.sampleSome) {
+        Some(UUID.randomUUID().toString.replace("-", ""))
+      } else None
 
     walletNameOpt match {
       case Some(walletName) =>
@@ -61,9 +62,16 @@ object BitcoinSTestAppConfig {
     BitcoinSAppConfig(tmpDir(), (overrideConf +: config).toVector)
   }
 
+  /** @param pgUrl
+    * @param config
+    * @param forceNamedWallet forces a wallet to have a name, if false there is a 50% chance the wallet will have a name
+    * @return
+    */
   def getNeutrinoWithEmbeddedDbTestConfig(
       pgUrl: () => Option[String],
-      config: Config*)(implicit system: ActorSystem): BitcoinSAppConfig = {
+      config: Vector[Config],
+      forceNamedWallet: Boolean = false)(implicit
+      system: ActorSystem): BitcoinSAppConfig = {
     val overrideConf = ConfigFactory
       .parseString {
         s"""
@@ -79,7 +87,7 @@ object BitcoinSTestAppConfig {
            |}
       """.stripMargin
       }
-      .withFallback(genWalletNameConf)
+      .withFallback(genWalletNameConf(forceNamedWallet))
 
     BitcoinSAppConfig(
       tmpDir(),
@@ -87,9 +95,16 @@ object BitcoinSTestAppConfig {
                                             pgUrl) +: config).toVector)
   }
 
+  /** @param pgUrl
+    * @param config
+    * @param forceNamedWallet forces a wallet to have a name, if false there is a 50% chance the wallet will have a name
+    * @return
+    */
   def getMultiPeerNeutrinoWithEmbeddedDbTestConfig(
       pgUrl: () => Option[String],
-      config: Config*)(implicit system: ActorSystem): BitcoinSAppConfig = {
+      config: Vector[Config],
+      forceNamedWallet: Boolean = false)(implicit
+      system: ActorSystem): BitcoinSAppConfig = {
     val overrideConf = ConfigFactory
       .parseString {
         s"""
@@ -106,7 +121,7 @@ object BitcoinSTestAppConfig {
            |}
       """.stripMargin
       }
-      .withFallback(genWalletNameConf)
+      .withFallback(genWalletNameConf(forceNamedWallet))
 
     BitcoinSAppConfig(
       tmpDir(),

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
@@ -82,4 +82,9 @@ trait BitcoinSAppConfigBitcoinFixtureStarted
     makeDependentFixture[(BitcoinSAppConfig, BitcoinSAppConfig)](builder,
                                                                  destroyF)(test)
   }
+
+  override def afterAll(): Unit = {
+    super[CachedBitcoindNewest].afterAll()
+    super[BitcoinSAppConfigFixture].afterAll()
+  }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
@@ -57,7 +57,7 @@ trait BitcoinSAppConfigBitcoinFixtureStarted
       test: OneArgAsyncTest): FutureOutcome = {
     val builder: () => Future[(BitcoinSAppConfig, BitcoinSAppConfig)] = () => {
       for {
-        bitcoind <- cachedBitcoindWithFundsF
+        _ <- cachedBitcoindWithFundsF
         bitcoinSAppConfig1 = BitcoinSTestAppConfig
           .getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
         bitcoinSAppConfig2 = BitcoinSTestAppConfig

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/BitcoinSAppConfigFixture.scala
@@ -59,9 +59,13 @@ trait BitcoinSAppConfigBitcoinFixtureStarted
       for {
         _ <- cachedBitcoindWithFundsF
         bitcoinSAppConfig1 = BitcoinSTestAppConfig
-          .getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+          .getNeutrinoWithEmbeddedDbTestConfig(pgUrl = pgUrl,
+                                               config = Vector.empty,
+                                               forceNamedWallet = true)
         bitcoinSAppConfig2 = BitcoinSTestAppConfig
-          .getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+          .getNeutrinoWithEmbeddedDbTestConfig(pgUrl = pgUrl,
+                                               config = Vector.empty,
+                                               forceNamedWallet = true)
         _ <- bitcoinSAppConfig1.start()
         _ <- bitcoinSAppConfig2.start()
       } yield (bitcoinSAppConfig1, bitcoinSAppConfig2)

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCDAOFixture.scala
@@ -78,7 +78,7 @@ trait DLCDAOFixture extends BitcoinSFixture with EmbeddedPg {
 
   implicit protected val config: BitcoinSAppConfig =
     BitcoinSTestAppConfig
-      .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl())
+      .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl(), Vector.empty)
 
   implicit private val dlcConfig: DLCAppConfig = config.dlcConf
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/NodeDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/NodeDAOFixture.scala
@@ -17,7 +17,8 @@ trait NodeDAOFixture extends NodeUnitTest with CachedBitcoinSAppConfig {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl,
+                                                              Vector.empty)
 
   private lazy val daos = {
     val tx = BroadcastAbleTransactionDAO()

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/WalletDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/WalletDAOFixture.scala
@@ -34,7 +34,7 @@ trait WalletDAOFixture extends BitcoinSFixture with EmbeddedPg {
 
   implicit protected val config: WalletAppConfig =
     BitcoinSTestAppConfig
-      .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl())
+      .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl(), Vector.empty)
       .walletConf
 
   final override type FixtureParam = WalletDAOs

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -560,7 +560,7 @@ object NodeUnitTest extends P2PLogger {
     * the setup phase for the next test.
     * @param appConfig
     */
-  private def cleanTables(appConfig: BitcoinSAppConfig): Unit = {
+  def cleanTables(appConfig: BitcoinSAppConfig): Unit = {
     appConfig.nodeConf.clean()
     appConfig.walletConf.clean()
     appConfig.chainConf.clean()

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -560,7 +560,7 @@ object NodeUnitTest extends P2PLogger {
     * the setup phase for the next test.
     * @param appConfig
     */
-  def cleanTables(appConfig: BitcoinSAppConfig): Unit = {
+  private def cleanTables(appConfig: BitcoinSAppConfig): Unit = {
     appConfig.nodeConf.clean()
     appConfig.walletConf.clean()
     appConfig.chainConf.clean()

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainUtil.scala
@@ -11,7 +11,6 @@ import org.bitcoins.rpc.config.{
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
-import org.bitcoins.testkit.node.NodeUnitTest
 import org.bitcoins.testkit.util.{FileUtil, TorUtil}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -59,7 +58,6 @@ object BitcoinSServerMainUtil {
 
   def destroyBitcoinSAppConfig(appConfig: BitcoinSAppConfig)(implicit
       ec: ExecutionContext): Future[Unit] = {
-    NodeUnitTest.cleanTables(appConfig)
     val stopF = appConfig
       .stop()
       .map(_ => BitcoinSTestAppConfig.deleteAppConfig(appConfig))

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainUtil.scala
@@ -11,6 +11,7 @@ import org.bitcoins.rpc.config.{
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.node.NodeUnitTest
 import org.bitcoins.testkit.util.{FileUtil, TorUtil}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -58,6 +59,7 @@ object BitcoinSServerMainUtil {
 
   def destroyBitcoinSAppConfig(appConfig: BitcoinSAppConfig)(implicit
       ec: ExecutionContext): Future[Unit] = {
+    NodeUnitTest.cleanTables(appConfig)
     val stopF = appConfig
       .stop()
       .map(_ => BitcoinSTestAppConfig.deleteAppConfig(appConfig))

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
@@ -52,4 +52,10 @@ trait BitcoindRpcBaseTest extends Logging { this: BitcoinSAkkaAsyncTest =>
 
 abstract class BitcoindRpcTest
     extends BitcoinSAsyncTest
-    with BitcoindRpcBaseTest
+    with BitcoindRpcBaseTest {
+
+  override def afterAll(): Unit = {
+    super[BitcoindRpcBaseTest].afterAll()
+    super[BitcoinSAsyncTest].afterAll()
+  }
+}

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoindRpcTest.scala
@@ -9,7 +9,7 @@ import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import scala.collection.mutable
 import scala.concurrent.{Await, Future}
 
-abstract class BitcoindRpcTest extends BitcoinSAsyncTest with Logging {
+trait BitcoindRpcBaseTest extends Logging { this: BitcoinSAkkaAsyncTest =>
 
   private val dirExists =
     Files.exists(BitcoindRpcTestClient.sbtBinaryDirectory)
@@ -25,7 +25,7 @@ abstract class BitcoindRpcTest extends BitcoinSAsyncTest with Logging {
     printerr(s"Run 'sbt downloadBitcoind' to fetch needed binaries")
     sys.error {
       val msg =
-        s""""bitcoind binary directory (${BitcoindRpcTestClient.sbtBinaryDirectory}) is empty. 
+        s""""bitcoind binary directory (${BitcoindRpcTestClient.sbtBinaryDirectory}) is empty.
            |Run 'sbt downloadBitcoind' to fetch needed binaries""".stripMargin
       msg
     }
@@ -43,10 +43,13 @@ abstract class BitcoindRpcTest extends BitcoinSAsyncTest with Logging {
   override def afterAll(): Unit = {
     val stopF = BitcoindRpcTestUtil.stopServers(clientAccum.result())
     Await.result(stopF, duration)
-    super.afterAll()
   }
 
   def startClient(client: BitcoindRpcClient): Future[Unit] = {
     BitcoindRpcTestUtil.startServers(Vector(client))
   }
 }
+
+abstract class BitcoindRpcTest
+    extends BitcoinSAsyncTest
+    with BitcoindRpcBaseTest

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -47,7 +47,7 @@ object BaseWalletTest {
 
   def getFreshConfig(pgUrl: () => Option[String], config: Vector[Config])(
       implicit system: ActorSystem): BitcoinSAppConfig = {
-    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl, config: _*)
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(pgUrl, config)
   }
 
   def getFreshWalletAppConfig(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -221,7 +221,8 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
     val confOverride = configForPurposeAndSeed(purpose)
     implicit val conf: WalletAppConfig =
       BitcoinSTestAppConfig
-        .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl(), confOverride)
+        .getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl(),
+                                             Vector(confOverride))
         .walletConf
 
     val testVectors = purpose match {


### PR DESCRIPTION
Makes it easier to directly test the actor using test fixtures. Previously in `P2PClientTest` we had simple parsing unit tests that do not need fixtures, and then complicate test cases testing the actor that would be nice to have test fixtures for.