### PR TITLE
Add rpc for `syncwithvalidationinterfacequeue`, use it in `NodeUnitTest.syncNeutrinoNode`

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BlockchainRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BlockchainRpc.scala
@@ -253,4 +253,12 @@ trait BlockchainRpc { self: Client =>
     bitcoindCall[Boolean]("verifychain",
                           List(JsNumber(level), JsNumber(blocks)))
   }
+
+  /** Waits for the validation interface queue to catch up on everything that was there when we entered this function
+    * @see [[https://github.com/bitcoin/bitcoin/issues/27085]]
+    * @return
+    */
+  def syncWithValidationInterfaceQueue(): Future[Unit] = {
+    bitcoindCall[Unit](command = "syncwithvalidationinterfacequeue", List.empty)
+  }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -532,6 +532,10 @@ object NodeUnitTest extends P2PLogger {
       system: ActorSystem): Future[NeutrinoNode] = {
     import system.dispatcher
     for {
+      //wait for bitcoind to be synced internally
+      //see: https://github.com/bitcoin/bitcoin/issues/27085
+      //see: https://github.com/bitcoin-s/bitcoin-s/issues/4976
+      _ <- bitcoind.syncWithValidationInterfaceQueue()
       _ <- node.sync()
       syncing <- node.chainApiFromDb().flatMap(_.isSyncing())
       _ = require(syncing)


### PR DESCRIPTION
fixes #4976 

The issue is described via this issue on bitcoin core: https://github.com/bitcoin/bitcoin/issues/27085

Now we make sure `bitcoind` is synced internally with itself by making sure all indices are built for filters. 