### PR TITLE
Check compact filter headers if we have already stored them in the database

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -81,6 +81,12 @@ case class CompactFilterHeaderDAO()(implicit
     read(hash)
   }
 
+  def findByHashes(hashes: Vector[DoubleSha256DigestBE]): Future[
+    Vector[CompactFilterHeaderDb]] = {
+    val query = findByPrimaryKeys(hashes).result
+    safeDatabase.runVec(query)
+  }
+
   def findByBlockHash(
       hash: DoubleSha256DigestBE): Future[Option[CompactFilterHeaderDb]] = {
     val query = table.filter(_.blockHash === hash).take(1)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -268,10 +268,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       for {
         _ <- NodeUnitTest.syncNeutrinoNode(node, bitcoind)
         _ <- AkkaUtil.nonBlockingSleep(3.seconds)
-        tip <- bitcoind.getBestBlockHash
-        hashes <- bitcoind.generateToAddress(2, junkAddress)
-        _ = logger.error(
-          s"@@@@@@@@@ hashes=${hashes} before.tip=$tip @@@@@@@@@")
+        _ <- bitcoind.generateToAddress(2, junkAddress)
         _ <- NodeTestUtil.awaitAllSync(node, bitcoind)
       } yield {
         succeed

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -268,7 +268,10 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       for {
         _ <- NodeUnitTest.syncNeutrinoNode(node, bitcoind)
         _ <- AkkaUtil.nonBlockingSleep(3.seconds)
-        _ <- bitcoind.generateToAddress(2, junkAddress)
+        tip <- bitcoind.getBestBlockHash
+        hashes <- bitcoind.generateToAddress(2, junkAddress)
+        _ = logger.error(
+          s"@@@@@@@@@ hashes=${hashes} before.tip=$tip @@@@@@@@@")
         _ <- NodeTestUtil.awaitAllSync(node, bitcoind)
       } yield {
         succeed


### PR DESCRIPTION
>2023-02-24 17:48:34,758 ERROR [SafeDatabase] org.sqlite.SQLiteException: [SQLITE_CONSTRAINT_PRIMARYKEY] A PRIMARY KEY constraint failed (UNIQUE constraint failed: cfheaders.hash)

This PR fixes this error message. This is caused when we try to add a filter header we have already stored in our `chaindb`. 

This PR filters out compact filter headers we have already seen before storing it in the database.