### PR TITLE
Fix `empty.tail` exception occurring on chain block filter / filter headers callbacks

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
@@ -112,7 +112,9 @@ object WebsocketUtil extends Logging {
         val emitBlockProccessedWhileIBDOnGoing =
           chainAppConfig.ibdBlockProcessedEvents
         isIBDF.flatMap { isIBD =>
-          if (isIBD && !emitBlockProccessedWhileIBDOnGoing && filterHeaders.nonEmpty) {
+          if (
+            isIBD && !emitBlockProccessedWhileIBDOnGoing && filterHeaders.nonEmpty
+          ) {
             val notifications =
               CompactFilterHeaderProcessedNotification(filterHeaders.last)
             sendHeadersToWs(Vector(notifications), queue)
@@ -132,7 +134,7 @@ object WebsocketUtil extends Logging {
         isIBDF.flatMap { isIBD =>
           if (
             isIBD && !emitBlockProccessedWhileIBDOnGoing && filters.nonEmpty
-            ) {
+          ) {
             val notifications = CompactFilterProcessedNotification(filters.last)
             sendHeadersToWs(Vector(notifications), queue)
           } else {

--- a/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
@@ -112,7 +112,7 @@ object WebsocketUtil extends Logging {
         val emitBlockProccessedWhileIBDOnGoing =
           chainAppConfig.ibdBlockProcessedEvents
         isIBDF.flatMap { isIBD =>
-          if (isIBD && !emitBlockProccessedWhileIBDOnGoing) {
+          if (isIBD && !emitBlockProccessedWhileIBDOnGoing && filterHeaders.nonEmpty) {
             val notifications =
               CompactFilterHeaderProcessedNotification(filterHeaders.last)
             sendHeadersToWs(Vector(notifications), queue)
@@ -130,7 +130,9 @@ object WebsocketUtil extends Logging {
         val emitBlockProccessedWhileIBDOnGoing =
           chainAppConfig.ibdBlockProcessedEvents
         isIBDF.flatMap { isIBD =>
-          if (isIBD && !emitBlockProccessedWhileIBDOnGoing) {
+          if (
+            isIBD && !emitBlockProccessedWhileIBDOnGoing && filters.nonEmpty
+            ) {
             val notifications = CompactFilterProcessedNotification(filters.last)
             sendHeadersToWs(Vector(notifications), queue)
           } else {


### PR DESCRIPTION
Fixes #5020 

Adds guards for the case where an empty `Vector` is passed to chain callbacks