### PR TITLE
Remove fetch compact filters in `NeutrinoNode.sync()` before fetching block headers / compact filter headers

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -106,11 +106,6 @@ case class NeutrinoNode(
       _ = updateDataMessageHandler(
         dataMessageHandler.copy(syncPeer = Some(syncPeer)))
       peerMsgSender <- peerManager.peerData(syncPeer).peerMessageSender
-
-      bestHash <- chainApi.getBestBlockHash()
-      _ <- peerMsgSender.sendGetCompactFilterCheckPointMessage(stopHash =
-        bestHash.flip)
-      chainApi <- chainApiFromDb()
       header <- chainApi.getBestBlockHeader()
       bestFilterHeaderOpt <- chainApi.getBestFilterHeader()
       bestFilterOpt <- chainApi.getBestFilter()


### PR DESCRIPTION
Likely related to #5022 

This was included in #4408 for some reason but i'm unsure why. It doesn't seem to make sense to me in any situation that we fetch compact filters before block headers / filter headers. 