### PR TITLE
2023 03 24 is tip stale

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -15,7 +15,7 @@ import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.util.{FutureUtil, NetworkUtil}
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.crypto.{
   DoubleSha256Digest,
@@ -289,6 +289,13 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
 
   override def isIBD(): Future[Boolean] = {
     getBlockChainInfo.map(_.initialblockdownload)
+  }
+
+  override def isTipStale(): Future[Boolean] = {
+    getBestBlockHeader().map { blockHeaderDb =>
+      NetworkUtil.isBlockHeaderStale(blockHeaderDb.blockHeader,
+                                     network.chainParams)
+    }
   }
 
   override def setSyncing(value: Boolean): Future[ChainApi] = {

--- a/chain-test/src/test/scala/org/bitcoins/chain/ChainCallbacksTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/ChainCallbacksTest.scala
@@ -6,11 +6,8 @@ import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.crypto.{CryptoUtil, DoubleSha256DigestBE}
-import org.bitcoins.testkit.chain.{
-  BlockHeaderHelper,
-  ChainDbUnitTest,
-  ChainUnitTest
-}
+import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainDbUnitTest}
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 import org.scalatest.FutureOutcome
 import scodec.bits.ByteVector
 
@@ -39,7 +36,7 @@ class ChainCallbacksTest extends ChainDbUnitTest {
       chainHandler.chainConfig.addCallbacks(callbacks)
 
       val newValidHeader =
-        BlockHeaderHelper.buildNextHeader(ChainUnitTest.genesisHeaderDb)
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.genesisHeaderDb)
 
       for {
         _ <- chainHandler.processHeader(newValidHeader.blockHeader)
@@ -64,12 +61,12 @@ class ChainCallbacksTest extends ChainDbUnitTest {
       chainHandler.chainConfig.addCallbacks(callbacks)
 
       val newValidHeader =
-        BlockHeaderHelper.buildNextHeader(ChainUnitTest.genesisHeaderDb)
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.genesisHeaderDb)
       val nextCompactFilterHeaderDb =
         CompactFilterHeaderDb(
           hashBE = DoubleSha256DigestBE.fromHex(
             "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f"),
-          previousFilterHeaderBE = ChainUnitTest.genesisFilterHeaderDb.hashBE,
+          previousFilterHeaderBE = ChainTestUtil.genesisFilterHeaderDb.hashBE,
           height = 1,
           filterHashBE = DoubleSha256DigestBE.fromHex(
             "555152535455565758595a5b5c5d5e5f555152535455565758595a5b5c5d5e5f"),
@@ -102,7 +99,7 @@ class ChainCallbacksTest extends ChainDbUnitTest {
       chainHandler.chainConfig.addCallbacks(callbacks)
 
       val newValidHeader =
-        BlockHeaderHelper.buildNextHeader(ChainUnitTest.genesisHeaderDb)
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.genesisHeaderDb)
 
       val bytes = ByteVector(scala.util.Random.nextBytes(32))
       val hashBE = CryptoUtil.doubleSHA256(bytes)
@@ -110,7 +107,7 @@ class ChainCallbacksTest extends ChainDbUnitTest {
         CompactFilterHeaderDb(
           hashBE = DoubleSha256DigestBE.fromHex(
             "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f"),
-          previousFilterHeaderBE = ChainUnitTest.genesisFilterHeaderDb.hashBE,
+          previousFilterHeaderBE = ChainTestUtil.genesisFilterHeaderDb.hashBE,
           height = 1,
           filterHashBE = hashBE.flip,
           blockHashBE = newValidHeader.hashBE

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -6,6 +6,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.testkit.chain.fixture.ChainFixture
 import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainUnitTest}
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 import org.scalatest.FutureOutcome
 
 import scala.collection.mutable
@@ -19,7 +20,7 @@ class BlockchainTest extends ChainUnitTest {
   behavior of "Blockchain"
 
   it must "have the correct toString" inFixtured { case ChainFixture.Empty =>
-    val genesis = ChainUnitTest.genesisHeaderDb
+    val genesis = ChainTestUtil.genesisHeaderDb
     val headerDb =
       BlockHeaderHelper.buildNextHeader(genesis)
     val chain = Blockchain(Vector(headerDb, genesis))
@@ -30,11 +31,11 @@ class BlockchainTest extends ChainUnitTest {
   it must "connect a new header to the current tip of a blockchain" inFixtured {
     case ChainFixture.Empty =>
       val blockchain = Blockchain.fromHeaders(
-        headers = Vector(ChainUnitTest.genesisHeaderDb)
+        headers = Vector(ChainTestUtil.genesisHeaderDb)
       )
 
       val newHeader =
-        BlockHeaderHelper.buildNextHeader(ChainUnitTest.genesisHeaderDb)
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.genesisHeaderDb)
 
       val connectTip =
         Blockchain.connectTip(header = newHeader.blockHeader, blockchain)
@@ -51,7 +52,7 @@ class BlockchainTest extends ChainUnitTest {
   it must "reconstruct a blockchain given a child header correctly" inFixtured {
     case ChainFixture.Empty =>
       val accum = new mutable.ArrayBuffer[BlockHeaderDb](5)
-      accum.+=(ChainUnitTest.genesisHeaderDb)
+      accum.+=(ChainTestUtil.genesisHeaderDb)
       //generate 4 headers
       0.until(4).foreach { _ =>
         val newHeader = BlockHeaderHelper.buildNextHeader(accum.last)
@@ -69,27 +70,27 @@ class BlockchainTest extends ChainUnitTest {
       val chain = reconstructed.head
       assert(chain.toVector.length == 5)
       assert(chain.tip == accum.last)
-      assert(chain.last == ChainUnitTest.genesisHeaderDb)
+      assert(chain.last == ChainTestUtil.genesisHeaderDb)
       assert(chain.toVector == accum.reverse.toVector)
   }
 
   it must "fail to reconstruct a blockchain if we do not have validly connected headers" inFixtured {
     case ChainFixture.Empty =>
       val missingHeader =
-        BlockHeaderHelper.buildNextHeader(ChainUnitTest.genesisHeaderDb)
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.genesisHeaderDb)
 
       val thirdHeader = BlockHeaderHelper.buildNextHeader(missingHeader)
 
       val reconstructed =
         Blockchain.reconstructFromHeaders(thirdHeader,
-                                          Vector(ChainUnitTest.genesisHeaderDb))
+                                          Vector(ChainTestUtil.genesisHeaderDb))
 
       assert(reconstructed.isEmpty)
   }
 
   it must "fail to create a BlockchainUpdate.Failed with incompatible successful headers" inFixtured {
     case ChainFixture.Empty =>
-      val genesis = ChainUnitTest.genesisHeaderDb
+      val genesis = ChainTestUtil.genesisHeaderDb
       val second = BlockHeaderHelper.buildNextHeader(genesis)
       val chain = Blockchain(Vector(second, genesis))
 
@@ -103,7 +104,7 @@ class BlockchainTest extends ChainUnitTest {
 
   it must "correctly calculate a BlockchainUpdate.Success's height" inFixtured {
     case ChainFixture.Empty =>
-      val genesis = ChainUnitTest.genesisHeaderDb
+      val genesis = ChainTestUtil.genesisHeaderDb
       val second = BlockHeaderHelper.buildNextHeader(genesis)
       val chain = Blockchain(Vector(second, genesis))
 
@@ -113,7 +114,7 @@ class BlockchainTest extends ChainUnitTest {
   }
 
   it must "correctly identify a bad tip" inFixtured { case ChainFixture.Empty =>
-    val genesis = ChainUnitTest.genesisHeaderDb
+    val genesis = ChainTestUtil.genesisHeaderDb
     val chain = Blockchain(Vector(genesis))
 
     val goodHeader = BlockHeaderHelper.buildNextHeader(genesis).blockHeader

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerCachedTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerCachedTest.scala
@@ -1,7 +1,8 @@
 package org.bitcoins.chain.blockchain
 
-import org.bitcoins.testkit.chain.{ChainDbUnitTest, ChainUnitTest}
+import org.bitcoins.testkit.chain.ChainDbUnitTest
 import org.bitcoins.testkit.chain.fixture.ChainFixtureTag
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 import org.scalatest.FutureOutcome
 
 class ChainHandlerCachedTest extends ChainDbUnitTest {
@@ -34,7 +35,7 @@ class ChainHandlerCachedTest extends ChainDbUnitTest {
         filterHeaderOpt <- noChainsChainHandler.getBestFilterHeader()
       } yield {
         assert(filterHeaderOpt.isDefined)
-        assert(filterHeaderOpt.get == ChainUnitTest.genesisFilterHeaderDb)
+        assert(filterHeaderOpt.get == ChainTestUtil.genesisFilterHeaderDb)
       }
   }
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/MainnetChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/MainnetChainHandlerTest.scala
@@ -4,13 +4,10 @@ import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.pow.Pow
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, BlockHeaderDbHelper}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.testkit.chain.{
-  ChainDbUnitTest,
-  ChainTestUtil,
-  ChainUnitTest
-}
+import org.bitcoins.testkit.chain.{ChainDbUnitTest, ChainUnitTest}
 import org.bitcoins.testkit.chain.fixture.ChainFixtureTag
 import org.bitcoins.testkit.util.FileUtil
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 import org.scalatest.FutureOutcome
 import play.api.libs.json.Json
 
@@ -34,7 +31,7 @@ class MainnetChainHandlerTest extends ChainDbUnitTest {
   val headersResult: Vector[BlockHeader] =
     Json.parse(arrStr).validate[Vector[BlockHeader]].get
 
-  val genesis: BlockHeaderDb = ChainUnitTest.genesisHeaderDb
+  val genesis: BlockHeaderDb = ChainTestUtil.genesisHeaderDb
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withChainHandlerCached(test)

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
@@ -6,12 +6,8 @@ import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
-import org.bitcoins.testkit.chain.{
-  BlockHeaderHelper,
-  ChainDbUnitTest,
-  ChainTestUtil,
-  ChainUnitTest
-}
+import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainDbUnitTest}
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 import org.scalatest.FutureOutcome
 import scodec.bits._
 
@@ -28,7 +24,7 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
 
   behavior of "BlockHeaderDAO"
 
-  private val genesisHeaderDb = ChainUnitTest.genesisHeaderDb
+  private val genesisHeaderDb = ChainTestUtil.genesisHeaderDb
   it should "insert and read the genesis block header back" in {
     blockHeaderDAO: BlockHeaderDAO =>
       val readF = blockHeaderDAO.read(genesisHeaderDb.hashBE)
@@ -326,10 +322,10 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
         foundGenesis <- foundGenesisF
       } yield {
         assert(noGenesisAncestors.length == 1)
-        assert(noGenesisAncestors == Vector(ChainUnitTest.genesisHeaderDb))
+        assert(noGenesisAncestors == Vector(ChainTestUtil.genesisHeaderDb))
 
         assert(foundGenesis.length == 1)
-        assert(foundGenesis == Vector(ChainUnitTest.genesisHeaderDb))
+        assert(foundGenesis == Vector(ChainTestUtil.genesisHeaderDb))
       }
 
       val oneChildF = for {

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterDAOTest.scala
@@ -3,11 +3,8 @@ package org.bitcoins.chain.models
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, CompactFilterDb}
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.crypto.{CryptoUtil, ECPrivateKey}
-import org.bitcoins.testkit.chain.{
-  BlockHeaderHelper,
-  ChainDbUnitTest,
-  ChainTestUtil
-}
+import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainDbUnitTest}
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 import org.bitcoins.testkitcore.gen.CryptoGenerators
 import org.scalatest.FutureOutcome
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterHeaderDAOTest.scala
@@ -1,11 +1,8 @@
 package org.bitcoins.chain.models
 
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, CompactFilterHeaderDb}
-import org.bitcoins.testkit.chain.{
-  BlockHeaderHelper,
-  ChainDbUnitTest,
-  ChainTestUtil
-}
+import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainDbUnitTest}
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 import org.bitcoins.testkitcore.gen.CryptoGenerators
 import org.scalatest.FutureOutcome
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
@@ -9,11 +9,8 @@ import org.bitcoins.core.protocol.blockchain.{
 }
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.testkit.chain.fixture.{ChainFixture, ChainFixtureTag}
-import org.bitcoins.testkit.chain.{
-  ChainDbUnitTest,
-  ChainTestUtil,
-  ChainUnitTest
-}
+import org.bitcoins.testkit.chain.{ChainDbUnitTest, ChainUnitTest}
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 import org.scalatest.{Assertion, FutureOutcome}
 
 import scala.concurrent.Future

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -12,7 +12,7 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.blockchain.BlockHeader
-import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.util.{FutureUtil, NetworkUtil}
 import org.bitcoins.crypto.{CryptoUtil, DoubleSha256DigestBE}
 
 import scala.annotation.tailrec
@@ -1079,6 +1079,13 @@ class ChainHandler(
       }
     } yield {
       this
+    }
+  }
+
+  override def isTipStale(): Future[Boolean] = {
+    getBestBlockHeader().map { blockHeaderDb =>
+      NetworkUtil.isBlockHeaderStale(blockHeaderDb.blockHeader,
+                                     chainConfig.chain)
     }
   }
 

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -127,13 +127,7 @@ sealed abstract class Pow {
   }
 
   def getBlockProof(header: BlockHeader): BigInt = {
-    val target = NumberUtil.targetExpansion(header.nBits)
-
-    if (target.isNegative || target.isOverflow) {
-      BigInt(0)
-    } else {
-      (BigInt(1) << 256) / (target.difficulty + BigInt(1))
-    }
+    BlockHeader.getBlockProof(header)
   }
 }
 

--- a/core-test/src/test/scala/org/bitcoins/core/util/NetworkUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NetworkUtilTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.util
 
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.blockchain.MainNetChainParams
+import org.bitcoins.core.protocol.blockchain.{BlockHeader, MainNetChainParams}
 import org.bitcoins.testkitcore.chain.ChainTestUtil
 import scodec.bits.ByteVector
 
@@ -20,15 +20,20 @@ class NetworkUtilTest extends BitcoinSUtilTest {
   }
 
   it must "determine if a block header is stale" in {
-    //val staleHeader = ChainTestUtil.genesisHeaderDb
-    //assert(
-    //  NetworkUtil.isBlockHeaderStale(staleHeader.blockHeader,
-    //                                 MainNetChainParams))
-
-    val nonStale = ChainTestUtil.genesisHeaderDb.copy(time =
-      UInt32(Instant.now.getEpochSecond))
-
+    val staleHeader = ChainTestUtil.genesisHeaderDb
     assert(
-      !NetworkUtil.isBlockHeaderStale(nonStale.blockHeader, MainNetChainParams))
+      NetworkUtil.isBlockHeaderStale(staleHeader.blockHeader,
+                                     MainNetChainParams))
+
+    val nonStale = BlockHeader(
+      ChainTestUtil.genesisHeaderDb.version,
+      ChainTestUtil.genesisHeaderDb.previousBlockHashBE.flip,
+      ChainTestUtil.genesisHeaderDb.merkleRootHashBE.flip,
+      time = UInt32(Instant.now.getEpochSecond),
+      nBits = ChainTestUtil.genesisHeaderDb.nBits,
+      nonce = ChainTestUtil.genesisHeaderDb.nonce
+    )
+
+    assert(!NetworkUtil.isBlockHeaderStale(nonStale, MainNetChainParams))
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/util/NetworkUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NetworkUtilTest.scala
@@ -1,6 +1,11 @@
 package org.bitcoins.core.util
 
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.blockchain.MainNetChainParams
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 import scodec.bits.ByteVector
+
+import java.time.Instant
 
 class NetworkUtilTest extends BitcoinSUtilTest {
   "NetworkUtil" must "convert torV3 pubkey to correct .onion address and vice versa" in {
@@ -12,5 +17,18 @@ class NetworkUtilTest extends BitcoinSUtilTest {
     val pubkeyFromAddress = ByteVector(NetworkUtil.torV3AddressToBytes(address))
     assert(address == addressFromKey)
     assert(pubkey == pubkeyFromAddress)
+  }
+
+  it must "determine if a block header is stale" in {
+    //val staleHeader = ChainTestUtil.genesisHeaderDb
+    //assert(
+    //  NetworkUtil.isBlockHeaderStale(staleHeader.blockHeader,
+    //                                 MainNetChainParams))
+
+    val nonStale = ChainTestUtil.genesisHeaderDb.copy(time =
+      UInt32(Instant.now.getEpochSecond))
+
+    assert(
+      !NetworkUtil.isBlockHeaderStale(nonStale.blockHeader, MainNetChainParams))
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/util/NetworkUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NetworkUtilTest.scala
@@ -6,6 +6,7 @@ import org.bitcoins.testkitcore.chain.ChainTestUtil
 import scodec.bits.ByteVector
 
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 class NetworkUtilTest extends BitcoinSUtilTest {
   "NetworkUtil" must "convert torV3 pubkey to correct .onion address and vice versa" in {
@@ -35,5 +36,35 @@ class NetworkUtilTest extends BitcoinSUtilTest {
     )
 
     assert(!NetworkUtil.isBlockHeaderStale(nonStale, MainNetChainParams))
+
+    val barleyStaleHeader = {
+      val timestamp = Instant.now.minus(31, ChronoUnit.MINUTES).getEpochSecond
+      BlockHeader(
+        ChainTestUtil.genesisHeaderDb.version,
+        ChainTestUtil.genesisHeaderDb.previousBlockHashBE.flip,
+        ChainTestUtil.genesisHeaderDb.merkleRootHashBE.flip,
+        time = UInt32(timestamp),
+        nBits = ChainTestUtil.genesisHeaderDb.nBits,
+        nonce = ChainTestUtil.genesisHeaderDb.nonce
+      )
+    }
+
+    assert(
+      NetworkUtil.isBlockHeaderStale(barleyStaleHeader, MainNetChainParams))
+
+    val barleyNotStaleHeader = {
+      val timestamp = Instant.now.minus(29, ChronoUnit.MINUTES).getEpochSecond
+      BlockHeader(
+        ChainTestUtil.genesisHeaderDb.version,
+        ChainTestUtil.genesisHeaderDb.previousBlockHashBE.flip,
+        ChainTestUtil.genesisHeaderDb.merkleRootHashBE.flip,
+        time = UInt32(timestamp),
+        nBits = ChainTestUtil.genesisHeaderDb.nBits,
+        nonce = ChainTestUtil.genesisHeaderDb.nonce
+      )
+    }
+
+    assert(
+      !NetworkUtil.isBlockHeaderStale(barleyNotStaleHeader, MainNetChainParams))
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -154,6 +154,11 @@ trait ChainApi extends ChainQueryApi {
 
   def isIBD(): Future[Boolean]
 
+  /** Checks if our chain tip is stale
+    * @see [[https://github.com/bitcoin/bitcoin/blob/664500fc71a32d5066db8cb4a19ddc7005a1c9e9/src/net_processing.cpp#L1235]]
+    */
+  def isTipStale(): Future[Boolean]
+
   def setSyncing(value: Boolean): Future[ChainApi]
 
   def setIBD(value: Boolean): Future[ChainApi]

--- a/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
@@ -24,6 +24,9 @@ case class BlockHeaderDb(
     require(blockHeader.version == version)
     require(blockHeader.nBits == nBits)
     require(blockHeader.nonce == nonce)
+    require(
+      blockHeader.time == time,
+      s"Inconsistent in memory time=$time vs serialized time=${blockHeader.time}")
 
     blockHeader
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -163,4 +163,14 @@ object BlockHeader extends Factory[BlockHeader] {
       difficulty: BigInt,
       isNegative: Boolean,
       isOverflow: Boolean)
+
+  def getBlockProof(header: BlockHeader): BigInt = {
+    val target = NumberUtil.targetExpansion(header.nBits)
+
+    if (target.isNegative || target.isOverflow) {
+      BigInt(0)
+    } else {
+      (BigInt(1) << 256) / (target.difficulty + BigInt(1))
+    }
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -356,11 +356,11 @@ object RegTestNetChainParams extends BitcoinChainParams {
   override lazy val networkId = "regtest"
 
   override lazy val genesisBlock: Block =
-    createGenesisBlock(UInt32(1296688602),
-                       UInt32(2),
-                       UInt32(0x207fffff),
-                       Int32.one,
-                       Satoshis(5000000000L))
+    createGenesisBlock(time = UInt32(1296688602),
+                       nonce = UInt32(2),
+                       nBits = UInt32(0x207fffff),
+                       version = Int32.one,
+                       amount = Satoshis(5000000000L))
 
   override lazy val base58Prefixes: Map[Base58Type, ByteVector] =
     TestNetChainParams.base58Prefixes

--- a/core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala
@@ -155,8 +155,6 @@ abstract class NetworkUtil {
       chainParams: ChainParams): Boolean = {
     val seconds = blockHeader.time.toLong
     val expected: Duration = chainParams.powTargetSpacing * 3
-    println(
-      s"second=$seconds expected=$expected diff=${Instant.now.getEpochSecond - seconds} 30min=${expected.toSeconds}")
     (Instant.now.getEpochSecond - seconds) > expected.toSeconds
   }
 

--- a/core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala
@@ -1,11 +1,14 @@
 package org.bitcoins.core.util
 
 import org.bitcoins.core.p2p.AddrV2Message
+import org.bitcoins.core.protocol.blockchain.{BlockHeader, ChainParams}
 import org.bitcoins.crypto.CryptoUtil
 import scodec.bits.ByteVector
 
 import java.net._
+import java.time.Instant
 import scala.annotation.tailrec
+import scala.concurrent.duration.Duration
 import scala.util.{Failure, Random, Success, Try}
 
 abstract class NetworkUtil {
@@ -141,6 +144,20 @@ abstract class NetworkUtil {
       case Success(value) => value
       case Failure(_)     => randomPort()
     }
+  }
+
+  /** Checks if the given block header is stale relative to the given chain parameters
+    *
+    * @see [[https://github.com/bitcoin/bitcoin/blob/664500fc71a32d5066db8cb4a19ddc7005a1c9e9/src/net_processing.cpp#L1235]]
+    */
+  def isBlockHeaderStale(
+      blockHeader: BlockHeader,
+      chainParams: ChainParams): Boolean = {
+    val seconds = blockHeader.time.toLong
+    val expected: Duration = chainParams.powTargetSpacing * 3
+    println(
+      s"second=$seconds expected=$expected diff=${Instant.now.getEpochSecond - seconds} 30min=${expected.toSeconds}")
+    (Instant.now.getEpochSecond - seconds) > expected.toSeconds
   }
 
 }

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -112,6 +112,10 @@ case class NeutrinoNode(
       blockchains <- blockchainsF
       // Get all of our cached headers in case of a reorg
       cachedHeaders = blockchains.flatMap(_.headers).map(_.hashBE.flip)
+      //need to add a check here to see if our last block header in our
+      //database has a timestamp within a reasonable amount of time on the p2p network
+      //if it does have a reasonable timestamp (within the last 10 minutes), we should sync filters
+      //if it doesn't have a reasonable timestamp we sync headers and not call syncFilter()
       _ <- peerMsgSender.sendGetHeadersMessage(cachedHeaders)
       _ <- syncFilters(bestFilterHeaderOpt = bestFilterHeaderOpt,
                        bestFilterOpt = bestFilterOpt,

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -112,10 +112,6 @@ case class NeutrinoNode(
       blockchains <- blockchainsF
       // Get all of our cached headers in case of a reorg
       cachedHeaders = blockchains.flatMap(_.headers).map(_.hashBE.flip)
-      //need to add a check here to see if our last block header in our
-      //database has a timestamp within a reasonable amount of time on the p2p network
-      //if it does have a reasonable timestamp (within the last 10 minutes), we should sync filters
-      //if it doesn't have a reasonable timestamp we sync headers and not call syncFilter()
       _ <- peerMsgSender.sendGetHeadersMessage(cachedHeaders)
       _ <- syncFilters(bestFilterHeaderOpt = bestFilterHeaderOpt,
                        bestFilterOpt = bestFilterOpt,

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/chain/ChainTestUtil.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/chain/ChainTestUtil.scala
@@ -1,8 +1,8 @@
-package org.bitcoins.testkit.chain
+package org.bitcoins.testkitcore.chain
 
-import org.bitcoins.chain.pow.Pow
 import org.bitcoins.core.api.chain.db._
 import org.bitcoins.core.gcs.{BlockFilter, FilterHeader, GolombFilter}
+import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.{
   BlockHeader,
   MainNetChainParams,
@@ -19,10 +19,10 @@ sealed abstract class ChainTestUtil {
     regTestChainParams.genesisBlock.blockHeader
 
   lazy val regTestGenesisHeaderDb: BlockHeaderDb = {
-    BlockHeaderDbHelper.fromBlockHeader(height = 0,
-                                        chainWork =
-                                          Pow.getBlockProof(regTestHeader),
-                                        bh = regTestHeader)
+    BlockHeaderDbHelper.fromBlockHeader(
+      height = 0,
+      chainWork = BlockHeader.getBlockProof(regTestHeader),
+      bh = regTestHeader)
   }
 
   lazy val regTestGenesisHeaderCompactFilter: GolombFilter =
@@ -42,6 +42,20 @@ sealed abstract class ChainTestUtil {
       regTestGenesisHeaderCompactFilterHeader,
       regTestHeader.hashBE,
       0)
+
+  val genesisHeaderDb: BlockHeaderDb = regTestGenesisHeaderDb
+
+  val genesisFilterDb: CompactFilterDb =
+    regTestGenesisHeaderCompactFilterDb
+
+  val genesisFilterHeaderDb: CompactFilterHeaderDb =
+    regTestGenesisHeaderCompactFilterHeaderDb
+
+  val genesisFilterMessage: CompactFilterMessage = {
+    CompactFilterMessage(filterType = genesisFilterDb.filterType,
+                         blockHash = genesisFilterDb.blockHashBE.flip,
+                         filterBytes = genesisFilterDb.golombFilter.bytes)
+  }
 
   lazy val mainnetChainParam: MainNetChainParams.type = MainNetChainParams
 
@@ -66,24 +80,27 @@ sealed abstract class ChainTestUtil {
       "000000200cd536b3eb1cd9c028e081f1455006276b293467c3e5170000000000000000007bc1b27489db01c85d38a4bc6d2280611e9804f506d83ad00d2a33ebd663992f76c7725c505b2e174fb90f55")
 
     lazy val blockHeaderDb564480 =
-      BlockHeaderDbHelper.fromBlockHeader(564480,
-                                          Pow.getBlockProof(blockHeader564480),
-                                          blockHeader564480)
+      BlockHeaderDbHelper.fromBlockHeader(
+        564480,
+        BlockHeader.getBlockProof(blockHeader564480),
+        blockHeader564480)
 
     lazy val blockHeader566494 = BlockHeader.fromHex(
       "00000020ea2cb07d670ddb7a158e72ddfcfd9e1b9bf4459278bb240000000000000000004fb33054d79de69bb84b4d5c7dd87d80473c416320427a882c72108f7e43fd0c3d3e855c505b2e178f328fe2")
 
     lazy val blockHeaderDb566494 =
-      BlockHeaderDbHelper.fromBlockHeader(566594,
-                                          Pow.getBlockProof(blockHeader566494),
-                                          blockHeader566494)
+      BlockHeaderDbHelper.fromBlockHeader(
+        566594,
+        BlockHeader.getBlockProof(blockHeader566494),
+        blockHeader566494)
 
     lazy val blockHeader566495 = BlockHeader.fromHex(
       "000000202164d8c4e5246ab003fdebe36c697b9418aa454ec4190d00000000000000000059134ad5aaad38a0e75946c7d4cb09b3ad45b459070195dd564cde193cf0ef29c33e855c505b2e17f61af734")
 
     lazy val blockHeaderDb566495 = {
       val chainWork =
-        blockHeaderDb566494.chainWork + Pow.getBlockProof(blockHeader566495)
+        blockHeaderDb566494.chainWork + BlockHeader.getBlockProof(
+          blockHeader566495)
       BlockHeaderDbHelper.fromBlockHeader(566495, chainWork, blockHeader566495)
     }
 
@@ -93,7 +110,8 @@ sealed abstract class ChainTestUtil {
 
     lazy val blockHeaderDb566496 = {
       val chainWork =
-        blockHeaderDb566495.chainWork + Pow.getBlockProof(blockHeader566496)
+        blockHeaderDb566495.chainWork + BlockHeader.getBlockProof(
+          blockHeader566496)
       BlockHeaderDbHelper.fromBlockHeader(566496, chainWork, blockHeader566496)
     }
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.testkit.node
 
 import akka.actor.{ActorSystem, Cancellable}
 import org.bitcoins.commons.config.AppConfig
-import org.bitcoins.core.api.chain.{ChainApi, ChainQueryApi, FilterSyncMarker}
 import org.bitcoins.core.api.chain.db.{
   BlockHeaderDb,
   CompactFilterDb,
   CompactFilterHeaderDb
 }
+import org.bitcoins.core.api.chain.{ChainApi, ChainQueryApi, FilterSyncMarker}
 import org.bitcoins.core.config.{NetworkParameters, RegTest}
 import org.bitcoins.core.gcs.FilterHeader
 import org.bitcoins.core.p2p.CompactFilterMessage
@@ -17,9 +17,9 @@ import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.EmbeddedPg
-import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.keymanager.KeyManagerTestUtil
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -92,7 +92,7 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
     override def getBlockCount(): Future[Int] = Future.successful(0)
 
     override def getBestBlockHeader(): Future[BlockHeaderDb] =
-      Future.successful(ChainUnitTest.genesisHeaderDb)
+      Future.successful(ChainTestUtil.genesisHeaderDb)
 
     override def processFilterHeaders(
         filterHeaders: Vector[FilterHeader],
@@ -178,6 +178,10 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
     override def isSyncing(): Future[Boolean] = Future.successful(false)
 
     override def isIBD(): Future[Boolean] = Future.successful(false)
+
+    override def isTipStale(): Future[Boolean] = {
+      Future.successful(false)
+    }
 
     override def setSyncing(value: Boolean): Future[ChainApi] =
       Future.successful(this)


### PR DESCRIPTION
Part of #4996 

Specifically this: https://github.com/bitcoin-s/bitcoin-s/issues/4996#issuecomment-1480219994

This implements logic to detect if a given block header is stale. I will use this feature in future PRs to implement logic to detect if we should be connecting to new peers on the p2p network similar to this in bitcoin core: https://github.com/bitcoin/bitcoin/blob/664500fc71a32d5066db8cb4a19ddc7005a1c9e9/src/net_processing.cpp#L5102

This PR includes a refactor moving test block header data structures from `ChainUnitTest` -> `ChainTestUtil`. This is needed because `ChainTestUtil` is available in `coreTest` while `ChainUnitTest` is not. That is why the diff is so big for this.