### PR TITLE
Bump clightning version to `v23.02.2`

### DIFF
--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04-latest
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:

--- a/clightning-rpc/clightning-rpc.sbt
+++ b/clightning-rpc/clightning-rpc.sbt
@@ -19,7 +19,7 @@ TaskKeys.downloadCLightning := {
     Files.createDirectories(binaryDir)
   }
 
-  val version = "0.10.2"
+  val version = "23.02.2"
 
   val (platform, suffix) =
     if (Properties.isLinux) ("Ubuntu-20.04", "tar.xz")

--- a/clightning-rpc/clightning-rpc.sbt
+++ b/clightning-rpc/clightning-rpc.sbt
@@ -22,7 +22,17 @@ TaskKeys.downloadCLightning := {
   val version = "23.02.2"
 
   val (platform, suffix) =
-    if (Properties.isLinux) ("Ubuntu-20.04", "tar.xz")
+    if (Properties.isLinux) {
+      //from: https://stackoverflow.com/a/51614324/967713
+      val processBuilder = new java.lang.ProcessBuilder("lsb_release", "-rs")
+      val inputStream = new java.io.InputStreamReader(processBuilder.start().getInputStream())
+      val version = new java.io.BufferedReader(inputStream).readLine()
+      if (version == "22.04")  {
+        ("Ubuntu-22.04", "tar.xz")
+      } else {
+        ("Ubuntu-20.04", "tar.xz")
+      }
+    }
 //    else if (Properties.isMac) ("darwin-amd64", "tar.gz") // todo c-lightning adding in a future release
     else sys.error(s"Unsupported OS: ${Properties.osName}")
 
@@ -52,8 +62,11 @@ TaskKeys.downloadCLightning := {
       .mkString
 
     val expectedHash =
-      if (Properties.isLinux)
+      if (platform == "Ubuntu-20.04") {
         "0068852306bca9df3d213c6a29bb90451eb538be83e413d6838e9e2d2729ff7f"
+      } else if (platform == "Ubuntu-22.04") {
+        "0c0763ff41656e0d76c955e4843894ea0c23c401ccde29e4ae369808862d4c0b"
+      }
       else sys.error(s"Unsupported OS: ${Properties.osName}")
 
     val success = hash.equalsIgnoreCase(expectedHash)

--- a/clightning-rpc/clightning-rpc.sbt
+++ b/clightning-rpc/clightning-rpc.sbt
@@ -53,7 +53,7 @@ TaskKeys.downloadCLightning := {
 
     val expectedHash =
       if (Properties.isLinux)
-        "de61bb1dec0f656e192f896de7dcb08f4b07cf9c2bdaef8c78d860cd80ea6776"
+        "0068852306bca9df3d213c6a29bb90451eb538be83e413d6838e9e2d2729ff7f"
       else sys.error(s"Unsupported OS: ${Properties.osName}")
 
     val success = hash.equalsIgnoreCase(expectedHash)

--- a/clightning-rpc/src/main/scala/com/bitcoins/clightning/rpc/CLightningRpcClient.scala
+++ b/clightning-rpc/src/main/scala/com/bitcoins/clightning/rpc/CLightningRpcClient.scala
@@ -375,7 +375,7 @@ class CLightningRpcClient(val instance: CLightningInstanceLocal, binary: File)(
 object CLightningRpcClient {
 
   /** The current version we support of clightning */
-  val version = "0.10.2"
+  val version = "23.02.2"
 
   private[clightning] def feeRateToJson(feeUnit: FeeUnit): JsString = {
     // clightning only takes SatoshisPerKiloByte or SatoshisPerKW

--- a/testkit/src/main/scala/org/bitcoins/testkit/clightning/CLightningRpcTestClient.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/clightning/CLightningRpcTestClient.scala
@@ -59,7 +59,7 @@ case class CLightningRpcTestClient(
           _ <- TestAsyncUtil.awaitCondition(
             () => clightning.instance.rpcFile.exists(),
             interval = 1.second,
-            maxTries = 500)
+            maxTries = 10)
           _ <- TestAsyncUtil.nonBlockingSleep(7.seconds)
         } yield {
           clientOpt = Some(clightning)


### PR DESCRIPTION
https://github.com/ElementsProject/lightning/releases/tag/v23.02.2

Clightning causes a lot of CI failures it seems, so lets try bumping the version.

The root cause of this is 

>2023-03-25 19:41:44,025UTC ERROR NativeProcessFactory$ - lightningd: gmp version mismatch: compiled 6.2.0, now 6.2.1

I get his error on my local ubuntu `22.04` machine. It appears there is a `gmp` library inconsistenty based on the OS version of Ubuntu. This is why `clightning` provides different artifacts for various ubuntu version.
 
This PR downloads the `clightning` version based on the version of Ubuntu you are using. This should make our clightning tests work regardless of the ubuntu OS version the github CI runners assign us.