### PR TITLE
Fix bug where `bip39Password` was not passed as param in test case

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -354,7 +354,9 @@ class WalletUnitTest extends BitcoinSWalletTest {
         }
         _ = wallet.walletConfig.migrate()
         //initialize it
-        initOldWallet <- Wallet.initialize(wallet, None)
+        initOldWallet <- Wallet.initialize(
+          wallet = wallet,
+          bip39PasswordOpt = wallet.walletConfig.bip39PasswordOpt)
         isOldWalletEmpty <- initOldWallet.isEmpty()
       } yield assert(!isOldWalletEmpty)
 


### PR DESCRIPTION
bug in the #5034 test case that causes this test case to fail intermittently on postgres database