### PR TITLE
Fix bug where compact filters weren't being processed in order of block height during IBD

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -619,6 +619,16 @@ class ChainHandlerTest extends ChainDbUnitTest {
     }
   }
 
+  it must "return filters in order by block height" in { chainHandler =>
+    val maxHeightF = chainHandler.getBestHashBlockHeight()
+    for {
+      maxHeight <- maxHeightF
+      filters <- chainHandler.getFiltersBetweenHeights(0, maxHeight)
+    } yield {
+      assert(filters.sortBy(_.blockHeight) == filters)
+    }
+  }
+
   it must "get the correct height from an epoch second" in {
     chainHandler: ChainHandler =>
       for {

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -403,7 +403,6 @@ class ChainHandler(
         newFilters <- newFiltersF
         filterHeaders <- filterHeaderDAO
           .findAllByBlockHashes(newFilters.map(_.blockHash.flip))
-          .map(_.sortBy(_.height))
       } yield filterHeaders
     }
 

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
@@ -133,7 +133,10 @@ case class CompactFilterDAO()(implicit
     Seq[CompactFilterDb],
     CompactFilterDb,
     Effect.Read] = {
-    table.filter(header => header.height >= from && header.height <= to).result
+    table
+      .filter(header => header.height >= from && header.height <= to)
+      .sortBy(_.height)
+      .result
   }
 
   private val bestFilterQuery = {

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -95,7 +95,9 @@ case class CompactFilterHeaderDAO()(implicit
 
   def findAllByBlockHashes(hashes: Vector[DoubleSha256DigestBE]): Future[
     Vector[CompactFilterHeaderDb]] = {
-    val query = table.filter(_.blockHash.inSet(hashes))
+    val query = table
+      .filter(_.blockHash.inSet(hashes))
+      .sortBy(_.height)
     safeDatabase.runVec(query.result)
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -179,8 +179,8 @@ abstract class Wallet
         } else {
           FutureUtil
             .batchAndParallelExecute(
-              blockFilters,
-              searchFilterMatches(scriptPubKeys.toVector)
+              elements = blockFilters,
+              f = searchFilterMatches(scriptPubKeys.toVector)
             )
             .map(_.flatten)
         }


### PR DESCRIPTION
fixes #5039 

This PR fixes a bug where compact filters could be sent to our callback system out of order with respect to block height. This could lead to consumers of the callback -- such as the wallet -- to process blocks out of order. 

This PR sorts compact filters by its corresponding block height, and then executes callbacks based on the sorted compact filters.