### PR TITLE
Refactor `HDPath` pattern matching to be safer.

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/hd/BIP32Path.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/BIP32Path.scala
@@ -130,21 +130,27 @@ object BIP32Path extends Factory[BIP32Path] with StringFactory[BIP32Path] {
       // and without (https://wiki.trezor.io/Standard_derivation_paths)
       .map(_.trim)
 
-    val head +: rest = parts
-    require(head == "m",
-            """The first element in a BIP32 path string must be "m"""")
+    if (parts.isEmpty || parts.length == 1) {
+      sys.error(
+        s"Cannot have bip32 path empty bip32 path or single element bip32 path, got=$string")
+    } else {
+      val head = parts.head
+      val rest = parts.tail
+      require(head == "m",
+              """The first element in a BIP32 path string must be "m"""")
 
-    val path = rest.map { str =>
-      val (index: String, hardened: Boolean) =
-        if (str.endsWith("'") || str.endsWith("h")) {
-          (str.dropRight(1), true)
-        } else {
-          (str, false)
-        }
-      BIP32Node(index.toInt, hardened)
+      val path = rest.map { str =>
+        val (index: String, hardened: Boolean) =
+          if (str.endsWith("'") || str.endsWith("h")) {
+            (str.dropRight(1), true)
+          } else {
+            (str, false)
+          }
+        BIP32Node(index.toInt, hardened)
+      }
+
+      BIP32PathImpl(path)
     }
-
-    BIP32PathImpl(path)
   }
 
   /** Takes in a BIP32 Path and verifies all paths are hardened

--- a/core/src/main/scala/org/bitcoins/core/hd/BIP32Path.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/BIP32Path.scala
@@ -130,9 +130,8 @@ object BIP32Path extends Factory[BIP32Path] with StringFactory[BIP32Path] {
       // and without (https://wiki.trezor.io/Standard_derivation_paths)
       .map(_.trim)
 
-    if (parts.isEmpty || parts.length == 1) {
-      sys.error(
-        s"Cannot have bip32 path empty bip32 path or single element bip32 path, got=$string")
+    if (parts.isEmpty) {
+      sys.error(s"Cannot have bip32 path empty bip32 path, got=$string")
     } else {
       val head = parts.head
       val rest = parts.tail

--- a/core/src/main/scala/org/bitcoins/core/hd/HDPathFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDPathFactory.scala
@@ -61,8 +61,11 @@ private[hd] trait HDPathFactory[PathType <: BIP32Path]
     require(children.length == 5,
             s"A $pathName path string must have five elements")
 
-    val _ :+ coinChild :+ accountChild :+ chainChild :+ addressChild =
-      children
+    val (coinChild, accountChild, chainChild, addressChild) = {
+      require(children.length == 5,
+              s"Must have 5 elements in HDPath, got=$children")
+      (children(1), children(2), children(3), children(4))
+    }
 
     require(coinChild.hardened, "The coin type child must be hardened!")
     require(accountChild.hardened, "The account child must be hardened!")


### PR DESCRIPTION
Pulled over from #3497

Our previous implementation produces warnings on scala 3 for the possibility of pattern match exceptions being thrown. This PR cleans that up.