### PR TITLE
Implement `getconnectioncount` rpc

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -1398,8 +1398,8 @@ object ConsoleCli {
               }))
         ),
       note(sys.props("line.separator") + "=== Network ==="),
-      cmd("getpeers")
-        .action((_, conf) => conf.copy(command = GetPeers))
+      cmd("getconnectioncount")
+        .action((_, conf) => conf.copy(command = GetConnectionCount))
         .text(s"List the connected peers"),
       cmd("stop")
         .action((_, conf) => conf.copy(command = Stop))
@@ -2197,8 +2197,8 @@ object ConsoleCli {
       // besthash
       case GetBestBlockHash => RequestParam("getbestblockhash")
       // peers
-      case GetPeers => RequestParam("getpeers")
-      case Stop     => RequestParam("stop")
+      case GetConnectionCount => RequestParam("getpeers")
+      case Stop               => RequestParam("stop")
       case SendRawTransaction(tx) =>
         RequestParam("sendrawtransaction", Seq(up.writeJs(tx)))
       // PSBTs
@@ -2490,7 +2490,7 @@ object CliCommand {
   case object GetDLCWalletAccounting extends AppServerCliCommand
 
   // Node
-  case object GetPeers extends AppServerCliCommand
+  case object GetConnectionCount extends AppServerCliCommand
   case object Stop extends AppServerCliCommand
 
   // Chain

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -1688,7 +1688,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       }
     }
 
-    "return the peer list" in {
+    "return the peer list" ignore {
       val route =
         nodeRoutes.handleCommand(ServerCommand("getpeers", Arr()))
 
@@ -1887,6 +1887,20 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         val expected =
           s"""{"result":{"myCollateral":1,"theirCollateral":1,"myPayout":2,"theirPayout":0,"pnl":1,"rateOfReturn":1},"error":null}""".stripMargin
         assert(str == expected)
+      }
+    }
+
+    "getConnectedPeerCount" in {
+      (() => mockNode.getConnectionCount)
+        .expects()
+        .returning(Future.successful(1))
+
+      val route =
+        nodeRoutes.handleCommand(ServerCommand("getconnectioncount", Arr()))
+
+      Get() ~> route ~> check {
+        assert(contentType == `application/json`)
+        assert(responseAs[String] == """{"result":1,"error":null}""")
       }
     }
   }

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -367,6 +367,10 @@ object BitcoindRpcBackendUtil extends Logging {
           transactions: Vector[Transaction]): Future[Unit] = {
         bitcoindRpcClient.broadcastTransactions(transactions)
       }
+
+      override def getConnectionCount: Future[Int] = {
+        bitcoindRpcClient.getConnectionCount
+      }
     }
   }
 

--- a/app/server/src/main/scala/org/bitcoins/server/NodeRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/NodeRoutes.scala
@@ -14,12 +14,12 @@ case class NodeRoutes(nodeApi: NodeApi)(implicit system: ActorSystem)
     extends ServerRoute {
   import system.dispatcher
 
-  def handleCommand: PartialFunction[ServerCommand, Route] = {
-    case ServerCommand("getpeers", _) =>
+  override def handleCommand: PartialFunction[ServerCommand, Route] = {
+    case ServerCommand("getconnectioncount", _) =>
       complete {
-        Server.httpSuccess("TODO implement getpeers")
+        nodeApi.getConnectionCount
+          .map(count => Server.httpSuccess(count))
       }
-
     case ServerCommand("stop", _) =>
       nodeApi match {
         case node: Node =>

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -307,6 +307,10 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
     logger.warn(s"Cannot set IBD of BitcoindRpcClient, this is a noop")
     Future.successful(this)
   }
+
+  override def getConnectionCount: Future[Int] = {
+    super[P2PRpc].getConnectionCount
+  }
 }
 
 object BitcoindRpcClient {

--- a/core/src/main/scala/org/bitcoins/core/api/node/NodeApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/NodeApi.scala
@@ -22,4 +22,5 @@ trait NodeApi {
     */
   def downloadBlocks(blockHashes: Vector[DoubleSha256Digest]): Future[Unit]
 
+  def getConnectionCount: Future[Int]
 }

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -342,7 +342,7 @@ the `-p 9999:9999` port mapping on the docker container to adjust for this.
  - `dropaddresslabels` `address` - drops all labels for the given address
 
 ### Network
- - `getpeers` - List the connected peers
+ - `getconnectioncount` - Get the number of connected peers
  - `stop` - Request a graceful shutdown of Bitcoin-S
  - `sendrawtransaction` `tx` `Broadcasts the raw transaction`
     - `tx` - Transaction serialized in hex

--- a/docs/node/node-api.md
+++ b/docs/node/node-api.md
@@ -88,6 +88,8 @@ val exampleCallback = createCallback(exampleProcessBlock)
       val blockFs = blockHashes.map(hash => bitcoind.getBlockRaw(hash))
       Future.sequence(blockFs).map(_ => ())
     }
+  
+    override def getConnectionCount: Future[Int] = bitcoind.getConnectionCount
   }
 
 // Finally, we can initialize our wallet with our own node api

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -149,6 +149,7 @@ val syncF: Future[ChainApi] = configF.flatMap { _ =>
 val wallet = Wallet(new NodeApi {
     override def broadcastTransactions(txs: Vector[Transaction]): Future[Unit] = Future.successful(())
     override def downloadBlocks(blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = Future.successful(())
+    override def getConnectionCount: Future[Int] = Future.successful(0)
   }, chainApi, ConstantFeeRateProvider(SatoshisPerVirtualByte.one))
 val walletF: Future[WalletApi] = configF.flatMap { _ =>
   Wallet.initialize(wallet, None)

--- a/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/DisconnectedPeerTest.scala
@@ -24,4 +24,10 @@ class DisconnectedPeerTest extends NodeUnitTest {
       node.broadcastTransaction(tx)
     }
   }
+
+  it must "count 0 peer connections correctly" in { node =>
+    for {
+      connectionCount <- node.getConnectionCount
+    } yield assert(connectionCount == 0)
+  }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -351,12 +351,12 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         _ = assert(initConnectionCount == 2)
         nodeUri0 <- NodeTestUtil.getNodeURIFromBitcoind(bitcoinds(0))
         _ <- bitcoinds(0).disconnectNode(nodeUri0)
-        _ <- AsyncUtil.nonBlockingSleep(5.seconds)
+        _ <- AsyncUtil.nonBlockingSleep(1.seconds)
         onePeerConnectionCount <- node.getConnectionCount
         _ = assert(onePeerConnectionCount == 1)
         nodeUri1 <- NodeTestUtil.getNodeURIFromBitcoind(bitcoinds(1))
         _ <- bitcoinds(1).disconnectNode(nodeUri1)
-        _ <- AsyncUtil.nonBlockingSleep(5.seconds)
+        _ <- AsyncUtil.nonBlockingSleep(1.seconds)
         zeroPeerConnectionCount <- node.getConnectionCount
       } yield assert(zeroPeerConnectionCount == 0)
   }

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -340,4 +340,24 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         succeed
       }
   }
+
+  it must "count peer connections correctly" in {
+    nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
+      val node = nodeConnectedWithBitcoind.node
+      val bitcoinds = nodeConnectedWithBitcoind.bitcoinds
+      for {
+        _ <- node.sync()
+        initConnectionCount <- node.getConnectionCount
+        _ = assert(initConnectionCount == 2)
+        nodeUri0 <- NodeTestUtil.getNodeURIFromBitcoind(bitcoinds(0))
+        _ <- bitcoinds(0).disconnectNode(nodeUri0)
+        _ <- AsyncUtil.nonBlockingSleep(5.seconds)
+        onePeerConnectionCount <- node.getConnectionCount
+        _ = assert(onePeerConnectionCount == 1)
+        nodeUri1 <- NodeTestUtil.getNodeURIFromBitcoind(bitcoinds(1))
+        _ <- bitcoinds(1).disconnectNode(nodeUri1)
+        _ <- AsyncUtil.nonBlockingSleep(5.seconds)
+        zeroPeerConnectionCount <- node.getConnectionCount
+      } yield assert(zeroPeerConnectionCount == 0)
+  }
 }

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -213,6 +213,10 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     }
   }
 
+  override def getConnectionCount: Future[Int] = {
+    Future.successful(peerManager.connectedPeerCount)
+  }
+
   /** Gets the height of the given block */
   override def getBlockHeight(
       blockHash: DoubleSha256DigestBE): Future[Option[Int]] =

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
@@ -99,6 +99,9 @@ abstract class SyncUtil extends Logging {
           ()
         }
       }
+
+      override def getConnectionCount: Future[Int] =
+        bitcoindRpcClient.getConnectionCount
     }
   }
 
@@ -156,6 +159,9 @@ abstract class SyncUtil extends Logging {
           transactions: Vector[Transaction]): Future[Unit] = {
         bitcoindRpcClient.broadcastTransactions(transactions)
       }
+
+      override def getConnectionCount: Future[Int] =
+        bitcoindRpcClient.getConnectionCount
     }
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/MockNodeApi.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/MockNodeApi.scala
@@ -16,4 +16,6 @@ object MockNodeApi extends NodeApi {
   override def downloadBlocks(
       blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = Future.unit
 
+  override def getConnectionCount: Future[Int] = Future.successful(0)
+
 }


### PR DESCRIPTION
Implements an easy way to query how many connections you have to your node. This is intended to chip away at the required features to fix #4996 