### PR TITLE
2023 04 20 decouple node

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
@@ -100,7 +100,10 @@ class P2PClientActorTest
     val peerMessageReceiverF =
       for {
         node <- NodeUnitTest.buildNode(peer, None)
-      } yield PeerMessageReceiver(node, peer)
+      } yield PeerMessageReceiver(
+        controlMessageHandler = node.controlMessageHandler,
+        dataMessageHandler = node.getDataMessageHandler,
+        peer = peer)
 
     val clientActorF: Future[TestActorRef[P2PClientActor]] =
       peerMessageReceiverF.map { peerMsgRecv =>

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -51,7 +51,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         dataMessageHandler = DataMessageHandler(
           chainApi = chainApi,
           walletCreationTimeOpt = None,
-          node = node,
+          peerManager = node.peerManager,
           state = HeaderSync,
           initialSyncDone = None,
           filterBatchCache = Set.empty,
@@ -101,7 +101,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
           DataMessageHandler(
             chainApi = chainApi,
             walletCreationTimeOpt = None,
-            node = node,
+            peerManager = node.peerManager,
             state = HeaderSync,
             initialSyncDone = None,
             filterBatchCache = Set.empty,
@@ -145,7 +145,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
           DataMessageHandler(
             chainApi = chainApi,
             walletCreationTimeOpt = None,
-            node = node,
+            peerManager = node.peerManager,
             state = HeaderSync,
             initialSyncDone = None,
             filterBatchCache = Set.empty,
@@ -211,7 +211,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
           DataMessageHandler(
             chainApi = chainApi,
             walletCreationTimeOpt = None,
-            node = node,
+            peerManager = node.peerManager,
             state = HeaderSync,
             initialSyncDone = None,
             filterBatchCache = Set.empty,

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -52,7 +52,7 @@ case class NeutrinoNode(
       DataMessageHandler(
         chainApi = chainApi,
         walletCreationTimeOpt = walletCreationTimeOpt,
-        node = this,
+        peerManager = peerManager,
         state = HeaderSync,
         initialSyncDone = None,
         filterBatchCache = Set.empty,
@@ -71,7 +71,7 @@ case class NeutrinoNode(
     this
   }
 
-  override val peerManager: PeerManager = PeerManager(paramPeers, this)
+  override lazy val peerManager: PeerManager = PeerManager(paramPeers, this)
 
   override def start(): Future[NeutrinoNode] = {
     val res = for {

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -37,7 +37,7 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
 
   implicit def executionContext: ExecutionContext = system.dispatcher
 
-  val peerManager: PeerManager
+  def peerManager: PeerManager
 
   /** The current data message handler.
     * It should be noted that the dataMessageHandler contains

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -33,7 +33,9 @@ case class PeerData(
 
   private lazy val client: Future[P2PClient] = {
     val peerMessageReceiver =
-      PeerMessageReceiver(node, peer)
+      PeerMessageReceiver(node.controlMessageHandler,
+                          node.getDataMessageHandler,
+                          peer)
     P2PClient(
       peer = peer,
       peerMessageReceiver = peerMessageReceiver,

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -478,8 +478,9 @@ case class PeerManager(
       newDmh = currentDmh.copy(syncPeer = Some(peer))
       _ = logger.info(s"Now syncing filter headers from $peer")
       sender <- peerDataMap(peer).peerMessageSender
-      newSyncing <- PeerManager.sendFirstGetCompactFilterHeadersCommand(sender,
-                                                            currentDmh.chainApi)
+      newSyncing <- PeerManager.sendFirstGetCompactFilterHeadersCommand(
+        sender,
+        currentDmh.chainApi)
     } yield {
       val syncPeerOpt = if (newSyncing) {
         Some(peer)
@@ -490,16 +491,17 @@ case class PeerManager(
     }
   }
 
-
 }
 
 case class ResponseTimeout(payload: NetworkPayload)
 
 object PeerManager {
+
   def sendFirstGetCompactFilterHeadersCommand(
-                                               peerMsgSender: PeerMessageSender,
-                                               chainApi: ChainApi)(implicit ec: ExecutionContext,
-                                                                   chainConfig: ChainAppConfig): Future[Boolean] = {
+      peerMsgSender: PeerMessageSender,
+      chainApi: ChainApi)(implicit
+      ec: ExecutionContext,
+      chainConfig: ChainAppConfig): Future[Boolean] = {
 
     for {
       bestFilterHeaderOpt <-

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -13,7 +13,7 @@ import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models._
 import org.bitcoins.node.networking.peer.DataMessageHandlerState._
-import org.bitcoins.node.{Node, P2PLogger, PeerManager}
+import org.bitcoins.node.{P2PLogger, PeerManager}
 
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future, Promise}
@@ -30,7 +30,7 @@ import scala.util.control.NonFatal
 case class DataMessageHandler(
     chainApi: ChainApi,
     walletCreationTimeOpt: Option[Instant],
-    node: Node,
+    peerManager: PeerManager,
     state: DataMessageHandlerState,
     initialSyncDone: Option[Promise[Done]],
     filterBatchCache: Set[CompactFilterMessage],
@@ -51,14 +51,12 @@ case class DataMessageHandler(
                                        syncPeer = None,
                                        state = HeaderSync)
 
-  def manager: PeerManager = node.peerManager
-
   def addToStream(
       payload: DataPayload,
       peerMsgSender: PeerMessageSender,
       peer: Peer): Future[Unit] = {
     val msg = DataMessageWrapper(payload, peerMsgSender, peer)
-    manager.dataMessageStream.offer(msg).map(_ => ())
+    peerManager.dataMessageStream.offer(msg).map(_ => ())
   }
 
   private def isChainIBD: Future[Boolean] = {
@@ -300,7 +298,8 @@ case class DataMessageHandler(
                     case ValidatingHeaders(inSyncWith, _, _) =>
                       //In the validation stage, some peer sent max amount of valid headers, revert to HeaderSync with that peer as syncPeer
                       //disconnect the ones that we have already checked since they are at least out of sync by 2000 headers
-                      val removeFs = inSyncWith.map(p => manager.removePeer(p))
+                      val removeFs =
+                        inSyncWith.map(p => peerManager.removePeer(p))
 
                       val newSyncPeer = Some(peer)
 
@@ -340,16 +339,17 @@ case class DataMessageHandler(
                       // headers are synced now with the current sync peer, now move to validating it for all peers
                       assert(syncPeer.get == peer)
 
-                      if (manager.peers.size > 1) {
+                      if (peerManager.peers.size > 1) {
                         val newState =
                           ValidatingHeaders(inSyncWith = Set(peer),
-                                            verifyingWith = manager.peers.toSet,
+                                            verifyingWith =
+                                              peerManager.peers.toSet,
                                             failedCheck = Set.empty[Peer])
 
                         logger.info(
                           s"Starting to validate headers now. Verifying with ${newState.verifyingWith}")
 
-                        val getHeadersAllF = manager.peerDataMap
+                        val getHeadersAllF = peerManager.peerDataMap
                           .filter(_._1 != peer)
                           .map(
                             _._2.peerMessageSender.flatMap(
@@ -550,17 +550,17 @@ case class DataMessageHandler(
       peerMsgSender: PeerMessageSender): Future[DataMessageHandler] = {
     state match {
       case HeaderSync =>
-        manager.peerDataMap(peer).updateInvalidMessageCount()
+        peerManager.peerDataMap(peer).updateInvalidMessageCount()
         if (
-          manager
+          peerManager
             .peerDataMap(peer)
-            .exceededMaxInvalidMessages && manager.peers.size > 1
+            .exceededMaxInvalidMessages && peerManager.peers.size > 1
         ) {
           logger.info(
             s"$peer exceeded max limit of invalid messages. Disconnecting.")
           for {
-            _ <- manager.removePeer(peer)
-            newDmh <- manager.syncFromNewPeer()
+            _ <- peerManager.removePeer(peer)
+            newDmh <- peerManager.syncFromNewPeer()
           } yield newDmh.copy(state = HeaderSync)
         } else {
           logger.info(s"Re-querying headers from $peer.")
@@ -597,11 +597,11 @@ case class DataMessageHandler(
   private def fetchCompactFilterHeaders(
       currentDmh: DataMessageHandler): Future[DataMessageHandler] = {
     for {
-      peer <- manager.randomPeerWithService(
+      peer <- peerManager.randomPeerWithService(
         ServiceIdentifier.NODE_COMPACT_FILTERS)
       newDmh = currentDmh.copy(syncPeer = Some(peer))
       _ = logger.info(s"Now syncing filter headers from $peer")
-      sender <- manager.peerDataMap(peer).peerMessageSender
+      sender <- peerManager.peerDataMap(peer).peerMessageSender
       newSyncing <- sendFirstGetCompactFilterHeadersCommand(sender)
     } yield {
       val syncPeerOpt = if (newSyncing) {
@@ -617,7 +617,7 @@ case class DataMessageHandler(
     logger.info(s"Header request timed out from $peer in state $state")
     state match {
       case HeaderSync =>
-        manager.syncFromNewPeer()
+        peerManager.syncFromNewPeer()
 
       case headerState @ ValidatingHeaders(_, failedCheck, _) =>
         val newHeaderState = headerState.copy(failedCheck = failedCheck + peer)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -627,7 +627,7 @@ case class DataMessageHandler(
           fetchCompactFilterHeaders(newDmh).map(_.copy(state = PostHeaderSync))
         } else Future.successful(newDmh)
 
-      case _: DataMessageHandlerState => Future.successful(this)
+      case PostHeaderSync => Future.successful(this)
     }
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -207,13 +207,14 @@ object NodeUnitTest extends P2PLogger {
       walletCreationTimeOpt: Option[Instant])(implicit
       appConfig: BitcoinSAppConfig,
       system: ActorSystem): Future[PeerMessageReceiver] = {
+    val node = buildNode(peer, chainApi, walletCreationTimeOpt)(
+      appConfig.chainConf,
+      appConfig.nodeConf,
+      system)
     val receiver =
-      PeerMessageReceiver(
-        node =
-          buildNode(peer, chainApi, walletCreationTimeOpt)(appConfig.chainConf,
-                                                           appConfig.nodeConf,
-                                                           system),
-        peer = peer)(system, appConfig.nodeConf)
+      PeerMessageReceiver(controlMessageHandler = node.controlMessageHandler,
+                          dataMessageHandler = node.getDataMessageHandler,
+                          peer = peer)(system, appConfig.nodeConf)
     Future.successful(receiver)
   }
 
@@ -388,9 +389,10 @@ object NodeUnitTest extends P2PLogger {
       nodeAppConfig: NodeAppConfig,
       chainAppConfig: ChainAppConfig,
       system: ActorSystem): Future[PeerMessageReceiver] = {
+    val node = buildNode(peer, chainApi, walletCreationTimeOpt)
     val receiver =
-      PeerMessageReceiver(node =
-                            buildNode(peer, chainApi, walletCreationTimeOpt),
+      PeerMessageReceiver(controlMessageHandler = node.controlMessageHandler,
+                          dataMessageHandler = node.getDataMessageHandler,
                           peer = peer)
     Future.successful(receiver)
   }


### PR DESCRIPTION
Decouples parts of `node` module. Mainly by only passing around `PeerManager` rather than the full `Node` object into things like `DataMessageHandler`.

This makes it easier to refactor the code base in the future, for instance using akka streams for each individual peer we are connected to. 