### PR TITLE
Implement `FutureUtil.batchAndParallelExecute` with `Future.traverse` rather than `Future.sequence`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/FutureUtil.scala
@@ -122,9 +122,8 @@ object FutureUtil {
       Future.successful(Vector.empty)
     } else {
       val batches = elements.grouped(batchSize).toVector
-      val execute: Vector[Future[U]] = batches.map(b => f(b))
-      val doneF = Future.sequence(execute)
-      doneF
+      val executeF: Future[Vector[U]] = Future.traverse(batches)(f(_))
+      executeF
     }
   }
 


### PR DESCRIPTION


Try to fix this flaky test: https://github.com/bitcoin-s/bitcoin-s/actions/runs/4758858452/jobs/8457441116?pr=5050#step:6:1414