### PR TITLE
2023 04 22 peermanager dmh refactor

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
@@ -102,7 +102,7 @@ class P2PClientActorTest
         node <- NodeUnitTest.buildNode(peer, None)
       } yield PeerMessageReceiver(
         controlMessageHandler = node.controlMessageHandler,
-        dataMessageHandler = node.getDataMessageHandler,
+        dataMessageHandler = node.peerManager.getDataMessageHandler,
         peer = peer)
 
     val clientActorF: Future[TestActorRef[P2PClientActor]] =

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -34,7 +34,7 @@ case class PeerData(
   private lazy val client: Future[P2PClient] = {
     val peerMessageReceiver =
       PeerMessageReceiver(node.controlMessageHandler,
-                          node.getDataMessageHandler,
+                          node.peerManager.getDataMessageHandler,
                           peer)
     P2PClient(
       peer = peer,

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -4,6 +4,7 @@ import akka.actor.{ActorRef, ActorSystem, Cancellable, Props}
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Sink, Source, SourceQueueWithComplete}
 import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.chain.blockchain.{ChainHandler}
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.node.NodeType
@@ -14,12 +15,16 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.{Peer, PeerDAO, PeerDb}
 import org.bitcoins.node.networking.peer._
 import org.bitcoins.node.networking.P2PClientSupervisor
+<<<<<<< HEAD
 import org.bitcoins.node.networking.peer.DataMessageHandlerState._
+=======
+import org.bitcoins.node.networking.peer.DataMessageHandlerState.HeaderSync
+>>>>>>> 461fb937056 (WIP: Move DataMessageHandler into PeerManager)
 import org.bitcoins.node.util.BitcoinSNodeUtil
 import scodec.bits.ByteVector
 
 import java.net.InetAddress
-import java.time.Duration
+import java.time.{Duration, Instant}
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future, Promise}
@@ -27,7 +32,8 @@ import scala.util.Random
 
 case class PeerManager(
     paramPeers: Vector[Peer] = Vector.empty,
-    node: NeutrinoNode)(implicit
+    node: NeutrinoNode,
+    walletCreationTimeOpt: Option[Instant])(implicit
     ec: ExecutionContext,
     system: ActorSystem,
     nodeAppConfig: NodeAppConfig,
@@ -363,9 +369,9 @@ case class PeerManager(
       //actor stopped for one of the persistent peers, can happen in case a reconnection attempt failed due to
       //reconnection tries exceeding the max limit in which the client was stopped to disconnect from it, remove it
       _peerDataMap.remove(peer)
-      val syncPeer = node.getDataMessageHandler.syncPeer
+      val syncPeer = getDataMessageHandler.syncPeer
       if (peers.length > 1 && syncPeer.isDefined && syncPeer.get == peer) {
-        syncFromNewPeer().map(_ => ())
+        node.syncFromNewPeer().map(_ => ())
       } else if (syncPeer.isEmpty) {
         Future.unit
       } else {
@@ -410,8 +416,8 @@ case class PeerManager(
       case _: GetHeadersMessage =>
         dataMessageStream.offer(HeaderTimeoutWrapper(peer)).map(_ => ())
       case _ =>
-        if (peer == node.getDataMessageHandler.syncPeer.get)
-          syncFromNewPeer().map(_ => ())
+        if (peer == getDataMessageHandler.syncPeer.get)
+          node.syncFromNewPeer().map(_ => ())
         else Future.unit
     }
   }
@@ -454,13 +460,6 @@ case class PeerManager(
     }
   }
 
-  def syncFromNewPeer(): Future[DataMessageHandler] = {
-    logger.info(s"Trying to sync from new peer")
-    val newNode =
-      node.updateDataMessageHandler(node.getDataMessageHandler.reset)
-    newNode.sync().map(_ => node.getDataMessageHandler)
-  }
-
   private val dataMessageStreamSource = Source
     .queue[StreamDataMessageWrapper](1500,
                                      overflowStrategy =
@@ -468,17 +467,17 @@ case class PeerManager(
     .mapAsync(1) {
       case msg @ DataMessageWrapper(payload, peerMsgSender, peer) =>
         logger.debug(s"Got ${payload.commandName} from peer=${peer} in stream")
-        node.getDataMessageHandler
+        getDataMessageHandler
           .handleDataPayload(payload, peerMsgSender, peer)
           .map { newDmh =>
-            node.updateDataMessageHandler(newDmh)
+            updateDataMessageHandler(newDmh)
             msg
           }
       case msg @ HeaderTimeoutWrapper(peer) =>
         logger.debug(s"Processing timeout header for $peer")
-        onHeaderRequestTimeout(peer, node.getDataMessageHandler.state).map {
+        onHeaderRequestTimeout(peer, getDataMessageHandler.state).map {
           newDmh =>
-            node.updateDataMessageHandler(newDmh)
+            updateDataMessageHandler(newDmh)
             logger.debug(s"Done processing timeout header for $peer")
             msg
         }
@@ -512,6 +511,26 @@ case class PeerManager(
       }
       newDmh.copy(syncPeer = syncPeerOpt)
     }
+  }
+
+  private var dataMessageHandler: DataMessageHandler = {
+    DataMessageHandler(
+      chainApi = ChainHandler.fromDatabase(),
+      walletCreationTimeOpt = walletCreationTimeOpt,
+      peerManager = this,
+      state = HeaderSync,
+      initialSyncDone = None,
+      filterBatchCache = Set.empty,
+      syncPeer = None
+    )
+  }
+
+  def getDataMessageHandler: DataMessageHandler = dataMessageHandler
+
+  def updateDataMessageHandler(
+      dataMessageHandler: DataMessageHandler): PeerManager = {
+    this.dataMessageHandler = dataMessageHandler
+    this
   }
 
 }

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -213,7 +213,8 @@ object NodeUnitTest extends P2PLogger {
       system)
     val receiver =
       PeerMessageReceiver(controlMessageHandler = node.controlMessageHandler,
-                          dataMessageHandler = node.getDataMessageHandler,
+                          dataMessageHandler =
+                            node.peerManager.getDataMessageHandler,
                           peer = peer)(system, appConfig.nodeConf)
     Future.successful(receiver)
   }
@@ -392,7 +393,8 @@ object NodeUnitTest extends P2PLogger {
     val node = buildNode(peer, chainApi, walletCreationTimeOpt)
     val receiver =
       PeerMessageReceiver(controlMessageHandler = node.controlMessageHandler,
-                          dataMessageHandler = node.getDataMessageHandler,
+                          dataMessageHandler =
+                            node.peerManager.getDataMessageHandler,
                           peer = peer)
     Future.successful(receiver)
   }


### PR DESCRIPTION
Refactor to place `DataMessageHandler` inside of `PeerManager` rather than `NeutrinoNode`. This PR still has the relationship of 1 `DataMessageHandler` to many `PeerMessageReceiver`. I would like to get that to a 1-1 relationship eventually so state isn't shared across peers inside of `DataMessageHandler.` This PR works towards that goal by refactoring.