### PR TITLE
Add `MisbehavingPeer` state

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -5,7 +5,10 @@ import org.bitcoins.core.p2p.{GetHeadersMessage, HeadersMessage}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.P2PClient.ExpectResponseCommand
-import org.bitcoins.node.networking.peer.DataMessageHandlerState.DoneSyncing
+import org.bitcoins.node.networking.peer.DataMessageHandlerState.{
+  DoneSyncing,
+  MisbehavingPeer
+}
 import org.bitcoins.node.networking.peer.{
   DataMessageHandlerState,
   SyncDataMessageHandlerState
@@ -96,7 +99,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         //old peer we were syncing with that just disconnected us
         oldSyncPeer = node.peerManager.getDataMessageHandler.state match {
           case state: SyncDataMessageHandlerState => state.syncPeer
-          case DoneSyncing =>
+          case DoneSyncing | _: MisbehavingPeer =>
             sys.error(s"Cannot be in DOneSyncing state while awaiting sync")
         }
         _ <- NodeTestUtil.awaitAllSync(node, bitcoinds(1))

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -15,7 +15,10 @@ import org.bitcoins.core.p2p.ServiceIdentifier
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
-import org.bitcoins.node.networking.peer.DataMessageHandlerState.DoneSyncing
+import org.bitcoins.node.networking.peer.DataMessageHandlerState.{
+  DoneSyncing,
+  MisbehavingPeer
+}
 import org.bitcoins.node.networking.peer.{
   ControlMessageHandler,
   DataMessageHandlerState,
@@ -169,7 +172,7 @@ case class NeutrinoNode(
           val peerMsgSender =
             peerManager.peerDataMap(syncState.syncPeer).peerMessageSender
           Some(peerMsgSender)
-        case DoneSyncing => None
+        case DoneSyncing | _: MisbehavingPeer => None
       }
     }
     val sendCompactFilterHeaderMsgF = syncPeerMsgSenderOptF match {

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -16,7 +16,10 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models._
-import org.bitcoins.node.networking.peer.DataMessageHandlerState.DoneSyncing
+import org.bitcoins.node.networking.peer.DataMessageHandlerState.{
+  DoneSyncing,
+  MisbehavingPeer
+}
 import org.bitcoins.node.networking.peer.{
   ControlMessageHandler,
   PeerMessageSender,
@@ -188,7 +191,7 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     if (isIBD) {
       val syncPeerOpt = peerManager.getDataMessageHandler.state match {
         case state: SyncDataMessageHandlerState => Some(state.syncPeer)
-        case DoneSyncing                        => None
+        case DoneSyncing | _: MisbehavingPeer   => None
       }
       syncPeerOpt match {
         case Some(peer) =>

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -440,9 +440,6 @@ case class PeerManager(
     Future.unit
   }
 
-  def syncFromNewPeer(): Future[DataMessageHandler] =
-    node.syncFromNewPeer().map(_ => getDataMessageHandler)
-
   private def onHeaderRequestTimeout(
       peer: Peer,
       state: DataMessageHandlerState): Future[DataMessageHandler] = {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -371,6 +371,7 @@ case class PeerManager(
       val syncPeerOpt = state match {
         case s: SyncDataMessageHandlerState =>
           Some(s.syncPeer)
+        case m: MisbehavingPeer => Some(m.badPeer)
         case DoneSyncing =>
           None
       }
@@ -425,8 +426,8 @@ case class PeerManager(
         val syncPeer = getDataMessageHandler.state match {
           case syncState: SyncDataMessageHandlerState =>
             syncState.syncPeer
-          case DoneSyncing =>
-            sys.error(s"Cannot have DoneSyncing and have a query timeout")
+          case s @ (DoneSyncing | _: MisbehavingPeer) =>
+            sys.error(s"Cannot have state=$s and have a query timeout")
         }
         if (peer == syncPeer)
           node.syncFromNewPeer().map(_ => ())
@@ -447,7 +448,7 @@ case class PeerManager(
       state: DataMessageHandlerState): Future[DataMessageHandler] = {
     logger.info(s"Header request timed out from $peer in state $state")
     state match {
-      case HeaderSync(_) =>
+      case HeaderSync(_) | MisbehavingPeer(_) =>
         node.syncFromNewPeer().map(_ => getDataMessageHandler)
 
       case headerState @ ValidatingHeaders(_, _, failedCheck, _) =>
@@ -485,9 +486,20 @@ case class PeerManager(
         logger.debug(s"Got ${payload.commandName} from peer=${peer} in stream")
         getDataMessageHandler
           .handleDataPayload(payload, peerMsgSender, peer)
-          .map { newDmh =>
-            updateDataMessageHandler(newDmh)
-            msg
+          .flatMap { newDmh =>
+            newDmh.state match {
+              case m: MisbehavingPeer =>
+                updateDataMessageHandler(newDmh)
+                //disconnect the misbehaving peer
+                for {
+                  _ <- removePeer(m.badPeer)
+                  _ <- node.syncFromNewPeer()
+                } yield msg
+              case _: SyncDataMessageHandlerState | DoneSyncing =>
+                updateDataMessageHandler(newDmh)
+                Future.successful(msg)
+            }
+
           }
       case msg @ HeaderTimeoutWrapper(peer) =>
         logger.debug(s"Processing timeout header for $peer")
@@ -513,9 +525,9 @@ case class PeerManager(
       currentDmh: DataMessageHandler): Future[DataMessageHandler] = {
     val syncPeer = currentDmh.state match {
       case s: SyncDataMessageHandlerState => s.syncPeer
-      case DoneSyncing =>
+      case state @ (DoneSyncing | _: MisbehavingPeer) =>
         sys.error(
-          s"Cannot fetch compact filter headers when we are in state=DoneSyncing")
+          s"Cannot fetch compact filter headers when we are in state=$state")
     }
     logger.info(
       s"Now syncing filter headers from $syncPeer in state=${currentDmh.state}")

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandlerState.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandlerState.scala
@@ -33,6 +33,10 @@ object DataMessageHandlerState {
     def validated: Boolean = inSyncWith ++ failedCheck == verifyingWith
   }
 
+  case class MisbehavingPeer(badPeer: Peer) extends DataMessageHandlerState {
+    override val isSyncing: Boolean = false
+  }
+
   /** State to indicate we are not currently syncing with a peer */
   case object DoneSyncing extends DataMessageHandlerState {
     override val isSyncing: Boolean = false


### PR DESCRIPTION
Adds `MisbehavingPeer` state. This state is used when a peer is misbehaving. 

This purpose for this is to give us a return value to indicate the peer is misbehaving, with the goal of decoupling `PeerManager` and `DataMessageHandler`. Now that we have a state to represent a misbehaving peer, we can move logic for syncing with a new peer from `DataMessageHandler` to `PeerManager`. 

This is the logic that is moved to `PeerManager` now.

https://github.com/bitcoin-s/bitcoin-s/compare/master...Christewart:2023-05-05-misbehaving-peer-state?expand=1#diff-61413f0a707d1e3e49431ad34fcb1af04b4fa36148e75c7abc692bebc07822b7L474

This PR works towards a higher level goal of using akka streams to create a pipeline for p2p message processing. Related to #5062 
