### PR TITLE
2023 05 05 encapsulate peermanager peermsgsender

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -99,8 +99,9 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       def allDisconn: Future[Unit] = AsyncUtil.retryUntilSatisfied(
         peers
           .map(p =>
-            !peerManager.peerDataMap.contains(
-              p) && !peerManager.waitingForDeletion
+            !peerManager
+              .getPeerData(p)
+              .isDefined && !peerManager.waitingForDeletion
               .contains(p))
           .forall(_ == true),
         maxTries = 5,

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -89,9 +89,8 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
           GetHeadersMessage(node.chainConfig.chain.genesisHash))
         //waiting for response to header query now
         client <- node.peerManager
-          .peerDataMap(bitcoindPeers(0))
-          .peerMessageSender
-          .map(_.client)
+          .getPeerMsgSender(bitcoindPeers(0))
+          .map(_.get.client)
         _ = client.actor ! expectHeaders
         nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoinds(0))
         _ <- bitcoinds(0).disconnectNode(nodeUri)
@@ -160,7 +159,9 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
                                                       node.chainConfig))
 
         invalidHeaderMessage = HeadersMessage(headers = Vector(invalidHeader))
-        sender <- node.peerManager.peerDataMap(peer).peerMessageSender
+        sender <- node.peerManager
+          .getPeerMsgSender(peer)
+          .map(_.get)
         _ <- node.peerManager.getDataMessageHandler.addToStream(
           invalidHeaderMessage,
           sender,
@@ -180,7 +181,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
       def sendInvalidHeaders(peer: Peer): Future[Unit] = {
         val invalidHeaderMessage =
           HeadersMessage(headers = Vector(invalidHeader))
-        val senderF = node.peerManager.peerDataMap(peer).peerMessageSender
+        val senderF = node.peerManager.getPeerData(peer).get.peerMessageSender
 
         for {
           sender <- senderF

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -90,7 +90,7 @@ case class NeutrinoNode(
       bestFilterOpt <- chainApi.getBestFilter()
       blockchains <- blockchainsF
       // Get all of our cached headers in case of a reorg
-      cachedHeaders = blockchains.flatMap(_.headers).map(_.hashBE.flip)
+      cachedHeaders = blockchains.flatMap(_.headers).map(_.hashBE)
       _ <- peerManager.sendGetHeadersMessage(cachedHeaders, Some(syncPeer))
       hasStaleTip <- chainApi.isTipStale()
       _ <- {

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -15,14 +15,9 @@ import org.bitcoins.core.p2p.ServiceIdentifier
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
-import org.bitcoins.node.networking.peer.DataMessageHandlerState.{
-  DoneSyncing,
-  MisbehavingPeer
-}
 import org.bitcoins.node.networking.peer.{
   ControlMessageHandler,
-  DataMessageHandlerState,
-  SyncDataMessageHandlerState
+  DataMessageHandlerState
 }
 
 import java.time.Instant
@@ -90,14 +85,13 @@ case class NeutrinoNode(
       peerManager.getDataMessageHandler.copy(state =
         DataMessageHandlerState.HeaderSync(syncPeer)))
     for {
-      peerMsgSender <- peerManager.peerDataMap(syncPeer).peerMessageSender
       header <- chainApi.getBestBlockHeader()
       bestFilterHeaderOpt <- chainApi.getBestFilterHeader()
       bestFilterOpt <- chainApi.getBestFilter()
       blockchains <- blockchainsF
       // Get all of our cached headers in case of a reorg
       cachedHeaders = blockchains.flatMap(_.headers).map(_.hashBE.flip)
-      _ <- peerMsgSender.sendGetHeadersMessage(cachedHeaders)
+      _ <- peerManager.sendGetHeadersMessage(cachedHeaders, Some(syncPeer))
       hasStaleTip <- chainApi.isTipStale()
       _ <- {
         if (hasStaleTip) {
@@ -144,10 +138,12 @@ case class NeutrinoNode(
           //do nothing
           Future.unit
         } else {
-          syncCompactFilters(bestFilterHeader, chainApi, Some(bestFilter))
+          peerManager.syncCompactFilters(bestFilterHeader,
+                                         chainApi,
+                                         Some(bestFilter))
         }
       case (Some(bestFilterHeader), None) =>
-        syncCompactFilters(bestFilterHeader, chainApi, None)
+        peerManager.syncCompactFilters(bestFilterHeader, chainApi, None)
     }
   }
 
@@ -157,63 +153,6 @@ case class NeutrinoNode(
         ServiceIdentifier.NODE_COMPACT_FILTERS)
       _ <- syncHelper(syncPeer)
     } yield ()
-  }
-
-  /** Starts sync compact filer headers.
-    * Only starts syncing compact filters if our compact filter headers are in sync with block headers
-    */
-  private def syncCompactFilters(
-      bestFilterHeader: CompactFilterHeaderDb,
-      chainApi: ChainApi,
-      bestFilterOpt: Option[CompactFilterDb]): Future[Unit] = {
-    val syncPeerMsgSenderOptF = {
-      peerManager.getDataMessageHandler.state match {
-        case syncState: SyncDataMessageHandlerState =>
-          val peerMsgSender =
-            peerManager.peerDataMap(syncState.syncPeer).peerMessageSender
-          Some(peerMsgSender)
-        case DoneSyncing | _: MisbehavingPeer => None
-      }
-    }
-    val sendCompactFilterHeaderMsgF = syncPeerMsgSenderOptF match {
-      case Some(syncPeerMsgSenderF) =>
-        syncPeerMsgSenderF.flatMap(
-          _.sendNextGetCompactFilterHeadersCommand(
-            chainApi = chainApi,
-            filterHeaderBatchSize = chainConfig.filterHeaderBatchSize,
-            prevStopHash = bestFilterHeader.blockHashBE)
-        )
-      case None => Future.successful(false)
-    }
-    sendCompactFilterHeaderMsgF.flatMap { isSyncFilterHeaders =>
-      // If we have started syncing filters
-      if (
-        !isSyncFilterHeaders &&
-        bestFilterOpt.isDefined &&
-        bestFilterOpt.get.hashBE != bestFilterHeader.filterHashBE
-      ) {
-        syncPeerMsgSenderOptF match {
-          case Some(syncPeerMsgSenderF) =>
-            //means we are not syncing filter headers, and our filters are NOT
-            //in sync with our compact filter headers
-            syncPeerMsgSenderF.flatMap { sender =>
-              sender
-                .sendNextGetCompactFilterCommand(chainApi = chainApi,
-                                                 filterBatchSize =
-                                                   chainConfig.filterBatchSize,
-                                                 startHeight =
-                                                   bestFilterOpt.get.height)
-                .map(_ => ())
-            }
-          case None =>
-            logger.warn(
-              s"Not syncing compact filters since we do not have a syncPeer set, bestFilterOpt=$bestFilterOpt")
-            Future.unit
-        }
-      } else {
-        Future.unit
-      }
-    }
   }
 
   /** Gets the number of compact filters in the database */

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -603,9 +603,10 @@ case class PeerManager(
   }
 
   private val dataMessageStreamSource = Source
-    .queue[StreamDataMessageWrapper](8,
-                                     overflowStrategy =
-                                       OverflowStrategy.backpressure)
+    .queue[StreamDataMessageWrapper](
+      8,
+      overflowStrategy = OverflowStrategy.backpressure,
+      maxConcurrentOffers = nodeAppConfig.maxConnectedPeers)
     .mapAsync(1) {
       case msg @ DataMessageWrapper(payload, peer) =>
         logger.debug(s"Got ${payload.commandName} from peer=${peer} in stream")

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -613,7 +613,7 @@ case class PeerManager(
         peerMsgSenderOptF.flatMap {
           case None =>
             Future.failed(new RuntimeException(
-              s"Couldn't find PeerMessageSender that corresponds with peer=$peer"))
+              s"Couldn't find PeerMessageSender that corresponds with peer=$peer msg=${payload.commandName}. Was it disconnected?"))
           case Some(peerMsgSender) =>
             getDataMessageHandler
               .handleDataPayload(payload, peerMsgSender, peer)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -603,7 +603,7 @@ case class PeerManager(
   }
 
   private val dataMessageStreamSource = Source
-    .queue[StreamDataMessageWrapper](1500,
+    .queue[StreamDataMessageWrapper](8,
                                      overflowStrategy =
                                        OverflowStrategy.backpressure)
     .mapAsync(1) {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -7,10 +7,11 @@ import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.chain.ChainApi
+import org.bitcoins.core.api.chain.db.{CompactFilterDb, CompactFilterHeaderDb}
 import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.util.{NetworkUtil, StartStopAsync}
-import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.{Peer, PeerDAO, PeerDb}
 import org.bitcoins.node.networking.peer._
@@ -78,6 +79,135 @@ case class PeerManager(
     Future
       .traverse(_peerDataMap.values)(_.peerMessageSender)
       .map(_.toVector)
+  }
+
+  def sendMsg(msg: NetworkPayload, peerOpt: Option[Peer]): Future[Unit] = {
+    val peerMsgSenderF = peerOpt match {
+      case Some(peer) =>
+        val peerMsgSenderF = peerDataMap(peer).peerMessageSender
+        peerMsgSenderF
+      case None =>
+        val peerMsgSenderF = randomPeerMsgSenderWithService(
+          ServiceIdentifier.NODE_NETWORK)
+        peerMsgSenderF
+    }
+    peerMsgSenderF.flatMap(_.sendMsg(msg))
+  }
+
+  /** Gossips the given message to all peers except the excluded peer. If None given as excluded peer, gossip message to all peers */
+  def gossipMessage(
+      msg: NetworkPayload,
+      excludedPeerOpt: Option[Peer]): Future[Unit] = {
+    val gossipPeers = excludedPeerOpt match {
+      case Some(excludedPeer) =>
+        peerDataMap
+          .filterNot(_._1 == excludedPeer)
+          .map(_._1)
+      case None => peerDataMap.map(_._1)
+    }
+
+    Future
+      .traverse(gossipPeers)(p => sendMsg(msg, Some(p)))
+      .map(_ => ())
+  }
+
+  def sendGetHeadersMessage(
+      hashes: Vector[DoubleSha256Digest],
+      peerOpt: Option[Peer]): Future[Unit] = {
+    val peerMsgSenderF = peerOpt match {
+      case Some(peer) =>
+        val peerMsgSenderF = peerDataMap(peer).peerMessageSender
+        peerMsgSenderF
+      case None =>
+        val peerMsgSenderF = randomPeerMsgSenderWithService(
+          ServiceIdentifier.NODE_NETWORK)
+        peerMsgSenderF
+    }
+    peerMsgSenderF.flatMap(_.sendGetHeadersMessage(hashes))
+  }
+
+  def sendGetDataMessage(
+      typeIdentifier: TypeIdentifier,
+      hash: DoubleSha256DigestBE,
+      peerOpt: Option[Peer]): Future[Unit] = {
+    sendGetDataMessages(typeIdentifier, Vector(hash), peerOpt)
+  }
+
+  def sendGetDataMessages(
+      typeIdentifier: TypeIdentifier,
+      hashes: Vector[DoubleSha256DigestBE],
+      peerOpt: Option[Peer]): Future[Unit] = {
+    peerOpt match {
+      case Some(peer) =>
+        val peerMsgSenderF = peerDataMap(peer).peerMessageSender
+        val flip = hashes.map(_.flip)
+        peerMsgSenderF
+          .flatMap(_.sendGetDataMessage(typeIdentifier, flip: _*))
+      case None =>
+        val peerMsgSenderF = randomPeerMsgSenderWithService(
+          ServiceIdentifier.NODE_NETWORK)
+        peerMsgSenderF.flatMap(
+          _.sendGetDataMessage(TypeIdentifier.MsgWitnessBlock,
+                               hashes.map(_.flip): _*))
+
+    }
+  }
+
+  /** Starts sync compact filer headers.
+    * Only starts syncing compact filters if our compact filter headers are in sync with block headers
+    */
+  def syncCompactFilters(
+      bestFilterHeader: CompactFilterHeaderDb,
+      chainApi: ChainApi,
+      bestFilterOpt: Option[CompactFilterDb])(implicit
+      chainAppConfig: ChainAppConfig): Future[Unit] = {
+    val syncPeerMsgSenderOptF = {
+      getDataMessageHandler.state match {
+        case syncState: SyncDataMessageHandlerState =>
+          val peerMsgSender =
+            peerDataMap(syncState.syncPeer).peerMessageSender
+          Some(peerMsgSender)
+        case DoneSyncing | _: MisbehavingPeer => None
+      }
+    }
+    val sendCompactFilterHeaderMsgF = syncPeerMsgSenderOptF match {
+      case Some(syncPeerMsgSenderF) =>
+        syncPeerMsgSenderF.flatMap(
+          _.sendNextGetCompactFilterHeadersCommand(
+            chainApi = chainApi,
+            filterHeaderBatchSize = chainAppConfig.filterHeaderBatchSize,
+            prevStopHash = bestFilterHeader.blockHashBE)
+        )
+      case None => Future.successful(false)
+    }
+    sendCompactFilterHeaderMsgF.flatMap { isSyncFilterHeaders =>
+      // If we have started syncing filters
+      if (
+        !isSyncFilterHeaders &&
+        bestFilterOpt.isDefined &&
+        bestFilterOpt.get.hashBE != bestFilterHeader.filterHashBE
+      ) {
+        syncPeerMsgSenderOptF match {
+          case Some(syncPeerMsgSenderF) =>
+            //means we are not syncing filter headers, and our filters are NOT
+            //in sync with our compact filter headers
+            syncPeerMsgSenderF.flatMap { sender =>
+              sender
+                .sendNextGetCompactFilterCommand(
+                  chainApi = chainApi,
+                  filterBatchSize = chainAppConfig.filterBatchSize,
+                  startHeight = bestFilterOpt.get.height)
+                .map(_ => ())
+            }
+          case None =>
+            logger.warn(
+              s"Not syncing compact filters since we do not have a syncPeer set, bestFilterOpt=$bestFilterOpt")
+            Future.unit
+        }
+      } else {
+        Future.unit
+      }
+    }
   }
 
   def getPeerMsgSender(peer: Peer): Future[Option[PeerMessageSender]] = {
@@ -223,7 +353,9 @@ case class PeerManager(
     }
   }
 
-  def peerDataMap: Map[Peer, PeerData] = _peerDataMap.toMap
+  private def peerDataMap: Map[Peer, PeerData] = _peerDataMap.toMap
+
+  def getPeerData(peer: Peer): Option[PeerData] = peerDataMap.get(peer)
 
   override def stop(): Future[PeerManager] = {
     logger.info(s"Stopping PeerManager")

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -49,15 +49,10 @@ case class DataMessageHandler(
   }
 
   def addToStream(payload: DataPayload, peer: Peer): Future[Unit] = {
-    val peerMsgSenderOptF = peerManager.getPeerMsgSender(peer)
-    peerMsgSenderOptF.flatMap {
-      case Some(peerMsgSender) =>
-        val msg = DataMessageWrapper(payload, peerMsgSender, peer)
-        peerManager.dataMessageStream.offer(msg).map(_ => ())
-      case None =>
-        Future.failed(new RuntimeException(
-          s"Couldn't find PeerMessageSender that corresponds with peer=$peer"))
-    }
+    val msg = DataMessageWrapper(payload, peer)
+    peerManager.dataMessageStream
+      .offer(msg)
+      .map(_ => ())
   }
 
   private def isChainIBD: Future[Boolean] = {
@@ -860,10 +855,7 @@ case class DataMessageHandler(
 
 sealed trait StreamDataMessageWrapper
 
-case class DataMessageWrapper(
-    payload: DataPayload,
-    peerMsgSender: PeerMessageSender,
-    peer: Peer)
+case class DataMessageWrapper(payload: DataPayload, peer: Peer)
     extends StreamDataMessageWrapper
 
 case class HeaderTimeoutWrapper(peer: Peer) extends StreamDataMessageWrapper

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -476,12 +476,15 @@ case class DataMessageHandler(
       peerMsgSender: PeerMessageSender): Future[DataMessageHandler] = {
     val result = state match {
       case HeaderSync(peer) =>
-        peerManager.peerDataMap(peer).updateInvalidMessageCount()
-        if (
-          peerManager
-            .peerDataMap(peer)
-            .exceededMaxInvalidMessages && peerManager.peers.size > 1
-        ) {
+        val peerDataOpt = peerManager.getPeerData(peer)
+        val peerData = peerDataOpt match {
+          case Some(peerData) => peerData
+          case None =>
+            sys.error(
+              s"Cannot find peer we are syncing with in PeerManager, peer=$peer")
+        }
+        peerData.updateInvalidMessageCount()
+        if (peerData.exceededMaxInvalidMessages && peerManager.peers.size > 1) {
           logger.warn(
             s"$peer exceeded max limit of invalid messages. Disconnecting.")
 
@@ -786,15 +789,12 @@ case class DataMessageHandler(
                 logger.info(
                   s"Starting to validate headers now. Verifying with ${newState.verifyingWith}")
 
-                val getHeadersAllF = peerManager.peerDataMap
-                  .filter(_._1 != peer)
-                  .map(
-                    _._2.peerMessageSender.flatMap(
-                      _.sendGetHeadersMessage(lastHash))
-                  )
+                val getHeadersAllF = {
+                  val msg = GetHeadersMessage(lastHash)
+                  peerManager.gossipMessage(msg, excludedPeerOpt = Some(peer))
+                }
 
-                Future
-                  .sequence(getHeadersAllF)
+                getHeadersAllF
                   .map(_ => newDmh.copy(state = newState))
               } else {
                 //if just one peer then can proceed ahead directly

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -72,7 +72,7 @@ case class PeerMessageReceiver(
                              sender = peerMsgSender,
                              curReceiverState = curState)
       case dataPayload: DataPayload =>
-        handleDataPayload(payload = dataPayload, sender = peerMsgSender)
+        handleDataPayload(payload = dataPayload)
           .map(_ => curState)
     }
   }
@@ -85,12 +85,11 @@ case class PeerMessageReceiver(
     * @param sender
     */
   private def handleDataPayload(
-      payload: DataPayload,
-      sender: PeerMessageSender): Future[PeerMessageReceiver] = {
+      payload: DataPayload): Future[PeerMessageReceiver] = {
     //else it means we are receiving this data payload from a peer,
     //we need to handle it
     dataMessageHandler
-      .addToStream(payload, sender, peer)
+      .addToStream(payload, peer)
       .map(_ =>
         new PeerMessageReceiver(controlMessageHandler,
                                 dataMessageHandler,

--- a/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
@@ -1,0 +1,34 @@
+package org.bitcoins.node.util
+
+import org.bitcoins.core.p2p.{NetworkPayload, TypeIdentifier}
+import org.bitcoins.crypto.{DoubleSha256DigestBE}
+import org.bitcoins.node.models.Peer
+
+import scala.concurrent.Future
+
+trait PeerMessageSenderApi {
+
+  def sendGetDataMessage(
+      typeIdentifier: TypeIdentifier,
+      hash: DoubleSha256DigestBE,
+      peerOpt: Option[Peer]): Future[Unit] = {
+    sendGetDataMessages(typeIdentifier, Vector(hash), peerOpt)
+  }
+
+  def sendGetDataMessages(
+      typeIdentifier: TypeIdentifier,
+      hashes: Vector[DoubleSha256DigestBE],
+      peerOpt: Option[Peer]): Future[Unit]
+
+  def sendGetHeadersMessage(
+      hashes: Vector[DoubleSha256DigestBE],
+      peerOpt: Option[Peer]): Future[Unit]
+
+  /** Gossips the given message to all peers except the excluded peer. If None given as excluded peer, gossip message to all peers */
+  def gossipMessage(
+      msg: NetworkPayload,
+      excludedPeerOpt: Option[Peer]): Future[Unit]
+
+  def sendMsg(msg: NetworkPayload, peerOpt: Option[Peer]): Future[Unit]
+
+}

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -57,7 +57,7 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <!-- inspect TCP details -->
     <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
@@ -65,7 +65,7 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
+    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->
     <!-- ╚════════════════════╝ -->

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -57,7 +57,7 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>
 
     <!-- inspect TCP details -->
     <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
@@ -65,7 +65,7 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
+    <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->
     <!-- ╚════════════════════╝ -->


### PR DESCRIPTION
Encapsulate `PeerManager.peerDataMap`. Use `getPeerMessageSender()` in various places. 

The purpose of this is to encapsulate implementation details inside of `PeerManager`. The goal is to eventually use akka streams to process all p2p messages in one pipeline.