### PR TITLE
Get PeerMessageSenderApi using akka streams for outbound p2p messages

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -352,7 +352,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       val node = nodeConnectedWithBitcoind.node
       val bitcoinds = nodeConnectedWithBitcoind.bitcoinds
       for {
-        _ <- node.sync()
+        _ <- AsyncUtil.retryUntilSatisfiedF(() => node.sync().map(_.isDefined))
         _ <- AsyncUtil.nonBlockingSleep(1.second)
         initConnectionCount <- node.getConnectionCount
         _ = assert(initConnectionCount == 2)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -323,7 +323,8 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
 
       //start syncing node
       val numBlocks = 5
-      val startSyncF = node.sync()
+      val startSyncF =
+        AsyncUtil.retryUntilSatisfiedF(() => node.sync().map(_.isDefined))
       val genBlocksF = {
         for {
           _ <- startSyncF

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -99,7 +99,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         oldSyncPeer = node.peerManager.getDataMessageHandler.state match {
           case state: SyncDataMessageHandlerState => state.syncPeer
           case DoneSyncing | _: MisbehavingPeer | _: RemovePeers =>
-            sys.error(s"Cannot be in DOneSyncing state while awaiting sync")
+            sys.error(s"Cannot be in DoneSyncing state while awaiting sync")
         }
         _ <- NodeTestUtil.awaitAllSync(node, bitcoinds(1))
         expectedSyncPeer = bitcoindPeers(1)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -239,7 +239,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
         _ <- bitcoind.generateToAddress(1, bitcoindAddr)
         //restart the node now that we have received funds
         startedNode <- stoppedNode.start()
-        _ <- startedNode.sync()
+        _ <- AsyncUtil.retryUntilSatisfiedF(() => startedNode.sync().map(_.isDefined))
         _ <- NodeTestUtil.awaitSync(node = startedNode, rpc = bitcoind)
         _ <- AsyncUtil.retryUntilSatisfiedF(() => {
           for {

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -239,7 +239,8 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
         _ <- bitcoind.generateToAddress(1, bitcoindAddr)
         //restart the node now that we have received funds
         startedNode <- stoppedNode.start()
-        _ <- AsyncUtil.retryUntilSatisfiedF(() => startedNode.sync().map(_.isDefined))
+        _ <- AsyncUtil.retryUntilSatisfiedF(() =>
+          startedNode.sync().map(_.isDefined))
         _ <- NodeTestUtil.awaitSync(node = startedNode, rpc = bitcoind)
         _ <- AsyncUtil.retryUntilSatisfiedF(() => {
           for {

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -48,8 +48,8 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
         peer <- peerF
         peerManager = node.peerManager
         //wait until the initialization of the peer is done
-        _ <- AsyncUtil.retryUntilSatisfiedF { () =>
-          peerManager.getPeerMsgSender(peer).map(_.isDefined)
+        _ <- AsyncUtil.retryUntilSatisfied {
+          peerManager.peers.exists(_ == peer)
         }
       } yield {
         assert(

--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
@@ -129,6 +129,7 @@ class P2PClientActorTest
           peer = peer,
           peerMsgHandlerReceiver = peerMsgRecv,
           peerMsgRecvState = PeerMessageReceiverState.fresh(),
+          peerMessageSenderApi = node.peerManager,
           maxReconnectionTries = 16
         ),
         probe.ref

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -21,7 +21,7 @@ import org.bitcoins.node.networking.peer.DataMessageHandlerState.{
   MisbehavingPeer,
   RemovePeers
 }
-import org.bitcoins.node.networking.peer.{SyncDataMessageHandlerState}
+import org.bitcoins.node.networking.peer.SyncDataMessageHandlerState
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -21,10 +21,7 @@ import org.bitcoins.node.networking.peer.DataMessageHandlerState.{
   MisbehavingPeer,
   RemovePeers
 }
-import org.bitcoins.node.networking.peer.{
-  PeerMessageSender,
-  SyncDataMessageHandlerState
-}
+import org.bitcoins.node.networking.peer.{SyncDataMessageHandlerState}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -57,9 +54,6 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
                                     CompactFilterDAO(),
                                     ChainStateDescriptorDAO())
   }
-
-  def peerMsgSendersF: Future[Vector[PeerMessageSender]] =
-    peerManager.peerMsgSendersF
 
   /** Sends the given P2P to our peer.
     * This method is useful for playing around

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -152,10 +152,8 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
         val connected = peerManager.peers.nonEmpty
         if (connected) {
           logger.info(s"Sending out tx message for tx=$txIds")
-          peerMsgSendersF.flatMap { peerMsgSenders =>
-            Future.traverse(peerMsgSenders)(
-              _.sendInventoryMessage(transactions: _*))
-          }
+          peerManager.sendInventoryMessage(transactions = transactions,
+                                           peerOpt = None)
         } else {
           Future.failed(
             new RuntimeException(

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -36,6 +36,7 @@ case class PeerData(
       peer = peer,
       peerMessageReceiver = peerMessageReceiver,
       peerMsgRecvState = PeerMessageReceiverState.fresh(),
+      peerMessageSenderApi = peerManager,
       maxReconnectionTries = 4,
       supervisor = supervisor
     )

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -8,6 +8,7 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.P2PClient
 import org.bitcoins.node.networking.peer._
+import org.bitcoins.node.util.PeerMessageSenderApi
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -18,6 +19,7 @@ case class PeerData(
     peer: Peer,
     controlMessageHandler: ControlMessageHandler,
     queue: SourceQueueWithComplete[StreamDataMessageWrapper],
+    peerMessageSenderApi: PeerMessageSenderApi,
     supervisor: ActorRef
 )(implicit
     system: ActorSystem,
@@ -36,7 +38,7 @@ case class PeerData(
       peer = peer,
       peerMessageReceiver = peerMessageReceiver,
       peerMsgRecvState = PeerMessageReceiverState.fresh(),
-      peerMessageSenderApi = peerManager,
+      peerMessageSenderApi = peerMessageSenderApi,
       maxReconnectionTries = 4,
       supervisor = supervisor
     )

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -231,7 +231,11 @@ case class PeerFinder(
 
   private def tryToReconnectPeer(peer: Peer): Future[Unit] = {
     _peerData.put(peer,
-                  PeerData(peer, controlMessageHandler, queue,peerMessageSenderApi, supervisor))
+                  PeerData(peer,
+                           controlMessageHandler,
+                           queue,
+                           peerMessageSenderApi,
+                           supervisor))
     _peerData(peer).peerMessageSender.map(_.reconnect())
 
   }

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -12,6 +12,7 @@ import org.bitcoins.node.networking.peer.{
   ControlMessageHandler,
   StreamDataMessageWrapper
 }
+import org.bitcoins.node.util.PeerMessageSenderApi
 
 import java.net.{InetAddress, UnknownHostException}
 import java.util.concurrent.atomic.AtomicBoolean
@@ -25,6 +26,7 @@ case class PeerFinder(
     paramPeers: Vector[Peer],
     controlMessageHandler: ControlMessageHandler,
     queue: SourceQueueWithComplete[StreamDataMessageWrapper],
+    peerMessageSenderApi: PeerMessageSenderApi,
     skipPeers: () => Vector[Peer],
     supervisor: ActorRef)(implicit
     ec: ExecutionContext,
@@ -219,13 +221,17 @@ case class PeerFinder(
   private def tryPeer(peer: Peer): Future[Unit] = {
     logger.debug(s"tryPeer=$peer")
     _peerData.put(peer,
-                  PeerData(peer, controlMessageHandler, queue, supervisor))
+                  PeerData(peer,
+                           controlMessageHandler,
+                           queue,
+                           peerMessageSenderApi,
+                           supervisor))
     _peerData(peer).peerMessageSender.map(_.connect())
   }
 
   private def tryToReconnectPeer(peer: Peer): Future[Unit] = {
     _peerData.put(peer,
-                  PeerData(peer, controlMessageHandler, queue, supervisor))
+                  PeerData(peer, controlMessageHandler, queue,peerMessageSenderApi, supervisor))
     _peerData(peer).peerMessageSender.map(_.reconnect())
 
   }

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -101,12 +101,6 @@ case class PeerManager(
 
   def peers: Vector[Peer] = _peerDataMap.keys.toVector
 
-  def peerMsgSendersF: Future[Vector[PeerMessageSender]] = {
-    Future
-      .traverse(_peerDataMap.values)(_.peerMessageSender)
-      .map(_.toVector)
-  }
-
   override def sendMsg(
       msg: NetworkPayload,
       peerOpt: Option[Peer]): Future[Unit] = {
@@ -769,12 +763,12 @@ case class PeerManager(
           case None =>
             Future.failed(new RuntimeException(
               s"Couldn't find PeerMessageSender that corresponds with peer=$peer msg=${payload.commandName}. Was it disconnected?"))
-          case Some(peerMsgSender) =>
+          case Some(_) =>
             val dmh = {
               getDataMessageHandler.copy(peerDataOpt = getPeerData(peer))
             }
             dmh
-              .handleDataPayload(payload, peerMsgSender, peer)
+              .handleDataPayload(payload, peer)
               .flatMap { newDmh =>
                 newDmh.state match {
                   case m: MisbehavingPeer =>

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -111,8 +111,7 @@ case class PeerManager(
       msg: NetworkPayload,
       peerOpt: Option[Peer]): Future[Unit] = {
     val networkMessage = NetworkMessage(nodeAppConfig.network, msg)
-    dataMessageStream
-      .offer(SendToPeer(msg = networkMessage, peerOpt = peerOpt))
+    offer(SendToPeer(msg = networkMessage, peerOpt = peerOpt))
       .map(_ => ())
   }
 

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -672,7 +672,7 @@ case class PeerManager(
     StreamDataMessageWrapper,
     SourceQueueWithComplete[StreamDataMessageWrapper]] = Source
     .queue[StreamDataMessageWrapper](
-      8 * nodeAppConfig.maxConnectedPeers,
+      16 * nodeAppConfig.maxConnectedPeers,
       overflowStrategy = OverflowStrategy.backpressure,
       maxConcurrentOffers = nodeAppConfig.maxConnectedPeers)
     .mapAsync(1) {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -717,7 +717,7 @@ case class PeerManager(
     StreamDataMessageWrapper,
     SourceQueueWithComplete[StreamDataMessageWrapper]] = Source
     .queue[StreamDataMessageWrapper](
-      16 * nodeAppConfig.maxConnectedPeers,
+      8 * nodeAppConfig.maxConnectedPeers,
       overflowStrategy = OverflowStrategy.backpressure,
       maxConcurrentOffers = nodeAppConfig.maxConnectedPeers)
     .mapAsync(1) {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -282,7 +282,8 @@ case class PeerManager(
     }
   }
 
-  def getPeerMsgSender(peer: Peer): Future[Option[PeerMessageSender]] = {
+  private def getPeerMsgSender(
+      peer: Peer): Future[Option[PeerMessageSender]] = {
     _peerDataMap.find(_._1 == peer).map(_._2.peerMessageSender) match {
       case Some(peerMsgSender) => peerMsgSender.map(Some(_))
       case None                => Future.successful(None)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -723,7 +723,8 @@ case class PeerManager(
               s"Unable to find peer message sender to send msg=${sendToPeer.msg.header.commandName} to"))
         }
       case msg @ DataMessageWrapper(payload, peer) =>
-        logger.debug(s"Got ${payload.commandName} from peer=${peer} in stream")
+        logger.debug(
+          s"Got ${payload.commandName} from peer=${peer} in stream state=${getDataMessageHandler.state}")
         val peerMsgSenderOptF = getPeerMsgSender(peer)
         peerMsgSenderOptF.flatMap {
           case None =>
@@ -781,7 +782,8 @@ case class PeerManager(
   private val dataMessageStreamSink =
     Sink.foreach[StreamDataMessageWrapper] {
       case DataMessageWrapper(payload, peer) =>
-        logger.debug(s"Done processing ${payload.commandName} in peer=${peer}")
+        logger.debug(
+          s"Done processing ${payload.commandName} in peer=${peer} state=${getDataMessageHandler.state}")
       case HeaderTimeoutWrapper(_)   =>
       case DisconnectedPeer(_, _)    =>
       case Initialized(_)            =>

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -508,12 +508,9 @@ case class PeerManager(
           val hasCf = serviceIdentifer.nodeCompactFilters
           logger.debug(s"Initialized peer $peer with $hasCf")
 
-          def sendAddrReq: Future[Unit] =
-            finder
-              .getData(peer)
-              .get
-              .peerMessageSender
-              .flatMap(_.sendGetAddrMessage())
+          def sendAddrReq: Future[Unit] = {
+            sendGetAddrMessage(Some(peer))
+          }
 
           def managePeerF(): Future[Unit] = {
             //if we have slots remaining, connect

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -402,7 +402,7 @@ case class P2PClientActor(
         val client = P2PClient(self, peer)
         currentPeerMsgRecvState =
           currentPeerMsgRecvState.connect(client,
-            peerMessageSenderApi,
+                                          peerMessageSenderApi,
                                           queue = peerMsgHandlerReceiver.queue)(
             context.system,
             nodeAppConfig,

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClient.scala
@@ -27,6 +27,7 @@ import org.bitcoins.node.networking.peer.{
   PeerMessageReceiver,
   PeerMessageReceiverState
 }
+import org.bitcoins.node.util.PeerMessageSenderApi
 import org.bitcoins.node.{P2PLogger, ResponseTimeout}
 import org.bitcoins.tor.Socks5Connection.{Socks5Connect, Socks5Connected}
 import org.bitcoins.tor.{Socks5Connection, Socks5ProxyParams}
@@ -71,6 +72,7 @@ case class P2PClientActor(
     peer: Peer,
     peerMsgHandlerReceiver: PeerMessageReceiver,
     initPeerMsgRecvState: PeerMessageReceiverState,
+    peerMessageSenderApi: PeerMessageSenderApi,
     maxReconnectionTries: Int
 )(implicit nodeAppConfig: NodeAppConfig, chainAppConfig: ChainAppConfig)
     extends Actor
@@ -400,6 +402,7 @@ case class P2PClientActor(
         val client = P2PClient(self, peer)
         currentPeerMsgRecvState =
           currentPeerMsgRecvState.connect(client,
+            peerMessageSenderApi,
                                           queue = peerMsgHandlerReceiver.queue)(
             context.system,
             nodeAppConfig,
@@ -478,7 +481,8 @@ case class P2PClientActor(
         case _ @(_: Normal | _: Waiting | Preconnection | _: Initializing) =>
           peerMsgHandlerReceiver.handleNetworkMessageReceived(
             msg,
-            currentPeerMsgRecvState)
+            currentPeerMsgRecvState,
+            peerMessageSenderApi)
         case _: Disconnected | _: InitializedDisconnectDone |
             _: InitializedDisconnect | _: StoppedReconnect =>
           logger.debug(
@@ -653,6 +657,7 @@ object P2PClient extends P2PLogger {
       peer: Peer,
       peerMsgHandlerReceiver: PeerMessageReceiver,
       peerMsgRecvState: PeerMessageReceiverState,
+      peerMessageSenderApi: PeerMessageSenderApi,
       maxReconnectionTries: Int)(implicit
       nodeAppConfig: NodeAppConfig,
       chainAppConfig: ChainAppConfig
@@ -662,6 +667,7 @@ object P2PClient extends P2PLogger {
       peer,
       peerMsgHandlerReceiver,
       peerMsgRecvState,
+      peerMessageSenderApi,
       maxReconnectionTries,
       nodeAppConfig,
       chainAppConfig
@@ -672,6 +678,7 @@ object P2PClient extends P2PLogger {
       peer: Peer,
       peerMessageReceiver: PeerMessageReceiver,
       peerMsgRecvState: PeerMessageReceiverState,
+      peerMessageSenderApi: PeerMessageSenderApi,
       maxReconnectionTries: Int = 16,
       supervisor: ActorRef)(implicit
       nodeAppConfig: NodeAppConfig,
@@ -681,6 +688,7 @@ object P2PClient extends P2PLogger {
       peer = peer,
       peerMsgHandlerReceiver = peerMessageReceiver,
       peerMsgRecvState = peerMsgRecvState,
+      peerMessageSenderApi,
       maxReconnectionTries = maxReconnectionTries
     )
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -494,7 +494,7 @@ case class DataMessageHandler(
     val result = state match {
       case HeaderSync(peer) =>
         peerData.updateInvalidMessageCount()
-        if (peerData.exceededMaxInvalidMessages && peers.size > 1) {
+        if (peerData.exceededMaxInvalidMessages) {
           logger.warn(
             s"$peer exceeded max limit of invalid messages. Disconnecting.")
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -887,9 +887,7 @@ case class DataMessageHandler(
   }
 }
 
-sealed trait StreamDataMessageWrapper {
-  def peer: Peer
-}
+sealed trait StreamDataMessageWrapper
 
 case class DataMessageWrapper(payload: DataPayload, peer: Peer)
     extends StreamDataMessageWrapper
@@ -907,5 +905,7 @@ case class QueryTimeout(peer: Peer, payload: ExpectsResponse)
     extends StreamDataMessageWrapper
 
 case class SendResponseTimeout(peer: Peer, payload: NetworkPayload)
+    extends StreamDataMessageWrapper
+
 case class SendToPeer(msg: NetworkMessage, peerOpt: Option[Peer])
     extends StreamDataMessageWrapper

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -903,4 +903,5 @@ case class QueryTimeout(peer: Peer, payload: ExpectsResponse)
     extends StreamDataMessageWrapper
 
 case class SendResponseTimeout(peer: Peer, payload: NetworkPayload)
+case class SendToPeer(msg: NetworkMessage, peerOpt: Option[Peer])
     extends StreamDataMessageWrapper

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -516,7 +516,7 @@ case class DataMessageHandler(
               .flatMap(_.headers)
               .map(_.hashBE)
             _ <- peerManager.sendGetHeadersMessage(cachedHeaders, Some(peer))
-          } yield this
+          } yield this.copy(state = HeaderSync(peer))
         }
 
       case headerState @ ValidatingHeaders(peer, _, failedCheck, _) =>

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -114,13 +114,7 @@ case class PeerMessageReceiver(
 
 object PeerMessageReceiver {
 
-  sealed abstract class PeerMessageReceiverMsg {
-
-    /** Who we need to use to send a reply to our peer
-      * if a response is needed for this message
-      */
-    def client: P2PClient
-  }
+  sealed abstract class PeerMessageReceiverMsg
 
   case class NetworkMessageReceived(msg: NetworkMessage, client: P2PClient)
       extends PeerMessageReceiverMsg

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverState.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverState.scala
@@ -24,6 +24,7 @@ import org.bitcoins.node.networking.peer.PeerMessageReceiverState.{
   StoppedReconnect,
   Waiting
 }
+import org.bitcoins.node.util.PeerMessageSenderApi
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
@@ -103,6 +104,7 @@ sealed abstract class PeerMessageReceiverState extends Logging {
     */
   protected[networking] def connect(
       client: P2PClient,
+      peerMessageSenderApi: PeerMessageSenderApi,
       queue: SourceQueueWithComplete[StreamDataMessageWrapper])(implicit
       system: ActorSystem,
       nodeAppConfig: NodeAppConfig,
@@ -128,9 +130,8 @@ sealed abstract class PeerMessageReceiverState extends Logging {
         val newState =
           Preconnection.toInitializing(client, initializationTimeoutCancellable)
 
-        val peerMsgSender = PeerMessageSender(client)
         val chainApi = ChainHandler.fromDatabase()
-        peerMsgSender.sendVersionMessage(chainApi)
+        peerMessageSenderApi.sendVersionMessage(chainApi, peer)
 
         newState
     }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -107,20 +107,6 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     sendMsg(pong)
   }
 
-  def sendGetHeadersMessage(lastHash: DoubleSha256Digest): Future[Unit] = {
-    val headersMsg = GetHeadersMessage(lastHash)
-    logger.trace(s"Sending getheaders=$headersMsg to peer=${client.peer}")
-    sendMsg(headersMsg)
-  }
-
-  def sendGetHeadersMessage(
-      hashes: Vector[DoubleSha256Digest]): Future[Unit] = {
-    // GetHeadersMessage has a max of 101 hashes
-    val headersMsg = GetHeadersMessage(hashes.distinct.take(101))
-    logger.trace(s"Sending getheaders=$headersMsg to peer=${client.peer}")
-    sendMsg(headersMsg)
-  }
-
   def sendHeadersMessage(): Future[Unit] = {
     val sendHeadersMsg = SendHeadersMessage
     sendMsg(sendHeadersMsg)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -247,9 +247,13 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     //version or verack messages are the only messages that
     //can be sent before we are fully initialized
     //as they are needed to complete our handshake with our peer
-    logger.debug(s"Sending msg=${msg.commandName} to peer=${socket}")
     val networkMsg = NetworkMessage(conf.network, msg)
-    client.actor ! networkMsg
+    sendMsg(networkMsg)
+  }
+
+  private[node] def sendMsg(msg: NetworkMessage): Future[Unit] = {
+    logger.debug(s"Sending msg=${msg.header.commandName} to peer=${socket}")
+    client.actor ! msg
     Future.unit
   }
 }
@@ -262,8 +266,6 @@ object PeerMessageSender {
     * This means we can send normal p2p messages now
     */
   case object HandshakeFinished extends PeerMessageHandlerMsg
-
-  case class SendToPeer(msg: NetworkMessage) extends PeerMessageHandlerMsg
 
   /** Accumulators network messages while we are doing a handshake with our peer
     * and caches a peer handler actor so we can send a [[HandshakeFinished]]

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -2,15 +2,12 @@ package org.bitcoins.node.networking.peer
 
 import akka.actor.ActorRef
 import akka.util.Timeout
-import org.bitcoins.core.api.chain.{ChainApi}
 import org.bitcoins.core.bloom.BloomFilter
-import org.bitcoins.core.number.Int32
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.{DoubleSha256Digest, HashDigest}
 import org.bitcoins.node.{P2PLogger}
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.constant.NodeConstants
 import org.bitcoins.node.networking.P2PClient
 
 import scala.concurrent.duration.DurationInt
@@ -56,60 +53,6 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
         Future.unit
     }
 
-  }
-
-  /** Sends a [[org.bitcoins.core.p2p.VersionMessage VersionMessage]] to our peer */
-  def sendVersionMessage(): Future[Unit] = {
-    val local = java.net.InetAddress.getLocalHost
-    val versionMsg = VersionMessage(
-      conf.network,
-      InetAddress(client.peer.socket.getAddress.getAddress),
-      InetAddress(local.getAddress),
-      relay = conf.relay)
-    logger.trace(s"Sending versionMsg=$versionMsg to peer=${client.peer}")
-    sendMsg(versionMsg)
-  }
-
-  def sendVersionMessage(chainApi: ChainApi)(implicit
-      ec: ExecutionContext): Future[Unit] = {
-    chainApi.getBestHashBlockHeight().flatMap { height =>
-      val localhost = java.net.InetAddress.getLocalHost
-      val versionMsg =
-        VersionMessage(conf.network,
-                       NodeConstants.userAgent,
-                       Int32(height),
-                       InetAddress(localhost.getAddress),
-                       InetAddress(localhost.getAddress),
-                       conf.relay)
-
-      logger.debug(s"Sending versionMsg=$versionMsg to peer=${client.peer}")
-      sendMsg(versionMsg)
-    }
-  }
-
-  def sendVerackMessage(): Future[Unit] = {
-    val verackMsg = VerAckMessage
-    sendMsg(verackMsg)
-  }
-
-  def sendSendAddrV2Message(): Future[Unit] = {
-    sendMsg(SendAddrV2Message)
-  }
-
-  def sendGetAddrMessage(): Future[Unit] = {
-    sendMsg(GetAddrMessage)
-  }
-
-  /** Responds to a ping message */
-  def sendPong(ping: PingMessage): Future[Unit] = {
-    val pong = PongMessage(ping.nonce)
-    logger.trace(s"Sending pong=$pong to peer=${client.peer}")
-    sendMsg(pong)
-  }
-
-  def sendHeadersMessage(): Future[Unit] = {
-    val sendHeadersMsg = SendHeadersMessage
-    sendMsg(sendHeadersMsg)
   }
 
   def sendFilterClearMessage(): Future[Unit] = {

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -2,17 +2,13 @@ package org.bitcoins.node.networking.peer
 
 import akka.actor.ActorRef
 import akka.util.Timeout
-import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
+import org.bitcoins.core.api.chain.{ChainApi}
 import org.bitcoins.core.bloom.BloomFilter
 import org.bitcoins.core.number.Int32
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.crypto.{
-  DoubleSha256Digest,
-  DoubleSha256DigestBE,
-  HashDigest
-}
-import org.bitcoins.node.P2PLogger
+import org.bitcoins.crypto.{DoubleSha256Digest, HashDigest}
+import org.bitcoins.node.{P2PLogger}
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.constant.NodeConstants
 import org.bitcoins.node.networking.P2PClient
@@ -162,85 +158,11 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     sendMsg(message)
   }
 
-  /** Sends a request for filtered blocks matching the given headers */
-  def sendGetDataMessage(
-      typeIdentifier: TypeIdentifier,
-      hashes: DoubleSha256Digest*): Future[Unit] = {
-    val inventories =
-      hashes.map(hash => Inventory(typeIdentifier, hash))
-    val message = GetDataMessage(inventories)
-    logger.debug(s"Sending getdata=$message to peer=${client.peer}")
-    sendMsg(message)
-  }
-
-  private def sendGetCompactFiltersMessage(
-      filterSyncMarker: FilterSyncMarker)(implicit
-      ec: ExecutionContext): Future[DataMessageHandlerState.FilterSync] = {
-    val message =
-      GetCompactFiltersMessage(if (filterSyncMarker.startHeight < 0) 0
-                               else filterSyncMarker.startHeight,
-                               filterSyncMarker.stopBlockHash)
-    logger.debug(s"Sending getcfilters=$message to peer ${client.peer}")
-    sendMsg(message).map(_ => DataMessageHandlerState.FilterSync(client.peer))
-  }
-
-  def sendGetCompactFilterHeadersMessage(
-      filterSyncMarker: FilterSyncMarker): Future[Unit] = {
-    val message =
-      GetCompactFilterHeadersMessage(if (filterSyncMarker.startHeight < 0) 0
-                                     else filterSyncMarker.startHeight,
-                                     filterSyncMarker.stopBlockHash)
-    logger.debug(s"Sending getcfheaders=$message to peer=${client.peer}")
-    sendMsg(message)
-  }
-
   def sendGetCompactFilterCheckPointMessage(
       stopHash: DoubleSha256Digest): Future[Unit] = {
     val message = GetCompactFilterCheckPointMessage(stopHash)
     logger.debug(s"Sending getcfcheckpt=$message to peer ${client.peer}")
     sendMsg(message)
-  }
-
-  /** @return a flag indicating if we are syncing or not
-    */
-  private[node] def sendNextGetCompactFilterCommand(
-      chainApi: ChainApi,
-      filterBatchSize: Int,
-      startHeight: Int)(implicit ec: ExecutionContext): Future[Boolean] = {
-    for {
-      filterSyncMarkerOpt <-
-        chainApi.nextFilterHeaderBatchRange(startHeight, filterBatchSize)
-      res <- filterSyncMarkerOpt match {
-        case Some(filterSyncMarker) =>
-          logger.info(s"Requesting compact filters from $filterSyncMarker")
-
-          sendGetCompactFiltersMessage(filterSyncMarker)
-            .map(_ => true)
-        case None =>
-          Future.successful(false)
-      }
-    } yield res
-  }
-
-  private[node] def sendNextGetCompactFilterHeadersCommand(
-      chainApi: ChainApi,
-      filterHeaderBatchSize: Int,
-      prevStopHash: DoubleSha256DigestBE)(implicit
-      ec: ExecutionContext): Future[Boolean] = {
-    for {
-      filterSyncMarkerOpt <- chainApi.nextBlockHeaderBatchRange(
-        prevStopHash = prevStopHash,
-        batchSize = filterHeaderBatchSize)
-      res <- filterSyncMarkerOpt match {
-        case Some(filterSyncMarker) =>
-          logger.info(
-            s"Requesting next compact filter headers from $filterSyncMarker")
-          sendGetCompactFilterHeadersMessage(filterSyncMarker)
-            .map(_ => true)
-        case None =>
-          Future.successful(false)
-      }
-    } yield res
   }
 
   private[node] def sendMsg(msg: NetworkPayload): Future[Unit] = {

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -126,16 +126,6 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     sendMsg(sendHeadersMsg)
   }
 
-  /** Sends a inventory message with the given transactions
-    */
-  def sendInventoryMessage(transactions: Transaction*): Future[Unit] = {
-    val inventories =
-      transactions.map(tx => Inventory(TypeIdentifier.MsgTx, tx.txId))
-    val message = InventoryMessage(inventories)
-    logger.trace(s"Sending inv=$message to peer=${client.peer}")
-    sendMsg(message)
-  }
-
   def sendFilterClearMessage(): Future[Unit] = {
     sendMsg(FilterClearMessage)
   }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -4,7 +4,6 @@ import akka.actor.ActorRef
 import akka.util.Timeout
 import org.bitcoins.core.bloom.BloomFilter
 import org.bitcoins.core.p2p._
-import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.{DoubleSha256Digest, HashDigest}
 import org.bitcoins.node.{P2PLogger}
 import org.bitcoins.node.config.NodeAppConfig
@@ -68,12 +67,6 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
   def sendFilterLoadMessage(bloom: BloomFilter): Future[Unit] = {
     val message = FilterLoadMessage(bloom)
     logger.trace(s"Sending filterload=$message to peer=${client.peer}")
-    sendMsg(message)
-  }
-
-  def sendTransactionMessage(transaction: Transaction): Future[Unit] = {
-    val message = TransactionMessage(transaction)
-    logger.debug(s"Sending txmessage=$message to peer=${client.peer}")
     sendMsg(message)
   }
 

--- a/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
@@ -1,10 +1,12 @@
 package org.bitcoins.node.util
 
+import org.bitcoins.core.api.chain.FilterSyncMarker
 import org.bitcoins.core.p2p.{NetworkPayload, TypeIdentifier}
-import org.bitcoins.crypto.{DoubleSha256DigestBE}
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.models.Peer
+import org.bitcoins.node.networking.peer.DataMessageHandlerState
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait PeerMessageSenderApi {
 
@@ -31,4 +33,12 @@ trait PeerMessageSenderApi {
 
   def sendMsg(msg: NetworkPayload, peerOpt: Option[Peer]): Future[Unit]
 
+  def sendGetCompactFilterHeadersMessage(
+      filterSyncMarker: FilterSyncMarker,
+      peerOpt: Option[Peer]): Future[Unit]
+
+  def sendGetCompactFiltersMessage(
+      filterSyncMarker: FilterSyncMarker,
+      peer: Peer)(implicit
+      ec: ExecutionContext): Future[DataMessageHandlerState.FilterSync]
 }

--- a/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
@@ -27,6 +27,12 @@ trait PeerMessageSenderApi {
       hashes: Vector[DoubleSha256DigestBE],
       peerOpt: Option[Peer]): Future[Unit]
 
+  def sendGetHeadersMessage(
+      lastHash: DoubleSha256DigestBE,
+      peerOpt: Option[Peer]): Future[Unit] = {
+    sendGetHeadersMessage(Vector(lastHash), peerOpt)
+  }
+
   /** Gossips the given message to all peers except the excluded peer. If None given as excluded peer, gossip message to all peers */
   def gossipMessage(
       msg: NetworkPayload,

--- a/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
@@ -10,6 +10,7 @@ import org.bitcoins.core.p2p.{
   PongMessage,
   SendAddrV2Message,
   SendHeadersMessage,
+  TransactionMessage,
   TypeIdentifier,
   VerAckMessage,
   VersionMessage
@@ -117,5 +118,12 @@ trait PeerMessageSenderApi {
   def sendVerackMessage(peer: Peer): Future[Unit] = {
     val verackMsg = VerAckMessage
     sendMsg(verackMsg, Some(peer))
+  }
+
+  def sendTransactionMessage(
+      transaction: Transaction,
+      peerOpt: Option[Peer]): Future[Unit] = {
+    val message = TransactionMessage(transaction)
+    sendMsg(message, peerOpt)
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
@@ -2,6 +2,7 @@ package org.bitcoins.node.util
 
 import org.bitcoins.core.api.chain.FilterSyncMarker
 import org.bitcoins.core.p2p.{NetworkPayload, TypeIdentifier}
+import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.DataMessageHandlerState
@@ -41,4 +42,8 @@ trait PeerMessageSenderApi {
       filterSyncMarker: FilterSyncMarker,
       peer: Peer)(implicit
       ec: ExecutionContext): Future[DataMessageHandlerState.FilterSync]
+
+  def sendInventoryMessage(
+      transactions: Vector[Transaction],
+      peerOpt: Option[Peer]): Future[Unit]
 }

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -65,7 +65,7 @@
 
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
-    
+
     <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
 
     <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="WARN">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -51,17 +51,17 @@
     <!-- ╚═════════════════╝ -->
 
     <!-- See incoming message names and the peer it's sent from -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>
 
     <logger name="org.bitcoins.node.networking.peer.ControlMessageHandler" level="WARN"/>
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="INFO"/>
 
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="ERROR">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -57,15 +57,15 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>
 
     <logger name="org.bitcoins.node.networking.peer.ControlMessageHandler" level="WARN"/>
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="INFO"/>
 
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
-
+    
     <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
 
     <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -51,7 +51,7 @@
     <!-- ╚═════════════════╝ -->
 
     <!-- See incoming message names and the peer it's sent from -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="WARN"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="WARN">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -57,11 +57,11 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <logger name="org.bitcoins.node.networking.peer.ControlMessageHandler" level="WARN"/>
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
 
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="ERROR">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -57,17 +57,17 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <logger name="org.bitcoins.node.networking.peer.ControlMessageHandler" level="WARN"/>
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
 
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
     
     <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
-
+    
     <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -67,7 +67,7 @@
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
     
     <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
-    
+
     <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -10,6 +10,7 @@ import org.bitcoins.node.networking.peer.{
   PeerMessageReceiver,
   PeerMessageReceiverState
 }
+import org.bitcoins.node.util.PeerMessageSenderApi
 import org.bitcoins.node.{NeutrinoNode, Node, P2PLogger}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.async.TestAsyncUtil
@@ -25,6 +26,7 @@ abstract class NodeTestUtil extends P2PLogger {
   def client(
       peer: Peer,
       peerMsgReceiver: PeerMessageReceiver,
+      peerMessageSenderApi: PeerMessageSenderApi,
       supervisor: ActorRef)(implicit
       nodeAppConfig: NodeAppConfig,
       chainAppConfig: ChainAppConfig,
@@ -34,6 +36,7 @@ abstract class NodeTestUtil extends P2PLogger {
       peer = peer,
       peerMessageReceiver = peerMsgReceiver,
       peerMsgRecvState = PeerMessageReceiverState.fresh(),
+      peerMessageSenderApi = peerMessageSenderApi,
       maxReconnectionTries = 16,
       supervisor = supervisor
     )


### PR DESCRIPTION
Use our streams implementation to send outbound p2p messages. This is necessary so we can eventually remove `PeerManager.getDataMessageHandler` and `PeerManager.updateDataMessageHandler`. 

Once we remove those two methods, we will be able to encapsulate the state of our node inside of our akka stream.