### PR TITLE
Fix `ReConnectionTest` part 2

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/P2PClientActorTest.scala
@@ -100,6 +100,9 @@ class P2PClientActorTest
     val peerMessageReceiverF =
       for {
         node <- NodeUnitTest.buildNode(peer, None)
+        //piggy back off of node infra to setup p2p clients, but don't actually use
+        //the node itself so stop it here an clean up resources allocated by it
+        _ <- node.stop()
       } yield PeerMessageReceiver(
         controlMessageHandler = node.controlMessageHandler,
         dataMessageHandler = node.peerManager.getDataMessageHandler,

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.node
 
 import akka.actor.{ActorRef, ActorSystem, Cancellable}
-import monix.execution.atomic.AtomicBoolean
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.p2p.ServiceIdentifier
@@ -10,6 +9,7 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.{Peer, PeerDAO, PeerDb}
 
 import java.net.{InetAddress, UnknownHostException}
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
@@ -28,6 +28,8 @@ case class PeerFinder(
     extends StartStopAsync[PeerFinder]
     with P2PLogger {
 
+  private val isStarted: AtomicBoolean = new AtomicBoolean(false)
+
   /** Returns peers by querying each dns seed once. These will be IPv4 addresses. */
   private def getPeersFromDnsSeeds: Vector[Peer] = {
     val dnsSeeds = nodeAppConfig.network.dnsSeeds
@@ -39,7 +41,7 @@ case class PeerFinder(
         } catch {
           case _: UnknownHostException =>
             logger.debug(s"DNS seed $seed is unavailable.")
-            Vector()
+            Vector.empty
         }
       })
       .distinct
@@ -119,17 +121,14 @@ case class PeerFinder(
 
   private val initialDelay: FiniteDuration = 30.minute
 
-  private val isConnectionSchedulerRunning = AtomicBoolean(false)
+  private val isConnectionSchedulerRunning = new AtomicBoolean(false)
 
   private lazy val peerConnectionScheduler: Cancellable =
     system.scheduler.scheduleWithFixedDelay(
       initialDelay = initialDelay,
       delay = nodeAppConfig.tryNextPeersInterval) { () =>
       {
-        if (
-          isConnectionSchedulerRunning.compareAndSet(expect = false,
-                                                     update = true)
-        ) {
+        if (isConnectionSchedulerRunning.compareAndSet(false, true)) {
           logger.info(s"Querying p2p network for peers...")
           logger.debug(s"Cache size: ${_peerData.size}. ${_peerData.keys}")
           if (_peersToTry.size < 32)
@@ -156,7 +155,7 @@ case class PeerFinder(
 
   override def start(): Future[PeerFinder] = {
     logger.debug(s"Starting PeerFinder")
-
+    isStarted.set(true)
     val peersToTry = (getPeersFromParam ++ getPeersFromConfig).distinct
     val initPeerF = Future.traverse(peersToTry)(tryPeer)
 
@@ -185,10 +184,17 @@ case class PeerFinder(
 
   def reconnect(peer: Peer): Future[Unit] = {
     logger.info(s"Attempting to reconnect peer=$peer")
-    tryToReconnectPeer(peer)
+    if (isStarted.get) {
+      tryToReconnectPeer(peer)
+    } else {
+      logger.error(
+        s"Ignoring reconnect attempt to peer=$peer as PeerFinder is not started")
+      Future.unit
+    }
   }
 
   override def stop(): Future[PeerFinder] = {
+    isStarted.set(false)
     //stop scheduler
     peerConnectionScheduler.cancel()
     //delete try queue
@@ -203,7 +209,9 @@ case class PeerFinder(
                            maxTries = 30)
       .map(_ => this)
 
-    closeF.flatMap(_ => waitStopF)
+    closeF.flatMap { _ =>
+      waitStopF
+    }
   }
 
   /** creates and initialises a new test peer */

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -183,6 +183,11 @@ case class PeerFinder(
     initPeerF.flatMap(_ => peerDiscoveryF)
   }
 
+  def reconnect(peer: Peer): Future[Unit] = {
+    logger.info(s"Attempting to reconnect peer=$peer")
+    tryToReconnectPeer(peer)
+  }
+
   override def stop(): Future[PeerFinder] = {
     //stop scheduler
     peerConnectionScheduler.cancel()
@@ -205,6 +210,11 @@ case class PeerFinder(
   private def tryPeer(peer: Peer): Future[Unit] = {
     _peerData.put(peer, PeerData(peer, node, supervisor))
     _peerData(peer).peerMessageSender.map(_.connect())
+  }
+
+  private def tryToReconnectPeer(peer: Peer): Future[Unit] = {
+    _peerData.put(peer, PeerData(peer, node, supervisor))
+    _peerData(peer).peerMessageSender.map(_.reconnect())
   }
 
   def removePeer(peer: Peer): Unit = {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -532,15 +532,11 @@ case class PeerManager(
       if (peers.length > 1 && syncPeerOpt.isDefined) {
         node.syncFromNewPeer().map(_ => ())
       } else if (syncPeerOpt.isDefined) {
-        println(s"here1")
         //means we aren't syncing with anyone, so do nothing?
         val exn = new RuntimeException(
           s"No new peers to sync from, cannot start new sync. Terminated sync with peer=$peer current syncPeer=$syncPeerOpt state=${state}")
         Future.failed(exn)
       } else {
-
-        /*        //means we are DoneSyncing, so no need to start syncing from a new peer
-        Future.unit*/
         finder.reconnect(peer)
       }
     } else if (waitingForDeletion.contains(peer)) {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -397,7 +397,7 @@ case class PeerManager(
 
     stopF.failed.foreach { e =>
       logger.error(
-        s"Failed to stop peer manager. Peers: $peers, waiting for deletion: $waitingForDeletion",
+        s"Failed to stop peer manager. Peers: ${_peerDataMap.map(_._1)}, waiting for deletion: $waitingForDeletion",
         e)
     }
 
@@ -490,7 +490,6 @@ case class PeerManager(
 
       for {
         _ <- sendAddrReq
-        peerData = finder.getData(peer).get
         _ <- createInDb(peer, peerData.serviceIdentifier)
         _ <- managePeerF()
       } yield ()

--- a/node/src/main/scala/org/bitcoins/node/networking/P2PClientSupervisor.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/P2PClientSupervisor.scala
@@ -2,6 +2,7 @@ package org.bitcoins.node.networking
 
 import akka.actor.SupervisorStrategy._
 import akka.actor.{Actor, OneForOneStrategy, Props}
+import akka.event.LoggingReceive
 import org.bitcoins.node.P2PLogger
 import org.bitcoins.node.util.BitcoinSNodeUtil
 
@@ -13,7 +14,7 @@ class P2PClientSupervisor extends Actor with P2PLogger {
       Stop
     }
 
-  def receive: Receive = { case props: Props =>
+  override def receive: Receive = LoggingReceive { case props: Props =>
     /* actors to be supervised need to built withing this context this creates an actor using props and sends back
     the ActorRef */
     sender() ! context.actorOf(props,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -30,6 +30,10 @@ case class PeerMessageSender(client: P2PClient)(implicit conf: NodeAppConfig)
     client.actor ! P2PClient.ConnectCommand
   }
 
+  def reconnect(): Unit = {
+    client.actor ! P2PClient.ReconnectCommand
+  }
+
   def isConnected()(implicit ec: ExecutionContext): Future[Boolean] = {
     client.isConnected()
   }

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="ERROR">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -51,7 +51,7 @@
     <!-- ╚═════════════════╝ -->
 
     <!-- See incoming message names and the peer it's sent from -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="WARN"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
@@ -60,7 +60,7 @@
     <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="DEBUG"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
 
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="ERROR">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -51,7 +51,7 @@
     <!-- ╚═════════════════╝ -->
 
     <!-- See incoming message names and the peer it's sent from -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
@@ -60,7 +60,7 @@
     <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <!-- inspect TCP details -->
-    <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.P2PClientActor" level="DEBUG"/>
 
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>


### PR DESCRIPTION
It was discovered in #5069 that `ReConnectionTest` was broken. It did not actually reconnect in the test case and trivially succeeded. 

This test case was broken in #4819 and #4926 when trying to fix #4793