### PR TITLE
Cancel oninit timeout scheduled job when we disconnect

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverState.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiverState.scala
@@ -159,7 +159,14 @@ sealed abstract class PeerMessageReceiverState extends Logging {
         logger.warn(
           s"Already initialized disconnected from peer=$peer, this is a noop")
         this
-      case state @ (_: Initializing | _: Normal) =>
+      case initializing: Initializing =>
+        initializing.initializationTimeoutCancellable.cancel()
+        val newState = InitializedDisconnect(initializing.clientConnectP,
+                                             initializing.clientDisconnectP,
+                                             initializing.versionMsgP,
+                                             initializing.verackMsgP)
+        newState
+      case state: Normal =>
         val newState = InitializedDisconnect(state.clientConnectP,
                                              state.clientDisconnectP,
                                              state.versionMsgP,


### PR DESCRIPTION
When we disconnect we shouldn't worry about on initialization timeout anymore.