### PR TITLE
2023 05 29 peermanager peerfinder refactor

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -8,7 +8,8 @@ import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.P2PClient.ExpectResponseCommand
 import org.bitcoins.node.networking.peer.DataMessageHandlerState.{
   DoneSyncing,
-  MisbehavingPeer
+  MisbehavingPeer,
+  RemovePeers
 }
 import org.bitcoins.node.networking.peer.{
   DataMessageHandlerState,
@@ -99,7 +100,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         //old peer we were syncing with that just disconnected us
         oldSyncPeer = node.peerManager.getDataMessageHandler.state match {
           case state: SyncDataMessageHandlerState => state.syncPeer
-          case DoneSyncing | _: MisbehavingPeer =>
+          case DoneSyncing | _: MisbehavingPeer | _: RemovePeers =>
             sys.error(s"Cannot be in DOneSyncing state while awaiting sync")
         }
         _ <- NodeTestUtil.awaitAllSync(node, bitcoinds(1))

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -18,7 +18,8 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models._
 import org.bitcoins.node.networking.peer.DataMessageHandlerState.{
   DoneSyncing,
-  MisbehavingPeer
+  MisbehavingPeer,
+  RemovePeers
 }
 import org.bitcoins.node.networking.peer.{
   PeerMessageSender,
@@ -185,8 +186,8 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
       blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = {
     if (isIBD) {
       val syncPeerOpt = peerManager.getDataMessageHandler.state match {
-        case state: SyncDataMessageHandlerState => Some(state.syncPeer)
-        case DoneSyncing | _: MisbehavingPeer   => None
+        case state: SyncDataMessageHandlerState                => Some(state.syncPeer)
+        case DoneSyncing | _: MisbehavingPeer | _: RemovePeers => None
       }
       syncPeerOpt match {
         case Some(peer) =>

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -24,7 +24,6 @@ case class PeerData(
     peer: Peer,
     controlMessageHandler: ControlMessageHandler,
     queue: SourceQueueWithComplete[StreamDataMessageWrapper],
-    peerManager: PeerManager,
     p2pClientCallbacks: P2PClientCallbacks,
     supervisor: ActorRef
 )(implicit

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -71,6 +71,8 @@ case class PeerData(
     _invalidMessagesCount += 1
   }
 
+  def getInvalidMessageCount = _invalidMessagesCount
+
   private var lastTimedOut: Long = 0
 
   def updateLastFailureTime(): Unit = {

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -221,7 +221,6 @@ case class PeerFinder(
                       PeerData(peer,
                                controlMessageHandler,
                                queue,
-                               peerManager,
                                p2pClientCallbacks,
                                supervisor))
         _peerData(peer).peerMessageSender.map(_.connect())
@@ -240,7 +239,6 @@ case class PeerFinder(
                       PeerData(peer,
                                controlMessageHandler,
                                queue,
-                               peerManager,
                                p2pClientCallbacks,
                                supervisor))
         _peerData(peer).peerMessageSender.map(_.reconnect())

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -217,9 +217,13 @@ case class PeerFinder(
   private def tryPeer(peer: Peer): Future[Unit] = {
     peerManager.dataMessageQueueOpt match {
       case Some(queue) =>
-        _peerData.put(
-          peer,
-          PeerData(peer, controlMessageHandler, queue, peerManager, p2pClientCallbacks, supervisor))
+        _peerData.put(peer,
+                      PeerData(peer,
+                               controlMessageHandler,
+                               queue,
+                               peerManager,
+                               p2pClientCallbacks,
+                               supervisor))
         _peerData(peer).peerMessageSender.map(_.connect())
       case None =>
         val exn = new RuntimeException(
@@ -232,9 +236,13 @@ case class PeerFinder(
   private def tryToReconnectPeer(peer: Peer): Future[Unit] = {
     peerManager.dataMessageQueueOpt match {
       case Some(queue) =>
-        _peerData.put(
-          peer,
-          PeerData(peer, controlMessageHandler, queue, peerManager,  p2pClientCallbacks, supervisor))
+        _peerData.put(peer,
+                      PeerData(peer,
+                               controlMessageHandler,
+                               queue,
+                               peerManager,
+                               p2pClientCallbacks,
+                               supervisor))
         _peerData(peer).peerMessageSender.map(_.reconnect())
       case None =>
         val exn = new RuntimeException(

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -404,6 +404,7 @@ case class PeerManager(
       _ <- watchCompletion()
       _ = {
         dataMessageQueueOpt = None //reset dataMessageQueue var
+        dataMessageHandlerOpt = None
       }
     } yield {
       logger.info(

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -503,7 +503,8 @@ case class DataMessageHandler(
 
           Future.successful(copy(state = MisbehavingPeer(peer)))
         } else {
-          logger.info(s"Re-querying headers from $peer.")
+          logger.info(
+            s"Re-querying headers from $peer. invalidMessages=${peerData.getInvalidMessageCount} peers.size=${peers.size}")
           for {
             blockchains <- BlockHeaderDAO().getBlockchains()
             cachedHeaders = blockchains

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandlerState.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandlerState.scala
@@ -37,6 +37,9 @@ object DataMessageHandlerState {
     override val isSyncing: Boolean = false
   }
 
+  case class RemovePeers(peers: Vector[Peer], isSyncing: Boolean)
+      extends DataMessageHandlerState
+
   /** State to indicate we are not currently syncing with a peer */
   case object DoneSyncing extends DataMessageHandlerState {
     override val isSyncing: Boolean = false

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -57,7 +57,7 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
 
     <!-- inspect TCP details -->
     <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
@@ -65,7 +65,7 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
+    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->
     <!-- ╚════════════════════╝ -->

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -57,7 +57,7 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
-    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>
 
     <!-- inspect TCP details -->
     <logger name="org.bitcoins.node.networking.P2PClientActor" level="WARN"/>
@@ -65,7 +65,7 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
+    <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->
     <!-- ╚════════════════════╝ -->

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -216,8 +216,7 @@ object NodeUnitTest extends P2PLogger {
       appConfig.nodeConf)
     val receiver =
       PeerMessageReceiver(controlMessageHandler = controlMessageHandler,
-                          dataMessageHandler =
-                            node.peerManager.getDataMessageHandler,
+                          queue = node.peerManager.dataMessageQueueOpt.get,
                           peer = peer)(system, appConfig.nodeConf)
     Future.successful(receiver)
   }
@@ -375,8 +374,7 @@ object NodeUnitTest extends P2PLogger {
       ControlMessageHandler(node.peerManager)(system.dispatcher, nodeAppConfig)
     val receiver =
       PeerMessageReceiver(controlMessageHandler = controlMessageHandler,
-                          dataMessageHandler =
-                            node.peerManager.getDataMessageHandler,
+                          queue = node.peerManager.dataMessageQueueOpt.get,
                           peer = peer)
     Future.successful(receiver)
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
@@ -31,7 +31,7 @@ trait BitcoinSAkkaAsyncTest extends BaseAsyncTest with Logging {
     system.dispatcher
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = false)
   }
 }
 


### PR DESCRIPTION
Realized in #5069  we need to break the crazy circular dependency between `PeerManager`, `PeerFinder`, `PeerData` and `NeutrinoNode`.

This PR tries to remove references to `Node` in `PeerData` and `PeerFinder`