### PR TITLE
Bump bitcoind minor versions to `24.1`/`23.2`

### DIFF
--- a/bitcoind-rpc/bitcoind-rpc.sbt
+++ b/bitcoind-rpc/bitcoind-rpc.sbt
@@ -95,8 +95,8 @@ TaskKeys.downloadBitcoind := {
         val expectedHash =
           if (Properties.isLinux)
             Map(
-              "24.1" -> "fb86cf6af7a10bc5f3ae6cd6a5b0348854e1462102fe71e755d30b51b6e317d1",
-              "23.2" -> "2cca490c1f2842884a3c5b0606f179f9f937177da4eadd628e3f7fd7e25d26d0",
+              "24.1" -> "c112af3d19cca7f5b5f942708ca4d522110d8e1dc1c0f8d3077f531c94e5f00f",
+              "23.2" -> "853b9b0a50800a5b355df7a39dbdd6d7a2339f765e2d31a36d14bd705e7dbce1",
               "22.0" -> "59ebd25dd82a51638b7a6bb914586201e67db67b919b2a1ff08925a7936d1b16",
               "0.21.1" -> "366eb44a7a0aa5bd342deea215ec19a184a11f2ca22220304ebb20b9c8917e2b",
             )
@@ -105,11 +105,11 @@ TaskKeys.downloadBitcoind := {
               "24.1" -> (if (System.getProperty("os.arch") == "aarch64")
                 "0bf7d0e313ac831a1b1c25c3871280721ab8fb7021bcca0f2acc280f4362a98e"
               else
-                "a2b7ba863e5536249a8e97b464bc9a91ad73a0b6340434bf1c09aa912ac52f29"),
+                "e06cffa770b162bf47ee1e7c8a5c286440a3e3cf6a543e25f865df5d4fbca9f7"),
               "23.2" -> (if (System.getProperty("os.arch") == "aarch64")
                            "33f8680f820327d5f9e64c02e476d03a5b2e5bd403e1b1cb0a82bd7ec2a8dc5e"
                          else
-                           "c816780583009a9dad426dc0c183c89be9da98906e1e2c7ebae91041c1aaaaf3"),
+                           "f56f2e21718c3ef13b962775f1e9985eed962ae6237684deebf6b59f799a912f"),
               "22.0" -> "2744d199c3343b2d94faffdfb2c94d75a630ba27301a70e47b0ad30a7e0155e9",
               "0.21.1" -> "1ea5cedb64318e9868a66d3ab65de14516f9ada53143e460d50af428b5aec3c7"
             )

--- a/bitcoind-rpc/bitcoind-rpc.sbt
+++ b/bitcoind-rpc/bitcoind-rpc.sbt
@@ -115,8 +115,8 @@ TaskKeys.downloadBitcoind := {
             )
           else if (Properties.isWin)
             Map(
-              "24.1" -> "09fa27956f2884434eee2ca1a9d2822712e8405c096e82ecedf64a638f42ca1a",
-              "23.2" -> "004b2e25b21e0f14cbcce6acec37f221447abbb3ea7931c689e508054bfc6cf6",
+              "24.1" -> "2b3181f73e3a7a10f57773bf57f11a622ec9f235b828e8bdbf41a2b17062ad62",
+              "23.2" -> "29dd4c94de8b292fd19fd9475f2f31f891d04f16238bd7defa48eef3f2f8546a",
               "22.0" -> "9485e4b52ed6cebfe474ab4d7d0c1be6d0bb879ba7246a8239326b2230a77eb1",
               "0.21.1" -> "94c80f90184cdc7e7e75988a55b38384de262336abd80b1b30121c6e965dc74e"
             )

--- a/bitcoind-rpc/bitcoind-rpc.sbt
+++ b/bitcoind-rpc/bitcoind-rpc.sbt
@@ -23,12 +23,12 @@ TaskKeys.downloadBitcoind := {
   }
 
   val versions =
-    List("24.0", "23.0", "22.0", "0.21.1")
+    List("24.1", "23.2", "22.0", "0.21.1")
 
   logger.debug(
     s"(Maybe) downloading Bitcoin Core binaries for versions: ${versions.mkString(",")}")
 
-  val arm64MacVersions = List("24.0", "23.0")
+  val arm64MacVersions = List("24.1", "23.2")
   def getPlatformAndSuffix(version: String): (String, String) = {
     if (Properties.isLinux) ("x86_64-linux-gnu", "tar.gz")
     else if (Properties.isMac) {
@@ -95,19 +95,19 @@ TaskKeys.downloadBitcoind := {
         val expectedHash =
           if (Properties.isLinux)
             Map(
-              "24.0" -> "fb86cf6af7a10bc5f3ae6cd6a5b0348854e1462102fe71e755d30b51b6e317d1",
-              "23.0" -> "2cca490c1f2842884a3c5b0606f179f9f937177da4eadd628e3f7fd7e25d26d0",
+              "24.1" -> "fb86cf6af7a10bc5f3ae6cd6a5b0348854e1462102fe71e755d30b51b6e317d1",
+              "23.2" -> "2cca490c1f2842884a3c5b0606f179f9f937177da4eadd628e3f7fd7e25d26d0",
               "22.0" -> "59ebd25dd82a51638b7a6bb914586201e67db67b919b2a1ff08925a7936d1b16",
               "0.21.1" -> "366eb44a7a0aa5bd342deea215ec19a184a11f2ca22220304ebb20b9c8917e2b",
             )
           else if (Properties.isMac)
             Map(
-              "24.0" -> (if (System.getProperty("os.arch") == "aarch64")
-                "03cbad3118ead19de6664ab80c43b6ee97302109e8789ca9a7e261bdc0aa6937"
+              "24.1" -> (if (System.getProperty("os.arch") == "aarch64")
+                "0bf7d0e313ac831a1b1c25c3871280721ab8fb7021bcca0f2acc280f4362a98e"
               else
                 "a2b7ba863e5536249a8e97b464bc9a91ad73a0b6340434bf1c09aa912ac52f29"),
-              "23.0" -> (if (System.getProperty("os.arch") == "aarch64")
-                           "7c8bc63731aa872b7b334a8a7d96e33536ad77d49029bad179b09dca32cd77ac"
+              "23.2" -> (if (System.getProperty("os.arch") == "aarch64")
+                           "33f8680f820327d5f9e64c02e476d03a5b2e5bd403e1b1cb0a82bd7ec2a8dc5e"
                          else
                            "c816780583009a9dad426dc0c183c89be9da98906e1e2c7ebae91041c1aaaaf3"),
               "22.0" -> "2744d199c3343b2d94faffdfb2c94d75a630ba27301a70e47b0ad30a7e0155e9",
@@ -115,8 +115,8 @@ TaskKeys.downloadBitcoind := {
             )
           else if (Properties.isWin)
             Map(
-              "24.0" -> "09fa27956f2884434eee2ca1a9d2822712e8405c096e82ecedf64a638f42ca1a",
-              "23.0" -> "004b2e25b21e0f14cbcce6acec37f221447abbb3ea7931c689e508054bfc6cf6",
+              "24.1" -> "09fa27956f2884434eee2ca1a9d2822712e8405c096e82ecedf64a638f42ca1a",
+              "23.2" -> "004b2e25b21e0f14cbcce6acec37f221447abbb3ea7931c689e508054bfc6cf6",
               "22.0" -> "9485e4b52ed6cebfe474ab4d7d0c1be6d0bb879ba7246a8239326b2230a77eb1",
               "0.21.1" -> "94c80f90184cdc7e7e75988a55b38384de262336abd80b1b30121c6e965dc74e"
             )


### PR DESCRIPTION
fixes #4932 

- https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-24.1.md
- https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-23.2.md