### PR TITLE
Remove check to see if seed exists when loading a wallet, the key manager can initiate the seed if it dne

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -95,8 +95,6 @@ sealed trait DLCWalletLoaderApi extends Logging with StartStopAsync[Unit] {
 
     (for {
       kmConfig <- kmConfigF
-      _ = if (!kmConfig.seedExists())
-        throw new RuntimeException(s"Wallet `${walletName}` does not exist")
 
       // First thing start the key manager to be able to fail fast if the password is invalid
       _ <- kmConfig.start()


### PR DESCRIPTION
This check was introduced in #4527 

I'm unsure of why it is necessary as the keymanager can create a seed if it does not exist when a wallet is loaded.

This check causes issues when initiating a wallet on statup for the first time with no pre-existing seed. I found this when testing #5093 

```
2023-06-06 15:33:14,243UTC ERROR [BitcoinSServerMain] Failed to startup server!
java.lang.RuntimeException: Wallet `` does not exist
        at org.bitcoins.server.DLCWalletLoaderApi.$anonfun$updateWalletConfigs$1(DLCWalletLoaderApi.scala:99)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
        at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:63)
        at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:100)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
        at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
        at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:100)
        at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:49)
        at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```