### PR TITLE
Rework `Node.sync()` to return `Future[Peer]` rather than `Future[Option[Peer]]`

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -299,7 +299,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         _ <- bitcoind.generate(1)
         //restart the node
         _ <- node.start()
-        _ <- AsyncUtil.retryUntilSatisfiedF(() => node.sync().map(_.isDefined))
+        _ <- node.sync()
         //await for us to sync compact filter headers filters
         //the sync process should get kicked off after we see the
         //newly mined block header
@@ -323,8 +323,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
 
       //start syncing node
       val numBlocks = 5
-      val startSyncF =
-        AsyncUtil.retryUntilSatisfiedF(() => node.sync().map(_.isDefined))
+      val startSyncF = node.sync()
       val genBlocksF = {
         for {
           _ <- startSyncF
@@ -352,7 +351,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       val node = nodeConnectedWithBitcoind.node
       val bitcoinds = nodeConnectedWithBitcoind.bitcoinds
       for {
-        _ <- AsyncUtil.retryUntilSatisfiedF(() => node.sync().map(_.isDefined))
+        _ <- node.sync()
         _ <- AsyncUtil.nonBlockingSleep(1.second)
         initConnectionCount <- node.getConnectionCount
         _ = assert(initConnectionCount == 2)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -239,8 +239,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
         _ <- bitcoind.generateToAddress(1, bitcoindAddr)
         //restart the node now that we have received funds
         startedNode <- stoppedNode.start()
-        _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-          startedNode.sync().map(_.isDefined))
+        _ <- startedNode.sync()
         _ <- NodeTestUtil.awaitSync(node = startedNode, rpc = bitcoind)
         _ <- AsyncUtil.retryUntilSatisfiedF(() => {
           for {
@@ -279,8 +278,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
 
       //bring node back online
       startedNode <- stoppedNode.start()
-      _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-        startedNode.sync().map(_.isDefined))
+      _ <- startedNode.sync()
       _ <- NodeTestUtil.awaitSync(startedNode, bitcoind)
       balanceAfterSpend <- wallet.getBalance()
     } yield {

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -114,9 +114,9 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     * we will not sync, otherwise we will keep syncing
     * until our best block hashes match up
     *
-    * @return
+    * @return the peer we are syncing with, or a failed Future if we could not find a peer to sync with after 5 seconds
     */
-  def sync(): Future[Option[Peer]]
+  def sync(): Future[Peer]
 
   /** Sync from a new peer
     * @return the new peer we are syncing from else none if we could not start syncing with another peer

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -518,7 +518,7 @@ object NodeUnitTest extends P2PLogger {
       //see: https://github.com/bitcoin/bitcoin/issues/27085
       //see: https://github.com/bitcoin-s/bitcoin-s/issues/4976
       _ <- bitcoind.syncWithValidationInterfaceQueue()
-      _ <- AsyncUtil.retryUntilSatisfiedF(() => node.sync().map(_.isDefined))
+      _ <- node.sync()
       syncing <- node.chainApiFromDb().flatMap(_.isSyncing())
       _ = require(syncing)
       _ <- NodeTestUtil.awaitSync(node, bitcoind)


### PR DESCRIPTION
Reverts parts of #5093 

A byproduct of #5093 was having to call `node.sync()` like this everywhere

```scala
AsyncUtil.retryUntilSatisfiedF(() => node.sync().map(_.isDefined))
```

This is annoying and needed because there is a race condition between `Node.start()` and `Node.sync()`. `Node.start()` kicks off the handshake process, which places nodes inside of `PeerManager._peerDataMap` after `version`/`verack` is exchanged.

`Node.sync()` selects a peer from `PeerManager._peerDataMap` and starts sending p2p messages from there. 

With this PR, if `_peerDataMap` is empty, we retry for 5 seconds and then timeout and return a failed `Future` if we could not select a PR in 5 seconds.