### PR TITLE
Add `PeerMessageSenderApi.gossipGetHeadersMessage()`, use it in `Node.sync()`

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -168,7 +168,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
       }
   }
 
-  it must "must disconnect a peer that keeps sending invalid headers" in {
+  it must "disconnect a peer that keeps sending invalid headers" in {
     nodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoinds.node
       val peerManager = node.peerManager
@@ -203,14 +203,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         _ <- AsyncUtil.retryUntilSatisfied(peerManager.peers.size == 1)
 
         _ <- node.sync()
-
         _ <- NodeTestUtil.awaitAllSync(node, bitcoinds(1))
-        _ = node.peerManager.updateDataMessageHandler(
-          node.peerManager.getDataMessageHandler.copy(state =
-            DataMessageHandlerState.HeaderSync(peer))(executionContext,
-                                                      node.nodeConfig,
-                                                      node.chainConfig))
-
         _ <- sendInvalidHeaders(peer)
         _ <- AsyncUtil.retryUntilSatisfied(
           !node.peerManager.peers.contains(peer))

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -152,12 +152,6 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         _ <- AsyncUtil.retryUntilSatisfied(node.peerManager.peers.size == 2)
         peers <- bitcoinPeersF
         peer = peers.head
-        _ = node.peerManager.updateDataMessageHandler(
-          node.peerManager.getDataMessageHandler.copy(state =
-            DataMessageHandlerState.HeaderSync(peer))(executionContext,
-                                                      node.nodeConfig,
-                                                      node.chainConfig))
-
         invalidHeaderMessage = HeadersMessage(headers = Vector(invalidHeader))
         _ <- node.peerManager.getDataMessageHandler
           .addToStream(invalidHeaderMessage, peer)

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -110,7 +110,7 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     *
     * @return the peer we are syncing with, or a failed Future if we could not find a peer to sync with after 5 seconds
     */
-  def sync(): Future[Peer]
+  def sync(): Future[Unit]
 
   /** Sync from a new peer
     * @return the new peer we are syncing from else none if we could not start syncing with another peer

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -134,6 +134,12 @@ case class PeerManager(
     sendMsg(headersMsg, peerOpt)
   }
 
+  override def gossipGetHeadersMessage(
+      hashes: Vector[DoubleSha256DigestBE]): Future[Unit] = {
+    val headersMsg = GetHeadersMessage(hashes.distinct.take(101).map(_.flip))
+    gossipMessage(headersMsg, None)
+  }
+
   override def sendGetDataMessages(
       typeIdentifier: TypeIdentifier,
       hashes: Vector[DoubleSha256DigestBE],

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -472,7 +472,7 @@ case class DataMessageHandler(
             newState <- {
               if (isIBD) {
                 peerMessgeSenderApi
-                  .sendGetHeadersMessage(Vector(bestBlockHash), Some(syncPeer))
+                  .gossipGetHeadersMessage(Vector(bestBlockHash))
                   .map { _ =>
                     //set to done syncing since we are technically done with IBD
                     //we just need to sync blocks that occurred while we were doing IBD

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -492,7 +492,8 @@ case class DataMessageHandler(
   private def recoverInvalidHeader(
       peerData: PeerData): Future[DataMessageHandler] = {
     val result = state match {
-      case HeaderSync(peer) =>
+      case HeaderSync(_) | DoneSyncing =>
+        val peer = peerData.peer
         peerData.updateInvalidMessageCount()
         if (peerData.exceededMaxInvalidMessages) {
           logger.warn(
@@ -527,7 +528,7 @@ case class DataMessageHandler(
         } else {
           Future.successful(newDmh)
         }
-      case DoneSyncing | _: FilterHeaderSync | _: FilterSync =>
+      case _: FilterHeaderSync | _: FilterSync =>
         Future.successful(this)
       case m @ (_: MisbehavingPeer | _: RemovePeers) =>
         sys.error(s"Cannot recover invalid headers, got=$m")

--- a/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
@@ -42,6 +42,10 @@ trait PeerMessageSenderApi {
       hashes: Vector[DoubleSha256DigestBE],
       peerOpt: Option[Peer]): Future[Unit]
 
+  /** Gossips the [[org.bitcoins.core.p2p.GetHeadersMessage]] to all of our peers to attempt ot get the best block headers */
+  def gossipGetHeadersMessage(
+      hashes: Vector[DoubleSha256DigestBE]): Future[Unit]
+
   def sendGetHeadersMessage(
       lastHash: DoubleSha256DigestBE,
       peerOpt: Option[Peer]): Future[Unit] = {


### PR DESCRIPTION
This PR now gossips `getheaders` messages to all of our peers when `Node.sync()` is called. This will help us get the best blockheader from our set of peers.

This PR also refactors the test suite `NeutrinoNodeWithUncachedBitcoindTest` to avoid reaching into internals of the akka stream (reference `DataMessageHandler` via `getDataMessageHandler`). The `getDataMessageHandler` method will be going away in #5098 to encapsulate state in the akka stream.

This also reverts parts of #5096 since we don't have a specific `Peer` we are syncing with when `Node.sync()` is called. We could be syncing with any peer inside of `PeerManager._peerDataMap`. 