### PR TITLE
Remove `chainApi` parameter from `NeutrinoNode`

### DIFF
--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -99,19 +99,11 @@ implicit val nodeConfig = appConfig.nodeConf
 
 val initNodeF = nodeConfig.start()
 
-//the node requires a chainHandler to store block information
-//use a helper method in our testkit to create the chain project
-val chainApiF = for {
-  chainHandler <- ChainUnitTest.createChainHandler()
-} yield chainHandler
-
-
 //yay! All setup done, let's create a node and then start it!
 val nodeF = for {
-  chainApi <- chainApiF
   peer <- peerF
 } yield {
-    NeutrinoNode(chainApi = chainApi,
+    NeutrinoNode(
         walletCreationTimeOpt = None, //you can set this to only sync compact filters after the timestamp
         paramPeers = Vector(peer),
         nodeConfig = nodeConfig,

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -2,6 +2,7 @@ package org.bitcoins.node
 
 import akka.actor.ActorSystem
 import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.core.api.chain.ChainApi
@@ -21,7 +22,6 @@ import java.time.Instant
 import scala.concurrent.Future
 
 case class NeutrinoNode(
-    chainApi: ChainApi,
     walletCreationTimeOpt: Option[Instant],
     nodeConfig: NodeAppConfig,
     chainConfig: ChainAppConfig,
@@ -83,6 +83,7 @@ case class NeutrinoNode(
     */
   private def syncHelper(syncPeerOpt: Option[Peer]): Future[Unit] = {
     logger.info(s"Syncing with peerOpt=$syncPeerOpt")
+    val chainApi: ChainApi = ChainHandler.fromDatabase()
     val blockchainsF =
       BlockHeaderDAO()(executionContext, chainConfig).getBlockchains()
     for {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -558,7 +558,6 @@ case class PeerManager(
             (forceReconnect || connectedPeerCount == 0) && isStarted.get
           if (peers.exists(_ != peer) && syncPeerOpt.isDefined) {
             node
-              .copy(chainApi = ChainHandler.fromDatabase())
               .syncFromNewPeer()
               .map(_ => ())
           } else if (syncPeerOpt.isDefined) {

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -2,14 +2,7 @@ package org.bitcoins.node.config
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import org.bitcoins.chain.blockchain.ChainHandlerCached
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.chain.models.{
-  BlockHeaderDAO,
-  ChainStateDescriptorDAO,
-  CompactFilterDAO,
-  CompactFilterHeaderDAO
-}
 import org.bitcoins.core.api.CallbackConfig
 import org.bitcoins.core.api.node.NodeType
 import org.bitcoins.core.config.{MainNet, RegTest, SigNet, TestNet3}
@@ -233,25 +226,15 @@ object NodeAppConfig extends AppConfigFactoryActorSystem[NodeAppConfig] {
       nodeConf: NodeAppConfig,
       chainConf: ChainAppConfig,
       system: ActorSystem): Future[Node] = {
-    import system.dispatcher
-
-    val blockHeaderDAO = BlockHeaderDAO()
-    val filterHeaderDAO = CompactFilterHeaderDAO()
-    val filterDAO = CompactFilterDAO()
-    val stateDAO = ChainStateDescriptorDAO()
-
-    val chainF = ChainHandlerCached
-      .fromDatabase(blockHeaderDAO, filterHeaderDAO, filterDAO, stateDAO)
 
     nodeConf.nodeType match {
       case NodeType.NeutrinoNode =>
-        chainF.map(chain =>
-          NeutrinoNode(chain,
-                       walletCreationTimeOpt,
-                       nodeConf,
-                       chainConf,
-                       system,
-                       paramPeers = peers))
+        val n = NeutrinoNode(walletCreationTimeOpt,
+                             nodeConf,
+                             chainConf,
+                             system,
+                             paramPeers = peers)
+        Future.successful(n)
       case NodeType.FullNode =>
         Future.failed(new RuntimeException("Not implemented"))
       case NodeType.BitcoindBackend =>


### PR DESCRIPTION
This removes the need for things like this: 

https://github.com/bitcoin-s/bitcoin-s/blob/295be36d632cf831fe373ba13509c87e6c1cc2f2/node/src/main/scala/org/bitcoins/node/PeerManager.scala#L555

We now get a new reference to `ChainApi` inside of `NeutrinoNode.syncHelper()`