### PR TITLE
Move {`syncFromNewPeer()`, `syncHelper()`} into PeerManager, remove reference to `Node` inside of `PeerManager`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -112,11 +112,6 @@ trait Node extends NodeApi with ChainQueryApi with P2PLogger {
     */
   def sync(): Future[Unit]
 
-  /** Sync from a new peer
-    * @return the new peer we are syncing from else none if we could not start syncing with another peer
-    */
-  def syncFromNewPeer(): Future[Option[Peer]]
-
   /** Broadcasts the given transaction over the P2P network */
   override def broadcastTransactions(
       transactions: Vector[Transaction]): Future[Unit] = {


### PR DESCRIPTION
This untangles more of our `NeutrinoNode` implementation. Now `PeerManager` doesn't take a reference to `Node` as parameter. Now `NeutrinoNode` has-a `PeerManager`, and `PeerManager` no longer has-a reference to `NeutrinoNode`. 

This also undoes #5057 where we put `syncFromNewPeer()` in the `Node` trait. 