### PR TITLE
Destroy wallet config when tearing down node

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -189,6 +189,7 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
     for {
       _ <- destroyNodeF
       _ <- destroyWalletF
+      _ <- BitcoinSWalletTest.destroyWalletAppConfig(appConfig.walletConf)
     } yield ()
   }
 


### PR DESCRIPTION
found this while looking at #5098 

Previously we would leave a bunch of threads allocated after test case runs that looked like this

![Screenshot from 2023-06-15 12-16-10](https://github.com/bitcoin-s/bitcoin-s/assets/3514957/0bf863f4-019c-439b-9550-d38296a08c33)

