### PR TITLE
Add `jdk.management.agent` module on dev builds

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -95,9 +95,17 @@ object CommonSettings {
     }
   )
 
-  lazy val jlinkModules = Seq(
-    "jdk.crypto.ec"
-  )
+  lazy val jlinkModules = {
+    val base = Seq(
+      "jdk.crypto.ec"
+    )
+    val dev = {
+      //needed for visualvm to profile/debug apps
+      Vector("jdk.management.agent")
+    }
+    if (!isCI) base ++ dev
+    else base
+  }
 
   //these are java modules we do not need
   //our artifacts do not use java.desktop


### PR DESCRIPTION
Adding `jdk.management.agent` allows you to monitor the JVM cpu usage to debug the app. 

This PR adds this module to the `jlink` build when the `isCI` flag is _not_ set. 

https://docs.oracle.com/en/java/javase/20/docs/api/jdk.management.agent/module-summary.html