### PR TITLE
Remove `offer(SendToPeer)` from `PeerManager` queue

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.node
 
 import org.bitcoins.asyncutil.AsyncUtil
-import org.bitcoins.core.p2p.{GetHeadersMessage, HeadersMessage, NetworkMessage}
+import org.bitcoins.core.p2p.{GetHeadersMessage, HeadersMessage}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.node.models.Peer
-import org.bitcoins.node.networking.peer.{DataMessageWrapper, SendToPeer}
+import org.bitcoins.node.networking.peer.DataMessageWrapper
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.node.fixture.NeutrinoNodeConnectedWithBitcoinds
@@ -76,8 +76,11 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         networkPayload =
           GetHeadersMessage(node.chainConfig.chain.genesisHash)
         //waiting for response to header query now
-        networkMessage = NetworkMessage(networkParam, networkPayload)
-        _ <- node.peerManager.offer(SendToPeer(networkMessage, Some(peer0)))
+        _ <- node.peerManager
+          .getPeerData(peer0)
+          .get
+          .peerMessageSenderApi
+          .sendMsg(networkPayload, Some(peer0))
         nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoinds(0))
         _ <- bitcoinds(0).disconnectNode(nodeUri)
         _ = logger.debug(

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -132,7 +132,8 @@ case class PeerManager(
                   randomPeerMsgSenderWithService(ServiceIdentifier.NODE_NETWORK)
               }
           }
-        case None => randomPeerMsgSenderWithService(ServiceIdentifier.NODE_NETWORK)
+        case None =>
+          randomPeerMsgSenderWithService(ServiceIdentifier.NODE_NETWORK)
       }
 
     peerMsgSenderOptF.flatMap {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -140,7 +140,6 @@ case class PeerManager(
       case Some(peerMsgSender) =>
         peerMsgSender
           .sendMsg(sendToPeer.msg)
-      //.map(_ => handleDisconnectedPeer(sendToPeer, peerMsgSender, dmh))
       case None =>
         Future.failed(new RuntimeException(
           s"Unable to find peer message sender to send msg=${sendToPeer.msg.header.commandName} to. This means we are not connected to any peers."))
@@ -750,7 +749,6 @@ case class PeerManager(
     StreamDataMessageWrapper,
     Future[DataMessageHandler]] = {
     Sink.foldAsync(initDmh) {
-      //case (dmh, sendToPeer: SendToPeer) =>
       case (dmh, DataMessageWrapper(payload, peer)) =>
         logger.debug(s"Got ${payload.commandName} from peer=${peer} in stream")
         val peerMsgSenderOptF = getPeerMsgSender(peer)
@@ -1004,38 +1002,6 @@ case class PeerManager(
       _ <- syncHelper(syncPeerOpt)
     } yield syncPeerOpt
   }
-
-  /** Handles the case where we need to send a message to a peer, but that peer was disconnected
-    * We change the peer and the adjust the state in [[DataMessageHandler]]
-    * @param sendToPeer the peer we were originally sending the message to
-    * @param peerMessageSender the new peer we are going to send the message to
-    * @param dmh the data message handler we need to adjust state of
-    */
-  /*  private def handleDisconnectedPeer(
-      sendToPeer: SendToPeer,
-      peerMessageSender: PeerMessageSender,
-      dmh: DataMessageHandler): DataMessageHandler = {
-    val destination = peerMessageSender.peer
-    val newState: DataMessageHandlerState = sendToPeer.peerOpt match {
-      case Some(originalPeer) =>
-        if (originalPeer != destination) {
-          //need to replace syncPeer with newSyncPeer
-          dmh.state match {
-            case s: SyncDataMessageHandlerState =>
-              s.replaceSyncPeer(destination)
-            case m: MisbehavingPeer => m
-            case r: RemovePeers     => r
-            case DoneSyncing        => DoneSyncing
-          }
-        } else {
-          dmh.state
-        }
-      case None =>
-        dmh.state
-    }
-
-    dmh.copy(state = newState)
-  }*/
 }
 
 case class ResponseTimeout(payload: NetworkPayload)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -898,4 +898,3 @@ case class SendResponseTimeout(peer: Peer, payload: NetworkPayload)
     extends StreamDataMessageWrapper
 
 case class SendToPeer(msg: NetworkMessage, peerOpt: Option[Peer])
-    extends StreamDataMessageWrapper


### PR DESCRIPTION
This removes a potential deadlock situation where we would try to offer `SendToPeer()` to our queue. 

This occurs when our queue buffer is full and we are backpressuring. We attempt to send a message, but it never gets sent because the queue is full, resuling in a deadlock.