### PR TITLE
Fix race condition between `NodeAppConfig.migrate()` calls when `bitcoin-s.tor.enabled=false`

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -95,10 +95,11 @@ case class BitcoinSAppConfig(
 
     val startedTorDependentConfigsF = for {
       _ <- torConfig
+      _ <- migrateTorDependentDbConfigsF
       _ <- Future.sequence(torDependentConfigs.map(_.start()))
     } yield ()
 
-    val startedNonTorConfigs = {
+    val startedNonTorConfigsF = {
       for {
         _ <- Future.traverse(nonTorConfigs)(_.start())
       } yield ()
@@ -106,7 +107,7 @@ case class BitcoinSAppConfig(
 
     for {
       _ <- migrateTorDependentDbConfigsF
-      _ <- startedNonTorConfigs
+      _ <- startedNonTorConfigsF
     } yield {
       logger.info(
         s"Done starting BitcoinSAppConfig, it took=${TimeUtil.currentEpochMs - start}ms")

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -96,7 +96,7 @@ case class BitcoinSAppConfig(
     val startedTorDependentConfigsF = for {
       _ <- torConfig
       _ <- migrateTorDependentDbConfigsF
-      _ <- Future.sequence(torDependentConfigs.map(_.start()))
+      _ <- Future.traverse(torDependentConfigs)(_.start())
     } yield ()
 
     val startedNonTorConfigsF = {


### PR DESCRIPTION
fixes #5114 

When we have `bitcoin-s.tor.enabled=false` there is a race condition whe applying migrations for the `node` module between these two lines 

```scala
    val migrateTorDependentDbConfigsF =
      Future.traverse(dbConfigsDependentOnTor)(dbConfig =>
        Future(dbConfig.migrate()))
```

```scala
    val startedTorDependentConfigsF = for {
      _ <- torConfig //if `bitcoin-s.tor.enabled=false, this is Future.unit
      _ <- Future.sequence(torDependentConfigs.map(_.start())) //also applying NodeAppConfig.migrate() here
    } yield ()
```