### PR TITLE
2023 06 28 connection fail logs

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -126,7 +126,7 @@ case class PeerFinder(
 
   private val maxPeerSearchCount: Int = 8
 
-  private val initialDelay: FiniteDuration = 30.second
+    private val initialDelay: FiniteDuration = 30.minute
 
   private val isConnectionSchedulerRunning = new AtomicBoolean(false)
 

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -126,7 +126,7 @@ case class PeerFinder(
 
   private val maxPeerSearchCount: Int = 8
 
-    private val initialDelay: FiniteDuration = 30.minute
+  private val initialDelay: FiniteDuration = 30.minute
 
   private val isConnectionSchedulerRunning = new AtomicBoolean(false)
 

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -124,9 +124,9 @@ case class PeerFinder(
 
   private val _peersToTry: PeerStack = PeerStack()
 
-  val maxPeerSearchCount: Int = 1000
+  private val maxPeerSearchCount: Int = 8
 
-  private val initialDelay: FiniteDuration = 30.minute
+  private val initialDelay: FiniteDuration = 30.second
 
   private val isConnectionSchedulerRunning = new AtomicBoolean(false)
 
@@ -138,10 +138,13 @@ case class PeerFinder(
         if (isConnectionSchedulerRunning.compareAndSet(false, true)) {
           logger.info(s"Querying p2p network for peers...")
           logger.debug(s"Cache size: ${_peerData.size}. ${_peerData.keys}")
-          if (_peersToTry.size < 32)
+          if (_peersToTry.size < maxPeerSearchCount)
             _peersToTry.pushAll(getPeersFromDnsSeeds)
 
-          val peers = (for { _ <- 1 to 32 } yield _peersToTry.pop()).distinct
+          val peers = (
+            1.to(maxPeerSearchCount)
+              .map(_ => _peersToTry.pop()))
+            .distinct
             .filterNot(p => skipPeers().contains(p) || _peerData.contains(p))
 
           logger.debug(s"Trying next set of peers $peers")
@@ -151,7 +154,8 @@ case class PeerFinder(
               isConnectionSchedulerRunning.set(false)
             case Failure(err) =>
               isConnectionSchedulerRunning.set(false)
-              logger.error(s"Failed to connect to peers=$peers", err)
+              logger.error(
+                s"Failed to connect to peers=$peers errMsg=${err.getMessage}")
           }
         } else {
           logger.warn(

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -98,8 +98,7 @@ case class PeerMessageSender(
            { case msgs: Vector[NetworkMessage] =>
              s"received msgs=${msgs.map(_.payload.commandName)} from peer=$peer"
            })
-      .withAttributes(Attributes.logLevels(onElement = Logging.DebugLevel,
-                                           onFailure = Logging.DebugLevel))
+      .withAttributes(Attributes.logLevels(onFailure = Logging.DebugLevel))
   }
 
   private val writeNetworkMsgFlow: Flow[NetworkMessage, ByteString, NotUsed] = {

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -2,8 +2,8 @@ package org.bitcoins.node.networking.peer
 
 import akka.NotUsed
 import akka.actor.{ActorRef, ActorSystem, Cancellable}
+import akka.event.Logging
 import akka.io.Tcp.SO.KeepAlive
-import akka.stream.{KillSwitches, UniqueKillSwitch}
 import akka.stream.scaladsl.{
   BidiFlow,
   Flow,
@@ -14,6 +14,7 @@ import akka.stream.scaladsl.{
   Source,
   Tcp
 }
+import akka.stream.{Attributes, KillSwitches, UniqueKillSwitch}
 import akka.util.ByteString
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
@@ -57,9 +58,7 @@ case class PeerMessageSender(
     ByteString,
     ByteString,
     Future[Tcp.OutgoingConnection]] = {
-    Tcp(system).outgoingConnection(peer.socket,
-                                   halfClose = false,
-                                   options = options)
+    Tcp(system).outgoingConnection(socket, halfClose = false, options = options)
   }
 
   private def parseHelper(
@@ -99,6 +98,8 @@ case class PeerMessageSender(
            { case msgs: Vector[NetworkMessage] =>
              s"received msgs=${msgs.map(_.payload.commandName)} from peer=$peer"
            })
+      .withAttributes(Attributes.logLevels(onElement = Logging.DebugLevel,
+                                           onFailure = Logging.DebugLevel))
   }
 
   private val writeNetworkMsgFlow: Flow[NetworkMessage, ByteString, NotUsed] = {
@@ -194,9 +195,13 @@ case class PeerMessageSender(
           buildConnectionGraph().run()
         }
 
-        outgoingConnectionF.map { o =>
-          logger.info(
-            s"Connected to remote=${o.remoteAddress}  local=${o.localAddress}")
+        outgoingConnectionF.onComplete {
+          case scala.util.Success(o) =>
+            logger.info(
+              s"Connected to remote=${o.remoteAddress}  local=${o.localAddress}")
+          case scala.util.Failure(err) =>
+            logger.info(
+              s"Failed to connect to peer=$peer with errMsg=${err.getMessage}")
         }
 
         val graph = ConnectionGraph(mergeHubSink = mergeHubSink,
@@ -216,9 +221,6 @@ case class PeerMessageSender(
           .flatMap { p =>
             p.disconnect(peer)
           }
-          .failed
-          .foreach(err =>
-            logger.error(s"Failed disconnect callback with peer=$peer", err))
 
         resultF.map(_ => ())
     }


### PR DESCRIPTION
Part of #5116 

This reworks logs in the case where we fail to connect to a peer. Now the log looks like 

```
2023-06-28 21:05:01,368UTC INFO [PeerMessageSender] Failed to connect to peer=Peer([2602:ffb8::208:72:57:200]:8333) with errMsg=Tcp command [Connect([2602:ffb8::208:72:57:200]/<unresolved>:8333,None,List(KeepAlive(true)),None,true)] failed because of java.net.SocketException: Network is unreachable
```

Previously it looked like 

```
2023-06-26 15:03:29,963UTC ERROR [Materializer] [parseToNetworkMsgFlow] Upstream failed.
akka.stream.StreamTcpException: Tcp command [Connect([2a00:ee2:1200:1900:8d3:d2ff:feb1:bc58]/<unresolved>:8333,None,List(KeepAlive(true)),None,true)] failed because of java.net.SocketException: Network is unreachable
Caused by: java.net.SocketException: Network is unreachable
	at java.base/sun.nio.ch.Net.connect0(Native Method)
	at java.base/sun.nio.ch.Net.connect(Net.java:580)
	at java.base/sun.nio.ch.Net.connect(Net.java:587)
	at java.base/sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:880)
	at akka.io.TcpOutgoingConnection.$anonfun$register$1(TcpOutgoingConnection.scala:98)
	at akka.io.TcpOutgoingConnection.akka$io$TcpOutgoingConnection$$reportConnectFailure(TcpOutgoingConnection.scala:53)
	at akka.io.TcpOutgoingConnection.register(TcpOutgoingConnection.scala:96)
	at akka.io.TcpOutgoingConnection$$anonfun$resolving$1.$anonfun$applyOrElse$2(TcpOutgoingConnection.scala:84)
	at akka.io.TcpOutgoingConnection.akka$io$TcpOutgoingConnection$$reportConnectFailure(TcpOutgoingConnection.scala:53)
	at akka.io.TcpOutgoingConnection$$anonfun$resolving$1.applyOrElse(TcpOutgoingConnection.scala:84)
	at akka.actor.Actor.aroundReceive(Actor.scala:537)
	at akka.actor.Actor.aroundReceive$(Actor.scala:535)
	at akka.io.TcpConnection.aroundReceive(TcpConnection.scala:33)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)
	at akka.actor.ActorCell.invoke(ActorCell.scala:547)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```