### PR TITLE
Implement call to `Node.stop()` when shutting down `BitcoinSServerMain`

### DIFF
--- a/app/server-routes/src/main/scala/org/bitcoins/server/util/ServerBindings.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/util/ServerBindings.scala
@@ -1,13 +1,15 @@
 package org.bitcoins.server.util
 
 import akka.http.scaladsl.Http
+import grizzled.slf4j.Logging
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
 case class ServerBindings(
     httpServer: Http.ServerBinding,
-    webSocketServerOpt: Option[Http.ServerBinding]) {
+    webSocketServerOpt: Option[Http.ServerBinding])
+    extends Logging {
 
   private val terminateTimeout = 5.seconds
 
@@ -22,6 +24,9 @@ case class ServerBindings(
         case None =>
           Future.unit
       }
-    } yield ()
+    } yield {
+      logger.info(s"ServerBindings stopped")
+      ()
+    }
   }
 }

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -253,7 +253,10 @@ sealed trait DLCWalletLoaderApi extends Logging with StartStopAsync[Unit] {
       _ <- rescanStopF
       _ <- walletStopF
       _ <- dlcStopF
-    } yield ()
+    } yield {
+      logger.info(s"DLCWalletLoaderApi stopped")
+      ()
+    }
   }
 }
 

--- a/app/server/src/main/scala/org/bitcoins/server/bitcoind/BitcoindSyncState.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/bitcoind/BitcoindSyncState.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.server.bitcoind
 
-import org.bitcoins.server.util.BitcoindPollingCancellabe
+import org.bitcoins.server.util.{BitcoindPollingCancellable}
 
 import scala.concurrent.Future
 
@@ -9,7 +9,7 @@ import scala.concurrent.Future
   */
 case class BitcoindSyncState(
     syncF: Future[Unit],
-    pollingCancellable: BitcoindPollingCancellabe) {
+    pollingCancellable: BitcoindPollingCancellable) {
 
   /** Stops syncing and polling bitcoind */
   def stop(): Future[Unit] = {

--- a/app/server/src/main/scala/org/bitcoins/server/util/BitcoindPollingCancellabe.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/BitcoindPollingCancellabe.scala
@@ -3,7 +3,7 @@ package org.bitcoins.server.util
 import akka.actor.Cancellable
 import grizzled.slf4j.Logging
 
-case class BitcoindPollingCancellabe(
+case class BitcoindPollingCancellable(
     blockPollingCancellable: Cancellable,
     mempoolPollingCancelable: Cancellable)
     extends Cancellable
@@ -20,7 +20,7 @@ case class BitcoindPollingCancellabe(
 
 object BitcoindPollingCancellabe {
 
-  val none: BitcoindPollingCancellabe = BitcoindPollingCancellabe(
+  val none: BitcoindPollingCancellable = BitcoindPollingCancellable(
     Cancellable.alreadyCancelled,
     Cancellable.alreadyCancelled)
 }


### PR DESCRIPTION
This fixes these error logs when shutting down `BitcoinSServermain` with a `bitcoin-s.node.mode=neutrino` backend.

This is because we didn't call `Node.stop()` which forces our akka stream to drain before the `Future` returned by `Node.stop()` completes.

```
2023-06-29 19:27:17,912UTC ERROR [DataMessageHandler] Failed to handle data payload=TransactionMessage(DoubleSha256BDigestBE(bb478cd38044d24cfab8a9953ef766c8cfa5549a018fe9a0d42cf24a45cbf3f7)) from Peer(127.0.0.1:8333) in state=FilterSync(Peer(127.0.0.1:8333)) errMsg=Stage with GraphStageLogic akka.stream.impl.QueueSource$$anon$1-queueSource stopped before async invocation was processed
akka.stream.StreamDetachedException: Stage with GraphStageLogic akka.stream.impl.QueueSource$$anon$1-queueSource stopped before async invocation was processed
2023-06-29 19:27:17,912UTC ERROR [DataMessageHandler] Failed to handle data payload=TransactionMessage(DoubleSha256BDigestBE(43f6ee63204ada145a616d7fa9b3286a4fd034175c2b128f5e887123b6b43294)) from Peer(127.0.0.1:8333) in state=FilterSync(Peer(127.0.0.1:8333)) errMsg=Stage with GraphStageLogic akka.stream.impl.QueueSource$$anon$1-queueSource stopped before async invocation was processed
akka.stream.StreamDetachedException: Stage with GraphStageLogic akka.stream.impl.QueueSource$$anon$1-queueSource stopped before async invocation was processed
2023-06-29 19:27:17,912UTC INFO [BitcoinSServerMain] Stopped neutrino node
2023-06-29 19:27:17,912UTC ERROR [DataMessageHandler] Failed to handle data payload=TransactionMessage(DoubleSha256BDigestBE(f18ffc400c944b2fa779d951a2068b2411b312c669d35265873c7876d6f05ef3)) from Peer(127.0.0.1:8333) in state=FilterSync(Peer(127.0.0.1:8333)) errMsg=Stage with GraphStageLogic akka.stream.impl.QueueSource$$anon$1-queueSource stopped before async invocation was processed
akka.stream.StreamDetachedException: Stage with GraphStageLogic akka.stream.impl.QueueSource$$anon$1-queueSource stopped before async invocation was processed
2023-06-29 19:27:17,912UTC ERROR [DataMessageHandler] Failed to handle data payload=TransactionMessage(DoubleSha256BDigestBE(815f7b9750e668e26ddf403a68df7724609ab8a63a62c289b7004c45112af67f)) from Peer(127.0.0.1:8333) in state=FilterSync(Peer(127.0.0.1:8333)) errMsg=Stage with GraphStageLogic akka.stream.impl.QueueSource$$anon$1-queueSource stopped before async invocation was processed
akka.stream.StreamDetachedException: Stage with GraphStageLogic akka.stream.impl.QueueSource$$anon$1-queueSource stopped before async invocation was processed
```