### PR TITLE
Move `Socks5ProxyParams`, `Credentials`, `Peer` into `core`

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -5,9 +5,9 @@ import com.typesafe.config.ConfigFactory
 import grizzled.slf4j.Logging
 import org.bitcoins.commons.util.NativeProcessFactory
 import org.bitcoins.core.api.commons.{InstanceFactory, InstanceFactoryLocal}
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.rpc.client.common.BitcoindVersion
-import org.bitcoins.tor.Socks5ProxyParams
 
 import java.io.File
 import java.net.URI

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindRpcAppConfig.scala
@@ -4,10 +4,10 @@ import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.config.{AppConfig, ConfigOps}
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.rpc.BitcoindException.InWarmUp
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.util.AppConfigFactoryActorSystem
-import org.bitcoins.tor.Socks5ProxyParams
 import org.bitcoins.tor.config.TorAppConfig
 
 import java.io.File

--- a/core/src/main/scala/org/bitcoins/core/api/node/Peer.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/Peer.scala
@@ -1,8 +1,7 @@
-package org.bitcoins.node.models
+package org.bitcoins.core.api.node
 
 import org.bitcoins.core.api.db.DbRowAutoInc
-import org.bitcoins.rpc.config.BitcoindInstance
-import org.bitcoins.tor.Socks5ProxyParams
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 
 import java.net.InetSocketAddress
 
@@ -27,14 +26,5 @@ object Peer {
       socket: InetSocketAddress,
       socks5ProxyParams: Option[Socks5ProxyParams]): Peer = {
     Peer(socket, socks5ProxyParams = socks5ProxyParams)
-  }
-
-  /** Constructs a peer from the given `bitcoind` instance
-    */
-  def fromBitcoind(
-      bitcoind: BitcoindInstance,
-      socks5ProxyParams: Option[Socks5ProxyParams]): Peer = {
-    val socket = new InetSocketAddress(bitcoind.uri.getHost, bitcoind.p2pPort)
-    fromSocket(socket, socks5ProxyParams = socks5ProxyParams)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/api/tor/Credentials.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/tor/Credentials.scala
@@ -1,0 +1,6 @@
+package org.bitcoins.core.api.tor
+
+case class Credentials(username: String, password: String) {
+  require(username.length < 256, "username is too long")
+  require(password.length < 256, "password is too long")
+}

--- a/core/src/main/scala/org/bitcoins/core/api/tor/Socks5ProxyParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/tor/Socks5ProxyParams.scala
@@ -1,0 +1,31 @@
+package org.bitcoins.core.api.tor
+
+import org.bitcoins.crypto.CryptoUtil
+
+import java.net.InetSocketAddress
+
+case class Socks5ProxyParams(
+    address: InetSocketAddress,
+    credentialsOpt: Option[Credentials],
+    randomizeCredentials: Boolean)
+
+object Socks5ProxyParams {
+
+  val DefaultPort = 9050
+
+  val defaultProxyParams: Socks5ProxyParams =
+    new Socks5ProxyParams(
+      address = InetSocketAddress.createUnresolved("127.0.0.1", DefaultPort),
+      credentialsOpt = None,
+      randomizeCredentials = true)
+
+  def proxyCredentials(proxyParams: Socks5ProxyParams): Option[Credentials] =
+    if (proxyParams.randomizeCredentials) {
+      // randomize credentials for every proxy connection to enable Tor stream isolation
+      Some(
+        Credentials(CryptoUtil.randomBytes(16).toHex,
+                    CryptoUtil.randomBytes(16).toHex))
+    } else {
+      proxyParams.credentialsOpt
+    }
+}

--- a/dlc-node-test/src/test/scala/org/bitcoins/dlc/node/DLCServerTorTest.scala
+++ b/dlc-node-test/src/test/scala/org/bitcoins/dlc/node/DLCServerTorTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.dlc.node
 import akka.actor.ActorRef
 import akka.testkit.{TestActorRef, TestProbe}
 import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.number.UInt16
 import org.bitcoins.core.protocol.BigSizeUInt
 import org.bitcoins.core.protocol.tlv.{LnMessage, PingTLV, PongTLV}
@@ -14,7 +15,7 @@ import org.bitcoins.testkit.tor.CachedTor
 import org.bitcoins.testkit.util.{BitcoinSActorFixtureWithDLCWallet, TorUtil}
 import org.bitcoins.testkit.util.TorUtil._
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
-import org.bitcoins.tor.{Socks5ProxyParams, TorController, TorProtocolHandler}
+import org.bitcoins.tor.{TorController, TorProtocolHandler}
 import org.scalatest.{Assertion, FutureOutcome}
 import scodec.bits.ByteVector
 

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCClient.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/DLCClient.scala
@@ -4,10 +4,11 @@ import akka.actor._
 import akka.event.LoggingReceive
 import akka.io.{IO, Tcp}
 import org.bitcoins.core.api.dlc.wallet.DLCWalletApi
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.protocol.BigSizeUInt
 import org.bitcoins.dlc.node.peer.Peer
 import org.bitcoins.tor.Socks5Connection.{Socks5Connect, Socks5Connected}
-import org.bitcoins.tor.{Socks5Connection, Socks5ProxyParams}
+import org.bitcoins.tor.Socks5Connection
 import scodec.bits.ByteVector
 
 import java.io.IOException

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/config/DLCNodeAppConfig.scala
@@ -5,10 +5,11 @@ import com.typesafe.config.Config
 import org.bitcoins.commons.config.{AppConfig, AppConfigFactory}
 import org.bitcoins.core.api.CallbackConfig
 import org.bitcoins.core.api.dlc.wallet.DLCWalletApi
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.util.{FutureUtil, NetworkUtil}
 import org.bitcoins.dlc.node.{DLCNode, DLCNodeCallbacks}
 import org.bitcoins.tor.config.TorAppConfig
-import org.bitcoins.tor.{Socks5ProxyParams, TorParams}
+import org.bitcoins.tor.TorParams
 
 import java.net.{InetSocketAddress, URI}
 import java.nio.file.Path

--- a/dlc-node/src/main/scala/org/bitcoins/dlc/node/peer/Peer.scala
+++ b/dlc-node/src/main/scala/org/bitcoins/dlc/node/peer/Peer.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.dlc.node.peer
 
 import org.bitcoins.core.api.db.DbRowAutoInc
-import org.bitcoins.tor.Socks5ProxyParams
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 
 import java.net.InetSocketAddress
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/EclairInstance.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/config/EclairInstance.scala
@@ -3,11 +3,11 @@ package org.bitcoins.eclair.rpc.config
 import akka.actor.ActorSystem
 import com.typesafe.config.{Config, ConfigFactory}
 import org.bitcoins.core.api.commons.InstanceFactoryLocal
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.config.{MainNet, NetworkParameters, RegTest, TestNet3}
 import org.bitcoins.core.protocol.ln.LnPolicy
 import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.rpc.config.{BitcoindAuthCredentials, ZmqConfig}
-import org.bitcoins.tor.Socks5ProxyParams
 
 import java.io.File
 import java.net.{InetSocketAddress, URI}

--- a/esplora-test/src/test/scala/org/bitcoins/esplora/EsploraClientTest.scala
+++ b/esplora-test/src/test/scala/org/bitcoins/esplora/EsploraClientTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.esplora
 
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.config.MainNet
 import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -8,7 +9,6 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto._
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import org.bitcoins.testkit.util.TorUtil._
-import org.bitcoins.tor.Socks5ProxyParams
 
 class EsploraClientTest extends BitcoinSAsyncTest {
 

--- a/esplora/src/main/scala/org/bitcoins/esplora/EsploraClient.scala
+++ b/esplora/src/main/scala/org/bitcoins/esplora/EsploraClient.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.client.RequestBuilding.Post
 import akka.http.scaladsl.model._
 import akka.util.ByteString
 import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}

--- a/fee-provider-test/src/test/scala/org/bitcoins/feeprovider/FeeRateProviderTest.scala
+++ b/fee-provider-test/src/test/scala/org/bitcoins/feeprovider/FeeRateProviderTest.scala
@@ -2,12 +2,12 @@ package org.bitcoins.feeprovider
 
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.feeprovider.FeeRateApi
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.config._
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.feeprovider.MempoolSpaceTarget._
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
-import org.bitcoins.tor.Socks5ProxyParams
 import org.scalatest.Assertion
 
 import scala.concurrent.Future

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/BitGoFeeRateProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/BitGoFeeRateProvider.scala
@@ -4,8 +4,8 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
 import org.bitcoins.commons.jsonmodels.wallet.BitGoResult
 import org.bitcoins.commons.serializers.JsonSerializers._
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.wallet.fee.SatoshisPerKiloByte
-import org.bitcoins.tor.Socks5ProxyParams
 import play.api.libs.json.{JsError, JsSuccess, Json}
 
 import scala.util.{Failure, Success, Try}

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/BitcoinerLiveFeeRateProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/BitcoinerLiveFeeRateProvider.scala
@@ -4,9 +4,9 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
 import org.bitcoins.commons.jsonmodels.wallet.BitcoinerLiveResult
 import org.bitcoins.commons.serializers.JsonSerializers._
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.feeprovider.BitcoinerLiveFeeRateProvider.validMinutes
-import org.bitcoins.tor.Socks5ProxyParams
 import play.api.libs.json.{JsError, JsSuccess, Json}
 
 import scala.util.{Failure, Success, Try}

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/FeeProviderFactory.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/FeeProviderFactory.scala
@@ -3,6 +3,7 @@ package org.bitcoins.feeprovider
 import akka.actor.ActorSystem
 import grizzled.slf4j.Logging
 import org.bitcoins.core.api.feeprovider.FeeRateApi
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.feeprovider.FeeProviderName.{
@@ -12,7 +13,6 @@ import org.bitcoins.feeprovider.FeeProviderName.{
   MempoolSpace
 }
 import org.bitcoins.feeprovider.MempoolSpaceTarget.HourFeeTarget
-import org.bitcoins.tor.Socks5ProxyParams
 
 trait FeeProviderFactory[T <: FeeRateApi] {
 

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/HttpFeeRateProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/HttpFeeRateProvider.scala
@@ -6,9 +6,10 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{HttpRequest, Uri}
 import akka.util.ByteString
 import org.bitcoins.core.api.feeprovider.FeeRateApi
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.tor.{Socks5ClientTransport, Socks5ProxyParams}
+import org.bitcoins.tor.Socks5ClientTransport
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.Try

--- a/fee-provider/src/main/scala/org/bitcoins/feeprovider/MempoolSpaceProvider.scala
+++ b/fee-provider/src/main/scala/org/bitcoins/feeprovider/MempoolSpaceProvider.scala
@@ -4,10 +4,10 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
 import org.bitcoins.commons.jsonmodels.wallet.MempoolSpaceResult
 import org.bitcoins.commons.serializers.JsonSerializers._
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.config._
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.feeprovider.MempoolSpaceTarget._
-import org.bitcoins.tor.Socks5ProxyParams
 import play.api.libs.json.{JsError, JsSuccess, Json}
 
 import scala.util.{Failure, Success, Try}

--- a/lnurl/src/main/scala/org/bitcoins/lnurl/LnURLClient.scala
+++ b/lnurl/src/main/scala/org/bitcoins/lnurl/LnURLClient.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.http.scaladsl.model.HttpRequest
 import akka.util.ByteString
 import grizzled.slf4j.Logging
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.currency._
 import org.bitcoins.core.protocol.ln.LnInvoice
 import org.bitcoins.core.protocol.ln.currency._

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -3,9 +3,10 @@ package org.bitcoins.node
 import akka.actor.Cancellable
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.models.{CompactFilterDAO, CompactFilterHeaderDAO}
+import org.bitcoins.core.api.node.Peer
 import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.node.models.{Peer, PeerDAO, PeerDb}
+import org.bitcoins.node.models.{PeerDAO, PeerDb}
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.node.fixture.NeutrinoNodeConnectedWithBitcoinds

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.node
 
 import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.core.api.node.Peer
 import org.bitcoins.core.p2p.{GetHeadersMessage, HeadersMessage}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.node.models.Peer
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.node.fixture.NeutrinoNodeConnectedWithBitcoinds

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -4,11 +4,10 @@ import akka.actor.ActorSystem
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
-import org.bitcoins.core.api.node.NodeType
+import org.bitcoins.core.api.node.{NodeType, Peer}
 import org.bitcoins.core.p2p.ServiceIdentifier
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.models.Peer
 
 import java.time.Instant
 import scala.concurrent.Future

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -10,7 +10,7 @@ import org.bitcoins.chain.models.{
   CompactFilterHeaderDAO
 }
 import org.bitcoins.core.api.chain._
-import org.bitcoins.core.api.node.NodeApi
+import org.bitcoins.core.api.node.{NodeApi, Peer}
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}

--- a/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
@@ -1,12 +1,12 @@
 package org.bitcoins.node
 
+import org.bitcoins.core.api.node.Peer
 import org.bitcoins.core.p2p.{
   DataPayload,
   ExpectsResponse,
   NetworkMessage,
   NetworkPayload
 }
-import org.bitcoins.node.models.Peer
 
 sealed abstract class NodeStreamMessage
 

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.node
 
-import akka.actor.{ActorSystem}
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.SourceQueueWithComplete
 import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.core.api.node.Peer
 import org.bitcoins.core.p2p.ServiceIdentifier
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer._
 import org.bitcoins.node.util.PeerMessageSenderApi
 

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -4,11 +4,12 @@ import akka.actor.{ActorSystem, Cancellable}
 import akka.stream.scaladsl.SourceQueueWithComplete
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.core.api.node.Peer
 import org.bitcoins.core.p2p.ServiceIdentifier
 import org.bitcoins.core.util.{NetworkUtil, StartStopAsync}
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.models.{Peer, PeerDAO, PeerDb}
-import org.bitcoins.node.networking.peer.{ControlMessageHandler}
+import org.bitcoins.node.models.{PeerDAO, PeerDb}
+import org.bitcoins.node.networking.peer.ControlMessageHandler
 import org.bitcoins.node.util.PeerMessageSenderApi
 
 import java.net.{InetAddress, UnknownHostException}

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -27,13 +27,13 @@ import org.bitcoins.core.api.chain.db.{
   CompactFilterDb,
   CompactFilterHeaderDb
 }
-import org.bitcoins.core.api.node.NodeType
+import org.bitcoins.core.api.node.{NodeType, Peer}
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.{NetworkUtil, StartStopAsync}
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.models.{Peer, PeerDAO, PeerDb}
+import org.bitcoins.node.models.{PeerDAO, PeerDb}
 import org.bitcoins.node.networking.peer.NodeState._
 import org.bitcoins.node.networking.peer._
 import org.bitcoins.node.util.PeerMessageSenderApi

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -4,18 +4,18 @@ import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.CallbackConfig
-import org.bitcoins.core.api.node.NodeType
+import org.bitcoins.core.api.node.{NodeType, Peer}
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.config.{MainNet, RegTest, SigNet, TestNet3}
 import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.db.{DbAppConfig, JdbcProfileComponent}
 import org.bitcoins.node._
 import org.bitcoins.node.callback.NodeCallbackStreamManager
 import org.bitcoins.node.db.NodeDbManagement
-import org.bitcoins.node.models.Peer
 import org.bitcoins.rpc.config.BitcoindRpcAppConfig
 import org.bitcoins.rpc.util.AppConfigFactoryActorSystem
 import org.bitcoins.tor.config.TorAppConfig
-import org.bitcoins.tor.{Socks5ProxyParams, TorParams}
+import org.bitcoins.tor.TorParams
 
 import java.nio.file.Path
 import java.time.{Duration, Instant}

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/ControlMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/ControlMessageHandler.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.node.networking.peer
 
+import org.bitcoins.core.api.node.Peer
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.PeerMessageReceiverState._
 import org.bitcoins.node.{NodeStreamMessage, P2PLogger, PeerManager}
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -6,7 +6,7 @@ import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.chain.db.CompactFilterHeaderDb
-import org.bitcoins.core.api.node.NodeType
+import org.bitcoins.core.api.node.{NodeType, Peer}
 import org.bitcoins.core.gcs.{BlockFilter, GolombFilter}
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.protocol.CompactSizeUInt

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/NodeState.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/NodeState.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.node.networking.peer
 
-import org.bitcoins.node.models.Peer
+import org.bitcoins.core.api.node.Peer
 import org.bitcoins.node.networking.peer.NodeState.{
   DoneSyncing,
   FilterHeaderSync,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageReceiver.scala
@@ -5,10 +5,9 @@ import akka.stream.QueueOfferResult
 import akka.stream.scaladsl.SourceQueueWithComplete
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.node.NodeType
+import org.bitcoins.core.api.node.{NodeType, Peer}
 import org.bitcoins.core.p2p._
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.PeerMessageReceiverState._
 import org.bitcoins.node.{NodeStreamMessage, P2PLogger}
 import org.bitcoins.node.util.PeerMessageSenderApi

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -18,6 +18,7 @@ import akka.stream.{Attributes, KillSwitches, UniqueKillSwitch}
 import akka.util.ByteString
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.core.api.node.Peer
 import org.bitcoins.core.bloom.BloomFilter
 import org.bitcoins.core.number.Int32
 import org.bitcoins.core.p2p._
@@ -26,7 +27,6 @@ import org.bitcoins.crypto.{DoubleSha256Digest, HashDigest}
 import org.bitcoins.node.P2PLogger
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.constant.NodeConstants
-import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.PeerMessageReceiver.NetworkMessageReceived
 import org.bitcoins.node.networking.peer.PeerMessageSender.ConnectionGraph
 import org.bitcoins.node.util.PeerMessageSenderApi

--- a/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.node.util
 
 import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
+import org.bitcoins.core.api.node.Peer
 import org.bitcoins.core.number.Int32
 import org.bitcoins.core.p2p.{
   GetAddrMessage,
@@ -19,7 +20,6 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.constant.NodeConstants
-import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer.NodeState
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/oracle-explorer-client/src/main/scala/org/bitcoins/explorer/client/SbExplorerClient.scala
+++ b/oracle-explorer-client/src/main/scala/org/bitcoins/explorer/client/SbExplorerClient.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.{Http, HttpExt}
 import akka.util.ByteString
 import org.bitcoins.commons.jsonmodels.ExplorerEnv
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.protocol.tlv.OracleAnnouncementTLV
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.{SchnorrPublicKey, Sha256Digest}
@@ -15,7 +16,7 @@ import org.bitcoins.explorer.model.{
   SbAnnouncementEvent
 }
 import org.bitcoins.explorer.picklers.ExplorerPicklers
-import org.bitcoins.tor.{Socks5ClientTransport, Socks5ProxyParams}
+import org.bitcoins.tor.{Socks5ClientTransport}
 import play.api.libs.json.{
   JsArray,
   JsBoolean,

--- a/oracle-explorer-client/src/test/scala/org/bitcoins/explorer/client/SbExplorerClientTest.scala
+++ b/oracle-explorer-client/src/test/scala/org/bitcoins/explorer/client/SbExplorerClientTest.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.explorer.client
 
 import org.bitcoins.commons.jsonmodels.ExplorerEnv
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.protocol.tlv.{
   OracleAnnouncementV0TLV,
   OracleAttestmentV0TLV
@@ -12,7 +13,6 @@ import org.bitcoins.explorer.model.{
   SbAnnouncementEvent
 }
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
-import org.bitcoins.tor.Socks5ProxyParams
 
 import scala.concurrent.Future
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -1,13 +1,13 @@
 package org.bitcoins.testkit.node
 
 import akka.actor.ActorSystem
+import org.bitcoins.core.api.node.Peer
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.node.models.Peer
 import org.bitcoins.node.{NeutrinoNode, Node, P2PLogger}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.async.TestAsyncUtil
 import org.bitcoins.testkit.util.TorUtil
-import org.bitcoins.tor.Socks5ProxyParams
 
 import java.net.{InetSocketAddress, URI}
 import scala.concurrent.duration._
@@ -53,7 +53,7 @@ abstract class NodeTestUtil extends P2PLogger {
     } else None
   }
 
-  /** Gets the [[org.bitcoins.node.models.Peer]] that
+  /** Gets the [[Peer]] that
     * corresponds to [[org.bitcoins.rpc.client.common.BitcoindRpcClient]]
     */
   def getBitcoindPeer(bitcoindRpcClient: BitcoindRpcClient)(implicit

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -1,9 +1,8 @@
 package org.bitcoins.testkit.node
 
 import akka.actor.ActorSystem
-import org.bitcoins.core.api.node.NodeType
+import org.bitcoins.core.api.node.{NodeType, Peer}
 import org.bitcoins.node.Node
-import org.bitcoins.node.models.Peer
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.node.NodeUnitTest

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -3,10 +3,9 @@ package org.bitcoins.testkit.node
 import akka.actor.ActorSystem
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.node.NodeType
+import org.bitcoins.core.api.node.{NodeType, Peer}
 import org.bitcoins.node._
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.models.Peer
 import org.bitcoins.node.networking.peer._
 import org.bitcoins.rpc.client.common.BitcoindVersion.V22
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}

--- a/tor/src/main/scala/org/bitcoins/tor/Socks5ClientTransport.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/Socks5ClientTransport.scala
@@ -13,6 +13,7 @@ import akka.stream.stage._
 import akka.stream.{Attributes, BidiShape, Inlet, Outlet}
 import akka.util.ByteString
 import grizzled.slf4j.Logging
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.util.NetworkUtil
 
 import java.net.{InetSocketAddress, URI}

--- a/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
@@ -2,10 +2,11 @@ package org.bitcoins.tor.client
 
 import grizzled.slf4j.Logging
 import org.bitcoins.commons.util.NativeProcessFactory
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.util.EnvUtil
 import org.bitcoins.tor.TorProtocolHandler._
 import org.bitcoins.tor.config.TorAppConfig
-import org.bitcoins.tor.{Socks5ProxyParams, TorParams}
+import org.bitcoins.tor.{TorParams}
 
 import java.io.{File, FileNotFoundException}
 import java.net.{InetAddress, InetSocketAddress}

--- a/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/config/TorAppConfig.scala
@@ -4,10 +4,11 @@ import com.typesafe.config.Config
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.commons.config.{AppConfig, AppConfigFactory, ConfigOps}
 import org.bitcoins.core.api.CallbackConfig
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.tor.TorProtocolHandler.{Password, SafeCookie}
 import org.bitcoins.tor.client.TorClient
-import org.bitcoins.tor.{Socks5ProxyParams, TorCallbacks, TorParams}
+import org.bitcoins.tor.{TorCallbacks, TorParams}
 
 import java.io.File
 import java.net.{InetAddress, InetSocketAddress}


### PR DESCRIPTION
When working on #5136 I realized the `Socks5ProxyParams`, `Credentials`, and `Peer` data structures would be very useful to have in `core` module rather than `tor` / `node` modules so that they can be used cross module without explicitly depending on `node` / `tor`. 

The diff is very large since these data structures are used across the codebase.