### PR TITLE
Make sure `PeerData.stop()` is called  when `PeerFinder.removePeer()` is called

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -191,7 +191,7 @@ case class PeerFinder(
     for {
       _ <- initPeerF
       peerFinder <- peerDiscoveryF
-      _ = logger.info(s"Done stopping PeerFinder")
+      _ = logger.info(s"Done starting PeerFinder")
     } yield peerFinder
   }
 
@@ -220,7 +220,10 @@ case class PeerFinder(
         .retryUntilSatisfied(_peerData.isEmpty,
                              interval = 1.seconds,
                              maxTries = 30)
-    } yield this
+    } yield {
+      logger.info(s"Done stopping PeerFinder")
+      this
+    }
 
     stopF.failed.foreach { e =>
       logger.error(s"Failed to stop peer finder. Peers: ${_peerData.map(_._1)}",

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -188,7 +188,11 @@ case class PeerFinder(
       initPeerF.map(_ => this)
     }
 
-    initPeerF.flatMap(_ => peerDiscoveryF)
+    for {
+      _ <- initPeerF
+      peerFinder <- peerDiscoveryF
+      _ = logger.info(s"Done stopping PeerFinder")
+    } yield peerFinder
   }
 
   def reconnect(peer: Peer): Future[Unit] = {
@@ -203,6 +207,7 @@ case class PeerFinder(
   }
 
   override def stop(): Future[PeerFinder] = {
+    logger.info(s"Stopping PeerFinder")
     isStarted.set(false)
     //stop scheduler
     peerConnectionScheduler.cancel()
@@ -210,7 +215,7 @@ case class PeerFinder(
     _peersToTry.clear()
 
     val stopF = for {
-      _ <- Future.traverse(_peerData.map(_._2))(_.stop())
+      _ <- Future.traverse(_peerData.map(_._1))(removePeer(_))
       _ <- AsyncUtil
         .retryUntilSatisfied(_peerData.isEmpty,
                              interval = 1.seconds,
@@ -241,10 +246,13 @@ case class PeerFinder(
 
   }
 
-  def removePeer(peer: Peer): Unit = {
+  def removePeer(peer: Peer): Future[Unit] = {
     logger.debug(s"Removing peer $peer")
-    _peerData.remove(peer)
-    ()
+    val peerData = _peerData(peer)
+    peerData.stop().map { _ =>
+      _peerData.remove(peer) //peer must be a member of _peerData
+      ()
+    }
   }
 
   def setServiceIdentifier(

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -563,8 +563,7 @@ case class PeerManager(
 
         if (finder.hasPeer(peer)) {
           //client actor for one of the test peers stopped, can remove it from map now
-          finder.removePeer(peer)
-          Future.successful(state)
+          finder.removePeer(peer).map(_ => state)
         } else if (peerDataMap.contains(peer)) {
           //actor stopped for one of the persistent peers, can happen in case a reconnection attempt failed due to
           //reconnection tries exceeding the max limit in which the client was stopped to disconnect from it, remove it


### PR DESCRIPTION
fixes #5140 

- `PeerFinder.removePeer()` is called we make sure `PeerData.stop()` is called to ensure the peer is disconnected. 
- use `PeerFinder.removePeer()` inside of `PeerFinder.stop()` rather than calling `PeerData.stop()` directly.