### PR TITLE
Defensively try to sync everytime a peer is a initialized

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -533,12 +533,13 @@ case class PeerManager(
             _ <- sendAddrReq
             _ <- createInDb(peer, peerData.serviceIdentifier)
             _ <- managePeerF()
+            _ <- syncHelper(Some(peer))
           } yield state
 
         } else if (peerDataMap.contains(peer)) {
           //one of the persistent peers initialized again, this can happen in case of a reconnection attempt
           //which succeeded which is all good, do nothing
-          Future.successful(state)
+          syncHelper(Some(peer)).map(_ => state)
         } else {
           logger.warn(s"onInitialization called for unknown $peer")
           Future.successful(state)

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -44,8 +44,7 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
                                                             appConfig.chainConf,
                                                             appConfig.nodeConf)
         started <- node.start()
-        _ <- NodeUnitTest.syncNeutrinoNode(started, bitcoind)
-      } yield NeutrinoNodeConnectedWithBitcoind(node, bitcoind)
+      } yield NeutrinoNodeConnectedWithBitcoind(started, bitcoind)
     }
 
     makeDependentFixture[NeutrinoNodeConnectedWithBitcoind](
@@ -93,8 +92,7 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
           appConfig.chainConf,
           appConfig.nodeConf)
         startedNode <- node.start()
-        syncedNode <- NodeUnitTest.syncNeutrinoNode(startedNode, bitcoinds(0))
-      } yield NeutrinoNodeConnectedWithBitcoinds(syncedNode, bitcoinds)
+      } yield NeutrinoNodeConnectedWithBitcoinds(startedNode, bitcoinds)
     }
     makeDependentFixture[NeutrinoNodeConnectedWithBitcoinds](
       build = nodeWithBitcoindBuilder,


### PR DESCRIPTION
When working on #5148 it was realized we need to defensively attempt to sync with a peer is `Initialized` on our message queue. 

This was apparent in #5148 when working on connection/reconnection logic. After connecting / reconnecting we should always send a `getheaders` message to see what our peers best block is. Inside of requiring a call that looks like 

```scala
val node: NeutrinoNode = ???
for { 
  _ <- node.start()
  _ <- node.sync()
yield ()
```

we can now just do 

```scala
val node: NeutrinoNode = ???
for { 
  _ <- node.start() //will start syncing after initialization is complete
yield ()
```