### PR TITLE
Fix bug in `ChainApi.processFilterHeaders()`

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -382,7 +382,7 @@ class ChainHandler(
           this
         // Should never have the case where we have (Some, None) or (None, Some) because that means the vec would be both empty and non empty
         case (_, _) =>
-          logger.warn("Was unable to process any filters headers")
+          logger.debug("Processed 0 filter headers")
           this
       }
     }

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -176,7 +176,8 @@ case class BlockHeaderDAO()(implicit
   def getNAncestors(
       childHash: DoubleSha256DigestBE,
       n: Int): Future[Vector[BlockHeaderDb]] = {
-    logger.debug(s"Getting $n ancestors for blockhash=$childHash")
+    require(n >= 0, s"Cannot get negative ancestors, N=$n")
+    logger.trace(s"Getting $n ancestors for blockhash=$childHash")
     val headerOptF = findByHash(childHash)
     for {
       headerOpt <- headerOptF


### PR DESCRIPTION
Fixes bug in `processFilterHeaders()` where if we receive a batch that ONLY contains duplicate filter headers, we will throw an exception. This is because `getNAncestors` will always return the block header associated with the `childHash` param. This means if we have an entire batch of duplicate filter headers, and `stopHash` exists.