### PR TITLE
Implement logic to restart `PeerManager` in inactivity checks when we have 0 peers

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/node/Peer.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/Peer.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.api.node
 import org.bitcoins.core.api.db.DbRowAutoInc
 import org.bitcoins.core.api.tor.Socks5ProxyParams
 
-import java.net.InetSocketAddress
+import java.net.{InetSocketAddress, URI}
 
 case class Peer(
     socket: InetSocketAddress,
@@ -26,5 +26,12 @@ object Peer {
       socket: InetSocketAddress,
       socks5ProxyParams: Option[Socks5ProxyParams]): Peer = {
     Peer(socket, socks5ProxyParams = socks5ProxyParams)
+  }
+
+  def fromURI(
+      uri: URI,
+      socks5ProxyParamsOpt: Option[Socks5ProxyParams]): Peer = {
+    val socket = new InetSocketAddress(uri.getHost, uri.getPort)
+    fromSocket(socket, socks5ProxyParamsOpt)
   }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -80,6 +80,7 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
 
   it must "reconnect a peer when inactivity checks run and we have 0 peers" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoind =>
+      //see: https://github.com/bitcoin-s/bitcoin-s/issues/5162
       val bitcoind = nodeConnectedWithBitcoind.bitcoind
       val startedF =
         getSmallInactivityCheckNeutrinoNode(nodeConnectedWithBitcoind.node)
@@ -94,8 +95,6 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
         _ <- AsyncUtil.retryUntilSatisfiedF(
           () => started.getConnectionCount.map(_ == 0),
           1.second)
-
-        //how do i make sure the logic to reconnect does not take affect in onP2PClientDisconnected
 
         //wait until there is a timeout for inactivity
         _ <- AsyncUtil.retryUntilSatisfiedF(

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -12,6 +12,7 @@ import org.bitcoins.testkit.node.{
 }
 import org.scalatest.FutureOutcome
 
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
@@ -60,32 +61,8 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
 
   it must "disconnect a peer after a period of inactivity" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoind =>
-      //val bitcoind = nodeConnectedWithBitcoind.bitcoind
-      val initNode = nodeConnectedWithBitcoind.node
-
-      //make a custom config, set the inactivity timeout very low
-      //so we will disconnect our peer organically
-      val config =
-        ConfigFactory.parseString("bitcoin-s.node.inactivity-timeout=5s")
-      val stoppedConfigF = initNode.nodeConfig.stop()
-      val newNodeAppConfigF =
-        stoppedConfigF.map(_ => initNode.nodeConfig.withOverrides(config))
-      val nodeF = {
-        for {
-          newNodeAppConfig <- newNodeAppConfigF
-          _ <- newNodeAppConfig.start()
-        } yield {
-          NeutrinoNode(
-            walletCreationTimeOpt = initNode.walletCreationTimeOpt,
-            nodeConfig = newNodeAppConfig,
-            chainConfig = initNode.chainAppConfig,
-            actorSystem = initNode.system,
-            paramPeers = initNode.paramPeers
-          )
-        }
-      }
-
-      val startedF = nodeF.flatMap(_.start())
+      val startedF =
+        getSmallInactivityCheckNeutrinoNode(nodeConnectedWithBitcoind.node)
       for {
         started <- startedF
         _ <- AsyncUtil.retryUntilSatisfiedF(() =>
@@ -99,6 +76,64 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
       } yield {
         succeed
       }
+  }
 
+  it must "reconnect a peer when inactivity checks run and we have 0 peers" in {
+    nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoind =>
+      val bitcoind = nodeConnectedWithBitcoind.bitcoind
+      val startedF =
+        getSmallInactivityCheckNeutrinoNode(nodeConnectedWithBitcoind.node)
+      for {
+        started <- startedF
+        _ <- AsyncUtil.retryUntilSatisfiedF(() =>
+          started.getConnectionCount.map(_ == 1))
+        //explicitly disconnect it
+        bitcoindPeer <- NodeTestUtil.getBitcoindPeer(bitcoind)
+        _ <- started.peerManager.disconnectPeer(bitcoindPeer)
+        //wait until we have zero connections
+        _ <- AsyncUtil.retryUntilSatisfiedF(
+          () => started.getConnectionCount.map(_ == 0),
+          1.second)
+
+        //how do i make sure the logic to reconnect does not take affect in onP2PClientDisconnected
+
+        //wait until there is a timeout for inactivity
+        _ <- AsyncUtil.retryUntilSatisfiedF(
+          () => started.getConnectionCount.map(_ == 1),
+          1.second)
+        _ <- started.stop()
+        _ <- started.nodeConfig.stop()
+      } yield {
+        succeed
+      }
+  }
+
+  private def getSmallInactivityCheckNeutrinoNode(
+      initNode: NeutrinoNode): Future[NeutrinoNode] = {
+
+    //make a custom config, set the inactivity timeout very low
+    //so we will disconnect our peer organically
+    val config =
+      ConfigFactory.parseString("bitcoin-s.node.inactivity-timeout=5s")
+    val stoppedConfigF = initNode.nodeConfig.stop()
+    val newNodeAppConfigF =
+      stoppedConfigF.map(_ => initNode.nodeConfig.withOverrides(config))
+    val nodeF = {
+      for {
+        newNodeAppConfig <- newNodeAppConfigF
+        _ <- newNodeAppConfig.start()
+      } yield {
+        NeutrinoNode(
+          walletCreationTimeOpt = initNode.walletCreationTimeOpt,
+          nodeConfig = newNodeAppConfig,
+          chainConfig = initNode.chainAppConfig,
+          actorSystem = initNode.system,
+          paramPeers = initNode.paramPeers
+        )
+      }
+    }
+
+    val startedF = nodeF.flatMap(_.start())
+    startedF
   }
 }

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -54,7 +54,7 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="WARN"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="DEBUG"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
     <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
@@ -66,7 +66,7 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
+    <logger name="org.bitcoins.node.PeerManager" level="DEBUG"/>
 
     <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>
     <!-- ╔════════════════════╗ -->

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -54,7 +54,7 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="WARN"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="DEBUG"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="WARN"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
     <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="WARN"/>
@@ -66,7 +66,7 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="DEBUG"/>
+    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
 
     <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>
     <!-- ╔════════════════════╗ -->


### PR DESCRIPTION
fixes #5162 

In #5144 we implemented inactivity checks for peers we are connected to. This PR missed the case where we have 0 peers when our inactivity checks ran. This PR now restarts the `PeerManager` in the case where inactivity checks run and we have 0 peers.
