### PR TITLE
2023 07 31 fix filterheader sync bug

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -175,7 +175,7 @@ case class DataMessageHandler(
                 } yield {
                   filterSyncStateOpt match {
                     case Some(filterSyncState) => filterSyncState
-                    case None => DoneSyncing(filterHeaderSync.peers)
+                    case None                  => DoneSyncing(filterHeaderSync.peers)
                   }
                 }
               }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -153,9 +153,7 @@ case class DataMessageHandler(
             filterHeaderCount <- newChainApi.getFilterHeaderCount()
             blockCount <- blockCountF
             newState <-
-              if (
-                filterHeaders.size == chainConfig.filterHeaderBatchSize && blockCount != filterHeaderCount
-              ) {
+              if (blockCount != filterHeaderCount) {
                 logger.debug(
                   s"Received maximum amount of filter headers in one header message. This means we are not synced, requesting more")
                 sendNextGetCompactFilterHeadersCommand(


### PR DESCRIPTION
Found this bug while workign on #5172 

There is a bug on this line

https://github.com/bitcoin-s/bitcoin-s/blob/99ca1b7abfc9e18f5a428a5d0346badbb1d3682f/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala#L153

When the blockchain tip ends up being a multiple of `chainConfig.filterHeaderBatchSize` we don't start syncing compact filters thus stalling sync. 

Now we check if `compactFilterHeaderCount == blockCount` and if so, start syncing compact filters.