### PR TITLE
2023 08 01 issue 5174

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -280,7 +280,6 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       _ <- callbacksF
       node <- startedNodeF
       _ <- startedTorConfigF
-      _ <- node.sync()
     } yield {
       nodeOpt = Some(node)
       logger.info(

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -98,7 +98,7 @@ case class PersistentPeerData(
   * we do not want to be persistently connected to this peer, just see if
   * we can connect to it and exchange version/verack messages
   */
-case class QueriedPeerData(
+case class AttemptToConnectPeerData(
     peer: Peer,
     controlMessageHandler: ControlMessageHandler,
     queue: SourceQueueWithComplete[NodeStreamMessage],

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -152,7 +152,7 @@ case class PeerFinder(
               isConnectionSchedulerRunning.set(false)
             case Failure(err) =>
               isConnectionSchedulerRunning.set(false)
-              logger.error(
+              logger.debug(
                 s"Failed to connect to peers=$peers errMsg=${err.getMessage}")
           }
         } else {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -504,7 +504,7 @@ case class PeerManager(
           }
         }
       case q: AttemptToConnectPeerData =>
-        q.stop() //successfully queried, don't try to sync with it and just stop it
+        q.stop() //successfully connected, don't try to sync with it and just stop it
     }
 
   }

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -62,7 +62,9 @@ case class PeerManager(
     with SourceQueue[NodeStreamMessage]
     with P2PLogger {
   private val isStarted: AtomicBoolean = new AtomicBoolean(false)
-  private val _peerDataMap: mutable.Map[Peer, PeerData] = mutable.Map.empty
+
+  private val _peerDataMap: mutable.Map[Peer, PersistentPeerData] =
+    mutable.Map.empty
 
   /** holds peers removed from peerData whose client actors are not stopped yet. Used for runtime sanity checks. */
   private val _waitingForDisconnection: mutable.Set[Peer] = mutable.Set.empty
@@ -382,9 +384,10 @@ case class PeerManager(
     }
   }
 
-  private def peerDataMap: Map[Peer, PeerData] = _peerDataMap.toMap
+  private def peerDataMap: Map[Peer, PersistentPeerData] = _peerDataMap.toMap
 
-  def getPeerData(peer: Peer): Option[PeerData] = peerDataMap.get(peer)
+  def getPeerData(peer: Peer): Option[PersistentPeerData] =
+    peerDataMap.get(peer)
 
   override def stop(): Future[PeerManager] = {
     logger.info(s"Stopping PeerManager")
@@ -1082,7 +1085,7 @@ case class PeerManager(
   @volatile private[this] var inactivityCancellableOpt: Option[Cancellable] =
     None
 
-  private def inactivityChecks(peerData: PeerData): Future[Unit] = {
+  private def inactivityChecks(peerData: PersistentPeerData): Future[Unit] = {
     if (peerData.isConnectionTimedOut) {
       val stopF = peerData.stop()
       stopF

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -16,7 +16,12 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models._
 import org.bitcoins.node.networking.peer.NodeState._
 import org.bitcoins.node.util.PeerMessageSenderApi
-import org.bitcoins.node.{NodeStreamMessage, P2PLogger, PeerData, PeerManager}
+import org.bitcoins.node.{
+  NodeStreamMessage,
+  P2PLogger,
+  PeerManager,
+  PersistentPeerData
+}
 
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
@@ -54,7 +59,7 @@ case class DataMessageHandler(
 
   def handleDataPayload(
       payload: DataPayload,
-      peerData: PeerData): Future[DataMessageHandler] = {
+      peerData: PersistentPeerData): Future[DataMessageHandler] = {
     state match {
       case syncState: SyncNodeState =>
         syncState match {
@@ -118,7 +123,7 @@ case class DataMessageHandler(
     */
   private def handleDataPayloadValidState(
       payload: DataPayload,
-      peerData: PeerData): Future[DataMessageHandler] = {
+      peerData: PersistentPeerData): Future[DataMessageHandler] = {
     val peer = peerData.peer
     val wrappedFuture: Future[Future[DataMessageHandler]] = Future {
       payload match {
@@ -471,7 +476,7 @@ case class DataMessageHandler(
 
   /** Recover the data message handler if we received an invalid block header from a peer */
   private def recoverInvalidHeader(
-      peerData: PeerData): Future[DataMessageHandler] = {
+      peerData: PersistentPeerData): Future[DataMessageHandler] = {
     val result = state match {
       case state @ (HeaderSync(_, _) | DoneSyncing(_)) =>
         val peer = peerData.peer


### PR DESCRIPTION
fixes #5174 

In #5154 we introduced logic to start syncing block headers after we initialize a peer. In some cases, such as when just attempting to connect to a peer on the p2p network to see if its available, we don't want to try syncing. This PR introduces this feature.

We now have two classifications of `PeerData` 

- `PersistentPeerData` a peer we intend to be connected to persistently
- `AttemptToConnectPeerData` a peer we just attempt to connect to, and then will disconnect

In the case we have `AttemptToConnectPeerData`, we don't attempt to sync after the connection is established. This fixes #5174