### PR TITLE
Add `Await.result() `to inactivity check runnable to make sure it completes

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -46,7 +46,7 @@ import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Random
 
 case class PeerManager(
@@ -1099,6 +1099,8 @@ case class PeerManager(
     } yield syncPeerOpt
   }
 
+  private[this] val INACTIVITY_CHECK_TIMEOUT = 60.seconds
+
   @volatile private[this] var inactivityCancellableOpt: Option[Cancellable] =
     None
 
@@ -1129,7 +1131,7 @@ case class PeerManager(
     resultF.failed.foreach(err =>
       logger.error(s"Failed to run inactivity checks for peers=${peers}", err))
 
-    ()
+    Await.result(resultF, INACTIVITY_CHECK_TIMEOUT)
   }
 
   private def startInactivityChecksJob(): Cancellable = {


### PR DESCRIPTION
this should help debug #5196 

This will tell us if the `Future` is never completing, or if something else is going wrong in the disconnection logic.