### PR TITLE
Remove `Initialized` from `NodeStreamMessage`, return `Initialized `from `ControlMessageHandler`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
@@ -24,8 +24,6 @@ object NodeStreamMessage {
   case class DisconnectedPeer(peer: Peer, forceReconnect: Boolean)
       extends NodeStreamMessage
 
-  case class Initialized(peer: Peer) extends NodeStreamMessage
-
   case class InitializationTimeout(peer: Peer) extends NodeStreamMessage
 
   case class QueryTimeout(peer: Peer, payload: ExpectsResponse)
@@ -35,4 +33,6 @@ object NodeStreamMessage {
       extends NodeStreamMessage
 
   case class SendToPeer(msg: NetworkMessage, peerOpt: Option[Peer])
+
+  case class Initialized(peer: Peer)
 }

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -124,14 +124,13 @@ case class PeerFinder(
 
   private val maxPeerSearchCount: Int = 8
 
-  private val initialDelay: FiniteDuration = 30.minute
+  private val initialDelay: FiniteDuration = 5.minute
 
   private val isConnectionSchedulerRunning = new AtomicBoolean(false)
 
   private lazy val peerConnectionScheduler: Cancellable =
-    system.scheduler.scheduleWithFixedDelay(
-      initialDelay = initialDelay,
-      delay = nodeAppConfig.tryNextPeersInterval) { () =>
+    system.scheduler.scheduleWithFixedDelay(initialDelay = initialDelay,
+                                            delay = initialDelay) { () =>
       {
         if (isConnectionSchedulerRunning.compareAndSet(false, true)) {
           logger.info(s"Querying p2p network for peers...")

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -124,13 +124,13 @@ case class PeerFinder(
 
   private val maxPeerSearchCount: Int = 8
 
-  private val initialDelay: FiniteDuration = 5.minute
+  private val initialDelay: FiniteDuration = 30.minute
 
   private val isConnectionSchedulerRunning = new AtomicBoolean(false)
 
   private lazy val peerConnectionScheduler: Cancellable =
     system.scheduler.scheduleWithFixedDelay(initialDelay = initialDelay,
-                                            delay = initialDelay) { () =>
+                                            delay = nodeAppConfig.tryNextPeersInterval) { () =>
       {
         if (isConnectionSchedulerRunning.compareAndSet(false, true)) {
           logger.info(s"Querying p2p network for peers...")

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -129,8 +129,9 @@ case class PeerFinder(
   private val isConnectionSchedulerRunning = new AtomicBoolean(false)
 
   private lazy val peerConnectionScheduler: Cancellable =
-    system.scheduler.scheduleWithFixedDelay(initialDelay = initialDelay,
-                                            delay = nodeAppConfig.tryNextPeersInterval) { () =>
+    system.scheduler.scheduleWithFixedDelay(
+      initialDelay = initialDelay,
+      delay = nodeAppConfig.tryNextPeersInterval) { () =>
       {
         if (isConnectionSchedulerRunning.compareAndSet(false, true)) {
           logger.info(s"Querying p2p network for peers...")

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -762,7 +762,7 @@ case class PeerManager(
     SourceQueueWithComplete[NodeStreamMessage]] = {
     Source
       .queue[NodeStreamMessage](
-        10 * nodeAppConfig.maxConnectedPeers,
+        100 * nodeAppConfig.maxConnectedPeers,
         overflowStrategy = OverflowStrategy.backpressure,
         maxConcurrentOffers = Runtime.getRuntime.availableProcessors())
   }


### PR DESCRIPTION
fixes #5198 

This prevents the possibility of deadlocking our queue when tried to offer a `Initialized` message to the queue after receiving `verack` from our peer. 


