### PR TITLE
Rework handling of `BlockMessage`, fix bug where callbacks executed when they shouldn't have been

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -369,7 +369,8 @@ case class DataMessageHandler(
                   s"Received block=${block.blockHeader.hashBE.hex} while in IBD, ignoring it until IBD complete state=${state}.")
                 Future.successful(this)
               } else if (!isIBD && headerOpt.isEmpty) {
-                logger.info(s"Received block=${block.blockHeader.hash.flip.hex}, processing block's header... state=$state")
+                logger.info(
+                  s"Received block=${block.blockHeader.hash.flip.hex}, processing block's header... state=$state")
                 val headersMessage =
                   HeadersMessage(CompactSizeUInt.one, Vector(block.blockHeader))
                 val newDmhF = handleDataPayload(payload = headersMessage,


### PR DESCRIPTION
Fixes a small bug revealed in #5200 

Previously when receiving a `BlockMessage`, we could execute `onBlockReceived` callbacks while we are in still in IBD. This PR fixes this bug. We only execute `onBlockReceived` callbacks when we have already seen the block header associated with this the block we received. 