### PR TITLE
Reduce best filter height sql query costliness by using a cheap check

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
@@ -162,8 +162,11 @@ case class CompactFilterDAO()(implicit
     safeDatabase.run(bestFilterQuery).map(_.headOption)
   }
 
-  private val bestFilterHeightQuery = {
-    bestFilterQuery.map(_.headOption.map(_.height))
+  private val bestFilterHeightQuery: DBIOAction[
+    Option[Int],
+    NoStream,
+    Effect.Read] = {
+    table.map(_.height).max.result
   }
 
   def getBestFilterHeight: Future[Int] = {


### PR DESCRIPTION
In #2617 we decided to leverage `bestFilterQuery` to implement `bestFilterHeightQuery`.

It turns out `bestFilterQuery` is an expensive sql query. This PR makes `bestFilterHeightQuery` cheap in the database so that `chainApi.getFilterCount()` is much cheaper.