### PR TITLE
Add `java.instrument` to `jlink` dev builds

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -101,7 +101,7 @@ object CommonSettings {
     )
     val dev = {
       //needed for visualvm to profile/debug apps
-      Vector("jdk.management.agent")
+      Vector("jdk.management.agent", "java.instrument")
     }
     if (!isCI) base ++ dev
     else base


### PR DESCRIPTION
Follow up on #5115 

When attempting to profile jdbc sql queries we need acces to the `java.instrument` module in our jre. This PR adds `java.instrument` for dev builds. 