### PR TITLE
remove usages of `new URL()` as constructor is deprecated on jdk 20+

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonReaders.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonReaders.scala
@@ -83,7 +83,7 @@ object JsonReaders {
   implicit object URLReads extends Reads[URL] {
 
     override def reads(json: JsValue): JsResult[URL] =
-      SerializerUtil.processJsString[URL](str => new URL(str))(json)
+      SerializerUtil.processJsString[URL](str => new URI(str).toURL)(json)
   }
 
   implicit object ZonedDateTimeReads extends Reads[ZonedDateTime] {

--- a/lnurl/src/main/scala/org/bitcoins/lnurl/LnURL.scala
+++ b/lnurl/src/main/scala/org/bitcoins/lnurl/LnURL.scala
@@ -5,7 +5,7 @@ import org.bitcoins.core.util._
 import org.bitcoins.crypto.StringFactory
 import scodec.bits.ByteVector
 
-import java.net.URL
+import java.net.{URI, URL}
 import scala.util.{Failure, Success, Try}
 
 class LnURL private (private val str: String) {
@@ -13,7 +13,7 @@ class LnURL private (private val str: String) {
   val url: URL = LnURL.decode(str) match {
     case Failure(_) =>
       throw new IllegalArgumentException("Invalid LnURL encoding")
-    case Success(value) => new URL(value)
+    case Success(value) => new URI(value).toURL
   }
 
   override def toString: String = str.toUpperCase


### PR DESCRIPTION
https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/net/URL.html#constructor-deprecation