### PR TITLE
2023 09 04 wssource backpressure

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -661,7 +661,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
   private def buildWsSource: (
       SourceQueueWithComplete[WsNotification[_]],
       Source[WsNotification[_], NotUsed]) = {
-    val maxBufferSize: Int = 25
+    val maxBufferSize: Int = 16
 
     /** This will queue [[maxBufferSize]] elements in the queue. Once the buffer size is reached,
       * we will drop the first element in the buffer

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -671,8 +671,8 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
       //the BroadcastHub.sink is needed to avoid these errors
       // 'Websocket handler failed with Processor actor'
       Source
-        .queue[WsNotification[_]](maxBufferSize, OverflowStrategy.dropHead)
-        .toMat(BroadcastHub.sink)(Keep.both)
+        .queue[WsNotification[_]](maxBufferSize, OverflowStrategy.backpressure)
+        .toMat(BroadcastHub.sink(maxBufferSize))(Keep.both)
         .run()
     }
 


### PR DESCRIPTION
Related to #5212 but doesn't necessarily fix it. This specifies a bufferSize for `BroadcastHub.sink()` that is the same as the queue buffer size. 

This also changes the OverflowStrategy from `dropNew` -> `backpressure`. This could lead to `OutOfMemory` errors as talked about in #5216 , but it doesn't seem to make things any worse than they already are. We don't want to drop data for our internal callback system as our wallet depends on this to make sure we are synced with the network correctly.