### PR TITLE
Optimize `bestFilterHeaderHeightQuery`

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -156,13 +156,14 @@ case class CompactFilterHeaderDAO()(implicit
     safeDatabase.run(bestFilterHeaderQuery).map(_.headOption)
   }
 
-  private val bestFilterHeaderHeightQuery = {
-    bestFilterHeaderQuery.map(_.headOption.map(_.height))
+  private val bestFilterHeaderHeightQuery: Rep[Option[Int]] = {
+    table.map(_.height).max
   }
 
   def getBestFilterHeaderHeight: Future[Int] = {
-    safeDatabase.run(bestFilterHeaderHeightQuery).map { filterHeaderHeightOpt =>
-      filterHeaderHeightOpt.getOrElse(0)
+    safeDatabase.run(bestFilterHeaderHeightQuery.result).map {
+      filterHeaderHeightOpt =>
+        filterHeaderHeightOpt.getOrElse(0)
     }
   }
 


### PR DESCRIPTION
Follow up on #5206 

Applies the same technique to filter headers rather than just filters.