### PR TITLE
Reduce `NodeCallbackStreamManager` to 32 to reduce chance of `OOM` errors

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class NodeCallbackStreamManager(
     callbacks: NodeCallbacks,
     overflowStrategy: OverflowStrategy = OverflowStrategy.backpressure,
-    maxBufferSize: Int = 1000)(implicit system: ActorSystem)
+    maxBufferSize: Int = 32)(implicit system: ActorSystem)
     extends NodeCallbacks
     with StartStopAsync[Unit]
     with Logging {


### PR DESCRIPTION
fixes #5216