### PR TITLE
Reduce NodeCallbackStreamManager from `32` -> `16`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class NodeCallbackStreamManager(
     callbacks: NodeCallbacks,
     overflowStrategy: OverflowStrategy = OverflowStrategy.backpressure,
-    maxBufferSize: Int = 32)(implicit system: ActorSystem)
+    maxBufferSize: Int = 16)(implicit system: ActorSystem)
     extends NodeCallbacks
     with StartStopAsync[Unit]
     with Logging {


### PR DESCRIPTION
This has a couple benefits: 

1. We can drain the network queue faster in case shutdown is requested. This means we will only have to process 16 p2p messages rather than 32
2. Reduces the chance of `OutOfMemory` errors (#5216 ) when doing initial block download with a wallet with a lot of utxos.

In general, this means bitcoin-s can operate with smaller heap sizes. I've tried this with existing wallets with `-Xmx1g` heap. We should probably consider making this configurable via `bitcoin-s.conf` in the future.