### PR TITLE
reduce default `bitcoin-s.chain.neutrino.filter-batch-size` to `250`

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -97,7 +97,7 @@ bitcoin-s {
       # to keep the sync time fast, however, for regtest it should be small
       # so it does not exceed the chain size.
 
-      filter-batch-size = 1000
+      filter-batch-size = 100
 
 
     }

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -97,7 +97,7 @@ bitcoin-s {
       # to keep the sync time fast, however, for regtest it should be small
       # so it does not exceed the chain size.
 
-      filter-batch-size = 100
+      filter-batch-size = 250
 
 
     }


### PR DESCRIPTION
Before #5206 #5223 we use to be extremely slow at processing block filters due to slow sql queries. The thinking in #2568 was to batch filters in memory and then send a large batch of them to the database to reduce the amount of time it takes to process them.

Now that we have improved performance, we can process smaller batches of filters. This is better because

1. It requires less memory making the likelihood of OOM (#5216) occurring less.
2. It allows us to clear our `NodeCallbackStreamManager` queue faster when shutdown is requested during initial block download
