### PR TITLE
Adjust so that requery in the case were we have just 1 peer

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -500,8 +500,11 @@ case class DataMessageHandler(
                   queryF.map(_ => HeaderSync(newPeer, state.peers))
                 case None =>
                   logger.warn(
-                    s"Received invalid header from peer=$peer. Only have 1 peer so cannot re-query, state=$state")
-                  Future.successful(state)
+                    s"Received invalid header from peer=$peer. Only have 1 peer so re-querying from same peer, state=$state")
+                  val queryF = peerMessageSenderApi.sendGetHeadersMessage(
+                    cachedHeaders,
+                    Some(peer))
+                  queryF.map(_ => state)
               }
 
             }


### PR DESCRIPTION
fixes #5139 

Now we will re-query in the case where we have 1 peer. We will re-query the peer that sent us the invalid headers message.

This is useful for the case where we finish IBD, but multiple blocks have occurred since we seen our last header. Now when our peer gossips us a block mined on the network, we will fail to add it to the chain. This means we have received an invalid header, and we will re-send `getheaders` to the peer we are connect to. Then our peer will send us the headers we missed on the network while IBD was ongoing.