### PR TITLE
Fix chain fixtures to use `ChainHandler` rather than always using `ChainHandlerCached`

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -216,7 +216,6 @@ trait ChainUnitTest
 
   def createChainHandlerWithGenesisFilter(): Future[ChainHandler] = {
     for {
-      _ <- cachedChainConf.start()
       chainHandler <- createChainHandler()
       filterHeaderChainApi <- chainHandler.processFilterHeader(
         ChainTestUtil.genesisFilterHeaderDb.filterHeader,


### PR DESCRIPTION
Realized this when working on #5017 


We should use `ChainHandler` for our test fixtures unless we explicity request a `ChainHandlerCached`