### PR TITLE
Move initialization of sync into PeerManager's queue

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -63,7 +63,7 @@ case class NeutrinoNode(
       peerManager.randomPeerWithService(serviceIdentifier).isDefined)
     for {
       _ <- peerAvailableF
-      _ <- peerManager.syncHelper(None)
+      _ <- peerManager.sync(None)
     } yield ()
   }
 

--- a/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
@@ -32,6 +32,7 @@ object NodeStreamMessage {
   case class SendResponseTimeout(peer: Peer, payload: NetworkPayload)
       extends NodeStreamMessage
 
+  case class StartSync(peerOpt: Option[Peer]) extends NodeStreamMessage
   case class SendToPeer(msg: NetworkMessage, peerOpt: Option[Peer])
 
   case class Initialized(peer: Peer)


### PR DESCRIPTION
This is necessary for a few other PRs.

We are trying to internalize all node state into `PeerManager`'s stream.