### PR TITLE
2023 10 03 node refactors

### DIFF
--- a/app/scripts/src/main/resources/logback.xml
+++ b/app/scripts/src/main/resources/logback.xml
@@ -61,7 +61,7 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerConnection" level="INFO"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
     <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>

--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -64,7 +64,7 @@
     <logger name="org.bitcoins.node.networking.peer.PeerMessageReceiver" level="INFO"/>
 
     <!-- See outgoing message names and the peer it's sent to -->
-    <logger name="org.bitcoins.node.networking.peer.PeerMessageSender" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerConnection" level="INFO"/>
 
     <!-- Inspect handling of headers and inventory messages  -->
     <logger name="org.bitcoins.node.networking.peer.DataMessageHandler" level="INFO"/>

--- a/core/src/main/scala/org/bitcoins/core/api/node/PeerManagerApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/PeerManagerApi.scala
@@ -27,4 +27,5 @@ trait PeerManagerApi {
   def gossipGetHeadersMessage(
       hashes: Vector[DoubleSha256DigestBE]): Future[Unit]
 
+  def sendToRandomPeer(payload: NetworkPayload): Future[Unit]
 }

--- a/core/src/main/scala/org/bitcoins/core/api/node/PeerManagerApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/PeerManagerApi.scala
@@ -21,7 +21,9 @@ trait PeerManagerApi {
   def isInitialized(peer: Peer): Future[Boolean]
 
   /** Gossips the given message to all peers except the excluded peer. If None given as excluded peer, gossip message to all peers */
-  def gossipMessage(msg: NetworkPayload, excludedPeerOpt: Option[Peer]): Future[Unit]
+  def gossipMessage(
+      msg: NetworkPayload,
+      excludedPeerOpt: Option[Peer]): Future[Unit]
 
   /** Gossips the [[org.bitcoins.core.p2p.GetHeadersMessage]] to all of our peers to attempt ot get the best block headers */
   def gossipGetHeadersMessage(

--- a/core/src/main/scala/org/bitcoins/core/api/node/PeerManagerApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/PeerManagerApi.scala
@@ -1,5 +1,8 @@
 package org.bitcoins.core.api.node
 
+import org.bitcoins.core.p2p.NetworkPayload
+import org.bitcoins.crypto.DoubleSha256DigestBE
+
 import scala.concurrent.Future
 
 trait PeerManagerApi {
@@ -16,5 +19,12 @@ trait PeerManagerApi {
   def isDisconnected(peer: Peer): Future[Boolean]
 
   def isInitialized(peer: Peer): Future[Boolean]
+
+  /** Gossips the given message to all peers except the excluded peer. If None given as excluded peer, gossip message to all peers */
+  def gossipMessage(msg: NetworkPayload, peers: Option[Peer]): Future[Unit]
+
+  /** Gossips the [[org.bitcoins.core.p2p.GetHeadersMessage]] to all of our peers to attempt ot get the best block headers */
+  def gossipGetHeadersMessage(
+      hashes: Vector[DoubleSha256DigestBE]): Future[Unit]
 
 }

--- a/core/src/main/scala/org/bitcoins/core/api/node/PeerManagerApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/PeerManagerApi.scala
@@ -21,7 +21,7 @@ trait PeerManagerApi {
   def isInitialized(peer: Peer): Future[Boolean]
 
   /** Gossips the given message to all peers except the excluded peer. If None given as excluded peer, gossip message to all peers */
-  def gossipMessage(msg: NetworkPayload, peers: Option[Peer]): Future[Unit]
+  def gossipMessage(msg: NetworkPayload, excludedPeerOpt: Option[Peer]): Future[Unit]
 
   /** Gossips the [[org.bitcoins.core.p2p.GetHeadersMessage]] to all of our peers to attempt ot get the best block headers */
   def gossipGetHeadersMessage(

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -52,11 +52,12 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         peer = node.peerManager.peers.head
         chainApi <- node.chainApiFromDb()
         _ = require(peerManager.getPeerData(peer).isDefined)
+        peerMsgSender = peerManager.getPeerData(peer).get.peerMessageSender
         dataMessageHandler = DataMessageHandler(
           chainApi = chainApi,
           walletCreationTimeOpt = None,
-          queue = peerManager.dataMessageQueueOpt.get,
-          peerMessageSenderApi = peerManager,
+          peerMessageSenderApi = peerMsgSender,
+          peerManager = peerManager,
           state = HeaderSync(peer, peerManager.peers, Set.empty)
         )(node.executionContext, node.nodeAppConfig, node.chainConfig)
 

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -31,8 +31,8 @@ sealed trait PeerData {
     peerMessageSender.disconnect()
   }
 
-  val peerMessageSender: PeerMessageSender = {
-    PeerMessageSender(peer, queue, peerMessageSenderApi)
+  val peerMessageSender: PeerConnection = {
+    PeerConnection(peer, queue, peerMessageSenderApi)
   }
 
   private[this] var _serviceIdentifier: Option[ServiceIdentifier] = None

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -28,10 +28,10 @@ sealed trait PeerData {
   def peerMessageSenderApi: PeerMessageSenderApi
 
   def stop(): Future[Unit] = {
-    peerMessageSender.disconnect()
+    peerConnection.disconnect()
   }
 
-  val peerMessageSender: PeerConnection = {
+  val peerConnection: PeerConnection = {
     PeerConnection(peer, queue, peerMessageSenderApi)
   }
 
@@ -74,7 +74,7 @@ case class PersistentPeerData(
     lastTimedOut = System.currentTimeMillis()
   }
 
-  def isConnectionTimedOut: Boolean = peerMessageSender.isConnectionTimedOut
+  def isConnectionTimedOut: Boolean = peerConnection.isConnectionTimedOut
 
   /** returns true if the peer has failed due to any reason within the past 30 minutes
     */

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -249,7 +249,7 @@ case class PeerFinder(
   }
 
   private def tryToReconnectPeer(peer: Peer): Future[Unit] = {
-    val peerConnection = _peerData(peer).peerConnection
+    val peerConnection = PeerConnection(peer, peerManager)
     val peerMessageSender = PeerMessageSender(peerConnection)
     _peerData.put(peer,
                   PersistentPeerData(peer, peerManager, peerMessageSender))

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -239,7 +239,7 @@ case class PeerFinder(
                                            controlMessageHandler,
                                            queue,
                                            peerMessageSenderApi))
-    _peerData(peer).peerMessageSender.connect()
+    _peerData(peer).peerConnection.connect()
   }
 
   /** creates and initialises a new test peer */
@@ -250,7 +250,7 @@ case class PeerFinder(
                                      controlMessageHandler,
                                      queue,
                                      peerMessageSenderApi))
-    _peerData(peer).peerMessageSender.connect()
+    _peerData(peer).peerConnection.connect()
   }
 
   private def tryToReconnectPeer(peer: Peer): Future[Unit] = {
@@ -259,7 +259,7 @@ case class PeerFinder(
                                      controlMessageHandler,
                                      queue,
                                      peerMessageSenderApi))
-    _peerData(peer).peerMessageSender.reconnect()
+    _peerData(peer).peerConnection.reconnect()
 
   }
 

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -1072,6 +1072,13 @@ case class PeerManager(
     gossipMessage(msg = headersMsg, excludedPeerOpt = None)
   }
 
+  def gossipGetHeadersMessage(
+      hashes: Vector[DoubleSha256DigestBE],
+      excludedPeerOpt: Option[Peer]): Future[Unit] = {
+    val headersMsg = GetHeadersMessage(hashes.distinct.take(101).map(_.flip))
+    gossipMessage(msg = headersMsg, excludedPeerOpt = excludedPeerOpt)
+  }
+
   override def sendToRandomPeer(payload: NetworkPayload): Future[Unit] = {
     val randomPeerOpt = randomPeerMsgSender(
       ServiceIdentifier.NODE_COMPACT_FILTERS)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -1067,13 +1067,6 @@ case class PeerManager(
     gossipMessage(msg = headersMsg, excludedPeerOpt = None)
   }
 
-  def gossipGetHeadersMessage(
-      hashes: Vector[DoubleSha256DigestBE],
-      excludedPeerOpt: Option[Peer]): Future[Unit] = {
-    val headersMsg = GetHeadersMessage(hashes.distinct.take(101).map(_.flip))
-    gossipMessage(msg = headersMsg, excludedPeerOpt = excludedPeerOpt)
-  }
-
   override def sendToRandomPeer(payload: NetworkPayload): Future[Unit] = {
     val randomPeerOpt = randomPeerConnection(
       ServiceIdentifier.NODE_COMPACT_FILTERS)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -150,7 +150,7 @@ case class PeerManager(
   }
 
   private def getPeerMsgSender(peer: Peer): Option[PeerConnection] = {
-    _peerDataMap.find(_._1 == peer).map(_._2.peerMessageSender) match {
+    _peerDataMap.find(_._1 == peer).map(_._2.peerConnection) match {
       case Some(peerMsgSender) => Some(peerMsgSender)
       case None                => None
     }
@@ -178,7 +178,7 @@ case class PeerManager(
     val randomPeerOpt = randomPeerWithService(services)
     randomPeerOpt match {
       case Some(peer) =>
-        val p = peerDataMap(peer).peerMessageSender
+        val p = peerDataMap(peer).peerConnection
         Some(p)
       case None => None
     }
@@ -309,7 +309,7 @@ case class PeerManager(
   def isConnected(peer: Peer): Future[Boolean] = {
     peerDataMap.get(peer) match {
       case None    => Future.successful(false)
-      case Some(p) => p.peerMessageSender.isConnected()
+      case Some(p) => p.peerConnection.isConnected()
     }
   }
 
@@ -400,7 +400,7 @@ case class PeerManager(
         if (finder.hasPeer(peer)) {
           //one of the peers we tries got initialized successfully
           val peerData = finder.getData(peer).get
-          val peerMsgSender = PeerMessageSender(peerData.peerMessageSender)
+          val peerMsgSender = PeerMessageSender(peerData.peerConnection)
           val serviceIdentifer = peerData.serviceIdentifier
           val hasCf = serviceIdentifer.nodeCompactFilters
           logger.debug(s"Initialized peer $peer with $hasCf")
@@ -1036,7 +1036,7 @@ case class PeerManager(
     } else {
       Future
         .traverse(gossipPeers) { p =>
-          val sender = PeerMessageSender(p.peerMessageSender)
+          val sender = PeerMessageSender(p.peerConnection)
           sender.sendMsg(msg)
         }
         .map(_ => ())

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -405,12 +405,11 @@ case class PeerManager(
           logger.debug(s"Initialized peer $peer with $hasCf")
 
           for {
+            _ <- peerMsgSender.sendGetAddrMessage()
+            _ <- createInDb(peer, peerData.serviceIdentifier)
             _ <- managePeerAfterInitialization(finder = finder,
                                                peerData = peerData,
                                                hasCf = hasCf)
-            _ <- peerMsgSender.sendGetAddrMessage()
-            _ <- createInDb(peer, peerData.serviceIdentifier)
-
           } yield state
 
         } else if (peerDataMap.contains(peer)) {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -21,7 +21,7 @@ import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.BlockHeaderDAO
-import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
+import org.bitcoins.core.api.chain.{ChainApi}
 import org.bitcoins.core.api.chain.db.{
   BlockHeaderDb,
   CompactFilterDb,
@@ -35,7 +35,6 @@ import org.bitcoins.core.api.node.{
   SyncNodeState
 }
 import org.bitcoins.core.p2p._
-import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.{NetworkUtil, StartStopAsync}
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.config.NodeAppConfig
@@ -64,7 +63,6 @@ case class PeerManager(
     chainAppConfig: ChainAppConfig)
     extends StartStopAsync[PeerManager]
     with PeerManagerApi
-    with PeerMessageSenderApi
     with SourceQueue[NodeStreamMessage]
     with P2PLogger {
   private val isStarted: AtomicBoolean = new AtomicBoolean(false)
@@ -108,135 +106,6 @@ case class PeerManager(
 
   override def peers: Set[Peer] = _peerDataMap.keys.toSet
 
-  override def sendMsg(
-      msg: NetworkPayload,
-      peerOpt: Option[Peer]): Future[Unit] = {
-    val networkMessage = NetworkMessage(nodeAppConfig.network, msg)
-
-    val sendToPeer = SendToPeer(networkMessage, peerOpt)
-    logger.debug(
-      s"Sending message ${sendToPeer.msg.payload.commandName} to peerOpt=${sendToPeer.peerOpt}")
-    val peerMsgSenderOpt: Option[PeerConnection] =
-      sendToPeer.peerOpt match {
-        case Some(peer) =>
-          getPeerMsgSender(peer) match {
-            case Some(peerMsgSender) => Some(peerMsgSender)
-            case None =>
-              sendToPeer.msg.payload match {
-                case _: ControlPayload =>
-                  //peer may not be fully initialized, we may be doing the handshake with a peer
-                  finderOpt.get
-                    .getData(peer)
-                    .map(_.peerMessageSender)
-                case _: DataPayload =>
-                  //peer must be fully initialized to send a data payload
-                  None
-              }
-          }
-        case None =>
-          randomPeerMsgSenderWithService(ServiceIdentifier.NODE_NETWORK)
-      }
-
-    peerMsgSenderOpt match {
-      case Some(peerMsgSender) =>
-        peerMsgSender
-          .sendMsg(sendToPeer.msg)
-      case None =>
-        val msg =
-          s"Cannot find peerOpt=${sendToPeer.peerOpt} in set of peers=$peers to send message=${sendToPeer.msg.payload.commandName} to. It may have been disconnected, or we have no peers."
-        logger.warn(msg)
-        Future.unit
-    }
-  }
-
-  /** Gossips the given message to all peers except the excluded peer. If None given as excluded peer, gossip message to all peers */
-  override def gossipMessage(
-      msg: NetworkPayload,
-      excludedPeerOpt: Option[Peer]): Future[Unit] = {
-    val gossipPeers = excludedPeerOpt match {
-      case Some(excludedPeer) =>
-        peerDataMap
-          .filterNot(_._1 == excludedPeer)
-          .map(_._1)
-      case None => peerDataMap.map(_._1)
-    }
-    if (gossipPeers.isEmpty) {
-      logger.warn(
-        s"We have 0 peers to gossip message=${msg.commandName} to peerDataMap=${peerDataMap
-          .map(_._1)}.")
-      Future.unit
-    } else {
-      Future
-        .traverse(gossipPeers) { p =>
-          sendMsg(msg, Some(p))
-        }
-        .map(_ => ())
-    }
-  }
-
-  override def sendGetHeadersMessage(
-      hashes: Vector[DoubleSha256DigestBE],
-      peerOpt: Option[Peer]): Future[Unit] = {
-    val headersMsg = GetHeadersMessage(hashes.distinct.take(101).map(_.flip))
-    sendMsg(headersMsg, peerOpt)
-  }
-
-  override def gossipGetHeadersMessage(
-      hashes: Vector[DoubleSha256DigestBE]): Future[Unit] = {
-    val headersMsg = GetHeadersMessage(hashes.distinct.take(101).map(_.flip))
-    gossipMessage(msg = headersMsg, excludedPeerOpt = None)
-  }
-
-  override def sendGetDataMessages(
-      typeIdentifier: TypeIdentifier,
-      hashes: Vector[DoubleSha256DigestBE],
-      peerOpt: Option[Peer]): Future[Unit] = {
-    val msg: NetworkPayload = {
-      val inventories =
-        hashes.map(hash => Inventory(typeIdentifier, hash.flip))
-      val message = GetDataMessage(inventories)
-      message
-    }
-
-    sendMsg(msg, peerOpt)
-  }
-
-  override def sendGetCompactFilterHeadersMessage(
-      filterSyncMarker: FilterSyncMarker,
-      peerOpt: Option[Peer]): Future[Unit] = {
-    val message =
-      GetCompactFilterHeadersMessage(if (filterSyncMarker.startHeight < 0) 0
-                                     else filterSyncMarker.startHeight,
-                                     filterSyncMarker.stopBlockHash)
-    sendMsg(message, peerOpt)
-  }
-
-  override def sendGetCompactFiltersMessage(
-      filterSyncMarker: FilterSyncMarker,
-      peer: Peer)(implicit ec: ExecutionContext): Future[Unit] = {
-    val message =
-      GetCompactFiltersMessage(if (filterSyncMarker.startHeight < 0) 0
-                               else filterSyncMarker.startHeight,
-                               filterSyncMarker.stopBlockHash)
-    logger.debug(s"Sending getcfilters=$message to peer ${peer}")
-    sendMsg(message, Some(peer)).map(_ => ())
-  }
-
-  override def sendInventoryMessage(
-      transactions: Vector[Transaction],
-      peerOpt: Option[Peer]): Future[Unit] = {
-    val inventories =
-      transactions.map(tx => Inventory(TypeIdentifier.MsgTx, tx.txId))
-    val message = InventoryMessage(inventories)
-    logger.trace(s"Sending inv=$message to peer=${peerOpt}")
-    peerOpt match {
-      case Some(_) =>
-        sendMsg(message, peerOpt)
-      case None =>
-        gossipMessage(msg = message, excludedPeerOpt = None)
-    }
-  }
-
   /** Starts sync compact filter headers.
     * Only starts syncing compact filters if our compact filter headers are in sync with block headers
     */
@@ -247,9 +116,14 @@ case class PeerManager(
       nodeState: SyncNodeState)(implicit
       chainAppConfig: ChainAppConfig): Future[Unit] = {
     val syncPeer = nodeState.syncPeer
+    val peerMsgSender = getPeerMsgSender(syncPeer) match {
+      case Some(conn) => PeerMessageSender(conn)
+      case None =>
+        sys.error(s"Could not find peer=$syncPeer")
+    }
     val sendCompactFilterHeaderMsgF =
       PeerManager.sendNextGetCompactFilterHeadersCommand(
-        peerMessageSenderApi = this,
+        peerMessageSenderApi = peerMsgSender,
         chainApi = chainApi,
         peer = syncPeer,
         filterHeaderBatchSize = chainAppConfig.filterHeaderBatchSize,
@@ -262,7 +136,7 @@ case class PeerManager(
       ) {
         PeerManager
           .sendNextGetCompactFilterCommand(
-            peerMessageSenderApi = this,
+            peerMessageSenderApi = peerMsgSender,
             chainApi = chainApi,
             filterBatchSize = chainAppConfig.filterBatchSize,
             startHeight = compactFilterStartHeight,
@@ -526,12 +400,13 @@ case class PeerManager(
         if (finder.hasPeer(peer)) {
           //one of the peers we tries got initialized successfully
           val peerData = finder.getData(peer).get
+          val peerMsgSender = PeerMessageSender(peerData.peerMessageSender)
           val serviceIdentifer = peerData.serviceIdentifier
           val hasCf = serviceIdentifer.nodeCompactFilters
           logger.debug(s"Initialized peer $peer with $hasCf")
 
           for {
-            _ <- sendGetAddrMessage(Some(peer))
+            _ <- peerMsgSender.sendGetAddrMessage()
             _ <- createInDb(peer, peerData.serviceIdentifier)
             _ <- managePeerAfterInitialization(finder = finder,
                                                peerData = peerData,
@@ -909,7 +784,10 @@ case class PeerManager(
       _ <- {
         syncPeerOpt match {
           case Some(peer) =>
-            sendGetHeadersMessage(cachedHeaders, Some(peer))
+            val peerMsgSender = PeerMessageSender(
+              getPeerMsgSender(peer).get
+            ) //check this .get
+            peerMsgSender.sendGetHeadersMessage(cachedHeaders)
           case None => gossipGetHeadersMessage(cachedHeaders)
         }
       }
@@ -1139,6 +1017,38 @@ case class PeerManager(
     } yield syncPeerOpt
   }
 
+  /** Gossips the given message to all peers except the excluded peer. If None given as excluded peer, gossip message to all peers */
+  override def gossipMessage(
+      msg: NetworkPayload,
+      excludedPeerOpt: Option[Peer]): Future[Unit] = {
+    val gossipPeers = excludedPeerOpt match {
+      case Some(excludedPeer) =>
+        peerDataMap
+          .filterNot(_._1 == excludedPeer)
+          .map(_._2)
+      case None => peerDataMap.map(_._2)
+    }
+    if (gossipPeers.isEmpty) {
+      logger.warn(
+        s"We have 0 peers to gossip message=${msg.commandName} to peerDataMap=${peerDataMap
+          .map(_._1)}.")
+      Future.unit
+    } else {
+      Future
+        .traverse(gossipPeers) { p =>
+          val sender = PeerMessageSender(p.peerMessageSender)
+          sender.sendMsg(msg)
+        }
+        .map(_ => ())
+    }
+  }
+
+  override def gossipGetHeadersMessage(
+      hashes: Vector[DoubleSha256DigestBE]): Future[Unit] = {
+    val headersMsg = GetHeadersMessage(hashes.distinct.take(101).map(_.flip))
+    gossipMessage(msg = headersMsg, excludedPeerOpt = None)
+  }
+
   private[this] val INACTIVITY_CHECK_TIMEOUT = 60.seconds
 
   @volatile private[this] var inactivityCancellableOpt: Option[Cancellable] =
@@ -1215,8 +1125,7 @@ object PeerManager extends Logging {
       res <- hashHeightOpt match {
         case Some(filterSyncMarker) =>
           peerMessageSenderApi
-            .sendGetCompactFilterHeadersMessage(filterSyncMarker,
-                                                Some(state.syncPeer))
+            .sendGetCompactFilterHeadersMessage(filterSyncMarker)
             .map(_ =>
               Some(
                 FilterHeaderSync(state.syncPeer,
@@ -1246,7 +1155,7 @@ object PeerManager extends Logging {
           logger.info(
             s"Requesting next compact filter headers from $filterSyncMarker with peer=$peer")
           peerMessageSenderApi
-            .sendGetCompactFilterHeadersMessage(filterSyncMarker, Some(peer))
+            .sendGetCompactFilterHeadersMessage(filterSyncMarker)
             .map(_ => true)
         case None =>
           Future.successful(false)
@@ -1271,7 +1180,7 @@ object PeerManager extends Logging {
             s"Requesting compact filters from $filterSyncMarker with peer=$peer")
 
           peerMessageSenderApi
-            .sendGetCompactFiltersMessage(filterSyncMarker, peer)
+            .sendGetCompactFiltersMessage(filterSyncMarker)
             .map(_ => true)
         case None =>
           Future.successful(false)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -116,7 +116,7 @@ case class PeerManager(
     val sendToPeer = SendToPeer(networkMessage, peerOpt)
     logger.debug(
       s"Sending message ${sendToPeer.msg.payload.commandName} to peerOpt=${sendToPeer.peerOpt}")
-    val peerMsgSenderOpt: Option[PeerMessageSender] =
+    val peerMsgSenderOpt: Option[PeerConnection] =
       sendToPeer.peerOpt match {
         case Some(peer) =>
           getPeerMsgSender(peer) match {
@@ -275,7 +275,7 @@ case class PeerManager(
     }
   }
 
-  private def getPeerMsgSender(peer: Peer): Option[PeerMessageSender] = {
+  private def getPeerMsgSender(peer: Peer): Option[PeerConnection] = {
     _peerDataMap.find(_._1 == peer).map(_._2.peerMessageSender) match {
       case Some(peerMsgSender) => Some(peerMsgSender)
       case None                => None
@@ -300,7 +300,7 @@ case class PeerManager(
   }
 
   private def randomPeerMsgSenderWithService(
-      services: ServiceIdentifier): Option[PeerMessageSender] = {
+      services: ServiceIdentifier): Option[PeerConnection] = {
     val randomPeerOpt = randomPeerWithService(services)
     randomPeerOpt match {
       case Some(peer) =>

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -1,18 +1,11 @@
 package org.bitcoins.node.networking.peer
 
-import akka.stream.scaladsl.SourceQueue
 import org.bitcoins.chain.blockchain.{DuplicateHeaders, InvalidBlockHeader}
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.chain.db.CompactFilterHeaderDb
-import org.bitcoins.core.api.node.{
-  NodeState,
-  NodeType,
-  Peer,
-  PeerManagerApi,
-  SyncNodeState
-}
+import org.bitcoins.core.api.node.{NodeState, NodeType, Peer, SyncNodeState}
 import org.bitcoins.core.gcs.{BlockFilter, GolombFilter}
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.protocol.CompactSizeUInt
@@ -22,12 +15,7 @@ import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models._
 import org.bitcoins.core.api.node.NodeState._
 import org.bitcoins.node.util.PeerMessageSenderApi
-import org.bitcoins.node.{
-  NodeStreamMessage,
-  P2PLogger,
-  PeerManager,
-  PersistentPeerData
-}
+import org.bitcoins.node.{P2PLogger, PeerManager, PersistentPeerData}
 
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
@@ -43,9 +31,8 @@ import scala.util.control.NonFatal
 case class DataMessageHandler(
     chainApi: ChainApi,
     walletCreationTimeOpt: Option[Instant],
-    queue: SourceQueue[NodeStreamMessage],
     peerMessageSenderApi: PeerMessageSenderApi,
-    peerManagerApi: PeerManagerApi,
+    peerManager: PeerManager,
     state: NodeState)(implicit
     ec: ExecutionContext,
     appConfig: NodeAppConfig,
@@ -482,7 +469,7 @@ case class DataMessageHandler(
                             syncNodeState.waitingForDisconnection)
             newState <- {
               if (isIBD) {
-                peerManagerApi
+                peerManager
                   .gossipGetHeadersMessage(Vector(bestBlockHash))
                   .map { _ =>
                     //set to done syncing since we are technically done with IBD

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -27,7 +27,7 @@ import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.node.NodeStreamMessage.DisconnectedPeer
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.constant.NodeConstants
-import org.bitcoins.node.networking.peer.PeerMessageSender.ConnectionGraph
+import org.bitcoins.node.networking.peer.PeerConnection.ConnectionGraph
 import org.bitcoins.node.util.PeerMessageSenderApi
 import org.bitcoins.node.{NodeStreamMessage, P2PLogger}
 import org.bitcoins.tor.Socks5Connection
@@ -39,7 +39,7 @@ import java.time.temporal.ChronoUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Future, Promise}
 
-case class PeerMessageSender(
+case class PeerConnection(
     peer: Peer,
     queue: SourceQueueWithComplete[NodeStreamMessage],
     peerMessageSenderApi: PeerMessageSenderApi)(implicit
@@ -401,7 +401,7 @@ case class PeerMessageSender(
   }
 }
 
-object PeerMessageSender {
+object PeerConnection {
 
   case class ConnectionGraph(
       mergeHubSink: Sink[ByteString, NotUsed],

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -1,0 +1,102 @@
+package org.bitcoins.node.networking.peer
+
+import org.bitcoins.core.api.chain.FilterSyncMarker
+import org.bitcoins.core.api.node.Peer
+import org.bitcoins.core.p2p.{
+  GetCompactFilterHeadersMessage,
+  GetCompactFiltersMessage,
+  GetDataMessage,
+  GetHeadersMessage,
+  InetAddress,
+  Inventory,
+  InventoryMessage,
+  NetworkMessage,
+  NetworkPayload,
+  TypeIdentifier,
+  VersionMessage
+}
+import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.node.NodeStreamMessage.SendToPeer
+import org.bitcoins.node.P2PLogger
+import org.bitcoins.node.config.NodeAppConfig
+import org.bitcoins.node.util.PeerMessageSenderApi
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class PeerMessageSender(peerConnection: PeerConnection)(implicit
+    nodeAppConfig: NodeAppConfig)
+    extends PeerMessageSenderApi
+    with P2PLogger {
+
+  private val peer: Peer = peerConnection.peer
+
+  override def sendMsg(msg: NetworkPayload): Future[Unit] = {
+    val networkMessage = NetworkMessage(nodeAppConfig.network, msg)
+
+    val sendToPeer = SendToPeer(networkMessage, Some(peer))
+    logger.debug(
+      s"Sending message ${sendToPeer.msg.payload.commandName} to peerOpt=${sendToPeer.peerOpt}")
+
+    peerConnection.sendMsg(msg)
+  }
+
+  override def sendGetHeadersMessage(
+      hashes: Vector[DoubleSha256DigestBE]): Future[Unit] = {
+    val headersMsg = GetHeadersMessage(hashes.distinct.take(101).map(_.flip))
+    sendMsg(headersMsg)
+  }
+
+  override def sendGetDataMessages(
+      typeIdentifier: TypeIdentifier,
+      hashes: Vector[DoubleSha256DigestBE]): Future[Unit] = {
+    val msg: NetworkPayload = {
+      val inventories =
+        hashes.map(hash => Inventory(typeIdentifier, hash.flip))
+      val message = GetDataMessage(inventories)
+      message
+    }
+
+    sendMsg(msg)
+  }
+
+  override def sendGetCompactFilterHeadersMessage(
+      filterSyncMarker: FilterSyncMarker): Future[Unit] = {
+    val message =
+      GetCompactFilterHeadersMessage(if (filterSyncMarker.startHeight < 0) 0
+                                     else filterSyncMarker.startHeight,
+                                     filterSyncMarker.stopBlockHash)
+    sendMsg(message)
+  }
+
+  override def sendGetCompactFiltersMessage(filterSyncMarker: FilterSyncMarker)(
+      implicit ec: ExecutionContext): Future[Unit] = {
+    val message =
+      GetCompactFiltersMessage(if (filterSyncMarker.startHeight < 0) 0
+                               else filterSyncMarker.startHeight,
+                               filterSyncMarker.stopBlockHash)
+    logger.debug(s"Sending getcfilters=$message to peer ${peer}")
+    sendMsg(message).map(_ => ())(ec)
+  }
+
+  override def sendInventoryMessage(
+      transactions: Vector[Transaction]): Future[Unit] = {
+    val inventories =
+      transactions.map(tx => Inventory(TypeIdentifier.MsgTx, tx.txId))
+    val message = InventoryMessage(inventories)
+    sendMsg(message)
+
+  }
+
+  /** Sends a [[org.bitcoins.core.p2p.VersionMessage VersionMessage]] to our peer */
+  override def sendVersionMessage()(implicit
+      conf: NodeAppConfig): Future[Unit] = {
+    val local = java.net.InetAddress.getLocalHost
+    val versionMsg = VersionMessage(
+      conf.network,
+      InetAddress(peer.socket.getAddress.getAddress),
+      InetAddress(local.getAddress),
+      relay = conf.relay)
+    sendMsg(versionMsg)
+  }
+}

--- a/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
@@ -1,7 +1,6 @@
 package org.bitcoins.node.util
 
 import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
-import org.bitcoins.core.api.node.{Peer}
 import org.bitcoins.core.number.Int32
 import org.bitcoins.core.p2p.{
   GetAddrMessage,
@@ -27,81 +26,53 @@ trait PeerMessageSenderApi {
 
   def sendGetDataMessage(
       typeIdentifier: TypeIdentifier,
-      hash: DoubleSha256DigestBE,
-      peerOpt: Option[Peer]): Future[Unit] = {
-    sendGetDataMessages(typeIdentifier, Vector(hash), peerOpt)
+      hash: DoubleSha256DigestBE): Future[Unit] = {
+    sendGetDataMessages(typeIdentifier, Vector(hash))
   }
 
   def sendGetDataMessages(
       typeIdentifier: TypeIdentifier,
-      hashes: Vector[DoubleSha256DigestBE],
-      peerOpt: Option[Peer]): Future[Unit]
-
-  def sendGetHeadersMessage(
-      hashes: Vector[DoubleSha256DigestBE],
-      peerOpt: Option[Peer]): Future[Unit]
-
-  /** Gossips the [[org.bitcoins.core.p2p.GetHeadersMessage]] to all of our peers to attempt ot get the best block headers */
-  def gossipGetHeadersMessage(
       hashes: Vector[DoubleSha256DigestBE]): Future[Unit]
 
-  def sendGetHeadersMessage(
-      lastHash: DoubleSha256DigestBE,
-      peerOpt: Option[Peer]): Future[Unit] = {
-    sendGetHeadersMessage(Vector(lastHash), peerOpt)
+  def sendGetHeadersMessage(hashes: Vector[DoubleSha256DigestBE]): Future[Unit]
+
+  def sendGetHeadersMessage(lastHash: DoubleSha256DigestBE): Future[Unit] = {
+    sendGetHeadersMessage(Vector(lastHash))
   }
 
-  /** Gossips the given message to all peers except the excluded peer. If None given as excluded peer, gossip message to all peers */
-  def gossipMessage(
-      msg: NetworkPayload,
-      excludedPeerOpt: Option[Peer]): Future[Unit]
-
-  def sendMsg(msg: NetworkPayload, peerOpt: Option[Peer]): Future[Unit]
+  def sendMsg(msg: NetworkPayload): Future[Unit]
 
   def sendGetCompactFilterHeadersMessage(
-      filterSyncMarker: FilterSyncMarker,
-      peerOpt: Option[Peer]): Future[Unit]
+      filterSyncMarker: FilterSyncMarker): Future[Unit]
 
-  def sendGetCompactFiltersMessage(
-      filterSyncMarker: FilterSyncMarker,
-      peer: Peer)(implicit ec: ExecutionContext): Future[Unit]
+  def sendGetCompactFiltersMessage(filterSyncMarker: FilterSyncMarker)(implicit
+      ec: ExecutionContext): Future[Unit]
 
-  def sendInventoryMessage(
-      transactions: Vector[Transaction],
-      peerOpt: Option[Peer]): Future[Unit]
+  def sendInventoryMessage(transactions: Vector[Transaction]): Future[Unit]
 
-  def sendSendAddrV2Message(peer: Peer): Future[Unit] = {
-    sendMsg(SendAddrV2Message, Some(peer))
+  def sendSendAddrV2Message(): Future[Unit] = {
+    sendMsg(SendAddrV2Message)
   }
 
-  def sendGetAddrMessage(peerOpt: Option[Peer]): Future[Unit] = {
-    sendMsg(GetAddrMessage, peerOpt)
+  def sendGetAddrMessage(): Future[Unit] = {
+    sendMsg(GetAddrMessage)
   }
 
   /** Responds to a ping message */
-  def sendPong(ping: PingMessage, peer: Peer): Future[Unit] = {
+  def sendPong(ping: PingMessage): Future[Unit] = {
     val pong = PongMessage(ping.nonce)
-    sendMsg(pong, Some(peer))
+    sendMsg(pong)
   }
 
-  def sendHeadersMessage(peer: Peer): Future[Unit] = {
+  def sendHeadersMessage(): Future[Unit] = {
     val sendHeadersMsg = SendHeadersMessage
-    sendMsg(sendHeadersMsg, Some(peer))
+    sendMsg(sendHeadersMsg)
   }
 
   /** Sends a [[org.bitcoins.core.p2p.VersionMessage VersionMessage]] to our peer */
-  def sendVersionMessage(peer: Peer)(implicit
-      conf: NodeAppConfig): Future[Unit] = {
-    val local = java.net.InetAddress.getLocalHost
-    val versionMsg = VersionMessage(
-      conf.network,
-      InetAddress(peer.socket.getAddress.getAddress),
-      InetAddress(local.getAddress),
-      relay = conf.relay)
-    sendMsg(versionMsg, Some(peer))
-  }
+  def sendVersionMessage()(implicit conf: NodeAppConfig): Future[Unit]
 
-  def sendVersionMessage(chainApi: ChainApi, peer: Peer)(implicit
+  def sendVersionMessage(chainApi: ChainApi)(implicit
       ec: ExecutionContext,
       conf: NodeAppConfig): Future[Unit] = {
     chainApi.getBestHashBlockHeight().flatMap { height =>
@@ -113,19 +84,17 @@ trait PeerMessageSenderApi {
                        InetAddress(localhost.getAddress),
                        InetAddress(localhost.getAddress),
                        conf.relay)
-      sendMsg(versionMsg, Some(peer))
+      sendMsg(versionMsg)
     }
   }
 
-  def sendVerackMessage(peer: Peer): Future[Unit] = {
+  def sendVerackMessage(): Future[Unit] = {
     val verackMsg = VerAckMessage
-    sendMsg(verackMsg, Some(peer))
+    sendMsg(verackMsg)
   }
 
-  def sendTransactionMessage(
-      transaction: Transaction,
-      peerOpt: Option[Peer]): Future[Unit] = {
+  def sendTransactionMessage(transaction: Transaction): Future[Unit] = {
     val message = TransactionMessage(transaction)
-    sendMsg(message, peerOpt)
+    sendMsg(message)
   }
 }


### PR DESCRIPTION
This PR is a grab bag of refactors: 

- Renames the old `PeerMessageSender` -> `PeerConnection`
- Creates a new `PeerMessageSender` that wraps `PeerConnection`
- Removes `peerOpt` parameters from `PeerMessageSenderApi`. Now `PeerMessageSenderApi` has a one to one relationship with a peer. Therefore if you are sending a `getdata` message, it will only be sent to 1 peer.
- Removes `gossip` messages from `PeerMessageSenderApi`, and moves them into `PeerManagerApi`