### PR TITLE
2023 10 16 Implement `WalletCallbackStreamManager,` `DLCWalletCallbackStreamManager`

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
@@ -41,7 +41,7 @@ import org.bitcoins.testkit.util.AkkaUtil
 import java.net.InetSocketAddress
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Future, Promise}
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
 
@@ -416,19 +416,7 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
 
     for {
       _ <- AkkaUtil.nonBlockingSleep(15.seconds)
-      _ = {
-        if (!promise.isCompleted) {
-          logger.error(s"@@@@@@@@@ promise not complete @@@@@@@@@")
-          promise.success(None)
-        } else {
-          promise.future.onComplete {
-            case Success(_) => logger.error(s"@@@@@@@@@ Success @@@@@@@@@")
-            case Failure(err) =>
-              logger.error(s"@@@@@@@@@ err=${err.getMessage} @@@@@@@@@", err)
-          }
-        }
-
-      }
+      _ = promise.success(None)
       notifications <- notificationsF
     } yield {
       val syncingNotifications =

--- a/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
@@ -50,7 +50,15 @@ import org.bitcoins.dlc.wallet.{
   OnDLCStateChange
 }
 import org.bitcoins.tor.{OnTorStarted, TorCallbacks}
-import org.bitcoins.wallet._
+import org.bitcoins.wallet.callback.{
+  OnFeeRateChanged,
+  OnNewAddressGenerated,
+  OnRescanComplete,
+  OnReservedUtxos,
+  OnTransactionBroadcast,
+  OnTransactionProcessed,
+  WalletCallbacks
+}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
@@ -44,7 +44,7 @@ import org.bitcoins.dlc.node.{
   OnSignFailed,
   OnSignSucceed
 }
-import org.bitcoins.dlc.wallet.{
+import org.bitcoins.dlc.wallet.callback.{
   DLCWalletCallbacks,
   OnDLCOfferAdd,
   OnDLCOfferRemove,

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
@@ -5,6 +5,7 @@ import org.bitcoins.core.protocol.dlc.models.{
   DLCStatus,
   SingleContractInfo
 }
+import org.bitcoins.dlc.wallet.callback.{DLCWalletCallbacks, OnDLCStateChange}
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
 import org.bitcoins.testkit.wallet.{BitcoinSDualWalletTest, DLCWalletUtil}
 import org.bitcoins.testkitcore.gen.CryptoGenerators

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -20,6 +20,7 @@ import org.bitcoins.core.protocol.tlv.DLCSerializationVersion
 import org.bitcoins.core.util.Mutable
 import org.bitcoins.db.DatabaseDriver._
 import org.bitcoins.db._
+import org.bitcoins.dlc.wallet.callback.DLCWalletCallbacks
 import org.bitcoins.dlc.wallet.internal.DLCDataManagement
 import org.bitcoins.dlc.wallet.models.{
   DLCSetupDbState,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -102,7 +102,7 @@ case class DLCAppConfig(
       case _: DLCWalletCallbacks =>
         Future.unit
     }
-    stopCallbacksF
+    stopCallbacksF.flatMap(_ => super.stop())
   }
 
   lazy val walletConf: WalletAppConfig =

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -488,7 +488,7 @@ abstract class DLCWallet
 
       _ <- safeDLCDatabase.run(offerActions)
       status <- findDLC(dlcId)
-      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, status.get)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(status.get)
     } yield offer
   }
 
@@ -714,7 +714,7 @@ abstract class DLCWallet
         }
       }
       status <- findDLC(dlcId)
-      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, status.get)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(status.get)
     } yield dlcAccept
   }
 
@@ -823,7 +823,7 @@ abstract class DLCWallet
             PayoutAddress(initializedAccept.pubKeys.payoutAddress,
                           isExternalAddress))
         )
-        _ = dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, status)
+        _ = dlcConfig.walletCallbacks.executeOnDLCStateChange(status)
         cetSigs <- signer.createCETSigsAsync()
         refundSig = signer.signRefundTx
         dlc = initializedAccept.dlc
@@ -1111,7 +1111,7 @@ abstract class DLCWallet
       _ <- updateDLCState(dlc.contractIdOpt.get, DLCState.Signed)
       _ = logger.info(s"DLC ${contractId.toHex} is signed")
       status <- findDLC(dlcId)
-      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, status.get)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(status.get)
     } yield {
       logger.info(
         s"Done creating sign message with contractId=${contractId.toHex} tempContractId=${dlc.tempContractId.hex}")
@@ -1137,8 +1137,7 @@ abstract class DLCWallet
       for {
         _ <- updatedF
         status <- findDLC(dlcDb.dlcId)
-        _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger,
-                                                               status.get)
+        _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(status.get)
         sigs <- signer.createCETSigsAsync()
 
         sigsDbs: Vector[DLCCETSignaturesDb] = sigs.outcomeSigs
@@ -1640,8 +1639,7 @@ abstract class DLCWallet
 
       _ <- processTransaction(tx, None)
       dlcStatusOpt <- findDLC(dlcId = dlcDb.dlcId)
-      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger,
-                                                             dlcStatusOpt.get)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(dlcStatusOpt.get)
     } yield tx
   }
 
@@ -1692,7 +1690,7 @@ abstract class DLCWallet
 
       _ <- processTransaction(refundTx, blockHashOpt = None)
       status <- findDLC(dlcDb.dlcId)
-      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, status.get)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(status.get)
     } yield refundTx
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/callback/DLCWalletCallbackStreamManager.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/callback/DLCWalletCallbackStreamManager.scala
@@ -32,7 +32,7 @@ case class DLCWalletCallbackStreamManager(
 
   private val stateChangeSink: Sink[DLCStatus, Future[Done]] = {
     Sink.foreachAsync(1) { case state =>
-      onStateChange.execute(state)
+      callbacks.executeOnDLCStateChange(state)
     }
   }
 
@@ -48,7 +48,7 @@ case class DLCWalletCallbackStreamManager(
 
   private val offerAddSink: Sink[IncomingDLCOfferDb, Future[Done]] = {
     Sink.foreachAsync(1) { case offer =>
-      onOfferAdd.execute(offer)
+      callbacks.executeOnDLCOfferAdd(offer)
     }
   }
 
@@ -57,14 +57,14 @@ case class DLCWalletCallbackStreamManager(
   }
 
   private val offerRemoveSource: Source[
-    IncomingDLCOfferDb,
-    SourceQueueWithComplete[IncomingDLCOfferDb]] = {
+    Sha256Digest,
+    SourceQueueWithComplete[Sha256Digest]] = {
     Source.queue(maxBufferSize, overflowStrategy)
   }
 
-  private val offerRemoveSink: Sink[IncomingDLCOfferDb, Future[Done]] = {
+  private val offerRemoveSink: Sink[Sha256Digest, Future[Done]] = {
     Sink.foreachAsync(1) { case offer =>
-      onOfferAdd.execute(offer)
+      callbacks.executeOnDLCOfferRemove(offer)
     }
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/callback/DLCWalletCallbackStreamManager.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/callback/DLCWalletCallbackStreamManager.scala
@@ -1,0 +1,125 @@
+package org.bitcoins.dlc.wallet.callback
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete}
+import grizzled.slf4j.{Logging}
+import org.bitcoins.core.api.CallbackHandler
+import org.bitcoins.core.api.dlc.wallet.db.IncomingDLCOfferDb
+import org.bitcoins.core.protocol.dlc.models.DLCStatus
+import org.bitcoins.core.util.StartStopAsync
+import org.bitcoins.crypto.Sha256Digest
+
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.{Future}
+
+case class DLCWalletCallbackStreamManager(
+    override val onStateChange: CallbackHandler[DLCStatus, OnDLCStateChange],
+    override val onOfferAdd: CallbackHandler[IncomingDLCOfferDb, OnDLCOfferAdd],
+    override val onOfferRemove: CallbackHandler[Sha256Digest, OnDLCOfferRemove],
+    overflowStrategy: OverflowStrategy = OverflowStrategy.backpressure,
+    maxBufferSize: Int = 16)(implicit system: ActorSystem)
+    extends DLCWalletCallbacks(onStateChange, onOfferAdd, onOfferRemove)
+    with StartStopAsync[Unit]
+    with Logging {
+
+  import system.dispatcher
+
+  private val stateChangeSource: Source[
+    DLCStatus,
+    SourceQueueWithComplete[DLCStatus]] = {
+    Source.queue(maxBufferSize, overflowStrategy)
+  }
+
+  private val stateChangeSink: Sink[DLCStatus, Future[Done]] = {
+    Sink.foreachAsync(1) { case state =>
+      onStateChange.execute(state)
+    }
+  }
+
+  private val (stateChangeQueue, stateChangeSinkCompleteF) = {
+    matSourceAndQueue(stateChangeSource, stateChangeSink)
+  }
+
+  private val offerAddSource: Source[
+    IncomingDLCOfferDb,
+    SourceQueueWithComplete[IncomingDLCOfferDb]] = {
+    Source.queue(maxBufferSize, overflowStrategy)
+  }
+
+  private val offerAddSink: Sink[IncomingDLCOfferDb, Future[Done]] = {
+    Sink.foreachAsync(1) { case offer =>
+      onOfferAdd.execute(offer)
+    }
+  }
+
+  private val (offerAddQueue, offerAddSinkCompleteF) = {
+    matSourceAndQueue(offerAddSource, offerAddSink)
+  }
+
+  private val offerRemoveSource: Source[
+    IncomingDLCOfferDb,
+    SourceQueueWithComplete[IncomingDLCOfferDb]] = {
+    Source.queue(maxBufferSize, overflowStrategy)
+  }
+
+  private val offerRemoveSink: Sink[IncomingDLCOfferDb, Future[Done]] = {
+    Sink.foreachAsync(1) { case offer =>
+      onOfferAdd.execute(offer)
+    }
+  }
+
+  private val (offerRemoveQueue, offerRemoveSinkCompleteF) = {
+    matSourceAndQueue(offerRemoveSource, offerRemoveSink)
+  }
+
+  override def +(other: DLCWalletCallbacks): DLCWalletCallbacks = {
+    val newCallbacks = other.+(this)
+    DLCWalletCallbacks(newCallbacks.onStateChange,
+                       newCallbacks.onOfferAdd,
+                       newCallbacks.onOfferRemove)
+  }
+
+  override def start(): Future[Unit] = Future.unit
+
+  private val isStopped: AtomicBoolean = new AtomicBoolean(false)
+
+  /** Completes all streams and waits until they are fully drained */
+  override def stop(): Future[Unit] = {
+    val start = System.currentTimeMillis()
+
+    //can't complete a stream twice
+    if (!isStopped.get()) {
+      //complete all queues
+      offerAddQueue.complete()
+      offerRemoveQueue.complete()
+      stateChangeQueue.complete()
+      isStopped.set(true)
+    } else {
+      logger.warn(
+        s"Already stopped all queues associated with this DLCWalletCallbackManagerStream")
+    }
+
+    for {
+      _ <- stateChangeSinkCompleteF
+      _ <- offerAddSinkCompleteF
+      _ <- offerRemoveSinkCompleteF
+    } yield {
+      logger.info(
+        s"Done draining akka streams for DLCWalletCallbackManagerStream, it took=${System
+          .currentTimeMillis() - start}ms")
+      ()
+    }
+  }
+
+  private def matSourceAndQueue[T](
+      source: Source[T, SourceQueueWithComplete[T]],
+      sink: Sink[T, Future[Done]]): (
+      SourceQueueWithComplete[T],
+      Future[Done]) = {
+    source
+      .toMat(sink)(Keep.both)
+      .run()
+  }
+}

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/callback/DLCWalletCallbacks.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/callback/DLCWalletCallbacks.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.dlc.wallet.callback
 
 import grizzled.slf4j.{Logger, Logging}
-import org.bitcoins.core.api.callback.ModuleCallbacks
+import org.bitcoins.core.api.callback.{CallbackFactory, ModuleCallbacks}
 import org.bitcoins.core.api.dlc.wallet.db.IncomingDLCOfferDb
 import org.bitcoins.core.api.{Callback, CallbackHandler}
 import org.bitcoins.core.protocol.dlc.models.DLCStatus
@@ -48,7 +48,7 @@ trait DLCWalletCallbacks
 
 }
 
-object DLCWalletCallbacks {
+object DLCWalletCallbacks extends CallbackFactory[DLCWalletCallbacks] {
 
   private case class DLCWalletCallbacksImpl(
       onStateChange: CallbackHandler[DLCStatus, OnDLCStateChange],

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/callback/DLCWalletCallbacks.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/callback/DLCWalletCallbacks.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.dlc.wallet
+package org.bitcoins.dlc.wallet.callback
 
 import grizzled.slf4j.Logger
 import org.bitcoins.core.api.dlc.wallet.db.IncomingDLCOfferDb

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/callback/DLCWalletCallbacks.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/callback/DLCWalletCallbacks.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.dlc.wallet.callback
 
-import grizzled.slf4j.{Logger, Logging}
+import grizzled.slf4j.{Logging}
 import org.bitcoins.core.api.callback.{CallbackFactory, ModuleCallbacks}
 import org.bitcoins.core.api.dlc.wallet.db.IncomingDLCOfferDb
 import org.bitcoins.core.api.{Callback, CallbackHandler}
@@ -19,7 +19,7 @@ trait DLCWalletCallbacks
 
   def onOfferRemove: CallbackHandler[Sha256Digest, OnDLCOfferRemove]
 
-  def executeOnDLCStateChange(logger: Logger, status: DLCStatus)(implicit
+  def executeOnDLCStateChange(status: DLCStatus)(implicit
       ec: ExecutionContext): Future[Unit] = {
     onStateChange.execute(
       status,
@@ -28,7 +28,7 @@ trait DLCWalletCallbacks
                      err))
   }
 
-  def executeOnDLCOfferAdd(logger: Logger, offerDb: IncomingDLCOfferDb)(implicit
+  def executeOnDLCOfferAdd(offerDb: IncomingDLCOfferDb)(implicit
       ec: ExecutionContext): Future[Unit] = {
     onOfferAdd.execute(
       offerDb,
@@ -37,7 +37,7 @@ trait DLCWalletCallbacks
                      err))
   }
 
-  def executeOnDLCOfferRemove(logger: Logger, offerHash: Sha256Digest)(implicit
+  def executeOnDLCOfferRemove(offerHash: Sha256Digest)(implicit
       ec: ExecutionContext): Future[Unit] = {
     onOfferRemove.execute(
       offerHash,

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -90,8 +90,7 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
           for {
             withOutcomeOpt <- calculateAndSetOutcome(withState)
             dlc <- findDLC(dlcDb.dlcId)
-            _ = dlcConfig.walletCallbacks.executeOnDLCStateChange(logger,
-                                                                  dlc.get)
+            _ = dlcConfig.walletCallbacks.executeOnDLCStateChange(dlc.get)
           } yield {
             withOutcomeOpt
           }
@@ -303,7 +302,7 @@ private[bitcoins] trait DLCTransactionProcessing extends TransactionProcessing {
       val sendF = updatedDlcDbsF.flatMap { updatedDlcDbs =>
         Future.sequence {
           updatedDlcDbs.map(u =>
-            dlcConfig.walletCallbacks.executeOnDLCStateChange(logger, u.get))
+            dlcConfig.walletCallbacks.executeOnDLCStateChange(u.get))
         }
       }
       sendF.map(_ => ())

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/IncomingDLCOffersHandling.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/IncomingDLCOffersHandling.scala
@@ -30,14 +30,14 @@ trait IncomingDLCOffersHandling { self: DLCWallet =>
           dlcWalletDAOs.contactDAO.createIfDoesNotExist(contactDb)
         case None => Future.successful(())
       }
-      _ <- dlcConfig.walletCallbacks.executeOnDLCOfferAdd(logger, added)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCOfferAdd(added)
     } yield dbo.hash
   }
 
   def rejectIncomingDLCOffer(offerHash: Sha256Digest): Future[Unit] = {
     for {
       _ <- dlcWalletDAOs.incomingDLCOfferDAO.delete(offerHash)
-      _ <- dlcConfig.walletCallbacks.executeOnDLCOfferRemove(logger, offerHash)
+      _ <- dlcConfig.walletCallbacks.executeOnDLCOfferRemove(offerHash)
     } yield ()
   }
 

--- a/docs/wallet/wallet-callbacks.md
+++ b/docs/wallet/wallet-callbacks.md
@@ -41,6 +41,7 @@ import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.config.BitcoindInstanceLocal
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.wallet._
+import org.bitcoins.wallet.callback._
 import org.bitcoins.wallet.config.WalletAppConfig
 import scala.concurrent.{ExecutionContextExecutor, Future}
 ```

--- a/docs/wallet/wallet-rescan.md
+++ b/docs/wallet/wallet-rescan.md
@@ -47,7 +47,7 @@ import org.bitcoins.testkit.wallet._
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.wallet.config.WalletAppConfig
-import org.bitcoins.wallet.WalletCallbacks
+import org.bitcoins.wallet.callback.WalletCallbacks
 import org.bitcoins.testkit.node.MockNodeApi
 import akka.actor.ActorSystem
 import scala.concurrent._

--- a/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
@@ -5,7 +5,6 @@ import akka.actor.ActorSystem
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete}
 import grizzled.slf4j.Logging
-import monix.execution.atomic.AtomicBoolean
 import org.bitcoins.core.api.CallbackHandler
 import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader, MerkleBlock}
@@ -14,6 +13,7 @@ import org.bitcoins.core.util.StartStopAsync
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.node._
 
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.{ExecutionContext, Future}
 
 /** Creates a wrapper around the give node callbacks with a stream */
@@ -108,7 +108,7 @@ case class NodeCallbackStreamManager(
 
   override def start(): Future[Unit] = Future.unit
 
-  private val isStopped: AtomicBoolean = AtomicBoolean(false)
+  private val isStopped: AtomicBoolean = new AtomicBoolean(false)
 
   /** Completes all streams and waits until they are fully drained */
   override def stop(): Future[Unit] = {

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="ERROR">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="ERROR">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -18,7 +18,7 @@ import org.bitcoins.testkit.rpc.{
 }
 import org.bitcoins.testkit.tor.CachedTor
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.wallet.WalletCallbacks
+import org.bitcoins.wallet.callback.WalletCallbacks
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -15,7 +15,7 @@ import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
 import org.bitcoins.testkit.node.fixture._
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletWithBitcoindRpc}
-import org.bitcoins.wallet.WalletCallbacks
+import org.bitcoins.wallet.callback.WalletCallbacks
 import org.scalatest.FutureOutcome
 
 import java.net.InetSocketAddress

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -26,8 +26,9 @@ import org.bitcoins.testkit.wallet.FundWalletUtil.{
 }
 import org.bitcoins.testkitcore.Implicits.GeneratorOps
 import org.bitcoins.testkitcore.gen._
+import org.bitcoins.wallet.callback.WalletCallbacks
 import org.bitcoins.wallet.config.WalletAppConfig
-import org.bitcoins.wallet.{Wallet, WalletCallbacks, WalletLogger}
+import org.bitcoins.wallet.{Wallet, WalletLogger}
 import org.scalatest._
 
 import java.util.UUID

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
@@ -8,6 +8,14 @@ import org.bitcoins.core.protocol.blockchain.{Block, RegTestNetChainParams}
 import org.bitcoins.core.protocol.transaction.{EmptyTransaction, Transaction}
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedWallet
+import org.bitcoins.wallet.callback.{
+  OnBlockProcessed,
+  OnNewAddressGenerated,
+  OnReservedUtxos,
+  OnTransactionBroadcast,
+  OnTransactionProcessed,
+  WalletCallbacks
+}
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.duration.DurationInt

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -39,6 +39,7 @@ import org.bitcoins.crypto._
 import org.bitcoins.db.SafeDatabase
 import org.bitcoins.db.models.MasterXPubDAO
 import org.bitcoins.keymanager.bip39.BIP39KeyManager
+import org.bitcoins.wallet.callback.WalletCallbacks
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.internal._
 import org.bitcoins.wallet.models._

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/OnBlockProcessed.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/OnBlockProcessed.scala
@@ -1,0 +1,6 @@
+package org.bitcoins.wallet.callback
+
+import org.bitcoins.core.api.Callback
+import org.bitcoins.core.protocol.blockchain.Block
+
+trait OnBlockProcessed extends Callback[Block]

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/OnFeeRateChanged.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/OnFeeRateChanged.scala
@@ -1,0 +1,6 @@
+package org.bitcoins.wallet.callback
+
+import org.bitcoins.core.api.Callback
+import org.bitcoins.core.wallet.fee.FeeUnit
+
+trait OnFeeRateChanged extends Callback[FeeUnit]

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/OnNewAddressGenerated.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/OnNewAddressGenerated.scala
@@ -1,0 +1,6 @@
+package org.bitcoins.wallet.callback
+
+import org.bitcoins.core.api.Callback
+import org.bitcoins.core.protocol.BitcoinAddress
+
+trait OnNewAddressGenerated extends Callback[BitcoinAddress]

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/OnRescanComplete.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/OnRescanComplete.scala
@@ -1,0 +1,6 @@
+package org.bitcoins.wallet.callback
+
+import org.bitcoins.core.api.Callback
+
+/** Triggered when a rescan is */
+trait OnRescanComplete extends Callback[String]

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/OnReservedUtxos.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/OnReservedUtxos.scala
@@ -1,0 +1,6 @@
+package org.bitcoins.wallet.callback
+
+import org.bitcoins.core.api.Callback
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
+
+trait OnReservedUtxos extends Callback[Vector[SpendingInfoDb]]

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/OnTransactionBroadcast.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/OnTransactionBroadcast.scala
@@ -1,0 +1,6 @@
+package org.bitcoins.wallet.callback
+
+import org.bitcoins.core.api.Callback
+import org.bitcoins.core.protocol.transaction.Transaction
+
+trait OnTransactionBroadcast extends Callback[Transaction]

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/OnTransactionProcessed.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/OnTransactionProcessed.scala
@@ -1,0 +1,7 @@
+package org.bitcoins.wallet.callback
+
+import org.bitcoins.core.api.Callback
+import org.bitcoins.core.protocol.transaction.Transaction
+
+/** Callback for handling a processed transaction */
+trait OnTransactionProcessed extends Callback[Transaction]

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/WalletCallbackStreamManager.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/WalletCallbackStreamManager.scala
@@ -5,7 +5,6 @@ import akka.actor.ActorSystem
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete}
 import grizzled.slf4j.Logging
-import monix.execution.atomic.AtomicBoolean
 import org.bitcoins.core.api.CallbackHandler
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -14,6 +13,7 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.StartStopAsync
 import org.bitcoins.core.wallet.fee.FeeUnit
 
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.Future
 
 case class WalletCallbackStreamManager(
@@ -142,7 +142,7 @@ case class WalletCallbackStreamManager(
 
   override def start(): Future[Unit] = Future.unit
 
-  private val isStopped: AtomicBoolean = AtomicBoolean(false)
+  private val isStopped: AtomicBoolean = new AtomicBoolean(false)
 
   override def stop(): Future[Unit] = {
     val start = System.currentTimeMillis()

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/WalletCallbackStreamManager.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/WalletCallbackStreamManager.scala
@@ -225,5 +225,8 @@ case class WalletCallbackStreamManager(
     callbacks.onFeeRateChanged
   }
 
-  override def +(other: WalletCallbacks): WalletCallbacks = ???
+  override def +(other: WalletCallbacks): WalletCallbacks = {
+    val newCallbacks = other.+(this)
+    WalletCallbackStreamManager(newCallbacks)
+  }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/WalletCallbackStreamManager.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/WalletCallbackStreamManager.scala
@@ -1,0 +1,229 @@
+package org.bitcoins.wallet.callback
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete}
+import grizzled.slf4j.Logging
+import monix.execution.atomic.AtomicBoolean
+import org.bitcoins.core.api.CallbackHandler
+import org.bitcoins.core.api.wallet.db.SpendingInfoDb
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.blockchain.Block
+import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.core.util.StartStopAsync
+import org.bitcoins.core.wallet.fee.FeeUnit
+
+import scala.concurrent.Future
+
+case class WalletCallbackStreamManager(
+    callbacks: WalletCallbacks,
+    overflowStrategy: OverflowStrategy = OverflowStrategy.backpressure,
+    maxBufferSize: Int = 16
+)(implicit system: ActorSystem)
+    extends WalletCallbacks
+    with StartStopAsync[Unit]
+    with Logging {
+  import system.dispatcher
+
+  private val txProcessedQueueSource: Source[
+    Transaction,
+    SourceQueueWithComplete[Transaction]] = {
+    Source.queue(maxBufferSize, overflowStrategy)
+  }
+
+  private val txProcessedSink: Sink[Transaction, Future[Done]] = {
+    Sink.foreachAsync(1) { case tx =>
+      callbacks.executeOnTransactionProcessed(tx)
+    }
+  }
+
+  private val (txProcessedQueue, txProcessedSinkF) = {
+    matSourceAndQueue(txProcessedQueueSource, txProcessedSink)
+  }
+
+  private val txBroadcastQueueSource: Source[
+    Transaction,
+    SourceQueueWithComplete[Transaction]] = {
+    Source.queue(maxBufferSize, overflowStrategy)
+  }
+
+  private val txBroadcastSink: Sink[Transaction, Future[Done]] = {
+    Sink.foreachAsync(1) { case tx =>
+      callbacks.executeOnTransactionBroadcast(tx)
+    }
+  }
+
+  private val (txBroadcastQueue, txBroadcastSinkF) = {
+    matSourceAndQueue(txBroadcastQueueSource, txBroadcastSink)
+  }
+
+  private val onReservedUtxosSource: Source[
+    Vector[SpendingInfoDb],
+    SourceQueueWithComplete[Vector[SpendingInfoDb]]] = {
+    Source.queue(maxBufferSize, overflowStrategy)
+  }
+
+  private val onReservedUtxosSink: Sink[
+    Vector[SpendingInfoDb],
+    Future[Done]] = {
+    Sink.foreachAsync(1) { case utxos =>
+      callbacks.executeOnReservedUtxos(utxos)
+    }
+  }
+
+  private val (onReservedUtxosQueue, onReservedUtxosSinkF) = {
+    matSourceAndQueue(onReservedUtxosSource, onReservedUtxosSink)
+  }
+
+  private val onAddressGeneratedSource: Source[
+    BitcoinAddress,
+    SourceQueueWithComplete[BitcoinAddress]] = {
+    Source.queue(maxBufferSize, overflowStrategy)
+  }
+
+  private val onAddressGeneratedSink: Sink[BitcoinAddress, Future[Done]] = {
+    Sink.foreachAsync(1) { case addr =>
+      callbacks.executeOnNewAddressGenerated(addr)
+    }
+  }
+
+  private val (onAddressGeneratedQueue, onAddressGeneratedSinkF) = {
+    matSourceAndQueue(onAddressGeneratedSource, onAddressGeneratedSink)
+  }
+
+  private val onBlockProcessedSource: Source[
+    Block,
+    SourceQueueWithComplete[Block]] = {
+    Source.queue(maxBufferSize, overflowStrategy)
+  }
+
+  private val onBockProcessedSink: Sink[Block, Future[Done]] = {
+    Sink.foreachAsync(1) { case block =>
+      callbacks.executeOnBlockProcessed(block)
+    }
+  }
+
+  private val (onBlockProcessedQueue, onBlockProcessedSinkF) = {
+    matSourceAndQueue(onBlockProcessedSource, onBockProcessedSink)
+  }
+
+  private val onRescanCompleteSource: Source[
+    String,
+    SourceQueueWithComplete[String]] = {
+    Source.queue(maxBufferSize, overflowStrategy)
+  }
+
+  private val onRescanCompleteSink: Sink[String, Future[Done]] = {
+    Sink.foreachAsync(1) { case str =>
+      callbacks.executeOnRescanComplete(str)
+    }
+  }
+
+  private val (onRescanCompleteQueue, onRescanCompleteSinkF) = {
+    matSourceAndQueue(onRescanCompleteSource, onRescanCompleteSink)
+  }
+
+  private val onFeeChangeSource: Source[
+    FeeUnit,
+    SourceQueueWithComplete[FeeUnit]] = {
+    Source.queue(maxBufferSize, overflowStrategy)
+  }
+
+  private val onFeeChangeSink: Sink[FeeUnit, Future[Done]] = {
+    Sink.foreachAsync(1) { case feeRate =>
+      callbacks.executeOnFeeRateChanged(feeRate)
+    }
+  }
+
+  private val (onFeeChangeSourceQueue, onFeeChangeSinkF) = {
+    matSourceAndQueue(onFeeChangeSource, onFeeChangeSink)
+  }
+
+  override def start(): Future[Unit] = Future.unit
+
+  private val isStopped: AtomicBoolean = AtomicBoolean(false)
+
+  override def stop(): Future[Unit] = {
+    val start = System.currentTimeMillis()
+
+    //can't complete a stream twice
+    if (!isStopped.get()) {
+      //complete all queues
+      txProcessedQueue.complete()
+      txBroadcastQueue.complete()
+      onReservedUtxosQueue.complete()
+      onAddressGeneratedQueue.complete()
+      onBlockProcessedQueue.complete()
+      onRescanCompleteQueue.complete()
+      onFeeChangeSourceQueue.complete()
+      isStopped.set(true)
+    } else {
+      logger.warn(
+        s"Already stopped all queues associated with this NodeCallBackStreamManager")
+    }
+
+    for {
+      _ <- txProcessedSinkF
+      _ <- txBroadcastSinkF
+      _ <- onReservedUtxosSinkF
+      _ <- onAddressGeneratedSinkF
+      _ <- onBlockProcessedSinkF
+      _ <- onRescanCompleteSinkF
+      _ <- onFeeChangeSinkF
+    } yield {
+      logger.info(
+        s"Done draining akka streams for WalletCallbackStreamManager, it took=${System
+          .currentTimeMillis() - start}ms")
+      ()
+    }
+  }
+
+  private def matSourceAndQueue[T](
+      source: Source[T, SourceQueueWithComplete[T]],
+      sink: Sink[T, Future[Done]]): (
+      SourceQueueWithComplete[T],
+      Future[Done]) = {
+    source
+      .toMat(sink)(Keep.both)
+      .run()
+  }
+
+  override def onTransactionProcessed: CallbackHandler[
+    Transaction,
+    OnTransactionProcessed] = {
+    callbacks.onTransactionProcessed
+  }
+
+  override def onTransactionBroadcast: CallbackHandler[
+    Transaction,
+    OnTransactionBroadcast] = {
+    callbacks.onTransactionBroadcast
+  }
+
+  override def onReservedUtxos: CallbackHandler[
+    Vector[SpendingInfoDb],
+    OnReservedUtxos] = {
+    callbacks.onReservedUtxos
+  }
+
+  override def onNewAddressGenerated: CallbackHandler[
+    BitcoinAddress,
+    OnNewAddressGenerated] = {
+    callbacks.onNewAddressGenerated
+  }
+
+  override def onBlockProcessed: CallbackHandler[Block, OnBlockProcessed] = {
+    callbacks.onBlockProcessed
+  }
+
+  override def onRescanComplete: CallbackHandler[String, OnRescanComplete] = {
+    callbacks.onRescanComplete
+  }
+
+  override def onFeeRateChanged: CallbackHandler[FeeUnit, OnFeeRateChanged] = {
+    callbacks.onFeeRateChanged
+  }
+
+  override def +(other: WalletCallbacks): WalletCallbacks = ???
+}

--- a/wallet/src/main/scala/org/bitcoins/wallet/callback/WalletCallbacks.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/callback/WalletCallbacks.scala
@@ -1,9 +1,9 @@
-package org.bitcoins.wallet
+package org.bitcoins.wallet.callback
 
 import grizzled.slf4j.Logging
+import org.bitcoins.core.api.CallbackHandler
 import org.bitcoins.core.api.callback.{CallbackFactory, ModuleCallbacks}
 import org.bitcoins.core.api.wallet.db.SpendingInfoDb
-import org.bitcoins.core.api.{Callback, CallbackHandler}
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.Transaction
@@ -24,6 +24,7 @@ trait WalletCallbacks extends ModuleCallbacks[WalletCallbacks] with Logging {
   def onTransactionBroadcast: CallbackHandler[
     Transaction,
     OnTransactionBroadcast]
+
   def onReservedUtxos: CallbackHandler[Vector[SpendingInfoDb], OnReservedUtxos]
 
   def onNewAddressGenerated: CallbackHandler[
@@ -105,22 +106,6 @@ trait WalletCallbacks extends ModuleCallbacks[WalletCallbacks] with Logging {
   }
 
 }
-
-/** Callback for handling a processed transaction */
-trait OnTransactionProcessed extends Callback[Transaction]
-
-trait OnTransactionBroadcast extends Callback[Transaction]
-
-trait OnReservedUtxos extends Callback[Vector[SpendingInfoDb]]
-
-trait OnNewAddressGenerated extends Callback[BitcoinAddress]
-
-trait OnBlockProcessed extends Callback[Block]
-
-/** Triggered when a rescan is */
-trait OnRescanComplete extends Callback[String]
-
-trait OnFeeRateChanged extends Callback[FeeUnit]
 
 object WalletCallbacks extends CallbackFactory[WalletCallbacks] {
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -18,7 +18,10 @@ import org.bitcoins.db.models.MasterXPubDAO
 import org.bitcoins.db.util.{DBMasterXPubApi, MasterXPubUtil}
 import org.bitcoins.keymanager.config.KeyManagerAppConfig
 import org.bitcoins.tor.config.TorAppConfig
-import org.bitcoins.wallet.callback.WalletCallbacks
+import org.bitcoins.wallet.callback.{
+  WalletCallbackStreamManager,
+  WalletCallbacks
+}
 import org.bitcoins.wallet.config.WalletAppConfig.RebroadcastTransactionsRunnable
 import org.bitcoins.wallet.db.WalletDbManagement
 import org.bitcoins.wallet.models.AccountDAO
@@ -226,18 +229,26 @@ case class WalletAppConfig(
   }
 
   override def stop(): Future[Unit] = {
+    val stopCallbacksF = callBacks match {
+      case stream: WalletCallbackStreamManager => stream.stop()
+      case _: WalletCallbacks =>
+        Future.unit
+    }
     if (isHikariLoggingEnabled) {
       stopHikariLogger()
     }
 
-    clearCallbacks()
-    stopRebroadcastTxsScheduler()
-    //this eagerly shuts down all scheduled tasks on the scheduler
-    //in the future, we should actually cancel all things that are scheduled
-    //manually, and then shutdown the scheduler
-    scheduler.shutdownNow()
-    rescanThreadPool.shutdownNow()
-    super.stop()
+    stopCallbacksF.flatMap { _ =>
+      clearCallbacks()
+      stopRebroadcastTxsScheduler()
+      //this eagerly shuts down all scheduled tasks on the scheduler
+      //in the future, we should actually cancel all things that are scheduled
+      //manually, and then shutdown the scheduler
+      scheduler.shutdownNow()
+      rescanThreadPool.shutdownNow()
+      super.stop()
+    }
+
   }
 
   /** The path to our encrypted mnemonic seed */

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -18,10 +18,11 @@ import org.bitcoins.db.models.MasterXPubDAO
 import org.bitcoins.db.util.{DBMasterXPubApi, MasterXPubUtil}
 import org.bitcoins.keymanager.config.KeyManagerAppConfig
 import org.bitcoins.tor.config.TorAppConfig
+import org.bitcoins.wallet.callback.WalletCallbacks
 import org.bitcoins.wallet.config.WalletAppConfig.RebroadcastTransactionsRunnable
 import org.bitcoins.wallet.db.WalletDbManagement
 import org.bitcoins.wallet.models.AccountDAO
-import org.bitcoins.wallet.{Wallet, WalletCallbacks, WalletLogger}
+import org.bitcoins.wallet.{Wallet, WalletLogger}
 
 import java.nio.file.{Files, Path, Paths}
 import java.time.Instant


### PR DESCRIPTION
Follow up on #4520 

Wraps callbacks in akka streams so they can be gracefully shutdown for the `Wallet` and `DLCWallet` modules.