### PR TITLE
2023 10 19 recursive rescan state

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -1721,6 +1721,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                              Future.successful(Vector.empty),
                              Promise())))
 
+      walletLoader.clearRescanState()
       val route1 =
         walletRoutes.handleCommand(
           ServerCommand("rescan", Arr(Arr(), Null, Null, true, true)))
@@ -1752,6 +1753,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                              Future.successful(Vector.empty),
                              Promise())))
 
+      walletLoader.clearRescanState()
       val route2 =
         walletRoutes.handleCommand(
           ServerCommand(
@@ -1784,6 +1786,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                              Future.successful(Vector.empty),
                              Promise())))
 
+      walletLoader.clearRescanState()
       val route3 =
         walletRoutes.handleCommand(
           ServerCommand(
@@ -1810,6 +1813,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                  executor)
         .returning(Future.successful(RescanState.RescanDone))
 
+      walletLoader.clearRescanState()
       val route4 =
         walletRoutes.handleCommand(
           ServerCommand("rescan",
@@ -1822,7 +1826,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
       }
 
       // negative cases
-
+      walletLoader.clearRescanState()
       val route5 =
         walletRoutes.handleCommand(
           ServerCommand("rescan",
@@ -1835,6 +1839,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
           String] == s"""{"result":null,"error":"Invalid blockstamp: abcd"}""")
       }
 
+      walletLoader.clearRescanState()
       val route6 =
         walletRoutes.handleCommand(
           ServerCommand(
@@ -1848,6 +1853,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
           responseAs[String] == s"""{"result":null,"error":"Invalid blockstamp: 2018-10-27T12:34:56"}""")
       }
 
+      walletLoader.clearRescanState()
       val route7 =
         walletRoutes.handleCommand(
           ServerCommand("rescan", Arr(Null, Num(-1), Null, true, false)))
@@ -1868,6 +1874,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .expects(None, None, 55, false, false, executor)
         .returning(Future.successful(RescanState.RescanDone))
 
+      walletLoader.clearRescanState()
       val route8 =
         walletRoutes.handleCommand(
           ServerCommand("rescan",

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -1714,8 +1714,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                               _: Boolean,
                               _: Boolean)(_: ExecutionContext))
         .expects(None, None, 100, false, false, executor)
-        .returning(Future.successful(RescanState
-          .RescanStarted(Promise(), Future.successful(Vector.empty))))
+        .returning(
+          Future.successful(
+            RescanState
+              .RescanStarted(Promise(),
+                             Future.successful(Vector.empty),
+                             Promise())))
 
       val route1 =
         walletRoutes.handleCommand(
@@ -1741,8 +1745,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
           false,
           false,
           executor)
-        .returning(Future.successful(RescanState
-          .RescanStarted(Promise(), Future.successful(Vector.empty))))
+        .returning(
+          Future.successful(
+            RescanState
+              .RescanStarted(Promise(),
+                             Future.successful(Vector.empty),
+                             Promise())))
 
       val route2 =
         walletRoutes.handleCommand(
@@ -1769,8 +1777,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
                  false,
                  false,
                  executor)
-        .returning(Future.successful(RescanState
-          .RescanStarted(Promise(), Future.successful(Vector.empty))))
+        .returning(
+          Future.successful(
+            RescanState
+              .RescanStarted(Promise(),
+                             Future.successful(Vector.empty),
+                             Promise())))
 
       val route3 =
         walletRoutes.handleCommand(

--- a/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
@@ -392,7 +392,7 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
                      ignoreCreationTime = false)
     val _ = ConsoleCli.exec(cmd, cliConfig)
     for {
-      _ <- AkkaUtil.nonBlockingSleep(5000.millis)
+      _ <- AkkaUtil.nonBlockingSleep(10.second)
       _ = promise.success(None)
       notifications <- notificationsF
     } yield {

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -139,7 +139,7 @@ sealed trait DLCWalletLoaderApi extends Logging with StartStopAsync[Unit] {
       case RescanState.RescanAlreadyStarted =>
       //do nothing in this case, we don't need to keep these states around
       //don't overwrite the existing reference to RescanStarted
-      case RescanState.RescanDone =>
+      case RescanState.RescanDone | RescanState.RescanNotNeeded =>
         //rescan is done, reset state
         rescanStateOpt = None
       case started: RescanState.RescanStarted =>

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -145,7 +145,7 @@ sealed trait DLCWalletLoaderApi extends Logging with StartStopAsync[Unit] {
       case started: RescanState.RescanStarted =>
         if (rescanStateOpt.isEmpty) {
           //add callback to reset state when the rescan is done
-          val resetStateCallbackF = started.doneF.map { _ =>
+          val resetStateCallbackF = started.entireRescanDoneF.map { _ =>
             rescanStateOpt = None
           }
           resetStateCallbackF.failed.foreach {

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -1143,7 +1143,7 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
 
     stateF.map {
       case started: RescanState.RescanStarted =>
-        started.doneF.map { _ =>
+        started.entireRescanDoneF.map { _ =>
           logger.info(s"Rescan finished, setting state to RescanDone")
           rescanStateOpt = Some(RescanState.RescanDone)
         }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -1104,7 +1104,7 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
                     //do nothing, we don't want to reset/stop a rescan that is running
                     Future.successful(started)
                   }
-                case RescanState.RescanDone =>
+                case RescanState.RescanDone | RescanState.RescanNotNeeded =>
                   //if the previous rescan is done, start another rescan
                   startRescan(rescan)
                 case RescanState.RescanAlreadyStarted =>
@@ -1147,7 +1147,8 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
           logger.info(s"Rescan finished, setting state to RescanDone")
           rescanStateOpt = Some(RescanState.RescanDone)
         }
-      case RescanState.RescanAlreadyStarted | RescanState.RescanDone =>
+      case RescanState.RescanAlreadyStarted | RescanState.RescanDone |
+          RescanState.RescanNotNeeded =>
       //do nothing in these cases, no state needs to be reset
     }
 
@@ -1158,7 +1159,7 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
     rescanState match {
       case RescanState.RescanAlreadyStarted | _: RescanState.RescanStarted =>
         "Rescan started."
-      case RescanState.RescanDone =>
+      case RescanState.RescanDone | RescanState.RescanNotNeeded =>
         "Rescan done."
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/rescan/RescanState.scala
@@ -26,7 +26,8 @@ object RescanState {
     * the rescan early by completing the promise
     * [[blocksMatchedF]] is a future that is completed when the rescan is done
     * this returns all blocks that were matched during the rescan.
-    * [[recursiveRescanP]] is a promise that is completed when there is a recursive rescan is started or there is not a recursive rescan started
+    * [[recursiveRescanP]] If the rescan is continued with a fresh pool of addresses it completes `recursiveRescanP` with the new `RescanState.RescanStarted`.
+    * If the rescan is done because `addressGapLimit` is satisfied,  `recursiveRescanP` with `RescanState.RescanNotNeeded`
     */
   case class RescanStarted(
       private val completeRescanEarlyP: Promise[Option[Int]],

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -142,12 +142,10 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         _ <- {
           rescanState match {
             case started: RescanState.RescanStarted =>
-              logger.error(s"@@@@@@ started=$started @@@@@@")
               started.entireRescanDoneF
             case _: RescanState => Future.unit
           }
         }
-        _ = logger.info(s"@@@@@@ doneF complete @@@@@@@")
         balance <- wallet.getBalance()
         unconfirmedBalance <- wallet.getUnconfirmedBalance()
       } yield {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -141,10 +141,13 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
                                                    force = false)
         _ <- {
           rescanState match {
-            case started: RescanState.RescanStarted => started.blocksMatchedF
-            case _: RescanState                     => Future.unit
+            case started: RescanState.RescanStarted =>
+              logger.error(s"@@@@@@ started=$started @@@@@@")
+              started.doneF
+            case _: RescanState => Future.unit
           }
         }
+        _ = logger.info(s"@@@@@@ doneF complete @@@@@@@")
         balance <- wallet.getBalance()
         unconfirmedBalance <- wallet.getUnconfirmedBalance()
       } yield {
@@ -460,7 +463,8 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
             started.fail(
               new RuntimeException(
                 "Purposefully terminate rescan early for test"))
-          case RescanState.RescanDone | RescanState.RescanAlreadyStarted =>
+          case RescanState.RescanDone | RescanState.RescanAlreadyStarted |
+              RescanState.RescanNotNeeded =>
             fail(s"Rescan must be started")
         }
         _ <- AsyncUtil.nonBlockingSleep(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -143,7 +143,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
           rescanState match {
             case started: RescanState.RescanStarted =>
               logger.error(s"@@@@@@ started=$started @@@@@@")
-              started.doneF
+              started.entireRescanDoneF
             case _: RescanState => Future.unit
           }
         }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -308,21 +308,18 @@ private[wallet] trait RescanHandling extends WalletLogger {
       endOpt: Option[BlockStamp],
       addressBatchSize: Int,
       forceGenerateSpks: Boolean): Future[RescanState] = {
-    logger.error(s"@@@@@@@ doNeutrinoRescan @@@@@@@")
     for {
       inProgress <- matchBlocks(endOpt = endOpt,
                                 startOpt = startOpt,
                                 account = account,
                                 addressBatchSize = addressBatchSize,
                                 forceGenerateSpks)
-      _ = logger.info(s"inProgress=$inProgress")
       _ = recursiveRescan(prevState = inProgress,
                           startOpt = startOpt,
                           endOpt = endOpt,
                           addressBatchSize = addressBatchSize,
                           account = account)
     } yield {
-      logger.error(s"@@@@@@ doNeutrinoRescan complete @@@@@@@")
       inProgress
     }
   }
@@ -338,12 +335,10 @@ private[wallet] trait RescanHandling extends WalletLogger {
       endOpt: Option[BlockStamp],
       addressBatchSize: Int,
       account: HDAccount): Future[Unit] = {
-    logger.info(s"recursiveRescan()")
     val awaitPreviousRescanF =
       RescanState.awaitSingleRescanDone(rescanState = prevState)
     for {
       _ <- awaitPreviousRescanF //this is where the deadlock occurs
-      _ = logger.info(s"awaitPreviousRescanF")
       externalGap <- calcAddressGap(HDChainType.External, account)
       changeGap <- calcAddressGap(HDChainType.Change, account)
       _ <- {
@@ -367,7 +362,6 @@ private[wallet] trait RescanHandling extends WalletLogger {
         }
       }
     } yield {
-      logger.info(s"Done recursiveRescan()")
       ()
     }
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -109,7 +109,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
 
           resF.map {
             case r: RescanState.RescanStarted =>
-              r.doneF.map(_ =>
+              r.entireRescanDoneF.map(_ =>
                 logger.info(s"Finished rescanning the wallet. It took ${System
                   .currentTimeMillis() - startTime}ms"))
             case RescanState.RescanDone | RescanState.RescanAlreadyStarted |
@@ -340,9 +340,9 @@ private[wallet] trait RescanHandling extends WalletLogger {
       account: HDAccount): Future[Unit] = {
     logger.info(s"recursiveRescan()")
     val awaitPreviousRescanF =
-      RescanState.awaitRescanDone(rescanState = prevState)
+      RescanState.awaitSingleRescanDone(rescanState = prevState)
     for {
-      _ <- awaitPreviousRescanF //this is where the deadlock occurs 
+      _ <- awaitPreviousRescanF //this is where the deadlock occurs
       _ = logger.info(s"awaitPreviousRescanF")
       externalGap <- calcAddressGap(HDChainType.External, account)
       changeGap <- calcAddressGap(HDChainType.Change, account)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -112,7 +112,8 @@ private[wallet] trait RescanHandling extends WalletLogger {
               r.doneF.map(_ =>
                 logger.info(s"Finished rescanning the wallet. It took ${System
                   .currentTimeMillis() - startTime}ms"))
-            case RescanState.RescanDone | RescanState.RescanAlreadyStarted =>
+            case RescanState.RescanDone | RescanState.RescanAlreadyStarted |
+                RescanState.RescanNotNeeded =>
             //nothing to log
           }
 
@@ -158,7 +159,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
     } yield ()
   }
 
-  lazy val walletCreationBlockHeight: Future[BlockHeight] =
+  private lazy val walletCreationBlockHeight: Future[BlockHeight] =
     chainQueryApi
       .epochSecondToBlockHeight(creationTime.getEpochSecond)
       .map(BlockHeight)
@@ -231,14 +232,18 @@ private[wallet] trait RescanHandling extends WalletLogger {
     val (completeRescanEarlyP, matchingBlocksF) =
       combine.toMat(rescanSink)(Keep.both).run()
 
+    val recursiveRescanP: Promise[RescanState] = Promise()
+
     //if we have seen the last filter, complete the rescanEarlyP so we are consistent
-    rescanCompletePromise.future.map(_ => completeRescanEarlyP.success(None))
+    rescanCompletePromise.future.map { _ =>
+      completeRescanEarlyP.success(None)
+    }
 
     val flatten = matchingBlocksF.map(_.flatten.toVector)
 
     //return RescanStarted with access to the ability to complete the rescan early
     //via the completeRescanEarlyP promise.
-    RescanState.RescanStarted(completeRescanEarlyP, flatten)
+    RescanState.RescanStarted(completeRescanEarlyP, flatten, recursiveRescanP)
   }
 
   /** Iterates over the block filters in order to find filters that match to the given addresses
@@ -257,14 +262,14 @@ private[wallet] trait RescanHandling extends WalletLogger {
     *                         (default [[Runtime.getRuntime.availableProcessors()]])
     * @return a list of matching block hashes
     */
-  def getMatchingBlocks(
+  private def getMatchingBlocks(
       startOpt: Option[BlockStamp],
       endOpt: Option[BlockStamp],
       addressBatchSize: Int,
       account: HDAccount,
       forceGenerateSpks: Boolean,
       parallelismLevel: Int = Runtime.getRuntime.availableProcessors())(implicit
-      ec: ExecutionContext): Future[RescanState] = {
+      ec: ExecutionContext): Future[RescanState.RescanStarted] = {
     require(addressBatchSize > 0, "batch size must be greater than zero")
     require(parallelismLevel > 0, "parallelism level must be greater than zero")
     for {
@@ -303,18 +308,21 @@ private[wallet] trait RescanHandling extends WalletLogger {
       endOpt: Option[BlockStamp],
       addressBatchSize: Int,
       forceGenerateSpks: Boolean): Future[RescanState] = {
+    logger.error(s"@@@@@@@ doNeutrinoRescan @@@@@@@")
     for {
       inProgress <- matchBlocks(endOpt = endOpt,
                                 startOpt = startOpt,
                                 account = account,
                                 addressBatchSize = addressBatchSize,
                                 forceGenerateSpks)
+      _ = logger.info(s"inProgress=$inProgress")
       _ = recursiveRescan(prevState = inProgress,
                           startOpt = startOpt,
                           endOpt = endOpt,
                           addressBatchSize = addressBatchSize,
                           account = account)
     } yield {
+      logger.error(s"@@@@@@ doNeutrinoRescan complete @@@@@@@")
       inProgress
     }
   }
@@ -325,15 +333,17 @@ private[wallet] trait RescanHandling extends WalletLogger {
     * do another rescan
     */
   private def recursiveRescan(
-      prevState: RescanState,
+      prevState: RescanState.RescanStarted,
       startOpt: Option[BlockStamp],
       endOpt: Option[BlockStamp],
       addressBatchSize: Int,
       account: HDAccount): Future[Unit] = {
+    logger.info(s"recursiveRescan()")
     val awaitPreviousRescanF =
-      RescanState.awaitRescanComplete(rescanState = prevState)
+      RescanState.awaitRescanDone(rescanState = prevState)
     for {
-      _ <- awaitPreviousRescanF
+      _ <- awaitPreviousRescanF //this is where the deadlock occurs 
+      _ = logger.info(s"awaitPreviousRescanF")
       externalGap <- calcAddressGap(HDChainType.External, account)
       changeGap <- calcAddressGap(HDChainType.Change, account)
       _ <- {
@@ -342,19 +352,24 @@ private[wallet] trait RescanHandling extends WalletLogger {
         ) {
           logger.info(
             s"Did not find any funds within the last ${walletConfig.addressGapLimit} addresses. Stopping our rescan.")
+          prevState.recursiveRescanP.success(RescanState.RescanNotNeeded)
           Future.unit
         } else {
           logger.info(
             s"Attempting rescan again with fresh pool of addresses as we had a " +
               s"match within our address gap limit of ${walletConfig.addressGapLimit} externalGap=$externalGap changeGap=$changeGap")
-          doNeutrinoRescan(account = account,
-                           startOpt = startOpt,
-                           endOpt = endOpt,
-                           addressBatchSize = addressBatchSize,
-                           forceGenerateSpks = true)
+          val recursiveF = doNeutrinoRescan(account = account,
+                                            startOpt = startOpt,
+                                            endOpt = endOpt,
+                                            addressBatchSize = addressBatchSize,
+                                            forceGenerateSpks = true)
+          recursiveF.map(r => prevState.recursiveRescanP.success(r))
         }
       }
-    } yield ()
+    } yield {
+      logger.info(s"Done recursiveRescan()")
+      ()
+    }
   }
 
   private def calcAddressGap(
@@ -402,7 +417,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
       startOpt: Option[BlockStamp],
       account: HDAccount,
       addressBatchSize: Int,
-      forceGenerateSpks: Boolean): Future[RescanState] = {
+      forceGenerateSpks: Boolean): Future[RescanState.RescanStarted] = {
     val rescanStateF = for {
       rescanState <- getMatchingBlocks(startOpt = startOpt,
                                        endOpt = endOpt,


### PR DESCRIPTION
Fixes #4563

In #4530 we were not able to reference rescans run on batches of addresses after the first pool of addresses is checked. This PR implements the ability to reference recursive rescans via the `recursiveRescanP` value inside of `RescanState.RescanStarted`. 

When the first rescan is complete and [`RescanHandling.recursiveRescan()`](https://github.com/Christewart/bitcoin-s-core/blob/d3f9bf540779515f7ac6cf64ce732ff9b3e25ccb/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala#L332) is called, we now complete `recursiveRescanP` `Promise` with the state of the rescan. 

If the rescan is continued with a fresh pool of addresses it completes `recursiveRescanP` with the new `RescanState.RescanStarted`. 

If the rescan is done because `addressGapLimit` is satisfied,  `recursiveRescanP` with `RescanState.RescanNotNeeded`