### PR TITLE
Replace inactivity logic with `Flow.idleTimeout`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -191,9 +191,7 @@ case class NeutrinoNode(
     val peers = peerManager.peers
     logger.debug(s"Running inactivity checks for peers=${peers}")
     val resultF = if (peers.nonEmpty) {
-      Future
-        .traverse(peers)(peerManager.inactivityChecks)
-        .map(_ => ())
+      Future.unit //do nothing?
     } else if (isStarted.get) {
       //stop and restart to get more peers
       stop()

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -67,8 +67,6 @@ case class PersistentPeerData(
     lastTimedOut = System.currentTimeMillis()
   }
 
-  def isConnectionTimedOut: Boolean = peerConnection.isConnectionTimedOut
-
   /** returns true if the peer has failed due to any reason within the past 30 minutes
     */
   def hasFailedRecently: Boolean = {

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -238,10 +238,11 @@ case class PeerFinder(
 
   private def tryToAttemptToConnectPeer(peer: Peer): Future[Unit] = {
     logger.debug(s"tryToAttemptToConnectPeer=$peer")
+
     val peerConnection = _peerData(peer).peerConnection
     val peerMessageSender = PeerMessageSender(peerConnection)
     _peerData.put(peer, AttemptToConnectPeerData(peer, peerMessageSender))
-    peerConnection.connect()
+    peerConnection.reconnect()
   }
 
   /** creates and initialises a new test peer */

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -349,8 +349,11 @@ case class PeerManager(
               s"$peer cannot be both a test and a persistent peer")
 
       if (finder.hasPeer(peer)) {
-        //client actor for one of the test peers stopped, can remove it from map now
-        finder.removePeer(peer).map(_ => state)
+        if (peers.isEmpty) {
+          finder.reconnect(peer).map(_ => state)
+        } else {
+          finder.removePeer(peer).map(_ => state)
+        }
       } else if (peerDataMap.contains(peer)) {
         val peerData = _peerDataMap(peer)
         _peerDataMap.remove(peer)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -916,23 +916,6 @@ case class PeerManager(
         Future.unit
     }
   }
-
-  private[node] def inactivityChecks(peer: Peer): Future[Unit] = {
-    val peerDataOpt = peerDataMap.get(peer)
-    peerDataOpt match {
-      case Some(peerData) =>
-        if (peerData.isConnectionTimedOut) {
-          val stopF = peerData.stop()
-          stopF
-        } else {
-          Future.unit
-        }
-      case None =>
-        logger.warn(
-          s"Could not find peerData to run inactivity check against for peer=$peer")
-        Future.unit
-    }
-  }
 }
 
 case class ResponseTimeout(payload: NetworkPayload)


### PR DESCRIPTION
Realized this simplifies inactivity checks when working on #5307 . Just use [`Flow.idleTimeout`](https://doc.akka.io/docs/akka/current/stream/operators/Source-or-Flow/idleTimeout.html#idletimeout) which will cause the stream to be completed with a `TimeoutException`