### PR TITLE
Move socks5 greeting into `Socks5Connection.socks5Handler()`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -255,16 +255,7 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
             _ = resetReconnect()
             _ = initializationCancellable.cancel()
             versionMsg <- versionMsgF
-            _ = {
-              nodeAppConfig.socks5ProxyParams match {
-                case Some(p) =>
-                  val greetingBytes =
-                    Socks5Connection.socks5Greeting(p.credentialsOpt.isDefined)
-                  logger.debug(s"Writing socks5 greeting")
-                  sendMsg(greetingBytes, graph.mergeHubSink)
-                case None => sendMsg(versionMsg)
-              }
-            }
+            _ <- sendMsg(versionMsg)
           } yield ()
         }
 

--- a/tor/src/main/scala/org/bitcoins/tor/Socks5Connection.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/Socks5Connection.scala
@@ -268,6 +268,9 @@ object Socks5Connection extends Logging {
           { case (state, bytes) =>
             state match {
               case Socks5ConnectionState.Disconnected =>
+                val passwordAuth = credentialsOpt.isDefined
+                logger.debug(s"Writing socks5 greeting")
+                Source.single(socks5Greeting(passwordAuth)).runWith(sink)
                 if (
                   parseGreetings(bytes,
                                  credentialsOpt.isDefined) == PasswordAuth


### PR DESCRIPTION
Fixes bug introduced in #5136

When implementing the akka streams version of our `Socks5Connection`, I didn't move the greeting into the `socks5Handler` flow. This means each individual usage would have to send the greeting message as done here

https://github.com/bitcoin-s/bitcoin-s/pull/5136/files#diff-b5d1d2ce6f740c7803b625747455cf87e11de5c22f09b6e2452149b9a01ab7cfR253

This PR moves the greeting into the flow so the user of `socks5Handler()` doesn't have to worry about this