### PR TITLE
2023 12 07 mat socks5handler

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -255,16 +255,7 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
             _ = resetReconnect()
             _ = initializationCancellable.cancel()
             versionMsg <- versionMsgF
-            _ = {
-              nodeAppConfig.socks5ProxyParams match {
-                case Some(p) =>
-                  val greetingBytes =
-                    Socks5Connection.socks5Greeting(p.credentialsOpt.isDefined)
-                  logger.debug(s"Writing socks5 greeting")
-                  sendMsg(greetingBytes, graph.mergeHubSink)
-                case None => sendMsg(versionMsg)
-              }
-            }
+            _ <- sendMsg(versionMsg)
           } yield ()
         }
 

--- a/tor/src/main/scala/org/bitcoins/tor/Socks5Connection.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/Socks5Connection.scala
@@ -268,6 +268,9 @@ object Socks5Connection extends Logging {
           { case (state, bytes) =>
             state match {
               case Socks5ConnectionState.Disconnected =>
+                val passwordAuth = credentialsOpt.isDefined
+                logger.debug(s"Writing socks5 greeting")
+                Source.single(socks5Greeting(passwordAuth)).runWith(sink)
                 if (
                   parseGreetings(bytes,
                                  credentialsOpt.isDefined) == PasswordAuth

--- a/tor/src/main/scala/org/bitcoins/tor/Socks5Connection.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/Socks5Connection.scala
@@ -243,11 +243,15 @@ object Socks5Connection extends Logging {
 
   def tryParseAuth(data: ByteString): Try[Boolean] = Try(parseAuth(data))
 
-  /** A flow to handle socks5 connections
-    * We emit Left(bytes) downstream when we have finished the socks5 handshake
-    * We emit Right(Socks5ConnectionState) downstream when we are still doing the socks5 handshake
-    * Emitting the Socks5ConnectionState downstream allows you to build your stream logic based on
-    * the state of the socks5 connection
+  /** @param socket the peer we are connecting to
+    * @param source the source that produces ByteStrings we need to send to our peer
+    * @param sink the sink that receives messages from our peer and performs application specific logic
+    * @param mergeHubSink a way for socks5Handler to send messages to the socks5 proxy to complete the handshake
+    * @param credentialsOpt the credentials to authenticate the socks5 proxy.
+    * @param mat
+    * @tparam MatSource the materialized value of the source given to us
+    * @tparam MatSink the materialized value of the sink given to us
+    * @return a running tcp connection along with the results of the materialize source and sink
     */
   def socks5Handler[MatSource, MatSink](
       socket: InetSocketAddress,


### PR DESCRIPTION
The purpose of this PR is to encapsulate all handshake logic for a socks5 proxy into `Socks5Connection.socks5Handler()`. Previously we would break encapsulation by sending the greeting for the socks5 handshake in the specific application as was done in `PeerConnection` here:

https://github.com/bitcoin-s/bitcoin-s/pull/5136/files#diff-b5d1d2ce6f740c7803b625747455cf87e11de5c22f09b6e2452149b9a01ab7cfR253

This PR changes the semantics of `Socks5Connection.socks5Handler`. We now materialize the flow inside of `socks5Handler()` instead of just returning a `Flow` to use else where in your application. 

`Socks5Connection.socks5Handler()` now takes 3 parameters
- socket - the peer we are connecting to
- source - the source that produces `ByteString`s we need to send to our peer
- sink - the sink that receives messages from our peer and performs application specific logic
- mergeHubSink - a way for `socks5Handler` to send messages to the socks5 proxy to complete the handshake
- credentialsOpt the credentials to authenticate the socks5 proxy.