### PR TITLE
Rework `ConnectionGraph.stop()` to return `Future[Done]`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.node
 
+import akka.Done
 import akka.actor.ActorSystem
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.node.Peer
@@ -22,7 +23,7 @@ sealed trait PeerData {
 
   def peerMessageSender: PeerMessageSender
 
-  def stop(): Future[Unit] = {
+  def stop(): Future[Done] = {
     peerConnection.disconnect()
   }
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -354,18 +354,17 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
   }
 
   /** Disconnects the given peer */
-  def disconnect(): Future[Unit] = {
+  def disconnect(): Future[Done] = {
     connectionGraphOpt match {
       case Some(cg) =>
         logger.info(s"Disconnecting peer=${peer}")
-        cg.stop()
         connectionGraphOpt = None
-        Future.unit
+        cg.stop()
       case None =>
         val err =
           s"Cannot disconnect client that is not connected to peer=${peer}!"
         logger.warn(err)
-        Future.unit
+        Future.successful(Done)
     }
   }
 
@@ -415,10 +414,10 @@ object PeerConnection {
       killswitch: UniqueKillSwitch,
       initializationCancellable: Cancellable) {
 
-    def stop(): Unit = {
+    def stop(): Future[Done] = {
       killswitch.shutdown()
       initializationCancellable.cancel()
-      ()
+      streamDoneF
     }
   }
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -107,7 +107,6 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
     Vector[NetworkMessage],
     NotUsed] = {
     Flow[ByteString]
-      .idleTimeout(nodeAppConfig.inactivityTimeout)
       .statefulMap(() => ByteString.empty)(parseHelper,
                                            { _: ByteString => None })
       .log(
@@ -143,6 +142,7 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
     Vector[NetworkMessage],
     (Future[Tcp.OutgoingConnection], UniqueKillSwitch)] =
     connection
+      .idleTimeout(nodeAppConfig.inactivityTimeout)
       .joinMat(bidiFlow)(Keep.left)
 
   private def connectionGraph(
@@ -299,12 +299,15 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
       //if we initiated the disconnect we've already called disconnect(), so don't do it twice
       Future.unit
     }
-    f.flatMap { _ =>
+    val offerP = Promise[Unit]()
+    f.onComplete { _ =>
       val disconnectedPeer = DisconnectedPeer(peer, false)
-      queue
+      val offerF = queue
         .offer(disconnectedPeer)
         .map(_ => ())
+      offerF.onComplete(offerP.complete(_))
     }
+    offerP.future
   }
 
   /** resets reconnect state after connecting to a peer */

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -154,8 +154,8 @@ bitcoin-s {
 
 
 akka {
-    loglevel = "OFF"
-    stdout-loglevel = "OFF"
+    loglevel = "INFO"
+    stdout-loglevel = "INFO"
     http {
         client {
             # The time after which an idle connection will be automatically closed.

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -154,8 +154,8 @@ bitcoin-s {
 
 
 akka {
-    loglevel = "INFO"
-    stdout-loglevel = "INFO"
+    loglevel = "OFF"
+    stdout-loglevel = "OFF"
     http {
         client {
             # The time after which an idle connection will be automatically closed.


### PR DESCRIPTION
Pulls this out of #5316

Now return a `Future[Done]` from `ConnectionGraph.stop()` so that you can build logic based off of the completion of the tcp connection with your peer.