### PR TITLE
Upgrade cache action to v3

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -20,5 +20,13 @@ jobs:
           distribution: 'adopt'
           java-version: '17'
           cache: 'sbt'
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.bitcoin-s/binaries
+          key: ${{ runner.os }}-compile-cache
       - name: Compile and Check Formatting
         run: sbt -J-Xmx2g +test:compile scalafmtCheckAll docs/mdoc

--- a/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: '17'
           cache: 'sbt'
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
@@ -30,6 +30,6 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-cache
+          key: ${{ runner.os }}-app-chain-core-tests-cache
       - name: run tests
         run: sbt coverage dbCommonsTest/test chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls cryptoTestJVM/test cryptoJVM/test cryptoJVM/coverageReport cryptoJVM/coverageAggregate cryptoJVM/coveralls coreTestJVM/test coreJVM/coverageReport coreJVM/coverageAggregate coreJVM/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test oracleServerTest/test lnurlTest/test

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '17'
           cache: 'sbt'
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -28,6 +28,6 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-cache
+          key: ${{ runner.os }}-keymanager-wallet-dlc-test-cache
       - name: run tests
         run: sbt coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test dlcWalletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtilsTestJVM/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls

--- a/.github/workflows/Linux_2.13_Node_Tests.yml
+++ b/.github/workflows/Linux_2.13_Node_Tests.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '17'
           cache: 'sbt'
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Linux_2.13_Node_Tests.yml
+++ b/.github/workflows/Linux_2.13_Node_Tests.yml
@@ -28,6 +28,6 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-cache
+          key: ${{ runner.os }}-node-test-cache
       - name: run tests
         run: sbt -J-Xmx2g cryptoTestJS/test coreJS/test 'set scalaJSStage in Global := FullOptStage' cryptoTestJS/test coreJS/test asyncUtilsTestJS/test coverage nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcNodeTest/test

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '17'
           cache: 'sbt'
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -28,6 +28,6 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-cache
+          key: ${{ runner.os }}-rpc-tests-cache
       - name: run tests
         run: sbt coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls lndRpcTest/test clightningRpcTest/test esploraTest/test

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -28,6 +28,6 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-cache
+          key: ${{ runner.os }}-rpc-tests-cache
       - name: run tests
         run: sbt coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls lndRpcTest/test esploraTest/test

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '17'
           cache: 'sbt'
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -28,6 +28,6 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-cache
+          key: ${{ runner.os }}-wallet-node-dlc-test-cache
       - name: run tests
         run: sbt coverage cryptoTestJVM/test coreTestJVM/test secp256k1jni/test appCommonsTest/test walletTest/test dlcWalletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcOracleTest/test asyncUtilsTestJVM/test dlcOracle/coverageReport dlcOracle/coveralls dlcNodeTest/test appServerTest/test

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '17'
           cache: 'sbt'
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -32,6 +32,6 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-cache
+          key: ${{ runner.os }}-postgres-cache
       - name: run tests
         run: sbt dbCommonsTest/test walletTest/test dlcWalletTest/test chainTest/test dlcOracleTest/test nodeTest/test

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: '17'
           cache: 'sbt'
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Secp_Disabled_Tests.yml
+++ b/.github/workflows/Secp_Disabled_Tests.yml
@@ -30,6 +30,6 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-cache
+          key: ${{ runner.os }}-secp-disabled-cache
       - name: run tests
         run: sbt cryptoTestJVM/test coreTestJVM/test

--- a/.github/workflows/Secp_Disabled_Tests.yml
+++ b/.github/workflows/Secp_Disabled_Tests.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: '17'
           cache: 'sbt'
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/TorTests.yml
+++ b/.github/workflows/TorTests.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: '17'
           cache: 'sbt'
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -27,7 +27,7 @@ jobs:
           java-version: '17'
           cache: 'sbt'
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.ivy2/cache


### PR DESCRIPTION
fixes #5258

Upgrade the cache action to v3
https://github.com/actions/cache

Also fixes cache names so we have a unique cache name per runner. This fixes the caching of various binaries used for testing such as bitcoind