### PR TITLE
Rework `randomPeerWithServices()` to be inside of `NodeState`

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -118,7 +118,8 @@ class ChainHandler(
         headersWeAlreadyHave.exists(_.hashBE == h.hashBE))
 
       if (filteredHeaders.isEmpty) {
-        return Future.failed(DuplicateHeaders(s"Received duplicate headers."))
+        return Future.failed(
+          DuplicateHeaders(s"Received duplicate block headers."))
       }
 
       val blockchainUpdates: Vector[BlockchainUpdate] = {

--- a/core/src/main/scala/org/bitcoins/core/api/node/NodeState.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/NodeState.scala
@@ -1,25 +1,34 @@
 package org.bitcoins.core.api.node
 
-import org.bitcoins.core.p2p.{CompactFilterMessage}
+import org.bitcoins.core.p2p.{CompactFilterMessage, ServiceIdentifier}
 
 import scala.util.Random
 
 sealed abstract class NodeState {
   def isSyncing: Boolean
 
+  def peersWithServices: Set[PeerWithServices]
+
   /** All peers the node is currently connected to */
-  def peers: Set[Peer]
+  def peers: Set[Peer] = peersWithServices.map(_.peer)
 
   def waitingForDisconnection: Set[Peer]
 
-  def replacePeers(newPeers: Set[Peer]): NodeState = this match {
-    case h: NodeState.HeaderSync        => h.copy(peers = newPeers)
-    case fh: NodeState.FilterHeaderSync => fh.copy(peers = newPeers)
-    case fs: NodeState.FilterSync       => fs.copy(peers = newPeers)
-    case d: NodeState.DoneSyncing       => d.copy(peers = newPeers)
-    case rm: NodeState.RemovePeers      => rm.copy(peers = newPeers)
-    case m: NodeState.MisbehavingPeer   => m.copy(peers = newPeers)
-  }
+  def replacePeers(peerWithServices: Set[PeerWithServices]): NodeState =
+    this match {
+      case h: NodeState.HeaderSync =>
+        h.copy(peersWithServices = peerWithServices)
+      case fh: NodeState.FilterHeaderSync =>
+        fh.copy(peersWithServices = peerWithServices)
+      case fs: NodeState.FilterSync =>
+        fs.copy(peersWithServices = peerWithServices)
+      case d: NodeState.DoneSyncing =>
+        d.copy(peersWithServices = peerWithServices)
+      case rm: NodeState.RemovePeers =>
+        rm.copy(peersWithServices = peerWithServices)
+      case m: NodeState.MisbehavingPeer =>
+        m.copy(peersWithServices = peerWithServices)
+    }
 
   def replaceWaitingForDisconnection(
       newWaitingForDisconnection: Set[Peer]): NodeState = {
@@ -39,23 +48,23 @@ sealed abstract class NodeState {
     }
   }
 
-  def randomPeer(excludePeers: Set[Peer]): Option[Peer] = {
+  def randomPeer(
+      excludePeers: Set[Peer],
+      services: ServiceIdentifier): Option[Peer] = {
     val filteredPeers =
-      peers
-        .filterNot(p => excludePeers.exists(_ == p))
+      peersWithServices
+        .filterNot(p => excludePeers.exists(_ == p.peer))
         //don't give peer a peer that we are waiting to disconnect
-        .filterNot(p => waitingForDisconnection.exists(_ == p))
-        //.filter(p => p._2.serviceIdentifier.hasServicesOf(services))
+        .filterNot(p => waitingForDisconnection.exists(_ == p.peer))
+        .filter(p => p.services.hasServicesOf(services))
         .toVector
-    //val (good, _) =
-    //  filteredPeers.partition(p => !peerDataMap(p).hasFailedRecently)
 
     val peerOpt = if (filteredPeers.nonEmpty) {
       Some(filteredPeers(Random.nextInt(filteredPeers.length)))
     } else {
       None
     }
-    peerOpt
+    peerOpt.map(_.peer)
   }
 }
 
@@ -81,19 +90,19 @@ object NodeState {
 
   case class HeaderSync(
       syncPeer: Peer,
-      peers: Set[Peer],
+      peersWithServices: Set[PeerWithServices],
       waitingForDisconnection: Set[Peer])
       extends SyncNodeState
 
   case class FilterHeaderSync(
       syncPeer: Peer,
-      peers: Set[Peer],
+      peersWithServices: Set[PeerWithServices],
       waitingForDisconnection: Set[Peer])
       extends SyncNodeState
 
   case class FilterSync(
       syncPeer: Peer,
-      peers: Set[Peer],
+      peersWithServices: Set[PeerWithServices],
       waitingForDisconnection: Set[Peer],
       filterBatchCache: Set[CompactFilterMessage])
       extends SyncNodeState {
@@ -105,7 +114,7 @@ object NodeState {
 
   case class MisbehavingPeer(
       badPeer: Peer,
-      peers: Set[Peer],
+      peersWithServices: Set[PeerWithServices],
       waitingForDisconnection: Set[Peer])
       extends NodeState {
     if (peers.nonEmpty) {
@@ -120,7 +129,7 @@ object NodeState {
 
   case class RemovePeers(
       peersToRemove: Vector[Peer],
-      peers: Set[Peer],
+      peersWithServices: Set[PeerWithServices],
       waitingForDisconnection: Set[Peer],
       isSyncing: Boolean)
       extends NodeState {
@@ -130,7 +139,9 @@ object NodeState {
   }
 
   /** State to indicate we are not currently syncing with a peer */
-  case class DoneSyncing(peers: Set[Peer], waitingForDisconnection: Set[Peer])
+  case class DoneSyncing(
+      peersWithServices: Set[PeerWithServices],
+      waitingForDisconnection: Set[Peer])
       extends NodeState {
     override val isSyncing: Boolean = false
   }

--- a/core/src/main/scala/org/bitcoins/core/api/node/NodeState.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/NodeState.scala
@@ -1,6 +1,8 @@
 package org.bitcoins.core.api.node
 
-import org.bitcoins.core.p2p.CompactFilterMessage
+import org.bitcoins.core.p2p.{CompactFilterMessage}
+
+import scala.util.Random
 
 sealed abstract class NodeState {
   def isSyncing: Boolean
@@ -37,6 +39,24 @@ sealed abstract class NodeState {
     }
   }
 
+  def randomPeer(excludePeers: Set[Peer]): Option[Peer] = {
+    val filteredPeers =
+      peers
+        .filterNot(p => excludePeers.exists(_ == p))
+        //don't give peer a peer that we are waiting to disconnect
+        .filterNot(p => waitingForDisconnection.exists(_ == p))
+        //.filter(p => p._2.serviceIdentifier.hasServicesOf(services))
+        .toVector
+    //val (good, _) =
+    //  filteredPeers.partition(p => !peerDataMap(p).hasFailedRecently)
+
+    val peerOpt = if (filteredPeers.nonEmpty) {
+      Some(filteredPeers(Random.nextInt(filteredPeers.length)))
+    } else {
+      None
+    }
+    peerOpt
+  }
 }
 
 /** State to indicate that we are syncing the blockchain */

--- a/core/src/main/scala/org/bitcoins/core/api/node/PeerWithServices.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/PeerWithServices.scala
@@ -1,0 +1,12 @@
+package org.bitcoins.core.api.node
+
+import org.bitcoins.core.api.tor.Socks5ProxyParams
+import org.bitcoins.core.p2p.ServiceIdentifier
+
+import java.net.InetSocketAddress
+
+case class PeerWithServices(peer: Peer, services: ServiceIdentifier) {
+  val id: Option[Long] = peer.id
+  val socket: InetSocketAddress = peer.socket
+  val socks5ProxyParams: Option[Socks5ProxyParams] = peer.socks5ProxyParams
+}

--- a/core/src/main/scala/org/bitcoins/core/p2p/ServiceIdentifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/ServiceIdentifier.scala
@@ -85,7 +85,7 @@ sealed abstract class ServiceIdentifier extends NetworkElement {
     val innerText =
       if (nodeNone) "none"
       else
-        s"network=$nodeNetwork, compactFilters=$nodeCompactFilters, getUtxo=$nodeGetUtxo, bloom=$nodeBloom, witness=$nodeWitness, xthin=$nodeXthin, networkLimited=$nodeNetworkLimited"
+        s"network=$nodeNetwork,compactFilters=$nodeCompactFilters,getUtxo=$nodeGetUtxo,bloom=$nodeBloom,witness=$nodeWitness,xthin=$nodeXthin,networkLimited=$nodeNetworkLimited"
     s"ServiceIdentifier($innerText)"
   }
 

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -396,8 +396,10 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         bestBlockHash0 <- bitcoind0.getBestBlockHash()
         _ <- bitcoind0.invalidateBlock(bestBlockHash0)
         //now generate a block, make sure we sync with them
-        _ <- bitcoind0.generate(1)
-        _ <- AsyncUtil.nonBlockingSleep(1.second)
+        hashes <- bitcoind0.generate(1)
+        chainApi <- node.chainApiFromDb()
+        _ <- AsyncUtil.retryUntilSatisfiedF(() =>
+          chainApi.getHeader(hashes.head).map(_.isDefined))
         //generate another block to make sure the reorg is complete
         _ <- bitcoind0.generate(1)
         _ <- NodeTestUtil.awaitAllSync(node, bitcoind0)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -227,7 +227,12 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       val bitcoindAddrF = bitcoind.getNewAddress
       val sendAmt = Bitcoins.one
       //stop the node to take us offline
-      val stopF = node.stop()
+      val stopF = {
+        for {
+          _ <- NodeTestUtil.awaitAllSync(node, bitcoind)
+          n <- node.stop()
+        } yield n
+      }
       for {
         initBalance <- initBalanceF
         receiveAddr <- receivedAddrF

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -58,7 +58,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
           walletCreationTimeOpt = None,
           peerMessageSenderApi = peerMsgSender,
           peerManager = peerManager,
-          state = HeaderSync(peer, peerManager.peers, Set.empty)
+          state = HeaderSync(peer, peerManager.peersWithServices, Set.empty)
         )(node.executionContext, node.nodeAppConfig, node.chainConfig)
 
         // Use signet genesis block header, this should be invalid for regtest

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -94,7 +94,8 @@ case class NeutrinoNode(
   override def start(): Future[NeutrinoNode] = {
     isStarted.set(true)
     val initState =
-      DoneSyncing(peers = Set.empty, waitingForDisconnection = Set.empty)
+      DoneSyncing(peersWithServices = Set.empty,
+                  waitingForDisconnection = Set.empty)
     val (queue, source) =
       dataMessageStreamSource.preMaterialize()
 

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -3,7 +3,7 @@ package org.bitcoins.node
 import akka.Done
 import akka.actor.ActorSystem
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.core.api.node.Peer
+import org.bitcoins.core.api.node.{Peer, PeerWithServices}
 import org.bitcoins.core.p2p.ServiceIdentifier
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.networking.peer._
@@ -20,6 +20,10 @@ sealed trait PeerData {
 
   implicit protected def system: ActorSystem
   def peer: Peer
+
+  def peerWithServicesOpt: Option[PeerWithServices] = {
+    _serviceIdentifier.map(PeerWithServices(peer, _))
+  }
 
   def peerMessageSender: PeerMessageSender
 


### PR DESCRIPTION
Try to move more state of the node into `NodeState`. This makes things easier to reason about by explicitly returning state rather than mutating state internally in `PeerManager._peerDataMap`. 