### PR TITLE
Rework `NodeTestUtil` to use a specific `bestBlockHash`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1181,6 +1181,8 @@ case class CompactFilterHeadersMessage(
     filterHashes: Vector[DoubleSha256Digest])
     extends DataPayload {
 
+  val stopHashBE: DoubleSha256DigestBE = stopHash.flip
+
   /** The number of hashes in this message */
   val filterHashesLength: CompactSizeUInt = CompactSizeUInt(
     UInt64(filterHashes.length))

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -389,20 +389,25 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       val bitcoind0 = bitcoinds(0)
       val bitcoind1 = bitcoinds(1)
       for {
-        _ <- NodeTestUtil.awaitAllSync(node, bitcoind0)
+        _ <- NodeTestUtil.awaitSyncAndIBD(node, bitcoind0)
         //disconnect bitcoind1 as we don't need it
         nodeUri1 <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind1)
         _ <- bitcoind1.disconnectNode(nodeUri1)
         bestBlockHash0 <- bitcoind0.getBestBlockHash()
         _ <- bitcoind0.invalidateBlock(bestBlockHash0)
+        _ <- AsyncUtil.retryUntilSatisfiedF(() =>
+          node.getConnectionCount.map(_ == 1))
         //now generate a block, make sure we sync with them
         hashes <- bitcoind0.generate(1)
         chainApi <- node.chainApiFromDb()
         _ <- AsyncUtil.retryUntilSatisfiedF(() =>
           chainApi.getHeader(hashes.head).map(_.isDefined))
         //generate another block to make sure the reorg is complete
-        _ <- bitcoind0.generate(1)
-        _ <- NodeTestUtil.awaitAllSync(node, bitcoind0)
+        hashes1 <- bitcoind0.generate(1)
+        _ = logger.info(s"hashes1=$hashes1")
+        _ <- NodeTestUtil.awaitAllSync(node = node,
+                                       bitcoind = bitcoind0,
+                                       bestBlockHashBE = Some(hashes1.head))
       } yield succeed
   }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -401,7 +401,6 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
           1.second)
         //now generate a block, make sure we sync with them
         hashes0 <- bitcoind0.generate(1)
-        _ = logger.info(s"hashes0=$hashes0")
         chainApi <- node.chainApiFromDb()
         _ <- AsyncUtil.retryUntilSatisfiedF(() =>
           chainApi.getHeader(hashes0.head).map(_.isDefined))

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -401,6 +401,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
           1.second)
         //now generate a block, make sure we sync with them
         hashes0 <- bitcoind0.generate(1)
+        _ = logger.info(s"hashes0=$hashes0")
         chainApi <- node.chainApiFromDb()
         _ <- AsyncUtil.retryUntilSatisfiedF(() =>
           chainApi.getHeader(hashes0.head).map(_.isDefined))

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -582,6 +582,7 @@ case class DataMessageHandler(
     for {
       (newFilterHeaderHeight, newFilterHeight) <- calcFilterHeaderFilterHeight(
         chainApi)
+      bestBlockHashBE <- chainApi.getBestBlockHash()
       isSynced <-
         if (newFilterHeight == 0 && walletCreationTimeOpt.isDefined) {
           //if we have zero filters in our database and are syncing filters after a wallet creation time

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -582,7 +582,6 @@ case class DataMessageHandler(
     for {
       (newFilterHeaderHeight, newFilterHeight) <- calcFilterHeaderFilterHeight(
         chainApi)
-      bestBlockHashBE <- chainApi.getBestBlockHash()
       isSynced <-
         if (newFilterHeight == 0 && walletCreationTimeOpt.isDefined) {
           //if we have zero filters in our database and are syncing filters after a wallet creation time

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -182,7 +182,7 @@ case class DataMessageHandler(
                 for {
                   sortedBlockFilters <- sortedBlockFiltersF
                   sortedFilterMessages = sortedBlockFilters.map(_._2)
-                  filterBestBlockHashBE=sortedFilterMessages.lastOption
+                  filterBestBlockHashBE = sortedFilterMessages.lastOption
                     .map(_.blockHashBE)
                   _ = logger.debug(
                     s"Processing ${filterBatch.size} filters bestBlockHashBE=${filterBestBlockHashBE}")
@@ -757,7 +757,7 @@ case class DataMessageHandler(
     val recoveredStateF: Future[NodeState] = getHeadersF.recoverWith {
       case _: DuplicateHeaders =>
         logger.warn(s"Received duplicate headers from ${peer} in state=$state")
-        val d = DoneSyncing(headerSyncState.peers,
+        val d = DoneSyncing(headerSyncState.peersWithServices,
                             headerSyncState.waitingForDisconnection)
         Future.successful(d)
       case _: InvalidBlockHeader =>

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -344,7 +344,7 @@ case class DataMessageHandler(
                 }
               } else {
                 logger.info(
-                  s"Received block=${block.blockHeader.hash.flip.hex} state=$state")
+                  s"Received block=${block.blockHeader.hash.flip.hex} state=$state isIBD=$isIBD headerOpt=${headerOpt.isDefined}")
                 appConfig.callBacks
                   .executeOnBlockReceivedCallbacks(block)
                   .map(_ => this)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -157,7 +157,7 @@ case class DataMessageHandler(
             .map(s => copy(state = s))
 
         case filter: CompactFilterMessage =>
-          logger.warn(
+          logger.debug(
             s"Received ${filter.commandName}, filter.blockHash=${filter.blockHash.flip} state=$state")
           val filterSyncState = state match {
             case f: FilterSync => f
@@ -810,7 +810,6 @@ case class DataMessageHandler(
             startHeightOpt <- PeerManager.getCompactFilterStartHeight(
               chainApi,
               walletCreationTimeOpt)
-            bestBlockHash <- bestBlockHashF
             filterSyncStateOpt <- sendFirstGetCompactFilterCommand(
               peerMessageSenderApi = peerMessageSenderApi,
               stopBlockHash = filterHeader.stopHashBE,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -157,7 +157,7 @@ case class DataMessageHandler(
             .map(s => copy(state = s))
 
         case filter: CompactFilterMessage =>
-          logger.debug(
+          logger.info(
             s"Received ${filter.commandName}, filter.blockHash=${filter.blockHash.flip} state=$state")
           val filterSyncState = state match {
             case f: FilterSync => f
@@ -792,8 +792,7 @@ case class DataMessageHandler(
     val blockCountF = chainApi.getBlockCount()
     val bestBlockHashF = chainApi.getBestBlockHash()
     for {
-      _ <- chainApi.processFilterHeaders(filterHeaders,
-                                         filterHeader.stopHash.flip)
+      _ <- chainApi.processFilterHeaders(filterHeaders, filterHeader.stopHashBE)
       filterHeaderCount <- chainApi.getFilterHeaderCount()
       blockCount <- blockCountF
       bestBlockHash <- bestBlockHashF
@@ -804,7 +803,7 @@ case class DataMessageHandler(
           sendNextGetCompactFilterHeadersCommand(
             peerMessageSenderApi = peerMessageSenderApi,
             syncPeer = peer,
-            prevStopHash = filterHeader.stopHash.flip,
+            prevStopHash = filterHeader.stopHashBE,
             stopHash = bestBlockHash).map(_ => filterHeaderSync)
         } else {
           for {
@@ -814,7 +813,7 @@ case class DataMessageHandler(
             bestBlockHash <- bestBlockHashF
             filterSyncStateOpt <- sendFirstGetCompactFilterCommand(
               peerMessageSenderApi = peerMessageSenderApi,
-              stopBlockHash = bestBlockHash,
+              stopBlockHash = filterHeader.stopHashBE,
               startHeight = startHeight,
               syncNodeState = filterHeaderSync)
           } yield {

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -157,7 +157,7 @@ case class DataMessageHandler(
             .map(s => copy(state = s))
 
         case filter: CompactFilterMessage =>
-          logger.info(
+          logger.debug(
             s"Received ${filter.commandName}, filter.blockHash=${filter.blockHash.flip} state=$state")
           val filterSyncState = state match {
             case f: FilterSync => f
@@ -344,7 +344,7 @@ case class DataMessageHandler(
                 }
               } else {
                 logger.info(
-                  s"Received block=${block.blockHeader.hash.flip.hex} state=$state isIBD=$isIBD headerOpt=${headerOpt.isDefined}")
+                  s"Received block=${block.blockHeader.hash.flip.hex} state=$state")
                 appConfig.callBacks
                   .executeOnBlockReceivedCallbacks(block)
                   .map(_ => this)

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -66,11 +66,11 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
+    <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
 
     <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>
 
-    <logger name="org.bitcoins.node.networking.peer.PeerConnection" level="WARN"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerConnection" level="INFO"/>
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->
     <!-- ╚════════════════════╝ -->

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -66,11 +66,11 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
+    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
 
     <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>
 
-    <logger name="org.bitcoins.node.networking.peer.PeerConnection" level="INFO"/>
+    <logger name="org.bitcoins.node.networking.peer.PeerConnection" level="WARN"/>
     <!-- ╔════════════════════╗ -->
     <!-- ║   Chain module     ║ -->
     <!-- ╚════════════════════╝ -->


### PR DESCRIPTION
this is useful in reorg situations where we expect _specific_ block headers to be our best block header / compact filter