### PR TITLE
2023 12 24 Make filter headers / filters sync work with block header reorgs

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -222,6 +222,7 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
 
   override def nextBlockHeaderBatchRange(
       prevStopHash: DoubleSha256DigestBE,
+      stopHash: DoubleSha256DigestBE,
       batchSize: Int): Future[Option[FilterSyncMarker]] =
     Future.failed(
       new UnsupportedOperationException(

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -229,7 +229,7 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
         s"Bitcoind chainApi doesn't allow you fetch block header batch range"))
 
   override def nextFilterHeaderBatchRange(
-      startHeight: Int,
+      stopBlockHash: DoubleSha256DigestBE,
       batchSize: Int): Future[Option[FilterSyncMarker]] =
     Future.failed(
       new UnsupportedOperationException(

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -230,7 +230,8 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
 
   override def nextFilterHeaderBatchRange(
       stopBlockHash: DoubleSha256DigestBE,
-      batchSize: Int): Future[Option[FilterSyncMarker]] =
+      batchSize: Int,
+      startHeightOpt: Option[Int]): Future[Option[FilterSyncMarker]] =
     Future.failed(
       new UnsupportedOperationException(
         s"Bitcoind chainApi doesn't allow you fetch filter header batch range"))

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -784,6 +784,28 @@ class ChainHandlerTest extends ChainDbUnitTest {
       assert3F
   }
 
+  it must "nextFilterHeaderBatchRange must honor the startHeightOpt parameter" in {
+    chainHandler =>
+      val reorgFixtureF = buildChainHandlerCompetingHeaders(chainHandler)
+      val chainHandlerF = reorgFixtureF.map(_.chainApi)
+      val newHeaderCF = reorgFixtureF.map(_.headerDb2)
+      val assert1F = for {
+        chainHandler <- chainHandlerF
+        newHeaderC <- newHeaderCF
+        rangeOpt <- chainHandler.nextFilterHeaderBatchRange(stopBlockHash =
+                                                              newHeaderC.hashBE,
+                                                            batchSize = 2,
+                                                            startHeightOpt =
+                                                              Some(0))
+      } yield {
+        assert(rangeOpt.nonEmpty, s"rangeOpt=$rangeOpt")
+        val range = rangeOpt.get
+        assert(range.startHeight == 0)
+        assert(range.stopBlockHashBE == newHeaderC.hashBE)
+      }
+      assert1F
+  }
+
   it must "read compact filters for the database" in {
     chainHandler: ChainHandler =>
       for {

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -38,7 +38,7 @@ class ChainHandlerTest extends ChainDbUnitTest {
     ChainFixtureTag.GenesisChainHandlerWithFilter
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
-    withChainHandlerGenesisFilter(test)
+    withChainHandler(test)
 
   val genesis: BlockHeaderDb = ChainTestUtil.genesisHeaderDb
   behavior of "ChainHandler"
@@ -52,6 +52,16 @@ class ChainHandlerTest extends ChainDbUnitTest {
       nBits = UInt32(545259519),
       nonce = UInt32(2083236893)
     )
+
+  private def insertGenesisFilterHeaderAndFilter(
+      chainHandler: ChainHandler): Future[Unit] = {
+    for {
+      _ <- chainHandler.processFilterHeader(
+        ChainTestUtil.genesisFilterHeaderDb.filterHeader,
+        ChainTestUtil.genesisHeaderDb.hashBE)
+      _ <- chainHandler.processFilter(ChainTestUtil.genesisFilterMessage)
+    } yield ()
+  }
 
   it must "process a new valid block header, and then be able to fetch that header" in {
     chainHandler: ChainHandler =>
@@ -218,9 +228,12 @@ class ChainHandlerTest extends ChainDbUnitTest {
   it must "get the highest filter header" in { chainHandler: ChainHandler =>
     {
       for {
+        initFhCount <- chainHandler.getFilterHeaderCount()
+        _ <- insertGenesisFilterHeaderAndFilter(chainHandler)
         count <- chainHandler.getFilterHeaderCount()
         genesisFilterHeader <- chainHandler.getFilterHeadersAtHeight(count)
       } yield {
+        assert(initFhCount == 0)
         assert(genesisFilterHeader.size == 1)
         assert(
           genesisFilterHeader.contains(ChainTestUtil.genesisFilterHeaderDb))
@@ -318,9 +331,12 @@ class ChainHandlerTest extends ChainDbUnitTest {
     {
       for {
         count <- chainHandler.getFilterCount()
-        genesisFilter <- chainHandler.getFiltersAtHeight(count)
+        _ <- insertGenesisFilterHeaderAndFilter(chainHandler)
+        genesisFilter <- chainHandler.getFiltersAtHeight(0)
+        count1 <- chainHandler.getFilterCount()
       } yield {
         assert(count == 0)
+        assert(count1 == 0)
         assert(genesisFilter.contains(ChainTestUtil.genesisFilterDb))
         assert(
           genesisFilter.head.golombFilter == ChainTestUtil.genesisFilterDb.golombFilter)
@@ -331,6 +347,7 @@ class ChainHandlerTest extends ChainDbUnitTest {
   it must "NOT create an unknown filter" in { chainHandler: ChainHandler =>
     {
       val unknownHashF = for {
+        _ <- insertGenesisFilterHeaderAndFilter(chainHandler)
         _ <- chainHandler.processHeader(nextBlockHeader)
         blockHashBE <- chainHandler.getHeadersAtHeight(1).map(_.head.hashBE)
         golombFilter = BlockFilter.fromHex("017fa880", blockHashBE.flip)
@@ -389,15 +406,17 @@ class ChainHandlerTest extends ChainDbUnitTest {
     }
   }
 
-  it must "generate a range for a block filter header query for the genesis block" in {
+  it must "generate a range for a filter header query for the genesis block" in {
     chainHandler: ChainHandler =>
       val genesisHeader =
         chainHandler.chainConfig.chain.genesisBlock.blockHeader
       val assert1F = for {
         rangeOpt <-
-          chainHandler.nextBlockHeaderBatchRange(DoubleSha256DigestBE.empty,
-                                                 genesisHeader.hashBE,
-                                                 1)
+          chainHandler.nextBlockHeaderBatchRange(prevStopHash =
+                                                   DoubleSha256DigestBE.empty,
+                                                 stopHash =
+                                                   genesisHeader.hashBE,
+                                                 batchSize = 1)
       } yield {
         assert(rangeOpt.nonEmpty)
         val marker = rangeOpt.get
@@ -432,7 +451,7 @@ class ChainHandlerTest extends ChainDbUnitTest {
       }
   }
 
-  it must "generate the correct range of block filter headers if a block header is reorged" in {
+  it must "generate the correct range of filter headers if a block header is reorged" in {
     chainHandler: ChainHandler =>
       val reorgFixtureF = buildChainHandlerCompetingHeaders(chainHandler)
       val chainHandlerF = reorgFixtureF.map(_.chainApi)
@@ -519,17 +538,86 @@ class ChainHandlerTest extends ChainDbUnitTest {
       assert1F
   }
 
-  it must "generate a range for a block filter header query" in {
+  it must "nextBlockHeaderBatchRange must honor the batchSize query" in {
     chainHandler: ChainHandler =>
-      for {
-        bestBlock <- chainHandler.getBestBlockHeader()
-        bestBlockHashBE = bestBlock.hashBE
-        rangeOpt <- chainHandler.nextFilterHeaderBatchRange(bestBlockHashBE, 1)
+      val reorgFixtureF = buildChainHandlerCompetingHeaders(chainHandler)
+      val chainHandlerF = reorgFixtureF.map(_.chainApi)
+      val newHeaderBF = reorgFixtureF.map(_.headerDb1)
+      val newHeaderCF = reorgFixtureF.map(_.headerDb2)
+
+      //two competing headers B,C built off of A
+      //first specify header C to be syncing filter headers from
+      val assert1F = for {
+        chainHandler <- chainHandlerF
+        newHeaderB <- newHeaderBF
+        newHeaderC <- newHeaderCF
+        blockHeaderBatchOpt <- chainHandler.nextBlockHeaderBatchRange(
+          prevStopHash = ChainTestUtil.regTestGenesisHeaderDb.hashBE,
+          stopHash = newHeaderC.hashBE,
+          batchSize = 1)
       } yield {
-        val marker = rangeOpt.get
-        assert(rangeOpt.nonEmpty)
-        assert(marker.startHeight == 0)
-        assert(marker.stopBlockHash == bestBlockHashBE.flip)
+        assert(blockHeaderBatchOpt.isDefined)
+        val marker = blockHeaderBatchOpt.get
+        ChainHandlerTest.checkReorgHeaders(header1 = newHeaderB,
+                                           header2 = newHeaderC,
+                                           bestHash = marker.stopBlockHash.flip)
+        assert(marker.startHeight == 1)
+        assert(newHeaderC.hashBE == marker.stopBlockHash.flip)
+      }
+
+      //now let's build a new block header ontop of C and process it
+      //when we call chainHandler.nextBlockHeaderBatchRange it
+      //should be C's hash instead of D's hash due to batchSize
+      val assert2F = for {
+        _ <- assert1F
+        chainHandler <- chainHandlerF
+        headerC <- newHeaderCF
+        headerD = BlockHeaderHelper.buildNextHeader(headerC)
+        chainApiD <- chainHandler.processHeader(headerD.blockHeader)
+        blockHeaderBatchOpt <- chainApiD.nextBlockHeaderBatchRange(
+          prevStopHash = ChainTestUtil.regTestGenesisHeaderDb.hashBE,
+          stopHash = headerD.hashBE,
+          batchSize = 1)
+      } yield {
+        assert(blockHeaderBatchOpt.isDefined)
+        val marker = blockHeaderBatchOpt.get
+        assert(marker.startHeight == 1)
+        assert(headerC.hashBE == marker.stopBlockHashBE)
+      }
+
+      val headerDF = {
+        newHeaderCF.map(headerC => BlockHeaderHelper.buildNextHeader(headerC))
+      }
+
+      val assert3F = for {
+        _ <- assert2F
+        chainHandler <- chainHandlerF
+        headerD <- headerDF
+        chainApiD <- chainHandler.processHeader(headerD.blockHeader)
+        blockHeaderBatchOpt <- chainApiD.nextBlockHeaderBatchRange(
+          prevStopHash = ChainTestUtil.regTestGenesisHeaderDb.hashBE,
+          stopHash = headerD.hashBE,
+          batchSize = 2)
+      } yield {
+        assert(blockHeaderBatchOpt.isDefined)
+        val marker = blockHeaderBatchOpt.get
+        assert(marker.startHeight == 1)
+        assert(headerD.hashBE == marker.stopBlockHash.flip)
+      }
+
+      //must return None in the case of reorg scenario between prevStopHash / stopHash
+      for {
+        _ <- assert3F
+        chainHandler <- chainHandlerF
+        headerB <- newHeaderBF
+        headerD <- headerDF
+        //note headerB and headerD are not part of the same chain as D is built ontop of C
+        blockHeaderBatchOpt <-
+          chainHandler.nextBlockHeaderBatchRange(prevStopHash = headerB.hashBE,
+                                                 stopHash = headerD.hashBE,
+                                                 batchSize = 1)
+      } yield {
+        assert(blockHeaderBatchOpt.isEmpty)
       }
   }
 
@@ -646,71 +734,6 @@ class ChainHandlerTest extends ChainDbUnitTest {
       }
   }
 
-  it must "nextBlockHeaderBatchRange must honor the batchSize query" in {
-    chainHandler: ChainHandler =>
-      val reorgFixtureF = buildChainHandlerCompetingHeaders(chainHandler)
-      val chainHandlerF = reorgFixtureF.map(_.chainApi)
-      val newHeaderBF = reorgFixtureF.map(_.headerDb1)
-      val newHeaderCF = reorgFixtureF.map(_.headerDb2)
-
-      //two competing headers B,C built off of A
-      //first specify header C to be syncing filter headers from
-      val assert1F = for {
-        chainHandler <- chainHandlerF
-        newHeaderB <- newHeaderBF
-        newHeaderC <- newHeaderCF
-        blockHeaderBatchOpt <- chainHandler.nextBlockHeaderBatchRange(
-          prevStopHash = ChainTestUtil.regTestGenesisHeaderDb.hashBE,
-          stopHash = newHeaderC.hashBE,
-          batchSize = 1)
-      } yield {
-        assert(blockHeaderBatchOpt.isDefined)
-        val marker = blockHeaderBatchOpt.get
-        ChainHandlerTest.checkReorgHeaders(header1 = newHeaderB,
-                                           header2 = newHeaderC,
-                                           bestHash = marker.stopBlockHash.flip)
-        assert(newHeaderC.height == marker.startHeight)
-        assert(newHeaderC.hashBE == marker.stopBlockHash.flip)
-      }
-
-      //now let's build a new block header ontop of C and process it
-      //when we call chainHandler.nextBlockHeaderBatchRange it
-      //should be C's hash instead of B's hash
-      val assert2F = for {
-        _ <- assert1F
-        chainHandler <- chainHandlerF
-        headerC <- newHeaderCF
-        headerD = BlockHeaderHelper.buildNextHeader(headerC)
-        chainApiD <- chainHandler.processHeader(headerD.blockHeader)
-        blockHeaderBatchOpt <- chainApiD.nextBlockHeaderBatchRange(
-          prevStopHash = ChainTestUtil.regTestGenesisHeaderDb.hashBE,
-          stopHash = headerD.hashBE,
-          batchSize = 1)
-      } yield {
-        assert(blockHeaderBatchOpt.isDefined)
-        val marker = blockHeaderBatchOpt.get
-        assert(headerC.height == marker.startHeight)
-        assert(headerC.hashBE == marker.stopBlockHash.flip)
-      }
-
-      for {
-        _ <- assert2F
-        chainHandler <- chainHandlerF
-        headerC <- newHeaderCF
-        headerD = BlockHeaderHelper.buildNextHeader(headerC)
-        chainApiD <- chainHandler.processHeader(headerD.blockHeader)
-        blockHeaderBatchOpt <- chainApiD.nextBlockHeaderBatchRange(
-          prevStopHash = ChainTestUtil.regTestGenesisHeaderDb.hashBE,
-          stopHash = headerD.hashBE,
-          batchSize = 2)
-      } yield {
-        assert(blockHeaderBatchOpt.isDefined)
-        val marker = blockHeaderBatchOpt.get
-        assert(headerC.height == marker.startHeight)
-        assert(headerD.hashBE == marker.stopBlockHash.flip)
-      }
-  }
-
   it must "nextFilterHeaderBatchRange must honor the batchSize query" in {
     chainHandler: ChainHandler =>
       val reorgFixtureF = buildChainHandlerCompetingHeaders(chainHandler)
@@ -737,30 +760,16 @@ class ChainHandlerTest extends ChainDbUnitTest {
         assert(newHeaderC.hashBE == marker.stopBlockHash.flip)
       }
 
+      val headerDF = {
+        newHeaderCF.map(headerC => BlockHeaderHelper.buildNextHeader(headerC))
+      }
       //now let's build a new block header ontop of C and process it
-      //when we call chainHandler.nextFilterHeaderBatchRange with batchSize=1
-      //should get C's hash back as the stop hash
-      val assert2F = for {
+      //when we call chainHandler.nextFilterHeaderBatchRange with batchSize=2
+      //should get D's hash back as the stop hash
+      val assert3F = for {
         _ <- assert1F
         chainHandler <- chainHandlerF
-        headerC <- newHeaderCF
-        headerD = BlockHeaderHelper.buildNextHeader(headerC)
-        chainApiD <- chainHandler.processHeader(headerD.blockHeader)
-        blockHeaderBatchOpt <- chainApiD.nextFilterHeaderBatchRange(
-          stopBlockHash = headerD.hashBE,
-          batchSize = 1)
-      } yield {
-        assert(blockHeaderBatchOpt.isDefined)
-        val marker = blockHeaderBatchOpt.get
-        assert(marker.startHeight == 0)
-        assert(headerC.hashBE == marker.stopBlockHash.flip)
-      }
-
-      for {
-        _ <- assert2F
-        chainHandler <- chainHandlerF
-        headerC <- newHeaderCF
-        headerD = BlockHeaderHelper.buildNextHeader(headerC)
+        headerD <- headerDF
         chainApiD <- chainHandler.processHeader(headerD.blockHeader)
         blockHeaderBatchOpt <- chainApiD.nextFilterHeaderBatchRange(
           stopBlockHash = headerD.hashBE,
@@ -771,11 +780,14 @@ class ChainHandlerTest extends ChainDbUnitTest {
         assert(marker.startHeight == 0)
         assert(marker.stopBlockHash.flip == headerD.hashBE)
       }
+
+      assert3F
   }
 
   it must "read compact filters for the database" in {
     chainHandler: ChainHandler =>
       for {
+        _ <- insertGenesisFilterHeaderAndFilter(chainHandler)
         bestBlock <- chainHandler.getBestBlockHeader()
         filterHeader <- chainHandler.getFilterHeader(bestBlock.hashBE)
         filter <- chainHandler.getFilter(bestBlock.hashBE)
@@ -878,7 +890,10 @@ class ChainHandlerTest extends ChainDbUnitTest {
   }
 
   it must "find filters between heights" in { chainHandler: ChainHandler =>
-    chainHandler.getFiltersBetweenHeights(0, 1).map { filters =>
+    for {
+      _ <- insertGenesisFilterHeaderAndFilter(chainHandler)
+      filters <- chainHandler.getFiltersBetweenHeights(0, 1)
+    } yield {
       val genesis = ChainTestUtil.genesisFilterDb
       val genesisFilterResponse = FilterResponse(genesis.golombFilter,
                                                  genesis.blockHashBE,
@@ -912,12 +927,10 @@ class ChainHandlerTest extends ChainDbUnitTest {
     chainHandler: ChainHandler =>
       val filter = ChainTestUtil.genesisFilterMessage
       val filters = Vector.fill(2)(filter)
-      val filterCountBeforeF = chainHandler.getFilterCount()
-      val processF =
-        filterCountBeforeF.flatMap(_ => chainHandler.processFilters(filters))
       for {
-        _ <- processF
-        beforeFilterCount <- filterCountBeforeF
+        _ <- insertGenesisFilterHeaderAndFilter(chainHandler)
+        beforeFilterCount <- chainHandler.getFilterCount()
+        _ <- chainHandler.processFilters(filters)
         filterCount <- chainHandler.getFilterCount()
       } yield {
         assert(beforeFilterCount == filterCount)
@@ -952,11 +965,10 @@ class ChainHandlerTest extends ChainDbUnitTest {
   }
 
   it must "get best filter" in { chainHandler: ChainHandler =>
-    val bestFilterOptF = chainHandler.getBestFilter()
-    val bestFilterHeaderOptF = chainHandler.getBestFilterHeader()
     for {
-      bestFilterHeaderOpt <- bestFilterHeaderOptF
-      bestFilterOpt <- bestFilterOptF
+      _ <- insertGenesisFilterHeaderAndFilter(chainHandler)
+      bestFilterHeaderOpt <- chainHandler.getBestFilterHeader()
+      bestFilterOpt <- chainHandler.getBestFilter()
     } yield {
       assert(bestFilterHeaderOpt.isDefined)
       assert(bestFilterOpt.isDefined)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -453,7 +453,6 @@ class ChainHandler(
             }
           }
         } yield {
-          println(s"fsmOptVec=$fsmOptVec")
           fsmOptVec.flatten.headOption
         }
       case None =>

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -250,14 +250,6 @@ class ChainHandler(
       }
       syncMarkerOpt
     }
-
-    /*    for {
-      blockchains <- blockHeaderDAO.getBlockchains()
-      syncMarkerOpt <- nextBlockHeaderBatchRangeWithChains(prevStopHash,
-                                                           batchSize,
-                                                           blockchains)
-    } yield syncMarkerOpt*/
-
   }
 
   /** Finds the next header in the chain. Uses chain work to break ties

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -191,118 +191,189 @@ class ChainHandler(
     getBestBlockHeader().map(_.hashBE)
   }
 
-  protected def nextBlockHeaderBatchRangeWithChains(
-      prevStopHash: DoubleSha256DigestBE,
-      batchSize: Int,
-      blockchains: Vector[Blockchain]): Future[Option[FilterSyncMarker]] = for {
-    prevBlockHeaderOpt <- getHeader(prevStopHash)
-    headerOpt <- {
-      prevBlockHeaderOpt match {
-        case Some(prevBlockHeader) =>
-          findNextHeader(prevBlockHeader, batchSize, blockchains)
-        case None =>
-          if (prevStopHash == DoubleSha256DigestBE.empty) {
-            getHeadersAtHeight(batchSize - 1).flatMap { headers =>
-              val fsmOptF = if (headers.isEmpty) {
-                //just get best height?
-                getBestBlockHeader().map { bestHeader =>
-                  val f = FilterSyncMarker(0, bestHeader.hash)
-                  Some(f)
-                }
-              } else if (headers.length == 1) {
-                val header = headers.head
-                val f = FilterSyncMarker(0, header.hash)
-                Future.successful(Some(f))
-              } else {
-                //just select first header, i guess
-                val header = headers.head
-                val f = FilterSyncMarker(0, header.hash)
-                Future.successful(Some(f))
-              }
-              fsmOptF
-            }
-          } else {
-            Future.successful(None)
-          }
-
-      }
-    }
-  } yield headerOpt
-
   /** @inheritdoc */
   override def nextBlockHeaderBatchRange(
       prevStopHash: DoubleSha256DigestBE,
       stopHash: DoubleSha256DigestBE,
       batchSize: Int): Future[Option[FilterSyncMarker]] = {
     if (prevStopHash == DoubleSha256DigestBE.empty) {
-      val fsm = FilterSyncMarker(0, stopHash.flip)
-      Future.successful(Some(fsm))
+      getHeadersAtHeight(batchSize - 1).map { headers =>
+        if (headers.length == 1) {
+          val fsm = FilterSyncMarker(0, headers.head.hash)
+          Some(fsm)
+        } else {
+          logger.warn(
+            s"ChainHandler.nextBlockHeaderBatchRange() did not find a single header, got zero or multiple=$headers")
+          None
+        }
+      }
     } else if (prevStopHash == stopHash) {
       //means are are in sync
       Future.successful(None)
     } else {
       val prevBlockHeaderOptF = getHeader(prevStopHash)
-      val syncMarkerOpt = prevBlockHeaderOptF.map {
-        case Some(prevBlockHeader) =>
-          val f = FilterSyncMarker(prevBlockHeader.height + 1, stopHash.flip)
-          Some(f)
-        case None => None
+      val stopBlockHeaderOptF = getHeader(stopHash)
+      val blockchainsF = blockHeaderDAO.getBlockchains()
+      for {
+        prevBlockHeaderOpt <- prevBlockHeaderOptF
+        stopBlockHeaderOpt <- stopBlockHeaderOptF
+        blockchains <- blockchainsF
+        fsmOpt <- getFilterSyncStopHash(prevBlockHeaderOpt = prevBlockHeaderOpt,
+                                        stopBlockHeaderOpt = stopBlockHeaderOpt,
+                                        blockchains = blockchains,
+                                        batchSize = batchSize)
+      } yield {
+        fsmOpt
       }
-      syncMarkerOpt
+    }
+  }
+
+  /** Retrieves a [[FilterSyncMarker]] respeciting the batchSize parameter. If the stopBlockHeader is not within the batchSize parameter
+    * we walk backwards until we find a header within the batchSize limit
+    */
+  private def getFilterSyncStopHash(
+      prevBlockHeaderOpt: Option[BlockHeaderDb],
+      stopBlockHeaderOpt: Option[BlockHeaderDb],
+      blockchains: Vector[Blockchain],
+      batchSize: Int): Future[Option[FilterSyncMarker]] = {
+    (prevBlockHeaderOpt, stopBlockHeaderOpt) match {
+      case (prevBlockHeaderOpt, Some(stopBlockHeader)) =>
+        findNextHeader(prevBlockHeaderOpt = prevBlockHeaderOpt,
+                       stopBlockHeaderDb = stopBlockHeader,
+                       batchSize = batchSize,
+                       blockchains = blockchains)
+      case (Some(prevBlockHeader), None) =>
+        val exn = new RuntimeException(
+          s"Cannot find a stopBlockHeader, only found prevBlockHeader=${prevBlockHeader.hashBE}")
+        Future.failed(exn)
+      case (None, None) =>
+        val exn = new RuntimeException(
+          s"Cannot find prevBlocKHeader or stopBlockHeader")
+        Future.failed(exn)
     }
   }
 
   /** Finds the next header in the chain. Uses chain work to break ties
     * returning only the header in the chain with the most work,
     * else returns None if there is no next header
+    * @param prevBlockHeaderOpt the previous block header we synced from, if None we are syncing from genesis
     */
   private def findNextHeader(
-      prevBlockHeader: BlockHeaderDb,
+      prevBlockHeaderOpt: Option[BlockHeaderDb],
+      stopBlockHeaderDb: BlockHeaderDb,
       batchSize: Int,
       blockchains: Vector[Blockchain]): Future[Option[FilterSyncMarker]] = {
-    val chainsF = {
+    val isInBatchSize =
+      (stopBlockHeaderDb.height - prevBlockHeaderOpt
+        .map(_.height)
+        .getOrElse(0)) <= batchSize
+
+    val prevBlockHeaderHeight = {
+      prevBlockHeaderOpt
+        .map(_.height)
+        .getOrElse(-1) //means we are syncing from the genesis block
+    }
+
+    val prevBlockHeaderHashBE = {
+      prevBlockHeaderOpt
+        .map(_.hashBE)
+        .getOrElse(
+          DoubleSha256DigestBE.empty
+        ) //means we are syncing from genesis block
+    }
+
+    val chainsF: Future[Vector[Blockchain]] = {
       val inMemoryBlockchains = {
-        blockchains.filter(
-          _.exists(_.previousBlockHashBE == prevBlockHeader.hashBE))
+        blockchains.filter { b =>
+          hasBothBlockHeaderHashes(blockchain = b,
+                                   prevBlockHeaderHashBE =
+                                     prevBlockHeaderHashBE,
+                                   stopBlockHeaderHashBE =
+                                     stopBlockHeaderDb.hashBE)
+        }
       }
       if (inMemoryBlockchains.nonEmpty) {
         Future.successful(inMemoryBlockchains)
       } else {
-        blockHeaderDAO.getBlockchainsBetweenHeights(
-          from = prevBlockHeader.height,
-          to = prevBlockHeader.height + batchSize)
+        if (isInBatchSize) {
+          blockHeaderDAO
+            .getBlockchainFrom(stopBlockHeaderDb)
+            .map {
+              case Some(blockchain) =>
+                val hasBothHashes =
+                  hasBothBlockHeaderHashes(
+                    blockchain = blockchain,
+                    prevBlockHeaderHashBE = prevBlockHeaderHashBE,
+                    stopBlockHeaderHashBE = stopBlockHeaderDb.hashBE)
+                if (hasBothHashes) {
+                  Vector(blockchain)
+                } else {
+                  Vector.empty
+                }
+              case None => Vector.empty
+            }
+
+        } else {
+          blockHeaderDAO.getBlockchainsBetweenHeights(
+            from = prevBlockHeaderHeight,
+            to = prevBlockHeaderHeight + batchSize)
+        }
+
       }
     }
 
-    val startHeight = {
-      if (prevBlockHeader.hashBE == chainConfig.chain.genesisHash.flip) {
-        1
-      } else {
-        prevBlockHeader.height + 1
-      }
-    }
+    val startHeight = prevBlockHeaderHeight + 1
 
     for {
       chains <- chainsF
     } yield {
-      val nextBlockHeaderOpt = getBestChainAtHeight(startHeight = startHeight,
-                                                    batchSize = batchSize,
-                                                    blockchains = chains)
+      val nextBlockHeaderOpt = {
+        if (chains.isEmpty) {
+          //means prevBlockHeader and stopBlockHeader do not form a blockchain
+          None
+        } else if (isInBatchSize) {
+          Some(FilterSyncMarker(startHeight, stopBlockHeaderDb.hash))
+        } else {
+          //means our requested stopBlockHeader is outside of batchSize
+          //we need to find an intermediate header within batchSize to sync against
+          getBestChainAtHeight(startHeight = startHeight,
+                               batchSize = batchSize,
+                               blockchains = chains)
+        }
+      }
+
       nextBlockHeaderOpt match {
         case Some(next) =>
           //this means we are synced, so return None
           val isSynced =
-            next.stopBlockHash == prevBlockHeader.hash || next.stopBlockHash == chainConfig.chain.genesisHash
+            next.stopBlockHashBE == prevBlockHeaderHashBE
           if (isSynced) {
             None
           } else {
             nextBlockHeaderOpt
           }
         case None =>
-          //log here?
           None
       }
     }
+  }
+
+  private def hasBothBlockHeaderHashes(
+      blockchain: Blockchain,
+      prevBlockHeaderHashBE: DoubleSha256DigestBE,
+      stopBlockHeaderHashBE: DoubleSha256DigestBE): Boolean = {
+    if (prevBlockHeaderHashBE == DoubleSha256DigestBE.empty) {
+      //carve out here in the case of genesis header,
+      //blockchains don't contain a block header with hash 0x000..0000
+      blockchain.exists(_.hashBE == stopBlockHeaderHashBE)
+    } else {
+      val hasHash1 =
+        blockchain.exists(_.hashBE == prevBlockHeaderHashBE)
+      val hasHash2 =
+        blockchain.exists(_.hashBE == stopBlockHeaderHashBE)
+      hasHash1 && hasHash2
+    }
+
   }
 
   /** Given a vector of blockchains, this method finds the chain with the most chain work
@@ -340,37 +411,54 @@ class ChainHandler(
       stopBlockHash: DoubleSha256DigestBE,
       batchSize: Int,
       startHeightOpt: Option[Int]): Future[Option[FilterSyncMarker]] = {
-    val bestFilterOptF = getBestFilter()
-    val stopBlockHeaderOptF = getHeader(stopBlockHash)
-    for {
-      bestFilterOpt <- bestFilterOptF
-      stopBlockHeaderOpt <- stopBlockHeaderOptF
-      startHeight = {
-        bestFilterOpt match {
-          case Some(bf) =>
-            if (bf.height == 0) 0
-            else bf.height + 1
-          case None => 0
-        }
+    val stopBlockHeaderDbOptF = getHeader(stopBlockHash)
+    val blockchainsF = blockHeaderDAO.getBlockchains()
+    val startHeadersOptF: Future[Option[Vector[BlockHeaderDb]]] =
+      startHeightOpt match {
+        case Some(startHeight) =>
+          getHeadersAtHeight(startHeight).map(Some(_))
+        case None =>
+          getBestFilter().flatMap {
+            case Some(bestFilter) =>
+              getHeader(bestFilter.blockHashBE)
+                .map(_.toVector)
+                .map(Some(_))
+            case None =>
+              //means we need to sync from genesis filter
+              Future.successful(None)
+          }
       }
-      fsmOpt = {
-        stopBlockHeaderOpt match {
-          case Some(sbh) =>
-            if (
-              stopBlockHash == chainConfig.network.chainParams.genesisHashBE
-            ) {
-              Some(FilterSyncMarker(0, stopBlockHash.flip))
-            } else if (startHeight > sbh.height) {
-              None
-            } else {
-              val f = FilterSyncMarker(startHeight, stopBlockHash.flip)
-              Some(f)
+
+    stopBlockHeaderDbOptF.flatMap {
+      case Some(stopBlockHeaderDb) =>
+        for {
+          startHeadersOpt <- startHeadersOptF
+          blockchains <- blockchainsF
+          fsmOptVec <- {
+            startHeadersOpt match {
+              case Some(startHeaders) =>
+                Future.traverse(startHeaders)(h =>
+                  findNextHeader(Some(h),
+                                 stopBlockHeaderDb,
+                                 batchSize,
+                                 blockchains))
+
+              case None =>
+                val fsmOptF = findNextHeader(prevBlockHeaderOpt = None,
+                                             stopBlockHeaderDb =
+                                               stopBlockHeaderDb,
+                                             batchSize = batchSize,
+                                             blockchains = blockchains)
+                fsmOptF.map(Vector(_))
             }
-          case None =>
-            None
+          }
+        } yield {
+          println(s"fsmOptVec=$fsmOptVec")
+          fsmOptVec.flatten.headOption
         }
-      }
-    } yield fsmOpt
+      case None =>
+        Future.successful(None)
+    }
   }
 
   /** @inheritdoc */

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandlerCached.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandlerCached.scala
@@ -8,7 +8,7 @@ import org.bitcoins.chain.models.{
   CompactFilterHeaderDAO
 }
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, CompactFilterHeaderDb}
-import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
+import org.bitcoins.core.api.chain.{ChainApi}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.crypto.DoubleSha256DigestBE
 
@@ -50,14 +50,6 @@ case class ChainHandlerCached(
 
   override def getBestFilterHeader(): Future[Option[CompactFilterHeaderDb]] = {
     getBestFilterHeaderWithChains(blockchains)
-  }
-
-  override def nextBlockHeaderBatchRange(
-      prevStopHash: DoubleSha256DigestBE,
-      batchSize: Int): Future[Option[FilterSyncMarker]] = {
-    nextBlockHeaderBatchRangeWithChains(prevStopHash = prevStopHash,
-                                        batchSize = batchSize,
-                                        blockchains = blockchains)
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -88,9 +88,24 @@ trait ChainApi extends ChainQueryApi {
 
   /** Generates a filter header range in form of (startHeight, stopHash) by the given stop hash.
     */
+  final def nextFilterHeaderBatchRange(
+      stopBlockHash: DoubleSha256DigestBE,
+      batchSize: Int): Future[Option[FilterSyncMarker]] = {
+    nextFilterHeaderBatchRange(stopBlockHash = stopBlockHash,
+                               batchSize = batchSize,
+                               startHeightOpt = None)
+  }
+
+  /** Generates a query for a range of compact filters
+    * @param stopBlockHash the block hash to stop receiving filters at
+    * @param batchSize
+    * @param startHeightOpt the block height to start syncing filters from. If None, we query our chainstate for the last filter we've seen
+    * @return
+    */
   def nextFilterHeaderBatchRange(
       stopBlockHash: DoubleSha256DigestBE,
-      batchSize: Int): Future[Option[FilterSyncMarker]]
+      batchSize: Int,
+      startHeightOpt: Option[Int]): Future[Option[FilterSyncMarker]]
 
   /** Adds a compact filter into the filter database.
     */

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -75,9 +75,15 @@ trait ChainApi extends ChainQueryApi {
 
   /** Generates a block range in form of (startHeight, stopHash) by the given stop hash.
     * Returns None if we are synced
+    *
+    * @param prevStopHash our previous block hash where filter header sync stopped
+    * @param stopHash the block hash we want to sync the new batch of filters to
+    * @param batchSize the batch size of filter headers
+    * @return
     */
   def nextBlockHeaderBatchRange(
       prevStopHash: DoubleSha256DigestBE,
+      stopHash: DoubleSha256DigestBE,
       batchSize: Int): Future[Option[FilterSyncMarker]]
 
   /** Generates a filter header range in form of (startHeight, stopHash) by the given stop hash.

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -89,7 +89,7 @@ trait ChainApi extends ChainQueryApi {
   /** Generates a filter header range in form of (startHeight, stopHash) by the given stop hash.
     */
   def nextFilterHeaderBatchRange(
-      startHeight: Int,
+      stopBlockHash: DoubleSha256DigestBE,
       batchSize: Int): Future[Option[FilterSyncMarker]]
 
   /** Adds a compact filter into the filter database.

--- a/core/src/main/scala/org/bitcoins/core/api/chain/FilterSyncMarker.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/FilterSyncMarker.scala
@@ -13,5 +13,5 @@ case class FilterSyncMarker(
     stopBlockHash: DoubleSha256Digest) {
 
   override def toString: String =
-    s"FilterSyncMarker(startHeight=$startHeight, stopBlockHash=${stopBlockHash.flip.hex})"
+    s"FilterSyncMarker(startHeight=$startHeight,stopBlockHashBE=${stopBlockHash.flip.hex})"
 }

--- a/core/src/main/scala/org/bitcoins/core/api/chain/FilterSyncMarker.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/FilterSyncMarker.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.api.chain
 
-import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 
 /** This is a helper class for syncing block filters following the
   * BIP157 protocol. This indicates the starting block height we are
@@ -11,6 +11,8 @@ import org.bitcoins.crypto.DoubleSha256Digest
 case class FilterSyncMarker(
     startHeight: Int,
     stopBlockHash: DoubleSha256Digest) {
+
+  val stopBlockHashBE: DoubleSha256DigestBE = stopBlockHash.flip
 
   override def toString: String =
     s"FilterSyncMarker(startHeight=$startHeight,stopBlockHashBE=${stopBlockHash.flip.hex})"

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1101,6 +1101,8 @@ case class CompactFilterMessage(
     filterBytes: ByteVector
 ) extends DataPayload {
 
+  val blockHashBE: DoubleSha256DigestBE = blockHash.flip
+
   /** The number of filter bytes in this message */
   val numFilterBytes: CompactSizeUInt = CompactSizeUInt(
     UInt64(filterBytes.length))

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -312,7 +312,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
           nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind1)
           _ <- bitcoind1.disconnectNode(nodeUri)
           _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-            node.getConnectionCount.map(_ == 1))
+            node.getConnectionCount.map(_ == 1), 1.second)
           //generate blocks while sync is ongoing
           _ <- bitcoind.generate(numBlocks)
         } yield {

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -303,11 +303,14 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       //2023-05-01T21:46:46Z [net] Failed to find block filter hashes in index: filter_type=basic, start_height=208, stop_hash=303cc906bf99b5370581e7f23285378c18005745882c6112dbbf3e61a82aeddb
       val node = nodeConnectedWithBitcoind.node
       val bitcoind = nodeConnectedWithBitcoind.bitcoinds(0)
+      val bitcoind1 = nodeConnectedWithBitcoind.bitcoinds(1)
 
       //start syncing node
       val numBlocks = 5
       val genBlocksF = {
         for {
+          nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind1)
+          _ <- bitcoind1.disconnectNode(nodeUri)
           //generate blocks while sync is ongoing
           _ <- bitcoind.generate(numBlocks)
         } yield {

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -311,8 +311,9 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         for {
           nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind1)
           _ <- bitcoind1.disconnectNode(nodeUri)
-          _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-            node.getConnectionCount.map(_ == 1), 1.second)
+          _ <- AsyncUtil.retryUntilSatisfiedF(
+            () => node.getConnectionCount.map(_ == 1),
+            1.second)
           //generate blocks while sync is ongoing
           _ <- bitcoind.generate(numBlocks)
         } yield {

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -311,6 +311,8 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         for {
           nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind1)
           _ <- bitcoind1.disconnectNode(nodeUri)
+          _ <- AsyncUtil.retryUntilSatisfiedF(() =>
+            node.getConnectionCount.map(_ == 1))
           //generate blocks while sync is ongoing
           _ <- bitcoind.generate(numBlocks)
         } yield {

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -163,7 +163,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         peer = peers(1)
         _ <- node.peerManager.isConnected(peer).map(assert(_))
         bitcoinds <- bitcoindsF
-        _ <- NodeTestUtil.awaitAllSync(node, bitcoinds(0))
+        _ <- NodeTestUtil.awaitAllSync(node, bitcoinds(1))
         //disconnect bitcoind(0) as its not needed for this test
         node0Uri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoinds(0))
         _ <- bitcoinds(0).disconnectNode(node0Uri)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -163,7 +163,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         peer = peers(1)
         _ <- node.peerManager.isConnected(peer).map(assert(_))
         bitcoinds <- bitcoindsF
-
+        _ <- NodeTestUtil.awaitAllSync(node, bitcoinds(0))
         //disconnect bitcoind(0) as its not needed for this test
         node0Uri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoinds(0))
         _ <- bitcoinds(0).disconnectNode(node0Uri)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -1060,7 +1060,7 @@ object PeerManager extends Logging {
       chainAppConfig: ChainAppConfig): Future[
     Option[NodeState.FilterHeaderSync]] = {
     logger.info(
-      s"Now syncing filter headers from ${state.syncPeer} in state=${state}")
+      s"Now syncing filter headers from ${state.syncPeer} in state=${state} stopBlockHashBE=${stopBlockHeaderDb.hashBE}")
     for {
       newSyncingStateOpt <- PeerManager.sendFirstGetCompactFilterHeadersCommand(
         peerMessageSenderApi = peerMessageSenderApi,
@@ -1096,7 +1096,7 @@ object PeerManager extends Logging {
     chainApi.getBestFilter().flatMap {
       case Some(f) =>
         //we have already started syncing filters, return the height of the last filter seen
-        Future.successful(f.height)
+        Future.successful(f.height + 1)
       case None =>
         walletCreationTimeOpt match {
           case Some(instant) =>

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -101,7 +101,7 @@ case class PeerManager(
             peerMessageSenderApi = peerMsgSender,
             chainApi = chainApi,
             filterBatchSize = chainAppConfig.filterBatchSize,
-            startHeight = compactFilterStartHeight,
+            stopBlockHash = bestFilterHeader.blockHashBE,
             peer = syncPeer
           )
           .map(_ => ())
@@ -1015,11 +1015,11 @@ object PeerManager extends Logging {
       peerMessageSenderApi: PeerMessageSenderApi,
       chainApi: ChainApi,
       filterBatchSize: Int,
-      startHeight: Int,
+      stopBlockHash: DoubleSha256DigestBE,
       peer: Peer)(implicit ec: ExecutionContext): Future[Boolean] = {
     for {
       filterSyncMarkerOpt <-
-        chainApi.nextFilterHeaderBatchRange(startHeight, filterBatchSize)
+        chainApi.nextFilterHeaderBatchRange(stopBlockHash, filterBatchSize)
       res <- filterSyncMarkerOpt match {
         case Some(filterSyncMarker) =>
           logger.info(

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -101,6 +101,7 @@ case class PeerManager(
             peerMessageSenderApi = peerMsgSender,
             chainApi = chainApi,
             filterBatchSize = chainAppConfig.filterBatchSize,
+            startHeightOpt = Some(compactFilterStartHeight),
             stopBlockHash = bestFilterHeader.blockHashBE,
             peer = syncPeer
           )
@@ -1015,11 +1016,14 @@ object PeerManager extends Logging {
       peerMessageSenderApi: PeerMessageSenderApi,
       chainApi: ChainApi,
       filterBatchSize: Int,
+      startHeightOpt: Option[Int],
       stopBlockHash: DoubleSha256DigestBE,
       peer: Peer)(implicit ec: ExecutionContext): Future[Boolean] = {
     for {
       filterSyncMarkerOpt <-
-        chainApi.nextFilterHeaderBatchRange(stopBlockHash, filterBatchSize)
+        chainApi.nextFilterHeaderBatchRange(stopBlockHash = stopBlockHash,
+                                            batchSize = filterBatchSize,
+                                            startHeightOpt = startHeightOpt)
       res <- filterSyncMarkerOpt match {
         case Some(filterSyncMarker) =>
           logger.info(

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -571,8 +571,6 @@ case class DataMessageHandler(
     for {
       (newFilterHeaderHeight, newFilterHeight) <- calcFilterHeaderFilterHeight(
         chainApi)
-      //_ = logger.warn(
-      //  s"isFiltersSynced() newFilterHeadersHeight=$newFilterHeaderHeight newFilterHeight=$newFilterHeight filterBatch.size=${filterBatch.size}")
       isSynced <-
         if (newFilterHeight == 0 && walletCreationTimeOpt.isDefined) {
           //if we have zero filters in our database and are syncing filters after a wallet creation time

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -100,6 +100,7 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
       Future.successful(this)
 
     override def nextBlockHeaderBatchRange(
+        prevStopHash: DoubleSha256DigestBE,
         stopHash: DoubleSha256DigestBE,
         batchSize: Int): Future[Option[FilterSyncMarker]] =
       Future.successful(None)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -107,7 +107,8 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
 
     override def nextFilterHeaderBatchRange(
         stopBlockHash: DoubleSha256DigestBE,
-        batchSize: Int): Future[Option[FilterSyncMarker]] =
+        batchSize: Int,
+        startHeightOpt: Option[Int]): Future[Option[FilterSyncMarker]] =
       Future.successful(None)
 
     override def processFilters(

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -106,7 +106,7 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
       Future.successful(None)
 
     override def nextFilterHeaderBatchRange(
-        startHeight: Int,
+        stopBlockHash: DoubleSha256DigestBE,
         batchSize: Int): Future[Option[FilterSyncMarker]] =
       Future.successful(None)
 


### PR DESCRIPTION
When working on #5332 I realized that our `ChainHandler` code does not work in reorg scenario for filter headers / filters. We can't specify a filter header to sync against a fork of the blockchain. This caused intermittent failures to happen in our `NeutrinoNodeTest` test suite when testing reorg scenarios. Sometimes we wouldn't sync a competing header's filter header / filter.

This PR fixes this by allowing us to specify the specific `stopBlockHash` for a competing block header in a reorg scenario. This means we can accurately track filter headers and filters for each side of a fork on the blockchain.

