### PR TITLE
Make `PeerManager.gossipMessage()` queue to avoid gossiping messages to peers being disconnected

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
@@ -37,5 +37,8 @@ object NodeStreamMessage {
   case class StartSync(peerOpt: Option[Peer]) extends NodeStreamMessage
   case class SendToPeer(msg: NetworkMessage, peerOpt: Option[Peer])
 
+  case class GossipMessage(msg: NetworkMessage, excludePeerOpt: Option[Peer])
+      extends NodeStreamMessage
+
   case class Initialized(peer: Peer)
 }

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -615,8 +615,16 @@ case class PeerManager(
         } else {
           Future
             .traverse(gossipPeers) { p =>
-              val sender = PeerMessageSender(getPeerConnection(p).get)
-              sender.sendMsg(msg)
+              getPeerConnection(p) match {
+                case Some(pc) =>
+                  val sender = PeerMessageSender(pc)
+                  sender.sendMsg(msg)
+                case None =>
+                  logger.warn(
+                    s"Attempting to gossip to peer that is availble in state.peers, but not peerDataMap? state=$state peerDataMap=${peerDataMap
+                      .map(_._1)}")
+                  Future.unit
+              }
             }
             .map(_ => state)
         }

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -600,6 +600,26 @@ case class PeerManager(
         onQueryTimeout(q.payload, q.peer, state).map(_ => state)
       case (dmh, srt: SendResponseTimeout) =>
         sendResponseTimeout(srt.peer, srt.payload).map(_ => dmh)
+      case (state, gossipMessage: GossipMessage) =>
+        val msg = gossipMessage.msg.payload
+        val gossipPeers = gossipMessage.excludePeerOpt match {
+          case Some(excludedPeer) =>
+            state.peers
+              .filterNot(_ == excludedPeer)
+          case None => state.peers
+        }
+        if (gossipPeers.isEmpty) {
+          logger.warn(
+            s"We have 0 peers to gossip message=${msg.commandName} to state=$state.")
+          Future.successful(state)
+        } else {
+          Future
+            .traverse(gossipPeers) { p =>
+              val sender = PeerMessageSender(getPeerConnection(p).get)
+              sender.sendMsg(msg)
+            }
+            .map(_ => state)
+        }
     }
   }
 
@@ -878,26 +898,10 @@ case class PeerManager(
   override def gossipMessage(
       msg: NetworkPayload,
       excludedPeerOpt: Option[Peer]): Future[Unit] = {
-    val gossipPeers = excludedPeerOpt match {
-      case Some(excludedPeer) =>
-        peerDataMap
-          .filterNot(_._1 == excludedPeer)
-          .map(_._2)
-      case None => peerDataMap.map(_._2)
-    }
-    if (gossipPeers.isEmpty) {
-      logger.warn(
-        s"We have 0 peers to gossip message=${msg.commandName} to peerDataMap=${peerDataMap
-          .map(_._1)}.")
-      Future.unit
-    } else {
-      Future
-        .traverse(gossipPeers) { p =>
-          val sender = PeerMessageSender(p.peerConnection)
-          sender.sendMsg(msg)
-        }
-        .map(_ => ())
-    }
+    val m = NetworkMessage(chainAppConfig.network, msg)
+    queue
+      .offer(GossipMessage(m, excludedPeerOpt))
+      .map(_ => ())
   }
 
   override def gossipGetHeadersMessage(


### PR DESCRIPTION
When working on #5333 it became evident we can have a race condition between gossiping message to peers and peers being disconnected.

This PR makes a stream message `GossipMessage` that will gossip messages to active peers in the stream state. This PR has a by product of reducing usage of `PeerManager.peerDataMap` to start encapsulating more PeerManager state. This is related to #5331 