### PR TITLE
Add `ChainApi.getBestChainTips()`

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -214,6 +214,10 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
   override def getHeadersAtHeight(height: Int): Future[Vector[BlockHeaderDb]] =
     getHeaderAtHeight(height).map(header => Vector(header))
 
+  override def getBestChainTips(): Future[Vector[BlockHeaderDb]] = {
+    ???
+  }
+
   override def getBestBlockHeader(): Future[BlockHeaderDb] =
     for {
       hash <- getBestBlockHash()

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -215,7 +215,10 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
     getHeaderAtHeight(height).map(header => Vector(header))
 
   override def getBestChainTips(): Future[Vector[BlockHeaderDb]] = {
-    ???
+    getChainTips.flatMap(tips =>
+      Future.traverse(tips) { tip =>
+        getBlockHeader(tip.hash).map(_.blockHeaderDb)
+      })
   }
 
   override def getBestBlockHeader(): Future[BlockHeaderDb] =

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -85,7 +85,7 @@ class ChainHandler(
   }
 
   override def getBestBlockHeader(): Future[BlockHeaderDb] = {
-    val tipsF: Future[Vector[BlockHeaderDb]] = blockHeaderDAO.getBestChainTips
+    val tipsF: Future[Vector[BlockHeaderDb]] = getBestChainTips()
     for {
       tips <- tipsF
       chains = tips.map(t => Blockchain.fromHeaders(Vector(t)))
@@ -903,7 +903,7 @@ class ChainHandler(
       case None => FutureUtil.none
       case Some(blockHeight) =>
         for {
-          tips <- blockHeaderDAO.getBestChainTips
+          tips <- getBestChainTips()
           getNAncestorsFs = tips.map { tip =>
             blockHeaderDAO.getNAncestors(tip.hashBE, tip.height - blockHeight)
           }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -192,6 +192,9 @@ class ChainHandler(
     getBestBlockHeader().map(_.hashBE)
   }
 
+  override def getBestChainTips(): Future[Vector[BlockHeaderDb]] =
+    blockHeaderDAO.getBestChainTips
+
   /** @inheritdoc */
   override def nextBlockHeaderBatchRange(
       prevStopHash: DoubleSha256DigestBE,

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/sync/ChainSync.scala
@@ -26,7 +26,7 @@ abstract class ChainSync extends ChainVerificationLogger {
       getBestBlockHashFunc: () => Future[DoubleSha256DigestBE])(implicit
       ec: ExecutionContext): Future[ChainApi] = {
     val currentTipsF: Future[Vector[BlockHeaderDb]] = {
-      chainHandler.blockHeaderDAO.getBestChainTips
+      chainHandler.getBestChainTips()
     }
 
     //TODO: We are implicitly trusting whatever

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -57,6 +57,9 @@ trait ChainApi extends ChainQueryApi {
   /** Gets the best block header we have */
   def getBestBlockHeader(): Future[BlockHeaderDb]
 
+  /** Gets all chain tips with the heaviest work */
+  def getBestChainTips(): Future[Vector[BlockHeaderDb]]
+
   /** Adds a compact filter header into the filter header chain and returns a new [[ChainApi chain api]]
     * that contains this header
     */

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -576,7 +576,8 @@ case class DataMessageHandler(
   private def isFiltersSynced(
       chainApi: ChainApi,
       filterBatch: Set[CompactFilterMessage]): Future[Boolean] = {
-    val bestBlockHashBEF = chainApi.getBestBlockHash()
+    val bestChainTipsF = chainApi.getBestChainTips()
+
     for {
       (newFilterHeaderHeight, newFilterHeight) <- calcFilterHeaderFilterHeight(
         chainApi)
@@ -604,8 +605,9 @@ case class DataMessageHandler(
           Future.successful(filterBatch.size == newFilterHeaderHeight + 1)
         } else {
           for {
-            bestBlockHashBE <- bestBlockHashBEF
-          } yield filterBatch.exists(_.blockHashBE == bestBlockHashBE)
+            bestChainTips <- bestChainTipsF
+          } yield filterBatch.exists(f =>
+            bestChainTips.exists(_.hashBE == f.blockHashBE))
         }
     } yield {
       isSynced

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -161,6 +161,10 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
     override def getBestBlockHash(): Future[DoubleSha256DigestBE] =
       Future.successful(DoubleSha256DigestBE.empty)
 
+    override def getBestChainTips(): Future[Vector[BlockHeaderDb]] = {
+      Future.successful(Vector.empty)
+    }
+
     override def getNumberOfConfirmations(
         blockHashOpt: DoubleSha256DigestBE): Future[Option[Int]] =
       Future.successful(None)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -161,7 +161,9 @@ abstract class NodeTestUtil extends P2PLogger {
         for {
           bestBitcoindHash <- bestBitcoindHashF
           bestBitcoinSHash <- bestBitcoinSHashF
-        } yield bestBitcoinSHash == bestBitcoindHash
+        } yield {
+          bestBitcoinSHash == bestBitcoindHash
+        }
       },
       interval = 1.second,
       maxTries = syncTries

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -161,9 +161,7 @@ abstract class NodeTestUtil extends P2PLogger {
         for {
           bestBitcoindHash <- bestBitcoindHashF
           bestBitcoinSHash <- bestBitcoinSHashF
-        } yield {
-          bestBitcoinSHash == bestBitcoindHash
-        }
+        } yield bestBitcoinSHash == bestBitcoindHash
       },
       interval = 1.second,
       maxTries = syncTries


### PR DESCRIPTION
There is a subtle bug still in #5337 , we need all best chain tips, not a _single_ best chain tip to determine if filters are synced.

This PR adds `ChainApi.getBestChainTips()` that fetches all current competing chain tips on the heaviest work chain. We in turn use this in `DataMessageHandler.isFiltersSynced()` to determine if the filter we received is a apart of _any_ of our best chains. Related to #5332 