### PR TITLE
Add logging to `PeerConnection.handleStreamComplete` 

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -307,6 +307,10 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
         .map(_ => ())
       offerF.onComplete(offerP.complete(_))
     }
+
+    offerP.future.failed.foreach(err =>
+      logger.error(s"Failed to handleStreamComplete()", err))
+
     offerP.future
   }
 


### PR DESCRIPTION
Now we can see why some connection tests are failing

```
ava.lang.RuntimeException: NeutrinoNode not started, cannot process p2p message until NeutrinoNode.start() is called                                                                                       
        at org.bitcoins.node.NeutrinoNode.offer(NeutrinoNode.scala:225)                                                                                                                                     
        at org.bitcoins.node.NeutrinoNode.offer(NeutrinoNode.scala:32)                                                                                                                                      
        at org.bitcoins.node.networking.peer.PeerConnection.$anonfun$handleStreamComplete$1(PeerConnection.scala:306)                                                                                       
        at org.bitcoins.node.networking.peer.PeerConnection.$anonfun$handleStreamComplete$1$adapted(PeerConnection.scala:303)                                                                               
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:484)                                                                                                                              
        at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:63)                                                                                                             
        at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:100)                                                                                                         
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)                                                                                                                          
        at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)                                                                                                                           
        at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:100)                                                                                                                    
        at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:49)                                                                                                                                    
        at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)                                                                                          
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)                                                                                                                        
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)                                                                                                       
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)                                                                                                                         
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)                                                                                                                    
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```