### PR TITLE
Dont initiate disconnect logic from bitcoind, its flakey for some reason

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -309,8 +309,8 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       val numBlocks = 5
       val genBlocksF = {
         for {
-          nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind1)
-          _ <- bitcoind1.disconnectNode(nodeUri)
+          peer1 <- NodeTestUtil.getBitcoindPeer(bitcoind1)
+          _ <- node.peerManager.disconnectPeer(peer1)
           _ <- AsyncUtil.retryUntilSatisfiedF(
             () => node.getConnectionCount.map(_ == 1),
             1.second)
@@ -391,8 +391,8 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
       for {
         _ <- NodeTestUtil.awaitSyncAndIBD(node, bitcoind0)
         //disconnect bitcoind1 as we don't need it
-        nodeUri1 <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind1)
-        _ <- bitcoind1.disconnectNode(nodeUri1)
+        peer1 <- NodeTestUtil.getBitcoindPeer(bitcoind1)
+        _ <- node.peerManager.disconnectPeer(peer1)
         bestBlockHash0 <- bitcoind0.getBestBlockHash()
         //invalidate blockhash to force a reorg when next block is generated
         _ <- bitcoind0.invalidateBlock(bestBlockHash0)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -63,14 +63,14 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
     nodeConnectedWithBitcoinds =>
       val node = nodeConnectedWithBitcoinds.node
       val bitcoinds = nodeConnectedWithBitcoinds.bitcoinds
-      def peers = node.peerManager.peers
 
       for {
         bitcoindPeers <- bitcoinPeersF
         _ <- node.start()
-        _ <- AsyncUtil.retryUntilSatisfied(peers.size == 2,
-                                           maxTries = 30,
-                                           interval = 1.second)
+        _ <- AsyncUtil.retryUntilSatisfiedF(
+          () => node.getConnectionCount.map(_ == 2),
+          maxTries = 30,
+          interval = 1.second)
         //sync from first bitcoind
         peer0 = bitcoindPeers(0)
         _ <- node.peerManager.disconnectPeer(peer0)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -73,10 +73,9 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
                                            interval = 1.second)
         //sync from first bitcoind
         peer0 = bitcoindPeers(0)
-        nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoinds(0))
-        _ <- bitcoinds(0).disconnectNode(nodeUri)
+        _ <- node.peerManager.disconnectPeer(peer0)
         _ = logger.debug(
-          s"Disconnected $nodeUri from bitcoind bitcoind(0).p2pPort=${peer0.socket.getPort} bitcoind(1).p2pPort=${bitcoinds(
+          s"Disconnected $peer0 from node bitcoind(0).p2pPort=${peer0.socket.getPort} bitcoind(1).p2pPort=${bitcoinds(
             1).instance.p2pPort}")
         //old peer we were syncing with that just disconnected us
         _ <- NodeTestUtil.awaitAllSync(node, bitcoinds(1))
@@ -167,8 +166,8 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
         bitcoind1 = bitcoinds(1)
         _ <- NodeTestUtil.awaitAllSync(node, bitcoind1)
         //disconnect bitcoind(0) as its not needed for this test
-        node0Uri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind0)
-        _ <- bitcoinds(0).disconnectNode(node0Uri)
+        peer0 <- NodeTestUtil.getBitcoindPeer(bitcoind0)
+        _ <- node.peerManager.disconnectPeer(peer0)
         _ <- AsyncUtil.retryUntilSatisfied(peerManager.peers.size == 1)
         _ <- NodeTestUtil.awaitAllSync(node, bitcoind1)
         _ <- sendInvalidHeaders(peer)


### PR DESCRIPTION
This causes spurious failures on CI with test cases. For some reason the seem to be test cases later in the test suite. I suspect there is some logic wrong with [`NodeTestUtil.getNodeURIFromBitcoind()`](https://github.com/bitcoin-s/bitcoin-s/blob/b39736fb8dfdb4c8b1fec58aa877ef8325850c11/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala#L252)