### PR TITLE
2024 01 18 fix native image build

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -33,6 +33,7 @@ jobs:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v13
         with:
+          # from https://github.com/graalvm/graalvm-ce-builds/releases
           java-version: graalvm@21.0.2=tgz+https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_${{runner.os}}-x64_bin.tar.gz
       - run: git fetch --tags || true
       - run: sbt cli/nativeImage

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v13
         with:
-          java-version: openjdk@1.17.0
+          java-version: graalvm@21.0.2=tgz+https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_${{runner.os}}-x64_bin.tar.gz
       - run: git fetch --tags || true
       - run: sbt cli/nativeImage
         shell: bash


### PR DESCRIPTION
It seems there was some sort of bug introduced for our native image `bitcoin-s-cli` builds in #5351 

This is probably because we used an ancient version of graalvm before this PR (the default on [sbt-native-image is `20.2.0`](https://github.com/scalameta/sbt-native-image#nativeimageversion)) which according [to the release notes](https://www.graalvm.org/release-notes/20_2/) is only built for java8 and java11. There have been many improvements for `native-image` since 2020 when `20.2.0` was released.

This PR downloads an official graalvm from the graalvm-ce repo. Its currently pinned to version `21.0.2` which is built ontop of jdk 21.

https://github.com/graalvm/graalvm-ce-builds/releases