### PR TITLE
Set flag `nativeImageInstalled =: true` so we don't overwrite system's `native-image`

### DIFF
--- a/app/cli/cli.sbt
+++ b/app/cli/cli.sbt
@@ -4,6 +4,8 @@ Universal / packageName := CommonSettings.buildPackageName((Universal /packageNa
 
 libraryDependencies ++= Deps.cli.value
 
+nativeImageInstalled := true
+
 nativeImageOptions ++= Seq(
   "-H:+ReportExceptionStackTraces",
   "--initialize-at-build-time",


### PR DESCRIPTION
Missed in #5357 