### PR TITLE
Fix bounds checking for `MultiSignatureScriptPubKey.maxSigsRequired`

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -412,6 +412,13 @@ class TransactionTest extends BitcoinSUnitTest {
     assert(tx.hex == hex)
   }
 
+  it must "parse decb09c41bc76bad8e006d92cf9f8c7ad4114e441a9cc6daf149e1495593a82f" in {
+    val hex =
+      "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff5303de1304040007762f44124d696e656420627920425443204775696c642cfabe6d6d4da12b2799cc8b6bba921e104cc9054fd1da40ed6c1b6287efd8460475f2a0440100000000000000080247961b56ae0000ffffffff018759b396000000001976a91427a1f12771de5cc3b73941664b2537c15316be4388ac00000000"
+    val tx = Transaction.fromHex(hex)
+    assert(tx.hex == hex)
+  }
+
   private def findInput(
       tx: Transaction,
       outPoint: TransactionOutPoint): Option[(TransactionInput, Int)] = {


### PR DESCRIPTION
This bug was found with this tx: https://mempool.space/tx/decb09c41bc76bad8e006d92cf9f8c7ad4114e441a9cc6daf149e1495593a82f

Previously our parsing logic recognized the `maxSigsRequired` _after_ `OP_CHECMULTISIG`/`OP_CHECKMULTISIGVERIFY` op code. This is not possible. This PR checks that `maxSigsRequired` occurs _before_ the `OP_CMS` op code.

This resulted in interpreting the scriptSig on this tx as a `p2sh(multisig)` scriptSig