### PR TITLE
Fix bug where `IndexOutOfBoundsException` was occuring when parsing `OP_CHECKMULTISIG`

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/MultiSignatureScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/MultiSignatureScriptPubKeyTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.script
 
+import org.bitcoins.core.script.crypto.OP_CHECKMULTISIG
 import org.bitcoins.crypto.ECPublicKeyBytes
 import org.bitcoins.testkitcore.gen.ScriptGenerators
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TestUtil}
@@ -61,6 +62,11 @@ class MultiSignatureScriptPubKeyTest extends BitcoinSUnitTest {
     multiSigScriptPubKey.maxSigs must be(3)
     multiSigScriptPubKey.requiredSigs must be(2)
 
+  }
+
+  it must "not throw an exception with a script with ONLY OP_CHECKMULTISIG" in {
+    val asm = Vector(OP_CHECKMULTISIG)
+    assert(MultiSignatureScriptPubKey.isValidAsm(asm) == false)
   }
 
   it must "serialization symmetry" in {

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -267,7 +267,7 @@ object MultiSignatureScriptPubKey
       //the second to last asm operation should be the maximum amount of public keys
       val hasMaximumSignaturesOpt: Option[Int] = {
         val maxSigsIdx = asm.length - 2
-        if (maxSigsIdx >= cmsIdx) {
+        if (maxSigsIdx >= cmsIdx || maxSigsIdx <= 0) {
           None
         } else {
           asm(maxSigsIdx) match {


### PR DESCRIPTION
Fixes a bug introduced in #5369 

We could have an `IndexOutOfBoundsException` occur for a Script that contains ONLY `OP_CHECKMULTISIG`

This PR adds a bounds check to make sure our index is not negative.