### PR TITLE
2024 01 26 rm lazy bytes

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -12,8 +12,6 @@ import scodec.bits.ByteVector
   */
 sealed abstract class Transaction extends NetworkElement {
 
-  override lazy val byteSize = bytes.length
-
   /** The `sha256(sha256(tx))` of this transaction,
     * Note that this is the little endian encoding of the hash, NOT the big endian encoding shown in block
     * explorers. See

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -139,7 +139,7 @@ object Transaction extends Factory[Transaction] {
 sealed abstract class NonWitnessTransaction extends Transaction {
   override def weight: Long = byteSize * 4
 
-  override lazy val bytes: ByteVector = {
+  override val bytes: ByteVector = {
     val versionBytes = version.bytes.reverse
     val inputBytes = BytesUtil.writeCmpctSizeUInt(inputs)
     val outputBytes = BytesUtil.writeCmpctSizeUInt(outputs)
@@ -226,7 +226,7 @@ case class WitnessTransaction(
     * Functionality inside of Bitcoin Core:
     * [[https://github.com/bitcoin/bitcoin/blob/e8cfe1ee2d01c493b758a67ad14707dca15792ea/src/primitives/transaction.h#L282-L287s]]
     */
-  override lazy val bytes: ByteVector = {
+  override val bytes: ByteVector = {
     val versionBytes = version.bytes.reverse
     val inputBytes = BytesUtil.writeCmpctSizeUInt(inputs)
     val outputBytes = BytesUtil.writeCmpctSizeUInt(outputs)

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionInput.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionInput.scala
@@ -15,7 +15,7 @@ sealed abstract class TransactionInput extends NetworkElement {
 
   def scriptSignature: ScriptSignature
   def sequence: UInt32
-  override lazy val bytes: ByteVector = RawTransactionInputParser.write(this)
+  override val bytes: ByteVector = RawTransactionInputParser.write(this)
 }
 
 case object EmptyTransactionInput extends TransactionInput {

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutput.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TransactionOutput.scala
@@ -8,11 +8,7 @@ import scodec.bits.ByteVector
 
 case class TransactionOutput(value: CurrencyUnit, scriptPubKey: ScriptPubKey)
     extends NetworkElement {
-
-  //https://bitcoin.org/en/developer-reference#txout
-  override lazy val byteSize: Long = scriptPubKey.byteSize + 8
-
-  override lazy val bytes: ByteVector = RawTransactionOutputParser.write(this)
+  override val bytes: ByteVector = RawTransactionOutputParser.write(this)
 }
 
 final object EmptyTransactionOutput

--- a/core/src/main/scala/org/bitcoins/core/util/BytesUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BytesUtil.scala
@@ -10,9 +10,8 @@ import scala.annotation.tailrec
 trait BytesUtil extends CryptoBytesUtil {
 
   def writeCmpctSizeUInt[T <: NetworkElement](ts: Seq[T]): ByteVector = {
-    val serialized = ts.map(_.bytes).foldLeft(ByteVector.empty)(_ ++ _)
     val cmpct = CompactSizeUInt(UInt64(ts.size))
-    cmpct.bytes ++ serialized
+    cmpct.bytes ++ ByteVector.concat(ts.map(_.bytes))
   }
 
   /** Used parse a byte sequence to a Seq[TransactionInput], Seq[TransactionOutput], etc

--- a/core/src/main/scala/org/bitcoins/core/util/BytesUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BytesUtil.scala
@@ -11,7 +11,7 @@ trait BytesUtil extends CryptoBytesUtil {
 
   def writeCmpctSizeUInt[T <: NetworkElement](ts: Seq[T]): ByteVector = {
     val cmpct = CompactSizeUInt(UInt64(ts.size))
-    cmpct.bytes ++ ByteVector.concat(ts.map(_.bytes))
+    ByteVector.concat(cmpct.bytes +: ts.map(_.bytes))
   }
 
   /** Used parse a byte sequence to a Seq[TransactionInput], Seq[TransactionOutput], etc


### PR DESCRIPTION
Remove lazy evaluation of `bytes` in `Transaction`, `TransactionOutput`, `TransactionInput`.

Also delegates to `ByteVector.concat()` for concatenating `ByteVector`'s in `BytesUtil.writeCmpctSizeUInt()`