### PR TITLE
2024 01 28 Refactor `PeerFinder.start()` to avoid initializing connections

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -173,7 +173,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
 
     //get a node that isn't started
     val nodeF = nodeConf.createNode(
-      peers = Vector.empty,
+      peers = nodeConf.peers,
       walletCreationTimeOpt = Some(creationTime))(chainConf, system)
 
     val defaultApi =

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -54,7 +54,8 @@ bitcoin-s {
     # time interval for trying next set of peers in peer discovery
     try-peers-interval = 12 hour
 
-    try-peers-start-delay = 1 seconds
+    # the delay until we start attempting to connect to peers
+    try-peers-start-delay = 1 second
   }
 
   # You can configure SOCKS5 proxy to use Tor for outgoing connections

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -49,10 +49,12 @@ bitcoin-s {
     # }
 
     # enable peer discovery on the p2p network by default
-    enable-peer-discovery = true
+    enable-peer-discovery = false
 
     # time interval for trying next set of peers in peer discovery
     try-peers-interval = 12 hour
+
+    try-peers-start-delay = 1 seconds
   }
 
   # You can configure SOCKS5 proxy to use Tor for outgoing connections

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -169,7 +169,10 @@ bitcoin-s {
         # initialization timeout once connected, reconnections resets this
         initialization-timeout = 10s
         # time interval for trying next set of peers in peer discovery
-        try-peers-interval = 1 hour
+        try-peers-interval = 12 hour
+        
+        # the delay until we start attempting to connect to peers
+        try-peers-start-delay = 1 second
         
         # wait time for queries like getheaders etc before switching to another
         query-wait-time = 120s

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -106,7 +106,7 @@ case class PeerFinder(
 
   private val _peersToTry: PeerStack = PeerStack()
 
-  private val maxPeerSearchCount: Int = 8
+  private val maxPeerSearchCount: Int = 2
 
   private val initialDelay: FiniteDuration = nodeAppConfig.tryPeersStartDelay
 
@@ -155,7 +155,8 @@ case class PeerFinder(
     val start = System.currentTimeMillis()
     isStarted.set(true)
     val peersToTry = (paramPeers ++ getPeersFromConfig).distinct
-    _peersToTry.pushAll(peersToTry)
+    //higher priority for param peers
+    _peersToTry.pushAll(peersToTry, priority = 2)
 
     val peerDiscoveryF = if (nodeAppConfig.enablePeerDiscovery) {
       val startedF = for {

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -179,7 +179,6 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
       val duration = config.getDuration("bitcoin-s.node.try-peers-start-delay")
       TimeUtil.durationToFiniteDuration(duration)
     } else {
-      println(s"couldn't find config for try-peers-start-delay")
       30.seconds
     }
   }

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -174,6 +174,16 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     } else 10.seconds
   }
 
+  lazy val tryPeersStartDelay: FiniteDuration = {
+    if (config.hasPath("bitcoin-s.node.try-peers-start-delay")) {
+      val duration = config.getDuration("bitcoin-s.node.try-peers-start-delay")
+      TimeUtil.durationToFiniteDuration(duration)
+    } else {
+      println(s"couldn't find config for try-peers-start-delay")
+      30.seconds
+    }
+  }
+
   /** time interval for trying next set of peers in peer discovery */
   lazy val tryNextPeersInterval: FiniteDuration = {
     if (config.hasPath("bitcoin-s.node.try-peers-interval")) {

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -12,10 +12,11 @@ import org.bitcoins.db.{DbAppConfig, JdbcProfileComponent}
 import org.bitcoins.node._
 import org.bitcoins.node.callback.NodeCallbackStreamManager
 import org.bitcoins.node.db.NodeDbManagement
+import org.bitcoins.node.util.BitcoinSNodeUtil
 import org.bitcoins.rpc.config.BitcoindRpcAppConfig
 import org.bitcoins.rpc.util.AppConfigFactoryActorSystem
-import org.bitcoins.tor.config.TorAppConfig
 import org.bitcoins.tor.TorParams
+import org.bitcoins.tor.config.TorAppConfig
 
 import java.nio.file.Path
 import java.time.{Duration, Instant}
@@ -97,13 +98,13 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
 
   /** List of peers
     */
-  lazy val peers: Vector[String] = {
+  lazy val peers: Vector[Peer] = {
     val list = config.getStringList("bitcoin-s.node.peers")
     val strs = 0
       .until(list.size())
       .foldLeft(Vector.empty[String])((acc, i) => acc :+ list.get(i))
     val result = strs.map(_.replace("localhost", "127.0.0.1"))
-    if (result.isEmpty && useDefaultPeers) {
+    val strPeers = if (result.isEmpty && useDefaultPeers) {
       logger.info(
         s"No peers found in configuration, resorting to default peers")
       network match {
@@ -115,6 +116,8 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     } else {
       result
     }
+
+    BitcoinSNodeUtil.stringsToPeers(strPeers)(this)
   }
 
   lazy val torConf: TorAppConfig =
@@ -214,9 +217,7 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   }
 
   /** Creates either a neutrino node or a spv node based on the [[NodeAppConfig]] given */
-  def createNode(
-      peers: Vector[Peer] = Vector.empty[Peer],
-      walletCreationTimeOpt: Option[Instant])(
+  def createNode(peers: Vector[Peer], walletCreationTimeOpt: Option[Instant])(
       chainConf: ChainAppConfig,
       system: ActorSystem): Future[Node] = {
     NodeAppConfig.createNode(peers, walletCreationTimeOpt)(this,

--- a/node/src/main/scala/org/bitcoins/node/util/BitcoinSNodeUtil.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/BitcoinSNodeUtil.scala
@@ -1,5 +1,9 @@
 package org.bitcoins.node.util
 
+import org.bitcoins.core.api.node.Peer
+import org.bitcoins.core.util.NetworkUtil
+import org.bitcoins.node.config.NodeAppConfig
+
 import scala.util.Random
 
 object BitcoinSNodeUtil {
@@ -18,4 +22,19 @@ object BitcoinSNodeUtil {
     */
   def createActorName(className: Class[_]): String =
     createActorName(className.getSimpleName)
+
+  def stringsToPeers(addresses: Vector[String])(implicit
+      nodeAppConfig: NodeAppConfig): Vector[Peer] = {
+    val formatStrings = addresses.map { s =>
+      //assumes strings are valid, todo: add util functions to check fully for different addresses
+      if (s.count(_ == ':') > 1 && s(0) != '[') //ipv6
+        "[" + s + "]"
+      else s
+    }
+    val inetSockets = formatStrings.map(
+      NetworkUtil.parseInetSocketAddress(_, nodeAppConfig.network.port))
+    val peers =
+      inetSockets.map(Peer.fromSocket(_, nodeAppConfig.socks5ProxyParams))
+    peers
+  }
 }

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -66,9 +66,9 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
+    <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
 
-    <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>
+    <logger name="org.bitcoins.node.PeerFinder" level="INFO"/>
 
     <logger name="org.bitcoins.node.networking.peer.PeerConnection" level="WARN"/>
     <!-- ╔════════════════════╗ -->

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -66,9 +66,9 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
+    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerFinder" level="INFO"/>
+    <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>
 
     <logger name="org.bitcoins.node.networking.peer.PeerConnection" level="WARN"/>
     <!-- ╔════════════════════╗ -->

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -62,6 +62,8 @@ bitcoin-s {
         #   password = ""
         # }
         inactivity-timeout = 20 minutes
+
+        try-peers-start-delay = 1 second
     }
 
 


### PR DESCRIPTION
This PR refactors `PeerFinder.start()`. Now we don't embed logic to attempt peer connections (via `tryPeer()`) in `PeerFinder.start()` directly. 

Now we delegate to `PeerFinder.peerConnectionScheduler` with a new configuration setting `bitcoin-s.node.try-peers-start-delay` which sets how long the initial delay is until we attempt to connect to peers on the p2p network. The default setting is `1.second`. The setting `bitcoin-s.node.try-peers-interval` indicates the frequency we attempt to connect to fresh peers. By default this is `12 hours`.

The rational for doing this is because we have no guarantees that `tryPeer()` will return a successful `Future`, what do we want to do if a future fails? This can be relatively common since there is no guarantee any peer we are connecting to is online. Now we handle this case in our `peerConnectionScheduler` logic, consolidating this logic to one place.