### PR TITLE
Create `NodeTestUtil.awaitConnectionCount()`

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -298,9 +298,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         for {
           peer1 <- NodeTestUtil.getBitcoindPeer(bitcoind1)
           _ <- node.peerManager.disconnectPeer(peer1)
-          _ <- AsyncUtil.retryUntilSatisfiedF(
-            () => node.getConnectionCount.map(_ == 1),
-            1.second)
+          _ <- NodeTestUtil.awaitConnectionCount(node, 1)
           //generate blocks while sync is ongoing
           _ <- bitcoind.generate(numBlocks)
         } yield {
@@ -334,8 +332,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         _ <- AsyncUtil.retryUntilSatisfiedF(
           () => node.peerManager.isDisconnected(peer0),
           1.second)
-        _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-          node.getConnectionCount.map(_ == 1))
+        _ <- NodeTestUtil.awaitConnectionCount(node, 1)
       } yield succeed
   }
 
@@ -382,8 +379,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         bestBlockHash0 <- bitcoind0.getBestBlockHash()
         //invalidate blockhash to force a reorg when next block is generated
         _ <- bitcoind0.invalidateBlock(bestBlockHash0)
-        _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-          node.getConnectionCount.map(_ == 1))
+        _ <- NodeTestUtil.awaitConnectionCount(node, 1)
         //now generate a block, make sure we sync with them
         hashes0 <- bitcoind0.generate(1)
         chainApi <- node.chainApiFromDb()

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.node
 
-import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.node.fixture.NeutrinoNodeConnectedWithBitcoind
@@ -47,11 +46,10 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
         _ <- node.start()
         peer <- peerF
         peerManager = node.peerManager
-        //wait until the initialization of the peer is done
-        _ <- AsyncUtil.retryUntilSatisfied {
-          peerManager.peers.exists(_ == peer)
-        }
+        _ <- NodeTestUtil.awaitConnectionCount(node = node,
+                                               expectedConnectionCount = 1)
       } yield {
+        assert(peerManager.peers.exists(_ == peer))
         assert(
           peerManager.paramPeers.nonEmpty
         ) //make sure we had a peer passed as a param

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -246,6 +246,18 @@ abstract class NodeTestUtil extends P2PLogger {
 
   }
 
+  /** returns a Future that isn't completed until the peer manager has [[expectedConnectionCount]] connections */
+  def awaitConnectionCount(
+      node: Node,
+      expectedConnectionCount: Int,
+      interval: FiniteDuration = 1.second,
+      maxTries: Int = 30)(implicit ec: ExecutionContext): Future[Unit] = {
+    AsyncUtil.retryUntilSatisfiedF(
+      () => node.getConnectionCount.map(_ == expectedConnectionCount),
+      interval = interval,
+      maxTries = maxTries)
+  }
+
   /** get our neutrino node's uri from a test bitcoind instance to send rpc commands for our node.
     * The peer must be initialized by the node.
     */

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -1,12 +1,10 @@
 package org.bitcoins.testkit.node
 
 import akka.actor.ActorSystem
-import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.node.{NodeType, Peer}
 import org.bitcoins.node.Node
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.server.BitcoinSAppConfig
-import org.bitcoins.testkit.node.NodeUnitTest
 import org.bitcoins.testkit.node.fixture.{
   NeutrinoNodeConnectedWithBitcoind,
   NeutrinoNodeConnectedWithBitcoinds
@@ -23,7 +21,6 @@ import org.bitcoins.wallet.callback.WalletCallbacks
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
 
 /** Test trait for using a bitcoin-s [[Node]] that requires a cached bitcoind.
   * The cached bitcoind will be share across tests in the test suite that extends
@@ -46,10 +43,8 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
                                                             appConfig.chainConf,
                                                             appConfig.nodeConf)
         started <- node.start()
-        _ <- AsyncUtil.retryUntilSatisfied(
-          node.peerManager.connectedPeerCount == 1,
-          interval = 1.second,
-          maxTries = 30)
+        _ <- NodeTestUtil.awaitConnectionCount(node = node,
+                                               expectedConnectionCount = 1)
       } yield NeutrinoNodeConnectedWithBitcoind(started, bitcoind)
     }
 
@@ -98,10 +93,8 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
           appConfig.chainConf,
           appConfig.nodeConf)
         startedNode <- node.start()
-        _ <- AsyncUtil.retryUntilSatisfied(
-          node.peerManager.connectedPeerCount == 1,
-          interval = 1.second,
-          maxTries = 30)
+        _ <- NodeTestUtil.awaitConnectionCount(node = node,
+                                               expectedConnectionCount = 1)
       } yield NeutrinoNodeConnectedWithBitcoinds(startedNode, bitcoinds)
     }
     makeDependentFixture[NeutrinoNodeConnectedWithBitcoinds](
@@ -126,10 +119,7 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
           appConfig.chainConf,
           appConfig.nodeConf)
         startedNode <- node.start()
-        _ <- AsyncUtil
-          .retryUntilSatisfied(node.peerManager.connectedPeerCount == 2,
-                               interval = 1.second,
-                               maxTries = 30)
+        _ <- NodeTestUtil.awaitConnectionCount(node, bitcoinds.size)
       } yield NeutrinoNodeConnectedWithBitcoinds(startedNode, bitcoinds)
     }
     makeDependentFixture[NeutrinoNodeConnectedWithBitcoinds](
@@ -154,6 +144,7 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
           appConfig.chainConf,
           appConfig.nodeConf)
         startedNode <- node.start()
+        _ <- NodeTestUtil.awaitConnectionCount(node, 1)
       } yield NeutrinoNodeConnectedWithBitcoind(startedNode, bitcoind)
     }
     makeDependentFixture[NeutrinoNodeConnectedWithBitcoind](

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -20,7 +20,6 @@ import org.scalatest.FutureOutcome
 
 import java.net.InetSocketAddress
 import java.time.Instant
-import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
 trait NodeUnitTest extends BaseNodeTest {
@@ -301,10 +300,8 @@ object NodeUnitTest extends P2PLogger {
         walletCallbacks = walletCallbacks)
 
       startedNode <- node.start()
-      _ <- AsyncUtil
-        .retryUntilSatisfied(node.peerManager.connectedPeerCount == 1,
-                             interval = 1.second,
-                             maxTries = 30)
+      _ <- NodeTestUtil.awaitConnectionCount(node = node,
+                                             expectedConnectionCount = 1)
       //callbacks are executed asynchronously, which is how we fund the wallet
       //so we need to wait until the wallet balances are correct
       _ <- BitcoinSWalletTest.awaitWalletBalances(fundedWallet)(


### PR DESCRIPTION
Helper method to await until our connections have been established between `NeutrinoNode` and a set of `bitcoinds`. This consolidates the various usages throughout the codebase into 1 helper method.