### PR TITLE
2024 01 31 Fix `PeerManager.connect()` bug where `PeerFinder` was unaware of peer

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -36,28 +36,6 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
 
   behavior of "ReConnectionTest"
 
-  it must "attempt to reconnect if max connections are full" in {
-    nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoind =>
-      val bitcoind = nodeConnectedWithBitcoind.bitcoind
-      val node = nodeConnectedWithBitcoind.node
-
-      val connectedF = for {
-        _ <- node.start()
-        //wait until we are fully connected before continuing test
-        _ <- NodeTestUtil.awaitConnectionCount(node, 1)
-        nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind)
-        peer <- NodeTestUtil.getBitcoindPeer(bitcoind)
-        _ <- bitcoind.disconnectNode(nodeUri)
-        _ <- AsyncUtil.retryUntilSatisfiedF(() =>
-          node.peerManager.isDisconnected(peer))
-        //make sure we re-connect
-        _ <- AsyncUtil.retryUntilSatisfiedF(conditionF = () =>
-          node.peerManager.isConnected(peer))
-      } yield succeed
-
-      connectedF
-  }
-
   it must "disconnect a peer after a period of inactivity" in {
     nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoind =>
       val bitcoind = nodeConnectedWithBitcoind.bitcoind

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -193,12 +193,23 @@ case class PeerFinder(
     }
   }
 
+  def connect(peer: Peer): Future[Unit] = {
+    logger.info(s"Attempting to connect peer=$peer")
+    if (isStarted.get()) {
+      tryPeer(peer)
+    } else {
+      logger.warn(
+        s"Ignoring connect attempt to peer=$peer as PeerFinder is not started")
+      Future.unit
+    }
+  }
+
   def reconnect(peer: Peer): Future[Unit] = {
     logger.info(s"Attempting to reconnect peer=$peer")
     if (isStarted.get) {
       tryToReconnectPeer(peer)
     } else {
-      logger.error(
+      logger.warn(
         s"Ignoring reconnect attempt to peer=$peer as PeerFinder is not started")
       Future.unit
     }

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -66,9 +66,9 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
+    <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
 
-    <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>
+    <logger name="org.bitcoins.node.PeerFinder" level="INFO"/>
 
     <logger name="org.bitcoins.node.networking.peer.PeerConnection" level="WARN"/>
     <!-- ╔════════════════════╗ -->

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
@@ -66,9 +66,9 @@
     <!-- See exceptions thrown in actor-->
     <logger name="org.bitcoins.node.networking.P2PClientSupervisor" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerManager" level="INFO"/>
+    <logger name="org.bitcoins.node.PeerManager" level="WARN"/>
 
-    <logger name="org.bitcoins.node.PeerFinder" level="INFO"/>
+    <logger name="org.bitcoins.node.PeerFinder" level="WARN"/>
 
     <logger name="org.bitcoins.node.networking.peer.PeerConnection" level="WARN"/>
     <!-- ╔════════════════════╗ -->


### PR DESCRIPTION
This PR fixes a bug in `PeerManager.connect()` where `PeerFinder` had never seen the `peer` we are attempting to connect to. Previously we would throw a `NoSuchElementException`. Now if `PeerFinder` has not seen the peer, we call a new method called `PeerFinder.connect()` to add it the list of peers we are attempting to connect to.

This PR also changes the logic of `PeerManager.onDisconnect()`. Previously, we would _always_ attempt to reconnect to a peer if we got disconnected and had 0 remaining connections. Its safe to change this logic as in #5162 / #5171 we introduced inactivity checks that handle the case where we have 0 peers. This means at most we can have 0 peers for the setting `bitcoin-s.node.inactivity-timeout` which is currently defaulted to 20 minutes.