### PR TITLE
Fix bug where we were only setting `bitcoin-s.node.inactivity-timeout` on regtest

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -79,6 +79,7 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
 
         //wait until there is a timeout for inactivity
         _ <- NodeTestUtil.awaitConnectionCount(started, 1)
+        _ <- started.peerManager.isConnected(bitcoindPeer)
         _ <- started.stop()
         _ <- started.nodeConfig.stop()
       } yield {

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -114,8 +114,6 @@ case class NeutrinoNode(
           inactivityCancellableOpt = Some(inactivityCancellable)
         }
       } yield {
-        logger.info(
-          s"inactivity-timeout=${nodeAppConfig.inactivityTimeout.toSeconds}")
         node.asInstanceOf[NeutrinoNode]
       }
 

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -378,9 +378,9 @@ case class PeerManager(
           if (forceReconnect && !isShuttingDown) {
             finder.reconnect(peer).map(_ => state)
           } else {
-            val exn = new RuntimeException(
+            logger.warn(
               s"No new peers to sync from, cannot start new sync. Terminated sync with peer=$peer current syncPeer=$syncPeerOpt state=${state} peers=$peers")
-            Future.failed(exn)
+            Future.successful(state)
           }
         } else {
           if (forceReconnect && !isShuttingDown) {


### PR DESCRIPTION
Fix bug where we were only setting `bitcoin-s.node.inactivity-timeout` on regtest

also no longer throw an exception when we are terminating a sync when we are disconnected with no other peers, just log a message.