### PR TITLE
Implement health checks for peers, first check is if we have any blockfilter peers

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -202,7 +202,14 @@ case class NeutrinoNode(
     val peers = peerManager.peers
     logger.info(s"Running inactivity checks for peers=${peers}")
     val resultF = if (peers.nonEmpty) {
-      Future.unit //do nothing?
+      queueOpt match {
+        case Some(q) =>
+          q.offer(NodeStreamMessage.PeerHealthCheck)
+            .map(_ => ())
+        case None =>
+          logger.warn(s"No queue defined for inactivity check")
+          Future.unit
+      }
     } else if (isStarted.get) {
       //stop and restart to get more peers
       stop()

--- a/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
@@ -46,5 +46,8 @@ object NodeStreamMessage {
 
   case object NodeShutdown extends NodeStreamMessage
 
+  /** Checks our peers are healthy, for instance checking that we are peered with compact filter peers */
+  case object PeerHealthCheck extends NodeStreamMessage
+
   case class Initialized(peer: Peer)
 }


### PR DESCRIPTION
Related to #5390 

This PR checks if any of our peers are block filter peers. If they aren't, we restart the finder and attempt to find block filter peers.