### PR TITLE
Remove `skipPeers`, better `PeerFinder.toString()`

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -53,12 +53,11 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         chainApi <- node.chainApiFromDb()
         _ = require(peerManager.getPeerData(peer).isDefined)
         peerMsgSender = peerManager.getPeerData(peer).get.peerMessageSender
-        peerFinder = PeerFinder(paramPeers = Vector.empty,
-                                queue = node,
-                                skipPeers = () => Set.empty)(system.dispatcher,
-                                                             system,
-                                                             node.nodeConfig,
-                                                             node.chainConfig)
+        peerFinder = PeerFinder(paramPeers = Vector.empty, queue = node)(
+          system.dispatcher,
+          system,
+          node.nodeConfig,
+          node.chainConfig)
         dataMessageHandler = DataMessageHandler(
           chainApi = chainApi,
           walletCreationTimeOpt = None,

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -94,9 +94,8 @@ case class NeutrinoNode(
         dataMessageStreamSource.preMaterialize()
 
       queueOpt = Some(queue)
-      val peerFinder: PeerFinder = PeerFinder(paramPeers = paramPeers,
-                                              queue = queue,
-                                              skipPeers = () => Set.empty)
+      val peerFinder: PeerFinder =
+        PeerFinder(paramPeers = paramPeers, queue = queue)
       val initState =
         DoneSyncing(peerDataMap = Map.empty,
                     waitingForDisconnection = Set.empty,

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -26,8 +26,7 @@ import scala.util.{Failure, Random, Success}
 
 case class PeerFinder(
     paramPeers: Vector[Peer],
-    queue: SourceQueue[NodeStreamMessage],
-    skipPeers: () => Set[Peer])(implicit
+    queue: SourceQueue[NodeStreamMessage])(implicit
     ec: ExecutionContext,
     system: ActorSystem,
     nodeAppConfig: NodeAppConfig,
@@ -132,7 +131,6 @@ case class PeerFinder(
             0.until(max)
               .map(_ => _peersToTry.pop()))
             .distinct
-            .filterNot(p => skipPeers().contains(p) || _peerData.contains(p))
 
           logger.debug(s"Trying next set of peers $peers")
           val peersF = Future.traverse(peers)(tryPeer)
@@ -309,6 +307,10 @@ case class PeerFinder(
     } else {
       logger.warn(s"onVersionMessage called for unknown $peer")
     }
+  }
+
+  override def toString: String = {
+    s"PeerFinder(paramPeers=$paramPeers)"
   }
 }
 


### PR DESCRIPTION
`skipPeers` isn't used