### PR TITLE
Fix inconsistency of `PeerDAO` primary key usage

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/node/Peer.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/Peer.scala
@@ -15,6 +15,8 @@ case class Peer(
     this.copy(id = Some(id))
   }
 
+  def port: Int = socket.getPort
+
   override def toString(): String =
     s"Peer(${socket.getHostString()}:${socket.getPort()})"
 

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -96,7 +96,7 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
         _ <- NodeTestUtil.awaitConnectionCount(node, 0)
         addrBytes = PeerDAOHelper.getAddrBytes(peer)
         peerDb <- PeerDAO()(system.dispatcher, node.nodeConfig)
-          .read((addrBytes, peer.socket.getPort))
+          .read((addrBytes, peer.port))
           .map(_.get)
       } yield {
         assert(timestamp.isBefore(peerDb.lastSeen))

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -96,7 +96,7 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
         _ <- NodeTestUtil.awaitConnectionCount(node, 0)
         addrBytes = PeerDAOHelper.getAddrBytes(peer)
         peerDb <- PeerDAO()(system.dispatcher, node.nodeConfig)
-          .read(addrBytes)
+          .read((addrBytes, peer.socket.getPort))
           .map(_.get)
       } yield {
         assert(timestamp.isBefore(peerDb.lastSeen))

--- a/node-test/src/test/scala/org/bitcoins/node/models/PeerDAOTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/models/PeerDAOTest.scala
@@ -24,7 +24,7 @@ class PeerDAOTest extends NodeDAOFixture {
 
     for {
       created <- peerDAO.create(peer)
-      read <- peerDAO.read(peer.address)
+      read <- peerDAO.read((peer.address, peer.port))
     } yield {
       assert(
         read.get.address == created.address &&

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -134,10 +134,7 @@ case class PeerManager(
           s"Unsupported address type of size $unknownSize bytes")
     }
     PeerDAO()
-      .upsertPeer(addrBytes,
-                  peer.socket.getPort,
-                  networkByte,
-                  serviceIdentifier)
+      .upsertPeer(addrBytes, peer.port, networkByte, serviceIdentifier)
   }
 
   private def replacePeer(replacePeer: Peer, withPeer: Peer): Future[Unit] = {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -336,8 +336,8 @@ case class PeerManager(
       s"Disconnected peer=$peer peers=$peers state=$state forceReconnect=$forceReconnect peerDataMap=${peerDataMap
         .map(_._1)}")
     val finder = state.peerFinder
-    val addrBytes = PeerDAOHelper.getAddrBytes(peer)
-    val updateLastSeenF = PeerDAO().updateLastSeenTime(addrBytes)
+
+    val updateLastSeenF = PeerDAO().updateLastSeenTime(peer)
     val stateF = {
       require(!finder.hasPeer(peer) || !peerDataMap.contains(peer),
               s"$peer cannot be both a test and a persistent peer")

--- a/node/src/main/scala/org/bitcoins/node/models/PeerDAO.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/PeerDAO.scala
@@ -89,7 +89,7 @@ case class PeerDAO()(implicit ec: ExecutionContext, appConfig: NodeAppConfig)
 
   def updateLastSeenTime(peer: Peer): Future[Option[PeerDb]] = {
     val address = PeerDAOHelper.getAddrBytes(peer)
-    val port = peer.socket.getPort
+    val port = peer.port
     val action = findByPrimaryKey((address, port)).result.headOption
     val updatedLastSeenA = action.flatMap {
       case Some(peerDb) =>


### PR DESCRIPTION
Were treating the primary key of `PeerDAO` as a `ByteVector` when at the sql level it was a composite primary key of `(ByteVector,Int)` representing `(address,port)`. 

This PR fixes the primary key handling.