### PR TITLE
2024 02 15 Fix duplicate sync bug when we have a misbehaving peer

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NodeState.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeState.scala
@@ -2,6 +2,7 @@ package org.bitcoins.node
 
 import org.bitcoins.core.api.node.{Peer, PeerWithServices}
 import org.bitcoins.core.p2p.{CompactFilterMessage, ServiceIdentifier}
+import org.bitcoins.node.NodeState.DoneSyncing
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.networking.peer.{PeerConnection, PeerMessageSender}
 
@@ -104,6 +105,10 @@ sealed trait NodeRunningState extends NodeState {
     randomPeer(excludePeers, services).flatMap { p =>
       getPeerMsgSender(p)
     }
+  }
+
+  def toDoneSyncing: DoneSyncing = {
+    DoneSyncing(peerDataMap, waitingForDisconnection, peerFinder)
   }
 }
 

--- a/node/src/main/scala/org/bitcoins/node/NodeState.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeState.scala
@@ -107,6 +107,12 @@ sealed trait NodeRunningState extends NodeState {
     }
   }
 
+  def isConnected(peer: Peer): Boolean = {
+    peerDataMap.filter(_._1.peer == peer).nonEmpty || peerFinder.hasPeer(peer)
+  }
+
+  def isDisconnected(peer: Peer): Boolean = !isConnected(peer)
+
   def toDoneSyncing: DoneSyncing = {
     DoneSyncing(peerDataMap, waitingForDisconnection, peerFinder)
   }

--- a/node/src/main/scala/org/bitcoins/node/PeerData.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerData.scala
@@ -95,4 +95,11 @@ case class AttemptToConnectPeerData(
     override val system: ActorSystem,
     override val nodeAppConfig: NodeAppConfig,
     override val chainAppConfig: ChainAppConfig)
-    extends PeerData
+    extends PeerData {
+
+  def toPersistentPeerData: PersistentPeerData = {
+    val p = PersistentPeerData(peer, peerMessageSender)
+    p.setServiceIdentifier(serviceIdentifier = serviceIdentifier)
+    p
+  }
+}

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -347,34 +347,19 @@ case class PeerManager(
         }
       } else if (peerDataMap.contains(peer)) {
         _peerDataMap.remove(peer)
-        val syncPeerOpt = state match {
-          case s: SyncNodeState =>
-            Some(s.syncPeer)
-          case _: DoneSyncing | _: RemovePeers | _: NodeShuttingDown |
-              _: MisbehavingPeer =>
-            None
-        }
         val isShuttingDown = state.isInstanceOf[NodeShuttingDown]
         if (state.peers.exists(_ != peer)) {
           state match {
             case s: SyncNodeState => switchSyncToRandomPeer(s, Some(peer))
             case d: DoneSyncing   =>
               //defensively try to sync with the new peer
-              val hs = d.toHeaderSync(peer)
-              switchSyncToRandomPeer(hs, Some(peer))
+              val hs = d.toHeaderSync
+              syncHelper(hs).map(_ => hs)
             case x @ (_: DoneSyncing | _: NodeShuttingDown |
                 _: MisbehavingPeer | _: RemovePeers) =>
               Future.successful(x)
           }
 
-        } else if (syncPeerOpt.isDefined) {
-          if (forceReconnect && !isShuttingDown) {
-            finder.reconnect(peer).map(_ => state)
-          } else {
-            logger.warn(
-              s"No new peers to sync from, cannot start new sync. Terminated sync with peer=$peer current syncPeer=$syncPeerOpt state=${state} peers=$peers")
-            Future.successful(state)
-          }
         } else {
           if (forceReconnect && !isShuttingDown) {
             finder.reconnect(peer).map(_ => state)
@@ -642,7 +627,7 @@ case class PeerManager(
                   peerManager = this,
                   state = runningState
                 )
-                val resultF = dmh
+                val resultF: Future[NodeState] = dmh
                   .handleDataPayload(payload, peerData)
                   .flatMap { newDmh =>
                     newDmh.state match {
@@ -650,22 +635,21 @@ case class PeerManager(
                         //disconnect the misbehaving peer
                         for {
                           _ <- disconnectPeer(m.badPeer)
-                          _ <- syncFromNewPeer(m)
-                        } yield newDmh
+                        } yield newDmh.state
                       case removePeers: RemovePeers =>
                         for {
                           _ <- Future.traverse(removePeers.peers)(
                             disconnectPeer)
-                        } yield newDmh
+                        } yield newDmh.state
                       case _: SyncNodeState | _: DoneSyncing |
                           _: NodeShuttingDown =>
-                        Future.successful(newDmh)
+                        Future.successful(newDmh.state)
                     }
                   }
                 resultF.map { r =>
                   logger.debug(
-                    s"Done processing ${payload.commandName} in peer=${peer} state=${r.state}")
-                  r.state
+                    s"Done processing ${payload.commandName} in peer=${peer} state=${r}")
+                  r
                 }
             }
         }
@@ -1104,7 +1088,8 @@ case class PeerManager(
       }
     }
   }
-
+  
+  /** Attempts to start syncing from a new peer. Returns None if we have no new peers to sync with */
   private def syncFromNewPeer(
       state: NodeRunningState): Future[Option[NodeRunningState]] = {
     val svcIdentifier = ServiceIdentifier.NODE_COMPACT_FILTERS


### PR DESCRIPTION
Pulls over changes from #5390 

Fixes a bug where we were duplicate syncing when we have a `MisBehavingPeer`. Now we wait until we get to the `onDisconnect()` logic which will kick off a new sync if necessary. 