### PR TITLE
2024 02 16 fix get filter sync marker from stop block header bug

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -423,7 +423,10 @@ class ChainHandler(
                       //we must be in a reorg scenario
                       getHeadersAtHeight(filter.height)
                     } else {
-                      Future.successful(headers)
+                      //remove the bestFilter's block header
+                      val filtered =
+                        headers.filter(_.hashBE != filter.blockHashBE)
+                      Future.successful(filtered)
                     }
                   }
                 case None => getHeadersAtHeight(0)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -416,14 +416,12 @@ class ChainHandler(
               bestFilterOpt match {
                 case Some(filter) =>
                   getHeadersAtHeight(filter.height)
-                    .flatMap(headers =>
-                      Future
-                        .traverse(headers)(h => getImmediateChildren(h.hashBE))
-                        .map(_.flatten))
                 case None => getHeadersAtHeight(0)
               }
             }
-          } yield candidateHeaders
+          } yield {
+            candidateHeaders
+          }
       }
 
     for {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -1192,6 +1192,9 @@ object PeerManager extends Logging {
                                            batchSize =
                                              chainConfig.filterHeaderBatchSize)
       }
+      //needed to work around this bug in bitcoin core:
+      //https://github.com/bitcoin/bitcoin/issues/27085
+      _ <- AsyncUtil.nonBlockingSleep(1.second)
       res <- hashHeightOpt match {
         case Some(filterSyncMarker) =>
           peerMessageSenderApi

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -195,7 +195,9 @@ abstract class NodeTestUtil extends P2PLogger {
         for {
           bestBitcoindHash <- bestBitcoindHashF
           bestBitcoinSHash <- bestBitcoinSHashF
-        } yield bestBitcoinSHash == bestBitcoindHash
+        } yield {
+          bestBitcoinSHash == bestBitcoindHash
+        }
       },
       interval = 1.second,
       maxTries = syncTries


### PR DESCRIPTION
This PR does two things 

1. Adds a `nonBlockingSleep()` call before sending our first `getcfheaders` message. This is needed because of https://github.com/bitcoin/bitcoin/issues/27085
2. Fix reorg handling for fetching filters. 

### Reorg handling fetching filters
For the case where have `bestFilter` in `chaindb.sqlite`, we now try to sync filters from the block header corresponding to `bestFilter.height + 1`. If no block header's are found at `bestFilter.height + 1`, we must be in a reorg scenario. In this case, we try to find competing block headers in `chaindb.sqlite` at `bestFilter.height`. If we find a block header that is not equal to `bestFilter.blockHashBE` we attempt to sync from that.