### PR TITLE
Fix handling invoice with minimal encoding of feature bits

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
@@ -577,4 +577,12 @@ class LnInvoiceUnitTest extends BitcoinSUnitTest {
 
     assert(invoice.nodeId == NodeId(priv.publicKey))
   }
+
+  it must "parse an invoice with minimally encoded features" in {
+    val str =
+      "lnbc2u1pjaxtm0dqqpp5g7xpa2xz7jkfcaczxkr0c7k0hxeh8y30f6ec0rvj0qe6xzmcuyxssp5nqd0ac3ctaruwkykjzdqm9jks20wp93e5m0xt35ae7zp7jf4hrsq9qrsgqcqpjnp4qddsxf0zurpkk6uxe7fmlllsypajk0cwuqcmsv6g958am7fhsx24zxqrrssrzjqte649ct9zh8ecjylt7w3a5d9mvpdchtgsgecu22yycumagdx3uukqqqqqqqqqqqqyqqqqqqqqqqqqqqrc5sgm8xfdg57alvd4s83rgqrzvm95c76az5d5c7cr6jldxex4p0qhdesrwrhvtqfkh9mdv6vd75qam8v5dcsj5wx7tfx7576m6wx8f2sq64klgu"
+
+    val invoiceT = LnInvoice.fromStringT(str)
+    assert(invoiceT.isSuccess)
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTags.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/ln/LnTags.scala
@@ -320,7 +320,7 @@ object LnTag {
         RoutingInfo.fromU5s(payload)
 
       case LnTagPrefix.Features =>
-        LnTag.FeaturesTag(bytes)
+        LnTag.FeaturesTag(payload)
 
       case prefix: LnTagPrefix.Unknown =>
         LnTag.UnknownTag(prefix, payload)
@@ -329,12 +329,24 @@ object LnTag {
     tag
   }
 
-  case class FeaturesTag(features: ByteVector) extends LnTag {
+  case class FeaturesTag(encoded: Vector[UInt5]) extends LnTag {
     override def prefix: LnTagPrefix = LnTagPrefix.Features
 
-    /** The payload for the tag without any meta information encoded with it */
-    override def encoded: Vector[UInt5] = {
-      Bech32.from8bitTo5bit(features)
+    def features: ByteVector = {
+      val u8s = Bech32.from5bitTo8bit(encoded)
+      UInt8.toBytes(u8s)
+    }
+  }
+
+  object FeaturesTag {
+
+    def apply(features: ByteVector): FeaturesTag = {
+      fromBytes(features)
+    }
+
+    def fromBytes(bytes: ByteVector): FeaturesTag = {
+      val u5s = Bech32.from8bitTo5bit(bytes)
+      FeaturesTag(u5s)
     }
   }
 


### PR DESCRIPTION
Closes #5404 

When encoding the signature data for the invoice, BOLT 11 says the features `SHOULD use the minimum data_length possible`, we were using the byte encoding which wouldn't guarantee that we were using the smallest uint5 encoding. 