### PR TITLE
Re-add `java.sql` module to `cli` `jlink` image to fix #5411

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -125,7 +125,6 @@ object CommonSettings {
   lazy val rmCliJlinkModules = {
     rmJlinkModules ++ Vector(
       "java.logging",
-      "java.sql",
       "jdk.unsupported"
     )
   }


### PR DESCRIPTION
Fixes #5411 

This is the result of ignoring java modules in our `jlink` image for `bitcoin-s-cli` (#4322). 

We have a deep nested dependency on `java.sql.Date`. This leads to the error message seen in #5411 

```
Error: Argument contractDescriptor failed when given '{"outcomes": {"lula": 0, "bolsonaro": 2, "outro": 1}}'. java/sql/Date
Try --help for more information.
```

When debugging further, it turns out the `JsonReaders` cannot even be initialized it seems. We get this error 

```
Could not initialize class org.bitcoins.commons.serializers.JsonReaders$
```

This is consistent with what the user reported, if they used `curl` rather than `bitcoin-s-cli` everything works as expected.

