### PR TITLE
Keeping finding peers until all peers are blockfilter peers

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -1376,13 +1376,14 @@ object PeerManager extends Logging {
 
   def handleHealthCheck(
       runningState: NodeRunningState): Future[NodeRunningState] = {
-    val blockFilterPeers = runningState.peerDataMap.filter(
-      _._2.serviceIdentifier.hasServicesOf(
-        ServiceIdentifier.NODE_COMPACT_FILTERS))
-    if (blockFilterPeers.nonEmpty) {
+    val nonBlockFilterPeers = runningState.peerDataMap.filterNot(
+      _._2.serviceIdentifier.nodeCompactFilters)
+    if (runningState.peerDataMap.nonEmpty && nonBlockFilterPeers.isEmpty) {
       //do nothing
       Future.successful(runningState)
     } else {
+      //keep querying for block filter peers until our connection
+      //slots are full of block filter peers
       val peerFinder = runningState.peerFinder
       peerFinder.queryForPeerConnections(excludePeers = Set.empty)
       Future.successful(runningState)


### PR DESCRIPTION
In #5393 we implemented the health check logic to only query for more peer connections if we have _zero_ block filter peers. 

This PR changes this logic to have the health checks run if one of our connection slots if occupied by a peer that _does not_ support block filters. Ideally we want all of our connection slots to be block filter peers, so that in the case we get disconnected from one we can easily switch to another that we have already found on the p2p network.