### PR TITLE
Rename `bitcoin-s.node.inactivity-timeout` -> `bitcoin-s.node.health-check-interval`, add `bitcoin-s.node.peer-timeout`

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -56,6 +56,10 @@ bitcoin-s {
 
     # the delay until we start attempting to connect to peers
     try-peers-start-delay = 1 second
+
+    # if the peer does not send us a message within this duration
+    # we disconnect it for inactivity
+    peer-timeout = 20 minute
   }
 
   # You can configure SOCKS5 proxy to use Tor for outgoing connections

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -179,9 +179,12 @@ bitcoin-s {
         # whether to have p2p peers relay us unconfirmed txs
         relay = false
         
-        # if a node doesn't send a message in this time frame 
-        # we disconnect them and try to connect to a new peer
-        inactivity-timeout = 5 minutes
+        # how often we run health checks for our peers
+        health-check-interval = 1 minutes
+        
+        # if the peer does not send us a message within this duration
+        # we disconnect it for inactivity
+        peer-timeout = 20 minute
     }
 
     proxy {

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -41,8 +41,7 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
       val bitcoind = nodeConnectedWithBitcoind.bitcoind
       val timeout = 5.seconds
       val startedF =
-        getSmallInactivityCheckNeutrinoNode(nodeConnectedWithBitcoind.node,
-                                            timeout)
+        getSmallHealthCheckNeutrinoNode(nodeConnectedWithBitcoind.node, timeout)
       for {
         started <- startedF
         _ <- NodeTestUtil.awaitConnectionCount(node = started,
@@ -66,8 +65,7 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
       val bitcoind = nodeConnectedWithBitcoind.bitcoind
       val timeout = 5.second
       val startedF =
-        getSmallInactivityCheckNeutrinoNode(nodeConnectedWithBitcoind.node,
-                                            timeout)
+        getSmallHealthCheckNeutrinoNode(nodeConnectedWithBitcoind.node, timeout)
       for {
         started <- startedF
         _ <- NodeTestUtil.awaitConnectionCount(started, 1)
@@ -87,15 +85,19 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
       }
   }
 
-  private def getSmallInactivityCheckNeutrinoNode(
+  private def getSmallHealthCheckNeutrinoNode(
       initNode: NeutrinoNode,
       timeout: FiniteDuration): Future[NeutrinoNode] = {
 
     //make a custom config, set the inactivity timeout very low
     //so we will disconnect our peer organically
+    val str =
+      s"""
+         |bitcoin-s.node.health-check-interval = ${timeout.toString()}
+         |bitcoin-s.node.peer-timeout = ${timeout.toString()}
+         |""".stripMargin
     val config =
-      ConfigFactory.parseString(
-        s"bitcoin-s.node.inactivity-timeout=${timeout.toString}")
+      ConfigFactory.parseString(str)
     val stoppedConfigF = initNode.nodeConfig.stop()
     val newNodeAppConfigF =
       stoppedConfigF.map(_ => initNode.nodeConfig.withOverrides(config))

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -189,11 +189,18 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     } else 10
   }
 
-  lazy val inactivityTimeout: FiniteDuration = {
-    if (config.hasPath("bitcoin-s.node.inactivity-timeout")) {
-      val duration = config.getDuration("bitcoin-s.node.inactivity-timeout")
+  lazy val healthCheckInterval: FiniteDuration = {
+    if (config.hasPath("bitcoin-s.node.health-check-interval")) {
+      val duration = config.getDuration("bitcoin-s.node.health-check-interval")
       TimeUtil.durationToFiniteDuration(duration)
-    } else 5.minute
+    } else 1.minute
+  }
+
+  lazy val peerTimeout: FiniteDuration = {
+    if (config.hasPath("bitcoin-s.node.peer-timeout")) {
+      val duration = config.getDuration("bitcoin-s.node.peer-timeout")
+      TimeUtil.durationToFiniteDuration(duration)
+    } else 20.minute
   }
 
   /** Creates either a neutrino node or a spv node based on the [[NodeAppConfig]] given */

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -142,7 +142,7 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
     Vector[NetworkMessage],
     (Future[Tcp.OutgoingConnection], UniqueKillSwitch)] =
     connection
-      .idleTimeout(nodeAppConfig.inactivityTimeout)
+      .idleTimeout(nodeAppConfig.peerTimeout)
       .joinMat(bidiFlow)(Keep.left)
 
   private def connectionGraph(

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -61,7 +61,7 @@ bitcoin-s {
         #   user = postgres
         #   password = ""
         # }
-        inactivity-timeout = 5 minutes
+        health-check-interval = 1 minutes
 
         try-peers-start-delay = 1 second
 


### PR DESCRIPTION
Related to #5144 

This PR breaks up our previous config setting `bitcoin-s.node.inactivity-timeout` into two separate configs

`bitcoin-s.node.health-check-interval` - this represents how often our health checks are run on our _set_ of peers. This checks things like how many peers we have, if they support block filters, etc. This is by default set to 1 minute.

`bitcoin-s.node.peer-timeout` - this is a timeout that occurs after a period of inactivity for a peer. This is by default set to 20 minutes.

Previously, the old config setting `bitcoin-s.node.inactivity-timeout` did both of these jobs. This lead to problems where if we wanted the health checks to run more frequently, we would have to set a smaller timeout for a peer before we disconnected it. This could result in disconnecting healthy peers in periods of inactivity on the bitcoin p2p network (especially if tx propogation was turned off via `bitcoins.node.relay=false`)