### PR TITLE
2024 02 23 `TaprootKeyPath.isValid()` bug

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -362,10 +362,12 @@ object TaprootKeyPath extends Factory[TaprootKeyPath] {
 
   def isValid(stack: Vector[ByteVector]): Boolean = {
     val noAnnex =
-      stack.length == 1 && (stack.head.length == 64 || stack.head.length == 65)
+      stack.length == 1 && (stack.head.length == 64 || stack.head.length == 65) &&
+        SchnorrPublicKey.fromBytesT(stack.head.take(32)).isSuccess
     val annex =
       stack.length == 2 && TaprootScriptPath.hasAnnex(stack) &&
-        (stack(1).length == 64 || stack(1).length == 65)
+        (stack(1).length == 64 || stack(1).length == 65) &&
+        SchnorrPublicKey.fromBytesT(stack(1).take(32)).isSuccess
     noAnnex || annex
   }
 }

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -210,7 +210,7 @@ object CommonSettings {
 
   lazy val testSettings: Seq[Setting[_]] = Seq(
     //show full stack trace (-oF) of failed tests and duration of tests (-oD)
-    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-S", "-7003891070744187126"),
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     Test / logBuffered := false,
     skip / publish := true
   ) ++ settings

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -210,7 +210,7 @@ object CommonSettings {
 
   lazy val testSettings: Seq[Setting[_]] = Seq(
     //show full stack trace (-oF) of failed tests and duration of tests (-oD)
-    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-S", "-7003891070744187126"),
     Test / logBuffered := false,
     skip / publish := true
   ) ++ settings


### PR DESCRIPTION
This PR fixes a small serialization bug found in how we determine if a `TaprootKeyPath` witness is valid. Previously we were not checking that if the potential x coordinate is valid or not. 

This was found via this CI failure on #5419 .

https://github.com/bitcoin-s/bitcoin-s/actions/runs/8021039000/job/21912196742?pr=5419#step:5:1630

You can reproduce the test case failure with the scalatest settings on this commit: 7119d0accec2bcf7e69e687a5c11f9d6414c8113