### PR TITLE
Fix bug in health checks

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -1374,11 +1374,12 @@ object PeerManager extends Logging {
     }
   }
 
-  def handleHealthCheck(
-      runningState: NodeRunningState): Future[NodeRunningState] = {
-    val nonBlockFilterPeers = runningState.peerDataMap.filterNot(
-      _._2.serviceIdentifier.nodeCompactFilters)
-    if (runningState.peerDataMap.nonEmpty && nonBlockFilterPeers.isEmpty) {
+  def handleHealthCheck(runningState: NodeRunningState)(implicit
+      nodeAppConfig: NodeAppConfig): Future[NodeRunningState] = {
+    val blockFilterPeers =
+      runningState.peerDataMap.filter(_._2.serviceIdentifier.nodeCompactFilters)
+    val slotsFull = blockFilterPeers.size == nodeAppConfig.maxConnectedPeers
+    if (runningState.peerDataMap.nonEmpty && slotsFull) {
       //do nothing
       Future.successful(runningState)
     } else {


### PR DESCRIPTION
Fixes a bug in #5417 

This fixes the bug for the case where we are connected to only block filter peer(s), but not at the `NodeAppConfig.maxConnectedPeers` threshold. 

As an example, if we were connected to 1 block filter peer, but could `NodeAppConfig.maxConnectedPeers=2`, our health check implementation in #5417 would not attempt to connect to any more peers to reach the 2 peer threshold. 

This PR makes it so we always try to maintain `NodeAppConfig.maxConnectedPeers` of block filter peers at all times.