### PR TITLE
Remove duplicate `PeerConnection.disconnect()` call

### DIFF
--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -162,8 +162,6 @@ bitcoin-s {
         # peers discovery configs, ideally you would not want to change this
         # timeout for tcp connection
         connection-timeout = 5s
-        # initialization timeout once connected, reconnections resets this
-        initialization-timeout = 10s
         # time interval for trying next set of peers in peer discovery
         try-peers-interval = 12 hour
         

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -198,6 +198,7 @@ case class PeerManager(
   private def onInitializationTimeout(
       peer: Peer,
       state: NodeRunningState): Future[Unit] = {
+    logger.debug(s"onInitializationTimeout() peer=$peer state=$state")
     val finder = state.peerFinder
     require(!finder.hasPeer(peer) || !peerDataMap.contains(peer),
             s"$peer cannot be both a test and a persistent peer")

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -149,14 +149,6 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     } else 5.seconds
   }
 
-  /** initialization timeout once connected, reconnections reset this */
-  lazy val initializationTimeout: FiniteDuration = {
-    if (config.hasPath("bitcoin-s.node.initialization-timeout")) {
-      val duration = config.getDuration("bitcoin-s.node.initialization-timeout")
-      TimeUtil.durationToFiniteDuration(duration)
-    } else 10.seconds
-  }
-
   lazy val tryPeersStartDelay: FiniteDuration = {
     if (config.hasPath("bitcoin-s.node.try-peers-start-delay")) {
       val duration = config.getDuration("bitcoin-s.node.try-peers-start-delay")

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -235,15 +235,6 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
           buildConnectionGraph()
         }
 
-        val initializationCancellable =
-          system.scheduler.scheduleOnce(nodeAppConfig.initializationTimeout) {
-            val offerF =
-              queue.offer(NodeStreamMessage.InitializationTimeout(peer))
-            offerF.failed.foreach(err =>
-              logger.error(s"Failed to offer initialize timeout for peer=$peer",
-                           err))
-          }
-
         outgoingConnectionF.onComplete {
           case scala.util.Success(o) =>
             val tcp = o._1._1
@@ -252,6 +243,11 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
           case scala.util.Failure(err) =>
             logger.info(
               s"Failed to connect to peer=$peer with errMsg=${err.getMessage}")
+            val offerF =
+              queue.offer(NodeStreamMessage.InitializationTimeout(peer))
+            offerF.failed.foreach(err =>
+              logger.error(s"Failed to offer initialize timeout for peer=$peer",
+                           err))
         }
 
         val resultF: Future[Unit] = {
@@ -261,8 +257,7 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
               mergeHubSink = mergeHubSink,
               connectionF = outgoingConnectionF.map(_._1._1),
               streamDoneF = outgoingConnection._2,
-              killswitch = outgoingConnection._1._2,
-              initializationCancellable = initializationCancellable
+              killswitch = outgoingConnection._1._2
             )
             _ = {
               connectionGraphOpt = Some(graph)
@@ -277,7 +272,6 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
                 }
             }
             _ = resetReconnect()
-            _ = initializationCancellable.cancel()
             _ <- {
               nodeAppConfig.socks5ProxyParams match {
                 case Some(_) => Future.unit
@@ -352,9 +346,6 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
         connectionGraphOpt = None
         cg.stop()
       case None =>
-        val err =
-          s"Cannot disconnect client that is not connected to peer=${peer}!"
-        logger.warn(err)
         Future.successful(Done)
     }
   }
@@ -403,12 +394,10 @@ object PeerConnection {
       mergeHubSink: Sink[ByteString, NotUsed],
       connectionF: Future[Tcp.OutgoingConnection],
       streamDoneF: Future[Done],
-      killswitch: UniqueKillSwitch,
-      initializationCancellable: Cancellable) {
+      killswitch: UniqueKillSwitch) {
 
     def stop(): Future[Done] = {
       killswitch.shutdown()
-      initializationCancellable.cancel()
       streamDoneF
     }
   }


### PR DESCRIPTION
This was causing these logs: 

```
2024-02-26 19:00:38,109UTC WARN [PeerConnection] Cannot disconnect client that is not connected to peer=Peer(73.237.194.108:8333)!
2024-02-26 19:00:38,109UTC WARN [PeerConnection] Cannot disconnect client that is not connected to peer=Peer(149.36.50.232:8333)!
...
```