### PR TITLE
Rework `NodeState.toString()`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NodeState.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeState.scala
@@ -116,6 +116,10 @@ sealed trait NodeRunningState extends NodeState {
   def toDoneSyncing: DoneSyncing = {
     DoneSyncing(peerDataMap, waitingForDisconnection, peerFinder)
   }
+
+  override def toString: String = {
+    s"${getClass.getSimpleName}(peers=${peers},waitingForDisconnection=${waitingForDisconnection})"
+  }
 }
 
 /** State to indicate that we are syncing the blockchain */


### PR DESCRIPTION
Now looks like
```
FilterHeaderSync(peers=Set(Peer(localhost:2699), Peer(localhost:48376)), waitingForDisconnection=Set()) 
```

rather than

```
DoneSyncing(Map(PeerWithServices(Peer(90.21.32.44:8333),ServiceIdentifier(network=false,compactFilters=true,getUtxo=false,bloom=false,witness=true,xthin=false,networkLimited=true)) -> PersistentPeerData(Peer(90.21.32.44:8333),PeerMessageSender(PeerConnection(Peer(90.21.32.44:8333),org.apache.pekko.stream.impl.QueueSource$$anon$1-queueSource))), PeerWithServices(Peer(3.236.246.84:8333),ServiceIdentifier(network=true,compactFilters=true,getUtxo=false,bloom=true,witness=true,xthin=false,networkLimited=true)) -> PersistentPeerData(Peer(3.236.246.84:8333),PeerMessageSender(PeerConnection(Peer(3.236.246.84:8333),org.apache.pekko.stream.impl.QueueSource$$anon$1-queueSource)))),Set(),PeerFinder(paramPeers=Vector())) forceReconnect=false peerDataMap=List(Peer(90.21.32.44:8333), Peer(3.236.246.84:8333))
```