### PR TITLE
Reduce various logs in `org.bitcoins.wallet` to `DEBUG`

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -395,7 +395,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
 
   private def downloadAndProcessBlocks(
       blocks: Vector[DoubleSha256Digest]): Future[Unit] = {
-    logger.info(s"Requesting ${blocks.size} block(s)")
+    logger.debug(s"Requesting ${blocks.size} block(s)")
     blocks.foldLeft(Future.unit) { (prevF, blockHash) =>
       val completedF = subscribeForBlockProcessingCompletionSignal(blockHash)
       for {
@@ -502,7 +502,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
     Flow[Vector[Int]].mapAsync(1) { case range: Vector[Int] =>
       val startHeight = range.head
       val endHeight = range.last
-      logger.info(
+      logger.debug(
         s"Searching filters from start=$startHeight to end=$endHeight")
       chainQueryApi.getFiltersBetweenHeights(startHeight = startHeight,
                                              endHeight = endHeight)
@@ -534,7 +534,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
       filtered <- findMatches(filtersResponse, scripts, parallelismLevel)(ec)
       _ <- downloadAndProcessBlocks(filtered.map(_.blockHash.flip))
     } yield {
-      logger.info(
+      logger.debug(
         s"Found ${filtered.length} matches from start=$startHeightOpt to end=$endHeightOpt")
       filtered
     }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -65,7 +65,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
     val isEmptyF = isEmpty()
     val heightF = chainQueryApi.getBlockHeight(block.blockHeader.hashBE)
     heightF.foreach { heightOpt =>
-      logger.info(
+      logger.debug(
         s"Processing block=${block.blockHeader.hash.flip.hex} heightOpt=$heightOpt")
     }
 


### PR DESCRIPTION
See examples of noisy logs in https://github.com/bitcoin-s/bitcoin-s/actions/runs/8070638512/job/22048462739?pr=5427