### PR TITLE
Fix `PeerDb.lastSeen` race condition in unit tests

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -139,7 +139,7 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         _ <- assertConnAndInit
         ourPeers <- Future.sequence(
           nodeConnectedWithBitcoind.bitcoinds.map(NodeTestUtil.getBitcoindPeer))
-        peerDbs <- PeerDAO()(executionContext, node.nodeAppConfig).findAll()
+        peerDbs <- PeerDAO()(node.nodeAppConfig, executionContext).findAll()
       } yield {
 
         val allInDb = ourPeers.forall { p =>

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -88,11 +88,11 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
       for {
         _ <- node.start()
         peer <- peerF
-        peerManager = node.peerManager
         _ <- NodeTestUtil.awaitSyncAndIBD(node = node, bitcoind = bitcoind)
         //disconnect
         timestamp = Instant.now()
-        _ <- peerManager.disconnectPeer(peer)
+        uri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind)
+        _ <- bitcoind.disconnectNode(uri)
         _ <- NodeTestUtil.awaitConnectionCount(node, 0)
         addrBytes = PeerDAOHelper.getAddrBytes(peer)
         peerDb <- PeerDAO()(system.dispatcher, node.nodeConfig)

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -70,7 +70,8 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
         peerManager = node.peerManager
         _ <- NodeTestUtil.awaitSyncAndIBD(node = node, bitcoind = bitcoind)
         //disconnect
-        _ <- peerManager.disconnectPeer(peer)
+        nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind)
+        _ <- bitcoind.disconnectNode(nodeUri)
         _ <- NodeTestUtil.awaitConnectionCount(node, 0)
         _ <- node.peerManager.connectPeer(peer)
         _ <- NodeTestUtil.awaitConnectionCount(node, 1)

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -95,7 +95,7 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
         _ <- bitcoind.disconnectNode(uri)
         _ <- NodeTestUtil.awaitConnectionCount(node, 0)
         addrBytes = PeerDAOHelper.getAddrBytes(peer)
-        peerDb <- PeerDAO()(system.dispatcher, node.nodeConfig)
+        peerDb <- PeerDAO()(node.nodeConfig, system.dispatcher)
           .read((addrBytes, peer.port))
           .map(_.get)
       } yield {

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -68,9 +68,16 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
         _ <- node.start()
         peer <- peerF
         peerManager = node.peerManager
+
         _ <- NodeTestUtil.awaitSyncAndIBD(node = node, bitcoind = bitcoind)
         //disconnect
-        nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind)
+        address <- peerManager
+          .getPeerData(peer)
+          .get
+          .peerConnection
+          .getLocalAddress
+          .map(_.get)
+        nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind, address)
         _ <- bitcoind.disconnectNode(nodeUri)
         _ <- NodeTestUtil.awaitConnectionCount(node, 0)
         _ <- node.peerManager.connectPeer(peer)
@@ -92,7 +99,13 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
         _ <- NodeTestUtil.awaitSyncAndIBD(node = node, bitcoind = bitcoind)
         //disconnect
         timestamp = Instant.now()
-        uri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind)
+        address <- node.peerManager
+          .getPeerData(peer)
+          .get
+          .peerConnection
+          .getLocalAddress
+          .map(_.get)
+        uri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind, address)
         _ <- bitcoind.disconnectNode(uri)
         _ <- NodeTestUtil.awaitConnectionCount(node, 0)
         addrBytes = PeerDAOHelper.getAddrBytes(peer)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -790,6 +790,8 @@ case class PeerManager(
               s"Shut down already requested, ignoring new shutdown request")
             Future.successful(s)
           case r: NodeRunningState =>
+            logger.info(
+              s"Received NodeShutdown message, beginning shutdown procedures")
             val shutdownState =
               NodeShuttingDown(peerDataMap = r.peerDataMap,
                                waitingForDisconnection =

--- a/node/src/main/scala/org/bitcoins/node/db/NodeDbManagement.scala
+++ b/node/src/main/scala/org/bitcoins/node/db/NodeDbManagement.scala
@@ -2,7 +2,7 @@ package org.bitcoins.node.db
 
 import org.bitcoins.db.{DbManagement, JdbcProfileComponent}
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.models.BroadcastAbleTransactionDAO
+import org.bitcoins.node.models.{BroadcastAbleTransactionDAO, PeerDAO}
 
 import scala.concurrent.ExecutionContext
 
@@ -17,6 +17,12 @@ trait NodeDbManagement extends DbManagement {
     BroadcastAbleTransactionDAO()(appConfig, ec).table
   }
 
-  override lazy val allTables: List[TableQuery[Table[_]]] = List(txTable)
+  private lazy val peerTable: TableQuery[Table[_]] = {
+    PeerDAO()(appConfig, ec).table
+  }
+
+  override lazy val allTables: List[TableQuery[Table[_]]] = {
+    List(txTable, peerTable)
+  }
 
 }

--- a/node/src/main/scala/org/bitcoins/node/models/PeerDAO.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/PeerDAO.scala
@@ -22,7 +22,7 @@ case class PeerDb(
     serviceBytes: ByteVector
 )
 
-case class PeerDAO()(implicit ec: ExecutionContext, appConfig: NodeAppConfig)
+case class PeerDAO()(implicit appConfig: NodeAppConfig, ec: ExecutionContext)
     extends CRUD[PeerDb, (ByteVector, Int)]
     with SlickUtil[PeerDb, (ByteVector, Int)] {
 

--- a/node/src/main/scala/org/bitcoins/node/models/PeerDAO.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/PeerDAO.scala
@@ -93,7 +93,8 @@ case class PeerDAO()(implicit ec: ExecutionContext, appConfig: NodeAppConfig)
     val action = findByPrimaryKey((address, port)).result.headOption
     val updatedLastSeenA = action.flatMap {
       case Some(peerDb) =>
-        updateAction(peerDb.copy(lastSeen = Instant.now()))
+        val now = Instant.now()
+        updateAction(peerDb.copy(lastSeen = now))
           .map(Some(_))
       case None => DBIOAction.successful(None)
     }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -220,6 +220,13 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
     runningStream
   }
 
+  def getLocalAddress: Future[Option[InetSocketAddress]] = {
+    connectionGraphOpt match {
+      case Some(g) => g.connectionF.map(c => Some(c.localAddress))
+      case None    => Future.successful(None)
+    }
+  }
+
   @volatile private[this] var connectionGraphOpt: Option[ConnectionGraph] = None
 
   /** Initiates a connection with the given peer */

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/NodeDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/NodeDAOFixture.scala
@@ -1,58 +1,56 @@
 package org.bitcoins.testkit.fixtures
 
-import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models.{BroadcastAbleTransactionDAO, PeerDAO}
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
-import org.bitcoins.testkit.node.{CachedBitcoinSAppConfig, NodeUnitTest}
+import org.bitcoins.testkit.node.{NodeUnitTest}
 import org.scalatest._
 
 import scala.concurrent.Future
 
-case class NodeDAOs(txDAO: BroadcastAbleTransactionDAO, peerDAO: PeerDAO)
+case class NodeDAOs(
+    txDAO: BroadcastAbleTransactionDAO,
+    peerDAO: PeerDAO,
+    nodeAppConfig: NodeAppConfig)
 
 /** Provides a fixture where all DAOs used by the node projects are provided */
-trait NodeDAOFixture extends NodeUnitTest with CachedBitcoinSAppConfig {
+trait NodeDAOFixture extends NodeUnitTest {
 
   /** Wallet config with data directory set to user temp directory */
   override protected def getFreshConfig: BitcoinSAppConfig =
     BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(() => pgUrl(),
                                                               Vector.empty)
 
-  private lazy val daos = {
-    val tx = BroadcastAbleTransactionDAO()
-    val peerDao = PeerDAO()
-    NodeDAOs(tx, peerDao)
-  }
-
   final override type FixtureParam = NodeDAOs
 
-  def withFixture(test: OneArgAsyncTest): FutureOutcome = {
-    makeFixture(build = () => {
-                  for {
-                    _ <- cachedChainConf.start()
-                    _ <- cachedNodeConf.start()
-                  } yield daos
-                },
-                destroy =
-                  () => destroyAppConfig(cachedChainConf, cachedNodeConf))(test)
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    makeDependentFixture[NodeDAOs](
+      build = () => {
+        val config = getFreshConfig
+        val nodeConf = config.nodeConf
+        for {
+          _ <- nodeConf.start()
+        } yield {
+          val tx = BroadcastAbleTransactionDAO()(nodeConf, executionContext)
+          val peerDao = PeerDAO()(nodeConf, executionContext)
+          NodeDAOs(tx, peerDao, nodeConf)
+        }
+      },
+      destroy = { case dao: NodeDAOs =>
+        destroyAppConfig(dao.nodeAppConfig)
+      }
+    )(test)
   }
 
-  private def destroyAppConfig(
-      chainConfig: ChainAppConfig,
-      nodeConfig: NodeAppConfig): Future[Unit] = {
-
+  private def destroyAppConfig(nodeConfig: NodeAppConfig): Future[Unit] = {
+    nodeConfig.clean()
     for {
-      _ <- nodeConfig.dropAll()
       _ <- nodeConfig.stop()
-      _ <- chainConfig.dropAll()
-      _ <- chainConfig.stop()
     } yield ()
   }
 
   override def afterAll(): Unit = {
-    super[CachedBitcoinSAppConfig].afterAll()
     super[NodeUnitTest].afterAll()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -5,6 +5,7 @@ import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.node.Peer
 import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.node.constant.NodeConstants
 import org.bitcoins.node.{NeutrinoNode, Node, P2PLogger}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.async.TestAsyncUtil
@@ -267,7 +268,10 @@ abstract class NodeTestUtil extends P2PLogger {
       system: ActorSystem): Future[URI] = {
     import system.dispatcher
     bitcoind.getPeerInfo.map { peerInfo =>
-      val localFilter = peerInfo.filter(_.networkInfo.addrlocal.isDefined)
+      val localFilter = peerInfo.filter { p =>
+        p.networkInfo.addrlocal.isDefined && p.subver.contains(
+          NodeConstants.userAgent)
+      }
       val result = localFilter.head.networkInfo.addr
       result
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -272,6 +272,7 @@ abstract class NodeTestUtil extends P2PLogger {
         p.networkInfo.addrlocal.isDefined && p.subver.contains(
           NodeConstants.userAgent)
       }
+      println(s"getNodeURIFromBitcoind.localFilter=$localFilter")
       val result = localFilter.head.networkInfo.addr
       result
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -264,15 +264,16 @@ abstract class NodeTestUtil extends P2PLogger {
   /** get our neutrino node's uri from a test bitcoind instance to send rpc commands for our node.
     * The peer must be initialized by the node.
     */
-  def getNodeURIFromBitcoind(bitcoind: BitcoindRpcClient)(implicit
+  def getNodeURIFromBitcoind(
+      bitcoind: BitcoindRpcClient,
+      localAddressBitcoinS: InetSocketAddress)(implicit
       system: ActorSystem): Future[URI] = {
     import system.dispatcher
     bitcoind.getPeerInfo.map { peerInfo =>
       val localFilter = peerInfo.filter { p =>
         p.networkInfo.addrlocal.isDefined && p.subver.contains(
-          NodeConstants.userAgent)
+          NodeConstants.userAgent) && p.networkInfo.addr.getPort == localAddressBitcoinS.getPort
       }
-      println(s"getNodeURIFromBitcoind.localFilter=$localFilter")
       val result = localFilter.head.networkInfo.addr
       result
     }


### PR DESCRIPTION
Fixes a race condition introduced in #5425 wrt to updating the `lastSeen` time of a peer.

This is what the failure looks like on CI: https://github.com/bitcoin-s/bitcoin-s/actions/runs/8071859918/job/22053452534?pr=5427#step:5:816

In #5425, we call `_peerData.remove()` when we receive a `InitializeDisconnect()` message over the stream. This will change our `connectionCount` to `0`. This means our test case continues executing, before we process the `DisconnectedPeer` message in the stream and update `lastSeen`.

This PR adjusts the test case to disconnect from the `bitcoind` side to avoid the race condition. 

This PR also fixes the bug described in #5343 , we now filter to make sure the peer we are disconnecting is a bitcoin-s peer inside of `NodeTestUtil.getNodeURIFromBitcoind()`