### PR TITLE
Use `NodeCallbackStreamManager` when calling `NodeCallbacks` constructors

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/Callback.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/Callback.scala
@@ -38,9 +38,16 @@ case class CallbackHandler[C, T <: Callback[C]](
     extends SeqWrapper[T] {
 
   def ++(other: CallbackHandler[C, T]): CallbackHandler[C, T] = {
-    require(name == other.name,
-            "Cannot combine callback handlers with different names")
-    CallbackHandler(name, wrapped ++ other.wrapped)
+    if (name == CallbackHandler.emptyName) {
+      CallbackHandler(other.name, wrapped ++ other.wrapped)
+    } else if (other.name == CallbackHandler.emptyName) {
+      this
+    } else {
+      require(
+        name == other.name,
+        s"Cannot combine callback handlers with different names name=$name other.name=${other.name}")
+      CallbackHandler(name, wrapped ++ other.wrapped)
+    }
   }
 
   /** Executes the callbacks synchronously, if any fail, they are recovered by recoverFunc */
@@ -62,7 +69,9 @@ case class CallbackHandler[C, T <: Callback[C]](
 
 object CallbackHandler {
 
+  final val emptyName: String = "empty"
+
   def empty[C, T <: Callback[C]]: CallbackHandler[C, T] = {
-    CallbackHandler("empty", Vector.empty)
+    CallbackHandler(emptyName, Vector.empty)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/api/Callback.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/Callback.scala
@@ -59,3 +59,10 @@ case class CallbackHandler[C, T <: Callback[C]](
     Future.sequence(executeFs).map(_ => ())
   }
 }
+
+object CallbackHandler {
+
+  def empty[C, T <: Callback[C]]: CallbackHandler[C, T] = {
+    CallbackHandler("empty", Vector.empty)
+  }
+}


### PR DESCRIPTION
Hopefully this fixes CI failures we see in `DataMessageHandlerTest`

