### PR TITLE
Set `max-open-requests = 64` for `appServerTest`

### DIFF
--- a/app/server-test/src/test/resources/reference.conf
+++ b/app/server-test/src/test/resources/reference.conf
@@ -6,3 +6,5 @@ bitcoin-s {
         peers = ["localhost"]
     }
 }
+
+pekko.http.host-connection-pool.max-connections = 64


### PR DESCRIPTION
Attempt to fix this occasional test case failure by just bumping max open requests.

https://github.com/bitcoin-s/bitcoin-s/actions/runs/8103758193/job/22149039314#step:5:4061

For more information on this setting:

https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/docs/client-side/pool-overflow.html?language=scala