### PR TITLE
2024 03 01 Fix `syncPeer` exceptions

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -405,6 +405,8 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
         node <- nodeF
         _ <- AsyncUtil.nonBlockingSleep(5.second)
         connCount <- node.getConnectionCount
+        _ <- node.stop()
+        _ <- node.nodeConfig.stop()
       } yield {
         assert(connCount == max)
       }

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.node
 
+import com.typesafe.config.ConfigFactory
 import org.apache.pekko.actor.Cancellable
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.models.{CompactFilterDAO, CompactFilterHeaderDAO}
@@ -391,5 +392,38 @@ class NeutrinoNodeTest extends NodeTestWithCachedBitcoindPair {
                                        bitcoind = bitcoind0,
                                        bestBlockHashBE = Some(hashes1.head))
       } yield succeed
+  }
+
+  it must "honor bitcoin-s.node.maxConnectedPeers" in {
+    nodeConnectedWithBitcoind: NeutrinoNodeConnectedWithBitcoinds =>
+      val max = 1
+      val nodeF = getCustomMaxConnectedPeers(initNode =
+                                               nodeConnectedWithBitcoind.node,
+                                             maxConnectedPeers = max)
+
+      for {
+        node <- nodeF
+        _ <- AsyncUtil.nonBlockingSleep(5.second)
+        connCount <- node.getConnectionCount
+      } yield {
+        assert(connCount == max)
+      }
+  }
+
+  private def getCustomMaxConnectedPeers(
+      initNode: NeutrinoNode,
+      maxConnectedPeers: Int): Future[NeutrinoNode] = {
+
+    require(initNode.nodeConfig.maxConnectedPeers != maxConnectedPeers,
+            s"maxConnectedPeers must be different")
+    //make a custom config, set the inactivity timeout very low
+    //so we will disconnect our peer organically
+    val str =
+      s"""
+         |bitcoin-s.node.maxConnectedPeers = $maxConnectedPeers
+         |""".stripMargin
+    val config =
+      ConfigFactory.parseString(str)
+    NodeTestUtil.getStartedNodeCustomConfig(initNode, config)
   }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -98,25 +98,6 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
          |""".stripMargin
     val config =
       ConfigFactory.parseString(str)
-    val stoppedConfigF = initNode.nodeConfig.stop()
-    val newNodeAppConfigF =
-      stoppedConfigF.map(_ => initNode.nodeConfig.withOverrides(config))
-    val nodeF = {
-      for {
-        newNodeAppConfig <- newNodeAppConfigF
-        _ <- newNodeAppConfig.start()
-      } yield {
-        NeutrinoNode(
-          walletCreationTimeOpt = initNode.walletCreationTimeOpt,
-          nodeConfig = newNodeAppConfig,
-          chainConfig = initNode.chainAppConfig,
-          actorSystem = initNode.system,
-          paramPeers = initNode.paramPeers
-        )
-      }
-    }
-
-    val startedF = nodeF.flatMap(_.start())
-    startedF
+    NodeTestUtil.getStartedNodeCustomConfig(initNode, config)
   }
 }

--- a/node/src/main/scala/org/bitcoins/node/NodeState.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeState.scala
@@ -29,6 +29,8 @@ sealed trait NodeRunningState extends NodeState {
 
   def peerFinder: PeerFinder
 
+  def connectedPeerCount: Int = peers.size
+
   def getPeerConnection(peer: Peer): Option[PeerConnection] = {
     peerDataMap.find(_._1.peer == peer).map(_._2.peerConnection) match {
       case Some(peerConnection) => Some(peerConnection)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -236,17 +236,10 @@ case class PeerManager(
     val hasConnectionSlot = connectedPeerCount < nodeAppConfig.maxConnectedPeers
     if (hasConnectionSlot || availableFilterSlot) {
       //we want to promote this peer, so pop from cache
-      val _ = state.peerFinder.popFromCache(peer)
-      val persistentPeerData = peerData match {
-        case p: PersistentPeerData       => p
-        case a: AttemptToConnectPeerData => a.toPersistentPeerData
-      }
+      val newState = state.addPeer(peer)
+      val persistentPeerData =
+        newState.peerDataMap.filter(_._1.peer == peer).head._2
       _peerDataMap.put(peer, persistentPeerData)
-
-      val peerWithSvcs = persistentPeerData.peerWithServicesOpt.get
-      val newPdm =
-        state.peerDataMap.+((peerWithSvcs, persistentPeerData))
-      val newState = state.replacePeers(newPdm)
       if (availableFilterSlot) {
         replacePeer(replacePeer = notCfPeers.head, withPeer = peer)
           .map(_ => newState)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -307,9 +307,7 @@ case class PeerManager(
       }
     }
 
-    stateF.map { s =>
-      s.replacePeers(peerWithServicesDataMap)
-    }
+    stateF
   }
 
   /** @param peer the peer we were disconencted from


### PR DESCRIPTION
This PR consolidates logic for disconnecting a peer into one spot. Previously this code was duplicated in two places

1. `PeerManager.onDisconnect()` for the case where our peer initializes the disconnection
2. `PeerManager.buildP2PMessageHandlerSink` when we initialize the disconnect (`InitializeDisconnect` message)

As a by product, this should fix exceptions being thrown in test cases that look like this

```
2024-03-02 13:28:18,142UTC ERROR NeutrinoNode - Error occurred while processing p2p pipeline stream                                                                                                         
java.lang.IllegalArgumentException: requirement failed: syncPeer must be a member of peers, syncPeer=Peer(localhost:45816) peers=Set()                                                                      
        at scala.Predef$.require(Predef.scala:337)                                                                                                                                                          
        at org.bitcoins.node.SyncNodeState.<init>(NodeState.scala:129)                                                                                                                                      
        at org.bitcoins.node.NodeState$FilterHeaderSync.<init>(NodeState.scala:157)                                                                                                                         
        at org.bitcoins.node.NodeState$FilterHeaderSync.copy(NodeState.scala:156)                                                                                                                           
        at org.bitcoins.node.NodeRunningState.replacePeers(NodeState.scala:48)                                                                                                                              
        at org.bitcoins.node.NodeRunningState.replacePeers$(NodeState.scala:40)                                                                                                                             
        at org.bitcoins.node.SyncNodeState.replacePeers(NodeState.scala:126)                                                                                                                                
        at org.bitcoins.node.PeerManager.$anonfun$buildP2PMessageHandlerSink$1(PeerManager.scala:603)                                                                                                       
        at org.apache.pekko.stream.impl.fusing.FoldAsync$$anon$19.onPush(Ops.scala:711)                                                                                                                     
        at org.apache.pekko.stream.impl.fusing.GraphInterpreter.processPush(GraphInterpreter.scala:555)                                                                                                     
```