### PR TITLE
fix bug where we weren't properly transferring state to `FilterHeaderSync`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -909,10 +909,12 @@ case class PeerManager(
           //after we are done syncing block headers
           Future.unit
         } else {
-          val fhs = FilterHeaderSync(syncPeer = syncNodeState.syncPeer,
-                                     peerDataMap = peerWithServicesDataMap,
-                                     waitingForDisconnection = Set.empty,
-                                     syncNodeState.peerFinder)
+          val fhs = FilterHeaderSync(
+            syncPeer = syncNodeState.syncPeer,
+            peerDataMap = syncNodeState.peerDataMap,
+            waitingForDisconnection = syncNodeState.waitingForDisconnection,
+            syncNodeState.peerFinder
+          )
           syncFilters(
             bestFilterHeaderOpt = bestFilterHeaderOpt,
             bestFilterOpt = bestFilterOpt,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -248,7 +248,7 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
             logger.info(
               s"Connected to remote=${tcp.remoteAddress}  local=${tcp.localAddress}")
           case scala.util.Failure(err) =>
-            logger.info(
+            logger.debug(
               s"Failed to connect to peer=$peer with errMsg=${err.getMessage}")
             val offerF =
               queue.offer(NodeStreamMessage.InitializationTimeout(peer))


### PR DESCRIPTION
This PR also reduces the log level to `DEBUG` when we fail to establish a connection to a peer.