### PR TITLE
Remove `PeerMessageSenderApi` param from `DataMessageHandler`

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -52,7 +52,6 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         peer = node.peerManager.peers.head
         chainApi <- node.chainApiFromDb()
         _ = require(peerManager.getPeerData(peer).isDefined)
-        peerMsgSender = peerManager.getPeerData(peer).get.peerMessageSender
         peerFinder = PeerFinder(peerManagerApi = peerManager,
                                 paramPeers = Vector.empty,
                                 queue = node)(system.dispatcher,
@@ -62,7 +61,6 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         dataMessageHandler = DataMessageHandler(
           chainApi = chainApi,
           walletCreationTimeOpt = None,
-          peerMessageSenderApi = peerMsgSender,
           peerManager = peerManager,
           state = HeaderSync(peer,
                              peerManager.peerWithServicesDataMap,

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -616,11 +616,9 @@ case class PeerManager(
                   s"Ignoring received msg=${payload.commandName} from peer=$peer because it was disconnected, peers=$peers state=${state}")
                 Future.successful(state)
               case Some(peerData) =>
-                val peerMsgSender = PeerMessageSender(peerData.peerConnection)
                 val dmh = DataMessageHandler(
                   chainApi = ChainHandler.fromDatabase(),
                   walletCreationTimeOpt = walletCreationTimeOpt,
-                  peerMessageSenderApi = peerMsgSender,
                   peerManager = this,
                   state = runningState
                 )


### PR DESCRIPTION
Redundant as its accessible from the `peerData` parameter in `DataMessageHandler.handleDataPayload()` 