### PR TITLE
Fix bug where we were executing block callbacks when we hadn't seen a block header

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -102,6 +102,8 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         nodeCallbacks = NodeCallbacks.onBlockReceived(callback)
         _ = node.nodeAppConfig.addCallbacks(nodeCallbacks)
         hash <- bitcoind.generateToAddress(blocks = 1, junkAddress).map(_.head)
+        _ <- NodeTestUtil.awaitAllSync(node, bitcoind)
+        _ <- node.downloadBlocks(Vector(hash.flip))
         result = Await.result(resultP.future, 30.seconds)
       } yield assert(result.blockHeader.hashBE == hash)
   }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -303,11 +303,7 @@ case class DataMessageHandler(
                   HeadersMessage(CompactSizeUInt.one, Vector(block.blockHeader))
                 val newDmhF = handleDataPayload(payload = headersMessage,
                                                 peerData = peerData)
-                newDmhF.flatMap { dmh =>
-                  appConfig.callBacks
-                    .executeOnBlockReceivedCallbacks(block)
-                    .map(_ => dmh)
-                }
+                newDmhF
               } else {
                 logger.info(
                   s"Received block=${block.blockHeader.hash.flip.hex} state=$state")

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -495,7 +495,7 @@ case class DataMessageHandler(
       stopBlockHash: DoubleSha256DigestBE,
       startHeightOpt: Option[Int],
       syncNodeState: SyncNodeState): Future[Option[NodeState.FilterSync]] = {
-    logger.info(s"Beginning to sync filters to stopBlockHashBE=$stopBlockHash")
+    logger.debug(s"Beginning to sync filters to stopBlockHashBE=$stopBlockHash")
 
     val fs = syncNodeState match {
       case x @ (_: HeaderSync | _: FilterHeaderSync) =>


### PR DESCRIPTION
fixes #5454 

This was a bug in #5201 , we shouldn't process a block via callbacks if we haven't seen its header.