### PR TITLE
Rework `NodeApi.downloadBlocks()` to use `DoubleSha256DigestBE` 

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
@@ -8,7 +8,7 @@ import org.bitcoins.core.api.wallet.{NeutrinoWalletApi, WalletApi}
 import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node._
 import org.bitcoins.node.callback.NodeCallbackStreamManager
 import org.bitcoins.wallet.WalletNotInitialized
@@ -29,8 +29,8 @@ object CallbackUtil extends Logging {
     }
 
     val compactFilterSink = {
-      Sink.foreachAsync[Vector[(DoubleSha256Digest, GolombFilter)]](1) {
-        case blockFilters: Vector[(DoubleSha256Digest, GolombFilter)] =>
+      Sink.foreachAsync[Vector[(DoubleSha256DigestBE, GolombFilter)]](1) {
+        case blockFilters: Vector[(DoubleSha256DigestBE, GolombFilter)] =>
           logger.debug(
             s"Executing onCompactFilters callback with filter count=${blockFilters.length}")
           wallet

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -17,11 +17,7 @@ import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.{FutureUtil, NetworkUtil}
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.crypto.{
-  DoubleSha256Digest,
-  DoubleSha256DigestBE,
-  StringFactory
-}
+import org.bitcoins.crypto.{DoubleSha256DigestBE, StringFactory}
 import org.bitcoins.rpc.client.v19.V19BlockFilterRpc
 import org.bitcoins.rpc.client.v20.{V20AssortedRpc, V20MultisigRpc}
 import org.bitcoins.rpc.client.v21.BitcoindV21RpcClient
@@ -174,7 +170,7 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
     FutureUtil.sequentially(transactions)(sendRawTransaction(_)).map(_ => ())
 
   override def downloadBlocks(
-      blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = Future.unit
+      blockHashes: Vector[DoubleSha256DigestBE]): Future[Unit] = Future.unit
 
   override def processHeaders(headers: Vector[BlockHeader]): Future[ChainApi] =
     Future.successful(this)

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/BitcoindStreamUtil.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/util/BitcoindStreamUtil.scala
@@ -4,7 +4,7 @@ import org.apache.pekko.NotUsed
 import org.apache.pekko.stream.scaladsl.Flow
 import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockHeaderResult
 import org.bitcoins.core.protocol.blockchain.Block
-import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 
 import scala.concurrent.ExecutionContext
@@ -15,10 +15,10 @@ object BitcoindStreamUtil {
   def fetchBlocksBitcoind(
       bitcoindRpcClient: BitcoindRpcClient,
       parallelism: Int)(implicit ec: ExecutionContext): Flow[
-    DoubleSha256Digest,
+    DoubleSha256DigestBE,
     (Block, GetBlockHeaderResult),
     NotUsed] = {
-    Flow[DoubleSha256Digest].mapAsync(parallelism = parallelism) { hash =>
+    Flow[DoubleSha256DigestBE].mapAsync(parallelism = parallelism) { hash =>
       val blockF = bitcoindRpcClient.getBlockRaw(hash)
       val blockHeaderResultF = bitcoindRpcClient.getBlockHeader(hash)
       for {

--- a/core/src/main/scala/org/bitcoins/core/api/node/NodeApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/NodeApi.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.api.node
 
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.crypto.{DoubleSha256DigestBE}
 
 import scala.concurrent.Future
 
@@ -20,7 +20,7 @@ trait NodeApi {
 
   /** Request the underlying node to download the given blocks from its peers and feed the blocks to [[org.bitcoins.node.NodeCallbacks]].
     */
-  def downloadBlocks(blockHashes: Vector[DoubleSha256Digest]): Future[Unit]
+  def downloadBlocks(blockHashes: Vector[DoubleSha256DigestBE]): Future[Unit]
 
   def getConnectionCount: Future[Int]
 }

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/NeutrinoWalletApi.scala
@@ -3,19 +3,19 @@ package org.bitcoins.core.api.wallet
 import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.wallet.rescan.RescanState
-import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
+import org.bitcoins.crypto.DoubleSha256DigestBE
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait NeutrinoWalletApi { self: WalletApi =>
 
   def processCompactFilter(
-      blockHash: DoubleSha256Digest,
+      blockHash: DoubleSha256DigestBE,
       blockFilter: GolombFilter): Future[NeutrinoHDWalletApi] =
     processCompactFilters(Vector((blockHash, blockFilter)))
 
   def processCompactFilters(
-      blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
+      blockFilters: Vector[(DoubleSha256DigestBE, GolombFilter)]): Future[
     NeutrinoHDWalletApi]
 
   /** Recreates the account using BIP-157 approach

--- a/docs/chain/chain-query-api.md
+++ b/docs/chain/chain-query-api.md
@@ -83,7 +83,7 @@ val nodeApi = MockNodeApi.mock
 // a block filter, the returned NodeCallbacks will contain the necessary items to initialize the callbacks
 def createCallbacks(
       processTransaction: Transaction => Future[Unit],
-      processCompactFilters: (Vector[(DoubleSha256Digest, GolombFilter)]) => Future[Unit],
+      processCompactFilters: (Vector[(DoubleSha256DigestBE, GolombFilter)]) => Future[Unit],
       processBlock: Block => Future[Unit]): NodeCallbacks = {
     lazy val onTx: OnTxReceived = { tx =>
       processTransaction(tx)
@@ -110,7 +110,7 @@ val exampleProcessBlock = (block: Block) =>
     Future.successful(println(s"Received block: ${block.blockHeader.hashBE}"))
 
 val exampleProcessFilters =
-    (filters: Vector[(DoubleSha256Digest, GolombFilter)]) =>
+    (filters: Vector[(DoubleSha256DigestBE, GolombFilter)]) =>
       Future.successful(println(s"Received filter: ${filters.head._1.flip.hex} ${filters.head._2.hash.flip.hex}"))
 
 val exampleCallbacks =

--- a/docs/node/node-api.md
+++ b/docs/node/node-api.md
@@ -37,7 +37,7 @@ The functions that the NodeApi supports are:
 trait NodeApi {
 
   /** Request the underlying node to download the given blocks from its peers and feed the blocks to [[org.bitcoins.node.NodeCallbacks]] */
-    def downloadBlocks(blockHashes: Vector[DoubleSha256Digest]): Future[Unit]
+    def downloadBlocks(blockHashes: Vector[DoubleSha256DigestBE]): Future[Unit]
 }
 ```
 
@@ -84,7 +84,7 @@ val exampleCallback = createCallback(exampleProcessBlock)
     }
 
     override def downloadBlocks(
-        blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = {
+        blockHashes: Vector[DoubleSha256DigestBE]): Future[Unit] = {
       val blockFs = blockHashes.map(hash => bitcoind.getBlockRaw(hash))
       Future.sequence(blockFs).map(_ => ())
     }
@@ -97,7 +97,7 @@ val wallet =
     Wallet(nodeApi = nodeApi, chainQueryApi = chainApi, feeRateApi = ConstantFeeRateProvider(SatoshisPerVirtualByte.one))
 
 // Then to trigger the event we can run
-val exampleBlock = DoubleSha256Digest(
+val exampleBlock = DoubleSha256DigestBE(
     "000000000010dc23dc0d5acad64667a7a2b3010b6e02da4868bf392c90b6431d")
 wallet.nodeApi.downloadBlocks(Vector(exampleBlock))
 

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -148,7 +148,7 @@ val syncF: Future[ChainApi] = configF.flatMap { _ =>
 // wallet
 val wallet = Wallet(new NodeApi {
     override def broadcastTransactions(txs: Vector[Transaction]): Future[Unit] = Future.successful(())
-    override def downloadBlocks(blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = Future.successful(())
+    override def downloadBlocks(blockHashes: Vector[DoubleSha256DigestBE]): Future[Unit] = Future.successful(())
     override def getConnectionCount: Future[Int] = Future.successful(0)
   }, chainApi, ConstantFeeRateProvider(SatoshisPerVirtualByte.one))
 val walletF: Future[WalletApi] = configF.flatMap { _ =>

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -155,7 +155,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         hash <- bitcoind.generateToAddress(blocks = 1, junkAddress).map(_.head)
         filter <- bitcoind.getBlockFilter(hash, FilterType.Basic)
         result = Await.result(resultP.future, 30.seconds)
-      } yield assert(result == Vector((hash.flip, filter.filter)))
+      } yield assert(result == Vector((hash, filter.filter)))
   }
 
   it must "verify OnTxReceived callbacks are executed" in {

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -101,7 +101,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         _ = node.nodeAppConfig.addCallbacks(nodeCallbacks)
         hash <- bitcoind.generateToAddress(blocks = 1, junkAddress).map(_.head)
         _ <- NodeTestUtil.awaitAllSync(node, bitcoind)
-        _ <- node.downloadBlocks(Vector(hash.flip))
+        _ <- node.downloadBlocks(Vector(hash))
         result = Await.result(resultP.future, 30.seconds)
       } yield assert(result.blockHeader.hashBE == hash)
   }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -7,7 +7,7 @@ import org.bitcoins.core.gcs.{FilterType, GolombFilter}
 import org.bitcoins.core.p2p.HeadersMessage
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.NodeState.HeaderSync
 import org.bitcoins.node._
 import org.bitcoins.server.BitcoinSAppConfig
@@ -137,10 +137,10 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
       val node = param.node
       val bitcoind = param.bitcoind
 
-      val resultP: Promise[Vector[(DoubleSha256Digest, GolombFilter)]] =
+      val resultP: Promise[Vector[(DoubleSha256DigestBE, GolombFilter)]] =
         Promise()
       val callback: OnCompactFiltersReceived = {
-        (filters: Vector[(DoubleSha256Digest, GolombFilter)]) =>
+        (filters: Vector[(DoubleSha256DigestBE, GolombFilter)]) =>
           Future {
             resultP.success(filters)
             ()

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -14,7 +14,7 @@ import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.StartStopAsync
-import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.models._
 
@@ -134,13 +134,13 @@ trait Node
   /** Fetches the given blocks from the peers and calls the appropriate [[callbacks]] when done.
     */
   override def downloadBlocks(
-      blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = {
+      blockHashes: Vector[DoubleSha256DigestBE]): Future[Unit] = {
     if (blockHashes.isEmpty) {
       Future.unit
     } else {
       val typeIdentifier = TypeIdentifier.MsgWitnessBlock
       val inventories =
-        blockHashes.map(hash => Inventory(typeIdentifier, hash))
+        blockHashes.map(hash => Inventory(typeIdentifier, hash.flip))
       val message = GetDataMessage(inventories)
       for {
         _ <- peerManager.sendToRandomPeer(message)

--- a/node/src/main/scala/org/bitcoins/node/NodeCallbacks.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeCallbacks.scala
@@ -7,7 +7,7 @@ import org.bitcoins.core.api.{Callback, Callback2, CallbackHandler}
 import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader, MerkleBlock}
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.callback.NodeCallbackStreamManager
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -19,7 +19,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait NodeCallbacks extends ModuleCallbacks[NodeCallbacks] with Logging {
 
   def onCompactFiltersReceived: CallbackHandler[
-    Vector[(DoubleSha256Digest, GolombFilter)],
+    Vector[(DoubleSha256DigestBE, GolombFilter)],
     OnCompactFiltersReceived]
 
   def onTxReceived: CallbackHandler[Transaction, OnTxReceived]
@@ -65,7 +65,7 @@ trait NodeCallbacks extends ModuleCallbacks[NodeCallbacks] with Logging {
   }
 
   def executeOnCompactFiltersReceivedCallbacks(
-      blockFilters: Vector[(DoubleSha256Digest, GolombFilter)])(implicit
+      blockFilters: Vector[(DoubleSha256DigestBE, GolombFilter)])(implicit
       ec: ExecutionContext): Future[Unit] = {
     onCompactFiltersReceived.execute(
       blockFilters,
@@ -97,7 +97,7 @@ trait OnTxReceived extends Callback[Transaction]
 
 /** Callback for handling a received compact block filter */
 trait OnCompactFiltersReceived
-    extends Callback[Vector[(DoubleSha256Digest, GolombFilter)]]
+    extends Callback[Vector[(DoubleSha256DigestBE, GolombFilter)]]
 
 /** Callback for handling a received block header */
 trait OnBlockHeadersReceived extends Callback[Vector[BlockHeader]]
@@ -107,7 +107,7 @@ object NodeCallbacks extends CallbackFactory[NodeCallbacks] {
   // Use Impl pattern here to enforce the correct names on the CallbackHandlers
   private case class NodeCallbacksImpl(
       onCompactFiltersReceived: CallbackHandler[
-        Vector[(DoubleSha256Digest, GolombFilter)],
+        Vector[(DoubleSha256DigestBE, GolombFilter)],
         OnCompactFiltersReceived],
       onTxReceived: CallbackHandler[Transaction, OnTxReceived],
       onBlockReceived: CallbackHandler[Block, OnBlockReceived],
@@ -174,7 +174,7 @@ object NodeCallbacks extends CallbackFactory[NodeCallbacks] {
       implicit system: ActorSystem): NodeCallbacks = {
     val n = NodeCallbacksImpl(
       onCompactFiltersReceived =
-        CallbackHandler[Vector[(DoubleSha256Digest, GolombFilter)],
+        CallbackHandler[Vector[(DoubleSha256DigestBE, GolombFilter)],
                         OnCompactFiltersReceived]("onCompactFilterReceived",
                                                   onCompactFiltersReceived),
       onTxReceived = CallbackHandler[Transaction, OnTxReceived]("onTxReceived",

--- a/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
@@ -15,7 +15,7 @@ import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader, MerkleBlock}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.StartStopAsync
-import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node._
 
 import java.util.concurrent.atomic.AtomicBoolean
@@ -32,13 +32,13 @@ case class NodeCallbackStreamManager(
   import system.dispatcher
 
   private val filterQueueSource: Source[
-    Vector[(DoubleSha256Digest, GolombFilter)],
-    SourceQueueWithComplete[Vector[(DoubleSha256Digest, GolombFilter)]]] = {
+    Vector[(DoubleSha256DigestBE, GolombFilter)],
+    SourceQueueWithComplete[Vector[(DoubleSha256DigestBE, GolombFilter)]]] = {
     Source.queue(maxBufferSize, overflowStrategy)
   }
 
   private val filterSink: Sink[
-    Vector[(DoubleSha256Digest, GolombFilter)],
+    Vector[(DoubleSha256DigestBE, GolombFilter)],
     Future[Done]] = {
     Sink.foreachAsync(1) { case vec =>
       callbacks.executeOnCompactFiltersReceivedCallbacks(vec)
@@ -158,7 +158,7 @@ case class NodeCallbackStreamManager(
   }
 
   override def onCompactFiltersReceived: CallbackHandler[
-    Vector[(DoubleSha256Digest, GolombFilter)],
+    Vector[(DoubleSha256DigestBE, GolombFilter)],
     OnCompactFiltersReceived] = {
     callbacks.onCompactFiltersReceived
   }
@@ -193,7 +193,7 @@ case class NodeCallbackStreamManager(
   }
 
   override def executeOnCompactFiltersReceivedCallbacks(
-      blockFilters: Vector[(DoubleSha256Digest, GolombFilter)])(implicit
+      blockFilters: Vector[(DoubleSha256DigestBE, GolombFilter)])(implicit
       ec: ExecutionContext): Future[Unit] = {
     filterQueue
       .offer(blockFilters)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -585,7 +585,7 @@ case class DataMessageHandler(
           val filterHeadersF: Future[Vector[CompactFilterHeaderDb]] = {
             Future
               .traverse(filterBatch)(f =>
-                chainApi.getFilterHeader(f.blockHash.flip))
+                chainApi.getFilterHeader(f.blockHashBE))
               .map(_.flatten.toVector)
           }
 
@@ -857,7 +857,7 @@ case class DataMessageHandler(
             _ = logger.debug(
               s"Processing ${filterBatch.size} filters bestBlockHashBE=${filterBestBlockHashBE}")
             newChainApi <- chainApi.processFilters(sortedFilterMessages)
-            sortedGolombFilters = sortedBlockFilters.map(x => (x._1, x._3))
+            sortedGolombFilters = sortedBlockFilters.map(x => (x._1.flip, x._3))
             _ <-
               appConfig.callBacks
                 .executeOnCompactFiltersReceivedCallbacks(sortedGolombFilters)

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/SyncUtil.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.testkit.chain
 
-import org.apache.pekko.actor.ActorSystem
 import grizzled.slf4j.Logging
+import org.apache.pekko.actor.ActorSystem
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.blockchain.sync.{
   ChainSync,
@@ -17,7 +17,7 @@ import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.client.v19.V19BlockFilterRpc
 import org.bitcoins.server.BitcoindRpcBackendUtil
@@ -77,9 +77,9 @@ abstract class SyncUtil extends Logging {
       /** Request the underlying node to download the given blocks from its peers and feed the blocks to [[org.bitcoins.node.NodeCallbacks]].
         */
       override def downloadBlocks(
-          blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = {
+          blockHashes: Vector[DoubleSha256DigestBE]): Future[Unit] = {
         logger.info(s"Fetching ${blockHashes.length} hashes from bitcoind")
-        val f: Vector[DoubleSha256Digest] => Future[Vector[Unit]] = {
+        val f: Vector[DoubleSha256DigestBE] => Future[Vector[Unit]] = {
           case hashes =>
             val blocks: Vector[Future[Unit]] = hashes.map {
               bitcoindRpcClient

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/MockNodeApi.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/MockNodeApi.scala
@@ -2,7 +2,7 @@ package org.bitcoins.testkit.node
 
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.crypto.DoubleSha256DigestBE
 
 import scala.concurrent.Future
 
@@ -14,7 +14,7 @@ object MockNodeApi extends NodeApi {
     Future.unit
 
   override def downloadBlocks(
-      blockHashes: Vector[DoubleSha256Digest]): Future[Unit] = Future.unit
+      blockHashes: Vector[DoubleSha256DigestBE]): Future[Unit] = Future.unit
 
   override def getConnectionCount: Future[Int] = Future.successful(0)
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -140,7 +140,7 @@ class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
 
       filterResult <- bitcoind.getBlockFilter(header.hashBE, FilterType.Basic)
       filter = filterResult.filter
-      _ <- wallet.processCompactFilter(header.hash, filter)
+      _ <- wallet.processCompactFilter(header.hashBE, filter)
 
       balance <- wallet.getBalance()
     } yield {
@@ -176,7 +176,7 @@ class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
 
         filterResult <- bitcoind.getBlockFilter(header.hashBE, FilterType.Basic)
         filter = filterResult.filter
-        _ <- wallet.processCompactFilter(header.hash, filter)
+        _ <- wallet.processCompactFilter(header.hashBE, filter)
 
         unconfirmedBalance <- wallet.getUnconfirmedBalance()
         confirmedBalance <- wallet.getConfirmedBalance()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -110,7 +110,7 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoindNewest {
       hashes <- bitcoind.generateToAddress(102, addr)
       filters <- FutureUtil.sequentially(hashes)(
         bitcoind.getBlockFilter(_, FilterType.Basic))
-      filtersWithBlockHash = hashes.map(_.flip).zip(filters.map(_.filter))
+      filtersWithBlockHash = hashes.zip(filters.map(_.filter))
       _ <- wallet.processCompactFilters(filtersWithBlockHash)
       coinbaseUtxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
       confirmedUtxos <- wallet.listUtxos(TxoState.ConfirmedReceived)

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -155,11 +155,11 @@ abstract class Wallet
   }
 
   override def processCompactFilters(
-      blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
+      blockFilters: Vector[(DoubleSha256DigestBE, GolombFilter)]): Future[
     Wallet] = {
     val utxosF = listUtxos()
     val spksF = listScriptPubKeys()
-    val blockHashOpt = blockFilters.lastOption.map(_._1.flip)
+    val blockHashOpt = blockFilters.lastOption.map(_._1)
     val heightOptF = blockHashOpt match {
       case Some(blockHash) =>
         chainQueryApi.getBlockHeight(blockHash)
@@ -187,7 +187,7 @@ abstract class Wallet
         }
       }
       _ <- nodeApi.downloadBlocks(blockHashToDownload)
-      hash = blockFilters.last._1.flip
+      hash = blockFilters.last._1
       heightOpt <- heightOptF
       _ <- {
         heightOpt match {
@@ -214,8 +214,8 @@ abstract class Wallet
   }
 
   private def searchFilterMatches(spks: Vector[ScriptPubKey])(
-      blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
-    Vector[DoubleSha256Digest]] = FutureUtil.makeAsync { () =>
+      blockFilters: Vector[(DoubleSha256DigestBE, GolombFilter)]): Future[
+    Vector[DoubleSha256DigestBE]] = FutureUtil.makeAsync { () =>
     val asmVec = spks.map(_.asmBytes)
     blockFilters.flatMap { case (blockHash, blockFilter) =>
       val matcher = SimpleFilterMatcher(blockFilter)

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -20,13 +20,7 @@ import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.hd.{AddressType, HDAccount, HDChainType, HDPurpose}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.Block
-import org.bitcoins.core.protocol.dlc.models.{
-  ContractInfo,
-  DLCMessage,
-  DLCState,
-  DLCStatus,
-  OracleSignatures
-}
+import org.bitcoins.core.protocol.dlc.models._
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.tlv._
 import org.bitcoins.core.protocol.transaction.{
@@ -49,11 +43,7 @@ import org.bitcoins.core.wallet.utxo.{
   AddressTagType,
   TxoState
 }
-import org.bitcoins.crypto.{
-  DoubleSha256Digest,
-  DoubleSha256DigestBE,
-  Sha256Digest
-}
+import org.bitcoins.crypto.{DoubleSha256DigestBE, Sha256Digest}
 import scodec.bits.ByteVector
 
 import java.net.InetSocketAddress
@@ -116,7 +106,7 @@ class WalletHolder(initWalletOpt: Option[DLCNeutrinoHDWalletApi])(implicit
     delegate(_.processBlock(block))
 
   override def processCompactFilters(
-      blockFilters: Vector[(DoubleSha256Digest, GolombFilter)]): Future[
+      blockFilters: Vector[(DoubleSha256DigestBE, GolombFilter)]): Future[
     NeutrinoHDWalletApi] = {
     delegate(_.processCompactFilters(blockFilters))
   }
@@ -715,7 +705,7 @@ class WalletHolder(initWalletOpt: Option[DLCNeutrinoHDWalletApi])(implicit
     _.getBalance(account))
 
   override def processCompactFilter(
-      blockHash: DoubleSha256Digest,
+      blockHash: DoubleSha256DigestBE,
       blockFilter: GolombFilter): Future[NeutrinoHDWalletApi] =
     delegate(_.processCompactFilter(blockHash, blockFilter))
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -16,7 +16,7 @@ import org.bitcoins.core.protocol.{BitcoinAddress, BlockStamp}
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.core.wallet.rescan.RescanState.RescanTerminatedEarly
-import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.wallet.{Wallet, WalletLogger}
 import slick.dbio.{DBIOAction, Effect, NoStream}
 
@@ -394,7 +394,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
   }
 
   private def downloadAndProcessBlocks(
-      blocks: Vector[DoubleSha256Digest]): Future[Unit] = {
+      blocks: Vector[DoubleSha256DigestBE]): Future[Unit] = {
     logger.debug(s"Requesting ${blocks.size} block(s)")
     blocks.foldLeft(Future.unit) { (prevF, blockHash) =>
       val completedF = subscribeForBlockProcessingCompletionSignal(blockHash)
@@ -532,7 +532,7 @@ private[wallet] trait RescanHandling extends WalletLogger {
     val endHeightOpt = filtersResponse.lastOption.map(_.blockHeight)
     for {
       filtered <- findMatches(filtersResponse, scripts, parallelismLevel)(ec)
-      _ <- downloadAndProcessBlocks(filtered.map(_.blockHash.flip))
+      _ <- downloadAndProcessBlocks(filtered.map(_.blockHash))
     } yield {
       logger.debug(
         s"Found ${filtered.length} matches from start=$startHeightOpt to end=$endHeightOpt")

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -16,7 +16,7 @@ import org.bitcoins.core.util.TimeUtil
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.TxoState._
 import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
-import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
+import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.wallet._
 
 import scala.concurrent.{Future, Promise}
@@ -95,7 +95,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
         }
 
         f.onComplete(failure =>
-          signalBlockProcessingCompletion(block.blockHeader.hash, failure))
+          signalBlockProcessingCompletion(block.blockHeader.hashBE, failure))
 
         f.foreach { _ =>
           val stop = TimeUtil.currentEpochMs
@@ -292,15 +292,15 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
   // Private methods
 
   private var blockProcessingSignals =
-    Map.empty[DoubleSha256Digest, Promise[DoubleSha256Digest]]
+    Map.empty[DoubleSha256DigestBE, Promise[DoubleSha256DigestBE]]
 
   private[wallet] def subscribeForBlockProcessingCompletionSignal(
-      blockHash: DoubleSha256Digest): Future[DoubleSha256Digest] =
+      blockHash: DoubleSha256DigestBE): Future[DoubleSha256DigestBE] =
     synchronized {
       blockProcessingSignals.get(blockHash) match {
         case Some(existingSignal) => existingSignal.future
         case None =>
-          val newSignal = Promise[DoubleSha256Digest]()
+          val newSignal = Promise[DoubleSha256DigestBE]()
           blockProcessingSignals =
             blockProcessingSignals.updated(blockHash, newSignal)
           newSignal.future
@@ -308,7 +308,7 @@ private[bitcoins] trait TransactionProcessing extends WalletLogger {
     }
 
   private def signalBlockProcessingCompletion(
-      blockHash: DoubleSha256Digest,
+      blockHash: DoubleSha256DigestBE,
       failure: Try[_]): Unit =
     synchronized {
       logger.debug(


### PR DESCRIPTION
Reworks some APIs to use take `DoubleSha256DigestBE` rather than `DoubleSha256Digest` as parameters. This attempts to make all APIs just take `DoubleSha256DigestBE` and we can handle the endianness issues with the bitcoin protocol internally in the bitcoin-s library. 