### PR TITLE
2024 03 07 Add `NodeState.FilterOrFilterHeaderSync`, refactor `PeerManager` to use it

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -1208,7 +1208,7 @@ object PeerManager extends Logging {
       peerMessageSenderApi: PeerMessageSenderApi,
       chainApi: ChainApi,
       stopBlockHeaderDb: BlockHeaderDb,
-      state: SyncNodeState)(implicit
+      state: FilterHeaderSync)(implicit
       ec: ExecutionContext,
       chainConfig: ChainAppConfig): Future[
     Option[NodeState.FilterHeaderSync]] = {
@@ -1249,13 +1249,7 @@ object PeerManager extends Logging {
           case Some(filterSyncMarker) =>
             peerMessageSenderApi
               .sendGetCompactFilterHeadersMessage(filterSyncMarker)
-              .map(_ =>
-                Some(
-                  FilterHeaderSync(syncPeer = state.syncPeer,
-                                   peerDataMap = state.peerDataMap,
-                                   waitingForDisconnection =
-                                     state.waitingForDisconnection,
-                                   state.peerFinder)))
+              .map(_ => Some(state))
           case None =>
             logger.info(
               s"Filter headers are synced! filterHeader.blockHashBE=$blockHash")
@@ -1324,7 +1318,7 @@ object PeerManager extends Logging {
   }
 
   def fetchCompactFilterHeaders(
-      state: SyncNodeState, //can we tighten this type up?
+      state: FilterHeaderSync, //can we tighten this type up?
       chainApi: ChainApi,
       peerMessageSenderApi: PeerMessageSenderApi,
       stopBlockHeaderDb: BlockHeaderDb)(implicit

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -881,14 +881,9 @@ case class PeerManager(
       blockchains <- blockchainsF
       // Get all of our cached headers in case of a reorg
       cachedHeaders = blockchains.flatMap(_.headers).map(_.hashBE)
-      _ <- {
-        headerSync.getPeerMsgSender(headerSync.syncPeer) match {
-          case Some(peerMsgSender) =>
-            peerMsgSender.sendGetHeadersMessage(cachedHeaders)
-          case None =>
-            gossipGetHeadersMessage(cachedHeaders)
-        }
-      }
+      _ <- headerSync
+        .syncPeerMessageSender()
+        .sendGetHeadersMessage(cachedHeaders)
     } yield headerSync
   }
 
@@ -1087,7 +1082,7 @@ case class PeerManager(
             fofhs match {
               case fhs: FilterHeaderSync =>
                 val peerMsgSender =
-                  fofhs.getPeerMsgSender(fhs.syncPeer).get
+                  fofhs.syncPeerMessageSender()
                 PeerManager
                   .sendFirstGetCompactFilterHeadersCommand(
                     peerMessageSenderApi = peerMsgSender,

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -961,7 +961,6 @@ case class PeerManager(
               Future.successful(job._1)
           }
         } else {
-          //come back and review this, i don't think this is right
           val exn = new RuntimeException(
             s"Cannot start sync when PeerManager is not started")
           Future.failed(exn)
@@ -1318,7 +1317,7 @@ object PeerManager extends Logging {
   }
 
   def fetchCompactFilterHeaders(
-      state: FilterHeaderSync, //can we tighten this type up?
+      state: FilterHeaderSync,
       chainApi: ChainApi,
       peerMessageSenderApi: PeerMessageSenderApi,
       stopBlockHeaderDb: BlockHeaderDb)(implicit

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -951,11 +951,10 @@ case class PeerManager(
           //
           // the filter sync job gets scheduled _after_ PeerManager.stop() has been called
           syncFilterCancellableOpt match {
-            case _: Some[(Peer, Cancellable)] =>
+            case Some((p, _)) =>
               //do nothing as we already have a job scheduled
-              Future.successful(
-                fofhs
-              ) //what if sync peer and job peer is not the same?
+              val replaced = fofhs.replaceSyncPeer(p)
+              Future.successful(replaced)
             case None =>
               val jobOpt = createFilterSyncJob(chainApi, fofhs)
               syncFilterCancellableOpt = jobOpt.map(j => (j._1.syncPeer, j._2))


### PR DESCRIPTION
Related to #5429 although idk if it fixes it

This PR adds `FilterOrFilterHeaderSync` and then refactors various compact filter header and compact filter messages inside of `PeerManager` to use it.


in #5429 we are having an issue where we get stuck in the `FilterSync` state. Its not clear to me how / why we are getting stuck in this state. This PR intends to give methods such as `PeerManager.syncFilters()` and `PeerManager.syncHelper()` a return type of `Option[FilterOrFilterHeaderSync]` so we can handle the case where we _don't_ start a filter related sync (represented by `None`).