### PR TITLE
Remove implicit `NodeAppConfig` from `PeerMessageSender`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NodeState.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeState.scala
@@ -10,7 +10,6 @@ import org.bitcoins.node.NodeState.{
   NodeShuttingDown,
   RemovePeers
 }
-import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.networking.peer.{PeerConnection, PeerMessageSender}
 
 import scala.util.Random
@@ -44,8 +43,7 @@ sealed trait NodeRunningState extends NodeState {
     }
   }
 
-  def getPeerMsgSender(peer: Peer)(implicit
-      nodeAppConfig: NodeAppConfig): Option[PeerMessageSender] = {
+  def getPeerMsgSender(peer: Peer): Option[PeerMessageSender] = {
     val randomPeerOpt = getPeerConnection(peer)
     randomPeerOpt.map(PeerMessageSender(_))
   }
@@ -159,8 +157,7 @@ sealed trait NodeRunningState extends NodeState {
 
   def randomPeerMessageSender(
       excludePeers: Set[Peer],
-      services: ServiceIdentifier)(implicit
-      nodeAppConfig: NodeAppConfig): Option[PeerMessageSender] = {
+      services: ServiceIdentifier): Option[PeerMessageSender] = {
     randomPeer(excludePeers, services).flatMap { p =>
       getPeerMsgSender(p)
     }
@@ -193,7 +190,7 @@ sealed abstract class SyncNodeState extends NodeRunningState {
   /** Services of our [[syncPeer]] */
   def services: ServiceIdentifier = getPeerServices(syncPeer).get
 
-  def syncPeerMessageSender()(implicit nodeAppConfig: NodeAppConfig) =
+  def syncPeerMessageSender =
     getPeerMsgSender(syncPeer).get
 
   def replaceSyncPeer(newSyncPeer: Peer): SyncNodeState = {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -74,7 +74,7 @@ case class PeerManager(
   chainAppConfig: ChainAppConfig): Future[Option[FilterOrFilterHeaderSync]] = {
     if (syncNodeState.services.nodeCompactFilters) {
       val syncPeer = syncNodeState.syncPeer
-      val peerMsgSender = syncNodeState.syncPeerMessageSender()
+      val peerMsgSender = syncNodeState.syncPeerMessageSender
       val bestBlockHashF = chainApi.getBestBlockHash()
       val sendCompactFilterHeaderMsgF: Future[Option[FilterHeaderSync]] =
         bestBlockHashF.flatMap { bestBlockHash =>
@@ -879,8 +879,7 @@ case class PeerManager(
       blockchains <- blockchainsF
       // Get all of our cached headers in case of a reorg
       cachedHeaders = blockchains.flatMap(_.headers).map(_.hashBE)
-      _ <- headerSync
-        .syncPeerMessageSender()
+      _ <- headerSync.syncPeerMessageSender
         .sendGetHeadersMessage(cachedHeaders)
     } yield headerSync
   }
@@ -1075,7 +1074,7 @@ case class PeerManager(
             fofhs match {
               case fhs: FilterHeaderSync =>
                 val peerMsgSender =
-                  fofhs.syncPeerMessageSender()
+                  fofhs.syncPeerMessageSender
                 PeerManager
                   .sendFirstGetCompactFilterHeadersCommand(
                     peerMessageSenderApi = peerMsgSender,
@@ -1301,10 +1300,10 @@ object PeerManager extends Logging {
         chainApi.nextFilterHeaderBatchRange(stopBlockHash = stopBlockHash,
                                             batchSize = filterBatchSize,
                                             startHeightOpt = startHeightOpt)
-      _ = logger.info(
-        s"Requesting compact filters from with peer=$peer stopBlockHashBE=${stopBlockHash.hex}")
       res <- filterSyncMarkerOpt match {
         case Some(filterSyncMarker) =>
+          logger.info(
+            s"Requesting compact filters from with peer=$peer stopBlockHashBE=${filterSyncMarker.stopBlockHashBE.hex}")
           peerMessageSenderApi
             .sendGetCompactFiltersMessage(filterSyncMarker)
             .map(_ => true)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerMessageSender.scala
@@ -10,34 +10,25 @@ import org.bitcoins.core.p2p.{
   InetAddress,
   Inventory,
   InventoryMessage,
-  NetworkMessage,
   NetworkPayload,
   TypeIdentifier,
   VersionMessage
 }
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.node.NodeStreamMessage.SendToPeer
 import org.bitcoins.node.P2PLogger
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.util.PeerMessageSenderApi
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class PeerMessageSender(peerConnection: PeerConnection)(implicit
-    nodeAppConfig: NodeAppConfig)
+case class PeerMessageSender(peerConnection: PeerConnection)
     extends PeerMessageSenderApi
     with P2PLogger {
 
   override val peer: Peer = peerConnection.peer
 
   override def sendMsg(msg: NetworkPayload): Future[Unit] = {
-    val networkMessage = NetworkMessage(nodeAppConfig.network, msg)
-
-    val sendToPeer = SendToPeer(networkMessage, Some(peer))
-    logger.debug(
-      s"Sending message ${sendToPeer.msg.payload.commandName} to peerOpt=${sendToPeer.peerOpt}")
-
     peerConnection.sendMsg(msg)
   }
 


### PR DESCRIPTION
This PR removes the implicit `NodeAppConfig` parameter from `PeerMessageSender`

As a by product, this decouples `NodeState` from `NodeAppConfig`

As a by product cleans up noisy logs when at `DEBUG` level in `org.bitcoins.node`