### PR TITLE
Fix bug where we weren't checking if `isFiltersSynced` 

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -848,7 +848,7 @@ case class DataMessageHandler(
         } else Future.successful((filterBatch, chainApi))
       }
       filterHeaderSyncStateOpt <-
-        if (batchSizeFull) {
+        if (batchSizeFull && !isFiltersSynced) {
           logger.debug(
             s"Received maximum amount of filters in one batch. This means we are not synced, requesting more")
           for {


### PR DESCRIPTION
fixes #5464 

If `isFiltersSynced` is true we should not send any more `getcfilters` messages to our peer