### PR TITLE
Re-implement `bitcoin-s.node.query-wait-time`

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -71,15 +71,7 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
 
         _ <- NodeTestUtil.awaitSyncAndIBD(node = node, bitcoind = bitcoind)
         //disconnect
-        address <- peerManager
-          .getPeerData(peer)
-          .get
-          .peerConnection
-          .getLocalAddress
-          .map(_.get)
-        nodeUri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind, address)
-        _ <- bitcoind.disconnectNode(nodeUri)
-        _ <- NodeTestUtil.awaitConnectionCount(node, 0)
+        _ <- NodeTestUtil.disconnectNode(bitcoind, node)
         _ <- node.peerManager.connectPeer(peer)
         _ <- NodeTestUtil.awaitConnectionCount(node, 1)
       } yield {
@@ -99,15 +91,7 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
         _ <- NodeTestUtil.awaitSyncAndIBD(node = node, bitcoind = bitcoind)
         //disconnect
         timestamp = Instant.now()
-        address <- node.peerManager
-          .getPeerData(peer)
-          .get
-          .peerConnection
-          .getLocalAddress
-          .map(_.get)
-        uri <- NodeTestUtil.getNodeURIFromBitcoind(bitcoind, address)
-        _ <- bitcoind.disconnectNode(uri)
-        _ <- NodeTestUtil.awaitConnectionCount(node, 0)
+        _ <- NodeTestUtil.disconnectNode(bitcoind, node)
         addrBytes = PeerDAOHelper.getAddrBytes(peer)
         peerDb <- PeerDAO()(node.nodeConfig, system.dispatcher)
           .read((addrBytes, peer.port))

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -1,6 +1,8 @@
 package org.bitcoins.node.networking.peer
 
+import com.typesafe.config.ConfigFactory
 import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.core.config.SigNet
 import org.bitcoins.core.currency._
 import org.bitcoins.core.gcs.{FilterType, GolombFilter}
@@ -8,7 +10,7 @@ import org.bitcoins.core.p2p.HeadersMessage
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.node.NodeState.HeaderSync
+import org.bitcoins.node.NodeState.{DoneSyncing, FilterHeaderSync, HeaderSync}
 import org.bitcoins.node._
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig
@@ -19,7 +21,8 @@ import org.bitcoins.testkit.node.{
 }
 import org.scalatest.{FutureOutcome, Outcome}
 
-import scala.concurrent.duration.DurationInt
+import java.time.Instant
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Await, Future, Promise}
 
 class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
@@ -62,10 +65,11 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
           chainApi = chainApi,
           walletCreationTimeOpt = None,
           peerManager = peerManager,
-          state = HeaderSync(peer,
-                             peerManager.peerWithServicesDataMap,
-                             Set.empty,
-                             peerFinder)
+          state = HeaderSync(syncPeer = peer,
+                             peerDataMap = peerManager.peerWithServicesDataMap,
+                             waitingForDisconnection = Set.empty,
+                             peerFinder = peerFinder,
+                             sentQuery = Instant.now())
         )(node.executionContext, node.nodeAppConfig, node.chainConfig)
 
         // Use signet genesis block header, this should be invalid for regtest
@@ -180,5 +184,84 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         tx <- bitcoind.getRawTransactionRaw(txId)
         result = Await.result(resultP.future, 30.seconds)
       } yield assert(result == tx)
+  }
+
+  it must "detect bitcoin-s.node.query-wait-time timing out" in {
+    param: FixtureParam =>
+      val initNode = param.node
+      val bitcoind = param.bitcoind
+      val queryWaitTime = 5.second
+      val nodeF = getCustomQueryWaitTime(initNode = initNode,
+                                         queryWaitTime = queryWaitTime)
+      for {
+        node <- nodeF
+        peerManager = node.peerManager
+        _ <- bitcoind.generate(1)
+        _ <- NodeTestUtil.awaitAllSync(node, bitcoind)
+        peer = peerManager.peers.head
+        chainApi = ChainHandler.fromDatabase()(executionContext,
+                                               node.chainConfig)
+        _ = require(peerManager.getPeerData(peer).isDefined)
+        peerFinder = PeerFinder(peerManagerApi = peerManager,
+                                paramPeers = Vector.empty,
+                                queue = node)(system.dispatcher,
+                                              system,
+                                              node.nodeConfig,
+                                              node.chainConfig)
+        dataMessageHandler = DataMessageHandler(
+          chainApi = chainApi,
+          walletCreationTimeOpt = None,
+          peerManager = peerManager,
+          state = HeaderSync(syncPeer = peer,
+                             peerDataMap = peerManager.peerWithServicesDataMap,
+                             waitingForDisconnection = Set.empty,
+                             peerFinder = peerFinder,
+                             sentQuery = Instant.now())
+        )(node.executionContext, node.nodeAppConfig, node.chainConfig)
+
+        //use bitcoind to generate a block, and then try to resend that header
+        //directly via the queue and make sure we get DoneSyncing back
+        peerData = peerManager.getPeerData(peer).get
+        _ <- NodeTestUtil.disconnectNode(bitcoind, node)
+        initBlockCount <- chainApi.getBlockCount()
+        hashes <- bitcoind.generate(2)
+        blockHeader0 <- bitcoind.getBlockHeaderRaw(hashes.head)
+        blockHeader1 <- bitcoind.getBlockHeaderRaw(hashes(1))
+        payload0 =
+          HeadersMessage(Vector(blockHeader0))
+        payload1 = HeadersMessage(Vector(blockHeader1))
+        //should time out, transitioning us to DoneSyncing
+        newDmh0 <- dataMessageHandler.handleDataPayload(payload0, peerData)
+        _ = assert(newDmh0.state.isInstanceOf[FilterHeaderSync])
+        _ <- AsyncUtil.nonBlockingSleep(queryWaitTime)
+        //now process another header, even though we are in FilterHeaderSync
+        //state, we should process the block header since our query timed out
+        newDmh1 <- newDmh0.handleDataPayload(payload1, peerData)
+        blockCount <- chainApi.getBlockCount()
+        _ <- node.stop()
+        _ <- node.nodeConfig.stop()
+      } yield {
+        //we should have processed both headers
+        assert(blockCount == initBlockCount + 2)
+        //should still be FilterHeaderSync state
+        assert(newDmh1.state.isInstanceOf[FilterHeaderSync])
+      }
+  }
+
+  private def getCustomQueryWaitTime(
+      initNode: NeutrinoNode,
+      queryWaitTime: FiniteDuration): Future[NeutrinoNode] = {
+
+    require(initNode.nodeConfig.queryWaitTime != queryWaitTime,
+            s"maxConnectedPeers must be different")
+    //make a custom config, set the inactivity timeout very low
+    //so we will disconnect our peer organically
+    val str =
+      s"""
+         |bitcoin-s.node.query-wait-time = $queryWaitTime
+         |""".stripMargin
+    val config =
+      ConfigFactory.parseString(str)
+    NodeTestUtil.getStartedNodeCustomConfig(initNode, config)
   }
 }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -10,7 +10,7 @@ import org.bitcoins.core.p2p.HeadersMessage
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.node.NodeState.{DoneSyncing, FilterHeaderSync, HeaderSync}
+import org.bitcoins.node.NodeState.{FilterHeaderSync, HeaderSync}
 import org.bitcoins.node._
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.BitcoinSTestAppConfig


### PR DESCRIPTION
fixes #5429 

Add `sentQuery` `Instant` to `SyncNodeState` subclasses, add logic in `DataMessageHandler.handlePayload()` to detect if a query has timed out.

in #5177 we removed the implement for `bitcoin-s.node.query-wait-time`. Previously we scheduled a job to send a message to our akka stream if a query has timed out.

The implementation in this PR now checks every time we receive a p2p message if a query has timed out. This works because

1. If we are receiving messages from other peers, our logic will eventually trigger a state transtion from `SyncNodeState` -> `DoneSyncing`. After transiting it attempts to process the p2p message we just received
2. If we are receiving no messages on the p2p network, we will have our health checks eventually disconnect the peer causing us to transition to `DoneSyncing`.

This means we can't get "stuck" in a `HeaderSync`, `FilterHeaderSync`, or `FilterSync` state.


