### PR TITLE
2024 03 11 `PeerFinder.getPeersFromDnsSeeds` async

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
+++ b/core/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
@@ -68,11 +68,11 @@ sealed abstract class MainNet extends BitcoinNetwork {
     */
   override def dnsSeeds: Vector[String] = {
     Vector(
-      "seed.bitcoin.sipa.be",
+      //"seed.bitcoin.sipa.be", very slow, commenting out for now
       "dnsseed.bluematt.me",
       "dnsseed.bitcoin.dashjr.org",
       "seed.bitcoinstats.com",
-      "seed.btc.petertodd.org",
+      //"seed.btc.petertodd.net", very slow, commenting out for now
       "seed.bitcoin.jonasschnelli.ch",
       "seed.bitcoin.sprovoost.nl",
       "dnsseed.emzy.de",

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -47,18 +47,18 @@ case class PeerFinder(
       .traverse(dnsSeeds) { seed =>
         Future {
           try {
-            InetAddress
+            val r = InetAddress
               .getAllByName(seed)
-              .map(_.toString)
               .toVector
+            r
           } catch {
             case _: UnknownHostException =>
               logger.debug(s"DNS seed $seed is unavailable.")
-              Vector.empty[String]
+              Vector.empty[InetAddress]
           }
         }
       }
-      .map(_.flatten.toVector)
+      .map(_.flatten.distinct.map(_.getHostAddress).toVector)
     addressesF.map(BitcoinSNodeUtil.stringsToPeers(_))
 
   }

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -25,7 +25,7 @@
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="DEBUG"/>
+    <logger name="org.bitcoins.node" level="WARN"/>
 
     <logger name="org.bitcoins.chain" level="WARN"/>
 

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -25,7 +25,7 @@
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="WARN"/>
+    <logger name="org.bitcoins.node" level="DEBUG"/>
 
     <logger name="org.bitcoins.chain" level="WARN"/>
 


### PR DESCRIPTION
This PR optimizes performance of `PeerFinder.getPeersFromDnsSeeds`. Before this PR this method could take minutes to complete!

This PR makes the resolution of DNS seeds async via `Future.traverse`. This PR also comments out the slow seeds that may be down (`"seed.bitcoin.sipa.be"`, `"seed.btc.petertodd.net"`). These can be uncommented in the future if their performance improves.