### PR TITLE
2024 03 18 rm unused configs

### DIFF
--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -159,9 +159,6 @@ bitcoin-s {
         # number of persistent peer connections to maintain for node use
         maxConnectedPeers = 1
         
-        # peers discovery configs, ideally you would not want to change this
-        # timeout for tcp connection
-        connection-timeout = 5s
         # time interval for trying next set of peers in peer discovery
         try-peers-interval = 12 hour
         

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -18,7 +18,7 @@ import org.bitcoins.tor.TorParams
 import org.bitcoins.tor.config.TorAppConfig
 
 import java.nio.file.Path
-import java.time.{Duration, Instant}
+import java.time.{Instant}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -132,13 +132,6 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     if (config.hasPath("bitcoin-s.node.enable-peer-discovery"))
       config.getBoolean("bitcoin-s.node.enable-peer-discovery")
     else false
-  }
-
-  // https://github.com/lightbend/config/blob/master/HOCON.md#duration-format
-  lazy val peerDiscoveryTimeout: Duration = {
-    if (config.hasPath("bitcoin-s.node.peer-discovery-timeout"))
-      config.getDuration("bitcoin-s.node.peer-discovery-timeout")
-    else Duration.ofMinutes(10)
   }
 
   lazy val tryPeersStartDelay: FiniteDuration = {

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -141,14 +141,6 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     else Duration.ofMinutes(10)
   }
 
-  /** timeout for tcp connection in P2PClient */
-  lazy val connectionTimeout: FiniteDuration = {
-    if (config.hasPath("bitcoin-s.node.connection-timeout")) {
-      val duration = config.getDuration("bitcoin-s.node.connection-timeout")
-      TimeUtil.durationToFiniteDuration(duration)
-    } else 5.seconds
-  }
-
   lazy val tryPeersStartDelay: FiniteDuration = {
     if (config.hasPath("bitcoin-s.node.try-peers-start-delay")) {
       val duration = config.getDuration("bitcoin-s.node.try-peers-start-delay")


### PR DESCRIPTION
Removes these unused configuration options from `NodeAppConfig`

`bitcoin-s.node.peer-discovery-timeout`
`bitcoin-s.node.connection-timeout`