### PR TITLE
Reduce stream failure log to DEBUG to avoid tor spam

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -273,7 +273,7 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
                   case scala.util.Success(_) =>
                     handleStreamComplete()
                   case scala.util.Failure(err) =>
-                    logger.info(
+                    logger.debug(
                       s"Connection with peer=$peer failed with err=${err.getMessage}")
                     handleStreamComplete()
                 }


### PR DESCRIPTION
This gets rid of these noisy logs by default when running with `bitcoin-s.tor.enabled=true`

```
2024-03-19 14:39:53,582UTC INFO [PeerConnection] Connection with peer=Peer(75.60.184.94:8333) failed with err=Tor connection request failed to target=75.60.184.94/<unresolved>:8333 errMsg=java.lang.RuntimeException: General failure, this likely means tor timed out when trying to connect. Try using telnet to reproduce error.
2024-03-19 14:39:53,582UTC INFO [PeerConnection] Connection with peer=Peer(82.10.148.165:8333) failed with err=Tor connection request failed to target=82.10.148.165/<unresolved>:8333 errMsg=java.lang.RuntimeException: General failure, this likely means tor timed out when trying to connect. Try using telnet to reproduce error.
2024-03-19 14:39:53,582UTC INFO [PeerConnection] Connection with peer=Peer(185.62.89.46:8333) failed with err=Tor connection request failed to target=185.62.89.46/<unresolved>:8333 errMsg=java.lang.RuntimeException: General failure, this likely means tor timed out when trying to connect. Try using telnet to reproduce error.
2024-03-19 14:39:53,582UTC INFO [PeerConnection] Connection with peer=Peer(129.13.189.202:8333) failed with err=Tor connection request failed to target=129.13.189.202/<unresolved>:8333 errMsg=java.lang.RuntimeException: General failure, this likely means tor timed out when trying to connect. Try using telnet to reproduce error.
2024-03-19 14:39:53,582UTC INFO [PeerConnection] Connection with peer=Peer([2001:e68:541b:c2d:6c46:a05a:c600:8613]:8333) failed with err=Tor connection request failed to target=[2001:e68:541b:c2d:6c46:a05a:c600:8613]/<unresolved>:8333 errMsg=java.lang.RuntimeException: General failure, this likely means tor timed out when trying to connect. Try using telnet to reproduce error.
2024-03-19 14:39:55,995UTC INFO [PeerConnection] Connection with peer=Peer(185.207.107.130:8333) failed with err=Tor connection request failed to target=185.207.107.130/<unresolved>:8333 errMsg=java.lang.RuntimeException: General failure, this likely means tor timed out when trying to connect. Try using telnet to reproduce error.
```