### PR TITLE
Fix build warnings for `--compress` flag in `jlink`

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -131,8 +131,7 @@ object CommonSettings {
 
   lazy val jlinkOptions = Seq(
     "--no-header-files",
-    "--no-man-pages",
-    "--compress=2"
+    "--no-man-pages"
   )
 
   private val commonCompilerOpts = {


### PR DESCRIPTION
Fixes these warnings

```
[error] Warning: The 2 argument for --compress is deprecated and may be removed in a future release
```

From `jlink --help`

```
      --compress <compress>             Compression to use in compressing resources:
                                        Accepted values are:
                                        zip-[0-9], where zip-0 provides no compression,
                                        and zip-9 provides the best compression.
                                        Default is zip-6.
                                        Deprecated values to be removed in a future release:
                                        0:  No compression. Equivalent to zip-0.
                                        1:  Constant String Sharing
                                        2:  Equivalent to zip-6.

```