### PR TITLE
Add `bitcoin-s.node.connection-attempt-cool-down-period`

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -60,6 +60,10 @@ bitcoin-s {
     # if the peer does not send us a message within this duration
     # we disconnect it for inactivity
     peer-timeout = 20 minute
+
+    # how long we wait until we attempt to re-connect to a peer we have
+    # in our database that we have connected to previously
+    connection-attempt-cool-down-period = 5 minutes
   }
 
   # You can configure SOCKS5 proxy to use Tor for outgoing connections

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -180,6 +180,10 @@ bitcoin-s {
         # if the peer does not send us a message within this duration
         # we disconnect it for inactivity
         peer-timeout = 20 minute
+        
+        # how long we wait until we attempt to re-connect to a peer we have
+        # in our database that we have connected to previously
+        connection-attempt-cool-down-period = 5 minutes
     }
 
     proxy {

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -98,7 +98,10 @@ case class PeerFinder(
     val cooldown = Instant
       .now()
       .minusMillis(nodeAppConfig.connectionAttemptCooldownPeriod.toMillis)
-    getPeersFromDb.map(_._2.filter(_.lastSeen.isBefore(cooldown)).take(dbSlots))
+    for {
+      potentialPeerDbs <- getPeersFromDb.map(_._2)
+      filtered = potentialPeerDbs.filter(_.lastSeen.isBefore(cooldown))
+    } yield Random.shuffle(filtered).take(dbSlots)
   }
 
   /** Returns peers from bitcoin-s.config file unless peers are supplied as an argument to [[PeerManager]] in which

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -180,6 +180,14 @@ case class NodeAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
     } else 20.minute
   }
 
+  lazy val connectionAttemptCooldownPeriod: FiniteDuration = {
+    if (config.hasPath("bitcoin-s.node.connection-attempt-cool-down-period")) {
+      val duration =
+        config.getDuration("bitcoin-s.node.connection-attempt-cool-down-period")
+      TimeUtil.durationToFiniteDuration(duration)
+    } else 5.minute
+  }
+
   /** Creates either a neutrino node or a spv node based on the [[NodeAppConfig]] given */
   def createNode(peers: Vector[Peer], walletCreationTimeOpt: Option[Instant])(
       chainConf: ChainAppConfig,

--- a/node/src/main/scala/org/bitcoins/node/models/PeerDAO.scala
+++ b/node/src/main/scala/org/bitcoins/node/models/PeerDAO.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.node.models
 
 import org.bitcoins.core.api.node.Peer
+import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.core.p2p.{AddrV2Message, ServiceIdentifier}
 import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.db.{CRUD, SlickUtil}
@@ -9,7 +10,7 @@ import scodec.bits.ByteVector
 import slick.dbio.DBIOAction
 import slick.lifted.ProvenShape
 
-import java.net.InetAddress
+import java.net.{InetAddress, InetSocketAddress}
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -20,7 +21,16 @@ case class PeerDb(
     firstSeen: Instant,
     networkId: Byte,
     serviceBytes: ByteVector
-)
+) {
+
+  def inetSocketAddress: InetSocketAddress = {
+    NetworkUtil.parseInetSocketAddress(address, port)
+  }
+
+  def peer(socks5ProxyParamsOpt: Option[Socks5ProxyParams]): Peer = {
+    Peer.fromSocket(inetSocketAddress, socks5ProxyParamsOpt)
+  }
+}
 
 case class PeerDAO()(implicit appConfig: NodeAppConfig, ec: ExecutionContext)
     extends CRUD[PeerDb, (ByteVector, Int)]


### PR DESCRIPTION
The problem this PR fixes is the case where we endlessly query for new peers on the p2p network. We never read peers from our database after the initial call to `PeerFinder.start()`. 

Now we add peers we have seen before `bitcoin-s.node.connection-attempt-cool-down-period` to our list of peers to query in `PeerFinder.queryForPeerConnections()`. This should give us access to peers that we have previously successfully connected to to hopefully keep us from querying for new peers on the p2p network constantly.

