### PR TITLE
Make `ECPublicKey` return `bytes` that were passed as a parameter 

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -31,4 +31,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-compile-cache
       - name: Compile and Check Formatting
-        run: sbt -J-Xmx4g +test:compile scalafmtCheckAll docs/mdoc cryptoTestJVM/test coreTestJVM/test
+        run: sbt -J-Xmx4g +test:compile scalafmtCheckAll cryptoTestJVM/test coreTestJVM/test docs/mdoc

--- a/crypto-test/.jvm/src/test/scala/org/bitcoins/crypto/BouncyCastleSecp256k1Test.scala
+++ b/crypto-test/.jvm/src/test/scala/org/bitcoins/crypto/BouncyCastleSecp256k1Test.scala
@@ -54,8 +54,9 @@ class BouncyCastleSecp256k1Test extends BitcoinSCryptoTest {
   }
 
   it must "compute public keys the same" in {
-    forAll(CryptoGenerators.privateKey) { privKey =>
-      testCompatibility(_.publicKey(privKey))
+    forAll(CryptoGenerators.privateKey, NumberGenerator.bool) {
+      (privKey, isCompressed) =>
+        testCompatibility(_.publicKey(privKey.toPrivateKeyBytes(isCompressed)))
     }
   }
 

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/CryptoGenerators.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/CryptoGenerators.scala
@@ -19,6 +19,10 @@ sealed abstract class CryptoGenerators {
     }
   }
 
+  def privateKeyBytesUncompressed: Gen[ECPrivateKeyBytes] = {
+    privateKey.map(_.toPrivateKeyBytes(isCompressed = false))
+  }
+
   def fieldElement: Gen[FieldElement] = privateKey.map(_.fieldElement)
 
   def smallFieldElement: Gen[FieldElement] =

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/ECPublicKeyTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/ECPublicKeyTest.scala
@@ -124,8 +124,8 @@ class ECPublicKeyTest extends BitcoinSCryptoTest {
   }
 
   it must "correctly compress keys" in {
-    forAll(CryptoGenerators.privateKey) { privKey =>
-      val pubKey = privKey.publicKey
+    forAll(CryptoGenerators.privateKeyBytesUncompressed) { privKeyBytes =>
+      val pubKey = privKeyBytes.publicKeyBytes.toPublicKey
       val pubKeyCompressed = pubKey.compressed
       val pubKeyDecompressed = pubKey.decompressed
 

--- a/crypto/.js/src/main/scala/org/bitcoins/crypto/BCryptoCryptoRuntime.scala
+++ b/crypto/.js/src/main/scala/org/bitcoins/crypto/BCryptoCryptoRuntime.scala
@@ -62,10 +62,11 @@ trait BCryptoCryptoRuntime extends CryptoRuntime {
     * @param privateKey   the private key we want the corresponding public key for
     * @param isCompressed whether the returned public key should be compressed or not
     */
-  override def toPublicKey(privateKey: ECPrivateKey): ECPublicKey = {
+  override def toPublicKey(privateKey: ECPrivateKeyBytes): ECPublicKey = {
     val buffer = CryptoJsUtil.toNodeBuffer(privateKey.bytes)
     val pubKeyBuffer =
-      SECP256k1.publicKeyCreate(key = buffer, compressed = false)
+      SECP256k1.publicKeyCreate(key = buffer,
+                                compressed = privateKey.isCompressed)
     val privKeyByteVec = CryptoJsUtil.toByteVector(pubKeyBuffer)
     ECPublicKey.fromBytes(privKeyByteVec)
   }
@@ -168,9 +169,10 @@ trait BCryptoCryptoRuntime extends CryptoRuntime {
     (key, keyWithSign)
   }
 
-  override def publicKey(privateKey: ECPrivateKey): ECPublicKey = {
+  override def publicKey(privateKey: ECPrivateKeyBytes): ECPublicKey = {
     val buffer = CryptoJsUtil.toNodeBuffer(privateKey.bytes)
-    val bufferPubKey = SECP256k1.publicKeyCreate(buffer, compressed = false)
+    val bufferPubKey =
+      SECP256k1.publicKeyCreate(buffer, compressed = privateKey.isCompressed)
     val byteVec = CryptoJsUtil.toByteVector(bufferPubKey)
     ECPublicKey.fromBytes(byteVec)
   }

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
@@ -60,7 +60,7 @@ object BouncyCastleUtil {
   def computePublicKey(privateKey: ECPrivateKeyBytes): ECPublicKey = {
     val priv = getBigInteger(privateKey.bytes)
     val point = G.multiply(priv)
-    val pubBytes = ByteVector(point.getEncoded(false))
+    val pubBytes = ByteVector(point.getEncoded(privateKey.isCompressed))
     ECPublicKey(pubBytes)
   }
 

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
@@ -57,7 +57,7 @@ object BouncyCastleUtil {
     } else publicKey
   }
 
-  def computePublicKey(privateKey: ECPrivateKey): ECPublicKey = {
+  def computePublicKey(privateKey: ECPrivateKeyBytes): ECPublicKey = {
     val priv = getBigInteger(privateKey.bytes)
     val point = G.multiply(priv)
     val pubBytes = ByteVector(point.getEncoded(false))

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncycastleCryptoRuntime.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncycastleCryptoRuntime.scala
@@ -146,7 +146,7 @@ trait BouncycastleCryptoRuntime extends CryptoRuntime {
     Sha256Hash160Digest(hash)
   }
 
-  override def toPublicKey(privateKey: ECPrivateKey): ECPublicKey = {
+  override def toPublicKey(privateKey: ECPrivateKeyBytes): ECPublicKey = {
     BouncyCastleUtil.computePublicKey(privateKey)
   }
 
@@ -176,7 +176,7 @@ trait BouncycastleCryptoRuntime extends CryptoRuntime {
       signature: ECDigitalSignature): Boolean =
     BouncyCastleUtil.verifyDigitalSignature(data, publicKey, signature)
 
-  override def publicKey(privateKey: ECPrivateKey): ECPublicKey =
+  override def publicKey(privateKey: ECPrivateKeyBytes): ECPublicKey =
     BouncyCastleUtil.computePublicKey(privateKey)
 
   override def tweakMultiply(

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoParams.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoParams.scala
@@ -27,7 +27,9 @@ sealed abstract class CryptoParams {
     "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
 
   // This needs to be lazy otherwise this class fails to initialize
-  lazy val getG: ECPublicKey = ECPublicKey(gDecompressedBytes)
+  lazy val getG: ECPublicKey = {
+    ECPublicKey(gDecompressedBytes).compressed
+  }
 
   /** This is used for canonicalising the S value of a digital signature.
     * https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoUtil.scala
@@ -20,7 +20,7 @@ trait CryptoUtil extends CryptoRuntime {
     cryptoRuntime.freshPrivateKey
   }
 
-  override def toPublicKey(privateKey: ECPrivateKey): ECPublicKey = {
+  override def toPublicKey(privateKey: ECPrivateKeyBytes): ECPublicKey = {
     cryptoRuntime.toPublicKey(privateKey)
   }
 
@@ -89,7 +89,7 @@ trait CryptoUtil extends CryptoRuntime {
     cryptoRuntime.recoverPublicKey(signature, message)
   }
 
-  override def publicKey(privateKey: ECPrivateKey): ECPublicKey =
+  override def publicKey(privateKey: ECPrivateKeyBytes): ECPublicKey =
     cryptoRuntime.publicKey(privateKey)
 
   override def sign(
@@ -145,8 +145,10 @@ trait CryptoUtil extends CryptoRuntime {
   override def add(pk1: ECPublicKey, pk2: ECPublicKey): ECPublicKey =
     cryptoRuntime.add(pk1, pk2)
 
-  override def combinePubKeys(pubKeys: Vector[ECPublicKey]): ECPublicKey =
-    cryptoRuntime.combinePubKeys(pubKeys)
+  override def combinePubKeys(
+      pubKeys: Vector[ECPublicKey],
+      isCompressed: Boolean = true): ECPublicKey =
+    cryptoRuntime.combinePubKeys(pubKeys, isCompressed)
 
   override def pubKeyTweakAdd(
       pubkey: ECPublicKey,

--- a/crypto/src/main/scala/org/bitcoins/crypto/SecpPoint.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SecpPoint.scala
@@ -42,11 +42,19 @@ case class SecpPointFinite(x: CurveCoordinate, y: CurveCoordinate)
     extends SecpPoint {
 
   override def bytes: ByteVector = {
-    ByteVector(0x04) ++ x.bytes ++ y.bytes
+    val pub = ECPublicKeyBytes(ByteVector(0x04) ++ x.bytes ++ y.bytes)
+    pub.compressed.bytes
   }
 
   def toPublicKey: ECPublicKey = {
     ECPublicKey(bytes)
+  }
+
+  def schnorrNonce: SchnorrNonce = {
+    val pub = toPublicKey
+    require(pub.isCompressed,
+            s"SchnorrNonce can only be created from compressed public keys")
+    pub.schnorrNonce
   }
 }
 


### PR DESCRIPTION
When working on #4913 I ran into issues with serializing descriptors with uncompressed public keys.

Previously when `ECPublicKey.bytes` was called, we would always return the _compressed_ version of the public key. This didn't work for descriptors that were about uncompressed public keys such as this descriptor 

```
pk(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)"
```

This force us to use a workaround to build the raw script that would retain the uncompressed public key: 

https://github.com/bitcoin-s/bitcoin-s/blob/dd5cdd18dd776ae8af63cf81104b626ba5dc938d/core/src/main/scala/org/bitcoins/core/protocol/script/descriptor/DescriptorExpression.scala#L337

There could be performance implications of this PR as documented in #2988 

