### PR TITLE
Migrate from `setup-scala` github action to `setup-java` github action in `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main, feature_electron_build]
+    branches: [master, main, feature_electron_build, 2024-04-04-setup-java-release]
     tags: ["*"]
   release:
     types: [ published ]
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v13
+      - name: Setup Scala
+        uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main, feature_electron_build, 2024-04-04-setup-java-release]
+    branches: [master, main, feature_electron_build]
     tags: ["*"]
   release:
     types: [ published ]


### PR DESCRIPTION
#5503 broke the release.yml build because the `setup-scala` action isn't aware of jdks past 17. This PR moves `release.yml` to setup-java. Related to #4466 