### PR TITLE
Add invariant to make sure we can't have `p2sh(p2sh())`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -359,6 +359,8 @@ object P2SHScriptPubKey extends ScriptFactory[P2SHScriptPubKey] {
   }
 
   def apply(scriptPubKey: ScriptPubKey): P2SHScriptPubKey = {
+    require(!scriptPubKey.isInstanceOf[P2SHScriptPubKey],
+            s"Cannot do p2sh(p2sh()), got=$scriptPubKey")
     val hash = CryptoUtil.sha256Hash160(scriptPubKey.asmBytes)
     P2SHScriptPubKey(hash)
   }


### PR DESCRIPTION
This is needed for #4913 , but is an invariant we add independent of #4913. Recursive `p2sh(p2sh())` is not allowed by the bitcoin protocol.