### PR TITLE
Add invariant to `P2WPKHWitnessSPKV0.apply()` to make sure `ECPublicKey` is compressed

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1366,6 +1366,9 @@ object P2WPKHWitnessSPKV0 extends ScriptFactory[P2WPKHWitnessSPKV0] {
 
   /** Creates a P2WPKH witness script pubkey */
   def apply(pubKey: ECPublicKey): P2WPKHWitnessSPKV0 = {
+    require(
+      pubKey.isCompressed,
+      s"Public key must be compressed to be used in a segwit script, see BIP143")
     val hash = CryptoUtil.sha256Hash160(pubKey.bytes)
     val pushop = BitcoinScriptUtil.calculatePushOp(hash.bytes)
     fromAsm(Seq(OP_0) ++ pushop ++ Seq(ScriptConstant(hash.bytes)))


### PR DESCRIPTION
In #5502 we modified `ECPublicKey` to return the `ByteVector` passed as a parameter rather than always returning the compressed public key bytes when `ECPublicKey.bytes` is called.

This can be unsafe for scripts such as `P2WPKHWitnessSPKV0` which according to BIP143 require public keys to be compressed. 

This PR adds this invariant. 