### PR TITLE
Tighten `P2WSHWitnessSPKV0.apply()` to only take `RawScriptPubKey`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1410,7 +1410,7 @@ object P2WSHWitnessSPKV0 extends ScriptFactory[P2WSHWitnessSPKV0] {
     fromAsm(Seq(OP_0) ++ pushop ++ Seq(ScriptConstant(hash.bytes)))
   }
 
-  def apply(spk: ScriptPubKey): P2WSHWitnessSPKV0 = {
+  def apply(spk: RawScriptPubKey): P2WSHWitnessSPKV0 = {
     require(
       BitcoinScriptUtil.isOnlyCompressedPubKey(spk),
       s"Public key must be compressed to be used in a segwit script, see BIP143")

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -346,7 +346,7 @@ sealed abstract class ScriptGenerators {
 
   /** Generates a random P2WSHWitnessSPKV0 as well as it's corresponding private keys and redeem script */
   def p2wshSPKV0: Gen[(P2WSHWitnessSPKV0, Seq[ECPrivateKey], ScriptPubKey)] =
-    randomNonP2SHScriptPubKey
+    rawScriptPubKey
       .suchThat { case (spk, _) =>
         !redeemScriptTooBig(spk)
       }


### PR DESCRIPTION
You can't spend p2wsh outputs from non `RawScriptPubKey`'s. This PR makes it illegal to construct them. This would found when working on #4913 