### PR TITLE
Repurpose `PublicKey` trait, extend it with {`SchnorrPublicKey`, `ECPublicKeyApi`, `XOnlyPubKey`}

### DIFF
--- a/crypto/.js/src/main/scala/org/bitcoins/crypto/BCryptoCryptoRuntime.scala
+++ b/crypto/.js/src/main/scala/org/bitcoins/crypto/BCryptoCryptoRuntime.scala
@@ -198,7 +198,7 @@ trait BCryptoCryptoRuntime extends CryptoRuntime {
   }
 
   override def verify(
-      publicKey: PublicKey,
+      publicKey: ECPublicKeyApi,
       data: ByteVector,
       signature: ECDigitalSignature): Boolean = {
     val dataBuffer = CryptoJsUtil.toNodeBuffer(data)
@@ -262,7 +262,7 @@ trait BCryptoCryptoRuntime extends CryptoRuntime {
     hi | lo
   }
 
-  override def isValidPubKey(pubKey: PublicKey): Boolean = {
+  override def isValidPubKey(pubKey: ECPublicKeyApi): Boolean = {
     val buffer = CryptoJsUtil.toNodeBuffer(pubKey.bytes)
     SECP256k1.publicKeyVerify(buffer)
   }

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
@@ -133,7 +133,7 @@ object BouncyCastleUtil {
 
   def verifyDigitalSignature(
       data: ByteVector,
-      publicKey: PublicKey,
+      publicKey: ECPublicKeyApi,
       signature: ECDigitalSignature): Boolean = {
     val resultTry = Try {
       val publicKeyParams =

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncycastleCryptoRuntime.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncycastleCryptoRuntime.scala
@@ -171,7 +171,7 @@ trait BouncycastleCryptoRuntime extends CryptoRuntime {
   }
 
   override def verify(
-      publicKey: PublicKey,
+      publicKey: ECPublicKeyApi,
       data: ByteVector,
       signature: ECDigitalSignature): Boolean =
     BouncyCastleUtil.verifyDigitalSignature(data, publicKey, signature)

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/LibSecp256k1CryptoRuntime.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/LibSecp256k1CryptoRuntime.scala
@@ -80,7 +80,7 @@ trait LibSecp256k1CryptoRuntime extends CryptoRuntime {
     NativeSecp256k1.secKeyVerify(privateKeyBytes.toArray)
 
   override def verify(
-      publicKey: PublicKey,
+      publicKey: ECPublicKeyApi,
       data: ByteVector,
       signature: ECDigitalSignature): Boolean = {
     val result =

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
@@ -184,7 +184,7 @@ trait CryptoRuntime {
   def secKeyVerify(privateKeybytes: ByteVector): Boolean
 
   def verify(
-      publicKey: PublicKey,
+      publicKey: ECPublicKeyApi,
       data: ByteVector,
       signature: ECDigitalSignature): Boolean
 
@@ -198,13 +198,13 @@ trait CryptoRuntime {
     }
   }
 
-  def decompressed[PK <: PublicKey](
+  def decompressed[PK <: ECPublicKeyApi](
       pubKeyBytes: ByteVector,
       fromBytes: ByteVector => PK): PK = {
     fromBytes(decompressed(pubKeyBytes))
   }
 
-  def decompressed[PK <: PublicKey](publicKey: PK): publicKey.type = {
+  def decompressed[PK <: ECPublicKeyApi](publicKey: PK): publicKey.type = {
     if (publicKey.isDecompressed) publicKey
     else decompressed(publicKey.bytes, publicKey.fromBytes(_))
   }
@@ -281,7 +281,7 @@ trait CryptoRuntime {
 
   def pubKeyTweakAdd(pubkey: ECPublicKey, privkey: ECPrivateKey): ECPublicKey
 
-  def isValidPubKey(pubKey: PublicKey): Boolean = {
+  def isValidPubKey(pubKey: ECPublicKeyApi): Boolean = {
     pubKey.decompressedBytesT.isSuccess &&
     pubKey.decompressedBytesT.get != ByteVector(0x00)
   }

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoUtil.scala
@@ -117,7 +117,7 @@ trait CryptoUtil extends CryptoRuntime {
     cryptoRuntime.secKeyVerify(privateKeybytes)
 
   override def verify(
-      publicKey: PublicKey,
+      publicKey: ECPublicKeyApi,
       data: ByteVector,
       signature: ECDigitalSignature): Boolean =
     cryptoRuntime.verify(publicKey, data, signature)
@@ -125,7 +125,8 @@ trait CryptoUtil extends CryptoRuntime {
   override def decompressed(pubKeyBytes: ByteVector): ByteVector =
     cryptoRuntime.decompressed(pubKeyBytes)
 
-  override def decompressed[PK <: PublicKey](publicKey: PK): publicKey.type =
+  override def decompressed[PK <: ECPublicKeyApi](
+      publicKey: PK): publicKey.type =
     cryptoRuntime.decompressed(publicKey)
 
   override def tweakMultiply(
@@ -155,7 +156,7 @@ trait CryptoUtil extends CryptoRuntime {
       privkey: ECPrivateKey): ECPublicKey =
     cryptoRuntime.pubKeyTweakAdd(pubkey, privkey)
 
-  override def isValidPubKey(pubKey: PublicKey): Boolean =
+  override def isValidPubKey(pubKey: ECPublicKeyApi): Boolean =
     cryptoRuntime.isValidPubKey(pubKey)
 
   override def schnorrSign(

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
@@ -47,7 +47,7 @@ object ECPrivateKeyBytes extends Factory[ECPrivateKeyBytes] {
 /** Represents any type which wraps public key bytes which can be used for ECDSA verification.
   * Should always be instantiated with class X extends PublicKey[X].
   */
-sealed trait PublicKey extends NetworkElement {
+sealed trait ECPublicKeyApi extends PublicKey {
 
   /** The fromBytes function for the PK type. */
   private[crypto] def fromBytes(bytes: ByteVector): this.type
@@ -111,7 +111,7 @@ sealed trait PublicKey extends NetworkElement {
 /** Wraps raw ECPublicKey bytes without doing any validation or deserialization (may be invalid). */
 case class ECPublicKeyBytes(bytes: ByteVector)
     extends ECKeyBytes
-    with PublicKey {
+    with ECPublicKeyApi {
 
   /** Parse these bytes into the bitcoin-s internal public key type. */
   def toPublicKey: ECPublicKey = ECPublicKey(bytes)
@@ -301,7 +301,9 @@ object ECPrivateKey extends Factory[ECPrivateKey] {
   * doing computations on public key (points) that may have intermediate 0x00 values, then you
   * should convert using toPoint, do computation, and then convert back toPublicKey in the end.
   */
-case class ECPublicKey(bytes: ByteVector) extends BaseECKey with PublicKey {
+case class ECPublicKey(bytes: ByteVector)
+    extends BaseECKey
+    with ECPublicKeyApi {
   require(isFullyValid, s"Invalid public key: ${bytes}: $decompressedBytesT")
 
   /** Converts this public key into the raw underlying point on secp256k1 for computation. */

--- a/crypto/src/main/scala/org/bitcoins/crypto/PublicKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/PublicKey.scala
@@ -1,0 +1,3 @@
+package org.bitcoins.crypto
+
+trait PublicKey extends NetworkElement

--- a/crypto/src/main/scala/org/bitcoins/crypto/SchnorrPublicKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SchnorrPublicKey.scala
@@ -5,7 +5,7 @@ import scodec.bits.ByteVector
 import scala.annotation.tailrec
 import scala.util.Try
 
-case class SchnorrPublicKey(bytes: ByteVector) extends NetworkElement {
+case class SchnorrPublicKey(bytes: ByteVector) extends PublicKey {
   require(bytes.length == 32,
           s"Schnorr public keys must be 32 bytes, got $bytes")
   require(Try(publicKey).isSuccess,

--- a/crypto/src/main/scala/org/bitcoins/crypto/XOnlyPubKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/XOnlyPubKey.scala
@@ -6,7 +6,7 @@ import scala.annotation.tailrec
 import scala.util.Try
 
 /** Represents the x-coordinate of an ECPublicKey, with undetermined y-coordinate parity */
-case class XOnlyPubKey(bytes: ByteVector) extends NetworkElement {
+case class XOnlyPubKey(bytes: ByteVector) extends PublicKey {
   require(bytes.length == 32,
           s"x-only public keys must be 32 bytes, got $bytes")
   require(Try(publicKey(EvenParity)).isSuccess,


### PR DESCRIPTION
The intention is to use this with #4913 

Depending on the Script type, we only allow certain types of public keys in the descriptor. From [BIP386](https://github.com/bitcoin/bips/blob/master/bip-0386.mediawiki#modified-key-expression)

>Key Expressions within a tr() expression must only create x-only public keys. Uncompressed public keys are not allowed, but compressed public keys would be implicitly converted to x-only public keys. The keys derived from extended keys must be serialized as x-only public keys. 

With this PR we should be able to parameterize all of our descriptor types with the type of public key we except :crossed_fingers: 

This PR renames the old `PublicKey` type to `ECPublicKeyApi` to be more representative of what it is.