### PR TITLE
`TapscriptTree`, `TapBranch`, `TapLeaf`

### DIFF
--- a/core-test/.jvm/src/test/resources/wallet-test-vectors.json
+++ b/core-test/.jvm/src/test/resources/wallet-test-vectors.json
@@ -1,0 +1,1613 @@
+
+
+
+
+
+
+<!DOCTYPE html>
+<html
+  lang="en"
+  
+  data-color-mode="auto" data-light-theme="light" data-dark-theme="dark"
+  data-a11y-animated-images="system" data-a11y-link-underlines="true"
+  >
+
+
+
+
+  <head>
+    <meta charset="utf-8">
+  <link rel="dns-prefetch" href="https://github.githubassets.com">
+  <link rel="dns-prefetch" href="https://avatars.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
+  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
+  <link rel="preconnect" href="https://github.githubassets.com" crossorigin>
+  <link rel="preconnect" href="https://avatars.githubusercontent.com">
+
+  
+
+
+  <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/light-0eace2597ca3.css" /><link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/dark-a167e256da9c.css" /><link data-color-theme="dark_dimmed" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_dimmed-d11f2cf8009b.css" /><link data-color-theme="dark_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_high_contrast-ea7373db06c8.css" /><link data-color-theme="dark_colorblind" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_colorblind-afa99dcf40f7.css" /><link data-color-theme="light_colorblind" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_colorblind-af6c685139ba.css" /><link data-color-theme="light_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_high_contrast-578cdbc8a5a9.css" /><link data-color-theme="light_tritanopia" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_tritanopia-5cb699a7e247.css" /><link data-color-theme="dark_tritanopia" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_tritanopia-9b32204967c6.css" />
+    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/primer-primitives-0b5bee5c70e9.css" />
+    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/primer-44fa1513ddd0.css" />
+    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/global-7a5e80eb7443.css" />
+    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/github-07f750db5d7c.css" />
+  <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/repository-fa69f138fe8d.css" />
+<link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/code-111be5e4092d.css" />
+
+  
+
+
+  <script type="application/json" id="client-env">{"locale":"en","featureFlags":["code_vulnerability_scanning","copilot_conversational_ux_history_refs","copilot_smell_icebreaker_ux","copilot_implicit_context","failbot_handle_non_errors","geojson_azure_maps","image_metric_tracking","marketing_forms_api_integration_contact_request","marketing_pages_search_explore_provider","turbo_experiment_risky","sample_network_conn_type","no_character_key_shortcuts_in_inputs","react_start_transition_for_navigations","custom_inp","remove_child_patch"]}</script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/wp-runtime-853092ccfb3d.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_dompurify_dist_purify_js-6890e890956f.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_oddbird_popover-polyfill_dist_popover_js-7bd350d761f4.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_smoothscroll-polyfill_dist_smoothscroll_js-node_modules_stacktrace-parse-a448e4-bb5415637fe0.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/environment-69a406071332.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_selector-observer_dist_index_esm_js-9f960d9b217c.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_behaviors_dist_esm_focus-zone_js-086f7a27bac0.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_relative-time-element_dist_index_js-c76945c5961a.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_combobox-nav_dist_index_js-node_modules_github_markdown-toolbar-e-820fc0-bc8f02b96749.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_auto-complete-element_dist_index_js-node_modules_github_catalyst_-392fe4-eed5a942c35c.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_text-expander-element_dist_index_js-8a621df59e80.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_filter-input-element_dist_index_js-node_modules_github_remote-inp-b7d8f4-7dc906febe69.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_delegated-events_dist_index_js-node_modules_stacktrace-parser_dist_stack-8585c6-7dc8343022ba.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_file-attachment-element_dist_index_js-node_modules_primer_view-co-3959a9-134c7fee9431.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/github-elements-14a1f6104f4b.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/element-registry-ea8c3b7e408f.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_mini-throttle_dist_index_js-node_modules_stacktrace-parser_dist_s-1acb1c-a745699a1cfa.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_lit-html_lit-html_js-5b376145beff.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_morphdom_dist_morphdom-esm_js-node_modules_github_memoize_dist_esm_index_js-05801f7ca718.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_turbo_dist_turbo_es2017-esm_js-c91f4ad18b62.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_remote-form_dist_index_js-node_modules_delegated-events_dist_inde-893f9f-8413f2cd68c5.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_scroll-anchoring_dist_scroll-anchoring_esm_js-node_modules_github_hotkey-1a1d91-49c03ceb2f0c.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_color-convert_index_js-72c9fbde5ad4.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_behaviors_dist_esm_dimensions_js-node_modules_github_jtml_lib_index_js-95b84ee6bc34.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_quote-selection_dist_index_js-node_modules_github_session-resume_-84957b-7b4e472db160.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_jtml-shimmed_jtml-shimmed_ts-ui_packages_safe-storage_safe-storage_ts-19f49df05d21.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_updatable-content_ts-ui_packages_hydro-analytics_hydro-analytics_ts-82813f-fb8253d1c2f5.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_task-list_ts-app_assets_modules_github_onfocus_ts-app_ass-421cec-9de4213015af.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_sticky-scroll-into-view_ts-94209c43e6af.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_ajax-error_ts-app_assets_modules_github_behaviors_include-2e2258-05fd80a7ea89.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_commenting_edit_ts-app_assets_modules_github_behaviors_ht-83c235-9285faa0e011.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/behaviors-a27b2a049b70.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_delegated-events_dist_index_js-node_modules_github_catalyst_lib_index_js-06ff531-2ea61fcc9a71.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/notifications-global-6d6db5144cc3.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/code-menu-6ed703a40ffd.js"></script>
+  
+  <script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/react-lib-1fbfc5be2c18.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_octicons-react_dist_index_esm_js-node_modules_primer_react_lib-es-541a38-6ce7d7c3f9ee.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Box_Box_js-8f8c5e2a2cbf.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Button_Button_js-95a7748e3c39.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_TooltipV2_Tooltip_js-70d5275ffcb7.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_ActionList_index_js-b5c64c43d649.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Overlay_Overlay_js-node_modules_primer_react_lib-es-fa1130-829932cf63db.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Link_Link_js-node_modules_primer_react_lib-esm_Text-e5cb30-846d162fec54.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_FormControl_FormControl_js-740100cbb60f.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_ActionMenu_ActionMenu_js-eaf74522e470.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Heading_Heading_js-node_modules_github_catalyst_lib-b39cf6-04084648a106.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_react-router-dom_dist_index_js-3b41341d50fe.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_PageLayout_PageLayout_js-5a4a31c01bca.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_ConfirmationDialog_ConfirmationDialog_js-8ab472e2f924.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Dialog_js-node_modules_react-virtual_dist_react-vir-155ebc-07457159712f.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_TreeView_TreeView_js-4d087b8e0c8a.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_AvatarStack_AvatarStack_js-node_modules_primer_reac-36b6f3-1b3c8357c7d0.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_mini-throttle_dist_index_js-node_modules_primer_react_lib-esm_Bre-b2e46d-c8ac19da4b57.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_react-core_create-browser-history_ts-ui_packages_safe-storage_safe-storage_ts-ui_-682c2c-7be102c61d97.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_react-core_register-app_ts-6ecc18606709.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_paths_index_ts-271d9b2a45a4.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_ref-selector_RefSelector_tsx-dbbdef4348e2.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_commit-attribution_index_ts-ui_packages_commit-checks-status_index_ts-ui_packages-baa075-642aa1eae490.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_react-shared_hooks_use-canonical-object_ts-ui_packages_code-view-shared_ho-e725dc-bccfdf9efa81.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_blob-anchor_ts-app_assets_modules_github_filter-sort_ts-app_assets_-e50ab6-fd8396d2490b.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/react-code-view-2166c00e294d.js"></script>
+
+
+  <title>bips/bip-0341/wallet-test-vectors.json at master · bitcoin/bips · GitHub</title>
+
+
+
+  <meta name="route-pattern" content="/:user_id/:repository/blob/*name(/*path)" data-turbo-transient>
+  <meta name="route-controller" content="blob" data-turbo-transient>
+  <meta name="route-action" content="show" data-turbo-transient>
+
+    
+  <meta name="current-catalog-service-hash" content="82c569b93da5c18ed649ebd4c2c79437db4611a6a1373e805a3cb001c64130b7">
+
+
+  <meta name="request-id" content="EBF0:8D48:1139A38:19618CB:6616F213" data-pjax-transient="true"/><meta name="html-safe-nonce" content="7cdd3639d27bf69d2286548fb2c3f416e2fee6f564c4a605aa798a148e417584" data-pjax-transient="true"/><meta name="visitor-payload" content="eyJyZWZlcnJlciI6IiIsInJlcXVlc3RfaWQiOiJFQkYwOjhENDg6MTEzOUEzODoxOTYxOENCOjY2MTZGMjEzIiwidmlzaXRvcl9pZCI6IjI4NzgxNTU0MDg5Mzc1MTM0OTEiLCJyZWdpb25fZWRnZSI6ImlhZCIsInJlZ2lvbl9yZW5kZXIiOiJpYWQifQ==" data-pjax-transient="true"/><meta name="visitor-hmac" content="3fe32848276229b48f0475009fbbf8c6aa2fad9e1d408913af8d939e530b656f" data-pjax-transient="true"/>
+
+
+    <meta name="hovercard-subject-tag" content="repository:14531737" data-turbo-transient>
+
+
+  <meta name="github-keyboard-shortcuts" content="repository,source-code,file-tree,copilot" data-turbo-transient="true" />
+  
+
+  <meta name="selected-link" value="repo_source" data-turbo-transient>
+  <link rel="assets" href="https://github.githubassets.com/">
+
+    <meta name="google-site-verification" content="c1kuD-K2HIVF635lypcsWPoD4kilo5-jA_wBFyT4uMY">
+  <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
+  <meta name="google-site-verification" content="Apib7-x98H0j5cPqHWwSMm6dNU4GmODRoqxLiDzdx9I">
+
+<meta name="octolytics-url" content="https://collector.github.com/github/collect" />
+
+  <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/blob/show" data-turbo-transient="true" />
+
+  
+
+
+
+
+
+    <meta name="user-login" content="">
+
+  
+
+    <meta name="viewport" content="width=device-width">
+    
+      <meta name="description" content="Bitcoin Improvement Proposals. Contribute to bitcoin/bips development by creating an account on GitHub.">
+      <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+    <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
+    <meta property="fb:app_id" content="1401488693436528">
+    <meta name="apple-itunes-app" content="app-id=1477376905, app-argument=https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json" />
+      <meta name="twitter:image:src" content="https://opengraph.githubassets.com/35ca2a40beb8c13649d17ee761a15dc5480a47a00bf471d2d32ee1f55c58525e/bitcoin/bips" /><meta name="twitter:site" content="@github" /><meta name="twitter:card" content="summary_large_image" /><meta name="twitter:title" content="bips/bip-0341/wallet-test-vectors.json at master · bitcoin/bips" /><meta name="twitter:description" content="Bitcoin Improvement Proposals. Contribute to bitcoin/bips development by creating an account on GitHub." />
+      <meta property="og:image" content="https://opengraph.githubassets.com/35ca2a40beb8c13649d17ee761a15dc5480a47a00bf471d2d32ee1f55c58525e/bitcoin/bips" /><meta property="og:image:alt" content="Bitcoin Improvement Proposals. Contribute to bitcoin/bips development by creating an account on GitHub." /><meta property="og:image:width" content="1200" /><meta property="og:image:height" content="600" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="bips/bip-0341/wallet-test-vectors.json at master · bitcoin/bips" /><meta property="og:url" content="https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json" /><meta property="og:description" content="Bitcoin Improvement Proposals. Contribute to bitcoin/bips development by creating an account on GitHub." />
+      
+
+
+
+        <meta name="hostname" content="github.com">
+
+
+
+        <meta name="expected-hostname" content="github.com">
+
+
+  <meta http-equiv="x-pjax-version" content="58fc2044de8917fa71c8cec3e297c3c19479904af7f0bde722fc9a689af4e9f3" data-turbo-track="reload">
+  <meta http-equiv="x-pjax-csp-version" content="f226bf37af9c33162063db3eb018fed7f088f86d0a20ca54c013fda96c7f2e05" data-turbo-track="reload">
+  <meta http-equiv="x-pjax-css-version" content="a7dca2c74324ba5eb1dfd20064b6873d31ef8a5cb55b7033a584b345d7ca8c16" data-turbo-track="reload">
+  <meta http-equiv="x-pjax-js-version" content="62dac6c0d51c71ec37728932e8a668dc92bfa8e8b5698c5d556effa1de1c5262" data-turbo-track="reload">
+
+  <meta name="turbo-cache-control" content="no-preview" data-turbo-transient="">
+
+      <meta name="turbo-cache-control" content="no-cache" data-turbo-transient>
+    <meta data-hydrostats="publish">
+  <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/react-code-view.959fb0b61e6a1de773e7.module.css" />
+
+  <meta name="go-import" content="github.com/bitcoin/bips git https://github.com/bitcoin/bips.git">
+
+  <meta name="octolytics-dimension-user_id" content="528860" /><meta name="octolytics-dimension-user_login" content="bitcoin" /><meta name="octolytics-dimension-repository_id" content="14531737" /><meta name="octolytics-dimension-repository_nwo" content="bitcoin/bips" /><meta name="octolytics-dimension-repository_public" content="true" /><meta name="octolytics-dimension-repository_is_fork" content="false" /><meta name="octolytics-dimension-repository_network_root_id" content="14531737" /><meta name="octolytics-dimension-repository_network_root_nwo" content="bitcoin/bips" />
+
+
+
+  <meta name="turbo-body-classes" content="logged-out env-production page-responsive">
+
+
+  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
+
+  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
+
+  <link rel="mask-icon" href="https://github.githubassets.com/assets/pinned-octocat-093da3e6fa40.svg" color="#000000">
+  <link rel="alternate icon" class="js-site-favicon" type="image/png" href="https://github.githubassets.com/favicons/favicon.png">
+  <link rel="icon" class="js-site-favicon" type="image/svg+xml" href="https://github.githubassets.com/favicons/favicon.svg">
+
+<meta name="theme-color" content="#1e2327">
+<meta name="color-scheme" content="light dark" />
+
+
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+
+  </head>
+
+  <body class="logged-out env-production page-responsive" style="word-wrap: break-word;">
+    <div data-turbo-body class="logged-out env-production page-responsive" style="word-wrap: break-word;">
+      
+
+
+    <div class="position-relative js-header-wrapper ">
+      <a href="#start-of-content" class="px-2 py-4 color-bg-accent-emphasis color-fg-on-emphasis show-on-focus js-skip-to-content">Skip to content</a>
+      <span data-view-component="true" class="progress-pjax-loader Progress position-fixed width-full">
+    <span style="width: 0%;" data-view-component="true" class="Progress-item progress-pjax-loader-bar left-0 top-0 color-bg-accent-emphasis"></span>
+</span>      
+      
+  
+
+
+
+
+
+
+
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Button_IconButton_js-node_modules_primer_react_lib--b964b4-8035f8c5edaa.js"></script>
+
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/keyboard-shortcuts-dialog-548fad62c9fa.js"></script>
+
+<react-partial
+  partial-name="keyboard-shortcuts-dialog"
+  data-ssr="false"
+>
+  
+  <script type="application/json" data-target="react-partial.embeddedData">{"props":{}}</script>
+  <div data-target="react-partial.reactRoot"></div>
+</react-partial>
+
+
+
+      
+
+        
+
+            
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_remote-form_dist_index_js-node_modules_delegated-events_dist_inde-94fd67-2dacc0a62744.js"></script>
+<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/sessions-694c8423e347.js"></script>
+<header class="Header-old header-logged-out js-details-container Details position-relative f4 py-3" role="banner" data-color-mode=light data-light-theme=light data-dark-theme=dark>
+  <button type="button" class="Header-backdrop d-lg-none border-0 position-fixed top-0 left-0 width-full height-full js-details-target" aria-label="Toggle navigation">
+    <span class="d-none">Toggle navigation</span>
+  </button>
+
+  <div class=" d-flex flex-column flex-lg-row flex-items-center p-responsive height-full position-relative z-1">
+    <div class="d-flex flex-justify-between flex-items-center width-full width-lg-auto">
+      <a class="mr-lg-3 color-fg-inherit flex-order-2" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
+        <svg height="32" aria-hidden="true" viewBox="0 0 16 16" version="1.1" width="32" data-view-component="true" class="octicon octicon-mark-github">
+    <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path>
+</svg>
+      </a>
+
+      <div class="flex-1">
+        <a href="/login?return_to=https%3A%2F%2Fgithub.com%2Fbitcoin%2Fbips%2Fblob%2Fmaster%2Fbip-0341%2Fwallet-test-vectors.json"
+          class="d-inline-block d-lg-none flex-order-1 f5 no-underline border color-border-default rounded-2 px-2 py-1 color-fg-inherit"
+          data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="e3eeb14657e31f8e374c5918df8787078a0f6a39d7a1c1da8498d77997771dd5"
+          data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">
+          Sign in
+        </a>
+      </div>
+
+      <div class="flex-1 flex-order-2 text-right">
+        <button aria-label="Toggle navigation" aria-expanded="false" type="button" data-view-component="true" class="js-details-target Button--link Button--medium Button d-lg-none color-fg-inherit p-1">  <span class="Button-content">
+    <span class="Button-label"><div class="HeaderMenu-toggle-bar rounded my-1"></div>
+            <div class="HeaderMenu-toggle-bar rounded my-1"></div>
+            <div class="HeaderMenu-toggle-bar rounded my-1"></div></span>
+  </span>
+</button>
+      </div>
+    </div>
+
+
+    <div class="HeaderMenu--logged-out p-responsive height-fit position-lg-relative d-lg-flex flex-column flex-auto pt-7 pb-4 top-0">
+      <div class="header-menu-wrapper d-flex flex-column flex-self-end flex-lg-row flex-justify-between flex-auto p-3 p-lg-0 rounded rounded-lg-0 mt-3 mt-lg-0">
+          <nav class="mt-0 px-3 px-lg-0 mb-3 mb-lg-0" aria-label="Global">
+            <ul class="d-lg-flex list-style-none">
+                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
+      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-3 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
+        Product
+        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
+    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
+</svg>
+      </button>
+      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 py-2 py-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 d-lg-flex dropdown-menu-wide">
+          <div class="px-lg-4 border-lg-right mb-4 mb-lg-0 pr-lg-7">
+            <ul class="list-style-none f5" >
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Actions&quot;,&quot;label&quot;:&quot;ref_cta:Actions;&quot;}" href="/features/actions">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-workflow color-fg-subtle mr-3">
+    <path d="M1 3a2 2 0 0 1 2-2h6.5a2 2 0 0 1 2 2v6.5a2 2 0 0 1-2 2H7v4.063C7 16.355 7.644 17 8.438 17H12.5v-2.5a2 2 0 0 1 2-2H21a2 2 0 0 1 2 2V21a2 2 0 0 1-2 2h-6.5a2 2 0 0 1-2-2v-2.5H8.437A2.939 2.939 0 0 1 5.5 15.562V11.5H3a2 2 0 0 1-2-2Zm2-.5a.5.5 0 0 0-.5.5v6.5a.5.5 0 0 0 .5.5h6.5a.5.5 0 0 0 .5-.5V3a.5.5 0 0 0-.5-.5ZM14.5 14a.5.5 0 0 0-.5.5V21a.5.5 0 0 0 .5.5H21a.5.5 0 0 0 .5-.5v-6.5a.5.5 0 0 0-.5-.5Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">Actions</div>
+        Automate any workflow
+      </div>
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Packages&quot;,&quot;label&quot;:&quot;ref_cta:Packages;&quot;}" href="/features/packages">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-package color-fg-subtle mr-3">
+    <path d="M12.876.64V.639l8.25 4.763c.541.313.875.89.875 1.515v9.525a1.75 1.75 0 0 1-.875 1.516l-8.25 4.762a1.748 1.748 0 0 1-1.75 0l-8.25-4.763a1.75 1.75 0 0 1-.875-1.515V6.917c0-.625.334-1.202.875-1.515L11.126.64a1.748 1.748 0 0 1 1.75 0Zm-1 1.298L4.251 6.34l7.75 4.474 7.75-4.474-7.625-4.402a.248.248 0 0 0-.25 0Zm.875 19.123 7.625-4.402a.25.25 0 0 0 .125-.216V7.639l-7.75 4.474ZM3.501 7.64v8.803c0 .09.048.172.125.216l7.625 4.402v-8.947Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">Packages</div>
+        Host and manage packages
+      </div>
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Security&quot;,&quot;label&quot;:&quot;ref_cta:Security;&quot;}" href="/features/security">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-shield-check color-fg-subtle mr-3">
+    <path d="M16.53 9.78a.75.75 0 0 0-1.06-1.06L11 13.19l-1.97-1.97a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.06 0l5-5Z"></path><path d="m12.54.637 8.25 2.675A1.75 1.75 0 0 1 22 4.976V10c0 6.19-3.771 10.704-9.401 12.83a1.704 1.704 0 0 1-1.198 0C5.77 20.705 2 16.19 2 10V4.976c0-.758.489-1.43 1.21-1.664L11.46.637a1.748 1.748 0 0 1 1.08 0Zm-.617 1.426-8.25 2.676a.249.249 0 0 0-.173.237V10c0 5.46 3.28 9.483 8.43 11.426a.199.199 0 0 0 .14 0C17.22 19.483 20.5 15.461 20.5 10V4.976a.25.25 0 0 0-.173-.237l-8.25-2.676a.253.253 0 0 0-.154 0Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">Security</div>
+        Find and fix vulnerabilities
+      </div>
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Codespaces&quot;,&quot;label&quot;:&quot;ref_cta:Codespaces;&quot;}" href="/features/codespaces">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-codespaces color-fg-subtle mr-3">
+    <path d="M3.5 3.75C3.5 2.784 4.284 2 5.25 2h13.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 18.75 13H5.25a1.75 1.75 0 0 1-1.75-1.75Zm-2 12c0-.966.784-1.75 1.75-1.75h17.5c.966 0 1.75.784 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75H3.25a1.75 1.75 0 0 1-1.75-1.75ZM5.25 3.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h13.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Zm-2 12a.25.25 0 0 0-.25.25v4c0 .138.112.25.25.25h17.5a.25.25 0 0 0 .25-.25v-4a.25.25 0 0 0-.25-.25Z"></path><path d="M10 17.75a.75.75 0 0 1 .75-.75h6.5a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1-.75-.75Zm-4 0a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1-.75-.75Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">Codespaces</div>
+        Instant dev environments
+      </div>
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Copilot&quot;,&quot;label&quot;:&quot;ref_cta:Copilot;&quot;}" href="/features/copilot">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-copilot color-fg-subtle mr-3">
+    <path d="M23.922 16.992c-.861 1.495-5.859 5.023-11.922 5.023-6.063 0-11.061-3.528-11.922-5.023A.641.641 0 0 1 0 16.736v-2.869a.841.841 0 0 1 .053-.22c.372-.935 1.347-2.292 2.605-2.656.167-.429.414-1.055.644-1.517a10.195 10.195 0 0 1-.052-1.086c0-1.331.282-2.499 1.132-3.368.397-.406.89-.717 1.474-.952 1.399-1.136 3.392-2.093 6.122-2.093 2.731 0 4.767.957 6.166 2.093.584.235 1.077.546 1.474.952.85.869 1.132 2.037 1.132 3.368 0 .368-.014.733-.052 1.086.23.462.477 1.088.644 1.517 1.258.364 2.233 1.721 2.605 2.656a.832.832 0 0 1 .053.22v2.869a.641.641 0 0 1-.078.256ZM12.172 11h-.344a4.323 4.323 0 0 1-.355.508C10.703 12.455 9.555 13 7.965 13c-1.725 0-2.989-.359-3.782-1.259a2.005 2.005 0 0 1-.085-.104L4 11.741v6.585c1.435.779 4.514 2.179 8 2.179 3.486 0 6.565-1.4 8-2.179v-6.585l-.098-.104s-.033.045-.085.104c-.793.9-2.057 1.259-3.782 1.259-1.59 0-2.738-.545-3.508-1.492a4.323 4.323 0 0 1-.355-.508h-.016.016Zm.641-2.935c.136 1.057.403 1.913.878 2.497.442.544 1.134.938 2.344.938 1.573 0 2.292-.337 2.657-.751.384-.435.558-1.15.558-2.361 0-1.14-.243-1.847-.705-2.319-.477-.488-1.319-.862-2.824-1.025-1.487-.161-2.192.138-2.533.529-.269.307-.437.808-.438 1.578v.021c0 .265.021.562.063.893Zm-1.626 0c.042-.331.063-.628.063-.894v-.02c-.001-.77-.169-1.271-.438-1.578-.341-.391-1.046-.69-2.533-.529-1.505.163-2.347.537-2.824 1.025-.462.472-.705 1.179-.705 2.319 0 1.211.175 1.926.558 2.361.365.414 1.084.751 2.657.751 1.21 0 1.902-.394 2.344-.938.475-.584.742-1.44.878-2.497Z"></path><path d="M14.5 14.25a1 1 0 0 1 1 1v2a1 1 0 0 1-2 0v-2a1 1 0 0 1 1-1Zm-5 0a1 1 0 0 1 1 1v2a1 1 0 0 1-2 0v-2a1 1 0 0 1 1-1Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">Copilot</div>
+        Write better code with AI
+      </div>
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Code review&quot;,&quot;label&quot;:&quot;ref_cta:Code review;&quot;}" href="/features/code-review">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-code-review color-fg-subtle mr-3">
+    <path d="M10.3 6.74a.75.75 0 0 1-.04 1.06l-2.908 2.7 2.908 2.7a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 0 1 1.06.04Zm3.44 1.06a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.908-2.7-2.908-2.7Z"></path><path d="M1.5 4.25c0-.966.784-1.75 1.75-1.75h17.5c.966 0 1.75.784 1.75 1.75v12.5a1.75 1.75 0 0 1-1.75 1.75h-9.69l-3.573 3.573A1.458 1.458 0 0 1 5 21.043V18.5H3.25a1.75 1.75 0 0 1-1.75-1.75ZM3.25 4a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h2.5a.75.75 0 0 1 .75.75v3.19l3.72-3.72a.749.749 0 0 1 .53-.22h10a.25.25 0 0 0 .25-.25V4.25a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">Code review</div>
+        Manage code changes
+      </div>
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Issues&quot;,&quot;label&quot;:&quot;ref_cta:Issues;&quot;}" href="/features/issues">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-issue-opened color-fg-subtle mr-3">
+    <path d="M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1ZM2.5 12a9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5A9.5 9.5 0 0 0 12 2.5 9.5 9.5 0 0 0 2.5 12Zm9.5 2a2 2 0 1 1-.001-3.999A2 2 0 0 1 12 14Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">Issues</div>
+        Plan and track work
+      </div>
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Discussions&quot;,&quot;label&quot;:&quot;ref_cta:Discussions;&quot;}" href="/features/discussions">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-comment-discussion color-fg-subtle mr-3">
+    <path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v9.5A1.75 1.75 0 0 1 14.25 14H8.061l-2.574 2.573A1.458 1.458 0 0 1 3 15.543V14H1.75A1.75 1.75 0 0 1 0 12.25v-9.5C0 1.784.784 1 1.75 1ZM1.5 2.75v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Z"></path><path d="M22.5 8.75a.25.25 0 0 0-.25-.25h-3.5a.75.75 0 0 1 0-1.5h3.5c.966 0 1.75.784 1.75 1.75v9.5A1.75 1.75 0 0 1 22.25 20H21v1.543a1.457 1.457 0 0 1-2.487 1.03L15.939 20H10.75A1.75 1.75 0 0 1 9 18.25v-1.465a.75.75 0 0 1 1.5 0v1.465c0 .138.112.25.25.25h5.5a.75.75 0 0 1 .53.22l2.72 2.72v-2.19a.75.75 0 0 1 .75-.75h2a.25.25 0 0 0 .25-.25v-9.5Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">Discussions</div>
+        Collaborate outside of code
+      </div>
+
+    
+</a></li>
+
+            </ul>
+          </div>
+          <div class="px-lg-4">
+              <span class="d-block h4 color-fg-default my-1" id="product-explore-heading">Explore</span>
+            <ul class="list-style-none f5" aria-labelledby="product-explore-heading">
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to All features&quot;,&quot;label&quot;:&quot;ref_cta:All features;&quot;}" href="/features">
+      All features
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Documentation&quot;,&quot;label&quot;:&quot;ref_cta:Documentation;&quot;}" href="https://docs.github.com">
+      Documentation
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to GitHub Skills&quot;,&quot;label&quot;:&quot;ref_cta:GitHub Skills;&quot;}" href="https://skills.github.com/">
+      GitHub Skills
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Blog&quot;,&quot;label&quot;:&quot;ref_cta:Blog;&quot;}" href="https://github.blog">
+      Blog
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+            </ul>
+          </div>
+      </div>
+</li>
+
+
+                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
+      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-3 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
+        Solutions
+        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
+    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
+</svg>
+      </button>
+      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 py-2 py-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 px-lg-4">
+          <div class="border-bottom pb-3 mb-3">
+              <span class="d-block h4 color-fg-default my-1" id="solutions-for-heading">For</span>
+            <ul class="list-style-none f5" aria-labelledby="solutions-for-heading">
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Enterprise&quot;,&quot;label&quot;:&quot;ref_cta:Enterprise;&quot;}" href="/enterprise">
+      Enterprise
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Teams&quot;,&quot;label&quot;:&quot;ref_cta:Teams;&quot;}" href="/team">
+      Teams
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Startups&quot;,&quot;label&quot;:&quot;ref_cta:Startups;&quot;}" href="/enterprise/startups">
+      Startups
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Education&quot;,&quot;label&quot;:&quot;ref_cta:Education;&quot;}" href="https://education.github.com">
+      Education
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+            </ul>
+          </div>
+          <div class="border-bottom pb-3 mb-3">
+              <span class="d-block h4 color-fg-default my-1" id="solutions-by-solution-heading">By Solution</span>
+            <ul class="list-style-none f5" aria-labelledby="solutions-by-solution-heading">
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to CI/CD &amp;amp; Automation&quot;,&quot;label&quot;:&quot;ref_cta:CI/CD &amp;amp; Automation;&quot;}" href="/solutions/ci-cd/">
+      CI/CD &amp; Automation
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to DevOps&quot;,&quot;label&quot;:&quot;ref_cta:DevOps;&quot;}" href="/solutions/devops/">
+      DevOps
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to DevSecOps&quot;,&quot;label&quot;:&quot;ref_cta:DevSecOps;&quot;}" href="https://resources.github.com/devops/fundamentals/devsecops/">
+      DevSecOps
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+            </ul>
+          </div>
+          <div class="">
+              <span class="d-block h4 color-fg-default my-1" id="solutions-resources-heading">Resources</span>
+            <ul class="list-style-none f5" aria-labelledby="solutions-resources-heading">
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Learning Pathways&quot;,&quot;label&quot;:&quot;ref_cta:Learning Pathways;&quot;}" href="https://resources.github.com/learn/pathways/">
+      Learning Pathways
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to White papers, Ebooks, Webinars&quot;,&quot;label&quot;:&quot;ref_cta:White papers, Ebooks, Webinars;&quot;}" href="https://resources.github.com/">
+      White papers, Ebooks, Webinars
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Customer Stories&quot;,&quot;label&quot;:&quot;ref_cta:Customer Stories;&quot;}" href="/customer-stories">
+      Customer Stories
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Partners&quot;,&quot;label&quot;:&quot;ref_cta:Partners;&quot;}" href="https://partner.github.com/">
+      Partners
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+            </ul>
+          </div>
+      </div>
+</li>
+
+
+                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
+      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-3 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
+        Open Source
+        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
+    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
+</svg>
+      </button>
+      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 py-2 py-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 px-lg-4">
+          <div class="border-bottom pb-3 mb-3">
+            <ul class="list-style-none f5" >
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Open Source&quot;,&quot;action&quot;:&quot;click to go to GitHub Sponsors&quot;,&quot;label&quot;:&quot;ref_cta:GitHub Sponsors;&quot;}" href="/sponsors">
+      
+      <div>
+        <div class="color-fg-default h4">GitHub Sponsors</div>
+        Fund open source developers
+      </div>
+
+    
+</a></li>
+
+            </ul>
+          </div>
+          <div class="border-bottom pb-3 mb-3">
+            <ul class="list-style-none f5" >
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Open Source&quot;,&quot;action&quot;:&quot;click to go to The ReadME Project&quot;,&quot;label&quot;:&quot;ref_cta:The ReadME Project;&quot;}" href="/readme">
+      
+      <div>
+        <div class="color-fg-default h4">The ReadME Project</div>
+        GitHub community articles
+      </div>
+
+    
+</a></li>
+
+            </ul>
+          </div>
+          <div class="">
+              <span class="d-block h4 color-fg-default my-1" id="open-source-repositories-heading">Repositories</span>
+            <ul class="list-style-none f5" aria-labelledby="open-source-repositories-heading">
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Open Source&quot;,&quot;action&quot;:&quot;click to go to Topics&quot;,&quot;label&quot;:&quot;ref_cta:Topics;&quot;}" href="/topics">
+      Topics
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Open Source&quot;,&quot;action&quot;:&quot;click to go to Trending&quot;,&quot;label&quot;:&quot;ref_cta:Trending;&quot;}" href="/trending">
+      Trending
+
+    
+</a></li>
+
+                <li>
+  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Open Source&quot;,&quot;action&quot;:&quot;click to go to Collections&quot;,&quot;label&quot;:&quot;ref_cta:Collections;&quot;}" href="/collections">
+      Collections
+
+    
+</a></li>
+
+            </ul>
+          </div>
+      </div>
+</li>
+
+
+                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
+    <a class="HeaderMenu-link no-underline px-0 px-lg-2 py-3 py-lg-2 d-block d-lg-inline-block" data-analytics-event="{&quot;category&quot;:&quot;Header menu top item (logged out)&quot;,&quot;action&quot;:&quot;click to go to Pricing&quot;,&quot;label&quot;:&quot;ref_cta:Pricing;&quot;}" href="/pricing">Pricing</a>
+</li>
+
+            </ul>
+          </nav>
+
+        <div class="d-lg-flex flex-items-center mb-3 mb-lg-0 text-center text-lg-left ml-3" style="">
+                
+
+
+<qbsearch-input class="search-input" data-scope="repo:bitcoin/bips" data-custom-scopes-path="/search/custom_scopes" data-delete-custom-scopes-csrf="Tnl5i8kKyGoLFPn_YCzFEvTt3NRrD_oWJG_OfjEphI1CXljoD2ej529QHV22O_rOuDqtwSeuI7l7DWqfp4_e3g" data-max-custom-scopes="10" data-header-redesign-enabled="false" data-initial-value="" data-blackbird-suggestions-path="/search/suggestions" data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations" data-current-repository="bitcoin/bips" data-current-org="bitcoin" data-current-owner="" data-logged-in="false" data-copilot-chat-enabled="false" data-blackbird-indexed-repo-csrf="<esi:include src=&quot;/_esi/rails_csrf_token_form_hidden?r=iwseHI13vQk77JVMchJfLUyru3aEymEgvNankS6tKBsUqhe5N%2FZKMEGHx%2FXbKmyl%2BaUqQMxiKzQujzElxKQdcu84WdDo%2BUfDoKpqRcoBagTFY%2FrZPXIDbkqLVR1XzrpHWgmULHPCXGhIbeGw8w1anmkqCXz6kDeuuDc7zGRb9EO67JQgTMqDB27aOJwKluQeuyo8%2FEPl7yOAP3VullEwM%2Bw9ZxqXRkqh8fhdIh58PgCEGqh58i9OO38Niq%2BR8sZ5H06PS8ptOFRXfyCflPeV%2FWScaKw4qU898%2Bz%2BM2mQQiqxTYmWGLqklOwNmdcoxxHL%2BlNzd1Qdj98MYVOUKOfga0xKCMfgGNJ%2FMHvW%2Fu%2BWAKU%2F8Eo%2BURSTsU4HGSwg54ZefcGEZ4VGdTOULEEoGDZASWsoRXa814M5rdmN1aGCl8I%2BNBFyHqxlJVe2uuXgzHPnZrzuV1hk3Wjj5KtlG2nt0lpkkRxiByjUTivYlXWOW%2BXpxNkzBIUvCtQEx0CW2kxDwqdinwUIagTcOWqPE52IA3nQi4Bx8QjIo2YafTSV2%2Bsofl2%2BLzdFxC4GCbxa26szmeDMssi7nU6hExjFXjf6v1vtJFk71A%3D%3D--aPEyJbidBPtxFM7g--MkWdl8cqBm%2BQr8I9KECw1w%3D%3D&quot; />">
+  <div
+    class="search-input-container search-with-dialog position-relative d-flex flex-row flex-items-center mr-4 rounded"
+    data-action="click:qbsearch-input#searchInputContainerClicked"
+  >
+      <button
+        type="button"
+        class="header-search-button placeholder  input-button form-control d-flex flex-1 flex-self-stretch flex-items-center no-wrap width-full py-0 pl-2 pr-0 text-left border-0 box-shadow-none"
+        data-target="qbsearch-input.inputButton"
+        placeholder="Search or jump to..."
+        data-hotkey=s,/
+        autocapitalize="off"
+        data-action="click:qbsearch-input#handleExpand"
+      >
+        <div class="mr-2 color-fg-muted">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
+    <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
+</svg>
+        </div>
+        <span class="flex-1" data-target="qbsearch-input.inputButtonText">Search or jump to...</span>
+          <div class="d-flex" data-target="qbsearch-input.hotkeyIndicator">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" aria-hidden="true" class="mr-1"><path fill="none" stroke="#979A9C" opacity=".4" d="M3.5.5h12c1.7 0 3 1.3 3 3v13c0 1.7-1.3 3-3 3h-12c-1.7 0-3-1.3-3-3v-13c0-1.7 1.3-3 3-3z"></path><path fill="#979A9C" d="M11.8 6L8 15.1h-.9L10.8 6h1z"></path></svg>
+
+          </div>
+      </button>
+
+    <input type="hidden" name="type" class="js-site-search-type-field">
+
+    
+<div class="Overlay--hidden " data-modal-dialog-overlay>
+  <modal-dialog data-action="close:qbsearch-input#handleClose cancel:qbsearch-input#handleClose" data-target="qbsearch-input.searchSuggestionsDialog" role="dialog" id="search-suggestions-dialog" aria-modal="true" aria-labelledby="search-suggestions-dialog-header" data-view-component="true" class="Overlay Overlay--width-large Overlay--height-auto">
+      <h1 id="search-suggestions-dialog-header" class="sr-only">Search code, repositories, users, issues, pull requests...</h1>
+    <div class="Overlay-body Overlay-body--paddingNone">
+      
+          <div data-view-component="true">        <div class="search-suggestions position-fixed width-full color-shadow-large border color-fg-default color-bg-default overflow-hidden d-flex flex-column query-builder-container"
+          style="border-radius: 12px;"
+          data-target="qbsearch-input.queryBuilderContainer"
+          hidden
+        >
+          <!-- '"` --><!-- </textarea></xmp> --></option></form><form id="query-builder-test-form" action="" accept-charset="UTF-8" method="get">
+  <query-builder data-target="qbsearch-input.queryBuilder" id="query-builder-query-builder-test" data-filter-key=":" data-view-component="true" class="QueryBuilder search-query-builder">
+    <div class="FormControl FormControl--fullWidth">
+      <label id="query-builder-test-label" for="query-builder-test" class="FormControl-label sr-only">
+        Search
+      </label>
+      <div
+        class="QueryBuilder-StyledInput width-fit "
+        data-target="query-builder.styledInput"
+      >
+          <span id="query-builder-test-leadingvisual-wrap" class="FormControl-input-leadingVisualWrap QueryBuilder-leadingVisualWrap">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search FormControl-input-leadingVisual">
+    <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
+</svg>
+          </span>
+        <div data-target="query-builder.styledInputContainer" class="QueryBuilder-StyledInputContainer">
+          <div
+            aria-hidden="true"
+            class="QueryBuilder-StyledInputContent"
+            data-target="query-builder.styledInputContent"
+          ></div>
+          <div class="QueryBuilder-InputWrapper">
+            <div aria-hidden="true" class="QueryBuilder-Sizer" data-target="query-builder.sizer"></div>
+            <input id="query-builder-test" name="query-builder-test" value="" autocomplete="off" type="text" role="combobox" spellcheck="false" aria-expanded="false" aria-describedby="validation-f4d831d7-7db4-4b63-bf4c-924f9551702f" data-target="query-builder.input" data-action="
+          input:query-builder#inputChange
+          blur:query-builder#inputBlur
+          keydown:query-builder#inputKeydown
+          focus:query-builder#inputFocus
+        " data-view-component="true" class="FormControl-input QueryBuilder-Input FormControl-medium" />
+          </div>
+        </div>
+          <span class="sr-only" id="query-builder-test-clear">Clear</span>
+          <button role="button" id="query-builder-test-clear-button" aria-labelledby="query-builder-test-clear query-builder-test-label" data-target="query-builder.clearButton" data-action="
+                click:query-builder#clear
+                focus:query-builder#clearButtonFocus
+                blur:query-builder#clearButtonBlur
+              " variant="small" hidden="hidden" type="button" data-view-component="true" class="Button Button--iconOnly Button--invisible Button--medium mr-1 px-2 py-0 d-flex flex-items-center rounded-1 color-fg-muted">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x-circle-fill Button-visual">
+    <path d="M2.343 13.657A8 8 0 1 1 13.658 2.343 8 8 0 0 1 2.343 13.657ZM6.03 4.97a.751.751 0 0 0-1.042.018.751.751 0 0 0-.018 1.042L6.94 8 4.97 9.97a.749.749 0 0 0 .326 1.275.749.749 0 0 0 .734-.215L8 9.06l1.97 1.97a.749.749 0 0 0 1.275-.326.749.749 0 0 0-.215-.734L9.06 8l1.97-1.97a.749.749 0 0 0-.326-1.275.749.749 0 0 0-.734.215L8 6.94Z"></path>
+</svg>
+</button>
+
+      </div>
+      <template id="search-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
+    <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
+</svg>
+</template>
+
+<template id="code-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code">
+    <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+</template>
+
+<template id="file-code-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-code">
+    <path d="M4 1.75C4 .784 4.784 0 5.75 0h5.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v8.586A1.75 1.75 0 0 1 14.25 15h-9a.75.75 0 0 1 0-1.5h9a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 10 4.25V1.5H5.75a.25.25 0 0 0-.25.25v2.5a.75.75 0 0 1-1.5 0Zm1.72 4.97a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734l1.47-1.47-1.47-1.47a.75.75 0 0 1 0-1.06ZM3.28 7.78 1.81 9.25l1.47 1.47a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-2-2a.75.75 0 0 1 0-1.06l2-2a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Zm8.22-6.218V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"></path>
+</svg>
+</template>
+
+<template id="history-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-history">
+    <path d="m.427 1.927 1.215 1.215a8.002 8.002 0 1 1-1.6 5.685.75.75 0 1 1 1.493-.154 6.5 6.5 0 1 0 1.18-4.458l1.358 1.358A.25.25 0 0 1 3.896 6H.25A.25.25 0 0 1 0 5.75V2.104a.25.25 0 0 1 .427-.177ZM7.75 4a.75.75 0 0 1 .75.75v2.992l2.028.812a.75.75 0 0 1-.557 1.392l-2.5-1A.751.751 0 0 1 7 8.25v-3.5A.75.75 0 0 1 7.75 4Z"></path>
+</svg>
+</template>
+
+<template id="repo-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo">
+    <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path>
+</svg>
+</template>
+
+<template id="bookmark-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-bookmark">
+    <path d="M3 2.75C3 1.784 3.784 1 4.75 1h6.5c.966 0 1.75.784 1.75 1.75v11.5a.75.75 0 0 1-1.227.579L8 11.722l-3.773 3.107A.751.751 0 0 1 3 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.91l3.023-2.489a.75.75 0 0 1 .954 0l3.023 2.49V2.75a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+</template>
+
+<template id="plus-circle-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-plus-circle">
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm7.25-3.25v2.5h2.5a.75.75 0 0 1 0 1.5h-2.5v2.5a.75.75 0 0 1-1.5 0v-2.5h-2.5a.75.75 0 0 1 0-1.5h2.5v-2.5a.75.75 0 0 1 1.5 0Z"></path>
+</svg>
+</template>
+
+<template id="circle-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-dot-fill">
+    <path d="M8 4a4 4 0 1 1 0 8 4 4 0 0 1 0-8Z"></path>
+</svg>
+</template>
+
+<template id="trash-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-trash">
+    <path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75ZM4.496 6.675l.66 6.6a.25.25 0 0 0 .249.225h5.19a.25.25 0 0 0 .249-.225l.66-6.6a.75.75 0 0 1 1.492.149l-.66 6.6A1.748 1.748 0 0 1 10.595 15h-5.19a1.75 1.75 0 0 1-1.741-1.575l-.66-6.6a.75.75 0 1 1 1.492-.15ZM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25Z"></path>
+</svg>
+</template>
+
+<template id="team-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-people">
+    <path d="M2 5.5a3.5 3.5 0 1 1 5.898 2.549 5.508 5.508 0 0 1 3.034 4.084.75.75 0 1 1-1.482.235 4 4 0 0 0-7.9 0 .75.75 0 0 1-1.482-.236A5.507 5.507 0 0 1 3.102 8.05 3.493 3.493 0 0 1 2 5.5ZM11 4a3.001 3.001 0 0 1 2.22 5.018 5.01 5.01 0 0 1 2.56 3.012.749.749 0 0 1-.885.954.752.752 0 0 1-.549-.514 3.507 3.507 0 0 0-2.522-2.372.75.75 0 0 1-.574-.73v-.352a.75.75 0 0 1 .416-.672A1.5 1.5 0 0 0 11 5.5.75.75 0 0 1 11 4Zm-5.5-.5a2 2 0 1 0-.001 3.999A2 2 0 0 0 5.5 3.5Z"></path>
+</svg>
+</template>
+
+<template id="project-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-project">
+    <path d="M1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25V1.75C0 .784.784 0 1.75 0ZM1.5 1.75v12.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25ZM11.75 3a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-1.5 0v-7.5a.75.75 0 0 1 .75-.75Zm-8.25.75a.75.75 0 0 1 1.5 0v5.5a.75.75 0 0 1-1.5 0ZM8 3a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 3Z"></path>
+</svg>
+</template>
+
+<template id="pencil-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-pencil">
+    <path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61Zm.176 4.823L9.75 4.81l-6.286 6.287a.253.253 0 0 0-.064.108l-.558 1.953 1.953-.558a.253.253 0 0 0 .108-.064Zm1.238-3.763a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354Z"></path>
+</svg>
+</template>
+
+<template id="copilot-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copilot">
+    <path d="M7.998 15.035c-4.562 0-7.873-2.914-7.998-3.749V9.338c.085-.628.677-1.686 1.588-2.065.013-.07.024-.143.036-.218.029-.183.06-.384.126-.612-.201-.508-.254-1.084-.254-1.656 0-.87.128-1.769.693-2.484.579-.733 1.494-1.124 2.724-1.261 1.206-.134 2.262.034 2.944.765.05.053.096.108.139.165.044-.057.094-.112.143-.165.682-.731 1.738-.899 2.944-.765 1.23.137 2.145.528 2.724 1.261.566.715.693 1.614.693 2.484 0 .572-.053 1.148-.254 1.656.066.228.098.429.126.612.012.076.024.148.037.218.924.385 1.522 1.471 1.591 2.095v1.872c0 .766-3.351 3.795-8.002 3.795Zm0-1.485c2.28 0 4.584-1.11 5.002-1.433V7.862l-.023-.116c-.49.21-1.075.291-1.727.291-1.146 0-2.059-.327-2.71-.991A3.222 3.222 0 0 1 8 6.303a3.24 3.24 0 0 1-.544.743c-.65.664-1.563.991-2.71.991-.652 0-1.236-.081-1.727-.291l-.023.116v4.255c.419.323 2.722 1.433 5.002 1.433ZM6.762 2.83c-.193-.206-.637-.413-1.682-.297-1.019.113-1.479.404-1.713.7-.247.312-.369.789-.369 1.554 0 .793.129 1.171.308 1.371.162.181.519.379 1.442.379.853 0 1.339-.235 1.638-.54.315-.322.527-.827.617-1.553.117-.935-.037-1.395-.241-1.614Zm4.155-.297c-1.044-.116-1.488.091-1.681.297-.204.219-.359.679-.242 1.614.091.726.303 1.231.618 1.553.299.305.784.54 1.638.54.922 0 1.28-.198 1.442-.379.179-.2.308-.578.308-1.371 0-.765-.123-1.242-.37-1.554-.233-.296-.693-.587-1.713-.7Z"></path><path d="M6.25 9.037a.75.75 0 0 1 .75.75v1.501a.75.75 0 0 1-1.5 0V9.787a.75.75 0 0 1 .75-.75Zm4.25.75v1.501a.75.75 0 0 1-1.5 0V9.787a.75.75 0 0 1 1.5 0Z"></path>
+</svg>
+</template>
+
+<template id="workflow-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-workflow">
+    <path d="M0 1.75C0 .784.784 0 1.75 0h3.5C6.216 0 7 .784 7 1.75v3.5A1.75 1.75 0 0 1 5.25 7H4v4a1 1 0 0 0 1 1h4v-1.25C9 9.784 9.784 9 10.75 9h3.5c.966 0 1.75.784 1.75 1.75v3.5A1.75 1.75 0 0 1 14.25 16h-3.5A1.75 1.75 0 0 1 9 14.25v-.75H5A2.5 2.5 0 0 1 2.5 11V7h-.75A1.75 1.75 0 0 1 0 5.25Zm1.75-.25a.25.25 0 0 0-.25.25v3.5c0 .138.112.25.25.25h3.5a.25.25 0 0 0 .25-.25v-3.5a.25.25 0 0 0-.25-.25Zm9 9a.25.25 0 0 0-.25.25v3.5c0 .138.112.25.25.25h3.5a.25.25 0 0 0 .25-.25v-3.5a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+</template>
+
+<template id="book-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-book">
+    <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"></path>
+</svg>
+</template>
+
+<template id="code-review-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code-review">
+    <path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 13H8.061l-2.574 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25v-8.5C0 1.784.784 1 1.75 1ZM1.5 2.75v8.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Zm5.28 1.72a.75.75 0 0 1 0 1.06L5.31 7l1.47 1.47a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-2-2a.75.75 0 0 1 0-1.06l2-2a.75.75 0 0 1 1.06 0Zm2.44 0a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.69 7 9.22 5.53a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+</template>
+
+<template id="codespaces-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-codespaces">
+    <path d="M0 11.25c0-.966.784-1.75 1.75-1.75h12.5c.966 0 1.75.784 1.75 1.75v3A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25Zm2-9.5C2 .784 2.784 0 3.75 0h8.5C13.216 0 14 .784 14 1.75v5a1.75 1.75 0 0 1-1.75 1.75h-8.5A1.75 1.75 0 0 1 2 6.75Zm1.75-.25a.25.25 0 0 0-.25.25v5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-5a.25.25 0 0 0-.25-.25Zm-2 9.5a.25.25 0 0 0-.25.25v3c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-3a.25.25 0 0 0-.25-.25Z"></path><path d="M7 12.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Zm-4 0a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1-.75-.75Z"></path>
+</svg>
+</template>
+
+<template id="comment-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-comment">
+    <path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h4.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+</template>
+
+<template id="comment-discussion-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-comment-discussion">
+    <path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"></path>
+</svg>
+</template>
+
+<template id="organization-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-organization">
+    <path d="M1.75 16A1.75 1.75 0 0 1 0 14.25V1.75C0 .784.784 0 1.75 0h8.5C11.216 0 12 .784 12 1.75v12.5c0 .085-.006.168-.018.25h2.268a.25.25 0 0 0 .25-.25V8.285a.25.25 0 0 0-.111-.208l-1.055-.703a.749.749 0 1 1 .832-1.248l1.055.703c.487.325.779.871.779 1.456v5.965A1.75 1.75 0 0 1 14.25 16h-3.5a.766.766 0 0 1-.197-.026c-.099.017-.2.026-.303.026h-3a.75.75 0 0 1-.75-.75V14h-1v1.25a.75.75 0 0 1-.75.75Zm-.25-1.75c0 .138.112.25.25.25H4v-1.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 .75.75v1.25h2.25a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25ZM3.75 6h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5ZM3 3.75A.75.75 0 0 1 3.75 3h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 3 3.75Zm4 3A.75.75 0 0 1 7.75 6h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 7 6.75ZM7.75 3h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5ZM3 9.75A.75.75 0 0 1 3.75 9h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 3 9.75ZM7.75 9h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5Z"></path>
+</svg>
+</template>
+
+<template id="rocket-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-rocket">
+    <path d="M14.064 0h.186C15.216 0 16 .784 16 1.75v.186a8.752 8.752 0 0 1-2.564 6.186l-.458.459c-.314.314-.641.616-.979.904v3.207c0 .608-.315 1.172-.833 1.49l-2.774 1.707a.749.749 0 0 1-1.11-.418l-.954-3.102a1.214 1.214 0 0 1-.145-.125L3.754 9.816a1.218 1.218 0 0 1-.124-.145L.528 8.717a.749.749 0 0 1-.418-1.11l1.71-2.774A1.748 1.748 0 0 1 3.31 4h3.204c.288-.338.59-.665.904-.979l.459-.458A8.749 8.749 0 0 1 14.064 0ZM8.938 3.623h-.002l-.458.458c-.76.76-1.437 1.598-2.02 2.5l-1.5 2.317 2.143 2.143 2.317-1.5c.902-.583 1.74-1.26 2.499-2.02l.459-.458a7.25 7.25 0 0 0 2.123-5.127V1.75a.25.25 0 0 0-.25-.25h-.186a7.249 7.249 0 0 0-5.125 2.123ZM3.56 14.56c-.732.732-2.334 1.045-3.005 1.148a.234.234 0 0 1-.201-.064.234.234 0 0 1-.064-.201c.103-.671.416-2.273 1.15-3.003a1.502 1.502 0 1 1 2.12 2.12Zm6.94-3.935c-.088.06-.177.118-.266.175l-2.35 1.521.548 1.783 1.949-1.2a.25.25 0 0 0 .119-.213ZM3.678 8.116 5.2 5.766c.058-.09.117-.178.176-.266H3.309a.25.25 0 0 0-.213.119l-1.2 1.95ZM12 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+</template>
+
+<template id="shield-check-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-shield-check">
+    <path d="m8.533.133 5.25 1.68A1.75 1.75 0 0 1 15 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.697 1.697 0 0 1-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 0 1 1.217-1.667l5.25-1.68a1.748 1.748 0 0 1 1.066 0Zm-.61 1.429.001.001-5.25 1.68a.251.251 0 0 0-.174.237V7c0 1.36.275 2.666 1.057 3.859.784 1.194 2.121 2.342 4.366 3.298a.196.196 0 0 0 .154 0c2.245-.957 3.582-2.103 4.366-3.297C13.225 9.666 13.5 8.358 13.5 7V3.48a.25.25 0 0 0-.174-.238l-5.25-1.68a.25.25 0 0 0-.153 0ZM11.28 6.28l-3.5 3.5a.75.75 0 0 1-1.06 0l-1.5-1.5a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l.97.97 2.97-2.97a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
+</svg>
+</template>
+
+<template id="heart-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-heart">
+    <path d="m8 14.25.345.666a.75.75 0 0 1-.69 0l-.008-.004-.018-.01a7.152 7.152 0 0 1-.31-.17 22.055 22.055 0 0 1-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.066 22.066 0 0 1-3.744 2.584l-.018.01-.006.003h-.002ZM4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.58 20.58 0 0 0 8 13.393a20.58 20.58 0 0 0 3.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.749.749 0 0 1-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5Z"></path>
+</svg>
+</template>
+
+<template id="server-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-server">
+    <path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v4c0 .372-.116.717-.314 1 .198.283.314.628.314 1v4a1.75 1.75 0 0 1-1.75 1.75H1.75A1.75 1.75 0 0 1 0 12.75v-4c0-.358.109-.707.314-1a1.739 1.739 0 0 1-.314-1v-4C0 1.784.784 1 1.75 1ZM1.5 2.75v4c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-4a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Zm.25 5.75a.25.25 0 0 0-.25.25v4c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-4a.25.25 0 0 0-.25-.25ZM7 4.75A.75.75 0 0 1 7.75 4h4.5a.75.75 0 0 1 0 1.5h-4.5A.75.75 0 0 1 7 4.75ZM7.75 10h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM3 4.75A.75.75 0 0 1 3.75 4h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 3 4.75ZM3.75 10h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5Z"></path>
+</svg>
+</template>
+
+<template id="globe-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-globe">
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM5.78 8.75a9.64 9.64 0 0 0 1.363 4.177c.255.426.542.832.857 1.215.245-.296.551-.705.857-1.215A9.64 9.64 0 0 0 10.22 8.75Zm4.44-1.5a9.64 9.64 0 0 0-1.363-4.177c-.307-.51-.612-.919-.857-1.215a9.927 9.927 0 0 0-.857 1.215A9.64 9.64 0 0 0 5.78 7.25Zm-5.944 1.5H1.543a6.507 6.507 0 0 0 4.666 5.5c-.123-.181-.24-.365-.352-.552-.715-1.192-1.437-2.874-1.581-4.948Zm-2.733-1.5h2.733c.144-2.074.866-3.756 1.58-4.948.12-.197.237-.381.353-.552a6.507 6.507 0 0 0-4.666 5.5Zm10.181 1.5c-.144 2.074-.866 3.756-1.58 4.948-.12.197-.237.381-.353.552a6.507 6.507 0 0 0 4.666-5.5Zm2.733-1.5a6.507 6.507 0 0 0-4.666-5.5c.123.181.24.365.353.552.714 1.192 1.436 2.874 1.58 4.948Z"></path>
+</svg>
+</template>
+
+<template id="issue-opened-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-issue-opened">
+    <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path>
+</svg>
+</template>
+
+<template id="device-mobile-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-device-mobile">
+    <path d="M3.75 0h8.5C13.216 0 14 .784 14 1.75v12.5A1.75 1.75 0 0 1 12.25 16h-8.5A1.75 1.75 0 0 1 2 14.25V1.75C2 .784 2.784 0 3.75 0ZM3.5 1.75v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25ZM8 13a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+</svg>
+</template>
+
+<template id="package-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+</template>
+
+<template id="credit-card-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-credit-card">
+    <path d="M10.75 9a.75.75 0 0 0 0 1.5h1.5a.75.75 0 0 0 0-1.5h-1.5Z"></path><path d="M0 3.75C0 2.784.784 2 1.75 2h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 14H1.75A1.75 1.75 0 0 1 0 12.25ZM14.5 6.5h-13v5.75c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25Zm0-2.75a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25V5h13Z"></path>
+</svg>
+</template>
+
+<template id="play-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-play">
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z"></path>
+</svg>
+</template>
+
+<template id="gift-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-gift">
+    <path d="M2 2.75A2.75 2.75 0 0 1 4.75 0c.983 0 1.873.42 2.57 1.232.268.318.497.668.68 1.042.183-.375.411-.725.68-1.044C9.376.42 10.266 0 11.25 0a2.75 2.75 0 0 1 2.45 4h.55c.966 0 1.75.784 1.75 1.75v2c0 .698-.409 1.301-1 1.582v4.918A1.75 1.75 0 0 1 13.25 16H2.75A1.75 1.75 0 0 1 1 14.25V9.332C.409 9.05 0 8.448 0 7.75v-2C0 4.784.784 4 1.75 4h.55c-.192-.375-.3-.8-.3-1.25ZM7.25 9.5H2.5v4.75c0 .138.112.25.25.25h4.5Zm1.5 0v5h4.5a.25.25 0 0 0 .25-.25V9.5Zm0-4V8h5.5a.25.25 0 0 0 .25-.25v-2a.25.25 0 0 0-.25-.25Zm-7 0a.25.25 0 0 0-.25.25v2c0 .138.112.25.25.25h5.5V5.5h-5.5Zm3-4a1.25 1.25 0 0 0 0 2.5h2.309c-.233-.818-.542-1.401-.878-1.793-.43-.502-.915-.707-1.431-.707ZM8.941 4h2.309a1.25 1.25 0 0 0 0-2.5c-.516 0-1 .205-1.43.707-.337.392-.646.975-.879 1.793Z"></path>
+</svg>
+</template>
+
+<template id="code-square-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code-square">
+    <path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25Zm7.47 3.97a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L10.69 8 9.22 6.53a.75.75 0 0 1 0-1.06ZM6.78 6.53 5.31 8l1.47 1.47a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215l-2-2a.75.75 0 0 1 0-1.06l2-2a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
+</svg>
+</template>
+
+<template id="device-desktop-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-device-desktop">
+    <path d="M14.25 1c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12h-3.727c.099 1.041.52 1.872 1.292 2.757A.752.752 0 0 1 11.25 16h-6.5a.75.75 0 0 1-.565-1.243c.772-.885 1.192-1.716 1.292-2.757H1.75A1.75 1.75 0 0 1 0 10.25v-7.5C0 1.784.784 1 1.75 1ZM1.75 2.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25ZM9.018 12H6.982a5.72 5.72 0 0 1-.765 2.5h3.566a5.72 5.72 0 0 1-.765-2.5Z"></path>
+</svg>
+</template>
+
+        <div class="position-relative">
+                <ul
+                  role="listbox"
+                  class="ActionListWrap QueryBuilder-ListWrap"
+                  aria-label="Suggestions"
+                  data-action="
+                    combobox-commit:query-builder#comboboxCommit
+                    mousedown:query-builder#resultsMousedown
+                  "
+                  data-target="query-builder.resultsList"
+                  data-persist-list=false
+                  id="query-builder-test-results"
+                ></ul>
+        </div>
+      <div class="FormControl-inlineValidation" id="validation-f4d831d7-7db4-4b63-bf4c-924f9551702f" hidden="hidden">
+        <span class="FormControl-inlineValidation--visual">
+          <svg aria-hidden="true" height="12" viewBox="0 0 12 12" version="1.1" width="12" data-view-component="true" class="octicon octicon-alert-fill">
+    <path d="M4.855.708c.5-.896 1.79-.896 2.29 0l4.675 8.351a1.312 1.312 0 0 1-1.146 1.954H1.33A1.313 1.313 0 0 1 .183 9.058ZM7 7V3H5v4Zm-1 3a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"></path>
+</svg>
+        </span>
+        <span></span>
+</div>    </div>
+    <div data-target="query-builder.screenReaderFeedback" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+</query-builder></form>
+          <div class="d-flex flex-row color-fg-muted px-3 text-small color-bg-default search-feedback-prompt">
+            <a target="_blank" href="https://docs.github.com/search-github/github-code-search/understanding-github-code-search-syntax" data-view-component="true" class="Link color-fg-accent text-normal ml-2">
+              Search syntax tips
+</a>            <div class="d-flex flex-1"></div>
+          </div>
+        </div>
+</div>
+
+    </div>
+</modal-dialog></div>
+  </div>
+  <div data-action="click:qbsearch-input#retract" class="dark-backdrop position-fixed" hidden data-target="qbsearch-input.darkBackdrop"></div>
+  <div class="color-fg-default">
+    
+<dialog-helper>
+  <dialog data-target="qbsearch-input.feedbackDialog" data-action="close:qbsearch-input#handleDialogClose cancel:qbsearch-input#handleDialogClose" id="feedback-dialog" aria-modal="true" aria-labelledby="feedback-dialog-title" aria-describedby="feedback-dialog-description" data-view-component="true" class="Overlay Overlay-whenNarrow Overlay--size-medium Overlay--motion-scaleFade">
+    <div data-view-component="true" class="Overlay-header">
+  <div class="Overlay-headerContentWrap">
+    <div class="Overlay-titleWrap">
+      <h1 class="Overlay-title " id="feedback-dialog-title">
+        Provide feedback
+      </h1>
+    </div>
+    <div class="Overlay-actionWrap">
+      <button data-close-dialog-id="feedback-dialog" aria-label="Close" type="button" data-view-component="true" class="close-button Overlay-closeButton"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg></button>
+    </div>
+  </div>
+</div>
+      <scrollable-region data-labelled-by="feedback-dialog-title">
+        <div data-view-component="true" class="Overlay-body">        <!-- '"` --><!-- </textarea></xmp> --></option></form><form id="code-search-feedback-form" data-turbo="false" action="/search/feedback" accept-charset="UTF-8" method="post"><input type="hidden" data-csrf="true" name="authenticity_token" value="swqFThf79dN9NvdSEl0Sni+odDdnJUzLFuGl5KQLuwg5HRLLtANMzRQB3nNjZN3D6vwyW97VLI7bBxKbsgtEdw==" />
+          <p>We read every piece of feedback, and take your input very seriously.</p>
+          <textarea name="feedback" class="form-control width-full mb-2" style="height: 120px" id="feedback"></textarea>
+          <input name="include_email" id="include_email" aria-label="Include my email address so I can be contacted" class="form-control mr-2" type="checkbox">
+          <label for="include_email" style="font-weight: normal">Include my email address so I can be contacted</label>
+</form></div>
+      </scrollable-region>
+      <div data-view-component="true" class="Overlay-footer Overlay-footer--alignEnd">          <button data-close-dialog-id="feedback-dialog" type="button" data-view-component="true" class="btn">    Cancel
+</button>
+          <button form="code-search-feedback-form" data-action="click:qbsearch-input#submitFeedback" type="submit" data-view-component="true" class="btn-primary btn">    Submit feedback
+</button>
+</div>
+</dialog></dialog-helper>
+
+    <custom-scopes data-target="qbsearch-input.customScopesManager">
+    
+<dialog-helper>
+  <dialog data-target="custom-scopes.customScopesModalDialog" data-action="close:qbsearch-input#handleDialogClose cancel:qbsearch-input#handleDialogClose" id="custom-scopes-dialog" aria-modal="true" aria-labelledby="custom-scopes-dialog-title" aria-describedby="custom-scopes-dialog-description" data-view-component="true" class="Overlay Overlay-whenNarrow Overlay--size-medium Overlay--motion-scaleFade">
+    <div data-view-component="true" class="Overlay-header Overlay-header--divided">
+  <div class="Overlay-headerContentWrap">
+    <div class="Overlay-titleWrap">
+      <h1 class="Overlay-title " id="custom-scopes-dialog-title">
+        Saved searches
+      </h1>
+        <h2 id="custom-scopes-dialog-description" class="Overlay-description">Use saved searches to filter your results more quickly</h2>
+    </div>
+    <div class="Overlay-actionWrap">
+      <button data-close-dialog-id="custom-scopes-dialog" aria-label="Close" type="button" data-view-component="true" class="close-button Overlay-closeButton"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg></button>
+    </div>
+  </div>
+</div>
+      <scrollable-region data-labelled-by="custom-scopes-dialog-title">
+        <div data-view-component="true" class="Overlay-body">        <div data-target="custom-scopes.customScopesModalDialogFlash"></div>
+
+        <div hidden class="create-custom-scope-form" data-target="custom-scopes.createCustomScopeForm">
+        <!-- '"` --><!-- </textarea></xmp> --></option></form><form id="custom-scopes-dialog-form" data-turbo="false" action="/search/custom_scopes" accept-charset="UTF-8" method="post"><input type="hidden" data-csrf="true" name="authenticity_token" value="+Ada5KMK/WQ+j1po+C07QwrZ3Ef7o0GfT4MFWdUBsmWaeob9X+K8KgHmHRbFmBBd/EO8Px9r/Rm9uFQelBPggA==" />
+          <div data-target="custom-scopes.customScopesModalDialogFlash"></div>
+
+          <input type="hidden" id="custom_scope_id" name="custom_scope_id" data-target="custom-scopes.customScopesIdField">
+
+          <div class="form-group">
+            <label for="custom_scope_name">Name</label>
+            <auto-check src="/search/custom_scopes/check_name" required>
+              <input
+                type="text"
+                name="custom_scope_name"
+                id="custom_scope_name"
+                data-target="custom-scopes.customScopesNameField"
+                class="form-control"
+                autocomplete="off"
+                placeholder="github-ruby"
+                required
+                maxlength="50">
+              <input type="hidden" data-csrf="true" value="hefFleUmJqqPGgekD/bENcPYwTS6YSQmqN7ke52QdazVn4TTtn1UQsTXuKygqyPHALzdulvT9eV39IbuqNOZBw==" />
+            </auto-check>
+          </div>
+
+          <div class="form-group">
+            <label for="custom_scope_query">Query</label>
+            <input
+              type="text"
+              name="custom_scope_query"
+              id="custom_scope_query"
+              data-target="custom-scopes.customScopesQueryField"
+              class="form-control"
+              autocomplete="off"
+              placeholder="(repo:mona/a OR repo:mona/b) AND lang:python"
+              required
+              maxlength="500">
+          </div>
+
+          <p class="text-small color-fg-muted">
+            To see all available qualifiers, see our <a class="Link--inTextBlock" href="https://docs.github.com/search-github/github-code-search/understanding-github-code-search-syntax">documentation</a>.
+          </p>
+</form>        </div>
+
+        <div data-target="custom-scopes.manageCustomScopesForm">
+          <div data-target="custom-scopes.list"></div>
+        </div>
+
+</div>
+      </scrollable-region>
+      <div data-view-component="true" class="Overlay-footer Overlay-footer--alignEnd Overlay-footer--divided">          <button data-action="click:custom-scopes#customScopesCancel" type="button" data-view-component="true" class="btn">    Cancel
+</button>
+          <button form="custom-scopes-dialog-form" data-action="click:custom-scopes#customScopesSubmit" data-target="custom-scopes.customScopesSubmitButton" type="submit" data-view-component="true" class="btn-primary btn">    Create saved search
+</button>
+</div>
+</dialog></dialog-helper>
+    </custom-scopes>
+  </div>
+</qbsearch-input><input type="hidden" data-csrf="true" class="js-data-jump-to-suggestions-path-csrf" value="eMxZCc6ICmJuBekcYQ74fRU3/0wtMrbjd3lpg2R+S5dcUDyl7i8zR84Jwqn3+ABHayF2y7OQ3yy6GOHt8GZWuw==" />
+
+
+          <div class="position-relative mr-lg-3 d-lg-inline-block">
+            <a href="/login?return_to=https%3A%2F%2Fgithub.com%2Fbitcoin%2Fbips%2Fblob%2Fmaster%2Fbip-0341%2Fwallet-test-vectors.json"
+              class="HeaderMenu-link HeaderMenu-link--sign-in flex-shrink-0 no-underline d-block d-lg-inline-block border border-lg-0 rounded rounded-lg-0 p-2 p-lg-0"
+              data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="e3eeb14657e31f8e374c5918df8787078a0f6a39d7a1c1da8498d77997771dd5"
+              data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">
+              Sign in
+            </a>
+          </div>
+
+            <a href="/signup?ref_cta=Sign+up&amp;ref_loc=header+logged+out&amp;ref_page=%2F%3Cuser-name%3E%2F%3Crepo-name%3E%2Fblob%2Fshow&amp;source=header-repo&amp;source_repo=bitcoin%2Fbips"
+              class="HeaderMenu-link HeaderMenu-link--sign-up flex-shrink-0 d-none d-lg-inline-block no-underline border color-border-default rounded px-2 py-1"
+              data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="e3eeb14657e31f8e374c5918df8787078a0f6a39d7a1c1da8498d77997771dd5"
+              data-analytics-event="{&quot;category&quot;:&quot;Sign up&quot;,&quot;action&quot;:&quot;click to sign up for account&quot;,&quot;label&quot;:&quot;ref_page:/&lt;user-name&gt;/&lt;repo-name&gt;/blob/show;ref_cta:Sign up;ref_loc:header logged out&quot;}"
+            >
+              Sign up
+            </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+      <div hidden="hidden" data-view-component="true" class="js-stale-session-flash stale-session-flash flash flash-warn flash-full mb-3">
+  
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-alert">
+    <path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+        <span class="js-stale-session-flash-signed-in" hidden>You signed in with another tab or window. <a class="Link--inTextBlock" href="">Reload</a> to refresh your session.</span>
+        <span class="js-stale-session-flash-signed-out" hidden>You signed out in another tab or window. <a class="Link--inTextBlock" href="">Reload</a> to refresh your session.</span>
+        <span class="js-stale-session-flash-switched" hidden>You switched accounts on another tab or window. <a class="Link--inTextBlock" href="">Reload</a> to refresh your session.</span>
+
+    <button id="icon-button-0728729c-97e2-4a79-b92f-288d245f8744" aria-labelledby="tooltip-d7cd8867-7570-487d-a309-af6add924fff" type="button" data-view-component="true" class="Button Button--iconOnly Button--invisible Button--medium flash-close js-flash-close">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x Button-visual">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+</button><tool-tip id="tooltip-d7cd8867-7570-487d-a309-af6add924fff" for="icon-button-0728729c-97e2-4a79-b92f-288d245f8744" popover="manual" data-direction="s" data-type="label" data-view-component="true" class="sr-only position-absolute">Dismiss alert</tool-tip>
+
+
+  
+</div>
+    </div>
+
+  <div id="start-of-content" class="show-on-focus"></div>
+
+
+
+
+
+
+
+
+    <div id="js-flash-container" data-turbo-replace>
+
+
+
+
+
+  <template class="js-flash-template">
+    
+<div class="flash flash-full   {{ className }}">
+  <div >
+    <button autofocus class="flash-close js-flash-close" type="button" aria-label="Dismiss this message">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+    </button>
+    <div aria-atomic="true" role="alert" class="js-flash-alert">
+      
+      <div>{{ message }}</div>
+
+    </div>
+  </div>
+</div>
+  </template>
+</div>
+
+
+    
+    <include-fragment class="js-notification-shelf-include-fragment" data-base-src="https://github.com/notifications/beta/shelf"></include-fragment>
+
+
+
+
+
+  <div
+    class="application-main "
+    data-commit-hovercards-enabled
+    data-discussion-hovercards-enabled
+    data-issue-and-pr-hovercards-enabled
+  >
+        <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
+    <main id="js-repo-pjax-container" >
+      
+      
+    
+
+    
+
+
+
+
+
+
+  
+  <div id="repository-container-header"  class="pt-3 hide-full-screen" style="background-color: var(--page-header-bgColor, var(--color-page-header-bg));" data-turbo-replace>
+
+      <div class="d-flex flex-wrap flex-justify-end mb-3  px-3 px-md-4 px-lg-5" style="gap: 1rem;">
+
+        <div class="flex-auto min-width-0 width-fit mr-3">
+            
+  <div class=" d-flex flex-wrap flex-items-center wb-break-word f3 text-normal">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo color-fg-muted mr-2">
+    <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path>
+</svg>
+    
+    <span class="author flex-self-stretch" itemprop="author">
+      <a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/bitcoin/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/bitcoin">
+        bitcoin
+</a>    </span>
+    <span class="mx-1 flex-self-stretch color-fg-muted">/</span>
+    <strong itemprop="name" class="mr-2 flex-self-stretch">
+      <a data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" href="/bitcoin/bips">bips</a>
+    </strong>
+
+    <span></span><span class="Label Label--secondary v-align-middle mr-1">Public</span>
+  </div>
+
+
+        </div>
+
+        <div id="repository-details-container" data-turbo-replace>
+            <ul class="pagehead-actions flex-shrink-0 d-none d-md-inline" style="padding: 2px 0;">
+    
+      
+
+  <li>
+            <a href="/login?return_to=%2Fbitcoin%2Fbips" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;notification subscription menu watch&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="7d713c29a1774cb3cff48555cc375b866f7aa57431aae7b88300a15dbf55f072" aria-label="You must be signed in to change notification settings" data-view-component="true" class="tooltipped tooltipped-s btn-sm btn">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-bell mr-2">
+    <path d="M8 16a2 2 0 0 0 1.985-1.75c.017-.137-.097-.25-.235-.25h-3.5c-.138 0-.252.113-.235.25A2 2 0 0 0 8 16ZM3 5a5 5 0 0 1 10 0v2.947c0 .05.015.098.042.139l1.703 2.555A1.519 1.519 0 0 1 13.482 13H2.518a1.516 1.516 0 0 1-1.263-2.36l1.703-2.554A.255.255 0 0 0 3 7.947Zm5-3.5A3.5 3.5 0 0 0 4.5 5v2.947c0 .346-.102.683-.294.97l-1.703 2.556a.017.017 0 0 0-.003.01l.001.006c0 .002.002.004.004.006l.006.004.007.001h10.964l.007-.001.006-.004.004-.006.001-.007a.017.017 0 0 0-.003-.01l-1.703-2.554a1.745 1.745 0 0 1-.294-.97V5A3.5 3.5 0 0 0 8 1.5Z"></path>
+</svg>Notifications
+</a>
+  </li>
+
+  <li>
+          <a icon="repo-forked" id="fork-button" href="/login?return_to=%2Fbitcoin%2Fbips" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;repo details fork button&quot;,&quot;repository_id&quot;:14531737,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="6074025b10affa938344bb4274491d4f739d03f1be8bcb976548f369ec1e7637" data-view-component="true" class="btn-sm btn">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo-forked mr-2">
+    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"></path>
+</svg>Fork
+    <span id="repo-network-counter" data-pjax-replace="true" data-turbo-replace="true" title="5,217" data-view-component="true" class="Counter">5.2k</span>
+</a>
+  </li>
+
+  <li>
+        <div data-view-component="true" class="BtnGroup d-flex">
+        <a href="/login?return_to=%2Fbitcoin%2Fbips" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;star button&quot;,&quot;repository_id&quot;:14531737,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="8834ed6c1b5af2e85b4700b61ace0e5d0750c87ef7089a9d6262a0696a56e0e6" aria-label="You must be signed in to star a repository" data-view-component="true" class="tooltipped tooltipped-s btn-sm btn BtnGroup-item">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-star v-align-text-bottom d-inline-block mr-2">
+    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z"></path>
+</svg><span data-view-component="true" class="d-inline">
+          Star
+</span>          <span id="repo-stars-counter-star" aria-label="8875 users starred this repository" data-singular-suffix="user starred this repository" data-plural-suffix="users starred this repository" data-turbo-replace="true" title="8,875" data-view-component="true" class="Counter js-social-count">8.9k</span>
+</a>        <button aria-label="You must be signed in to add this repository to a list" type="button" disabled="disabled" data-view-component="true" class="btn-sm btn BtnGroup-item px-2">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down">
+    <path d="m4.427 7.427 3.396 3.396a.25.25 0 0 0 .354 0l3.396-3.396A.25.25 0 0 0 11.396 7H4.604a.25.25 0 0 0-.177.427Z"></path>
+</svg>
+</button></div>
+  </li>
+
+    <li>
+        
+
+    </li>
+</ul>
+
+        </div>
+      </div>
+
+        <div id="responsive-meta-container" data-turbo-replace>
+</div>
+
+
+          <nav data-pjax="#js-repo-pjax-container" aria-label="Repository" data-view-component="true" class="js-repo-nav js-sidenav-container-pjax js-responsive-underlinenav overflow-hidden UnderlineNav px-3 px-md-4 px-lg-5">
+
+  <ul data-view-component="true" class="UnderlineNav-body list-style-none">
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="code-tab" href="/bitcoin/bips" data-tab-item="i0code-tab" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages repo_deployments repo_attestations /bitcoin/bips" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g c" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Code&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" aria-current="page" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item selected">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code UnderlineNav-octicon d-none d-sm-inline">
+    <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+        <span data-content="Code">Code</span>
+          <span id="code-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="pull-requests-tab" href="/bitcoin/bips/pulls" data-tab-item="i1pull-requests-tab" data-selected-links="repo_pulls checks /bitcoin/bips/pulls" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g p" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Pull requests&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-pull-request UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"></path>
+</svg>
+        <span data-content="Pull requests">Pull requests</span>
+          <span id="pull-requests-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="138" data-view-component="true" class="Counter">138</span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="actions-tab" href="/bitcoin/bips/actions" data-tab-item="i2actions-tab" data-selected-links="repo_actions /bitcoin/bips/actions" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g a" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Actions&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-play UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z"></path>
+</svg>
+        <span data-content="Actions">Actions</span>
+          <span id="actions-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="wiki-tab" href="/bitcoin/bips/wiki" data-tab-item="i3wiki-tab" data-selected-links="repo_wiki /bitcoin/bips/wiki" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g w" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Wiki&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-book UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"></path>
+</svg>
+        <span data-content="Wiki">Wiki</span>
+          <span id="wiki-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="security-tab" href="/bitcoin/bips/security" data-tab-item="i4security-tab" data-selected-links="security overview alerts policy token_scanning code_scanning /bitcoin/bips/security" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g s" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Security&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-shield UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M7.467.133a1.748 1.748 0 0 1 1.066 0l5.25 1.68A1.75 1.75 0 0 1 15 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.697 1.697 0 0 1-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 0 1 1.217-1.667Zm.61 1.429a.25.25 0 0 0-.153 0l-5.25 1.68a.25.25 0 0 0-.174.238V7c0 1.358.275 2.666 1.057 3.86.784 1.194 2.121 2.34 4.366 3.297a.196.196 0 0 0 .154 0c2.245-.956 3.582-2.104 4.366-3.298C13.225 9.666 13.5 8.36 13.5 7V3.48a.251.251 0 0 0-.174-.237l-5.25-1.68ZM8.75 4.75v3a.75.75 0 0 1-1.5 0v-3a.75.75 0 0 1 1.5 0ZM9 10.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+        <span data-content="Security">Security</span>
+          <include-fragment src="/bitcoin/bips/security/overall-count" accept="text/fragment+html"></include-fragment>
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="insights-tab" href="/bitcoin/bips/pulse" data-tab-item="i5insights-tab" data-selected-links="repo_graphs repo_contributors dependency_graph dependabot_updates pulse people community /bitcoin/bips/pulse" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Insights&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-graph UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M1.5 1.75V13.5h13.75a.75.75 0 0 1 0 1.5H.75a.75.75 0 0 1-.75-.75V1.75a.75.75 0 0 1 1.5 0Zm14.28 2.53-5.25 5.25a.75.75 0 0 1-1.06 0L7 7.06 4.28 9.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.25-3.25a.75.75 0 0 1 1.06 0L10 7.94l4.72-4.72a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
+</svg>
+        <span data-content="Insights">Insights</span>
+          <span id="insights-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+</ul>
+    <div style="visibility:hidden;" data-view-component="true" class="UnderlineNav-actions js-responsive-underlinenav-overflow position-absolute pr-3 pr-md-4 pr-lg-5 right-0">      <action-menu data-select-variant="none" data-view-component="true">
+  <focus-group direction="vertical" mnemonics retain>
+    <button id="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-button" popovertarget="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-overlay" aria-controls="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-list" aria-haspopup="true" aria-labelledby="tooltip-1bdf5c40-f9b2-4dfb-b2d9-c6f55b2e6dcf" type="button" data-view-component="true" class="Button Button--iconOnly Button--secondary Button--medium UnderlineNav-item">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-kebab-horizontal Button-visual">
+    <path d="M8 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm13 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path>
+</svg>
+</button><tool-tip id="tooltip-1bdf5c40-f9b2-4dfb-b2d9-c6f55b2e6dcf" for="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-button" popover="manual" data-direction="s" data-type="label" data-view-component="true" class="sr-only position-absolute">Additional navigation options</tool-tip>
+
+
+<anchored-position id="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-overlay" anchor="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-button" align="start" side="outside-bottom" anchor-offset="normal" popover="auto" data-view-component="true">
+  <div data-view-component="true" class="Overlay Overlay--size-auto">
+    
+      <div data-view-component="true" class="Overlay-body Overlay-body--paddingNone">          <action-list>
+  <div data-view-component="true">
+    <ul aria-labelledby="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-button" id="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-list" role="menu" data-view-component="true" class="ActionListWrap--inset ActionListWrap">
+        <li hidden="hidden" data-menu-item="i0code-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    <a tabindex="-1" id="item-68a80e29-e9b6-4a1d-8dd3-120927cf8331" href="/bitcoin/bips" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code">
+    <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Code
+</span></a>
+  
+  
+</li>
+        <li hidden="hidden" data-menu-item="i1pull-requests-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    <a tabindex="-1" id="item-19f23caf-e281-47f9-9917-f87e1a3661a3" href="/bitcoin/bips/pulls" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-pull-request">
+    <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Pull requests
+</span></a>
+  
+  
+</li>
+        <li hidden="hidden" data-menu-item="i2actions-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    <a tabindex="-1" id="item-e9ce0e41-2365-4257-abaa-9a7e8faaee4a" href="/bitcoin/bips/actions" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-play">
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Actions
+</span></a>
+  
+  
+</li>
+        <li hidden="hidden" data-menu-item="i3wiki-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    <a tabindex="-1" id="item-d922dcdf-cfb6-4a4a-a99a-291cf8389c97" href="/bitcoin/bips/wiki" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-book">
+    <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Wiki
+</span></a>
+  
+  
+</li>
+        <li hidden="hidden" data-menu-item="i4security-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    <a tabindex="-1" id="item-57a2b497-2c6e-4143-b7f7-6906f27c20ad" href="/bitcoin/bips/security" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-shield">
+    <path d="M7.467.133a1.748 1.748 0 0 1 1.066 0l5.25 1.68A1.75 1.75 0 0 1 15 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.697 1.697 0 0 1-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 0 1 1.217-1.667Zm.61 1.429a.25.25 0 0 0-.153 0l-5.25 1.68a.25.25 0 0 0-.174.238V7c0 1.358.275 2.666 1.057 3.86.784 1.194 2.121 2.34 4.366 3.297a.196.196 0 0 0 .154 0c2.245-.956 3.582-2.104 4.366-3.298C13.225 9.666 13.5 8.36 13.5 7V3.48a.251.251 0 0 0-.174-.237l-5.25-1.68ZM8.75 4.75v3a.75.75 0 0 1-1.5 0v-3a.75.75 0 0 1 1.5 0ZM9 10.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Security
+</span></a>
+  
+  
+</li>
+        <li hidden="hidden" data-menu-item="i5insights-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    <a tabindex="-1" id="item-b5435faa-8cf2-485b-8621-cd527f81344f" href="/bitcoin/bips/pulse" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-graph">
+    <path d="M1.5 1.75V13.5h13.75a.75.75 0 0 1 0 1.5H.75a.75.75 0 0 1-.75-.75V1.75a.75.75 0 0 1 1.5 0Zm14.28 2.53-5.25 5.25a.75.75 0 0 1-1.06 0L7 7.06 4.28 9.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.25-3.25a.75.75 0 0 1 1.06 0L10 7.94l4.72-4.72a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Insights
+</span></a>
+  
+  
+</li>
+</ul>    
+</div></action-list>
+
+
+</div>
+      
+</div></anchored-position>  </focus-group>
+</action-menu></div>
+</nav>
+
+  </div>
+
+  
+
+
+
+<turbo-frame id="repo-content-turbo-frame" target="_top" data-turbo-action="advance" class="">
+    <div id="repo-content-pjax-container" class="repository-content " >
+    
+
+
+
+    
+      
+    
+
+
+
+
+
+<react-app
+  app-name="react-code-view"
+  initial-path="/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json"
+  style="min-height: calc(100vh - 64px)" 
+  data-ssr="false"
+  data-lazy="false"
+  data-alternate="false"
+>
+  
+  <script type="application/json" data-target="react-app.embeddedData">{"payload":{"allShortcutsEnabled":false,"fileTree":{"bip-0341":{"items":[{"name":"tree.png","path":"bip-0341/tree.png","contentType":"file"},{"name":"wallet-test-vectors.json","path":"bip-0341/wallet-test-vectors.json","contentType":"file"}],"totalCount":2},"":{"items":[{"name":".github","path":".github","contentType":"directory"},{"name":"bip-0001","path":"bip-0001","contentType":"directory"},{"name":"bip-0002","path":"bip-0002","contentType":"directory"},{"name":"bip-0008","path":"bip-0008","contentType":"directory"},{"name":"bip-0009","path":"bip-0009","contentType":"directory"},{"name":"bip-0016","path":"bip-0016","contentType":"directory"},{"name":"bip-0032","path":"bip-0032","contentType":"directory"},{"name":"bip-0039","path":"bip-0039","contentType":"directory"},{"name":"bip-0042","path":"bip-0042","contentType":"directory"},{"name":"bip-0047","path":"bip-0047","contentType":"directory"},{"name":"bip-0052","path":"bip-0052","contentType":"directory"},{"name":"bip-0068","path":"bip-0068","contentType":"directory"},{"name":"bip-0069","path":"bip-0069","contentType":"directory"},{"name":"bip-0070","path":"bip-0070","contentType":"directory"},{"name":"bip-0073","path":"bip-0073","contentType":"directory"},{"name":"bip-0075","path":"bip-0075","contentType":"directory"},{"name":"bip-0098","path":"bip-0098","contentType":"directory"},{"name":"bip-0114","path":"bip-0114","contentType":"directory"},{"name":"bip-0119","path":"bip-0119","contentType":"directory"},{"name":"bip-0122","path":"bip-0122","contentType":"directory"},{"name":"bip-0135","path":"bip-0135","contentType":"directory"},{"name":"bip-0144","path":"bip-0144","contentType":"directory"},{"name":"bip-0152","path":"bip-0152","contentType":"directory"},{"name":"bip-0156","path":"bip-0156","contentType":"directory"},{"name":"bip-0158","path":"bip-0158","contentType":"directory"},{"name":"bip-0174","path":"bip-0174","contentType":"directory"},{"name":"bip-0300","path":"bip-0300","contentType":"directory"},{"name":"bip-0301","path":"bip-0301","contentType":"directory"},{"name":"bip-0324","path":"bip-0324","contentType":"directory"},{"name":"bip-0327","path":"bip-0327","contentType":"directory"},{"name":"bip-0330","path":"bip-0330","contentType":"directory"},{"name":"bip-0340","path":"bip-0340","contentType":"directory"},{"name":"bip-0341","path":"bip-0341","contentType":"directory"},{"name":"bip-0345","path":"bip-0345","contentType":"directory"},{"name":"scripts","path":"scripts","contentType":"directory"},{"name":".gitattributes","path":".gitattributes","contentType":"file"},{"name":"README.mediawiki","path":"README.mediawiki","contentType":"file"},{"name":"bip-0001.mediawiki","path":"bip-0001.mediawiki","contentType":"file"},{"name":"bip-0002.mediawiki","path":"bip-0002.mediawiki","contentType":"file"},{"name":"bip-0008.mediawiki","path":"bip-0008.mediawiki","contentType":"file"},{"name":"bip-0009.mediawiki","path":"bip-0009.mediawiki","contentType":"file"},{"name":"bip-0010.mediawiki","path":"bip-0010.mediawiki","contentType":"file"},{"name":"bip-0011.mediawiki","path":"bip-0011.mediawiki","contentType":"file"},{"name":"bip-0012.mediawiki","path":"bip-0012.mediawiki","contentType":"file"},{"name":"bip-0013.mediawiki","path":"bip-0013.mediawiki","contentType":"file"},{"name":"bip-0014.mediawiki","path":"bip-0014.mediawiki","contentType":"file"},{"name":"bip-0015.mediawiki","path":"bip-0015.mediawiki","contentType":"file"},{"name":"bip-0016.mediawiki","path":"bip-0016.mediawiki","contentType":"file"},{"name":"bip-0017.mediawiki","path":"bip-0017.mediawiki","contentType":"file"},{"name":"bip-0018.mediawiki","path":"bip-0018.mediawiki","contentType":"file"},{"name":"bip-0019.mediawiki","path":"bip-0019.mediawiki","contentType":"file"},{"name":"bip-0020.mediawiki","path":"bip-0020.mediawiki","contentType":"file"},{"name":"bip-0021.mediawiki","path":"bip-0021.mediawiki","contentType":"file"},{"name":"bip-0022.mediawiki","path":"bip-0022.mediawiki","contentType":"file"},{"name":"bip-0023.mediawiki","path":"bip-0023.mediawiki","contentType":"file"},{"name":"bip-0030.mediawiki","path":"bip-0030.mediawiki","contentType":"file"},{"name":"bip-0031.mediawiki","path":"bip-0031.mediawiki","contentType":"file"},{"name":"bip-0032.mediawiki","path":"bip-0032.mediawiki","contentType":"file"},{"name":"bip-0033.mediawiki","path":"bip-0033.mediawiki","contentType":"file"},{"name":"bip-0034.mediawiki","path":"bip-0034.mediawiki","contentType":"file"},{"name":"bip-0035.mediawiki","path":"bip-0035.mediawiki","contentType":"file"},{"name":"bip-0036.mediawiki","path":"bip-0036.mediawiki","contentType":"file"},{"name":"bip-0037.mediawiki","path":"bip-0037.mediawiki","contentType":"file"},{"name":"bip-0038.mediawiki","path":"bip-0038.mediawiki","contentType":"file"},{"name":"bip-0039.mediawiki","path":"bip-0039.mediawiki","contentType":"file"},{"name":"bip-0042.mediawiki","path":"bip-0042.mediawiki","contentType":"file"},{"name":"bip-0043.mediawiki","path":"bip-0043.mediawiki","contentType":"file"},{"name":"bip-0044.mediawiki","path":"bip-0044.mediawiki","contentType":"file"},{"name":"bip-0045.mediawiki","path":"bip-0045.mediawiki","contentType":"file"},{"name":"bip-0047.mediawiki","path":"bip-0047.mediawiki","contentType":"file"},{"name":"bip-0048.mediawiki","path":"bip-0048.mediawiki","contentType":"file"},{"name":"bip-0049.mediawiki","path":"bip-0049.mediawiki","contentType":"file"},{"name":"bip-0050.mediawiki","path":"bip-0050.mediawiki","contentType":"file"},{"name":"bip-0052.mediawiki","path":"bip-0052.mediawiki","contentType":"file"},{"name":"bip-0060.mediawiki","path":"bip-0060.mediawiki","contentType":"file"},{"name":"bip-0061.mediawiki","path":"bip-0061.mediawiki","contentType":"file"},{"name":"bip-0062.mediawiki","path":"bip-0062.mediawiki","contentType":"file"},{"name":"bip-0064.mediawiki","path":"bip-0064.mediawiki","contentType":"file"},{"name":"bip-0065.mediawiki","path":"bip-0065.mediawiki","contentType":"file"},{"name":"bip-0066.mediawiki","path":"bip-0066.mediawiki","contentType":"file"},{"name":"bip-0067.mediawiki","path":"bip-0067.mediawiki","contentType":"file"},{"name":"bip-0068.mediawiki","path":"bip-0068.mediawiki","contentType":"file"},{"name":"bip-0069.mediawiki","path":"bip-0069.mediawiki","contentType":"file"},{"name":"bip-0070.mediawiki","path":"bip-0070.mediawiki","contentType":"file"},{"name":"bip-0071.mediawiki","path":"bip-0071.mediawiki","contentType":"file"},{"name":"bip-0072.mediawiki","path":"bip-0072.mediawiki","contentType":"file"},{"name":"bip-0073.mediawiki","path":"bip-0073.mediawiki","contentType":"file"},{"name":"bip-0074.mediawiki","path":"bip-0074.mediawiki","contentType":"file"},{"name":"bip-0075.mediawiki","path":"bip-0075.mediawiki","contentType":"file"},{"name":"bip-0078.mediawiki","path":"bip-0078.mediawiki","contentType":"file"},{"name":"bip-0079.mediawiki","path":"bip-0079.mediawiki","contentType":"file"},{"name":"bip-0080.mediawiki","path":"bip-0080.mediawiki","contentType":"file"},{"name":"bip-0081.mediawiki","path":"bip-0081.mediawiki","contentType":"file"},{"name":"bip-0083.mediawiki","path":"bip-0083.mediawiki","contentType":"file"},{"name":"bip-0084.mediawiki","path":"bip-0084.mediawiki","contentType":"file"},{"name":"bip-0085.mediawiki","path":"bip-0085.mediawiki","contentType":"file"},{"name":"bip-0086.mediawiki","path":"bip-0086.mediawiki","contentType":"file"},{"name":"bip-0087.mediawiki","path":"bip-0087.mediawiki","contentType":"file"},{"name":"bip-0088.mediawiki","path":"bip-0088.mediawiki","contentType":"file"},{"name":"bip-0090.mediawiki","path":"bip-0090.mediawiki","contentType":"file"},{"name":"bip-0091.mediawiki","path":"bip-0091.mediawiki","contentType":"file"},{"name":"bip-0093.mediawiki","path":"bip-0093.mediawiki","contentType":"file"},{"name":"bip-0098.mediawiki","path":"bip-0098.mediawiki","contentType":"file"},{"name":"bip-0099.mediawiki","path":"bip-0099.mediawiki","contentType":"file"},{"name":"bip-0100.mediawiki","path":"bip-0100.mediawiki","contentType":"file"},{"name":"bip-0101.mediawiki","path":"bip-0101.mediawiki","contentType":"file"},{"name":"bip-0102.mediawiki","path":"bip-0102.mediawiki","contentType":"file"},{"name":"bip-0103.mediawiki","path":"bip-0103.mediawiki","contentType":"file"},{"name":"bip-0104.mediawiki","path":"bip-0104.mediawiki","contentType":"file"},{"name":"bip-0105.mediawiki","path":"bip-0105.mediawiki","contentType":"file"},{"name":"bip-0106.mediawiki","path":"bip-0106.mediawiki","contentType":"file"},{"name":"bip-0107.mediawiki","path":"bip-0107.mediawiki","contentType":"file"},{"name":"bip-0109.mediawiki","path":"bip-0109.mediawiki","contentType":"file"},{"name":"bip-0111.mediawiki","path":"bip-0111.mediawiki","contentType":"file"},{"name":"bip-0112.mediawiki","path":"bip-0112.mediawiki","contentType":"file"},{"name":"bip-0113.mediawiki","path":"bip-0113.mediawiki","contentType":"file"},{"name":"bip-0114.mediawiki","path":"bip-0114.mediawiki","contentType":"file"},{"name":"bip-0115.mediawiki","path":"bip-0115.mediawiki","contentType":"file"},{"name":"bip-0116.mediawiki","path":"bip-0116.mediawiki","contentType":"file"},{"name":"bip-0117.mediawiki","path":"bip-0117.mediawiki","contentType":"file"},{"name":"bip-0118.mediawiki","path":"bip-0118.mediawiki","contentType":"file"},{"name":"bip-0119.mediawiki","path":"bip-0119.mediawiki","contentType":"file"},{"name":"bip-0120.mediawiki","path":"bip-0120.mediawiki","contentType":"file"},{"name":"bip-0121.mediawiki","path":"bip-0121.mediawiki","contentType":"file"},{"name":"bip-0122.mediawiki","path":"bip-0122.mediawiki","contentType":"file"},{"name":"bip-0123.mediawiki","path":"bip-0123.mediawiki","contentType":"file"},{"name":"bip-0124.mediawiki","path":"bip-0124.mediawiki","contentType":"file"},{"name":"bip-0125.mediawiki","path":"bip-0125.mediawiki","contentType":"file"},{"name":"bip-0126.mediawiki","path":"bip-0126.mediawiki","contentType":"file"},{"name":"bip-0127.mediawiki","path":"bip-0127.mediawiki","contentType":"file"},{"name":"bip-0129.mediawiki","path":"bip-0129.mediawiki","contentType":"file"},{"name":"bip-0130.mediawiki","path":"bip-0130.mediawiki","contentType":"file"},{"name":"bip-0131.mediawiki","path":"bip-0131.mediawiki","contentType":"file"},{"name":"bip-0132.mediawiki","path":"bip-0132.mediawiki","contentType":"file"},{"name":"bip-0133.mediawiki","path":"bip-0133.mediawiki","contentType":"file"},{"name":"bip-0134.mediawiki","path":"bip-0134.mediawiki","contentType":"file"},{"name":"bip-0135.mediawiki","path":"bip-0135.mediawiki","contentType":"file"},{"name":"bip-0136.mediawiki","path":"bip-0136.mediawiki","contentType":"file"},{"name":"bip-0137.mediawiki","path":"bip-0137.mediawiki","contentType":"file"},{"name":"bip-0140.mediawiki","path":"bip-0140.mediawiki","contentType":"file"},{"name":"bip-0141.mediawiki","path":"bip-0141.mediawiki","contentType":"file"},{"name":"bip-0142.mediawiki","path":"bip-0142.mediawiki","contentType":"file"},{"name":"bip-0143.mediawiki","path":"bip-0143.mediawiki","contentType":"file"},{"name":"bip-0144.mediawiki","path":"bip-0144.mediawiki","contentType":"file"},{"name":"bip-0145.mediawiki","path":"bip-0145.mediawiki","contentType":"file"},{"name":"bip-0146.mediawiki","path":"bip-0146.mediawiki","contentType":"file"},{"name":"bip-0147.mediawiki","path":"bip-0147.mediawiki","contentType":"file"},{"name":"bip-0148.mediawiki","path":"bip-0148.mediawiki","contentType":"file"},{"name":"bip-0149.mediawiki","path":"bip-0149.mediawiki","contentType":"file"},{"name":"bip-0150.mediawiki","path":"bip-0150.mediawiki","contentType":"file"},{"name":"bip-0151.mediawiki","path":"bip-0151.mediawiki","contentType":"file"},{"name":"bip-0152.mediawiki","path":"bip-0152.mediawiki","contentType":"file"},{"name":"bip-0154.mediawiki","path":"bip-0154.mediawiki","contentType":"file"},{"name":"bip-0155.mediawiki","path":"bip-0155.mediawiki","contentType":"file"},{"name":"bip-0156.mediawiki","path":"bip-0156.mediawiki","contentType":"file"},{"name":"bip-0157.mediawiki","path":"bip-0157.mediawiki","contentType":"file"},{"name":"bip-0158.mediawiki","path":"bip-0158.mediawiki","contentType":"file"},{"name":"bip-0159.mediawiki","path":"bip-0159.mediawiki","contentType":"file"},{"name":"bip-0171.mediawiki","path":"bip-0171.mediawiki","contentType":"file"},{"name":"bip-0173.mediawiki","path":"bip-0173.mediawiki","contentType":"file"},{"name":"bip-0174.mediawiki","path":"bip-0174.mediawiki","contentType":"file"},{"name":"bip-0175.mediawiki","path":"bip-0175.mediawiki","contentType":"file"},{"name":"bip-0176.mediawiki","path":"bip-0176.mediawiki","contentType":"file"},{"name":"bip-0178.mediawiki","path":"bip-0178.mediawiki","contentType":"file"},{"name":"bip-0179.mediawiki","path":"bip-0179.mediawiki","contentType":"file"},{"name":"bip-0180.mediawiki","path":"bip-0180.mediawiki","contentType":"file"},{"name":"bip-0197.mediawiki","path":"bip-0197.mediawiki","contentType":"file"},{"name":"bip-0199.mediawiki","path":"bip-0199.mediawiki","contentType":"file"},{"name":"bip-0300.mediawiki","path":"bip-0300.mediawiki","contentType":"file"},{"name":"bip-0301.mediawiki","path":"bip-0301.mediawiki","contentType":"file"},{"name":"bip-0310.mediawiki","path":"bip-0310.mediawiki","contentType":"file"},{"name":"bip-0320.mediawiki","path":"bip-0320.mediawiki","contentType":"file"},{"name":"bip-0322.mediawiki","path":"bip-0322.mediawiki","contentType":"file"},{"name":"bip-0324.mediawiki","path":"bip-0324.mediawiki","contentType":"file"},{"name":"bip-0325.mediawiki","path":"bip-0325.mediawiki","contentType":"file"},{"name":"bip-0326.mediawiki","path":"bip-0326.mediawiki","contentType":"file"},{"name":"bip-0327.mediawiki","path":"bip-0327.mediawiki","contentType":"file"},{"name":"bip-0329.mediawiki","path":"bip-0329.mediawiki","contentType":"file"},{"name":"bip-0330.mediawiki","path":"bip-0330.mediawiki","contentType":"file"},{"name":"bip-0338.mediawiki","path":"bip-0338.mediawiki","contentType":"file"},{"name":"bip-0339.mediawiki","path":"bip-0339.mediawiki","contentType":"file"},{"name":"bip-0340.mediawiki","path":"bip-0340.mediawiki","contentType":"file"},{"name":"bip-0341.mediawiki","path":"bip-0341.mediawiki","contentType":"file"},{"name":"bip-0342.mediawiki","path":"bip-0342.mediawiki","contentType":"file"},{"name":"bip-0343.mediawiki","path":"bip-0343.mediawiki","contentType":"file"},{"name":"bip-0345.mediawiki","path":"bip-0345.mediawiki","contentType":"file"},{"name":"bip-0350.mediawiki","path":"bip-0350.mediawiki","contentType":"file"},{"name":"bip-0351.mediawiki","path":"bip-0351.mediawiki","contentType":"file"},{"name":"bip-0370.mediawiki","path":"bip-0370.mediawiki","contentType":"file"},{"name":"bip-0371.mediawiki","path":"bip-0371.mediawiki","contentType":"file"},{"name":"bip-0372.mediawiki","path":"bip-0372.mediawiki","contentType":"file"},{"name":"bip-0380.mediawiki","path":"bip-0380.mediawiki","contentType":"file"},{"name":"bip-0381.mediawiki","path":"bip-0381.mediawiki","contentType":"file"},{"name":"bip-0382.mediawiki","path":"bip-0382.mediawiki","contentType":"file"},{"name":"bip-0383.mediawiki","path":"bip-0383.mediawiki","contentType":"file"},{"name":"bip-0384.mediawiki","path":"bip-0384.mediawiki","contentType":"file"},{"name":"bip-0385.mediawiki","path":"bip-0385.mediawiki","contentType":"file"},{"name":"bip-0386.mediawiki","path":"bip-0386.mediawiki","contentType":"file"},{"name":"bip-0389.mediawiki","path":"bip-0389.mediawiki","contentType":"file"}],"totalCount":199}},"fileTreeProcessingTime":29.015655000000002,"foldersToFetch":[],"repo":{"id":14531737,"defaultBranch":"master","name":"bips","ownerLogin":"bitcoin","currentUserCanPush":false,"isFork":false,"isEmpty":false,"createdAt":"2013-11-19T17:18:41.000Z","ownerAvatar":"https://avatars.githubusercontent.com/u/528860?v=4","public":true,"private":false,"isOrgOwned":true},"codeLineWrapEnabled":false,"symbolsExpanded":false,"treeExpanded":true,"refInfo":{"name":"master","listCacheKey":"v0:1708729485.0","canEdit":false,"refType":"branch","currentOid":"b3701faef2bdb98a0d7ace4eedbeefa2da4c89ed"},"path":"bip-0341/wallet-test-vectors.json","currentUser":null,"blob":{"rawLines":["{","    \"version\": 1,","    \"scriptPubKey\": [","        {","            \"given\": {","                \"internalPubkey\": \"d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d\",","                \"scriptTree\": null","            },","            \"intermediary\": {","                \"merkleRoot\": null,","                \"tweak\": \"b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70\",","                \"tweakedPubkey\": \"53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343\"","            },","            \"expected\": {","                \"scriptPubKey\": \"512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343\",","                \"bip350Address\": \"bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5\"","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27\",","                \"scriptTree\": {","                    \"id\": 0,","                    \"script\": \"20d85a959b0290bf19bb89ed43c916be835475d013da4b362117393e25a48229b8ac\",","                    \"leafVersion\": 192","                }","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21\"","                ],","                \"merkleRoot\": \"5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21\",","                \"tweak\": \"cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001\",","                \"tweakedPubkey\": \"147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3\"","            },","            \"expected\": {","                \"scriptPubKey\": \"5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3\",","                \"bip350Address\": \"bc1pz37fc4cn9ah8anwm4xqqhvxygjf9rjf2resrw8h8w4tmvcs0863sa2e586\",","                \"scriptPathControlBlocks\": [","                    \"c1187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27\"","                ]","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820\",","                \"scriptTree\": {","                    \"id\": 0,","                    \"script\": \"20b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007ac\",","                    \"leafVersion\": 192","                }","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b\"","                ],","                \"merkleRoot\": \"c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b\",","                \"tweak\": \"6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30\",","                \"tweakedPubkey\": \"e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e\"","            },","            \"expected\": {","                \"scriptPubKey\": \"5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e\",","                \"bip350Address\": \"bc1punvppl2stp38f7kwv2u2spltjuvuaayuqsthe34hd2dyy5w4g58qqfuag5\",","                \"scriptPathControlBlocks\": [","                    \"c093478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820\"","                ]","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592\",","                \"scriptTree\": [","                    {","                        \"id\": 0,","                        \"script\": \"20387671353e273264c495656e27e39ba899ea8fee3bb69fb2a680e22093447d48ac\",","                        \"leafVersion\": 192","                    },","                    {","                        \"id\": 1,","                        \"script\": \"06424950333431\",","                        \"leafVersion\": 250","                    }","                ]","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7\",","                    \"f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a\"","                ],","                \"merkleRoot\": \"6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef\",","                \"tweak\": \"9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9\",","                \"tweakedPubkey\": \"712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5\"","            },","            \"expected\": {","                \"scriptPubKey\": \"5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5\",","                \"bip350Address\": \"bc1pwyjywgrd0ffr3tx8laflh6228dj98xkjj8rum0zfpd6h0e930h6saqxrrm\",","                \"scriptPathControlBlocks\": [","                    \"c0ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a\",","                    \"faee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf37865928ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7\"","                ]","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8\",","                \"scriptTree\": [","                    {","                        \"id\": 0,","                        \"script\": \"2044b178d64c32c4a05cc4f4d1407268f764c940d20ce97abfd44db5c3592b72fdac\",","                        \"leafVersion\": 192","                    },","                    {","                        \"id\": 1,","                        \"script\": \"07546170726f6f74\",","                        \"leafVersion\": 192","                    }","                ]","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"64512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89\",","                    \"2cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb\"","                ],","                \"merkleRoot\": \"ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc\",","                \"tweak\": \"639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e\",","                \"tweakedPubkey\": \"77e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220\"","            },","            \"expected\": {","                \"scriptPubKey\": \"512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220\",","                \"bip350Address\": \"bc1pwl3s54fzmk0cjnpl3w9af39je7pv5ldg504x5guk2hpecpg2kgsqaqstjq\",","                \"scriptPathControlBlocks\": [","                    \"c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd82cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb\",","                    \"c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd864512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89\"","                ]","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f\",","                \"scriptTree\": [","                    {","                        \"id\": 0,","                        \"script\": \"2072ea6adcf1d371dea8fba1035a09f3d24ed5a059799bae114084130ee5898e69ac\",","                        \"leafVersion\": 192","                    },","                    [","                        {","                            \"id\": 1,","                            \"script\": \"202352d137f2f3ab38d1eaa976758873377fa5ebb817372c71e2c542313d4abda8ac\",","                            \"leafVersion\": 192","                        },","                        {","                            \"id\": 2,","                            \"script\": \"207337c0dd4253cb86f2c43a2351aadd82cccb12a172cd120452b9bb8324f2186aac\",","                            \"leafVersion\": 192","                        }","                    ]","                ]","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817\",","                    \"ba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c\",","                    \"9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf6\"","                ],","                \"merkleRoot\": \"ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2\",","                \"tweak\": \"b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4\",","                \"tweakedPubkey\": \"91b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605\"","            },","            \"expected\": {","                \"scriptPubKey\": \"512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605\",","                \"bip350Address\": \"bc1pjxmy65eywgafs5tsunw95ruycpqcqnev6ynxp7jaasylcgtcxczs6n332e\",","                \"scriptPathControlBlocks\": [","                    \"c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fffe578e9ea769027e4f5a3de40732f75a88a6353a09d767ddeb66accef85e553\",","                    \"c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf62645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817\",","                    \"c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817\"","                ]","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d\",","                \"scriptTree\": [","                    {","                        \"id\": 0,","                        \"script\": \"2071981521ad9fc9036687364118fb6ccd2035b96a423c59c5430e98310a11abe2ac\",","                        \"leafVersion\": 192","                    },","                    [","                        {","                            \"id\": 1,","                            \"script\": \"20d5094d2dbe9b76e2c245a2b89b6006888952e2faa6a149ae318d69e520617748ac\",","                            \"leafVersion\": 192","                        },","                        {","                            \"id\": 2,","                            \"script\": \"20c440b462ad48c7a77f94cd4532d8f2119dcebbd7c9764557e62726419b08ad4cac\",","                            \"leafVersion\": 192","                        }","                    ]","                ]","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d\",","                    \"737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711\",","                    \"d7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7\"","                ],","                \"merkleRoot\": \"2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def\",","                \"tweak\": \"6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9\",","                \"tweakedPubkey\": \"75169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831\"","            },","            \"expected\": {","                \"scriptPubKey\": \"512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831\",","                \"bip350Address\": \"bc1pw5tf7sqp4f50zka7629jrr036znzew70zxyvvej3zrpf8jg8hqcssyuewe\",","                \"scriptPathControlBlocks\": [","                    \"c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d3cd369a528b326bc9d2133cbd2ac21451acb31681a410434672c8e34fe757e91\",","                    \"c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312dd7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d\",","                    \"c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d\"","                ]","            }","        }","    ],","    \"keyPathSpending\": [","        {","            \"given\": {","                \"rawUnsignedTx\": \"02000000097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a418420000000000fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0065cd1d\",","                \"utxosSpent\": [","                    {","                        \"scriptPubKey\": \"512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343\",","                        \"amountSats\": 420000000","                    },","                    {","                        \"scriptPubKey\": \"5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3\",","                        \"amountSats\": 462000000","                    },","                    {","                        \"scriptPubKey\": \"76a914751e76e8199196d454941c45d1b3a323f1433bd688ac\",","                        \"amountSats\": 294000000","                    },","                    {","                        \"scriptPubKey\": \"5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e\",","                        \"amountSats\": 504000000","                    },","                    {","                        \"scriptPubKey\": \"512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605\",","                        \"amountSats\": 630000000","                    },","                    {","                        \"scriptPubKey\": \"00147dd65592d0ab2fe0d0257d571abf032cd9db93dc\",","                        \"amountSats\": 378000000","                    },","                    {","                        \"scriptPubKey\": \"512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831\",","                        \"amountSats\": 672000000","                    },","                    {","                        \"scriptPubKey\": \"5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5\",","                        \"amountSats\": 546000000","                    },","                    {","                        \"scriptPubKey\": \"512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220\",","                        \"amountSats\": 588000000","                    }","                ]","            },","            \"intermediary\": {","                \"hashAmounts\": \"58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde6\",","                \"hashOutputs\": \"a2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc5\",","                \"hashPrevouts\": \"e3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f\",","                \"hashScriptPubkeys\": \"23ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e21\",","                \"hashSequences\": \"18959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e\"","            },","            \"inputSpending\": [","                {","                    \"given\": {","                        \"txinIndex\": 0,","                        \"internalPrivkey\": \"6b973d88838f27366ed61c9ad6367663045cb456e28335c109e30717ae0c6baa\",","                        \"merkleRoot\": null,","                        \"hashType\": 3","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d\",","                        \"tweak\": \"b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70\",","                        \"tweakedPrivkey\": \"2405b971772ad26915c8dcdf10f238753a9b837e5f8e6a86fd7c0cce5b7296d9\",","                        \"sigMsg\": \"0003020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0000000000d0418f0e9a36245b9a50ec87f8bf5be5bcae434337b87139c3a5b1f56e33cba0\",","                        \"precomputedUsed\": [","                            \"hashAmounts\",","                            \"hashPrevouts\",","                            \"hashScriptPubkeys\",","                            \"hashSequences\"","                        ],","                        \"sigHash\": \"2514a6272f85cfa0f45eb907fcb0d121b808ed37c6ea160a5a9046ed5526d555\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c03\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 1,","                        \"internalPrivkey\": \"1e4da49f6aaf4e5cd175fe08a32bb5cb4863d963921255f33d3bc31e1343907f\",","                        \"merkleRoot\": \"5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21\",","                        \"hashType\": 131","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27\",","                        \"tweak\": \"cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001\",","                        \"tweakedPrivkey\": \"ea260c3b10e60f6de018455cd0278f2f5b7e454be1999572789e6a9565d26080\",","                        \"sigMsg\": \"0083020000000065cd1d00d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd9900000000808f891b00000000225120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3ffffffffffcef8fb4ca7efc5433f591ecfc57391811ce1e186a3793024def5c884cba51d\",","                        \"precomputedUsed\": [],","                        \"sigHash\": \"325a644af47e8a5a2591cda0ab0723978537318f10e6a63d4eed783b96a71a4d\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 3,","                        \"internalPrivkey\": \"d3c7af07da2d54f7a7735d3d0fc4f0a73164db638b2f2f7c43f711f6d4aa7e64\",","                        \"merkleRoot\": \"c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b\",","                        \"hashType\": 1","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820\",","                        \"tweak\": \"6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30\",","                        \"tweakedPrivkey\": \"97323385e57015b75b0339a549c56a948eb961555973f0951f555ae6039ef00d\",","                        \"sigMsg\": \"0001020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50003000000\",","                        \"precomputedUsed\": [","                            \"hashAmounts\",","                            \"hashOutputs\",","                            \"hashPrevouts\",","                            \"hashScriptPubkeys\",","                            \"hashSequences\"","                        ],","                        \"sigHash\": \"bf013ea93474aa67815b1b6cc441d23b64fa310911d991e713cd34c7f5d46669\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a01\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 4,","                        \"internalPrivkey\": \"f36bb07a11e469ce941d16b63b11b9b9120a84d9d87cff2c84a8d4affb438f4e\",","                        \"merkleRoot\": \"ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2\",","                        \"hashType\": 0","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f\",","                        \"tweak\": \"b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4\",","                        \"tweakedPrivkey\": \"a8e7aa924f0d58854185a490e6c41f6efb7b675c0f3331b7f14b549400b4d501\",","                        \"sigMsg\": \"0000020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50004000000\",","                        \"precomputedUsed\": [","                            \"hashAmounts\",","                            \"hashOutputs\",","                            \"hashPrevouts\",","                            \"hashScriptPubkeys\",","                            \"hashSequences\"","                        ],","                        \"sigHash\": \"4f900a0bae3f1446fd48490c2958b5a023228f01661cda3496a11da502a7f7ef\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 6,","                        \"internalPrivkey\": \"415cfe9c15d9cea27d8104d5517c06e9de48e2f986b695e4f5ffebf230e725d8\",","                        \"merkleRoot\": \"2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def\",","                        \"hashType\": 2","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d\",","                        \"tweak\": \"6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9\",","                        \"tweakedPrivkey\": \"241c14f2639d0d7139282aa6abde28dd8a067baa9d633e4e7230287ec2d02901\",","                        \"sigMsg\": \"0002020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0006000000\",","                        \"precomputedUsed\": [","                            \"hashAmounts\",","                            \"hashPrevouts\",","                            \"hashScriptPubkeys\",","                            \"hashSequences\"","                        ],","                        \"sigHash\": \"15f25c298eb5cdc7eb1d638dd2d45c97c4c59dcaec6679cfc16ad84f30876b85\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee002\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 7,","                        \"internalPrivkey\": \"c7b0e81f0a9a0b0499e112279d718cca98e79a12e2f137c72ae5b213aad0d103\",","                        \"merkleRoot\": \"6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef\",","                        \"hashType\": 130","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592\",","                        \"tweak\": \"9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9\",","                        \"tweakedPrivkey\": \"65b6000cd2bfa6b7cf736767a8955760e62b6649058cbc970b7c0871d786346b\",","                        \"sigMsg\": \"0082020000000065cd1d00e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf00000000804c8b2000000000225120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5ffffffff\",","                        \"precomputedUsed\": [],","                        \"sigHash\": \"cd292de50313804dabe4685e83f923d2969577191a3e1d2882220dca88cbeb10\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c482\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 8,","                        \"internalPrivkey\": \"77863416be0d0665e517e1c375fd6f75839544eca553675ef7fdf4949518ebaa\",","                        \"merkleRoot\": \"ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc\",","                        \"hashType\": 129","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8\",","                        \"tweak\": \"639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e\",","                        \"tweakedPrivkey\": \"ec18ce6af99f43815db543f47b8af5ff5df3b2cb7315c955aa4a86e8143d2bf5\",","                        \"sigMsg\": \"0081020000000065cd1da2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc500a778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af101000000002b0c230000000022512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220ffffffff\",","                        \"precomputedUsed\": [","                            \"hashOutputs\"","                        ],","                        \"sigHash\": \"cccb739eca6c13a8a89e6e5cd317ffe55669bbda23f2fd37b0f18755e008edd2\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd981\"","                        ]","                    }","                }","            ],","            \"auxiliary\": {","                \"fullySignedTx\": \"020000000001097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a41842000000006b4830450221008f3b8f8f0537c420654d2283673a761b7ee2ea3c130753103e08ce79201cf32a022079e7ab904a1980ef1c5890b648c8783f4d10103dd62f740d13daa79e298d50c201210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0141ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c030141052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83000141ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a010140b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f0247304402202b795e4de72646d76eab3f0ab27dfa30b810e856ff3a46c9a702df53bb0d8cc302203ccc4d822edab5f35caddb10af1be93583526ccfbade4b4ead350781e2f8adcd012102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f90141a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee0020141ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c4820141bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd9810065cd1d\"","            }","        }","    ]","}"],"stylingDirectives":[[],[{"s":4,"e":13,"c":"pl-ent"},{"s":15,"e":16,"c":"pl-c1"}],[{"s":4,"e":18,"c":"pl-ent"}],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":34,"c":"pl-c1"}],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":34,"c":"pl-c1"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":24,"c":"pl-ent"},{"s":26,"e":27,"c":"pl-c1"}],[{"s":20,"e":28,"c":"pl-ent"},{"s":30,"e":100,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":20,"e":33,"c":"pl-ent"},{"s":35,"e":38,"c":"pl-c1"}],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":88,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":87,"e":88,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":24,"c":"pl-ent"},{"s":26,"e":27,"c":"pl-c1"}],[{"s":20,"e":28,"c":"pl-ent"},{"s":30,"e":100,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":20,"e":33,"c":"pl-ent"},{"s":35,"e":38,"c":"pl-c1"}],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":88,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":87,"e":88,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":104,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":50,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":49,"e":50,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":104,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":52,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":51,"e":52,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":104,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[],[{"s":28,"e":32,"c":"pl-ent"},{"s":34,"e":35,"c":"pl-c1"}],[{"s":28,"e":36,"c":"pl-ent"},{"s":38,"e":108,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-ent"},{"s":43,"e":46,"c":"pl-c1"}],[],[],[{"s":28,"e":32,"c":"pl-ent"},{"s":34,"e":35,"c":"pl-c1"}],[{"s":28,"e":36,"c":"pl-ent"},{"s":38,"e":108,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-ent"},{"s":43,"e":46,"c":"pl-c1"}],[],[],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[{"s":20,"e":216,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":215,"e":216,"c":"pl-pds"}],[{"s":20,"e":216,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":215,"e":216,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":104,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[],[{"s":28,"e":32,"c":"pl-ent"},{"s":34,"e":35,"c":"pl-c1"}],[{"s":28,"e":36,"c":"pl-ent"},{"s":38,"e":108,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-ent"},{"s":43,"e":46,"c":"pl-c1"}],[],[],[{"s":28,"e":32,"c":"pl-ent"},{"s":34,"e":35,"c":"pl-c1"}],[{"s":28,"e":36,"c":"pl-ent"},{"s":38,"e":108,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-ent"},{"s":43,"e":46,"c":"pl-c1"}],[],[],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[{"s":20,"e":216,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":215,"e":216,"c":"pl-pds"}],[{"s":20,"e":216,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":215,"e":216,"c":"pl-pds"}],[],[],[],[],[{"s":4,"e":21,"c":"pl-ent"}],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":943,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":942,"e":943,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":92,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":91,"e":92,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":86,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":29,"c":"pl-ent"},{"s":31,"e":97,"c":"pl-s"},{"s":31,"e":32,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":29,"c":"pl-ent"},{"s":31,"e":97,"c":"pl-s"},{"s":31,"e":32,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":98,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":97,"e":98,"c":"pl-pds"}],[{"s":16,"e":35,"c":"pl-ent"},{"s":37,"e":103,"c":"pl-s"},{"s":37,"e":38,"c":"pl-pds"},{"s":102,"e":103,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":27,"c":"pl-ent"}],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":42,"c":"pl-c1"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":37,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":386,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":385,"e":386,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":42,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":41,"e":42,"c":"pl-pds"}],[{"s":28,"e":47,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":46,"e":47,"c":"pl-pds"}],[{"s":28,"e":43,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":42,"e":43,"c":"pl-pds"}],[],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":39,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":288,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":287,"e":288,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":37,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":386,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":385,"e":386,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":42,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":41,"e":42,"c":"pl-pds"}],[{"s":28,"e":47,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":46,"e":47,"c":"pl-pds"}],[{"s":28,"e":43,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":42,"e":43,"c":"pl-pds"}],[],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":37,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":386,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":385,"e":386,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":42,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":41,"e":42,"c":"pl-pds"}],[{"s":28,"e":47,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":46,"e":47,"c":"pl-pds"}],[{"s":28,"e":43,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":42,"e":43,"c":"pl-pds"}],[],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":158,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":157,"e":158,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":37,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":322,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":321,"e":322,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":42,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":41,"e":42,"c":"pl-pds"}],[{"s":28,"e":47,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":46,"e":47,"c":"pl-pds"}],[{"s":28,"e":43,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":42,"e":43,"c":"pl-pds"}],[],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":39,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":224,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":223,"e":224,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":39,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":288,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":287,"e":288,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":23,"c":"pl-ent"}],[],[],[],[],[]],"colorizedLines":null,"csv":null,"csvError":null,"dependabotInfo":{"showConfigurationBanner":false,"configFilePath":null,"networkDependabotPath":"/bitcoin/bips/network/updates","dismissConfigurationNoticePath":"/settings/dismiss-notice/dependabot_configuration_notice","configurationNoticeDismissed":null},"displayName":"wallet-test-vectors.json","displayUrl":"https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json?raw=true","headerInfo":{"blobSize":"28.6 KB","deleteTooltip":"You must be signed in to make or propose changes","editTooltip":"You must be signed in to make or propose changes","ghDesktopPath":"https://desktop.github.com","isGitLfs":false,"onBranch":true,"shortPath":"11261b0","siteNavLoginPath":"/login?return_to=https%3A%2F%2Fgithub.com%2Fbitcoin%2Fbips%2Fblob%2Fmaster%2Fbip-0341%2Fwallet-test-vectors.json","isCSV":false,"isRichtext":false,"toc":null,"lineInfo":{"truncatedLoc":"452","truncatedSloc":"452"},"mode":"file"},"image":false,"isCodeownersFile":null,"isPlain":false,"isValidLegacyIssueTemplate":false,"issueTemplate":null,"discussionTemplate":null,"language":"JSON","languageID":174,"large":false,"planSupportInfo":{"repoIsFork":null,"repoOwnedByCurrentUser":null,"requestFullPath":"/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json","showFreeOrgGatedFeatureMessage":null,"showPlanSupportBanner":null,"upgradeDataAttributes":null,"upgradePath":null},"publishBannersInfo":{"dismissActionNoticePath":"/settings/dismiss-notice/publish_action_from_dockerfile","releasePath":"/bitcoin/bips/releases/new?marketplace=true","showPublishActionBanner":false},"rawBlobUrl":"https://github.com/bitcoin/bips/raw/master/bip-0341/wallet-test-vectors.json","renderImageOrRaw":false,"richText":null,"renderedFileInfo":null,"shortPath":null,"symbolsEnabled":true,"tabSize":8,"topBannersInfo":{"overridingGlobalFundingFile":false,"globalPreferredFundingPath":null,"showInvalidCitationWarning":false,"citationHelpUrl":"https://docs.github.com/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files","actionsOnboardingTip":null},"truncated":false,"viewable":true,"workflowRedirectUrl":null,"symbols":{"timed_out":false,"not_analyzed":true,"symbols":[]}},"copilotInfo":null,"copilotAccessAllowed":false,"csrf_tokens":{"/bitcoin/bips/branches":{"post":"5shwOg5_ZG2ZT_6VIYhT_jWxxXF326L2YXgVPwGs0-fC-ZSXp6Oa0EvY80IvCVFS3bPr5-3NVtzfxiqO8AvpMQ"},"/repos/preferences":{"post":"td6ISQbU84G_9yyOfWy4yJ6NZl_dxaZNGoVvgwNyKipbFZR9Ju-VtejLvqpmwg0lAuHKRA-3ivRM48mcFHHI4w"}}},"title":"bips/bip-0341/wallet-test-vectors.json at master · bitcoin/bips","appPayload":{"helpUrl":"https://docs.github.com","findFileWorkerPath":"/assets-cdn/worker/find-file-worker-a007d7f370d6.js","findInFileWorkerPath":"/assets-cdn/worker/find-in-file-worker-d0f0ff069004.js","githubDevUrl":null,"enabled_features":{"code_nav_ui_events":false,"copilot_conversational_ux":false,"react_blob_overlay":false,"copilot_conversational_ux_embedding_update":false,"copilot_popover_file_editor_header":false,"copilot_smell_icebreaker_ux":true,"copilot_workspace":false}}}</script>
+  <div data-target="react-app.reactRoot"></div>
+</react-app>
+</turbo-frame>
+
+
+
+  </div>
+
+</turbo-frame>
+
+    </main>
+  </div>
+
+  </div>
+
+          <footer class="footer pt-8 pb-6 f6 color-fg-muted p-responsive" role="contentinfo" >
+  <h2 class='sr-only'>Footer</h2>
+
+  
+
+
+  <div class="d-flex flex-justify-center flex-items-center flex-column-reverse flex-lg-row flex-wrap flex-lg-nowrap">
+    <div class="d-flex flex-items-center flex-shrink-0 mx-2">
+      <a aria-label="Homepage" title="GitHub" class="footer-octicon mr-2" href="https://github.com">
+        <svg aria-hidden="true" height="24" viewBox="0 0 16 16" version="1.1" width="24" data-view-component="true" class="octicon octicon-mark-github">
+    <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path>
+</svg>
+</a>
+      <span>
+        &copy; 2024 GitHub,&nbsp;Inc.
+      </span>
+    </div>
+
+    <nav aria-label="Footer">
+      <h3 class="sr-only" id="sr-footer-heading">Footer navigation</h3>
+
+      <ul class="list-style-none d-flex flex-justify-center flex-wrap mb-2 mb-lg-0" aria-labelledby="sr-footer-heading">
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to Terms&quot;,&quot;label&quot;:&quot;text:terms&quot;}" href="https://docs.github.com/site-policy/github-terms/github-terms-of-service" data-view-component="true" class="Link--secondary Link">Terms</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to privacy&quot;,&quot;label&quot;:&quot;text:privacy&quot;}" href="https://docs.github.com/site-policy/privacy-policies/github-privacy-statement" data-view-component="true" class="Link--secondary Link">Privacy</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to security&quot;,&quot;label&quot;:&quot;text:security&quot;}" href="/security" data-view-component="true" class="Link--secondary Link">Security</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to status&quot;,&quot;label&quot;:&quot;text:status&quot;}" href="https://www.githubstatus.com/" data-view-component="true" class="Link--secondary Link">Status</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to docs&quot;,&quot;label&quot;:&quot;text:docs&quot;}" href="https://docs.github.com/" data-view-component="true" class="Link--secondary Link">Docs</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to contact&quot;,&quot;label&quot;:&quot;text:contact&quot;}" href="https://support.github.com?tags=dotcom-footer" data-view-component="true" class="Link--secondary Link">Contact</a>
+          </li>
+
+          <li class="mr-3" >
+  <cookie-consent-link>
+    <button type="button" class="Link--secondary underline-on-hover border-0 p-0 color-bg-transparent" data-action="click:cookie-consent-link#showConsentManagement">
+      Manage cookies
+    </button>
+  </cookie-consent-link>
+</li>
+
+<li class="mr-3">
+  <cookie-consent-link>
+    <button type="button" class="Link--secondary underline-on-hover border-0 p-0 color-bg-transparent" data-action="click:cookie-consent-link#showConsentManagement">
+      Do not share my personal information
+    </button>
+  </cookie-consent-link>
+</li>
+
+      </ul>
+    </nav>
+  </div>
+</footer>
+
+
+
+
+    <cookie-consent id="cookie-consent-banner" class="position-fixed bottom-0 left-0" style="z-index: 999999" data-initial-cookie-consent-allowed="" data-cookie-consent-required="false"></cookie-consent>
+
+
+  <div id="ajax-error-message" class="ajax-error-message flash flash-error" hidden>
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-alert">
+    <path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+    <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+    </button>
+    You can’t perform that action at this time.
+  </div>
+
+    <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default color-fg-default hx_rsm" open>
+    <summary role="button" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast hx_rsm-dialog hx_rsm-modal">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
+
+    <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
+  <div class="Popover-message Popover-message--bottom-left Popover-message--large Box color-shadow-large" style="width:360px;">
+  </div>
+</div>
+
+    <template id="snippet-clipboard-copy-button">
+  <div class="zeroclipboard-container position-absolute right-0 top-0">
+    <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+    <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>
+</svg>
+    </clipboard-copy>
+  </div>
+</template>
+<template id="snippet-clipboard-copy-button-unpositioned">
+  <div class="zeroclipboard-container">
+    <clipboard-copy aria-label="Copy" class="ClipboardButton btn btn-invisible js-clipboard-copy m-2 p-0 tooltipped-no-delay d-flex flex-justify-center flex-items-center" data-copy-feedback="Copied!" data-tooltip-direction="w">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon">
+    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none">
+    <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>
+</svg>
+    </clipboard-copy>
+  </div>
+</template>
+
+
+
+
+    </div>
+
+    <div id="js-global-screen-reader-notice" class="sr-only" aria-live="polite" aria-atomic="true" ></div>
+    <div id="js-global-screen-reader-notice-assertive" class="sr-only" aria-live="assertive" aria-atomic="true"></div>
+  </body>
+</html>
+

--- a/core-test/.jvm/src/test/resources/wallet-test-vectors.json
+++ b/core-test/.jvm/src/test/resources/wallet-test-vectors.json
@@ -1,1613 +1,452 @@
-
-
-
-
-
-
-<!DOCTYPE html>
-<html
-  lang="en"
-  
-  data-color-mode="auto" data-light-theme="light" data-dark-theme="dark"
-  data-a11y-animated-images="system" data-a11y-link-underlines="true"
-  >
-
-
-
-
-  <head>
-    <meta charset="utf-8">
-  <link rel="dns-prefetch" href="https://github.githubassets.com">
-  <link rel="dns-prefetch" href="https://avatars.githubusercontent.com">
-  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
-  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
-  <link rel="preconnect" href="https://github.githubassets.com" crossorigin>
-  <link rel="preconnect" href="https://avatars.githubusercontent.com">
-
-  
-
-
-  <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/light-0eace2597ca3.css" /><link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/dark-a167e256da9c.css" /><link data-color-theme="dark_dimmed" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_dimmed-d11f2cf8009b.css" /><link data-color-theme="dark_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_high_contrast-ea7373db06c8.css" /><link data-color-theme="dark_colorblind" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_colorblind-afa99dcf40f7.css" /><link data-color-theme="light_colorblind" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_colorblind-af6c685139ba.css" /><link data-color-theme="light_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_high_contrast-578cdbc8a5a9.css" /><link data-color-theme="light_tritanopia" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_tritanopia-5cb699a7e247.css" /><link data-color-theme="dark_tritanopia" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_tritanopia-9b32204967c6.css" />
-    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/primer-primitives-0b5bee5c70e9.css" />
-    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/primer-44fa1513ddd0.css" />
-    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/global-7a5e80eb7443.css" />
-    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/github-07f750db5d7c.css" />
-  <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/repository-fa69f138fe8d.css" />
-<link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/code-111be5e4092d.css" />
-
-  
-
-
-  <script type="application/json" id="client-env">{"locale":"en","featureFlags":["code_vulnerability_scanning","copilot_conversational_ux_history_refs","copilot_smell_icebreaker_ux","copilot_implicit_context","failbot_handle_non_errors","geojson_azure_maps","image_metric_tracking","marketing_forms_api_integration_contact_request","marketing_pages_search_explore_provider","turbo_experiment_risky","sample_network_conn_type","no_character_key_shortcuts_in_inputs","react_start_transition_for_navigations","custom_inp","remove_child_patch"]}</script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/wp-runtime-853092ccfb3d.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_dompurify_dist_purify_js-6890e890956f.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_oddbird_popover-polyfill_dist_popover_js-7bd350d761f4.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_smoothscroll-polyfill_dist_smoothscroll_js-node_modules_stacktrace-parse-a448e4-bb5415637fe0.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/environment-69a406071332.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_selector-observer_dist_index_esm_js-9f960d9b217c.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_behaviors_dist_esm_focus-zone_js-086f7a27bac0.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_relative-time-element_dist_index_js-c76945c5961a.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_combobox-nav_dist_index_js-node_modules_github_markdown-toolbar-e-820fc0-bc8f02b96749.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_auto-complete-element_dist_index_js-node_modules_github_catalyst_-392fe4-eed5a942c35c.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_text-expander-element_dist_index_js-8a621df59e80.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_filter-input-element_dist_index_js-node_modules_github_remote-inp-b7d8f4-7dc906febe69.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_delegated-events_dist_index_js-node_modules_stacktrace-parser_dist_stack-8585c6-7dc8343022ba.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_file-attachment-element_dist_index_js-node_modules_primer_view-co-3959a9-134c7fee9431.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/github-elements-14a1f6104f4b.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/element-registry-ea8c3b7e408f.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_mini-throttle_dist_index_js-node_modules_stacktrace-parser_dist_s-1acb1c-a745699a1cfa.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_lit-html_lit-html_js-5b376145beff.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_morphdom_dist_morphdom-esm_js-node_modules_github_memoize_dist_esm_index_js-05801f7ca718.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_turbo_dist_turbo_es2017-esm_js-c91f4ad18b62.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_remote-form_dist_index_js-node_modules_delegated-events_dist_inde-893f9f-8413f2cd68c5.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_scroll-anchoring_dist_scroll-anchoring_esm_js-node_modules_github_hotkey-1a1d91-49c03ceb2f0c.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_color-convert_index_js-72c9fbde5ad4.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_behaviors_dist_esm_dimensions_js-node_modules_github_jtml_lib_index_js-95b84ee6bc34.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_quote-selection_dist_index_js-node_modules_github_session-resume_-84957b-7b4e472db160.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_jtml-shimmed_jtml-shimmed_ts-ui_packages_safe-storage_safe-storage_ts-19f49df05d21.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_updatable-content_ts-ui_packages_hydro-analytics_hydro-analytics_ts-82813f-fb8253d1c2f5.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_task-list_ts-app_assets_modules_github_onfocus_ts-app_ass-421cec-9de4213015af.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_sticky-scroll-into-view_ts-94209c43e6af.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_ajax-error_ts-app_assets_modules_github_behaviors_include-2e2258-05fd80a7ea89.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_commenting_edit_ts-app_assets_modules_github_behaviors_ht-83c235-9285faa0e011.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/behaviors-a27b2a049b70.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_delegated-events_dist_index_js-node_modules_github_catalyst_lib_index_js-06ff531-2ea61fcc9a71.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/notifications-global-6d6db5144cc3.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/code-menu-6ed703a40ffd.js"></script>
-  
-  <script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/react-lib-1fbfc5be2c18.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_octicons-react_dist_index_esm_js-node_modules_primer_react_lib-es-541a38-6ce7d7c3f9ee.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Box_Box_js-8f8c5e2a2cbf.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Button_Button_js-95a7748e3c39.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_TooltipV2_Tooltip_js-70d5275ffcb7.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_ActionList_index_js-b5c64c43d649.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Overlay_Overlay_js-node_modules_primer_react_lib-es-fa1130-829932cf63db.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Link_Link_js-node_modules_primer_react_lib-esm_Text-e5cb30-846d162fec54.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_FormControl_FormControl_js-740100cbb60f.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_ActionMenu_ActionMenu_js-eaf74522e470.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Heading_Heading_js-node_modules_github_catalyst_lib-b39cf6-04084648a106.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_react-router-dom_dist_index_js-3b41341d50fe.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_PageLayout_PageLayout_js-5a4a31c01bca.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_ConfirmationDialog_ConfirmationDialog_js-8ab472e2f924.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Dialog_js-node_modules_react-virtual_dist_react-vir-155ebc-07457159712f.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_TreeView_TreeView_js-4d087b8e0c8a.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_AvatarStack_AvatarStack_js-node_modules_primer_reac-36b6f3-1b3c8357c7d0.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_mini-throttle_dist_index_js-node_modules_primer_react_lib-esm_Bre-b2e46d-c8ac19da4b57.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_react-core_create-browser-history_ts-ui_packages_safe-storage_safe-storage_ts-ui_-682c2c-7be102c61d97.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_react-core_register-app_ts-6ecc18606709.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_paths_index_ts-271d9b2a45a4.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_ref-selector_RefSelector_tsx-dbbdef4348e2.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/ui_packages_commit-attribution_index_ts-ui_packages_commit-checks-status_index_ts-ui_packages-baa075-642aa1eae490.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_react-shared_hooks_use-canonical-object_ts-ui_packages_code-view-shared_ho-e725dc-bccfdf9efa81.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_blob-anchor_ts-app_assets_modules_github_filter-sort_ts-app_assets_-e50ab6-fd8396d2490b.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/react-code-view-2166c00e294d.js"></script>
-
-
-  <title>bips/bip-0341/wallet-test-vectors.json at master · bitcoin/bips · GitHub</title>
-
-
-
-  <meta name="route-pattern" content="/:user_id/:repository/blob/*name(/*path)" data-turbo-transient>
-  <meta name="route-controller" content="blob" data-turbo-transient>
-  <meta name="route-action" content="show" data-turbo-transient>
-
-    
-  <meta name="current-catalog-service-hash" content="82c569b93da5c18ed649ebd4c2c79437db4611a6a1373e805a3cb001c64130b7">
-
-
-  <meta name="request-id" content="EBF0:8D48:1139A38:19618CB:6616F213" data-pjax-transient="true"/><meta name="html-safe-nonce" content="7cdd3639d27bf69d2286548fb2c3f416e2fee6f564c4a605aa798a148e417584" data-pjax-transient="true"/><meta name="visitor-payload" content="eyJyZWZlcnJlciI6IiIsInJlcXVlc3RfaWQiOiJFQkYwOjhENDg6MTEzOUEzODoxOTYxOENCOjY2MTZGMjEzIiwidmlzaXRvcl9pZCI6IjI4NzgxNTU0MDg5Mzc1MTM0OTEiLCJyZWdpb25fZWRnZSI6ImlhZCIsInJlZ2lvbl9yZW5kZXIiOiJpYWQifQ==" data-pjax-transient="true"/><meta name="visitor-hmac" content="3fe32848276229b48f0475009fbbf8c6aa2fad9e1d408913af8d939e530b656f" data-pjax-transient="true"/>
-
-
-    <meta name="hovercard-subject-tag" content="repository:14531737" data-turbo-transient>
-
-
-  <meta name="github-keyboard-shortcuts" content="repository,source-code,file-tree,copilot" data-turbo-transient="true" />
-  
-
-  <meta name="selected-link" value="repo_source" data-turbo-transient>
-  <link rel="assets" href="https://github.githubassets.com/">
-
-    <meta name="google-site-verification" content="c1kuD-K2HIVF635lypcsWPoD4kilo5-jA_wBFyT4uMY">
-  <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
-  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
-  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
-  <meta name="google-site-verification" content="Apib7-x98H0j5cPqHWwSMm6dNU4GmODRoqxLiDzdx9I">
-
-<meta name="octolytics-url" content="https://collector.github.com/github/collect" />
-
-  <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/blob/show" data-turbo-transient="true" />
-
-  
-
-
-
-
-
-    <meta name="user-login" content="">
-
-  
-
-    <meta name="viewport" content="width=device-width">
-    
-      <meta name="description" content="Bitcoin Improvement Proposals. Contribute to bitcoin/bips development by creating an account on GitHub.">
-      <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
-    <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
-    <meta property="fb:app_id" content="1401488693436528">
-    <meta name="apple-itunes-app" content="app-id=1477376905, app-argument=https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json" />
-      <meta name="twitter:image:src" content="https://opengraph.githubassets.com/35ca2a40beb8c13649d17ee761a15dc5480a47a00bf471d2d32ee1f55c58525e/bitcoin/bips" /><meta name="twitter:site" content="@github" /><meta name="twitter:card" content="summary_large_image" /><meta name="twitter:title" content="bips/bip-0341/wallet-test-vectors.json at master · bitcoin/bips" /><meta name="twitter:description" content="Bitcoin Improvement Proposals. Contribute to bitcoin/bips development by creating an account on GitHub." />
-      <meta property="og:image" content="https://opengraph.githubassets.com/35ca2a40beb8c13649d17ee761a15dc5480a47a00bf471d2d32ee1f55c58525e/bitcoin/bips" /><meta property="og:image:alt" content="Bitcoin Improvement Proposals. Contribute to bitcoin/bips development by creating an account on GitHub." /><meta property="og:image:width" content="1200" /><meta property="og:image:height" content="600" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="bips/bip-0341/wallet-test-vectors.json at master · bitcoin/bips" /><meta property="og:url" content="https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json" /><meta property="og:description" content="Bitcoin Improvement Proposals. Contribute to bitcoin/bips development by creating an account on GitHub." />
-      
-
-
-
-        <meta name="hostname" content="github.com">
-
-
-
-        <meta name="expected-hostname" content="github.com">
-
-
-  <meta http-equiv="x-pjax-version" content="58fc2044de8917fa71c8cec3e297c3c19479904af7f0bde722fc9a689af4e9f3" data-turbo-track="reload">
-  <meta http-equiv="x-pjax-csp-version" content="f226bf37af9c33162063db3eb018fed7f088f86d0a20ca54c013fda96c7f2e05" data-turbo-track="reload">
-  <meta http-equiv="x-pjax-css-version" content="a7dca2c74324ba5eb1dfd20064b6873d31ef8a5cb55b7033a584b345d7ca8c16" data-turbo-track="reload">
-  <meta http-equiv="x-pjax-js-version" content="62dac6c0d51c71ec37728932e8a668dc92bfa8e8b5698c5d556effa1de1c5262" data-turbo-track="reload">
-
-  <meta name="turbo-cache-control" content="no-preview" data-turbo-transient="">
-
-      <meta name="turbo-cache-control" content="no-cache" data-turbo-transient>
-    <meta data-hydrostats="publish">
-  <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/react-code-view.959fb0b61e6a1de773e7.module.css" />
-
-  <meta name="go-import" content="github.com/bitcoin/bips git https://github.com/bitcoin/bips.git">
-
-  <meta name="octolytics-dimension-user_id" content="528860" /><meta name="octolytics-dimension-user_login" content="bitcoin" /><meta name="octolytics-dimension-repository_id" content="14531737" /><meta name="octolytics-dimension-repository_nwo" content="bitcoin/bips" /><meta name="octolytics-dimension-repository_public" content="true" /><meta name="octolytics-dimension-repository_is_fork" content="false" /><meta name="octolytics-dimension-repository_network_root_id" content="14531737" /><meta name="octolytics-dimension-repository_network_root_nwo" content="bitcoin/bips" />
-
-
-
-  <meta name="turbo-body-classes" content="logged-out env-production page-responsive">
-
-
-  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
-
-  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
-
-  <link rel="mask-icon" href="https://github.githubassets.com/assets/pinned-octocat-093da3e6fa40.svg" color="#000000">
-  <link rel="alternate icon" class="js-site-favicon" type="image/png" href="https://github.githubassets.com/favicons/favicon.png">
-  <link rel="icon" class="js-site-favicon" type="image/svg+xml" href="https://github.githubassets.com/favicons/favicon.svg">
-
-<meta name="theme-color" content="#1e2327">
-<meta name="color-scheme" content="light dark" />
-
-
-  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
-
-  </head>
-
-  <body class="logged-out env-production page-responsive" style="word-wrap: break-word;">
-    <div data-turbo-body class="logged-out env-production page-responsive" style="word-wrap: break-word;">
-      
-
-
-    <div class="position-relative js-header-wrapper ">
-      <a href="#start-of-content" class="px-2 py-4 color-bg-accent-emphasis color-fg-on-emphasis show-on-focus js-skip-to-content">Skip to content</a>
-      <span data-view-component="true" class="progress-pjax-loader Progress position-fixed width-full">
-    <span style="width: 0%;" data-view-component="true" class="Progress-item progress-pjax-loader-bar left-0 top-0 color-bg-accent-emphasis"></span>
-</span>      
-      
-  
-
-
-
-
-
-
-
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_react_lib-esm_Button_IconButton_js-node_modules_primer_react_lib--b964b4-8035f8c5edaa.js"></script>
-
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/keyboard-shortcuts-dialog-548fad62c9fa.js"></script>
-
-<react-partial
-  partial-name="keyboard-shortcuts-dialog"
-  data-ssr="false"
->
-  
-  <script type="application/json" data-target="react-partial.embeddedData">{"props":{}}</script>
-  <div data-target="react-partial.reactRoot"></div>
-</react-partial>
-
-
-
-      
-
-        
-
-            
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_remote-form_dist_index_js-node_modules_delegated-events_dist_inde-94fd67-2dacc0a62744.js"></script>
-<script crossorigin="anonymous" defer="defer" type="application/javascript" src="https://github.githubassets.com/assets/sessions-694c8423e347.js"></script>
-<header class="Header-old header-logged-out js-details-container Details position-relative f4 py-3" role="banner" data-color-mode=light data-light-theme=light data-dark-theme=dark>
-  <button type="button" class="Header-backdrop d-lg-none border-0 position-fixed top-0 left-0 width-full height-full js-details-target" aria-label="Toggle navigation">
-    <span class="d-none">Toggle navigation</span>
-  </button>
-
-  <div class=" d-flex flex-column flex-lg-row flex-items-center p-responsive height-full position-relative z-1">
-    <div class="d-flex flex-justify-between flex-items-center width-full width-lg-auto">
-      <a class="mr-lg-3 color-fg-inherit flex-order-2" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
-        <svg height="32" aria-hidden="true" viewBox="0 0 16 16" version="1.1" width="32" data-view-component="true" class="octicon octicon-mark-github">
-    <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path>
-</svg>
-      </a>
-
-      <div class="flex-1">
-        <a href="/login?return_to=https%3A%2F%2Fgithub.com%2Fbitcoin%2Fbips%2Fblob%2Fmaster%2Fbip-0341%2Fwallet-test-vectors.json"
-          class="d-inline-block d-lg-none flex-order-1 f5 no-underline border color-border-default rounded-2 px-2 py-1 color-fg-inherit"
-          data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="e3eeb14657e31f8e374c5918df8787078a0f6a39d7a1c1da8498d77997771dd5"
-          data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">
-          Sign in
-        </a>
-      </div>
-
-      <div class="flex-1 flex-order-2 text-right">
-        <button aria-label="Toggle navigation" aria-expanded="false" type="button" data-view-component="true" class="js-details-target Button--link Button--medium Button d-lg-none color-fg-inherit p-1">  <span class="Button-content">
-    <span class="Button-label"><div class="HeaderMenu-toggle-bar rounded my-1"></div>
-            <div class="HeaderMenu-toggle-bar rounded my-1"></div>
-            <div class="HeaderMenu-toggle-bar rounded my-1"></div></span>
-  </span>
-</button>
-      </div>
-    </div>
-
-
-    <div class="HeaderMenu--logged-out p-responsive height-fit position-lg-relative d-lg-flex flex-column flex-auto pt-7 pb-4 top-0">
-      <div class="header-menu-wrapper d-flex flex-column flex-self-end flex-lg-row flex-justify-between flex-auto p-3 p-lg-0 rounded rounded-lg-0 mt-3 mt-lg-0">
-          <nav class="mt-0 px-3 px-lg-0 mb-3 mb-lg-0" aria-label="Global">
-            <ul class="d-lg-flex list-style-none">
-                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
-      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-3 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
-        Product
-        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
-    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
-</svg>
-      </button>
-      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 py-2 py-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 d-lg-flex dropdown-menu-wide">
-          <div class="px-lg-4 border-lg-right mb-4 mb-lg-0 pr-lg-7">
-            <ul class="list-style-none f5" >
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Actions&quot;,&quot;label&quot;:&quot;ref_cta:Actions;&quot;}" href="/features/actions">
-      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-workflow color-fg-subtle mr-3">
-    <path d="M1 3a2 2 0 0 1 2-2h6.5a2 2 0 0 1 2 2v6.5a2 2 0 0 1-2 2H7v4.063C7 16.355 7.644 17 8.438 17H12.5v-2.5a2 2 0 0 1 2-2H21a2 2 0 0 1 2 2V21a2 2 0 0 1-2 2h-6.5a2 2 0 0 1-2-2v-2.5H8.437A2.939 2.939 0 0 1 5.5 15.562V11.5H3a2 2 0 0 1-2-2Zm2-.5a.5.5 0 0 0-.5.5v6.5a.5.5 0 0 0 .5.5h6.5a.5.5 0 0 0 .5-.5V3a.5.5 0 0 0-.5-.5ZM14.5 14a.5.5 0 0 0-.5.5V21a.5.5 0 0 0 .5.5H21a.5.5 0 0 0 .5-.5v-6.5a.5.5 0 0 0-.5-.5Z"></path>
-</svg>
-      <div>
-        <div class="color-fg-default h4">Actions</div>
-        Automate any workflow
-      </div>
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Packages&quot;,&quot;label&quot;:&quot;ref_cta:Packages;&quot;}" href="/features/packages">
-      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-package color-fg-subtle mr-3">
-    <path d="M12.876.64V.639l8.25 4.763c.541.313.875.89.875 1.515v9.525a1.75 1.75 0 0 1-.875 1.516l-8.25 4.762a1.748 1.748 0 0 1-1.75 0l-8.25-4.763a1.75 1.75 0 0 1-.875-1.515V6.917c0-.625.334-1.202.875-1.515L11.126.64a1.748 1.748 0 0 1 1.75 0Zm-1 1.298L4.251 6.34l7.75 4.474 7.75-4.474-7.625-4.402a.248.248 0 0 0-.25 0Zm.875 19.123 7.625-4.402a.25.25 0 0 0 .125-.216V7.639l-7.75 4.474ZM3.501 7.64v8.803c0 .09.048.172.125.216l7.625 4.402v-8.947Z"></path>
-</svg>
-      <div>
-        <div class="color-fg-default h4">Packages</div>
-        Host and manage packages
-      </div>
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Security&quot;,&quot;label&quot;:&quot;ref_cta:Security;&quot;}" href="/features/security">
-      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-shield-check color-fg-subtle mr-3">
-    <path d="M16.53 9.78a.75.75 0 0 0-1.06-1.06L11 13.19l-1.97-1.97a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.06 0l5-5Z"></path><path d="m12.54.637 8.25 2.675A1.75 1.75 0 0 1 22 4.976V10c0 6.19-3.771 10.704-9.401 12.83a1.704 1.704 0 0 1-1.198 0C5.77 20.705 2 16.19 2 10V4.976c0-.758.489-1.43 1.21-1.664L11.46.637a1.748 1.748 0 0 1 1.08 0Zm-.617 1.426-8.25 2.676a.249.249 0 0 0-.173.237V10c0 5.46 3.28 9.483 8.43 11.426a.199.199 0 0 0 .14 0C17.22 19.483 20.5 15.461 20.5 10V4.976a.25.25 0 0 0-.173-.237l-8.25-2.676a.253.253 0 0 0-.154 0Z"></path>
-</svg>
-      <div>
-        <div class="color-fg-default h4">Security</div>
-        Find and fix vulnerabilities
-      </div>
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Codespaces&quot;,&quot;label&quot;:&quot;ref_cta:Codespaces;&quot;}" href="/features/codespaces">
-      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-codespaces color-fg-subtle mr-3">
-    <path d="M3.5 3.75C3.5 2.784 4.284 2 5.25 2h13.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 18.75 13H5.25a1.75 1.75 0 0 1-1.75-1.75Zm-2 12c0-.966.784-1.75 1.75-1.75h17.5c.966 0 1.75.784 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75H3.25a1.75 1.75 0 0 1-1.75-1.75ZM5.25 3.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h13.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Zm-2 12a.25.25 0 0 0-.25.25v4c0 .138.112.25.25.25h17.5a.25.25 0 0 0 .25-.25v-4a.25.25 0 0 0-.25-.25Z"></path><path d="M10 17.75a.75.75 0 0 1 .75-.75h6.5a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1-.75-.75Zm-4 0a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1-.75-.75Z"></path>
-</svg>
-      <div>
-        <div class="color-fg-default h4">Codespaces</div>
-        Instant dev environments
-      </div>
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Copilot&quot;,&quot;label&quot;:&quot;ref_cta:Copilot;&quot;}" href="/features/copilot">
-      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-copilot color-fg-subtle mr-3">
-    <path d="M23.922 16.992c-.861 1.495-5.859 5.023-11.922 5.023-6.063 0-11.061-3.528-11.922-5.023A.641.641 0 0 1 0 16.736v-2.869a.841.841 0 0 1 .053-.22c.372-.935 1.347-2.292 2.605-2.656.167-.429.414-1.055.644-1.517a10.195 10.195 0 0 1-.052-1.086c0-1.331.282-2.499 1.132-3.368.397-.406.89-.717 1.474-.952 1.399-1.136 3.392-2.093 6.122-2.093 2.731 0 4.767.957 6.166 2.093.584.235 1.077.546 1.474.952.85.869 1.132 2.037 1.132 3.368 0 .368-.014.733-.052 1.086.23.462.477 1.088.644 1.517 1.258.364 2.233 1.721 2.605 2.656a.832.832 0 0 1 .053.22v2.869a.641.641 0 0 1-.078.256ZM12.172 11h-.344a4.323 4.323 0 0 1-.355.508C10.703 12.455 9.555 13 7.965 13c-1.725 0-2.989-.359-3.782-1.259a2.005 2.005 0 0 1-.085-.104L4 11.741v6.585c1.435.779 4.514 2.179 8 2.179 3.486 0 6.565-1.4 8-2.179v-6.585l-.098-.104s-.033.045-.085.104c-.793.9-2.057 1.259-3.782 1.259-1.59 0-2.738-.545-3.508-1.492a4.323 4.323 0 0 1-.355-.508h-.016.016Zm.641-2.935c.136 1.057.403 1.913.878 2.497.442.544 1.134.938 2.344.938 1.573 0 2.292-.337 2.657-.751.384-.435.558-1.15.558-2.361 0-1.14-.243-1.847-.705-2.319-.477-.488-1.319-.862-2.824-1.025-1.487-.161-2.192.138-2.533.529-.269.307-.437.808-.438 1.578v.021c0 .265.021.562.063.893Zm-1.626 0c.042-.331.063-.628.063-.894v-.02c-.001-.77-.169-1.271-.438-1.578-.341-.391-1.046-.69-2.533-.529-1.505.163-2.347.537-2.824 1.025-.462.472-.705 1.179-.705 2.319 0 1.211.175 1.926.558 2.361.365.414 1.084.751 2.657.751 1.21 0 1.902-.394 2.344-.938.475-.584.742-1.44.878-2.497Z"></path><path d="M14.5 14.25a1 1 0 0 1 1 1v2a1 1 0 0 1-2 0v-2a1 1 0 0 1 1-1Zm-5 0a1 1 0 0 1 1 1v2a1 1 0 0 1-2 0v-2a1 1 0 0 1 1-1Z"></path>
-</svg>
-      <div>
-        <div class="color-fg-default h4">Copilot</div>
-        Write better code with AI
-      </div>
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Code review&quot;,&quot;label&quot;:&quot;ref_cta:Code review;&quot;}" href="/features/code-review">
-      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-code-review color-fg-subtle mr-3">
-    <path d="M10.3 6.74a.75.75 0 0 1-.04 1.06l-2.908 2.7 2.908 2.7a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 0 1 1.06.04Zm3.44 1.06a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.908-2.7-2.908-2.7Z"></path><path d="M1.5 4.25c0-.966.784-1.75 1.75-1.75h17.5c.966 0 1.75.784 1.75 1.75v12.5a1.75 1.75 0 0 1-1.75 1.75h-9.69l-3.573 3.573A1.458 1.458 0 0 1 5 21.043V18.5H3.25a1.75 1.75 0 0 1-1.75-1.75ZM3.25 4a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h2.5a.75.75 0 0 1 .75.75v3.19l3.72-3.72a.749.749 0 0 1 .53-.22h10a.25.25 0 0 0 .25-.25V4.25a.25.25 0 0 0-.25-.25Z"></path>
-</svg>
-      <div>
-        <div class="color-fg-default h4">Code review</div>
-        Manage code changes
-      </div>
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center pb-lg-3" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Issues&quot;,&quot;label&quot;:&quot;ref_cta:Issues;&quot;}" href="/features/issues">
-      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-issue-opened color-fg-subtle mr-3">
-    <path d="M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1ZM2.5 12a9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5A9.5 9.5 0 0 0 12 2.5 9.5 9.5 0 0 0 2.5 12Zm9.5 2a2 2 0 1 1-.001-3.999A2 2 0 0 1 12 14Z"></path>
-</svg>
-      <div>
-        <div class="color-fg-default h4">Issues</div>
-        Plan and track work
-      </div>
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Discussions&quot;,&quot;label&quot;:&quot;ref_cta:Discussions;&quot;}" href="/features/discussions">
-      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-comment-discussion color-fg-subtle mr-3">
-    <path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v9.5A1.75 1.75 0 0 1 14.25 14H8.061l-2.574 2.573A1.458 1.458 0 0 1 3 15.543V14H1.75A1.75 1.75 0 0 1 0 12.25v-9.5C0 1.784.784 1 1.75 1ZM1.5 2.75v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Z"></path><path d="M22.5 8.75a.25.25 0 0 0-.25-.25h-3.5a.75.75 0 0 1 0-1.5h3.5c.966 0 1.75.784 1.75 1.75v9.5A1.75 1.75 0 0 1 22.25 20H21v1.543a1.457 1.457 0 0 1-2.487 1.03L15.939 20H10.75A1.75 1.75 0 0 1 9 18.25v-1.465a.75.75 0 0 1 1.5 0v1.465c0 .138.112.25.25.25h5.5a.75.75 0 0 1 .53.22l2.72 2.72v-2.19a.75.75 0 0 1 .75-.75h2a.25.25 0 0 0 .25-.25v-9.5Z"></path>
-</svg>
-      <div>
-        <div class="color-fg-default h4">Discussions</div>
-        Collaborate outside of code
-      </div>
-
-    
-</a></li>
-
-            </ul>
-          </div>
-          <div class="px-lg-4">
-              <span class="d-block h4 color-fg-default my-1" id="product-explore-heading">Explore</span>
-            <ul class="list-style-none f5" aria-labelledby="product-explore-heading">
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to All features&quot;,&quot;label&quot;:&quot;ref_cta:All features;&quot;}" href="/features">
-      All features
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Documentation&quot;,&quot;label&quot;:&quot;ref_cta:Documentation;&quot;}" href="https://docs.github.com">
-      Documentation
-
-    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
-    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
-</svg>
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to GitHub Skills&quot;,&quot;label&quot;:&quot;ref_cta:GitHub Skills;&quot;}" href="https://skills.github.com/">
-      GitHub Skills
-
-    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
-    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
-</svg>
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Product&quot;,&quot;action&quot;:&quot;click to go to Blog&quot;,&quot;label&quot;:&quot;ref_cta:Blog;&quot;}" href="https://github.blog">
-      Blog
-
-    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
-    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
-</svg>
-</a></li>
-
-            </ul>
-          </div>
-      </div>
-</li>
-
-
-                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
-      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-3 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
-        Solutions
-        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
-    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
-</svg>
-      </button>
-      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 py-2 py-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 px-lg-4">
-          <div class="border-bottom pb-3 mb-3">
-              <span class="d-block h4 color-fg-default my-1" id="solutions-for-heading">For</span>
-            <ul class="list-style-none f5" aria-labelledby="solutions-for-heading">
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Enterprise&quot;,&quot;label&quot;:&quot;ref_cta:Enterprise;&quot;}" href="/enterprise">
-      Enterprise
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Teams&quot;,&quot;label&quot;:&quot;ref_cta:Teams;&quot;}" href="/team">
-      Teams
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Startups&quot;,&quot;label&quot;:&quot;ref_cta:Startups;&quot;}" href="/enterprise/startups">
-      Startups
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Education&quot;,&quot;label&quot;:&quot;ref_cta:Education;&quot;}" href="https://education.github.com">
-      Education
-
-    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
-    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
-</svg>
-</a></li>
-
-            </ul>
-          </div>
-          <div class="border-bottom pb-3 mb-3">
-              <span class="d-block h4 color-fg-default my-1" id="solutions-by-solution-heading">By Solution</span>
-            <ul class="list-style-none f5" aria-labelledby="solutions-by-solution-heading">
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to CI/CD &amp;amp; Automation&quot;,&quot;label&quot;:&quot;ref_cta:CI/CD &amp;amp; Automation;&quot;}" href="/solutions/ci-cd/">
-      CI/CD &amp; Automation
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to DevOps&quot;,&quot;label&quot;:&quot;ref_cta:DevOps;&quot;}" href="/solutions/devops/">
-      DevOps
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to DevSecOps&quot;,&quot;label&quot;:&quot;ref_cta:DevSecOps;&quot;}" href="https://resources.github.com/devops/fundamentals/devsecops/">
-      DevSecOps
-
-    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
-    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
-</svg>
-</a></li>
-
-            </ul>
-          </div>
-          <div class="">
-              <span class="d-block h4 color-fg-default my-1" id="solutions-resources-heading">Resources</span>
-            <ul class="list-style-none f5" aria-labelledby="solutions-resources-heading">
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Learning Pathways&quot;,&quot;label&quot;:&quot;ref_cta:Learning Pathways;&quot;}" href="https://resources.github.com/learn/pathways/">
-      Learning Pathways
-
-    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
-    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
-</svg>
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to White papers, Ebooks, Webinars&quot;,&quot;label&quot;:&quot;ref_cta:White papers, Ebooks, Webinars;&quot;}" href="https://resources.github.com/">
-      White papers, Ebooks, Webinars
-
-    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
-    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
-</svg>
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Customer Stories&quot;,&quot;label&quot;:&quot;ref_cta:Customer Stories;&quot;}" href="/customer-stories">
-      Customer Stories
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" target="_blank" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Solutions&quot;,&quot;action&quot;:&quot;click to go to Partners&quot;,&quot;label&quot;:&quot;ref_cta:Partners;&quot;}" href="https://partner.github.com/">
-      Partners
-
-    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
-    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
-</svg>
-</a></li>
-
-            </ul>
-          </div>
-      </div>
-</li>
-
-
-                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
-      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-3 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
-        Open Source
-        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
-    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
-</svg>
-      </button>
-      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 py-2 py-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 px-lg-4">
-          <div class="border-bottom pb-3 mb-3">
-            <ul class="list-style-none f5" >
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Open Source&quot;,&quot;action&quot;:&quot;click to go to GitHub Sponsors&quot;,&quot;label&quot;:&quot;ref_cta:GitHub Sponsors;&quot;}" href="/sponsors">
-      
-      <div>
-        <div class="color-fg-default h4">GitHub Sponsors</div>
-        Fund open source developers
-      </div>
-
-    
-</a></li>
-
-            </ul>
-          </div>
-          <div class="border-bottom pb-3 mb-3">
-            <ul class="list-style-none f5" >
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Open Source&quot;,&quot;action&quot;:&quot;click to go to The ReadME Project&quot;,&quot;label&quot;:&quot;ref_cta:The ReadME Project;&quot;}" href="/readme">
-      
-      <div>
-        <div class="color-fg-default h4">The ReadME Project</div>
-        GitHub community articles
-      </div>
-
-    
-</a></li>
-
-            </ul>
-          </div>
-          <div class="">
-              <span class="d-block h4 color-fg-default my-1" id="open-source-repositories-heading">Repositories</span>
-            <ul class="list-style-none f5" aria-labelledby="open-source-repositories-heading">
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Open Source&quot;,&quot;action&quot;:&quot;click to go to Topics&quot;,&quot;label&quot;:&quot;ref_cta:Topics;&quot;}" href="/topics">
-      Topics
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Open Source&quot;,&quot;action&quot;:&quot;click to go to Trending&quot;,&quot;label&quot;:&quot;ref_cta:Trending;&quot;}" href="/trending">
-      Trending
-
-    
-</a></li>
-
-                <li>
-  <a class="HeaderMenu-dropdown-link lh-condensed d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;category&quot;:&quot;Header dropdown (logged out), Open Source&quot;,&quot;action&quot;:&quot;click to go to Collections&quot;,&quot;label&quot;:&quot;ref_cta:Collections;&quot;}" href="/collections">
-      Collections
-
-    
-</a></li>
-
-            </ul>
-          </div>
-      </div>
-</li>
-
-
-                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
-    <a class="HeaderMenu-link no-underline px-0 px-lg-2 py-3 py-lg-2 d-block d-lg-inline-block" data-analytics-event="{&quot;category&quot;:&quot;Header menu top item (logged out)&quot;,&quot;action&quot;:&quot;click to go to Pricing&quot;,&quot;label&quot;:&quot;ref_cta:Pricing;&quot;}" href="/pricing">Pricing</a>
-</li>
-
-            </ul>
-          </nav>
-
-        <div class="d-lg-flex flex-items-center mb-3 mb-lg-0 text-center text-lg-left ml-3" style="">
-                
-
-
-<qbsearch-input class="search-input" data-scope="repo:bitcoin/bips" data-custom-scopes-path="/search/custom_scopes" data-delete-custom-scopes-csrf="Tnl5i8kKyGoLFPn_YCzFEvTt3NRrD_oWJG_OfjEphI1CXljoD2ej529QHV22O_rOuDqtwSeuI7l7DWqfp4_e3g" data-max-custom-scopes="10" data-header-redesign-enabled="false" data-initial-value="" data-blackbird-suggestions-path="/search/suggestions" data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations" data-current-repository="bitcoin/bips" data-current-org="bitcoin" data-current-owner="" data-logged-in="false" data-copilot-chat-enabled="false" data-blackbird-indexed-repo-csrf="<esi:include src=&quot;/_esi/rails_csrf_token_form_hidden?r=iwseHI13vQk77JVMchJfLUyru3aEymEgvNankS6tKBsUqhe5N%2FZKMEGHx%2FXbKmyl%2BaUqQMxiKzQujzElxKQdcu84WdDo%2BUfDoKpqRcoBagTFY%2FrZPXIDbkqLVR1XzrpHWgmULHPCXGhIbeGw8w1anmkqCXz6kDeuuDc7zGRb9EO67JQgTMqDB27aOJwKluQeuyo8%2FEPl7yOAP3VullEwM%2Bw9ZxqXRkqh8fhdIh58PgCEGqh58i9OO38Niq%2BR8sZ5H06PS8ptOFRXfyCflPeV%2FWScaKw4qU898%2Bz%2BM2mQQiqxTYmWGLqklOwNmdcoxxHL%2BlNzd1Qdj98MYVOUKOfga0xKCMfgGNJ%2FMHvW%2Fu%2BWAKU%2F8Eo%2BURSTsU4HGSwg54ZefcGEZ4VGdTOULEEoGDZASWsoRXa814M5rdmN1aGCl8I%2BNBFyHqxlJVe2uuXgzHPnZrzuV1hk3Wjj5KtlG2nt0lpkkRxiByjUTivYlXWOW%2BXpxNkzBIUvCtQEx0CW2kxDwqdinwUIagTcOWqPE52IA3nQi4Bx8QjIo2YafTSV2%2Bsofl2%2BLzdFxC4GCbxa26szmeDMssi7nU6hExjFXjf6v1vtJFk71A%3D%3D--aPEyJbidBPtxFM7g--MkWdl8cqBm%2BQr8I9KECw1w%3D%3D&quot; />">
-  <div
-    class="search-input-container search-with-dialog position-relative d-flex flex-row flex-items-center mr-4 rounded"
-    data-action="click:qbsearch-input#searchInputContainerClicked"
-  >
-      <button
-        type="button"
-        class="header-search-button placeholder  input-button form-control d-flex flex-1 flex-self-stretch flex-items-center no-wrap width-full py-0 pl-2 pr-0 text-left border-0 box-shadow-none"
-        data-target="qbsearch-input.inputButton"
-        placeholder="Search or jump to..."
-        data-hotkey=s,/
-        autocapitalize="off"
-        data-action="click:qbsearch-input#handleExpand"
-      >
-        <div class="mr-2 color-fg-muted">
-          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
-    <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
-</svg>
-        </div>
-        <span class="flex-1" data-target="qbsearch-input.inputButtonText">Search or jump to...</span>
-          <div class="d-flex" data-target="qbsearch-input.hotkeyIndicator">
-            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" aria-hidden="true" class="mr-1"><path fill="none" stroke="#979A9C" opacity=".4" d="M3.5.5h12c1.7 0 3 1.3 3 3v13c0 1.7-1.3 3-3 3h-12c-1.7 0-3-1.3-3-3v-13c0-1.7 1.3-3 3-3z"></path><path fill="#979A9C" d="M11.8 6L8 15.1h-.9L10.8 6h1z"></path></svg>
-
-          </div>
-      </button>
-
-    <input type="hidden" name="type" class="js-site-search-type-field">
-
-    
-<div class="Overlay--hidden " data-modal-dialog-overlay>
-  <modal-dialog data-action="close:qbsearch-input#handleClose cancel:qbsearch-input#handleClose" data-target="qbsearch-input.searchSuggestionsDialog" role="dialog" id="search-suggestions-dialog" aria-modal="true" aria-labelledby="search-suggestions-dialog-header" data-view-component="true" class="Overlay Overlay--width-large Overlay--height-auto">
-      <h1 id="search-suggestions-dialog-header" class="sr-only">Search code, repositories, users, issues, pull requests...</h1>
-    <div class="Overlay-body Overlay-body--paddingNone">
-      
-          <div data-view-component="true">        <div class="search-suggestions position-fixed width-full color-shadow-large border color-fg-default color-bg-default overflow-hidden d-flex flex-column query-builder-container"
-          style="border-radius: 12px;"
-          data-target="qbsearch-input.queryBuilderContainer"
-          hidden
-        >
-          <!-- '"` --><!-- </textarea></xmp> --></option></form><form id="query-builder-test-form" action="" accept-charset="UTF-8" method="get">
-  <query-builder data-target="qbsearch-input.queryBuilder" id="query-builder-query-builder-test" data-filter-key=":" data-view-component="true" class="QueryBuilder search-query-builder">
-    <div class="FormControl FormControl--fullWidth">
-      <label id="query-builder-test-label" for="query-builder-test" class="FormControl-label sr-only">
-        Search
-      </label>
-      <div
-        class="QueryBuilder-StyledInput width-fit "
-        data-target="query-builder.styledInput"
-      >
-          <span id="query-builder-test-leadingvisual-wrap" class="FormControl-input-leadingVisualWrap QueryBuilder-leadingVisualWrap">
-            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search FormControl-input-leadingVisual">
-    <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
-</svg>
-          </span>
-        <div data-target="query-builder.styledInputContainer" class="QueryBuilder-StyledInputContainer">
-          <div
-            aria-hidden="true"
-            class="QueryBuilder-StyledInputContent"
-            data-target="query-builder.styledInputContent"
-          ></div>
-          <div class="QueryBuilder-InputWrapper">
-            <div aria-hidden="true" class="QueryBuilder-Sizer" data-target="query-builder.sizer"></div>
-            <input id="query-builder-test" name="query-builder-test" value="" autocomplete="off" type="text" role="combobox" spellcheck="false" aria-expanded="false" aria-describedby="validation-f4d831d7-7db4-4b63-bf4c-924f9551702f" data-target="query-builder.input" data-action="
-          input:query-builder#inputChange
-          blur:query-builder#inputBlur
-          keydown:query-builder#inputKeydown
-          focus:query-builder#inputFocus
-        " data-view-component="true" class="FormControl-input QueryBuilder-Input FormControl-medium" />
-          </div>
-        </div>
-          <span class="sr-only" id="query-builder-test-clear">Clear</span>
-          <button role="button" id="query-builder-test-clear-button" aria-labelledby="query-builder-test-clear query-builder-test-label" data-target="query-builder.clearButton" data-action="
-                click:query-builder#clear
-                focus:query-builder#clearButtonFocus
-                blur:query-builder#clearButtonBlur
-              " variant="small" hidden="hidden" type="button" data-view-component="true" class="Button Button--iconOnly Button--invisible Button--medium mr-1 px-2 py-0 d-flex flex-items-center rounded-1 color-fg-muted">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x-circle-fill Button-visual">
-    <path d="M2.343 13.657A8 8 0 1 1 13.658 2.343 8 8 0 0 1 2.343 13.657ZM6.03 4.97a.751.751 0 0 0-1.042.018.751.751 0 0 0-.018 1.042L6.94 8 4.97 9.97a.749.749 0 0 0 .326 1.275.749.749 0 0 0 .734-.215L8 9.06l1.97 1.97a.749.749 0 0 0 1.275-.326.749.749 0 0 0-.215-.734L9.06 8l1.97-1.97a.749.749 0 0 0-.326-1.275.749.749 0 0 0-.734.215L8 6.94Z"></path>
-</svg>
-</button>
-
-      </div>
-      <template id="search-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
-    <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
-</svg>
-</template>
-
-<template id="code-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code">
-    <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"></path>
-</svg>
-</template>
-
-<template id="file-code-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-code">
-    <path d="M4 1.75C4 .784 4.784 0 5.75 0h5.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v8.586A1.75 1.75 0 0 1 14.25 15h-9a.75.75 0 0 1 0-1.5h9a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 10 4.25V1.5H5.75a.25.25 0 0 0-.25.25v2.5a.75.75 0 0 1-1.5 0Zm1.72 4.97a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734l1.47-1.47-1.47-1.47a.75.75 0 0 1 0-1.06ZM3.28 7.78 1.81 9.25l1.47 1.47a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-2-2a.75.75 0 0 1 0-1.06l2-2a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Zm8.22-6.218V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"></path>
-</svg>
-</template>
-
-<template id="history-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-history">
-    <path d="m.427 1.927 1.215 1.215a8.002 8.002 0 1 1-1.6 5.685.75.75 0 1 1 1.493-.154 6.5 6.5 0 1 0 1.18-4.458l1.358 1.358A.25.25 0 0 1 3.896 6H.25A.25.25 0 0 1 0 5.75V2.104a.25.25 0 0 1 .427-.177ZM7.75 4a.75.75 0 0 1 .75.75v2.992l2.028.812a.75.75 0 0 1-.557 1.392l-2.5-1A.751.751 0 0 1 7 8.25v-3.5A.75.75 0 0 1 7.75 4Z"></path>
-</svg>
-</template>
-
-<template id="repo-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo">
-    <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path>
-</svg>
-</template>
-
-<template id="bookmark-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-bookmark">
-    <path d="M3 2.75C3 1.784 3.784 1 4.75 1h6.5c.966 0 1.75.784 1.75 1.75v11.5a.75.75 0 0 1-1.227.579L8 11.722l-3.773 3.107A.751.751 0 0 1 3 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.91l3.023-2.489a.75.75 0 0 1 .954 0l3.023 2.49V2.75a.25.25 0 0 0-.25-.25Z"></path>
-</svg>
-</template>
-
-<template id="plus-circle-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-plus-circle">
-    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm7.25-3.25v2.5h2.5a.75.75 0 0 1 0 1.5h-2.5v2.5a.75.75 0 0 1-1.5 0v-2.5h-2.5a.75.75 0 0 1 0-1.5h2.5v-2.5a.75.75 0 0 1 1.5 0Z"></path>
-</svg>
-</template>
-
-<template id="circle-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-dot-fill">
-    <path d="M8 4a4 4 0 1 1 0 8 4 4 0 0 1 0-8Z"></path>
-</svg>
-</template>
-
-<template id="trash-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-trash">
-    <path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75ZM4.496 6.675l.66 6.6a.25.25 0 0 0 .249.225h5.19a.25.25 0 0 0 .249-.225l.66-6.6a.75.75 0 0 1 1.492.149l-.66 6.6A1.748 1.748 0 0 1 10.595 15h-5.19a1.75 1.75 0 0 1-1.741-1.575l-.66-6.6a.75.75 0 1 1 1.492-.15ZM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25Z"></path>
-</svg>
-</template>
-
-<template id="team-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-people">
-    <path d="M2 5.5a3.5 3.5 0 1 1 5.898 2.549 5.508 5.508 0 0 1 3.034 4.084.75.75 0 1 1-1.482.235 4 4 0 0 0-7.9 0 .75.75 0 0 1-1.482-.236A5.507 5.507 0 0 1 3.102 8.05 3.493 3.493 0 0 1 2 5.5ZM11 4a3.001 3.001 0 0 1 2.22 5.018 5.01 5.01 0 0 1 2.56 3.012.749.749 0 0 1-.885.954.752.752 0 0 1-.549-.514 3.507 3.507 0 0 0-2.522-2.372.75.75 0 0 1-.574-.73v-.352a.75.75 0 0 1 .416-.672A1.5 1.5 0 0 0 11 5.5.75.75 0 0 1 11 4Zm-5.5-.5a2 2 0 1 0-.001 3.999A2 2 0 0 0 5.5 3.5Z"></path>
-</svg>
-</template>
-
-<template id="project-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-project">
-    <path d="M1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25V1.75C0 .784.784 0 1.75 0ZM1.5 1.75v12.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25ZM11.75 3a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-1.5 0v-7.5a.75.75 0 0 1 .75-.75Zm-8.25.75a.75.75 0 0 1 1.5 0v5.5a.75.75 0 0 1-1.5 0ZM8 3a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 3Z"></path>
-</svg>
-</template>
-
-<template id="pencil-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-pencil">
-    <path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61Zm.176 4.823L9.75 4.81l-6.286 6.287a.253.253 0 0 0-.064.108l-.558 1.953 1.953-.558a.253.253 0 0 0 .108-.064Zm1.238-3.763a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354Z"></path>
-</svg>
-</template>
-
-<template id="copilot-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copilot">
-    <path d="M7.998 15.035c-4.562 0-7.873-2.914-7.998-3.749V9.338c.085-.628.677-1.686 1.588-2.065.013-.07.024-.143.036-.218.029-.183.06-.384.126-.612-.201-.508-.254-1.084-.254-1.656 0-.87.128-1.769.693-2.484.579-.733 1.494-1.124 2.724-1.261 1.206-.134 2.262.034 2.944.765.05.053.096.108.139.165.044-.057.094-.112.143-.165.682-.731 1.738-.899 2.944-.765 1.23.137 2.145.528 2.724 1.261.566.715.693 1.614.693 2.484 0 .572-.053 1.148-.254 1.656.066.228.098.429.126.612.012.076.024.148.037.218.924.385 1.522 1.471 1.591 2.095v1.872c0 .766-3.351 3.795-8.002 3.795Zm0-1.485c2.28 0 4.584-1.11 5.002-1.433V7.862l-.023-.116c-.49.21-1.075.291-1.727.291-1.146 0-2.059-.327-2.71-.991A3.222 3.222 0 0 1 8 6.303a3.24 3.24 0 0 1-.544.743c-.65.664-1.563.991-2.71.991-.652 0-1.236-.081-1.727-.291l-.023.116v4.255c.419.323 2.722 1.433 5.002 1.433ZM6.762 2.83c-.193-.206-.637-.413-1.682-.297-1.019.113-1.479.404-1.713.7-.247.312-.369.789-.369 1.554 0 .793.129 1.171.308 1.371.162.181.519.379 1.442.379.853 0 1.339-.235 1.638-.54.315-.322.527-.827.617-1.553.117-.935-.037-1.395-.241-1.614Zm4.155-.297c-1.044-.116-1.488.091-1.681.297-.204.219-.359.679-.242 1.614.091.726.303 1.231.618 1.553.299.305.784.54 1.638.54.922 0 1.28-.198 1.442-.379.179-.2.308-.578.308-1.371 0-.765-.123-1.242-.37-1.554-.233-.296-.693-.587-1.713-.7Z"></path><path d="M6.25 9.037a.75.75 0 0 1 .75.75v1.501a.75.75 0 0 1-1.5 0V9.787a.75.75 0 0 1 .75-.75Zm4.25.75v1.501a.75.75 0 0 1-1.5 0V9.787a.75.75 0 0 1 1.5 0Z"></path>
-</svg>
-</template>
-
-<template id="workflow-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-workflow">
-    <path d="M0 1.75C0 .784.784 0 1.75 0h3.5C6.216 0 7 .784 7 1.75v3.5A1.75 1.75 0 0 1 5.25 7H4v4a1 1 0 0 0 1 1h4v-1.25C9 9.784 9.784 9 10.75 9h3.5c.966 0 1.75.784 1.75 1.75v3.5A1.75 1.75 0 0 1 14.25 16h-3.5A1.75 1.75 0 0 1 9 14.25v-.75H5A2.5 2.5 0 0 1 2.5 11V7h-.75A1.75 1.75 0 0 1 0 5.25Zm1.75-.25a.25.25 0 0 0-.25.25v3.5c0 .138.112.25.25.25h3.5a.25.25 0 0 0 .25-.25v-3.5a.25.25 0 0 0-.25-.25Zm9 9a.25.25 0 0 0-.25.25v3.5c0 .138.112.25.25.25h3.5a.25.25 0 0 0 .25-.25v-3.5a.25.25 0 0 0-.25-.25Z"></path>
-</svg>
-</template>
-
-<template id="book-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-book">
-    <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"></path>
-</svg>
-</template>
-
-<template id="code-review-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code-review">
-    <path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 13H8.061l-2.574 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25v-8.5C0 1.784.784 1 1.75 1ZM1.5 2.75v8.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Zm5.28 1.72a.75.75 0 0 1 0 1.06L5.31 7l1.47 1.47a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-2-2a.75.75 0 0 1 0-1.06l2-2a.75.75 0 0 1 1.06 0Zm2.44 0a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.69 7 9.22 5.53a.75.75 0 0 1 0-1.06Z"></path>
-</svg>
-</template>
-
-<template id="codespaces-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-codespaces">
-    <path d="M0 11.25c0-.966.784-1.75 1.75-1.75h12.5c.966 0 1.75.784 1.75 1.75v3A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25Zm2-9.5C2 .784 2.784 0 3.75 0h8.5C13.216 0 14 .784 14 1.75v5a1.75 1.75 0 0 1-1.75 1.75h-8.5A1.75 1.75 0 0 1 2 6.75Zm1.75-.25a.25.25 0 0 0-.25.25v5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-5a.25.25 0 0 0-.25-.25Zm-2 9.5a.25.25 0 0 0-.25.25v3c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-3a.25.25 0 0 0-.25-.25Z"></path><path d="M7 12.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Zm-4 0a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1-.75-.75Z"></path>
-</svg>
-</template>
-
-<template id="comment-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-comment">
-    <path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h4.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
-</svg>
-</template>
-
-<template id="comment-discussion-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-comment-discussion">
-    <path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"></path>
-</svg>
-</template>
-
-<template id="organization-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-organization">
-    <path d="M1.75 16A1.75 1.75 0 0 1 0 14.25V1.75C0 .784.784 0 1.75 0h8.5C11.216 0 12 .784 12 1.75v12.5c0 .085-.006.168-.018.25h2.268a.25.25 0 0 0 .25-.25V8.285a.25.25 0 0 0-.111-.208l-1.055-.703a.749.749 0 1 1 .832-1.248l1.055.703c.487.325.779.871.779 1.456v5.965A1.75 1.75 0 0 1 14.25 16h-3.5a.766.766 0 0 1-.197-.026c-.099.017-.2.026-.303.026h-3a.75.75 0 0 1-.75-.75V14h-1v1.25a.75.75 0 0 1-.75.75Zm-.25-1.75c0 .138.112.25.25.25H4v-1.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 .75.75v1.25h2.25a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25ZM3.75 6h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5ZM3 3.75A.75.75 0 0 1 3.75 3h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 3 3.75Zm4 3A.75.75 0 0 1 7.75 6h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 7 6.75ZM7.75 3h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5ZM3 9.75A.75.75 0 0 1 3.75 9h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 3 9.75ZM7.75 9h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5Z"></path>
-</svg>
-</template>
-
-<template id="rocket-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-rocket">
-    <path d="M14.064 0h.186C15.216 0 16 .784 16 1.75v.186a8.752 8.752 0 0 1-2.564 6.186l-.458.459c-.314.314-.641.616-.979.904v3.207c0 .608-.315 1.172-.833 1.49l-2.774 1.707a.749.749 0 0 1-1.11-.418l-.954-3.102a1.214 1.214 0 0 1-.145-.125L3.754 9.816a1.218 1.218 0 0 1-.124-.145L.528 8.717a.749.749 0 0 1-.418-1.11l1.71-2.774A1.748 1.748 0 0 1 3.31 4h3.204c.288-.338.59-.665.904-.979l.459-.458A8.749 8.749 0 0 1 14.064 0ZM8.938 3.623h-.002l-.458.458c-.76.76-1.437 1.598-2.02 2.5l-1.5 2.317 2.143 2.143 2.317-1.5c.902-.583 1.74-1.26 2.499-2.02l.459-.458a7.25 7.25 0 0 0 2.123-5.127V1.75a.25.25 0 0 0-.25-.25h-.186a7.249 7.249 0 0 0-5.125 2.123ZM3.56 14.56c-.732.732-2.334 1.045-3.005 1.148a.234.234 0 0 1-.201-.064.234.234 0 0 1-.064-.201c.103-.671.416-2.273 1.15-3.003a1.502 1.502 0 1 1 2.12 2.12Zm6.94-3.935c-.088.06-.177.118-.266.175l-2.35 1.521.548 1.783 1.949-1.2a.25.25 0 0 0 .119-.213ZM3.678 8.116 5.2 5.766c.058-.09.117-.178.176-.266H3.309a.25.25 0 0 0-.213.119l-1.2 1.95ZM12 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
-</svg>
-</template>
-
-<template id="shield-check-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-shield-check">
-    <path d="m8.533.133 5.25 1.68A1.75 1.75 0 0 1 15 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.697 1.697 0 0 1-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 0 1 1.217-1.667l5.25-1.68a1.748 1.748 0 0 1 1.066 0Zm-.61 1.429.001.001-5.25 1.68a.251.251 0 0 0-.174.237V7c0 1.36.275 2.666 1.057 3.859.784 1.194 2.121 2.342 4.366 3.298a.196.196 0 0 0 .154 0c2.245-.957 3.582-2.103 4.366-3.297C13.225 9.666 13.5 8.358 13.5 7V3.48a.25.25 0 0 0-.174-.238l-5.25-1.68a.25.25 0 0 0-.153 0ZM11.28 6.28l-3.5 3.5a.75.75 0 0 1-1.06 0l-1.5-1.5a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l.97.97 2.97-2.97a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
-</svg>
-</template>
-
-<template id="heart-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-heart">
-    <path d="m8 14.25.345.666a.75.75 0 0 1-.69 0l-.008-.004-.018-.01a7.152 7.152 0 0 1-.31-.17 22.055 22.055 0 0 1-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.066 22.066 0 0 1-3.744 2.584l-.018.01-.006.003h-.002ZM4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.58 20.58 0 0 0 8 13.393a20.58 20.58 0 0 0 3.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.749.749 0 0 1-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5Z"></path>
-</svg>
-</template>
-
-<template id="server-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-server">
-    <path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v4c0 .372-.116.717-.314 1 .198.283.314.628.314 1v4a1.75 1.75 0 0 1-1.75 1.75H1.75A1.75 1.75 0 0 1 0 12.75v-4c0-.358.109-.707.314-1a1.739 1.739 0 0 1-.314-1v-4C0 1.784.784 1 1.75 1ZM1.5 2.75v4c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-4a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Zm.25 5.75a.25.25 0 0 0-.25.25v4c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-4a.25.25 0 0 0-.25-.25ZM7 4.75A.75.75 0 0 1 7.75 4h4.5a.75.75 0 0 1 0 1.5h-4.5A.75.75 0 0 1 7 4.75ZM7.75 10h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM3 4.75A.75.75 0 0 1 3.75 4h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 3 4.75ZM3.75 10h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5Z"></path>
-</svg>
-</template>
-
-<template id="globe-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-globe">
-    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM5.78 8.75a9.64 9.64 0 0 0 1.363 4.177c.255.426.542.832.857 1.215.245-.296.551-.705.857-1.215A9.64 9.64 0 0 0 10.22 8.75Zm4.44-1.5a9.64 9.64 0 0 0-1.363-4.177c-.307-.51-.612-.919-.857-1.215a9.927 9.927 0 0 0-.857 1.215A9.64 9.64 0 0 0 5.78 7.25Zm-5.944 1.5H1.543a6.507 6.507 0 0 0 4.666 5.5c-.123-.181-.24-.365-.352-.552-.715-1.192-1.437-2.874-1.581-4.948Zm-2.733-1.5h2.733c.144-2.074.866-3.756 1.58-4.948.12-.197.237-.381.353-.552a6.507 6.507 0 0 0-4.666 5.5Zm10.181 1.5c-.144 2.074-.866 3.756-1.58 4.948-.12.197-.237.381-.353.552a6.507 6.507 0 0 0 4.666-5.5Zm2.733-1.5a6.507 6.507 0 0 0-4.666-5.5c.123.181.24.365.353.552.714 1.192 1.436 2.874 1.58 4.948Z"></path>
-</svg>
-</template>
-
-<template id="issue-opened-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-issue-opened">
-    <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path>
-</svg>
-</template>
-
-<template id="device-mobile-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-device-mobile">
-    <path d="M3.75 0h8.5C13.216 0 14 .784 14 1.75v12.5A1.75 1.75 0 0 1 12.25 16h-8.5A1.75 1.75 0 0 1 2 14.25V1.75C2 .784 2.784 0 3.75 0ZM3.5 1.75v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25ZM8 13a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
-</svg>
-</template>
-
-<template id="package-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package">
-    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
-</svg>
-</template>
-
-<template id="credit-card-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-credit-card">
-    <path d="M10.75 9a.75.75 0 0 0 0 1.5h1.5a.75.75 0 0 0 0-1.5h-1.5Z"></path><path d="M0 3.75C0 2.784.784 2 1.75 2h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 14H1.75A1.75 1.75 0 0 1 0 12.25ZM14.5 6.5h-13v5.75c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25Zm0-2.75a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25V5h13Z"></path>
-</svg>
-</template>
-
-<template id="play-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-play">
-    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z"></path>
-</svg>
-</template>
-
-<template id="gift-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-gift">
-    <path d="M2 2.75A2.75 2.75 0 0 1 4.75 0c.983 0 1.873.42 2.57 1.232.268.318.497.668.68 1.042.183-.375.411-.725.68-1.044C9.376.42 10.266 0 11.25 0a2.75 2.75 0 0 1 2.45 4h.55c.966 0 1.75.784 1.75 1.75v2c0 .698-.409 1.301-1 1.582v4.918A1.75 1.75 0 0 1 13.25 16H2.75A1.75 1.75 0 0 1 1 14.25V9.332C.409 9.05 0 8.448 0 7.75v-2C0 4.784.784 4 1.75 4h.55c-.192-.375-.3-.8-.3-1.25ZM7.25 9.5H2.5v4.75c0 .138.112.25.25.25h4.5Zm1.5 0v5h4.5a.25.25 0 0 0 .25-.25V9.5Zm0-4V8h5.5a.25.25 0 0 0 .25-.25v-2a.25.25 0 0 0-.25-.25Zm-7 0a.25.25 0 0 0-.25.25v2c0 .138.112.25.25.25h5.5V5.5h-5.5Zm3-4a1.25 1.25 0 0 0 0 2.5h2.309c-.233-.818-.542-1.401-.878-1.793-.43-.502-.915-.707-1.431-.707ZM8.941 4h2.309a1.25 1.25 0 0 0 0-2.5c-.516 0-1 .205-1.43.707-.337.392-.646.975-.879 1.793Z"></path>
-</svg>
-</template>
-
-<template id="code-square-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code-square">
-    <path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25Zm7.47 3.97a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L10.69 8 9.22 6.53a.75.75 0 0 1 0-1.06ZM6.78 6.53 5.31 8l1.47 1.47a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215l-2-2a.75.75 0 0 1 0-1.06l2-2a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
-</svg>
-</template>
-
-<template id="device-desktop-icon">
-  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-device-desktop">
-    <path d="M14.25 1c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12h-3.727c.099 1.041.52 1.872 1.292 2.757A.752.752 0 0 1 11.25 16h-6.5a.75.75 0 0 1-.565-1.243c.772-.885 1.192-1.716 1.292-2.757H1.75A1.75 1.75 0 0 1 0 10.25v-7.5C0 1.784.784 1 1.75 1ZM1.75 2.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25ZM9.018 12H6.982a5.72 5.72 0 0 1-.765 2.5h3.566a5.72 5.72 0 0 1-.765-2.5Z"></path>
-</svg>
-</template>
-
-        <div class="position-relative">
-                <ul
-                  role="listbox"
-                  class="ActionListWrap QueryBuilder-ListWrap"
-                  aria-label="Suggestions"
-                  data-action="
-                    combobox-commit:query-builder#comboboxCommit
-                    mousedown:query-builder#resultsMousedown
-                  "
-                  data-target="query-builder.resultsList"
-                  data-persist-list=false
-                  id="query-builder-test-results"
-                ></ul>
-        </div>
-      <div class="FormControl-inlineValidation" id="validation-f4d831d7-7db4-4b63-bf4c-924f9551702f" hidden="hidden">
-        <span class="FormControl-inlineValidation--visual">
-          <svg aria-hidden="true" height="12" viewBox="0 0 12 12" version="1.1" width="12" data-view-component="true" class="octicon octicon-alert-fill">
-    <path d="M4.855.708c.5-.896 1.79-.896 2.29 0l4.675 8.351a1.312 1.312 0 0 1-1.146 1.954H1.33A1.313 1.313 0 0 1 .183 9.058ZM7 7V3H5v4Zm-1 3a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"></path>
-</svg>
-        </span>
-        <span></span>
-</div>    </div>
-    <div data-target="query-builder.screenReaderFeedback" aria-live="polite" aria-atomic="true" class="sr-only"></div>
-</query-builder></form>
-          <div class="d-flex flex-row color-fg-muted px-3 text-small color-bg-default search-feedback-prompt">
-            <a target="_blank" href="https://docs.github.com/search-github/github-code-search/understanding-github-code-search-syntax" data-view-component="true" class="Link color-fg-accent text-normal ml-2">
-              Search syntax tips
-</a>            <div class="d-flex flex-1"></div>
-          </div>
-        </div>
-</div>
-
-    </div>
-</modal-dialog></div>
-  </div>
-  <div data-action="click:qbsearch-input#retract" class="dark-backdrop position-fixed" hidden data-target="qbsearch-input.darkBackdrop"></div>
-  <div class="color-fg-default">
-    
-<dialog-helper>
-  <dialog data-target="qbsearch-input.feedbackDialog" data-action="close:qbsearch-input#handleDialogClose cancel:qbsearch-input#handleDialogClose" id="feedback-dialog" aria-modal="true" aria-labelledby="feedback-dialog-title" aria-describedby="feedback-dialog-description" data-view-component="true" class="Overlay Overlay-whenNarrow Overlay--size-medium Overlay--motion-scaleFade">
-    <div data-view-component="true" class="Overlay-header">
-  <div class="Overlay-headerContentWrap">
-    <div class="Overlay-titleWrap">
-      <h1 class="Overlay-title " id="feedback-dialog-title">
-        Provide feedback
-      </h1>
-    </div>
-    <div class="Overlay-actionWrap">
-      <button data-close-dialog-id="feedback-dialog" aria-label="Close" type="button" data-view-component="true" class="close-button Overlay-closeButton"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
-    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
-</svg></button>
-    </div>
-  </div>
-</div>
-      <scrollable-region data-labelled-by="feedback-dialog-title">
-        <div data-view-component="true" class="Overlay-body">        <!-- '"` --><!-- </textarea></xmp> --></option></form><form id="code-search-feedback-form" data-turbo="false" action="/search/feedback" accept-charset="UTF-8" method="post"><input type="hidden" data-csrf="true" name="authenticity_token" value="swqFThf79dN9NvdSEl0Sni+odDdnJUzLFuGl5KQLuwg5HRLLtANMzRQB3nNjZN3D6vwyW97VLI7bBxKbsgtEdw==" />
-          <p>We read every piece of feedback, and take your input very seriously.</p>
-          <textarea name="feedback" class="form-control width-full mb-2" style="height: 120px" id="feedback"></textarea>
-          <input name="include_email" id="include_email" aria-label="Include my email address so I can be contacted" class="form-control mr-2" type="checkbox">
-          <label for="include_email" style="font-weight: normal">Include my email address so I can be contacted</label>
-</form></div>
-      </scrollable-region>
-      <div data-view-component="true" class="Overlay-footer Overlay-footer--alignEnd">          <button data-close-dialog-id="feedback-dialog" type="button" data-view-component="true" class="btn">    Cancel
-</button>
-          <button form="code-search-feedback-form" data-action="click:qbsearch-input#submitFeedback" type="submit" data-view-component="true" class="btn-primary btn">    Submit feedback
-</button>
-</div>
-</dialog></dialog-helper>
-
-    <custom-scopes data-target="qbsearch-input.customScopesManager">
-    
-<dialog-helper>
-  <dialog data-target="custom-scopes.customScopesModalDialog" data-action="close:qbsearch-input#handleDialogClose cancel:qbsearch-input#handleDialogClose" id="custom-scopes-dialog" aria-modal="true" aria-labelledby="custom-scopes-dialog-title" aria-describedby="custom-scopes-dialog-description" data-view-component="true" class="Overlay Overlay-whenNarrow Overlay--size-medium Overlay--motion-scaleFade">
-    <div data-view-component="true" class="Overlay-header Overlay-header--divided">
-  <div class="Overlay-headerContentWrap">
-    <div class="Overlay-titleWrap">
-      <h1 class="Overlay-title " id="custom-scopes-dialog-title">
-        Saved searches
-      </h1>
-        <h2 id="custom-scopes-dialog-description" class="Overlay-description">Use saved searches to filter your results more quickly</h2>
-    </div>
-    <div class="Overlay-actionWrap">
-      <button data-close-dialog-id="custom-scopes-dialog" aria-label="Close" type="button" data-view-component="true" class="close-button Overlay-closeButton"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
-    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
-</svg></button>
-    </div>
-  </div>
-</div>
-      <scrollable-region data-labelled-by="custom-scopes-dialog-title">
-        <div data-view-component="true" class="Overlay-body">        <div data-target="custom-scopes.customScopesModalDialogFlash"></div>
-
-        <div hidden class="create-custom-scope-form" data-target="custom-scopes.createCustomScopeForm">
-        <!-- '"` --><!-- </textarea></xmp> --></option></form><form id="custom-scopes-dialog-form" data-turbo="false" action="/search/custom_scopes" accept-charset="UTF-8" method="post"><input type="hidden" data-csrf="true" name="authenticity_token" value="+Ada5KMK/WQ+j1po+C07QwrZ3Ef7o0GfT4MFWdUBsmWaeob9X+K8KgHmHRbFmBBd/EO8Px9r/Rm9uFQelBPggA==" />
-          <div data-target="custom-scopes.customScopesModalDialogFlash"></div>
-
-          <input type="hidden" id="custom_scope_id" name="custom_scope_id" data-target="custom-scopes.customScopesIdField">
-
-          <div class="form-group">
-            <label for="custom_scope_name">Name</label>
-            <auto-check src="/search/custom_scopes/check_name" required>
-              <input
-                type="text"
-                name="custom_scope_name"
-                id="custom_scope_name"
-                data-target="custom-scopes.customScopesNameField"
-                class="form-control"
-                autocomplete="off"
-                placeholder="github-ruby"
-                required
-                maxlength="50">
-              <input type="hidden" data-csrf="true" value="hefFleUmJqqPGgekD/bENcPYwTS6YSQmqN7ke52QdazVn4TTtn1UQsTXuKygqyPHALzdulvT9eV39IbuqNOZBw==" />
-            </auto-check>
-          </div>
-
-          <div class="form-group">
-            <label for="custom_scope_query">Query</label>
-            <input
-              type="text"
-              name="custom_scope_query"
-              id="custom_scope_query"
-              data-target="custom-scopes.customScopesQueryField"
-              class="form-control"
-              autocomplete="off"
-              placeholder="(repo:mona/a OR repo:mona/b) AND lang:python"
-              required
-              maxlength="500">
-          </div>
-
-          <p class="text-small color-fg-muted">
-            To see all available qualifiers, see our <a class="Link--inTextBlock" href="https://docs.github.com/search-github/github-code-search/understanding-github-code-search-syntax">documentation</a>.
-          </p>
-</form>        </div>
-
-        <div data-target="custom-scopes.manageCustomScopesForm">
-          <div data-target="custom-scopes.list"></div>
-        </div>
-
-</div>
-      </scrollable-region>
-      <div data-view-component="true" class="Overlay-footer Overlay-footer--alignEnd Overlay-footer--divided">          <button data-action="click:custom-scopes#customScopesCancel" type="button" data-view-component="true" class="btn">    Cancel
-</button>
-          <button form="custom-scopes-dialog-form" data-action="click:custom-scopes#customScopesSubmit" data-target="custom-scopes.customScopesSubmitButton" type="submit" data-view-component="true" class="btn-primary btn">    Create saved search
-</button>
-</div>
-</dialog></dialog-helper>
-    </custom-scopes>
-  </div>
-</qbsearch-input><input type="hidden" data-csrf="true" class="js-data-jump-to-suggestions-path-csrf" value="eMxZCc6ICmJuBekcYQ74fRU3/0wtMrbjd3lpg2R+S5dcUDyl7i8zR84Jwqn3+ABHayF2y7OQ3yy6GOHt8GZWuw==" />
-
-
-          <div class="position-relative mr-lg-3 d-lg-inline-block">
-            <a href="/login?return_to=https%3A%2F%2Fgithub.com%2Fbitcoin%2Fbips%2Fblob%2Fmaster%2Fbip-0341%2Fwallet-test-vectors.json"
-              class="HeaderMenu-link HeaderMenu-link--sign-in flex-shrink-0 no-underline d-block d-lg-inline-block border border-lg-0 rounded rounded-lg-0 p-2 p-lg-0"
-              data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="e3eeb14657e31f8e374c5918df8787078a0f6a39d7a1c1da8498d77997771dd5"
-              data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">
-              Sign in
-            </a>
-          </div>
-
-            <a href="/signup?ref_cta=Sign+up&amp;ref_loc=header+logged+out&amp;ref_page=%2F%3Cuser-name%3E%2F%3Crepo-name%3E%2Fblob%2Fshow&amp;source=header-repo&amp;source_repo=bitcoin%2Fbips"
-              class="HeaderMenu-link HeaderMenu-link--sign-up flex-shrink-0 d-none d-lg-inline-block no-underline border color-border-default rounded px-2 py-1"
-              data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="e3eeb14657e31f8e374c5918df8787078a0f6a39d7a1c1da8498d77997771dd5"
-              data-analytics-event="{&quot;category&quot;:&quot;Sign up&quot;,&quot;action&quot;:&quot;click to sign up for account&quot;,&quot;label&quot;:&quot;ref_page:/&lt;user-name&gt;/&lt;repo-name&gt;/blob/show;ref_cta:Sign up;ref_loc:header logged out&quot;}"
-            >
-              Sign up
-            </a>
-        </div>
-      </div>
-    </div>
-  </div>
-</header>
-
-      <div hidden="hidden" data-view-component="true" class="js-stale-session-flash stale-session-flash flash flash-warn flash-full mb-3">
-  
-        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-alert">
-    <path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
-</svg>
-        <span class="js-stale-session-flash-signed-in" hidden>You signed in with another tab or window. <a class="Link--inTextBlock" href="">Reload</a> to refresh your session.</span>
-        <span class="js-stale-session-flash-signed-out" hidden>You signed out in another tab or window. <a class="Link--inTextBlock" href="">Reload</a> to refresh your session.</span>
-        <span class="js-stale-session-flash-switched" hidden>You switched accounts on another tab or window. <a class="Link--inTextBlock" href="">Reload</a> to refresh your session.</span>
-
-    <button id="icon-button-0728729c-97e2-4a79-b92f-288d245f8744" aria-labelledby="tooltip-d7cd8867-7570-487d-a309-af6add924fff" type="button" data-view-component="true" class="Button Button--iconOnly Button--invisible Button--medium flash-close js-flash-close">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x Button-visual">
-    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
-</svg>
-</button><tool-tip id="tooltip-d7cd8867-7570-487d-a309-af6add924fff" for="icon-button-0728729c-97e2-4a79-b92f-288d245f8744" popover="manual" data-direction="s" data-type="label" data-view-component="true" class="sr-only position-absolute">Dismiss alert</tool-tip>
-
-
-  
-</div>
-    </div>
-
-  <div id="start-of-content" class="show-on-focus"></div>
-
-
-
-
-
-
-
-
-    <div id="js-flash-container" data-turbo-replace>
-
-
-
-
-
-  <template class="js-flash-template">
-    
-<div class="flash flash-full   {{ className }}">
-  <div >
-    <button autofocus class="flash-close js-flash-close" type="button" aria-label="Dismiss this message">
-      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
-    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
-</svg>
-    </button>
-    <div aria-atomic="true" role="alert" class="js-flash-alert">
-      
-      <div>{{ message }}</div>
-
-    </div>
-  </div>
-</div>
-  </template>
-</div>
-
-
-    
-    <include-fragment class="js-notification-shelf-include-fragment" data-base-src="https://github.com/notifications/beta/shelf"></include-fragment>
-
-
-
-
-
-  <div
-    class="application-main "
-    data-commit-hovercards-enabled
-    data-discussion-hovercards-enabled
-    data-issue-and-pr-hovercards-enabled
-  >
-        <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
-    <main id="js-repo-pjax-container" >
-      
-      
-    
-
-    
-
-
-
-
-
-
-  
-  <div id="repository-container-header"  class="pt-3 hide-full-screen" style="background-color: var(--page-header-bgColor, var(--color-page-header-bg));" data-turbo-replace>
-
-      <div class="d-flex flex-wrap flex-justify-end mb-3  px-3 px-md-4 px-lg-5" style="gap: 1rem;">
-
-        <div class="flex-auto min-width-0 width-fit mr-3">
-            
-  <div class=" d-flex flex-wrap flex-items-center wb-break-word f3 text-normal">
-      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo color-fg-muted mr-2">
-    <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path>
-</svg>
-    
-    <span class="author flex-self-stretch" itemprop="author">
-      <a class="url fn" rel="author" data-hovercard-type="organization" data-hovercard-url="/orgs/bitcoin/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/bitcoin">
-        bitcoin
-</a>    </span>
-    <span class="mx-1 flex-self-stretch color-fg-muted">/</span>
-    <strong itemprop="name" class="mr-2 flex-self-stretch">
-      <a data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" href="/bitcoin/bips">bips</a>
-    </strong>
-
-    <span></span><span class="Label Label--secondary v-align-middle mr-1">Public</span>
-  </div>
-
-
-        </div>
-
-        <div id="repository-details-container" data-turbo-replace>
-            <ul class="pagehead-actions flex-shrink-0 d-none d-md-inline" style="padding: 2px 0;">
-    
-      
-
-  <li>
-            <a href="/login?return_to=%2Fbitcoin%2Fbips" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;notification subscription menu watch&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="7d713c29a1774cb3cff48555cc375b866f7aa57431aae7b88300a15dbf55f072" aria-label="You must be signed in to change notification settings" data-view-component="true" class="tooltipped tooltipped-s btn-sm btn">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-bell mr-2">
-    <path d="M8 16a2 2 0 0 0 1.985-1.75c.017-.137-.097-.25-.235-.25h-3.5c-.138 0-.252.113-.235.25A2 2 0 0 0 8 16ZM3 5a5 5 0 0 1 10 0v2.947c0 .05.015.098.042.139l1.703 2.555A1.519 1.519 0 0 1 13.482 13H2.518a1.516 1.516 0 0 1-1.263-2.36l1.703-2.554A.255.255 0 0 0 3 7.947Zm5-3.5A3.5 3.5 0 0 0 4.5 5v2.947c0 .346-.102.683-.294.97l-1.703 2.556a.017.017 0 0 0-.003.01l.001.006c0 .002.002.004.004.006l.006.004.007.001h10.964l.007-.001.006-.004.004-.006.001-.007a.017.017 0 0 0-.003-.01l-1.703-2.554a1.745 1.745 0 0 1-.294-.97V5A3.5 3.5 0 0 0 8 1.5Z"></path>
-</svg>Notifications
-</a>
-  </li>
-
-  <li>
-          <a icon="repo-forked" id="fork-button" href="/login?return_to=%2Fbitcoin%2Fbips" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;repo details fork button&quot;,&quot;repository_id&quot;:14531737,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="6074025b10affa938344bb4274491d4f739d03f1be8bcb976548f369ec1e7637" data-view-component="true" class="btn-sm btn">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo-forked mr-2">
-    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"></path>
-</svg>Fork
-    <span id="repo-network-counter" data-pjax-replace="true" data-turbo-replace="true" title="5,217" data-view-component="true" class="Counter">5.2k</span>
-</a>
-  </li>
-
-  <li>
-        <div data-view-component="true" class="BtnGroup d-flex">
-        <a href="/login?return_to=%2Fbitcoin%2Fbips" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;star button&quot;,&quot;repository_id&quot;:14531737,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="8834ed6c1b5af2e85b4700b61ace0e5d0750c87ef7089a9d6262a0696a56e0e6" aria-label="You must be signed in to star a repository" data-view-component="true" class="tooltipped tooltipped-s btn-sm btn BtnGroup-item">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-star v-align-text-bottom d-inline-block mr-2">
-    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z"></path>
-</svg><span data-view-component="true" class="d-inline">
-          Star
-</span>          <span id="repo-stars-counter-star" aria-label="8875 users starred this repository" data-singular-suffix="user starred this repository" data-plural-suffix="users starred this repository" data-turbo-replace="true" title="8,875" data-view-component="true" class="Counter js-social-count">8.9k</span>
-</a>        <button aria-label="You must be signed in to add this repository to a list" type="button" disabled="disabled" data-view-component="true" class="btn-sm btn BtnGroup-item px-2">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down">
-    <path d="m4.427 7.427 3.396 3.396a.25.25 0 0 0 .354 0l3.396-3.396A.25.25 0 0 0 11.396 7H4.604a.25.25 0 0 0-.177.427Z"></path>
-</svg>
-</button></div>
-  </li>
-
-    <li>
-        
-
-    </li>
-</ul>
-
-        </div>
-      </div>
-
-        <div id="responsive-meta-container" data-turbo-replace>
-</div>
-
-
-          <nav data-pjax="#js-repo-pjax-container" aria-label="Repository" data-view-component="true" class="js-repo-nav js-sidenav-container-pjax js-responsive-underlinenav overflow-hidden UnderlineNav px-3 px-md-4 px-lg-5">
-
-  <ul data-view-component="true" class="UnderlineNav-body list-style-none">
-      <li data-view-component="true" class="d-inline-flex">
-  <a id="code-tab" href="/bitcoin/bips" data-tab-item="i0code-tab" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages repo_deployments repo_attestations /bitcoin/bips" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g c" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Code&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" aria-current="page" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item selected">
-    
-              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code UnderlineNav-octicon d-none d-sm-inline">
-    <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"></path>
-</svg>
-        <span data-content="Code">Code</span>
-          <span id="code-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
-
-
-    
-</a></li>
-      <li data-view-component="true" class="d-inline-flex">
-  <a id="pull-requests-tab" href="/bitcoin/bips/pulls" data-tab-item="i1pull-requests-tab" data-selected-links="repo_pulls checks /bitcoin/bips/pulls" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g p" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Pull requests&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
-    
-              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-pull-request UnderlineNav-octicon d-none d-sm-inline">
-    <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"></path>
-</svg>
-        <span data-content="Pull requests">Pull requests</span>
-          <span id="pull-requests-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="138" data-view-component="true" class="Counter">138</span>
-
-
-    
-</a></li>
-      <li data-view-component="true" class="d-inline-flex">
-  <a id="actions-tab" href="/bitcoin/bips/actions" data-tab-item="i2actions-tab" data-selected-links="repo_actions /bitcoin/bips/actions" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g a" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Actions&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
-    
-              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-play UnderlineNav-octicon d-none d-sm-inline">
-    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z"></path>
-</svg>
-        <span data-content="Actions">Actions</span>
-          <span id="actions-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
-
-
-    
-</a></li>
-      <li data-view-component="true" class="d-inline-flex">
-  <a id="wiki-tab" href="/bitcoin/bips/wiki" data-tab-item="i3wiki-tab" data-selected-links="repo_wiki /bitcoin/bips/wiki" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g w" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Wiki&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
-    
-              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-book UnderlineNav-octicon d-none d-sm-inline">
-    <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"></path>
-</svg>
-        <span data-content="Wiki">Wiki</span>
-          <span id="wiki-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
-
-
-    
-</a></li>
-      <li data-view-component="true" class="d-inline-flex">
-  <a id="security-tab" href="/bitcoin/bips/security" data-tab-item="i4security-tab" data-selected-links="security overview alerts policy token_scanning code_scanning /bitcoin/bips/security" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g s" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Security&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
-    
-              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-shield UnderlineNav-octicon d-none d-sm-inline">
-    <path d="M7.467.133a1.748 1.748 0 0 1 1.066 0l5.25 1.68A1.75 1.75 0 0 1 15 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.697 1.697 0 0 1-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 0 1 1.217-1.667Zm.61 1.429a.25.25 0 0 0-.153 0l-5.25 1.68a.25.25 0 0 0-.174.238V7c0 1.358.275 2.666 1.057 3.86.784 1.194 2.121 2.34 4.366 3.297a.196.196 0 0 0 .154 0c2.245-.956 3.582-2.104 4.366-3.298C13.225 9.666 13.5 8.36 13.5 7V3.48a.251.251 0 0 0-.174-.237l-5.25-1.68ZM8.75 4.75v3a.75.75 0 0 1-1.5 0v-3a.75.75 0 0 1 1.5 0ZM9 10.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
-</svg>
-        <span data-content="Security">Security</span>
-          <include-fragment src="/bitcoin/bips/security/overall-count" accept="text/fragment+html"></include-fragment>
-
-    
-</a></li>
-      <li data-view-component="true" class="d-inline-flex">
-  <a id="insights-tab" href="/bitcoin/bips/pulse" data-tab-item="i5insights-tab" data-selected-links="repo_graphs repo_contributors dependency_graph dependabot_updates pulse people community /bitcoin/bips/pulse" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Insights&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
-    
-              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-graph UnderlineNav-octicon d-none d-sm-inline">
-    <path d="M1.5 1.75V13.5h13.75a.75.75 0 0 1 0 1.5H.75a.75.75 0 0 1-.75-.75V1.75a.75.75 0 0 1 1.5 0Zm14.28 2.53-5.25 5.25a.75.75 0 0 1-1.06 0L7 7.06 4.28 9.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.25-3.25a.75.75 0 0 1 1.06 0L10 7.94l4.72-4.72a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
-</svg>
-        <span data-content="Insights">Insights</span>
-          <span id="insights-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
-
-
-    
-</a></li>
-</ul>
-    <div style="visibility:hidden;" data-view-component="true" class="UnderlineNav-actions js-responsive-underlinenav-overflow position-absolute pr-3 pr-md-4 pr-lg-5 right-0">      <action-menu data-select-variant="none" data-view-component="true">
-  <focus-group direction="vertical" mnemonics retain>
-    <button id="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-button" popovertarget="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-overlay" aria-controls="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-list" aria-haspopup="true" aria-labelledby="tooltip-1bdf5c40-f9b2-4dfb-b2d9-c6f55b2e6dcf" type="button" data-view-component="true" class="Button Button--iconOnly Button--secondary Button--medium UnderlineNav-item">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-kebab-horizontal Button-visual">
-    <path d="M8 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm13 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path>
-</svg>
-</button><tool-tip id="tooltip-1bdf5c40-f9b2-4dfb-b2d9-c6f55b2e6dcf" for="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-button" popover="manual" data-direction="s" data-type="label" data-view-component="true" class="sr-only position-absolute">Additional navigation options</tool-tip>
-
-
-<anchored-position id="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-overlay" anchor="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-button" align="start" side="outside-bottom" anchor-offset="normal" popover="auto" data-view-component="true">
-  <div data-view-component="true" class="Overlay Overlay--size-auto">
-    
-      <div data-view-component="true" class="Overlay-body Overlay-body--paddingNone">          <action-list>
-  <div data-view-component="true">
-    <ul aria-labelledby="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-button" id="action-menu-8683a89b-84c8-4aac-9549-bf5a7e0e2b79-list" role="menu" data-view-component="true" class="ActionListWrap--inset ActionListWrap">
-        <li hidden="hidden" data-menu-item="i0code-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
-    
-    <a tabindex="-1" id="item-68a80e29-e9b6-4a1d-8dd3-120927cf8331" href="/bitcoin/bips" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
-        <span class="ActionListItem-visual ActionListItem-visual--leading">
-          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code">
-    <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"></path>
-</svg>
-        </span>
-      
-        <span data-view-component="true" class="ActionListItem-label">
-          Code
-</span></a>
-  
-  
-</li>
-        <li hidden="hidden" data-menu-item="i1pull-requests-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
-    
-    <a tabindex="-1" id="item-19f23caf-e281-47f9-9917-f87e1a3661a3" href="/bitcoin/bips/pulls" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
-        <span class="ActionListItem-visual ActionListItem-visual--leading">
-          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-pull-request">
-    <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"></path>
-</svg>
-        </span>
-      
-        <span data-view-component="true" class="ActionListItem-label">
-          Pull requests
-</span></a>
-  
-  
-</li>
-        <li hidden="hidden" data-menu-item="i2actions-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
-    
-    <a tabindex="-1" id="item-e9ce0e41-2365-4257-abaa-9a7e8faaee4a" href="/bitcoin/bips/actions" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
-        <span class="ActionListItem-visual ActionListItem-visual--leading">
-          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-play">
-    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z"></path>
-</svg>
-        </span>
-      
-        <span data-view-component="true" class="ActionListItem-label">
-          Actions
-</span></a>
-  
-  
-</li>
-        <li hidden="hidden" data-menu-item="i3wiki-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
-    
-    <a tabindex="-1" id="item-d922dcdf-cfb6-4a4a-a99a-291cf8389c97" href="/bitcoin/bips/wiki" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
-        <span class="ActionListItem-visual ActionListItem-visual--leading">
-          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-book">
-    <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"></path>
-</svg>
-        </span>
-      
-        <span data-view-component="true" class="ActionListItem-label">
-          Wiki
-</span></a>
-  
-  
-</li>
-        <li hidden="hidden" data-menu-item="i4security-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
-    
-    <a tabindex="-1" id="item-57a2b497-2c6e-4143-b7f7-6906f27c20ad" href="/bitcoin/bips/security" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
-        <span class="ActionListItem-visual ActionListItem-visual--leading">
-          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-shield">
-    <path d="M7.467.133a1.748 1.748 0 0 1 1.066 0l5.25 1.68A1.75 1.75 0 0 1 15 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.697 1.697 0 0 1-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 0 1 1.217-1.667Zm.61 1.429a.25.25 0 0 0-.153 0l-5.25 1.68a.25.25 0 0 0-.174.238V7c0 1.358.275 2.666 1.057 3.86.784 1.194 2.121 2.34 4.366 3.297a.196.196 0 0 0 .154 0c2.245-.956 3.582-2.104 4.366-3.298C13.225 9.666 13.5 8.36 13.5 7V3.48a.251.251 0 0 0-.174-.237l-5.25-1.68ZM8.75 4.75v3a.75.75 0 0 1-1.5 0v-3a.75.75 0 0 1 1.5 0ZM9 10.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
-</svg>
-        </span>
-      
-        <span data-view-component="true" class="ActionListItem-label">
-          Security
-</span></a>
-  
-  
-</li>
-        <li hidden="hidden" data-menu-item="i5insights-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
-    
-    <a tabindex="-1" id="item-b5435faa-8cf2-485b-8621-cd527f81344f" href="/bitcoin/bips/pulse" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
-        <span class="ActionListItem-visual ActionListItem-visual--leading">
-          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-graph">
-    <path d="M1.5 1.75V13.5h13.75a.75.75 0 0 1 0 1.5H.75a.75.75 0 0 1-.75-.75V1.75a.75.75 0 0 1 1.5 0Zm14.28 2.53-5.25 5.25a.75.75 0 0 1-1.06 0L7 7.06 4.28 9.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.25-3.25a.75.75 0 0 1 1.06 0L10 7.94l4.72-4.72a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
-</svg>
-        </span>
-      
-        <span data-view-component="true" class="ActionListItem-label">
-          Insights
-</span></a>
-  
-  
-</li>
-</ul>    
-</div></action-list>
-
-
-</div>
-      
-</div></anchored-position>  </focus-group>
-</action-menu></div>
-</nav>
-
-  </div>
-
-  
-
-
-
-<turbo-frame id="repo-content-turbo-frame" target="_top" data-turbo-action="advance" class="">
-    <div id="repo-content-pjax-container" class="repository-content " >
-    
-
-
-
-    
-      
-    
-
-
-
-
-
-<react-app
-  app-name="react-code-view"
-  initial-path="/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json"
-  style="min-height: calc(100vh - 64px)" 
-  data-ssr="false"
-  data-lazy="false"
-  data-alternate="false"
->
-  
-  <script type="application/json" data-target="react-app.embeddedData">{"payload":{"allShortcutsEnabled":false,"fileTree":{"bip-0341":{"items":[{"name":"tree.png","path":"bip-0341/tree.png","contentType":"file"},{"name":"wallet-test-vectors.json","path":"bip-0341/wallet-test-vectors.json","contentType":"file"}],"totalCount":2},"":{"items":[{"name":".github","path":".github","contentType":"directory"},{"name":"bip-0001","path":"bip-0001","contentType":"directory"},{"name":"bip-0002","path":"bip-0002","contentType":"directory"},{"name":"bip-0008","path":"bip-0008","contentType":"directory"},{"name":"bip-0009","path":"bip-0009","contentType":"directory"},{"name":"bip-0016","path":"bip-0016","contentType":"directory"},{"name":"bip-0032","path":"bip-0032","contentType":"directory"},{"name":"bip-0039","path":"bip-0039","contentType":"directory"},{"name":"bip-0042","path":"bip-0042","contentType":"directory"},{"name":"bip-0047","path":"bip-0047","contentType":"directory"},{"name":"bip-0052","path":"bip-0052","contentType":"directory"},{"name":"bip-0068","path":"bip-0068","contentType":"directory"},{"name":"bip-0069","path":"bip-0069","contentType":"directory"},{"name":"bip-0070","path":"bip-0070","contentType":"directory"},{"name":"bip-0073","path":"bip-0073","contentType":"directory"},{"name":"bip-0075","path":"bip-0075","contentType":"directory"},{"name":"bip-0098","path":"bip-0098","contentType":"directory"},{"name":"bip-0114","path":"bip-0114","contentType":"directory"},{"name":"bip-0119","path":"bip-0119","contentType":"directory"},{"name":"bip-0122","path":"bip-0122","contentType":"directory"},{"name":"bip-0135","path":"bip-0135","contentType":"directory"},{"name":"bip-0144","path":"bip-0144","contentType":"directory"},{"name":"bip-0152","path":"bip-0152","contentType":"directory"},{"name":"bip-0156","path":"bip-0156","contentType":"directory"},{"name":"bip-0158","path":"bip-0158","contentType":"directory"},{"name":"bip-0174","path":"bip-0174","contentType":"directory"},{"name":"bip-0300","path":"bip-0300","contentType":"directory"},{"name":"bip-0301","path":"bip-0301","contentType":"directory"},{"name":"bip-0324","path":"bip-0324","contentType":"directory"},{"name":"bip-0327","path":"bip-0327","contentType":"directory"},{"name":"bip-0330","path":"bip-0330","contentType":"directory"},{"name":"bip-0340","path":"bip-0340","contentType":"directory"},{"name":"bip-0341","path":"bip-0341","contentType":"directory"},{"name":"bip-0345","path":"bip-0345","contentType":"directory"},{"name":"scripts","path":"scripts","contentType":"directory"},{"name":".gitattributes","path":".gitattributes","contentType":"file"},{"name":"README.mediawiki","path":"README.mediawiki","contentType":"file"},{"name":"bip-0001.mediawiki","path":"bip-0001.mediawiki","contentType":"file"},{"name":"bip-0002.mediawiki","path":"bip-0002.mediawiki","contentType":"file"},{"name":"bip-0008.mediawiki","path":"bip-0008.mediawiki","contentType":"file"},{"name":"bip-0009.mediawiki","path":"bip-0009.mediawiki","contentType":"file"},{"name":"bip-0010.mediawiki","path":"bip-0010.mediawiki","contentType":"file"},{"name":"bip-0011.mediawiki","path":"bip-0011.mediawiki","contentType":"file"},{"name":"bip-0012.mediawiki","path":"bip-0012.mediawiki","contentType":"file"},{"name":"bip-0013.mediawiki","path":"bip-0013.mediawiki","contentType":"file"},{"name":"bip-0014.mediawiki","path":"bip-0014.mediawiki","contentType":"file"},{"name":"bip-0015.mediawiki","path":"bip-0015.mediawiki","contentType":"file"},{"name":"bip-0016.mediawiki","path":"bip-0016.mediawiki","contentType":"file"},{"name":"bip-0017.mediawiki","path":"bip-0017.mediawiki","contentType":"file"},{"name":"bip-0018.mediawiki","path":"bip-0018.mediawiki","contentType":"file"},{"name":"bip-0019.mediawiki","path":"bip-0019.mediawiki","contentType":"file"},{"name":"bip-0020.mediawiki","path":"bip-0020.mediawiki","contentType":"file"},{"name":"bip-0021.mediawiki","path":"bip-0021.mediawiki","contentType":"file"},{"name":"bip-0022.mediawiki","path":"bip-0022.mediawiki","contentType":"file"},{"name":"bip-0023.mediawiki","path":"bip-0023.mediawiki","contentType":"file"},{"name":"bip-0030.mediawiki","path":"bip-0030.mediawiki","contentType":"file"},{"name":"bip-0031.mediawiki","path":"bip-0031.mediawiki","contentType":"file"},{"name":"bip-0032.mediawiki","path":"bip-0032.mediawiki","contentType":"file"},{"name":"bip-0033.mediawiki","path":"bip-0033.mediawiki","contentType":"file"},{"name":"bip-0034.mediawiki","path":"bip-0034.mediawiki","contentType":"file"},{"name":"bip-0035.mediawiki","path":"bip-0035.mediawiki","contentType":"file"},{"name":"bip-0036.mediawiki","path":"bip-0036.mediawiki","contentType":"file"},{"name":"bip-0037.mediawiki","path":"bip-0037.mediawiki","contentType":"file"},{"name":"bip-0038.mediawiki","path":"bip-0038.mediawiki","contentType":"file"},{"name":"bip-0039.mediawiki","path":"bip-0039.mediawiki","contentType":"file"},{"name":"bip-0042.mediawiki","path":"bip-0042.mediawiki","contentType":"file"},{"name":"bip-0043.mediawiki","path":"bip-0043.mediawiki","contentType":"file"},{"name":"bip-0044.mediawiki","path":"bip-0044.mediawiki","contentType":"file"},{"name":"bip-0045.mediawiki","path":"bip-0045.mediawiki","contentType":"file"},{"name":"bip-0047.mediawiki","path":"bip-0047.mediawiki","contentType":"file"},{"name":"bip-0048.mediawiki","path":"bip-0048.mediawiki","contentType":"file"},{"name":"bip-0049.mediawiki","path":"bip-0049.mediawiki","contentType":"file"},{"name":"bip-0050.mediawiki","path":"bip-0050.mediawiki","contentType":"file"},{"name":"bip-0052.mediawiki","path":"bip-0052.mediawiki","contentType":"file"},{"name":"bip-0060.mediawiki","path":"bip-0060.mediawiki","contentType":"file"},{"name":"bip-0061.mediawiki","path":"bip-0061.mediawiki","contentType":"file"},{"name":"bip-0062.mediawiki","path":"bip-0062.mediawiki","contentType":"file"},{"name":"bip-0064.mediawiki","path":"bip-0064.mediawiki","contentType":"file"},{"name":"bip-0065.mediawiki","path":"bip-0065.mediawiki","contentType":"file"},{"name":"bip-0066.mediawiki","path":"bip-0066.mediawiki","contentType":"file"},{"name":"bip-0067.mediawiki","path":"bip-0067.mediawiki","contentType":"file"},{"name":"bip-0068.mediawiki","path":"bip-0068.mediawiki","contentType":"file"},{"name":"bip-0069.mediawiki","path":"bip-0069.mediawiki","contentType":"file"},{"name":"bip-0070.mediawiki","path":"bip-0070.mediawiki","contentType":"file"},{"name":"bip-0071.mediawiki","path":"bip-0071.mediawiki","contentType":"file"},{"name":"bip-0072.mediawiki","path":"bip-0072.mediawiki","contentType":"file"},{"name":"bip-0073.mediawiki","path":"bip-0073.mediawiki","contentType":"file"},{"name":"bip-0074.mediawiki","path":"bip-0074.mediawiki","contentType":"file"},{"name":"bip-0075.mediawiki","path":"bip-0075.mediawiki","contentType":"file"},{"name":"bip-0078.mediawiki","path":"bip-0078.mediawiki","contentType":"file"},{"name":"bip-0079.mediawiki","path":"bip-0079.mediawiki","contentType":"file"},{"name":"bip-0080.mediawiki","path":"bip-0080.mediawiki","contentType":"file"},{"name":"bip-0081.mediawiki","path":"bip-0081.mediawiki","contentType":"file"},{"name":"bip-0083.mediawiki","path":"bip-0083.mediawiki","contentType":"file"},{"name":"bip-0084.mediawiki","path":"bip-0084.mediawiki","contentType":"file"},{"name":"bip-0085.mediawiki","path":"bip-0085.mediawiki","contentType":"file"},{"name":"bip-0086.mediawiki","path":"bip-0086.mediawiki","contentType":"file"},{"name":"bip-0087.mediawiki","path":"bip-0087.mediawiki","contentType":"file"},{"name":"bip-0088.mediawiki","path":"bip-0088.mediawiki","contentType":"file"},{"name":"bip-0090.mediawiki","path":"bip-0090.mediawiki","contentType":"file"},{"name":"bip-0091.mediawiki","path":"bip-0091.mediawiki","contentType":"file"},{"name":"bip-0093.mediawiki","path":"bip-0093.mediawiki","contentType":"file"},{"name":"bip-0098.mediawiki","path":"bip-0098.mediawiki","contentType":"file"},{"name":"bip-0099.mediawiki","path":"bip-0099.mediawiki","contentType":"file"},{"name":"bip-0100.mediawiki","path":"bip-0100.mediawiki","contentType":"file"},{"name":"bip-0101.mediawiki","path":"bip-0101.mediawiki","contentType":"file"},{"name":"bip-0102.mediawiki","path":"bip-0102.mediawiki","contentType":"file"},{"name":"bip-0103.mediawiki","path":"bip-0103.mediawiki","contentType":"file"},{"name":"bip-0104.mediawiki","path":"bip-0104.mediawiki","contentType":"file"},{"name":"bip-0105.mediawiki","path":"bip-0105.mediawiki","contentType":"file"},{"name":"bip-0106.mediawiki","path":"bip-0106.mediawiki","contentType":"file"},{"name":"bip-0107.mediawiki","path":"bip-0107.mediawiki","contentType":"file"},{"name":"bip-0109.mediawiki","path":"bip-0109.mediawiki","contentType":"file"},{"name":"bip-0111.mediawiki","path":"bip-0111.mediawiki","contentType":"file"},{"name":"bip-0112.mediawiki","path":"bip-0112.mediawiki","contentType":"file"},{"name":"bip-0113.mediawiki","path":"bip-0113.mediawiki","contentType":"file"},{"name":"bip-0114.mediawiki","path":"bip-0114.mediawiki","contentType":"file"},{"name":"bip-0115.mediawiki","path":"bip-0115.mediawiki","contentType":"file"},{"name":"bip-0116.mediawiki","path":"bip-0116.mediawiki","contentType":"file"},{"name":"bip-0117.mediawiki","path":"bip-0117.mediawiki","contentType":"file"},{"name":"bip-0118.mediawiki","path":"bip-0118.mediawiki","contentType":"file"},{"name":"bip-0119.mediawiki","path":"bip-0119.mediawiki","contentType":"file"},{"name":"bip-0120.mediawiki","path":"bip-0120.mediawiki","contentType":"file"},{"name":"bip-0121.mediawiki","path":"bip-0121.mediawiki","contentType":"file"},{"name":"bip-0122.mediawiki","path":"bip-0122.mediawiki","contentType":"file"},{"name":"bip-0123.mediawiki","path":"bip-0123.mediawiki","contentType":"file"},{"name":"bip-0124.mediawiki","path":"bip-0124.mediawiki","contentType":"file"},{"name":"bip-0125.mediawiki","path":"bip-0125.mediawiki","contentType":"file"},{"name":"bip-0126.mediawiki","path":"bip-0126.mediawiki","contentType":"file"},{"name":"bip-0127.mediawiki","path":"bip-0127.mediawiki","contentType":"file"},{"name":"bip-0129.mediawiki","path":"bip-0129.mediawiki","contentType":"file"},{"name":"bip-0130.mediawiki","path":"bip-0130.mediawiki","contentType":"file"},{"name":"bip-0131.mediawiki","path":"bip-0131.mediawiki","contentType":"file"},{"name":"bip-0132.mediawiki","path":"bip-0132.mediawiki","contentType":"file"},{"name":"bip-0133.mediawiki","path":"bip-0133.mediawiki","contentType":"file"},{"name":"bip-0134.mediawiki","path":"bip-0134.mediawiki","contentType":"file"},{"name":"bip-0135.mediawiki","path":"bip-0135.mediawiki","contentType":"file"},{"name":"bip-0136.mediawiki","path":"bip-0136.mediawiki","contentType":"file"},{"name":"bip-0137.mediawiki","path":"bip-0137.mediawiki","contentType":"file"},{"name":"bip-0140.mediawiki","path":"bip-0140.mediawiki","contentType":"file"},{"name":"bip-0141.mediawiki","path":"bip-0141.mediawiki","contentType":"file"},{"name":"bip-0142.mediawiki","path":"bip-0142.mediawiki","contentType":"file"},{"name":"bip-0143.mediawiki","path":"bip-0143.mediawiki","contentType":"file"},{"name":"bip-0144.mediawiki","path":"bip-0144.mediawiki","contentType":"file"},{"name":"bip-0145.mediawiki","path":"bip-0145.mediawiki","contentType":"file"},{"name":"bip-0146.mediawiki","path":"bip-0146.mediawiki","contentType":"file"},{"name":"bip-0147.mediawiki","path":"bip-0147.mediawiki","contentType":"file"},{"name":"bip-0148.mediawiki","path":"bip-0148.mediawiki","contentType":"file"},{"name":"bip-0149.mediawiki","path":"bip-0149.mediawiki","contentType":"file"},{"name":"bip-0150.mediawiki","path":"bip-0150.mediawiki","contentType":"file"},{"name":"bip-0151.mediawiki","path":"bip-0151.mediawiki","contentType":"file"},{"name":"bip-0152.mediawiki","path":"bip-0152.mediawiki","contentType":"file"},{"name":"bip-0154.mediawiki","path":"bip-0154.mediawiki","contentType":"file"},{"name":"bip-0155.mediawiki","path":"bip-0155.mediawiki","contentType":"file"},{"name":"bip-0156.mediawiki","path":"bip-0156.mediawiki","contentType":"file"},{"name":"bip-0157.mediawiki","path":"bip-0157.mediawiki","contentType":"file"},{"name":"bip-0158.mediawiki","path":"bip-0158.mediawiki","contentType":"file"},{"name":"bip-0159.mediawiki","path":"bip-0159.mediawiki","contentType":"file"},{"name":"bip-0171.mediawiki","path":"bip-0171.mediawiki","contentType":"file"},{"name":"bip-0173.mediawiki","path":"bip-0173.mediawiki","contentType":"file"},{"name":"bip-0174.mediawiki","path":"bip-0174.mediawiki","contentType":"file"},{"name":"bip-0175.mediawiki","path":"bip-0175.mediawiki","contentType":"file"},{"name":"bip-0176.mediawiki","path":"bip-0176.mediawiki","contentType":"file"},{"name":"bip-0178.mediawiki","path":"bip-0178.mediawiki","contentType":"file"},{"name":"bip-0179.mediawiki","path":"bip-0179.mediawiki","contentType":"file"},{"name":"bip-0180.mediawiki","path":"bip-0180.mediawiki","contentType":"file"},{"name":"bip-0197.mediawiki","path":"bip-0197.mediawiki","contentType":"file"},{"name":"bip-0199.mediawiki","path":"bip-0199.mediawiki","contentType":"file"},{"name":"bip-0300.mediawiki","path":"bip-0300.mediawiki","contentType":"file"},{"name":"bip-0301.mediawiki","path":"bip-0301.mediawiki","contentType":"file"},{"name":"bip-0310.mediawiki","path":"bip-0310.mediawiki","contentType":"file"},{"name":"bip-0320.mediawiki","path":"bip-0320.mediawiki","contentType":"file"},{"name":"bip-0322.mediawiki","path":"bip-0322.mediawiki","contentType":"file"},{"name":"bip-0324.mediawiki","path":"bip-0324.mediawiki","contentType":"file"},{"name":"bip-0325.mediawiki","path":"bip-0325.mediawiki","contentType":"file"},{"name":"bip-0326.mediawiki","path":"bip-0326.mediawiki","contentType":"file"},{"name":"bip-0327.mediawiki","path":"bip-0327.mediawiki","contentType":"file"},{"name":"bip-0329.mediawiki","path":"bip-0329.mediawiki","contentType":"file"},{"name":"bip-0330.mediawiki","path":"bip-0330.mediawiki","contentType":"file"},{"name":"bip-0338.mediawiki","path":"bip-0338.mediawiki","contentType":"file"},{"name":"bip-0339.mediawiki","path":"bip-0339.mediawiki","contentType":"file"},{"name":"bip-0340.mediawiki","path":"bip-0340.mediawiki","contentType":"file"},{"name":"bip-0341.mediawiki","path":"bip-0341.mediawiki","contentType":"file"},{"name":"bip-0342.mediawiki","path":"bip-0342.mediawiki","contentType":"file"},{"name":"bip-0343.mediawiki","path":"bip-0343.mediawiki","contentType":"file"},{"name":"bip-0345.mediawiki","path":"bip-0345.mediawiki","contentType":"file"},{"name":"bip-0350.mediawiki","path":"bip-0350.mediawiki","contentType":"file"},{"name":"bip-0351.mediawiki","path":"bip-0351.mediawiki","contentType":"file"},{"name":"bip-0370.mediawiki","path":"bip-0370.mediawiki","contentType":"file"},{"name":"bip-0371.mediawiki","path":"bip-0371.mediawiki","contentType":"file"},{"name":"bip-0372.mediawiki","path":"bip-0372.mediawiki","contentType":"file"},{"name":"bip-0380.mediawiki","path":"bip-0380.mediawiki","contentType":"file"},{"name":"bip-0381.mediawiki","path":"bip-0381.mediawiki","contentType":"file"},{"name":"bip-0382.mediawiki","path":"bip-0382.mediawiki","contentType":"file"},{"name":"bip-0383.mediawiki","path":"bip-0383.mediawiki","contentType":"file"},{"name":"bip-0384.mediawiki","path":"bip-0384.mediawiki","contentType":"file"},{"name":"bip-0385.mediawiki","path":"bip-0385.mediawiki","contentType":"file"},{"name":"bip-0386.mediawiki","path":"bip-0386.mediawiki","contentType":"file"},{"name":"bip-0389.mediawiki","path":"bip-0389.mediawiki","contentType":"file"}],"totalCount":199}},"fileTreeProcessingTime":29.015655000000002,"foldersToFetch":[],"repo":{"id":14531737,"defaultBranch":"master","name":"bips","ownerLogin":"bitcoin","currentUserCanPush":false,"isFork":false,"isEmpty":false,"createdAt":"2013-11-19T17:18:41.000Z","ownerAvatar":"https://avatars.githubusercontent.com/u/528860?v=4","public":true,"private":false,"isOrgOwned":true},"codeLineWrapEnabled":false,"symbolsExpanded":false,"treeExpanded":true,"refInfo":{"name":"master","listCacheKey":"v0:1708729485.0","canEdit":false,"refType":"branch","currentOid":"b3701faef2bdb98a0d7ace4eedbeefa2da4c89ed"},"path":"bip-0341/wallet-test-vectors.json","currentUser":null,"blob":{"rawLines":["{","    \"version\": 1,","    \"scriptPubKey\": [","        {","            \"given\": {","                \"internalPubkey\": \"d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d\",","                \"scriptTree\": null","            },","            \"intermediary\": {","                \"merkleRoot\": null,","                \"tweak\": \"b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70\",","                \"tweakedPubkey\": \"53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343\"","            },","            \"expected\": {","                \"scriptPubKey\": \"512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343\",","                \"bip350Address\": \"bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5\"","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27\",","                \"scriptTree\": {","                    \"id\": 0,","                    \"script\": \"20d85a959b0290bf19bb89ed43c916be835475d013da4b362117393e25a48229b8ac\",","                    \"leafVersion\": 192","                }","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21\"","                ],","                \"merkleRoot\": \"5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21\",","                \"tweak\": \"cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001\",","                \"tweakedPubkey\": \"147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3\"","            },","            \"expected\": {","                \"scriptPubKey\": \"5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3\",","                \"bip350Address\": \"bc1pz37fc4cn9ah8anwm4xqqhvxygjf9rjf2resrw8h8w4tmvcs0863sa2e586\",","                \"scriptPathControlBlocks\": [","                    \"c1187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27\"","                ]","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820\",","                \"scriptTree\": {","                    \"id\": 0,","                    \"script\": \"20b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007ac\",","                    \"leafVersion\": 192","                }","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b\"","                ],","                \"merkleRoot\": \"c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b\",","                \"tweak\": \"6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30\",","                \"tweakedPubkey\": \"e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e\"","            },","            \"expected\": {","                \"scriptPubKey\": \"5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e\",","                \"bip350Address\": \"bc1punvppl2stp38f7kwv2u2spltjuvuaayuqsthe34hd2dyy5w4g58qqfuag5\",","                \"scriptPathControlBlocks\": [","                    \"c093478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820\"","                ]","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592\",","                \"scriptTree\": [","                    {","                        \"id\": 0,","                        \"script\": \"20387671353e273264c495656e27e39ba899ea8fee3bb69fb2a680e22093447d48ac\",","                        \"leafVersion\": 192","                    },","                    {","                        \"id\": 1,","                        \"script\": \"06424950333431\",","                        \"leafVersion\": 250","                    }","                ]","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7\",","                    \"f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a\"","                ],","                \"merkleRoot\": \"6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef\",","                \"tweak\": \"9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9\",","                \"tweakedPubkey\": \"712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5\"","            },","            \"expected\": {","                \"scriptPubKey\": \"5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5\",","                \"bip350Address\": \"bc1pwyjywgrd0ffr3tx8laflh6228dj98xkjj8rum0zfpd6h0e930h6saqxrrm\",","                \"scriptPathControlBlocks\": [","                    \"c0ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a\",","                    \"faee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf37865928ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7\"","                ]","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8\",","                \"scriptTree\": [","                    {","                        \"id\": 0,","                        \"script\": \"2044b178d64c32c4a05cc4f4d1407268f764c940d20ce97abfd44db5c3592b72fdac\",","                        \"leafVersion\": 192","                    },","                    {","                        \"id\": 1,","                        \"script\": \"07546170726f6f74\",","                        \"leafVersion\": 192","                    }","                ]","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"64512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89\",","                    \"2cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb\"","                ],","                \"merkleRoot\": \"ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc\",","                \"tweak\": \"639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e\",","                \"tweakedPubkey\": \"77e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220\"","            },","            \"expected\": {","                \"scriptPubKey\": \"512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220\",","                \"bip350Address\": \"bc1pwl3s54fzmk0cjnpl3w9af39je7pv5ldg504x5guk2hpecpg2kgsqaqstjq\",","                \"scriptPathControlBlocks\": [","                    \"c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd82cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb\",","                    \"c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd864512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89\"","                ]","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f\",","                \"scriptTree\": [","                    {","                        \"id\": 0,","                        \"script\": \"2072ea6adcf1d371dea8fba1035a09f3d24ed5a059799bae114084130ee5898e69ac\",","                        \"leafVersion\": 192","                    },","                    [","                        {","                            \"id\": 1,","                            \"script\": \"202352d137f2f3ab38d1eaa976758873377fa5ebb817372c71e2c542313d4abda8ac\",","                            \"leafVersion\": 192","                        },","                        {","                            \"id\": 2,","                            \"script\": \"207337c0dd4253cb86f2c43a2351aadd82cccb12a172cd120452b9bb8324f2186aac\",","                            \"leafVersion\": 192","                        }","                    ]","                ]","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817\",","                    \"ba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c\",","                    \"9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf6\"","                ],","                \"merkleRoot\": \"ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2\",","                \"tweak\": \"b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4\",","                \"tweakedPubkey\": \"91b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605\"","            },","            \"expected\": {","                \"scriptPubKey\": \"512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605\",","                \"bip350Address\": \"bc1pjxmy65eywgafs5tsunw95ruycpqcqnev6ynxp7jaasylcgtcxczs6n332e\",","                \"scriptPathControlBlocks\": [","                    \"c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fffe578e9ea769027e4f5a3de40732f75a88a6353a09d767ddeb66accef85e553\",","                    \"c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf62645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817\",","                    \"c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817\"","                ]","            }","        },","        {","            \"given\": {","                \"internalPubkey\": \"55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d\",","                \"scriptTree\": [","                    {","                        \"id\": 0,","                        \"script\": \"2071981521ad9fc9036687364118fb6ccd2035b96a423c59c5430e98310a11abe2ac\",","                        \"leafVersion\": 192","                    },","                    [","                        {","                            \"id\": 1,","                            \"script\": \"20d5094d2dbe9b76e2c245a2b89b6006888952e2faa6a149ae318d69e520617748ac\",","                            \"leafVersion\": 192","                        },","                        {","                            \"id\": 2,","                            \"script\": \"20c440b462ad48c7a77f94cd4532d8f2119dcebbd7c9764557e62726419b08ad4cac\",","                            \"leafVersion\": 192","                        }","                    ]","                ]","            },","            \"intermediary\": {","                \"leafHashes\": [","                    \"f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d\",","                    \"737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711\",","                    \"d7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7\"","                ],","                \"merkleRoot\": \"2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def\",","                \"tweak\": \"6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9\",","                \"tweakedPubkey\": \"75169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831\"","            },","            \"expected\": {","                \"scriptPubKey\": \"512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831\",","                \"bip350Address\": \"bc1pw5tf7sqp4f50zka7629jrr036znzew70zxyvvej3zrpf8jg8hqcssyuewe\",","                \"scriptPathControlBlocks\": [","                    \"c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d3cd369a528b326bc9d2133cbd2ac21451acb31681a410434672c8e34fe757e91\",","                    \"c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312dd7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d\",","                    \"c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d\"","                ]","            }","        }","    ],","    \"keyPathSpending\": [","        {","            \"given\": {","                \"rawUnsignedTx\": \"02000000097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a418420000000000fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0065cd1d\",","                \"utxosSpent\": [","                    {","                        \"scriptPubKey\": \"512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343\",","                        \"amountSats\": 420000000","                    },","                    {","                        \"scriptPubKey\": \"5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3\",","                        \"amountSats\": 462000000","                    },","                    {","                        \"scriptPubKey\": \"76a914751e76e8199196d454941c45d1b3a323f1433bd688ac\",","                        \"amountSats\": 294000000","                    },","                    {","                        \"scriptPubKey\": \"5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e\",","                        \"amountSats\": 504000000","                    },","                    {","                        \"scriptPubKey\": \"512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605\",","                        \"amountSats\": 630000000","                    },","                    {","                        \"scriptPubKey\": \"00147dd65592d0ab2fe0d0257d571abf032cd9db93dc\",","                        \"amountSats\": 378000000","                    },","                    {","                        \"scriptPubKey\": \"512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831\",","                        \"amountSats\": 672000000","                    },","                    {","                        \"scriptPubKey\": \"5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5\",","                        \"amountSats\": 546000000","                    },","                    {","                        \"scriptPubKey\": \"512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220\",","                        \"amountSats\": 588000000","                    }","                ]","            },","            \"intermediary\": {","                \"hashAmounts\": \"58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde6\",","                \"hashOutputs\": \"a2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc5\",","                \"hashPrevouts\": \"e3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f\",","                \"hashScriptPubkeys\": \"23ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e21\",","                \"hashSequences\": \"18959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e\"","            },","            \"inputSpending\": [","                {","                    \"given\": {","                        \"txinIndex\": 0,","                        \"internalPrivkey\": \"6b973d88838f27366ed61c9ad6367663045cb456e28335c109e30717ae0c6baa\",","                        \"merkleRoot\": null,","                        \"hashType\": 3","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d\",","                        \"tweak\": \"b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70\",","                        \"tweakedPrivkey\": \"2405b971772ad26915c8dcdf10f238753a9b837e5f8e6a86fd7c0cce5b7296d9\",","                        \"sigMsg\": \"0003020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0000000000d0418f0e9a36245b9a50ec87f8bf5be5bcae434337b87139c3a5b1f56e33cba0\",","                        \"precomputedUsed\": [","                            \"hashAmounts\",","                            \"hashPrevouts\",","                            \"hashScriptPubkeys\",","                            \"hashSequences\"","                        ],","                        \"sigHash\": \"2514a6272f85cfa0f45eb907fcb0d121b808ed37c6ea160a5a9046ed5526d555\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c03\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 1,","                        \"internalPrivkey\": \"1e4da49f6aaf4e5cd175fe08a32bb5cb4863d963921255f33d3bc31e1343907f\",","                        \"merkleRoot\": \"5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21\",","                        \"hashType\": 131","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27\",","                        \"tweak\": \"cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001\",","                        \"tweakedPrivkey\": \"ea260c3b10e60f6de018455cd0278f2f5b7e454be1999572789e6a9565d26080\",","                        \"sigMsg\": \"0083020000000065cd1d00d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd9900000000808f891b00000000225120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3ffffffffffcef8fb4ca7efc5433f591ecfc57391811ce1e186a3793024def5c884cba51d\",","                        \"precomputedUsed\": [],","                        \"sigHash\": \"325a644af47e8a5a2591cda0ab0723978537318f10e6a63d4eed783b96a71a4d\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 3,","                        \"internalPrivkey\": \"d3c7af07da2d54f7a7735d3d0fc4f0a73164db638b2f2f7c43f711f6d4aa7e64\",","                        \"merkleRoot\": \"c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b\",","                        \"hashType\": 1","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820\",","                        \"tweak\": \"6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30\",","                        \"tweakedPrivkey\": \"97323385e57015b75b0339a549c56a948eb961555973f0951f555ae6039ef00d\",","                        \"sigMsg\": \"0001020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50003000000\",","                        \"precomputedUsed\": [","                            \"hashAmounts\",","                            \"hashOutputs\",","                            \"hashPrevouts\",","                            \"hashScriptPubkeys\",","                            \"hashSequences\"","                        ],","                        \"sigHash\": \"bf013ea93474aa67815b1b6cc441d23b64fa310911d991e713cd34c7f5d46669\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a01\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 4,","                        \"internalPrivkey\": \"f36bb07a11e469ce941d16b63b11b9b9120a84d9d87cff2c84a8d4affb438f4e\",","                        \"merkleRoot\": \"ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2\",","                        \"hashType\": 0","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f\",","                        \"tweak\": \"b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4\",","                        \"tweakedPrivkey\": \"a8e7aa924f0d58854185a490e6c41f6efb7b675c0f3331b7f14b549400b4d501\",","                        \"sigMsg\": \"0000020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50004000000\",","                        \"precomputedUsed\": [","                            \"hashAmounts\",","                            \"hashOutputs\",","                            \"hashPrevouts\",","                            \"hashScriptPubkeys\",","                            \"hashSequences\"","                        ],","                        \"sigHash\": \"4f900a0bae3f1446fd48490c2958b5a023228f01661cda3496a11da502a7f7ef\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 6,","                        \"internalPrivkey\": \"415cfe9c15d9cea27d8104d5517c06e9de48e2f986b695e4f5ffebf230e725d8\",","                        \"merkleRoot\": \"2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def\",","                        \"hashType\": 2","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d\",","                        \"tweak\": \"6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9\",","                        \"tweakedPrivkey\": \"241c14f2639d0d7139282aa6abde28dd8a067baa9d633e4e7230287ec2d02901\",","                        \"sigMsg\": \"0002020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0006000000\",","                        \"precomputedUsed\": [","                            \"hashAmounts\",","                            \"hashPrevouts\",","                            \"hashScriptPubkeys\",","                            \"hashSequences\"","                        ],","                        \"sigHash\": \"15f25c298eb5cdc7eb1d638dd2d45c97c4c59dcaec6679cfc16ad84f30876b85\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee002\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 7,","                        \"internalPrivkey\": \"c7b0e81f0a9a0b0499e112279d718cca98e79a12e2f137c72ae5b213aad0d103\",","                        \"merkleRoot\": \"6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef\",","                        \"hashType\": 130","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592\",","                        \"tweak\": \"9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9\",","                        \"tweakedPrivkey\": \"65b6000cd2bfa6b7cf736767a8955760e62b6649058cbc970b7c0871d786346b\",","                        \"sigMsg\": \"0082020000000065cd1d00e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf00000000804c8b2000000000225120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5ffffffff\",","                        \"precomputedUsed\": [],","                        \"sigHash\": \"cd292de50313804dabe4685e83f923d2969577191a3e1d2882220dca88cbeb10\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c482\"","                        ]","                    }","                },","                {","                    \"given\": {","                        \"txinIndex\": 8,","                        \"internalPrivkey\": \"77863416be0d0665e517e1c375fd6f75839544eca553675ef7fdf4949518ebaa\",","                        \"merkleRoot\": \"ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc\",","                        \"hashType\": 129","                    },","                    \"intermediary\": {","                        \"internalPubkey\": \"f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8\",","                        \"tweak\": \"639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e\",","                        \"tweakedPrivkey\": \"ec18ce6af99f43815db543f47b8af5ff5df3b2cb7315c955aa4a86e8143d2bf5\",","                        \"sigMsg\": \"0081020000000065cd1da2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc500a778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af101000000002b0c230000000022512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220ffffffff\",","                        \"precomputedUsed\": [","                            \"hashOutputs\"","                        ],","                        \"sigHash\": \"cccb739eca6c13a8a89e6e5cd317ffe55669bbda23f2fd37b0f18755e008edd2\"","                    },","                    \"expected\": {","                        \"witness\": [","                            \"bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd981\"","                        ]","                    }","                }","            ],","            \"auxiliary\": {","                \"fullySignedTx\": \"020000000001097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a41842000000006b4830450221008f3b8f8f0537c420654d2283673a761b7ee2ea3c130753103e08ce79201cf32a022079e7ab904a1980ef1c5890b648c8783f4d10103dd62f740d13daa79e298d50c201210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0141ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c030141052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83000141ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a010140b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f0247304402202b795e4de72646d76eab3f0ab27dfa30b810e856ff3a46c9a702df53bb0d8cc302203ccc4d822edab5f35caddb10af1be93583526ccfbade4b4ead350781e2f8adcd012102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f90141a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee0020141ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c4820141bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd9810065cd1d\"","            }","        }","    ]","}"],"stylingDirectives":[[],[{"s":4,"e":13,"c":"pl-ent"},{"s":15,"e":16,"c":"pl-c1"}],[{"s":4,"e":18,"c":"pl-ent"}],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":34,"c":"pl-c1"}],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":34,"c":"pl-c1"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":24,"c":"pl-ent"},{"s":26,"e":27,"c":"pl-c1"}],[{"s":20,"e":28,"c":"pl-ent"},{"s":30,"e":100,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":20,"e":33,"c":"pl-ent"},{"s":35,"e":38,"c":"pl-c1"}],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":88,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":87,"e":88,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":24,"c":"pl-ent"},{"s":26,"e":27,"c":"pl-c1"}],[{"s":20,"e":28,"c":"pl-ent"},{"s":30,"e":100,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":20,"e":33,"c":"pl-ent"},{"s":35,"e":38,"c":"pl-c1"}],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":88,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":87,"e":88,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":104,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":50,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":49,"e":50,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":104,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":52,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":51,"e":52,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":104,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[],[{"s":28,"e":32,"c":"pl-ent"},{"s":34,"e":35,"c":"pl-c1"}],[{"s":28,"e":36,"c":"pl-ent"},{"s":38,"e":108,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-ent"},{"s":43,"e":46,"c":"pl-c1"}],[],[],[{"s":28,"e":32,"c":"pl-ent"},{"s":34,"e":35,"c":"pl-c1"}],[{"s":28,"e":36,"c":"pl-ent"},{"s":38,"e":108,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-ent"},{"s":43,"e":46,"c":"pl-c1"}],[],[],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[{"s":20,"e":216,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":215,"e":216,"c":"pl-pds"}],[{"s":20,"e":216,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":215,"e":216,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":32,"c":"pl-ent"},{"s":34,"e":100,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":99,"e":100,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[],[{"s":24,"e":28,"c":"pl-ent"},{"s":30,"e":31,"c":"pl-c1"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":104,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":37,"c":"pl-ent"},{"s":39,"e":42,"c":"pl-c1"}],[],[],[],[{"s":28,"e":32,"c":"pl-ent"},{"s":34,"e":35,"c":"pl-c1"}],[{"s":28,"e":36,"c":"pl-ent"},{"s":38,"e":108,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-ent"},{"s":43,"e":46,"c":"pl-c1"}],[],[],[{"s":28,"e":32,"c":"pl-ent"},{"s":34,"e":35,"c":"pl-c1"}],[{"s":28,"e":36,"c":"pl-ent"},{"s":38,"e":108,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-ent"},{"s":43,"e":46,"c":"pl-c1"}],[],[],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":28,"c":"pl-ent"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":20,"e":86,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[],[{"s":16,"e":28,"c":"pl-ent"},{"s":30,"e":96,"c":"pl-s"},{"s":30,"e":31,"c":"pl-pds"},{"s":95,"e":96,"c":"pl-pds"}],[{"s":16,"e":23,"c":"pl-ent"},{"s":25,"e":91,"c":"pl-s"},{"s":25,"e":26,"c":"pl-pds"},{"s":90,"e":91,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":22,"c":"pl-ent"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":102,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":101,"e":102,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":97,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":41,"c":"pl-ent"}],[{"s":20,"e":152,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":151,"e":152,"c":"pl-pds"}],[{"s":20,"e":216,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":215,"e":216,"c":"pl-pds"}],[{"s":20,"e":216,"c":"pl-s"},{"s":20,"e":21,"c":"pl-pds"},{"s":215,"e":216,"c":"pl-pds"}],[],[],[],[],[{"s":4,"e":21,"c":"pl-ent"}],[],[{"s":12,"e":19,"c":"pl-ent"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":943,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":942,"e":943,"c":"pl-pds"}],[{"s":16,"e":28,"c":"pl-ent"}],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":92,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":91,"e":92,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":86,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":85,"e":86,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[{"s":24,"e":38,"c":"pl-ent"},{"s":40,"e":110,"c":"pl-s"},{"s":40,"e":41,"c":"pl-pds"},{"s":109,"e":110,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":47,"c":"pl-c1"}],[],[],[],[{"s":12,"e":26,"c":"pl-ent"}],[{"s":16,"e":29,"c":"pl-ent"},{"s":31,"e":97,"c":"pl-s"},{"s":31,"e":32,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":29,"c":"pl-ent"},{"s":31,"e":97,"c":"pl-s"},{"s":31,"e":32,"c":"pl-pds"},{"s":96,"e":97,"c":"pl-pds"}],[{"s":16,"e":30,"c":"pl-ent"},{"s":32,"e":98,"c":"pl-s"},{"s":32,"e":33,"c":"pl-pds"},{"s":97,"e":98,"c":"pl-pds"}],[{"s":16,"e":35,"c":"pl-ent"},{"s":37,"e":103,"c":"pl-s"},{"s":37,"e":38,"c":"pl-pds"},{"s":102,"e":103,"c":"pl-pds"}],[{"s":16,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[],[{"s":12,"e":27,"c":"pl-ent"}],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":42,"c":"pl-c1"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":37,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":386,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":385,"e":386,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":42,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":41,"e":42,"c":"pl-pds"}],[{"s":28,"e":47,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":46,"e":47,"c":"pl-pds"}],[{"s":28,"e":43,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":42,"e":43,"c":"pl-pds"}],[],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":39,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":288,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":287,"e":288,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":37,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":386,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":385,"e":386,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":42,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":41,"e":42,"c":"pl-pds"}],[{"s":28,"e":47,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":46,"e":47,"c":"pl-pds"}],[{"s":28,"e":43,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":42,"e":43,"c":"pl-pds"}],[],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":37,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":386,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":385,"e":386,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":42,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":41,"e":42,"c":"pl-pds"}],[{"s":28,"e":47,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":46,"e":47,"c":"pl-pds"}],[{"s":28,"e":43,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":42,"e":43,"c":"pl-pds"}],[],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":158,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":157,"e":158,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":37,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":322,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":321,"e":322,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[{"s":28,"e":42,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":41,"e":42,"c":"pl-pds"}],[{"s":28,"e":47,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":46,"e":47,"c":"pl-pds"}],[{"s":28,"e":43,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":42,"e":43,"c":"pl-pds"}],[],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":39,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":224,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":223,"e":224,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":20,"e":27,"c":"pl-ent"}],[{"s":24,"e":35,"c":"pl-ent"},{"s":37,"e":38,"c":"pl-c1"}],[{"s":24,"e":41,"c":"pl-ent"},{"s":43,"e":109,"c":"pl-s"},{"s":43,"e":44,"c":"pl-pds"},{"s":108,"e":109,"c":"pl-pds"}],[{"s":24,"e":36,"c":"pl-ent"},{"s":38,"e":104,"c":"pl-s"},{"s":38,"e":39,"c":"pl-pds"},{"s":103,"e":104,"c":"pl-pds"}],[{"s":24,"e":34,"c":"pl-ent"},{"s":36,"e":39,"c":"pl-c1"}],[],[{"s":20,"e":34,"c":"pl-ent"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":31,"c":"pl-ent"},{"s":33,"e":99,"c":"pl-s"},{"s":33,"e":34,"c":"pl-pds"},{"s":98,"e":99,"c":"pl-pds"}],[{"s":24,"e":40,"c":"pl-ent"},{"s":42,"e":108,"c":"pl-s"},{"s":42,"e":43,"c":"pl-pds"},{"s":107,"e":108,"c":"pl-pds"}],[{"s":24,"e":32,"c":"pl-ent"},{"s":34,"e":288,"c":"pl-s"},{"s":34,"e":35,"c":"pl-pds"},{"s":287,"e":288,"c":"pl-pds"}],[{"s":24,"e":41,"c":"pl-ent"}],[{"s":28,"e":41,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":40,"e":41,"c":"pl-pds"}],[],[{"s":24,"e":33,"c":"pl-ent"},{"s":35,"e":101,"c":"pl-s"},{"s":35,"e":36,"c":"pl-pds"},{"s":100,"e":101,"c":"pl-pds"}],[],[{"s":20,"e":30,"c":"pl-ent"}],[{"s":24,"e":33,"c":"pl-ent"}],[{"s":28,"e":160,"c":"pl-s"},{"s":28,"e":29,"c":"pl-pds"},{"s":159,"e":160,"c":"pl-pds"}],[],[],[],[],[{"s":12,"e":23,"c":"pl-ent"}],[],[],[],[],[]],"colorizedLines":null,"csv":null,"csvError":null,"dependabotInfo":{"showConfigurationBanner":false,"configFilePath":null,"networkDependabotPath":"/bitcoin/bips/network/updates","dismissConfigurationNoticePath":"/settings/dismiss-notice/dependabot_configuration_notice","configurationNoticeDismissed":null},"displayName":"wallet-test-vectors.json","displayUrl":"https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json?raw=true","headerInfo":{"blobSize":"28.6 KB","deleteTooltip":"You must be signed in to make or propose changes","editTooltip":"You must be signed in to make or propose changes","ghDesktopPath":"https://desktop.github.com","isGitLfs":false,"onBranch":true,"shortPath":"11261b0","siteNavLoginPath":"/login?return_to=https%3A%2F%2Fgithub.com%2Fbitcoin%2Fbips%2Fblob%2Fmaster%2Fbip-0341%2Fwallet-test-vectors.json","isCSV":false,"isRichtext":false,"toc":null,"lineInfo":{"truncatedLoc":"452","truncatedSloc":"452"},"mode":"file"},"image":false,"isCodeownersFile":null,"isPlain":false,"isValidLegacyIssueTemplate":false,"issueTemplate":null,"discussionTemplate":null,"language":"JSON","languageID":174,"large":false,"planSupportInfo":{"repoIsFork":null,"repoOwnedByCurrentUser":null,"requestFullPath":"/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json","showFreeOrgGatedFeatureMessage":null,"showPlanSupportBanner":null,"upgradeDataAttributes":null,"upgradePath":null},"publishBannersInfo":{"dismissActionNoticePath":"/settings/dismiss-notice/publish_action_from_dockerfile","releasePath":"/bitcoin/bips/releases/new?marketplace=true","showPublishActionBanner":false},"rawBlobUrl":"https://github.com/bitcoin/bips/raw/master/bip-0341/wallet-test-vectors.json","renderImageOrRaw":false,"richText":null,"renderedFileInfo":null,"shortPath":null,"symbolsEnabled":true,"tabSize":8,"topBannersInfo":{"overridingGlobalFundingFile":false,"globalPreferredFundingPath":null,"showInvalidCitationWarning":false,"citationHelpUrl":"https://docs.github.com/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files","actionsOnboardingTip":null},"truncated":false,"viewable":true,"workflowRedirectUrl":null,"symbols":{"timed_out":false,"not_analyzed":true,"symbols":[]}},"copilotInfo":null,"copilotAccessAllowed":false,"csrf_tokens":{"/bitcoin/bips/branches":{"post":"5shwOg5_ZG2ZT_6VIYhT_jWxxXF326L2YXgVPwGs0-fC-ZSXp6Oa0EvY80IvCVFS3bPr5-3NVtzfxiqO8AvpMQ"},"/repos/preferences":{"post":"td6ISQbU84G_9yyOfWy4yJ6NZl_dxaZNGoVvgwNyKipbFZR9Ju-VtejLvqpmwg0lAuHKRA-3ivRM48mcFHHI4w"}}},"title":"bips/bip-0341/wallet-test-vectors.json at master · bitcoin/bips","appPayload":{"helpUrl":"https://docs.github.com","findFileWorkerPath":"/assets-cdn/worker/find-file-worker-a007d7f370d6.js","findInFileWorkerPath":"/assets-cdn/worker/find-in-file-worker-d0f0ff069004.js","githubDevUrl":null,"enabled_features":{"code_nav_ui_events":false,"copilot_conversational_ux":false,"react_blob_overlay":false,"copilot_conversational_ux_embedding_update":false,"copilot_popover_file_editor_header":false,"copilot_smell_icebreaker_ux":true,"copilot_workspace":false}}}</script>
-  <div data-target="react-app.reactRoot"></div>
-</react-app>
-</turbo-frame>
-
-
-
-  </div>
-
-</turbo-frame>
-
-    </main>
-  </div>
-
-  </div>
-
-          <footer class="footer pt-8 pb-6 f6 color-fg-muted p-responsive" role="contentinfo" >
-  <h2 class='sr-only'>Footer</h2>
-
-  
-
-
-  <div class="d-flex flex-justify-center flex-items-center flex-column-reverse flex-lg-row flex-wrap flex-lg-nowrap">
-    <div class="d-flex flex-items-center flex-shrink-0 mx-2">
-      <a aria-label="Homepage" title="GitHub" class="footer-octicon mr-2" href="https://github.com">
-        <svg aria-hidden="true" height="24" viewBox="0 0 16 16" version="1.1" width="24" data-view-component="true" class="octicon octicon-mark-github">
-    <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path>
-</svg>
-</a>
-      <span>
-        &copy; 2024 GitHub,&nbsp;Inc.
-      </span>
-    </div>
-
-    <nav aria-label="Footer">
-      <h3 class="sr-only" id="sr-footer-heading">Footer navigation</h3>
-
-      <ul class="list-style-none d-flex flex-justify-center flex-wrap mb-2 mb-lg-0" aria-labelledby="sr-footer-heading">
-
-          <li class="mx-2">
-            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to Terms&quot;,&quot;label&quot;:&quot;text:terms&quot;}" href="https://docs.github.com/site-policy/github-terms/github-terms-of-service" data-view-component="true" class="Link--secondary Link">Terms</a>
-          </li>
-
-          <li class="mx-2">
-            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to privacy&quot;,&quot;label&quot;:&quot;text:privacy&quot;}" href="https://docs.github.com/site-policy/privacy-policies/github-privacy-statement" data-view-component="true" class="Link--secondary Link">Privacy</a>
-          </li>
-
-          <li class="mx-2">
-            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to security&quot;,&quot;label&quot;:&quot;text:security&quot;}" href="/security" data-view-component="true" class="Link--secondary Link">Security</a>
-          </li>
-
-          <li class="mx-2">
-            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to status&quot;,&quot;label&quot;:&quot;text:status&quot;}" href="https://www.githubstatus.com/" data-view-component="true" class="Link--secondary Link">Status</a>
-          </li>
-
-          <li class="mx-2">
-            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to docs&quot;,&quot;label&quot;:&quot;text:docs&quot;}" href="https://docs.github.com/" data-view-component="true" class="Link--secondary Link">Docs</a>
-          </li>
-
-          <li class="mx-2">
-            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to contact&quot;,&quot;label&quot;:&quot;text:contact&quot;}" href="https://support.github.com?tags=dotcom-footer" data-view-component="true" class="Link--secondary Link">Contact</a>
-          </li>
-
-          <li class="mr-3" >
-  <cookie-consent-link>
-    <button type="button" class="Link--secondary underline-on-hover border-0 p-0 color-bg-transparent" data-action="click:cookie-consent-link#showConsentManagement">
-      Manage cookies
-    </button>
-  </cookie-consent-link>
-</li>
-
-<li class="mr-3">
-  <cookie-consent-link>
-    <button type="button" class="Link--secondary underline-on-hover border-0 p-0 color-bg-transparent" data-action="click:cookie-consent-link#showConsentManagement">
-      Do not share my personal information
-    </button>
-  </cookie-consent-link>
-</li>
-
-      </ul>
-    </nav>
-  </div>
-</footer>
-
-
-
-
-    <cookie-consent id="cookie-consent-banner" class="position-fixed bottom-0 left-0" style="z-index: 999999" data-initial-cookie-consent-allowed="" data-cookie-consent-required="false"></cookie-consent>
-
-
-  <div id="ajax-error-message" class="ajax-error-message flash flash-error" hidden>
-    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-alert">
-    <path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
-</svg>
-    <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
-      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
-    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
-</svg>
-    </button>
-    You can’t perform that action at this time.
-  </div>
-
-    <template id="site-details-dialog">
-  <details class="details-reset details-overlay details-overlay-dark lh-default color-fg-default hx_rsm" open>
-    <summary role="button" aria-label="Close dialog"></summary>
-    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast hx_rsm-dialog hx_rsm-modal">
-      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
-        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
-    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
-</svg>
-      </button>
-      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
-    </details-dialog>
-  </details>
-</template>
-
-    <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
-  <div class="Popover-message Popover-message--bottom-left Popover-message--large Box color-shadow-large" style="width:360px;">
-  </div>
-</div>
-
-    <template id="snippet-clipboard-copy-button">
-  <div class="zeroclipboard-container position-absolute right-0 top-0">
-    <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w">
-      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
-    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
-</svg>
-      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
-    <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>
-</svg>
-    </clipboard-copy>
-  </div>
-</template>
-<template id="snippet-clipboard-copy-button-unpositioned">
-  <div class="zeroclipboard-container">
-    <clipboard-copy aria-label="Copy" class="ClipboardButton btn btn-invisible js-clipboard-copy m-2 p-0 tooltipped-no-delay d-flex flex-justify-center flex-items-center" data-copy-feedback="Copied!" data-tooltip-direction="w">
-      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon">
-    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
-</svg>
-      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none">
-    <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>
-</svg>
-    </clipboard-copy>
-  </div>
-</template>
-
-
-
-
-    </div>
-
-    <div id="js-global-screen-reader-notice" class="sr-only" aria-live="polite" aria-atomic="true" ></div>
-    <div id="js-global-screen-reader-notice-assertive" class="sr-only" aria-live="assertive" aria-atomic="true"></div>
-  </body>
-</html>
-
+{
+  "version": 1,
+  "scriptPubKey": [
+    {
+      "given": {
+        "internalPubkey": "d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d",
+        "scriptTree": null
+      },
+      "intermediary": {
+        "merkleRoot": null,
+        "tweak": "b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70",
+        "tweakedPubkey": "53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343"
+      },
+      "expected": {
+        "scriptPubKey": "512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343",
+        "bip350Address": "bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5"
+      }
+    },
+    {
+      "given": {
+        "internalPubkey": "187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27",
+        "scriptTree": {
+          "id": 0,
+          "script": "20d85a959b0290bf19bb89ed43c916be835475d013da4b362117393e25a48229b8ac",
+          "leafVersion": 192
+        }
+      },
+      "intermediary": {
+        "leafHashes": [
+          "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21"
+        ],
+        "merkleRoot": "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+        "tweak": "cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001",
+        "tweakedPubkey": "147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3"
+      },
+      "expected": {
+        "scriptPubKey": "5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3",
+        "bip350Address": "bc1pz37fc4cn9ah8anwm4xqqhvxygjf9rjf2resrw8h8w4tmvcs0863sa2e586",
+        "scriptPathControlBlocks": [
+          "c1187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27"
+        ]
+      }
+    },
+    {
+      "given": {
+        "internalPubkey": "93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820",
+        "scriptTree": {
+          "id": 0,
+          "script": "20b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007ac",
+          "leafVersion": 192
+        }
+      },
+      "intermediary": {
+        "leafHashes": [
+          "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b"
+        ],
+        "merkleRoot": "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+        "tweak": "6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30",
+        "tweakedPubkey": "e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e"
+      },
+      "expected": {
+        "scriptPubKey": "5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e",
+        "bip350Address": "bc1punvppl2stp38f7kwv2u2spltjuvuaayuqsthe34hd2dyy5w4g58qqfuag5",
+        "scriptPathControlBlocks": [
+          "c093478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820"
+        ]
+      }
+    },
+    {
+      "given": {
+        "internalPubkey": "ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592",
+        "scriptTree": [
+          {
+            "id": 0,
+            "script": "20387671353e273264c495656e27e39ba899ea8fee3bb69fb2a680e22093447d48ac",
+            "leafVersion": 192
+          },
+          {
+            "id": 1,
+            "script": "06424950333431",
+            "leafVersion": 250
+          }
+        ]
+      },
+      "intermediary": {
+        "leafHashes": [
+          "8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7",
+          "f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a"
+        ],
+        "merkleRoot": "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+        "tweak": "9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9",
+        "tweakedPubkey": "712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5"
+      },
+      "expected": {
+        "scriptPubKey": "5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5",
+        "bip350Address": "bc1pwyjywgrd0ffr3tx8laflh6228dj98xkjj8rum0zfpd6h0e930h6saqxrrm",
+        "scriptPathControlBlocks": [
+          "c0ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a",
+          "faee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf37865928ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7"
+        ]
+      }
+    },
+    {
+      "given": {
+        "internalPubkey": "f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8",
+        "scriptTree": [
+          {
+            "id": 0,
+            "script": "2044b178d64c32c4a05cc4f4d1407268f764c940d20ce97abfd44db5c3592b72fdac",
+            "leafVersion": 192
+          },
+          {
+            "id": 1,
+            "script": "07546170726f6f74",
+            "leafVersion": 192
+          }
+        ]
+      },
+      "intermediary": {
+        "leafHashes": [
+          "64512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89",
+          "2cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb"
+        ],
+        "merkleRoot": "ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc",
+        "tweak": "639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e",
+        "tweakedPubkey": "77e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220"
+      },
+      "expected": {
+        "scriptPubKey": "512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220",
+        "bip350Address": "bc1pwl3s54fzmk0cjnpl3w9af39je7pv5ldg504x5guk2hpecpg2kgsqaqstjq",
+        "scriptPathControlBlocks": [
+          "c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd82cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb",
+          "c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd864512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89"
+        ]
+      }
+    },
+    {
+      "given": {
+        "internalPubkey": "e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f",
+        "scriptTree": [
+          {
+            "id": 0,
+            "script": "2072ea6adcf1d371dea8fba1035a09f3d24ed5a059799bae114084130ee5898e69ac",
+            "leafVersion": 192
+          },
+          [
+            {
+              "id": 1,
+              "script": "202352d137f2f3ab38d1eaa976758873377fa5ebb817372c71e2c542313d4abda8ac",
+              "leafVersion": 192
+            },
+            {
+              "id": 2,
+              "script": "207337c0dd4253cb86f2c43a2351aadd82cccb12a172cd120452b9bb8324f2186aac",
+              "leafVersion": 192
+            }
+          ]
+        ]
+      },
+      "intermediary": {
+        "leafHashes": [
+          "2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+          "ba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c",
+          "9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf6"
+        ],
+        "merkleRoot": "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+        "tweak": "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+        "tweakedPubkey": "91b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605"
+      },
+      "expected": {
+        "scriptPubKey": "512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+        "bip350Address": "bc1pjxmy65eywgafs5tsunw95ruycpqcqnev6ynxp7jaasylcgtcxczs6n332e",
+        "scriptPathControlBlocks": [
+          "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fffe578e9ea769027e4f5a3de40732f75a88a6353a09d767ddeb66accef85e553",
+          "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf62645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+          "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817"
+        ]
+      }
+    },
+    {
+      "given": {
+        "internalPubkey": "55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d",
+        "scriptTree": [
+          {
+            "id": 0,
+            "script": "2071981521ad9fc9036687364118fb6ccd2035b96a423c59c5430e98310a11abe2ac",
+            "leafVersion": 192
+          },
+          [
+            {
+              "id": 1,
+              "script": "20d5094d2dbe9b76e2c245a2b89b6006888952e2faa6a149ae318d69e520617748ac",
+              "leafVersion": 192
+            },
+            {
+              "id": 2,
+              "script": "20c440b462ad48c7a77f94cd4532d8f2119dcebbd7c9764557e62726419b08ad4cac",
+              "leafVersion": 192
+            }
+          ]
+        ]
+      },
+      "intermediary": {
+        "leafHashes": [
+          "f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
+          "737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711",
+          "d7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7"
+        ],
+        "merkleRoot": "2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def",
+        "tweak": "6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9",
+        "tweakedPubkey": "75169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831"
+      },
+      "expected": {
+        "scriptPubKey": "512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831",
+        "bip350Address": "bc1pw5tf7sqp4f50zka7629jrr036znzew70zxyvvej3zrpf8jg8hqcssyuewe",
+        "scriptPathControlBlocks": [
+          "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d3cd369a528b326bc9d2133cbd2ac21451acb31681a410434672c8e34fe757e91",
+          "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312dd7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
+          "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d"
+        ]
+      }
+    }
+  ],
+  "keyPathSpending": [
+    {
+      "given": {
+        "rawUnsignedTx": "02000000097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a418420000000000fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0065cd1d",
+        "utxosSpent": [
+          {
+            "scriptPubKey": "512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343",
+            "amountSats": 420000000
+          },
+          {
+            "scriptPubKey": "5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3",
+            "amountSats": 462000000
+          },
+          {
+            "scriptPubKey": "76a914751e76e8199196d454941c45d1b3a323f1433bd688ac",
+            "amountSats": 294000000
+          },
+          {
+            "scriptPubKey": "5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e",
+            "amountSats": 504000000
+          },
+          {
+            "scriptPubKey": "512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+            "amountSats": 630000000
+          },
+          {
+            "scriptPubKey": "00147dd65592d0ab2fe0d0257d571abf032cd9db93dc",
+            "amountSats": 378000000
+          },
+          {
+            "scriptPubKey": "512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831",
+            "amountSats": 672000000
+          },
+          {
+            "scriptPubKey": "5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5",
+            "amountSats": 546000000
+          },
+          {
+            "scriptPubKey": "512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220",
+            "amountSats": 588000000
+          }
+        ]
+      },
+      "intermediary": {
+        "hashAmounts": "58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde6",
+        "hashOutputs": "a2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc5",
+        "hashPrevouts": "e3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f",
+        "hashScriptPubkeys": "23ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e21",
+        "hashSequences": "18959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e"
+      },
+      "inputSpending": [
+        {
+          "given": {
+            "txinIndex": 0,
+            "internalPrivkey": "6b973d88838f27366ed61c9ad6367663045cb456e28335c109e30717ae0c6baa",
+            "merkleRoot": null,
+            "hashType": 3
+          },
+          "intermediary": {
+            "internalPubkey": "d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d",
+            "tweak": "b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70",
+            "tweakedPrivkey": "2405b971772ad26915c8dcdf10f238753a9b837e5f8e6a86fd7c0cce5b7296d9",
+            "sigMsg": "0003020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0000000000d0418f0e9a36245b9a50ec87f8bf5be5bcae434337b87139c3a5b1f56e33cba0",
+            "precomputedUsed": [
+              "hashAmounts",
+              "hashPrevouts",
+              "hashScriptPubkeys",
+              "hashSequences"
+            ],
+            "sigHash": "2514a6272f85cfa0f45eb907fcb0d121b808ed37c6ea160a5a9046ed5526d555"
+          },
+          "expected": {
+            "witness": [
+              "ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c03"
+            ]
+          }
+        },
+        {
+          "given": {
+            "txinIndex": 1,
+            "internalPrivkey": "1e4da49f6aaf4e5cd175fe08a32bb5cb4863d963921255f33d3bc31e1343907f",
+            "merkleRoot": "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+            "hashType": 131
+          },
+          "intermediary": {
+            "internalPubkey": "187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27",
+            "tweak": "cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001",
+            "tweakedPrivkey": "ea260c3b10e60f6de018455cd0278f2f5b7e454be1999572789e6a9565d26080",
+            "sigMsg": "0083020000000065cd1d00d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd9900000000808f891b00000000225120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3ffffffffffcef8fb4ca7efc5433f591ecfc57391811ce1e186a3793024def5c884cba51d",
+            "precomputedUsed": [],
+            "sigHash": "325a644af47e8a5a2591cda0ab0723978537318f10e6a63d4eed783b96a71a4d"
+          },
+          "expected": {
+            "witness": [
+              "052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83"
+            ]
+          }
+        },
+        {
+          "given": {
+            "txinIndex": 3,
+            "internalPrivkey": "d3c7af07da2d54f7a7735d3d0fc4f0a73164db638b2f2f7c43f711f6d4aa7e64",
+            "merkleRoot": "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+            "hashType": 1
+          },
+          "intermediary": {
+            "internalPubkey": "93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820",
+            "tweak": "6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30",
+            "tweakedPrivkey": "97323385e57015b75b0339a549c56a948eb961555973f0951f555ae6039ef00d",
+            "sigMsg": "0001020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50003000000",
+            "precomputedUsed": [
+              "hashAmounts",
+              "hashOutputs",
+              "hashPrevouts",
+              "hashScriptPubkeys",
+              "hashSequences"
+            ],
+            "sigHash": "bf013ea93474aa67815b1b6cc441d23b64fa310911d991e713cd34c7f5d46669"
+          },
+          "expected": {
+            "witness": [
+              "ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a01"
+            ]
+          }
+        },
+        {
+          "given": {
+            "txinIndex": 4,
+            "internalPrivkey": "f36bb07a11e469ce941d16b63b11b9b9120a84d9d87cff2c84a8d4affb438f4e",
+            "merkleRoot": "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+            "hashType": 0
+          },
+          "intermediary": {
+            "internalPubkey": "e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f",
+            "tweak": "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+            "tweakedPrivkey": "a8e7aa924f0d58854185a490e6c41f6efb7b675c0f3331b7f14b549400b4d501",
+            "sigMsg": "0000020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50004000000",
+            "precomputedUsed": [
+              "hashAmounts",
+              "hashOutputs",
+              "hashPrevouts",
+              "hashScriptPubkeys",
+              "hashSequences"
+            ],
+            "sigHash": "4f900a0bae3f1446fd48490c2958b5a023228f01661cda3496a11da502a7f7ef"
+          },
+          "expected": {
+            "witness": [
+              "b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f"
+            ]
+          }
+        },
+        {
+          "given": {
+            "txinIndex": 6,
+            "internalPrivkey": "415cfe9c15d9cea27d8104d5517c06e9de48e2f986b695e4f5ffebf230e725d8",
+            "merkleRoot": "2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def",
+            "hashType": 2
+          },
+          "intermediary": {
+            "internalPubkey": "55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d",
+            "tweak": "6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9",
+            "tweakedPrivkey": "241c14f2639d0d7139282aa6abde28dd8a067baa9d633e4e7230287ec2d02901",
+            "sigMsg": "0002020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0006000000",
+            "precomputedUsed": [
+              "hashAmounts",
+              "hashPrevouts",
+              "hashScriptPubkeys",
+              "hashSequences"
+            ],
+            "sigHash": "15f25c298eb5cdc7eb1d638dd2d45c97c4c59dcaec6679cfc16ad84f30876b85"
+          },
+          "expected": {
+            "witness": [
+              "a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee002"
+            ]
+          }
+        },
+        {
+          "given": {
+            "txinIndex": 7,
+            "internalPrivkey": "c7b0e81f0a9a0b0499e112279d718cca98e79a12e2f137c72ae5b213aad0d103",
+            "merkleRoot": "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+            "hashType": 130
+          },
+          "intermediary": {
+            "internalPubkey": "ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592",
+            "tweak": "9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9",
+            "tweakedPrivkey": "65b6000cd2bfa6b7cf736767a8955760e62b6649058cbc970b7c0871d786346b",
+            "sigMsg": "0082020000000065cd1d00e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf00000000804c8b2000000000225120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5ffffffff",
+            "precomputedUsed": [],
+            "sigHash": "cd292de50313804dabe4685e83f923d2969577191a3e1d2882220dca88cbeb10"
+          },
+          "expected": {
+            "witness": [
+              "ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c482"
+            ]
+          }
+        },
+        {
+          "given": {
+            "txinIndex": 8,
+            "internalPrivkey": "77863416be0d0665e517e1c375fd6f75839544eca553675ef7fdf4949518ebaa",
+            "merkleRoot": "ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc",
+            "hashType": 129
+          },
+          "intermediary": {
+            "internalPubkey": "f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8",
+            "tweak": "639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e",
+            "tweakedPrivkey": "ec18ce6af99f43815db543f47b8af5ff5df3b2cb7315c955aa4a86e8143d2bf5",
+            "sigMsg": "0081020000000065cd1da2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc500a778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af101000000002b0c230000000022512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220ffffffff",
+            "precomputedUsed": [
+              "hashOutputs"
+            ],
+            "sigHash": "cccb739eca6c13a8a89e6e5cd317ffe55669bbda23f2fd37b0f18755e008edd2"
+          },
+          "expected": {
+            "witness": [
+              "bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd981"
+            ]
+          }
+        }
+      ],
+      "auxiliary": {
+        "fullySignedTx": "020000000001097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a41842000000006b4830450221008f3b8f8f0537c420654d2283673a761b7ee2ea3c130753103e08ce79201cf32a022079e7ab904a1980ef1c5890b648c8783f4d10103dd62f740d13daa79e298d50c201210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0141ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c030141052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83000141ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a010140b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f0247304402202b795e4de72646d76eab3f0ab27dfa30b810e856ff3a46c9a702df53bb0d8cc302203ccc4d822edab5f35caddb10af1be93583526ccfbade4b4ead350781e2f8adcd012102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f90141a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee0020141ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c4820141bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd9810065cd1d"
+      }
+    }
+  ]
+}

--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestCase.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestCase.scala
@@ -36,8 +36,7 @@ case class Intermediary(
 
 case class Expected(
     scriptPubKey: TaprootScriptPubKey,
-    bip350Address: Bech32mAddress,
-    scriptPathControlBlocks: Vector[ControlBlock])
+    bip350Address: Bech32mAddress)
 
 case class TaprootWalletTestCase(
     `given`: Given,
@@ -66,17 +65,7 @@ object TaprootWalletTestCase {
           TaprootScriptPubKey.fromAsmHex(expectedObj("scriptPubKey").str)
         val bip350Address =
           Bech32mAddress.fromString(expectedObj("bip350Address").str)
-        val controlBlocks = {
-          if (expectedObj.keys.exists(_ == "scriptPathControlBlocks")) {
-            expectedObj("scriptPathControlBlocks").arr.map { value =>
-              ControlBlock.fromHex(value.str)
-            }
-          } else {
-            Vector.empty
-          }
-
-        }
-        val expected = Expected(spk, bip350Address, controlBlocks.toVector)
+        val expected = Expected(spk, bip350Address)
 
         TaprootWalletTestCase(`given`, intermediary, expected)
 

--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestCase.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestCase.scala
@@ -1,15 +1,7 @@
 package org.bitcoins.core.protocol.transaction
 
 import org.bitcoins.core.protocol.Bech32mAddress
-import org.bitcoins.core.protocol.script.{
-  ControlBlock,
-  ScriptPubKey,
-  TapBranch,
-  TapLeaf,
-  TaprootScriptPath,
-  TaprootScriptPubKey,
-  TapscriptTree
-}
+import org.bitcoins.core.protocol.script._
 import org.bitcoins.crypto.{Sha256Digest, XOnlyPubKey}
 import upickle.default._
 

--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestCase.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestCase.scala
@@ -1,0 +1,90 @@
+package org.bitcoins.core.protocol.transaction
+
+import org.bitcoins.core.protocol.Bech32mAddress
+import org.bitcoins.core.protocol.script.{ScriptPubKey, TaprootScriptPubKey}
+import org.bitcoins.crypto.{Sha256Digest, XOnlyPubKey}
+import upickle.default._
+
+case class ScriptTree(id: Int, spk: ScriptPubKey, leafVersion: Byte)
+
+case class Given(internalPubkey: XOnlyPubKey, scriptTrees: Vector[ScriptTree])
+
+case class Intermediary(
+    leafHashes: Option[Vector[Sha256Digest]],
+    merkleRootOpt: Option[Sha256Digest],
+    tweak: Sha256Digest,
+    tweakedPubkey: XOnlyPubKey)
+
+case class Expected(
+    scriptPubKey: TaprootScriptPubKey,
+    bip350Address: Bech32mAddress)
+
+case class TaprootWalletTestCase(
+    `given`: Given,
+    intermediary: Intermediary,
+    expected: Expected)
+
+case class TaprootWalletTestCases(tests: Vector[TaprootWalletTestCase])
+
+object TaprootWalletTestCase {
+
+  implicit val walletTestVectorReader: Reader[TaprootWalletTestCases] = {
+    reader[ujson.Obj].map { obj =>
+      val testCases = obj("scriptPubKey").arr.map { testCase =>
+        val givenObj = testCase("given").obj
+        val internalPubkey = XOnlyPubKey.fromHex(givenObj("internalPubkey").str)
+        val scriptTree = parseScriptTree(givenObj("scriptTree"))
+
+        val `given` = Given(internalPubkey, scriptTree)
+
+        val intermediaryObj = testCase("intermediary").obj
+
+        val intermediary = parseIntermediary(intermediaryObj)
+
+        val expectedObj = testCase("expected").obj
+        val spk =
+          TaprootScriptPubKey.fromAsmHex(expectedObj("scriptPubKey").str)
+        val bip350Address =
+          Bech32mAddress.fromString(expectedObj("bip350Address").str)
+        val expected = Expected(spk, bip350Address)
+
+        TaprootWalletTestCase(`given`, intermediary, expected)
+
+      }
+      TaprootWalletTestCases(testCases.toVector)
+    }
+  }
+
+  private def parseScriptTree(`given`: ujson.Value): Vector[ScriptTree] = {
+    if (`given`.isNull) Vector.empty
+    else if (`given`.objOpt.isDefined) {
+      val givenObj = `given`.obj
+      val id = givenObj.obj("id").num.toInt
+      val script = ScriptPubKey.fromAsmHex(givenObj("script").str)
+      val leafVersion = givenObj("leafVersion").num.toByte
+      Vector(ScriptTree(id, script, leafVersion))
+    } else {
+      `given`.arr.map(parseScriptTree).flatten.toVector
+    }
+  }
+
+  private def parseIntermediary(intermediaryObj: ujson.Obj): Intermediary = {
+    val merkleRootOpt = {
+      if (intermediaryObj("merkleRoot").isNull) None
+      else Some(Sha256Digest.fromHex(intermediaryObj("merkleRoot").str))
+    }
+    val tweak = Sha256Digest.fromHex(intermediaryObj("tweak").str)
+    val tweakedPubkey =
+      XOnlyPubKey.fromHex(intermediaryObj("tweakedPubkey").str)
+
+    val leafHashesOpt =
+      if (intermediaryObj.value.exists(_._1 == "leafHashes")) {
+        val leaves = intermediaryObj("leafHashes").arr.map(l =>
+          Sha256Digest.fromHex(l.str))
+        Some(leaves.toVector)
+      } else {
+        None
+      }
+    Intermediary(leafHashesOpt, merkleRootOpt, tweak, tweakedPubkey)
+  }
+}

--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestCase.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestCase.scala
@@ -19,7 +19,7 @@ case class Given(internalPubkey: XOnlyPubKey, scriptTrees: Vector[ScriptTree]) {
     TaprootScriptPath.computeTapleafHash(s.leaf)
   }
 
-  val merkleRootOpt: Option[Sha256Digest] = {
+  def merkleRootOpt: Option[Sha256Digest] = {
     if (scriptTrees.isEmpty) None
     else {
       val c =
@@ -92,7 +92,7 @@ object TaprootWalletTestCase {
       val givenObj = `given`.obj
       val id = givenObj.obj("id").num.toInt
       val script = ScriptPubKey.fromAsmHex(givenObj("script").str)
-      val leafVersion = givenObj("leafVersion").num.toByte
+      val leafVersion = givenObj("leafVersion").num.toInt
       val leaf = TapLeaf(leafVersion, script)
       Vector(ScriptTree(id, leaf))
     } else {

--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestVectors.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestVectors.scala
@@ -27,10 +27,10 @@ class TaprootWalletTestVectors extends BitcoinSUnitTest {
     tests.foreach { test =>
       val `given` = test.`given`
       val intermediary = test.intermediary
-      if (`given`.scriptTrees.isEmpty) {
+      if (`given`.treeOpt.isEmpty) {
         checkOutput(test)
       } else {
-        val leafHashes = `given`.scriptTrees.map(_.leaf.sha256)
+        val leafHashes = `given`.leafHashes
         assert(leafHashes == intermediary.leafHashes.get)
         assert(`given`.merkleRootOpt == intermediary.merkleRootOpt,
                s"test=${test.expected.bip350Address}")

--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestVectors.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestVectors.scala
@@ -1,5 +1,8 @@
 package org.bitcoins.core.protocol.transaction
 
+import org.bitcoins.core.config.MainNet
+import org.bitcoins.core.protocol.Bech32mAddress
+import org.bitcoins.core.protocol.script.TaprootScriptPubKey
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 
 class TaprootWalletTestVectors extends BitcoinSUnitTest {
@@ -20,8 +23,28 @@ class TaprootWalletTestVectors extends BitcoinSUnitTest {
   lazy val tests = testCase.tests
 
   it must "build correct taproot spks" in {
-    tests.foreach(t => println(t))
-    succeed
+    tests.foreach { test =>
+      val `given` = test.`given`
+      val intermediary = test.intermediary
+      val expected = test.expected
+      if (`given`.scriptTrees.isEmpty) {
+        //val expectedAddr = test.expected.bip350Address
+        //val expectedSPK = test.expected.scriptPubKey
+        val internal = `given`.internalPubkey
+        val tweakHash =
+          internal.computeTapTweakHash(intermediary.merkleRootOpt)
+        assert(tweakHash == test.intermediary.tweak)
+        val (_, tweakedKey) =
+          internal.createTapTweak(intermediary.merkleRootOpt)
+        assert(tweakedKey == intermediary.tweakedPubkey)
+        val spk = TaprootScriptPubKey.fromPubKey(tweakedKey)
+        val addr = Bech32mAddress.fromScriptPubKey(spk, MainNet)
+        assert(spk == expected.scriptPubKey)
+        assert(addr == expected.bip350Address)
+      } else {
+        fail(s"test=$test")
+      }
+    }
 
   }
 }

--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestVectors.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestVectors.scala
@@ -4,6 +4,7 @@ import org.bitcoins.core.config.MainNet
 import org.bitcoins.core.protocol.Bech32mAddress
 import org.bitcoins.core.protocol.script.TaprootScriptPubKey
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import org.scalatest.Assertion
 
 class TaprootWalletTestVectors extends BitcoinSUnitTest {
   behavior of "TaprootWalletTestVectors"
@@ -20,31 +21,38 @@ class TaprootWalletTestVectors extends BitcoinSUnitTest {
       TaprootWalletTestCase.walletTestVectorReader)
   }
 
-  lazy val tests = testCase.tests
+  lazy val tests: Vector[TaprootWalletTestCase] = testCase.tests
 
   it must "build correct taproot spks" in {
     tests.foreach { test =>
       val `given` = test.`given`
       val intermediary = test.intermediary
-      val expected = test.expected
       if (`given`.scriptTrees.isEmpty) {
-        //val expectedAddr = test.expected.bip350Address
-        //val expectedSPK = test.expected.scriptPubKey
-        val internal = `given`.internalPubkey
-        val tweakHash =
-          internal.computeTapTweakHash(intermediary.merkleRootOpt)
-        assert(tweakHash == test.intermediary.tweak)
-        val (_, tweakedKey) =
-          internal.createTapTweak(intermediary.merkleRootOpt)
-        assert(tweakedKey == intermediary.tweakedPubkey)
-        val spk = TaprootScriptPubKey.fromPubKey(tweakedKey)
-        val addr = Bech32mAddress.fromScriptPubKey(spk, MainNet)
-        assert(spk == expected.scriptPubKey)
-        assert(addr == expected.bip350Address)
+        checkOutput(test)
       } else {
-        fail(s"test=$test")
+        val leafHashes = `given`.scriptTrees.map(_.leaf.sha256)
+        assert(leafHashes == intermediary.leafHashes.get)
+        assert(`given`.merkleRootOpt == intermediary.merkleRootOpt,
+               s"test=${test.expected.bip350Address}")
+        checkOutput(test)
       }
     }
+  }
 
+  private def checkOutput(test: TaprootWalletTestCase): Assertion = {
+    val `given` = test.`given`
+    val intermediary = test.intermediary
+    val expected = test.expected
+    val internal = `given`.internalPubkey
+    val tweakHash =
+      internal.computeTapTweakHash(intermediary.merkleRootOpt)
+    assert(tweakHash == test.intermediary.tweak)
+    val (_, tweakedKey) =
+      internal.createTapTweak(intermediary.merkleRootOpt)
+    assert(tweakedKey == intermediary.tweakedPubkey)
+    val spk = TaprootScriptPubKey.fromPubKey(tweakedKey)
+    val addr = Bech32mAddress.fromScriptPubKey(spk, MainNet)
+    assert(spk == expected.scriptPubKey)
+    assert(addr == expected.bip350Address)
   }
 }

--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestVectors.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/transaction/TaprootWalletTestVectors.scala
@@ -1,0 +1,27 @@
+package org.bitcoins.core.protocol.transaction
+
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+
+class TaprootWalletTestVectors extends BitcoinSUnitTest {
+  behavior of "TaprootWalletTestVectors"
+
+  //from: https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json
+  lazy val url = getClass.getResource("/wallet-test-vectors.json")
+
+  lazy val lines = {
+    scala.io.Source.fromURL(url).getLines().mkString
+  }
+
+  lazy val testCase: TaprootWalletTestCases = {
+    upickle.default.read[TaprootWalletTestCases](lines)(
+      TaprootWalletTestCase.walletTestVectorReader)
+  }
+
+  lazy val tests = testCase.tests
+
+  it must "build correct taproot spks" in {
+    tests.foreach(t => println(t))
+    succeed
+
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/TaprootWitnessTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/TaprootWitnessTest.scala
@@ -47,7 +47,8 @@ class TaprootWitnessTest extends BitcoinSUnitTest {
       "7520c7b5db9562078049719228db2ac80cb9643ec96c8055aa3b29c2c03d4d99edb0ac"
     val spk = ScriptPubKey.fromAsmHex(asmHex)
     assert(asmHex == spk.asmHex)
-    val hash = TaprootScriptPath.computeTapleafHash(0xc0.toByte, spk)
+    val leaf = TapLeaf(0xc0.toByte, spk)
+    val hash = TaprootScriptPath.computeTapleafHash(leaf)
     assert(hash.hex == expected)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
@@ -70,7 +70,7 @@ object TapscriptControlBlock extends Factory[TapscriptControlBlock] {
     if (bytes.isEmpty) {
       false
     } else {
-      knownLeafVersions.contains(bytes.head) &&
+      /*knownLeafVersions.contains(bytes.head) &&*/
       ControlBlock.isValid(bytes) &&
       XOnlyPubKey.fromBytesT(bytes.slice(1, 33)).isSuccess
     }
@@ -83,6 +83,13 @@ object TapscriptControlBlock extends Factory[TapscriptControlBlock] {
 
   override def fromBytes(bytes: ByteVector): TapscriptControlBlock = {
     new TapscriptControlBlock(bytes)
+  }
+
+  def apply(
+      internalKey: XOnlyPubKey,
+      leafHashes: Vector[TapLeaf]): ControlBlock = {
+    val bytes = internalKey.bytes ++ ByteVector.concat(leafHashes.map(_.bytes))
+    ControlBlock(bytes)
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
@@ -70,7 +70,7 @@ object TapscriptControlBlock extends Factory[TapscriptControlBlock] {
     if (bytes.isEmpty) {
       false
     } else {
-      /*knownLeafVersions.contains(bytes.head) &&*/
+      knownLeafVersions.contains(bytes.head) &&
       ControlBlock.isValid(bytes) &&
       XOnlyPubKey.fromBytesT(bytes.slice(1, 33)).isSuccess
     }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -503,7 +503,7 @@ object TaprootScriptPath extends Factory[TaprootScriptPath] {
     */
   def computeTapleafHash(leaf: TapLeaf): Sha256Digest = {
     val bytes =
-      ByteVector.fromByte(leaf.leafVersion) ++ leaf.spk.bytes
+      ByteVector.fromInt(i = leaf.leafVersion, size = 1) ++ leaf.spk.bytes
     CryptoUtil.tapLeafHash(bytes)
   }
 
@@ -544,7 +544,12 @@ object TaprootScriptPath extends Factory[TaprootScriptPath] {
         val result = hashes.grouped(2).map { x =>
           if (x.size == 1) x.head
           else {
-            CryptoUtil.tapBranchHash(x(0).bytes ++ x(1).bytes)
+            val sorted = if (x(0).bytes.compare(x(1).bytes) <= 0) {
+              x(0).bytes ++ x(1).bytes
+            } else {
+              x(1).bytes ++ x(0).bytes
+            }
+            CryptoUtil.tapBranchHash(sorted)
           }
         }
         loop(result.toVector)

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/TapLeaf.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/TapLeaf.scala
@@ -3,8 +3,9 @@ package org.bitcoins.core.protocol.script
 import org.bitcoins.crypto.{CryptoUtil, NetworkElement, Sha256Digest}
 import scodec.bits.ByteVector
 
-case class TapLeaf(leafVersion: Byte, spk: ScriptPubKey)
-    extends NetworkElement {
-  override val bytes: ByteVector = leafVersion +: spk.bytes
+case class TapLeaf(leafVersion: Int, spk: ScriptPubKey) extends NetworkElement {
+
+  override val bytes: ByteVector =
+    ByteVector.fromInt(leafVersion, 1) ++ spk.bytes
   val sha256: Sha256Digest = CryptoUtil.tapLeafHash(bytes)
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/TapLeaf.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/TapLeaf.scala
@@ -3,9 +3,26 @@ package org.bitcoins.core.protocol.script
 import org.bitcoins.crypto.{CryptoUtil, NetworkElement, Sha256Digest}
 import scodec.bits.ByteVector
 
-case class TapLeaf(leafVersion: Int, spk: ScriptPubKey) extends NetworkElement {
+sealed abstract class TapscriptTree extends NetworkElement {
+  def leafs: Vector[TapLeaf]
+}
+
+case class TapBranch(tree1: TapscriptTree, tree2: TapscriptTree)
+    extends TapscriptTree {
+
+  override val bytes: ByteVector = {
+    tree1.bytes ++ tree2.bytes
+  }
+
+  override def leafs: Vector[TapLeaf] = {
+    tree1.leafs ++ tree2.leafs
+  }
+}
+
+case class TapLeaf(leafVersion: Int, spk: ScriptPubKey) extends TapscriptTree {
 
   override val bytes: ByteVector =
     ByteVector.fromInt(leafVersion, 1) ++ spk.bytes
   val sha256: Sha256Digest = CryptoUtil.tapLeafHash(bytes)
+  override val leafs: Vector[TapLeaf] = Vector(this)
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/TapLeaf.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/TapLeaf.scala
@@ -1,0 +1,10 @@
+package org.bitcoins.core.protocol.script
+
+import org.bitcoins.crypto.{CryptoUtil, NetworkElement, Sha256Digest}
+import scodec.bits.ByteVector
+
+case class TapLeaf(leafVersion: Byte, spk: ScriptPubKey)
+    extends NetworkElement {
+  override val bytes: ByteVector = leafVersion +: spk.bytes
+  val sha256: Sha256Digest = CryptoUtil.tapLeafHash(bytes)
+}

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -3,6 +3,7 @@ package org.bitcoins.core.script
 import org.bitcoins.core.crypto._
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script.{
+  TapLeaf,
   TaprootKeyPath,
   TaprootScriptPath,
   TaprootUnknownPath,
@@ -84,9 +85,8 @@ sealed trait ScriptProgram {
   /** Calculates the leaf hash if we have a tapscript, else returns None if we don't have a tapscript */
   def tapLeafHashOpt: Option[Sha256Digest] = {
     getTapscriptOpt.map { sp =>
-      val hash = TaprootScriptPath.computeTapleafHash(
-        TaprootScriptPath.TAPROOT_LEAF_TAPSCRIPT,
-        sp.script)
+      val leaf = TapLeaf(TaprootScriptPath.TAPROOT_LEAF_TAPSCRIPT, sp.script)
+      val hash = TaprootScriptPath.computeTapleafHash(leaf)
       hash
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -653,9 +653,8 @@ sealed abstract class ScriptInterpreter {
             val controlBlock = taprootScriptPath.controlBlock
             val script = taprootScriptPath.script
             //execdata.m_tapleaf_hash = ComputeTapleafHash(control[0] & TAPROOT_LEAF_MASK, exec_script);
-            val tapLeafHash = TaprootScriptPath.computeTapleafHash(
-              controlBlock.leafVersion,
-              script)
+            val leaf = TapLeaf(controlBlock.leafVersion, script)
+            val tapLeafHash = TaprootScriptPath.computeTapleafHash(leaf)
             val isValidTaprootCommitment =
               TaprootScriptPath.verifyTaprootCommitment(
                 controlBlock = controlBlock,

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
@@ -50,6 +50,10 @@ trait CryptoRuntime {
     CryptoUtil.taggedSha256(bytes, "TapBranch")
   }
 
+  def tapLeafHash(bytes: ByteVector): Sha256Digest = {
+    CryptoUtil.taggedSha256(bytes, "TapLeaf")
+  }
+
   /** Performs sha256(sha256(bytes)). */
   def doubleSHA256(bytes: ByteVector): DoubleSha256Digest = {
     val hash: ByteVector = sha256(sha256(bytes).bytes).bytes

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
@@ -42,6 +42,14 @@ trait CryptoRuntime {
     sha256(tagBytes ++ bytes)
   }
 
+  def tapTweakHash(bytes: ByteVector): Sha256Digest = {
+    CryptoUtil.taggedSha256(bytes, "TapTweak")
+  }
+
+  def tapBranchHash(bytes: ByteVector): Sha256Digest = {
+    CryptoUtil.taggedSha256(bytes, "TapBranch")
+  }
+
   /** Performs sha256(sha256(bytes)). */
   def doubleSHA256(bytes: ByteVector): DoubleSha256Digest = {
     val hash: ByteVector = sha256(sha256(bytes).bytes).bytes

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
@@ -6,7 +6,7 @@ import java.math.BigInteger
 import scala.util.Try
 
 /** Represents the raw bytes which are meant to represent an ECKey without deserializing. */
-sealed trait ECKeyBytes extends NetworkElement
+sealed abstract class ECKeyBytes extends NetworkElement
 
 /** Represents a serialization sensitive ECPrivateKey (such as is used in WIF). */
 case class ECPrivateKeyBytes(bytes: ByteVector, isCompressed: Boolean = true)

--- a/crypto/src/main/scala/org/bitcoins/crypto/XOnlyPubKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/XOnlyPubKey.scala
@@ -63,7 +63,7 @@ case class XOnlyPubKey(bytes: ByteVector) extends PublicKey {
   }
 
   private def tapTweakHash(bytes: ByteVector): Sha256Digest = {
-    CryptoUtil.taggedSha256(bytes, "TapTweak")
+    CryptoUtil.tapTweakHash(bytes)
   }
 }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/XOnlyPubKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/XOnlyPubKey.scala
@@ -62,6 +62,19 @@ case class XOnlyPubKey(bytes: ByteVector) extends PublicKey {
     }
   }
 
+  /** @see https://github.com/bitcoin/bitcoin/blob/bdb33ec51986570ea17406c83bad2c955ae23186/src/pubkey.cpp#L249
+    * @param merkleRootOpt if the merkle root is empty we have no scripts.
+    * @return
+    */
+  def createTapTweak(
+      merkleRootOpt: Option[Sha256Digest]): (KeyParity, XOnlyPubKey) = {
+    val taggedHash = computeTapTweakHash(merkleRootOpt)
+    val result = CryptoParams.getG
+      .multiply(FieldElement(taggedHash.bytes))
+      .add(this.publicKey)
+    (result.parity, result.toXOnly)
+  }
+
   private def tapTweakHash(bytes: ByteVector): Sha256Digest = {
     CryptoUtil.tapTweakHash(bytes)
   }


### PR DESCRIPTION
This PR adds data structures to represent a full `TapscriptTree` tree. It has two subtypes 

- `TapBranch` 
- `TapLeaf`

This PR also incorporates the `wallet-test-vectors.json` from [BIP341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki). This PR does not fully implement the test vectors, rather just tests `TaprootScriptPubKey` construction from the given `TapscriptTree`'s inside of `wallet-test-vectors.json`. In a future PR we will add tests to building spends from the given `TapscriptTree`.

This is needed for #4913 