### PR TITLE
2024 04 16 descriptor fidelity

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/hd/HDAccountTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/hd/HDAccountTest.scala
@@ -40,7 +40,7 @@ class HDAccountTest extends BitcoinSUnitTest {
   }
 
   it must "succeed if we add an arbitrary element onto the end of the path" in {
-    val extraNode = defaultPath.:+(BIP32Node(0, true))
+    val extraNode = defaultPath.:+(BIP32Node(0, HardenedType.defaultOpt))
 
     val isSame = HDAccount.isSameAccount(extraNode, defaultAcct)
 

--- a/core-test/src/test/scala/org/bitcoins/core/hd/HDPathTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/hd/HDPathTest.scala
@@ -129,7 +129,7 @@ class HDPathTest extends BitcoinSUnitTest {
     forAll(HDGenerators.hdPathWithConstructor) { case (hd, hdApply) =>
       val nonHardenedCoinChildren = hd.path.zipWithIndex.map {
         case (child, index) =>
-          if (index == LegacyHDPath.COIN_INDEX) child.copy(hardened = false)
+          if (index == LegacyHDPath.COIN_INDEX) child.copy(hardenedOpt = None)
           else child
       }
 
@@ -144,7 +144,7 @@ class HDPathTest extends BitcoinSUnitTest {
       val nonHardenedAccountChildren = hd.path.zipWithIndex.map {
         case (child, index) =>
           if (index == LegacyHDPath.ACCOUNT_INDEX)
-            child.copy(hardened = false)
+            child.copy(hardenedOpt = None)
           else child
       }
       val badAccountAttempt = hdApply(nonHardenedAccountChildren)
@@ -157,7 +157,8 @@ class HDPathTest extends BitcoinSUnitTest {
 
       val hardenedChainChildren = hd.path.zipWithIndex.map {
         case (child, index) =>
-          if (index == LegacyHDPath.CHAIN_INDEX) child.copy(hardened = true)
+          if (index == LegacyHDPath.CHAIN_INDEX)
+            child.copy(hardenedOpt = HardenedType.defaultOpt)
           else child
       }
       val badChainAttempt =
@@ -171,7 +172,8 @@ class HDPathTest extends BitcoinSUnitTest {
 
       val hardenedAddressChildren = hd.path.zipWithIndex.map {
         case (child, index) =>
-          if (index == LegacyHDPath.ADDRESS_INDEX) child.copy(hardened = true)
+          if (index == LegacyHDPath.ADDRESS_INDEX)
+            child.copy(hardenedOpt = HardenedType.defaultOpt)
           else child
       }
       val badAddrAttempt =

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/descriptor/DescriptorChecksumTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/descriptor/DescriptorChecksumTest.scala
@@ -7,32 +7,43 @@ class DescriptorChecksumTest extends BitcoinSUnitTest {
 
   behavior of "DescriptorChecksumTest"
 
-  val expression =
-    RawScriptExpression(NonStandardScriptPubKey.fromAsmHex("deadbeef"))
+  val descriptor =
+    RawDescriptor(
+      RawScriptExpression(NonStandardScriptPubKey.fromAsmHex("deadbeef")),
+      None)
   it must "calculate correct checksums from BIP380 examples" in {
     val str0 = "raw(deadbeef)#89f8spxm"
     val split0 = str0.split("#")
     val (payload, checksum) = (split0(0), split0(1))
     assert(Descriptor.createChecksum(payload) == checksum)
 
-    assert(Descriptor.isValidChecksum(expression, Some(checksum)))
+    assert(Descriptor.isValidChecksum(descriptor, Some(checksum)))
 
     //expression with nochecksum should be valid
-    assert(Descriptor.isValidChecksum(expression, None))
+    assert(Descriptor.isValidChecksum(descriptor, None))
+
+//    val descriptor1 =
+//      Descriptor.fromString(
+//        "wpkh([d34db33f/84h/0h/0h]xpub6DJ2dNUysrn5Vt36jH2KLBT2i1auw1tTSSomg8PhqNiUtx8QX2SvC9nrHu81fT41fvDUnhMjEzQgXnQjKEu3oaqMSzhSrHMxyyoEAmUHQbY/0/*)")
+//    val checksum1 = "cjjspncu"
+//    assert(Descriptor.createChecksum(descriptor1) == checksum1)
+//    assert(Descriptor.isValidChecksum(descriptor1, Some(checksum1)))
   }
 
   it must "fail when a bad checksum is given" in {
     //Missing checksum
-    assert(!Descriptor.isValidChecksum(expression, Some("#")))
+    assert(!Descriptor.isValidChecksum(descriptor, Some("#")))
     //Too long checksum (9 chars)
-    assert(!Descriptor.isValidChecksum(expression, Some("89f8spxmx")))
+    assert(!Descriptor.isValidChecksum(descriptor, Some("89f8spxmx")))
     //Too short checksum (7 chars)
-    assert(!Descriptor.isValidChecksum(expression, Some("89f8spx")))
+    assert(!Descriptor.isValidChecksum(descriptor, Some("89f8spx")))
     //Error in payload
     val bad =
-      RawScriptExpression(NonStandardScriptPubKey.fromAsmHex("deedbeef"))
+      RawDescriptor(
+        RawScriptExpression(NonStandardScriptPubKey.fromAsmHex("deedbeef")),
+        None)
     assert(!Descriptor.isValidChecksum(bad, Some("89f8spxm")))
     //Error in checksum
-    assert(!Descriptor.isValidChecksum(expression, Some("#9f8spxm")))
+    assert(!Descriptor.isValidChecksum(descriptor, Some("#9f8spxm")))
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/descriptor/DescriptorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/descriptor/DescriptorTest.scala
@@ -452,6 +452,14 @@ class DescriptorTest extends BitcoinSUnitTest {
     runFailTest(str4)
   }
 
+  it must "have fidelity with the type of hardened derivation used as input" in {
+    //note using h instead of ' for hardened derivation path
+    val str =
+      "wpkh([d34db33f/84h/0h/0h]xpub6DJ2dNUysrn5Vt36jH2KLBT2i1auw1tTSSomg8PhqNiUtx8QX2SvC9nrHu81fT41fvDUnhMjEzQgXnQjKEu3oaqMSzhSrHMxyyoEAmUHQbY/0/*)"
+    val desc = Descriptor.fromString(str)
+    assert(desc.toString == str)
+  }
+
   def runTest(descriptor: String, expectedSPK: String): Assertion = {
     val desc = ScriptDescriptor.fromString(descriptor)
     assert(desc.toString == descriptor)

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/descriptor/KeyExpressionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/descriptor/KeyExpressionTest.scala
@@ -13,8 +13,8 @@ class KeyExpressionTest extends BitcoinSUnitTest {
     val str2 = "[deadbeef/0'/0h/0']"
     val keyOrigin = KeyOriginExpression.fromString(str0)
     assert(str0 == keyOrigin.toString)
-    assert(keyOrigin == KeyOriginExpression.fromString(str1))
-    keyOrigin == KeyOriginExpression.fromString(str2)
+    assert(KeyOriginExpression.fromString(str1).toString == str1)
+    assert(KeyOriginExpression.fromString(str2).toString == str2)
   }
 
   it must "parse valid private key expressions from BIP380" in {

--- a/core/src/main/scala/org/bitcoins/core/hd/HDAccount.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDAccount.scala
@@ -16,7 +16,7 @@ case class HDAccount(
   require(index >= 0, s"Account index ($index) must be positive!")
 
   override val path: Vector[BIP32Node] = {
-    coin.path :+ BIP32Node(index, hardened = true)
+    coin.path :+ BIP32Node(index, hardenedOpt = HardenedType.defaultOpt)
   }
 
   def purpose: HDPurpose = coin.purpose

--- a/core/src/main/scala/org/bitcoins/core/hd/HDAddress.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDAddress.scala
@@ -8,7 +8,7 @@ sealed abstract class HDAddress extends BIP32Path {
   require(index >= 0, s"Address index ($index) must be positive!")
 
   override val path: Vector[BIP32Node] = {
-    chain.path :+ BIP32Node(index, hardened = false)
+    chain.path :+ BIP32Node(index, hardenedOpt = None)
   }
 
   def purpose: HDPurpose

--- a/core/src/main/scala/org/bitcoins/core/hd/HDChain.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDChain.scala
@@ -7,7 +7,7 @@ package org.bitcoins.core.hd
 sealed abstract class HDChain extends BIP32Path {
 
   override val path: Vector[BIP32Node] = {
-    account.path :+ BIP32Node(toInt, hardened = false)
+    account.path :+ BIP32Node(toInt, hardenedOpt = None)
   }
 
   def purpose: HDPurpose

--- a/core/src/main/scala/org/bitcoins/core/hd/HDCoin.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDCoin.scala
@@ -7,7 +7,7 @@ package org.bitcoins.core.hd
 case class HDCoin(purpose: HDPurpose, coinType: HDCoinType) extends BIP32Path {
 
   override def path: Vector[BIP32Node] =
-    purpose.path :+ BIP32Node(coinType.toInt, hardened = true)
+    purpose.path :+ BIP32Node(coinType.toInt, HardenedType.defaultOpt)
 
   def toAccount(index: Int): HDAccount = HDAccount(this, index)
 }

--- a/core/src/main/scala/org/bitcoins/core/hd/HDPathFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDPathFactory.scala
@@ -41,15 +41,16 @@ private[hd] trait HDPathFactory[PathType <: BIP32Path]
     val maybePurpose = children.head
 
     val purpose: HDPurpose = maybePurpose match {
-      case BIP32Node(_, false) =>
+      case BIP32Node(_, None) =>
         throw new IllegalArgumentException(
           "The first child in a HD path must be hardened")
-      case BIP32Node(HDPurposes.Legacy.constant, true) => HDPurposes.Legacy
-      case BIP32Node(HDPurposes.SegWit.constant, true) => HDPurposes.SegWit
-      case BIP32Node(HDPurposes.NestedSegWit.constant, true) =>
+      case BIP32Node(HDPurposes.Legacy.constant, Some(_)) => HDPurposes.Legacy
+      case BIP32Node(HDPurposes.SegWit.constant, Some(_)) => HDPurposes.SegWit
+      case BIP32Node(HDPurposes.NestedSegWit.constant, Some(_)) =>
         HDPurposes.NestedSegWit
-      case BIP32Node(HDPurposes.Multisig.constant, true) => HDPurposes.Multisig
-      case BIP32Node(unknown, true) =>
+      case BIP32Node(HDPurposes.Multisig.constant, Some(_)) =>
+        HDPurposes.Multisig
+      case BIP32Node(unknown, Some(_)) =>
         throw new IllegalArgumentException(
           s"Purpose constant ($unknown) is not a known purpose constant")
     }
@@ -103,7 +104,7 @@ private[hd] trait HDPathFactory[PathType <: BIP32Path]
   protected lazy val hdPurpose: HDPurpose =
     HDPurposes.fromConstant(PURPOSE).get // todo
 
-  lazy val purposeChild: BIP32Node = BIP32Node(PURPOSE, hardened = true)
+  lazy val purposeChild: BIP32Node = BIP32Node(PURPOSE, HardenedType.defaultOpt)
 
   /** The index of the coin segement of a BIP44 path
     */

--- a/core/src/main/scala/org/bitcoins/core/hd/HDPurpose.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDPurpose.scala
@@ -18,7 +18,7 @@ package org.bitcoins.core.hd
 case class HDPurpose(constant: Int) extends BIP32Path {
 
   override val path: Vector[BIP32Node] = Vector(
-    BIP32Node(constant, hardened = true))
+    BIP32Node(constant, HardenedType.defaultOpt))
 }
 
 object HDPurposes {

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/descriptor/Descriptor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/descriptor/Descriptor.scala
@@ -141,7 +141,9 @@ sealed abstract class DescriptorFactory[
       //now check for a valid checksum
       val checksumOpt =
         if (checksum.nonEmpty) Some(checksum.tail) else None //drop '#'
-      val isValidChecksum = Descriptor.isValidChecksum(expression, checksumOpt)
+      val isValidChecksum = Descriptor.isValidChecksum(
+        descriptor = createDescriptor(expression, None),
+        checksumOpt = checksumOpt)
       if (isValidChecksum) {
         createDescriptor(expression, checksumOpt)
       } else {
@@ -468,13 +470,17 @@ object Descriptor extends StringFactory[Descriptor] {
     builder.result()
   }
 
+  def createChecksum(descriptor: Descriptor): String = {
+    createChecksum(descriptor.toString)
+  }
+
   def isValidChecksum(
-      expression: DescriptorExpression,
+      descriptor: Descriptor,
       checksumOpt: Option[String]): Boolean = {
     checksumOpt match {
       case None => true //trivially true if we have no checksum
       case Some(checksum) =>
-        val t = Try(createChecksum(expression.toString))
+        val t = Try(createChecksum(descriptor.toString))
         if (t.isFailure) false
         else t.get == checksum
     }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/descriptor/DescriptorIterator.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/descriptor/DescriptorIterator.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol.script.descriptor
 
 import org.bitcoins.core.crypto.{ECPrivateKeyUtil, ExtKey, ExtPublicKey}
-import org.bitcoins.core.hd.BIP32Path
+import org.bitcoins.core.hd.{BIP32Path, HardenedType}
 import org.bitcoins.core.protocol.script.{
   MultiSignatureScriptPubKey,
   RawScriptPubKey
@@ -10,10 +10,6 @@ import org.bitcoins.crypto._
 
 case class DescriptorIterator(descriptor: String) {
   private var index: Int = 0
-
-  private val hardenedChars: Vector[Char] = {
-    Vector('\'', 'h', 'H')
-  }
 
   def current: String = {
     descriptor.drop(index)
@@ -46,15 +42,20 @@ case class DescriptorIterator(descriptor: String) {
     }
   }
 
-  def takeChildrenHardenedOpt(): Option[Boolean] = {
+  def takeChildrenHardenedOpt(): Option[Option[HardenedType]] = {
     if (current.nonEmpty && current.charAt(0) == '*') {
       skip(1)
-      if (current.nonEmpty && hardenedChars.exists(_ == current.charAt(0))) {
+      val hardenedOpt = HardenedType.fromStringOpt(current.take(1))
+//      if (current.nonEmpty && hardenedChars.exists(_ == current.charAt(0))) {
+//        skip(1)
+//        Some(true)
+//      } else {
+//        Some(false)
+//      }
+      if (hardenedOpt.isDefined) {
         skip(1)
-        Some(true)
-      } else {
-        Some(false)
       }
+      Some(hardenedOpt)
     } else {
       None
     }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -749,8 +749,8 @@ abstract class DLCWallet
       account: AccountDb,
       keyIndex: Int): AdaptorSign = {
     val bip32Path = BIP32Path(
-      account.hdAccount.path ++ Vector(BIP32Node(0, hardened = false),
-                                       BIP32Node(keyIndex, hardened = false)))
+      account.hdAccount.path ++ Vector(BIP32Node(0, hardenedOpt = None),
+                                       BIP32Node(keyIndex, hardenedOpt = None)))
     val privKeyPath = HDPath.fromString(bip32Path.toString)
     keyManager.toSign(privKeyPath)
   }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCDataManagement.scala
@@ -572,8 +572,8 @@ case class DLCDataManagement(dlcWalletDAOs: DLCWalletDAOs)(implicit
 
           val bip32Path = BIP32Path(
             dlcDb.account.path ++ Vector(
-              BIP32Node(dlcDb.changeIndex.index, hardened = false),
-              BIP32Node(dlcDb.keyIndex, hardened = false)))
+              BIP32Node(dlcDb.changeIndex.index, hardenedOpt = None),
+              BIP32Node(dlcDb.keyIndex, hardenedOpt = None)))
 
           val privKeyPath = HDPath.fromString(bip32Path.toString)
           val fundingPrivKey = keyManager.toSign(privKeyPath)

--- a/docs/crypto/sign.md
+++ b/docs/crypto/sign.md
@@ -51,7 +51,7 @@ val extPrivKey = ExtPrivateKey(ExtKeyVersion.SegWitMainNetPriv)
 
 extPrivKey.sign(DoubleSha256Digest.empty.bytes)
 
-val path = BIP32Path(Vector(BIP32Node(0,false)))
+val path = BIP32Path(Vector(BIP32Node(0,HardenedType.defaultOpt)))
 
 extPrivKey.sign(DoubleSha256Digest.empty.bytes,path)
 ```

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/HDGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/HDGenerators.scala
@@ -8,6 +8,8 @@ import scala.util.Try
   */
 object HDGenerators {
 
+  def hardenedType: Gen[HardenedType] = Gen.oneOf(HardenedType.all)
+
   /** Generates a BIP 32 path segment
     */
   def bip32Child: Gen[BIP32Node] = Gen.oneOf(softBip32Child, hardBip32Child)
@@ -17,14 +19,15 @@ object HDGenerators {
   def softBip32Child: Gen[BIP32Node] =
     for {
       index <- NumberGenerator.positiveInts
-    } yield BIP32Node(index, hardened = false)
+    } yield BIP32Node(index, hardenedOpt = None)
 
   /** Generates a hardened BIP 32 path segment
     */
   def hardBip32Child: Gen[BIP32Node] =
     for {
       soft <- softBip32Child
-    } yield soft.copy(hardened = true)
+      hardened <- hardenedType
+    } yield soft.copy(hardenedOpt = Some(hardened))
 
   /** Generates a BIP32 path
     */

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/util/GetAddresses.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/util/GetAddresses.scala
@@ -37,9 +37,9 @@ object GetAddresses extends App {
     accountIndex <- 0 until 3
   } yield {
     val accountPath = BIP32Path(
-      BIP32Node(constant.constant, hardened = true),
-      BIP32Node(coin.toInt, hardened = true),
-      BIP32Node(accountIndex, hardened = true)
+      BIP32Node(constant.constant, HardenedType.defaultOpt),
+      BIP32Node(coin.toInt, HardenedType.defaultOpt),
+      BIP32Node(accountIndex, HardenedType.defaultOpt)
     )
 
     val pathType =
@@ -68,11 +68,11 @@ object GetAddresses extends App {
       addressIndex <- 0 until 3
     } yield {
       val path = BIP32Path(
-        BIP32Node(constant.constant, hardened = true),
-        BIP32Node(coin.toInt, hardened = true),
-        BIP32Node(accountIndex, hardened = true),
-        BIP32Node(chainType.index, hardened = false),
-        BIP32Node(addressIndex, hardened = false)
+        BIP32Node(constant.constant, HardenedType.defaultOpt),
+        BIP32Node(coin.toInt, HardenedType.defaultOpt),
+        BIP32Node(accountIndex, HardenedType.defaultOpt),
+        BIP32Node(chainType.index, HardenedType.defaultOpt),
+        BIP32Node(addressIndex, None)
       )
 
       val addressCmd = s"trezorctl get-address -n $path -t $trezorPathType"


### PR DESCRIPTION
This is needed for #5494 and is related to #5525 

We need the ability to represent the serialized descriptor's `HardenedType` to compute checkums correctly for a descriptor. For instance, when working with bitcoind that serves descriptors with a `h` hardened type, if we attempt to compute the checksum for a descriptor with `'` rather than `h` we can an invalid descriptor.

This PR introduces `HardenedType` as a parameter to `BIP32Node` so we can store in memory what the serialized version of the `BIP32Node` is.