### PR TITLE
Update dialect to `scala213source3`

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = "3.8.1"
 # See Documentation at https://scalameta.org/scalafmt/#Configuration
-runner.dialect=scala213
+runner.dialect=scala213source3
 align = some
 align {
     openParenDefnSite = false


### PR DESCRIPTION
Allow scala3 source to be used in scalafmt to make the transition less painless in #3497 , related to #5501 

https://scalameta.org/scalafmt/docs/configuration.html#scala-2-with--xsource3