### PR TITLE
Make `wallet.dat` be the default wallet name for bitcoind in our codebase

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MultiWalletRpcTest.scala
@@ -70,6 +70,7 @@ class MultiWalletRpcTest extends BitcoindFixturesCachedPairNewest {
       _ <- PekkoUtil.nonBlockingSleep(1.second)
       started <- walletClient.start()
       _ <- walletClient.loadWallet(walletName)
+      _ <- walletClient.loadWallet(BitcoindRpcClient.DEFAULT_WALLET_NAME)
 
       wallets <- walletClient.listWallets
       wallets2 <- client.listWallets

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -79,6 +79,7 @@ class WalletRpcTest extends BitcoindFixturesCachedPairNewest {
       // hasn't released its locks on the datadir. This is prevent that.
       _ <- PekkoUtil.nonBlockingSleep(1.second)
       _ <- walletClient.start()
+      _ <- walletClient.loadWallet(BitcoindRpcClient.DEFAULT_WALLET_NAME)
     } yield walletClient
   }
 
@@ -91,8 +92,7 @@ class WalletRpcTest extends BitcoindFixturesCachedPairNewest {
     for {
       wallets <- client.listWallets
     } yield {
-
-      val expectedFileName = ""
+      val expectedFileName = BitcoindRpcClient.DEFAULT_WALLET_NAME
 
       assert(wallets == Vector(expectedFileName))
     }
@@ -651,11 +651,11 @@ class WalletRpcTest extends BitcoindFixturesCachedPairNewest {
   it should "create a descriptor wallet" in { nodePair: FixtureParam =>
     val client = nodePair.node1
     for {
-      _ <- client.unloadWallet("")
+      _ <- client.unloadWallet(BitcoindRpcClient.DEFAULT_WALLET_NAME)
       _ <- client.createWallet("descriptorWallet", descriptors = true)
       descript <- client.getWalletInfo("descriptorWallet")
       _ <- client.unloadWallet("descriptorWallet")
-      _ <- client.loadWallet("")
+      _ <- client.loadWallet(BitcoindRpcClient.DEFAULT_WALLET_NAME)
     } yield {
       descript match {
         case walletInfoPostV22: GetWalletInfoResultPostV22 =>
@@ -668,11 +668,11 @@ class WalletRpcTest extends BitcoindFixturesCachedPairNewest {
     nodePair: FixtureParam =>
       val client = nodePair.node1
       for {
-        _ <- client.unloadWallet("")
+        _ <- client.unloadWallet(BitcoindRpcClient.DEFAULT_WALLET_NAME)
         _ <- client.createWallet("privKeyWallet", disablePrivateKeys = true)
         walletPriv <- client.getWalletInfo("privKeyWallet")
         _ <- client.unloadWallet("privKeyWallet")
-        _ <- client.loadWallet("")
+        _ <- client.loadWallet(BitcoindRpcClient.DEFAULT_WALLET_NAME)
       } yield {
         walletPriv match {
           case walletInfoPostV22: GetWalletInfoResultPostV22 =>
@@ -724,12 +724,12 @@ class WalletRpcTest extends BitcoindFixturesCachedPairNewest {
       next = None
     )
     for {
-      _ <- client.unloadWallet("")
+      _ <- client.unloadWallet(BitcoindRpcClient.DEFAULT_WALLET_NAME)
       _ <- client.createWallet(walletName, descriptors = true)
       _ <- client.importDescriptor(imp, Some(walletName))
       decoded <- client.decodeScript(p2wpkh)
       _ <- client.unloadWallet(walletName)
-      _ <- client.loadWallet("")
+      _ <- client.loadWallet(BitcoindRpcClient.DEFAULT_WALLET_NAME)
     } yield {
       decoded match {
         case decodedV22: DecodeScriptResultV22 =>

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -303,6 +303,8 @@ object BitcoindRpcClient {
   implicit private lazy val system: ActorSystem =
     ActorSystem.create(ActorSystemName)
 
+  val DEFAULT_WALLET_NAME: String = "wallet.dat"
+
   /** Creates an RPC client from the given instance.
     *
     * Behind the scenes, we create an actor system for you. You can use

--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -314,7 +314,8 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
         val createWalletF = for {
           version <- server.version
           descriptors = true
-          _ <- res.createWallet("", descriptors = descriptors)
+          _ <- res.createWallet(BitcoindRpcClient.DEFAULT_WALLET_NAME,
+                                descriptors = descriptors)
         } yield res
 
         createWalletF


### PR DESCRIPTION
Instead of using `""` as the default wallet name when we call `createwallet` with bitcoind for our test framekwork, this PR makes the file name `wallet.dat` as the default wallet name for `createwallet` in our test framework.