### PR TITLE
rework `bitcoind-rpc` to take a `walletName` parameter that is a String

### DIFF
--- a/bitcoin-s-docs/src/main/scala/org/bitcoins/docs/DocsGen.scala
+++ b/bitcoin-s-docs/src/main/scala/org/bitcoins/docs/DocsGen.scala
@@ -3,8 +3,8 @@ package org.bitcoins.docs
 import mdoc.MainSettings
 import scala.meta.io.AbsolutePath
 
-/** This is cribbed from how Bloop does
-  * docs generation: https://github.com/scalacenter/bloop/blob/6c8dc54b7bdf5a6145b31f94b73456693c0d1230/docs-gen/src/main/scala/bloop/Docs.scala#L8-L35
+/** This is cribbed from how Bloop does docs generation:
+  * https://github.com/scalacenter/bloop/blob/6c8dc54b7bdf5a6145b31f94b73456693c0d1230/docs-gen/src/main/scala/bloop/Docs.scala#L8-L35
   */
 object DocsGen extends App {
   val cwd0 = AbsolutePath.workingDirectory

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/TransactionRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/TransactionRpc.scala
@@ -75,12 +75,12 @@ trait TransactionRpc { self: Client =>
   def getTransaction(
       txid: DoubleSha256DigestBE,
       watchOnly: Boolean = false,
-      walletNameOpt: Option[String] = None
+      walletName: String = BitcoindRpcClient.DEFAULT_WALLET_NAME
   ): Future[GetTransactionResult] = {
     bitcoindCall[GetTransactionResult](
       "gettransaction",
       List(JsString(txid.hex), JsBoolean(watchOnly)),
-      uriExtensionOpt = walletNameOpt.map(walletExtension)
+      uriExtensionOpt = Some(walletExtension(walletName))
     )
   }
 

--- a/docs/rpc/bitcoind.md
+++ b/docs/rpc/bitcoind.md
@@ -75,7 +75,7 @@ val client = BitcoindRpcClient.fromDatadir(binary=new File("/path/to/bitcoind"),
 
 for {
   _ <- client.start()
-  _ <- client.walletPassphrase("mypassword", 10000, Some("walletName"))
+  _ <- client.walletPassphrase("mypassword", 10000, "walletName")
   balance <- client.getBalance("walletName")
 } yield balance
 ```


### PR DESCRIPTION
Previously we would take in an `Option[String]` which doesn't really make sense. We _need_ a wallet name. We can give a default parameter of `BitcoindRpcClient.DEFAULT_WALLET_NAME` (#5543). 

This is need to remove unit test cases from `BitcoindV24RpcClientTest` to close out #4587 