### PR TITLE
Bump github actions to setup-java-v4

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/Linux_2.13_Node_Tests.yml
+++ b/.github/workflows/Linux_2.13_Node_Tests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
+++ b/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
+++ b/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
@@ -21,8 +21,6 @@ jobs:
           distribution: 'adopt'
           java-version: '21'
           cache: 'sbt'
-      - name: install sbt as workaround https://github.com/actions/setup-java/issues/627
-        run: brew install sbt
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -21,8 +21,6 @@ jobs:
           distribution: 'adopt'
           java-version: '21'
           cache: 'sbt'
-      - name: install sbt as workaround https://github.com/actions/setup-java/issues/627
-        run: brew install sbt
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -21,8 +21,6 @@ jobs:
           distribution: 'adopt'
           java-version: '21'
           cache: 'sbt'
-      - name: install sbt as workaround https://github.com/actions/setup-java/issues/627
-        run: brew install sbt
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/TorTests.yml
+++ b/.github/workflows/TorTests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '21'


### PR DESCRIPTION
https://github.com/actions/setup-java/releases/tag/v4.0.0 

Builds seem to be failing on macOS complaing that sbt cannot be found, try bumping the github actions version to see if this fixes the issue (#5545 , #5543 )

https://github.com/bitcoin-s/bitcoin-s/actions/runs/8838330872/job/24269209569?pr=5545#step:5:1