### PR TITLE
Ignore mempool testnet api tests for now as unit tests consistently fail

### DIFF
--- a/fee-provider-test/src/test/scala/org/bitcoins/feeprovider/FeeRateProviderTest.scala
+++ b/fee-provider-test/src/test/scala/org/bitcoins/feeprovider/FeeRateProviderTest.scala
@@ -17,7 +17,7 @@ class FeeRateProviderTest extends BitcoinSAsyncTest {
 
   private val proxyParams = Option.empty[Socks5ProxyParams]
 
-  it must "get a valid fee rate from bitcoiner.live" ignore {
+  it must "get a valid fee rate from bitcoiner.live" in {
     val provider = BitcoinerLiveFeeRateProvider(60, proxyParams)
     testProvider(provider)
   }
@@ -47,18 +47,18 @@ class FeeRateProviderTest extends BitcoinSAsyncTest {
     testProvider(provider)
   }
 
-  it must "get a valid fee rate from mempool.space/testnet using the fastest fee target" in {
+  it must "get a valid fee rate from mempool.space/testnet using the fastest fee target" ignore {
     val provider = MempoolSpaceProvider(FastestFeeTarget, TestNet3, proxyParams)
     testProvider(provider)
   }
 
-  it must "get a valid fee rate from mempool.space/testnet using a half hour fee target" in {
+  it must "get a valid fee rate from mempool.space/testnet using a half hour fee target" ignore {
     val provider =
       MempoolSpaceProvider(HalfHourFeeTarget, TestNet3, proxyParams)
     testProvider(provider)
   }
 
-  it must "get a valid fee rate from mempool.space/testnet using an hour fee target" in {
+  it must "get a valid fee rate from mempool.space/testnet using an hour fee target" ignore {
     val provider = MempoolSpaceProvider(HourFeeTarget, TestNet3, proxyParams)
     testProvider(provider)
   }


### PR DESCRIPTION
These tests seem to fail consistently now on ONLY testnet (not signet, mainnet). I'll file an issue to re-enable these. 

This PR also re-enables the `bitcoiner.live` fee rate provider (undoing part of #5433 )