### PR TITLE
Try `brew install sbt` as workaround for macOS Ci runners failing to install sbt

### DIFF
--- a/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
+++ b/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
@@ -21,6 +21,8 @@ jobs:
           distribution: 'adopt'
           java-version: '21'
           cache: 'sbt'
+      - name: install sbt as workaround https://github.com/actions/setup-java/issues/627
+        run: brew install sbt
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-13
+    runs-on: macos-latest
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -21,6 +21,8 @@ jobs:
           distribution: 'adopt'
           java-version: '21'
           cache: 'sbt'
+      - name: install sbt as workaround https://github.com/actions/setup-java/issues/627
+        run: brew install sbt
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -21,6 +21,8 @@ jobs:
           distribution: 'adopt'
           java-version: '21'
           cache: 'sbt'
+      - name: install sbt as workaround https://github.com/actions/setup-java/issues/627
+        run: brew install sbt
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/bitcoind-rpc/bitcoind-rpc.sbt
+++ b/bitcoind-rpc/bitcoind-rpc.sbt
@@ -107,11 +107,11 @@ TaskKeys.downloadBitcoind := {
               "26.1" -> (if (System.getProperty("os.arch") == "aarch64")
                 "8a8e415763b7ffd5988153cf03967d812eca629016dd3b0ddf6da3ab6f4a3621"
               else
-                ""),
+                "acb50edd20692a9d023de12da573b64ca0fd9b4e9a2b88d1251020a3022b0f27"),
               "27.0" -> (if (System.getProperty("os.arch") == "aarch64")
                 "1d9d9b837297a73fc7a3b1cfed376644e3fa25c4e1672fbc143d5946cb52431d"
               else
-                "")
+                "e1efd8c4605b2aabc876da93b6eee2bedd868ce7d1f02b0220c1001f903b3e2c")
             )
           else if (Properties.isWin)
             Map(


### PR DESCRIPTION
Related to #5546 

Implements the workaround cited here: https://github.com/actions/setup-java/issues/627#issuecomment-2080463090