### PR TITLE
Rework `PeerManagerApi.{sendToRandomPeer, gossipMessage}`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/node/PeerManagerApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/PeerManagerApi.scala
@@ -28,14 +28,14 @@ trait PeerManagerApi {
   def gossipMessage(
       msg: NetworkPayload,
       excludedPeerOpt: Option[Peer]
-  ): Future[Unit]
+  ): Unit
 
   /** Gossips the [[org.bitcoins.core.p2p.GetHeadersMessage]] to all of our
     * peers to attempt ot get the best block headers
     */
   def gossipGetHeadersMessage(
       hashes: Vector[DoubleSha256DigestBE]
-  ): Future[Unit]
+  ): Unit
 
-  def sendToRandomPeer(payload: NetworkPayload): Future[Unit]
+  def sendToRandomPeer(payload: NetworkPayload): Unit
 }

--- a/node/src/main/scala/org/bitcoins/node/Node.scala
+++ b/node/src/main/scala/org/bitcoins/node/Node.scala
@@ -123,7 +123,7 @@ trait Node
 
     for {
       _ <- addToDbF
-      _ <- {
+      _ = {
         val connected = peerManager.peers.nonEmpty
         if (connected) {
           logger.info(s"Sending out tx message for tx=$txIds")
@@ -132,10 +132,8 @@ trait Node
           val invMsg = InventoryMessage(inventories)
           peerManager.sendToRandomPeer(invMsg)
         } else {
-          Future.failed(
-            new RuntimeException(
-              s"Error broadcasting transaction $txIds, no peers connected"
-            )
+          throw new RuntimeException(
+            s"Error broadcasting transaction $txIds, no peers connected"
           )
         }
       }
@@ -155,9 +153,8 @@ trait Node
       val inventories =
         blockHashes.map(hash => Inventory(typeIdentifier, hash.flip))
       val message = GetDataMessage(inventories)
-      for {
-        _ <- peerManager.sendToRandomPeer(message)
-      } yield ()
+      peerManager.sendToRandomPeer(message)
+      Future.unit
     }
   }
 


### PR DESCRIPTION
fixes #5498 

Rework `PeerManagerApi.{sendToRandomPeer, gossipMessage}` to return `Unit` rather than `Future[Unit]`, this removes the possibility of deadlocking on a full queue