### PR TITLE
2024 05 02 intellij compile

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/hd/HDPathTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/hd/HDPathTest.scala
@@ -364,10 +364,10 @@ class HDPathTest extends BitcoinSUnitTest {
     val xpub = xpriv.extPublicKey
 
     assert(ExtPrivateKey.fromStringT("zprvAWgYBB").isFailure)
-    val Success(expectedXpriv) = ExtPrivateKey.fromStringT(
+    val expectedXpriv = ExtPrivateKey.fromString(
       "zprvAWgYBBk7JR8Gjrh4UJQ2uJdG1r3WNRRfURiABBE3RvMXYSrRJL62XuezvGdPvG6GFBZduosCc1YP5wixPox7zhZLfiUm8aunE96BBa4Kei5"
     )
-    val Success(expectedXpub) = ExtPublicKey.fromStringT(
+    val expectedXpub = ExtPublicKey.fromString(
       "zpub6jftahH18ngZxLmXaKw3GSZzZsszmt9WqedkyZdezFtWRFBZqsQH5hyUmb4pCEeZGmVfQuP5bedXTB8is6fTv19U1GQRyQUKQGUTzyHACMF"
     )
 
@@ -493,8 +493,8 @@ class HDPathTest extends BitcoinSUnitTest {
       val rootXpriv =
         ExtPrivateKey.fromBIP39Seed(ExtKeyVersion.LegacyMainNetPriv, seed)
       val path = LegacyHDPath.fromString("m/44'/0'/0'/0/0")
-      val Success(xpub) = rootXpriv.deriveChildPubKey(path)
-      val Success(expectedXpub) = ExtPublicKey.fromStringT(
+      val xpub = rootXpriv.deriveChildPubKey(path).get
+      val expectedXpub = ExtPublicKey.fromString(
         "xpub6FR8LqriB4qyPvdtZwhHW2HQP4daR2qXsYAAsfaiF8DoFJJ5AqGCpiGM3kFC4Z9AZWnReXrzp2nzhp91myPjz96e3wrJoMvgnCyMBjKz8vJ"
       )
       assert(xpub == expectedXpub)
@@ -505,8 +505,8 @@ class HDPathTest extends BitcoinSUnitTest {
       val rootXpriv =
         ExtPrivateKey.fromBIP39Seed(ExtKeyVersion.LegacyTestNet3Priv, seed)
       val path = LegacyHDPath.fromString("m/44'/0'/0'/0/0")
-      val Success(xpub) = rootXpriv.deriveChildPubKey(path)
-      val Success(expectedXpub) = ExtPublicKey.fromStringT(
+      val xpub = rootXpriv.deriveChildPubKey(path).get
+      val expectedXpub = ExtPublicKey.fromString(
         "tpubDFnks5gPtLoRfipk28gNhwcmiBjEQRLbRAkUEDdrb2ygzaxnF47Hy9wBHnKyb46QMRKLG7NsM8d3PzddAqEysaYw7YbcUtavNAZkwjM7aqi"
       )
       assert(xpub == expectedXpub)
@@ -517,8 +517,8 @@ class HDPathTest extends BitcoinSUnitTest {
       val rootXpriv =
         ExtPrivateKey.fromBIP39Seed(ExtKeyVersion.NestedSegWitMainNetPriv, seed)
       val path = NestedSegWitHDPath.fromString("m/49'/0'/0'/0/0")
-      val Success(xpub) = rootXpriv.deriveChildPubKey(path)
-      val Success(expectedXpub) = ExtPublicKey.fromStringT(
+      val xpub = rootXpriv.deriveChildPubKey(path).get
+      val expectedXpub = ExtPublicKey.fromString(
         "ypub6c6461WnUp9LoRskZCU3bHBJahDvtrPwCCo1WEtuhsrFGZ8Mn2YMNGab2tj5eujgsMx5U1BZz7hA1q87ZdVSXZdArxM9G5Y9iZchQFrov4q"
       )
       assert(xpub == expectedXpub)
@@ -532,8 +532,8 @@ class HDPathTest extends BitcoinSUnitTest {
           seed
         )
       val path = NestedSegWitHDPath.fromString("m/49'/0'/0'/0/0")
-      val Success(xpub) = rootXpriv.deriveChildPubKey(path)
-      val Success(expectedXpub) = ExtPublicKey.fromStringT(
+      val xpub = rootXpriv.deriveChildPubKey(path).get
+      val expectedXpub = ExtPublicKey.fromString(
         "upub5JkzsLq7t5yRQF7HDmKYkvoHtpe98NRwXki8NfKNBrLj49sSmPt6t1x2x4tjfH81EoUrU6oL9UGxUgfrgqqPLctmPbZSvSGCdfN7qyMHU7g"
       )
       assert(xpub == expectedXpub)
@@ -544,8 +544,8 @@ class HDPathTest extends BitcoinSUnitTest {
       val rootXpriv =
         ExtPrivateKey.fromBIP39Seed(ExtKeyVersion.SegWitMainNetPriv, seed)
       val path = SegWitHDPath.fromString("m/84'/0'/0'/0/0")
-      val Success(xpub) = rootXpriv.deriveChildPubKey(path)
-      val Success(expectedXpub) = ExtPublicKey.fromStringT(
+      val xpub = rootXpriv.deriveChildPubKey(path).get
+      val expectedXpub = ExtPublicKey.fromString(
         "zpub6vibtacmZKTajuFATBMJPq629qFzaonkAHzWDBEgpHnuhDBozTVWxbF4zJ1Hm4tdkAMJTg9kUqizEz4JQXGkxyotn3MCxbT92mJ8XVcNN5E"
       )
       assert(xpub == expectedXpub)
@@ -556,8 +556,8 @@ class HDPathTest extends BitcoinSUnitTest {
       val rootXpriv =
         ExtPrivateKey.fromBIP39Seed(ExtKeyVersion.SegWitTestNet3Priv, seed)
       val path = SegWitHDPath.fromString("m/84'/0'/0'/0/0")
-      val Success(xpub) = rootXpriv.deriveChildPubKey(path)
-      val Success(expectedXpub) = ExtPublicKey.fromStringT(
+      val xpub = rootXpriv.deriveChildPubKey(path).get
+      val expectedXpub = ExtPublicKey.fromString(
         "vpub5dPYfuw6xbHfLiUh7kCoZUi1TxgCpKpkVqud5bf9JGHPUovtypqGULcWuUAwmSGx7bt5TmmWeCJnhqc3Xjchn35VJgZWcxBBws3Yy6zYa7G"
       )
       assert(xpub == expectedXpub)
@@ -568,8 +568,8 @@ class HDPathTest extends BitcoinSUnitTest {
       val rootXpriv =
         ExtPrivateKey.fromBIP39Seed(ExtKeyVersion.LegacyMainNetPriv, seed)
       val path = MultisigHDPath.fromString("m/45'/0'/0'/0/0")
-      val Success(xpub) = rootXpriv.deriveChildPubKey(path)
-      val Success(expectedXpub) = ExtPublicKey.fromStringT(
+      val xpub = rootXpriv.deriveChildPubKey(path).get
+      val expectedXpub = ExtPublicKey.fromString(
         "xpub6GqDvL47MZ2baAovXNzG6UuZa7LR37JDG9Qt6nbns4L1q4owu8wnvkiZgTkYgbeyW6EmMjqe5B7TFKb8JvueU9T73pTW4RWf7gEoXFCqMKv"
       )
       assert(xpub == expectedXpub)
@@ -580,8 +580,8 @@ class HDPathTest extends BitcoinSUnitTest {
       val rootXpriv =
         ExtPrivateKey.fromBIP39Seed(ExtKeyVersion.LegacyTestNet3Priv, seed)
       val path = MultisigHDPath.fromString("m/45'/0'/0'/0/0")
-      val Success(xpub) = rootXpriv.deriveChildPubKey(path)
-      val Success(expectedXpub) = ExtPublicKey.fromStringT(
+      val xpub = rootXpriv.deriveChildPubKey(path).get
+      val expectedXpub = ExtPublicKey.fromString(
         "tpubDHCrSZso4pz3qxzmyZyMJQEvuES52VoGon1BTLewCy5uaMUeyMnt5CPPvVqLD6cDHzmfyKMWcGwVwW5jhnktMauQ7RCojxAthdqDHJNNVUx"
       )
       assert(xpub == expectedXpub)
@@ -618,7 +618,7 @@ class HDPathTest extends BitcoinSUnitTest {
     // we pass in the wrong version bytes to make the test vector
     // from bip49 pass
     val rootXpriv = seed.toExtPrivateKey(ExtKeyVersion.LegacyTestNet3Priv)
-    val Success(expectedRootXpriv) = ExtPrivateKey.fromStringT(
+    val expectedRootXpriv = ExtPrivateKey.fromString(
       "tprv8ZgxMBicQKsPe5YMU9gHen4Ez3ApihUfykaqUorj9t6FDqy3nP6eoXiAo2ssvpAjoLroQxHqr3R5nE3a5dU3DHTjTgJDd7zrbniJr6nrCzd"
     )
 
@@ -626,7 +626,7 @@ class HDPathTest extends BitcoinSUnitTest {
 
     val firstAccount = path.account
     val accountXpriv = rootXpriv.deriveChildPrivKey(firstAccount)
-    val Success(expectedAccountXpriv) = ExtPrivateKey.fromStringT(
+    val expectedAccountXpriv = ExtPrivateKey.fromString(
       "tprv8gRrNu65W2Msef2BdBSUgFdRTGzC8EwVXnV7UGS3faeXtuMVtGfEdidVeGbThs4ELEoayCAzZQ4uUji9DUiAs7erdVskqju7hrBcDvDsdbY"
     )
     assert(expectedAccountXpriv == accountXpriv)
@@ -685,10 +685,10 @@ class HDPathTest extends BitcoinSUnitTest {
       val accountXpriv = rootXpriv.deriveChildPrivKey(legacyPathAccount)
       val accountXpub = accountXpriv.extPublicKey
 
-      val Success(expectedAccountXpriv) = ExtPrivateKey.fromStringT(
+      val expectedAccountXpriv = ExtPrivateKey.fromString(
         "xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb"
       )
-      val Success(expectedAccountXpub) = ExtPublicKey.fromStringT(
+      val expectedAccountXpub = ExtPublicKey.fromString(
         "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj"
       )
 
@@ -706,10 +706,10 @@ class HDPathTest extends BitcoinSUnitTest {
       val accountXpriv = rootXpriv.deriveChildPrivKey(nestedSegwithPathAccount)
       val accountXpub = accountXpriv.extPublicKey
 
-      val Success(expectedAccountXpriv) = ExtPrivateKey.fromStringT(
+      val expectedAccountXpriv = ExtPrivateKey.fromString(
         "yprvAHwhK6RbpuS3dgCYHM5jc2ZvEKd7Bi61u9FVhYMpgMSuZS613T1xxQeKTffhrHY79hZ5PsskBjcc6C2V7DrnsMsNaGDaWev3GLRQRgV7hxF"
       )
-      val Success(expectedAccountXpub) = ExtPublicKey.fromStringT(
+      val expectedAccountXpub = ExtPublicKey.fromString(
         "ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP"
       )
 
@@ -726,10 +726,10 @@ class HDPathTest extends BitcoinSUnitTest {
       val accountXpriv = rootXpriv.deriveChildPrivKey(segwithPathAccount)
       val accountXpub = accountXpriv.extPublicKey
 
-      val Success(expectedAccountXpriv) = ExtPrivateKey.fromStringT(
+      val expectedAccountXpriv = ExtPrivateKey.fromString(
         "zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE"
       )
-      val Success(expectedAccountXpub) = ExtPublicKey.fromStringT(
+      val expectedAccountXpub = ExtPublicKey.fromString(
         "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs"
       )
 

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -10,7 +10,52 @@ import invoicesrpc.LookupInvoiceMsg.InvoiceRef
 import io.grpc.{CallCredentials, Metadata}
 import lnrpc.ChannelPoint.FundingTxid.FundingTxidBytes
 import lnrpc.CloseStatusUpdate.Update.{ChanClose, ClosePending}
-import lnrpc.{AbandonChannelRequest, AddressType, ChanBackupSnapshot, Channel, ChannelBackupSubscription, ChannelBalanceRequest, ChannelEventSubscription, ChannelEventUpdate, ChannelPoint, CloseChannelRequest, ConnectPeerRequest, GenSeedRequest, GenSeedResponse, GetInfoRequest, GetInfoResponse, GetStateRequest, GetTransactionsRequest, GraphTopologySubscription, GraphTopologyUpdate, InitWalletRequest, Invoice, InvoiceSubscription, LightningAddress, LightningClient, ListChannelsRequest, ListPeersRequest, ListUnspentRequest, NewAddressRequest, OpenChannelRequest, OutPoint, Payment, Peer, PeerEvent, PeerEventSubscription, PendingChannelsRequest, PendingChannelsResponse, SendCustomMessageRequest, StateClient, StopRequest, SubscribeCustomMessagesRequest, UnlockWalletRequest, WalletBalanceRequest, WalletState, WalletUnlockerClient}
+import lnrpc.{
+  AbandonChannelRequest,
+  AddressType,
+  ChanBackupSnapshot,
+  Channel,
+  ChannelBackupSubscription,
+  ChannelBalanceRequest,
+  ChannelEventSubscription,
+  ChannelEventUpdate,
+  ChannelPoint,
+  CloseChannelRequest,
+  ConnectPeerRequest,
+  GenSeedRequest,
+  GenSeedResponse,
+  GetInfoRequest,
+  GetInfoResponse,
+  GetStateRequest,
+  GetTransactionsRequest,
+  GraphTopologySubscription,
+  GraphTopologyUpdate,
+  InitWalletRequest,
+  Invoice,
+  InvoiceSubscription,
+  LightningAddress,
+  LightningClient,
+  ListChannelsRequest,
+  ListPeersRequest,
+  ListUnspentRequest,
+  NewAddressRequest,
+  OpenChannelRequest,
+  OutPoint,
+  Payment,
+  Peer,
+  PeerEvent,
+  PeerEventSubscription,
+  PendingChannelsRequest,
+  PendingChannelsResponse,
+  SendCustomMessageRequest,
+  StateClient,
+  StopRequest,
+  SubscribeCustomMessagesRequest,
+  UnlockWalletRequest,
+  WalletBalanceRequest,
+  WalletState,
+  WalletUnlockerClient
+}
 import org.apache.pekko.grpc.{GrpcClientSettings, SSLContextUtils}
 import org.bitcoins.commons.jsonmodels.lnd._
 import org.bitcoins.commons.util.{BitcoinSLogger, NativeProcessFactory}
@@ -24,7 +69,11 @@ import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
 import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.tlv._
-import org.bitcoins.core.protocol.transaction.{TransactionOutPoint, TransactionOutput, Transaction => Tx}
+import org.bitcoins.core.protocol.transaction.{
+  TransactionOutPoint,
+  TransactionOutput,
+  Transaction => Tx
+}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.util.StartStopAsync
 import org.bitcoins.core.wallet.fee.{SatoshisPerKW, SatoshisPerVirtualByte}
@@ -40,7 +89,17 @@ import signrpc.{SignDescriptor, SignMethod, SignReq, SignerClient}
 import verrpc.{Version, VersionRequest, VersionerClient}
 import walletrpc.FundPsbtRequest.Fees.SatPerVbyte
 import walletrpc.FundPsbtRequest.Template.Psbt
-import walletrpc.{FinalizePsbtRequest, FundPsbtRequest, LeaseOutputRequest, ListLeasesRequest, ReleaseOutputRequest, SendOutputsRequest, SignPsbtRequest, TxTemplate, WalletKitClient}
+import walletrpc.{
+  FinalizePsbtRequest,
+  FundPsbtRequest,
+  LeaseOutputRequest,
+  ListLeasesRequest,
+  ReleaseOutputRequest,
+  SendOutputsRequest,
+  SignPsbtRequest,
+  TxTemplate,
+  WalletKitClient
+}
 
 import java.io._
 import java.net.InetSocketAddress

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -1,16 +1,16 @@
 package org.bitcoins.lnd.rpc
 
+import chainrpc.{ChainNotifierClient, ConfDetails, ConfEvent, ConfRequest}
 import org.apache.pekko.NotUsed
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl.{Sink, Source}
-import chainrpc._
 import com.google.protobuf.ByteString
+import invoicesrpc.{CancelInvoiceMsg, InvoicesClient, LookupInvoiceMsg}
 import invoicesrpc.LookupInvoiceMsg.InvoiceRef
-import invoicesrpc._
 import io.grpc.{CallCredentials, Metadata}
 import lnrpc.ChannelPoint.FundingTxid.FundingTxidBytes
 import lnrpc.CloseStatusUpdate.Update.{ChanClose, ClosePending}
-import lnrpc._
+import lnrpc.{AbandonChannelRequest, AddressType, ChanBackupSnapshot, Channel, ChannelBackupSubscription, ChannelBalanceRequest, ChannelEventSubscription, ChannelEventUpdate, ChannelPoint, CloseChannelRequest, ConnectPeerRequest, GenSeedRequest, GenSeedResponse, GetInfoRequest, GetInfoResponse, GetStateRequest, GetTransactionsRequest, GraphTopologySubscription, GraphTopologyUpdate, InitWalletRequest, Invoice, InvoiceSubscription, LightningAddress, LightningClient, ListChannelsRequest, ListPeersRequest, ListUnspentRequest, NewAddressRequest, OpenChannelRequest, OutPoint, Payment, Peer, PeerEvent, PeerEventSubscription, PendingChannelsRequest, PendingChannelsResponse, SendCustomMessageRequest, StateClient, StopRequest, SubscribeCustomMessagesRequest, UnlockWalletRequest, WalletBalanceRequest, WalletState, WalletUnlockerClient}
 import org.apache.pekko.grpc.{GrpcClientSettings, SSLContextUtils}
 import org.bitcoins.commons.jsonmodels.lnd._
 import org.bitcoins.commons.util.{BitcoinSLogger, NativeProcessFactory}
@@ -24,11 +24,7 @@ import org.bitcoins.core.protocol.ln.currency.MilliSatoshis
 import org.bitcoins.core.protocol.ln.node.NodeId
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.tlv._
-import org.bitcoins.core.protocol.transaction.{
-  TransactionOutPoint,
-  TransactionOutput,
-  Transaction => Tx
-}
+import org.bitcoins.core.protocol.transaction.{TransactionOutPoint, TransactionOutput, Transaction => Tx}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.util.StartStopAsync
 import org.bitcoins.core.wallet.fee.{SatoshisPerKW, SatoshisPerVirtualByte}
@@ -38,18 +34,13 @@ import org.bitcoins.lnd.rpc.LndUtils._
 import org.bitcoins.lnd.rpc.config._
 import org.bitcoins.lnd.rpc.internal._
 import peersrpc.PeersClient
-import routerrpc._
+import routerrpc.{RouterClient, SendPaymentRequest}
 import scodec.bits._
-import signrpc._
-import verrpc._
+import signrpc.{SignDescriptor, SignMethod, SignReq, SignerClient}
+import verrpc.{Version, VersionRequest, VersionerClient}
 import walletrpc.FundPsbtRequest.Fees.SatPerVbyte
 import walletrpc.FundPsbtRequest.Template.Psbt
-import walletrpc.{
-  AddressType => _,
-  ListUnspentRequest => _,
-  Transaction => _,
-  _
-}
+import walletrpc.{FinalizePsbtRequest, FundPsbtRequest, LeaseOutputRequest, ListLeasesRequest, ReleaseOutputRequest, SendOutputsRequest, SignPsbtRequest, TxTemplate, WalletKitClient}
 
 import java.io._
 import java.net.InetSocketAddress


### PR DESCRIPTION
Fixes some build warnings in `coreTestJVM` that cause builds to fail when using intellij's internal build tool.


This PR does not fix the `lndRpc` module import issues. It seems there is a bug when using intellij's internal build tool. I've filed an issue here. Users should use the `sbt`build / import until this gets resolved.

https://www.jetbrains.com/help/idea/sbt.html

https://youtrack.jetbrains.com/issue/IDEA-352907/akka-GRPC-build-fails-when-using-intellij-build-but-succeeds-when-using-sbt