### PR TITLE
Rework `BitcoindRpcTestUtil.getBinary()` to match major and minor version of `bitcoind`

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -378,15 +378,15 @@ object BitcoindVersion
   val known: Vector[BitcoindVersion] = standard
 
   case object V25 extends BitcoindVersion {
-    override def toString: String = "v25"
+    override def toString: String = "v25.2"
   }
 
   case object V26 extends BitcoindVersion {
-    override def toString: String = "v26"
+    override def toString: String = "v26.1"
   }
 
   case object V27 extends BitcoindVersion {
-    override def toString: String = "v27"
+    override def toString: String = "v27.0"
   }
 
   case object Unknown extends BitcoindVersion {
@@ -415,6 +415,19 @@ object BitcoindVersion
           s"Unsupported Bitcoin Core version: $int. The latest supported version is ${BitcoindVersion.newest}"
         )
         newest
+    }
+  }
+
+  def findVersion(version: String): Option[BitcoindVersion] = {
+    // first try to match the version exactly
+    BitcoindVersion.known
+      .find(v => version == v.toString) match {
+      case Some(r) => Some(r)
+      case None    =>
+        // try to match the major version if we can't match it exactly
+        BitcoindVersion.known.find { v =>
+          version.startsWith(v.toString)
+        }
     }
   }
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -51,22 +51,18 @@ sealed trait BitcoindInstanceLocal extends BitcoindInstance {
   def getVersion: BitcoindVersion = {
 
     val binaryPath = binary.getAbsolutePath
-
     val versionT = Try {
       val foundVersion =
         Seq(binaryPath, "--version").!!.split(Properties.lineSeparator).head
           .split(" ")
           .last
-      BitcoindVersion.known
-        .find(v => foundVersion.startsWith(v.toString))
-        .getOrElse {
-          println(
-            s"Unsupported Bitcoin Core version: $foundVersion. The latest supported version is ${BitcoindVersion.newest}")
-          logger.warn(
-            s"Unsupported Bitcoin Core version: $foundVersion. The latest supported version is ${BitcoindVersion.newest}"
-          )
-          BitcoindVersion.newest
-        }
+      BitcoindVersion.findVersion(foundVersion).getOrElse {
+        // else just default to the newest version of bitcoind
+        logger.warn(
+          s"Unsupported Bitcoin Core version: $foundVersion. The latest supported version is ${BitcoindVersion.newest}"
+        )
+        BitcoindVersion.newest
+      }
     }
 
     versionT match {


### PR DESCRIPTION
This is useful for PRs such as #5564 where we want to have a binary with version `27.99`. Our previous logic would just match the official `27.0` release rather than running the binary built for a specific feature that bitcoin-s wants to run tests against.