### PR TITLE
Implement `getrawmempool` verbose

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/BlockchainResult.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/BlockchainResult.scala
@@ -236,6 +236,35 @@ case class GetChainTxStatsResult(
     txrate: Option[BigDecimal]
 ) extends BlockchainResult
 
+sealed abstract class GetRawMempoolResult extends BlockchainResult {
+  def txids: Vector[DoubleSha256DigestBE]
+}
+
+case class GetRawMempoolTxIds(txids: Vector[DoubleSha256DigestBE])
+    extends GetRawMempoolResult
+
+case class GetRawMempoolVerboseResult(
+    vsize: Int,
+    weight: Int,
+    time: Long,
+    height: Int,
+    descendantcount: Int,
+    descendantsize: Int,
+    ancestorcount: Int,
+    ancestorsize: Int,
+    wtxid: DoubleSha256DigestBE,
+    fees: FeeInfo,
+    depends: Vector[DoubleSha256DigestBE],
+    spentby: Vector[DoubleSha256DigestBE],
+    `bip125-replaceable`: Boolean,
+    unbroadcast: Boolean)
+
+case class GetRawMempoolVerbose(
+    map: Map[DoubleSha256DigestBE, GetRawMempoolVerboseResult])
+    extends GetRawMempoolResult {
+  override val txids: Vector[DoubleSha256DigestBE] = map.keys.toVector
+}
+
 sealed trait GetMemPoolResult extends BlockchainResult {
   def size: Int
   def time: UInt32

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
@@ -3,7 +3,7 @@ package org.bitcoins.commons.serializers
 import org.bitcoins.commons.jsonmodels.SerializedTransaction.tokenToString
 import org.bitcoins.commons.jsonmodels._
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.AddressType
-import org.bitcoins.commons.jsonmodels.bitcoind._
+import org.bitcoins.commons.jsonmodels.bitcoind.{GetRawMempoolVerboseResult, _}
 import org.bitcoins.commons.jsonmodels.clightning.CLightningJsonModels._
 import org.bitcoins.commons.jsonmodels.wallet._
 import org.bitcoins.commons.serializers.JsonReaders._
@@ -323,6 +323,35 @@ object JsonSerializers {
 
   implicit val getMemPoolInfoResultReads: Reads[GetMemPoolInfoResult] =
     Json.reads[GetMemPoolInfoResult]
+
+  implicit val getRawMempoolVerboseResultReads
+      : Reads[GetRawMempoolVerboseResult] =
+    Json.reads[GetRawMempoolVerboseResult]
+
+  implicit object GetRawMempoolTxIdsReads extends Reads[GetRawMempoolTxIds] {
+    override def reads(json: JsValue): JsResult[GetRawMempoolTxIds] = {
+      json match {
+        case arr: JsArray =>
+          arr
+            .validate[Vector[DoubleSha256DigestBE]]
+            .map(GetRawMempoolTxIds)
+        case x @ (_: JsNumber | _: JsString | JsNull | _: JsObject |
+            _: JsBoolean) =>
+          JsError(s"Invalid json for getrawmempool, got=$x")
+      }
+    }
+  }
+  implicit object GetRawMempoolVerboseReads
+      extends Reads[GetRawMempoolVerbose] {
+    override def reads(json: JsValue): JsResult[GetRawMempoolVerbose] = {
+      json
+        .validate[Map[DoubleSha256DigestBE, GetRawMempoolVerboseResult]]
+        .map(GetRawMempoolVerbose)
+    }
+  }
+
+  implicit val getRawMempoolResultReads: Reads[GetRawMempoolResult] =
+    Json.reads[GetRawMempoolResult]
 
   implicit val getTxOutResultV22Reads: Reads[GetTxOutResultV22] =
     Json.reads[GetTxOutResultV22]

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
@@ -151,7 +151,7 @@ class ScanBitcoind()(implicit
   def getMemPoolSource(
       bitcoind: BitcoindRpcClient
   ): Future[Source[Transaction, NotUsed]] = {
-    val mempoolF = bitcoind.getRawMemPool
+    val mempoolF = bitcoind.getRawMemPool().map(_.txids)
     val sourceF: Future[Source[DoubleSha256DigestBE, NotUsed]] =
       mempoolF.map(Source(_))
 

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -12,7 +12,7 @@ import org.apache.pekko.stream.scaladsl.{
 }
 import org.apache.pekko.{Done, NotUsed}
 import org.bitcoins.chain.ChainCallbacks
-import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockHeaderResult
+import org.bitcoins.commons.jsonmodels.bitcoind.{GetBlockHeaderResult}
 import org.bitcoins.commons.util.BitcoinSLogger
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.api.wallet.{NeutrinoHDWalletApi, WalletApi}
@@ -621,7 +621,7 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
         }
 
         val res = for {
-          mempool <- bitcoind.getRawMemPool
+          mempool <- bitcoind.getRawMempoolTxIds().map(_.txids)
           newTxIds = getDiffAndReplace(mempool.toSet)
           _ = logger.debug(s"Found ${newTxIds.size} new mempool transactions")
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
@@ -56,7 +56,7 @@ class BlockchainRpcTest extends BitcoindFixturesCachedPairNewest {
       blocks <- client.generate(1)
       mostRecentBlock <- client.getBlock(blocks.head)
       _ <- client.invalidateBlock(blocks.head)
-      mempool <- client.getRawMemPool
+      mempool <- client.getRawMemPool().map(_.txids)
       count1 <- client.getBlockCount()
       count2 <- otherClient.getBlockCount()
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
@@ -222,6 +222,8 @@ class MempoolRpcTest extends BitcoindFixturesCachedPairNewest {
   it must "getrawmempool verbose" in { case nodePair =>
     val client = nodePair.node1
     for {
+      // generate block to clear out mempool for test
+      _ <- client.generate(1)
       verbose0 <- client.getRawMempoolVerbose()
       addr0 <- client.getNewAddress
       txid <- client.sendToAddress(addr0, Bitcoins.one)

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/MempoolRpcTest.scala
@@ -40,7 +40,7 @@ class MempoolRpcTest extends BitcoindFixturesCachedPairNewest {
       for {
         transaction <-
           BitcoindRpcTestUtil.sendCoinbaseTransaction(client, otherClient)
-        mempool <- client.getRawMemPool
+        mempool <- client.getRawMemPool().map(_.txids)
       } yield {
         assert(mempool.length == 1)
         assert(mempool.head == transaction.txid)
@@ -149,7 +149,7 @@ class MempoolRpcTest extends BitcoindFixturesCachedPairNewest {
           address1,
           Bitcoins(2)
         )
-        mempool <- client.getRawMemPool
+        mempool <- client.getRawMemPool().map(_.txids)
         address2 <- client.getNewAddress
 
         createdTx <- {
@@ -217,5 +217,19 @@ class MempoolRpcTest extends BitcoindFixturesCachedPairNewest {
       tx <- client.getRawTransaction(txid).map(_.hex)
       spending <- client.getTxSpendingPrevOut(tx.inputs.head.previousOutput)
     } yield assert(spending.spendingtxid.contains(txid))
+  }
+
+  it must "getrawmempool verbose" in { case nodePair =>
+    val client = nodePair.node1
+    for {
+      verbose0 <- client.getRawMempoolVerbose()
+      addr0 <- client.getNewAddress
+      txid <- client.sendToAddress(addr0, Bitcoins.one)
+      verbose1 <- client.getRawMempoolVerbose()
+    } yield {
+      assert(verbose0.txids.isEmpty)
+      assert(verbose1.txids.exists(_ == txid))
+    }
+
   }
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MempoolRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/MempoolRpc.scala
@@ -111,11 +111,26 @@ trait MempoolRpc { self: Client =>
     bitcoindCall[GetMemPoolInfoResult]("getmempoolinfo")
   }
 
-  def getRawMemPool: Future[Vector[DoubleSha256DigestBE]] = {
-    bitcoindCall[Vector[DoubleSha256DigestBE]](
+  def getRawMempoolTxIds(): Future[GetRawMempoolTxIds] = {
+    bitcoindCall[GetRawMempoolTxIds](
       "getrawmempool",
       List(JsBoolean(false))
     )
+  }
+
+  def getRawMempoolVerbose(): Future[GetRawMempoolVerbose] = {
+    bitcoindCall[GetRawMempoolVerbose](
+      "getrawmempool",
+      List(JsBoolean(true))
+    )
+  }
+  def getRawMemPool(verbose: Boolean = false): Future[GetRawMempoolResult] = {
+    if (verbose) {
+      getRawMempoolVerbose()
+    } else {
+      getRawMempoolTxIds()
+    }
+
   }
 
   def getRawMemPoolWithTransactions


### PR DESCRIPTION
This PR implements the verbose variant of `gerawmempool` that returns detailed information about mempool entrys. 

https://bitcoincore.org/en/doc/24.0.0/rpc/blockchain/getrawmempool/

Needed for #5564 

