### PR TITLE
Add `-datadir` to when obtaining `bitcoind -version` to avoid using default datadir

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/config/BitcoindInstance.scala
@@ -52,8 +52,13 @@ sealed trait BitcoindInstanceLocal extends BitcoindInstance {
 
     val binaryPath = binary.getAbsolutePath
     val versionT = Try {
+      val cmd =
+        Seq(binaryPath, s"-datadir=${datadir.toPath.toString}", "--version")
       val foundVersion =
-        Seq(binaryPath, "--version").!!.split(Properties.lineSeparator).head
+        cmd
+          .!!(NativeProcessFactory.processLogger)
+          .split(Properties.lineSeparator)
+          .head
           .split(" ")
           .last
       BitcoindVersion.findVersion(foundVersion).getOrElse {
@@ -69,7 +74,7 @@ sealed trait BitcoindInstanceLocal extends BitcoindInstance {
       case Success(value) => value
       case Failure(exception) =>
         logger.error("Error getting bitcoind version", exception)
-        BitcoindVersion.newest
+        throw exception
     }
   }
 }


### PR DESCRIPTION
These error logs were introduced in #5550 . This is because when running `bitcoind --version` inside of `BitcoindInstanceLocal.getVersion`, we would use the default `-datadir` on your OS rather than the test suite `-datadir`. 

```
2024-05-09 01:19:20,586UTC ERROR NativeProcessFactory$ - Error: Settings file could not be written:                                                                                                         
2024-05-09 01:19:20,586UTC ERROR NativeProcessFactory$ - - Failed renaming settings file /Users/chris/Library/Application Support/Bitcoin/settings.json.tmp to /Users/chris/Library/Application Support/Bitc
oin/settings.json 
```

```
2024-05-09 01:19:20,587UTC ERROR BitcoindInstanceLocal$BitcoindInstanceLocalImpl - Error getting bitcoind version                                                                       20:19:20 [910/36780]
java.lang.RuntimeException: Nonzero exit value: 1                                                                                                                                                           
        at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.slurp(ProcessBuilderImpl.scala:164)                                                                                                         
        at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.$bang$bang(ProcessBuilderImpl.scala:122)                                                                                                    
        at org.bitcoins.rpc.config.BitcoindInstanceLocal.$anonfun$getVersion$1(BitcoindInstance.scala:59)                                                                                                   
        at scala.util.Try$.apply(Try.scala:217)                                                                                                                                                             
        at org.bitcoins.rpc.config.BitcoindInstanceLocal.getVersion(BitcoindInstance.scala:54)                                                                                                              
        at org.bitcoins.rpc.config.BitcoindInstanceLocal.getVersion$(BitcoindInstance.scala:51)                                                                                                             
        at org.bitcoins.rpc.config.BitcoindInstanceLocal$BitcoindInstanceLocalImpl.getVersion(BitcoindInstance.scala:90)                                                                                    
        at org.bitcoins.rpc.client.common.Client.$anonfun$start$5(Client.scala:193)                                                                                                                         
        at org.bitcoins.rpc.client.common.Client.$anonfun$start$5$adapted(Client.scala:191)                                                                                                                 

```

This PR fixes this bug by calling `bitcoind -datadir=${datadir.toPath.toString} --version`