### PR TITLE
Add `-Xsource:3` to `docs/`

### DIFF
--- a/async-utils-test/src/test/scala/org/bitcoins/asyncutil/AsyncUtilTest.scala
+++ b/async-utils-test/src/test/scala/org/bitcoins/asyncutil/AsyncUtilTest.scala
@@ -110,7 +110,7 @@ class AsyncUtilTest extends BitcoinSJvmTest {
     val expectedCount = 1000
     val counters = Vector.fill(numCounters)(new AtomicInteger(0))
 
-    //try to run all these in parallel, and see if it works
+    // try to run all these in parallel, and see if it works
     val async: Vector[Future[Unit]] = counters.map { counter =>
       AsyncUtil.retryUntilSatisfiedF(
         () => incrementAndCheckF(counter, expectedCount),
@@ -122,15 +122,15 @@ class AsyncUtilTest extends BitcoinSJvmTest {
   }
 
   it must "handle blocking tasks ok" in {
-    //schedule a blocking task first
+    // schedule a blocking task first
     val start = TimeUtil.currentEpochMs
     val sleepMs = 10000
     val stop = start + sleepMs
     def blockingTask(): Boolean = {
       while (stop < System.currentTimeMillis()) {
-        //do nothing, block until 10 seconds has passed
-        //can't do the dumb thing and use Thread.sleep()
-        //as that isn't available on scalajs
+        // do nothing, block until 10 seconds has passed
+        // can't do the dumb thing and use Thread.sleep()
+        // as that isn't available on scalajs
       }
       true
     }
@@ -138,12 +138,12 @@ class AsyncUtilTest extends BitcoinSJvmTest {
     val _ =
       AsyncUtil.awaitCondition(() => blockingTask())
 
-    //schedule a non blocking task second
+    // schedule a non blocking task second
     val counter1 = new AtomicInteger(0)
     val secondF =
       AsyncUtil.awaitCondition(() => incrementAndCheck(counter1, 10))
 
-    //the second task should not be blocked to completion by the first
+    // the second task should not be blocked to completion by the first
     for {
       _ <- secondF
     } yield {
@@ -159,16 +159,16 @@ class AsyncUtilTest extends BitcoinSJvmTest {
         .map(_ => true)
     }
 
-    //schedule a blocking task first
+    // schedule a blocking task first
     val _ =
       AsyncUtil.awaitConditionF(() => blockingTask())
 
-    //schedule a non blocking task second
+    // schedule a non blocking task second
     val counter1 = new AtomicInteger(0)
     val secondF =
       AsyncUtil.awaitConditionF(() => incrementAndCheckF(counter1, 10))
 
-    //the second task should not be blocked to completion by the first
+    // the second task should not be blocked to completion by the first
     for {
       _ <- secondF
     } yield succeed

--- a/build.sbt
+++ b/build.sbt
@@ -673,6 +673,7 @@ lazy val testkit = project
 lazy val docs = project
   .in(file("bitcoin-s-docs")) // important: it must not be docs/
   .settings(CommonSettings.testSettings: _*)
+  .settings(scalacOptions += "-Xsource:3")
   .settings(libraryDependencies ++= Deps.docs.value)
   .settings(
     name := "bitcoin-s-docs",

--- a/docs/chain/chain.md
+++ b/docs/chain/chain.md
@@ -31,8 +31,8 @@ import java.nio.file.Files
 
 ```scala mdoc:compile-only
 
-implicit val ec = ExecutionContext.global
-implicit val system = ActorSystem("System")
+implicit val ec: ExecutionContext = ExecutionContext.global
+implicit val system: ActorSystem = ActorSystem("System")
 // We are assuming that a `bitcoind` regtest node is running the background.
 // You can see our `bitcoind` guides to see how to connect
 // to a local or remote `bitcoind` node.
@@ -59,7 +59,7 @@ val config = ConfigFactory.parseString {
     |""".stripMargin
 }
 
-implicit val chainConfig = ChainAppConfig(datadir, Vector(config))
+implicit val chainConfig: ChainAppConfig = ChainAppConfig(datadir, Vector(config))
 
 // Initialize the needed database tables if they don't exist:
 val chainProjectInitF = chainConfig.start()

--- a/docs/chain/filter-sync.md
+++ b/docs/chain/filter-sync.md
@@ -27,12 +27,14 @@ import org.apache.pekko.actor.ActorSystem
 import org.bitcoins.core.gcs._
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.chain.blockchain.sync._
+import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.rpc.config._
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.chain._
 import org.bitcoins.testkit.chain.fixture.BitcoindBaseVersionChainHandlerViaRpc
 
+import scala.concurrent.ExecutionContext
 ```
 
 ```scala mdoc:compile-only
@@ -52,9 +54,9 @@ We are going to implement `getFilterFunc` with bitcoind and then sync a few filt
 
 ```scala mdoc:compile-only
 
-implicit val system = ActorSystem(s"filter-sync-example")
-implicit val ec = system.dispatcher
-implicit val chainAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig().chainConf
+implicit val system: ActorSystem = ActorSystem(s"filter-sync-example")
+implicit val ec: ExecutionContext = system.dispatcher
+implicit val chainAppConfig: ChainAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig().chainConf
 
 val instance = BitcoindInstanceLocal.fromConfigFile(BitcoindConfig.DEFAULT_CONF_FILE)
 val bitcoind = BitcoindRpcClient(instance)

--- a/docs/core/adding-spks.md
+++ b/docs/core/adding-spks.md
@@ -303,12 +303,12 @@ You will then want to add all of the relevant accessor methods. For our case of 
 sealed trait P2PKWithTimeoutScriptPubKey extends RawScriptPubKey {
 
   lazy val pubKey: ECPublicKey =
-    ECPublicKey.fromBytes(asm(2).bytes)
+    ECPublicKey.fromBytes(this.asm(2).bytes)
 
-  lazy val lockTime: ScriptNumber = ScriptNumber.fromBytes(asm(5).bytes)
+  lazy val lockTime: ScriptNumber = ScriptNumber.fromBytes(this.asm(5).bytes)
 
   lazy val timeoutPubKey: ECPublicKey =
-    ECPublicKey.fromBytes(asm(9).bytes)
+    ECPublicKey.fromBytes(this.asm(9).bytes)
 }
 ```
 ```scala mdoc:invisible
@@ -415,7 +415,7 @@ sealed trait P2PKScriptSignature extends ScriptSignature {
 
   /** The digital signatures inside of the scriptSig */
   def signatures: Seq[ECDigitalSignature] = {
-    Seq(ECDigitalSignature(BitcoinScriptUtil.filterPushOps(asm).head.hex))
+    Seq(ECDigitalSignature(BitcoinScriptUtil.filterPushOps(this.asm).head.hex))
   }
 
   override def toString = s"P2PKScriptSignature($signature)"

--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -42,8 +42,10 @@ For your node to be able to service these filters you will need set
 
 ```scala mdoc:invisible
 import org.apache.pekko.actor.ActorSystem
+import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.node._
+import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.testkit.node._
 import org.bitcoins.testkit.node.fixture._
@@ -55,12 +57,13 @@ import scala.concurrent._
 import scala.concurrent.duration._
 import java.nio.file.Files
 import com.typesafe.config.ConfigFactory
+import scala.concurrent.ExecutionContext
 ```
 
 ```scala mdoc:compile-only
 
-implicit val system = ActorSystem(s"node-example")
-implicit val ec = system.dispatcher
+implicit val system: ActorSystem = ActorSystem(s"node-example")
+implicit val ec: ExecutionContext = system.dispatcher
 
 //we also require a bitcoind instance to connect to
 //so let's start one (make sure you ran 'sbt downloadBitcoind')
@@ -93,9 +96,9 @@ val config = ConfigFactory.parseString {
     |""".stripMargin
 }
 
-implicit val appConfig = BitcoinSAppConfig(datadir, Vector(config))
-implicit val chainConfig = appConfig.chainConf
-implicit val nodeConfig = appConfig.nodeConf
+implicit val appConfig: BitcoinSAppConfig = BitcoinSAppConfig(datadir, Vector(config))
+implicit val chainConfig: ChainAppConfig = appConfig.chainConf
+implicit val nodeConfig: NodeAppConfig = appConfig.nodeConf
 
 val initNodeF = nodeConfig.start()
 
@@ -116,7 +119,7 @@ val startedNodeF = nodeF.flatMap(_.start())
 
 //let's make a simple callback that print's the
 //blockhash everytime we receive a block on the network
-val blockReceivedFunc: OnBlockReceived = { block: Block =>
+val blockReceivedFunc: OnBlockReceived = { (block: Block) =>
 Future.successful(
   println(s"Received blockhash=${block.blockHeader.hashBE}"))
 }

--- a/docs/rpc/bitcoind.md
+++ b/docs/rpc/bitcoind.md
@@ -6,14 +6,9 @@ title: bitcoind/Bitcoin Core
 ## Downloading bitcoind
 
 The Bitcoin Core RPC client in Bitcoin-S currently supports the Bitcoin Core
-- 0.16
-- 0.17
-- 0.18
-- 0.19
-- 0.20
-- 0.21
-- 22
-- 23
+- 25
+- 26
+- 27
 
 version lines. It can be set up to work with both local and remote Bitcoin Core servers.
 
@@ -31,6 +26,7 @@ The binaries will be stored in `~/.bitcoin-s/binaries/bitcoind/`
 
 ### Getting started quickly, with default options:
 ```scala mdoc:invisible
+//import org.apache.pekko.actor.ActorSystem
 import scala.concurrent._
 
 import java.io._
@@ -50,7 +46,7 @@ import org.apache.pekko.actor.ActorSystem
 ```scala mdoc:compile-only
 
 implicit val ec: ExecutionContext = ExecutionContext.global
-implicit val system = ActorSystem("System")
+implicit val system: ActorSystem = ActorSystem("System")
 // this reads authentication credentials and
 // connection details from the default data
 // directory on your platform
@@ -70,7 +66,7 @@ To do so the wallet rpc functions have an optional `walletName` parameter.
 ```scala mdoc:compile-only
 
 implicit val ec: ExecutionContext = ExecutionContext.global
-implicit val system = ActorSystem("System")
+implicit val system: ActorSystem = ActorSystem("System")
 val client = BitcoindRpcClient.fromDatadir(binary=new File("/path/to/bitcoind"), datadir=new File("/path/to/bitcoind-datadir"))
 
 for {
@@ -98,7 +94,7 @@ ready to create the connection with our RPC client
 ```scala mdoc:compile-only
 
 implicit val ec: ExecutionContext = ExecutionContext.global
-implicit val system = ActorSystem("System")
+implicit val system: ActorSystem = ActorSystem("System")
 val username = "FILL_ME_IN" //this username comes from 'rpcuser' in your bitcoin.conf file
 val password = "FILL_ME_IN" //this password comes from your 'rpcpassword' in your bitcoin.conf file
 
@@ -135,7 +131,7 @@ handling could look:
 
 ```scala mdoc:compile-only
 
-implicit val ec = ExecutionContext.global
+implicit val ec: ExecutionContext = ExecutionContext.global
 
 // let's assume you have an already running client,
 // so there's no need to start this one

--- a/docs/rpc/eclair.md
+++ b/docs/rpc/eclair.md
@@ -5,7 +5,7 @@ title: Eclair
 
 This is a RPC client for [Eclair](https://github.com/acinq/eclair). It assumes that a bitcoind instance is running.
 
-Currently this RPC client is written for [v0.5.0](https://github.com/ACINQ/eclair/releases/tag/v0.5.0) version of Eclair.
+Currently this RPC client is written for [v0.10.0](https://github.com/ACINQ/eclair/releases/tag/v0.10.0) version of Eclair.
 
 ## Configuration of Eclair
 
@@ -18,7 +18,7 @@ You can find the configuration we use for our testing infrastrture for eclair [h
 
 You need to download the jar from the [eclair's github](https://github.com/ACINQ/eclair/releases/tag/v0.5.0).
 
-To run Eclair by unzipping the `eclair-node-0.5.0-ac08560-bin.zip` and then running
+To run Eclair by unzipping the `eclair-node-0.10.0-a63d2c2-bin.zip` and then running
 
 ```bash
 $ ./eclair-node-0.5.0-ac08560/bin/eclair-node.sh
@@ -38,15 +38,16 @@ import org.apache.pekko.actor.ActorSystem
 import org.bitcoins.eclair.rpc.client.EclairRpcClient
 import org.bitcoins.eclair.rpc.config.EclairInstanceLocal
 import java.nio.file.Paths
+import scala.concurrent.ExecutionContext
 ```
 
 ```scala mdoc:compile-only
 
-implicit val system = ActorSystem(s"eclair-rpc-${System.currentTimeMillis}")
-implicit val ec = system.dispatcher
+implicit val system: ActorSystem = ActorSystem(s"eclair-rpc-${System.currentTimeMillis}")
+implicit val ec: ExecutionContext = system.dispatcher
 
 val datadirPath = Paths.get("path", "to", "datadir")
-val binaryPath = Paths.get("path", "to", "eclair-node-0.5.0-ac08560", "bin", "eclair-node.sh")
+val binaryPath = Paths.get("path", "to", "eclair-node-0.10.0-a63d2c2", "bin", "eclair-node.sh")
 val instance = EclairInstanceLocal.fromDatadir(datadirPath.toFile, logbackXml = None, proxyParams = None)
 val client = new EclairRpcClient(instance, Some(binaryPath.toFile))
 
@@ -62,5 +63,5 @@ for {
 
 ### Connecting to the websocket
 
-As of `v0.3.3` eclair supports a websocket endpoint. This means you can receive updates of what is happening with eclair
+As of `v0.10.0` eclair supports a websocket endpoint. This means you can receive updates of what is happening with eclair
 in real time. You can see an example of us testing this [here](https://github.com/bitcoin-s/bitcoin-s/blob/a043d3858ef33da51229ee59c478d2a6c9d5a46f/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala#L591)

--- a/docs/rpc/lnd.md
+++ b/docs/rpc/lnd.md
@@ -5,7 +5,7 @@ title: LND
 
 This is an RPC client for [LND](https://github.com/LightningNetwork/lnd). It assumes that a bitcoind instance is running.
 
-Currently, this RPC client is written for [v0.17.3](https://github.com/lightningnetwork/lnd/releases/tag/v0.17.3-beta) version of LND.
+Currently, this RPC client is written for [v0.17.5](https://github.com/lightningnetwork/lnd/releases/tag/v0.17.3-beta) version of LND.
 
 ## Configuration of LND
 
@@ -17,7 +17,7 @@ You can find the configuration we use for our testing infrastructure for lnd [he
 
 You need to download the binaries from the [LND's github](https://github.com/lightningnetwork/lnd/releases/tag/v0.17.3-beta).
 
-To run lnd by unzipping the `lnd-linux-amd64-v0.17.3-beta.tar.gz` (or whichever platform you are on) and then running
+To run lnd by unzipping the `lnd-linux-amd64-v0.17.5-beta.tar.gz` (or whichever platform you are on) and then running
 
 ```bash
 $ ./lnd-linux-amd64-v0.17.3-beta/lnd
@@ -34,15 +34,16 @@ import org.apache.pekko.actor.ActorSystem
 import org.bitcoins.lnd.rpc._
 import org.bitcoins.lnd.rpc.config._
 import java.nio.file.Paths
+import scala.concurrent.ExecutionContext
 ```
 
 ```scala mdoc:compile-only
 
-implicit val system = ActorSystem(s"lnd-rpc-${System.currentTimeMillis}")
-implicit val ec = system.dispatcher
+implicit val system: ActorSystem = ActorSystem(s"lnd-rpc-${System.currentTimeMillis}")
+implicit val ec: ExecutionContext = system.dispatcher
 
 val datadirPath = Paths.get("path", "to", "datadir")
-val binaryPath = Paths.get("path", "to", "lnd-linux-amd64-v0.17.3-beta", "lnd")
+val binaryPath = Paths.get("path", "to", "lnd-linux-amd64-v0.17.5-beta", "lnd")
 val instance = LndInstanceLocal.fromDataDir(datadirPath.toFile)
 val client = new LndRpcClient(instance, Some(binaryPath.toFile))
 

--- a/docs/testkit/testkit.md
+++ b/docs/testkit/testkit.md
@@ -34,8 +34,8 @@ This gives you the ability to start spending money immediately with that bitcoin
 
 ```scala mdoc:compile-only
 
-implicit val system = ActorSystem("bitcoind-testkit-example")
-implicit val ec = system.dispatcher
+implicit val system: ActorSystem = ActorSystem("bitcoind-testkit-example")
+implicit val ec: ExecutionContext = system.dispatcher
 
 //pick our bitcoind version we want to spin up
 val bitcoindV = BitcoindVersion.newest
@@ -106,8 +106,8 @@ Make sure to run `sbt downloadBitcoind downloadEclair` before running this so yo
 //4. assert the node has received the payment
 //5. cleanup
 
-implicit val system = ActorSystem("eclair-testkit-example")
-implicit val ec = system.dispatcher
+implicit val system: ActorSystem = ActorSystem("eclair-testkit-example")
+implicit val ec: ExecutionContext = system.dispatcher
 
 //we need a bitcoind to connect eclair nodes to
 lazy val bitcoindRpcClientF: Future[BitcoindRpcClient] = {

--- a/docs/wallet/address-tagging.md
+++ b/docs/wallet/address-tagging.md
@@ -125,7 +125,7 @@ object UserIdTags extends AddressTagFactory[UserIdTag] {
 
   override val all: Vector[UserIdTag] = Vector(Company, InsuranceFund)
 
-  override val tagNames = Vector(CompanyTagName, InsuranceFundTagName)
+  override val tagNames: Vector[AddressTagName] = Vector(CompanyTagName, InsuranceFundTagName)
 
   override def fromStringOpt(str: String): Option[UserIdTag] = {
     all.find(tag => str.toLowerCase() == tag.toString.toLowerCase) match {

--- a/docs/wallet/wallet-sync.md
+++ b/docs/wallet/wallet-sync.md
@@ -105,15 +105,15 @@ val bitcoind = Await.result(bitcoindRpcClientF, 10.seconds)
 
 val getBestBlockHashFunc = () => bitcoind.getBestBlockHash
 
-val getBlockHeaderFunc = { hash: DoubleSha256DigestBE => bitcoind.getBlockHeaderRaw(hash) }
+val getBlockHeaderFunc = { (hash: DoubleSha256DigestBE) => bitcoind.getBlockHeaderRaw(hash) }
 
-val getBlockFunc = {hash: DoubleSha256DigestBE => bitcoind.getBlockRaw(hash) }
+val getBlockFunc = { (hash: DoubleSha256DigestBE) => bitcoind.getBlockRaw(hash) }
 
 val genesisHashBEF = bitcoind.getBlockHash(0)
 
 //yay! We are now all setup. Using our 3 functions above and a wallet, we can now sync
 //a fresh wallet
-implicit val walletAppConfig = WalletAppConfig.fromDefaultDatadir()
+implicit val walletAppConfig: WalletAppConfig = WalletAppConfig.fromDefaultDatadir()
 
 val feeRateProvider: FeeRateApi = MempoolSpaceProvider.fromBlockTarget(6, proxyParams = None)
 val wallet = Wallet(bitcoind, bitcoind, feeRateProvider)

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -84,8 +84,8 @@ val chainApi = new ChainQueryApi {
 ```
 
 ```scala mdoc:compile-only
-implicit val ec = scala.concurrent.ExecutionContext.global
-implicit val system = ActorSystem("System")
+implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+implicit val system: ActorSystem = ActorSystem("System")
 
 val config = ConfigFactory.parseString {
     """
@@ -99,10 +99,10 @@ val config = ConfigFactory.parseString {
 val datadir = Files.createTempDirectory("bitcoin-s-wallet")
 
 
-implicit val walletConfig = WalletAppConfig(datadir, Vector(config))
+implicit val walletConfig: WalletAppConfig = WalletAppConfig(datadir, Vector(config))
 
 // we also need to store chain state for syncing purposes
-implicit val chainConfig = ChainAppConfig(datadir, Vector(config))
+implicit val chainConfig: ChainAppConfig = ChainAppConfig(datadir, Vector(config))
 
 // when this future completes, we have
 // created the necessary directories and
@@ -126,7 +126,7 @@ val syncF: Future[ChainApi] = configF.flatMap { _ =>
     }
 
     
-    val getBlockHeaderFunc = { hash: DoubleSha256DigestBE =>
+    val getBlockHeaderFunc = { (hash: DoubleSha256DigestBE) =>
         bitcoind.getBlockHeader(hash).map(_.blockHeader)
     }
 


### PR DESCRIPTION
Adds `-Xsource:3` flag to `docs/`

This also fixes our `release.yml` build that fails on `docs/publishWebsite` after #5580 

https://github.com/bitcoin-s/bitcoin-s/actions/runs/9034988272/job/24828786430