### PR TITLE
2024 05 10 keymanager xsource3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -722,11 +722,13 @@ lazy val docs = project
 
 lazy val keyManager = project
   .in(file("key-manager"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.prodSettings: _*)
   .dependsOn(coreJVM, appCommons)
 
 lazy val keyManagerTest = project
   .in(file("key-manager-test"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.testSettings: _*)
   .settings(name := "bitcoin-s-keymanager-test",
             libraryDependencies ++= Deps.keyManagerTest)

--- a/build.sbt
+++ b/build.sbt
@@ -110,6 +110,7 @@ lazy val asyncUtilsTestJS = asyncUtilsTest.js
 lazy val testkitCore = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .in(file("testkit-core"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.prodSettings: _*)
   .settings(name := "bitcoin-s-testkit-core",
             libraryDependencies ++= Deps.testkitCore.value)

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
@@ -59,7 +59,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "write and read an encrypted mnemonic to disk" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
 
       val writtenMnemonic = getAndWriteMnemonic(walletConf)
@@ -85,7 +85,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "write and read an encrypted seed to disk" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
 
       val writtenXprv = getAndWriteXprv(walletConf)
@@ -110,7 +110,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "write and read an unencrypted mnemonic to disk" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
       val writtenMnemonic =
@@ -137,7 +137,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "write and read an unencrypted xprv to disk" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
       val xprv = CryptoGenerators.extPrivateKey.sampleSome
       val writtenXprv = DecryptedExtPrivKey(xprv, TimeUtil.now, None, false)
@@ -163,7 +163,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "change the password of an encrypted mnemonic" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
 
       val writtenMnemonic = getAndWriteMnemonic(walletConf)
@@ -194,7 +194,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "change the password of an unencrypted mnemonic" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
       val writtenMnemonic =
@@ -227,7 +227,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "remove the password from an encrypted mnemonic" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
 
       val writtenMnemonic = getAndWriteMnemonic(walletConf)
@@ -258,7 +258,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "fail to change the aes password when given the wrong password" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
 
       getAndWriteMnemonic(walletConf)
@@ -276,7 +276,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "fail to change the aes password when given no password" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
 
       getAndWriteMnemonic(walletConf)
@@ -294,7 +294,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "fail to set the aes password when given an oldPassword" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
       val writtenMnemonic =
@@ -627,7 +627,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "write and read an encrypted ExtPrivateKey from disk" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
 
       val password = getBIP39PasswordOpt().getOrElse(BIP39Seed.EMPTY_PASSWORD)
@@ -657,7 +657,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "write and read an unencrypted ExtPrivateKey from disk" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
       val writtenMnemonic =
@@ -690,7 +690,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "fail to read unencrypted ExtPrivateKey from disk that doesn't exist" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
       val seedPath = getSeedPath(walletConf)
       val keyVersion = SegWitMainNetPriv
@@ -702,7 +702,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "safely create 2 seeds in the seed folder" in {
-    walletConfA: WalletAppConfig =>
+    (walletConfA: WalletAppConfig) =>
       assert(!walletConfA.kmConf.seedExists())
       getAndWriteMnemonic(walletConfA)
       assert(walletConfA.kmConf.seedExists())
@@ -739,7 +739,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
       }
   }
 
-  it must "backup an unencrypted seed" in { walletConf: WalletAppConfig =>
+  it must "backup an unencrypted seed" in { (walletConf: WalletAppConfig) =>
     assert(!walletConf.kmConf.seedExists())
     val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
     val writtenMnemonic =
@@ -768,7 +768,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
     )
   }
 
-  it must "backup an encrypted seed" in { walletConf: WalletAppConfig =>
+  it must "backup an encrypted seed" in { (walletConf: WalletAppConfig) =>
     assert(!walletConf.kmConf.seedExists())
     val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
     val writtenMnemonic =
@@ -799,7 +799,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "set imported flag for an encrypted seed" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
       val seedPath = getSeedPath(walletConf)
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome
@@ -830,7 +830,7 @@ class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
   }
 
   it must "set imported flag for an unencrypted seed" in {
-    walletConf: WalletAppConfig =>
+    (walletConf: WalletAppConfig) =>
       assert(!walletConf.kmConf.seedExists())
       val seedPath = getSeedPath(walletConf)
       val mnemonicCode = CryptoGenerators.mnemonicCode.sampleSome

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/DLCFeeTestUtil.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/DLCFeeTestUtil.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.scalatest.{Assertion, Assertions}
 
 object DLCFeeTestUtil extends Assertions {
-
+  import org.bitcoins.core.currency.currencyUnitNumeric
   def validateFees(
       builder: DLCTxBuilder,
       fundingTx: Transaction,

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CreditingTxGen.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CreditingTxGen.scala
@@ -363,10 +363,10 @@ sealed abstract class CreditingTxGen {
 
   def random: Gen[ScriptSignatureParams[InputInfo]] =
     nonEmptyOutputs.flatMap { outputs =>
-      Gen.choose(0, outputs.size - 1).flatMap { outputIndex: Int =>
+      Gen.choose(0, outputs.size - 1).flatMap { (outputIndex: Int) =>
         ScriptGenerators.scriptPubKey.flatMap { case (spk, keys) =>
-          WitnessGenerators.scriptWitness.flatMap { wit: ScriptWitness =>
-            CryptoGenerators.hashType.map { hashType: HashType =>
+          WitnessGenerators.scriptWitness.flatMap { (wit: ScriptWitness) =>
+            CryptoGenerators.hashType.map { (hashType: HashType) =>
               val tc = TransactionConstants
               val signers: Vector[Sign] = keys.toVector
               val creditingTx =

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/BaseAsyncTest.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/BaseAsyncTest.scala
@@ -188,7 +188,7 @@ trait BaseAsyncTest
   def forAllParallel[A](
       gen: Gen[A]
   )(func: A => Assertion): Future[Assertion] = {
-    forAllAsync(gen) { a: A =>
+    forAllAsync(gen) { (a: A) =>
       FutureUtil.makeAsync { () =>
         func(a)
       }


### PR DESCRIPTION
Introduce `-Xsource:3` flag to `key-manager`, `key-manager-test`

from #3497 and built ontop of #5582