### PR TITLE
2024 05 10 dbcommons xsource3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -493,6 +493,7 @@ lazy val chainTest = project
 
 lazy val dbCommons = project
   .in(file("db-commons"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.prodSettings: _*)
   .settings(
     name := "bitcoin-s-db-commons",
@@ -502,6 +503,7 @@ lazy val dbCommons = project
 
 lazy val dbCommonsTest = project
   .in(file("db-commons-test"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.testSettings: _*)
   .settings(
     name := "bitcoin-s-db-commons-test"

--- a/db-commons-test/src/test/scala/org/bitcoins/db/models/MasterXPubDAOTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/models/MasterXPubDAOTest.scala
@@ -8,7 +8,7 @@ import java.sql.SQLException
 class MasterXPubDAOTest extends TestAppConfigFixture {
   behavior of "MasterXPubDAO"
 
-  it must "create and find a master xpub" in { testAppConfig: TestAppConfig =>
+  it must "create and find a master xpub" in { (testAppConfig: TestAppConfig) =>
     val xpriv = ExtPrivateKey.freshRootKey(ExtKeyVersion.SegWitTestNet3Priv)
     val xpub = xpriv.extPublicKey
     val masterXpub =
@@ -30,7 +30,7 @@ class MasterXPubDAOTest extends TestAppConfigFixture {
     }
   }
 
-  it must "create only one master xpub" in { testAppConfig: TestAppConfig =>
+  it must "create only one master xpub" in { (testAppConfig: TestAppConfig) =>
     val masterXpubDAO =
       MasterXPubDAO()(executionContext, appConfig = testAppConfig)
 
@@ -52,7 +52,7 @@ class MasterXPubDAOTest extends TestAppConfigFixture {
   }
 
   it must "validate the masterxpub and succeed in the database" in {
-    testAppConfig: TestAppConfig =>
+    (testAppConfig: TestAppConfig) =>
       val xpriv = ExtPrivateKey.freshRootKey(ExtKeyVersion.SegWitTestNet3Priv)
       val xpub = xpriv.extPublicKey
       val masterXpub =
@@ -67,7 +67,7 @@ class MasterXPubDAOTest extends TestAppConfigFixture {
   }
 
   it must "throw an exception is the stored master xpub is different than the given" in {
-    testAppConfig: TestAppConfig =>
+    (testAppConfig: TestAppConfig) =>
       val xpriv = ExtPrivateKey.freshRootKey(ExtKeyVersion.SegWitTestNet3Priv)
       val xpub = xpriv.extPublicKey
       val masterXpub =

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -185,7 +185,7 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
 
   implicit val uint64Mapper: BaseColumnType[UInt64] = {
     MappedColumnType.base[UInt64, String](
-      { u64: UInt64 =>
+      { (u64: UInt64) =>
         uInt64ToHex(u64)
       },
       UInt64.fromHex


### PR DESCRIPTION
Introduce `-Xsource:3` flag to `db-commons`

from #3497 and built ontop of #5584 