### PR TITLE
Add -Xsource:3 to rpc projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,7 @@ lazy val coreJS = core.js
 lazy val asyncUtils = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .in(file("async-utils"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.prodSettings: _*)
   .settings(name := "bitcoin-s-async-utils",
             libraryDependencies ++= Deps.asyncUtils.value)
@@ -124,6 +125,7 @@ lazy val testkitCoreJS = testkitCore.js
 
 lazy val bitcoindRpc = project
   .in(file("bitcoind-rpc"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.prodSettings: _*)
   .dependsOn(
     asyncUtilsJVM,
@@ -133,16 +135,19 @@ lazy val bitcoindRpc = project
 
 lazy val eclairRpc = project
   .in(file("eclair-rpc"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.prodSettings: _*)
   .dependsOn(asyncUtilsJVM, bitcoindRpc)
 
 lazy val lndRpc = project
   .in(file("lnd-rpc"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.prodSettings: _*)
   .dependsOn(asyncUtilsJVM, appCommons)
 
 lazy val clightningRpc = project
   .in(file("clightning-rpc"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.prodSettings: _*)
   .dependsOn(asyncUtilsJVM, bitcoindRpc)
 
@@ -590,6 +595,7 @@ lazy val bench = project
 
 lazy val eclairRpcTest = project
   .in(file("eclair-rpc-test"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.testSettings: _*)
   .settings(
     libraryDependencies ++= Deps.eclairRpcTest.value,
@@ -599,6 +605,7 @@ lazy val eclairRpcTest = project
 
 lazy val clightningRpcTest = project
   .in(file("clightning-rpc-test"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.testSettings: _*)
   .settings(
     libraryDependencies ++= Deps.clightningRpcTest.value,
@@ -608,6 +615,7 @@ lazy val clightningRpcTest = project
 
 lazy val lndRpcTest = project
   .in(file("lnd-rpc-test"))
+  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.testSettings: _*)
   .settings(
     libraryDependencies ++= Deps.eclairRpcTest.value,

--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,6 @@ lazy val eclairRpc = project
 
 lazy val lndRpc = project
   .in(file("lnd-rpc"))
-  .settings(scalacOptions += "-Xsource:3")
   .settings(CommonSettings.prodSettings: _*)
   .dependsOn(asyncUtilsJVM, appCommons)
 

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -1177,7 +1177,7 @@ class LndRpcClient(val instance: LndInstance, binaryOpt: Option[File] = None)(
 
         // register callback that publishes a payment to our actor system's
         // event stream,
-        receivedInfoF.foreach { info: Invoice =>
+        receivedInfoF.foreach { (info: Invoice) =>
           if (info.state.isSettled) {
             // invoice has been paid, let's publish to event stream
             // so subscribers so the even stream can see that a payment

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -165,8 +165,7 @@ object CommonSettings {
       "-Xlint:constant",
       "-Xlint:nonlocal-return",
       "-Xlint:implicit-not-found",
-      "-Xlint:serial",
-      "-quickfix:any"
+      "-Xlint:serial"
     )
   }
 

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -165,7 +165,8 @@ object CommonSettings {
       "-Xlint:constant",
       "-Xlint:nonlocal-return",
       "-Xlint:implicit-not-found",
-      "-Xlint:serial"
+      "-Xlint:serial",
+      "-quickfix:any"
     )
   }
 


### PR DESCRIPTION
This PR adds `-Xsource:3` flag to `lnd-rpc-test`, `clightning-rpc`, `clightning-rpc-test`, `eclair-rpc`, `eclair-rpc-test`.

This PR does not add the `-Xsource:3` flag to `lnd-rpc/`. It seems there are some issues between pekko-grpc, protobufs, and the `-Xsource:3` flag.