### PR TITLE
2024 05 14 mac electron release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         # Can run conditional steps below with https://github.community/t/what-is-the-correct-if-condition-syntax-for-checking-matrix-os-version/16221
         # This is here to get friendly labels for output filenames
         include:
-        - os: macos-latest
+        - os: macos-13
           TARGET: mac
         - os: ubuntu-latest
           TARGET: linux
@@ -134,11 +134,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest] # windows-latest
+        os: [macos-13, ubuntu-latest] # windows-latest
         # If os values you don't include the matrix os list above are set here, they will be included
         # This is here to get friendly labels for output filenames
         include:
-        - os: macos-latest
+        - os: macos-13
           TARGET: mac
           FORMAT: zip # dmg
         - os: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main, 2024-05-14-mac-electron-release]
+    branches: [master, main]
     tags: ["*"]
   release:
     types: [ published ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [master, main, feature_electron_build]
+    branches: [master, main, 2024-05-14-mac-electron-release]
     tags: ["*"]
   release:
     types: [ published ]
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest] # 
+        os: [macos-13, ubuntu-latest, windows-latest] #
         # If os values you don't include the matrix os list above are set here, they will be included
         # If you want multiple variables per os see https://github.community/t/create-matrix-with-multiple-os-and-env-for-each-one/16895
         # Can run conditional steps below with https://github.community/t/what-is-the-correct-if-condition-syntax-for-checking-matrix-os-version/16221


### PR DESCRIPTION
Fix mac build in `release.yml` for electron app.

It seems that `macos-latest` now runs on arm64 rather than x86 by default. I'm not sure how to specify the architecture - so for now just pin to `macos-13`

https://github.com/actions/runner-images