### PR TITLE
Add previous tag to electron build steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,11 @@ jobs:
       W_OUT: "bitcoin-s-ts/wallet-electron-ts/out"
       W_MAKE: "bitcoin-s-ts/wallet-electron-ts/out/make"
     steps:
+      - name: Get Previous tag
+        id: previoustag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
       # macos keychain unlocking for signing identity access
       - name: (macos) Import developer cert to keychain
         if: startsWith(matrix.os,'macos')


### PR DESCRIPTION
Hopefully fixes #4821 

On our 1.9.9 release it appears our electron artifacts got tagged with the version `1.9.7`. Hopefully this makes sure we get the correct tag - its worth noting that other jobs (such as publishing jars) is tagged with the correct version.