### PR TITLE
add checkout action to electron build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,9 @@ jobs:
       W_OUT: "bitcoin-s-ts/wallet-electron-ts/out"
       W_MAKE: "bitcoin-s-ts/wallet-electron-ts/out/make"
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Get Previous tag
         id: previoustag
         uses: WyriHaximus/github-action-get-previous-tag@v1


### PR DESCRIPTION
fixes these CI failures introduced in #5599 

https://github.com/bitcoin-s/bitcoin-s/actions/runs/9257991133/job/25467588111