### PR TITLE
Add migration code to put app data in proper spot on mac for fresh installs

### DIFF
--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -32,4 +32,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-rpc-tests-cache
       - name: run tests
-        run: sbt coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls lndRpcTest/test esploraTest/test
+        run: sbt coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls lndRpcTest/test eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls esploraTest/test

--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -246,7 +246,7 @@ object AppConfig extends BitcoinSLogger {
       val full = Paths
         .get(Properties.userHome)
         .resolve("Library")
-        .resolve("Application Support")
+        .resolve(s"Application\\ Support")
         .resolve("bitcoin-s")
       if (Files.exists(full)) {
         full

--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -246,7 +246,7 @@ object AppConfig extends BitcoinSLogger {
       val full = Paths
         .get(Properties.userHome)
         .resolve("Library")
-        .resolve(s"Application\\ Support")
+        .resolve("Application Support")
         .resolve("bitcoin-s")
       if (Files.exists(full)) {
         full

--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -2,11 +2,11 @@ package org.bitcoins.commons.config
 
 import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions}
 import org.bitcoins.commons.util.BitcoinSLogger
-import org.bitcoins.core.config._
+import org.bitcoins.core.config.*
 import org.bitcoins.core.protocol.blockchain.BitcoinChainParams
-import org.bitcoins.core.util.StartStopAsync
+import org.bitcoins.core.util.{EnvUtil, StartStopAsync}
 
-import java.nio.file._
+import java.nio.file.*
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.util.Properties
@@ -237,8 +237,37 @@ object AppConfig extends BitcoinSLogger {
     * TODO: use different directories on Windows and Mac, should probably mimic
     * what Bitcoin Core does
     */
-  private[bitcoins] lazy val DEFAULT_BITCOIN_S_DATADIR: Path =
-    Paths.get(Properties.userHome, ".bitcoin-s")
+  private[bitcoins] lazy val DEFAULT_BITCOIN_S_DATADIR: Path = {
+    val base = Paths.get(Properties.userHome, ".bitcoin-s")
+    if (EnvUtil.isLinux) {
+      base
+    } else if (EnvUtil.isMac) {
+      // migration code to use proper location on mac
+      val full = Paths
+        .get(Properties.userHome)
+        .resolve("Library")
+        .resolve("Application Support")
+        .resolve("bitcoin-s")
+      if (Files.exists(full)) {
+        full
+      } else {
+        if (Files.exists(base)) {
+          // just use old directory for now
+          // we will eventually migrate this in the future
+          base
+        } else {
+          // fresh install, so use the proper spot
+          full
+        }
+      }
+    } else if (EnvUtil.isWindows) {
+      // windows
+      base
+    } else {
+      sys.error(s"Unsupported os=${EnvUtil.osName}")
+    }
+
+  }
 
   private[bitcoins] lazy val DEFAULT_BITCOIN_S_CONF_FILE: String =
     "bitcoin-s.conf"

--- a/bitcoind-rpc/bitcoind-rpc.sbt
+++ b/bitcoind-rpc/bitcoind-rpc.sbt
@@ -41,7 +41,7 @@ TaskKeys.downloadBitcoind := {
   }
 
   implicit val ec = scala.concurrent.ExecutionContext.global
-  val downloads = versions.map { version =>
+  val downloads = Future.traverse(versions) { version =>
     val (platform, suffix) = getPlatformAndSuffix(version)
     val archiveLocation = binaryDir resolve s"$version.$suffix"
     val location =
@@ -122,8 +122,7 @@ TaskKeys.downloadBitcoind := {
         if (success) {
           logger.info(s"Download complete and verified, unzipping result")
 
-          val extractCommand =
-            s"tar -xzf $archiveLocation --directory $binaryDir"
+          val extractCommand = s"""tar -xzf $archiveLocation --directory \"$binaryDir\""""
           logger.info(s"Extracting archive with command: $extractCommand")
           extractCommand.!!
         } else {
@@ -143,5 +142,5 @@ TaskKeys.downloadBitcoind := {
   }
 
   //timeout if we cannot download in 5 minutes
-  Await.result(Future.sequence(downloads), 5.minutes)
+  Await.result(downloads, 2.minutes)
 }

--- a/bitcoind-rpc/bitcoind-rpc.sbt
+++ b/bitcoind-rpc/bitcoind-rpc.sbt
@@ -121,10 +121,16 @@ TaskKeys.downloadBitcoind := {
         val success = hash.equalsIgnoreCase(expectedHash(version))
         if (success) {
           logger.info(s"Download complete and verified, unzipping result")
-
-          val extractCommand = s"""tar -xzf $archiveLocation --directory \"$binaryDir\""""
-          logger.info(s"Extracting archive with command: $extractCommand")
-          extractCommand.!!
+          val cmds = Vector(
+            "tar",
+            "-xzf",
+            archiveLocation.toString,
+            "--directory",
+            binaryDir.toString
+          )
+          //val extractCommand = s"""tar -xzf \"$archiveLocation\" --directory \"$binaryDir\""""
+          logger.info(s"Extracting archive with command: $cmds")
+          cmds.!!
         } else {
           Files.deleteIfExists(expectedEndLocation)
           logger.error(

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -148,7 +148,6 @@ trait Client
         logger.debug(
           s"starting bitcoind with datadir ${local.datadir} and binary path $binaryPath"
         )
-        println(s"cmd=$cmd")
         cmd
 
     }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -148,7 +148,7 @@ trait Client
         logger.debug(
           s"starting bitcoind with datadir ${local.datadir} and binary path $binaryPath"
         )
-        // println(s"cmd=$cmd")
+        println(s"cmd=$cmd")
         cmd
 
     }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -148,7 +148,7 @@ trait Client
         logger.debug(
           s"starting bitcoind with datadir ${local.datadir} and binary path $binaryPath"
         )
-
+        // println(s"cmd=$cmd")
         cmd
 
     }

--- a/clightning-rpc/clightning-rpc.sbt
+++ b/clightning-rpc/clightning-rpc.sbt
@@ -72,10 +72,15 @@ TaskKeys.downloadCLightning := {
     val success = hash.equalsIgnoreCase(expectedHash)
     if (hash.equalsIgnoreCase(expectedHash)) {
       logger.info(s"Download complete and verified, unzipping result")
-
-      val extractCommand = s"tar -xf $archiveLocation --directory $versionDir"
-      logger.info(s"Extracting archive with command: $extractCommand")
-      extractCommand.!!
+      val cmds = Vector(
+        "tar",
+        "-xf",
+        archiveLocation.toString,
+        "--directory",
+        versionDir.toString
+      )
+      logger.info(s"Extracting archive with command: $cmds")
+      cmds.!!
     } else {
       logger.error(
         s"Downloaded invalid version of c-lightning, got $hash, expected $expectedHash")

--- a/core/src/main/scala/org/bitcoins/core/util/EnvUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/EnvUtil.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.util
 import scala.util.Properties
 
 object EnvUtil {
-  private val osName = System.getProperty("os.name")
+  lazy val osName: String = System.getProperty("os.name")
 
   lazy val isLinux: Boolean = osName.startsWith("Linux")
 

--- a/eclair-rpc/eclair-rpc.sbt
+++ b/eclair-rpc/eclair-rpc.sbt
@@ -52,10 +52,14 @@ TaskKeys.downloadEclair := {
     val success = hash.equalsIgnoreCase(expectedHash)
     if (success) {
       logger.info(s"Download complete and verified, unzipping result")
-
-      val extractCommand = s"unzip $archiveLocation -d $versionDir"
-      logger.info(s"Extracting archive with command: $extractCommand")
-      extractCommand.!!
+      val cmds = Vector(
+        "unzip",
+        archiveLocation.toString,
+        "-d",
+        versionDir.toString
+      )
+      logger.info(s"Extracting archive with command: $cmds")
+      cmds.!!
     } else {
       Files.deleteIfExists(versionDir)
       logger.error(

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -23,8 +23,8 @@ import org.apache.pekko.http.scaladsl.model.{
 import org.apache.pekko.stream.scaladsl.{Flow, Sink, Source}
 import org.apache.pekko.util.ByteString
 import org.bitcoins.asyncutil.AsyncUtil
-import org.bitcoins.commons.jsonmodels.eclair._
-import org.bitcoins.commons.serializers.JsonReaders._
+import org.bitcoins.commons.jsonmodels.eclair.*
+import org.bitcoins.commons.serializers.JsonReaders.*
 import org.bitcoins.commons.util.NativeProcessFactory
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.protocol.ln.channel.{
@@ -38,14 +38,14 @@ import org.bitcoins.core.protocol.ln.routing.{ChannelRoute, NodeRoute, Route}
 import org.bitcoins.core.protocol.ln.{LnInvoice, LnParams, PaymentPreimage}
 import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.{Address, BitcoinAddress}
-import org.bitcoins.core.util.{BytesUtil, StartStopAsync}
+import org.bitcoins.core.util.{BytesUtil, EnvUtil, StartStopAsync}
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.crypto.{DoubleSha256DigestBE, Sha256Digest}
-import org.bitcoins.eclair.rpc.api._
+import org.bitcoins.eclair.rpc.api.*
 import org.bitcoins.eclair.rpc.config.EclairInstance
 import org.bitcoins.rpc.client.common.BitcoindVersion
 import org.bitcoins.tor.Socks5ClientTransport
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.io.File
 import java.net.InetSocketAddress
@@ -823,7 +823,7 @@ class EclairRpcClient(
       // default to provided binary
       case (Some(binary), _) =>
         if (binary.exists) {
-          binary.toPath.toAbsolutePath.toString
+          binary.getAbsolutePath
         } else {
           throw new NoSuchFileException(
             s"Given binary ($binary) does not exist!"
@@ -833,7 +833,7 @@ class EclairRpcClient(
         val eclairBinDir =
           s"eclair-node-${EclairRpcClient.version}-${EclairRpcClient.commit}${File.separator}bin${File.separator}"
         val eclairV =
-          if (sys.props("os.name").toLowerCase.contains("windows"))
+          if (EnvUtil.isWindows)
             eclairBinDir + "eclair-node.bat"
           else
             eclairBinDir + "eclair-node.sh"
@@ -866,6 +866,8 @@ class EclairRpcClient(
       case Some(logback) => base.appended(logback)
       case None          => base
     }
+
+    // println(s"cmd=$cmd")
     cmd
   }
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -867,7 +867,7 @@ class EclairRpcClient(
       case None          => base
     }
 
-    // println(s"cmd=$cmd")
+    println(s"cmd=$cmd")
     cmd
   }
 

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -866,8 +866,6 @@ class EclairRpcClient(
       case Some(logback) => base.appended(logback)
       case None          => base
     }
-
-    println(s"cmd=$cmd")
     cmd
   }
 

--- a/lnd-rpc/lnd-rpc.sbt
+++ b/lnd-rpc/lnd-rpc.sbt
@@ -87,10 +87,15 @@ TaskKeys.downloadLnd := {
     val success = hash.equalsIgnoreCase(expectedHash)
     if (success) {
       logger.info(s"Download complete and verified, unzipping result")
-
-      val extractCommand = s"tar -xzf $archiveLocation --directory $binaryDir"
-      logger.info(s"Extracting archive with command: $extractCommand")
-      extractCommand.!!
+      val cmds = Vector(
+        "tar",
+        "-xzf",
+        archiveLocation.toString,
+        "--directory",
+        binaryDir.toString
+      )
+      logger.info(s"Extracting archive with command: $cmds")
+      cmds.!!
     } else {
       Files.deleteIfExists(versionDir)
       logger.error(

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -252,6 +252,7 @@ object CommonSettings {
           base
         } else {
           // fresh install, so use the proper spot
+          Files.createDirectories(full)
           full
         }
       }

--- a/project/EnvUtil.scala
+++ b/project/EnvUtil.scala
@@ -1,7 +1,7 @@
 import scala.util.Properties
 
 object EnvUtil {
-  private val osName = System.getProperty("os.name")
+  val osName = System.getProperty("os.name")
 
   lazy val isLinux: Boolean = osName.startsWith("Linux")
 

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="ERROR">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="ERROR">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/TestkitBinaries.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/TestkitBinaries.scala
@@ -2,8 +2,7 @@ package org.bitcoins.testkit.util
 
 import org.bitcoins.commons.config.AppConfig
 
-import java.nio.file.{Path, Paths}
-import scala.util.Properties
+import java.nio.file.{Path}
 
 object TestkitBinaries {
 
@@ -12,15 +11,5 @@ object TestkitBinaries {
 
   /** The base directory where binaries needed in tests are located.
     */
-  lazy val baseBinaryDirectory: Path = {
-    val home = Paths.get(Properties.userHome)
-    fromRoot(home)
-  }
-
-  /** Gives you an arbitrary root path, and then tacks on .bitcoin-s/binaries/
-    * onto the end of it
-    */
-  private def fromRoot(path: Path): Path = {
-    path.resolve(base)
-  }
+  lazy val baseBinaryDirectory: Path = base
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/TestkitBinaries.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/TestkitBinaries.scala
@@ -1,12 +1,14 @@
 package org.bitcoins.testkit.util
 
-import java.nio.file.{Path, Paths}
+import org.bitcoins.commons.config.AppConfig
 
+import java.nio.file.{Path, Paths}
 import scala.util.Properties
 
 object TestkitBinaries {
 
-  private val base: Path = Paths.get(".bitcoin-s", "binaries")
+  private val base: Path = AppConfig.DEFAULT_BITCOIN_S_DATADIR
+    .resolve("binaries")
 
   /** The base directory where binaries needed in tests are located.
     */
@@ -18,7 +20,7 @@ object TestkitBinaries {
   /** Gives you an arbitrary root path, and then tacks on .bitcoin-s/binaries/
     * onto the end of it
     */
-  def fromRoot(path: Path): Path = {
+  private def fromRoot(path: Path): Path = {
     path.resolve(base)
   }
 }


### PR DESCRIPTION
Addresses this comment for macOS https://github.com/bitcoin-s/bitcoin-s/blob/981669e02567b860ea94abc21b2f69a764d3e8e4/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala#L236

This now will place all application data inside of `~/Library/Application Support/bitcoin-s` for fresh installs.

This PR does not currently provide migration code to move from `~/.bitcoin-s` -> `~/Library/Application Support/bitcoin-s`. This will be done on a separate PR.