### PR TITLE
Rework `NativeProcessFactory.cmd` to be `Vector[String]`

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/util/NativeProcessFactory.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/NativeProcessFactory.scala
@@ -15,7 +15,7 @@ trait NativeProcessFactory extends BitcoinSLogger {
   private lazy val process: ProcessBuilder = scala.sys.process.Process(cmd)
 
   /** The command to start the daemon on the underlying OS */
-  def cmd: String
+  def cmd: Vector[String]
 
   def isAlive(): Boolean = {
     processOpt match {

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -131,16 +131,16 @@ trait Client
 
   def getDaemon: BitcoindInstance = instance
 
-  override lazy val cmd: String = {
+  override lazy val cmd: Vector[String] = {
     instance match {
       case _: BitcoindInstanceRemote =>
         logger.warn(
           s"Cannot start remote instance with local binary command. You've likely misconfigured something"
         )
-        ""
+        Vector.empty
       case local: BitcoindInstanceLocal =>
         val binaryPath = local.binary.getAbsolutePath
-        val cmd = List(
+        val cmd = Vector(
           binaryPath,
           "-datadir=" + local.datadir,
           "-rpcport=" + instance.rpcUri.getPort,
@@ -150,7 +150,7 @@ trait Client
           s"starting bitcoind with datadir ${local.datadir} and binary path $binaryPath"
         )
 
-        cmd.mkString(" ")
+        cmd
 
     }
   }

--- a/clightning-rpc/src/main/scala/com/bitcoins/clightning/rpc/CLightningRpcClient.scala
+++ b/clightning-rpc/src/main/scala/com/bitcoins/clightning/rpc/CLightningRpcClient.scala
@@ -396,12 +396,17 @@ class CLightningRpcClient(val instance: CLightningInstanceLocal, binary: File)(
     clightningCall[SendCustomMessageResult]("sendcustommsg", params)
   }
 
-  override val cmd: String = {
+  override val cmd: Vector[String] = {
     val logFileConf = instance.logFileOpt
       .map(f => s"--log-file=${f.getAbsolutePath}")
       .getOrElse("")
 
-    s"$binary --lightning-dir=${instance.datadir.toAbsolutePath} --rpc-file=${instance.rpcFile.getAbsolutePath} $logFileConf"
+    Vector(
+      binary.toString,
+      s"--lightning-dir=${instance.datadir.toAbsolutePath}",
+      s"--rpc-file=${instance.rpcFile.getAbsolutePath}",
+      logFileConf
+    )
   }
 
   override def start(): Future[CLightningRpcClient] = {

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -823,7 +823,7 @@ class EclairRpcClient(
       // default to provided binary
       case (Some(binary), _) =>
         if (binary.exists) {
-          binary.toString
+          binary.toPath.toAbsolutePath.toString
         } else {
           throw new NoSuchFileException(
             s"Given binary ($binary) does not exist!"
@@ -856,15 +856,15 @@ class EclairRpcClient(
   }
 
   override def cmd: Vector[String] = {
-    val logback = instance.logbackXmlPath
+    val logbackOpt = instance.logbackXmlPath
       .map(path => s"-Dlogback.configurationFile=$path")
-      .getOrElse("")
-    val cmd = {
-      Vector(
-        pathToEclairJar,
-        s"-Declair.datadir=${instance.authCredentials.datadir.get}",
-        logback
-      )
+    val base = Vector(
+      pathToEclairJar,
+      s"-Declair.datadir=${instance.authCredentials.datadir.get}"
+    )
+    val cmd = logbackOpt match {
+      case Some(logback) => base.appended(logback)
+      case None          => base
     }
     cmd
   }

--- a/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
+++ b/eclair-rpc/src/main/scala/org/bitcoins/eclair/rpc/client/EclairRpcClient.scala
@@ -855,12 +855,16 @@ class EclairRpcClient(
     }
   }
 
-  override def cmd: String = {
+  override def cmd: Vector[String] = {
     val logback = instance.logbackXmlPath
       .map(path => s"-Dlogback.configurationFile=$path")
       .getOrElse("")
     val cmd = {
-      s"${pathToEclairJar} -Declair.datadir=${instance.authCredentials.datadir.get} $logback"
+      Vector(
+        pathToEclairJar,
+        s"-Declair.datadir=${instance.authCredentials.datadir.get}",
+        logback
+      )
     }
     cmd
   }

--- a/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
+++ b/lnd-rpc/src/main/scala/org/bitcoins/lnd/rpc/LndRpcClient.scala
@@ -129,10 +129,13 @@ class LndRpcClient(val instance: LndInstance, binaryOpt: Option[File] = None)(
   }
 
   /** The command to start the daemon on the underlying OS */
-  override def cmd: String = instance match {
+  override def cmd: Vector[String] = instance match {
     case local: LndInstanceLocal =>
-      s"${binaryOpt.get} --lnddir=${local.datadir.toAbsolutePath}"
-    case _: LndInstanceRemote => ""
+      Vector(
+        binaryOpt.get.toString,
+        s"--lnddir=${local.datadir.toAbsolutePath}"
+      )
+    case _: LndInstanceRemote => Vector.empty
   }
 
   implicit val executionContext: ExecutionContext = system.dispatcher

--- a/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/client/TorClient.scala
@@ -59,7 +59,7 @@ class TorClient()(implicit
   private lazy val executable = TorClient.torBinaryFromResource(conf.torDir)
 
   /** The command to start the daemon on the underlying OS */
-  override lazy val cmd: String = {
+  override lazy val cmd: Vector[String] = {
 
     val args = Vector(
       "--ExitRelay 0", // ensure we aren't an exit relay
@@ -71,9 +71,9 @@ class TorClient()(implicit
       s"""--Log "notice file ${conf.torLogFile.toAbsolutePath}" """,
       s"""--GeoIPFile "${conf.torDir.toAbsolutePath.resolve("geoip")}" """,
       s"""--GeoIPv6File "${conf.torDir.toAbsolutePath.resolve("geoip6")}" """
-    ).mkString(" ")
+    )
 
-    s"$executable $args"
+    executable.toString +: args
   }
 
 }


### PR DESCRIPTION
Needed for #5622 

This will now allow us to input paths with a space in them such as `Application Support` for macosx