### PR TITLE
Move `WalletDAOs` to `src`

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/WalletDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/WalletDAOFixture.scala
@@ -8,31 +8,6 @@ import org.scalatest._
 
 import scala.concurrent.{Await, Future}
 
-case class WalletDAOs(
-    accountDAO: AccountDAO,
-    addressDAO: AddressDAO,
-    addressTagDAO: AddressTagDAO,
-    utxoDAO: SpendingInfoDAO,
-    transactionDAO: TransactionDAO,
-    incomingTxDAO: IncomingTransactionDAO,
-    outgoingTxDAO: OutgoingTransactionDAO,
-    scriptPubKeyDAO: ScriptPubKeyDAO,
-    stateDescriptorDAO: WalletStateDescriptorDAO
-) {
-
-  val list = Vector(
-    scriptPubKeyDAO,
-    accountDAO,
-    addressDAO,
-    addressTagDAO,
-    transactionDAO,
-    incomingTxDAO,
-    utxoDAO,
-    outgoingTxDAO,
-    stateDescriptorDAO
-  )
-}
-
 trait WalletDAOFixture extends BitcoinSFixture with EmbeddedPg {
 
   implicit protected val config: WalletAppConfig =

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -1,24 +1,24 @@
 package org.bitcoins.testkit.wallet
 
-import org.bitcoins.core.api.wallet.db._
+import org.bitcoins.core.api.wallet.db.*
 import org.bitcoins.core.config.RegTest
-import org.bitcoins.core.crypto._
-import org.bitcoins.core.currency._
-import org.bitcoins.core.hd._
+import org.bitcoins.core.crypto.*
+import org.bitcoins.core.currency.*
+import org.bitcoins.core.hd.*
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.{
   ChainParams,
   RegTestNetChainParams
 }
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.protocol.{Bech32Address, P2SHAddress}
-import org.bitcoins.core.wallet.utxo._
+import org.bitcoins.core.wallet.utxo.*
 import org.bitcoins.crypto.{CryptoUtil, DoubleSha256DigestBE, ECPublicKey}
-import org.bitcoins.testkit.fixtures.WalletDAOs
-import org.bitcoins.testkitcore.Implicits._
+import org.bitcoins.testkitcore.Implicits.*
 import org.bitcoins.testkitcore.gen.{CryptoGenerators, NumberGenerator}
 import org.bitcoins.wallet.config.WalletAppConfig
+import org.bitcoins.wallet.models.WalletDAOs
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/WalletDAOs.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/WalletDAOs.scala
@@ -1,0 +1,26 @@
+package org.bitcoins.wallet.models
+
+case class WalletDAOs(
+    accountDAO: AccountDAO,
+    addressDAO: AddressDAO,
+    addressTagDAO: AddressTagDAO,
+    utxoDAO: SpendingInfoDAO,
+    transactionDAO: TransactionDAO,
+    incomingTxDAO: IncomingTransactionDAO,
+    outgoingTxDAO: OutgoingTransactionDAO,
+    scriptPubKeyDAO: ScriptPubKeyDAO,
+    stateDescriptorDAO: WalletStateDescriptorDAO
+) {
+
+  val list = Vector(
+    scriptPubKeyDAO,
+    accountDAO,
+    addressDAO,
+    addressTagDAO,
+    transactionDAO,
+    incomingTxDAO,
+    utxoDAO,
+    outgoingTxDAO,
+    stateDescriptorDAO
+  )
+}


### PR DESCRIPTION
Makes it easier to pass around DAOs in src. 

Related to #3139 