### PR TITLE
Remove `WalletHolder` parameter from `DLCWalletLoaderApi.loadWallet()`

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -47,7 +47,6 @@ sealed trait DLCWalletLoaderApi
   ): Future[(WalletHolder, WalletAppConfig, DLCAppConfig)]
 
   protected def loadWallet(
-      walletHolder: WalletHolder,
       chainQueryApi: ChainQueryApi,
       nodeApi: NodeApi,
       feeProviderApi: FeeRateApi,
@@ -67,15 +66,6 @@ sealed trait DLCWalletLoaderApi
         walletName,
         aesPasswordOpt
       )
-      _ <- {
-        if (walletHolder.isInitialized) {
-          walletHolder
-            .stop()
-            .map(_ => ())
-        } else {
-          Future.unit
-        }
-      }
       _ <- walletConfig.start()
       _ <- dlcConfig.start()
       dlcWallet <- dlcConfig.createDLCWallet(
@@ -308,7 +298,6 @@ case class DLCWalletNeutrinoBackendLoader(
       _ <- stopCallbackF
       _ <- stopRescanF
       (dlcWallet, walletConfig, dlcConfig) <- loadWallet(
-        walletHolder = walletHolder,
         chainQueryApi = chainQueryApi,
         nodeApi = nodeApi,
         feeProviderApi = feeRateApi,
@@ -359,7 +348,6 @@ case class DLCWalletBitcoindBackendLoader(
       _ <- stopCallbackF
       _ <- stopRescanF
       (dlcWallet, walletConfig, dlcConfig) <- loadWallet(
-        walletHolder = walletHolder,
         chainQueryApi = bitcoind,
         nodeApi = nodeApi,
         feeProviderApi = feeProvider,


### PR DESCRIPTION
The call to `WalletHolder.stop()` is not needed as it occurs in [`WalletHolder.replaceWallet()`](https://github.com/bitcoin-s/bitcoin-s/blob/f5adc331f1af68419076fcfd2663076524c70f08/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala#L75)

This is redundant because both instances of [`DLCWalletLoaderApi.loadWallet()`](https://github.com/bitcoin-s/bitcoin-s/blob/5664a7fb95b20f9a568a778565c438a5d3c096fa/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala#L44) call `WalletHolder.replaceWallet()` which in turn calls the underlying [`Wallet.stop()`](https://github.com/bitcoin-s/bitcoin-s/blob/e68ebeadbce1ed35dbfe411eb243acc20d3b5713/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala#L59)