### PR TITLE
Refactor `WalletApi.createNewAccount` to not use `KeyManagerParams`

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -864,7 +864,8 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
     case ServerCommand("createnewaccount", _) =>
       complete {
         for {
-          newWallet <- wallet.createNewAccount(wallet.keyManager.kmParams)
+          newWallet <- wallet.createNewAccount(
+            wallet.keyManager.kmParams.purpose)
           accounts <- newWallet.listAccounts()
         } yield {
           val xpubs = accounts.map(_.xpub)

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/HDWalletApi.scala
@@ -16,7 +16,6 @@ import org.bitcoins.core.wallet.builder.{
   ShufflingNonInteractiveFinalizer
 }
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.core.wallet.utxo.AddressTag
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -487,7 +486,8 @@ trait HDWalletApi extends WalletApi {
       ec: ExecutionContext): Future[Vector[AccountDb]] =
     listAccounts().map(_.filter(_.hdAccount.purpose == purpose))
 
-  def createNewAccount(keyManagerParams: KeyManagerParams): Future[HDWalletApi]
+  /** Creates a new account with the given purpose */
+  def createNewAccount(purpose: HDPurpose): Future[HDWalletApi]
 
   /** Tries to create a new account in this wallet. Fails if the most recent
     * account has no transaction history, as per BIP44
@@ -495,9 +495,7 @@ trait HDWalletApi extends WalletApi {
     * @see
     *   [[https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#account BIP44 account section]]
     */
-  def createNewAccount(
-      hdAccount: HDAccount,
-      keyManagerParams: KeyManagerParams): Future[HDWalletApi]
+  def createNewAccount(hdAccount: HDAccount): Future[HDWalletApi]
 
   def findAccount(account: HDAccount): Future[Option[AccountDb]]
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
@@ -35,8 +35,7 @@ trait BitcoinSServerMainBitcoindFixture
 
         // needed for fundWalletWithBitcoind
         _ <- walletHolder.createNewAccount(
-          hdAccount = account1,
-          keyManagerParams = walletHolder.keyManager.kmParams
+          hdAccount = account1
         )
         walletWithBitcoind = WalletWithBitcoindRpc(
           walletHolder,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -389,8 +389,7 @@ object BitcoinSWalletTest extends WalletLogger {
       wallet <- defaultWalletF
       account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
       newAccountWallet <- wallet.createNewAccount(
-        hdAccount = account1,
-        kmParams = wallet.keyManager.kmParams
+        hdAccount = account1
       )
     } yield newAccountWallet
 
@@ -409,8 +408,7 @@ object BitcoinSWalletTest extends WalletLogger {
       )
       account1 = WalletTestUtil.getHdAccount1(wallet.walletConfig)
       newAccountWallet <- wallet.createNewAccount(
-        hdAccount = account1,
-        kmParams = wallet.keyManager.kmParams
+        hdAccount = account1
       )
     } yield newAccountWallet.asInstanceOf[DLCWallet]
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -218,7 +218,7 @@ class FundTransactionHandlingTest
       val bitcoind = fundedWallet.bitcoind
       val fundedTxF = for {
         feeRate <- wallet.getFeeRate()
-        _ <- wallet.createNewAccount(wallet.keyManager.kmParams)
+        _ <- wallet.createNewAccount(wallet.keyManager.kmParams.purpose)
         accounts <- wallet.listAccounts()
         account2 = accounts.find(_.hdAccount.index == 2).get
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -195,7 +195,7 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
     val accountsToCreate = existing.length until testVectors.length
     FutureUtil
       .sequentially(accountsToCreate) { _ =>
-        wallet.createNewAccount(keyManagerParams)
+        wallet.createNewAccount(keyManagerParams.purpose)
       }
       .map(_ => ())
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -26,7 +26,6 @@ import org.bitcoins.core.script.control.OP_RETURN
 import org.bitcoins.core.util.{BitcoinScriptUtil, FutureUtil, HDUtil}
 import org.bitcoins.core.wallet.builder.*
 import org.bitcoins.core.wallet.fee.*
-import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.core.wallet.utxo.*
 import org.bitcoins.core.wallet.utxo.TxoState.*
 import org.bitcoins.crypto.*
@@ -898,25 +897,24 @@ abstract class Wallet
     *
     * @return
     */
-  override def createNewAccount(kmParams: KeyManagerParams): Future[Wallet] = {
-    getLastAccountOpt(kmParams.purpose).flatMap {
+  override def createNewAccount(purpose: HDPurpose): Future[Wallet] = {
+    getLastAccountOpt(purpose).flatMap {
       case Some(accountDb) =>
         val hdAccount = accountDb.hdAccount
         val newAccount = hdAccount.copy(index = hdAccount.index + 1)
-        createNewAccount(newAccount, kmParams)
+        createNewAccount(newAccount)
       case None =>
-        createNewAccount(walletConfig.defaultAccount, kmParams)
+        createNewAccount(walletConfig.defaultAccount)
     }
   }
 
   // todo: check if there's addresses in the most recent
   // account before creating new
   override def createNewAccount(
-      hdAccount: HDAccount,
-      kmParams: KeyManagerParams
+      hdAccount: HDAccount
   ): Future[Wallet] = {
     logger.info(
-      s"Creating new account at index ${hdAccount.index} for purpose ${kmParams.purpose}"
+      s"Creating new account at index ${hdAccount.index} for purpose ${hdAccount.purpose}"
     )
 
     val xpub: ExtPublicKey = {

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -35,7 +35,6 @@ import org.bitcoins.core.wallet.builder.{
   ShufflingNonInteractiveFinalizer
 }
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
-import org.bitcoins.core.wallet.keymanagement.KeyManagerParams
 import org.bitcoins.core.wallet.rescan.RescanState
 import org.bitcoins.core.wallet.utxo.{
   AddressTag,
@@ -659,15 +658,13 @@ class WalletHolder(initWalletOpt: Option[DLCNeutrinoHDWalletApi])(implicit
   )
 
   override def createNewAccount(
-      keyManagerParams: KeyManagerParams
-  ): Future[HDWalletApi] = delegate(_.createNewAccount(keyManagerParams))
+      purpose: HDPurpose
+  ): Future[HDWalletApi] = delegate(_.createNewAccount(purpose))
 
-  override def createNewAccount(
-      hdAccount: HDAccount,
-      keyManagerParams: KeyManagerParams
-  ): Future[HDWalletApi] = delegate(
-    _.createNewAccount(hdAccount, keyManagerParams)
-  )
+  override def createNewAccount(hdAccount: HDAccount): Future[HDWalletApi] =
+    delegate(
+      _.createNewAccount(hdAccount)
+    )
 
   override def getSyncDescriptorOpt(): Future[Option[SyncHeightDescriptor]] =
     delegate(_.getSyncDescriptorOpt())


### PR DESCRIPTION
There doesn't seem to be a purpose of using `KeyManagerParams` in the `WalletApi.createNewAccounts()` APIs. 