### PR TITLE
refactor: Change interval param of `BitcoindRpcBackendUtil.startBitcoindBlockPolling`

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -2,14 +2,21 @@ package org.bitcoins.server
 
 import org.apache.pekko.actor.{ActorSystem, Cancellable}
 import org.apache.pekko.stream.OverflowStrategy
-import org.apache.pekko.stream.scaladsl.{Flow, Keep, RunnableGraph, Sink, Source, SourceQueueWithComplete}
+import org.apache.pekko.stream.scaladsl.{
+  Flow,
+  Keep,
+  RunnableGraph,
+  Sink,
+  Source,
+  SourceQueueWithComplete
+}
 import org.apache.pekko.{Done, NotUsed}
 import org.bitcoins.chain.ChainCallbacks
 import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockHeaderResult
 import org.bitcoins.commons.util.BitcoinSLogger
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.api.wallet.{NeutrinoHDWalletApi, WalletApi}
-import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
+import org.bitcoins.core.config.{MainNet, RegTest, SigNet, TestNet3}
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.Transaction
@@ -430,8 +437,8 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
     *   The starting block height of the wallet
     * @param interval
     *   The amount of time between polls, this should not be too aggressive as
-    *   the wallet will need to process the new blocks. If you do not provide this we
-   *   will intelligently choose one depending on the network we are on
+    *   the wallet will need to process the new blocks. If you do not provide
+    *   this we will intelligently choose one depending on the network we are on
     */
   def startBitcoindBlockPolling(
       wallet: WalletApi,
@@ -443,8 +450,8 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
     import system.dispatcher
     val interval = intervalOpt.getOrElse {
       bitcoind.bitcoindRpcAppConfig.network match {
-        case MainNet | TestNet3 => 10.seconds
-        case RegTest => 1.second
+        case MainNet | TestNet3 | SigNet => 10.seconds
+        case RegTest                     => 1.second
       }
     }
     val processingBitcoindBlocks = new AtomicBoolean(false)

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -2,20 +2,14 @@ package org.bitcoins.server
 
 import org.apache.pekko.actor.{ActorSystem, Cancellable}
 import org.apache.pekko.stream.OverflowStrategy
-import org.apache.pekko.stream.scaladsl.{
-  Flow,
-  Keep,
-  RunnableGraph,
-  Sink,
-  Source,
-  SourceQueueWithComplete
-}
+import org.apache.pekko.stream.scaladsl.{Flow, Keep, RunnableGraph, Sink, Source, SourceQueueWithComplete}
 import org.apache.pekko.{Done, NotUsed}
 import org.bitcoins.chain.ChainCallbacks
-import org.bitcoins.commons.jsonmodels.bitcoind.{GetBlockHeaderResult}
+import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockHeaderResult
 import org.bitcoins.commons.util.BitcoinSLogger
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.api.wallet.{NeutrinoHDWalletApi, WalletApi}
+import org.bitcoins.core.config.{MainNet, RegTest, TestNet3}
 import org.bitcoins.core.gcs.FilterType
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.Transaction
@@ -436,17 +430,23 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
     *   The starting block height of the wallet
     * @param interval
     *   The amount of time between polls, this should not be too aggressive as
-    *   the wallet will need to process the new blocks
+    *   the wallet will need to process the new blocks. If you do not provide this we
+   *   will intelligently choose one depending on the network we are on
     */
   def startBitcoindBlockPolling(
       wallet: WalletApi,
       bitcoind: BitcoindRpcClient,
       chainCallbacksOpt: Option[ChainCallbacks],
-      interval: FiniteDuration = 10.seconds
+      intervalOpt: Option[FiniteDuration] = None
   )(processBlock: Block => Future[Unit])(implicit
       system: ActorSystem): Cancellable = {
     import system.dispatcher
-
+    val interval = intervalOpt.getOrElse {
+      bitcoind.bitcoindRpcAppConfig.network match {
+        case MainNet | TestNet3 => 10.seconds
+        case RegTest => 1.second
+      }
+    }
     val processingBitcoindBlocks = new AtomicBoolean(false)
 
     system.scheduler.scheduleWithFixedDelay(0.seconds, interval) { () =>

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBlockPollingTest.scala
@@ -50,8 +50,7 @@ class BitcoindBlockPollingTest
         cancellable = BitcoindRpcBackendUtil.startBitcoindBlockPolling(
           wallet,
           bitcoind,
-          None,
-          1.second
+          None
         )(wallet.processBlock(_).map(_ => ()))
         _ <- bitcoind.generateToAddress(6, bech32Address)
 


### PR DESCRIPTION
The parameter `interval` is now an `Option`, if none given we select a sane parameter based on the network we are on. This should speed up unit tests that run on `RegTest` such as `WebsocketTests`