### PR TITLE
wallet: Remove unecessary type parameter to `TxCRUDComponent#TxTable`

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRemoteTxDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRemoteTxDAO.scala
@@ -25,7 +25,7 @@ case class DLCRemoteTxDAO()(implicit
     TableQuery[DLCRemoteTxTable]
 
   class DLCRemoteTxTable(tag: Tag)
-      extends TxTable[TransactionDb](tag, schemaName, "watch_only_tx_table") {
+      extends TxTable(tag, schemaName, "watch_only_tx_table") {
     def txIdBE: Rep[DoubleSha256DigestBE] = column("txIdBE", O.PrimaryKey)
 
     def transaction: Rep[Transaction] = column("transaction")

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/IncomingTransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/IncomingTransactionDAO.scala
@@ -24,7 +24,7 @@ case class IncomingTransactionDAO()(implicit
   }
 
   class IncomingTransactionTable(tag: Tag)
-      extends TxTable[IncomingTransactionDb](
+      extends TxTable(
         tag,
         schemaName,
         "wallet_incoming_txs"

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/OutgoingTransactionDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/OutgoingTransactionDAO.scala
@@ -25,7 +25,7 @@ case class OutgoingTransactionDAO()(implicit
   }
 
   class OutgoingTransactionTable(tag: Tag)
-      extends TxTable[OutgoingTransactionDb](
+      extends TxTable(
         tag,
         schemaName,
         "wallet_outgoing_txs"


### PR DESCRIPTION
This type parameter is not needed. Hopefully removing it makes it easier to upgrade to scala3 (#3497 )