### PR TITLE
Make `WebsocketTests` rescan test more robust

### DIFF
--- a/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
+++ b/app/server-routes/src/main/scala/org/bitcoins/server/routes/Server.scala
@@ -308,7 +308,7 @@ object Server extends BitcoinSLogger {
   }
 
   def httpBadRequest(ex: Throwable): HttpResponse = {
-    logger.error(s"Http bad request", ex)
+    logger.info(s"Http bad request", ex)
     val msg = ex.getMessage
     val entity = httpError(msg)
     HttpResponse(status = StatusCodes.BadRequest, entity = entity)

--- a/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTest.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/BitcoinSServerMainBitcoindTest.scala
@@ -110,7 +110,7 @@ class BitcoinSServerMainBitcoindTest
       // again switch to bob
       val imported2 =
         ConsoleCli.exec(ImportSeed(bob, mnemonic, None), cliConfig)
-      assert(imported2.isFailure)
+      assert(!upickle.default.read[Boolean](imported2.get))
       val bobLoaded2 =
         ConsoleCli.exec(LoadWallet(bob, None, None), cliConfig)
       assert(bobLoaded2.get == "bob")

--- a/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
@@ -13,6 +13,8 @@ import org.apache.pekko.http.scaladsl.model.ws.{
 }
 import org.apache.pekko.http.scaladsl.model.{HttpHeader, StatusCodes}
 import org.apache.pekko.stream.scaladsl.{Flow, Keep, Sink, Source}
+import org.bitcoins.asyncutil.AsyncUtil
+import org.bitcoins.cli.CliCommand.WalletInfo
 import org.bitcoins.cli.ConsoleCli.exec
 import org.bitcoins.cli.{CliCommand, Config, ConsoleCli}
 import org.bitcoins.commons.jsonmodels.ws.ChainNotification.{
@@ -24,9 +26,9 @@ import org.bitcoins.commons.jsonmodels.ws.DLCNodeNotification.{
   DLCNodeConnectionFailed,
   DLCNodeConnectionInitiated
 }
-import org.bitcoins.commons.jsonmodels.ws.WalletNotification._
-import org.bitcoins.commons.jsonmodels.ws._
-import org.bitcoins.commons.rpc._
+import org.bitcoins.commons.jsonmodels.ws.WalletNotification.*
+import org.bitcoins.commons.jsonmodels.ws.*
+import org.bitcoins.commons.rpc.*
 import org.bitcoins.commons.serializers.{Picklers, WsPicklers}
 import org.bitcoins.core.currency.Bitcoins
 import org.bitcoins.core.protocol.BitcoinAddress
@@ -304,7 +306,7 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
 
     val addressF = bitcoind.getNewAddress
     val timeout =
-      15.seconds // any way we can remove this timeout and just check?
+      5.seconds // any way we can remove this timeout and just check?
     for {
       address <- addressF
       hashes <- bitcoind.generateToAddress(1, address)
@@ -442,7 +444,11 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
     )
     val _ = ConsoleCli.exec(cmd, cliConfig)
     for {
-      _ <- PekkoUtil.nonBlockingSleep(10.second)
+      _ <- AsyncUtil.retryUntilSatisfied({
+        val walletInfoStr = ConsoleCli.exec(WalletInfo, cliConfig)
+        val i = upickle.default.read(walletInfoStr.get)(Picklers.walletInfo)
+        !i.rescan
+      })
       _ = promise.success(None)
       notifications <- notificationsF
     } yield {

--- a/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WebsocketTests.scala
@@ -189,7 +189,7 @@ class WebsocketTests extends BitcoinSServerMainBitcoindFixture {
       val expectedAddress = BitcoinAddress.fromString(expectedAddressStr)
 
       for {
-        _ <- PekkoUtil.nonBlockingSleep(500.millis)
+        _ <- PekkoUtil.nonBlockingSleep(1.second)
         _ = promise.success(None)
         notifications <- walletNotificationsF
       } yield {

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -930,9 +930,14 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
                 )
             }
 
-            WalletStorage.writeSeedToDisk(seedPath, mnemonicState)
-
-            Server.httpSuccess(ujson.Null)
+            if (Files.exists(seedPath)) {
+              logger.warn(
+                s"Seed already exists at file path=$seedPath, ignoring import request")
+              Server.httpSuccess(ujson.Bool(false))
+            } else {
+              WalletStorage.writeSeedToDisk(seedPath, mnemonicState)
+              Server.httpSuccess(ujson.Bool(true))
+            }
           }
       }
 

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -1086,25 +1086,11 @@ case class WalletRoutes(loadWalletApi: DLCWalletLoaderApi)(implicit
   }
 
   /** Returns information about the state of our wallet */
-  def getInfo: Future[Obj] = {
+  def getInfo: Future[Value] = {
     for {
       info <- wallet.getInfo()
     } yield {
-      Obj(
-        WalletAppConfig.moduleName ->
-          Obj(
-            KeyManagerAppConfig.moduleName -> Obj(
-              "rootXpub" -> Str(info.rootXpub.toString)
-            ),
-            "walletName" -> Str(info.walletName),
-            "xpub" -> Str(info.xpub.toString),
-            "hdPath" -> Str(info.hdAccount.toString),
-            "height" -> Num(info.height),
-            "blockHash" -> Str(info.blockHash.hex),
-            "rescan" -> info.rescan,
-            "imported" -> info.imported
-          )
-      )
+      upickle.default.writeJs(info)(Picklers.walletInfo)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/hd/HDAccount.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDAccount.scala
@@ -1,6 +1,7 @@
 package org.bitcoins.core.hd
 
 import org.bitcoins.core.crypto.ExtKeyVersion
+import org.bitcoins.crypto.StringFactory
 
 /** Represents a
   * [[https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Account BIP44]],
@@ -26,7 +27,7 @@ case class HDAccount(
     HDChain(chainType = chainType, account = this)
 }
 
-object HDAccount {
+object HDAccount extends StringFactory[HDAccount] {
 
   def fromPath(path: BIP32Path): Option[HDAccount] = {
 
@@ -38,6 +39,12 @@ object HDAccount {
         None
       }
     }
+  }
+
+  override def fromString(string: String): HDAccount = {
+    val path = BIP32Path.fromString(string)
+    fromPath(path).getOrElse(
+      sys.error(s"Could not parse HDAccount from string=$string"))
   }
 
   /** This method is meant to take in an arbitrary bip32 path and see if it has

--- a/core/src/main/scala/org/bitcoins/core/serializers/PicklerKeys.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/PicklerKeys.scala
@@ -171,4 +171,12 @@ object PicklerKeys {
 
   val errorKey: String = "error"
 
+  val walletKey: String = "wallet"
+  val keyManagerKey: String = "keymanager"
+  val rootXpubKey: String = "rootXpub"
+  val walletNameKey: String = "walletName"
+  val hdAccountKey: String = "hdAccount"
+  val xpubKey: String = "xpub"
+  val rescanKey: String = "rescan"
+  val importKey: String = "imported"
 }

--- a/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/callback/NodeCallbackStreamManager.scala
@@ -134,10 +134,6 @@ case class NodeCallbackStreamManager(
       merkleBlockQueue.complete()
       blockQueue.complete()
       isStopped.set(true)
-    } else {
-      logger.warn(
-        s"Already stopped all queues associated with this NodeCallBackStreamManager"
-      )
     }
 
     for {


### PR DESCRIPTION
Make the rescan `"receive updates when a rescan is complete"` more robust by checking when the `rescan` flag is `false` based on `walletinfo` response.