### PR TITLE
Add caveat for `ConnectPeer` logic to only attempt to sync from a peer when a query is timed out

### DIFF
--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -35,7 +35,7 @@
         <appender-ref ref="ASYNC-FILE"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="INFO"/>
+    <logger name="org.bitcoins.node" level="DEBUG"/>
 
     <logger name="org.bitcoins.chain" level="INFO"/>
 

--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -35,7 +35,7 @@
         <appender-ref ref="ASYNC-FILE"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="DEBUG"/>
+    <logger name="org.bitcoins.node" level="INFO"/>
 
     <logger name="org.bitcoins.chain" level="INFO"/>
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -118,7 +118,7 @@ case class PeerConnection(peer: Peer, queue: SourceQueue[NodeStreamMessage])(
       .log(
         "parseToNetworkMsgFlow",
         { case msgs: Vector[NetworkMessage] =>
-          s"received msgs=${msgs.map(_.payload.commandName)} from peer=$peer socket=$socket"
+          s"received msgs=${msgs.map(_.payload.commandName)} from peer=$peer"
         }
       )
       .withAttributes(Attributes.logLevels(onFailure = Logging.DebugLevel))


### PR DESCRIPTION
fixes #5665 

Now we only attempt to sync if the current query is timed out. This should avoid this log 

>2024-09-12 15:41:54,685UTC WARN [DataMessageHandler] Received duplicate headers from Peer(216.232.100.159:8333) in state=DoneSyncing(peers=Set(Peer(216.232.100.159:8333)),waitingForDisconnection=Set()) 

Previously we would _always_ attempt to re-request block headers if we were in `SyncNodeState` and we connected with a new peer.