### PR TITLE
refactor: Move more methods out of `WalletApi`

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -18,6 +18,7 @@ import org.bitcoins.core.api.wallet.{
   FundTransactionHandlingApi,
   RescanHandlingApi,
   SendFundsHandlingApi,
+  TransactionProcessingApi,
   UtxoHandlingApi
 }
 import org.bitcoins.core.config.RegTest
@@ -103,6 +104,9 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
   val mockAccountHandlingApi: AccountHandlingApi = mock[AccountHandlingApi]
 
   val mockAddressHandlingApi: AddressHandlingApi = mock[AddressHandlingApi]
+
+  val mockTransactionProcessingApi: TransactionProcessingApi =
+    mock[TransactionProcessingApi]
 
   val mockFundTxHandlingApi: FundTransactionHandlingApi =
     mock[FundTransactionHandlingApi]
@@ -453,6 +457,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     val spendingInfoDb = TransactionTestUtil.spendingInfoDb
 
     "return the wallet's balances in bitcoin" in {
+
+      (() => mockWalletApi.utxoHandling)
+        .expects()
+        .returning(mockUtxoHandlingApi)
+        .anyNumberOfTimes()
+
       (() => mockWalletApi.getConfirmedBalance())
         .expects()
         .returning(Future.successful(Bitcoins(50)))
@@ -461,7 +471,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .expects()
         .returning(Future.successful(Bitcoins(50)))
 
-      (mockWalletApi
+      (mockWalletApi.utxoHandling
         .listUtxos(_: TxoState))
         .expects(TxoState.Reserved)
         .returning(Future.successful(Vector(spendingInfoDb)))
@@ -488,7 +498,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .expects()
         .returning(Future.successful(Bitcoins(50)))
 
-      (mockWalletApi
+      (() => mockWalletApi.utxoHandling)
+        .expects()
+        .returning(mockUtxoHandlingApi)
+        .anyNumberOfTimes()
+
+      (mockWalletApi.utxoHandling
         .listUtxos(_: TxoState))
         .expects(TxoState.Reserved)
         .returning(Future.successful(Vector(spendingInfoDb)))
@@ -537,8 +552,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     }
 
     "return the wallet utxos" in {
+      (() => mockWalletApi.utxoHandling)
+        .expects()
+        .returning(mockUtxoHandlingApi)
+        .anyNumberOfTimes()
 
-      (() => mockWalletApi.listUtxos())
+      (() => mockWalletApi.utxoHandling.listUtxos())
         .expects()
         .returning(Future.successful(Vector(spendingInfoDb)))
 
@@ -554,8 +573,11 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     }
 
     "return the reserved wallet utxos" in {
-
-      (mockWalletApi
+      (() => mockWalletApi.utxoHandling)
+        .expects()
+        .returning(mockUtxoHandlingApi)
+        .anyNumberOfTimes()
+      (mockWalletApi.utxoHandling
         .listUtxos(_: TxoState))
         .expects(TxoState.Reserved)
         .returning(Future.successful(Vector(spendingInfoDb)))
@@ -799,24 +821,34 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
     }
 
     "lock unspent" in {
-      (() => mockWalletApi.listUtxos())
+      (() => mockWalletApi.utxoHandling)
+        .expects()
+        .returning(mockUtxoHandlingApi)
+        .anyNumberOfTimes()
+
+      (() => mockWalletApi.utxoHandling.listUtxos())
         .expects()
         .returning(Future.successful(Vector(spendingInfoDb)))
         .anyNumberOfTimes()
 
-      (mockWalletApi
+      (mockWalletApi.utxoHandling
         .listUtxos(_: TxoState))
         .expects(TxoState.Reserved)
         .returning(Future.successful(Vector(spendingInfoDb)))
         .anyNumberOfTimes()
 
-      (mockWalletApi
+      (() => mockWalletApi.utxoHandling)
+        .expects()
+        .returning(mockUtxoHandlingApi)
+        .anyNumberOfTimes()
+
+      (mockWalletApi.utxoHandling
         .markUTXOsAsReserved(_: Vector[SpendingInfoDb]))
         .expects(Vector(spendingInfoDb))
         .returning(Future.successful(Vector(spendingInfoDb)))
         .anyNumberOfTimes()
 
-      (mockWalletApi
+      (mockWalletApi.utxoHandling
         .unmarkUTXOsAsReserved(_: Vector[SpendingInfoDb]))
         .expects(Vector(spendingInfoDb))
         .returning(Future.successful(Vector(spendingInfoDb)))
@@ -1116,7 +1148,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
 
       val txDb = TransactionDbHelper.fromTransaction(tx, None)
 
-      (mockWalletApi
+      (() => mockWalletApi.transactionProcessing)
+        .expects()
+        .returning(mockTransactionProcessingApi)
+        .anyNumberOfTimes()
+
+      (mockWalletApi.transactionProcessing
         .findByTxIds(_: Vector[DoubleSha256DigestBE]))
         .expects(Vector(tx.txIdBE))
         .returning(Future.successful(Vector(txDb)))

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSServerMain.scala
@@ -620,7 +620,7 @@ class BitcoinSServerMain(override val serverArgParser: ServerArgParser)(implicit
         wallet,
         chainCallbacksOpt
       )(system)
-      _ = syncF.map(_ => wallet.updateUtxoPendingStates())
+      _ = syncF.map(_ => wallet.utxoHandling.updateUtxoPendingStates())
 
       // don't start polling until initial sync is done
       pollingCancellable <- syncF.flatMap { _ =>

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -102,7 +102,7 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
       bitcoindHeight: Int
   )(implicit ex: ExecutionContext): Future[Range.Inclusive] = {
     for {
-      txDbs <- wallet.listTransactions()
+      txDbs <- wallet.transactionProcessing.listTransactions()
       lastConfirmedOpt = txDbs
         .filter(_.blockHashOpt.isDefined)
         .lastOption
@@ -391,7 +391,7 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
         for {
           _ <- doneF
           w <- walletF
-          _ <- w.updateUtxoPendingStates()
+          _ <- w.utxoHandling.updateUtxoPendingStates()
         } yield ()
       }
 

--- a/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
@@ -60,7 +60,7 @@ object CallbackUtil extends BitcoinSLogger {
         if (headers.isEmpty) {
           Future.unit
         } else {
-          wallet.updateUtxoPendingStates().map(_ => ())
+          wallet.utxoHandling.updateUtxoPendingStates().map(_ => ())
         }
       }
     }

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/AddressHandlingApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/AddressHandlingApi.scala
@@ -59,6 +59,11 @@ trait AddressHandlingApi {
       address: BitcoinAddress,
       tagType: AddressTagType
   ): Future[Vector[AddressTagDb]]
+
+  /** Determines if the given output is from this wallet and is a change output
+    * from this wallet
+    */
+  def isChange(output: TransactionOutput): Future[Boolean]
   def listAddresses(): Future[Vector[AddressDb]]
   def listUnusedAddresses(): Future[Vector[AddressDb]]
   def listScriptPubKeys(): Future[Vector[ScriptPubKeyDb]]

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/SendFundsHandlingApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/SendFundsHandlingApi.scala
@@ -29,7 +29,7 @@ trait SendFundsHandlingApi {
   def bumpFeeCPFP(
       txId: DoubleSha256DigestBE,
       feeRate: FeeUnit): Future[Transaction]
-
+  def getTransactionsToBroadcast: Future[Vector[Transaction]]
   def makeOpReturnCommitment(
       message: String,
       hashMessage: Boolean,

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/TransactionProcessingApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/TransactionProcessingApi.scala
@@ -6,11 +6,24 @@ import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.{OutputWithIndex, Transaction}
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.AddressTag
-import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait TransactionProcessingApi {
+  def findByTxIds(
+      txIds: Vector[DoubleSha256DigestBE]): Future[Vector[TransactionDb]]
+  final def findByTxId(txId: DoubleSha256DigestBE)(implicit
+      ec: ExecutionContext): Future[Option[TransactionDb]] = {
+    findByTxIds(Vector(txId)).map(_.headOption)
+  }
+  final def findByTxId(txId: DoubleSha256Digest)(implicit
+      ec: ExecutionContext): Future[Option[TransactionDb]] = {
+    findByTxId(txId.flip)
+  }
+
+  def listTransactions(): Future[Vector[TransactionDb]]
+
   def processTransaction(
       transaction: Transaction,
       blockHashOpt: Option[DoubleSha256DigestBE]
@@ -32,7 +45,6 @@ trait TransactionProcessingApi {
   def findTransaction(
       txId: DoubleSha256DigestBE
   ): Future[Option[TransactionDb]]
-  def listTransactions(): Future[Vector[TransactionDb]]
 
   def subscribeForBlockProcessingCompletionSignal(
       blockHash: DoubleSha256DigestBE

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/WalletApi.scala
@@ -3,21 +3,14 @@ package org.bitcoins.core.api.wallet
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
-import org.bitcoins.core.api.wallet.db.*
 import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.core.protocol.script.ScriptPubKey
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionOutPoint,
-  TransactionOutput
-}
+import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.StartStopAsync
 import org.bitcoins.core.wallet.fee.FeeUnit
-import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
-import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
+import org.bitcoins.crypto.DoubleSha256DigestBE
 
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
@@ -46,8 +39,6 @@ trait WalletApi extends StartStopAsync[WalletApi] {
   def broadcastTransaction(transaction: Transaction): Future[Unit] =
     nodeApi.broadcastTransaction(transaction)
 
-  def getTransactionsToBroadcast: Future[Vector[Transaction]]
-
   def getFeeRate(): Future[FeeUnit] = feeRateApi.getFeeRate()
 
   def start(): Future[WalletApi]
@@ -65,22 +56,8 @@ trait WalletApi extends StartStopAsync[WalletApi] {
     } yield confirmed + unconfirmed
   }
 
-  /** Gets the sum of all UTXOs in this wallet with the address tag */
-  def getBalance(tag: AddressTag)(implicit
-      ec: ExecutionContext): Future[CurrencyUnit] = {
-    val confirmedF = getConfirmedBalance(tag)
-    val unconfirmedF = getUnconfirmedBalance(tag)
-
-    for {
-      confirmed <- confirmedF
-      unconfirmed <- unconfirmedF
-    } yield confirmed + unconfirmed
-  }
-
   /** Gets the sum of all confirmed UTXOs in this wallet */
   def getConfirmedBalance(): Future[CurrencyUnit]
-
-  def getConfirmedBalance(tag: AddressTag): Future[CurrencyUnit]
 
   def getNewAddress(): Future[BitcoinAddress]
 
@@ -89,31 +66,8 @@ trait WalletApi extends StartStopAsync[WalletApi] {
   /** Gets the sum of all unconfirmed UTXOs in this wallet */
   def getUnconfirmedBalance(): Future[CurrencyUnit]
 
-  def getUnconfirmedBalance(tag: AddressTag): Future[CurrencyUnit]
-
-  def listTransactions(): Future[Vector[TransactionDb]]
-
-  def listUtxos(): Future[Vector[SpendingInfoDb]]
-
-  def listUtxos(state: TxoState): Future[Vector[SpendingInfoDb]]
-
-  def listUtxos(tag: AddressTag): Future[Vector[SpendingInfoDb]]
-
   /** Checks if the wallet contains any data */
   def isEmpty(): Future[Boolean]
-
-  protected def determineFeeRate(feeRateOpt: Option[FeeUnit]): Future[FeeUnit] =
-    feeRateOpt match {
-      case None =>
-        feeRateApi.getFeeRate()
-      case Some(feeRate) =>
-        Future.successful(feeRate)
-    }
-
-  /** Determines if the given output is from this wallet and is a change output
-    * from this wallet
-    */
-  def isChange(output: TransactionOutput): Future[Boolean]
 
   def getSyncState(): Future[BlockSyncState]
 
@@ -124,54 +78,6 @@ trait WalletApi extends StartStopAsync[WalletApi] {
   def getWalletName(): Future[String]
 
   def getInfo(): Future[WalletInfo]
-
-  def findByOutPoints(
-      outPoints: Vector[TransactionOutPoint]): Future[Vector[SpendingInfoDb]]
-
-  def findByOutPoint(outPoint: TransactionOutPoint)(implicit
-      ec: ExecutionContext): Future[Option[SpendingInfoDb]] = {
-    findByOutPoints(Vector(outPoint)).map(_.headOption)
-  }
-
-  def findByTxIds(
-      txIds: Vector[DoubleSha256DigestBE]): Future[Vector[TransactionDb]]
-
-  def findByTxId(txId: DoubleSha256DigestBE)(implicit
-      ec: ExecutionContext): Future[Option[TransactionDb]] = {
-    findByTxIds(Vector(txId)).map(_.headOption)
-  }
-
-  def findByTxId(txId: DoubleSha256Digest)(implicit
-      ec: ExecutionContext): Future[Option[TransactionDb]] = {
-    findByTxId(txId.flip)
-  }
-
-  /** Finds all the outputs in our wallet being spent in the given transaction
-    */
-  def findOutputsBeingSpent(tx: Transaction): Future[Vector[SpendingInfoDb]]
-
-  def findByScriptPubKey(
-      scriptPubKey: ScriptPubKey): Future[Vector[SpendingInfoDb]]
-
-  /** Takes in a block header and updates our TxoStates to the new chain tip
-    * @param blockHeader
-    *   Block header we are processing
-    */
-  def updateUtxoPendingStates(): Future[Vector[SpendingInfoDb]]
-
-  def markUTXOsAsReserved(
-      utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]]
-
-  /** Marks all utxos that are ours in this transactions as reserved */
-  def markUTXOsAsReserved(tx: Transaction): Future[Vector[SpendingInfoDb]]
-
-  def unmarkUTXOsAsReserved(
-      utxos: Vector[SpendingInfoDb]): Future[Vector[SpendingInfoDb]]
-
-  /** Unmarks all utxos that are ours in this transactions indicating they are
-    * no longer reserved
-    */
-  def unmarkUTXOsAsReserved(tx: Transaction): Future[Vector[SpendingInfoDb]]
 }
 
 case class WalletInfo(

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
@@ -92,8 +92,8 @@ class MultiWalletDLCTest extends BitcoinSWalletTest {
       // now unreserve the utxo
       val reservedUtxoF = for {
         _ <- offerF
-        utxos <- wallet.listUtxos(TxoState.Reserved)
-        _ <- wallet.unmarkUTXOsAsReserved(utxos)
+        utxos <- wallet.utxoHandling.listUtxos(TxoState.Reserved)
+        _ <- wallet.utxoHandling.unmarkUTXOsAsReserved(utxos)
       } yield ()
 
       // now cancel the offer

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -25,7 +25,7 @@ import org.bitcoins.core.wallet.builder.{
   FundRawTxHelper,
   ShufflingNonInteractiveFinalizer
 }
-import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
+import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.utxo.*
 import org.bitcoins.crypto.*
 import org.bitcoins.db.SafeDatabase
@@ -2247,6 +2247,14 @@ abstract class DLCWallet
       )
     }
   }
+
+  private def determineFeeRate(feeRateOpt: Option[FeeUnit]): Future[FeeUnit] =
+    feeRateOpt match {
+      case None =>
+        feeRateApi.getFeeRate()
+      case Some(feeRate) =>
+        Future.successful(feeRate)
+    }
 }
 
 object DLCWallet extends WalletLogger {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -66,6 +66,12 @@ case class DLCTransactionProcessing(
     dlcWalletDAOs.dlcAnnouncementDAO
   private lazy val safeDLCDatabase: SafeDatabase = dlcDAO.safeDatabase
 
+  override def findByTxIds(
+      txIds: Vector[DoubleSha256DigestBE]
+  ): Future[Vector[TransactionDb]] = {
+    transactionDAO.findByTxIds(txIds)
+  }
+
   /** Calculates the new state of the DLCDb based on the closing transaction,
     * will delete old CET sigs that are no longer needed after execution
     * @return

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -124,7 +124,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
         maxTries = 30
       )
       // assert we got the full tx with witness data
-      txs <- wallet.listTransactions()
+      txs <- wallet.transactionProcessing.listTransactions()
     } yield assert(txs.exists(_.transaction == expectedTx))
   }
 
@@ -159,7 +159,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       _ <- generateBlock()
 
       // verify
-      txs <- wallet.listTransactions()
+      txs <- wallet.transactionProcessing.listTransactions()
     } yield assert(txs.exists(_.txIdBE == txSent.txIdBE))
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -256,12 +256,12 @@ class AddressHandlingTest extends BitcoinSWalletTest {
       for {
         nonChange <- wallet.getNewAddress()
         output0 = TransactionOutput(Satoshis.zero, nonChange.scriptPubKey)
-        res0 <- wallet.isChange(output0)
+        res0 <- wallet.addressHandling.isChange(output0)
         _ = assert(!res0)
 
         change <- wallet.getNewChangeAddress()
         output1 = TransactionOutput(Satoshis.zero, change.scriptPubKey)
-        res1 <- wallet.isChange(output1)
+        res1 <- wallet.addressHandling.isChange(output1)
       } yield assert(res1)
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
@@ -48,7 +48,7 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
       tx <- bitcoind.getRawTransactionRaw(txId)
 
       // before processing TX, wallet should be completely empty
-      _ <- wallet.listUtxos().map(utxos => assert(utxos.isEmpty))
+      _ <- wallet.utxoHandling.listUtxos().map(utxos => assert(utxos.isEmpty))
       _ <- wallet.getBalance().map(confirmed => assert(confirmed == 0.bitcoin))
       _ <-
         wallet
@@ -60,7 +60,7 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
 
       // we should now have one UTXO in the wallet
       // it should not be confirmed
-      utxosPostAdd <- wallet.listUtxos()
+      utxosPostAdd <- wallet.utxoHandling.listUtxos()
       _ = assert(utxosPostAdd.length == 2)
       _ <-
         wallet
@@ -74,10 +74,10 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
       _ = assert(incomingTx.isDefined)
       _ = assert(incomingTx.get.incomingAmount == valueFromBitcoind * 2)
 
-      taggedUtxosPostAdd <- wallet.listUtxos(exampleTag)
+      taggedUtxosPostAdd <- wallet.utxoHandling.listUtxos(exampleTag)
       _ = assert(taggedUtxosPostAdd.length == 1)
       _ <-
-        wallet
+        wallet.utxoHandling
           .getUnconfirmedBalance(exampleTag)
           .map(unconfirmed => assert(unconfirmed == valueFromBitcoind))
 
@@ -95,9 +95,9 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
       signedTx = rawTxHelper.signedTx
       _ <- wallet.transactionProcessing.processTransaction(signedTx, None)
 
-      utxos <- wallet.listUtxos()
+      utxos <- wallet.utxoHandling.listUtxos()
       balancePostSend <- wallet.getBalance()
-      tagBalancePostSend <- wallet.getBalance(exampleTag)
+      tagBalancePostSend <- wallet.utxoHandling.getBalance(exampleTag)
     } yield {
       // One change one external
       assert(utxos.size == 2)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -109,7 +109,7 @@ class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
 
       _ <- BitcoindRpcBackendUtil.syncWalletToBitcoind(bitcoind, wallet, None)
 
-      utxos <- wallet.listUtxos(TxoState.ConfirmedReceived)
+      utxos <- wallet.utxoHandling.listUtxos(TxoState.ConfirmedReceived)
     } yield {
       assert(utxos.size == 1)
       val utxo = utxos.head

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -256,10 +256,10 @@ class FundTransactionHandlingTest
           markAsReserved = true
         )
 
-        spendingInfos <- wallet.findOutputsBeingSpent(
+        spendingInfos <- wallet.utxoHandling.findOutputsBeingSpent(
           fundRawTxHelper.unsignedTx
         )
-        reserved <- wallet.listUtxos(TxoState.Reserved)
+        reserved <- wallet.utxoHandling.listUtxos(TxoState.Reserved)
       } yield {
         assert(spendingInfos.exists(_.state == TxoState.Reserved))
         assert(reserved.size == spendingInfos.size)
@@ -277,10 +277,10 @@ class FundTransactionHandlingTest
         wallet.sendFundsHandling.sendToAddress(taggedAddr,
                                                destination.value * 2,
                                                Some(feeRate))
-      taggedBalance <- wallet.getBalance(tag)
+      taggedBalance <- wallet.utxoHandling.getBalance(tag)
       _ = assert(taggedBalance == destination.value * 2)
 
-      expectedUtxos <- wallet.listUtxos(tag)
+      expectedUtxos <- wallet.utxoHandling.listUtxos(tag)
       fundRawTxHelper <-
         wallet.fundTxHandling
           .fundRawTransaction(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -33,13 +33,13 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
       wallet: WalletApi
   )(action: => Future[_]): Future[Assertion] =
     for {
-      oldTransactions <- wallet.listTransactions()
-      oldUtxos <- wallet.listUtxos()
+      oldTransactions <- wallet.transactionProcessing.listTransactions()
+      oldUtxos <- wallet.utxoHandling.listUtxos()
       oldUnconfirmed <- wallet.getUnconfirmedBalance()
       oldConfirmed <- wallet.getBalance()
       _ <- action // by name
-      newTransactions <- wallet.listTransactions()
-      newUtxos <- wallet.listUtxos()
+      newTransactions <- wallet.transactionProcessing.listTransactions()
+      newUtxos <- wallet.utxoHandling.listUtxos()
       newUnconfirmed <- wallet.getUnconfirmedBalance()
       newConfirmed <- wallet.getBalance()
 
@@ -79,7 +79,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
         )
         newConfirmed <- wallet.getConfirmedBalance()
         newUnconfirmed <- wallet.getUnconfirmedBalance()
-        utxosPostAdd <- wallet.listUtxos()
+        utxosPostAdd <- wallet.utxoHandling.listUtxos()
 
         // repeating the action should not make a difference
         _ <- checkUtxosAndBalance(wallet) {
@@ -118,7 +118,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
         _ <- wallet.transactionProcessing.processTransaction(tx, None)
         newConfirmed <- wallet.getConfirmedBalance()
         newUnconfirmed <- wallet.getUnconfirmedBalance()
-        utxosPostAdd <- wallet.listUtxos()
+        utxosPostAdd <- wallet.utxoHandling.listUtxos()
 
         // repeating the action should not make a difference
         _ <- checkUtxosAndBalance(wallet) {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
@@ -109,10 +109,10 @@ class WalletCallbackTest extends BitcoinSWalletTest {
       )
 
       for {
-        txno <- wallet.listTransactions().map(_.size)
+        txno <- wallet.transactionProcessing.listTransactions().map(_.size)
         _ <- wallet.transactionProcessing.processTransaction(tx, None)
         _ <- AsyncUtil.nonBlockingSleep(50.millis)
-        txs <- wallet.listTransactions()
+        txs <- wallet.transactionProcessing.listTransactions()
       } yield {
         assert(txs.size == txno)
         assert(!resultP.isCompleted)
@@ -160,8 +160,8 @@ class WalletCallbackTest extends BitcoinSWalletTest {
       val wallet = fundedWallet.wallet
 
       for {
-        utxos <- wallet.listUtxos()
-        _ <- wallet.markUTXOsAsReserved(Vector(utxos.head))
+        utxos <- wallet.utxoHandling.listUtxos()
+        _ <- wallet.utxoHandling.markUTXOsAsReserved(Vector(utxos.head))
         result <- resultP.future
       } yield assert(
         // just compare outPoints because states will be changed so they won't be equal
@@ -185,11 +185,11 @@ class WalletCallbackTest extends BitcoinSWalletTest {
       val wallet = fundedWallet.wallet
 
       for {
-        utxos <- wallet.listUtxos()
-        reserved <- wallet.markUTXOsAsReserved(Vector(utxos.head))
+        utxos <- wallet.utxoHandling.listUtxos()
+        reserved <- wallet.utxoHandling.markUTXOsAsReserved(Vector(utxos.head))
         _ = fundedWallet.wallet.walletConfig.addCallbacks(callbacks)
 
-        _ <- wallet.unmarkUTXOsAsReserved(reserved)
+        _ <- wallet.utxoHandling.unmarkUTXOsAsReserved(reserved)
         result <- resultP.future
         // just compare outPoints because states will be changed so they won't be equal
       } yield assert(result.map(_.outPoint) == reserved.map(_.outPoint))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.core.currency._
+import org.bitcoins.core.currency.*
 import org.bitcoins.core.hd.HDChainType
-import org.bitcoins.core.number._
+import org.bitcoins.core.number.*
 import org.bitcoins.core.protocol.script.EmptyScriptSignature
-import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.TxoState
@@ -62,7 +62,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       tx <- bitcoind.getRawTransactionRaw(txId)
 
       // before processing TX, wallet should be completely empty
-      _ <- wallet.listUtxos().map(utxos => assert(utxos.isEmpty))
+      _ <- wallet.utxoHandling.listUtxos().map(utxos => assert(utxos.isEmpty))
       _ <- wallet.getBalance().map(confirmed => assert(confirmed == 0.bitcoin))
       _ <-
         wallet
@@ -74,7 +74,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
       // we should now have one UTXO in the wallet
       // it should not be confirmed
-      utxosPostAdd <- wallet.listUtxos()
+      utxosPostAdd <- wallet.utxoHandling.listUtxos()
       _ = assert(utxosPostAdd.length == 1)
       _ <-
         wallet
@@ -94,7 +94,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       // after this, tx should be confirmed
       _ <- wallet.transactionProcessing.processTransaction(tx, rawTx.blockhash)
       _ <-
-        wallet
+        wallet.utxoHandling
           .listUtxos()
           .map { utxos =>
             // we want to make sure no new utxos were added,
@@ -126,7 +126,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       _ <- bitcoind.generate(1)
       tx <- bitcoind.getRawTransaction(txid)
 
-      utxos <- wallet.listUtxos()
+      utxos <- wallet.utxoHandling.listUtxos()
       _ = utxos match {
         case utxo +: Vector() =>
           assert(utxo.privKeyPath.chain.chainType == HDChainType.Change)
@@ -225,7 +225,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
       replacementInfo <- bitcoind.getRawTransaction(replacementTx.txIdBE)
 
-      utxos <- wallet.findOutputsBeingSpent(replacementTx)
+      utxos <- wallet.utxoHandling.findOutputsBeingSpent(replacementTx)
     } yield {
       assert(utxos.forall(_.spendingTxIdOpt.contains(replacementTx.txIdBE)))
       // Check correct one was confirmed
@@ -339,9 +339,9 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
         _ <- wallet.transactionProcessing.processBlock(block)
 
         // Verify we funded the wallet
-        allUtxos <- wallet.listUtxos()
+        allUtxos <- wallet.utxoHandling.listUtxos()
         _ = assert(allUtxos.size == 1)
-        utxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
+        utxos <- wallet.utxoHandling.listUtxos(TxoState.ImmatureCoinbase)
         _ = assert(utxos.size == 1)
 
         bitcoindAddr <- bitcoind.getNewAddress
@@ -368,7 +368,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
         // Make coinbase mature
         _ <- bitcoind.generateToAddress(101, bitcoindAddr)
-        _ <- wallet.updateUtxoPendingStates()
+        _ <- wallet.utxoHandling.updateUtxoPendingStates()
 
         // Create valid spending tx
         psbt = PSBT.fromUnsignedTx(spendingTx)
@@ -379,9 +379,10 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
         // Process tx, validate correctly moved to
         _ <- wallet.transactionProcessing.processTransaction(signedTx, None)
-        newCoinbaseUtxos <- wallet.listUtxos(TxoState.ImmatureCoinbase)
+        newCoinbaseUtxos <- wallet.utxoHandling.listUtxos(
+          TxoState.ImmatureCoinbase)
         _ = assert(newCoinbaseUtxos.isEmpty)
-        spentUtxos <- wallet.listUtxos(TxoState.BroadcastSpent)
+        spentUtxos <- wallet.utxoHandling.listUtxos(TxoState.BroadcastSpent)
         _ = assert(spentUtxos.size == 1)
 
         // Assert spending tx valid to bitcoind

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -238,7 +238,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
   it should "correctly send entire outpoints" in { fundedWallet =>
     val wallet = fundedWallet.wallet
     for {
-      allUtxos <- wallet.listUtxos()
+      allUtxos <- wallet.utxoHandling.listUtxos()
       // use half of them
       utxos = allUtxos.drop(allUtxos.size / 2)
       outPoints = utxos.map(_.outPoint)
@@ -287,7 +287,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
   it should "correctly sweep the wallet" in { fundedWallet =>
     val wallet = fundedWallet.wallet
     for {
-      utxos <- wallet.listUtxos()
+      utxos <- wallet.utxoHandling.listUtxos()
       tx <- wallet.sendFundsHandling.sweepWallet(testAddress, None)
       balance <- wallet.getBalance()
     } yield {
@@ -387,7 +387,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
 
     for {
       addr <- wallet.getNewAddress()
-      utxo <- wallet.listUtxos().map(_.head)
+      utxo <- wallet.utxoHandling.listUtxos().map(_.head)
 
       // Create tx not signaling RBF
       input = TransactionInput(
@@ -485,7 +485,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
     fundedWallet =>
       val wallet = fundedWallet.wallet
       for {
-        allUtxos <- wallet.listUtxos()
+        allUtxos <- wallet.utxoHandling.listUtxos()
         // Make one already spent
         spent = allUtxos.head
           .copyWithSpendingTxId(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -346,7 +346,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
       _ <- wallet.transactionProcessing.processTransaction(dummyPrevTx1,
                                                            blockHashOpt = None)
 
-      toBroadcast <- wallet.getTransactionsToBroadcast
+      toBroadcast <- wallet.sendFundsHandling.getTransactionsToBroadcast
     } yield assert(toBroadcast.map(_.txIdBE) == Vector(dummyPrevTx1.txIdBE))
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/WalletHolder.scala
@@ -11,23 +11,16 @@ import org.bitcoins.core.api.dlc.wallet.db.{
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.api.wallet.*
-import org.bitcoins.core.api.wallet.db.*
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.dlc.accounting.DLCWalletAccounting
 import org.bitcoins.core.gcs.GolombFilter
 import org.bitcoins.core.hd.HDAccount
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.dlc.models.*
-import org.bitcoins.core.protocol.script.ScriptPubKey
 import org.bitcoins.core.protocol.tlv.*
-import org.bitcoins.core.protocol.transaction.{
-  Transaction,
-  TransactionOutPoint,
-  TransactionOutput
-}
+import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.protocol.BitcoinAddress
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
-import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
 import org.bitcoins.crypto.{DoubleSha256DigestBE, Sha256Digest}
 import scodec.bits.ByteVector
 
@@ -136,59 +129,15 @@ class WalletHolder(initWalletOpt: Option[DLCNeutrinoHDWalletApi])(implicit
 
     res
   }
-
-  override def updateUtxoPendingStates(): Future[Vector[SpendingInfoDb]] =
-    delegate(_.updateUtxoPendingStates())
-
   override def getConfirmedBalance(): Future[CurrencyUnit] = delegate(
     _.getConfirmedBalance()
   )
-
-  override def getConfirmedBalance(tag: AddressTag): Future[CurrencyUnit] =
-    delegate(_.getConfirmedBalance(tag))
 
   override def getUnconfirmedBalance(): Future[CurrencyUnit] = delegate(
     _.getUnconfirmedBalance()
   )
 
-  override def getUnconfirmedBalance(tag: AddressTag): Future[CurrencyUnit] =
-    delegate(_.getUnconfirmedBalance(tag))
-
-  override def listTransactions(): Future[Vector[TransactionDb]] = {
-    delegate(_.listTransactions())
-  }
-  override def listUtxos(): Future[Vector[SpendingInfoDb]] = delegate(
-    _.listUtxos()
-  )
-
-  override def listUtxos(state: TxoState): Future[Vector[SpendingInfoDb]] =
-    delegate(_.listUtxos(state))
-
-  override def listUtxos(tag: AddressTag): Future[Vector[SpendingInfoDb]] = {
-    delegate(_.listUtxos(tag))
-  }
-
-  override def markUTXOsAsReserved(
-      utxos: Vector[SpendingInfoDb]
-  ): Future[Vector[SpendingInfoDb]] = delegate(_.markUTXOsAsReserved(utxos))
-
-  override def markUTXOsAsReserved(
-      tx: Transaction
-  ): Future[Vector[SpendingInfoDb]] = delegate(_.markUTXOsAsReserved(tx))
-
-  override def unmarkUTXOsAsReserved(
-      utxos: Vector[SpendingInfoDb]
-  ): Future[Vector[SpendingInfoDb]] = delegate(_.unmarkUTXOsAsReserved(utxos))
-
-  override def unmarkUTXOsAsReserved(
-      tx: Transaction
-  ): Future[Vector[SpendingInfoDb]] = delegate(_.unmarkUTXOsAsReserved(tx))
-
   override def isEmpty(): Future[Boolean] = delegate(_.isEmpty())
-
-  override def isChange(output: TransactionOutput): Future[Boolean] = delegate(
-    _.isChange(output)
-  )
 
   override def getSyncState(): Future[BlockSyncState] = delegate(
     _.getSyncState()
@@ -375,19 +324,11 @@ class WalletHolder(initWalletOpt: Option[DLCNeutrinoHDWalletApi])(implicit
   override def broadcastTransaction(transaction: Transaction): Future[Unit] =
     delegate(_.broadcastTransaction(transaction))
 
-  override def getTransactionsToBroadcast: Future[Vector[Transaction]] = {
-    delegate(_.getTransactionsToBroadcast)
-  }
-
   override def getFeeRate(): Future[FeeUnit] = delegate(_.getFeeRate())
 
   override def getBalance()(implicit
       ec: ExecutionContext
   ): Future[CurrencyUnit] = delegate(_.getBalance())
-
-  override def getBalance(tag: AddressTag)(implicit
-      ec: ExecutionContext
-  ): Future[CurrencyUnit] = delegate(_.getBalance(tag))
 
   def getBalance(account: HDAccount)(implicit
       ec: ExecutionContext
@@ -466,30 +407,6 @@ class WalletHolder(initWalletOpt: Option[DLCNeutrinoHDWalletApi])(implicit
       oracleSig: OracleSignatures
   ): Future[Option[Transaction]] =
     delegate(_.executeDLC(contractId, oracleSig))
-
-  override def findByOutPoints(
-      outPoints: Vector[TransactionOutPoint]
-  ): Future[Vector[SpendingInfoDb]] = {
-    delegate(_.findByOutPoints(outPoints))
-  }
-
-  override def findByTxIds(
-      txIds: Vector[DoubleSha256DigestBE]
-  ): Future[Vector[TransactionDb]] = {
-    delegate(_.findByTxIds(txIds))
-  }
-
-  override def findOutputsBeingSpent(
-      tx: Transaction
-  ): Future[Vector[SpendingInfoDb]] = {
-    delegate(_.findOutputsBeingSpent(tx))
-  }
-
-  override def findByScriptPubKey(
-      scriptPubKey: ScriptPubKey
-  ): Future[Vector[SpendingInfoDb]] = {
-    delegate(_.findByScriptPubKey(scriptPubKey))
-  }
 }
 
 object WalletHolder {

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -439,7 +439,7 @@ object WalletAppConfig
 
     override def run(): Unit = {
       val f = for {
-        txs <- wallet.getTransactionsToBroadcast
+        txs <- wallet.sendFundsHandling.getTransactionsToBroadcast
 
         _ = {
           if (txs.size > 1)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -293,6 +293,13 @@ case class AddressHandling(
     }
   }
 
+  override def isChange(output: TransactionOutput): Future[Boolean] = {
+    addressDAO.findByScriptPubKey(output.scriptPubKey).map {
+      case Some(db) => db.isChange
+      case None     => false
+    }
+  }
+
   override def tagAddress(
       address: BitcoinAddress,
       tag: AddressTag

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
@@ -230,6 +230,16 @@ case class SendFundsHandlingHandling(
     } yield childTx
   }
 
+  override def getTransactionsToBroadcast: Future[Vector[Transaction]] = {
+    for {
+      mempoolUtxos <- spendingInfoDAO.findAllInMempool
+      txIds = mempoolUtxos.map { utxo =>
+        utxo.spendingTxIdOpt.getOrElse(utxo.txid)
+      }
+      txDbs <- transactionDAO.findByTxIdBEs(txIds)
+    } yield txDbs.map(_.transaction)
+  }
+
   override def makeOpReturnCommitment(
       message: String,
       hashMessage: Boolean,

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -73,6 +73,11 @@ case class TransactionProcessing(
 
   /////////////////////
   // Public facing API
+  override def findByTxIds(
+      txIds: Vector[DoubleSha256DigestBE]
+  ): Future[Vector[TransactionDb]] = {
+    transactionDAO.findByTxIds(txIds)
+  }
 
   /** @inheritdoc */
   override def processTransaction(


### PR DESCRIPTION
Related to #3139 