### PR TITLE
Reduce `BitcoindRpcTestUtil.awaitConnection()` interval from 10.second …

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/rpc/BitcoindRpcTestUtil.scala
@@ -658,7 +658,7 @@ trait BitcoindRpcTestUtil extends BitcoinSLogger {
     val connectedPairsF = addNodesF.flatMap { _ =>
       val futures = pairs.map { case (first, second) =>
         BitcoindRpcTestUtil
-          .awaitConnection(first, second, interval = 10.second)
+          .awaitConnection(first, second, interval = 1.second)
       }
       Future.sequence(futures)
     }


### PR DESCRIPTION
from `10.second` -> `1.second`

Discovered while looking at #5696 