### PR TITLE
Remove `TableAutoInc[T]` type parameter, its unnecessary and causes issues

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/CRUDAutoInc.scala
@@ -12,7 +12,7 @@ abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](implicit
   import profile.api._
 
   /** The table inside our database we are inserting into */
-  override val table: profile.api.TableQuery[_ <: TableAutoInc[T]]
+  override val table: profile.api.TableQuery[? <: TableAutoInc]
 
   override def createAllAction(
       ts: Vector[T]
@@ -33,12 +33,12 @@ abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](implicit
 
   override protected def findByPrimaryKey(
       id: Long
-  ): Query[TableAutoInc[T], T, Seq] =
+  ): Query[TableAutoInc, T, Seq] =
     table.filter(_.id === id)
 
   override def findByPrimaryKeys(
       ids: Vector[Long]
-  ): Query[TableAutoInc[T], T, Seq] = {
+  ): Query[TableAutoInc, T, Seq] = {
     table.filter { t =>
       t.id.inSet(ids)
     }
@@ -60,7 +60,7 @@ abstract class CRUDAutoInc[T <: DbRowAutoInc[T]](implicit
 trait TableAutoIncComponent[T <: DbRowAutoInc[T]] { self: CRUDAutoInc[T] =>
   import profile.api._
 
-  abstract class TableAutoInc[T](
+  abstract class TableAutoInc(
       tag: profile.api.Tag,
       schemaName: Option[String],
       tableName: String

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleAnnouncementDataDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/OracleAnnouncementDataDAO.scala
@@ -52,7 +52,7 @@ case class OracleAnnouncementDataDAO()(implicit
   }
 
   class OracleAnnouncementsTable(tag: Tag)
-      extends TableAutoInc[OracleAnnouncementDataDb](
+      extends TableAutoInc(
         tag,
         schemaName,
         "oracle_announcement_data"

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/ScriptPubKeyDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/ScriptPubKeyDAO.scala
@@ -72,7 +72,7 @@ case class ScriptPubKeyDAO()(implicit
   }
 
   case class ScriptPubKeyTable(tag: Tag)
-      extends TableAutoInc[ScriptPubKeyDb](tag, schemaName, "pub_key_scripts") {
+      extends TableAutoInc(tag, schemaName, "pub_key_scripts") {
 
     def scriptPubKey: Rep[ScriptPubKey] = column("script_pub_key")
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/models/SpendingInfoDAO.scala
@@ -774,7 +774,7 @@ case class SpendingInfoDAO()(implicit
     * of the transaction that created this output.
     */
   case class SpendingInfoTable(tag: Tag)
-      extends TableAutoInc[UTXORecord](tag, schemaName, "txo_spending_info") {
+      extends TableAutoInc(tag, schemaName, "txo_spending_info") {
 
     def outPoint: Rep[TransactionOutPoint] =
       column("tx_outpoint", O.Unique)


### PR DESCRIPTION
`TableAutoInc` is already type parameterized by `TableAutoIncComponent[T]`

Similar to #5650 and related to #3497