### PR TITLE
Use default play-json json serialization macros for bitcoind json classes

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/RawTransactionResult.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/RawTransactionResult.scala
@@ -57,7 +57,7 @@ case class RpcTransactionOutputV22(
 sealed trait RpcScriptPubKey extends RawTransactionResult {
   def asm: String
   def hex: String
-  def scriptType: ScriptType
+  def `type`: ScriptType
   def addresses: Option[Vector[BitcoinAddress]]
 }
 
@@ -65,27 +65,27 @@ case class RpcScriptPubKeyPreV22(
     asm: String,
     hex: String,
     reqSigs: Option[Int],
-    scriptType: ScriptType,
+    `type`: ScriptType,
     addresses: Option[Vector[BitcoinAddress]]
 ) extends RpcScriptPubKey
 
 case class RpcScriptPubKeyPostV22(
     asm: String,
     hex: String,
-    scriptType: ScriptType,
+    `type`: ScriptType,
     addresses: Option[Vector[BitcoinAddress]],
     address: Option[BitcoinAddress]
 ) extends RpcScriptPubKey
 
 sealed trait DecodeScriptResult extends RawTransactionResult {
   def asm: String
-  def typeOfScript: Option[ScriptType]
+  def `type`: Option[ScriptType]
   def address: BitcoinAddress
 }
 
 case class DecodeScriptResultV22(
     asm: String,
-    typeOfScript: Option[ScriptType],
+    `type`: Option[ScriptType],
     address: BitcoinAddress
 ) extends DecodeScriptResult
 

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
@@ -129,13 +129,7 @@ object JsonSerializers {
         .readNullable[Vector[BitcoinAddress]])(RpcScriptPubKeyPreV22.apply)
 
   implicit val rpcScriptPubKeyPostV22Reads: Reads[RpcScriptPubKeyPostV22] =
-    ((__ \ "asm").read[String] and
-      (__ \ "hex").read[String] and
-      (__ \ "type").read[ScriptType] and
-      (__ \ "addresses")
-        .readNullable[Vector[BitcoinAddress]] and
-      (__ \ "address")
-        .readNullable[BitcoinAddress])(RpcScriptPubKeyPostV22.apply)
+    Json.reads[RpcScriptPubKeyPostV22]
 
   implicit val rpcTransactionOutputPreV22Reads
       : Reads[RpcTransactionOutputPreV22] =
@@ -147,10 +141,9 @@ object JsonSerializers {
   implicit val rpcTransactionV22Reads: Reads[RpcTransactionV22] =
     Json.reads[RpcTransactionV22]
 
-  implicit val decodeScriptResultV22Reads: Reads[DecodeScriptResultV22] =
-    ((__ \ "asm").read[String] and
-      (__ \ "type").readNullable[ScriptType] and
-      (__ \ "address").read[BitcoinAddress])(DecodeScriptResultV22.apply)
+  implicit val decodeScriptResultV22Reads: Reads[DecodeScriptResultV22] = {
+    Json.reads[DecodeScriptResultV22]
+  }
 
   implicit val fundRawTransactionResultReads: Reads[FundRawTransactionResult] =
     Json.reads[FundRawTransactionResult]

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -741,7 +741,7 @@ class WalletRpcTest extends BitcoindFixturesCachedPairNewest {
     } yield {
       decoded match {
         case decodedV22: DecodeScriptResultV22 =>
-          assert(decodedV22.typeOfScript.contains(ScriptType.PUBKEYHASH))
+          assert(decodedV22.`type`.contains(ScriptType.PUBKEYHASH))
       }
     }
   }


### PR DESCRIPTION
For some reason these cause `NullPointerException`s with scala3 on #5713 

https://github.com/bitcoin-s/bitcoin-s/actions/runs/11369881581/job/31628353529?pr=5713#step:5:16736

```
[info] - should be able to get utxo info *** FAILED *** (6 milliseconds)
[info]   java.lang.NullPointerException: Cannot invoke "play.api.libs.json.Reads.reads(play.api.libs.json.JsValue)" because "reads$2" is null
[info]   at play.api.libs.json.PathReads.at$$anonfun$1$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.JsSuccess.flatMap(JsResult.scala:22)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at play.api.libs.json.Reads$$anon$1$$anon$2.reads(Reads.scala:219)
[info]   at play.api.libs.json.Reads.map$$anonfun$1(Reads.scala:48)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at play.api.libs.json.Reads$$anon$1$$anon$2.reads(Reads.scala:219)
[info]   at play.api.libs.json.Reads.map$$anonfun$1(Reads.scala:48)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at play.api.libs.json.Reads$$anon$1$$anon$2.reads(Reads.scala:219)
[info]   at play.api.libs.json.Reads.map$$anonfun$1(Reads.scala:48)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.JsSuccess.flatMap(JsResult.scala:22)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$.$anonfun$2$$anonfun$1(JsonSerializers.scala:145)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$$anon$4.reads(JsonSerializers.scala:145)
[info]   at play.api.libs.json.LowPriorityDefaultReads$$anon$8.reads$$anonfun$1(Reads.scala:289)
[info]   at scala.collection.IterableOnceOps.foldLeft(IterableOnce.scala:727)
[info]   at scala.collection.IterableOnceOps.foldLeft$(IterableOnce.scala:721)
[info]   at scala.collection.AbstractIterator.foldLeft(Iterator.scala:1303)
[info]   at play.api.libs.json.LowPriorityDefaultReads$$anon$8.reads(Reads.scala:295)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.JsSuccess.flatMap(JsResult.scala:22)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$.$anonfun$3$$anonfun$1(JsonSerializers.scala:148)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$$anon$5.reads(JsonSerializers.scala:148)
[info]   at play.api.libs.json.LowPriorityDefaultReads$$anon$8.reads$$anonfun$1(Reads.scala:289)
[info]   at scala.collection.IterableOnceOps.foldLeft(IterableOnce.scala:727)
[info]   at scala.collection.IterableOnceOps.foldLeft$(IterableOnce.scala:721)
[info]   at scala.collection.AbstractIterator.foldLeft(Iterator.scala:1303)
[info]   at play.api.libs.json.LowPriorityDefaultReads$$anon$8.reads(Reads.scala:295)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.JsSuccess.flatMap(JsResult.scala:22)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$.$anonfun$31$$anonfun$1(JsonSerializers.scala:279)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$$anon$35.reads(JsonSerializers.scala:279)
[info]   at play.api.libs.json.JsValue.validate(JsValue.scala:18)
[info]   at play.api.libs.json.JsValue.validate$(JsValue.scala:16)
[info]   at play.api.libs.json.JsObject.validate(JsValue.scala:116)
[info]   at play.api.libs.json.JsLookupResult.validate(JsLookup.scala:169)
[info]   at play.api.libs.json.JsLookupResult.validate$(JsLookup.scala:136)
[info]   at play.api.libs.json.JsDefined.validate(JsLookup.scala:192)
[info]   at org.bitcoins.rpc.client.common.Client.bitcoindCall$$anonfun$1(Client.scala:364)
[info]   at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
[info]   at org.apache.pekko.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:73)
[info]   at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run$$anonfun$1(BatchingExecutor.scala:110)
[info]   at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run$$anonfun$adapted$1(BatchingExecutor.scala:119)
[info]   at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
[info]   at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:119)
[info]   at org.apache.pekko.dispatch.TaskInvocation.run(AbstractDispatcher.scala:59)
[info]   at org.apache.pekko.dispatch.ForkJoinExecutorConfigurator$PekkoForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:61)
[info]   at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
[info]   at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
[info]   at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
[info]   at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
[info]   at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
[info] - should be able to fail to get utxo info *** FAILED *** (8 milliseconds)
[info]   java.lang.NullPointerException: Cannot invoke "play.api.libs.json.Reads.reads(play.api.libs.json.JsValue)" because "reads$2" is null
[info]   at play.api.libs.json.PathReads.at$$anonfun$1$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.JsSuccess.flatMap(JsResult.scala:22)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at play.api.libs.json.Reads$$anon$1$$anon$2.reads(Reads.scala:219)
[info]   at play.api.libs.json.Reads.map$$anonfun$1(Reads.scala:48)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at play.api.libs.json.Reads$$anon$1$$anon$2.reads(Reads.scala:219)
[info]   at play.api.libs.json.Reads.map$$anonfun$1(Reads.scala:48)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at play.api.libs.json.Reads$$anon$1$$anon$2.reads(Reads.scala:219)
[info]   at play.api.libs.json.Reads.map$$anonfun$1(Reads.scala:48)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.JsSuccess.flatMap(JsResult.scala:22)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$.$anonfun$2$$anonfun$1(JsonSerializers.scala:145)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$$anon$4.reads(JsonSerializers.scala:145)
[info]   at play.api.libs.json.LowPriorityDefaultReads$$anon$8.reads$$anonfun$1(Reads.scala:289)
[info]   at scala.collection.IterableOnceOps.foldLeft(IterableOnce.scala:727)
[info]   at scala.collection.IterableOnceOps.foldLeft$(IterableOnce.scala:721)
[info]   at scala.collection.AbstractIterator.foldLeft(Iterator.scala:1303)
[info]   at play.api.libs.json.LowPriorityDefaultReads$$anon$8.reads(Reads.scala:295)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.JsSuccess.flatMap(JsResult.scala:22)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$.$anonfun$3$$anonfun$1(JsonSerializers.scala:148)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$$anon$5.reads(JsonSerializers.scala:148)
[info]   at play.api.libs.json.LowPriorityDefaultReads$$anon$8.reads$$anonfun$1(Reads.scala:289)
[info]   at scala.collection.IterableOnceOps.foldLeft(IterableOnce.scala:727)
[info]   at scala.collection.IterableOnceOps.foldLeft$(IterableOnce.scala:721)
[info]   at scala.collection.AbstractIterator.foldLeft(Iterator.scala:1303)
[info]   at play.api.libs.json.LowPriorityDefaultReads$$anon$8.reads(Reads.scala:295)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.JsSuccess.flatMap(JsResult.scala:22)
[info]   at play.api.libs.json.PathReads.at$$anonfun$1(JsConstraints.scala:34)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$.$anonfun$31$$anonfun$1(JsonSerializers.scala:279)
[info]   at play.api.libs.json.Reads$$anon$6.reads(Reads.scala:244)
[info]   at org.bitcoins.commons.serializers.JsonSerializers$$anon$35.reads(JsonSerializers.scala:279)
[info]   at play.api.libs.json.JsValue.validate(JsValue.scala:18)
[info]   at play.api.libs.json.JsValue.validate$(JsValue.scala:16)
[info]   at play.api.libs.json.JsObject.validate(JsValue.scala:116)
[info]   at play.api.libs.json.JsLookupResult.validate(JsLookup.scala:169)
[info]   at play.api.libs.json.JsLookupResult.validate$(JsLookup.scala:136)
[info]   at play.api.libs.json.JsDefined.validate(JsLookup.scala:192)
[info]   at org.bitcoins.rpc.client.common.Client.bitcoindCall$$anonfun$1(Client.scala:364)
[info]   at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
[info]   at org.apache.pekko.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:73)
[info]   at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run$$anonfun$1(BatchingExecutor.scala:110)
[info]   at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run$$anonfun$adapted$1(BatchingExecutor.scala:119)
[info]   at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
[info]   at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:119)
[info]   at org.apache.pekko.dispatch.TaskInvocation.run(AbstractDispatcher.scala:59)
[info]   at org.apache.pekko.dispatch.ForkJoinExecutorConfigurator$PekkoForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:61)
[info]   at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
[info]   at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
[info]   at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
[info]   at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
[info]   at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```