### PR TITLE
Rework `Block` and `Transaction` data structures to use `Vector`

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoInterpreterTest.scala
@@ -225,7 +225,10 @@ class CryptoInterpreterTest extends BitcoinSJvmTest {
     )
     val empty = EmptyTransaction
     val tx =
-      BaseTransaction(empty.version, Seq(input), empty.outputs, empty.lockTime)
+      BaseTransaction(empty.version,
+                      Vector(input),
+                      empty.outputs,
+                      empty.lockTime)
     val t = BaseTxSigComponent(
       transaction = tx,
       inputIndex = UInt32.zero,

--- a/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
@@ -60,7 +60,7 @@ class LockTimeInterpreterTest extends BitcoinSUnitTest {
     val txAdjustedSequenceNumber =
       BaseTransaction(
         emptyTx.version,
-        Seq(txInputAdjustedSequenceNumber),
+        Vector(txInputAdjustedSequenceNumber),
         emptyTx.outputs,
         emptyTx.lockTime
       )
@@ -101,7 +101,7 @@ class LockTimeInterpreterTest extends BitcoinSUnitTest {
     val txAdjustedSequenceNumber =
       BaseTransaction(
         emptyTx.version,
-        Seq(txInputAdjustedSequenceNumber),
+        Vector(txInputAdjustedSequenceNumber),
         emptyTx.outputs,
         emptyTx.lockTime
       )
@@ -134,7 +134,7 @@ class LockTimeInterpreterTest extends BitcoinSUnitTest {
     val txAdjustedSequenceNumber =
       BaseTransaction(
         emptyTx.version,
-        Seq(txInputAdjustedSequenceNumber),
+        Vector(txInputAdjustedSequenceNumber),
         emptyTx.outputs,
         emptyTx.lockTime
       )
@@ -167,7 +167,7 @@ class LockTimeInterpreterTest extends BitcoinSUnitTest {
     val txAdjustedSequenceNumber =
       BaseTransaction(
         emptyTx.version,
-        Seq(txInputAdjustedSequenceNumber),
+        Vector(txInputAdjustedSequenceNumber),
         emptyTx.outputs,
         emptyTx.lockTime
       )
@@ -204,7 +204,7 @@ class LockTimeInterpreterTest extends BitcoinSUnitTest {
     val txAdjustedSequenceNumber =
       BaseTransaction(
         emptyTx.version,
-        Seq(txInputAdjustedSequenceNumber),
+        Vector(txInputAdjustedSequenceNumber),
         emptyTx.outputs,
         emptyTx.lockTime
       )
@@ -238,7 +238,7 @@ class LockTimeInterpreterTest extends BitcoinSUnitTest {
     val txAdjustedSequenceNumber =
       BaseTransaction(
         emptyTx.version,
-        Seq(txInputAdjustedSequenceNumber),
+        Vector(txInputAdjustedSequenceNumber),
         emptyTx.outputs,
         emptyTx.lockTime
       )

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
@@ -39,7 +39,7 @@ class RawTxSignerTest extends BitcoinSUnitTest {
       Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(
       TransactionConstants.validLockVersion,
-      Nil,
+      Vector.empty,
       Vector(creditingOutput),
       TransactionConstants.lockTime
     )
@@ -81,7 +81,7 @@ class RawTxSignerTest extends BitcoinSUnitTest {
       Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(
       TransactionConstants.validLockVersion,
-      Nil,
+      Vector.empty,
       Vector(creditingOutput),
       TransactionConstants.lockTime
     )
@@ -121,7 +121,7 @@ class RawTxSignerTest extends BitcoinSUnitTest {
       Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(creditingOutput),
       lockTime = TransactionConstants.lockTime
     )
@@ -168,7 +168,7 @@ class RawTxSignerTest extends BitcoinSUnitTest {
 
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(TransactionOutput(Bitcoins.one, cltvSPK)),
       lockTime = TransactionConstants.lockTime
     )
@@ -219,7 +219,7 @@ class RawTxSignerTest extends BitcoinSUnitTest {
 
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(TransactionOutput(Bitcoins.one, cltvSPK)),
       lockTime = TransactionConstants.lockTime
     )

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/ShufflingNonInteractiveFinalizerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/ShufflingNonInteractiveFinalizerTest.scala
@@ -122,7 +122,7 @@ class ShufflingNonInteractiveFinalizerTest extends BitcoinSUnitTest {
       Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(creditingOutput),
       lockTime = TransactionConstants.lockTime
     )
@@ -159,7 +159,7 @@ class ShufflingNonInteractiveFinalizerTest extends BitcoinSUnitTest {
       Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(creditingOutput),
       lockTime = TransactionConstants.lockTime
     )

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/StandardNonInteractiveFinalizerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/StandardNonInteractiveFinalizerTest.scala
@@ -118,7 +118,7 @@ class StandardNonInteractiveFinalizerTest extends BitcoinSUnitTest {
       Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(creditingOutput),
       lockTime = TransactionConstants.lockTime
     )
@@ -155,7 +155,7 @@ class StandardNonInteractiveFinalizerTest extends BitcoinSUnitTest {
       Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey))
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(creditingOutput),
       lockTime = TransactionConstants.lockTime
     )

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/InputInfoTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/InputInfoTest.scala
@@ -59,7 +59,7 @@ class InputInfoTest extends BitcoinSUnitTest {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(creditingOutput),
       lockTime = TransactionConstants.lockTime
     )
@@ -84,7 +84,7 @@ class InputInfoTest extends BitcoinSUnitTest {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(creditingOutput),
       lockTime = TransactionConstants.lockTime
     )

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/InputSigningInfoTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/utxo/InputSigningInfoTest.scala
@@ -19,7 +19,7 @@ class InputSigningInfoTest extends BitcoinSUnitTest {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2sh)
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(creditingOutput),
       lockTime = TransactionConstants.lockTime
     )
@@ -56,7 +56,7 @@ class InputSigningInfoTest extends BitcoinSUnitTest {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wsh)
     val creditingTx = BaseTransaction(
       TransactionConstants.validLockVersion,
-      Nil,
+      Vector.empty,
       Vector(creditingOutput),
       TransactionConstants.lockTime
     )
@@ -100,7 +100,7 @@ class InputSigningInfoTest extends BitcoinSUnitTest {
       TransactionOutput(value = CurrencyUnits.zero, scriptPubKey = p2wpkh)
     val creditingTx = BaseTransaction(
       version = TransactionConstants.validLockVersion,
-      inputs = Nil,
+      inputs = Vector.empty,
       outputs = Vector(creditingOutput),
       lockTime = TransactionConstants.lockTime
     )
@@ -138,7 +138,7 @@ class InputSigningInfoTest extends BitcoinSUnitTest {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wpkh)
     val creditingTx = BaseTransaction(
       TransactionConstants.validLockVersion,
-      Nil,
+      Vector.empty,
       Vector(creditingOutput),
       TransactionConstants.lockTime
     )
@@ -181,7 +181,7 @@ class InputSigningInfoTest extends BitcoinSUnitTest {
     val creditingOutput = TransactionOutput(CurrencyUnits.zero, p2wpkh)
     val creditingTx = BaseTransaction(
       TransactionConstants.validLockVersion,
-      Nil,
+      Vector.empty,
       Vector(creditingOutput),
       TransactionConstants.lockTime
     )
@@ -226,7 +226,7 @@ class InputSigningInfoTest extends BitcoinSUnitTest {
     val creditingTx =
       BaseTransaction(
         TransactionConstants.validLockVersion,
-        Nil,
+        Vector.empty,
         Vector(TransactionOutput(CurrencyUnits.oneBTC, p2wpkh)),
         TransactionConstants.lockTime
       )

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -493,8 +493,8 @@ sealed abstract class TransactionSignatureSerializer {
     * inputIndex.
     */
   private def setSequenceNumbersZero(
-      inputs: Seq[TransactionInput],
-      inputIndex: UInt32): Seq[TransactionInput] =
+      inputs: Vector[TransactionInput],
+      inputIndex: UInt32): Vector[TransactionInput] =
     for {
       (input, index) <- inputs.zipWithIndex
     } yield {
@@ -515,11 +515,11 @@ sealed abstract class TransactionSignatureSerializer {
     // [[https://github.com/bitcoinj/bitcoinj/blob/09a2ca64d2134b0dcbb27b1a6eb17dda6087f448/core/src/main/java/org/bitcoinj/core/Transaction.java#L957]]
     // means that no outputs are signed at all
     // set the sequence number of all inputs to 0 EXCEPT the input at inputIndex
-    val updatedInputs: Seq[TransactionInput] =
+    val updatedInputs: Vector[TransactionInput] =
       setSequenceNumbersZero(spendingTransaction.inputs, inputIndex)
     val sigHashNoneTx = BaseTransaction(spendingTransaction.version,
                                         updatedInputs,
-                                        Nil,
+                                        Vector.empty,
                                         spendingTransaction.lockTime)
     // append hash type byte onto the end of the tx bytes
     sigHashNoneTx
@@ -535,7 +535,7 @@ sealed abstract class TransactionSignatureSerializer {
     // [[https://github.com/bitcoinj/bitcoinj/blob/09a2ca64d2134b0dcbb27b1a6eb17dda6087f448/core/src/main/java/org/bitcoinj/core/Transaction.java#L964]]
     // In SIGHASH_SINGLE the outputs after the matching input index are deleted, and the outputs before
     // that position are "nulled out". Unintuitively, the value in a "null" transaction is set to -1.
-    val updatedOutputsOpt: Seq[Option[TransactionOutput]] = for {
+    val updatedOutputsOpt: Vector[Option[TransactionOutput]] = for {
       (output, index) <- spendingTransaction.outputs.zipWithIndex
     } yield {
       if (UInt32(index) < inputIndex) {
@@ -543,11 +543,11 @@ sealed abstract class TransactionSignatureSerializer {
       } else if (UInt32(index) == inputIndex) Some(output)
       else None
     }
-    val updatedOutputs: Seq[TransactionOutput] = updatedOutputsOpt.flatten
+    val updatedOutputs: Vector[TransactionOutput] = updatedOutputsOpt.flatten
 
     // create blank inputs with sequence numbers set to zero EXCEPT
     // the input at the inputIndex
-    val updatedInputs: Seq[TransactionInput] =
+    val updatedInputs: Vector[TransactionInput] =
       setSequenceNumbersZero(spendingTransaction.inputs, inputIndex)
     val sigHashSingleTx = BaseTransaction(spendingTransaction.version,
                                           updatedInputs,
@@ -570,7 +570,7 @@ sealed abstract class TransactionSignatureSerializer {
       spendingTransaction: Transaction,
       input: TransactionInput): Transaction = {
     BaseTransaction(spendingTransaction.version,
-                    Seq(input),
+                    Vector(input),
                     spendingTransaction.outputs,
                     spendingTransaction.lockTime)
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
@@ -24,9 +24,9 @@ sealed abstract class Block extends NetworkElement {
   def txCount: CompactSizeUInt
 
   /** The transactions contained in this block */
-  def transactions: Seq[Transaction]
+  def transactions: Vector[Transaction]
 
-  override def bytes = RawBlockSerializer.write(this)
+  override lazy val bytes: ByteVector = RawBlockSerializer.write(this)
 
   /** This is the new computation to determine the maximum size of a block as
     * per BIP141
@@ -52,7 +52,7 @@ object Block extends Factory[Block] {
   private case class BlockImpl(
       blockHeader: BlockHeader,
       txCount: CompactSizeUInt,
-      transactions: Seq[Transaction])
+      transactions: Vector[Transaction])
       extends Block {
 
     override def toString: String = {
@@ -63,11 +63,13 @@ object Block extends Factory[Block] {
   def apply(
       blockHeader: BlockHeader,
       txCount: CompactSizeUInt,
-      transactions: Seq[Transaction]): Block = {
+      transactions: Vector[Transaction]): Block = {
     BlockImpl(blockHeader, txCount, transactions)
   }
 
-  def apply(blockHeader: BlockHeader, transactions: Seq[Transaction]): Block = {
+  def apply(
+      blockHeader: BlockHeader,
+      transactions: Vector[Transaction]): Block = {
     val txCount = CompactSizeUInt(UInt64(transactions.size))
     Block(blockHeader, txCount, transactions)
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/ChainParams.scala
@@ -168,15 +168,15 @@ sealed abstract class ChainParams {
     val input = CoinbaseInput(scriptSignature, TransactionConstants.sequence)
     val output = TransactionOutput(amount, scriptPubKey)
     val tx = BaseTransaction(TransactionConstants.version,
-                             Seq(input),
-                             Seq(output),
+                             Vector(input),
+                             Vector(output),
                              TransactionConstants.lockTime)
     val prevBlockHash = DoubleSha256Digest(
       "0000000000000000000000000000000000000000000000000000000000000000")
     val merkleRootHash = Merkle.computeMerkleRoot(Seq(tx))
     val genesisBlockHeader =
       BlockHeader(version, prevBlockHash, merkleRootHash, time, nBits, nonce)
-    val genesisBlock = Block(genesisBlockHeader, Seq(tx))
+    val genesisBlock = Block(genesisBlockHeader, Vector(tx))
     genesisBlock
   }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -31,10 +31,10 @@ sealed abstract class Transaction extends NetworkElement {
   def version: Int32
 
   /** The inputs for this transaction */
-  def inputs: Seq[TransactionInput]
+  def inputs: Vector[TransactionInput]
 
   /** The outputs for this transaction */
-  def outputs: Seq[TransactionOutput]
+  def outputs: Vector[TransactionOutput]
 
   /** The locktime for this transaction */
   def lockTime: UInt32
@@ -156,8 +156,8 @@ sealed abstract class NonWitnessTransaction extends Transaction {
 
 case class BaseTransaction(
     version: Int32,
-    inputs: Seq[TransactionInput],
-    outputs: Seq[TransactionOutput],
+    inputs: Vector[TransactionInput],
+    outputs: Vector[TransactionOutput],
     lockTime: UInt32)
     extends NonWitnessTransaction
 
@@ -177,7 +177,7 @@ object BaseTransaction extends Factory[BaseTransaction] {
   }
 
   def unapply(tx: NonWitnessTransaction): Option[
-    (Int32, Seq[TransactionInput], Seq[TransactionOutput], UInt32)] = {
+    (Int32, Vector[TransactionInput], Vector[TransactionOutput], UInt32)] = {
     Some((tx.version, tx.inputs, tx.outputs, tx.lockTime))
   }
 }
@@ -192,8 +192,8 @@ case object EmptyTransaction extends NonWitnessTransaction {
 
 case class WitnessTransaction(
     version: Int32,
-    inputs: Seq[TransactionInput],
-    outputs: Seq[TransactionOutput],
+    inputs: Vector[TransactionInput],
+    outputs: Vector[TransactionOutput],
     lockTime: UInt32,
     witness: TransactionWitness)
     extends Transaction {

--- a/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/RawBitcoinSerializerHelper.scala
@@ -17,7 +17,7 @@ sealed abstract class RawSerializerHelper {
     */
   final def parseCmpctSizeUIntSeq[T <: NetworkElement](
       bytes: ByteVector,
-      constructor: ByteVector => T): (Seq[T], ByteVector) = {
+      constructor: ByteVector => T): (Vector[T], ByteVector) = {
     val count = CompactSizeUInt.parse(bytes)
     val (_, payload) = bytes.splitAt(count.byteSize.toInt)
     var counter = 0

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/BlockchainElementsGenerator.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/BlockchainElementsGenerator.scala
@@ -21,7 +21,9 @@ sealed abstract class BlockchainElementsGenerator {
     for {
       randomNum <- Gen.choose(1, 10)
       neededTxs = if ((randomNum - txs.size) >= 0) randomNum else 0
-      genTxs <- Gen.listOfN(neededTxs, TransactionGenerators.transaction)
+      genTxs <- Gen
+        .listOfN(neededTxs, TransactionGenerators.transaction)
+        .map(_.toVector)
       allTxs = genTxs ++ txs
       header <- blockHeader(allTxs)
     } yield Block(header, allTxs)

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CreditingTxGen.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CreditingTxGen.scala
@@ -23,9 +23,11 @@ sealed abstract class CreditingTxGen {
   private val max = 3
 
   /** Note this generator does NOT generate outputs with negative values */
-  private def nonEmptyOutputs: Gen[Seq[TransactionOutput]] =
+  private def nonEmptyOutputs: Gen[Vector[TransactionOutput]] =
     Gen.choose(1, 5).flatMap { n =>
-      Gen.listOfN(n, TransactionGenerators.realisticOutput)
+      Gen
+        .listOfN(n, TransactionGenerators.realisticOutput)
+        .map(_.toVector)
     }
 
   /** Generator for non-script hash based output */
@@ -233,7 +235,10 @@ sealed abstract class CreditingTxGen {
         val oldOutputs = o.prevTransaction.outputs
         val updated = oldOutputs.updated(o.outPoint.vout.toInt, updatedOutput)
         val creditingTx =
-          BaseTransaction(tc.validLockVersion, Nil, updated, tc.lockTime)
+          BaseTransaction(tc.validLockVersion,
+                          Vector.empty,
+                          updated,
+                          tc.lockTime)
 
         ScriptSignatureParams(
           InputInfo(
@@ -267,7 +272,10 @@ sealed abstract class CreditingTxGen {
           val updated =
             oldOutputs.updated(o.outPoint.vout.toInt, updatedOutput)
           val creditingTx =
-            BaseTransaction(tc.validLockVersion, Nil, updated, tc.lockTime)
+            BaseTransaction(tc.validLockVersion,
+                            Vector.empty,
+                            updated,
+                            tc.lockTime)
 
           ScriptSignatureParams(
             InputInfo(
@@ -301,7 +309,10 @@ sealed abstract class CreditingTxGen {
           val updated =
             oldOutputs.updated(o.outPoint.vout.toInt, updatedOutput)
           val creditingTx =
-            BaseTransaction(tc.validLockVersion, Nil, updated, tc.lockTime)
+            BaseTransaction(tc.validLockVersion,
+                            Vector.empty,
+                            updated,
+                            tc.lockTime)
 
           ScriptSignatureParams(
             InputInfo(
@@ -370,7 +381,10 @@ sealed abstract class CreditingTxGen {
               val tc = TransactionConstants
               val signers: Vector[Sign] = keys.toVector
               val creditingTx =
-                BaseTransaction(tc.validLockVersion, Nil, outputs, tc.lockTime)
+                BaseTransaction(tc.validLockVersion,
+                                Vector.empty,
+                                outputs,
+                                tc.lockTime)
               ScriptSignatureParams(
                 InputInfo(
                   TransactionOutPoint(
@@ -459,7 +473,8 @@ sealed abstract class CreditingTxGen {
           val old = outputs(idx)
           val updated = outputs.updated(idx, TransactionOutput(old.value, spk))
           val tc = TransactionConstants
-          val btx = BaseTransaction(tc.version, Nil, updated, tc.lockTime)
+          val btx =
+            BaseTransaction(tc.version, Vector.empty, updated, tc.lockTime)
           ScriptSignatureParams(
             InputInfo(
               TransactionOutPoint(btx.txId, UInt32.apply(idx)),

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TransactionGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TransactionGenerators.scala
@@ -51,8 +51,11 @@ object TransactionGenerators {
       ScriptGenerators.scriptPubKey.map(spk => TransactionOutput(amt, spk._1))
     }
 
-  def realisticOutputs: Gen[Seq[TransactionOutput]] =
-    Gen.choose(1, 5).flatMap(n => Gen.listOfN(n, realisticOutput))
+  def realisticOutputs: Gen[Vector[TransactionOutput]] =
+    Gen
+      .choose(1, 5)
+      .flatMap(n => Gen.listOfN(n, realisticOutput))
+      .map(_.toVector)
 
   def realisticWitnessOutput: Gen[TransactionOutput] = {
     CurrencyUnitGenerator.positiveRealistic.flatMap { amt =>
@@ -61,21 +64,30 @@ object TransactionGenerators {
     }
   }
 
-  def realisticWitnessOutputs: Gen[Seq[TransactionOutput]] = {
-    Gen.choose(1, 5).flatMap(n => Gen.listOfN(n, realisticWitnessOutput))
+  def realisticWitnessOutputs: Gen[Vector[TransactionOutput]] = {
+    Gen
+      .choose(1, 5)
+      .flatMap(n => Gen.listOfN(n, realisticWitnessOutput))
+      .map(_.toVector)
   }
 
   /** Generates a small list of TX outputs paying to the given SPK */
-  def smallOutputsTo(spk: ScriptPubKey): Gen[Seq[TransactionOutput]] =
-    Gen.choose(1, 5).flatMap(i => Gen.listOfN(i, outputTo(spk)))
+  def smallOutputsTo(spk: ScriptPubKey): Gen[Vector[TransactionOutput]] =
+    Gen
+      .choose(1, 5)
+      .flatMap(i => Gen.listOfN(i, outputTo(spk)))
+      .map(_.toVector)
 
   /** Generates a small list of
     * [[org.bitcoins.core.protocol.transaction.TransactionOutput TransactionOutput]]
     */
-  def smallOutputs: Gen[Seq[TransactionOutput]] =
-    Gen.choose(0, 5).flatMap(i => Gen.listOfN(i, output))
+  def smallOutputs: Gen[Vector[TransactionOutput]] =
+    Gen
+      .choose(0, 5)
+      .flatMap(i => Gen.listOfN(i, output))
+      .map(_.toVector)
 
-  private def genAmounts(totalAmount: CurrencyUnit): Seq[CurrencyUnit] = {
+  private def genAmounts(totalAmount: CurrencyUnit): Vector[CurrencyUnit] = {
     val numOutputs = Gen.choose(0, 5).sampleSome
     @tailrec
     def loop(
@@ -93,7 +105,7 @@ object TransactionGenerators {
         loop(remaining - 1, remainingAmount - amt, amt +: accum)
       }
     }
-    loop(numOutputs, totalAmount, Nil)
+    loop(numOutputs, totalAmount, Nil).toVector
   }
 
   /** Creates a small sequence of outputs whose total sum is <= totalAmount */
@@ -156,14 +168,20 @@ object TransactionGenerators {
   /** Generates a small list of
     * [[org.bitcoins.core.protocol.transaction.TransactionInput TransactionInput]]
     */
-  def smallInputs: Gen[Seq[TransactionInput]] =
-    Gen.choose(1, 5).flatMap(i => Gen.listOfN(i, input))
+  def smallInputs: Gen[Vector[TransactionInput]] =
+    Gen
+      .choose(1, 5)
+      .flatMap(i => Gen.listOfN(i, input))
+      .map(_.toVector)
 
   /** Generates a small non empty list of
     * [[org.bitcoins.core.protocol.transaction.TransactionInput TransactionInput]]
     */
-  def smallInputsNonEmpty: Gen[Seq[TransactionInput]] =
-    Gen.choose(1, 5).flatMap(i => Gen.listOfN(i, input))
+  def smallInputsNonEmpty: Gen[Vector[TransactionInput]] =
+    Gen
+      .choose(1, 5)
+      .flatMap(i => Gen.listOfN(i, input))
+      .map(_.toVector)
 
   def outputReference: Gen[OutputReference] = {
     for {
@@ -186,16 +204,24 @@ object TransactionGenerators {
     * will not evaluate to true inside of the
     * [[org.bitcoins.core.script.interpreter.ScriptInterpreter ScriptInterpreter]]
     */
-  def transactions: Gen[Seq[Transaction]] = Gen.listOf(transaction)
+  def transactions: Gen[Vector[Transaction]] = Gen
+    .listOf(transaction)
+    .map(_.toVector)
 
   /** Generates a small list of
     * [[org.bitcoins.core.protocol.transaction.Transaction Transaction]]
     */
-  def smallTransactions: Gen[Seq[Transaction]] =
-    Gen.choose(0, 10).flatMap(i => Gen.listOfN(i, transaction))
+  def smallTransactions: Gen[Vector[Transaction]] =
+    Gen
+      .choose(0, 10)
+      .flatMap(i => Gen.listOfN(i, transaction))
+      .map(_.toVector)
 
-  def nonEmptySmallTransactions: Gen[Seq[Transaction]] = {
-    Gen.choose(1, 10).flatMap(i => Gen.listOfN(i, transaction))
+  def nonEmptySmallTransactions: Gen[Vector[Transaction]] = {
+    Gen
+      .choose(1, 10)
+      .flatMap(i => Gen.listOfN(i, transaction))
+      .map(_.toVector)
   }
 
   def transaction: Gen[Transaction] =
@@ -257,7 +283,7 @@ object TransactionGenerators {
 
   /** To avoid duplicating logic */
   private def witnessTxHelper(
-      outputs: Seq[TransactionOutput]
+      outputs: Vector[TransactionOutput]
   ): Gen[WitnessTransaction] = {
     for {
       version <- NumberGenerator.int32s
@@ -638,7 +664,7 @@ object TransactionGenerators {
       outputIndex,
       locktime,
       sequence,
-      Seq(output)
+      Vector(output)
     )
   }
 
@@ -649,16 +675,16 @@ object TransactionGenerators {
       outputIndex: UInt32,
       locktime: UInt32,
       sequence: UInt32,
-      outputs: Seq[TransactionOutput]
+      outputs: Vector[TransactionOutput]
   ): (Transaction, UInt32) = {
     val os = if (outputs.isEmpty) {
-      Seq(TransactionOutput(CurrencyUnits.zero, EmptyScriptPubKey))
+      Vector(TransactionOutput(CurrencyUnits.zero, EmptyScriptPubKey))
     } else {
       outputs
     }
     val outpoint = TransactionOutPoint(creditingTx.txId, outputIndex)
     val input = TransactionInput(outpoint, scriptSignature, sequence)
-    val tx = BaseTransaction(version, Seq(input), os, locktime)
+    val tx = BaseTransaction(version, Vector(input), os, locktime)
     (tx, UInt32.zero)
   }
 
@@ -729,8 +755,8 @@ object TransactionGenerators {
     )
   }
 
-  def dummyOutputs: Seq[TransactionOutput] =
-    Seq(TransactionOutput(CurrencyUnits.zero, EmptyScriptPubKey))
+  val dummyOutputs: Vector[TransactionOutput] =
+    Vector(TransactionOutput(CurrencyUnits.zero, EmptyScriptPubKey))
 
   def buildSpendingTransaction(
       version: Int32,
@@ -740,12 +766,12 @@ object TransactionGenerators {
       locktime: UInt32,
       sequence: UInt32,
       witness: TransactionWitness,
-      outputs: Seq[TransactionOutput]
+      outputs: Vector[TransactionOutput]
   ): (WitnessTransaction, UInt32) = {
     val outpoint = TransactionOutPoint(creditingTx.txId, outputIndex)
     val input = TransactionInput(outpoint, scriptSignature, sequence)
     (
-      WitnessTransaction(version, Seq(input), outputs, locktime, witness),
+      WitnessTransaction(version, Vector(input), outputs, locktime, witness),
       UInt32.zero
     )
   }
@@ -849,8 +875,8 @@ object TransactionGenerators {
       TransactionInput(outpoint, scriptSignature, TransactionConstants.sequence)
     val tx = BaseTransaction(
       version,
-      Seq(input),
-      Seq(output),
+      Vector(input),
+      Vector(output),
       TransactionConstants.lockTime
     )
     (tx, UInt32.zero)

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/TransactionTestUtil.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/TransactionTestUtil.scala
@@ -68,8 +68,8 @@ trait TransactionTestUtil {
 
     val tx = BaseTransaction(
       TransactionConstants.version,
-      Seq(input),
-      Seq(output),
+      Vector(input),
+      Vector(output),
       TransactionConstants.lockTime
     )
     (tx, UInt32.zero)
@@ -115,8 +115,8 @@ trait TransactionTestUtil {
         val output = TransactionOutput(amount, EmptyScriptPubKey)
         WitnessTransaction(
           TransactionConstants.version,
-          Seq(input),
-          Seq(output),
+          Vector(input),
+          Vector(output),
           TransactionConstants.lockTime,
           txWitness
         )
@@ -124,8 +124,8 @@ trait TransactionTestUtil {
         val output = TransactionOutput(CurrencyUnits.zero, EmptyScriptPubKey)
         BaseTransaction(
           TransactionConstants.version,
-          Seq(input),
-          Seq(output),
+          Vector(input),
+          Vector(output),
           TransactionConstants.lockTime
         )
 
@@ -252,8 +252,8 @@ trait TransactionTestUtil {
   def testTransaction: Transaction =
     BaseTransaction(
       EmptyTransaction.version,
-      Seq(EmptyTransactionInput),
-      Nil,
+      Vector(EmptyTransactionInput),
+      Vector.empty,
       EmptyTransaction.lockTime
     )
 


### PR DESCRIPTION
Previously they would use a more generic type called `Seq`. The problem with this is we can have pathological `O(N)` performance if the implementation is `List` instead of `Vector` when we do random access operations such as `vec(n)`. 

I think we are hitting some of this pathological performance in #5728 

For more information on perf characteristics: https://www.lihaoyi.com/post/BenchmarkingScalaCollections.html