### PR TITLE
Refactor `TransactionProcessing.processTransaction()` to use `BlockHashWithConfs`

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
@@ -25,7 +25,7 @@ object CallbackUtil extends BitcoinSLogger {
     val txSink = Sink.foreachAsync[Transaction](1) { case tx: Transaction =>
       logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")
       wallet.transactionProcessing
-        .processTransaction(tx, blockHashOpt = None)
+        .processTransaction(tx, blockHashWithConfsOpt = None)
         .map(_ => ())
     }
 
@@ -109,7 +109,7 @@ object CallbackUtil extends BitcoinSLogger {
     val txSink = Sink.foreachAsync[Transaction](1) { case tx: Transaction =>
       logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")
       wallet.transactionProcessing
-        .processTransaction(tx, blockHashOpt = None)
+        .processTransaction(tx, blockHashWithConfsOpt = None)
         .map(_ => ())
     }
     val onTx: OnTxReceived = { tx =>

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/TransactionProcessingApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/TransactionProcessingApi.scala
@@ -4,6 +4,7 @@ import org.bitcoins.core.api.wallet.db.{SpendingInfoDb, TransactionDb}
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.{OutputWithIndex, Transaction}
+import org.bitcoins.core.util.BlockHashWithConfs
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.utxo.AddressTag
 import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
@@ -26,7 +27,7 @@ trait TransactionProcessingApi {
 
   def processTransaction(
       transaction: Transaction,
-      blockHashOpt: Option[DoubleSha256DigestBE]
+      blockHashWithConfsOpt: Option[BlockHashWithConfs]
   ): Future[Unit]
 
   /** Processes TXs originating from our wallet. This is called right after
@@ -37,7 +38,7 @@ trait TransactionProcessingApi {
       feeRate: FeeUnit,
       inputAmount: CurrencyUnit,
       sentAmount: CurrencyUnit,
-      blockHashOpt: Option[DoubleSha256DigestBE],
+      blockHashWithConfsOpt: Option[BlockHashWithConfs],
       newTags: Vector[AddressTag]
   ): Future[ProcessTxResult]
 
@@ -52,7 +53,7 @@ trait TransactionProcessingApi {
 
   def processReceivedUtxos(
       tx: Transaction,
-      blockHashOpt: Option[DoubleSha256DigestBE],
+      blockHashWithConfsOpt: Option[BlockHashWithConfs],
       spendingInfoDbs: Vector[SpendingInfoDb],
       newTags: Vector[AddressTag],
       relevantReceivedOutputs: Vector[OutputWithIndex]
@@ -61,7 +62,7 @@ trait TransactionProcessingApi {
   def processSpentUtxos(
       transaction: Transaction,
       outputsBeingSpent: Vector[SpendingInfoDb],
-      blockHashOpt: Option[DoubleSha256DigestBE]
+      blockHashWithConfsOpt: Option[BlockHashWithConfs]
   ): Future[Vector[SpendingInfoDb]]
 
   def insertTransaction(

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCWalletCallbackTest.scala
@@ -5,6 +5,7 @@ import org.bitcoins.core.protocol.dlc.models.{
   DLCStatus,
   SingleContractInfo
 }
+import org.bitcoins.core.util.BlockHashWithConfs
 import org.bitcoins.dlc.wallet.callback.{DLCWalletCallbacks, OnDLCStateChange}
 import org.bitcoins.testkit.wallet.FundWalletUtil.FundedDLCWallet
 import org.bitcoins.testkit.wallet.{BitcoinSDualWalletTest, DLCWalletUtil}
@@ -96,9 +97,11 @@ class DLCWalletCallbackTest extends BitcoinSDualWalletTest {
       _ <- initF
       contractId <- DLCWalletUtil.getContractId(wallets._1.wallet)
       fundingTx <- walletA.getDLCFundingTx(contractId)
+      blockHash = CryptoGenerators.doubleSha256DigestBE.sample.get
+      blockHashWithConfs = BlockHashWithConfs(blockHash, Some(1))
       _ <- walletA.transactionProcessing.processTransaction(
         transaction = fundingTx,
-        blockHashOpt = Some(CryptoGenerators.doubleSha256DigestBE.sample.get)
+        blockHashWithConfsOpt = Some(blockHashWithConfs)
       )
       sigs = {
         DLCWalletUtil.sampleContractInfo match {
@@ -207,9 +210,11 @@ class DLCWalletCallbackTest extends BitcoinSDualWalletTest {
       _ <- initF
       contractId <- DLCWalletUtil.getContractId(wallets._1.wallet)
       fundingTx <- walletA.getDLCFundingTx(contractId)
+      blockHash = CryptoGenerators.doubleSha256DigestBE.sample.get
+      blockHashWithConfs = BlockHashWithConfs(blockHash, Some(1))
       _ <- walletA.transactionProcessing.processTransaction(
         transaction = fundingTx,
-        blockHashOpt = Some(CryptoGenerators.doubleSha256DigestBE.sample.get)
+        blockHashWithConfsOpt = Some(blockHashWithConfs)
       )
       transaction <- walletA.executeDLCRefund(contractId)
       _ <- walletB.transactionProcessing.processTransaction(transaction, None)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1935,7 +1935,8 @@ case class DLCWallet(override val walletApi: Wallet)(implicit
       _ <- updateClosingTxId(contractId, refundTx.txIdBE)
 
       _ <- transactionProcessing.processTransaction(refundTx,
-                                                    blockHashOpt = None)
+                                                    blockHashWithConfsOpt =
+                                                      None)
       status <- findDLC(dlcDb.dlcId)
       _ <- dlcConfig.walletCallbacks.executeOnDLCStateChange(status.get)
     } yield refundTx

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/MockChainQueryApi.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/MockChainQueryApi.scala
@@ -5,7 +5,7 @@ import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
 import org.bitcoins.core.gcs.BlockFilter
 import org.bitcoins.core.protocol.BlockStamp
 import org.bitcoins.core.protocol.blockchain.RegTestNetChainParams
-import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.util.{BlockHashWithConfs, FutureUtil}
 import org.bitcoins.crypto.DoubleSha256DigestBE
 
 import scala.concurrent.Future
@@ -18,6 +18,9 @@ object MockChainQueryApi extends ChainQueryApi {
   val testBlockHash: DoubleSha256DigestBE = DoubleSha256DigestBE.fromHex(
     "00000000496dcc754fabd97f3e2df0a7337eab417d75537fecf97a7ebb0e7c75"
   )
+
+  val blockHashWithConfs: BlockHashWithConfs =
+    BlockHashWithConfs(testBlockHash, Some(6))
 
   /** Gets the height of the given block */
   override def getBlockHeight(
@@ -41,7 +44,7 @@ object MockChainQueryApi extends ChainQueryApi {
       blockHash: DoubleSha256DigestBE
   ): Future[Option[Int]] = {
     if (blockHash == testBlockHash) {
-      Future.successful(Some(6))
+      Future.successful(blockHashWithConfs.confirmationsOpt)
     } else FutureUtil.none
   }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -25,6 +25,7 @@ import org.bitcoins.testkit.wallet.FundWalletUtil.{
 import org.bitcoins.testkitcore.gen.TransactionGenerators
 import org.bitcoins.testkitcore.util.TransactionTestUtil
 import org.bitcoins.wallet.config.WalletAppConfig
+import org.bitcoins.wallet.util.WalletUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -107,7 +108,10 @@ trait FundWalletUtil extends BitcoinSLogger {
       addresses <- addressesF
       addressAmountMap = addresses.zip(amts).toMap
       (tx, blockHash) <- fundAddressesWithBitcoind(addressAmountMap, bitcoind)
-      _ <- wallet.transactionProcessing.processTransaction(tx, Some(blockHash))
+      blockHashWithConfs <- WalletUtil.getBlockHashWithConfs(bitcoind,
+                                                             blockHash)
+      _ <- wallet.transactionProcessing.processTransaction(tx,
+                                                           blockHashWithConfs)
     } yield (tx, blockHash)
 
     txAndHashF.map(_ => wallet)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -75,17 +75,18 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
 
         _ <- wallet.transactionProcessing.processTransaction(
           tx,
-          Some(MockChainQueryApi.testBlockHash)
+          Some(MockChainQueryApi.blockHashWithConfs)
         )
         newConfirmed <- wallet.getConfirmedBalance()
         newUnconfirmed <- wallet.getUnconfirmedBalance()
         utxosPostAdd <- wallet.utxoHandling.listUtxos()
 
         // repeating the action should not make a difference
+
         _ <- checkUtxosAndBalance(wallet) {
           wallet.transactionProcessing.processTransaction(
             tx,
-            Some(MockChainQueryApi.testBlockHash))
+            Some(MockChainQueryApi.blockHashWithConfs))
         }
       } yield {
         val ourOutputs =
@@ -196,7 +197,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
         )
         _ <- wallet.transactionProcessing.processTransaction(
           transaction = rawTxHelper.signedTx,
-          blockHashOpt = None
+          blockHashWithConfsOpt = None
         )
         balance <- wallet.getBalance()
       } yield assert(balance == amount)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -11,6 +11,8 @@ import org.bitcoins.testkit.wallet.{
   BitcoinSWalletTestCachedBitcoindNewest,
   WalletWithBitcoindRpc
 }
+import org.bitcoins.wallet.util.WalletUtil
+
 import scala.concurrent.duration.DurationInt
 
 class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
@@ -110,9 +112,12 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         bitcoindAddr <- bitcoindAddrF
         blockHashes <-
           bitcoind.generateToAddress(blocks = numBlocks, address = bitcoindAddr)
+        blockHashWithConfs <- WalletUtil.getBlockHashWithConfs(
+          bitcoind,
+          blockHashes.headOption)
         _ <- wallet.transactionProcessing.processTransaction(
           transaction = tx,
-          blockHashOpt = blockHashes.headOption
+          blockHashWithConfsOpt = blockHashWithConfs
         )
         balance <- wallet.getBalance()
         unconfirmedBalance <- wallet.getUnconfirmedBalance()
@@ -171,9 +176,12 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         bitcoindAddr <- bitcoindAddrF
         blockHashes <-
           bitcoind.generateToAddress(blocks = numBlocks, address = bitcoindAddr)
+        blockHashWithConfs <- WalletUtil.getBlockHashWithConfs(
+          bitcoind,
+          blockHashes.headOption)
         _ <- wallet.transactionProcessing.processTransaction(
           transaction = tx,
-          blockHashOpt = blockHashes.headOption
+          blockHashWithConfsOpt = blockHashWithConfs
         )
         balance <- wallet.getBalance()
         unconfirmedBalance <- wallet.getUnconfirmedBalance()
@@ -235,9 +243,12 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         bitcoindAddr <- bitcoindAddrF
         blockHashes <-
           bitcoind.generateToAddress(blocks = numBlocks, address = bitcoindAddr)
+        blockHashWithConfs <- WalletUtil.getBlockHashWithConfs(
+          bitcoind,
+          blockHashes.headOption)
         _ <- wallet.transactionProcessing.processTransaction(
           transaction = tx,
-          blockHashOpt = blockHashes.headOption
+          blockHashWithConfsOpt = blockHashWithConfs
         )
         balance <- wallet.getBalance()
         unconfirmedBalance <- wallet.getUnconfirmedBalance()
@@ -523,9 +534,12 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         bitcoindAddr <- bitcoindAddrF
         blockHashes <-
           bitcoind.generateToAddress(blocks = numBlocks, address = bitcoindAddr)
+        blockHashWithConfs <- WalletUtil.getBlockHashWithConfs(
+          bitcoind,
+          blockHashes.headOption)
         _ <- wallet.transactionProcessing.processTransaction(
           transaction = tx,
-          blockHashOpt = blockHashes.headOption
+          blockHashWithConfsOpt = blockHashWithConfs
         )
         balance <- wallet.getBalance()
         unconfirmedBalance <- wallet.getUnconfirmedBalance()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -19,6 +19,7 @@ import org.bitcoins.wallet.models.{
   IncomingTransactionDAO,
   OutgoingTransactionDAO
 }
+import org.bitcoins.wallet.util.WalletUtil
 import org.scalatest.{FutureOutcome, Outcome}
 
 import scala.concurrent.Future
@@ -92,7 +93,11 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       rawTx <- bitcoind.getRawTransaction(txId)
 
       // after this, tx should be confirmed
-      _ <- wallet.transactionProcessing.processTransaction(tx, rawTx.blockhash)
+      blockHashWithConfsOpt <- WalletUtil.getBlockHashWithConfs(bitcoind,
+                                                                rawTx.blockhash)
+      _ <- wallet.transactionProcessing.processTransaction(
+        tx,
+        blockHashWithConfsOpt)
       _ <-
         wallet.utxoHandling
           .listUtxos()
@@ -176,8 +181,11 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       txId <- bitcoind.sendToAddress(addr, valueFromBitcoind)
       rawTx <- bitcoind.getRawTransaction(txId)
       _ <- bitcoind.generate(6)
-      _ <- wallet.transactionProcessing.processTransaction(rawTx.hex,
-                                                           rawTx.blockhash)
+      blockHashWithConfsOpt <- WalletUtil.getBlockHashWithConfs(bitcoind,
+                                                                rawTx.blockhash)
+      _ <- wallet.transactionProcessing.processTransaction(
+        rawTx.hex,
+        blockHashWithConfsOpt)
 
       // Verify we funded the wallet
       balance <- wallet.getBalance()
@@ -243,8 +251,11 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       txId <- bitcoind.sendToAddress(addr, valueFromBitcoind)
       _ <- bitcoind.generate(6)
       rawTx <- bitcoind.getRawTransaction(txId)
-      _ <- wallet.transactionProcessing.processTransaction(rawTx.hex,
-                                                           rawTx.blockhash)
+      blockHashWithConfsOpt <- WalletUtil.getBlockHashWithConfs(bitcoind,
+                                                                rawTx.blockhash)
+      _ <- wallet.transactionProcessing.processTransaction(
+        rawTx.hex,
+        blockHashWithConfsOpt)
 
       // Verify we funded the wallet
       balance <- wallet.getBalance()
@@ -262,8 +273,11 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       _ <- bitcoind.generate(1)
       rawTx1 <- bitcoind.getRawTransaction(rbf.txIdBE)
       _ = require(rawTx1.blockhash.isDefined)
-      _ <- wallet.transactionProcessing.processTransaction(rbf,
-                                                           rawTx1.blockhash)
+      blockHashWithConfsOpt <- WalletUtil.getBlockHashWithConfs(bitcoind,
+                                                                rawTx.blockhash)
+      _ <- wallet.transactionProcessing.processTransaction(
+        rbf,
+        blockHashWithConfsOpt)
 
       // fail to RBF confirmed tx
       res <- recoverToSucceededIf[IllegalArgumentException] {
@@ -283,8 +297,11 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       txId <- bitcoind.sendToAddress(addr, valueFromBitcoind)
       rawTx <- bitcoind.getRawTransaction(txId)
       _ <- bitcoind.generate(6)
-      _ <- wallet.transactionProcessing.processTransaction(rawTx.hex,
-                                                           rawTx.blockhash)
+      blockHashWithConfsOpt <- WalletUtil.getBlockHashWithConfs(bitcoind,
+                                                                rawTx.blockhash)
+      _ <- wallet.transactionProcessing.processTransaction(
+        rawTx.hex,
+        blockHashWithConfsOpt)
 
       // Verify we funded the wallet
       balance <- wallet.getBalance()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -19,6 +19,7 @@ import org.bitcoins.testkitcore.Implicits.GeneratorOps
 import org.bitcoins.testkitcore.gen.FeeUnitGen
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.models.{OutgoingTransactionDAO, SpendingInfoDAO}
+import org.bitcoins.wallet.util.WalletUtil
 import org.scalatest.{Assertion, FutureOutcome}
 import scodec.bits.ByteVector
 
@@ -379,9 +380,12 @@ class WalletSendingTest extends BitcoinSWalletTest {
       tx <- wallet.sendFundsHandling.sendToAddress(testAddress,
                                                    amountToSend,
                                                    feeRate)
+      blockHashWithConfsOpt <- WalletUtil.getBlockHashWithConfs(
+        chainQueryApi,
+        Some(DoubleSha256DigestBE.empty))
       _ <- wallet.transactionProcessing.processTransaction(
         tx,
-        Some(DoubleSha256DigestBE.empty))
+        blockHashWithConfsOpt)
 
       res <- recoverToSucceededIf[IllegalArgumentException] {
         wallet.sendFundsHandling.bumpFeeRBF(tx.txIdBE, newFeeRate)
@@ -470,9 +474,12 @@ class WalletSendingTest extends BitcoinSWalletTest {
       tx <- wallet.sendFundsHandling.sendToAddress(testAddress,
                                                    amountToSend,
                                                    feeRate)
+      blockHashWithConfsOpt <- WalletUtil.getBlockHashWithConfs(
+        chainQueryApi,
+        Some(DoubleSha256DigestBE.empty))
       _ <- wallet.transactionProcessing.processTransaction(
         tx,
-        Some(DoubleSha256DigestBE.empty))
+        blockHashWithConfsOpt)
 
       res <- recoverToSucceededIf[IllegalArgumentException] {
         wallet.sendFundsHandling.bumpFeeCPFP(tx.txIdBE, feeRate)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -254,9 +254,9 @@ class WalletUnitTest extends BitcoinSWalletTest {
         spk = addr.scriptPubKey
         _ = assert(spk == P2PKHScriptPubKey(walletKey))
         dummyPrevTx = dummyTx(spk = spk)
-        _ <- wallet.transactionProcessing.processTransaction(dummyPrevTx,
-                                                             blockHashOpt =
-                                                               None)
+        _ <- wallet.transactionProcessing.processTransaction(
+          dummyPrevTx,
+          blockHashWithConfsOpt = None)
 
         psbt = dummyPSBT(prevTxId = dummyPrevTx.txId)
 
@@ -280,9 +280,9 @@ class WalletUnitTest extends BitcoinSWalletTest {
         spk = addr.scriptPubKey
         _ = assert(spk == P2SHScriptPubKey(P2WPKHWitnessSPKV0(walletKey)))
         dummyPrevTx = dummyTx(spk = spk)
-        _ <- wallet.transactionProcessing.processTransaction(dummyPrevTx,
-                                                             blockHashOpt =
-                                                               None)
+        _ <- wallet.transactionProcessing.processTransaction(
+          dummyPrevTx,
+          blockHashWithConfsOpt = None)
 
         psbt = dummyPSBT(prevTxId = dummyPrevTx.txId)
 
@@ -306,9 +306,9 @@ class WalletUnitTest extends BitcoinSWalletTest {
         spk = addr.scriptPubKey
         _ = assert(spk == P2WPKHWitnessSPKV0(walletKey))
         dummyPrevTx = dummyTx(spk = spk)
-        _ <- wallet.transactionProcessing.processTransaction(dummyPrevTx,
-                                                             blockHashOpt =
-                                                               None)
+        _ <- wallet.transactionProcessing.processTransaction(
+          dummyPrevTx,
+          blockHashWithConfsOpt = None)
 
         psbt = dummyPSBT(prevTxId = dummyPrevTx.txId)
           .addUTXOToInput(dummyPrevTx, 0)
@@ -339,12 +339,14 @@ class WalletUnitTest extends BitcoinSWalletTest {
       spk = addr.scriptPubKey
       _ = assert(spk == P2WPKHWitnessSPKV0(walletKey))
       dummyPrevTx = dummyTx(spk = spk)
-      _ <- wallet.transactionProcessing.processTransaction(dummyPrevTx,
-                                                           blockHashOpt = None)
+      _ <- wallet.transactionProcessing.processTransaction(
+        dummyPrevTx,
+        blockHashWithConfsOpt = None)
 
       dummyPrevTx1 = dummyTx(prevTxId = dummyPrevTx.txId, spk = spk)
-      _ <- wallet.transactionProcessing.processTransaction(dummyPrevTx1,
-                                                           blockHashOpt = None)
+      _ <- wallet.transactionProcessing.processTransaction(
+        dummyPrevTx1,
+        blockHashWithConfsOpt = None)
 
       toBroadcast <- wallet.sendFundsHandling.getTransactionsToBroadcast
     } yield assert(toBroadcast.map(_.txIdBE) == Vector(dummyPrevTx1.txIdBE))

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -232,7 +232,8 @@ case class Wallet(
     for {
       _ <- nodeApi.broadcastTransaction(transaction)
       _ <- transactionProcessing.processTransaction(transaction,
-                                                    blockHashOpt = None)
+                                                    blockHashWithConfsOpt =
+                                                      None)
       _ <- walletCallbacks.executeOnTransactionBroadcast(transaction)
     } yield ()
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
@@ -604,7 +604,7 @@ case class SendFundsHandlingHandling(
         feeRate = feeRate,
         inputAmount = creditingAmount,
         sentAmount = sentAmount,
-        blockHashOpt = None,
+        blockHashWithConfsOpt = None,
         newTags = newTags
       )
     } yield {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -24,6 +24,7 @@ import org.bitcoins.db.SafeDatabase
 import org.bitcoins.wallet.callback.WalletCallbacks
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.models.{AddressDAO, SpendingInfoDAO, TransactionDAO}
+import org.bitcoins.wallet.util.WalletUtil
 import slick.dbio.{DBIOAction, Effect, NoStream}
 
 import scala.concurrent.Future
@@ -258,9 +259,8 @@ case class UtxoHandling(
         case (blockHashOpt, spendingInfoDbs) =>
           blockHashOpt match {
             case Some(blockHash) =>
-              chainQueryApi
-                .getNumberOfConfirmations(blockHash)
-                .map(confs => Some(BlockHashWithConfs(blockHash, confs)))
+              WalletUtil
+                .getBlockHashWithConfs(chainQueryApi, blockHash)
                 .map(blockWithConfsOpt => (blockWithConfsOpt, spendingInfoDbs))
             case None =>
               Future.successful((None, spendingInfoDbs))

--- a/wallet/src/main/scala/org/bitcoins/wallet/util/WalletUtil.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/util/WalletUtil.scala
@@ -1,0 +1,30 @@
+package org.bitcoins.wallet.util
+
+import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.util.BlockHashWithConfs
+import org.bitcoins.crypto.DoubleSha256DigestBE
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object WalletUtil {
+
+  def getBlockHashWithConfs(
+      chainQueryApi: ChainQueryApi,
+      blockHashOpt: Option[DoubleSha256DigestBE])(implicit
+      ec: ExecutionContext): Future[Option[BlockHashWithConfs]] = {
+    blockHashOpt match {
+      case Some(blockHash) =>
+        chainQueryApi
+          .getNumberOfConfirmations(blockHash)
+          .map(confsOpt => Some(BlockHashWithConfs(blockHash, confsOpt)))
+      case None => Future.successful(None)
+    }
+  }
+
+  def getBlockHashWithConfs(
+      chainQueryApi: ChainQueryApi,
+      blockHash: DoubleSha256DigestBE)(implicit
+      ec: ExecutionContext): Future[Option[BlockHashWithConfs]] = {
+    getBlockHashWithConfs(chainQueryApi, Some(blockHash))
+  }
+}


### PR DESCRIPTION
This saves us various external API calls through the `wallet` codebase to fetch the # of confirmations associated with the given block we are processing. Now we can just fetch the # of confirmations once and use that for processing the block or transaction.