### PR TITLE
2024 10 31 digitalsignature

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
@@ -297,8 +297,8 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
       val scriptPubKey = MultiSignatureScriptPubKey(1, Seq(publicKey))
       val (creditingTx, outputIndex) =
         TransactionTestUtil.buildCreditingTransaction(scriptPubKey)
-      val scriptSig = MultiSignatureScriptSignature(
-        Seq(ECDigitalSignature.emptyDigitalSignature))
+      val scriptSig =
+        MultiSignatureScriptSignature(Seq(ECDigitalSignature.empty))
       val (spendingTx, inputIndex) =
         TransactionTestUtil.buildSpendingTransaction(
           creditingTx,
@@ -351,8 +351,8 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
       val scriptPubKey = P2SHScriptPubKey(redeemScript)
       val (creditingTx, outputIndex) =
         TransactionTestUtil.buildCreditingTransaction(scriptPubKey)
-      val scriptSig = MultiSignatureScriptSignature(
-        Seq(ECDigitalSignature.emptyDigitalSignature))
+      val scriptSig =
+        MultiSignatureScriptSignature(Seq(ECDigitalSignature.empty))
 
       val (spendingTx, inputIndex) =
         TransactionTestUtil.buildSpendingTransaction(
@@ -403,8 +403,7 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
     val scriptPubKey = P2SHScriptPubKey(redeemScript)
     val (creditingTx, outputIndex) =
       TransactionTestUtil.buildCreditingTransaction(scriptPubKey)
-    val scriptSig = MultiSignatureScriptSignature(
-      Seq(ECDigitalSignature.emptyDigitalSignature))
+    val scriptSig = MultiSignatureScriptSignature(Seq(ECDigitalSignature.empty))
 
     val (spendingTx, inputIndex) =
       TransactionTestUtil.buildSpendingTransaction(

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
@@ -12,12 +12,7 @@ import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.wallet.builder.StandardNonInteractiveFinalizer
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.core.wallet.utxo.{ECSignatureParams, P2PKHInputInfo}
-import org.bitcoins.crypto.{
-  ECDigitalSignature,
-  ECPrivateKey,
-  EmptyDigitalSignature,
-  HashType
-}
+import org.bitcoins.crypto.{ECDigitalSignature, ECPrivateKey, HashType}
 import org.bitcoins.testkitcore.util.TransactionTestUtil
 import org.bitcoins.testkitcore.gen.{CreditingTxGen, ScriptGenerators}
 import org.bitcoins.testkitcore.util.BitcoinSJvmTest
@@ -302,7 +297,8 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
       val scriptPubKey = MultiSignatureScriptPubKey(1, Seq(publicKey))
       val (creditingTx, outputIndex) =
         TransactionTestUtil.buildCreditingTransaction(scriptPubKey)
-      val scriptSig = MultiSignatureScriptSignature(Seq(EmptyDigitalSignature))
+      val scriptSig = MultiSignatureScriptSignature(
+        Seq(ECDigitalSignature.emptyDigitalSignature))
       val (spendingTx, inputIndex) =
         TransactionTestUtil.buildSpendingTransaction(
           creditingTx,
@@ -355,7 +351,8 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
       val scriptPubKey = P2SHScriptPubKey(redeemScript)
       val (creditingTx, outputIndex) =
         TransactionTestUtil.buildCreditingTransaction(scriptPubKey)
-      val scriptSig = MultiSignatureScriptSignature(Seq(EmptyDigitalSignature))
+      val scriptSig = MultiSignatureScriptSignature(
+        Seq(ECDigitalSignature.emptyDigitalSignature))
 
       val (spendingTx, inputIndex) =
         TransactionTestUtil.buildSpendingTransaction(
@@ -406,7 +403,8 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
     val scriptPubKey = P2SHScriptPubKey(redeemScript)
     val (creditingTx, outputIndex) =
       TransactionTestUtil.buildCreditingTransaction(scriptPubKey)
-    val scriptSig = MultiSignatureScriptSignature(Seq(EmptyDigitalSignature))
+    val scriptSig = MultiSignatureScriptSignature(
+      Seq(ECDigitalSignature.emptyDigitalSignature))
 
     val (spendingTx, inputIndex) =
       TransactionTestUtil.buildSpendingTransaction(

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TxSigComponentTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TxSigComponentTest.scala
@@ -60,8 +60,7 @@ class TxSigComponentTest extends BitcoinSUnitTest {
       Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey)),
       UInt32.zero,
       TransactionWitness(
-        Vector(
-          P2WPKHWitnessV0(pubKey, ECDigitalSignature.dummyECDigitalSignature))
+        Vector(P2WPKHWitnessV0(pubKey, ECDigitalSignature.dummy))
       )
     )
 

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TxSigComponentTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TxSigComponentTest.scala
@@ -3,13 +3,9 @@ package org.bitcoins.core.crypto
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction._
-import org.bitcoins.crypto.{
-  DoubleSha256Digest,
-  DummyECDigitalSignature,
-  ECPublicKey
-}
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
+import org.bitcoins.crypto.{DoubleSha256Digest, ECDigitalSignature, ECPublicKey}
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 
 class TxSigComponentTest extends BitcoinSUnitTest {
@@ -64,7 +60,8 @@ class TxSigComponentTest extends BitcoinSUnitTest {
       Vector(TransactionOutput(Satoshis.one, EmptyScriptPubKey)),
       UInt32.zero,
       TransactionWitness(
-        Vector(P2WPKHWitnessV0(pubKey, DummyECDigitalSignature))
+        Vector(
+          P2WPKHWitnessV0(pubKey, ECDigitalSignature.dummyECDigitalSignature))
       )
     )
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
@@ -46,7 +46,7 @@ class DLCMessageTest extends BitcoinSJvmTest {
   )
 
   val dummySig: PartialSignature =
-    PartialSignature(dummyPubKey, DummyECDigitalSignature)
+    PartialSignature(dummyPubKey, ECDigitalSignature.emptyDigitalSignature)
 
   it must "not allow a negative collateral for a DLCOffer" in {
     assertThrows[IllegalArgumentException](

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
@@ -46,7 +46,7 @@ class DLCMessageTest extends BitcoinSJvmTest {
   )
 
   val dummySig: PartialSignature =
-    PartialSignature(dummyPubKey, ECDigitalSignature.emptyDigitalSignature)
+    PartialSignature(dummyPubKey, ECDigitalSignature.empty)
 
   it must "not allow a negative collateral for a DLCOffer" in {
     assertThrows[IllegalArgumentException](

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
@@ -488,7 +488,7 @@ class LnInvoiceUnitTest extends BitcoinSUnitTest {
 
   it must "fail to create an invoice if the digital signature is invalid" in {
     intercept[IllegalArgumentException] {
-      val sig = EmptyDigitalSignature
+      val sig = ECDigitalSignature.emptyDigitalSignature
       val tags =
         LnTaggedFields(
           paymentHash = paymentTag,

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/ln/LnInvoiceUnitTest.scala
@@ -488,7 +488,7 @@ class LnInvoiceUnitTest extends BitcoinSUnitTest {
 
   it must "fail to create an invoice if the digital signature is invalid" in {
     intercept[IllegalArgumentException] {
-      val sig = ECDigitalSignature.emptyDigitalSignature
+      val sig = ECDigitalSignature.empty
       val tags =
         LnTaggedFields(
           paymentHash = paymentTag,

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.protocol.transaction
 
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.crypto.{DummyECDigitalSignature, ECPrivateKey}
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.crypto.{ECDigitalSignature, ECPrivateKey}
 import org.bitcoins.testkitcore.gen.WitnessGenerators
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import org.scalacheck.Prop
@@ -21,7 +21,8 @@ class TransactionWitnessSpec extends BitcoinSUnitTest {
   it must "be able to resize a witness to the given index" in {
     val empty = EmptyWitness.fromN(0)
     val pubKey = ECPrivateKey.freshPrivateKey.publicKey
-    val p2pkh = P2PKHScriptSignature(DummyECDigitalSignature, pubKey)
+    val p2pkh =
+      P2PKHScriptSignature(ECDigitalSignature.emptyDigitalSignature, pubKey)
     val scriptWit = P2WPKHWitnessV0.fromP2PKHScriptSig(p2pkh)
     val updated = empty.updated(2, scriptWit)
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
@@ -22,7 +22,7 @@ class TransactionWitnessSpec extends BitcoinSUnitTest {
     val empty = EmptyWitness.fromN(0)
     val pubKey = ECPrivateKey.freshPrivateKey.publicKey
     val p2pkh =
-      P2PKHScriptSignature(ECDigitalSignature.emptyDigitalSignature, pubKey)
+      P2PKHScriptSignature(ECDigitalSignature.dummyECDigitalSignature, pubKey)
     val scriptWit = P2WPKHWitnessV0.fromP2PKHScriptSig(p2pkh)
     val updated = empty.updated(2, scriptWit)
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionWitnessSpec.scala
@@ -22,7 +22,7 @@ class TransactionWitnessSpec extends BitcoinSUnitTest {
     val empty = EmptyWitness.fromN(0)
     val pubKey = ECPrivateKey.freshPrivateKey.publicKey
     val p2pkh =
-      P2PKHScriptSignature(ECDigitalSignature.dummyECDigitalSignature, pubKey)
+      P2PKHScriptSignature(ECDigitalSignature.dummy, pubKey)
     val scriptWit = P2WPKHWitnessV0.fromP2PKHScriptSig(p2pkh)
     val updated = empty.updated(2, scriptWit)
 

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
@@ -377,7 +377,7 @@ class RawTxSignerTest extends BitcoinSUnitTest {
             assert(
               btx.inputs.forall(
                 _.scriptSignature.signatures.forall(
-                  _ == ECDigitalSignature.lowRDummyECDigitalSignature
+                  _ == ECDigitalSignature.dummyLowR
                 )
               )
             )
@@ -385,10 +385,9 @@ class RawTxSignerTest extends BitcoinSUnitTest {
             assert(
               wtx.witness.witnesses.forall {
                 case p2wsh: P2WSHWitnessV0 =>
-                  p2wsh.signatures.forall(
-                    _ == ECDigitalSignature.lowRDummyECDigitalSignature)
+                  p2wsh.signatures.forall(_ == ECDigitalSignature.dummyLowR)
                 case p2wpkh: P2WPKHWitnessV0 =>
-                  p2wpkh.signature == ECDigitalSignature.lowRDummyECDigitalSignature
+                  p2wpkh.signature == ECDigitalSignature.dummyLowR
                 case EmptyScriptWitness =>
                   true
 

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxSignerTest.scala
@@ -2,8 +2,8 @@ package org.bitcoins.core.wallet.builder
 
 import org.bitcoins.core.currency.{Bitcoins, CurrencyUnits, Satoshis}
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.script.constant.ScriptNumber
 import org.bitcoins.core.util.BitcoinScriptUtil
 import org.bitcoins.core.wallet.fee.{SatoshisPerByte, SatoshisPerVirtualByte}
@@ -15,12 +15,12 @@ import org.bitcoins.core.wallet.utxo.{
 }
 import org.bitcoins.crypto.{
   DoubleSha256DigestBE,
+  ECDigitalSignature,
   ECPrivateKey,
   HashType,
-  LowRDummyECDigitalSignature,
   Sign
 }
-import org.bitcoins.testkitcore.Implicits._
+import org.bitcoins.testkitcore.Implicits.*
 import org.bitcoins.testkitcore.gen.{CreditingTxGen, ScriptGenerators}
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 
@@ -377,7 +377,7 @@ class RawTxSignerTest extends BitcoinSUnitTest {
             assert(
               btx.inputs.forall(
                 _.scriptSignature.signatures.forall(
-                  _ == LowRDummyECDigitalSignature
+                  _ == ECDigitalSignature.lowRDummyECDigitalSignature
                 )
               )
             )
@@ -385,9 +385,10 @@ class RawTxSignerTest extends BitcoinSUnitTest {
             assert(
               wtx.witness.witnesses.forall {
                 case p2wsh: P2WSHWitnessV0 =>
-                  p2wsh.signatures.forall(_ == LowRDummyECDigitalSignature)
+                  p2wsh.signatures.forall(
+                    _ == ECDigitalSignature.lowRDummyECDigitalSignature)
                 case p2wpkh: P2WPKHWitnessV0 =>
-                  p2wpkh.signature == LowRDummyECDigitalSignature
+                  p2wpkh.signature == ECDigitalSignature.lowRDummyECDigitalSignature
                 case EmptyScriptWitness =>
                   true
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -51,7 +51,7 @@ sealed abstract class P2WPKHWitnessV0 extends ScriptWitnessV0 {
 
   def signature: ECDigitalSignature =
     stack(1) match {
-      case ByteVector.empty     => ECDigitalSignature.emptyDigitalSignature
+      case ByteVector.empty     => ECDigitalSignature.empty
       case nonEmpty: ByteVector => ECDigitalSignature(nonEmpty)
     }
 
@@ -69,11 +69,11 @@ object P2WPKHWitnessV0 {
 
   private[bitcoins] def apply(
       pubKeyBytes: ECPublicKeyBytes): P2WPKHWitnessV0 = {
-    P2WPKHWitnessV0(pubKeyBytes, ECDigitalSignature.emptyDigitalSignature)
+    P2WPKHWitnessV0(pubKeyBytes, ECDigitalSignature.empty)
   }
 
   def apply(pubKey: ECPublicKey): P2WPKHWitnessV0 = {
-    P2WPKHWitnessV0(pubKey, ECDigitalSignature.emptyDigitalSignature)
+    P2WPKHWitnessV0(pubKey, ECDigitalSignature.empty)
   }
 
   private[bitcoins] def apply(

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -51,7 +51,7 @@ sealed abstract class P2WPKHWitnessV0 extends ScriptWitnessV0 {
 
   def signature: ECDigitalSignature =
     stack(1) match {
-      case ByteVector.empty     => EmptyDigitalSignature
+      case ByteVector.empty     => ECDigitalSignature.emptyDigitalSignature
       case nonEmpty: ByteVector => ECDigitalSignature(nonEmpty)
     }
 
@@ -69,11 +69,11 @@ object P2WPKHWitnessV0 {
 
   private[bitcoins] def apply(
       pubKeyBytes: ECPublicKeyBytes): P2WPKHWitnessV0 = {
-    P2WPKHWitnessV0(pubKeyBytes, EmptyDigitalSignature)
+    P2WPKHWitnessV0(pubKeyBytes, ECDigitalSignature.emptyDigitalSignature)
   }
 
   def apply(pubKey: ECPublicKey): P2WPKHWitnessV0 = {
-    P2WPKHWitnessV0(pubKey, EmptyDigitalSignature)
+    P2WPKHWitnessV0(pubKey, ECDigitalSignature.emptyDigitalSignature)
   }
 
   private[bitcoins] def apply(

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
@@ -3,7 +3,7 @@ package org.bitcoins.core.protocol.transaction
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits, Satoshis}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
-import org.bitcoins.core.protocol.script._
+import org.bitcoins.core.protocol.script.*
 import org.bitcoins.core.script.control.OP_RETURN
 import org.bitcoins.core.wallet.builder.{
   AddWitnessDataFinalizer,
@@ -13,8 +13,8 @@ import org.bitcoins.core.wallet.builder.{
 }
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.signer.BitcoinSigner
-import org.bitcoins.core.wallet.utxo._
-import org.bitcoins.crypto.{DummyECDigitalSignature, HashType, Sign}
+import org.bitcoins.core.wallet.utxo.*
+import org.bitcoins.crypto.{ECDigitalSignature, HashType, Sign}
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
@@ -173,8 +173,8 @@ object TxUtil {
       case (inputInfo, index) =>
         val mockSigners =
           inputInfo.pubKeys.take(inputInfo.requiredSigs).map { pubKey =>
-            Sign(_ => DummyECDigitalSignature,
-                 (_, _) => DummyECDigitalSignature,
+            Sign(_ => ECDigitalSignature.dummyECDigitalSignature,
+                 (_, _) => ECDigitalSignature.dummyECDigitalSignature,
                  pubKey)
           }
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
@@ -173,8 +173,8 @@ object TxUtil {
       case (inputInfo, index) =>
         val mockSigners =
           inputInfo.pubKeys.take(inputInfo.requiredSigs).map { pubKey =>
-            Sign(_ => ECDigitalSignature.dummyECDigitalSignature,
-                 (_, _) => ECDigitalSignature.dummyECDigitalSignature,
+            Sign(_ => ECDigitalSignature.dummy,
+                 (_, _) => ECDigitalSignature.dummy,
                  pubKey)
           }
 

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTRecord.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTRecord.scala
@@ -181,7 +181,7 @@ object InputPSBTRecord extends Factory[InputPSBTRecord] {
 
     def dummyPartialSig(
         pubKey: ECPublicKey = ECPublicKey.freshPublicKey): PartialSignature = {
-      PartialSignature(pubKey, ECDigitalSignature.dummyECDigitalSignature)
+      PartialSignature(pubKey, ECDigitalSignature.dummy)
     }
 
     override def fromBytes(bytes: ByteVector): PartialSignature =

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTRecord.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTRecord.scala
@@ -181,7 +181,7 @@ object InputPSBTRecord extends Factory[InputPSBTRecord] {
 
     def dummyPartialSig(
         pubKey: ECPublicKey = ECPublicKey.freshPublicKey): PartialSignature = {
-      PartialSignature(pubKey, DummyECDigitalSignature)
+      PartialSignature(pubKey, ECDigitalSignature.dummyECDigitalSignature)
     }
 
     override def fromBytes(bytes: ByteVector): PartialSignature =

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -22,7 +22,7 @@ sealed abstract class SignerUtils {
       hashType: HashType,
       isDummySignature: Boolean): ECDigitalSignature = {
     if (isDummySignature) {
-      ECDigitalSignature.dummyECDigitalSignature
+      ECDigitalSignature.dummy
     } else {
       TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
     }
@@ -35,7 +35,7 @@ sealed abstract class SignerUtils {
       hashType: HashType,
       isDummySignature: Boolean): ECDigitalSignature = {
     if (isDummySignature) {
-      ECDigitalSignature.lowRDummyECDigitalSignature
+      ECDigitalSignature.dummyLowR
     } else {
       TransactionSignatureCreator.createSig(unsignedTx,
                                             signingInfo,

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -22,7 +22,7 @@ sealed abstract class SignerUtils {
       hashType: HashType,
       isDummySignature: Boolean): ECDigitalSignature = {
     if (isDummySignature) {
-      DummyECDigitalSignature
+      ECDigitalSignature.dummyECDigitalSignature
     } else {
       TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
     }
@@ -35,7 +35,7 @@ sealed abstract class SignerUtils {
       hashType: HashType,
       isDummySignature: Boolean): ECDigitalSignature = {
     if (isDummySignature) {
-      LowRDummyECDigitalSignature
+      ECDigitalSignature.lowRDummyECDigitalSignature
     } else {
       TransactionSignatureCreator.createSig(unsignedTx,
                                             signingInfo,

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputInfo.scala
@@ -216,24 +216,24 @@ object InputInfo {
       case _: P2PKInputInfo =>
         ScriptSigLenAndStackHeight(
           P2PKScriptSignature(
-            ECDigitalSignature.lowRDummyECDigitalSignature).asmBytes.length.toInt,
+            ECDigitalSignature.dummyLowR).asmBytes.length.toInt,
           1)
       case _: P2PKHInputInfo =>
         ScriptSigLenAndStackHeight(
-          P2PKHScriptSignature(ECDigitalSignature.lowRDummyECDigitalSignature,
+          P2PKHScriptSignature(ECDigitalSignature.dummyLowR,
                                ECPublicKey.dummy).asmBytes.length.toInt,
           2)
       case info: P2PKWithTimeoutInputInfo =>
         ScriptSigLenAndStackHeight(
           P2PKWithTimeoutScriptSignature(
             info.isBeforeTimeout,
-            ECDigitalSignature.lowRDummyECDigitalSignature).asmBytes.length.toInt,
+            ECDigitalSignature.dummyLowR).asmBytes.length.toInt,
           2)
       case info: MultiSignatureInputInfo =>
         ScriptSigLenAndStackHeight(
           MultiSignatureScriptSignature(
             Vector.fill(info.requiredSigs)(
-              ECDigitalSignature.lowRDummyECDigitalSignature)).asmBytes.length.toInt,
+              ECDigitalSignature.dummyLowR)).asmBytes.length.toInt,
           1 + info.requiredSigs
         )
       case info: ConditionalInputInfo =>

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputInfo.scala
@@ -3,15 +3,15 @@ package org.bitcoins.core.wallet.utxo
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.script.constant.{OP_TRUE, ScriptConstant}
 import org.bitcoins.core.util.{BitcoinScriptUtil, BytesUtil}
 import org.bitcoins.crypto.{
+  ECDigitalSignature,
   ECPublicKey,
   ECPublicKeyBytes,
   HashType,
-  LowRDummyECDigitalSignature,
   NetworkElement,
   Sign
 }
@@ -216,25 +216,26 @@ object InputInfo {
       case _: P2PKInputInfo =>
         ScriptSigLenAndStackHeight(
           P2PKScriptSignature(
-            LowRDummyECDigitalSignature).asmBytes.length.toInt,
+            ECDigitalSignature.lowRDummyECDigitalSignature).asmBytes.length.toInt,
           1)
       case _: P2PKHInputInfo =>
         ScriptSigLenAndStackHeight(
-          P2PKHScriptSignature(LowRDummyECDigitalSignature,
+          P2PKHScriptSignature(ECDigitalSignature.lowRDummyECDigitalSignature,
                                ECPublicKey.dummy).asmBytes.length.toInt,
           2)
       case info: P2PKWithTimeoutInputInfo =>
         ScriptSigLenAndStackHeight(
           P2PKWithTimeoutScriptSignature(
             info.isBeforeTimeout,
-            LowRDummyECDigitalSignature).asmBytes.length.toInt,
+            ECDigitalSignature.lowRDummyECDigitalSignature).asmBytes.length.toInt,
           2)
       case info: MultiSignatureInputInfo =>
         ScriptSigLenAndStackHeight(
           MultiSignatureScriptSignature(
             Vector.fill(info.requiredSigs)(
-              LowRDummyECDigitalSignature)).asmBytes.length.toInt,
-          1 + info.requiredSigs)
+              ECDigitalSignature.lowRDummyECDigitalSignature)).asmBytes.length.toInt,
+          1 + info.requiredSigs
+        )
       case info: ConditionalInputInfo =>
         val ScriptSigLenAndStackHeight(maxLen, stackHeight) =
           maxScriptSigLenAndStackHeight(info.nestedInputInfo, forP2WSH)

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/DERSignatureUtilTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/DERSignatureUtilTest.scala
@@ -96,8 +96,7 @@ class DERSignatureUtilTest extends BitcoinSCryptoTest {
     DERSignatureUtil.isValidSignatureEncoding(ECDigitalSignature("")) must be(
       true
     )
-    DERSignatureUtil.isValidSignatureEncoding(
-      ECDigitalSignature.emptyDigitalSignature) must be(
+    DERSignatureUtil.isValidSignatureEncoding(ECDigitalSignature.empty) must be(
       true
     )
   }

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/DERSignatureUtilTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/DERSignatureUtilTest.scala
@@ -96,7 +96,8 @@ class DERSignatureUtilTest extends BitcoinSCryptoTest {
     DERSignatureUtil.isValidSignatureEncoding(ECDigitalSignature("")) must be(
       true
     )
-    DERSignatureUtil.isValidSignatureEncoding(EmptyDigitalSignature) must be(
+    DERSignatureUtil.isValidSignatureEncoding(
+      ECDigitalSignature.emptyDigitalSignature) must be(
       true
     )
   }

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/ECDigitalSignatureTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/ECDigitalSignatureTest.scala
@@ -37,8 +37,8 @@ class ECDigitalSignatureTest extends BitcoinSCryptoTest {
   }
 
   it must "say that the empty digital signatures r,s values are both 0" in {
-    EmptyDigitalSignature.r must be(0)
-    EmptyDigitalSignature.s must be(0)
+    ECDigitalSignature.emptyDigitalSignature.r must be(0)
+    ECDigitalSignature.emptyDigitalSignature.s must be(0)
   }
 
   it must "create an empty digital signature when given 0 in hex or byte format" in {

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/ECDigitalSignatureTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/ECDigitalSignatureTest.scala
@@ -37,8 +37,8 @@ class ECDigitalSignatureTest extends BitcoinSCryptoTest {
   }
 
   it must "say that the empty digital signatures r,s values are both 0" in {
-    ECDigitalSignature.emptyDigitalSignature.r must be(0)
-    ECDigitalSignature.emptyDigitalSignature.s must be(0)
+    ECDigitalSignature.empty.r must be(0)
+    ECDigitalSignature.empty.s must be(0)
   }
 
   it must "create an empty digital signature when given 0 in hex or byte format" in {

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
@@ -144,14 +144,13 @@ object BouncyCastleUtil {
 
       val signer = new ECDSASigner
       signer.init(false, publicKeyParams)
-      signature match {
-        case EmptyDigitalSignature =>
-          signer.verifySignature(data.toArray,
-                                 java.math.BigInteger.valueOf(0),
-                                 java.math.BigInteger.valueOf(0))
-        case _: ECDigitalSignature =>
-          val (r, s) = signature.decodeSignature
-          signer.verifySignature(data.toArray, r.bigInteger, s.bigInteger)
+      if (signature == ECDigitalSignature.emptyDigitalSignature) {
+        signer.verifySignature(data.toArray,
+                               java.math.BigInteger.valueOf(0),
+                               java.math.BigInteger.valueOf(0))
+      } else {
+        val (r, s) = signature.decodeSignature
+        signer.verifySignature(data.toArray, r.bigInteger, s.bigInteger)
       }
     }
     resultTry.getOrElse(false)

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/BouncyCastleUtil.scala
@@ -144,7 +144,7 @@ object BouncyCastleUtil {
 
       val signer = new ECDSASigner
       signer.init(false, publicKeyParams)
-      if (signature == ECDigitalSignature.emptyDigitalSignature) {
+      if (signature == ECDigitalSignature.empty) {
         signer.verifySignature(data.toArray,
                                java.math.BigInteger.valueOf(0),
                                java.math.BigInteger.valueOf(0))

--- a/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
@@ -83,7 +83,7 @@ sealed abstract class DERSignatureUtil {
     *   boolean indicating whether the signature was der encoded or not
     */
   def isValidSignatureEncoding(signature: ECDigitalSignature): Boolean = {
-    if (ECDigitalSignature.emptyDigitalSignature == signature) {
+    if (ECDigitalSignature.empty == signature) {
       true
     } else {
       isValidSignatureEncoding(signature.bytes)

--- a/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
@@ -83,10 +83,10 @@ sealed abstract class DERSignatureUtil {
     *   boolean indicating whether the signature was der encoded or not
     */
   def isValidSignatureEncoding(signature: ECDigitalSignature): Boolean = {
-    signature match {
-      case EmptyDigitalSignature => true
-      case signature: ECDigitalSignature =>
-        isValidSignatureEncoding(signature.bytes)
+    if (ECDigitalSignature.emptyDigitalSignature == signature) {
+      true
+    } else {
+      isValidSignatureEncoding(signature.bytes)
     }
   }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/DigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/DigitalSignature.scala
@@ -1,0 +1,3 @@
+package org.bitcoins.crypto
+
+abstract class DigitalSignature extends NetworkElement

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
@@ -96,8 +96,11 @@ case class ECDigitalSignature(bytes: ByteVector) extends DigitalSignature {
 object ECDigitalSignature extends Factory[ECDigitalSignature] {
 
   lazy val emptyDigitalSignature: ECDigitalSignature = {
-    val bytes: ByteVector = ByteVector(Array.fill(72)(0.toByte))
-    new ECDigitalSignature(bytes)
+    val bytes: ByteVector = ByteVector.empty
+    new ECDigitalSignature(bytes) {
+      override def r: BigInt = java.math.BigInteger.valueOf(0)
+      override def s: BigInt = r
+    }
   }
 
   /** The point of this case object is to help with fee estimation an average

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
@@ -4,7 +4,7 @@ import scodec.bits.ByteVector
 
 /** Created by chris on 2/26/16.
   */
-sealed abstract class ECDigitalSignature extends NetworkElement {
+sealed abstract class ECDigitalSignature extends DigitalSignature {
   require(r.signum == 1 || r.signum == 0, s"r must not be negative, got $r")
   require(s.signum == 1 || s.signum == 0, s"s must not be negative, got $s")
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
@@ -95,7 +95,7 @@ case class ECDigitalSignature(bytes: ByteVector) extends DigitalSignature {
 
 object ECDigitalSignature extends Factory[ECDigitalSignature] {
 
-  lazy val emptyDigitalSignature: ECDigitalSignature = {
+  val empty: ECDigitalSignature = {
     val bytes: ByteVector = ByteVector.empty
     new ECDigitalSignature(bytes) {
       override def r: BigInt = java.math.BigInteger.valueOf(0)
@@ -108,7 +108,7 @@ object ECDigitalSignature extends Factory[ECDigitalSignature] {
     * vary, 72 bytes is the most likely though according to
     * https://en.bitcoin.it/wiki/Elliptic_Curve_Digital_Signature_Algorithm
     */
-  lazy val dummyECDigitalSignature: ECDigitalSignature = {
+  val dummy: ECDigitalSignature = {
     val bytes: ByteVector = ByteVector(Array.fill(72)(0.toByte))
     new ECDigitalSignature(bytes) {
       override def r: BigInt = BigInt(0)
@@ -120,24 +120,23 @@ object ECDigitalSignature extends Factory[ECDigitalSignature] {
     * low r signing. Technically this number can vary, 71 bytes is the most
     * likely when using low r signing
     */
-  val lowRDummyECDigitalSignature: ECDigitalSignature = {
+  val dummyLowR: ECDigitalSignature = {
     val bytes: ByteVector = ByteVector(Array.fill(71)(0.toByte))
     new ECDigitalSignature(bytes) {
-      override def r: BigInt = emptyDigitalSignature.r
+      override def r: BigInt = empty.r
       override def s: BigInt = r
     }
   }
 
   override def fromBytes(bytes: ByteVector): ECDigitalSignature = {
     // this represents the empty signature
-    if (bytes.size == 1 && bytes.head == 0x0) emptyDigitalSignature
+    if (bytes.size == 1 && bytes.head == 0x0) empty
     else if (bytes.size == 0) {
-      println(s"here?")
-      emptyDigitalSignature
-    } else if (bytes == dummyECDigitalSignature.bytes)
-      dummyECDigitalSignature
-    else if (bytes == lowRDummyECDigitalSignature.bytes)
-      lowRDummyECDigitalSignature
+      empty
+    } else if (bytes == dummy.bytes)
+      dummy
+    else if (bytes == dummyLowR.bytes)
+      dummyLowR
     else {
       // make sure the signature follows BIP62's low-s value
       // https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Low_S_values_in_signatures

--- a/crypto/src/main/scala/org/bitcoins/crypto/SchnorrDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SchnorrDigitalSignature.scala
@@ -3,7 +3,7 @@ package org.bitcoins.crypto
 import scodec.bits.ByteVector
 
 case class SchnorrDigitalSignature(rx: SchnorrNonce, sig: FieldElement)
-    extends NetworkElement {
+    extends DigitalSignature {
   override def bytes: ByteVector = rx.bytes ++ sig.bytes
 }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/SchnorrDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SchnorrDigitalSignature.scala
@@ -4,7 +4,7 @@ import scodec.bits.ByteVector
 
 case class SchnorrDigitalSignature(rx: SchnorrNonce, sig: FieldElement)
     extends DigitalSignature {
-  override def bytes: ByteVector = rx.bytes ++ sig.bytes
+  override val bytes: ByteVector = rx.bytes ++ sig.bytes
 }
 
 object SchnorrDigitalSignature extends Factory[SchnorrDigitalSignature] {

--- a/crypto/src/main/scala/org/bitcoins/crypto/Sign.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/Sign.scala
@@ -109,7 +109,7 @@ object AsyncSign {
     * server
     */
   def dummySign(publicKey: ECPublicKey): AsyncSign = {
-    constant(EmptyDigitalSignature, publicKey)
+    constant(ECDigitalSignature.emptyDigitalSignature, publicKey)
   }
 }
 
@@ -217,7 +217,7 @@ object Sign {
   }
 
   def dummySign(publicKey: ECPublicKey): Sign = {
-    constant(EmptyDigitalSignature, publicKey)
+    constant(ECDigitalSignature.emptyDigitalSignature, publicKey)
   }
 }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/Sign.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/Sign.scala
@@ -109,7 +109,7 @@ object AsyncSign {
     * server
     */
   def dummySign(publicKey: ECPublicKey): AsyncSign = {
-    constant(ECDigitalSignature.emptyDigitalSignature, publicKey)
+    constant(ECDigitalSignature.empty, publicKey)
   }
 }
 
@@ -217,7 +217,7 @@ object Sign {
   }
 
   def dummySign(publicKey: ECPublicKey): Sign = {
-    constant(ECDigitalSignature.emptyDigitalSignature, publicKey)
+    constant(ECDigitalSignature.empty, publicKey)
   }
 }
 

--- a/docs/core/adding-spks.md
+++ b/docs/core/adding-spks.md
@@ -7,7 +7,7 @@ title: Adding New Script Types
 /* In order to allow the code in this document to be compiled, we must add these
  * imports here in this invisible, executed code block. We must also not import any
  * sealed traits that get extended as this will cause errors, and so instead we define
- * new ones in this invisible code block of the same names and add implicit conversions
+ * new ones in this invisible code block of the same names a                                                                                                                                  nd add implicit conversions
  * where needed so that our fake type can be returned anywhere the real one is expected
  * and vice-versa. We also add defs to traits where there are overrides to avoid errors,
  * as well as defs for all vals that are out of scope in code executed below.
@@ -15,12 +15,12 @@ title: Adding New Script Types
  * Note that as this code is never used outside of simply defining things below (only
  * compiled), we can use ??? everywhere where implementations are expected.
  *
- * Also note that when defining our "new" traits in the actual doc, they must be put in
+ * Also note that when defining our "new" traits in the actual                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   doc, they must be put in
  * silent mode rather than compile-only mode to make them accessible to the rest of the doc.
  */
 
 import org.bitcoins.crypto._
-import org.bitcoins.core.crypto._
+import org.bitcoins.core.crypto._                                                                                                                                                                                                                                                                               
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.control._
 import org.bitcoins.core.script.crypto._
@@ -746,7 +746,7 @@ Lastly, we need to construct a generator that returns both a `ScriptPubKey` and 
       hashType <- CryptoGenerators.hashType
     } yield {
       val emptyScriptSig = P2PKWithTimeoutScriptSignature(beforeTimeout = true,
-                                                          EmptyDigitalSignature)
+                                                          ECDigitalSignature.empty)
       val (creditingTx, outputIndex) =
         TransactionGenerators.buildCreditingTransaction(spk)
       val (spendingTx, inputIndex) = TransactionGenerators

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -22,7 +22,6 @@ import org.bitcoins.crypto.{
   ECDigitalSignature,
   ECPrivateKey,
   ECPublicKey,
-  EmptyDigitalSignature,
   HashType
 }
 import org.scalacheck.Gen
@@ -745,7 +744,8 @@ sealed abstract class ScriptGenerators {
       publicKeys = privateKeys.map(_.publicKey)
       multiSigScriptPubKey =
         MultiSignatureScriptPubKey(requiredSigs, publicKeys)
-      emptyDigitalSignatures = privateKeys.map(_ => EmptyDigitalSignature)
+      emptyDigitalSignatures = privateKeys.map(_ =>
+        ECDigitalSignature.emptyDigitalSignature)
       scriptSig = MultiSignatureScriptSignature(emptyDigitalSignatures)
       (creditingTx, outputIndex) =
         TransactionGenerators

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -744,8 +744,7 @@ sealed abstract class ScriptGenerators {
       publicKeys = privateKeys.map(_.publicKey)
       multiSigScriptPubKey =
         MultiSignatureScriptPubKey(requiredSigs, publicKeys)
-      emptyDigitalSignatures = privateKeys.map(_ =>
-        ECDigitalSignature.emptyDigitalSignature)
+      emptyDigitalSignatures = privateKeys.map(_ => ECDigitalSignature.empty)
       scriptSig = MultiSignatureScriptSignature(emptyDigitalSignatures)
       (creditingTx, outputIndex) =
         TransactionGenerators

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -183,7 +183,7 @@ object DLCWalletUtil extends BitcoinSLogger {
   lazy val dummyKey2: ECPublicKey = ECPublicKey.freshPublicKey
 
   lazy val dummyPartialSig: PartialSignature =
-    PartialSignature(dummyKey, ECDigitalSignature.dummyECDigitalSignature)
+    PartialSignature(dummyKey, ECDigitalSignature.dummy)
 
   lazy val minimalPartialSig: PartialSignature = {
     PartialSignature(dummyKey, ECDigitalSignature.minimalEncodedZeroSig)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -183,7 +183,7 @@ object DLCWalletUtil extends BitcoinSLogger {
   lazy val dummyKey2: ECPublicKey = ECPublicKey.freshPublicKey
 
   lazy val dummyPartialSig: PartialSignature =
-    PartialSignature(dummyKey, DummyECDigitalSignature)
+    PartialSignature(dummyKey, ECDigitalSignature.dummyECDigitalSignature)
 
   lazy val minimalPartialSig: PartialSignature = {
     PartialSignature(dummyKey, ECDigitalSignature.minimalEncodedZeroSig)


### PR DESCRIPTION
This PR creates a parent type for all signatures in the codebase - called `DigitalSignature`.

This is the counterpart for #5517 . This is needed for taproot signing logic to be integrated into the rest of signing logic - because we have a different signature scheme - `SchnorrDigitalSignature`. 