### PR TITLE
Add `Sign.{schnorrSign(),schnorrSignWithNonce()}` to `Sign` interface

### DIFF
--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/dlc/testgen/ConstRandAdaptorSign.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/dlc/testgen/ConstRandAdaptorSign.scala
@@ -37,6 +37,18 @@ case class ConstRandAdaptorSign(privKey: ECPrivateKey) extends AdaptorSign {
   ): ECAdaptorSignature = {
     privKey.adaptorSign(adaptorPoint, msg, auxRand)
   }
+
+  override def schnorrSign(
+      dataToSign: ByteVector,
+      auxRand: ByteVector): SchnorrDigitalSignature = {
+    privKey.schnorrSign(dataToSign, auxRand)
+  }
+
+  override def schnorrSignWithNonce(
+      dataToSign: ByteVector,
+      nonce: ECPrivateKey): SchnorrDigitalSignature = {
+    privKey.schnorrSignWithNonce(dataToSign, nonce)
+  }
 }
 
 object ConstRandAdaptorSign {

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKey.scala
@@ -266,6 +266,18 @@ sealed abstract class ExtPrivateKey
   def toHardened: ExtPrivateKeyHardened = {
     ExtPrivateKeyHardened(version, depth, fingerprint, childNum, chainCode, key)
   }
+
+  override def schnorrSign(
+      dataToSign: ByteVector,
+      auxRand: ByteVector): SchnorrDigitalSignature = {
+    key.schnorrSign(dataToSign, auxRand)
+  }
+
+  override def schnorrSignWithNonce(
+      dataToSign: ByteVector,
+      nonce: ECPrivateKey): SchnorrDigitalSignature = {
+    key.schnorrSignWithNonce(dataToSign, nonce)
+  }
 }
 
 object ExtPrivateKey

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
@@ -14,7 +14,7 @@ import org.bitcoins.core.wallet.builder.{
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.signer.BitcoinSigner
 import org.bitcoins.core.wallet.utxo.*
-import org.bitcoins.crypto.{ECDigitalSignature, HashType, Sign}
+import org.bitcoins.crypto.{HashType, Sign}
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
@@ -173,9 +173,7 @@ object TxUtil {
       case (inputInfo, index) =>
         val mockSigners =
           inputInfo.pubKeys.take(inputInfo.requiredSigs).map { pubKey =>
-            Sign(_ => ECDigitalSignature.dummy,
-                 (_, _) => ECDigitalSignature.dummy,
-                 pubKey)
+            Sign.dummySign(pubKey)
           }
 
         val mockSpendingInfo =

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
@@ -176,18 +176,13 @@ case class ECPrivateKey(bytes: ByteVector)
     CryptoUtil.signWithEntropy(this, bytes, entropy)
   }
 
-  def schnorrSign(dataToSign: ByteVector): SchnorrDigitalSignature = {
-    val auxRand = ECPrivateKey.freshPrivateKey.bytes
-    schnorrSign(dataToSign, auxRand)
-  }
-
-  def schnorrSign(
+  override def schnorrSign(
       dataToSign: ByteVector,
       auxRand: ByteVector): SchnorrDigitalSignature = {
     CryptoUtil.schnorrSign(dataToSign, this, auxRand)
   }
 
-  def schnorrSignWithNonce(
+  override def schnorrSignWithNonce(
       dataToSign: ByteVector,
       nonce: ECPrivateKey): SchnorrDigitalSignature = {
     CryptoUtil.schnorrSignWithNonce(dataToSign, this, nonce)
@@ -244,10 +239,6 @@ case class ECPrivateKey(bytes: ByteVector)
   /** Derives the public for a the private key */
   override def publicKey: ECPublicKey =
     CryptoUtil.publicKey(toPrivateKeyBytes())
-
-  def schnorrPublicKey: SchnorrPublicKey = {
-    SchnorrPublicKey(publicKey.bytes)
-  }
 
   def toXOnly: XOnlyPubKey = schnorrPublicKey.toXOnly
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/SchnorrDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SchnorrDigitalSignature.scala
@@ -29,7 +29,6 @@ case class SchnorrDigitalSignature(
 }
 
 object SchnorrDigitalSignature extends Factory[SchnorrDigitalSignature] {
-
   // If the sig is 65 bytes long, return sig[64] ≠ 0x00[20] and
   // Verify(q, hashTapSighash(0x00 || SigMsg(sig[64], 0)), sig[0:64]).
   override def fromBytes(bytes: ByteVector): SchnorrDigitalSignature = {
@@ -43,7 +42,7 @@ object SchnorrDigitalSignature extends Factory[SchnorrDigitalSignature] {
                             hashTypeOpt.map(HashType.fromByte))
   }
 
-  lazy val dummy: SchnorrDigitalSignature =
+  val dummy: SchnorrDigitalSignature =
     SchnorrDigitalSignature(FieldElement.one.getPublicKey.schnorrNonce,
                             FieldElement.one,
                             hashTypeOpt = None)

--- a/crypto/src/main/scala/org/bitcoins/crypto/Sign.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/Sign.scala
@@ -211,6 +211,12 @@ trait Sign extends AsyncSign {
   def schnorrSignWithNonce(
       dataToSign: ByteVector,
       nonce: ECPrivateKey): SchnorrDigitalSignature
+
+  final def schnorrSignWithHashType(
+      dataToSign: ByteVector,
+      hashType: HashType): SchnorrDigitalSignature = {
+    schnorrSign(dataToSign).appendHashType(hashType)
+  }
 }
 
 object Sign {


### PR DESCRIPTION
Alternative to #5753 , just add the `schnorrSign()`,`schnorrSignWithNonce`, `schnorrPublicKey` to `Sign` interface.