### PR TITLE
Add `Sign.{signWithHashType(),signLowRWithHashType}`

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
@@ -162,7 +162,7 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
               val oldSig =
                 TransactionSignatureCreator.createSig(
                   txSignatureComponent,
-                  signer.sign(_),
+                  signer.signWithHashType(_, _),
                   signInfo.hashType
                 )
 
@@ -170,7 +170,7 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
                 TransactionSignatureCreator.createSig(
                   spendingTx,
                   signInfo,
-                  signer.sign(_),
+                  signer.signWithHashType,
                   signInfo.hashType
                 )
 

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -8,8 +8,8 @@ import org.bitcoins.core.crypto.{
 import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.script.PreExecutionScriptProgram
@@ -19,7 +19,7 @@ import org.bitcoins.core.wallet.builder.{
   StandardNonInteractiveFinalizer
 }
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
-import org.bitcoins.core.wallet.utxo._
+import org.bitcoins.core.wallet.utxo.*
 import org.bitcoins.crypto.ECDigitalSignature
 import org.bitcoins.testkitcore.gen.{
   CreditingTxGen,
@@ -152,52 +152,6 @@ class SignerTest extends BitcoinSUnitTest {
         succeed
     }
   }
-
-//  it should "have old and new doSign functions agree" in {
-//    forAll(CreditingTxGen.inputsAndOutputs(), ScriptGenerators.scriptPubKey) {
-//      case ((creditingTxsInfo, destinations), (changeSPK, _)) =>
-//        val fee = SatoshisPerVirtualByte(Satoshis(100))
-//
-//        val spendingTx = StandardNonInteractiveFinalizer
-//          .txFrom(
-//            outputs = destinations,
-//            utxos = creditingTxsInfo,
-//            feeRate = fee,
-//            changeSPK = changeSPK
-//          )
-//
-//        val prevOutMap =
-//          PreviousOutputMap.fromScriptSignatureParams(creditingTxsInfo)
-//
-//        val correctSigs =
-//          creditingTxsInfo.flatMap { signInfo =>
-//            signInfo.signers.map { signer =>
-//              val txSignatureComponent =
-//                TxSigComponent(signInfo.inputInfo, spendingTx, prevOutMap)
-//              @nowarn val oldSig = BitcoinSigner.doSign(
-//                txSignatureComponent,
-//                signer.sign,
-//                signInfo.hashType,
-//                isDummySignature = false
-//              )
-//
-//              val newSig = BitcoinSigner.doSign(
-//                spendingTx,
-//                signInfo,
-//                signer.sign,
-//                signInfo.hashType,
-//                isDummySignature = false
-//              )
-//
-//              (oldSig.r == newSig.r) &&
-//              (oldSig.s == newSig.s) &&
-//              (oldSig.hex == newSig.hex)
-//            }
-//          }
-//
-//        assert(correctSigs.forall(_ == true))
-//    }
-//  }
 
   def inputIndex(
       spendingInfo: InputSigningInfo[InputInfo],

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -2,7 +2,6 @@ package org.bitcoins.core.wallet.signer
 
 import org.bitcoins.core.crypto.{
   BaseTxSigComponent,
-  TxSigComponent,
   WitnessTxSigComponentP2SH,
   WitnessTxSigComponentRaw
 }
@@ -15,7 +14,6 @@ import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
-import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.wallet.builder.{
   RawTxSigner,
   StandardNonInteractiveFinalizer
@@ -30,8 +28,6 @@ import org.bitcoins.testkitcore.gen.{
   TransactionGenerators
 }
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
-
-import scala.annotation.nowarn
 
 class SignerTest extends BitcoinSUnitTest {
 
@@ -157,64 +153,57 @@ class SignerTest extends BitcoinSUnitTest {
     }
   }
 
-  it should "have old and new doSign functions agree" in {
-    forAll(CreditingTxGen.inputsAndOutputs(), ScriptGenerators.scriptPubKey) {
-      case ((creditingTxsInfo, destinations), (changeSPK, _)) =>
-        val fee = SatoshisPerVirtualByte(Satoshis(100))
-
-        val spendingTx = StandardNonInteractiveFinalizer
-          .txFrom(
-            outputs = destinations,
-            utxos = creditingTxsInfo,
-            feeRate = fee,
-            changeSPK = changeSPK
-          )
-
-        val prevOutMap =
-          PreviousOutputMap.fromScriptSignatureParams(creditingTxsInfo)
-
-        val correctSigs =
-          creditingTxsInfo.flatMap { signInfo =>
-            signInfo.signers.map { signer =>
-              val txSignatureComponent =
-                TxSigComponent(signInfo.inputInfo, spendingTx, prevOutMap)
-              @nowarn val oldSig = BitcoinSigner.doSign(
-                txSignatureComponent,
-                signer.sign,
-                signInfo.hashType,
-                isDummySignature = false
-              )
-
-              val newSig = BitcoinSigner.doSign(
-                spendingTx,
-                signInfo,
-                signer.sign,
-                signInfo.hashType,
-                isDummySignature = false
-              )
-
-              (oldSig.r == newSig.r) &&
-              (oldSig.s == newSig.s) &&
-              (oldSig.hex == newSig.hex)
-            }
-          }
-
-        assert(correctSigs.forall(_ == true))
-    }
-  }
+//  it should "have old and new doSign functions agree" in {
+//    forAll(CreditingTxGen.inputsAndOutputs(), ScriptGenerators.scriptPubKey) {
+//      case ((creditingTxsInfo, destinations), (changeSPK, _)) =>
+//        val fee = SatoshisPerVirtualByte(Satoshis(100))
+//
+//        val spendingTx = StandardNonInteractiveFinalizer
+//          .txFrom(
+//            outputs = destinations,
+//            utxos = creditingTxsInfo,
+//            feeRate = fee,
+//            changeSPK = changeSPK
+//          )
+//
+//        val prevOutMap =
+//          PreviousOutputMap.fromScriptSignatureParams(creditingTxsInfo)
+//
+//        val correctSigs =
+//          creditingTxsInfo.flatMap { signInfo =>
+//            signInfo.signers.map { signer =>
+//              val txSignatureComponent =
+//                TxSigComponent(signInfo.inputInfo, spendingTx, prevOutMap)
+//              @nowarn val oldSig = BitcoinSigner.doSign(
+//                txSignatureComponent,
+//                signer.sign,
+//                signInfo.hashType,
+//                isDummySignature = false
+//              )
+//
+//              val newSig = BitcoinSigner.doSign(
+//                spendingTx,
+//                signInfo,
+//                signer.sign,
+//                signInfo.hashType,
+//                isDummySignature = false
+//              )
+//
+//              (oldSig.r == newSig.r) &&
+//              (oldSig.s == newSig.s) &&
+//              (oldSig.hex == newSig.hex)
+//            }
+//          }
+//
+//        assert(correctSigs.forall(_ == true))
+//    }
+//  }
 
   def inputIndex(
       spendingInfo: InputSigningInfo[InputInfo],
       tx: Transaction
   ): Int = {
-    tx.inputs.zipWithIndex
-      .find(_._1.previousOutput == spendingInfo.outPoint) match {
-      case Some((_, index)) => index
-      case None =>
-        throw new IllegalArgumentException(
-          "Transaction did not contain expected input."
-        )
-    }
+    TxUtil.inputIndex(spendingInfo.inputInfo, tx)
   }
 
   def createProgram(

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
@@ -9,17 +9,16 @@ import org.bitcoins.core.crypto.{
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.dlc.build.DLCTxBuilder
-import org.bitcoins.core.protocol.dlc.models._
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.dlc.models.*
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.protocol.{Bech32Address, BitcoinAddress}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.util.{FutureUtil, Indexed}
 import org.bitcoins.core.wallet.signer.BitcoinSigner
-import org.bitcoins.core.wallet.utxo._
-import org.bitcoins.crypto.{HashType, _}
-import scodec.bits.ByteVector
+import org.bitcoins.core.wallet.utxo.*
+import org.bitcoins.crypto.{HashType, *}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -378,12 +377,11 @@ object DLCTxSigner {
       remoteAdaptorSig: ECAdaptorSignature,
       remoteFundingPubKey: ECPublicKey,
       oracleSigs: Vector[OracleSignatures]): WitnessTransaction = {
-    val signLowR: ByteVector => ECDigitalSignature =
-      cetSigningInfo.signer.signLowR(_: ByteVector)
-    val localSig = TransactionSignatureCreator.createSig(ucet,
-                                                         cetSigningInfo,
-                                                         signLowR,
-                                                         HashType.sigHashAll)
+    val localSig = TransactionSignatureCreator.createSig(
+      ucet,
+      cetSigningInfo,
+      cetSigningInfo.signer.signLowRWithHashType,
+      HashType.sigHashAll)
     val oracleSigSum =
       OracleSignatures.computeAggregateSignature(outcome, oracleSigs)
 
@@ -419,12 +417,11 @@ object DLCTxSigner {
   ): PartialSignature = {
     val fundingPubKey = refundSigningInfo.signer.publicKey
 
-    val signLowR: ByteVector => ECDigitalSignature =
-      refundSigningInfo.signer.signLowR(_: ByteVector)
-    val sig = TransactionSignatureCreator.createSig(refundTx,
-                                                    refundSigningInfo,
-                                                    signLowR,
-                                                    HashType.sigHashAll)
+    val sig = TransactionSignatureCreator.createSig(
+      refundTx,
+      refundSigningInfo,
+      refundSigningInfo.signer.signLowRWithHashType,
+      HashType.sigHashAll)
 
     PartialSignature(fundingPubKey, sig)
   }

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -15,23 +15,23 @@ import scodec.bits.ByteVector
 
 sealed abstract class SignerUtils {
 
-  @deprecated("use an InputSigningInfo[InputInfo] instead", since = "6/23/2020")
-  def doSign(
-      sigComponent: TxSigComponent,
-      sign: ByteVector => ECDigitalSignature,
-      hashType: HashType,
-      isDummySignature: Boolean): ECDigitalSignature = {
-    if (isDummySignature) {
-      ECDigitalSignature.dummy
-    } else {
-      TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
-    }
-  }
+//  @deprecated("use an InputSigningInfo[InputInfo] instead", since = "6/23/2020")
+//  def doSign(
+//      sigComponent: TxSigComponent,
+//      sign: ByteVector => ECDigitalSignature,
+//      hashType: HashType,
+//      isDummySignature: Boolean): ECDigitalSignature = {
+//    if (isDummySignature) {
+//      ECDigitalSignature.dummy
+//    } else {
+//      TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
+//    }
+//  }
 
   def doSign(
       unsignedTx: Transaction,
       signingInfo: InputSigningInfo[InputInfo],
-      sign: ByteVector => ECDigitalSignature,
+      sign: (ByteVector, HashType) => ECDigitalSignature,
       hashType: HashType,
       isDummySignature: Boolean): ECDigitalSignature = {
     if (isDummySignature) {
@@ -60,7 +60,7 @@ sealed abstract class SignerUtils {
     val signature = doSign(
       unsignedTx = tx,
       signingInfo = spendingInfo,
-      sign = spendingInfo.signer.signLowR,
+      sign = spendingInfo.signer.signLowRWithHashType,
       hashType = spendingInfo.hashType,
       isDummySignature = isDummySignature
     )
@@ -563,7 +563,7 @@ sealed abstract class P2WPKHSigner extends Signer[P2WPKHV0InputInfo] {
           val signature =
             doSign(unsignedTx,
                    spendingInfo,
-                   signer.signLowR,
+                   signer.signLowRWithHashType,
                    hashType,
                    isDummySignature)
 

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -15,19 +15,6 @@ import scodec.bits.ByteVector
 
 sealed abstract class SignerUtils {
 
-//  @deprecated("use an InputSigningInfo[InputInfo] instead", since = "6/23/2020")
-//  def doSign(
-//      sigComponent: TxSigComponent,
-//      sign: ByteVector => ECDigitalSignature,
-//      hashType: HashType,
-//      isDummySignature: Boolean): ECDigitalSignature = {
-//    if (isDummySignature) {
-//      ECDigitalSignature.dummy
-//    } else {
-//      TransactionSignatureCreator.createSig(sigComponent, sign, hashType)
-//    }
-//  }
-
   def doSign(
       unsignedTx: Transaction,
       signingInfo: InputSigningInfo[InputInfo],

--- a/crypto/src/main/scala/org/bitcoins/crypto/Sign.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/Sign.scala
@@ -130,7 +130,20 @@ trait AsyncAdaptorSign extends AsyncSign {
 
 trait Sign extends AsyncSign {
   def sign(bytes: ByteVector): ECDigitalSignature
+  def signWithHashType(
+      bytes: ByteVector,
+      hashType: HashType): ECDigitalSignature = {
+    val sigNoHashType = sign(bytes)
+    sigNoHashType.copy(bytes =
+      sigNoHashType.bytes ++ ByteVector.fromByte(hashType.byte))
+  }
 
+  def signLowRWithHashType(
+      bytes: ByteVector,
+      hashType: HashType): ECDigitalSignature = {
+    val lowR = signLowR(bytes)
+    lowR.copy(lowR.bytes ++ ByteVector.fromByte(hashType.byte))
+  }
   override def asyncSign(bytes: ByteVector): Future[ECDigitalSignature] = {
     Future.successful(sign(bytes))
   }


### PR DESCRIPTION
This lays ground work for abstracting the digital signature type produced by `TransactionSignatureCreator`.

`SchnorrDigitalSignature` and `ECDigitalSignature` have slightly different semantics for their `HashType`'s. This PR now encapsulates this logic inside of the `sign` function passed to `TransactionSigantureCreator.createSig()`