### PR TITLE
2024 11 09 schnorrsig hashtype

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/util/OrderedSchnorrSignaturesTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/OrderedSchnorrSignaturesTest.scala
@@ -13,13 +13,15 @@ class OrderedSchnorrSignaturesTest extends BitcoinSUnitTest {
       SchnorrNonce(
         "c4b89873c8753de3f0a9e94c4a6190badaa983513a6624a3469eb4577904bfea"
       ),
-      FieldElement.one
+      FieldElement.one,
+      hashTypeOpt = None
     ),
     SchnorrDigitalSignature(
       SchnorrNonce(
         "92efe81609c773d97da2b084eb691f48ef5e926acc6eecd629f80fb1184711bc"
       ),
-      FieldElement.one
+      FieldElement.one,
+      hashTypeOpt = None
     )
   )
 

--- a/core/src/main/scala/org/bitcoins/core/api/dlcoracle/OracleEvent.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlcoracle/OracleEvent.scala
@@ -71,7 +71,8 @@ sealed trait CompletedOracleEvent extends OracleEvent {
   def signatures: OrderedSchnorrSignatures = {
     val unsorted = nonces.toVector
       .zip(attestations)
-      .map(sigPieces => SchnorrDigitalSignature(sigPieces._1, sigPieces._2))
+      .map(sigPieces =>
+        SchnorrDigitalSignature(sigPieces._1, sigPieces._2, hashTypeOpt = None))
     OrderedSchnorrSignatures.fromUnsorted(unsorted)
   }
 
@@ -84,7 +85,10 @@ sealed trait CompletedOracleEvent extends OracleEvent {
         // announcementSignatures evaluate to true
         val unsorted = ann.eventTLV.nonces
           .zip(attestations)
-          .map(sigPieces => SchnorrDigitalSignature(sigPieces._1, sigPieces._2))
+          .map(sigPieces =>
+            SchnorrDigitalSignature(sigPieces._1,
+                                    sigPieces._2,
+                                    hashTypeOpt = None))
         OracleAttestmentV0TLV(eventName,
                               pubkey,
                               unsorted,

--- a/core/src/main/scala/org/bitcoins/core/api/dlcoracle/db/EventDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/dlcoracle/db/EventDb.scala
@@ -37,7 +37,7 @@ case class EventDb(
     eventDescriptorTLV: EventDescriptorTLV) {
 
   lazy val sigOpt: Option[SchnorrDigitalSignature] =
-    attestationOpt.map(SchnorrDigitalSignature(nonce, _))
+    attestationOpt.map(SchnorrDigitalSignature(nonce, _, hashTypeOpt = None))
 
   lazy val toOracleEvent: OracleEvent = OracleEvent.fromEventDbs(Vector(this))
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/compute/DLCUtil.scala
@@ -179,7 +179,8 @@ object DLCUtil {
       val index = allAdaptorPoints.indexOf(adaptorPoint)
       val outcome: OracleOutcome = contractInfo.allOutcomes(index)
 
-      (SchnorrDigitalSignature(outcome.aggregateNonce, s), outcome)
+      (SchnorrDigitalSignature(outcome.aggregateNonce, s, hashTypeOpt = None),
+       outcome)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTMap.scala
@@ -650,10 +650,8 @@ case class InputPSBTMap(elements: Vector[InputPSBTRecord])
         keySpendSignatureOpt match {
           case Some(keySpendSignature) =>
             val sig = keySpendSignature.signature
-            val hashType =
-              sigHashTypeOpt.map(_.hashType).getOrElse(SIGHASH_DEFAULT)
 
-            val witnessScript = TaprootKeyPath(sig, hashType, None)
+            val witnessScript = TaprootKeyPath(sig, None)
             Success(wipeAndAdd(EmptyScriptSignature, Some(witnessScript)))
           case None =>
             // todo add script spend support

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/musig/MuSigTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/musig/MuSigTest.scala
@@ -38,7 +38,10 @@ class MuSigTest extends BitcoinSCryptoTest {
 
         val sig = signAgg(Vector(s), aggNonce)
 
-        assert(sig == SchnorrDigitalSignature(aggNonce.schnorrNonce, s))
+        assert(
+          sig == SchnorrDigitalSignature(aggNonce.schnorrNonce,
+                                         s,
+                                         hashTypeOpt = None))
 
         val aggPub = keySet.aggPubKey
 

--- a/crypto/.jvm/src/main/scala/org/bitcoins/crypto/LibSecp256k1CryptoRuntime.scala
+++ b/crypto/.jvm/src/main/scala/org/bitcoins/crypto/LibSecp256k1CryptoRuntime.scala
@@ -186,9 +186,17 @@ trait LibSecp256k1CryptoRuntime extends CryptoRuntime {
       data: ByteVector,
       schnorrPubKey: SchnorrPublicKey,
       signature: SchnorrDigitalSignature): Boolean = {
-    NativeSecp256k1.schnorrVerify(signature.bytes.toArray,
-                                  data.toArray,
-                                  schnorrPubKey.bytes.toArray)
+    if (signature.hashTypeOpt.isDefined) {
+      // drop hashType byte
+      NativeSecp256k1.schnorrVerify(signature.bytes.dropRight(1).toArray,
+                                    data.toArray,
+                                    schnorrPubKey.bytes.toArray)
+    } else {
+      NativeSecp256k1.schnorrVerify(signature.bytes.toArray,
+                                    data.toArray,
+                                    schnorrPubKey.bytes.toArray)
+    }
+
   }
 
   // TODO: add a native implementation

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoRuntime.scala
@@ -339,7 +339,7 @@ trait CryptoRuntime {
     val challenge = x.multiply(FieldElement(e))
     val sig = k.add(challenge)
 
-    SchnorrDigitalSignature(rx, sig)
+    SchnorrDigitalSignature(rx, sig, hashTypeOpt = None)
   }
 
   def schnorrVerify(

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoUtil.scala
@@ -184,8 +184,9 @@ trait CryptoUtil extends CryptoRuntime {
   override def schnorrVerify(
       data: ByteVector,
       schnorrPubKey: SchnorrPublicKey,
-      signature: SchnorrDigitalSignature): Boolean =
+      signature: SchnorrDigitalSignature): Boolean = {
     cryptoRuntime.schnorrVerify(data, schnorrPubKey, signature)
+  }
 
   override def schnorrComputeSigPoint(
       data: ByteVector,

--- a/crypto/src/main/scala/org/bitcoins/crypto/DigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/DigitalSignature.scala
@@ -1,3 +1,6 @@
 package org.bitcoins.crypto
 
-abstract class DigitalSignature extends NetworkElement
+abstract class DigitalSignature extends NetworkElement {
+  def hashTypeOpt: Option[HashType]
+  def appendHashType(hashType: HashType): DigitalSignature
+}

--- a/crypto/src/main/scala/org/bitcoins/crypto/SchnorrDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SchnorrDigitalSignature.scala
@@ -2,9 +2,23 @@ package org.bitcoins.crypto
 
 import scodec.bits.ByteVector
 
-case class SchnorrDigitalSignature(rx: SchnorrNonce, sig: FieldElement)
+case class SchnorrDigitalSignature(
+    rx: SchnorrNonce,
+    sig: FieldElement,
+    hashTypeOpt: Option[HashType])
     extends DigitalSignature {
   override val bytes: ByteVector = rx.bytes ++ sig.bytes
+  require(
+    bytes.length == 64 || bytes.length == 65,
+    s"SchnorrDigitalSignature must be 64/65 bytes in size, got=${bytes.length}")
+
+  override def appendHashType(hashType: HashType): SchnorrDigitalSignature = {
+    require(this.hashTypeOpt.isEmpty,
+            "Cannot append HashType to signature which already has HashType")
+
+    val bytesWithHashType = bytes.:+(hashType.byte)
+    SchnorrDigitalSignature.fromBytes(bytesWithHashType)
+  }
 }
 
 object SchnorrDigitalSignature extends Factory[SchnorrDigitalSignature] {
@@ -12,13 +26,18 @@ object SchnorrDigitalSignature extends Factory[SchnorrDigitalSignature] {
   // If the sig is 65 bytes long, return sig[64] ≠ 0x00[20] and
   // Verify(q, hashTapSighash(0x00 || SigMsg(sig[64], 0)), sig[0:64]).
   override def fromBytes(bytes: ByteVector): SchnorrDigitalSignature = {
-    require(bytes.length == 64,
+    require(bytes.length == 64 || bytes.length == 65,
             s"SchnorrDigitalSignature must be exactly 64 bytes, got $bytes")
-    SchnorrDigitalSignature(SchnorrNonce(bytes.take(32)),
-                            FieldElement(bytes.drop(32)))
+    val r = bytes.take(32)
+    val s = bytes.drop(32).take(32)
+    val hashTypeOpt = if (bytes.length == 65) Some(bytes(65)) else None
+    SchnorrDigitalSignature(SchnorrNonce(r),
+                            FieldElement(s),
+                            hashTypeOpt.map(HashType.fromByte))
   }
 
   lazy val dummy: SchnorrDigitalSignature =
     SchnorrDigitalSignature(FieldElement.one.getPublicKey.schnorrNonce,
-                            FieldElement.one)
+                            FieldElement.one,
+                            hashTypeOpt = None)
 }

--- a/crypto/src/main/scala/org/bitcoins/crypto/musig/MuSigUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/musig/MuSigUtil.scala
@@ -170,6 +170,6 @@ object MuSigUtil {
       case None            => sSum
     }
 
-    SchnorrDigitalSignature(aggPubNonce.schnorrNonce, s)
+    SchnorrDigitalSignature(aggPubNonce.schnorrNonce, s, hashTypeOpt = None)
   }
 }

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/DLCOracleTest.scala
@@ -314,7 +314,8 @@ class DLCOracleTest extends DLCOracleFixture {
           assert(
             SchnorrDigitalSignature(
               completedEvent.nonces.head,
-              completedEvent.attestation
+              completedEvent.attestation,
+              hashTypeOpt = None
             ) == sig
           )
           assert(
@@ -368,7 +369,8 @@ class DLCOracleTest extends DLCOracleFixture {
           assert(
             SchnorrDigitalSignature(
               completedEvent.nonces.head,
-              completedEvent.attestations.head
+              completedEvent.attestations.head,
+              hashTypeOpt = None
             ) == signSig
           )
 
@@ -382,7 +384,8 @@ class DLCOracleTest extends DLCOracleFixture {
           assert(
             SchnorrDigitalSignature(
               completedEvent.nonces(1),
-              completedEvent.attestations(1)
+              completedEvent.attestations(1),
+              hashTypeOpt = None
             ) == sig100
           )
 
@@ -396,7 +399,8 @@ class DLCOracleTest extends DLCOracleFixture {
           assert(
             SchnorrDigitalSignature(
               completedEvent.nonces(2),
-              completedEvent.attestations(2)
+              completedEvent.attestations(2),
+              hashTypeOpt = None
             ) == sig10
           )
 
@@ -410,7 +414,8 @@ class DLCOracleTest extends DLCOracleFixture {
           assert(
             SchnorrDigitalSignature(
               completedEvent.nonces(3),
-              completedEvent.attestations(3)
+              completedEvent.attestations(3),
+              hashTypeOpt = None
             ) == sig1
           )
         case _: PendingOracleEvent | _: CompletedOracleEvent =>
@@ -458,7 +463,8 @@ class DLCOracleTest extends DLCOracleFixture {
           assert(
             SchnorrDigitalSignature(
               completedEvent.nonces.head,
-              completedEvent.attestations.head
+              completedEvent.attestations.head,
+              hashTypeOpt = None
             ) == signSig
           )
 
@@ -472,7 +478,8 @@ class DLCOracleTest extends DLCOracleFixture {
           assert(
             SchnorrDigitalSignature(
               completedEvent.nonces(1),
-              completedEvent.attestations(1)
+              completedEvent.attestations(1),
+              hashTypeOpt = None
             ) == sig100
           )
 
@@ -486,7 +493,8 @@ class DLCOracleTest extends DLCOracleFixture {
           assert(
             SchnorrDigitalSignature(
               completedEvent.nonces(2),
-              completedEvent.attestations(2)
+              completedEvent.attestations(2),
+              hashTypeOpt = None
             ) == sig10
           )
 
@@ -500,7 +508,8 @@ class DLCOracleTest extends DLCOracleFixture {
           assert(
             SchnorrDigitalSignature(
               completedEvent.nonces(3),
-              completedEvent.attestations(3)
+              completedEvent.attestations(3),
+              hashTypeOpt = None
             ) == sig1
           )
         case _: PendingOracleEvent | _: CompletedOracleEvent =>
@@ -550,7 +559,8 @@ class DLCOracleTest extends DLCOracleFixture {
             assert(
               SchnorrDigitalSignature(
                 completedEvent.nonces.head,
-                completedEvent.attestations.head
+                completedEvent.attestations.head,
+                hashTypeOpt = None
               ) == sig100
             )
 
@@ -564,7 +574,8 @@ class DLCOracleTest extends DLCOracleFixture {
             assert(
               SchnorrDigitalSignature(
                 completedEvent.nonces(1),
-                completedEvent.attestations(1)
+                completedEvent.attestations(1),
+                hashTypeOpt = None
               ) == sig10
             )
 
@@ -578,7 +589,8 @@ class DLCOracleTest extends DLCOracleFixture {
             assert(
               SchnorrDigitalSignature(
                 completedEvent.nonces(2),
-                completedEvent.attestations(2)
+                completedEvent.attestations(2),
+                hashTypeOpt = None
               ) == sig1
             )
           case _: PendingOracleEvent | _: CompletedOracleEvent =>
@@ -725,7 +737,7 @@ class DLCOracleTest extends DLCOracleFixture {
         futureTime,
         None,
         None,
-        SchnorrDigitalSignature(nonce, FieldElement.one),
+        SchnorrDigitalSignature(nonce, FieldElement.one, hashTypeOpt = None),
         testDescriptor
       )
 

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventDAOTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventDAOTest.scala
@@ -34,7 +34,7 @@ class EventDAOTest extends DLCOracleDAOFixture {
     RValueDb(nonce, eventName, HDPurpose(0), HDCoinType.Bitcoin, 0, 0, 0)
 
   val dummySig: SchnorrDigitalSignature =
-    SchnorrDigitalSignature(nonce, FieldElement.one)
+    SchnorrDigitalSignature(nonce, FieldElement.one, hashTypeOpt = None)
 
   def descriptor: EventDescriptorTLV = TLVGen.eventDescriptorTLV.sampleSome
 

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAOTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/storage/EventOutcomeDAOTest.scala
@@ -49,7 +49,7 @@ class EventOutcomeDAOTest extends DLCOracleDAOFixture {
       time,
       None,
       None,
-      SchnorrDigitalSignature(nonce, FieldElement.one),
+      SchnorrDigitalSignature(nonce, FieldElement.one, hashTypeOpt = None),
       descriptor
     )
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleEnumExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleEnumExecutionTest.scala
@@ -216,7 +216,7 @@ class DLCMultiOracleEnumExecutionTest extends BitcoinSDualWalletTest {
       .reduce(_.add(_))
 
     val aggregateSignature =
-      SchnorrDigitalSignature(aggR, aggS)
+      SchnorrDigitalSignature(aggR, aggS, hashTypeOpt = None)
     aggregateSignature == statusB.oracleSig
   }
 }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleExactNumericExecutionTest.scala
@@ -225,7 +225,7 @@ class DLCMultiOracleExactNumericExecutionTest extends BitcoinSDualWalletTest {
           .reduce(_.add(_))
 
         val aggregateSignature =
-          SchnorrDigitalSignature(aggR, aggS)
+          SchnorrDigitalSignature(aggR, aggS, hashTypeOpt = None)
         aggregateSignature == statusB.oracleSig
     }
   }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCMultiOracleNumericExecutionTest.scala
@@ -238,7 +238,7 @@ class DLCMultiOracleNumericExecutionTest
           .reduce(_.add(_))
 
         val aggregateSignature =
-          SchnorrDigitalSignature(aggR, aggS)
+          SchnorrDigitalSignature(aggR, aggS, hashTypeOpt = None)
         aggregateSignature == statusB.oracleSig
     }
   }

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCNumericExecutionTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/DLCNumericExecutionTest.scala
@@ -236,7 +236,7 @@ class DLCNumericExecutionTest extends BitcoinSDualWalletTest {
           .reduce(_.add(_))
 
         val aggregateSignature =
-          SchnorrDigitalSignature(aggR, aggS)
+          SchnorrDigitalSignature(aggR, aggS, hashTypeOpt = None)
         aggregateSignature == statusB.oracleSig
     }
   }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -1871,7 +1871,8 @@ case class DLCWallet(override val walletApi: Wallet)(implicit
         OracleSignatures.computeAggregateSignature(outcome, sigsUsed)
       aggSig = SchnorrDigitalSignature(
         outcome.aggregateNonce,
-        oracleSigSum.fieldElement
+        oracleSigSum.fieldElement,
+        hashTypeOpt = None
       )
       _ <- updateAggregateSignature(contractId, aggSig)
 

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/DLCTest.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/DLCTest.scala
@@ -1290,7 +1290,7 @@ trait DLCTest {
         sVals.reduce(_.add(_))
     }
 
-    val aggSig = SchnorrDigitalSignature(aggR, aggS)
+    val aggSig = SchnorrDigitalSignature(aggR, aggS, hashTypeOpt = None)
 
     // Must use stored adaptor sigs because adaptor signing nonce is not deterministic (auxRand)
     val offerRefundSig = dlcOffer.dlcTxSigner.signRefundTx

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
@@ -234,11 +234,29 @@ sealed abstract class CryptoGenerators {
     }
   }
 
-  def schnorrDigitalSignature: Gen[SchnorrDigitalSignature] = {
+  def schnorrDigitalSignatureNoHashType: Gen[SchnorrDigitalSignature] = {
     for {
       privKey <- privateKey
       hash <- CryptoGenerators.doubleSha256Digest
-    } yield privKey.schnorrSign(hash.bytes)
+      sigNoHashType = privKey.schnorrSign(hash.bytes)
+    } yield {
+      sigNoHashType
+    }
+  }
+
+  def schnorrDigitalSignatureHashType: Gen[SchnorrDigitalSignature] = {
+    for {
+      privKey <- privateKey
+      hash <- CryptoGenerators.doubleSha256Digest
+      sigNoHashType = privKey.schnorrSign(hash.bytes)
+      hashType <- hashType
+    } yield {
+      sigNoHashType.appendHashType(hashType)
+    }
+  }
+  def schnorrDigitalSignature: Gen[SchnorrDigitalSignature] = {
+    Gen.oneOf(schnorrDigitalSignatureHashType,
+              schnorrDigitalSignatureNoHashType)
   }
 
   def adaptorSignature: Gen[ECAdaptorSignature] = {

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/TLVGen.scala
@@ -146,7 +146,7 @@ trait TLVGen {
 
   def oracleAnnouncementV0TLV: Gen[OracleAnnouncementV0TLV] = {
     for {
-      sig <- CryptoGenerators.schnorrDigitalSignature
+      sig <- CryptoGenerators.schnorrDigitalSignatureNoHashType
       pubkey <- CryptoGenerators.schnorrPublicKey
       eventTLV <- oracleEventV0TLV
     } yield OracleAnnouncementV0TLV(sig, pubkey, eventTLV)
@@ -159,7 +159,7 @@ trait TLVGen {
       numSigs <- Gen.choose(1, 10)
       unsorted <-
         Gen
-          .listOfN(numSigs, CryptoGenerators.schnorrDigitalSignature)
+          .listOfN(numSigs, CryptoGenerators.schnorrDigitalSignatureNoHashType)
           .map(_.toVector)
       sigs = OrderedSchnorrSignatures.fromUnsorted(unsorted)
       outcomes <-

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/WitnessGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/WitnessGenerators.scala
@@ -45,9 +45,8 @@ sealed abstract class WitnessGenerators {
   def taprootKeyPath: Gen[TaprootKeyPath] = {
     for {
       signature <- CryptoGenerators.schnorrDigitalSignature
-      hashType <- CryptoGenerators.hashType
       annexOpt <- Gen.option(annex)
-    } yield TaprootKeyPath(signature, hashType, annexOpt)
+    } yield TaprootKeyPath(signature, annexOpt)
   }
 
   def taprootScriptPath: Gen[TaprootScriptPath] = {


### PR DESCRIPTION
Add `hashType` to `SchnorrDigitalSignature`. This PR removes the param `hashTypeOpt` from `TaprootKeyPath`. 

This is need to adhere to the `(ByteVector,HashType) => DigitalSiganture` type signature. This allows us to inject the BIP340 schnorr signature algorithm rather than the ECDSA algorithm that is currently use in `TransactionSignatureCreator.createSig()`. See #5757 for more information