### PR TITLE
2024 11 15 partialsig typeparam

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/SerializedPSBT.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/SerializedPSBT.scala
@@ -1,14 +1,14 @@
 package org.bitcoins.commons.jsonmodels
 
-import org.bitcoins.commons.jsonmodels.SerializedTransaction._
-import org.bitcoins.commons.serializers.JsonSerializers._
+import org.bitcoins.commons.jsonmodels.SerializedTransaction.*
+import org.bitcoins.commons.serializers.JsonSerializers.*
 import org.bitcoins.core.crypto.ExtPublicKey
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
-import org.bitcoins.core.psbt._
+import org.bitcoins.core.psbt.*
 import org.bitcoins.core.script.constant.ScriptToken
-import org.bitcoins.crypto.HashType
-import play.api.libs.json._
+import org.bitcoins.crypto.{DigitalSignature, HashType}
+import play.api.libs.json.*
 import scodec.bits.ByteVector
 
 case class SerializedPSBT(
@@ -29,7 +29,7 @@ case class SerializedPSBTGlobalMap(
 case class SerializedPSBTInputMap(
     nonWitnessUtxo: Option[SerializedTransaction],
     witnessUtxo: Option[SerializedTransactionOutput],
-    signatures: Option[Vector[PartialSignature]],
+    signatures: Option[Vector[PartialSignature[DigitalSignature]]],
     sigHashType: Option[HashType],
     redeemScript: Option[Vector[ScriptToken]],
     witScript: Option[Vector[ScriptToken]],
@@ -68,7 +68,7 @@ object SerializedPSBT {
     val witnessUtxo = input.witnessUTXOOpt.map(rec =>
       decodeTransactionOutput(rec.witnessUTXO, index))
 
-    val sigs = input.partialSignatures
+    val sigs = input.partialSignatures[DigitalSignature]
     val sigsOpt = if (sigs.nonEmpty) Some(sigs) else None
     val hashType = input.sigHashTypeOpt.map(_.hashType)
     val redeemScript = input.redeemScriptOpt.map(_.redeemScript.asm.toVector)

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
@@ -848,8 +848,10 @@ object JsonSerializers {
   implicit val serializedPSBTGlobalWrites: Writes[SerializedPSBTGlobalMap] =
     Json.writes[SerializedPSBTGlobalMap]
 
-  implicit val serializedPSBTInputWrites: Writes[SerializedPSBTInputMap] =
+  implicit val serializedPSBTInputWrites: Writes[SerializedPSBTInputMap] = {
+    import JsonWriters.PartialSignatureWrites
     Json.writes[SerializedPSBTInputMap]
+  }
 
   implicit val serializedPSBTOutputWrites: Writes[SerializedPSBTOutputMap] =
     Json.writes[SerializedPSBTOutputMap]

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonWriters.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonWriters.scala
@@ -257,9 +257,10 @@ object JsonWriters {
   }
 
   implicit object PartialSignatureWrites
-      extends Writes[InputPSBTRecord.PartialSignature] {
+      extends Writes[InputPSBTRecord.PartialSignature[DigitalSignature]] {
 
-    override def writes(o: InputPSBTRecord.PartialSignature): JsValue =
+    override def writes(
+        o: InputPSBTRecord.PartialSignature[DigitalSignature]): JsValue =
       JsObject(
         Seq(
           ("pubkey", JsString(o.pubKey.hex)),

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -140,7 +140,7 @@ object Picklers {
       : ReadWriter[SchnorrDigitalSignature] =
     readwriter[String].bimap(_.hex, SchnorrDigitalSignature.fromHex)
 
-  implicit val partialSignaturePickler: ReadWriter[PartialSignature] =
+  implicit val partialSignaturePickler: ReadWriter[PartialSignature[?]] =
     readwriter[String].bimap(_.hex, PartialSignature.fromHex)
 
   implicit val lnMessageDLCOfferTLVPickler: ReadWriter[LnMessage[DLCOfferTLV]] =

--- a/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/CliReaders.scala
@@ -291,11 +291,11 @@ object CliReaders {
         str => SchnorrDigitalSignature.fromHex(str.trim)
     }
 
-  implicit val partialSigReads: Read[PartialSignature] =
-    new Read[PartialSignature] {
+  implicit val partialSigReads: Read[PartialSignature[DigitalSignature]] =
+    new Read[PartialSignature[DigitalSignature]] {
       override def arity: Int = 1
 
-      override def reads: String => PartialSignature =
+      override def reads: String => PartialSignature[DigitalSignature] =
         PartialSignature.fromHex
     }
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/WalletRpcTest.scala
@@ -554,7 +554,8 @@ class WalletRpcTest extends BitcoindFixturesCachedPairNewest {
           privKey,
           HashType.sigHashAll
         ),
-        transaction
+        transaction,
+        privKey.signLowRWithHashType
       )
 
       signedTx match {

--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/dlc/testgen/DLCTLVGen.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/dlc/testgen/DLCTLVGen.scala
@@ -212,7 +212,7 @@ object DLCTLVGen {
   def partialSig(
       pubKey: ECPublicKey = ECPublicKey.freshPublicKey,
       sigHashByte: Boolean = true
-  ): PartialSignature = {
+  ): PartialSignature[ECDigitalSignature] = {
     PartialSignature(pubKey, ecdsaSig(sigHashByte))
   }
 
@@ -236,7 +236,7 @@ object DLCTLVGen {
 
   def refundSigs(
       fundingPubKey: ECPublicKey = ECPublicKey.freshPublicKey
-  ): PartialSignature = {
+  ): PartialSignature[ECDigitalSignature] = {
     partialSig(fundingPubKey, sigHashByte = false)
   }
 
@@ -367,7 +367,7 @@ object DLCTLVGen {
       changeAddress: BitcoinAddress = address(),
       changeSerialId: UInt64 = DLCMessage.genSerialId(),
       cetSignatures: CETSignatures = cetSigs(),
-      refundSignatures: PartialSignature = refundSigs(),
+      refundSignatures: PartialSignature[ECDigitalSignature] = refundSigs(),
       tempContractId: Sha256Digest = hash()
   ): DLCAccept = {
     DLCAccept(
@@ -393,7 +393,7 @@ object DLCTLVGen {
       changeAddress: BitcoinAddress = address(),
       changeSerialId: UInt64 = DLCMessage.genSerialId(),
       cetSignatures: CETSignatures = cetSigs(),
-      refundSignatures: PartialSignature = refundSigs(),
+      refundSignatures: PartialSignature[ECDigitalSignature] = refundSigs(),
       tempContractId: Sha256Digest = hash()
   ): DLCAcceptTLV = {
     dlcAccept(
@@ -499,7 +499,7 @@ object DLCTLVGen {
 
   def dlcSign(
       cetSignatures: CETSignatures = cetSigs(),
-      refundSignatures: PartialSignature = refundSigs(),
+      refundSignatures: PartialSignature[ECDigitalSignature] = refundSigs(),
       fundingSignatures: FundingSignatures = fundingSigs(),
       contractId: ByteVector = hash().bytes
   ): DLCSign = {
@@ -508,7 +508,7 @@ object DLCTLVGen {
 
   def dlcSignTLV(
       cetSignatures: CETSignatures = cetSigs(),
-      refundSignatures: PartialSignature = refundSigs(),
+      refundSignatures: PartialSignature[ECDigitalSignature] = refundSigs(),
       fundingSignatures: FundingSignatures = fundingSigs(),
       contractId: ByteVector = hash().bytes
   ): DLCSignTLV = {
@@ -522,7 +522,7 @@ object DLCTLVGen {
 
   def dlcSignParsingTestVector(
       cetSignatures: CETSignatures = cetSigs(),
-      refundSignatures: PartialSignature = refundSigs(),
+      refundSignatures: PartialSignature[ECDigitalSignature] = refundSigs(),
       fundingSignatures: FundingSignatures = fundingSigs(),
       contractId: ByteVector = hash().bytes
   ): DLCParsingTestVector = {

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCreatorTest.scala
@@ -129,7 +129,7 @@ class TransactionSignatureCreatorTest extends BitcoinSJvmTest {
       TransactionSignatureCreator.createSig(
         transaction,
         signingInfo,
-        privateKey,
+        privateKey.signLowRWithHashType,
         HashType.sigHashAll
       )
     txSignature.r must be(expectedSig.r)

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/dlc/DLCMessageTest.scala
@@ -45,7 +45,7 @@ class DLCMessageTest extends BitcoinSJvmTest {
     Vector(EnumOutcome(dummyStr))
   )
 
-  val dummySig: PartialSignature =
+  val dummySig: PartialSignature[ECDigitalSignature] =
     PartialSignature(dummyPubKey, ECDigitalSignature.empty)
 
   it must "not allow a negative collateral for a DLCOffer" in {

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/signer/SignerTest.scala
@@ -110,7 +110,8 @@ class SignerTest extends BitcoinSUnitTest {
               val keyAndSig =
                 BitcoinSigner.signSingle(
                   singleInfo,
-                  unsignedTx
+                  unsignedTx,
+                  singleInfo.signer.signLowRWithHashType
                 )
 
               keyAndSig.signature
@@ -235,7 +236,7 @@ class SignerTest extends BitcoinSUnitTest {
           changeSPK
         )
 
-      val singleSigs: Vector[Vector[PartialSignature]] = {
+      val singleSigs: Vector[Vector[PartialSignature[ECDigitalSignature]]] = {
         val singleInfosVec: Vector[Vector[ECSignatureParams[InputInfo]]] =
           creditingTxsInfos.toVector.map(_.toSingles)
         singleInfosVec.map { singleInfos =>
@@ -248,7 +249,9 @@ class SignerTest extends BitcoinSUnitTest {
                 unsignedTx.lockTime,
                 EmptyWitness.fromInputs(unsignedTx.inputs)
               )
-            BitcoinSigner.signSingle(singleInfo, wtx)
+            BitcoinSigner.signSingle(singleInfo,
+                                     wtx,
+                                     singleInfo.signer.signLowRWithHashType)
 
           }
         }

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -10,7 +10,6 @@ import org.bitcoins.core.protocol.script.{
   TaprootKeyPath
 }
 import org.bitcoins.core.protocol.transaction.TransactionOutput
-import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.script.flag.{ScriptFlag, ScriptFlagUtil}
 import org.bitcoins.core.script.result.{
@@ -35,32 +34,22 @@ trait TransactionSignatureChecker {
       txSignatureComponent: TxSigComponent,
       pubKeyBytes: ECPublicKeyBytes,
       signature: ECDigitalSignature): TransactionSignatureCheckerResult =
-    checkSignature(txSignatureComponent,
-                   PartialSignature(pubKeyBytes, signature))
+    checkSignature(txSignatureComponent = txSignatureComponent,
+                   script = txSignatureComponent.output.scriptPubKey.asm.toList,
+                   pubKey = pubKeyBytes,
+                   signature = signature)
 
   def checkSignature(
       txSignatureComponent: TxSigComponent,
       pubKey: ECPublicKey,
-      signature: ECDigitalSignature): TransactionSignatureCheckerResult =
-    checkSignature(txSignatureComponent, PartialSignature(pubKey, signature))
-
-  def checkSignature(
-      txSignatureComponent: TxSigComponent,
-      partialSignature: PartialSignature): TransactionSignatureCheckerResult = {
-    checkSignature(txSignatureComponent,
-                   txSignatureComponent.output.scriptPubKey.asm.toList,
-                   partialSignature.pubKey,
-                   partialSignature.signature)
+      signature: ECDigitalSignature): TransactionSignatureCheckerResult = {
+    checkSignature(
+      txSignatureComponent = txSignatureComponent,
+      script = txSignatureComponent.output.scriptPubKey.asm.toList,
+      pubKey = pubKey.toPublicKeyBytes(),
+      signature = signature
+    )
   }
-
-  def checkSignature(
-      txSignatureComponent: TxSigComponent,
-      script: Seq[ScriptToken],
-      partialSignature: PartialSignature): TransactionSignatureCheckerResult =
-    checkSignature(txSignatureComponent,
-                   script,
-                   partialSignature.pubKey,
-                   partialSignature.signature)
 
   /** @param txSigComponent
     * @param schnorrSignature

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureCreator.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureCreator.scala
@@ -90,25 +90,6 @@ sealed abstract class TransactionSignatureCreator {
     }
   }
 
-  /** Creates a signature from a tx signature component
-    *
-    * @param privateKey
-    *   the private key which we are signing the hash with
-    * @param hashType
-    *   the procedure to use for hashing to transaction
-    * @return
-    */
-  def createSig(
-      spendingTransaction: Transaction,
-      signingInfo: InputSigningInfo[InputInfo],
-      privateKey: ECPrivateKey,
-      hashType: HashType): ECDigitalSignature = {
-    createSig(spendingTransaction,
-              signingInfo,
-              privateKey.signWithHashType,
-              hashType)
-  }
-
   /** This is intended to be a low level hardware wallet API. At a fundamental
     * level, a hardware wallet expects a scodec.bits.ByteVector as input, and
     * returns an [[ECDigitalSignature]] if it is able to sign the
@@ -122,11 +103,11 @@ sealed abstract class TransactionSignatureCreator {
     * @return
     *   the digital signature returned by the hardware wallet
     */
-  def createSig(
+  def createSig[Sig <: DigitalSignature](
       spendingTransaction: Transaction,
       signingInfo: InputSigningInfo[InputInfo],
-      sign: (ByteVector, HashType) => ECDigitalSignature,
-      hashType: HashType): ECDigitalSignature = {
+      sign: (ByteVector, HashType) => Sig,
+      hashType: HashType): Sig = {
     val hash = TransactionSignatureSerializer.hashForSignature(
       spendingTransaction = spendingTransaction,
       signingInfo = signingInfo,

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/execution/DLCExecutor.scala
@@ -3,12 +3,12 @@ package org.bitcoins.core.protocol.dlc.execution
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.protocol.dlc.build.DLCTxBuilder
 import org.bitcoins.core.protocol.dlc.compute.{CETCalculator, DLCUtil}
-import org.bitcoins.core.protocol.dlc.models._
+import org.bitcoins.core.protocol.dlc.models.*
 import org.bitcoins.core.protocol.dlc.sign.DLCTxSigner
 import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.util.Indexed
-import org.bitcoins.crypto.{AdaptorSign, ECPublicKey}
+import org.bitcoins.crypto.{AdaptorSign, ECDigitalSignature, ECPublicKey}
 
 import scala.util.{Success, Try}
 
@@ -22,7 +22,7 @@ case class DLCExecutor(signer: DLCTxSigner) {
     */
   def setupDLCOffer(
       cetSigs: CETSignatures,
-      refundSig: PartialSignature): Try[SetupDLC] = {
+      refundSig: PartialSignature[ECDigitalSignature]): Try[SetupDLC] = {
     require(isInitiator, "You should call setupDLCAccept")
 
     setupDLC(cetSigs, refundSig, None, None)
@@ -34,7 +34,7 @@ case class DLCExecutor(signer: DLCTxSigner) {
     */
   def setupDLCAccept(
       cetSigs: CETSignatures,
-      refundSig: PartialSignature,
+      refundSig: PartialSignature[ECDigitalSignature],
       fundingSigs: FundingSignatures,
       cetsOpt: Option[Vector[WitnessTransaction]]): Try[SetupDLC] = {
     require(!isInitiator, "You should call setupDLCOffer")
@@ -47,7 +47,7 @@ case class DLCExecutor(signer: DLCTxSigner) {
     */
   def setupDLC(
       cetSigs: CETSignatures,
-      refundSig: PartialSignature,
+      refundSig: PartialSignature[ECDigitalSignature],
       fundingSigsOpt: Option[FundingSignatures],
       cetsOpt: Option[Vector[WitnessTransaction]]): Try[SetupDLC] = {
     if (!isInitiator) {
@@ -114,7 +114,8 @@ case class DLCExecutor(signer: DLCTxSigner) {
     RefundDLCOutcome(fundingTx, refundTx)
   }
 
-  def executeRefundDLC(refundSig: PartialSignature): RefundDLCOutcome = {
+  def executeRefundDLC(
+      refundSig: PartialSignature[ECDigitalSignature]): RefundDLCOutcome = {
     val refundTx = signer.completeRefundTx(refundSig)
     val fundingTx = signer.builder.buildFundingTx
     RefundDLCOutcome(fundingTx, refundTx)

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/models/DLCMessage.scala
@@ -196,7 +196,7 @@ object DLCMessage {
       changeAddress: BitcoinAddress,
       payoutSerialId: UInt64,
       changeSerialId: UInt64,
-      refundSig: PartialSignature,
+      refundSig: PartialSignature[ECDigitalSignature],
       negotiationFields: DLCAccept.NegotiationFields,
       tempContractId: Sha256Digest) {
 
@@ -229,7 +229,8 @@ object DLCMessage {
       negotiationFields: DLCAccept.NegotiationFields,
       tempContractId: Sha256Digest) {
 
-    def withRefundSigs(refundSig: PartialSignature): DLCAcceptWithoutCetSigs = {
+    def withRefundSigs(refundSig: PartialSignature[ECDigitalSignature])
+        : DLCAcceptWithoutCetSigs = {
       DLCAcceptWithoutCetSigs(
         totalCollateral = totalCollateral,
         pubKeys = pubKeys,
@@ -245,7 +246,7 @@ object DLCMessage {
 
     def withSigs(
         cetSigs: CETSignatures,
-        refundSig: PartialSignature): DLCAccept = {
+        refundSig: PartialSignature[ECDigitalSignature]): DLCAccept = {
       DLCAccept(
         collateral = totalCollateral,
         pubKeys = pubKeys,
@@ -269,7 +270,7 @@ object DLCMessage {
       payoutSerialId: UInt64,
       changeSerialId: UInt64,
       cetSigs: CETSignatures,
-      refundSig: PartialSignature,
+      refundSig: PartialSignature[ECDigitalSignature],
       negotiationFields: DLCAccept.NegotiationFields,
       tempContractId: Sha256Digest,
       isExternalAddress: Boolean = false)
@@ -428,7 +429,7 @@ object DLCMessage {
 
   case class DLCSign(
       cetSigs: CETSignatures,
-      refundSig: PartialSignature,
+      refundSig: PartialSignature[ECDigitalSignature],
       fundingSigs: FundingSignatures,
       contractId: ByteVector)
       extends DLCMessage {

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/sign/DLCTxSigner.scala
@@ -200,12 +200,13 @@ case class DLCTxSigner(
   }
 
   /** Creates this party's signature of the refund transaction */
-  lazy val signRefundTx: PartialSignature = {
+  lazy val signRefundTx: PartialSignature[ECDigitalSignature] = {
     DLCTxSigner.signRefundTx(cetSigningInfo, builder.buildRefundTx)
   }
 
   /** Constructs the signed refund transaction given remote's signature */
-  def completeRefundTx(remoteSig: PartialSignature): WitnessTransaction = {
+  def completeRefundTx(
+      remoteSig: PartialSignature[ECDigitalSignature]): WitnessTransaction = {
     val localSig = signRefundTx
 
     DLCTxSigner.completeRefundTx(localSig,
@@ -414,7 +415,7 @@ object DLCTxSigner {
   def signRefundTx(
       refundSigningInfo: ECSignatureParams[P2WSHV0InputInfo],
       refundTx: WitnessTransaction
-  ): PartialSignature = {
+  ): PartialSignature[ECDigitalSignature] = {
     val fundingPubKey = refundSigningInfo.signer.publicKey
 
     val sig = TransactionSignatureCreator.createSig(
@@ -428,8 +429,8 @@ object DLCTxSigner {
 
   // TODO: Without PSBTs
   def completeRefundTx(
-      localSig: PartialSignature,
-      remoteSig: PartialSignature,
+      localSig: PartialSignature[ECDigitalSignature],
+      remoteSig: PartialSignature[ECDigitalSignature],
       fundingMultiSig: MultiSignatureScriptPubKey,
       fundingTx: Transaction,
       uRefundTx: WitnessTransaction): WitnessTransaction = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/verify/DLCSignatureVerifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/verify/DLCSignatureVerifier.scala
@@ -17,7 +17,12 @@ import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.util.{FutureUtil, Indexed}
-import org.bitcoins.crypto.{ECAdaptorSignature, ECPublicKey, HashType}
+import org.bitcoins.crypto.{
+  ECAdaptorSignature,
+  ECDigitalSignature,
+  ECPublicKey,
+  HashType
+}
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -76,7 +81,7 @@ case class DLCSignatureVerifier(builder: DLCTxBuilder, isInitiator: Boolean) {
   }
 
   /** Verifies remote's refund signature */
-  def verifyRefundSig(sig: PartialSignature): Boolean = {
+  def verifyRefundSig(sig: PartialSignature[ECDigitalSignature]): Boolean = {
     val refundTx = builder.buildRefundTx
 
     DLCSignatureVerifier.validateRefundSignature(sig,
@@ -114,7 +119,7 @@ object DLCSignatureVerifier {
   }
 
   def validateRefundSignature(
-      refundSig: PartialSignature,
+      refundSig: PartialSignature[ECDigitalSignature],
       fundingTx: Transaction,
       fundOutputIndex: Int,
       refundTx: WitnessTransaction

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/TLV.scala
@@ -2051,7 +2051,7 @@ case class DLCAcceptTLV(
       negotiationFields.bytes
   }
 
-  val refundPartialSignature: PartialSignature = {
+  val refundPartialSignature: PartialSignature[ECDigitalSignature] = {
     PartialSignature(fundingPubKey, refundSignature)
   }
 }
@@ -2108,7 +2108,8 @@ case class DLCSignTLV(
       fundingSignatures.bytes
   }
 
-  def getPartialSignature(fundingPubKey: ECPublicKey): PartialSignature = {
+  def getPartialSignature(
+      fundingPubKey: ECPublicKey): PartialSignature[ECDigitalSignature] = {
     PartialSignature(fundingPubKey, refundSignature)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBT.scala
@@ -690,18 +690,20 @@ case class PSBT(
     PSBT(globalMap, newInputMaps, outputMaps)
   }
 
-  def addSignature(
+  def addSignature[Sig <: DigitalSignature](
       pubKey: ECPublicKey,
-      sig: ECDigitalSignature,
+      sig: Sig,
       inputIndex: Int): PSBT =
-    addSignature(PartialSignature(pubKey, sig), inputIndex)
+    addSignature(PartialSignature(pubKey.toPublicKeyBytes(), sig), inputIndex)
 
-  def addSignature(partialSignature: PartialSignature, inputIndex: Int): PSBT =
+  def addSignature[Sig <: DigitalSignature](
+      partialSignature: PartialSignature[Sig],
+      inputIndex: Int): PSBT =
     addSignatures(Vector(partialSignature), inputIndex)
 
   /** Adds all the PartialSignatures to the input map at the given index */
-  def addSignatures(
-      partialSignatures: Vector[PartialSignature],
+  def addSignatures[Sig <: DigitalSignature](
+      partialSignatures: Vector[PartialSignature[Sig]],
       inputIndex: Int): PSBT = {
     require(
       inputIndex < inputMaps.size,

--- a/core/src/main/scala/org/bitcoins/core/psbt/PSBTKeyId.scala
+++ b/core/src/main/scala/org/bitcoins/core/psbt/PSBTKeyId.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.psbt
 
-import org.bitcoins.crypto.Factory
+import org.bitcoins.crypto.{DigitalSignature, Factory}
 import scodec.bits.ByteVector
 
 /** A PSBTKeyId refers to the first byte of a key that signifies which kind of
@@ -74,7 +74,7 @@ object PSBTInputKeyId extends PSBTKeyIdFactory[PSBTInputKeyId] {
     byte match {
       case NonWitnessUTXOKeyId.byte            => NonWitnessUTXOKeyId
       case WitnessUTXOKeyId.byte               => WitnessUTXOKeyId
-      case PartialSignatureKeyId.byte          => PartialSignatureKeyId
+      case PartialSignatureKeyId.byte          => PartialSignatureKeyId()
       case SigHashTypeKeyId.byte               => SigHashTypeKeyId
       case RedeemScriptKeyId.byte              => RedeemScriptKeyId
       case WitnessScriptKeyId.byte             => WitnessScriptKeyId
@@ -106,9 +106,14 @@ object PSBTInputKeyId extends PSBTKeyIdFactory[PSBTInputKeyId] {
     type RecordType = InputPSBTRecord.WitnessUTXO
   }
 
-  case object PartialSignatureKeyId extends PSBTInputKeyId {
+  case class PartialSignatureKeyId[Sig <: DigitalSignature]()
+      extends PSBTInputKeyId {
     override val byte: Byte = 0x02.byteValue
-    type RecordType = InputPSBTRecord.PartialSignature
+    type RecordType = InputPSBTRecord.PartialSignature[Sig]
+  }
+
+  object PartialSignatureKeyId {
+    val byte: Byte = PartialSignatureKeyId().byte
   }
 
   case object SigHashTypeKeyId extends PSBTInputKeyId {

--- a/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/signer/Signer.scala
@@ -20,16 +20,17 @@ sealed abstract class SignerUtils {
       signingInfo: InputSigningInfo[InputInfo],
       sign: (ByteVector, HashType) => Sig,
       hashType: HashType): Sig = {
-      TransactionSignatureCreator.createSig(unsignedTx,
-                                            signingInfo,
-                                            sign,
-                                            hashType)
+    TransactionSignatureCreator.createSig(unsignedTx,
+                                          signingInfo,
+                                          sign,
+                                          hashType)
   }
 
   def signSingle[Sig <: DigitalSignature](
       spendingInfo: ECSignatureParams[InputInfo],
       unsignedTx: Transaction,
-      signWithHashType: (ByteVector, HashType) => Sig): PartialSignature[Sig] = {
+      signWithHashType: (ByteVector, HashType) => Sig)
+      : PartialSignature[Sig] = {
 
     val tx = spendingInfo.inputInfo match {
       case _: SegwitV0NativeInputInfo | _: P2SHNestedSegwitV0InputInfo |
@@ -254,20 +255,11 @@ object BitcoinSigner extends SignerUtils {
                 wtx
             }
         }
-        signSingle(spendingInfo,
-                   txToSign,
-                   signer.signLowRWithHashType,
-                   isDummySignature)
+        signSingle(spendingInfo, txToSign, signer.signLowRWithHashType)
       case _: TaprootScriptPubKey =>
-        signSingle(spendingInfo,
-                   tx,
-                   signer.schnorrSignWithHashType,
-                   isDummySignature)
+        signSingle(spendingInfo, tx, signer.schnorrSignWithHashType)
       case _: NonWitnessScriptPubKey =>
-        signSingle(spendingInfo,
-                   tx,
-                   signer.signLowRWithHashType,
-                   isDummySignature)
+        signSingle(spendingInfo, tx, signer.signLowRWithHashType)
       case u: UnassignedWitnessScriptPubKey =>
         sys.error(s"Cannot sign unsupported witSPK=$u")
     }
@@ -295,9 +287,7 @@ sealed abstract class RawSingleKeyBitcoinSigner[-InputType <: RawInputInfo]
 
     val single = spendingInfo.toSingle(0)
     val partialSignature =
-      signSingle(single,
-                 unsignedTx,
-                 single.signer.signLowRWithHashType)
+      signSingle(single, unsignedTx, single.signer.signLowRWithHashType)
 
     val scriptSig =
       keyAndSigToScriptSig(partialSignature.pubKey.toPublicKey,

--- a/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputSigningInfo.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/utxo/InputSigningInfo.scala
@@ -68,7 +68,7 @@ case class ScriptSignatureParams[+InputType <: InputInfo](
   def signer: Sign = {
     require(
       signers.length == 1,
-      "This method is for spending infos with a single signer, if you mean signers.head be explicit")
+      s"This method is for spending infos with a single signer, if you mean signers.head be explicit, signers=$signers")
 
     signers.head
   }

--- a/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbCommonsColumnMappers.scala
@@ -423,18 +423,32 @@ class DbCommonsColumnMappers(val profile: JdbcProfile) {
     )
   }
 
-  implicit val partialSigMapper: BaseColumnType[PartialSignature] = {
+  implicit val partialSigMapper
+      : BaseColumnType[PartialSignature[DigitalSignature]] = {
     MappedColumnType
-      .base[PartialSignature, String](_.hex, PartialSignature.fromHex)
+      .base[PartialSignature[DigitalSignature], String](
+        _.hex,
+        PartialSignature.fromHex)
   }
 
-  implicit val partialSigsMapper: BaseColumnType[Vector[PartialSignature]] = {
+  implicit val ecPartialSigMapper
+      : BaseColumnType[PartialSignature[ECDigitalSignature]] = {
     MappedColumnType
-      .base[Vector[PartialSignature], String](
+      .base[PartialSignature[ECDigitalSignature], String](
+        _.hex,
+        PartialSignature
+          .fromHex(_)
+          .asInstanceOf[PartialSignature[ECDigitalSignature]])
+  }
+
+  implicit val partialSigsMapper
+      : BaseColumnType[Vector[PartialSignature[DigitalSignature]]] = {
+    MappedColumnType
+      .base[Vector[PartialSignature[DigitalSignature]], String](
         _.foldLeft("")(_ ++ _.hex),
         hex =>
           if (hex.isEmpty) Vector.empty
-          else InputPSBTMap(hex ++ "00").partialSignatures
+          else InputPSBTMap(hex ++ "00").partialSignatures[DigitalSignature]
       )
   }
 

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -31,6 +31,7 @@ import org.bitcoins.core.wallet.utxo.{
 }
 import org.bitcoins.crypto.{
   DoubleSha256DigestBE,
+  ECDigitalSignature,
   SchnorrDigitalSignature,
   Sha256Digest
 }
@@ -396,7 +397,7 @@ case class DLCTransactionProcessing(
   private def buildSignMessage(
       dlcDb: DLCDb,
       sigDbs: Vector[DLCCETSignaturesDb],
-      offerRefundSig: PartialSignature,
+      offerRefundSig: PartialSignature[ECDigitalSignature],
       fundingInputDbs: Vector[DLCFundingInputDb]
   ): DLCSign = {
     {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCAcceptDb.scala
@@ -28,7 +28,7 @@ case class DLCAcceptDb(
       tempContractId: Sha256Digest,
       fundingInputs: Vector[DLCFundingInput],
       outcomeSigs: Vector[(ECPublicKey, ECAdaptorSignature)],
-      refundSig: PartialSignature
+      refundSig: PartialSignature[ECDigitalSignature]
   ): DLCAccept = {
     val pubKeys =
       DLCPublicKeys(fundingKey, payoutAddress)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigsDAO.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigsDAO.scala
@@ -2,7 +2,7 @@ package org.bitcoins.dlc.wallet.models
 
 import org.bitcoins.core.api.dlc.wallet.db.DLCDb
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
-import org.bitcoins.crypto.Sha256Digest
+import org.bitcoins.crypto.{ECDigitalSignature, Sha256Digest}
 import org.bitcoins.db.{CRUD, SlickUtil}
 import org.bitcoins.dlc.wallet.DLCAppConfig
 import slick.lifted.{ForeignKeyQuery, ProvenShape}
@@ -71,9 +71,11 @@ case class DLCRefundSigsDAO()(implicit
 
     def dlcId: Rep[Sha256Digest] = column("dlc_id", O.PrimaryKey)
 
-    def accepterSig: Rep[PartialSignature] = column("accepter_sig")
+    def accepterSig: Rep[PartialSignature[ECDigitalSignature]] = column(
+      "accepter_sig")
 
-    def initiatorSig: Rep[Option[PartialSignature]] = column("initiator_sig")
+    def initiatorSig: Rep[Option[PartialSignature[ECDigitalSignature]]] =
+      column("initiator_sig")
 
     def * : ProvenShape[DLCRefundSigsDb] =
       (dlcId, accepterSig, initiatorSig).<>(

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigsDb.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/models/DLCRefundSigsDb.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.dlc.wallet.models
 
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
-import org.bitcoins.crypto.Sha256Digest
+import org.bitcoins.crypto.{ECDigitalSignature, Sha256Digest}
 
 case class DLCRefundSigsDb(
     dlcId: Sha256Digest,
-    accepterSig: PartialSignature,
-    initiatorSig: Option[PartialSignature]
+    accepterSig: PartialSignature[ECDigitalSignature],
+    initiatorSig: Option[PartialSignature[ECDigitalSignature]]
 )

--- a/docs/core/adding-spks.md
+++ b/docs/core/adding-spks.md
@@ -126,7 +126,7 @@ sealed abstract class Signer[-InputType <: InputInfo] {
   def signSingle(
       spendingInfo: UTXOSigningInfo[InputInfo],
       unsignedTx: Transaction)(
-      implicit ec: ExecutionContext): Future[PartialSignature] = ???
+      implicit ec: ExecutionContext): Future[PartialSignature[ECDigitalSignature]] = ???
 }
 sealed abstract class RawSingleKeyBitcoinSigner[-InputType <: RawInputInfo]
     extends Signer[InputType] {
@@ -180,7 +180,7 @@ object BitcoinSigner {
     def signSingle(
         spendingInfo: UTXOSigningInfo[InputInfo],
         unsignedTx: Transaction)(
-        implicit ec: ExecutionContext): Future[PartialSignature] = ???
+        implicit ec: ExecutionContext): Future[PartialSignature[ECDigitalSignature]] = ???
 }
 
 def asm: Seq[ScriptToken] = ???

--- a/docs/core/psbts.md
+++ b/docs/core/psbts.md
@@ -127,7 +127,8 @@ val spendingInfoSingle = ECSignatureParams(
 // Then we can sign the transaction
 val signature = BitcoinSigner.signSingle(
     spendingInfo = spendingInfoSingle,
-    unsignedTx = unsignedTransaction)
+    unsignedTx = unsignedTransaction,
+    privKey0.signLowRWithHashType)
 
 // We can then add the signature to the PSBT
 // Note: this signature could be produced by us or another party

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/DLCTest.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/DLCTest.scala
@@ -699,22 +699,27 @@ trait DLCTest {
       publishTransaction: Transaction => Future[?]
   )(implicit ec: ExecutionContext): Future[(SetupDLC, SetupDLC)] = {
     val offerSigReceiveP = {
-      Promise[(CETSignatures, PartialSignature)]()
+      Promise[(CETSignatures, PartialSignature[ECDigitalSignature])]()
     }
-    val sendAcceptSigs: (CETSignatures, PartialSignature) => Future[Unit] = {
-      case (cetSigs: CETSignatures, refundSig: PartialSignature) =>
+    val sendAcceptSigs: (
+        CETSignatures,
+        PartialSignature[ECDigitalSignature]) => Future[Unit] = {
+      case (cetSigs: CETSignatures,
+            refundSig: PartialSignature[ECDigitalSignature]) =>
         val _ = offerSigReceiveP.success((cetSigs, refundSig))
         FutureUtil.unit
     }
 
     val acceptSigReceiveP = {
-      Promise[(CETSignatures, PartialSignature, FundingSignatures)]()
+      Promise[(CETSignatures,
+               PartialSignature[ECDigitalSignature],
+               FundingSignatures)]()
     }
 
     val sendOfferSigs = {
       (
           cetSigs: CETSignatures,
-          refundSig: PartialSignature,
+          refundSig: PartialSignature[ECDigitalSignature],
           fundingSigs: FundingSignatures
       ) =>
         val _ = acceptSigReceiveP.success((cetSigs, refundSig, fundingSigs))

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/TestDLCClient.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/dlc/TestDLCClient.scala
@@ -74,8 +74,12 @@ case class TestDLCClient(
     * from them
     */
   def setupDLCAccept(
-      sendSigs: (CETSignatures, PartialSignature) => Future[Unit],
-      getSigs: Future[(CETSignatures, PartialSignature, FundingSignatures)]
+      sendSigs: (
+          CETSignatures,
+          PartialSignature[ECDigitalSignature]) => Future[Unit],
+      getSigs: Future[(CETSignatures,
+                       PartialSignature[ECDigitalSignature],
+                       FundingSignatures)]
   ): Future[SetupDLC] = {
     require(!isInitiator, "You should call setupDLCOffer")
 
@@ -98,10 +102,10 @@ case class TestDLCClient(
     * signed funding transaction
     */
   def setupDLCOffer(
-      getSigs: Future[(CETSignatures, PartialSignature)],
+      getSigs: Future[(CETSignatures, PartialSignature[ECDigitalSignature])],
       sendSigs: (
           CETSignatures,
-          PartialSignature,
+          PartialSignature[ECDigitalSignature],
           FundingSignatures
       ) => Future[Unit],
       getFundingTx: Future[Transaction]

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/PSBTGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/PSBTGenerators.scala
@@ -148,7 +148,7 @@ object PSBTGenerators {
         val newInputsMaps = psbt.inputMaps.map { map =>
           InputPSBTMap(
             map.elements.filterNot(element =>
-              PSBTInputKeyId.fromBytes(element.key) == PartialSignatureKeyId)
+              PSBTInputKeyId.fromBytes(element.key) == PartialSignatureKeyId())
           )
         }
 

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/BytesUtil.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/BytesUtil.scala
@@ -23,7 +23,8 @@ object BytesUtil {
     ECDigitalSignature(flipAtIndex(signature.bytes, 60))
   }
 
-  def flipBit(partialSignature: PartialSignature): PartialSignature = {
+  def flipBit(partialSignature: PartialSignature[ECDigitalSignature])
+      : PartialSignature[ECDigitalSignature] = {
     partialSignature.copy(signature = flipBit(partialSignature.signature))
   }
 
@@ -63,8 +64,8 @@ object BytesUtil {
 
   def flipBit(
       cetSigs: CETSignatures,
-      refundSig: PartialSignature
-  ): (CETSignatures, PartialSignature) = {
+      refundSig: PartialSignature[ECDigitalSignature]
+  ): (CETSignatures, PartialSignature[ECDigitalSignature]) = {
     val badOutcomeSigs = cetSigs.outcomeSigs.map { case (outcome, sig) =>
       outcome -> flipBit(sig)
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/DLCWalletUtil.scala
@@ -182,10 +182,10 @@ object DLCWalletUtil extends BitcoinSLogger {
 
   lazy val dummyKey2: ECPublicKey = ECPublicKey.freshPublicKey
 
-  lazy val dummyPartialSig: PartialSignature =
+  lazy val dummyPartialSig: PartialSignature[ECDigitalSignature] =
     PartialSignature(dummyKey, ECDigitalSignature.dummy)
 
-  lazy val minimalPartialSig: PartialSignature = {
+  lazy val minimalPartialSig: PartialSignature[ECDigitalSignature] = {
     PartialSignature(dummyKey, ECDigitalSignature.minimalEncodedZeroSig)
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -6,13 +6,13 @@ import org.bitcoins.core.api.wallet.db.{AddressDb, TransactionDbHelper}
 import org.bitcoins.core.hd.HDChainType.{Change, External}
 import org.bitcoins.core.hd.{AddressType, HDAccount, HDChainType}
 import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.core.protocol.script._
+import org.bitcoins.core.protocol.script.*
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.crypto.{CryptoUtil, ECPublicKey}
+import org.bitcoins.crypto.{CryptoUtil, ECDigitalSignature, ECPublicKey}
 import org.bitcoins.keymanager.{DecryptedMnemonic, WalletStorage}
 import org.bitcoins.testkit.chain.MockChainQueryApi
 import org.bitcoins.testkit.wallet.BitcoinSWalletTest
-import org.bitcoins.testkitcore.util.TransactionTestUtil._
+import org.bitcoins.testkitcore.util.TransactionTestUtil.*
 import org.scalatest.FutureOutcome
 import org.scalatest.compatible.Assertion
 
@@ -238,7 +238,8 @@ class WalletUnitTest extends BitcoinSWalletTest {
     } yield {
       assert(signed != psbt)
       assert(
-        signed.inputMaps.head.partialSignatures
+        signed.inputMaps.head
+          .partialSignatures[ECDigitalSignature]
           .exists(_.pubKey.toPublicKey == walletKey)
       )
     }
@@ -264,7 +265,8 @@ class WalletUnitTest extends BitcoinSWalletTest {
       } yield {
         assert(signed != psbt)
         assert(
-          signed.inputMaps.head.partialSignatures
+          signed.inputMaps.head
+            .partialSignatures[ECDigitalSignature]
             .exists(_.pubKey.toPublicKey == walletKey)
         )
       }
@@ -290,7 +292,8 @@ class WalletUnitTest extends BitcoinSWalletTest {
       } yield {
         assert(signed != psbt)
         assert(
-          signed.inputMaps.head.partialSignatures
+          signed.inputMaps.head
+            .partialSignatures[ECDigitalSignature]
             .exists(_.pubKey.toPublicKey == walletKey)
         )
       }
@@ -317,7 +320,8 @@ class WalletUnitTest extends BitcoinSWalletTest {
       } yield {
         assert(signed != psbt)
         assert(
-          signed.inputMaps.head.partialSignatures
+          signed.inputMaps.head
+            .partialSignatures[ECDigitalSignature]
             .exists(_.pubKey.toPublicKey == walletKey)
         )
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
@@ -47,7 +47,7 @@ import org.bitcoins.core.wallet.fee.{
   SatoshisPerVirtualByte
 }
 import org.bitcoins.core.wallet.utxo.{AddressTag, TxoState}
-import org.bitcoins.crypto.{CryptoUtil, DoubleSha256DigestBE}
+import org.bitcoins.crypto.{CryptoUtil, DigitalSignature, DoubleSha256DigestBE}
 import org.bitcoins.wallet.config.WalletAppConfig
 import org.bitcoins.wallet.models.{
   AccountDAO,
@@ -560,11 +560,12 @@ case class SendFundsHandlingHandling(
             keyPaths.foldLeft(withData) { (accum, hdPath) =>
               val sign = keyManager.toSign(hdPath)
               // Only sign if that key doesn't have a signature yet
-              if (
-                !input.partialSignatures.exists(
+              val sigExists = input
+                .partialSignatures[DigitalSignature]
+                .exists(
                   _.pubKey.toPublicKey == sign.publicKey
                 )
-              ) {
+              if (!sigExists) {
                 logger.debug(
                   s"Signing input $index with key ${sign.publicKey.hex}"
                 )


### PR DESCRIPTION
This PR parameterizes `PartialSignature` by a `DigitalSignature` type. This allows us to re-use this data structure for either `ECDigitalSignature` in pre-taproot, and use `SchnorrDigitalSignature` in a taproot world.

This is needed to integrate taproot into our wallet.