### PR TITLE
2024 11 20 prevoutmap ordering

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxSigner.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxSigner.scala
@@ -106,7 +106,9 @@ object RawTxSigner {
     require(utxoInfos.distinct.length == utxoInfos.length,
             "All UTXOSatisfyingInfos must be unique. ")
     val utxOutPoints = utx.inputs.map(_.previousOutput)
-    utxoInfos.foreach { u =>
+    val sortedUtxoInfos = utxoInfos.map(u =>
+      u.copy(inputInfo = u.inputInfo.sortPreviousOutputMap(utxOutPoints)))
+    sortedUtxoInfos.foreach { u =>
       val outPoints = u.inputInfo.previousOutputMap.keys.toVector
       require(
         utxOutPoints == outPoints,
@@ -125,7 +127,7 @@ object RawTxSigner {
           .setLockTime(utx.lockTime)
           .++=(utx.outputs)
 
-        val inputsAndWitnesses = utxoInfos.map { utxo =>
+        val inputsAndWitnesses = sortedUtxoInfos.map { utxo =>
           val txSigComp =
             BitcoinSigner.sign(utxo, utx)
           val scriptWitnessOpt = TxSigComponent.getScriptWitness(txSigComp)

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxSigner.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxSigner.scala
@@ -1,8 +1,14 @@
 package org.bitcoins.core.wallet.builder
 
 import org.bitcoins.core.crypto.TxSigComponent
-import org.bitcoins.core.protocol.script.ScriptWitness
-import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.script.{
+  NonWitnessScriptPubKey,
+  ScriptWitness,
+  TaprootScriptPubKey,
+  UnassignedWitnessScriptPubKey,
+  WitnessScriptPubKeyV0
+}
+import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.wallet.fee.FeeUnit
 import org.bitcoins.core.wallet.signer.BitcoinSigner
 import org.bitcoins.core.wallet.utxo.{
@@ -106,13 +112,16 @@ object RawTxSigner {
     require(utxoInfos.distinct.length == utxoInfos.length,
             "All UTXOSatisfyingInfos must be unique. ")
     val utxOutPoints = utx.inputs.map(_.previousOutput)
-    val sortedUtxoInfos = utxoInfos.map(u =>
-      u.copy(inputInfo = u.inputInfo.sortPreviousOutputMap(utxOutPoints)))
-    sortedUtxoInfos.foreach { u =>
-      val outPoints = u.inputInfo.previousOutputMap.keys.toVector
-      require(
-        utxOutPoints == outPoints,
-        s"OutputMap must have same ordering as unsigned transaction inputs utxOutPoints=$utxOutPoints outPointMap=$outPoints")
+    val sortedUtxoInfos = utxoInfos.map { u =>
+      u.output.scriptPubKey match {
+        case _: NonWitnessScriptPubKey | _: WitnessScriptPubKeyV0 |
+            _: UnassignedWitnessScriptPubKey =>
+          // no sorting needed for these spk types as the sighash algorithm
+          // doesn't include all outputs
+          u
+        case _: TaprootScriptPubKey =>
+          u.copy(inputInfo = u.inputInfo.sortPreviousOutputMap(utxOutPoints))
+      }
     }
 
     val signedTx =

--- a/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxSigner.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/builder/RawTxSigner.scala
@@ -105,9 +105,13 @@ object RawTxSigner {
       s"Must provide exactly one UTXOSatisfyingInfo per input, ${utxoInfos.length} != ${utx.inputs.length}")
     require(utxoInfos.distinct.length == utxoInfos.length,
             "All UTXOSatisfyingInfos must be unique. ")
-    require(utxoInfos.forall(utxo =>
-              utx.inputs.exists(_.previousOutput == utxo.outPoint)),
-            "All UTXOSatisfyingInfos must correspond to an input.")
+    val utxOutPoints = utx.inputs.map(_.previousOutput)
+    utxoInfos.foreach { u =>
+      val outPoints = u.inputInfo.previousOutputMap.keys.toVector
+      require(
+        utxOutPoints == outPoints,
+        s"OutputMap must have same ordering as unsigned transaction inputs utxOutPoints=$utxOutPoints outPointMap=$outPoints")
+    }
 
     val signedTx =
       if (

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -29,7 +29,7 @@
 
     <logger name="org.bitcoins.chain" level="WARN"/>
 
-    <logger name="org.bitcoins.wallet" level="WARN"/>
+    <logger name="org.bitcoins.wallet" level="DEBUG"/>
 
     <logger name="org.bitcoins.dlc.wallet" level="WARN"/>
 

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -29,7 +29,7 @@
 
     <logger name="org.bitcoins.chain" level="WARN"/>
 
-    <logger name="org.bitcoins.wallet" level="DEBUG"/>
+    <logger name="org.bitcoins.wallet" level="WARN"/>
 
     <logger name="org.bitcoins.dlc.wallet" level="WARN"/>
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -431,7 +431,6 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       _ = assert(balance1 == valueFromBitcoind * 2)
       bitcoindAddr1 <- bitcoindAddr1F
       sweepTx <- wallet.sendFundsHandling.sweepWallet(bitcoindAddr1, None)
-      _ = println(s"sweepTx=$sweepTx")
       _ <- bitcoind.sendRawTransaction(sweepTx)
       balance2 <- wallet.getBalance()
     } yield {

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
@@ -488,9 +488,9 @@ case class SendFundsHandlingHandling(
 
       txBuilder = RawTxBuilder() ++= inputs += dummyOutput
       finalizer = SubtractFeeFromOutputsFinalizer(
-        inputInfos,
-        feeRate,
-        Vector(address.scriptPubKey)
+        inputInfos = inputInfos,
+        feeRate = feeRate,
+        spks = Vector(address.scriptPubKey)
       )
         .andThen(ShuffleFinalizer)
         .andThen(AddWitnessDataFinalizer(inputInfos))
@@ -503,7 +503,10 @@ case class SendFundsHandlingHandling(
         tmp.outputs.size == 1,
         s"Created tx is not as expected, does not have 1 output, got $tmp"
       )
-      rawTxHelper = FundRawTxHelper(withFinalizer, utxos, feeRate, Future.unit)
+      rawTxHelper = FundRawTxHelper(txBuilderWithFinalizer = withFinalizer,
+                                    scriptSigParams = utxos,
+                                    feeRate = feeRate,
+                                    reservedUTXOsCallbackF = Future.unit)
       tx <- finishSend(
         rawTxHelper,
         tmp.outputs.head.value,


### PR DESCRIPTION
fixes bug in #5767 where we need to guarantee the `InputInfo.previousOutputMap()` is sorted the same way that outpoints are stored in `Transaction.inputs`

This PR adds a test for this case, and sorts`InputInfo.previousOutputMap` inside `RawTxSigner.sign()`