### PR TITLE
core: Fix bug where we weren't checking for valid hash types in `TaprootKeyPath.isValid()`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -88,7 +88,7 @@ trait TransactionSignatureChecker {
     val hashType =
       schnorrSignature.hashTypeOpt.getOrElse(HashType.sigHashDefault)
     // bip341 restricts valid hash types: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#common-signature-message
-    val validHashType = checkTaprootHashType(hashType)
+    val validHashType = HashType.checkTaprootHashType(hashType)
     if (!validHashType) {
       ScriptErrorSchnorrSigHashType
     } else {
@@ -99,19 +99,6 @@ trait TransactionSignatureChecker {
       val result = pubKey.verify(hash, schnorrSignature)
       if (result) ScriptOk else ScriptErrorSchnorrSig
     }
-  }
-
-  //    (hash_type <= 0x03 || (hash_type >= 0x81 && hash_type <= 0x83))
-  private val validTaprootHashTypes: Vector[Byte] = Vector(0x00.toByte,
-                                                           0x01.toByte,
-                                                           0x02.toByte,
-                                                           0x03.toByte,
-                                                           0x81.toByte,
-                                                           0x82.toByte,
-                                                           0x83.toByte)
-
-  def checkTaprootHashType(hashType: HashType): Boolean = {
-    validTaprootHashTypes.contains(hashType.byte)
   }
 
   /** Checks the signature of a scriptSig in the spending transaction against

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -331,12 +331,25 @@ object TaprootKeyPath extends Factory[TaprootKeyPath] {
   def isValid(stack: Vector[ByteVector]): Boolean = {
     val noAnnex =
       stack.length == 1 && (stack.head.length == 64 || stack.head.length == 65) &&
-        SchnorrPublicKey.fromBytesT(stack.head.take(32)).isSuccess
+        SchnorrPublicKey
+          .fromBytesT(stack.head.take(32))
+          .isSuccess && checkHashType(stack.head)
     val annex =
       stack.length == 2 && TaprootScriptPath.hasAnnex(stack) &&
         (stack(1).length == 64 || stack(1).length == 65) &&
-        SchnorrPublicKey.fromBytesT(stack(1).take(32)).isSuccess
+        SchnorrPublicKey
+          .fromBytesT(stack(1).take(32))
+          .isSuccess && checkHashType(stack(1))
     noAnnex || annex
+  }
+
+  private def checkHashType(bytes: ByteVector): Boolean = {
+    require(bytes.length == 64 || bytes.length == 65)
+    if (bytes.length == 64) true
+    else {
+      val h = HashType.fromByte(bytes(64))
+      HashType.checkTaprootHashType(h)
+    }
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
@@ -226,7 +226,7 @@ sealed abstract class CryptoInterpreter {
       helperE match {
         case Right(helper) =>
           val validHashType =
-            TransactionSignatureChecker.checkTaprootHashType(helper.hashType)
+            HashType.checkTaprootHashType(helper.hashType)
           if (validHashType) {
             val result = TransactionSignatureChecker.checkSigTapscript(
               txSignatureComponent = program.txSignatureComponent,

--- a/crypto/src/main/scala/org/bitcoins/crypto/HashType.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/HashType.scala
@@ -200,6 +200,19 @@ object HashType extends Factory[HashType] {
   def isDefinedHashtypeSignature(sig: ECDigitalSignature): Boolean = {
     sig.bytes.nonEmpty && hashTypeBytes.contains(sig.bytes.last)
   }
+
+  //    (hash_type <= 0x03 || (hash_type >= 0x81 && hash_type <= 0x83))
+  private val validTaprootHashTypes: Vector[Byte] = Vector(0x00.toByte,
+                                                           0x01.toByte,
+                                                           0x02.toByte,
+                                                           0x03.toByte,
+                                                           0x81.toByte,
+                                                           0x82.toByte,
+                                                           0x83.toByte)
+
+  def checkTaprootHashType(hashType: HashType): Boolean = {
+    validTaprootHashTypes.contains(hashType.byte)
+  }
 }
 
 case object SIGHASH_DEFAULT extends HashType {

--- a/crypto/src/main/scala/org/bitcoins/crypto/HashType.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/HashType.scala
@@ -202,16 +202,17 @@ object HashType extends Factory[HashType] {
   }
 
   //    (hash_type <= 0x03 || (hash_type >= 0x81 && hash_type <= 0x83))
-  private val validTaprootHashTypes: Vector[Byte] = Vector(0x00.toByte,
-                                                           0x01.toByte,
-                                                           0x02.toByte,
-                                                           0x03.toByte,
-                                                           0x81.toByte,
-                                                           0x82.toByte,
-                                                           0x83.toByte)
+  val validTaprootHashTypes: Vector[HashType] =
+    Vector(0x00.toByte,
+           0x01.toByte,
+           0x02.toByte,
+           0x03.toByte,
+           0x81.toByte,
+           0x82.toByte,
+           0x83.toByte).map(HashType.fromByte)
 
   def checkTaprootHashType(hashType: HashType): Boolean = {
-    validTaprootHashTypes.contains(hashType.byte)
+    validTaprootHashTypes.contains(hashType)
   }
 }
 

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -169,6 +169,7 @@ object CommonSettings {
   lazy val testSettings: Seq[Setting[_]] = Seq(
     //show full stack trace (-oF) of failed tests and duration of tests (-oD)
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
+    //Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest,"-S","-2582694989510866987"),
     Test / logBuffered := false,
     skip / publish := true
   ) ++ settings

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
@@ -244,12 +244,14 @@ sealed abstract class CryptoGenerators {
     }
   }
 
+  def taprootHashType: Gen[HashType] = Gen.oneOf(HashType.validTaprootHashTypes)
+
   def schnorrDigitalSignatureHashType: Gen[SchnorrDigitalSignature] = {
     for {
       privKey <- privateKey
       hash <- CryptoGenerators.doubleSha256Digest
       sigNoHashType = privKey.schnorrSign(hash.bytes)
-      hashType <- hashType
+      hashType <- taprootHashType
     } yield {
       sigNoHashType.appendHashType(hashType)
     }


### PR DESCRIPTION
Fixes bug where the Script below can be classified as a `TaprootKeyPath` (a false positive). This PR checks for the valid hash types for a schnorr digital signature according to [BIP341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_ref-13-0)


```
stack=Vector(ByteVector(65 bytes, 0x64002103fcd25a5cf33457b50e3a3054dfd64cea6fae143bda1485f710dbfb44bdea3c6451ae6776a9148e0dba04818a092796fb281db67337ad6f25511988ac68)) redeemScript=NotIfConditionalScriptPubKey(multi(0,03fcd25a5cf33457b50e3a3054dfd64cea6fae143bda1485f710dbfb44bdea3c64), pkh(8e0dba04818a092796fb281db67337ad6f255119))
asm=Vector(OP_NOTIF, OP_0, BytesToPushOntoStackImpl(33), ScriptConstantImpl(ByteVector(33 bytes, 0x03fcd25a5cf33457b50e3a3054dfd64cea6fae143bda1485f710dbfb44bdea3c64)), OP_1, OP_CHECKMULTISIG, OP_ELSE, OP_DUP, OP_HASH160, BytesToPushOntoStackImpl(20), ScriptConstantImpl(ByteVector(20 bytes, 0x8e0dba04818a092796fb281db67337ad6f255119)), OP_EQUALVERIFY, OP_CHECKSIG, OP_ENDIF)
```