### PR TITLE
config: Rename config option `bitcoin-s.wallet.defaultAccountType` -> `bitcoin-s.wallet.purpose`

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -137,7 +137,7 @@ bitcoin-s {
   wallet = ${bitcoin-s.dbDefault}
     # settings for wallet module
   wallet {
-      defaultAccountType = segwit # legacy, segwit, nested-segwit
+      purpose = segwit # legacy, segwit, nested-segwit
 
       bloomFalsePositiveRate = 0.0001 # percentage
 

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -256,7 +256,7 @@ bitcoin-s {
         # The wallet name can contain letters, numbers, and underscores '_'.
         # walletName = MyWallet0
 
-        defaultAccountType = segwit # legacy, segwit, nested-segwit
+        purpose = segwit # legacy, segwit, nested-segwit, taproot
 
         bloomFalsePositiveRate = 0.0001 # percentage
 

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/config/KeyManagerAppConfigTest.scala
@@ -142,7 +142,7 @@ class KeyManagerAppConfigTest extends BitcoinSAsyncTest {
       val mnemonic = MnemonicCode.fromEntropy(entropy)
       val bip39Seed = BIP39Seed.fromMnemonic(mnemonic, None)
       val version = ExtKeyPrivVersion
-        .fromPurpose(appConfig1.defaultAccountKind, networkParam)
+        .fromPurpose(appConfig1.defaultPurpose, networkParam)
         .get
       val xpriv = bip39Seed.toExtPrivateKey(version)
       val xpub = xpriv.extPublicKey

--- a/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/server/BitcoinSServerMainBitcoindFixture.scala
@@ -36,9 +36,8 @@ trait BitcoinSServerMainBitcoindFixture
         // needed for fundWalletWithBitcoind
         cliConfig = Config(rpcPortOpt = Some(config.rpcPort),
                            rpcPassword = config.rpcPassword)
-        _ = ConsoleCli.exec(
-          CreateNewAccount(config.walletConf.defaultAccountKind),
-          cliConfig)
+        _ = ConsoleCli.exec(CreateNewAccount(config.walletConf.defaultPurpose),
+                            cliConfig)
         addresses = Vector
           .fill(3)(ConsoleCli.exec(GetNewAddress(None), cliConfig))
           .map(_.get)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BaseWalletTest.scala
@@ -62,16 +62,16 @@ object BaseWalletTest {
   }
 
   val legacyWalletConf: Config =
-    ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = legacy")
+    ConfigFactory.parseString("bitcoin-s.wallet.purpose = legacy")
 
-  val nestedSegwitWalletConf: Config = ConfigFactory.parseString(
-    "bitcoin-s.wallet.defaultAccountType = nested-segwit")
+  val nestedSegwitWalletConf: Config =
+    ConfigFactory.parseString("bitcoin-s.wallet.purpose = nested-segwit")
 
   val segwitWalletConf: Config =
-    ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = segwit")
+    ConfigFactory.parseString("bitcoin-s.wallet.purpose = segwit")
 
   val taprootWalletConf: Config =
-    ConfigFactory.parseString("bitcoin-s.wallet.defaultAccountType = taproot")
+    ConfigFactory.parseString("bitcoin-s.wallet.purpose = taproot")
   private val accountTypes =
     Vector(legacyWalletConf,
            nestedSegwitWalletConf,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/WalletTestUtil.scala
@@ -107,7 +107,7 @@ object WalletTestUtil {
     HDAccount(HDCoin(HDPurpose.SegWit, hdCoinType), 0)
 
   def getHdAccount1(walletAppConfig: WalletAppConfig): HDAccount = {
-    val purpose = walletAppConfig.defaultAccountKind
+    val purpose = walletAppConfig.defaultPurpose
     HDAccount(coin = HDCoin(purpose, HDCoinType.Testnet), index = 1)
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -136,7 +136,7 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
       case other                  => fail(s"unexpected purpose: $other")
     }
     val entropy = mnemonic.toEntropy.toHex
-    val confStr = s"""bitcoin-s.wallet.defaultAccountType = $purposeStr
+    val confStr = s"""bitcoin-s.wallet.purpose = $purposeStr
                      |bitcoin-s.network = mainnet
                      |bitcoin-s.keymanager.entropy=${entropy}
                      |""".stripMargin

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
@@ -51,18 +51,18 @@ class WalletAppConfigTest extends BitcoinSAsyncTest {
 
   it must "be overridable without screwing up other options" in {
     val otherConf = ConfigFactory.parseString(
-      s"bitcoin-s.wallet.defaultAccountType = segwit"
+      s"bitcoin-s.wallet.purpose = segwit"
     )
     val thirdConf = ConfigFactory.parseString(
-      s"bitcoin-s.wallet.defaultAccountType = nested-segwit"
+      s"bitcoin-s.wallet.purpose = nested-segwit"
     )
 
     val overriden = config.withOverrides(otherConf)
 
     val twiceOverriden = overriden.withOverrides(thirdConf)
 
-    assert(overriden.defaultAccountKind == HDPurpose.SegWit)
-    assert(twiceOverriden.defaultAccountKind == HDPurpose.NestedSegWit)
+    assert(overriden.defaultPurpose == HDPurpose.SegWit)
+    assert(twiceOverriden.defaultPurpose == HDPurpose.NestedSegWit)
 
     assert(config.datadir == overriden.datadir)
     assert(twiceOverriden.datadir == overriden.datadir)

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -102,10 +102,10 @@ case class WalletAppConfig(
   lazy val kmConf: KeyManagerAppConfig =
     kmConfOpt.getOrElse(KeyManagerAppConfig(baseDatadir, configOverrides))
 
-  lazy val defaultAccountKind: HDPurpose = kmConf.defaultAccountKind
+  lazy val defaultPurpose: HDPurpose = kmConf.defaultPurpose
 
   lazy val defaultAddressType: AddressType = {
-    defaultAccountKind match {
+    defaultPurpose match {
       case HDPurpose.Legacy       => AddressType.Legacy
       case HDPurpose.NestedSegWit => AddressType.NestedSegWit
       case HDPurpose.SegWit       => AddressType.SegWit
@@ -117,7 +117,7 @@ case class WalletAppConfig(
   }
 
   lazy val defaultAccount: HDAccount = {
-    val purpose = defaultAccountKind
+    val purpose = defaultPurpose
     HDAccount(
       coin = HDCoin(purpose, HDCoinType.fromNetwork(network)),
       index = 0
@@ -272,7 +272,7 @@ case class WalletAppConfig(
   override lazy val seedPath: Path = kmConf.seedPath
 
   def kmParams: KeyManagerParams =
-    KeyManagerParams(kmConf.seedPath, defaultAccountKind, network)
+    KeyManagerParams(kmConf.seedPath, defaultPurpose, network)
 
   /** How much elements we can have in
     * [[org.bitcoins.wallet.internal.AddressHandling.addressRequestQueue]]

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AccountHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AccountHandling.scala
@@ -522,7 +522,7 @@ case class AccountHandling(
   /** The default HD coin for this wallet, read from config */
   protected[wallet] lazy val DEFAULT_HD_COIN: HDCoin = {
     val coinType = DEFAULT_HD_COIN_TYPE
-    HDCoin(walletConfig.defaultAccountKind, coinType)
+    HDCoin(walletConfig.defaultPurpose, coinType)
   }
 
   /** The default HD coin type for this wallet, derived from the network we're
@@ -540,5 +540,5 @@ case class AccountHandling(
 
   /** The default HD purpose for this wallet, read from config */
   protected[wallet] lazy val DEFAULT_HD_PURPOSE: HDPurpose =
-    walletConfig.defaultAccountKind
+    walletConfig.defaultPurpose
 }


### PR DESCRIPTION
fixes #5774 

Keeps backwards compatibility for now but config `bitcoin-s.wallet.defaultAccountType` will be removed in the future.