### PR TITLE
wallet: Batch database actions in `processBlockCachedUtxos()`

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -226,7 +226,7 @@ case class TransactionProcessing(
       }
 
     actionsF
-      .flatMap(actions => Future.sequence(actions.map(safeDatabase.run)))
+      .flatMap(actions => safeDatabase.run(DBIOAction.sequence(actions)))
       .map(_ => ())
   }
 


### PR DESCRIPTION
fixes #5785 and #5760

In #5740 we refactored `processBlockCachedUtxos()` to use `DBIOAction`. I didn't realize we could exhaust our database queue by sending individual `DBIOAction` to the database instead of batching them all into one single database actions.

This PR batches all `n` `DBIOAction` into 1 `DBIOAction` before sending it to the database