### PR TITLE
wallet: Don't cache `TransactionProcessing` now that it doesn't have internal state

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCWallet.scala
@@ -131,7 +131,7 @@ case class DLCWallet(override val walletApi: Wallet)(implicit
     DLCActionBuilder(dlcWalletDAOs)
   }
 
-  override lazy val transactionProcessing: DLCTransactionProcessing = {
+  override def transactionProcessing: DLCTransactionProcessing = {
     val txProcessing = TransactionProcessing(
       walletApi = this,
       chainQueryApi = chainQueryApi,
@@ -150,7 +150,7 @@ case class DLCWallet(override val walletApi: Wallet)(implicit
     )
   }
 
-  override lazy val rescanHandling: RescanHandlingApi = {
+  override def rescanHandling: RescanHandlingApi = {
     RescanHandling(
       transactionProcessing = transactionProcessing,
       accountHandling = accountHandling,

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -97,7 +97,7 @@ case class Wallet(
   def addressHandling: AddressHandling =
     AddressHandling(accountHandling, walletDAOs)
 
-  override lazy val transactionProcessing: TransactionProcessingApi = {
+  override def transactionProcessing: TransactionProcessingApi = {
     TransactionProcessing(
       walletApi = this,
       chainQueryApi = chainQueryApi,
@@ -105,7 +105,7 @@ case class Wallet(
       walletDAOs = walletDAOs
     )
   }
-  override lazy val rescanHandling: RescanHandlingApi = {
+  override def rescanHandling: RescanHandlingApi = {
     RescanHandling(
       transactionProcessing = transactionProcessing,
       accountHandling = accountHandling,


### PR DESCRIPTION
Follow up on #5795 