### PR TITLE
Add `NodeState.NoPeers`, cache network messages

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -318,8 +318,9 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
           DEFAULT_ADDR_BATCH_SIZE)
         _ <- node.peerManager.connectPeer(peer1)
         _ <- AsyncUtil.retryUntilSatisfiedF(() => {
-          wallet.getInfo().map(!_.rescan)
-        })
+                                              wallet.getInfo().map(!_.rescan)
+                                            },
+                                            maxTries = 100)
         balanceAfterRescan <- wallet.getBalance()
       } yield assert(balanceAfterRescan == initBalance)
   }

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -3,7 +3,6 @@ package org.bitcoins.node
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
-import NodeState.DoneSyncing
 import org.apache.pekko.{Done, NotUsed}
 import org.apache.pekko.actor.{ActorSystem, Cancellable}
 import org.apache.pekko.stream.{
@@ -106,11 +105,9 @@ case class NeutrinoNode(
           queue = queue
         )
       val initState =
-        DoneSyncing(
-          peerWithServicesDataMap = Map.empty,
-          waitingForDisconnection = Set.empty,
-          peerFinder
-        )
+        NodeState.NoPeers(waitingForDisconnection = Set.empty,
+                          peerFinder,
+                          cachedOutboundMessages = Vector.empty)
 
       val graph =
         buildDataMessageStreamGraph(initState = initState, source = source)

--- a/node/src/main/scala/org/bitcoins/node/NodeState.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeState.scala
@@ -342,7 +342,7 @@ object NodeState {
     )
 
     /** Means we have no good peers are removing these peers */
-    def isEmpty: Boolean = {
+    def isDisconnected: Boolean = {
       peerWithServicesDataMap.keys.toSet == peersToRemove.toSet
     }
   }
@@ -414,7 +414,12 @@ object NodeState {
 
     def toDoneSyncing(
         map: Map[PeerWithServices, PersistentPeerData]): DoneSyncing = {
-      // discards cached messages? Probably need to send them before returning?
+      require(
+        map.nonEmpty,
+        s"Cannot convert NoPeers -> DoneSyncing with no peers to connected")
+      require(
+        cachedOutboundMessages.isEmpty,
+        s"Cannot drop messages that are cached, length=${cachedOutboundMessages.length}")
       DoneSyncing(peerWithServicesDataMap = map,
                   waitingForDisconnection = waitingForDisconnection,
                   peerFinder = peerFinder)

--- a/node/src/main/scala/org/bitcoins/node/NodeState.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeState.scala
@@ -1,7 +1,11 @@
 package org.bitcoins.node
 
 import org.bitcoins.core.api.node.{Peer, PeerWithServices}
-import org.bitcoins.core.p2p.{CompactFilterMessage, ServiceIdentifier}
+import org.bitcoins.core.p2p.{
+  CompactFilterMessage,
+  NetworkMessage,
+  ServiceIdentifier
+}
 import org.bitcoins.node.NodeState.{
   DoneSyncing,
   FilterHeaderSync,
@@ -13,7 +17,7 @@ import org.bitcoins.node.NodeState.{
 import org.bitcoins.node.networking.peer.{PeerConnection, PeerMessageSender}
 
 import java.time.Instant
-import java.time.temporal.{ChronoUnit}
+import java.time.temporal.ChronoUnit
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Random
 
@@ -63,22 +67,31 @@ sealed trait NodeRunningState extends NodeState {
   def replacePeers(
       peerWithServicesDataMap: Map[PeerWithServices, PersistentPeerData]
   ): NodeRunningState = {
-    this match {
-      case h: NodeState.HeaderSync =>
-        h.copy(peerWithServicesDataMap = peerWithServicesDataMap)
-      case fh: NodeState.FilterHeaderSync =>
-        fh.copy(peerWithServicesDataMap = peerWithServicesDataMap)
-      case fs: NodeState.FilterSync =>
-        fs.copy(peerWithServicesDataMap = peerWithServicesDataMap)
-      case d: NodeState.DoneSyncing =>
-        d.copy(peerWithServicesDataMap = peerWithServicesDataMap)
-      case rm: NodeState.RemovePeers =>
-        rm.copy(peerWithServicesDataMap = peerWithServicesDataMap)
-      case m: NodeState.MisbehavingPeer =>
-        m.copy(peerWithServicesDataMap = peerWithServicesDataMap)
-      case s: NodeState.NodeShuttingDown =>
-        s.copy(peerWithServicesDataMap = peerWithServicesDataMap)
+    if (peerWithServicesDataMap.isEmpty) {
+      NodeState.NoPeers(waitingForDisconnection, peerFinder, Vector.empty)
+    } else {
+      this match {
+        case h: NodeState.HeaderSync =>
+          h.copy(peerWithServicesDataMap = peerWithServicesDataMap)
+        case fh: NodeState.FilterHeaderSync =>
+          fh.copy(peerWithServicesDataMap = peerWithServicesDataMap)
+        case fs: NodeState.FilterSync =>
+          fs.copy(peerWithServicesDataMap = peerWithServicesDataMap)
+        case d: NodeState.DoneSyncing =>
+          d.copy(peerWithServicesDataMap = peerWithServicesDataMap)
+        case rm: NodeState.RemovePeers =>
+          rm.copy(peerWithServicesDataMap = peerWithServicesDataMap)
+        case m: NodeState.MisbehavingPeer =>
+          m.copy(peerWithServicesDataMap = peerWithServicesDataMap)
+        case s: NodeState.NodeShuttingDown =>
+          s.copy(peerWithServicesDataMap = peerWithServicesDataMap)
+        case n: NodeState.NoPeers =>
+          DoneSyncing(peerWithServicesDataMap,
+                      n.waitingForDisconnection,
+                      n.peerFinder)
+      }
     }
+
   }
 
   def addPeer(peer: Peer): NodeRunningState = {
@@ -112,7 +125,7 @@ sealed trait NodeRunningState extends NodeState {
             case Some(newSyncNodeState) =>
               newSyncNodeState.replacePeers(filtered)
             case None =>
-              toDoneSyncing.replacePeers(filtered)
+              sync.toDoneSyncing.replacePeers(filtered)
           }
         } else {
           sync.replacePeers(filtered)
@@ -120,6 +133,8 @@ sealed trait NodeRunningState extends NodeState {
       case x @ (_: DoneSyncing | _: MisbehavingPeer | _: RemovePeers |
           _: NodeShuttingDown) =>
         x.replacePeers(filtered)
+      case n: NodeState.NoPeers =>
+        sys.error(s"Cannot remove peer=$peer when we have no peers! $n")
     }
   }
 
@@ -141,6 +156,8 @@ sealed trait NodeRunningState extends NodeState {
         m.copy(waitingForDisconnection = newWaitingForDisconnection)
       case s: NodeState.NodeShuttingDown =>
         s.copy(waitingForDisconnection = newWaitingForDisconnection)
+      case n: NodeState.NoPeers =>
+        n.copy(waitingForDisconnection = newWaitingForDisconnection)
     }
   }
 
@@ -178,10 +195,6 @@ sealed trait NodeRunningState extends NodeState {
   }
 
   def isDisconnected(peer: Peer): Boolean = !isConnected(peer)
-
-  def toDoneSyncing: DoneSyncing = {
-    DoneSyncing(peerWithServicesDataMap, waitingForDisconnection, peerFinder)
-  }
 
   override def toString: String = {
     s"${getClass.getSimpleName}(peers=${peers},waitingForDisconnection=${waitingForDisconnection})"
@@ -243,6 +256,10 @@ sealed abstract class SyncNodeState extends NodeRunningState {
       peerFinder = peerFinder,
       sentQuery = Instant.now
     )
+  }
+
+  def toDoneSyncing: DoneSyncing = {
+    DoneSyncing(peerWithServicesDataMap, waitingForDisconnection, peerFinder)
   }
 
   /** The time when we sent the last query */
@@ -323,6 +340,11 @@ object NodeState {
       peersToRemove.forall(rm => peers.exists(_ == rm)),
       s"peersToRemove must be subset of peers, peersToRemove=$peersToRemove peers=$peers"
     )
+
+    /** Means we have no good peers are removing these peers */
+    def isEmpty: Boolean = {
+      peerWithServicesDataMap.keys.toSet == peersToRemove.toSet
+    }
   }
 
   /** State to indicate we are not currently syncing with a peer */
@@ -331,6 +353,9 @@ object NodeState {
       waitingForDisconnection: Set[Peer],
       peerFinder: PeerFinder
   ) extends NodeRunningState {
+    require(
+      peerWithServicesDataMap.nonEmpty,
+      s"Cannot have 0 peers, use NoPeers to represent state where we have 0 peers")
     override val isSyncing: Boolean = false
 
     /** Selects a random peer and returns us a header sync state returns None if
@@ -376,6 +401,24 @@ object NodeState {
       peerFinder: PeerFinder
   ) extends NodeRunningState {
     override val isSyncing: Boolean = false
+  }
+
+  case class NoPeers(
+      waitingForDisconnection: Set[Peer],
+      peerFinder: PeerFinder,
+      cachedOutboundMessages: Vector[NetworkMessage])
+      extends NodeRunningState {
+    override val isSyncing: Boolean = false
+    override val peerWithServicesDataMap: Map[PeerWithServices, Nothing] =
+      Map.empty
+
+    def toDoneSyncing(
+        map: Map[PeerWithServices, PersistentPeerData]): DoneSyncing = {
+      // discards cached messages? Probably need to send them before returning?
+      DoneSyncing(peerWithServicesDataMap = map,
+                  waitingForDisconnection = waitingForDisconnection,
+                  peerFinder = peerFinder)
+    }
   }
 
 }

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -624,7 +624,7 @@ case class PeerManager(
                 case n: NoPeers =>
                   val peerData = peerDataMap(c.peer)
                   // send cached messages
-                  logger.info(
+                  logger.debug(
                     s"Sending ${n.cachedOutboundMessages.length} cached messages")
                   val sendMsgsF = Future.traverse(n.cachedOutboundMessages)(m =>
                     peerData.peerMessageSender.sendMsg(m.payload))

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -127,7 +127,7 @@ case class DataMessageHandler(
               s"Cannot continue processing p2p messages from peer we were suppose to remove, peer=${peerData.peer}"
             )
           )
-        } else if (r.isEmpty) {
+        } else if (r.isDisconnected) {
           val n = NoPeers(waitingForDisconnection = r.waitingForDisconnection,
                           peerFinder = r.peerFinder,
                           cachedOutboundMessages = Vector.empty)

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,16 +20,16 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="INFO"/>
+    <logger name="org.bitcoins.node" level="WARN"/>
 
     <logger name="org.bitcoins.chain" level="WARN"/>
 
-    <logger name="org.bitcoins.wallet" level="INFO"/>
+    <logger name="org.bitcoins.wallet" level="WARN"/>
 
     <logger name="org.bitcoins.dlc.wallet" level="WARN"/>
 

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,16 +20,16 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="WARN"/>
+    <logger name="org.bitcoins.node" level="INFO"/>
 
     <logger name="org.bitcoins.chain" level="WARN"/>
 
-    <logger name="org.bitcoins.wallet" level="WARN"/>
+    <logger name="org.bitcoins.wallet" level="INFO"/>
 
     <logger name="org.bitcoins.dlc.wallet" level="WARN"/>
 


### PR DESCRIPTION
`NodeState.NoPeers` allows us to cache messages that need to be sent when we establish a p2p connection.

This fixes #5745 and #5231