### PR TITLE
node: Update DNS seeds, optimize `PeerFinder.start()` to start querying…

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
+++ b/core/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
@@ -75,7 +75,7 @@ sealed abstract class MainNet extends BitcoinNetwork {
       "dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us",
       "seed.bitcoinstats.com",
       // "seed.btc.petertodd.net", very slow, commenting out for now
-      //"seed.bitcoin.jonasschnelli.ch", seems to be down?
+      // "seed.bitcoin.jonasschnelli.ch", seems to be down?
       "seed.bitcoin.sprovoost.nl",
       "dnsseed.emzy.de",
       "seed.bitcoin.wiz.biz",

--- a/core/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
+++ b/core/src/main/scala/org/bitcoins/core/config/NetworkParameters.scala
@@ -72,13 +72,14 @@ sealed abstract class MainNet extends BitcoinNetwork {
     Vector(
       // "seed.bitcoin.sipa.be", very slow, commenting out for now
       "dnsseed.bluematt.me",
-      "dnsseed.bitcoin.dashjr.org",
+      "dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us",
       "seed.bitcoinstats.com",
       // "seed.btc.petertodd.net", very slow, commenting out for now
-      "seed.bitcoin.jonasschnelli.ch",
+      //"seed.bitcoin.jonasschnelli.ch", seems to be down?
       "seed.bitcoin.sprovoost.nl",
       "dnsseed.emzy.de",
-      "seed.bitcoin.wiz.biz"
+      "seed.bitcoin.wiz.biz",
+      "seed.mainnet.achownodes.xyz"
     )
   }
 
@@ -104,10 +105,13 @@ sealed abstract class TestNet3 extends BitcoinNetwork {
   /** @inheritdoc
     */
   override def dnsSeeds: Seq[String] =
-    Seq("testnet-seed.bitcoin.jonasschnelli.ch",
-        "seed.tbtc.petertodd.org",
-        "seed.testnet.bitcoin.sprovoost.nl",
-        "testnet-seed.bluematt.me")
+    Seq(
+      "testnet-seed.bitcoin.jonasschnelli.ch",
+      "seed.tbtc.petertodd.org",
+      "seed.testnet.bitcoin.sprovoost.nl",
+      "testnet-seed.bluematt.me",
+      "seed.testnet.achownodes.xyz"
+    )
   /*
    * @inheritdoc
    */


### PR DESCRIPTION
Add DNS seeds from https://github.com/bitcoin/bitcoin/pull/30007

Also disable seeds that are allegedly valid, but constantly fail in pratice.

Also optimize `PeerFinder` by querying DNS seeds as early as possible in `PeerFinder.start()` and caching the results of `PeerFinder.getPeersFromDnsSeeds`