### PR TITLE
chain: Add invariant that we have at least 1 header in Blockchain

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/BaseBlockChain.scala
@@ -29,17 +29,13 @@ import scala.annotation.tailrec
   * }}}
   */
 private[blockchain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
-
-  protected[blockchain] def compObjectFromHeaders(
-      headers: scala.collection.immutable.Seq[BlockHeaderDb]
-  ): Blockchain
-
-  lazy val tip: BlockHeaderDb = headers.head
-
+  require(headers.nonEmpty, s"Cannot have empty Blockchain")
   require(
-    headers.size <= 1 || headers(1).height == tip.height - 1,
+    headers.size == 1 || headers(1).height == tip.height - 1,
     s"Headers must be in descending order, got ${headers.take(5)}"
   )
+
+  lazy val tip: BlockHeaderDb = headers.head
 
   /** The height of the chain */
   lazy val height: Int = tip.height
@@ -60,7 +56,7 @@ private[blockchain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
   def fromHeader(header: BlockHeaderDb): Option[Blockchain] = {
     val headerIdxOpt = findHeaderIdx(header.hashBE)
     headerIdxOpt.map { idx =>
-      val newChain = this.compObjectFromHeaders(headers.splitAt(idx)._2)
+      val newChain = Blockchain.fromHeaders(headers.splitAt(idx)._2)
       require(newChain.tip == header)
       newChain
     }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/Blockchain.scala
@@ -3,14 +3,7 @@ package org.bitcoins.chain.blockchain
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 
 /** @inheritdoc */
-case class Blockchain(headers: Vector[BlockHeaderDb]) extends BaseBlockChain {
-
-  protected[blockchain] def compObjectFromHeaders(
-      headers: scala.collection.immutable.Seq[BlockHeaderDb]
-  ) =
-    Blockchain.fromHeaders(headers)
-
-}
+case class Blockchain(headers: Vector[BlockHeaderDb]) extends BaseBlockChain
 
 object Blockchain extends BaseBlockChainCompObject {
 


### PR DESCRIPTION
This invariant is needed for `Blockchain.tip`. This invariant is implicit anyway as demonstrated in #5805 