### PR TITLE
server: Deduplicate wrapping callbacks in streams

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/CallbackUtil.scala
@@ -1,18 +1,12 @@
 package org.bitcoins.server.util
 
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import org.bitcoins.commons.util.BitcoinSLogger
 import org.bitcoins.core.api.callback.OnBlockReceived
 import org.bitcoins.core.api.dlc.wallet.DLCNeutrinoHDWalletApi
 import org.bitcoins.core.api.wallet.{NeutrinoWalletApi, WalletApi}
-import org.bitcoins.core.gcs.GolombFilter
-import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
-import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.*
 import org.bitcoins.node.callback.NodeCallbackStreamManager
-import org.bitcoins.wallet.WalletNotInitialized
 
 import scala.concurrent.Future
 
@@ -22,73 +16,34 @@ object CallbackUtil extends BitcoinSLogger {
       wallet: WalletApi & NeutrinoWalletApi
   )(implicit system: ActorSystem): Future[NodeCallbackStreamManager] = {
     import system.dispatcher
-    val txSink = Sink.foreachAsync[Transaction](1) { case tx: Transaction =>
-      logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")
+
+    lazy val onTx: OnTxReceived = { tx =>
       wallet.transactionProcessing
         .processTransaction(tx, blockHashWithConfsOpt = None)
         .map(_ => ())
     }
-
-    val compactFilterSink = {
-      Sink.foreachAsync[Vector[(DoubleSha256DigestBE, GolombFilter)]](1) {
-        case blockFilters: Vector[(DoubleSha256DigestBE, GolombFilter)] =>
-          logger.debug(
-            s"Executing onCompactFilters callback with filter count=${blockFilters.length}"
-          )
-          wallet
-            .processCompactFilters(blockFilters = blockFilters)
-            .map(_ => ())
-      }
-    }
-
-    val blockSink = {
-      Sink.foreachAsync[Block](1) { case block: Block =>
-        logger.debug(
-          s"Executing onBlock callback=${block.blockHeader.hashBE.hex}"
-        )
-        wallet.transactionProcessing
-          .processBlock(block)
-          .map(_ => ())
-      }
-    }
-
-    val onHeaderSink = {
-      Sink.foreachAsync(1) { (headers: Vector[BlockHeader]) =>
-        logger.debug(
-          s"Executing block header with header count=${headers.length}"
-        )
-        if (headers.isEmpty) {
-          Future.unit
-        } else {
-          wallet.utxoHandling.updateUtxoPendingStates().map(_ => ())
-        }
-      }
-    }
-
-    lazy val onTx: OnTxReceived = { tx =>
-      Source
-        .single(tx)
-        .runWith(txSink)
-        .map(_ => ())
-    }
     lazy val onCompactFilters: OnCompactFiltersReceived = { blockFilters =>
-      Source
-        .single(blockFilters)
-        .runWith(compactFilterSink)
+      logger.debug(
+        s"Executing onCompactFilters callback with filter count=${blockFilters.length}"
+      )
+      wallet
+        .processCompactFilters(blockFilters = blockFilters)
         .map(_ => ())
-        .recover { case _: WalletNotInitialized => () }
     }
     lazy val onBlock: OnBlockReceived = { block =>
-      Source
-        .single(block)
-        .runWith(blockSink)
+      logger.debug(
+        s"Executing onBlock callback=${block.blockHeader.hashBE.hex}"
+      )
+      wallet.transactionProcessing
+        .processBlock(block)
         .map(_ => ())
     }
     lazy val onHeaders: OnBlockHeadersReceived = { headers =>
-      Source
-        .single(headers)
-        .runWith(onHeaderSink)
-        .map(_ => ())
+      if (headers.isEmpty) {
+        Future.unit
+      } else {
+        wallet.utxoHandling.updateUtxoPendingStates().map(_ => ())
+      }
     }
 
     val callbacks = NodeCallbacks(
@@ -106,28 +61,16 @@ object CallbackUtil extends BitcoinSLogger {
       wallet: DLCNeutrinoHDWalletApi
   )(implicit system: ActorSystem): Future[NodeCallbackStreamManager] = {
     import system.dispatcher
-    val txSink = Sink.foreachAsync[Transaction](1) { case tx: Transaction =>
+    val onTx: OnTxReceived = { tx =>
       logger.debug(s"Receiving transaction txid=${tx.txIdBE.hex} as a callback")
       wallet.transactionProcessing
         .processTransaction(tx, blockHashWithConfsOpt = None)
         .map(_ => ())
     }
-    val onTx: OnTxReceived = { tx =>
-      Source
-        .single(tx)
-        .runWith(txSink)
-        .map(_ => ())
-    }
 
-    val blockSink = Sink.foreachAsync[Block](1) { block =>
+    val onBlock: OnBlockReceived = { block =>
       wallet.transactionProcessing
         .processBlock(block)
-        .map(_ => ())
-    }
-    val onBlock: OnBlockReceived = { block =>
-      Source
-        .single(block)
-        .runWith(blockSink)
         .map(_ => ())
     }
     val callbacks = NodeCallbacks(onTxReceived = Vector(onTx),


### PR DESCRIPTION
In #4516 we wrapped data passed via callbacks in a single use akka stream to provide an ordering to data going through the stream.

In #4520 we implemented `NodeStreamCallbackManager` to handle this in a single place.

Since we have `NodeStreamCallbackManager`, we no longer need pekko stream logic inside of `CallbackUtil` as its handled by `NodeStreamCallbackManager`. 

Possibly related to #5806 