### PR TITLE
node: Move killswitch downstream to avoid queue deadlocks

### DIFF
--- a/tor/src/main/scala/org/bitcoins/tor/Socks5Connection.scala
+++ b/tor/src/main/scala/org/bitcoins/tor/Socks5Connection.scala
@@ -287,17 +287,14 @@ object Socks5Connection extends BitcoinSLogger {
       socket: InetSocketAddress,
       source: Source[
         ByteString,
-        (
-            Future[org.apache.pekko.stream.scaladsl.Tcp.OutgoingConnection],
-            MatSource
-        )
+        Future[org.apache.pekko.stream.scaladsl.Tcp.OutgoingConnection]
       ],
       sink: Sink[Either[ByteString, Socks5ConnectionState], MatSink],
       mergeHubSink: Sink[ByteString, NotUsed],
       credentialsOpt: Option[Credentials]
   )(implicit mat: Materializer): Future[
     (
-        (org.apache.pekko.stream.scaladsl.Tcp.OutgoingConnection, MatSource),
+        org.apache.pekko.stream.scaladsl.Tcp.OutgoingConnection,
         MatSink
     )
   ] = {
@@ -389,7 +386,7 @@ object Socks5Connection extends BitcoinSLogger {
         )
     }
 
-    val ((tcpConnectionF, matSource), matSink) = source
+    val (tcpConnectionF, matSink) = source
       .viaMat(flowState)(Keep.left)
       .toMat(sink)(Keep.both)
       .run()
@@ -403,7 +400,7 @@ object Socks5Connection extends BitcoinSLogger {
 
       greetingSource.to(mergeHubSink).run()
 
-      ((conn, matSource), matSink)
+      (conn, matSink)
     }(mat.executionContext)
   }
 


### PR DESCRIPTION
fixes #5806 

This is the behavior of `UniqueKillSwitch.shutdown()`

```
After calling #shutdown the running instance of the Graph of FlowShape that materialized to the UniqueKillSwitch will complete its downstream and cancel its upstream (unless if finished or failed already in which case the command is ignored). Subsequent invocations of completion commands will be ignored.
```

We previously placed the killswitch immediately after the `Tcp.outgoingConnection()` flow inside of `PeerConnection`. This could lead to a dead lock in the scenario where `PeerConnection.queue` is backpressured, and `PeerData.stop()` is called inside of [PeerManager](https://github.com/bitcoin-s/bitcoin-s/blob/eb6edab240f17f01f8b8467ad29c16169dd008df/node/src/main/scala/org/bitcoins/node/PeerManager.scala#L763). This behavior was introduced in #5390 

The deadlock occurs because [`ConnectionGraph.stop()`](https://github.com/bitcoin-s/bitcoin-s/blob/cbccecf95d30deb2c163e6d1ac93c45c3657fc8a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala#L431) returns `streamDoneF`. This `Future` is completed  when all downstream elements are processed. Since our queue is backpressured, we cannot make progress on processing downstream elements until the current element in the queue -- an `addr` message -- is processed. 

If our `PeerFinder` is already aware of a peer relayed in the `addr` message, and we are attempting to establish a connection with that peer, we can deadlock our queue. This is fairly likely to occur if we receive 2 `addr` messages from 2 distinct peers in quick succession.

Now that `Killswitch` is at the end of the stream, we no longer have downstream elements being processed. This should avoid the potential deadlocking scenario of receiving 2 `addr` messages.