### PR TITLE
wallet: Refactor {`UTXOHandlingApi`,`AccountHandlingApi`,`AddressHandlingApi`} method names

### DIFF
--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -246,8 +246,8 @@ object ConsoleCli extends BitcoinSLogger {
       cmd("getutxos")
         .action((_, conf) => conf.copy(command = GetUtxos))
         .text("Returns list of all wallet utxos"),
-      cmd("listreservedutxos")
-        .action((_, conf) => conf.copy(command = ListReservedUtxos))
+      cmd("getreservedutxos")
+        .action((_, conf) => conf.copy(command = GetReservedUtxos))
         .text("Returns list of all reserved wallet utxos"),
       cmd("getaddresses")
         .action((_, conf) => conf.copy(command = GetAddresses))
@@ -2159,8 +2159,8 @@ object CliCommand {
         RequestParam("getmediantimepast")
       case GetUtxos =>
         RequestParam("getutxos")
-      case ListReservedUtxos =>
-        RequestParam("listreservedutxos")
+      case GetReservedUtxos =>
+        RequestParam("getreservedutxos")
       case GetAddresses =>
         RequestParam("getaddresses")
       case GetSpentAddresses =>
@@ -2673,7 +2673,7 @@ object CliCommand {
 
   case object GetAddressLabels extends AppServerCliCommand
   case object GetUtxos extends AppServerCliCommand
-  case object ListReservedUtxos extends AppServerCliCommand
+  case object GetReservedUtxos extends AppServerCliCommand
   case object GetAddresses extends AppServerCliCommand
   case object GetSpentAddresses extends AppServerCliCommand
   case object GetFundedAddresses extends AppServerCliCommand

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -471,7 +471,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(Future.successful(Bitcoins(50)))
 
       (mockWalletApi.utxoHandling
-        .listUtxos(_: TxoState))
+        .getUtxos(_: TxoState))
         .expects(TxoState.Reserved)
         .returning(Future.successful(Vector(spendingInfoDb)))
 
@@ -503,7 +503,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .anyNumberOfTimes()
 
       (mockWalletApi.utxoHandling
-        .listUtxos(_: TxoState))
+        .getUtxos(_: TxoState))
         .expects(TxoState.Reserved)
         .returning(Future.successful(Vector(spendingInfoDb)))
 
@@ -556,7 +556,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(mockUtxoHandlingApi)
         .anyNumberOfTimes()
 
-      (() => mockWalletApi.utxoHandling.listUtxos())
+      (() => mockWalletApi.utxoHandling.getUtxos())
         .expects()
         .returning(Future.successful(Vector(spendingInfoDb)))
 
@@ -577,12 +577,12 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(mockUtxoHandlingApi)
         .anyNumberOfTimes()
       (mockWalletApi.utxoHandling
-        .listUtxos(_: TxoState))
+        .getUtxos(_: TxoState))
         .expects(TxoState.Reserved)
         .returning(Future.successful(Vector(spendingInfoDb)))
 
       val route =
-        walletRoutes.handleCommand(ServerCommand("listreservedutxos", Arr()))
+        walletRoutes.handleCommand(ServerCommand("getreservedutxos", Arr()))
 
       Get() ~> route ~> check {
         assert(contentType == `application/json`)
@@ -606,7 +606,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(mockAddressHandlingApi)
         .anyNumberOfTimes()
 
-      (() => mockWalletApi.addressHandling.listAddresses())
+      (() => mockWalletApi.addressHandling.getAddresses())
         .expects()
         .returning(Future.successful(Vector(addressDb)))
 
@@ -637,7 +637,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(mockAddressHandlingApi)
         .anyNumberOfTimes()
 
-      (() => mockWalletApi.addressHandling.listSpentAddresses())
+      (() => mockWalletApi.addressHandling.getSpentAddresses())
         .expects()
         .returning(Future.successful(Vector(addressDb)))
 
@@ -668,7 +668,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(mockAddressHandlingApi)
         .anyNumberOfTimes()
 
-      (() => mockWalletApi.addressHandling.listFundedAddresses())
+      (() => mockWalletApi.addressHandling.getFundedAddresses())
         .expects()
         .returning(Future.successful(Vector((addressDb, Satoshis.zero))))
 
@@ -698,7 +698,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(mockAddressHandlingApi)
         .anyNumberOfTimes()
 
-      (() => mockWalletApi.addressHandling.listUnusedAddresses())
+      (() => mockWalletApi.addressHandling.getUnusedAddresses())
         .expects()
         .returning(Future.successful(Vector(addressDb)))
 
@@ -722,7 +722,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(mockAccountHandlingApi)
         .anyNumberOfTimes()
 
-      (() => mockWalletApi.accountHandling.listAccounts())
+      (() => mockWalletApi.accountHandling.getAccounts())
         .expects()
         .returning(Future.successful(Vector(accountDb)))
 
@@ -825,13 +825,13 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(mockUtxoHandlingApi)
         .anyNumberOfTimes()
 
-      (() => mockWalletApi.utxoHandling.listUtxos())
+      (() => mockWalletApi.utxoHandling.getUtxos())
         .expects()
         .returning(Future.successful(Vector(spendingInfoDb)))
         .anyNumberOfTimes()
 
       (mockWalletApi.utxoHandling
-        .listUtxos(_: TxoState))
+        .getUtxos(_: TxoState))
         .expects(TxoState.Reserved)
         .returning(Future.successful(Vector(spendingInfoDb)))
         .anyNumberOfTimes()
@@ -1925,7 +1925,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         .returning(mockUtxoHandlingApi)
         .anyNumberOfTimes()
 
-      (() => mockWalletApi.sendFundsHandling.utxoHandling.listUtxos())
+      (() => mockWalletApi.sendFundsHandling.utxoHandling.getUtxos())
         .expects()
         .returning(Future.successful(Vector.empty))
 

--- a/app/server-test/src/test/scala/org/bitcoins/server/WalletRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/WalletRoutesSpec.scala
@@ -180,7 +180,7 @@ class WalletRoutesSpec
         .expects(HDPurpose.default)
         .returning(Future.successful(extPubKey))
 
-      (() => mockWalletApi.accountHandling.listAccounts())
+      (() => mockWalletApi.accountHandling.getAccounts())
         .expects()
         .returning(Future.successful(Vector(accountDb)))
 

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/AccountHandlingApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/AccountHandlingApi.scala
@@ -41,10 +41,10 @@ trait AccountHandlingApi {
   def getUnconfirmedBalance(account: HDAccount): Future[CurrencyUnit]
 
   def getDefaultAccount(): Future[AccountDb]
-  def listAccounts(): Future[Vector[AccountDb]]
-  def listAccounts(purpose: HDPurpose)(implicit
+  def getAccounts(): Future[Vector[AccountDb]]
+  def getAccounts(purpose: HDPurpose)(implicit
       ec: ExecutionContext): Future[Vector[AccountDb]] = {
-    listAccounts().map(_.filter(_.hdAccount.purpose == purpose))
+    getAccounts().map(_.filter(_.hdAccount.purpose == purpose))
   }
   def getDefaultAccountForType(addressType: AddressType): Future[AccountDb]
   def getNewAddress(
@@ -88,14 +88,14 @@ trait AccountHandlingApi {
       addressBatchSize: Int,
       forceGenerateSpks: Boolean
   ): Future[Vector[ScriptPubKey]]
-  def listUnusedAddresses(
+  def getUnusedAddresses(
       account: HDAccount
   ): Future[Vector[AddressDb]]
-  def listSpentAddresses(
+  def getSpentAddresses(
       account: HDAccount
   ): Future[Vector[AddressDb]]
-  def listAddresses(account: HDAccount): Future[Vector[AddressDb]]
-  def listFundedAddresses(
+  def getAddresses(account: HDAccount): Future[Vector[AddressDb]]
+  def getFundedAddresses(
       account: HDAccount
   ): Future[Vector[(AddressDb, CurrencyUnit)]]
 }

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/AddressHandlingApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/AddressHandlingApi.scala
@@ -25,9 +25,9 @@ trait AddressHandlingApi {
   )(implicit ec: ExecutionContext): Future[Boolean] = {
     val possibleAddressesF = accountOpt match {
       case Some((ah, account)) =>
-        ah.listAddresses(account)
+        ah.getAddresses(account)
       case None =>
-        listAddresses()
+        getAddresses()
     }
 
     possibleAddressesF.map { possibleAddresses =>
@@ -86,11 +86,11 @@ trait AddressHandlingApi {
     * from this wallet
     */
   def isChange(output: TransactionOutput): Future[Boolean]
-  def listAddresses(): Future[Vector[AddressDb]]
-  def listUnusedAddresses(): Future[Vector[AddressDb]]
-  def listScriptPubKeys(): Future[Vector[ScriptPubKeyDb]]
-  def listSpentAddresses(): Future[Vector[AddressDb]]
-  def listFundedAddresses(): Future[Vector[(AddressDb, CurrencyUnit)]]
+  def getAddresses(): Future[Vector[AddressDb]]
+  def getUnusedAddresses(): Future[Vector[AddressDb]]
+  def getScriptPubKeys(): Future[Vector[ScriptPubKeyDb]]
+  def getSpentAddresses(): Future[Vector[AddressDb]]
+  def getFundedAddresses(): Future[Vector[(AddressDb, CurrencyUnit)]]
   def tagAddress(
       address: BitcoinAddress,
       tag: AddressTag

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/SendFundsHandlingApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/SendFundsHandlingApi.scala
@@ -402,7 +402,7 @@ trait SendFundsHandlingApi {
       ec: ExecutionContext
   ): Future[Transaction] = {
     for {
-      utxos <- utxoHandling.listUtxos()
+      utxos <- utxoHandling.getUtxos()
       outpoints = utxos.map(_.outPoint)
       tx <- sendFromOutPoints(outpoints, address, feeRate)
     } yield tx

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/UtxoHandlingApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/UtxoHandlingApi.scala
@@ -62,23 +62,23 @@ trait UtxoHandlingApi {
     * @return
     *   Vector[SpendingInfoDb]
     */
-  def listUtxos(): Future[Vector[SpendingInfoDb]]
+  def getUtxos(): Future[Vector[SpendingInfoDb]]
 
-  def listUtxos(tag: AddressTag): Future[Vector[SpendingInfoDb]]
+  def getUtxos(tag: AddressTag): Future[Vector[SpendingInfoDb]]
 
-  def listUtxos(state: TxoState): Future[Vector[SpendingInfoDb]]
+  def getUtxos(state: TxoState): Future[Vector[SpendingInfoDb]]
 
-  def listUtxos(account: HDAccount): Future[Vector[SpendingInfoDb]]
+  def getUtxos(account: HDAccount): Future[Vector[SpendingInfoDb]]
 
-  def listUtxos(
+  def getUtxos(
       hdAccount: HDAccount,
       tag: AddressTag): Future[Vector[SpendingInfoDb]]
 
-  def listUtxos(
+  def getUtxos(
       hdAccount: HDAccount,
       state: TxoState): Future[Vector[SpendingInfoDb]]
 
-  def listUtxos(
+  def getUtxos(
       outPoints: Vector[TransactionOutPoint]
   ): Future[Vector[SpendingInfoDb]]
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/MultiWalletDLCTest.scala
@@ -92,7 +92,7 @@ class MultiWalletDLCTest extends BitcoinSWalletTest {
       // now unreserve the utxo
       val reservedUtxoF = for {
         _ <- offerF
-        utxos <- wallet.utxoHandling.listUtxos(TxoState.Reserved)
+        utxos <- wallet.utxoHandling.getUtxos(TxoState.Reserved)
         _ <- wallet.utxoHandling.unmarkUTXOsAsReserved(utxos)
       } yield ()
 

--- a/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
+++ b/dlc-wallet-test/src/test/scala/org/bitcoins/dlc/wallet/WalletDLCSetupTest.scala
@@ -557,7 +557,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
       for {
         oldBalance <- dlcWalletA.getBalance()
-        oldReserved <- walletApiA.utxoHandling.listUtxos(TxoState.Reserved)
+        oldReserved <- walletApiA.utxoHandling.getUtxos(TxoState.Reserved)
         _ = assert(oldReserved.isEmpty)
 
         offer <- dlcWalletA.createDLCOffer(
@@ -583,7 +583,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         )
 
         balance <- dlcWalletA.getBalance()
-        reserved <- walletApiA.utxoHandling.listUtxos(TxoState.Reserved)
+        reserved <- walletApiA.utxoHandling.getUtxos(TxoState.Reserved)
         dlcOpt <- dlcWalletA.findDLC(dlcId)
       } yield {
         assert(balance == oldBalance)
@@ -607,7 +607,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
       for {
         oldBalance <- dlcWalletB.getBalance()
-        oldReserved <- walletApiB.utxoHandling.listUtxos(TxoState.Reserved)
+        oldReserved <- walletApiB.utxoHandling.getUtxos(TxoState.Reserved)
         _ = assert(oldReserved.isEmpty)
 
         offer <- dlcWalletA.createDLCOffer(
@@ -627,7 +627,7 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         _ <- dlcWalletB.cancelDLC(dlcId)
 
         balance <- dlcWalletB.getBalance()
-        reserved <- walletApiB.utxoHandling.listUtxos(TxoState.Reserved)
+        reserved <- walletApiB.utxoHandling.getUtxos(TxoState.Reserved)
         dlcOpt <- dlcWalletB.findDLC(dlcId)
       } yield {
         assert(balance == oldBalance)
@@ -648,13 +648,13 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
 
       for {
         oldBalanceA <- dlcWalletA.getBalance()
-        oldReservedA <- walletApiA.utxoHandling.listUtxos(
+        oldReservedA <- walletApiA.utxoHandling.getUtxos(
           TxoState.Reserved
         )
         _ = assert(oldReservedA.isEmpty)
 
         oldBalanceB <- dlcWalletB.getBalance()
-        oldReservedB <- walletApiB.utxoHandling.listUtxos(
+        oldReservedB <- walletApiB.utxoHandling.getUtxos(
           TxoState.Reserved
         )
         _ = assert(oldReservedB.isEmpty)
@@ -679,11 +679,11 @@ class WalletDLCSetupTest extends BitcoinSDualWalletTest {
         _ <- dlcWalletB.cancelDLC(dlcId)
 
         balanceA <- dlcWalletA.getBalance()
-        reservedA <- walletApiA.utxoHandling.listUtxos(TxoState.Reserved)
+        reservedA <- walletApiA.utxoHandling.getUtxos(TxoState.Reserved)
         dlcAOpt <- dlcWalletA.findDLC(dlcId)
 
         balanceB <- dlcWalletB.getBalance()
-        reservedB <- walletApiB.utxoHandling.listUtxos(TxoState.Reserved)
+        reservedB <- walletApiB.utxoHandling.getUtxos(TxoState.Reserved)
         dlcBOpt <- dlcWalletB.findDLC(dlcId)
       } yield {
         assert(balanceA == oldBalanceA)

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -502,7 +502,7 @@ case class DLCTransactionProcessing(
   ): Future[Vector[ScriptSignatureParams[InputInfo]]] = {
     val outPoints =
       fundingInputs.filter(_.isInitiator == dlcDb.isInitiator).map(_.outPoint)
-    val utxosF = utxoHandling.listUtxos(outPoints)
+    val utxosF = utxoHandling.getUtxos(outPoints)
     for {
       utxos <- utxosF
       map = SpendingInfoDb.toPreviousOutputMap(utxos)

--- a/docs/applications/server.md
+++ b/docs/applications/server.md
@@ -189,7 +189,7 @@ the `-p 9999:9999` port mapping on the docker container to adjust for this.
  - `getaddressinfo` `address` - Returns list of all wallet accounts
     - `address` - Address to get information about
  - `getnewaddress` - Get a new address
- - `listreservedutxos` - lists all utxos that are reserved in the wallet
+ - `getreservedutxos` - lists all utxos that are reserved in the wallet
  - `sendtoaddress` `address` `amount` `[options]` - Send money to the given address
     - `address` - Address to send to
     - `amount` - Amount to send in BTC

--- a/docs/wallet/wallet-rpc.md
+++ b/docs/wallet/wallet-rpc.md
@@ -3,14 +3,14 @@ title: Wallet RPC Examples
 id: wallet-rpc
 ---
 
-### `listreservedutxos`
+### `getreservedutxos`
 
 Lists all reserved utxos in the wallet.
 These utxos will not be unreserved unless you manually
 unreserve them with `lockunspent` or they are spent in the blockchain
 
 ```bash
-bitcoin-s-cli listreservedutxos
+bitcoin-s-cli getreservedutxos
 [
   {
     "outpoint": {

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -60,8 +60,8 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
     ): Future[Boolean] = {
       for {
         balance <- wallet.getBalance()
-        addresses <- wallet.addressHandling.listAddresses()
-        utxos <- wallet.utxoHandling.listUtxos()
+        addresses <- wallet.addressHandling.getAddresses()
+        utxos <- wallet.utxoHandling.getUtxos()
       } yield {
         // +- fee rate because signatures could vary in size
         (expectedBalance === balance +- FeeRate.currencyUnit) &&
@@ -174,8 +174,8 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       for {
         rescan <- wallet.isRescanning()
         balance <- wallet.getBalance()
-        addresses <- wallet.addressHandling.listAddresses()
-        utxos <- wallet.utxoHandling.listUtxos()
+        addresses <- wallet.addressHandling.getAddresses()
+        utxos <- wallet.utxoHandling.getUtxos()
         spks = utxos
           .map(_.output.scriptPubKey)
       } yield {
@@ -187,8 +187,8 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
     }
 
     for {
-      addresses <- wallet.addressHandling.listAddresses()
-      utxos <- wallet.utxoHandling.listUtxos()
+      addresses <- wallet.addressHandling.getAddresses()
+      utxos <- wallet.utxoHandling.getUtxos()
       _ = assert(addresses.size == 3)
       _ = assert(utxos.size == 3)
 
@@ -197,8 +197,8 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
         bitcoind
           .sendToAddress(address, TestAmount)
 
-      addresses <- wallet.addressHandling.listAddresses()
-      utxos <- wallet.utxoHandling.listUtxos()
+      addresses <- wallet.addressHandling.getAddresses()
+      utxos <- wallet.utxoHandling.getUtxos()
       _ = assert(addresses.size == 4)
       _ = assert(utxos.size == 3)
       _ <-
@@ -213,8 +213,8 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
           .map(_.get.height == bitcoindHeight)
       })
       _ <- wallet.utxoHandling.clearAllUtxos()
-      addresses <- wallet.addressHandling.listAddresses()
-      utxos <- wallet.utxoHandling.listUtxos()
+      addresses <- wallet.addressHandling.getAddresses()
+      utxos <- wallet.utxoHandling.getUtxos()
       _ = assert(addresses.nonEmpty)
       _ = assert(utxos.isEmpty)
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressHandlingTest.scala
@@ -47,7 +47,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
       val addressF = wallet.accountHandling.getNewAddress(account1)
       for {
         address <- addressF
-        listAddressesForAcct <- wallet.accountHandling.listAddresses(account1)
+        listAddressesForAcct <- wallet.accountHandling.getAddresses(account1)
         exists <- wallet.addressHandling.contains(
           address,
           Some((wallet.accountHandling, account1)))
@@ -109,7 +109,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
     val wallet = fundedWallet.wallet
 
     for {
-      emptySpentAddresses <- wallet.addressHandling.listSpentAddresses()
+      emptySpentAddresses <- wallet.addressHandling.getSpentAddresses()
       _ = assert(
         emptySpentAddresses.isEmpty,
         s"Wallet did not start with empty spent addresses, got $emptySpentAddresses"
@@ -120,7 +120,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
                                                    Bitcoins(1),
                                                    None)
       spentDbs <- wallet.utxoHandling.findOutputsBeingSpent(tx)
-      spentAddresses <- wallet.addressHandling.listSpentAddresses()
+      spentAddresses <- wallet.addressHandling.getSpentAddresses()
     } yield {
       val diff = spentDbs
         .map(_.output.scriptPubKey)
@@ -134,8 +134,8 @@ class AddressHandlingTest extends BitcoinSWalletTest {
       val wallet = fundedWallet.wallet
 
       for {
-        unspentDbs <- wallet.utxoHandling.listUtxos()
-        fundedAddresses <- wallet.addressHandling.listFundedAddresses()
+        unspentDbs <- wallet.utxoHandling.getUtxos()
+        fundedAddresses <- wallet.addressHandling.getFundedAddresses()
       } yield {
         val diff = unspentDbs
           .map(_.output)
@@ -154,7 +154,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
         SpendingInfoDAO()(executionContext, fundedWallet.walletConfig)
       for {
         addrDbs <- spendingInfoDAO.findAllSpendingInfos()
-        fundedAddresses <- wallet.addressHandling.listUnusedAddresses()
+        fundedAddresses <- wallet.addressHandling.getUnusedAddresses()
       } yield {
         val intersect = addrDbs
           .map(_.output.scriptPubKey)
@@ -241,9 +241,9 @@ class AddressHandlingTest extends BitcoinSWalletTest {
     val wallet = fundedWallet.wallet
     val spk = EmptyScriptPubKey
     for {
-      before <- wallet.addressHandling.listScriptPubKeys()
+      before <- wallet.addressHandling.getScriptPubKeys()
       spkDb <- wallet.addressHandling.watchScriptPubKey(spk)
-      after <- wallet.addressHandling.listScriptPubKeys()
+      after <- wallet.addressHandling.getScriptPubKeys()
     } yield {
       assert(before.size + 1 == after.size)
       assert(spkDb.scriptPubKey == spk)
@@ -302,7 +302,7 @@ class AddressHandlingTest extends BitcoinSWalletTest {
 
       for {
         addr <- addrF
-        addresses <- wallet.addressHandling.listAddresses()
+        addresses <- wallet.addressHandling.getAddresses()
       } yield {
         assert(!addresses.exists(_.address == addr))
       }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/AddressTagIntegrationTest.scala
@@ -48,7 +48,7 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
       tx <- bitcoind.getRawTransactionRaw(txId)
 
       // before processing TX, wallet should be completely empty
-      _ <- wallet.utxoHandling.listUtxos().map(utxos => assert(utxos.isEmpty))
+      _ <- wallet.utxoHandling.getUtxos().map(utxos => assert(utxos.isEmpty))
       _ <- wallet.getBalance().map(confirmed => assert(confirmed == 0.bitcoin))
       _ <-
         wallet
@@ -60,7 +60,7 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
 
       // we should now have one UTXO in the wallet
       // it should not be confirmed
-      utxosPostAdd <- wallet.utxoHandling.listUtxos()
+      utxosPostAdd <- wallet.utxoHandling.getUtxos()
       _ = assert(utxosPostAdd.length == 2)
       _ <-
         wallet
@@ -74,7 +74,7 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
       _ = assert(incomingTx.isDefined)
       _ = assert(incomingTx.get.incomingAmount == valueFromBitcoind * 2)
 
-      taggedUtxosPostAdd <- wallet.utxoHandling.listUtxos(exampleTag)
+      taggedUtxosPostAdd <- wallet.utxoHandling.getUtxos(exampleTag)
       _ = assert(taggedUtxosPostAdd.length == 1)
       _ <-
         wallet.utxoHandling
@@ -95,7 +95,7 @@ class AddressTagIntegrationTest extends BitcoinSWalletTest {
       signedTx = rawTxHelper.signedTx
       _ <- wallet.transactionProcessing.processTransaction(signedTx, None)
 
-      utxos <- wallet.utxoHandling.listUtxos()
+      utxos <- wallet.utxoHandling.getUtxos()
       balancePostSend <- wallet.getBalance()
       tagBalancePostSend <- wallet.utxoHandling.getBalance(exampleTag)
     } yield {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/BitcoindBackendTest.scala
@@ -109,7 +109,7 @@ class BitcoindBackendTest extends WalletAppConfigWithBitcoindNewestFixtures {
 
       _ <- BitcoindRpcBackendUtil.syncWalletToBitcoind(bitcoind, wallet, None)
 
-      utxos <- wallet.utxoHandling.listUtxos(TxoState.ConfirmedReceived)
+      utxos <- wallet.utxoHandling.getUtxos(TxoState.ConfirmedReceived)
     } yield {
       assert(utxos.size == 1)
       val utxo = utxos.head

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/FundTransactionHandlingTest.scala
@@ -218,7 +218,7 @@ class FundTransactionHandlingTest
       val bitcoind = fundedWallet.bitcoind
       val fundedTxF = for {
         feeRate <- wallet.getFeeRate()
-        accounts <- wallet.accountHandling.listAccounts()
+        accounts <- wallet.accountHandling.getAccounts()
         account2 = accounts.find(_.hdAccount.index == 2).get
 
         addr <- wallet.accountHandling.getNewAddress(account2)
@@ -227,7 +227,7 @@ class FundTransactionHandlingTest
         block <- bitcoind.getBlockRaw(hash)
         _ <- wallet.transactionProcessing.processBlock(block)
 
-        utxos <- wallet.utxoHandling.listUtxos(account2.hdAccount)
+        utxos <- wallet.utxoHandling.getUtxos(account2.hdAccount)
         _ = assert(utxos.size == 1)
 
         fundedTx <-
@@ -259,7 +259,7 @@ class FundTransactionHandlingTest
         spendingInfos <- wallet.utxoHandling.findOutputsBeingSpent(
           fundRawTxHelper.unsignedTx
         )
-        reserved <- wallet.utxoHandling.listUtxos(TxoState.Reserved)
+        reserved <- wallet.utxoHandling.getUtxos(TxoState.Reserved)
       } yield {
         assert(spendingInfos.exists(_.state == TxoState.Reserved))
         assert(reserved.size == spendingInfos.size)
@@ -280,7 +280,7 @@ class FundTransactionHandlingTest
       taggedBalance <- wallet.utxoHandling.getBalance(tag)
       _ = assert(taggedBalance == destination.value * 2)
 
-      expectedUtxos <- wallet.utxoHandling.listUtxos(tag)
+      expectedUtxos <- wallet.utxoHandling.getUtxos(tag)
       fundRawTxHelper <-
         wallet.fundTxHandling
           .fundRawTransaction(

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/LegacyWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/LegacyWalletTest.scala
@@ -18,7 +18,7 @@ class LegacyWalletTest extends BitcoinSWalletTest {
       account <- wallet.accountHandling.getDefaultAccount()
       otherAddr <- wallet.getNewAddress()
       thirdAddr <- wallet.addressHandling.getNewAddress(AddressType.Legacy)
-      allAddrs <- wallet.addressHandling.listAddresses()
+      allAddrs <- wallet.addressHandling.getAddresses()
     } yield {
       assert(account.hdAccount.purpose == HDPurpose.Legacy)
       assert(allAddrs.forall(_.address.isInstanceOf[P2PKHAddress]))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessBlockTest.scala
@@ -42,7 +42,7 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoindNewest {
     val bitcoind = param.bitcoind
 
     for {
-      startingUtxos <- wallet.utxoHandling.listUtxos()
+      startingUtxos <- wallet.utxoHandling.getUtxos()
       _ = assert(startingUtxos.isEmpty)
 
       addr <- wallet.getNewAddress()
@@ -54,7 +54,7 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoindNewest {
       block <- bitcoind.getBlockRaw(hash)
 
       _ <- wallet.transactionProcessing.processBlock(block)
-      utxos <- wallet.utxoHandling.listUtxos()
+      utxos <- wallet.utxoHandling.getUtxos()
       height <- bitcoind.getBlockCount()
       bestHash <- bitcoind.getBestBlockHash()
       syncHeightOpt <- wallet.getSyncDescriptorOpt()
@@ -74,7 +74,7 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoindNewest {
     val wallet = param.wallet
     val bitcoind = param.bitcoind
     for {
-      startingUtxos <- wallet.utxoHandling.listUtxos(TxoState.ImmatureCoinbase)
+      startingUtxos <- wallet.utxoHandling.getUtxos(TxoState.ImmatureCoinbase)
       startingBalance <- wallet.getBalance()
       _ = assert(startingUtxos.isEmpty)
       _ = assert(startingBalance == Satoshis.zero)
@@ -83,9 +83,8 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoindNewest {
       blocks <- FutureUtil.sequentially(hashes)(bitcoind.getBlockRaw)
       _ <- FutureUtil.sequentially(blocks)(
         wallet.transactionProcessing.processBlock)
-      coinbaseUtxos <- wallet.utxoHandling.listUtxos(TxoState.ImmatureCoinbase)
-      confirmedUtxos <- wallet.utxoHandling.listUtxos(
-        TxoState.ConfirmedReceived)
+      coinbaseUtxos <- wallet.utxoHandling.getUtxos(TxoState.ImmatureCoinbase)
+      confirmedUtxos <- wallet.utxoHandling.getUtxos(TxoState.ConfirmedReceived)
       balance <- wallet.getConfirmedBalance()
 
       height <- bitcoind.getBlockCount()
@@ -108,7 +107,7 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoindNewest {
     val bitcoind = param.bitcoind
 
     for {
-      startingUtxos <- wallet.utxoHandling.listUtxos(TxoState.ImmatureCoinbase)
+      startingUtxos <- wallet.utxoHandling.getUtxos(TxoState.ImmatureCoinbase)
       startingBalance <- wallet.getBalance()
       _ = assert(startingUtxos.isEmpty)
       _ = assert(startingBalance == Satoshis.zero)
@@ -119,9 +118,8 @@ class ProcessBlockTest extends BitcoinSWalletTestCachedBitcoindNewest {
       )
       filtersWithBlockHash = hashes.zip(filters.map(_.filter))
       _ <- wallet.processCompactFilters(filtersWithBlockHash)
-      coinbaseUtxos <- wallet.utxoHandling.listUtxos(TxoState.ImmatureCoinbase)
-      confirmedUtxos <- wallet.utxoHandling.listUtxos(
-        TxoState.ConfirmedReceived)
+      coinbaseUtxos <- wallet.utxoHandling.getUtxos(TxoState.ImmatureCoinbase)
+      confirmedUtxos <- wallet.utxoHandling.getUtxos(TxoState.ConfirmedReceived)
       balance <- wallet.getConfirmedBalance()
 
       height <- bitcoind.getBlockCount()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -34,12 +34,12 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
   )(action: => Future[_]): Future[Assertion] =
     for {
       oldTransactions <- wallet.transactionProcessing.listTransactions()
-      oldUtxos <- wallet.utxoHandling.listUtxos()
+      oldUtxos <- wallet.utxoHandling.getUtxos()
       oldUnconfirmed <- wallet.getUnconfirmedBalance()
       oldConfirmed <- wallet.getBalance()
       _ <- action // by name
       newTransactions <- wallet.transactionProcessing.listTransactions()
-      newUtxos <- wallet.utxoHandling.listUtxos()
+      newUtxos <- wallet.utxoHandling.getUtxos()
       newUnconfirmed <- wallet.getUnconfirmedBalance()
       newConfirmed <- wallet.getBalance()
 
@@ -79,7 +79,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
         )
         newConfirmed <- wallet.getConfirmedBalance()
         newUnconfirmed <- wallet.getUnconfirmedBalance()
-        utxosPostAdd <- wallet.utxoHandling.listUtxos()
+        utxosPostAdd <- wallet.utxoHandling.getUtxos()
 
         // repeating the action should not make a difference
 
@@ -119,7 +119,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
         _ <- wallet.transactionProcessing.processTransaction(tx, None)
         newConfirmed <- wallet.getConfirmedBalance()
         newUnconfirmed <- wallet.getUnconfirmedBalance()
-        utxosPostAdd <- wallet.utxoHandling.listUtxos()
+        utxosPostAdd <- wallet.utxoHandling.getUtxos()
 
         // repeating the action should not make a difference
         _ <- checkUtxosAndBalance(wallet) {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -28,16 +28,16 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
       for {
         accountDb <- wallet.accountHandling.getDefaultAccount()
         account = accountDb.hdAccount
-        utxos <- wallet.utxoHandling.listUtxos(account)
+        utxos <- wallet.utxoHandling.getUtxos(account)
         _ = assert(utxos.nonEmpty)
 
-        addresses <- wallet.accountHandling.listAddresses(account)
+        addresses <- wallet.accountHandling.getAddresses(account)
         _ = assert(addresses.nonEmpty)
 
         _ <- wallet.accountHandling.clearUtxos(account)
 
-        clearedUtxos <- wallet.utxoHandling.listUtxos(account)
-        clearedAddresses <- wallet.accountHandling.listAddresses(account)
+        clearedUtxos <- wallet.utxoHandling.getUtxos(account)
+        clearedAddresses <- wallet.accountHandling.getAddresses(account)
       } yield {
         assert(clearedUtxos.isEmpty)
         assert(clearedAddresses.nonEmpty)
@@ -51,16 +51,16 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
       for {
         balance <- wallet.getBalance()
         _ = assert(balance != Satoshis.zero)
-        utxos <- wallet.utxoHandling.listUtxos()
+        utxos <- wallet.utxoHandling.getUtxos()
         _ = assert(utxos.nonEmpty)
 
-        addresses <- wallet.addressHandling.listAddresses()
+        addresses <- wallet.addressHandling.getAddresses()
         _ = assert(addresses.nonEmpty)
 
         _ <- wallet.utxoHandling.clearAllUtxos()
 
-        clearedUtxos <- wallet.utxoHandling.listUtxos()
-        clearedAddresses <- wallet.addressHandling.listAddresses()
+        clearedUtxos <- wallet.utxoHandling.getUtxos()
+        clearedAddresses <- wallet.addressHandling.getAddresses()
       } yield {
         assert(clearedUtxos.isEmpty)
         assert(clearedAddresses.nonEmpty)
@@ -200,7 +200,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         account <- defaultAccountF
         txIds <-
           wallet.utxoHandling
-            .listUtxos(account.hdAccount)
+            .getUtxos(account.hdAccount)
             .map(_.map(_.txid))
         _ <- wallet.transactionProcessing
           .findByTxIds(txIds)
@@ -285,7 +285,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
       val initBalanceF = wallet.getBalance()
 
       // find the first block a utxo was created in
-      val utxosF = wallet.utxoHandling.listUtxos()
+      val utxosF = wallet.utxoHandling.getUtxos()
       val oldestHeightF = for {
         utxos <- utxosF
         blockhashes <- wallet.transactionProcessing
@@ -373,7 +373,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
           force = false
         )
 
-        usedAddresses <- wallet.addressHandling.listFundedAddresses()
+        usedAddresses <- wallet.addressHandling.getFundedAddresses()
 
         _ = assert(
           !usedAddresses.exists(_._1.address == address),
@@ -383,8 +383,8 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         hashes <- bitcoind.generateToAddress(1, address)
         block <- bitcoind.getBlockRaw(hashes.head)
         _ <- wallet.transactionProcessing.processBlock(block)
-        fundedAddresses <- wallet.addressHandling.listFundedAddresses()
-        utxos <- wallet.utxoHandling.listUtxos(TxoState.ImmatureCoinbase)
+        fundedAddresses <- wallet.addressHandling.getFundedAddresses()
+        utxos <- wallet.utxoHandling.getUtxos(TxoState.ImmatureCoinbase)
         _ <- RescanState.awaitRescanDone(state)
       } yield {
         // note 25 bitcoin reward from coinbase tx here
@@ -561,7 +561,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         account <- defaultAccountF
         txIds <-
           wallet.utxoHandling
-            .listUtxos(account.hdAccount)
+            .getUtxos(account.hdAccount)
             .map(_.map(_.txid))
         _ <- wallet.transactionProcessing
           .findByTxIds(txIds)
@@ -597,7 +597,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
           DEFAULT_ADDR_BATCH_SIZE)
         _ = assert(rescanState.isInstanceOf[RescanState.RescanStarted])
         _ <- RescanState.awaitRescanDone(rescanState)
-        addresses <- wallet.addressHandling.listAddresses()
+        addresses <- wallet.addressHandling.getAddresses()
       } yield {
         assert(addresses.exists(_.isChange))
         assert(addresses.exists(!_.isChange))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/SegwitWalletTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/SegwitWalletTest.scala
@@ -19,7 +19,7 @@ class SegwitWalletTest extends BitcoinSWalletTest {
       account <- wallet.accountHandling.getDefaultAccount()
       otherAddr <- wallet.getNewAddress()
       thirdAddr <- wallet.addressHandling.getNewAddress(AddressType.SegWit)
-      allAddrs <- wallet.addressHandling.listAddresses()
+      allAddrs <- wallet.addressHandling.getAddresses()
     } yield {
       assert(account.hdAccount.purpose == HDPurpose.SegWit)
       assert(allAddrs.forall(_.address.isInstanceOf[Bech32Address]))

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -243,14 +243,14 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
 
     val assertionsF: Future[Seq[Assertion]] = for {
       wallet <- getWallet(conf)
-      existingAccounts <- wallet.accountHandling.listAccounts(purpose)
+      existingAccounts <- wallet.accountHandling.getAccounts(purpose)
       _ <- createNeededAccounts(
         wallet,
         existingAccounts,
         conf.kmParams,
         testVectors
       )
-      accounts <- wallet.accountHandling.listAccounts(purpose)
+      accounts <- wallet.accountHandling.getAccounts(purpose)
       // we want to find all accounts for the given account type,
       // and match it with its corresponding test vector
       accountsWithVectors = {

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletCallbackTest.scala
@@ -160,7 +160,7 @@ class WalletCallbackTest extends BitcoinSWalletTest {
       val wallet = fundedWallet.wallet
 
       for {
-        utxos <- wallet.utxoHandling.listUtxos()
+        utxos <- wallet.utxoHandling.getUtxos()
         _ <- wallet.utxoHandling.markUTXOsAsReserved(Vector(utxos.head))
         result <- resultP.future
       } yield assert(
@@ -185,7 +185,7 @@ class WalletCallbackTest extends BitcoinSWalletTest {
       val wallet = fundedWallet.wallet
 
       for {
-        utxos <- wallet.utxoHandling.listUtxos()
+        utxos <- wallet.utxoHandling.getUtxos()
         reserved <- wallet.utxoHandling.markUTXOsAsReserved(Vector(utxos.head))
         _ = fundedWallet.walletConfig.addCallbacks(callbacks)
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletIntegrationTest.scala
@@ -63,7 +63,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       tx <- bitcoind.getRawTransactionRaw(txId)
 
       // before processing TX, wallet should be completely empty
-      _ <- wallet.utxoHandling.listUtxos().map(utxos => assert(utxos.isEmpty))
+      _ <- wallet.utxoHandling.getUtxos().map(utxos => assert(utxos.isEmpty))
       _ <- wallet.getBalance().map(confirmed => assert(confirmed == 0.bitcoin))
       _ <-
         wallet
@@ -75,7 +75,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
       // we should now have one UTXO in the wallet
       // it should not be confirmed
-      utxosPostAdd <- wallet.utxoHandling.listUtxos()
+      utxosPostAdd <- wallet.utxoHandling.getUtxos()
       _ = assert(utxosPostAdd.length == 1)
       _ <-
         wallet
@@ -100,7 +100,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
         blockHashWithConfsOpt)
       _ <-
         wallet.utxoHandling
-          .listUtxos()
+          .getUtxos()
           .map { utxos =>
             // we want to make sure no new utxos were added,
             // i.e. that we only modified an existing one
@@ -131,7 +131,7 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
       _ <- bitcoind.generate(1)
       tx <- bitcoind.getRawTransaction(txid)
 
-      utxos <- wallet.utxoHandling.listUtxos()
+      utxos <- wallet.utxoHandling.getUtxos()
       _ = utxos match {
         case utxo +: Vector() =>
           assert(utxo.privKeyPath.chain.chainType == HDChainType.Change)
@@ -356,9 +356,9 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
         _ <- wallet.transactionProcessing.processBlock(block)
 
         // Verify we funded the wallet
-        allUtxos <- wallet.utxoHandling.listUtxos()
+        allUtxos <- wallet.utxoHandling.getUtxos()
         _ = assert(allUtxos.size == 1)
-        utxos <- wallet.utxoHandling.listUtxos(TxoState.ImmatureCoinbase)
+        utxos <- wallet.utxoHandling.getUtxos(TxoState.ImmatureCoinbase)
         _ = assert(utxos.size == 1)
 
         bitcoindAddr <- bitcoind.getNewAddress
@@ -396,10 +396,10 @@ class WalletIntegrationTest extends BitcoinSWalletTestCachedBitcoindNewest {
 
         // Process tx, validate correctly moved to
         _ <- wallet.transactionProcessing.processTransaction(signedTx, None)
-        newCoinbaseUtxos <- wallet.utxoHandling.listUtxos(
+        newCoinbaseUtxos <- wallet.utxoHandling.getUtxos(
           TxoState.ImmatureCoinbase)
         _ = assert(newCoinbaseUtxos.isEmpty)
-        spentUtxos <- wallet.utxoHandling.listUtxos(TxoState.BroadcastSpent)
+        spentUtxos <- wallet.utxoHandling.getUtxos(TxoState.BroadcastSpent)
         _ = assert(spentUtxos.size == 1)
 
         // Assert spending tx valid to bitcoind

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -245,7 +245,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
   it should "correctly send entire outpoints" in { fundedWallet =>
     val wallet = fundedWallet.wallet
     for {
-      allUtxos <- wallet.utxoHandling.listUtxos()
+      allUtxos <- wallet.utxoHandling.getUtxos()
       // use half of them
       utxos = allUtxos.drop(allUtxos.size / 2)
       outPoints = utxos.map(_.outPoint)
@@ -304,7 +304,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
   it should "correctly sweep the wallet" in { fundedWallet =>
     val wallet = fundedWallet.wallet
     for {
-      utxos <- wallet.utxoHandling.listUtxos()
+      utxos <- wallet.utxoHandling.getUtxos()
       tx <- wallet.sendFundsHandling.sweepWallet(testAddress, None)
       balance <- wallet.getBalance()
     } yield {
@@ -408,7 +408,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
 
     for {
       addr <- wallet.getNewAddress()
-      utxo <- wallet.utxoHandling.listUtxos().map(_.head)
+      utxo <- wallet.utxoHandling.getUtxos().map(_.head)
 
       // Create tx not signaling RBF
       input = TransactionInput(
@@ -510,7 +510,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
     fundedWallet =>
       val wallet = fundedWallet.wallet
       for {
-        allUtxos <- wallet.utxoHandling.listUtxos()
+        allUtxos <- wallet.utxoHandling.getUtxos()
         // Make one already spent
         spent = allUtxos.head
           .copyWithSpendingTxId(
@@ -539,7 +539,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
       account <- wallet.accountHandling.getDefaultAccount()
       feeRate <- wallet.getFeeRate()
       allUtxos <- wallet.utxoHandling
-        .listUtxos(account.hdAccount)
+        .getUtxos(account.hdAccount)
         .map(_.map(CoinSelectorUtxo.fromSpendingInfoDb))
 
       output = TransactionOutput(amountToSend, testAddress.scriptPubKey)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -36,8 +36,8 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
   it should "create a new wallet" in { (wallet: Wallet) =>
     for {
-      accounts <- wallet.accountHandling.listAccounts()
-      addresses <- wallet.addressHandling.listAddresses()
+      accounts <- wallet.accountHandling.getAccounts()
+      addresses <- wallet.addressHandling.getAddresses()
     } yield {
       assert(accounts.length == 4) // legacy, segwit, nested segwit, taproot
       assert(addresses.isEmpty)
@@ -48,7 +48,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
     for {
       addr <- wallet.getNewAddress()
       otherAddr <- wallet.getNewAddress()
-      allAddrs <- wallet.addressHandling.listAddresses()
+      allAddrs <- wallet.addressHandling.getAddresses()
     } yield {
       assert(allAddrs.length == 2)
       assert(allAddrs.exists(_.address == addr))

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -157,8 +157,8 @@ case class Wallet(
   override def processCompactFilters(
       blockFilters: Vector[(DoubleSha256DigestBE, GolombFilter)]
   ): Future[Wallet] = {
-    val utxosF = utxoHandling.listUtxos()
-    val spksF = addressHandling.listScriptPubKeys()
+    val utxosF = utxoHandling.getUtxos()
+    val spksF = addressHandling.getScriptPubKeys()
     val blockHashOpt = blockFilters.lastOption.map(_._1)
     val heightOptF = blockHashOpt match {
       case Some(blockHash) =>

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AccountHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AccountHandling.scala
@@ -105,7 +105,7 @@ case class AccountHandling(
   }
 
   /** @inheritdoc */
-  override def listAccounts(): Future[Vector[AccountDb]] =
+  override def getAccounts(): Future[Vector[AccountDb]] =
     accountDAO.findAll()
 
   private def getOrThrowAccount(account: Option[AccountDb]): AccountDb =
@@ -332,7 +332,7 @@ case class AccountHandling(
     safeDatabase.run(findAccountAction(account))
   }
 
-  override def listUnusedAddresses(
+  override def getUnusedAddresses(
       account: HDAccount): Future[Vector[AddressDb]] = {
     val unusedAddressesF = addressDAO.getUnusedAddresses
     unusedAddressesF.map { unusedAddresses =>
@@ -341,7 +341,7 @@ case class AccountHandling(
     }
   }
 
-  override def listAddresses(account: HDAccount): Future[Vector[AddressDb]] = {
+  override def getAddresses(account: HDAccount): Future[Vector[AddressDb]] = {
     val allAddressesF: Future[Vector[AddressDb]] = addressDAO.findAllAddresses()
 
     val accountAddressesF = {
@@ -356,13 +356,13 @@ case class AccountHandling(
     accountAddressesF
   }
 
-  override def listSpentAddresses(
+  override def getSpentAddresses(
       account: HDAccount
   ): Future[Vector[AddressDb]] = {
     addressDAO.getSpentAddresses(account)
   }
 
-  override def listFundedAddresses(
+  override def getFundedAddresses(
       account: HDAccount
   ): Future[Vector[(AddressDb, CurrencyUnit)]] = {
     addressDAO.getFundedAddresses(account)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/AddressHandling.scala
@@ -50,23 +50,23 @@ case class AddressHandling(
   private val scriptPubKeyDAO: ScriptPubKeyDAO = walletDAOs.scriptPubKeyDAO
   private val networkParameters: NetworkParameters = walletConfig.network
 
-  override def listAddresses(): Future[Vector[AddressDb]] =
+  override def getAddresses(): Future[Vector[AddressDb]] =
     addressDAO.findAllAddressDbForAccount(walletConfig.defaultAccount)
 
-  override def listSpentAddresses(): Future[Vector[AddressDb]] = {
+  override def getSpentAddresses(): Future[Vector[AddressDb]] = {
     addressDAO.getSpentAddresses(walletConfig.defaultAccount)
   }
 
-  override def listFundedAddresses()
+  override def getFundedAddresses()
       : Future[Vector[(AddressDb, CurrencyUnit)]] = {
     addressDAO.getFundedAddresses(walletConfig.defaultAccount)
   }
 
-  override def listUnusedAddresses(): Future[Vector[AddressDb]] = {
+  override def getUnusedAddresses(): Future[Vector[AddressDb]] = {
     addressDAO.getUnusedAddresses(walletConfig.defaultAccount)
   }
 
-  override def listScriptPubKeys(): Future[Vector[ScriptPubKeyDb]] = {
+  override def getScriptPubKeys(): Future[Vector[ScriptPubKeyDb]] = {
     scriptPubKeyDAO.findAll()
   }
 
@@ -82,7 +82,7 @@ case class AddressHandling(
       transaction: Transaction
   ): Future[Vector[(TransactionOutput, TransactionOutPoint)]] =
     for {
-      spks <- listScriptPubKeys()
+      spks <- getScriptPubKeys()
     } yield transaction.outputs.zipWithIndex.collect {
       case (out, index)
           if spks.map(_.scriptPubKey).contains(out.scriptPubKey) =>

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
@@ -445,7 +445,7 @@ case class SendFundsHandlingHandling(
     val outputs = Vector(TransactionOutput(Satoshis.zero, address.scriptPubKey))
     for {
       _ <- invariantF
-      utxos <- utxoHandling.listUtxos(outPoints)
+      utxos <- utxoHandling.getUtxos(outPoints)
       outputMap = SpendingInfoDb.toPreviousOutputMap(utxos)
       utxosWithTxs <- fundTxHandling.getPreviousTransactions(utxos)
       inputInfos = utxosWithTxs

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/UtxoHandling.scala
@@ -105,18 +105,18 @@ case class UtxoHandling(
   }
 
   /** @inheritdoc */
-  override def listUtxos(): Future[Vector[SpendingInfoDb]] = {
-    listUtxos(walletConfig.defaultAccount)
+  override def getUtxos(): Future[Vector[SpendingInfoDb]] = {
+    getUtxos(walletConfig.defaultAccount)
   }
 
-  def listUtxos(
+  def getUtxos(
       hdAccount: HDAccount
   ): Future[Vector[SpendingInfoDb]] = {
     spendingInfoDAO.findAllUnspentForAccount(hdAccount)
   }
 
   /** Returns all the utxos originating from the given outpoints */
-  override def listUtxos(
+  override def getUtxos(
       outPoints: Vector[TransactionOutPoint]
   ): Future[Vector[SpendingInfoDb]] = {
     spendingInfoDAO
@@ -124,11 +124,11 @@ case class UtxoHandling(
       .map(_.filter(spendingInfo => outPoints.contains(spendingInfo.outPoint)))
   }
 
-  override def listUtxos(tag: AddressTag): Future[Vector[SpendingInfoDb]] = {
-    listUtxos(walletConfig.defaultAccount, tag)
+  override def getUtxos(tag: AddressTag): Future[Vector[SpendingInfoDb]] = {
+    getUtxos(walletConfig.defaultAccount, tag)
   }
 
-  override def listUtxos(
+  override def getUtxos(
       hdAccount: HDAccount,
       tag: AddressTag
   ): Future[Vector[SpendingInfoDb]] = {
@@ -139,11 +139,11 @@ case class UtxoHandling(
     }
   }
 
-  override def listUtxos(state: TxoState): Future[Vector[SpendingInfoDb]] = {
-    listUtxos(walletConfig.defaultAccount, state)
+  override def getUtxos(state: TxoState): Future[Vector[SpendingInfoDb]] = {
+    getUtxos(walletConfig.defaultAccount, state)
   }
 
-  override def listUtxos(
+  override def getUtxos(
       hdAccount: HDAccount,
       state: TxoState
   ): Future[Vector[SpendingInfoDb]] = {


### PR DESCRIPTION
use 'get' prefix rather than 'list' prefix for method names

Also renames `listreservedutxos` RPC endpoint to `getreservedutxos`