### PR TITLE
tests: Cleanup `BitcoindBlockPollingTest` producing ERROR logs during test fixture destruction

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -477,7 +477,7 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
               )
             } // reset polling variable
             f.failed.foreach(err =>
-              logger.error(s"Failed to poll bitcoind", err))
+              logger.error(s"Failed to poll bitcoind ${system}", err))
           } else {
             logger.info(s"Previous bitcoind polling still running")
           }

--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -477,7 +477,7 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
               )
             } // reset polling variable
             f.failed.foreach(err =>
-              logger.error(s"Failed to poll bitcoind ${system}", err))
+              logger.error(s"Failed to poll bitcoind", err))
           } else {
             logger.info(s"Previous bitcoind polling still running")
           }


### PR DESCRIPTION


Clean up these error logs that occasionally occur when destructing `BitcoindBlockPollingTest` test case 

```
2024-12-31 16:39:05,036UTC ERROR BitcoindRpcBackendUtil$ - Failed to poll bitcoind
org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (no such table: state_descriptors)
	at org.sqlite.core.DB.newSQLException(DB.java:1179)
	at org.sqlite.core.DB.newSQLException(DB.java:1190)
	at org.sqlite.core.DB.throwex(DB.java:1150)
	at org.sqlite.core.NativeDB.prepare_utf8(Native Method)
	at org.sqlite.core.NativeDB.prepare(NativeDB.java:135)
	at org.sqlite.core.DB.prepare(DB.java:264)
	at org.sqlite.core.CorePreparedStatement.<init>(CorePreparedStatement.java:46)
	at org.sqlite.jdbc3.JDBC3PreparedStatement.<init>(JDBC3PreparedStatement.java:32)
```