### PR TITLE
Try pinning CI image to ubuntu 22.04 for now as a workaround until `setup-java` supports `sbt` installation

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   compile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       DISABLE_SECP256K1: "true"

--- a/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     env:

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:

--- a/.github/workflows/Linux_2.13_Node_Tests.yml
+++ b/.github/workflows/Linux_2.13_Node_Tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ on:
     tags: ["*"]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - name: Check Out Repo

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -18,12 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [macOS-latest, ubuntu-22.04]
         include:
           - os: macOS-latest
             uploaded_filename: bitcoin-s-cli-x86_64-apple-darwin
             local_path: app/cli/target/native-image/bitcoin-s-cli
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             uploaded_filename: bitcoin-s-cli-x86_64-pc-linux
             local_path: app/cli/target/native-image/bitcoin-s-cli
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, ubuntu-latest, windows-latest] #
+        os: [macos-13, ubuntu-22.04, windows-latest] #
         # If os values you don't include the matrix os list above are set here, they will be included
         # If you want multiple variables per os see https://github.community/t/create-matrix-with-multiple-os-and-env-for-each-one/16895
         # Can run conditional steps below with https://github.community/t/what-is-the-correct-if-condition-syntax-for-checking-matrix-os-version/16221
@@ -42,7 +42,7 @@ jobs:
         include:
         - os: macos-13
           TARGET: mac
-        - os: ubuntu-latest
+        - os: ubuntu-22.04
           TARGET: linux
         - os: windows-latest
         # TODO : Do we want to use 'win' or 'windows'?
@@ -134,14 +134,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, ubuntu-latest] # windows-latest
+        os: [macos-13, ubuntu-22.04] # windows-latest
         # If os values you don't include the matrix os list above are set here, they will be included
         # This is here to get friendly labels for output filenames
         include:
         - os: macos-13
           TARGET: mac
           FORMAT: zip # dmg
-        - os: ubuntu-latest
+        - os: ubuntu-22.04
           TARGET: linux
           FORMAT: deb
         # - os: windows-latest


### PR DESCRIPTION
Workaround for #5842 until this issue is resolved in setup-java https://github.com/actions/setup-java/issues/712

We shouldn't pin to ubuntu 22.04 forever, but it seems like we can do this in the short term.