### PR TITLE
wallet: Try to avoid spurious failures on WalletSendingTest double spending test

### DIFF
--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -583,29 +583,27 @@ class WalletSendingTest extends BitcoinSWalletTest {
       // i expected an error saying insufficient balance
 
       val addr1F = fundedWallet.wallet.getNewAddress()
-      val addr2F = fundedWallet.wallet.getNewAddress()
       val balanceF = fundedWallet.wallet.getBalance()
 
       val failedTx: Future[Unit] = for {
         balance <- balanceF
         addr1 <- addr1F
-        addr2 <- addr2F
         amt = balance - Satoshis(
           5000
         ) // for fee, fee rates are random so we might need a lot
 
         // build these transactions in parallel intentionally
-        tx1F = fundedWallet.wallet.sendFundsHandling.sendToAddress(
-          addr1,
-          amt,
-          Some(SatoshisPerVirtualByte.one))
-        tx2F = fundedWallet.wallet.sendFundsHandling.sendToAddress(
-          addr2,
-          amt,
-          Some(SatoshisPerVirtualByte.one))
-        // one of these should fail because we don't have enough money
-        _ <- tx1F
-        _ <- tx2F
+        outputs = Vector(TransactionOutput(amt, addr1.scriptPubKey))
+        _ <- fundedWallet.wallet.fundTxHandling.fundRawTransaction(
+          destinations = outputs,
+          feeRate = SatoshisPerVirtualByte.one,
+          fromTagOpt = None,
+          markAsReserved = true)
+        _ <- fundedWallet.wallet.fundTxHandling.fundRawTransaction(
+          destinations = outputs,
+          feeRate = SatoshisPerVirtualByte.one,
+          fromTagOpt = None,
+          markAsReserved = true)
       } yield ()
 
       val exnF: Future[RuntimeException] =

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletSendingTest.scala
@@ -591,16 +591,18 @@ class WalletSendingTest extends BitcoinSWalletTest {
         addr1 <- addr1F
         addr2 <- addr2F
         amt = balance - Satoshis(
-          500000
+          5000
         ) // for fee, fee rates are random so we might need a lot
 
         // build these transactions in parallel intentionally
-        tx1F = fundedWallet.wallet.sendFundsHandling.sendToAddress(addr1,
-                                                                   amt,
-                                                                   None)
-        tx2F = fundedWallet.wallet.sendFundsHandling.sendToAddress(addr2,
-                                                                   amt,
-                                                                   None)
+        tx1F = fundedWallet.wallet.sendFundsHandling.sendToAddress(
+          addr1,
+          amt,
+          Some(SatoshisPerVirtualByte.one))
+        tx2F = fundedWallet.wallet.sendFundsHandling.sendToAddress(
+          addr2,
+          amt,
+          Some(SatoshisPerVirtualByte.one))
         // one of these should fail because we don't have enough money
         _ <- tx1F
         _ <- tx2F
@@ -612,7 +614,7 @@ class WalletSendingTest extends BitcoinSWalletTest {
       exnF.map(err =>
         assert(
           err.getMessage.contains(
-            "Not enough value in given outputs to make transaction spending 599500000 sats plus fees"
+            "Not enough value in given outputs to make transaction spending 599995000 sats plus fees"
           )
         ))
 


### PR DESCRIPTION
Try to fix this failure seen on CI

https://github.com/bitcoin-s/bitcoin-s/actions/runs/12726521090/job/35475005096?pr=5845#step:5:716

