### PR TITLE
node: Fix bug where we were dropping cached outbound messages on the floor

### DIFF
--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -35,7 +35,7 @@
         <appender-ref ref="ASYNC-FILE"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="INFO"/>
+    <logger name="org.bitcoins.node" level="DEBUG"/>
 
     <logger name="org.bitcoins.chain" level="INFO"/>
 

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -72,7 +72,6 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
       for {
         _ <- node.start()
         peer <- peerF
-        peerManager = node.peerManager
 
         _ <- NodeTestUtil.awaitSyncAndIBD(node = node, bitcoind = bitcoind)
         // disconnect

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -378,7 +378,7 @@ case class PeerFinder(
       val peersF = {
         for {
           peers <- peersToTryF
-          _ = logger.debug(s"Trying next set of peers $peers")
+          _ = logger.debug(s"Trying next set of peers ${peers.map(_.peer)}")
           _ <- {
             Future.traverse(peers) { p =>
               // check if we already have an active connection

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -140,16 +140,6 @@ case class PeerManager(
       .upsertPeer(addrBytes, peer.port, networkByte, serviceIdentifier)
   }
 
-//  private def replacePeer(replacePeer: Peer, withPeer: Peer): Future[Unit] = {
-//    logger.debug(s"Replacing $replacePeer with $withPeer")
-//    for {
-//      _ <- disconnectPeer(replacePeer)
-//      _ <- connectPeer(withPeer)
-//    } yield {
-//      ()
-//    }
-//  }
-
   def disconnectPeer(peer: Peer): Future[Unit] = {
     logger.debug(s"Disconnecting persistent peer=$peer")
     queue.offer(InitializeDisconnect(peer)).map(_ => ())
@@ -851,7 +841,7 @@ case class PeerManager(
       state: NodeRunningState,
       stp: SendToPeer
   ): Future[NodeRunningState] = {
-    logger.info(s"sendToPeerHelper() stp=$stp state=$state")
+    logger.debug(s"sendToPeerHelper() stp=$stp state=$state")
     val nodeStateF: Future[NodeRunningState] = stp.peerOpt match {
       case Some(p) =>
         state
@@ -1223,7 +1213,7 @@ case class PeerManager(
         }
 
         addPeerF.flatMap { addPeer =>
-          if (availableFilterSlot) {
+          if (availableFilterSlot && notCfPeers.nonEmpty) {
             disconnectPeer(notCfPeers.head).map(_ => addPeer)
           } else {
             Future.successful(addPeer)

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -1210,6 +1210,8 @@ case class PeerManager(
             val peerWithSvcs = peerData.peerWithServicesOpt.get
             val map = Vector((peerWithSvcs, peerData)).toMap
             val d = DoneSyncing(map, n.waitingForDisconnection, n.peerFinder)
+            logger.debug(
+              s"Sending ${n.cachedOutboundMessages.length} cached message to peer=$peer")
             val sendMsgsF = Future.traverse(n.cachedOutboundMessages)(m =>
               peerData.peerMessageSender.sendMsg(m.payload))
             val h = d.toHeaderSync(peer)


### PR DESCRIPTION
fixes #5852 

related to #5800 

Calls to `NoPeers.replacePeers()` are dangerous because `cachedOutboundMessages` could be dropped without them being sent to a peer. This was the root cause of #5852

We need to make sure that we don't call `NoPeers.replacePeers()` as it isn't safe. This PR adds an invariant to make sure it doesn't happen. The type hierarchy probably needs to be reconsidered to make sure `NoPeers.replacePeers()` cannot be called.