### PR TITLE
node: Use appropriate `ServiceIdentifier` throughout `node` module

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/p2p/ServiceIdentifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/ServiceIdentifier.scala
@@ -157,7 +157,7 @@ object ServiceIdentifier
     */
   val NODE_XTHIN: ServiceIdentifier = ServiceIdentifier(1 << 4)
 
-  val NODE_COMPACT_FILTERS = ServiceIdentifier(1 << 6)
+  val NODE_COMPACT_FILTERS: ServiceIdentifier = ServiceIdentifier(1 << 6)
 
   /** This means the same as `NODE_NETWORK` with the limitation of only serving
     * the last 288 (2 days) blocks
@@ -196,4 +196,34 @@ object ServiceIdentifier
   def apply(num: BigInt): ServiceIdentifier = ServiceIdentifier(UInt64(num))
 
   def apply(uInt64: UInt64): ServiceIdentifier = ServiceIdentifierImpl(uInt64)
+
+  def fromNetworkMessage(msg: NetworkMessage): ServiceIdentifier = {
+    fromNetworkPayload(msg.payload)
+  }
+
+  def fromNetworkPayload(payload: NetworkPayload): ServiceIdentifier = {
+    payload match {
+      case _: CompactFilterMessage | _: CompactFilterHeadersMessage |
+          _: GetCompactFilterHeadersMessage | _: GetCompactFiltersMessage |
+          _: CompactFilterCheckPointMessage |
+          _: GetCompactFilterCheckPointMessage =>
+        NODE_COMPACT_FILTERS
+      case _: GetHeadersMessage | _: HeadersMessage | SendHeadersMessage =>
+        NODE_NETWORK
+      case _: InventoryMessage => NODE_NETWORK
+      case _: MerkleBlockMessage | _: FilterAddMessage | FilterClearMessage |
+          _: FilterLoadMessage =>
+        NODE_BLOOM
+      case MemPoolMessage        => NODE_NETWORK
+      case _: TransactionMessage => NODE_NETWORK
+      case _: GossipAddrMessage | SendAddrV2Message | GetAddrMessage =>
+        NODE_NETWORK
+      case _: BlockMessage | _: GetBlocksMessage => NODE_NETWORK
+      case _: VersionMessage | VerAckMessage     => NODE_NETWORK
+      case _: PingMessage | _: PongMessage       => NODE_NETWORK
+      case _: RejectMessage                      => NODE_NETWORK
+      case _: FeeFilterMessage                   => NODE_NETWORK
+      case _: GetDataMessage                     => NODE_NETWORK
+    }
+  }
 }

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -535,7 +535,7 @@ case class PeerManager(
               case d: DoneSyncing =>
                 d.randomPeer(
                   Set.empty,
-                  ServiceIdentifier.NODE_COMPACT_FILTERS
+                  ServiceIdentifier.NODE_NETWORK
                 ) match {
                   case Some(p) =>
                     val h =
@@ -842,6 +842,7 @@ case class PeerManager(
       stp: SendToPeer
   ): Future[NodeRunningState] = {
     logger.debug(s"sendToPeerHelper() stp=$stp state=$state")
+
     val nodeStateF: Future[NodeRunningState] = stp.peerOpt match {
       case Some(p) =>
         state
@@ -857,10 +858,11 @@ case class PeerManager(
               .map(_ => s)
           case x @ (_: DoneSyncing | _: MisbehavingPeer | _: NodeShuttingDown |
               _: RemovePeers) =>
+            val svcId = ServiceIdentifier.fromNetworkMessage(stp.msg)
             val pms = x
               .randomPeerMessageSender(
                 Set.empty,
-                ServiceIdentifier.NODE_COMPACT_FILTERS
+                svcId
               )
               .get
             pms
@@ -1092,7 +1094,7 @@ case class PeerManager(
     val svcIdentifier = ServiceIdentifier.NODE_COMPACT_FILTERS
     val syncPeerOpt = state match {
       case s: SyncNodeState =>
-        s.randomPeer(excludePeers = Set(s.syncPeer), svcIdentifier)
+        s.randomPeer(excludePeers = Set(s.syncPeer))
       case m: MisbehavingPeer =>
         m.randomPeer(excludePeers = Set(m.badPeer), svcIdentifier)
       case rm: RemovePeers =>


### PR DESCRIPTION
fixes #5869 

Previously all p2p requests would be made to nodes that had the `NODE_COMPACT_FILTERS` service identifier. This is unnecessary as not all p2p requests are related to compact filters. For instance, during rescans we request full blocks. During IBD, we request headers messages first which can be fetched from any peer that supports `NODE_NETWORK` (this probably could be loosened even further).