### PR TITLE
appServer: Disable tor by default

### DIFF
--- a/app/server/src/main/resources/reference.conf
+++ b/app/server/src/main/resources/reference.conf
@@ -7,12 +7,12 @@ bitcoin-s {
     }
     proxy {
         # Configure SOCKS5 proxy to use Tor for outgoing connections
-        enabled = true
+        enabled = false
         socks5 = "127.0.0.1:9050"
     }
     tor {
         # Enable Tor for incoming DLC connections
-        enabled = true
+        enabled = false
         control = "127.0.0.1:9051"
     }
 }


### PR DESCRIPTION
The tor binary doesn't work anymore on all platforms and needs to be disabled until we recompile and ship a new tor binary #5294 