### PR TITLE
node: Limit initial stack push in `PeerFinder.start()` to `maxSearchCount^2`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -367,7 +367,7 @@ case class PeerFinder(
       val dnsPeersF = if (_peersToTry.size < maxPeerSearchCount) {
         val pdsF = getPeersFromDnsSeeds
           .map { dnsPeers =>
-            val shuffled = getPeersFromResources ++ dnsPeers
+            val shuffled = Random.shuffle(getPeersFromResources ++ dnsPeers)
             val pds = shuffled.map(p => buildPeerData(p, isPersistent = false))
             _peersToTry.pushAll(pds)
           }

--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -175,9 +175,9 @@ case class PeerFinder(
             }
           }
           dbNonCf = dbNonCfPeerDb.map(_.peer(nodeAppConfig.socks5ProxyParams))
-          dbCf = (dbCfPeerDb
-            .map(_.peer(nodeAppConfig.socks5ProxyParams)))
+          dbCf = dbCfPeerDb
             .take(maxStackPush)
+            .map(_.peer(nodeAppConfig.socks5ProxyParams))
           dns <- dnsF
           peersDbs = {
             if (dbNonCf.isEmpty) {

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,12 +20,12 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="INFO"/>
+    <logger name="org.bitcoins.node" level="WARN"/>
 
     <logger name="org.bitcoins.chain" level="WARN"/>
 

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,12 +20,12 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="WARN"/>
+    <logger name="org.bitcoins.node" level="INFO"/>
 
     <logger name="org.bitcoins.chain" level="WARN"/>
 


### PR DESCRIPTION
This seems to dramatically improve performance in `PeerFinder.start()`. This means we will only push 64 peers to search onto our stack to start inside of our entire databases content. 