### PR TITLE
2025 01 23 Sequentially disconnect peers during shutdown, don't offer to queue

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -756,8 +756,9 @@ case class PeerManager(
                 waitingForDisconnection = r.waitingForDisconnection,
                 peerFinder = r.peerFinder
               )
-            Future
-              .traverse(r.peers)(disconnectPeer(_))
+            FutureUtil
+              .sequentially(r.peers)(
+                handleInitializeDisconnect(shutdownState, _))
               .map(_ => shutdownState)
 
         }


### PR DESCRIPTION
fixes #5878 

Offering to the queue can lead us to hit our `maxConcurrentOffers` limit when shutting down the node. Just call `handleInitializeDisconnect()` directly.