### PR TITLE
node: Fix bug where we we could have more connections than allowed by `bitcoin-s.node.maxConnectedPeers`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -1193,6 +1193,7 @@ case class PeerManager(
           )
           Future.successful(running)
         } else {
+          logger.info(s"Initializing disconnect for peer=$peer state=$state")
           val client: PeerData =
             running.getPeerData(peer) match {
               case Some(p) => p


### PR DESCRIPTION
fixes #5884 and is also related to #5883 and #5878

This PR does 2 things

1. Fixes a bug where we could have more connections than allowed by `bitcoin-s.node.maxConnectedPeers`. This could happened because we wouldnt disconnect the peer in the case where it wasn't used because we had more than `maxConnectedPeers` and no `availableFilterSlots`. This means these peers could be connected in `PeerFinder` forever, but never promoted to `PeerManager` peers that we exchange p2p messages with.
2. Avoids offering to the queue by calling `disconnectPeer()` inside of the stream. This could theoretically deadlock if we are backpressuring