### PR TITLE
core: Optimize `ScriptParser.parseOperationByte()`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -230,7 +230,9 @@ sealed abstract class ScriptParser
         // means that we need to push x amount of bytes on to the stack
         val (constant, newTail) = sliceConstant(bytesToPushOntoStack, tail)
         val scriptConstant = ScriptConstant(constant)
-        ParsingHelper(newTail, scriptConstant +: bytesToPushOntoStack +: accum)
+        ParsingHelper(
+          newTail,
+          accum.prependedAll(Vector(scriptConstant, bytesToPushOntoStack)))
       case OP_PUSHDATA1 => parseOpPushData(op, accum, tail)
       case OP_PUSHDATA2 => parseOpPushData(op, accum, tail)
       case OP_PUSHDATA4 => parseOpPushData(op, accum, tail)


### PR DESCRIPTION
```scala
scriptConstant +: bytesToPushOntoStack +: accum
```

is inefficient because prepending to a Vector is O(n). Unlike List, which has efficient prepends (O(1)), Vector needs to copy the entire underlying array when an element is added to the front.

Instead of chaining +:, use .prependedAll, which is optimized for adding multiple elements at once. This reduces intermediate allocations compared to repeated +: operations.

Here is the visualvm run before this change with performance impact

![Screenshot from 2025-02-01 10-21-33](https://github.com/user-attachments/assets/3f397bfa-0210-4baa-98dc-827571125561)
