### PR TITLE
core: Optimize `Int64.fromBytes()`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -568,7 +568,7 @@ object Int64
 
   override def fromBytes(bytes: ByteVector): Int64 = {
     require(bytes.size <= 8, "We cannot have an Int64 be larger than 8 bytes")
-    Int64(BigInt(bytes.toArray).toLong)
+    Int64(bytes.toLong(signed = true))
   }
 
   def apply(long: Long): Int64 = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -293,6 +293,9 @@ object WitnessTransaction extends Factory[WitnessTransaction] {
       BytesUtil.parseCmpctSizeUIntSeq(outputBytes, TransactionOutput)
     val witness = TransactionWitness(witnessBytes, inputs.size)
     val lockTimeBytes = witnessBytes.drop(witness.byteSize)
+    require(
+      lockTimeBytes.length >= 4,
+      s"Must have at least 4 bytes for locktime, got=${lockTimeBytes.length}")
     val lockTime = UInt32(lockTimeBytes.take(4).reverse)
 
     WitnessTransaction(version, inputs, outputs, lockTime, witness)


### PR DESCRIPTION
This avoids array copies when deserializing an `Int64`. 

As a by product of this, this unit test started failing. It seems we were relying our previous deserialization implementation to catch this corner case. 

https://github.com/bitcoin-s/bitcoin-s/blob/654d4086b993c35d4cd343a2009daed40c27d7b0/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala#L86

This led me to add the invariant that we must have at least 4 bytes for the locktime when deserializing a witness transaction.