### PR TITLE
core: Check if `P2SHScriptSignature` is push only when type checking

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -260,7 +260,8 @@ object P2SHScriptSignature extends ScriptFactory[P2SHScriptSignature] {
 
     // this will return false if the redeemScript is not a
     // supported scriptpubkey type in our library
-    asm.size > 1 && isRedeemScript(asm.last)
+    asm.size > 1 && BitcoinScriptUtil.isPushOnly(
+      asm.dropRight(1)) && isRedeemScript(asm.last)
   }
 
   /** Detects if the given script token is a redeem script */


### PR DESCRIPTION
From [BIP16](https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki#specification)

>Validation fails if there are any operations other than "push data" operations in the scriptSig.

This should also increase performance when parsing scripts, we can identify if something is a P2SHScriptSignature before trying to parse the last element as a redeemScript, which is an expensive operation

https://github.com/bitcoin-s/bitcoin-s/blob/145ff87511eca856245dd83de2e4c4bf79446079/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala#L268

