### PR TITLE
core: Check `maxPushSize` limit inside of `P2SHScriptSignature.isValidAsm()`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -261,7 +261,8 @@ object P2SHScriptSignature extends ScriptFactory[P2SHScriptSignature] {
     // this will return false if the redeemScript is not a
     // supported scriptpubkey type in our library
     asm.size > 1 && BitcoinScriptUtil.isPushOnly(
-      asm.dropRight(1)) && isRedeemScript(asm.last)
+      asm.dropRight(1)) && BitcoinScriptUtil.isValidPushSizes(
+      asm) && isRedeemScript(asm.last)
   }
 
   /** Detects if the given script token is a redeem script */

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -746,6 +746,11 @@ trait BitcoinScriptUtil {
       Failure(new RuntimeException(s"Input $index was invalid: $inputResult"))
     }
   }
+
+  /** Check if asm complies with max push size limits enforced by Script */
+  def isValidPushSizes(asm: Seq[ScriptToken]): Boolean = {
+    asm.forall(_.byteSize <= ScriptInterpreter.MAX_PUSH_SIZE)
+  }
 }
 
 object BitcoinScriptUtil extends BitcoinScriptUtil

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -126,7 +126,10 @@ sealed abstract class ScriptGenerators {
     */
   def p2shScriptSignature: Gen[P2SHScriptSignature] =
     for {
-      (scriptPubKey, _) <- randomNonP2SHScriptPubKey
+      // p2sh redeemScripts have a 520 byte script length
+      // see: https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki#520-byte-limitation-on-serialized-script-size
+      (scriptPubKey, _) <- randomNonP2SHScriptPubKey.suchThat(
+        _._1.asmBytes.size <= ScriptInterpreter.MAX_PUSH_SIZE)
       scriptSig <- pickCorrespondingScriptSignature(scriptPubKey)
       p2shScriptSig = P2SHScriptSignature(scriptSig, scriptPubKey)
     } yield p2shScriptSig


### PR DESCRIPTION
From [BIP16](https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki#520-byte-limitation-on-serialized-script-size)

Check that all elements are less than 520 bytes before attempting to parse the redeemScript

