### PR TITLE
core: Use `ArrayBuffer` instead of `Vector` inside of `ScriptParser.parse()`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -167,7 +167,7 @@ sealed abstract class ScriptParser
         accum
       }
     }
-    loop(bytes, new ArrayBuffer[ScriptToken]()).reverse.toVector
+    loop(bytes, new ArrayBuffer[ScriptToken]()).toVector
 
   }
 
@@ -233,13 +233,13 @@ sealed abstract class ScriptParser
         val scriptConstant = ScriptConstant(constant)
         ParsingHelper(
           newTail,
-          accum.prependedAll(Vector(scriptConstant, bytesToPushOntoStack)))
+          accum.appendedAll(Vector(bytesToPushOntoStack, scriptConstant)))
       case OP_PUSHDATA1 => parseOpPushData(op, accum, tail)
       case OP_PUSHDATA2 => parseOpPushData(op, accum, tail)
       case OP_PUSHDATA4 => parseOpPushData(op, accum, tail)
       case _            =>
         // means that we need to push the operation onto the stack
-        ParsingHelper(tail, op +: accum)
+        ParsingHelper(tail, accum.appended(op))
     }
   }
 
@@ -318,10 +318,12 @@ sealed abstract class ScriptParser
       accum: ArrayBuffer[ScriptToken]): ParsingHelper = {
     if (bytesToPushOntoStack.hex == "00") {
       // if we need to push 0 bytes onto the stack we do not add the script constant
-      ParsingHelper(restOfBytes, bytesToPushOntoStack +: op +: accum)
-    } else
       ParsingHelper(restOfBytes,
-                    scriptConstant +: bytesToPushOntoStack +: op +: accum)
+                    accum.appendedAll(Vector(op, bytesToPushOntoStack)))
+    } else
+      ParsingHelper(
+        restOfBytes,
+        accum.appendedAll(Vector(op, bytesToPushOntoStack, scriptConstant)))
   }
 
   /** Checks if a string can be cast to an int */

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -231,8 +231,9 @@ sealed abstract class ScriptParser
         // means that we need to push x amount of bytes on to the stack
         val (constant, newTail) = sliceConstant(bytesToPushOntoStack, tail)
         val scriptConstant = ScriptConstant(constant)
-        ParsingHelper(newTail,
-                      accum.++=(Vector(bytesToPushOntoStack, scriptConstant)))
+        ParsingHelper(
+          newTail,
+          accum.++=(ArrayBuffer(bytesToPushOntoStack, scriptConstant)))
       case OP_PUSHDATA1 => parseOpPushData(op, accum, tail)
       case OP_PUSHDATA2 => parseOpPushData(op, accum, tail)
       case OP_PUSHDATA4 => parseOpPushData(op, accum, tail)
@@ -317,10 +318,12 @@ sealed abstract class ScriptParser
       accum: ArrayBuffer[ScriptToken]): ParsingHelper = {
     if (bytesToPushOntoStack.hex == "00") {
       // if we need to push 0 bytes onto the stack we do not add the script constant
-      ParsingHelper(restOfBytes, accum.++=(Vector(op, bytesToPushOntoStack)))
-    } else
       ParsingHelper(restOfBytes,
-                    accum.++=(Vector(op, bytesToPushOntoStack, scriptConstant)))
+                    accum.++=(ArrayBuffer(op, bytesToPushOntoStack)))
+    } else
+      ParsingHelper(
+        restOfBytes,
+        accum.++=(ArrayBuffer(op, bytesToPushOntoStack, scriptConstant)))
   }
 
   /** Checks if a string can be cast to an int */

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -1,13 +1,14 @@
 package org.bitcoins.core.serializers.script
 
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.script._
-import org.bitcoins.core.script.constant._
+import org.bitcoins.core.script.*
+import org.bitcoins.core.script.constant.*
 import org.bitcoins.core.util.BytesUtil
 import org.bitcoins.crypto.{Factory, StringFactory}
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
+import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 
 /** Created by chris on 1/7/16.
@@ -155,7 +156,7 @@ sealed abstract class ScriptParser
     @tailrec
     def loop(
         bytes: ByteVector,
-        accum: Vector[ScriptToken]): Vector[ScriptToken] = {
+        accum: ArrayBuffer[ScriptToken]): ArrayBuffer[ScriptToken] = {
       // logger.debug("Byte to be parsed: " + bytes.headOption)
       if (bytes.nonEmpty) {
         val op = ScriptOperation.fromByte(bytes.head)
@@ -166,7 +167,7 @@ sealed abstract class ScriptParser
         accum
       }
     }
-    loop(bytes, Vector.empty).reverse
+    loop(bytes, new ArrayBuffer[ScriptToken]()).reverse.toVector
 
   }
 
@@ -212,7 +213,7 @@ sealed abstract class ScriptParser
 
   sealed private case class ParsingHelper(
       tail: ByteVector,
-      accum: Vector[ScriptToken])
+      accum: ArrayBuffer[ScriptToken])
 
   /** Parses an operation if the tail is a scodec.bits.ByteVector If the
     * operation is a bytesToPushOntoStack, it pushes the number of bytes onto
@@ -222,7 +223,7 @@ sealed abstract class ScriptParser
     */
   private def parseOperationByte(
       op: ScriptOperation,
-      accum: Vector[ScriptToken],
+      accum: ArrayBuffer[ScriptToken],
       tail: ByteVector): ParsingHelper = {
     op match {
       case bytesToPushOntoStack: BytesToPushOntoStack =>
@@ -255,7 +256,7 @@ sealed abstract class ScriptParser
     */
   private def parseOpPushData(
       op: ScriptOperation,
-      accum: Vector[ScriptToken],
+      accum: ArrayBuffer[ScriptToken],
       tail: ByteVector): ParsingHelper = {
 
     def parseOpPushDataHelper(numBytes: Int): ParsingHelper = {
@@ -314,7 +315,7 @@ sealed abstract class ScriptParser
       bytesToPushOntoStack: ScriptConstant,
       scriptConstant: ScriptConstant,
       restOfBytes: ByteVector,
-      accum: Vector[ScriptToken]): ParsingHelper = {
+      accum: ArrayBuffer[ScriptToken]): ParsingHelper = {
     if (bytesToPushOntoStack.hex == "00") {
       // if we need to push 0 bytes onto the stack we do not add the script constant
       ParsingHelper(restOfBytes, bytesToPushOntoStack +: op +: accum)

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -231,15 +231,14 @@ sealed abstract class ScriptParser
         // means that we need to push x amount of bytes on to the stack
         val (constant, newTail) = sliceConstant(bytesToPushOntoStack, tail)
         val scriptConstant = ScriptConstant(constant)
-        ParsingHelper(
-          newTail,
-          accum.appendedAll(Vector(bytesToPushOntoStack, scriptConstant)))
+        ParsingHelper(newTail,
+                      accum.++=(Vector(bytesToPushOntoStack, scriptConstant)))
       case OP_PUSHDATA1 => parseOpPushData(op, accum, tail)
       case OP_PUSHDATA2 => parseOpPushData(op, accum, tail)
       case OP_PUSHDATA4 => parseOpPushData(op, accum, tail)
       case _            =>
         // means that we need to push the operation onto the stack
-        ParsingHelper(tail, accum.appended(op))
+        ParsingHelper(tail, accum.+=(op))
     }
   }
 
@@ -318,12 +317,10 @@ sealed abstract class ScriptParser
       accum: ArrayBuffer[ScriptToken]): ParsingHelper = {
     if (bytesToPushOntoStack.hex == "00") {
       // if we need to push 0 bytes onto the stack we do not add the script constant
-      ParsingHelper(restOfBytes,
-                    accum.appendedAll(Vector(op, bytesToPushOntoStack)))
+      ParsingHelper(restOfBytes, accum.++=(Vector(op, bytesToPushOntoStack)))
     } else
-      ParsingHelper(
-        restOfBytes,
-        accum.appendedAll(Vector(op, bytesToPushOntoStack, scriptConstant)))
+      ParsingHelper(restOfBytes,
+                    accum.++=(Vector(op, bytesToPushOntoStack, scriptConstant)))
   }
 
   /** Checks if a string can be cast to an int */


### PR DESCRIPTION
This avoids Array copies which ends up being a performance bottleneck when parsing Scripts