### PR TITLE
core: Tighten `MultiSignatureScriptPubKey.isValidAsm()` check

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -255,7 +255,7 @@ object MultiSignatureScriptPubKey
   /** Determines if the given script tokens are a multisignature `scriptPubKey`
     */
   override def isValidAsm(asm: Seq[ScriptToken]): Boolean = {
-    if (asm.nonEmpty && opCmsOPs.exists(_ == asm.last)) {
+    if (asm.length > 2 && opCmsOPs.exists(_ == asm.last)) {
       val cmsIdx = asm.size - 1
       // we need either the first or second asm operation to indicate how many signatures are required
       val hasRequiredSignaturesOpt: Option[Int] = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -245,7 +245,7 @@ object MultiSignatureScriptPubKey
   def fromAsm(asm: Seq[ScriptToken]): MultiSignatureScriptPubKey = {
     buildScript(asm.toVector,
                 MultiSignatureScriptPubKeyImpl.apply,
-                "Given asm was not a MultSignatureScriptPubKey, got: " + asm)
+                s"Given asm was not a MultSignatureScriptPubKey, got: $asm")
   }
 
   def apply(asm: Seq[ScriptToken]): MultiSignatureScriptPubKey = fromAsm(asm)


### PR DESCRIPTION
<required_sigs> <max_sigs> OP_CHECMULTISIG{VERIFY}

This should allow us to fail faster if a Script is not a multisig script.