### PR TITLE
bitcoindRpc: Make 'gettxout' RPC handle null return correctly

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
@@ -363,6 +363,12 @@ object JsonSerializers {
   implicit val getTxOutResultV22Reads: Reads[GetTxOutResultV22] =
     Json.reads[GetTxOutResultV22]
 
+  implicit val getTxOutResultV22OptReads: Reads[Option[GetTxOutResultV22]] = {
+    case JsNull => JsSuccess(None) // Handle null case
+    case json: JsValue =>
+      getTxOutResultV22Reads.reads(json).map(Some(_)) // Handle valid object
+  }
+
   implicit val getTxOutSetInfoResultReads: Reads[GetTxOutSetInfoResult] =
     Json.reads[GetTxOutSetInfoResult]
 

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/UTXORpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/UTXORpcTest.scala
@@ -56,16 +56,16 @@ class UTXORpcTest extends BitcoindFixturesFundedCachedNewest {
     for {
       block <- BitcoindRpcTestUtil.getFirstBlock(client)
       info1 <- client.getTxOut(block.tx.head.txid, 0)
-    } yield assert(info1.coinbase)
+    } yield {
+      assert(info1.isDefined)
+      assert(info1.get.coinbase)
+    }
   }
 
   it should "be able to fail to get utxo info" in { case client =>
     for {
-      block <- BitcoindRpcTestUtil.getFirstBlock(client)
-      info1 <- client.getTxOutOpt(block.tx.head.txid, 0)
-      info2 <- client.getTxOutOpt(DoubleSha256DigestBE.empty, 0)
+      info2 <- client.getTxOut(DoubleSha256DigestBE.empty, 0)
     } yield {
-      assert(info1.exists(_.coinbase))
       assert(info2.isEmpty)
     }
   }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/TransactionRpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/TransactionRpc.scala
@@ -98,24 +98,11 @@ trait TransactionRpc { self: Client =>
       txid: DoubleSha256DigestBE,
       vout: Long,
       includeMemPool: Boolean = true
-  ): Future[GetTxOutResult] = {
-    bitcoindCall[GetTxOutResultV22](
-      "gettxout",
-      List(JsString(txid.hex), JsNumber(vout), JsBoolean(includeMemPool))
-    )
-  }
-
-  def getTxOutOpt(
-      txid: DoubleSha256DigestBE,
-      vout: Long,
-      includeMemPool: Boolean = true
   ): Future[Option[GetTxOutResult]] = {
-    bitcoindCall[GetTxOutResultV22](
+    bitcoindCall[Option[GetTxOutResultV22]](
       "gettxout",
       List(JsString(txid.hex), JsNumber(vout), JsBoolean(includeMemPool))
     )
-      .map(Some(_))
-      .recover(_ => None)
   }
 
   private def getTxOutProof(


### PR DESCRIPTION
`gettxout` returns null in the case that a utxo doesnt exist. This can be because it was spent, or it was never created. This PR handles this case correctly rather than having the workaround in #4797 that produces noisy logs 