### PR TITLE
core: Add carveout for parsing 'nonstandard' string to ScriptType.NONSTANDARD

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/script/ScriptTypeTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/ScriptTypeTest.scala
@@ -11,6 +11,8 @@ class ScriptTypeTest extends BitcoinSUnitTest {
 
       assert(newScriptType.contains(scriptType))
     }
+
+    assert(ScriptType.fromString("nonstandard") == ScriptType.NONSTANDARD)
   }
 
   it must "fail when nonsense ScriptType is used" in {

--- a/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
+++ b/core/src/main/scala/org/bitcoins/core/number/NumberType.scala
@@ -550,14 +550,14 @@ object Int64
             s"Cannot create ${super.getClass.getSimpleName} from $underlying")
   }
 
-  lazy val zero = checkCached(0)
-  lazy val one = checkCached(1)
+  lazy val zero: Int64 = checkCached(0)
+  lazy val one: Int64 = checkCached(1)
 
   private lazy val minUnderlying: A = -9223372036854775808L
   private lazy val maxUnderlying: A = 9223372036854775807L
 
-  lazy val min = Int64(minUnderlying)
-  lazy val max = Int64(maxUnderlying)
+  lazy val min: Int64 = Int64(minUnderlying)
+  lazy val max: Int64 = Int64(maxUnderlying)
 
   final override def fromNativeNumber(long: Long): Int64 = {
     Int64Impl(long)

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1486,8 +1486,8 @@ object TaprootScriptPubKey extends ScriptFactory[TaprootScriptPubKey] {
     val asmBytes = BytesUtil.toByteVector(asm)
     asm.length == 3 &&
     asm.headOption.contains(OP_1) &&
-    WitnessScriptPubKey.isValidAsm(asm) &&
     asmBytes.size == 34 &&
+    WitnessScriptPubKey.isValidAsm(asm) &&
     // have to make sure we have a valid xonly pubkey, not just 32 bytes
     XOnlyPubKey.fromBytesT(asm(2).bytes).isSuccess
   }

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptType.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptType.scala
@@ -66,7 +66,12 @@ object ScriptType extends StringFactory[ScriptType] {
   )
 
   override def fromStringOpt(string: String): Option[ScriptType] =
-    all.find(_.toString == string)
+    all.find(_.toString.toLowerCase == string.toLowerCase) match {
+      case Some(x) => Some(x)
+      case None =>
+        if (string.toLowerCase == "nonstandard") Some(NONSTANDARD)
+        else None
+    }
 
   /** Throws if given string is invalid */
   override def fromString(string: String): ScriptType =

--- a/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/Constants.scala
@@ -427,6 +427,8 @@ object ScriptConstant extends Factory[ScriptConstant] {
 
   /** Represent a public key or hash of a public key on our stack. */
   private case class ScriptConstantImpl(bytes: ByteVector)
-      extends ScriptConstant
+      extends ScriptConstant {
+    override def toString: String = bytes.toHex
+  }
 
 }

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala
@@ -167,7 +167,6 @@ sealed abstract class ScriptParser
       }
     }
     loop(bytes).toVector
-
   }
 
   /** Parses a redeem script from the given script token */
@@ -238,6 +237,7 @@ sealed abstract class ScriptParser
 
   /** Parses OP_PUSHDATA operations correctly. Slices the appropriate amount of
     * bytes off of the tail and pushes them onto the accumulator.
+    *
     * @param op
     *   the script operation that is being parsed, this should be OP_PUSHDATA1,
     *   OP_PUSHDATA2, OP_PUSHDATA4 or else it throws an exception
@@ -317,7 +317,6 @@ sealed abstract class ScriptParser
       accum.++=(ArrayBuffer(op, bytesToPushOntoStack, scriptConstant))
       restOfBytes
     }
-
   }
 
   /** Checks if a string can be cast to an int */

--- a/core/src/main/scala/org/bitcoins/core/util/Base58.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/Base58.scala
@@ -5,7 +5,6 @@ import org.bitcoins.core.protocol.blockchain._
 import org.bitcoins.crypto.CryptoUtil
 import scodec.bits.ByteVector
 
-import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
 /** Created by chris on 5/16/16. source of values:
@@ -43,24 +42,7 @@ sealed abstract class Base58 {
     * [[org.bitcoins.core.protocol.blockchain.Base58Type Base58Type]] string.
     */
   def encode(bytes: ByteVector): String = {
-    val ones: String = bytes.toSeq.takeWhile(_ == 0).map(_ => '1').mkString
-    @tailrec
-    def loop(current: BigInt, str: String): String =
-      current match {
-        case _ if current == BigInt(0) =>
-          ones + str.reverse
-        case _: BigInt =>
-          val quotient: BigInt = current / BigInt(58L)
-          val remainder: BigInt = current.mod(58L)
-          val char = base58Characters.charAt(remainder.toInt).toString
-          val accum = str + char
-          loop(quotient, accum)
-      }
-    if (bytes.isEmpty) ""
-    else {
-      val big: BigInt = BigInt(1, bytes.toArray)
-      loop(big, "")
-    }
+    bytes.toBase58
   }
 
   /** Encodes a hex string to its


### PR DESCRIPTION
In #5525 we changed the serialization of `ScriptType.NONSTANDARD` from `nonstandard` -> `raw` to suppport [BIP385](https://github.com/bitcoin/bips/blob/master/bip-0385.mediawiki).

Unfortunately some bitcoin core RPCs -- such as `gettxout` --  return `nonstandard` rather than `raw` as the script type. This PR adds support for deserializing `nonstandard` to `ScriptType.NONSTANDARD`