### PR TITLE
core: Fix bug when converting `OP_0` to Long

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/script/constant/ScriptNumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/constant/ScriptNumberUtil.scala
@@ -54,7 +54,10 @@ trait ScriptNumberUtil {
     */
   def toLong(bytes: ByteVector): Long = {
     val reversedBytes = bytes.reverse
-    if (bytes.size == 1 && bytes.head == -128) {
+
+    if (bytes.isEmpty) {
+      0
+    } else if (bytes.size == 1 && bytes.head == -128) {
       // the case for negative zero
       0
     } else if (isPositive(bytes)) {


### PR DESCRIPTION
`OP_0` is an empty byte vector on the stack. Previously we would throw an `OutOfBoundsException` when calling `ScriptNumberUtil.toLong()` on the empty byte vector