### PR TITLE
core: Add `TaprootWitness.sigVersion`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
@@ -450,8 +450,8 @@ case class TaprootTxSigComponent(
 
   override def sigVersion: SigVersionTaproot = {
     witness match {
-      case _: TaprootKeyPath => SigVersionTaprootKeySpend
-      case _: TaprootScriptPath | _: TaprootUnknownPath => SigVersionTapscript
+      case _: TaprootKeyPath  => SigVersionTaprootKeySpend
+      case sp: TaprootWitness => sp.sigVersion
     }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
@@ -448,12 +448,8 @@ case class TaprootTxSigComponent(
 
   override val witnessVersion: WitnessVersion1.type = WitnessVersion1
 
-  override def sigVersion: SigVersionTaproot = {
-    witness match {
-      case _: TaprootKeyPath  => SigVersionTaprootKeySpend
-      case sp: TaprootWitness => sp.sigVersion
-    }
-  }
+  override def sigVersion: SigVersionTaproot = witness.sigVersion
+
 }
 
 object BaseTxSigComponent {

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptWitness.scala
@@ -281,7 +281,8 @@ case class TaprootKeyPath(
     }
   }
 
-  override def sigVersion: SigVersionTaproot = SigVersionTaprootKeySpend
+  override def sigVersion: SigVersionTaprootKeySpend.type =
+    SigVersionTaprootKeySpend
 }
 
 object TaprootKeyPath extends Factory[TaprootKeyPath] {
@@ -409,7 +410,7 @@ case class TaprootScriptPath(stack: Vector[ByteVector]) extends TaprootWitness {
 
   def leafVersion: LeafVersion = controlBlock.leafVersion
 
-  def sigVersion: SigVersionTaproot = leafVersion match {
+  override def sigVersion: SigVersionTapscript.type = leafVersion match {
     case LeafVersion.Tapscript => SigVersionTapscript
     case UnknownLeafVersion(toByte) =>
       sys.error(s"Unknown leaf version=$toByte, cannot determine sigVersion")


### PR DESCRIPTION
This can be determined off of the `TaprootWitness` type. This avoids us having to pattern match elsewhere in the codebase.