### PR TITLE
core: Fix `TapscriptControlBlock` bugs

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/TaprootWitnessTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/TaprootWitnessTest.scala
@@ -142,6 +142,7 @@ class TaprootWitnessTest extends BitcoinSUnitTest {
   it must "have a correct constructor" in {
     val x = TapscriptControlBlock.apply(controlBlock.leafVersion,
                                         controlBlock.p,
+                                        controlBlock.parity,
                                         leafHashes = controlBlock.hashes)
     assert(x.bytes.toHex == controlBlock.bytes.toHex)
     assert(x == controlBlock)

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
@@ -39,8 +39,10 @@ case class TapscriptControlBlock(bytes: ByteVector) extends ControlBlock {
   require(TapscriptControlBlock.isValid(bytes),
           s"Invalid tapscript control block, got=$bytes")
 
-  def parity: KeyParity = if ((bytes.head & 1) == 1) { OddParity }
-  else EvenParity
+  def parity: KeyParity = {
+    if ((bytes.head & 1) == 1) OddParity
+    else EvenParity
+  }
 }
 
 /** A control block that does not have a leaf version defined as per BIP342 This

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ControlBlock.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.protocol.script
 
-import org.bitcoins.crypto.{Factory, NetworkElement, Sha256Digest, XOnlyPubKey}
+import org.bitcoins.crypto.*
 import scodec.bits.ByteVector
 
 /** Control block as defined by BIP341
@@ -38,6 +38,9 @@ sealed abstract class ControlBlock extends NetworkElement {
 case class TapscriptControlBlock(bytes: ByteVector) extends ControlBlock {
   require(TapscriptControlBlock.isValid(bytes),
           s"Invalid tapscript control block, got=$bytes")
+
+  def parity: KeyParity = if ((bytes.head & 1) == 1) { OddParity }
+  else EvenParity
 }
 
 /** A control block that does not have a leaf version defined as per BIP342 This
@@ -87,21 +90,31 @@ object TapscriptControlBlock extends Factory[TapscriptControlBlock] {
     new TapscriptControlBlock(bytes)
   }
 
-  def fromLeaves(
-      leafVersion: LeafVersion,
-      internalKey: XOnlyPubKey,
-      leafs: Vector[TapLeaf]): TapscriptControlBlock = {
-    TapscriptControlBlock(leafVersion, internalKey, leafs.map(_.sha256))
-  }
-
   def apply(
       leafVersion: LeafVersion,
       internalKey: XOnlyPubKey,
+      parity: KeyParity,
       leafHashes: Vector[Sha256Digest]): TapscriptControlBlock = {
+    val parityByte: Byte = parity match {
+      case OddParity  => 0x01
+      case EvenParity => 0x0
+    }
     val bytes =
-      ((leafVersion.toByte | 0x1).toByte +: internalKey.bytes) ++ ByteVector
+      ((parityByte | leafVersion.toByte).toByte +: internalKey.bytes) ++ ByteVector
         .concat(leafHashes.map(_.bytes))
     TapscriptControlBlock(bytes)
+  }
+
+  /** Constructs a tapscript control block for the case where we have one single
+    * [[TapLeaf]] in the entire tree In this case, we don't have any elements in
+    * the control block besides the internal key, leaf version and parity of the
+    * output xonly pubkey
+    */
+  def fromSingleLeaf(
+      leafVersion: LeafVersion,
+      internalKey: XOnlyPubKey,
+      parity: KeyParity): TapscriptControlBlock = {
+    TapscriptControlBlock(leafVersion, internalKey, parity, Vector.empty)
   }
 }
 

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/TransactionTestUtil.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/TransactionTestUtil.scala
@@ -6,17 +6,11 @@ import org.bitcoins.core.currency.{Bitcoins, CurrencyUnit, CurrencyUnits}
 import org.bitcoins.core.hd.{HDChainType, HDCoinType, SegWitHDPath}
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.Bech32mAddress
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.utxo.TxoState
-import org.bitcoins.crypto.{
-  DoubleSha256Digest,
-  DoubleSha256DigestBE,
-  ECPrivateKey,
-  ECPublicKey,
-  ECPublicKeyBytes
-}
+import org.bitcoins.crypto.*
 
 /** Created by chris on 2/12/16.
   */
@@ -256,6 +250,16 @@ trait TransactionTestUtil {
       Vector.empty,
       EmptyTransaction.lockTime
     )
+
+  def testWitnessTransaction: WitnessTransaction = {
+    WitnessTransaction(
+      EmptyTransaction.version,
+      Vector(EmptyTransactionInput),
+      Vector.empty,
+      EmptyTransaction.lockTime,
+      EmptyWitness.fromN(1)
+    )
+  }
 
   /** Builds a dummy transaction that sends money to the given output */
   def buildTransactionTo(output: TransactionOutput): Transaction = {


### PR DESCRIPTION
In #5951 weren't properly constructing the TapscriptControlBlock _merkle path_, rather we were just taking the hash of all the leaves in the `TapscriptTree` which is not how tapscript works.

This PR also now correctly encodes the key parity of the the output public key `TapscriptControlBlock`. This was previously incorrectly handled in #5951 #4394 #5520

This PR doesn't add any builders to create a `TapscriptControlBlock` other than a utility method called `TapscriptControlBlock.fromSingleLeaf()` that will create a correct `TapscriptControlBlock` in the case where the `TapscriptTree` has one single `TapLeaf` in the entire tree.