### PR TITLE
refactor: Rename `TxSigComponent.output` -> `TxSigComponent.fundingOutput`

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
@@ -3,14 +3,14 @@ package org.bitcoins.core.crypto
 import org.bitcoins.core.currency.{Bitcoins, CurrencyUnits, Satoshis}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.serializers.script.ScriptParser
-import org.bitcoins.core.util._
+import org.bitcoins.core.util.*
 import org.bitcoins.core.wallet.builder.StandardNonInteractiveFinalizer
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
-import org.bitcoins.crypto._
+import org.bitcoins.crypto.*
 import org.bitcoins.testkitcore.gen.{CreditingTxGen, ScriptGenerators}
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
@@ -618,7 +618,7 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
               val oldScript =
                 BitcoinScriptUtil.calculateScriptForSigning(
                   txSigComponent,
-                  txSigComponent.output.scriptPubKey.asm
+                  txSigComponent.fundingOutput.scriptPubKey.asm
                 )
 
               val newScript =

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -1,26 +1,13 @@
 package org.bitcoins.core.crypto
 
 import org.bitcoins.core.policy.Policy
-import org.bitcoins.core.protocol.script.{
-  ScriptPubKey,
-  SigVersionBase,
-  SigVersionTaprootKeySpend,
-  SigVersionTapscript,
-  SigVersionWitnessV0,
-  TaprootKeyPath
-}
+import org.bitcoins.core.protocol.script.*
 import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.script.flag.{ScriptFlag, ScriptFlagUtil}
-import org.bitcoins.core.script.result.{
-  ScriptErrorSchnorrSig,
-  ScriptErrorSchnorrSigHashType,
-  ScriptErrorWitnessPubKeyType,
-  ScriptOk,
-  ScriptResult
-}
+import org.bitcoins.core.script.result.*
 import org.bitcoins.core.util.BitcoinScriptUtil
-import org.bitcoins.crypto._
+import org.bitcoins.crypto.*
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
@@ -35,7 +22,8 @@ trait TransactionSignatureChecker {
       pubKeyBytes: ECPublicKeyBytes,
       signature: ECDigitalSignature): TransactionSignatureCheckerResult =
     checkSignature(txSignatureComponent = txSignatureComponent,
-                   script = txSignatureComponent.output.scriptPubKey.asm.toList,
+                   script =
+                     txSignatureComponent.fundingOutput.scriptPubKey.asm.toList,
                    pubKey = pubKeyBytes,
                    signature = signature)
 
@@ -45,7 +33,7 @@ trait TransactionSignatureChecker {
       signature: ECDigitalSignature): TransactionSignatureCheckerResult = {
     checkSignature(
       txSignatureComponent = txSignatureComponent,
-      script = txSignatureComponent.output.scriptPubKey.asm.toList,
+      script = txSignatureComponent.fundingOutput.scriptPubKey.asm.toList,
       pubKey = pubKey.toPublicKeyBytes(),
       signature = signature
     )
@@ -179,7 +167,7 @@ trait TransactionSignatureChecker {
               val sigsRemovedTxSigComponent = BaseTxSigComponent(
                 b.transaction,
                 b.inputIndex,
-                TransactionOutput(b.output.value, spk),
+                TransactionOutput(b.fundingOutput.value, spk),
                 b.flags)
               TransactionSignatureSerializer.hashForSignature(
                 sigsRemovedTxSigComponent,
@@ -189,7 +177,7 @@ trait TransactionSignatureChecker {
               val sigsRemovedTxSigComponent = WitnessTxSigComponentRebuilt(
                 wtx = r.transaction,
                 inputIndex = r.inputIndex,
-                output = TransactionOutput(r.output.value, spk),
+                output = TransactionOutput(r.fundingOutput.value, spk),
                 witScriptPubKey = r.witnessScriptPubKey,
                 flags = r.flags)
               TransactionSignatureSerializer.hashForSignature(

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -40,7 +40,7 @@ sealed abstract class TransactionSignatureSerializer {
       taprootOptions: TaprootSerializationOptions): ByteVector = {
     val spendingTransaction = txSigComponent.transaction
     val inputIndex = txSigComponent.inputIndex
-    val output = txSigComponent.output
+    val output = txSigComponent.fundingOutput
     val script = BitcoinScriptUtil.calculateScriptForSigning(
       txSigComponent,
       output.scriptPubKey.asm)
@@ -59,7 +59,7 @@ sealed abstract class TransactionSignatureSerializer {
         serializeForSignature(spendingTransaction,
                               inputIndex,
                               hashType,
-                              t.outputs,
+                              t.fundingOutputs,
                               script,
                               txSigComponent.sigVersion,
                               taprootOptions)

--- a/core/src/main/scala/org/bitcoins/core/protocol/dlc/verify/DLCSignatureVerifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/dlc/verify/DLCSignatureVerifier.scala
@@ -133,7 +133,7 @@ object DLCSignatureVerifier {
     TransactionSignatureChecker
       .checkSignature(
         sigComponent,
-        sigComponent.output.scriptPubKey.asm.toVector,
+        sigComponent.fundingOutput.scriptPubKey.asm.toVector,
         refundSig.pubKey,
         refundSig.signature,
         Policy.standardFlags

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -1,31 +1,31 @@
 package org.bitcoins.core.script.interpreter
 
 import org.bitcoins.core.consensus.Consensus
-import org.bitcoins.core.crypto._
+import org.bitcoins.core.crypto.*
 import org.bitcoins.core.currency.{CurrencyUnit, CurrencyUnits}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction._
-import org.bitcoins.core.script._
-import org.bitcoins.core.script.arithmetic._
-import org.bitcoins.core.script.bitwise._
-import org.bitcoins.core.script.constant._
-import org.bitcoins.core.script.control._
-import org.bitcoins.core.script.crypto._
-import org.bitcoins.core.script.flag._
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
+import org.bitcoins.core.script.*
+import org.bitcoins.core.script.arithmetic.*
+import org.bitcoins.core.script.bitwise.*
+import org.bitcoins.core.script.constant.*
+import org.bitcoins.core.script.control.*
+import org.bitcoins.core.script.crypto.*
+import org.bitcoins.core.script.flag.*
 import org.bitcoins.core.script.locktime.{
   LockTimeInterpreter,
   OP_CHECKLOCKTIMEVERIFY,
   OP_CHECKSEQUENCEVERIFY
 }
-import org.bitcoins.core.script.reserved._
-import org.bitcoins.core.script.result._
-import org.bitcoins.core.script.splice._
-import org.bitcoins.core.script.stack._
+import org.bitcoins.core.script.reserved.*
+import org.bitcoins.core.script.result.*
+import org.bitcoins.core.script.splice.*
+import org.bitcoins.core.script.stack.*
 import org.bitcoins.core.script.util.PreviousOutputMap
-import org.bitcoins.core.util._
+import org.bitcoins.core.util.*
 import org.bitcoins.crypto.SchnorrPublicKey
 
 import scala.annotation.tailrec
@@ -1461,7 +1461,8 @@ sealed abstract class ScriptInterpreter {
   private def rebuildWTxSigComponent(
       old: WitnessTxSigComponent,
       rebuildScriptPubKey: ScriptPubKey): Try[WitnessTxSigComponentRebuilt] = {
-    val updatedOutput = TransactionOutput(old.output.value, rebuildScriptPubKey)
+    val updatedOutput =
+      TransactionOutput(old.fundingOutput.value, rebuildScriptPubKey)
     old match {
       case wTxSigComponentRaw: WitnessTxSigComponentRaw =>
         Success(
@@ -1474,7 +1475,7 @@ sealed abstract class ScriptInterpreter {
         wTxSigComponentP2SH.witnessScriptPubKey.map {
           (wit: WitnessScriptPubKey) =>
             val updatedOutput =
-              TransactionOutput(old.output.value, rebuildScriptPubKey)
+              TransactionOutput(old.fundingOutput.value, rebuildScriptPubKey)
             WitnessTxSigComponentRebuilt(old.transaction,
                                          old.inputIndex,
                                          updatedOutput,

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/WitnessGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/WitnessGenerators.scala
@@ -1,11 +1,11 @@
 package org.bitcoins.testkitcore.gen
 
-import org.bitcoins.core.crypto._
+import org.bitcoins.core.crypto.*
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
-import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.crypto.{ECPrivateKey, HashType}
 import org.scalacheck.Gen
@@ -144,7 +144,7 @@ sealed abstract class WitnessGenerators {
         txWitness
       )
       signedWtxSigComponent =
-        WitnessTxSigComponentRaw(wtx, u.inputIndex, u.output, u.flags)
+        WitnessTxSigComponentRaw(wtx, u.inputIndex, u.fundingOutput, u.flags)
     } yield (txWitness, signedWtxSigComponent, Seq(privKeys))
 
   def signedP2WSHP2PKHTransactionWitness
@@ -179,7 +179,7 @@ sealed abstract class WitnessGenerators {
         txWitness
       )
       signedWtxSigComponent =
-        WitnessTxSigComponentRaw(wtx, u.inputIndex, u.output, u.flags)
+        WitnessTxSigComponentRaw(wtx, u.inputIndex, u.fundingOutput, u.flags)
     } yield (txWitness, signedWtxSigComponent, Seq(privKey))
 
   def signedP2WSHMultiSigTransactionWitness
@@ -212,7 +212,7 @@ sealed abstract class WitnessGenerators {
         txWitness
       )
       signedWtxSigComponent =
-        WitnessTxSigComponentRaw(wtx, u.inputIndex, u.output, u.flags)
+        WitnessTxSigComponentRaw(wtx, u.inputIndex, u.fundingOutput, u.flags)
     } yield (txWitness, signedWtxSigComponent, privKeys)
 
   /** Generates a random signed
@@ -295,7 +295,7 @@ sealed abstract class WitnessGenerators {
         WitnessTxSigComponent(
           signedSpendingTx,
           unsignedWTxComponent.inputIndex,
-          wtxP2SH.output,
+          wtxP2SH.fundingOutput,
           PreviousOutputMap.empty,
           unsignedWTxComponent.flags
         )
@@ -303,7 +303,7 @@ sealed abstract class WitnessGenerators {
         WitnessTxSigComponent(
           signedSpendingTx,
           unsignedWTxComponent.inputIndex,
-          wtxRaw.output,
+          wtxRaw.fundingOutput,
           PreviousOutputMap.empty,
           unsignedWTxComponent.flags
         )


### PR DESCRIPTION
Disambiguates the name