### PR TITLE
2025 03 15 Remove `data.length == 32` requirement from secp256k1jni

### DIFF
--- a/secp256k1jni/src/main/java/org/bitcoin/NativeSecp256k1.java
+++ b/secp256k1jni/src/main/java/org/bitcoin/NativeSecp256k1.java
@@ -17,13 +17,13 @@
 
 package org.bitcoin;
 
+import java.math.BigInteger;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-
-import java.math.BigInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import static org.bitcoin.NativeSecp256k1Util.*;
 
 /**
@@ -571,7 +571,7 @@ public class NativeSecp256k1 {
      * @param secKey key to sign with
      */
     public static byte[] schnorrSign(byte[] data, byte[] secKey, byte[] auxRand) throws AssertFailException {
-        checkArgument(data.length == 32 && secKey.length == 32 && auxRand.length == 32);
+        checkArgument(secKey.length == 32 && auxRand.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < 32 + 32 + 32) {
@@ -608,7 +608,7 @@ public class NativeSecp256k1 {
      * @param nonce the nonce (k value) used in signing
      */
     public static byte[] schnorrSignWithNonce(byte[] data, byte[] secKey, byte[] nonce) throws AssertFailException {
-        checkArgument(data.length == 32 && secKey.length == 32 && nonce.length == 32);
+        checkArgument(secKey.length == 32 && nonce.length == 32);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
         if (byteBuff == null || byteBuff.capacity() < 32 + 32 + 32) {

--- a/secp256k1jni/src/main/java/org/bitcoin/NativeSecp256k1.java
+++ b/secp256k1jni/src/main/java/org/bitcoin/NativeSecp256k1.java
@@ -679,7 +679,7 @@ public class NativeSecp256k1 {
      * @param pubx the key that did the signing
      */
     public static boolean schnorrVerify(byte[] sig, byte[] data, byte[] pubx) throws AssertFailException {
-        checkArgument(sig.length == 64 && data.length == 32 && pubx.length == 32);
+        checkArgument(sig.length == 64 && pubx.length == 32);
 
         ByteBuffer byteBuffer = nativeECDSABuffer.get();
         if (byteBuffer == null || byteBuffer.capacity() < 64 + 32 + 32) {


### PR DESCRIPTION
fixes #5436 

@nau I could have swore at some point that BIP340 stated that the data length must be 32 bytes, but either I imagined that or it was removed from the spec. I'm too lazy to do the git history to find out if it existed at any point.

Also I thought I tried this before and ran into testing issues, we will see if CI finds any failed tests.

Sorry for the delay on this, my bad.
