### PR TITLE
Rework `ScanBitcoind` to take a `Sink` to send data to

### DIFF
--- a/app/scripts/src/main/scala/org/bitcoins/scripts/CheckHASH256.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/CheckHASH256.scala
@@ -1,0 +1,79 @@
+package org.bitcoins.scripts
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.bitcoins.core.util.{FutureUtil, NumberUtil}
+import org.bitcoins.crypto.{CryptoUtil, DoubleSha256Digest, Sha256Digest}
+import org.bitcoins.scripts.GenP2SH.getIter
+import org.bitcoins.server.routes.BitcoinSRunner
+import org.bitcoins.server.util.BitcoinSAppScalaDaemon
+import scodec.bits.ByteVector
+
+import java.time.{Duration, Instant}
+import scala.concurrent.Future
+
+class CheckHASH256(implicit
+    override val system: ActorSystem
+) extends BitcoinSRunner[Unit] {
+
+  private val hash256s = Vector(
+    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+    "3036419579d0abe63b46836a74380f1e2fd4a1e89f3aad616b171ddcdcbede43").map(
+    DoubleSha256Digest.apply)
+  private val sha256s = Vector(
+    "5efe500c58a4847dab87162f88a79f08249b988265d5061696b5d0c94fd8080d",
+    "3f6d4081222a35483cdf4cefd128167f133c33e1e0f0b1d638be131a14dc2c5e").map(
+    Sha256Digest.apply)
+  override def start(): Future[Unit] = {
+    val startTime = Instant.now()
+    val start = 0L
+    val resultF: Future[Seq[(Long, Int, Sha256Digest, DoubleSha256Digest)]] = {
+      Source
+        .fromIterator(() => getIter(start))
+        .mapAsync(FutureUtil.getParallelism) { case (i, byteSize) =>
+          Future {
+            val max = NumberUtil.pow2(8 * 3)
+            val percentage = ((i.toDouble - start) / max.toDouble) * 100
+            if (i % 1_000_000 == 0) {
+              logger.info(
+                s"Generated $i hashes" + f"$percentage%.2f" + s" % time=${Duration
+                    .between(startTime, Instant.now())}")
+            }
+            val bytes = ByteVector.fromLong(i, size = byteSize)
+            val sha256 = CryptoUtil.sha256(bytes)
+            val hash256 = CryptoUtil.doubleSHA256(bytes)
+            (i, byteSize, sha256, hash256)
+          }
+        }
+        .filter { case (_, _, sha256, hash256) =>
+          hash256s.contains(hash256) || sha256s.contains(sha256)
+        }
+        .toMat(Sink.seq)(Keep.right)
+        .run()
+    }
+
+    resultF.failed.foreach { err =>
+      logger.error(s"exn", err)
+    }
+    resultF.map { result =>
+      logger.info(
+        s"Done searching, it took=${Duration.between(startTime, Instant.now())}")
+      result.foreach { r =>
+        logger.info(s"Found hash! $r")
+      }
+      ()
+    }
+  }
+  override def stop(): Future[Unit] = {
+    system.terminate().map(_ => ())
+  }
+}
+
+object CheckHASH256 extends BitcoinSAppScalaDaemon {
+  override val actorSystemName: String =
+    s"check-hash256-${System.currentTimeMillis()}"
+
+  override val customFinalDirOpt = None
+
+  new CheckHASH256().run()
+}

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/CheckP2SH.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/CheckP2SH.scala
@@ -1,0 +1,123 @@
+package org.bitcoins.scripts
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.{IOResult, OverflowStrategy}
+import org.apache.pekko.stream.scaladsl.{FileIO, Framing, Keep, Sink, Source}
+import org.apache.pekko.util.ByteString
+import org.bitcoins.commons.jsonmodels.bitcoind.{
+  RpcOpts,
+  ScanTxoutSetRequest,
+  ScanTxoutSetResult
+}
+import org.bitcoins.core.protocol.script.descriptor.{
+  AddressDescriptor,
+  Descriptor
+}
+import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.rpc.config.BitcoindRpcAppConfig
+import org.bitcoins.server.routes.BitcoinSRunner
+import org.bitcoins.server.util.BitcoinSAppScalaDaemon
+import play.api.libs.json.Json
+
+import java.nio.file.{Files, Path, Paths}
+import java.time.{Duration, Instant}
+import scala.concurrent.{ExecutionContext, Future}
+
+case class CheckP2SH()(implicit
+    override val system: ActorSystem,
+    rpcAppConfig: BitcoindRpcAppConfig
+) extends BitcoinSRunner[Unit] {
+  private val bitcoindF = rpcAppConfig.clientF
+
+  val filePath: Path = Paths.get("p2sh-7.json")
+  val lineCount = Files.lines(filePath).count() // Uses Java Streams API
+  override def start(): Future[Unit] = {
+    val start = Instant.now()
+    val grouping = 645_000
+    val drop = 230_265_000
+    var count = drop
+    val fmt = { combo: Combo => AddressDescriptor(combo.bitcoinAddress) }
+
+    val parallelism = 1
+    val source =
+      CheckP2SH.getP2SHSource(filePath, fmt, grouping, drop, parallelism)
+    val resultF: Future[Seq[ScanTxoutSetResult]] = source
+      .mapAsync(parallelism) { descs: Vector[Descriptor] =>
+        val batchStart = Instant.now()
+        val req = ScanTxoutSetRequest(action = RpcOpts.ScanBlocksOpt.Start,
+                                      descs = descs)
+        count += descs.length
+        val percent = (count.toDouble / lineCount) * 100.0
+        val totalTime = Duration.between(start, Instant.now())
+        logger.info(
+          s"Searching $count addresses " + f"$percent%.2f" + s"% total time=$totalTime")
+        bitcoindF.flatMap(_.scanTxoutSet(req)).map { result =>
+          val secs = Duration.between(batchStart, Instant.now).getSeconds
+          logger.info(s"result=$result it took ${secs}secs")
+          result
+        }
+      }
+      .filter(_.txouts > 0)
+      .toMat(Sink.seq)(Keep.right)
+      .run()
+
+    resultF.map { results =>
+      logger.info(
+        s"Done scanning p2sh, found ${results.length} relevant blocks, it took ${Duration
+            .between(start, Instant.now())}minutes")
+
+      results.foreach(r => logger.info(s"r=$r"))
+      ()
+    }
+  }
+
+  override def stop(): Future[Unit] = {
+    system.terminate().map(_ => ())
+  }
+}
+
+object CheckP2SH extends BitcoinSAppScalaDaemon {
+
+  override val actorSystemName: String =
+    s"check-p2sh-${System.currentTimeMillis()}"
+
+  override val customFinalDirOpt = None
+
+  implicit val rpcAppConfig: BitcoindRpcAppConfig =
+    BitcoindRpcAppConfig.fromDefaultDatadir()(system)
+
+  def getP2SHSource[T](
+      filePath: Path,
+      fmt: Combo => T,
+      grouping: Int,
+      drop: Int,
+      parallelism: Int = FutureUtil.getParallelism)(implicit
+      ec: ExecutionContext): Source[Vector[T], Future[IOResult]] = {
+    val initDrop = drop - grouping
+    val source: Source[Vector[T], Future[IOResult]] = FileIO
+      .fromPath(filePath, chunkSize = 8_388_608) // 8mb
+      .buffer(128, OverflowStrategy.backpressure)
+      .async
+      .via(
+        Framing.delimiter(delimiter = ByteString("\n"),
+                          maximumFrameLength = 1024,
+                          allowTruncation = false)
+      )
+      .drop(initDrop)
+      .mapAsync(FutureUtil.getParallelism) { line =>
+        Future {
+          val json = Json.parse(line.utf8String)
+          val c = json.validate[Combo](Combo.reads).get
+          fmt(c)
+        }
+      } // Read line by line
+      .buffer(grouping * parallelism, OverflowStrategy.backpressure)
+      .batch(grouping, { t => Vector(t) }) { case (accum, t) =>
+        accum.appended(t)
+      }
+
+    source
+  }
+
+  new CheckP2SH().run()
+}

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/CheckP2SHDb.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/CheckP2SHDb.scala
@@ -1,0 +1,143 @@
+package org.bitcoins.scripts
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{Keep, Sink}
+import org.bitcoins.core.protocol.script.ScriptPubKey
+import org.bitcoins.core.util.{EnvUtil, FutureUtil}
+import org.bitcoins.rpc.config.BitcoindRpcAppConfig
+import org.bitcoins.server.routes.BitcoinSRunner
+import org.bitcoins.server.util.BitcoinSAppScalaDaemon
+
+import java.nio.file.{Files, Path, Paths}
+import java.time.{Duration, Instant}
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.Future
+
+case class CheckP2SHDb()(override implicit val system: ActorSystem)
+    extends BitcoinSRunner[Unit] {
+  import slick.jdbc.SQLiteProfile
+  import slick.jdbc.SQLiteProfile.api.{
+    BaseColumnType,
+    Database,
+    MappedColumnType,
+    Table,
+    TableQuery,
+    Tag,
+    intColumnType,
+    stringColumnType
+  }
+  import slick.lifted.BaseColumnExtensionMethods
+
+  // Define your table schema (adjust data types as needed)
+  class Utxos(tag: Tag)
+      extends Table[(String, Int, Int, Int, Int, ScriptPubKey)](tag, "utxos") {
+    val db = new org.bitcoins.db.DbCommonsColumnMappers(SQLiteProfile)
+    implicit val scriptPubKeyAsmMapper: BaseColumnType[ScriptPubKey] = {
+      MappedColumnType.base[ScriptPubKey, String](_.asmHex,
+                                                  ScriptPubKey.fromAsmHex)
+    }
+    def txid = column[String]("txid")
+    def vout = column[Int]("vout")
+    def value = column[Int]("value")
+    def coinbase = column[Int]("coinbase")
+    def height = column[Int]("height")
+    def scriptpubkey = column[ScriptPubKey]("scriptpubkey")
+
+    def * = (txid, vout, value, coinbase, height, scriptpubkey)
+  }
+
+  implicit val scriptPubKeyAsmMapper: BaseColumnType[ScriptPubKey] = {
+    MappedColumnType.base[ScriptPubKey, String](_.asmHex,
+                                                ScriptPubKey.fromAsmHex)
+  }
+
+  val filePath: Path = {
+    if (EnvUtil.isMac) {
+      Paths.get("/Users/chrisstewart/dev/bitcoin-s/p2sh-size.json")
+    } else {
+      // Paths.get("p2sh-2.json") x
+      Paths.get("p2sh-3.json")
+    }
+  }
+  val lineCountF = Future {
+    Files.lines(filePath).count()
+  } // Uses Java Streams API
+  val dbPath = if (EnvUtil.isMac) {
+    "jdbc:sqlite:/Users/chrisstewart/dev/bitcoin-s/2025-02-19-utxo.sqlite"
+  } else {
+    "jdbc:sqlite:/home/chris/dev/bitcoin-s/2025-02-19-utxo.sqlite"
+  }
+
+  override def start(): Future[Unit] = {
+    val db = Database.forURL(
+      dbPath,
+      driver = "org.sqlite.JDBC"
+    ) // Use the correct JDBC driver
+    val utxos = TableQuery[Utxos]
+    val start = Instant.now()
+    val grouping = 15_000
+    val drop = 0
+    val count = new AtomicInteger(drop)
+    val fmt = { combo: Combo => combo.spk }
+
+    val parallelism = FutureUtil.getParallelism
+    val source =
+      CheckP2SH.getP2SHSource(filePath, fmt, grouping, drop, parallelism)
+
+    val resultF: Future[Vector[(String, Int, Int, Int, Int, ScriptPubKey)]] = {
+      def runStream(lineCountOpt: Option[Long], spks: Vector[ScriptPubKey])
+          : Future[Vector[(String, Int, Int, Int, Int, ScriptPubKey)]] = {
+        val lineCount = lineCountOpt.getOrElse(Long.MaxValue)
+        val percent = (count.get().toDouble / lineCount) * 100.0
+        val totalTime = Duration.between(start, Instant.now())
+
+        if (count.get() % grouping == 0) {
+          logger.info(
+            s"Searching $count addresses " + f"$percent%.2f" + s"% total time=$totalTime batchSize=${spks.length}")
+        }
+        import slick.jdbc.SQLiteProfile.api.streamableQueryActionExtensionMethods
+        val query = utxos.filter(u =>
+          new BaseColumnExtensionMethods(u.scriptpubkey).inSet(spks))
+        count.addAndGet(spks.length)
+        db.run(query.result).map(_.toVector)
+      }
+
+      source
+        .mapAsync(parallelism) { spks =>
+          if (lineCountF.isCompleted) {
+            lineCountF.flatMap { lineCount =>
+              runStream(Some(lineCount), spks)
+            }
+          } else {
+            runStream(None, spks)
+          }
+        }
+        .filter(_.nonEmpty)
+        .toMat(Sink.seq)(Keep.right)
+        .run()
+        .map(_.flatten.toVector)
+    }
+
+    resultF.map { results =>
+      logger.info(
+        s"Found a total of ${results.length} spks in the utxo set in file=${filePath.toAbsolutePath}, it took=${Duration
+            .between(start, Instant.now())}")
+      results.foreach(r => logger.info(s"result=$r"))
+      ()
+    }
+  }
+  override def stop(): Future[Unit] = system.terminate().map(_ => ())
+}
+
+object CheckP2SHDb extends BitcoinSAppScalaDaemon {
+
+  override val actorSystemName: String =
+    s"check-p2sh-${System.currentTimeMillis()}"
+
+  override val customFinalDirOpt = None
+
+  implicit val rpcAppConfig: BitcoindRpcAppConfig =
+    BitcoindRpcAppConfig.fromDefaultDatadir()(system)
+
+  new CheckP2SHDb().run()
+}

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/Combo.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/Combo.scala
@@ -1,0 +1,18 @@
+package org.bitcoins.scripts
+
+import org.bitcoins.core.protocol.BitcoinAddress
+import org.bitcoins.core.protocol.script.ScriptPubKey
+import play.api.libs.json.{Json, Reads, Writes}
+
+case class Combo(num: Long, p2sh: String, addr: String, size: Int) {
+  val spk: ScriptPubKey = {
+    ScriptPubKey.fromAsmHex(p2sh.drop(3).dropRight(1))
+  }
+
+  val bitcoinAddress: BitcoinAddress = BitcoinAddress.fromString(addr)
+}
+
+object Combo {
+  implicit val reads: Reads[Combo] = Json.reads[Combo]
+  implicit val writes: Writes[Combo] = Json.writes[Combo]
+}

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/GenP2SH.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/GenP2SH.scala
@@ -1,0 +1,109 @@
+package org.bitcoins.scripts
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.{Attributes, IOResult, OverflowStrategy}
+import org.apache.pekko.stream.scaladsl.{FileIO, Flow, Keep, Sink, Source}
+import org.apache.pekko.util.ByteString
+import org.bitcoins.core.config.MainNet
+import org.bitcoins.core.protocol.P2SHAddress
+import org.bitcoins.core.protocol.script.{
+  NonStandardScriptPubKey,
+  P2SHScriptPubKey
+}
+import org.bitcoins.core.util.{FutureUtil, NumberUtil}
+import org.bitcoins.scripts.GenP2SH.getIter
+import org.bitcoins.server.routes.BitcoinSRunner
+import org.bitcoins.server.util.BitcoinSAppScalaDaemon
+import play.api.libs.json.Json
+import scodec.bits.ByteVector
+
+import java.nio.file.Paths
+import java.time.{Duration, Instant}
+import scala.concurrent.Future
+
+class GenP2SH()(implicit
+    override val system: ActorSystem
+) extends BitcoinSRunner[Unit] {
+  import Combo._
+
+  private val fileSink: Sink[ByteString, Future[IOResult]] =
+    FileIO.toPath(Paths.get("p2sh-size-test.json"))
+  private val batchedSink = Flow[String]
+    .batch(50_000, { t => Vector(t) }) { (vec, t) => vec.appended(t) }
+    .map(batch => ByteString(batch.mkString))
+    .toMat(fileSink)(Keep.right)
+
+  override def start(): Future[Unit] = {
+    val startTime = Instant.now()
+    val start = 0L
+    val allCombinations: Iterator[(Long, Int)] = getIter(start)
+    val x: Future[IOResult] = Source
+      .fromIterator(() => allCombinations)
+      .mapAsync(FutureUtil.getParallelism) { case (i, byteSize) =>
+        Future {
+          val bytes = ByteVector.fromLong(i, size = byteSize)
+          val p2sh =
+            P2SHScriptPubKey(NonStandardScriptPubKey.fromAsmBytes(bytes))
+          val addr = P2SHAddress(p2sh, MainNet)
+          val num = bytes.toLong(signed = false)
+          val max = NumberUtil.pow2(8 * 3)
+          val percentage = ((num.toDouble - start) / max.toDouble) * 100
+          if (num % 1_000_000 == 0) {
+            logger.info(
+              s"Generated $num p2sh addresses " + f"$percentage%.2f" + " %")
+          }
+          val c = Combo(num = num,
+                        p2sh = p2sh.toString,
+                        addr = addr.toString,
+                        byteSize)
+          val json = Json.toJson(c)
+          val str = Json.stringify(json) + "\n"
+          str
+        }
+      }
+      .buffer(10000,
+              OverflowStrategy.backpressure
+      ) // Buffer up to 10,000 elements before writing
+      .addAttributes(Attributes
+        .inputBuffer(initial = 64, max = 256)) // Tune internal buffering
+      .runWith(batchedSink)
+
+    x.map { _ =>
+      logger.info(
+        s"Done generating p2sh addresses, took=${Duration.between(startTime, Instant.now()).toMinutes} minutes")
+      ()
+    }
+
+  }
+
+  override def stop(): Future[Unit] = system.terminate().map(_ => ())
+}
+
+object GenP2SH extends BitcoinSAppScalaDaemon {
+
+  def getIter(start: Long): Iterator[(Long, Int)] = {
+    val byteSizes = 0.until(4)
+
+    val allCombinations: Iterator[(Long, Int)] = byteSizes
+      .map { byteSize =>
+        Iterator
+          .iterate(start)(_ + 1)
+          .takeWhile(_ < NumberUtil.pow2(8 * byteSize))
+          .map(l => (l, byteSize))
+          .iterator
+      }
+      .iterator
+      .flatten
+    allCombinations
+  }
+
+  override val actorSystemName: String =
+    s"gen-p2sh-${System.currentTimeMillis()}"
+
+  override val customFinalDirOpt = None
+
+//  implicit val rpcAppConfig: BitcoindRpcAppConfig =
+//    BitcoindRpcAppConfig.fromDefaultDatadir()(system)
+
+  new GenP2SH().run()
+}

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ReadNegativeNumberResult.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ReadNegativeNumberResult.scala
@@ -1,0 +1,70 @@
+package org.bitcoins.scripts
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{FileIO, Framing, Sink}
+import org.apache.pekko.util.ByteString
+import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.bitcoins.rpc.config.BitcoindRpcAppConfig
+import org.bitcoins.scripts.ReadNegativeNumberResult.NegativeNumberResult
+import org.bitcoins.server.routes.BitcoinSRunner
+import org.bitcoins.server.util.BitcoinSAppScalaDaemon
+import play.api.libs.json.{Json, Reads, Writes}
+
+import java.nio.file.Paths
+import scala.concurrent.Future
+
+case class ReadNegativeNumberResult()(implicit override val system: ActorSystem)
+    extends BitcoinSRunner[Unit] {
+  import ReadNegativeNumberResult.negativeNumberResultReads
+  val filePath =
+    Paths.get("/Users/chrisstewart/dev/bitcoin-s/negative-number-txs.json")
+  val stream = FileIO
+    .fromPath(filePath) // 8mb
+    .via(
+      Framing.delimiter(delimiter = ByteString("\n"),
+                        maximumFrameLength = 300000,
+                        allowTruncation = false)
+    )
+    .mapAsync(FutureUtil.getParallelism) { line =>
+      Future {
+        val json = Json.parse(line.utf8String)
+        val c = json.validate[NegativeNumberResult].get
+        c
+      }
+    } // Read line by line
+  override def start(): Future[Unit] = {
+    stream
+      .runWith(Sink.foreach(println))
+      .map(_ => ())
+  }
+  override def stop(): Future[Unit] = {
+    system.terminate().map(_ => ())
+  }
+
+}
+
+object ReadNegativeNumberResult extends BitcoinSAppScalaDaemon {
+  override val actorSystemName: String =
+    s"scan-bitcoind-${System.currentTimeMillis()}"
+
+  override val customFinalDirOpt = None
+
+  implicit val rpcAppConfig: BitcoindRpcAppConfig =
+    BitcoindRpcAppConfig.fromDefaultDatadir()(system)
+
+  case class NegativeNumberResult(
+      txid: DoubleSha256DigestBE,
+      idx: Int,
+      asm: String,
+      negatives: String,
+      `type`: String)
+
+  import org.bitcoins.commons.serializers.JsonWriters.DoubleSha256DigestBEWrites
+  import org.bitcoins.commons.serializers.JsonReaders.DoubleSha256DigestBEReads
+  implicit lazy val negativeNumberResultWrites: Writes[NegativeNumberResult] =
+    Json.writes[NegativeNumberResult]
+  implicit lazy val negativeNumberResultReads: Reads[NegativeNumberResult] =
+    Json.reads[NegativeNumberResult]
+
+  new ReadNegativeNumberResult().run()
+}

--- a/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
+++ b/app/scripts/src/main/scala/org/bitcoins/scripts/ScanBitcoind.scala
@@ -2,18 +2,26 @@ package org.bitcoins.scripts
 
 import org.apache.pekko.NotUsed
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.apache.pekko.stream.scaladsl.{FileIO, Flow, Keep, Sink, Source}
+import org.apache.pekko.stream.{ActorAttributes, IOResult, Supervision}
+import org.apache.pekko.util.ByteString
+import org.bitcoins.commons.serializers.JsonReaders
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.script._
-import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
+import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.script.arithmetic.OP_NEGATE
+import org.bitcoins.core.script.constant.{ScriptToken, _}
+import org.bitcoins.core.script.control.OP_RETURN
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.config.BitcoindRpcAppConfig
 import org.bitcoins.server.routes.BitcoinSRunner
 import org.bitcoins.server.util.BitcoinSAppScalaDaemon
+import play.api.libs.json._
 
-import java.time.Instant
+import java.nio.file.{Paths}
+import java.time.{Duration, Instant}
 import scala.concurrent.Future
 
 /** Useful script for scanning bitcoind This file assumes you have
@@ -27,22 +35,36 @@ class ScanBitcoind()(implicit
     rpcAppConfig: BitcoindRpcAppConfig
 ) extends BitcoinSRunner[Unit] {
 
+  implicit val tupleFormat: Format[(DoubleSha256DigestBE, String)] = {
+    implicit val tupleFmt: Format[(DoubleSha256DigestBE, String)] =
+      new Format[(DoubleSha256DigestBE, String)] {
+        def writes(tuple: (DoubleSha256DigestBE, String)): JsValue = Json.obj(
+          "txid" -> tuple._1.hex,
+          "tx" -> tuple._2
+        )
+
+        def reads(json: JsValue): JsResult[(DoubleSha256DigestBE, String)] =
+          for {
+            digest <- (json \ "txid").validate[DoubleSha256DigestBE](
+              JsonReaders.DoubleSha256DigestBEReads)
+            str <- (json \ "tx").validate[String]
+          } yield (digest, str)
+      }
+    tupleFmt
+  }
+
   override def start(): Future[Unit] = {
 
     val bitcoindF = rpcAppConfig.clientF
-
-    //    val startHeight = 675000
-    val endHeightF: Future[Int] = bitcoindF.flatMap(_.getBlockCount())
-
     val f = for {
       bitcoind <- bitcoindF
-      endHeight <- endHeightF
-      // _ <- countWitV1MempoolTxs(bitcoind)
-      _ <- countTaprootTxsInBlocks(endHeight, 50000, bitcoind)
-    } yield ()
+      _ <- countLargeInputOutputSize(bitcoind)
+    } yield {
+      ()
+    }
     f.failed.foreach(err =>
       logger.error(s"Failed to count witness v1 mempool txs", err))
-    Future.unit
+    f
   }
 
   override def stop(): Future[Unit] = {
@@ -51,15 +73,21 @@ class ScanBitcoind()(implicit
       .map(_ => ())
   }
 
+  val decider: Supervision.Decider = { exn =>
+    logger.error(s"Stream exception", exn)
+    Supervision.Resume
+  }
+
   /** Searches a given Source[Int] that represents block heights applying f to
     * them and returning a Seq[T] with the results
     */
-  def searchBlocks[T](
+  def searchBlocks[T, Mat](
       bitcoind: BitcoindRpcClient,
       source: Source[Int, NotUsed],
       f: Block => T,
+      sink: Sink[T, Future[Mat]],
       numParallelism: Int = Runtime.getRuntime.availableProcessors()
-  ): Future[Seq[T]] = {
+  ): Future[Mat] = {
     source
       .mapAsync(parallelism = numParallelism) { height =>
         bitcoind
@@ -75,7 +103,8 @@ class ScanBitcoind()(implicit
           f(block)
         }
       }
-      .toMat(Sink.seq)(Keep.right)
+      .withAttributes(ActorAttributes.supervisionStrategy(decider))
+      .toMat(sink)(Keep.right)
       .run()
   }
 
@@ -92,7 +121,10 @@ class ScanBitcoind()(implicit
       block.transactions.count(_.isInstanceOf[WitnessTransaction])
     }
     val countsF: Future[Seq[Int]] = for {
-      counts <- searchBlocks[Int](bitcoind, source, countSegwitTxs)
+      counts <- searchBlocks[Int, Seq[Int]](bitcoind,
+                                            source,
+                                            countSegwitTxs,
+                                            Sink.seq[Int])
     } yield counts
 
     val countF: Future[Int] = countsF.map(_.sum)
@@ -104,6 +136,219 @@ class ScanBitcoind()(implicit
         s"Count of segwit txs from height=${startHeight} to endHeight=${endHeight} is ${count}. It took ${endTime - startTime}ms "
       )
     } yield ()
+  }
+
+  case class InputOutputSize(
+      txid: DoubleSha256DigestBE,
+      inputCount: Int,
+      outputCount: Int,
+      outputAmounts: Vector[Long])
+  import JsonReaders.DoubleSha256DigestBEReads
+  import org.bitcoins.commons.serializers.JsonWriters.DoubleSha256DigestBEWrites
+  implicit val inputOutputSizeReads: Reads[InputOutputSize] =
+    Json.reads[InputOutputSize]
+  implicit val inputOutputSizeWrites: Writes[InputOutputSize] =
+    Json.writes[InputOutputSize]
+  def countLargeInputOutputSize(bitcoind: BitcoindRpcClient): Future[Unit] = {
+    val startTime = Instant.now()
+    val startHeight = 0
+    var counter = 0L
+    val endHeightF = bitcoind.getBlockCount()
+    val sourceF: Future[Source[Int, NotUsed]] = {
+      endHeightF.map(endHeight => Source(startHeight.to(endHeight)))
+    }
+
+    // in this simple example, we are going to count the number of witness transactions
+    val countLargeInputsOutputs: Block => Vector[InputOutputSize] = {
+      (block: Block) =>
+        block.transactions
+          .filter { tx =>
+            tx.inputs.size >= 64 || tx.outputs.size >= 64
+          }
+          .map { tx =>
+            counter += 1
+            InputOutputSize(tx.txIdBE,
+                            tx.inputs.size,
+                            tx.outputs.size,
+                            tx.outputs.map(_.value.satoshis.toLong))
+          }
+    }
+    val sink = Flow[Vector[InputOutputSize]]
+      .mapConcat(identity)
+      .map(inputOutputSizeWrites.writes)
+      .map(b => Json.stringify(b) + "\n")
+      .batch(50_000, { t => Vector(t) }) { (vec, t) => vec.appended(t) }
+      .map(batch => ByteString(batch.mkString))
+      .toMat(FileIO.toPath(Paths.get("large-input-outputs.json")))(Keep.right)
+    val countsF: Future[IOResult] = for {
+      source <- sourceF
+      ioResult <- searchBlocks[Vector[InputOutputSize], IOResult](
+        bitcoind,
+        source,
+        countLargeInputsOutputs,
+        sink)
+    } yield ioResult
+
+    for {
+      count <- countsF
+      endTime = Instant.now()
+      endHeight <- endHeightF
+      _ = logger.info(
+        s"Count of large input/output txs from height=${startHeight} to endHeight=${endHeight} is ${counter} $count. It took ${Duration
+            .between(startTime, endTime)}"
+      )
+    } yield ()
+  }
+
+  private def isPrevOpPushData(
+      asm: Seq[ScriptToken],
+      currentIdx: Int): Boolean = {
+    if (currentIdx > 0) {
+      val prev = asm(currentIdx - 1)
+      StackPushOperationFactory.pushDataOperations.contains(prev) || prev
+        .isInstanceOf[BytesToPushOntoStack]
+    } else {
+      false
+    }
+  }
+
+  private def existsNegative(
+      asm: Seq[ScriptToken]): (Boolean, Vector[(ScriptToken, Long)]) = {
+    val result: Vector[(Boolean, Vector[(ScriptToken, Long)])] =
+      asm.zipWithIndex.toVector.map { case (token, idx) =>
+        token match {
+          case s: ScriptNumber =>
+            if (s.toLong < 0 && !isPrevOpPushData(asm, idx)) {
+              (true, Vector((s, s.toLong)))
+            } else (false, Vector.empty)
+          case const: ScriptConstant =>
+            if (const.bytes.size < 5) {
+              // largest number in the script is 4 bytes (OP_CLTV/OP_CSV input must be positive)
+              if (const.toLong < 0 && !isPrevOpPushData(asm, idx)) {
+                (true, Vector((const, const.toLong)))
+              } else (false, Vector.empty)
+            } else {
+              (false, Vector.empty)
+            }
+          case op: ScriptOperation =>
+            if (op == OP_NEGATE) {
+              (true, Vector((op, op.toLong)))
+            } else {
+              (false, Vector.empty)
+            }
+        }
+      }
+
+    if (result.exists(_._1)) {
+      val consolidate = result.filter(_._1).flatMap(_._2)
+      (true, consolidate)
+    } else {
+      (false, Vector.empty)
+    }
+  }
+
+  import ReadNegativeNumberResult.NegativeNumberResult
+  def findNegativeNumbers(bitcoind: BitcoindRpcClient): Future[IOResult] = {
+    val start = Instant.now()
+    val startHeight = 0
+    val endHeightF = bitcoind.getBlockCount()
+    val sourceF: Future[Source[Int, NotUsed]] =
+      endHeightF.map(h => Source(startHeight.to(h)))
+    val find: Block => Vector[NegativeNumberResult] = { block =>
+      block.transactions.flatMap { tx =>
+        // search outputs and inputs for negative numbers
+        val inputs: Vector[NegativeNumberResult] =
+          tx.inputs.zipWithIndex
+            .flatMap { case (i, idx) =>
+              val scriptSig = ((i, idx), existsNegative(i.scriptSignature.asm))
+              i.scriptSignature match {
+                case p2sh: P2SHScriptSignature =>
+                  val redeemScript =
+                    ((i, idx), existsNegative(p2sh.redeemScript.asm))
+                  Vector(scriptSig, redeemScript)
+                case _: ScriptSignature => Vector.empty
+              }
+            }
+            // filter out coinbase transaction's scriptSigs
+            // due to branding in the coinbase tx
+            .filter(_._2._1 && !tx.isCoinbase)
+            .map { case ((i, idx), (_, negativeOps)) =>
+              NegativeNumberResult(tx.txIdBE,
+                                   idx,
+                                   i.scriptSignature.asm.mkString(" "),
+                                   negativeOps.mkString(" "),
+                                   "scriptsig")
+            }
+
+        val outputs: Vector[NegativeNumberResult] =
+          tx.outputs.zipWithIndex
+            .map { case (o, idx) =>
+              ((o, idx), existsNegative(o.scriptPubKey.asm))
+            }
+            .filter(tup =>
+              tup._2._1 && !tup._1._1.scriptPubKey.asm.contains(OP_RETURN))
+            .map { case ((o, idx), (_, negativeOps)) =>
+              NegativeNumberResult(tx.txIdBE,
+                                   idx,
+                                   o.scriptPubKey.asm.mkString(" "),
+                                   negativeOps.mkString(" "),
+                                   "scriptpubkey")
+            }
+        val wit: Vector[NegativeNumberResult] = tx match {
+          case wtx: WitnessTransaction =>
+            wtx.witness.witnesses.zipWithIndex
+              .flatMap { case (wit, idx) =>
+                val consts = wit.stack.map(ScriptConstant.fromBytes)
+                val stack = ((consts, idx), existsNegative(consts))
+                val script = wit match {
+                  case _: P2WPKHWitnessV0 => Vector.empty
+                  case p2wsh: P2WSHWitnessV0 =>
+                    Vector(((p2wsh.redeemScript.asm, idx),
+                            existsNegative(p2wsh.redeemScript.asm)))
+                  case _: TaprootKeyPath => Vector.empty
+                  case tr: TaprootScriptPath =>
+                    Vector(
+                      ((tr.script.asm, idx), existsNegative(tr.script.asm)))
+                  case EmptyScriptWitness    => Vector.empty
+                  case _: TaprootUnknownPath => Vector.empty
+                }
+
+                Vector(stack) ++ script
+
+              }
+              .filter(_._2._1)
+              .map { case ((wit, idx), (_, negativeOps)) =>
+                NegativeNumberResult(tx.txIdBE,
+                                     idx,
+                                     wit.mkString(" "),
+                                     negativeOps.mkString(" "),
+                                     "witness")
+              }
+          case _: NonWitnessTransaction =>
+            Vector.empty
+        }
+        inputs ++ outputs ++ wit
+      }
+    }
+
+    for {
+      source <- sourceF
+      sink = Flow[Vector[NegativeNumberResult]]
+        .mapConcat(identity)
+        .map(
+          Json.toJson(_)(ReadNegativeNumberResult.negativeNumberResultWrites))
+        .map(b => Json.stringify(b) + "\n")
+        .batch(50_000, { t => Vector(t) }) { (vec, t) => vec.appended(t) }
+        .map(batch => ByteString(batch.mkString))
+        .toMat(FileIO.toPath(Paths.get("negative-number-txs.json")))(Keep.right)
+      result <- searchBlocks(bitcoind, source, find, sink)
+      endHeight <- endHeightF
+    } yield {
+      logger.info(
+        s"Done searching blocks endHeight=$endHeight, it took=${Duration
+            .between(start, Instant.now())}")
+      result
+    }
   }
 
   def countTaprootTxsInBlocks(
@@ -122,7 +367,10 @@ class ScanBitcoind()(implicit
     }
 
     val countsF: Future[Seq[Int]] = for {
-      counts <- searchBlocks[Int](bitcoind, source, countTaprootOutputs)
+      counts <- searchBlocks[Int, Seq[Int]](bitcoind,
+                                            source,
+                                            countTaprootOutputs,
+                                            Sink.seq)
     } yield counts
 
     val countF: Future[Int] = countsF.map(_.sum)


### PR DESCRIPTION
Rework scripts to use a `Sink` to send results from `scanBitcoind()`. This allows us to stream results to files so that we don't keep them in memory. In certain cases we would max out our heap size if we kept results in memory while scanning the entire blockchain.