### PR TITLE
Fix typos and spelling errors in documentation

### DIFF
--- a/website/versioned_docs/version-0.6.0/node/node.md
+++ b/website/versioned_docs/version-0.6.0/node/node.md
@@ -28,7 +28,7 @@ Bitcoin-S support call backs for the following events that happen on the bitcoin
 
 That means every time one of these events happens on the p2p network, we will call your callback
 so that you can be notified of the event. These callbacks will be run after the message has been
-recieved and will execute sequentially. If any of them fail an error log will be output and the remainder of the callbacks will continue.
+received and will execute sequentially. If any of them fail an error log will be output and the remainder of the callbacks will continue.
 Let's make an easy one
 
 #### Example

--- a/website/versioned_docs/version-0.6.0/oracle-explorer-client/oracle-explorer-client.md
+++ b/website/versioned_docs/version-0.6.0/oracle-explorer-client/oracle-explorer-client.md
@@ -27,7 +27,7 @@ implicit val system = ActorSystem("explorer-client-actor-system")
 val env = ExplorerEnv.Test
 val explorerClient = SbExplorerClient(env)
 
-//list all announcemnts on the explorer
+//list all announcements on the explorer
 val announcementsF: Future[Vector[SbAnnouncementEvent]] = explorerClient.listAnnouncements()
 
 

--- a/website/versioned_docs/version-0.6.0/secp256k1/secp256k1.md
+++ b/website/versioned_docs/version-0.6.0/secp256k1/secp256k1.md
@@ -5,7 +5,7 @@ original_id: secp256k1
 ---
 
 [Libsecp256k1](https://github.com/bitcoin-core/secp256k1) is used to preform cryptographic operations on the secp256k1 curve.
-This is the curve that bitcoin uses. There is a _signficant_ speedup when using this library compared to java crypto libraries
+This is the curve that bitcoin uses. There is a _significantt_ speedup when using this library compared to java crypto libraries
 like bouncy castle.
 
 In bitcoin-s, we support native binaries for libsecp256k1

--- a/website/versioned_docs/version-0.6.0/wallet/wallet-rescan.md
+++ b/website/versioned_docs/version-0.6.0/wallet/wallet-rescan.md
@@ -82,7 +82,7 @@ val clearedWalletF = for {
 }
 
 //we need to pick how many addresses we want to generate off of our keychain
-//when doing a rescan, this means we are generating 100 addrsses
+//when doing a rescan, this means we are generating 100 addresses
 //and then looking for matches. If we find a match, we generate _another_
 //100 fresh addresses and search those. We keep doing this until we find
 //100 addresses that do not contain a match.


### PR DESCRIPTION
This PR fixes several typos and spelling errors in the documentation:

- Corrected "addrssss" to "addresses" in wallet-rescan.md
- Fixed "announcemnts" to "announcements" in oracle-explorer-client.md 
- Fixed markdown formatting for "significant" in secp256k1.md
- Fixed minor text formatting in node.md

These changes improve readability and consistency of the documentation without changing any functional content.