### PR TITLE
specifiy explicit sonatype endpoint to publish jars to

### DIFF
--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -3,28 +3,16 @@ import com.typesafe.sbt.SbtNativePackager.Docker
 import com.typesafe.sbt.SbtNativePackager.autoImport.packageName
 
 import java.nio.file.Paths
-import com.typesafe.sbt.packager.Keys.{
-  daemonUser,
-  daemonUserUid,
-  dockerAlias,
-  dockerAliases,
-  dockerCommands,
-  dockerExposedVolumes,
-  dockerRepository,
-  dockerUpdateLatest,
-  maintainer
-}
+import com.typesafe.sbt.packager.Keys.{daemonUser, daemonUserUid, dockerAlias, dockerAliases, dockerCommands, dockerExposedVolumes, dockerRepository, dockerUpdateLatest, maintainer}
 import com.typesafe.sbt.packager.archetypes.jlink.JlinkPlugin.autoImport.JlinkIgnore
 import com.typesafe.sbt.packager.docker.{Cmd, DockerChmodType}
-import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.{
-  dockerAdditionalPermissions,
-  dockerBaseImage
-}
-import sbt._
-import sbt.Keys._
+import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport.{dockerAdditionalPermissions, dockerBaseImage}
+import sbt.*
+import sbt.Keys.*
 import sbtprotoc.ProtocPlugin.autoImport.PB
-import sbtassembly.AssemblyKeys._
+import sbtassembly.AssemblyKeys.*
 import sbtdynver.DynVer
+import xerial.sbt.Sonatype.autoImport.sonatypeCredentialHost
 
 import scala.sys.process.Process
 import scala.util.Properties
@@ -51,6 +39,7 @@ object CommonSettings {
         url("https://twitter.com/Chris_Stewart_5")
       )
     ),
+    sonatypeCredentialHost := "s01.oss.sonatype.org",
     Compile / scalacOptions ++= compilerOpts,
     Test / scalacOptions ++= testCompilerOpts,
     Test / scalacOptions --= scala2_13SourceCompilerOpts,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -62,3 +62,6 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 
 //https://github.com/sbt/sbt-assembly
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+
+//https://github.com/xerial/sbt-sonatype
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")


### PR DESCRIPTION
To be compatible with the changes in sbt ci release 1.11.x (#sbt-ci- and fix this error on CI publishing in #6004

```
[error] (cryptoJS / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (dbCommons / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (eclairRpcTest / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (cryptoTestJVM / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (torTest / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (appCommonsTest / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (coreTestJVM / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (feeProviderTest / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (tor / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (keyManagerTest / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (testkit / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (dlcOracleTest / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (coreJS / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (zmq / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (cryptoJVM / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] (secp256k1jni / publish) java.net.ProtocolException: Server redirected too many times (20)
[error] Total time: 396 s (0:06:36.0), completed Jun 14, 2025, 5:11:11 PM
```