### PR TITLE
Fix typos and spelling errors in documentation

### DIFF
--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/Client.scala
@@ -333,7 +333,7 @@ trait Client
     isStartedF.map(started => !started)
   }
 
-  // This RPC call is here to avoid circular trait depedency
+  // This RPC call is here to avoid circular trait dependency
   def ping(): Future[Unit] = {
     bitcoindCall[Unit]("ping")
   }

--- a/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
+++ b/eclair-rpc-test/src/test/scala/org/bitcoins/eclair/rpc/EclairRpcClientTest.scala
@@ -905,7 +905,7 @@ class EclairRpcClientTest extends BitcoinSAsyncTest {
     }
   }
 
-  it should "fail to get received info about an invoice that hasn't been paid too, and then sucessfully get the info after the payment happened" in {
+  it should "fail to get received info about an invoice that hasn't been paid too, and then successfully get the info after the payment happened" in {
     val amt = 1000.msat
     for {
       c1 <- clientF

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/UTXOHandlingTest.scala
@@ -113,7 +113,7 @@ class UTXOHandlingTest extends BitcoinSUnitTest {
     val withSpendingTxId =
       reserved.copyWithSpendingTxId(DoubleSha256DigestBE.empty)
 
-    // it must transition from reserved to broacast spent
+    // it must transition from reserved to broadcast spent
     assert(
       UtxoHandling
         .updateSpentTxoWithConfs(withSpendingTxId, 0, requiredConfs)

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/SendFundsHandlingHandling.scala
@@ -580,7 +580,7 @@ case class SendFundsHandlingHandling(
 
     processedTxF.recoverWith { case _ =>
       // if something fails, we need to unreserve the utxos associated with this tx
-      // and then propogate the failed future upwards
+      // and then propagate the failed future upwards
       utxoHandling.unmarkUTXOsAsReserved(signed).flatMap(_ => processedTxF)
     }
   }


### PR DESCRIPTION
Fix typos and spelling errors in documentation