### PR TITLE
bitcoindRpc: Fix `listUnspent()` for `Vector[BitcoinAddress]` param

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/UTXORpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/UTXORpcTest.scala
@@ -20,6 +20,16 @@ class UTXORpcTest extends BitcoindFixturesFundedCachedNewest {
 
   behavior of "UTXORpc"
 
+  it should "be able to get utxo info" in { case client =>
+    for {
+      block <- BitcoindRpcTestUtil.getFirstBlock(client)
+      info1 <- client.getTxOut(block.tx.head.txid, 0)
+    } yield {
+      assert(info1.isDefined)
+      assert(info1.get.coinbase)
+    }
+  }
+
   it should "be able to list utxos" in { case client =>
     for {
       unspent0 <- client.listUnspent
@@ -63,16 +73,6 @@ class UTXORpcTest extends BitcoindFixturesFundedCachedNewest {
         assert(secondSuccess)
         assert(newLocked.isEmpty)
       }
-  }
-
-  it should "be able to get utxo info" in { case client =>
-    for {
-      block <- BitcoindRpcTestUtil.getFirstBlock(client)
-      info1 <- client.getTxOut(block.tx.head.txid, 0)
-    } yield {
-      assert(info1.isDefined)
-      assert(info1.get.coinbase)
-    }
   }
 
   it should "be able to fail to get utxo info" in { case client =>

--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/UTXORpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/UTXORpcTest.scala
@@ -22,8 +22,15 @@ class UTXORpcTest extends BitcoindFixturesFundedCachedNewest {
 
   it should "be able to list utxos" in { case client =>
     for {
-      unspent <- client.listUnspent
-    } yield assert(unspent.nonEmpty)
+      unspent0 <- client.listUnspent
+      address <- client.getNewAddress
+      _ <- client.sendToAddress(address, Bitcoins.one)
+      _ <- client.generate(1)
+      unspent1 <- client.listUnspent(Vector(address))
+    } yield {
+      assert(unspent0.nonEmpty)
+      assert(unspent1.size == 1)
+    }
 
   }
 

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/UTXORpc.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/UTXORpc.scala
@@ -45,7 +45,7 @@ trait UTXORpc { self: Client =>
   def listUnspent(
       addresses: Vector[BitcoinAddress]
   ): Future[Vector[UnspentOutput]] =
-    listUnspent(addresses = addresses)
+    listUnspent(addresses = Some(addresses))
 
   def listUnspent(
       minConfirmations: Int,


### PR DESCRIPTION
fixes #6035 