### PR TITLE
Allow `UnassignedWitnessScriptPubKey` in `WitnessTxSigComponentRaw`

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -2,12 +2,13 @@ package org.bitcoins.core.protocol.transaction
 
 import org.bitcoins.core.crypto.{
   BaseTxSigComponent,
+  TaprootTxSigComponent,
   WitnessTxSigComponentP2SH,
   WitnessTxSigComponentRaw
 }
 import org.bitcoins.core.currency.{Bitcoins, CurrencyUnits}
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.script._
+import org.bitcoins.core.protocol.script.*
 import org.bitcoins.core.protocol.transaction.testprotocol.CoreTransactionTestCase
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
@@ -19,7 +20,7 @@ import org.bitcoins.testkitcore.util.{
   TestUtil,
   TransactionTestUtil
 }
-import scodec.bits._
+import scodec.bits.*
 
 class TransactionTest extends BitcoinSUnitTest {
   behavior of "Transaction"
@@ -194,7 +195,8 @@ class TransactionTest extends BitcoinSUnitTest {
                     flags = testCase.flags
                   )
               }
-            case wit: WitnessScriptPubKey =>
+            case wit @ (_: WitnessScriptPubKeyV0 |
+                _: UnassignedWitnessScriptPubKey) =>
               tx match {
                 case btx: NonWitnessTransaction =>
                   BaseTxSigComponent(
@@ -208,6 +210,23 @@ class TransactionTest extends BitcoinSUnitTest {
                     transaction = wtx,
                     inputIndex = UInt32(inputIndex),
                     output = TransactionOutput(amount, wit),
+                    flags = testCase.flags
+                  )
+              }
+            case tr: TaprootScriptPubKey =>
+              tx match {
+                case btx: NonWitnessTransaction =>
+                  BaseTxSigComponent(
+                    transaction = btx,
+                    inputIndex = UInt32(inputIndex),
+                    output = TransactionOutput(amount, tr),
+                    flags = testCase.flags
+                  )
+                case wtx: WitnessTransaction =>
+                  TaprootTxSigComponent(
+                    transaction = wtx,
+                    inputIndex = UInt32(inputIndex),
+                    outputMap = testCase.outputMap,
                     flags = testCase.flags
                   )
               }
@@ -271,7 +290,8 @@ class TransactionTest extends BitcoinSUnitTest {
                         flags = testCase.flags
                       )
                   }
-                case wit: WitnessScriptPubKey =>
+                case wit @ (_: WitnessScriptPubKeyV0 |
+                    _: UnassignedWitnessScriptPubKey) =>
                   tx match {
                     case btx: NonWitnessTransaction =>
                       BaseTxSigComponent(
@@ -285,6 +305,23 @@ class TransactionTest extends BitcoinSUnitTest {
                         transaction = wtx,
                         inputIndex = UInt32(inputIndex),
                         output = TransactionOutput(amount, wit),
+                        flags = testCase.flags
+                      )
+                  }
+                case tr: TaprootScriptPubKey =>
+                  tx match {
+                    case btx: NonWitnessTransaction =>
+                      BaseTxSigComponent(
+                        transaction = btx,
+                        inputIndex = UInt32(inputIndex),
+                        output = TransactionOutput(amount, tr),
+                        flags = testCase.flags
+                      )
+                    case wtx: WitnessTransaction =>
+                      TaprootTxSigComponent(
+                        transaction = wtx,
+                        inputIndex = UInt32(inputIndex),
+                        outputMap = testCase.outputMap,
                         flags = testCase.flags
                       )
                   }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/testprotocol/CoreTransactionTestCase.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/testprotocol/CoreTransactionTestCase.scala
@@ -3,14 +3,19 @@ package org.bitcoins.core.protocol.transaction.testprotocol
 import org.bitcoins.core.currency.{CurrencyUnit, Satoshis}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script.ScriptPubKey
-import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
+import org.bitcoins.core.protocol.transaction.{
+  Transaction,
+  TransactionOutPoint,
+  TransactionOutput
+}
 import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.script.flag.{ScriptFlag, ScriptFlagFactory}
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.serializers.script.ScriptParser
 import org.bitcoins.core.util.BytesUtil
 import org.bitcoins.crypto.DoubleSha256Digest
-import ujson._
-import upickle.default._
+import ujson.*
+import upickle.default.*
 
 /** Created by chris on 5/4/16. Used to represent the test cases found inside of
   * tx_valid.json & tx_invalid.json from bitcoin core
@@ -22,7 +27,17 @@ case class CoreTransactionTestCase(
     spendingTx: Transaction,
     flags: Seq[ScriptFlag],
     raw: String
-)
+) {
+  lazy val outputMap: PreviousOutputMap = {
+    val map = creditingTxsInfo.flatMap { c =>
+      c._3 match {
+        case Some(amt) => Some((c._1, TransactionOutput(amt, c._2)))
+        case None      => None
+      }
+    }.toMap
+    PreviousOutputMap(map)
+  }
+}
 
 object CoreTransactionTestCase {
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
@@ -543,13 +543,13 @@ object WitnessTxSigComponentRaw {
       output: TransactionOutput,
       flags: Seq[ScriptFlag]): WitnessTxSigComponentRaw = {
     output.scriptPubKey match {
-      case _: WitnessScriptPubKey =>
+      case _: WitnessScriptPubKeyV0 | _: UnassignedWitnessScriptPubKey =>
         WitnessTxSigComponentRawImpl(transaction, inputIndex, output, flags)
       case x @ (_: P2PKScriptPubKey | _: P2PKHScriptPubKey |
           _: P2PKWithTimeoutScriptPubKey | _: MultiSignatureScriptPubKey |
           _: P2SHScriptPubKey | _: LockTimeScriptPubKey |
           _: ConditionalScriptPubKey | _: NonStandardScriptPubKey |
-          _: WitnessCommitment | EmptyScriptPubKey) =>
+          _: WitnessCommitment | EmptyScriptPubKey | _: TaprootScriptPubKey) =>
         throw new IllegalArgumentException(
           s"Cannot create a WitnessTxSigComponentRaw with a spk of $x")
     }


### PR DESCRIPTION
This PR does two things

1. Updates the test harness code in `TransactionTest` to support taproot scripts in the `tx_valid.json` and `tx_invalid.json` file. 
2. Loosens the invariant on `WitnessTxSigComponentRaw` to allow for `UnassignedWitnessScriptPubKey` to be assigned to this type.

`WitnessTxSigComponentRaw` is a bit of an ambiguous type. Initially it was introduced to distinguish between "raw" and "wrapped" (p2sh) witness programs.

When we introduced Taproot support (#4409) we created a separate TxSigComponent type for taproot (`TaprootTxSigComponent`) despite it technically being a "raw" witness program. Its a good thing to provide type specific information for taproot, but we may need to think about renaming `WitnessTxSigComponentRaw` -> `WitnessTxSigComponentV0` and having a "catch all" `TxSigComponent` for unassigned witness spks