### PR TITLE
core: Make `ReservedOperation`s dynamic based on allocated opcodes

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
@@ -101,7 +101,7 @@ object ScriptOperation extends ScriptOperationFactory[ScriptOperation] {
     * popular opcodes to the front of the vector so when we iterate through it,
     * we are more likely to find the op code we are looking for sooner
     */
-  final override val operations: Vector[ScriptOperation] = {
+  final override lazy val operations: Vector[ScriptOperation] = {
     nonReservedOpCodes ++ ReservedOperation.operations
   }
 

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
@@ -84,11 +84,7 @@ trait ScriptOperationFactory[T <: ScriptOperation] extends StringFactory[T] {
 
 object ScriptOperation extends ScriptOperationFactory[ScriptOperation] {
 
-  /** This contains duplicate operations There is an optimization here by moving
-    * popular opcodes to the front of the vector so when we iterate through it,
-    * we are more likely to find the op code we are looking for sooner
-    */
-  final override val operations: Vector[ScriptOperation] = {
+  private[script] val nonReservedOpCodes: Vector[ScriptOperation] = {
     StackPushOperationFactory.pushDataOperations ++
       StackOperation.operations ++
       LocktimeOperation.operations ++
@@ -98,8 +94,15 @@ object ScriptOperation extends ScriptOperationFactory[ScriptOperation] {
       ArithmeticOperation.operations ++
       BytesToPushOntoStack.operations ++
       SpliceOperation.operations ++
-      ReservedOperation.operations ++
       ScriptNumberOperation.operations
+  }
+
+  /** This contains duplicate operations There is an optimization here by moving
+    * popular opcodes to the front of the vector so when we iterate through it,
+    * we are more likely to find the op code we are looking for sooner
+    */
+  final override val operations: Vector[ScriptOperation] = {
+    nonReservedOpCodes ++ ReservedOperation.operations
   }
 
 }

--- a/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.script.reserved
 
-import org.bitcoins.core.script.ScriptOperationFactory
+import org.bitcoins.core.script.{ScriptOperation, ScriptOperationFactory}
 import org.bitcoins.core.script.constant.ScriptOperation
 
 /** Created by chris on 1/22/16.
@@ -90,12 +90,16 @@ case object OP_NOP10 extends NOP {
 case class UndefinedOP_NOP(opCode: Int) extends ReservedOperation
 
 object ReservedOperation extends ScriptOperationFactory[ReservedOperation] {
-  lazy val undefinedOpCodes = for { i <- 0xbb to 0xff } yield UndefinedOP_NOP(i)
 
-  override val operations: scala.collection.immutable.Vector[
-    org.bitcoins.core.script.reserved.ReservedOperation
-      with Product
-      with java.io.Serializable] =
+  /** Filter out allocated opcodes so this set of [[ReservedOperation]] NOPs
+    * stays up to date
+    */
+  private lazy val undefinedOpCodes: Vector[ReservedOperation] = (0xbb to 0xff)
+    .filterNot(b => ScriptOperation.nonReservedOpCodes.exists(_.opCode == b))
+    .map(UndefinedOP_NOP(_))
+    .toVector
+
+  override val operations: Vector[ReservedOperation] =
     Vector(OP_RESERVED,
            OP_VER,
            OP_VERIF,

--- a/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala
@@ -94,7 +94,7 @@ object ReservedOperation extends ScriptOperationFactory[ReservedOperation] {
   /** Filter out allocated opcodes so this set of [[ReservedOperation]] NOPs
     * stays up to date
     */
-  private lazy val undefinedOpCodes: Vector[ReservedOperation] = (0xbb to 0xff)
+  private val undefinedOpCodes: Vector[ReservedOperation] = (0xbb to 0xff)
     .filterNot(b => ScriptOperation.nonReservedOpCodes.exists(_.opCode == b))
     .map(UndefinedOP_NOP(_))
     .toVector


### PR DESCRIPTION
This makes adding new opcodes simpler, you no longer have to remember to remove the byte that is the new opcode in 

https://github.com/bitcoin-s/bitcoin-s/blob/654d4086b993c35d4cd343a2009daed40c27d7b0/core/src/main/scala/org/bitcoins/core/script/reserved/ReservedOperations.scala#L93

Tested on #6064 to make sure it works as expected