### PR TITLE
node: Add invalid block header error message to log

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -846,9 +846,9 @@ case class DataMessageHandler(
         logger.warn(s"Received duplicate headers from ${peer} in state=$state")
         val d = headerSyncState.toDoneSyncing
         Future.successful(d)
-      case _: InvalidBlockHeader =>
+      case i: InvalidBlockHeader =>
         logger.warn(
-          s"Invalid headers of count $count sent from ${peer} in state=$state"
+          s"Invalid headers of count $count sent from ${peer} in state=$state error=$i"
         )
         recoverInvalidHeader(peerData)
       case e: Throwable => throw e

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,12 +20,12 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="WARN"/>
+    <logger name="org.bitcoins.node" level="INFO"/>
 
     <logger name="org.bitcoins.chain" level="WARN"/>
 


### PR DESCRIPTION
Add reason block header failed to connect to an internal chain state in our log