### PR TITLE
Allow `logback.xml` to be configured at runtime via the file in `conf/logback.xml`

### DIFF
--- a/app/server/src/universal/wallet-server-extra-startup-script.sh
+++ b/app/server/src/universal/wallet-server-extra-startup-script.sh
@@ -58,7 +58,7 @@ if [[ $chip == "arm64" || $chip == "aarch64" ]]; then
   declare java_cmd=$(get_java_no_jlink)
 
   # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
-  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file  ") "$@"
 
   run "$@"
 fi

--- a/build.sbt
+++ b/build.sbt
@@ -421,9 +421,6 @@ lazy val appServer = project
   .settings(jlinkOptions ++= CommonSettings.jlinkOptions)
   .settings(jlinkIgnoreMissingDependency := CommonSettings.appServerJlinkIgnore)
   .settings(bashScriptExtraDefines ++= IO.readLines(baseDirectory.value / "src" / "universal" / "wallet-server-extra-startup-script.sh"))
-/*  .settings(
-    // The correct form to define the path as ABSOLUTE from the app root ($app_home)
-    bashScriptExtraDefines += """addJava "-Dlogback.configurationFile=$app_home/../conf/logback.xml"""")*/
   .dependsOn(
     serverRoutes,
     appCommons,

--- a/build.sbt
+++ b/build.sbt
@@ -421,6 +421,9 @@ lazy val appServer = project
   .settings(jlinkOptions ++= CommonSettings.jlinkOptions)
   .settings(jlinkIgnoreMissingDependency := CommonSettings.appServerJlinkIgnore)
   .settings(bashScriptExtraDefines ++= IO.readLines(baseDirectory.value / "src" / "universal" / "wallet-server-extra-startup-script.sh"))
+/*  .settings(
+    // The correct form to define the path as ABSOLUTE from the app root ($app_home)
+    bashScriptExtraDefines += """addJava "-Dlogback.configurationFile=$app_home/../conf/logback.xml"""")*/
   .dependsOn(
     serverRoutes,
     appCommons,


### PR DESCRIPTION
fixes #5811 

If you want to modify the logging behavior at runtime, you can modify the file in `conf/logback.xml`. This file is configured to be rescanned by logback every 15 seconds.