### PR TITLE
ci: Use zulu jdk for docker release to avoid temurin jlink/jdep bug

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Setup Scala
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          # for some reason there seems to be a bug in the temurin runtime with jlink/jdeps
+          # this can likely be reverted back to temurin in the future
+          distribution: 'zulu'
           java-version: '25'
           cache: 'sbt'
       - name: Install sbt


### PR DESCRIPTION
missed in #6101 