### PR TITLE
core: Move NodeConstants to core, use it in the version message

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/node/constant/NodeConstants.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/node/constant/NodeConstants.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.node.constant
+package org.bitcoins.core.api.node.constant
 
 case object NodeConstants {
   val userAgent = "/bitcoin-s:1.9.11/"

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.p2p
 
+import org.bitcoins.core.api.node.constant.NodeConstants
 import org.bitcoins.core.bloom.{BloomFilter, BloomFlag}
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.gcs.{FilterHeader, FilterType, GolombFilter}
@@ -7,11 +8,10 @@ import org.bitcoins.core.number.{Int32, Int64, UInt16, UInt32, UInt64}
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader, MerkleBlock}
 import org.bitcoins.core.protocol.transaction.Transaction
-import org.bitcoins.core.serializers.p2p.messages._
+import org.bitcoins.core.serializers.p2p.messages.*
 import org.bitcoins.core.util.BytesUtil
 import org.bitcoins.core.wallet.fee.{SatoshisPerByte, SatoshisPerKiloByte}
-import org.bitcoins.crypto._
-
+import org.bitcoins.crypto.*
 import scodec.bits.ByteVector
 
 /** Trait that represents a payload for a message on the Bitcoin p2p network
@@ -1516,7 +1516,7 @@ object VersionMessage extends Factory[VersionMessage] {
       transmittingIpAddress: InetAddress,
       relay: Boolean): VersionMessage = {
     VersionMessage(network,
-                   ProtocolVersion.userAgent,
+                   NodeConstants.userAgent,
                    Int32.zero,
                    receivingIpAddress,
                    transmittingIpAddress,

--- a/core/src/main/scala/org/bitcoins/core/p2p/ProtocolVersion.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/ProtocolVersion.scala
@@ -15,9 +15,6 @@ object ProtocolVersion extends Factory[ProtocolVersion] {
   /** The default protocol version */
   val default: ProtocolVersion = ProtocolVersion70013
 
-  /** The Bitcoin-S node useragent */
-  val userAgent = "/bitcoins-spv-node/0.0.1"
-
   val versions: Seq[ProtocolVersion] = List(
     ProtocolVersion106,
     ProtocolVersion209,

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -21,12 +21,12 @@ import org.apache.pekko.util.ByteString
 import org.bitcoins.chain.blockchain.ChainHandler
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.node.Peer
+import org.bitcoins.core.api.node.constant.NodeConstants
 import org.bitcoins.core.number.Int32
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.node.NodeStreamMessage.DisconnectedPeer
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.constant.NodeConstants
 import org.bitcoins.node.networking.peer.PeerConnection.ConnectionGraph
 import org.bitcoins.node.{NodeStreamMessage, P2PLogger}
 import org.bitcoins.tor.{Socks5Connection, Socks5ConnectionState}

--- a/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
+++ b/node/src/main/scala/org/bitcoins/node/util/PeerMessageSenderApi.scala
@@ -2,6 +2,7 @@ package org.bitcoins.node.util
 
 import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
 import org.bitcoins.core.api.node.Peer
+import org.bitcoins.core.api.node.constant.NodeConstants
 import org.bitcoins.core.number.Int32
 import org.bitcoins.core.p2p.{
   GetAddrMessage,
@@ -19,7 +20,6 @@ import org.bitcoins.core.p2p.{
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.constant.NodeConstants
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -4,9 +4,9 @@ import com.typesafe.config.Config
 import org.apache.pekko.actor.ActorSystem
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.node.Peer
+import org.bitcoins.core.api.node.constant.NodeConstants
 import org.bitcoins.core.api.tor.Socks5ProxyParams
 import org.bitcoins.crypto.DoubleSha256DigestBE
-import org.bitcoins.node.constant.NodeConstants
 import org.bitcoins.node.{NeutrinoNode, Node, P2PLogger}
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.testkit.async.TestAsyncUtil


### PR DESCRIPTION
Use `NodeConstants.userAgent` in the version message. The version message exists in `core`, so move `NodeConstants` there.