### PR TITLE
2025 10 21 Store `VersionMessage` for each peer in `PeerData`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerFinder.scala
@@ -324,11 +324,11 @@ case class PeerFinder(
     }
   }
 
-  def setServiceIdentifier(
+  def setVersionMessage(
       peer: Peer,
-      serviceIdentifier: ServiceIdentifier
+      versionMessage: VersionMessage
   ): Unit = {
-    _peerData(peer).setServiceIdentifier(serviceIdentifier)
+    _peerData(peer).setVersionMessage(versionMessage)
   }
 
   def popFromCache(peer: Peer): Option[PeerData] = {
@@ -347,12 +347,8 @@ case class PeerFinder(
     _peersToTry.pushAll(peers, priority)
   }
 
-  def onVersionMessage(peer: Peer, versionMsg: VersionMessage): Unit = {
-    if (hasPeer(peer)) {
-      getPeerData(peer).get.setServiceIdentifier(versionMsg.services)
-    } else {
-      logger.warn(s"onVersionMessage called for unknown $peer")
-    }
+  def onVersionMessage(peer: Peer, versionMsg: VersionMessage): Option[Unit] = {
+    getPeerData(peer).map(_.setVersionMessage(versionMsg))
   }
 
   def buildPeerData(p: Peer, isPersistent: Boolean): PeerData = {

--- a/node/src/main/scala/org/bitcoins/node/PeerManager.scala
+++ b/node/src/main/scala/org/bitcoins/node/PeerManager.scala
@@ -1105,7 +1105,8 @@ case class PeerManager(
       peer: Peer,
       runningState: NodeRunningState): Future[NodeRunningState] = {
     val peerDataOpt = runningState.peerFinder.getPeerData(peer)
-    require(peerDataOpt.exists(_.peerWithServicesOpt.isDefined),
+    require(peerDataOpt.isDefined && peerDataOpt.exists(
+              _.peerWithServicesOpt.isDefined),
             s"Could not find services for peer=$peer!")
     val hasCf = peerDataOpt
       .exists(_.peerWithServicesOpt.exists(_.services.nodeCompactFilters))
@@ -1177,7 +1178,7 @@ case class PeerManager(
         _peerDataMap.put(peer, persistentPeerData)
       }
       logger.info(
-        s"Connected to peer $peer with compact filter support=$hasCf. Connected peer count ${newState.peerDataMap.size} state=$newState"
+        s"Connected to peer=$peer with compact filter support=$hasCf userAgent=${peerDataOpt.get.userAgent}. Connected peer count ${newState.peerDataMap.size} state=$newState"
       )
       newState
     }

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/ControlMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/ControlMessageHandler.scala
@@ -25,10 +25,15 @@ case class ControlMessageHandler(peerFinder: PeerFinder)(implicit
       s"Received control message=${payload.commandName} from peer=$peer")
     payload match {
       case versionMsg: VersionMessage =>
-        peerFinder.onVersionMessage(peer, versionMsg)
-        peerMsgSenderApi
-          .sendVerackMessage()
-          .map(_ => None)
+        peerFinder.onVersionMessage(peer, versionMsg) match {
+          case Some(_) =>
+            peerMsgSenderApi
+              .sendVerackMessage()
+              .map(_ => None)
+          case None =>
+            logger.warn(s"Could not find peer=$peer in PeerFinder!")
+            Future.successful(None)
+        }
 
       case VerAckMessage =>
         val i = ControlMessageHandler.Initialized(peer)


### PR DESCRIPTION
This PR stores the `VersionMessage` we receive from our Peer inside of `PeerData`. Previously we would store the `ServiceIdentifier` (#3773). 

This allows us to access all information in the version message for the lifetime of the peer. As a by product of this, we fix #6087 by adding the peer's user agent to our log.