### PR TITLE
bitcoindRpc: Cleanup old bitcoind data strutures

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/BlockchainResult.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/BlockchainResult.scala
@@ -105,7 +105,7 @@ case class GetBlockResult(
     ] // once v29 is minimal supported version, remove Option
 ) extends BlockchainResult
 
-abstract trait GetBlockWithTransactionsResult extends BlockchainResult {
+sealed trait GetBlockWithTransactionsResult extends BlockchainResult {
   def hash: DoubleSha256DigestBE
   def confirmations: Int
   def strippedsize: Int
@@ -181,28 +181,6 @@ case class GetBlockChainInfoResultPostV27(
       String
     ] // once v29 is minimal supported version, remove Option
 ) extends GetBlockChainInfoResult
-
-case class SoftforkPreV19(
-    id: String,
-    version: Int,
-    enforce: Option[Map[String, SoftforkProgressPreV19]],
-    reject: SoftforkProgressPreV19
-) extends BlockchainResult
-
-case class SoftforkProgressPreV19(
-    status: Option[Boolean],
-    found: Option[Int],
-    required: Option[Int],
-    window: Option[Int]
-) extends BlockchainResult
-
-case class Bip9SoftforkPreV19(
-    status: String,
-    bit: Option[Int],
-    startTime: Int,
-    timeout: BigInt,
-    since: Int
-) extends BlockchainResult
 
 sealed trait SoftforkPostV19 extends BlockchainResult
 
@@ -327,23 +305,6 @@ sealed trait GetMemPoolResult extends BlockchainResult {
   def depends: Vector[DoubleSha256DigestBE]
 }
 
-case class GetMemPoolResultPreV19(
-    size: Int,
-    fee: Option[Bitcoins],
-    modifiedfee: Option[Bitcoins],
-    time: UInt32,
-    height: Int,
-    descendantcount: Int,
-    descendantsize: Int,
-    descendantfees: Option[Bitcoins],
-    ancestorcount: Int,
-    ancestorsize: Int,
-    ancestorfees: Option[Bitcoins],
-    wtxid: DoubleSha256DigestBE,
-    fees: FeeInfo,
-    depends: Vector[DoubleSha256DigestBE]
-) extends GetMemPoolResult
-
 // v23 removes 'fee', 'modifiedfee', 'descendantfees', 'ancestorfees'
 case class GetMemPoolResultPostV23(
     vsize: Int,
@@ -379,23 +340,6 @@ sealed trait GetMemPoolEntryResult extends BlockchainResult {
   def fees: FeeInfo
   def depends: Option[Vector[DoubleSha256DigestBE]]
 }
-
-case class GetMemPoolEntryResultPreV19(
-    size: Int,
-    fee: Bitcoins,
-    modifiedfee: Bitcoins,
-    time: UInt32,
-    height: Int,
-    descendantcount: Int,
-    descendantsize: Int,
-    descendantfees: BitcoinFeeUnit,
-    ancestorcount: Int,
-    ancestorsize: Int,
-    ancestorfees: BitcoinFeeUnit,
-    wtxid: DoubleSha256DigestBE,
-    fees: FeeInfo,
-    depends: Option[Vector[DoubleSha256DigestBE]]
-) extends GetMemPoolEntryResult
 
 case class GetMemPoolEntryResultPostV23(
     vsize: Int,
@@ -456,7 +400,7 @@ case class GetMemPoolInfoResultV30(
     total_fee: Bitcoins
 ) extends GetMemPoolInfoResult
 
-sealed abstract trait GetTxOutResult extends BlockchainResult {
+sealed abstract class GetTxOutResult extends BlockchainResult {
   def bestblock: DoubleSha256DigestBE
   def confirmations: Int
   def value: Bitcoins

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/NetworkResult.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/NetworkResult.scala
@@ -71,25 +71,6 @@ case class GetNetworkInfoResultV28(
     warnings: Vector[String]
 ) extends GetNetworkInfoResult
 
-case class GetNetworkInfoResultPostV21(
-    version: Int,
-    subversion: String,
-    protocolversion: Int,
-    localservices: String,
-    localservicesnames: Option[Vector[ServiceIdentifier]],
-    localrelay: Boolean,
-    timeoffset: Int,
-    networkactive: Boolean,
-    connections: Int,
-    connections_in: Int,
-    connections_out: Int,
-    networks: Vector[Network],
-    relayfee: Bitcoins,
-    incrementalfee: Bitcoins,
-    localaddresses: Vector[NetworkAddress],
-    warnings: String
-) extends GetNetworkInfoResult
-
 case class Network(
     name: String,
     limited: Boolean,
@@ -141,7 +122,7 @@ case class PeerInfoResponseV25(
   override val addnode: Boolean = connection_type == "manual"
 }
 
-trait PeerNetworkInfo extends NetworkResult {
+sealed trait PeerNetworkInfo extends NetworkResult {
   def addr: URI
   def addrbind: URI
   def addrlocal: Option[URI]
@@ -158,24 +139,6 @@ trait PeerNetworkInfo extends NetworkResult {
   def minping: Option[BigDecimal]
   def pingwait: Option[BigDecimal]
 }
-
-case class PeerNetworkInfoPreV21(
-    addr: URI,
-    addrbind: URI,
-    addrlocal: Option[URI],
-    services: String,
-    servicesnames: Option[Vector[ServiceIdentifier]],
-    relaytxes: Boolean,
-    lastsend: UInt32,
-    lastrecv: UInt32,
-    bytessent: Int,
-    bytesrecv: Int,
-    conntime: UInt32,
-    timeoffset: Int,
-    pingtime: Option[BigDecimal],
-    minping: Option[BigDecimal],
-    pingwait: Option[BigDecimal]
-) extends PeerNetworkInfo
 
 case class PeerNetworkInfoPostV21(
     addr: URI,
@@ -204,13 +167,6 @@ trait NodeBan extends NetworkResult {
   def banned_until: UInt32
   def ban_created: UInt32
 }
-
-case class NodeBanPreV20(
-    address: URI,
-    banned_until: UInt32,
-    ban_created: UInt32,
-    ban_reason: String
-) extends NodeBan
 
 case class NodeBanPostV22(
     address: URI,

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/OtherResult.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/OtherResult.scala
@@ -9,12 +9,7 @@ import org.bitcoins.core.protocol.script.descriptor.Descriptor
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.SeqWrapper
 import org.bitcoins.core.wallet.fee.BitcoinFeeUnit
-import org.bitcoins.crypto.{
-  DoubleSha256Digest,
-  DoubleSha256DigestBE,
-  ECPublicKey,
-  Sha256Hash160Digest
-}
+import org.bitcoins.crypto.{DoubleSha256Digest, DoubleSha256DigestBE}
 import play.api.libs.json.JsObject
 
 sealed abstract class OtherResult
@@ -126,51 +121,13 @@ case class MemoryManager(
   *   This is defined as a trait and not just a raw case class (as is done in
   *   other RPC return values) in order to make it possible to deprecate fields.
   */
-trait ValidateAddressResult {
-
+sealed trait ValidateAddressResult {
   def isvalid: Boolean
   def address: Option[BitcoinAddress]
   def scriptPubKey: Option[ScriptPubKey]
   def error_locations: Option[Vector[Int]]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def ismine: Option[Boolean]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def iswatchonly: Option[Boolean]
   def isscript: Option[Boolean]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def script: Option[String]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def hex: Option[String]
-
   def sigsrequired: Option[Int]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def pubkey: Option[ECPublicKey]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def iscompressed: Option[Boolean]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def account: Option[String]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def hdkeypath: Option[String]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def hdmasterkeyid: Option[Sha256Hash160Digest]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def ischange: Option[Boolean]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def solvable: Option[Boolean]
-
-  @deprecated("Use 'getaddressinfo' instead", since = "0.16")
-  def desc: Option[String]
 }
 
 case class ValidateAddressResultImpl(
@@ -178,20 +135,8 @@ case class ValidateAddressResultImpl(
     address: Option[BitcoinAddress],
     scriptPubKey: Option[ScriptPubKey],
     error_locations: Option[Vector[Int]],
-    ismine: Option[Boolean],
-    iswatchonly: Option[Boolean],
     isscript: Option[Boolean],
-    script: Option[String],
-    hex: Option[String],
-    sigsrequired: Option[Int],
-    pubkey: Option[ECPublicKey],
-    iscompressed: Option[Boolean],
-    account: Option[String],
-    hdkeypath: Option[String],
-    hdmasterkeyid: Option[Sha256Hash160Digest],
-    ischange: Option[Boolean],
-    solvable: Option[Boolean],
-    desc: Option[String]
+    sigsrequired: Option[Int]
 ) extends ValidateAddressResult
 
 case class EstimateSmartFeeResult(

--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/RawTransactionResult.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/RawTransactionResult.scala
@@ -42,12 +42,6 @@ sealed trait RpcTransactionOutput extends RawTransactionResult {
   def scriptPubKey: RpcScriptPubKey
 }
 
-case class RpcTransactionOutputPreV22(
-    value: Bitcoins,
-    n: Int,
-    scriptPubKey: RpcScriptPubKeyPreV22
-) extends RpcTransactionOutput
-
 case class RpcTransactionOutputV22(
     value: Bitcoins,
     n: Int,
@@ -60,14 +54,6 @@ sealed trait RpcScriptPubKey extends RawTransactionResult {
   def `type`: ScriptType
   def addresses: Option[Vector[BitcoinAddress]]
 }
-
-case class RpcScriptPubKeyPreV22(
-    asm: String,
-    hex: String,
-    reqSigs: Option[Int],
-    `type`: ScriptType,
-    addresses: Option[Vector[BitcoinAddress]]
-) extends RpcScriptPubKey
 
 case class RpcScriptPubKeyPostV22(
     asm: String,

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/JsonSerializers.scala
@@ -119,21 +119,8 @@ object JsonSerializers {
     override def writes(key: ExtPrivateKey): JsValue = JsString(key.toString)
   }
 
-  // Transaction Models
-  implicit val rpcScriptPubKeyPreV22Reads: Reads[RpcScriptPubKeyPreV22] =
-    ((__ \ "asm").read[String] and
-      (__ \ "hex").read[String] and
-      (__ \ "reqSigs").readNullable[Int] and
-      (__ \ "type").read[ScriptType] and
-      (__ \ "addresses")
-        .readNullable[Vector[BitcoinAddress]])(RpcScriptPubKeyPreV22.apply _)
-
   implicit val rpcScriptPubKeyPostV22Reads: Reads[RpcScriptPubKeyPostV22] =
     Json.reads[RpcScriptPubKeyPostV22]
-
-  implicit val rpcTransactionOutputPreV22Reads
-      : Reads[RpcTransactionOutputPreV22] =
-    Json.reads[RpcTransactionOutputPreV22]
 
   implicit val rpcTransactionOutputV22Reads: Reads[RpcTransactionOutputV22] =
     Json.reads[RpcTransactionOutputV22]
@@ -186,9 +173,6 @@ object JsonSerializers {
   implicit val getNetworkInfoV28Reads: Reads[GetNetworkInfoResultV28] =
     Json.reads[GetNetworkInfoResultV28]
 
-  implicit val getNetworkInfoPostV21Reads: Reads[GetNetworkInfoResultPostV21] =
-    Json.reads[GetNetworkInfoResultPostV21]
-
   implicit val getNetworkInfoReads: Reads[GetNetworkInfoResult] = {
     Json.reads[GetNetworkInfoResult]
   }
@@ -224,9 +208,6 @@ object JsonSerializers {
   implicit val OutputReferenceWrites: OWrites[OutputReference] =
     Json.writes[OutputReference]
 
-  implicit val peerNetworkInfoPreV21Reads: Reads[PeerNetworkInfoPreV21] =
-    Json.reads[PeerNetworkInfoPreV21]
-
   implicit val peerNetworkInfoPostV21Reads: Reads[PeerNetworkInfoPostV21] =
     Json.reads[PeerNetworkInfoPostV21]
 
@@ -253,9 +234,6 @@ object JsonSerializers {
   implicit val nodeBanPostV22Reads: Reads[NodeBanPostV22] =
     Json.reads[NodeBanPostV22]
 
-  implicit val nodeBanPreV20Reads: Reads[NodeBanPreV20] =
-    Json.reads[NodeBanPreV20]
-
   // Blockchain Models
   implicit val dumpTxOutSetResultReads: Reads[DumpTxOutSetResult] =
     Json.reads[DumpTxOutSetResult]
@@ -270,15 +248,6 @@ object JsonSerializers {
   implicit val getBlockWithTransactionsResultV22Reads
       : Reads[GetBlockWithTransactionsResultV22] =
     Json.reads[GetBlockWithTransactionsResultV22]
-
-  implicit val softforkProgressPreV19Reads: Reads[SoftforkProgressPreV19] =
-    Json.reads[SoftforkProgressPreV19]
-
-  implicit val softforkPreV19Reads: Reads[SoftforkPreV19] =
-    Json.reads[SoftforkPreV19]
-
-  implicit val bip9SoftforkPreV19Reads: Reads[Bip9SoftforkPreV19] =
-    Json.reads[Bip9SoftforkPreV19]
 
   implicit val bip9SoftforkDetailsReads: Reads[Bip9SoftforkDetails] =
     Json.reads[Bip9SoftforkDetails]
@@ -310,15 +279,8 @@ object JsonSerializers {
 
   implicit val feeInfoReads: Reads[FeeInfo] = Json.reads[FeeInfo]
 
-  implicit val getMemPoolResultPreV19Reads: Reads[GetMemPoolResultPreV19] =
-    Json.reads[GetMemPoolResultPreV19]
-
   implicit val getMemPoolResultPostV23Reads: Reads[GetMemPoolResultPostV23] =
     Json.reads[GetMemPoolResultPostV23]
-
-  implicit val getMemPoolEntryResultPreV19Reads
-      : Reads[GetMemPoolEntryResultPreV19] =
-    Json.reads[GetMemPoolEntryResultPreV19]
 
   implicit val getMemPoolEntryResultPostV23Reads
       : Reads[GetMemPoolEntryResultPostV23] =
@@ -913,21 +875,10 @@ object JsonSerializers {
   implicit val serializedPSBTWrites: Writes[SerializedPSBT] =
     Json.writes[SerializedPSBT]
 
-  // Map stuff
-  implicit def mapDoubleSha256DigestReadsPreV19
-      : Reads[Map[DoubleSha256Digest, GetMemPoolResultPreV19]] =
-    Reads.mapReads[DoubleSha256Digest, GetMemPoolResultPreV19](s =>
-      JsSuccess(DoubleSha256Digest.fromHex(s)))
-
   implicit def mapDoubleSha256DigestReadsPostV23
       : Reads[Map[DoubleSha256Digest, GetMemPoolResultPostV23]] =
     Reads.mapReads[DoubleSha256Digest, GetMemPoolResultPostV23](s =>
       JsSuccess(DoubleSha256Digest.fromHex(s)))
-
-  implicit def mapDoubleSha256DigestBEReadsPreV19
-      : Reads[Map[DoubleSha256DigestBE, GetMemPoolResultPreV19]] =
-    Reads.mapReads[DoubleSha256DigestBE, GetMemPoolResultPreV19](s =>
-      JsSuccess(DoubleSha256DigestBE.fromHex(s)))
 
   implicit def mapDoubleSha256DigestBEReadsPostV23
       : Reads[Map[DoubleSha256DigestBE, GetMemPoolResultPostV23]] =


### PR DESCRIPTION
We only support bitcoind v28, v29, v30, remove data structures from unsupported bitcoind versions.