### PR TITLE
node: Remove the duplicate chainConfig/nodeConfig in NeutrinoNode

### DIFF
--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -109,10 +109,7 @@ val nodeF = for {
 } yield {
     NeutrinoNode(
         walletCreationTimeOpt = None, //you can set this to only sync compact filters after the timestamp
-        paramPeers = Vector(peer),
-        nodeConfig = nodeConfig,
-        chainConfig = chainConfig,
-        actorSystem = system)
+        paramPeers = Vector(peer))
 }
 
 //let's start it

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithUncachedBitcoindTest.scala
@@ -143,7 +143,7 @@ class NeutrinoNodeWithUncachedBitcoindTest extends NodeUnitTest with CachedTor {
           HeadersMessage(headers = Vector(invalidHeader))
         val sendFs = {
           val count = 1
-            .to(node.nodeConfig.maxInvalidResponsesAllowed + 1)
+            .to(node.nodeAppConfig.maxInvalidResponsesAllowed + 1)
           FutureUtil.sequentially[Int, Unit](count) { _ =>
             val msg =
               NodeStreamMessage.DataMessageWrapper(invalidHeaderMessage, peer)

--- a/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/NeutrinoNodeWithWalletTest.scala
@@ -374,7 +374,7 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
       : DataMessageHandler = {
     DataMessageHandler(
       chainApi =
-        ChainHandler.fromDatabase()(node.executionContext, node.chainConfig),
+        ChainHandler.fromDatabase()(node.executionContext, node.chainAppConfig),
       walletCreationTimeOpt = Some(wallet.creationTime),
       peerManager = node.peerManager,
       state = DoneSyncing(
@@ -384,9 +384,12 @@ class NeutrinoNodeWithWalletTest extends NodeTestWithCachedBitcoindNewest {
           peerManagerApi = node.peerManager,
           paramPeers = Vector.empty,
           queue = node.peerManager.queue
-        )(node.executionContext, node.system, node.nodeConfig, node.chainConfig)
+        )(node.executionContext,
+          node.system,
+          node.nodeAppConfig,
+          node.chainAppConfig)
       )
-    )(node.executionContext, node.nodeConfig, node.chainConfig)
+    )(node.executionContext, node.nodeAppConfig, node.chainAppConfig)
   }
 
 }

--- a/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerManagerTest.scala
@@ -97,7 +97,7 @@ class PeerManagerTest extends NodeTestWithCachedBitcoindNewest {
         timestamp = Instant.now()
         _ <- NodeTestUtil.disconnectNode(bitcoind, node)
         addrBytes = PeerDAOHelper.getAddrBytes(peer)
-        peerDb <- PeerDAO()(node.nodeConfig, system.dispatcher)
+        peerDb <- PeerDAO()(node.nodeAppConfig, system.dispatcher)
           .read((addrBytes, peer.port))
           .map(_.get)
       } yield {

--- a/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/ReConnectionTest.scala
@@ -60,7 +60,7 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
           expectedConnectionCount = 0
         )
         _ <- started.stop()
-        _ <- started.nodeConfig.stop()
+        _ <- started.nodeAppConfig.stop()
       } yield {
         succeed
       }
@@ -86,7 +86,7 @@ class ReConnectionTest extends NodeTestWithCachedBitcoindNewest {
         _ <- NodeTestUtil.awaitConnectionCount(started, 1)
         _ <- started.peerManager.isConnected(bitcoindPeer)
         _ <- started.stop()
-        _ <- started.nodeConfig.stop()
+        _ <- started.nodeAppConfig.stop()
       } yield {
         succeed
       }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -65,7 +65,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
           peerManagerApi = peerManager,
           paramPeers = Vector.empty,
           queue = node
-        )(system.dispatcher, system, node.nodeConfig, node.chainConfig)
+        )(system.dispatcher, system, node.nodeAppConfig, node.chainAppConfig)
         dataMessageHandler = DataMessageHandler(
           chainApi = chainApi,
           walletCreationTimeOpt = None,
@@ -77,7 +77,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
             peerFinder = peerFinder,
             sentQuery = Instant.now()
           )
-        )(node.executionContext, node.nodeAppConfig, node.chainConfig)
+        )(node.executionContext, node.nodeAppConfig, node.chainAppConfig)
 
         // Use signet genesis block header, this should be invalid for regtest
         invalidPayload =
@@ -211,14 +211,14 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         peer = peerManager.peers.head
         chainApi = ChainHandler.fromDatabase()(
           executionContext,
-          node.chainConfig
+          node.chainAppConfig
         )
         _ = require(peerManager.getPeerData(peer).isDefined)
         peerFinder = PeerFinder(
           peerManagerApi = peerManager,
           paramPeers = Vector.empty,
           queue = node
-        )(system.dispatcher, system, node.nodeConfig, node.chainConfig)
+        )(system.dispatcher, system, node.nodeAppConfig, node.chainAppConfig)
         dataMessageHandler = DataMessageHandler(
           chainApi = chainApi,
           walletCreationTimeOpt = None,
@@ -230,7 +230,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
             peerFinder = peerFinder,
             sentQuery = Instant.now()
           )
-        )(node.executionContext, node.nodeAppConfig, node.chainConfig)
+        )(node.executionContext, node.nodeAppConfig, node.chainAppConfig)
 
         // disconnect our node from bitcoind, then
         // use bitcoind to generate 2 blocks, and then try to send the headers
@@ -254,7 +254,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         newDmh1 <- newDmh0.handleDataPayload(payload1, peerData)
         blockCount <- chainApi.getBlockCount()
         _ <- node.stop()
-        _ <- node.nodeConfig.stop()
+        _ <- node.nodeAppConfig.stop()
       } yield {
         // we should have processed both headers
         assert(blockCount == initBlockCount + 2)
@@ -274,14 +274,14 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         peer = peerManager.peers.head
         chainApi = ChainHandler.fromDatabase()(
           executionContext,
-          node.chainConfig
+          node.chainAppConfig
         )
         _ = require(peerManager.getPeerData(peer).isDefined)
         peerFinder = PeerFinder(
           peerManagerApi = peerManager,
           paramPeers = Vector.empty,
           queue = node
-        )(system.dispatcher, system, node.nodeConfig, node.chainConfig)
+        )(system.dispatcher, system, node.nodeAppConfig, node.chainAppConfig)
         sentQuery0 = Instant.now()
         dataMessageHandler = DataMessageHandler(
           chainApi = chainApi,
@@ -294,7 +294,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
             peerFinder = peerFinder,
             sentQuery = sentQuery0
           )
-        )(node.executionContext, node.nodeAppConfig, node.chainConfig)
+        )(node.executionContext, node.nodeAppConfig, node.chainAppConfig)
 
         // disconnect our node from bitcoind, then
         // use bitcoind to generate 2,000 blocks, and then try to send the headers
@@ -304,7 +304,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         _ <- NodeTestUtil.disconnectNode(bitcoind, node)
         // fully functioning node no longer needed so shut it down
         _ <- node.stop()
-        _ <- node.nodeConfig.stop()
+        _ <- node.nodeAppConfig.stop()
         hashes <- bitcoind.generate(2000)
         blockHeaders <- Source(hashes)
           .mapAsync(FutureUtil.getParallelism)(bitcoind.getBlockHeaderRaw)
@@ -325,7 +325,7 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
   ): Future[NeutrinoNode] = {
 
     require(
-      initNode.nodeConfig.queryWaitTime != queryWaitTime,
+      initNode.nodeAppConfig.queryWaitTime != queryWaitTime,
       s"maxConnectedPeers must be different"
     )
     // make a custom config, set the inactivity timeout very low

--- a/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
+++ b/node/src/main/scala/org/bitcoins/node/NeutrinoNode.scala
@@ -36,23 +36,19 @@ import scala.concurrent.{Await, Future}
 
 case class NeutrinoNode(
     walletCreationTimeOpt: Option[Instant],
-    nodeConfig: NodeAppConfig,
-    chainConfig: ChainAppConfig,
-    actorSystem: ActorSystem,
     paramPeers: Vector[Peer]
-) extends Node
+)(
+    implicit override val nodeAppConfig: NodeAppConfig,
+    implicit override val chainAppConfig: ChainAppConfig,
+    implicit override val system: ActorSystem)
+    extends Node
     with SourceQueue[NodeStreamMessage] {
   require(
-    nodeConfig.nodeType == NodeType.NeutrinoNode,
-    s"We need our Neutrino mode enabled to be able to construct a Neutrino node, got=${nodeConfig.nodeType}!"
+    nodeAppConfig.nodeType == NodeType.NeutrinoNode,
+    s"We need our Neutrino mode enabled to be able to construct a Neutrino node, got=${nodeAppConfig.nodeType}!"
   )
 
   private val isStarted: AtomicBoolean = new AtomicBoolean(false)
-  implicit override def system: ActorSystem = actorSystem
-
-  implicit override def nodeAppConfig: NodeAppConfig = nodeConfig
-
-  implicit override def chainAppConfig: ChainAppConfig = chainConfig
 
   private val dataMessageStreamSource: Source[
     NodeStreamMessage,

--- a/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
+++ b/node/src/main/scala/org/bitcoins/node/config/NodeAppConfig.scala
@@ -237,9 +237,6 @@ object NodeAppConfig extends AppConfigFactoryActorSystem[NodeAppConfig] {
       case NodeType.NeutrinoNode =>
         val n = NeutrinoNode(
           walletCreationTimeOpt,
-          nodeConf,
-          chainConf,
-          system,
           paramPeers = peers
         )
         Future.successful(n)

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -331,10 +331,10 @@ abstract class NodeTestUtil extends P2PLogger {
   ): Future[NeutrinoNode] = {
     val stoppedConfigF = for {
       _ <- initNode.stop()
-      _ <- initNode.nodeConfig.stop()
+      _ <- initNode.nodeAppConfig.stop()
     } yield ()
     val newNodeAppConfigF =
-      stoppedConfigF.map(_ => initNode.nodeConfig.withOverrides(config))
+      stoppedConfigF.map(_ => initNode.nodeAppConfig.withOverrides(config))
     val nodeF = {
       for {
         newNodeAppConfig <- newNodeAppConfigF
@@ -342,11 +342,8 @@ abstract class NodeTestUtil extends P2PLogger {
       } yield {
         NeutrinoNode(
           walletCreationTimeOpt = initNode.walletCreationTimeOpt,
-          nodeConfig = newNodeAppConfig,
-          chainConfig = initNode.chainAppConfig,
-          actorSystem = initNode.system,
           paramPeers = initNode.paramPeers
-        )
+        )(newNodeAppConfig, initNode.chainAppConfig, initNode.system)
       }
     }
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -37,8 +37,8 @@ trait NodeUnitTest extends BaseNodeTest {
         )
         // we aren't calling node.start(), but we need to call appConfig.start()
         // to make sure migrations are run
-        _ <- node.chainConfig.start()
-        _ <- node.nodeConfig.start()
+        _ <- node.chainAppConfig.start()
+        _ <- node.nodeAppConfig.start()
       } yield node
     }
 
@@ -152,7 +152,7 @@ object NodeUnitTest extends P2PLogger {
       chainConfStartedF.map(_ => buildNeutrinoNode(peer, walletCreationTimeOpt))
     for {
       node <- nodeF
-      _ <- node.nodeConfig.start()
+      _ <- node.nodeAppConfig.start()
       startedNode <- node.start()
     } yield {
       startedNode
@@ -169,9 +169,6 @@ object NodeUnitTest extends P2PLogger {
   ): NeutrinoNode = {
     NeutrinoNode(
       walletCreationTimeOpt,
-      nodeConf,
-      chainConf,
-      system,
       paramPeers = Vector(peer)
     )
   }
@@ -394,10 +391,7 @@ object NodeUnitTest extends P2PLogger {
     } yield {
       NeutrinoNode(
         walletCreationTimeOpt,
-        paramPeers = Vector(peer),
-        nodeConfig = nodeAppConfig,
-        chainConfig = chainAppConfig,
-        actorSystem = system
+        paramPeers = Vector(peer)
       )
     }
 
@@ -426,10 +420,7 @@ object NodeUnitTest extends P2PLogger {
     } yield {
       NeutrinoNode(
         walletCreationTimeOpt,
-        paramPeers = Vector(peer),
-        nodeConfig = nodeAppConfig,
-        chainConfig = chainAppConfig,
-        actorSystem = system
+        paramPeers = Vector(peer)
       )
     }
 
@@ -462,10 +453,7 @@ object NodeUnitTest extends P2PLogger {
     } yield {
       NeutrinoNode(
         walletCreationTimeOpt = creationTimeOpt,
-        paramPeers = peers,
-        nodeConfig = nodeAppConfig,
-        chainConfig = chainAppConfig,
-        actorSystem = system
+        paramPeers = peers
       )
     }
 


### PR DESCRIPTION
Remove `nodeConfig`/`chainConfig` parameters that are immediately overshadowed by the implicit `nodeAppConfig`/`chainAppConfig` in `Node`. They are duplicate and confusing