### PR TITLE
Fix Taproot fundingOutputs ordering to comply with BIP-341

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TxSigComponent.scala
@@ -433,7 +433,13 @@ case class TaprootTxSigComponent(
     outputMap(outpoint)
   }
 
-  val fundingOutputs: Vector[TransactionOutput] = outputMap.values.toVector
+  // BIP-341 requires outputs to be ordered according to transaction inputs
+  // Cannot use outputMap.values.toVector because Map does not guarantee order
+  val fundingOutputs: Vector[TransactionOutput] = {
+    transaction.inputs.map { input =>
+      outputMap(input.previousOutput)
+    }.toVector
+  }
 
   override def scriptPubKey: TaprootScriptPubKey = {
     fundingOutput.scriptPubKey.asInstanceOf[TaprootScriptPubKey]


### PR DESCRIPTION
The previous implementation used outputMap.values.toVector which does not guarantee ordering. BIP-341 requires that outputs be ordered according to the transaction inputs order for correct sighash calculation.

This bug only affects Taproot transactions with multiple inputs that have different amounts, causing signature verification to fail.