### PR TITLE
wallet: Fix bug in `TransactionProcessing.subscribeForBlockProcessingCompletionSignal()`

### DIFF
--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/RescanHandling.scala
@@ -473,12 +473,12 @@ case class RescanHandling(
       blocks: Vector[DoubleSha256DigestBE]
   ): Future[Unit] = {
     logger.debug(s"Requesting ${blocks.size} block(s)")
-    val subs = blocks.map(
+    val subsF = Future.traverse(blocks)(
       transactionProcessing.subscribeForBlockProcessingCompletionSignal)
     val downloadF = nodeApi.downloadBlocks(blocks)
     for {
       _ <- downloadF
-      _ <- Future.sequence(subs)
+      _ <- subsF
     } yield ()
   }
 


### PR DESCRIPTION
In #5795 we moved to a pekko stream based implementation for allowing users to subscribe to when a block has been process by the wallet.

We have a bug in this implementation, where we would complete the returned `Future` from `subscribeForBlockProcessingCompletionSignal()` when _any_ block is processed by the wallet, not when the specific `blockHash` requested by the user is processed by the wallet.

This can lead to issues on rescans where we don't appropriately backpressure our rescan, thus leading to overloading our outbound requests to our peer and leading to other bugs like #5890 

related: #6131