### PR TITLE
node: Refactor tests to use `withBitcoinSAppConfig()` test fixture to avoid resource leaks

### DIFF
--- a/node-test/src/test/scala/org/bitcoins/node/PeerStackTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/PeerStackTest.scala
@@ -6,51 +6,58 @@ import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.node.Peer
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.node.networking.peer.{PeerConnection, PeerMessageSender}
-import org.bitcoins.testkit.util.BitcoinSAsyncTest
-
+import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.BitcoinSTestAppConfig
+import org.bitcoins.testkit.node.NodeUnitTest
+import org.scalatest.FutureOutcome
 import java.net.InetSocketAddress
-import java.nio.file.Files
 
-class PeerStackTest extends BitcoinSAsyncTest {
+class PeerStackTest extends NodeUnitTest {
+
+  override protected def getFreshConfig: BitcoinSAppConfig =
+    BitcoinSTestAppConfig.getNeutrinoWithEmbeddedDbTestConfig(
+      () => pgUrl(),
+      Vector.empty
+    )
+
+  override type FixtureParam = BitcoinSAppConfig
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+    withBitcoinSAppConfig(test)
 
   behavior of "PeerStack"
 
-  val tempDir = Files.createTempDirectory("bitcoin-s")
-
-  private implicit val nodeAppConfig: NodeAppConfig =
-    NodeAppConfig(baseDatadir = tempDir, Vector.empty)
-  private implicit val chainAppConfig: ChainAppConfig = {
-    ChainAppConfig(tempDir, Vector.empty)
-  }
   it must "not push the same ip address twice" in {
-    val stack = PeerStack()
-    val queue: SourceQueue[NodeStreamMessage] = Source
-      .queue[NodeStreamMessage](1, OverflowStrategy.backpressure)
-      .preMaterialize()
-      ._1
-    val peer0 =
-      Peer(InetSocketAddress.createUnresolved("127.0.0.1", 8333), None, None)
-    val peerMessageSender0 = PeerMessageSender(PeerConnection(peer0, queue))
-    val pd0: PeerData =
-      PersistentPeerData(peer = peer0, peerMessageSender = peerMessageSender0)
+    case param: BitcoinSAppConfig =>
+      implicit val chainAppConfig: ChainAppConfig = param.chainConf
+      implicit val nodeAppConfig: NodeAppConfig = param.nodeConf
+      val stack = PeerStack()
+      val queue: SourceQueue[NodeStreamMessage] = Source
+        .queue[NodeStreamMessage](1, OverflowStrategy.backpressure)
+        .preMaterialize()
+        ._1
+      val peer0 =
+        Peer(InetSocketAddress.createUnresolved("127.0.0.1", 8333), None, None)
+      val peerMessageSender0 = PeerMessageSender(PeerConnection(peer0, queue))
+      val pd0: PeerData =
+        PersistentPeerData(peer = peer0, peerMessageSender = peerMessageSender0)
 
-    stack.pushAll(Vector(pd0, pd0))
-    assert(stack.size == 1)
+      stack.pushAll(Vector(pd0, pd0))
+      assert(stack.size == 1)
 
-    val peer1 =
-      Peer(InetSocketAddress.createUnresolved("128.0.0.1", 8333), None, None)
+      val peer1 =
+        Peer(InetSocketAddress.createUnresolved("128.0.0.1", 8333), None, None)
 
-    val peerMessageSender1 = PeerMessageSender(PeerConnection(peer1, queue))
+      val peerMessageSender1 = PeerMessageSender(PeerConnection(peer1, queue))
 
-    val pd1: PeerData =
-      PersistentPeerData(peer = peer1, peerMessageSender = peerMessageSender1)
+      val pd1: PeerData =
+        PersistentPeerData(peer = peer1, peerMessageSender = peerMessageSender1)
 
-    stack.pushAll(Vector(pd1, pd1))
-    assert(stack.size == 2)
-    val popPd1 = stack.pop()
-    assert(popPd1 == pd1)
-    val popPd0 = stack.pop()
-    assert(popPd0 == pd0)
-    assert(stack.size == 0)
+      stack.pushAll(Vector(pd1, pd1))
+      assert(stack.size == 2)
+      val popPd1 = stack.pop()
+      assert(popPd1 == pd1)
+      val popPd0 = stack.pop()
+      assert(popPd0 == pd0)
+      assert(stack.size == 0)
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -4,14 +4,16 @@ import org.apache.pekko.actor.ActorSystem
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.core.api.node.{NodeType, Peer}
-import org.bitcoins.node._
+import org.bitcoins.node.*
 import org.bitcoins.node.config.NodeAppConfig
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.rpc.util.RpcUtil
 import org.bitcoins.server.BitcoinSAppConfig
+import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.fixtures.BitcoinSFixture
-import org.bitcoins.testkit.node.fixture._
+import org.bitcoins.testkit.node.fixture.*
+import org.bitcoins.testkit.server.BitcoinSServerMainUtil
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletWithBitcoindRpc}
 import org.bitcoins.wallet.callback.WalletCallbacks
 import org.scalatest.FutureOutcome
@@ -127,6 +129,19 @@ trait NodeUnitTest extends BaseNodeTest {
       destroy = NodeUnitTest.destroyNodeFundedWalletBitcoind(
         _: NodeFundedWalletBitcoind
       )(system, appConfig)
+    )(test)
+  }
+
+  def withBitcoinSAppConfig(test: OneArgAsyncTest): FutureOutcome = {
+    makeDependentFixture(
+      build = () => {
+        val bitcoinSAppConfig = BitcoinSTestAppConfig.getNeutrinoTestConfig()
+        val startBitcoinSAppConfigF = bitcoinSAppConfig.start()
+        startBitcoinSAppConfigF.map(_ => bitcoinSAppConfig)
+      },
+      destroy = { (s: BitcoinSAppConfig) =>
+        BitcoinSServerMainUtil.destroyBitcoinSAppConfig(s)
+      }
     )(test)
   }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -570,9 +570,7 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         _ <- wallet.utxoHandling.clearAllUtxos()
         _ <- wallet.utxoHandling.clearAllAddresses()
         balanceAfterClear <- wallet.getBalance()
-        rescanState <- wallet.rescanHandling.fullRescanNeutrinoWallet(1,
-                                                                      force =
-                                                                        true)
+        rescanState <- wallet.rescanHandling.fullRescanNeutrinoWallet(1, true)
         _ <- RescanState.awaitRescanDone(rescanState)
         _ <- AsyncUtil.awaitConditionF(
           () => wallet.getBalance().map(_ == balanceAfterPayment1),

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/RescanHandlingTest.scala
@@ -570,7 +570,9 @@ class RescanHandlingTest extends BitcoinSWalletTestCachedBitcoindNewest {
         _ <- wallet.utxoHandling.clearAllUtxos()
         _ <- wallet.utxoHandling.clearAllAddresses()
         balanceAfterClear <- wallet.getBalance()
-        rescanState <- wallet.rescanHandling.fullRescanNeutrinoWallet(1, true)
+        rescanState <- wallet.rescanHandling.fullRescanNeutrinoWallet(1,
+                                                                      force =
+                                                                        true)
         _ <- RescanState.awaitRescanDone(rescanState)
         _ <- AsyncUtil.awaitConditionF(
           () => wallet.getBalance().map(_ == balanceAfterPayment1),


### PR DESCRIPTION
Fixes a resource leak in `PeerStackTest` where we weren't properly destructing things after a test run. Now we use a test fixture across the node tests rather than ad hoc cleaning up after ourselves.