### PR TITLE
core: Add ability to construct a scriptsig from the scriptPubKey it is spending

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -637,4 +637,38 @@ object ScriptSignature extends ScriptFactory[ScriptSignature] {
     }
 
   override def isValidAsm(asm: Seq[ScriptToken]): Boolean = true
+
+  def fromScriptPubKey(
+      scriptPubKey: ScriptPubKey,
+      asm: Vector[ScriptToken]): ScriptSignature = {
+    scriptPubKey match {
+      case _: P2PKHScriptPubKey =>
+        P2PKHScriptSignature.fromAsm(asm)
+      case _: P2SHScriptPubKey =>
+        P2SHScriptSignature.fromAsm(asm)
+      case _: MultiSignatureScriptPubKey =>
+        MultiSignatureScriptSignature.fromAsm(asm)
+      case _: P2PKScriptPubKey =>
+        P2PKScriptSignature.fromAsm(asm)
+      case _: P2PKWithTimeoutScriptPubKey =>
+        P2PKWithTimeoutScriptSignature.fromAsm(asm)
+      case lockTime: LockTimeScriptPubKey =>
+        lockTime match {
+          case _: CLTVScriptPubKey =>
+            CLTVScriptSignature.fromAsm(asm)
+          case _: CSVScriptPubKey =>
+            CSVScriptSignature.fromAsm(asm)
+        }
+      case _: ConditionalScriptPubKey =>
+        ConditionalScriptSignature.fromAsm(asm)
+      case _: WitnessScriptPubKey =>
+        ScriptSignature.empty
+      case _: WitnessCommitment =>
+        ScriptSignature.empty
+      case EmptyScriptPubKey =>
+        ScriptSignature.empty
+      case _: NonStandardScriptPubKey =>
+        NonStandardScriptSignature.fromAsm(asm)
+    }
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptSignature.scala
@@ -665,9 +665,7 @@ object ScriptSignature extends ScriptFactory[ScriptSignature] {
         ScriptSignature.empty
       case _: WitnessCommitment =>
         ScriptSignature.empty
-      case EmptyScriptPubKey =>
-        ScriptSignature.empty
-      case _: NonStandardScriptPubKey =>
+      case _: NonStandardScriptPubKey | EmptyScriptPubKey =>
         NonStandardScriptSignature.fromAsm(asm)
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -2,7 +2,11 @@ package org.bitcoins.core.protocol.transaction
 
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.{Int32, UInt32}
-import org.bitcoins.core.protocol.script.{EmptyScriptWitness, ScriptSignature, ScriptWitness}
+import org.bitcoins.core.protocol.script.{
+  EmptyScriptWitness,
+  ScriptSignature,
+  ScriptWitness
+}
 import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.util.BytesUtil
 import org.bitcoins.core.wallet.builder.RawTxBuilder
@@ -139,10 +143,10 @@ object Transaction extends Factory[Transaction] {
     tx
   }
 
-  /** This allows us to accurately type
-    * transaction input's [[org.bitcoins.core.protocol.script.ScriptSignature]] as
-    * we have the corresponding
-    * [[org.bitcoins.core.protocol.script.ScriptPubKey]] the input is spending.
+  /** This allows us to accurately type transaction input's
+    * [[org.bitcoins.core.protocol.script.ScriptSignature]] as we have the
+    * corresponding [[org.bitcoins.core.protocol.script.ScriptPubKey]] the input
+    * is spending.
     */
   def fromSpentOutputs(
       initTx: Transaction,

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -2,10 +2,11 @@ package org.bitcoins.core.protocol.transaction
 
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.{Int32, UInt32}
-import org.bitcoins.core.protocol.script.{EmptyScriptWitness, ScriptWitness}
+import org.bitcoins.core.protocol.script.{EmptyScriptWitness, ScriptSignature, ScriptWitness}
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.util.BytesUtil
 import org.bitcoins.core.wallet.builder.RawTxBuilder
-import org.bitcoins.crypto._
+import org.bitcoins.crypto.*
 import scodec.bits.ByteVector
 
 /** Created by chris on 7/14/15.
@@ -136,6 +137,30 @@ object Transaction extends Factory[Transaction] {
       }
     }
     tx
+  }
+
+  /** This allows us to accurately type
+    * transaction input's [[org.bitcoins.core.protocol.script.ScriptSignature]] as
+    * we have the corresponding
+    * [[org.bitcoins.core.protocol.script.ScriptPubKey]] the input is spending.
+    */
+  def fromSpentOutputs(
+      initTx: Transaction,
+      spentOutputs: PreviousOutputMap): Transaction = {
+    require(initTx.inputs.size == spentOutputs.size)
+    require(initTx.inputs.exists(i => spentOutputs.contains(i.previousOutput)))
+    initTx.inputs.zipWithIndex.foldLeft(initTx) { case (tx, (input, idx)) =>
+      val prevOutput = spentOutputs(input.previousOutput)
+      val updatedScriptSig =
+        ScriptSignature.fromScriptPubKey(prevOutput.scriptPubKey,
+                                         input.scriptSignature.asm.toVector)
+      val updatedInput = TransactionInput(
+        input.previousOutput,
+        updatedScriptSig,
+        input.sequence
+      )
+      tx.updateInput(idx, updatedInput)
+    }
   }
 }
 


### PR DESCRIPTION
This PR allows you to always correctly type a `ScriptSignature` if you have access to the corresponding `ScriptPubKey` it is spending. 

Previously in our codebase, we made a best guess of what the type of a `ScriptSignature` is without access to the `ScriptPubKey` it was spending. This works in 99% of cases, but will fail occassionaly - for instance when a nonstandard p2sh redeem script is being spent (#55, #57, #1533, #1594, #5920, #5921)