### PR TITLE
Add BIP47 Reusable Payment Codes Support

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/bip47/BIP47Test.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/bip47/BIP47Test.scala
@@ -1,0 +1,114 @@
+package org.bitcoins.core.bip47
+
+import org.bitcoins.core.config.MainNet
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import scodec.bits.ByteVector
+
+class BIP47Test extends BitcoinSUnitTest {
+
+  behavior of "BIP47"
+
+  val testSeedAlice: ByteVector = ByteVector.fromValidHex(
+    "64dca76abc9c6f0cf3d212d248c380c4622c8f93b2c425ec6a5567fd5db57e10d3e6f94a2f6af4ac2edb8998571f8664ec056d6281dc2fdc3fed1e8ae0eb7b5a"
+  )
+
+  val testSeedBob: ByteVector = ByteVector.fromValidHex(
+    "87eaaac5a539ab028df44d9110f5b2a8ef4edce19cf8a7e4cffd5f4d826a7f53a0a1a10b2e4f8e35ad0c3f5e0c6d7c7e8d2a6f9b8c7d6e5f4a3b2c1d0e9f8a7b6"
+  )
+
+  it must "create a payment code from seed" in {
+    val account = BIP47Account.fromSeed(testSeedAlice, MainNet, 0)
+    val paymentCode = account.paymentCode
+
+    assert(paymentCode.isValid)
+    assert(paymentCode.pubKey.bytes.size == 33)
+    assert(paymentCode.chainCode.bytes.size == 32)
+  }
+
+  it must "serialize and deserialize payment code symmetrically" in {
+    val account = BIP47Account.fromSeed(testSeedAlice, MainNet, 0)
+    val paymentCode = account.paymentCode
+
+    val serialized = paymentCode.bytes
+    val deserialized = PaymentCode.fromBytes(serialized)
+
+    assert(deserialized.pubKey == paymentCode.pubKey)
+    assert(deserialized.chainCode == paymentCode.chainCode)
+    assert(deserialized.version == paymentCode.version)
+  }
+
+  it must "compute symmetric ECDH shared secrets" in {
+    val aliceAccount = BIP47Account.fromSeed(testSeedAlice, MainNet, 0)
+    val bobAccount = BIP47Account.fromSeed(testSeedBob, MainNet, 0)
+
+    val alicePriv = aliceAccount.notificationKey.key
+    val bobPriv = bobAccount.notificationKey.key
+
+    val alicePub = alicePriv.publicKey
+    val bobPub = bobPriv.publicKey
+
+    val secretAliceToBob = SecretPoint(alicePriv, bobPub)
+    val secretBobToAlice = SecretPoint(bobPriv, alicePub)
+
+    assert(secretAliceToBob.ecdhSecret == secretBobToAlice.ecdhSecret)
+  }
+
+  it must "mask and unmask payment code payload" in {
+    val account = BIP47Account.fromSeed(testSeedAlice, MainNet, 0)
+    val payload = account.paymentCode.payload
+
+    val fakeSecretPoint = ByteVector.fill(32)(0x42)
+    val fakeOutpoint = ByteVector.fill(36)(0x01)
+
+    val mask = PaymentCode.getMask(fakeSecretPoint, fakeOutpoint)
+    val blinded = PaymentCode.blind(payload, mask)
+    val unblinded = PaymentCode.blind(blinded, mask)
+
+    assert(unblinded == payload)
+  }
+
+  it must "derive mutual payment addresses" in {
+    val aliceAccount = BIP47Account.fromSeed(testSeedAlice, MainNet, 0)
+    val bobAccount = BIP47Account.fromSeed(testSeedBob, MainNet, 0)
+
+    val alicePaymentCode = aliceAccount.paymentCode
+    val bobPaymentCode = bobAccount.paymentCode
+
+    val aliceSendsToBob =
+      aliceAccount.paymentAddressForSending(bobPaymentCode, 0)
+    val bobReceivesFromAlice =
+      bobAccount.paymentAddressForReceiving(alicePaymentCode, 0)
+
+    val aliceSendAddress = aliceSendsToBob.segwitAddressForSend
+    val bobReceiveAddress = bobReceivesFromAlice.segwitAddressForReceive
+
+    assert(aliceSendAddress == bobReceiveAddress)
+  }
+
+  it must "generate valid segwit addresses" in {
+    val account = BIP47Account.fromSeed(testSeedAlice, MainNet, 0)
+    val address = account.addressAt(0)
+
+    assert(address.value.startsWith("bc1"))
+  }
+
+  it must "derive keys at correct indices" in {
+    val account = BIP47Account.fromSeed(testSeedAlice, MainNet, 0)
+
+    val key0 = account.privateKeyAt(0)
+    val key1 = account.privateKeyAt(1)
+
+    assert(key0 != key1)
+    assert(key0.publicKey != key1.publicKey)
+  }
+
+  it must "create watch-only account from payment code" in {
+    val account = BIP47Account.fromSeed(testSeedAlice, MainNet, 0)
+    val paymentCode = account.paymentCode
+
+    val watchOnly = WatchOnlyBIP47Account(paymentCode, MainNet)
+
+    assert(watchOnly.publicKeyAt(0) == account.publicKeyAt(0))
+    assert(watchOnly.publicKeyAt(1) == account.publicKeyAt(1))
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/bip47/BIP47Account.scala
+++ b/core/src/main/scala/org/bitcoins/core/bip47/BIP47Account.scala
@@ -1,0 +1,204 @@
+package org.bitcoins.core.bip47
+
+import org.bitcoins.core.config.{MainNet, NetworkParameters}
+import org.bitcoins.core.crypto._
+import org.bitcoins.core.crypto.ExtKeyVersion.LegacyMainNetPriv
+import org.bitcoins.core.crypto.ExtKeyVersion.LegacyTestNet3Priv
+import org.bitcoins.core.crypto.ExtKeyPubVersion.LegacyMainNetPub
+import org.bitcoins.core.crypto.ExtKeyPubVersion.LegacyTestNet3Pub
+import org.bitcoins.core.number.{UInt32, UInt8}
+import org.bitcoins.core.protocol.{Bech32Address, P2PKHAddress}
+import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
+import org.bitcoins.crypto.{CryptoUtil, ECPrivateKey, ECPublicKey}
+import scodec.bits.ByteVector
+
+import scala.util.Try
+
+/** Represents a BIP47 account at derivation path m/47'/coin_type'/account'.
+  * @see
+  *   [[https://github.com/bitcoin/bips/blob/master/bip-0047.mediawiki BIP47]]
+  */
+sealed abstract class BIP47Account {
+
+  def extPrivKey: ExtPrivateKey
+
+  def network: NetworkParameters
+
+  def accountIndex: Int
+
+  def paymentCode: PaymentCode = {
+    val accountKey = extPrivKey
+    PaymentCode(accountKey.key.publicKey, accountKey.chainCode)
+  }
+
+  def notificationKey: ExtPrivateKey = deriveKey(0)
+
+  def notificationAddress: P2PKHAddress = {
+    val pubKey = notificationKey.key.publicKey
+    val hash = CryptoUtil.sha256Hash160(pubKey.bytes)
+    P2PKHAddress(hash, network)
+  }
+
+  def notificationSegwitAddress: Bech32Address = {
+    val pubKey = notificationKey.key.publicKey
+    val spk = P2WPKHWitnessSPKV0(pubKey)
+    Bech32Address(spk, network)
+  }
+
+  def deriveKey(index: Int): ExtPrivateKey = {
+    extPrivKey.deriveChildPrivKey(UInt32(index))
+  }
+
+  def privateKeyAt(index: Int): ECPrivateKey = deriveKey(index).key
+
+  def publicKeyAt(index: Int): ECPublicKey = privateKeyAt(index).publicKey
+
+  def addressAt(index: Int): Bech32Address = {
+    val pubKey = publicKeyAt(index)
+    val spk = P2WPKHWitnessSPKV0(pubKey)
+    Bech32Address(spk, network)
+  }
+
+  /** Creates a PaymentAddress for sending to a remote party. */
+  def paymentAddressForSending(
+      remotePaymentCode: PaymentCode,
+      index: Int): PaymentAddress = {
+    PaymentAddress.forSending(
+      localPrivKey = notificationKey.key,
+      remotePaymentCode = remotePaymentCode,
+      index = index,
+      network = network
+    )
+  }
+
+  /** Creates a PaymentAddress for receiving from a remote party. */
+  def paymentAddressForReceiving(
+      remotePaymentCode: PaymentCode,
+      index: Int): PaymentAddress = {
+    PaymentAddress.forReceiving(
+      localPaymentCode = paymentCode,
+      localPrivKeyAtIndex = privateKeyAt(index),
+      remotePaymentCode = remotePaymentCode,
+      index = index,
+      network = network
+    )
+  }
+}
+
+object BIP47Account {
+  val Purpose: Int = 47
+  val HardenedOffset: Long = 0x80000000L
+
+  private case class BIP47AccountImpl(
+      extPrivKey: ExtPrivateKey,
+      network: NetworkParameters,
+      accountIndex: Int)
+      extends BIP47Account
+
+  def apply(
+      extPrivKey: ExtPrivateKey,
+      network: NetworkParameters,
+      accountIndex: Int): BIP47Account = {
+    BIP47AccountImpl(extPrivKey, network, accountIndex)
+  }
+
+  /** Creates a BIP47Account from a seed at the standard derivation path. */
+  def fromSeed(
+      seed: ByteVector,
+      network: NetworkParameters,
+      accountIndex: Int = 0): BIP47Account = {
+    val version = network match {
+      case _: MainNet => LegacyMainNetPriv
+      case _          => LegacyTestNet3Priv
+    }
+
+    val master = ExtPrivateKey(version, Some(seed))
+
+    val purposeKey =
+      master.deriveChildPrivKey(UInt32(Purpose + HardenedOffset))
+    val coinTypeKey =
+      purposeKey.deriveChildPrivKey(UInt32(coinType(network) + HardenedOffset))
+    val accountKey =
+      coinTypeKey.deriveChildPrivKey(UInt32(accountIndex + HardenedOffset))
+
+    BIP47AccountImpl(accountKey, network, accountIndex)
+  }
+
+  def fromExtendedKey(
+      accountKey: ExtPrivateKey,
+      network: NetworkParameters,
+      accountIndex: Int): BIP47Account = {
+    BIP47AccountImpl(accountKey, network, accountIndex)
+  }
+
+  def fromPaymentCode(
+      paymentCode: PaymentCode,
+      network: NetworkParameters): WatchOnlyBIP47Account = {
+    WatchOnlyBIP47Account(paymentCode, network)
+  }
+
+  private def coinType(network: NetworkParameters): Long = network match {
+    case _: MainNet => 0L
+    case _          => 1L
+  }
+}
+
+/** Watch-only BIP47 account created from a payment code (no private keys). */
+sealed abstract class WatchOnlyBIP47Account {
+
+  def paymentCode: PaymentCode
+
+  def network: NetworkParameters
+
+  def publicKeyAt(index: Int): ECPublicKey = {
+    val masterKey = ExtPublicKey(
+      extKeyVersion(network),
+      UInt8.zero,
+      ByteVector.fill(4)(0),
+      UInt32.zero,
+      paymentCode.chainCode,
+      paymentCode.pubKey
+    )
+    masterKey.deriveChildPubKey(index).get.key
+  }
+
+  def addressAt(index: Int): Bech32Address = {
+    val pubKey = publicKeyAt(index)
+    val spk = P2WPKHWitnessSPKV0(pubKey)
+    Bech32Address(spk, network)
+  }
+
+  def notificationAddress: P2PKHAddress = {
+    val pubKey = publicKeyAt(0)
+    val hash = CryptoUtil.sha256Hash160(pubKey.bytes)
+    P2PKHAddress(hash, network)
+  }
+
+  private def extKeyVersion(network: NetworkParameters): ExtKeyPubVersion =
+    network match {
+      case _: MainNet => LegacyMainNetPub
+      case _          => LegacyTestNet3Pub
+    }
+}
+
+object WatchOnlyBIP47Account {
+
+  private case class WatchOnlyBIP47AccountImpl(
+      paymentCode: PaymentCode,
+      network: NetworkParameters)
+      extends WatchOnlyBIP47Account
+
+  def apply(
+      paymentCode: PaymentCode,
+      network: NetworkParameters): WatchOnlyBIP47Account = {
+    WatchOnlyBIP47AccountImpl(paymentCode, network)
+  }
+
+  def fromBase58(
+      base58: String,
+      network: NetworkParameters): Try[WatchOnlyBIP47Account] = {
+    PaymentCode.fromBase58(base58).map { pc =>
+      WatchOnlyBIP47AccountImpl(pc, network)
+    }
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/bip47/PaymentAddress.scala
+++ b/core/src/main/scala/org/bitcoins/core/bip47/PaymentAddress.scala
@@ -6,13 +6,7 @@ import org.bitcoins.core.crypto.ExtKeyPubVersion.LegacyMainNetPub
 import org.bitcoins.core.number.{UInt32, UInt8}
 import org.bitcoins.core.protocol.Bech32Address
 import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
-import org.bitcoins.crypto.{
-  CryptoParams,
-  CryptoUtil,
-  ECPrivateKey,
-  ECPublicKey,
-  FieldElement
-}
+import org.bitcoins.crypto.{CryptoUtil, ECPrivateKey, ECPublicKey, FieldElement}
 import scodec.bits.ByteVector
 
 import java.math.BigInteger
@@ -39,9 +33,8 @@ sealed abstract class PaymentAddress {
 
   def tweakFieldElement: FieldElement = {
     val s = new BigInteger(1, sharedSecretHash.toArray)
-    val n = CryptoParams.getN
-    if (s.compareTo(BigInteger.ONE) <= 0 || s.compareTo(n) >= 0) {
-      throw new IllegalStateException("Secret point not on secp256k1 curve")
+    if (s.compareTo(BigInteger.ONE) <= 0) {
+      throw new IllegalStateException("Invalid scalar for EC operations")
     }
     FieldElement(sharedSecretHash)
   }

--- a/core/src/main/scala/org/bitcoins/core/bip47/PaymentAddress.scala
+++ b/core/src/main/scala/org/bitcoins/core/bip47/PaymentAddress.scala
@@ -1,0 +1,147 @@
+package org.bitcoins.core.bip47
+
+import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.crypto.ExtPublicKey
+import org.bitcoins.core.crypto.ExtKeyPubVersion.LegacyMainNetPub
+import org.bitcoins.core.number.{UInt32, UInt8}
+import org.bitcoins.core.protocol.Bech32Address
+import org.bitcoins.core.protocol.script.P2WPKHWitnessSPKV0
+import org.bitcoins.crypto.{
+  CryptoParams,
+  CryptoUtil,
+  ECPrivateKey,
+  ECPublicKey,
+  FieldElement
+}
+import scodec.bits.ByteVector
+
+import java.math.BigInteger
+
+/** Represents a derived payment address for BIP47 transactions. Used for both
+  * sending and receiving payments.
+  */
+sealed abstract class PaymentAddress {
+
+  def paymentCode: PaymentCode
+
+  def index: Int
+
+  def network: NetworkParameters
+
+  protected def localPrivKey: ECPrivateKey
+
+  protected def remotePublicKey: ECPublicKey
+
+  def secretPoint: SecretPoint = SecretPoint(localPrivKey, remotePublicKey)
+
+  def sharedSecretHash: ByteVector =
+    CryptoUtil.sha256(secretPoint.ecdhSecret).bytes
+
+  def tweakFieldElement: FieldElement = {
+    val s = new BigInteger(1, sharedSecretHash.toArray)
+    val n = CryptoParams.getN
+    if (s.compareTo(BigInteger.ONE) <= 0 || s.compareTo(n) >= 0) {
+      throw new IllegalStateException("Secret point not on secp256k1 curve")
+    }
+    FieldElement(sharedSecretHash)
+  }
+
+  /** Derives the public key for sending to the remote party. */
+  def sendPublicKey: ECPublicKey = {
+    val tweak = tweakFieldElement
+    CryptoUtil.pubKeyTweakAdd(remotePublicKey, tweak.toPrivateKey)
+  }
+
+  /** Derives the private key for receiving from the remote party. */
+  def receivePrivateKey: ECPrivateKey = {
+    val tweak = tweakFieldElement
+    val result = localPrivKey.fieldElement.add(tweak)
+    result.toPrivateKey
+  }
+
+  /** Generates a SegWit address for sending to the remote party. */
+  def segwitAddressForSend: Bech32Address = {
+    val spk = P2WPKHWitnessSPKV0(sendPublicKey)
+    Bech32Address(spk, network)
+  }
+
+  /** Generates a SegWit address for receiving from the remote party. */
+  def segwitAddressForReceive: Bech32Address = {
+    val spk = P2WPKHWitnessSPKV0(receivePrivateKey.publicKey)
+    Bech32Address(spk, network)
+  }
+}
+
+object PaymentAddress {
+
+  private case class PaymentAddressImpl(
+      paymentCode: PaymentCode,
+      index: Int,
+      localPrivKey: ECPrivateKey,
+      remotePublicKey: ECPublicKey,
+      network: NetworkParameters)
+      extends PaymentAddress
+
+  /** Creates a PaymentAddress for sending to a remote party.
+    * @param localPrivKey
+    *   your private key at index 0
+    * @param remotePaymentCode
+    *   the recipient's payment code
+    * @param index
+    *   the address index
+    * @param network
+    *   the network parameters
+    */
+  def forSending(
+      localPrivKey: ECPrivateKey,
+      remotePaymentCode: PaymentCode,
+      index: Int,
+      network: NetworkParameters): PaymentAddress = {
+    val remoteKey = derivePublicKeyAtIndex(remotePaymentCode, index)
+    PaymentAddressImpl(remotePaymentCode,
+                       index,
+                       localPrivKey,
+                       remoteKey,
+                       network)
+  }
+
+  /** Creates a PaymentAddress for receiving from a remote party.
+    * @param localPaymentCode
+    *   your payment code
+    * @param localPrivKeyAtIndex
+    *   your private key at the specified index
+    * @param remotePaymentCode
+    *   the sender's payment code
+    * @param index
+    *   the address index
+    * @param network
+    *   the network parameters
+    */
+  def forReceiving(
+      localPaymentCode: PaymentCode,
+      localPrivKeyAtIndex: ECPrivateKey,
+      remotePaymentCode: PaymentCode,
+      index: Int,
+      network: NetworkParameters): PaymentAddress = {
+    val remoteKey = derivePublicKeyAtIndex(remotePaymentCode, index)
+    PaymentAddressImpl(localPaymentCode,
+                       index,
+                       localPrivKeyAtIndex,
+                       remoteKey,
+                       network)
+  }
+
+  private def derivePublicKeyAtIndex(
+      paymentCode: PaymentCode,
+      index: Int): ECPublicKey = {
+    val masterKey = ExtPublicKey(
+      LegacyMainNetPub,
+      UInt8.zero,
+      ByteVector.fill(4)(0),
+      UInt32.zero,
+      paymentCode.chainCode,
+      paymentCode.pubKey
+    )
+    masterKey.deriveChildPubKey(index).get.key
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/bip47/PaymentCode.scala
+++ b/core/src/main/scala/org/bitcoins/core/bip47/PaymentCode.scala
@@ -41,8 +41,8 @@ sealed abstract class PaymentCode extends NetworkElement {
 
   def isValid: Boolean = {
     pubKey.bytes.size == 33 &&
-    (pubKey.bytes.head == 0x02 || pubKey.bytes.head == 0x03) &&
-    chainCode.bytes.size == 32
+    (pubKey.bytes.head == 0x02 || pubKey.bytes.head == 0x03)
+    // chainCode size is already enforced by ChainCode constructor
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/bip47/PaymentCode.scala
+++ b/core/src/main/scala/org/bitcoins/core/bip47/PaymentCode.scala
@@ -1,0 +1,165 @@
+package org.bitcoins.core.bip47
+
+import org.bitcoins.core.crypto.ChainCode
+import org.bitcoins.core.util.Base58
+import org.bitcoins.crypto.{CryptoUtil, ECPublicKey, Factory, NetworkElement}
+import scodec.bits.ByteVector
+
+import scala.util.{Failure, Try}
+
+/** Represents a BIP47 reusable payment code.
+  * @see
+  *   [[https://github.com/bitcoin/bips/blob/master/bip-0047.mediawiki BIP47]]
+  */
+sealed abstract class PaymentCode extends NetworkElement {
+
+  def version: PaymentCodeVersion
+
+  def pubKey: ECPublicKey
+
+  def chainCode: ChainCode
+
+  def features: Byte
+
+  def payload: ByteVector = {
+    val typeByte = version match {
+      case PaymentCodeVersion.V1 => 0x01.toByte
+      case PaymentCodeVersion.V2 => 0x02.toByte
+    }
+    ByteVector(typeByte,
+               features) ++ pubKey.bytes ++ chainCode.bytes ++ ByteVector
+      .fill(13)(0)
+  }
+
+  override def bytes: ByteVector =
+    ByteVector(PaymentCode.VersionByte) ++ payload
+
+  override def toString: String = {
+    val checksum = CryptoUtil.doubleSHA256(bytes).bytes.take(4)
+    Base58.encode(bytes ++ checksum)
+  }
+
+  def isValid: Boolean = {
+    pubKey.bytes.size == 33 &&
+    (pubKey.bytes.head == 0x02 || pubKey.bytes.head == 0x03) &&
+    chainCode.bytes.size == 32
+  }
+}
+
+object PaymentCode extends Factory[PaymentCode] {
+  val PayloadLength: Int = 80
+  val VersionByte: Byte = 0x47
+
+  private val PublicKeyYOffset: Int = 2
+  private val PublicKeyXOffset: Int = 3
+  private val ChainOffset: Int = 35
+  private val PublicKeyXLen: Int = 32
+  private val PublicKeyYLen: Int = 1
+  private val ChainLen: Int = 32
+
+  private case class PaymentCodeImpl(
+      version: PaymentCodeVersion,
+      pubKey: ECPublicKey,
+      chainCode: ChainCode,
+      features: Byte)
+      extends PaymentCode
+
+  def apply(pubKey: ECPublicKey, chainCode: ChainCode): PaymentCode = {
+    apply(PaymentCodeVersion.V1, pubKey, chainCode, 0x00.toByte)
+  }
+
+  def apply(
+      version: PaymentCodeVersion,
+      pubKey: ECPublicKey,
+      chainCode: ChainCode,
+      features: Byte): PaymentCode = {
+    require(pubKey.isCompressed,
+            "Payment code public key must be compressed (33 bytes)")
+    PaymentCodeImpl(version, pubKey, chainCode, features)
+  }
+
+  def fromBase58(str: String): Try[PaymentCode] = {
+    Base58.decodeCheck(str).flatMap { decoded =>
+      if (decoded.isEmpty || decoded.head != VersionByte) {
+        Failure(
+          new IllegalArgumentException(
+            s"Invalid payment code version byte, expected 0x47"))
+      } else {
+        Try(fromBytes(decoded))
+      }
+    }
+  }
+
+  override def fromBytes(bytes: ByteVector): PaymentCode = {
+    require(
+      bytes.size >= PayloadLength + 1,
+      s"Payment code must be at least ${PayloadLength + 1} bytes, got ${bytes.size}")
+
+    val payload =
+      if (bytes.head == VersionByte) {
+        bytes.drop(1).take(PayloadLength)
+      } else {
+        bytes.take(PayloadLength)
+      }
+
+    val typeByte = payload(0)
+    val version = typeByte match {
+      case 0x01 => PaymentCodeVersion.V1
+      case 0x02 => PaymentCodeVersion.V2
+      case other =>
+        throw new IllegalArgumentException(s"Unknown payment code type: $other")
+    }
+
+    val features = payload(1)
+    val pubKeyBytes =
+      payload.slice(PublicKeyYOffset,
+                    PublicKeyYOffset + PublicKeyYLen + PublicKeyXLen)
+    val chainCodeBytes = payload.slice(ChainOffset, ChainOffset + ChainLen)
+
+    require(
+      pubKeyBytes.head == 0x02 || pubKeyBytes.head == 0x03,
+      s"Invalid public key prefix: ${pubKeyBytes.head}"
+    )
+
+    val pubKey = ECPublicKey(pubKeyBytes)
+    val chainCode = ChainCode(chainCodeBytes)
+
+    PaymentCodeImpl(version, pubKey, chainCode, features)
+  }
+
+  /** Generates a mask for blinding a payment code in a notification
+    * transaction.
+    */
+  def getMask(secretPoint: ByteVector, outpoint: ByteVector): ByteVector = {
+    CryptoUtil.hmac512(outpoint, secretPoint)
+  }
+
+  /** Blinds or unblinds a payment code payload using XOR masking. */
+  def blind(payload: ByteVector, mask: ByteVector): ByteVector = {
+    require(payload.size == PayloadLength,
+            s"Payload must be $PayloadLength bytes")
+    require(mask.size == 64, "Mask must be 64 bytes")
+
+    val pubKeyX =
+      payload.slice(PublicKeyXOffset, PublicKeyXOffset + PublicKeyXLen)
+    val chain = payload.slice(ChainOffset, ChainOffset + ChainLen)
+
+    val maskPubKey = mask.take(PublicKeyXLen)
+    val maskChain = mask.slice(PublicKeyXLen, PublicKeyXLen + ChainLen)
+
+    val blindedPubKeyX = xor(pubKeyX, maskPubKey)
+    val blindedChain = xor(chain, maskChain)
+
+    payload.take(PublicKeyXOffset) ++
+      blindedPubKeyX ++
+      payload.slice(PublicKeyXOffset + PublicKeyXLen, ChainOffset) ++
+      blindedChain ++
+      payload.drop(ChainOffset + ChainLen)
+  }
+
+  private def xor(a: ByteVector, b: ByteVector): ByteVector = {
+    require(a.size == b.size,
+            s"XOR operands must have same size: ${a.size} vs ${b.size}")
+    a.xor(b)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/bip47/PaymentCodeVersion.scala
+++ b/core/src/main/scala/org/bitcoins/core/bip47/PaymentCodeVersion.scala
@@ -1,0 +1,8 @@
+package org.bitcoins.core.bip47
+
+sealed abstract class PaymentCodeVersion
+
+object PaymentCodeVersion {
+  case object V1 extends PaymentCodeVersion
+  case object V2 extends PaymentCodeVersion
+}

--- a/core/src/main/scala/org/bitcoins/core/bip47/SecretPoint.scala
+++ b/core/src/main/scala/org/bitcoins/core/bip47/SecretPoint.scala
@@ -1,0 +1,50 @@
+package org.bitcoins.core.bip47
+
+import org.bitcoin.{NativeSecp256k1, Secp256k1Context}
+import org.bitcoins.crypto.{ECPrivateKey, ECPublicKey, FieldElement}
+import scodec.bits.ByteVector
+
+/** Represents an ECDH shared secret point between two parties. Used in BIP47 to
+  * derive shared secrets for payment address generation.
+  */
+sealed abstract class SecretPoint {
+  def ecdhSecret: ByteVector
+}
+
+object SecretPoint {
+
+  private case class SecretPointImpl(ecdhSecret: ByteVector)
+      extends SecretPoint {
+    require(ecdhSecret.size == 32,
+            s"ECDH secret must be 32 bytes, got ${ecdhSecret.size}")
+  }
+
+  /** Computes the ECDH shared secret between a private key and public key. The
+    * result is the x-coordinate of privKey * pubKey.
+    */
+  def apply(privKey: ECPrivateKey, pubKey: ECPublicKey): SecretPoint = {
+    val secret =
+      if (Secp256k1Context.isEnabled) {
+        computeECDHNative(privKey, pubKey)
+      } else {
+        computeECDHPure(privKey, pubKey)
+      }
+    SecretPointImpl(secret)
+  }
+
+  private def computeECDHNative(
+      privKey: ECPrivateKey,
+      pubKey: ECPublicKey): ByteVector = {
+    val result = NativeSecp256k1.createECDHSecret(privKey.bytes.toArray,
+                                                  pubKey.bytes.toArray)
+    ByteVector(result)
+  }
+
+  private def computeECDHPure(
+      privKey: ECPrivateKey,
+      pubKey: ECPublicKey): ByteVector = {
+    val tweak = FieldElement(privKey.bytes)
+    val resultPoint = pubKey.multiply(tweak)
+    resultPoint.bytes.tail.take(32)
+  }
+}

--- a/core/src/main/scala/org/bitcoins/core/crypto/ExtKeyVersion.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/ExtKeyVersion.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.crypto
 
-import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.config._
 import org.bitcoins.core.hd.{HDCoinType, HDPurpose}
 import org.bitcoins.crypto.{Factory, NetworkElement}
 import scodec.bits.*
@@ -100,6 +100,13 @@ object ExtKeyPrivVersion {
     ExtKeyVersion.NestedSegWitTestNet3Priv
   )
 
+  def legacyFromNetwork(network: NetworkParameters): ExtKeyPrivVersion =
+    network match {
+      case MainNet => ExtKeyVersion.LegacyMainNetPriv
+      case TestNet3 | TestNet4 | RegTest | SigNet =>
+        ExtKeyVersion.LegacyTestNet3Priv
+    }
+
   private val purposeMap: Map[HDPurpose, Vector[ExtKeyPrivVersion]] = Map(
     HDPurpose.Legacy -> Vector(ExtKeyVersion.LegacyMainNetPriv,
                                ExtKeyVersion.LegacyTestNet3Priv),
@@ -134,6 +141,12 @@ object ExtKeyPubVersion extends Factory[ExtKeyPubVersion] {
     NestedSegWitMainNetPub,
     NestedSegWitTestNet3Pub
   )
+
+  def legacyFromNetwork(network: NetworkParameters): ExtKeyPubVersion =
+    network match {
+      case MainNet                                => LegacyMainNetPub
+      case TestNet3 | TestNet4 | RegTest | SigNet => LegacyTestNet3Pub
+    }
 
   /** Generating a [[org.bitcoins.core.crypto.ExtPublicKey ExtPublicKey]] with
     * this version makes keys start with `xpub`


### PR DESCRIPTION
## Summary
Implements BIP47 (Reusable Payment Codes) for bitcoin-s core, enabling privacy-preserving payment address generation between two parties.

## Components

### PaymentCode
- 80-byte payload encoding/decoding with Base58Check (0x47 version prefix)
- XOR masking for notification transaction blinding
- V1/V2 version support

### SecretPoint
- ECDH shared secret computation
- Native secp256k1 with pure Scala fallback

### PaymentAddress
- Ephemeral address derivation for send/receive operations
- SHA256-based key tweaking from ECDH secrets
- SegWit address generation

### BIP47Account
- HD account at derivation path m/47'/coin_type'/account'
- Factory methods: fromSeed, fromExtendedKey, fromPaymentCode
- WatchOnlyBIP47Account for watch-only wallet support

## Test plan
- [x] Payment code creation from seed
- [x] Payment code serialization symmetry (bytes → PaymentCode → bytes)
- [x] ECDH shared secret symmetry (Alice·Bob == Bob·Alice)
- [x] Masking/unmasking roundtrip
- [x] Mutual address derivation (Alice sends to Bob == Bob receives from Alice)
- [x] SegWit address derivation
- [x] Key derivation at correct indices
- [x] Watch-only account creation from payment code

## Wallets & Services Using BIP47

### Wallets
- Stack Wallet
- Sparrow Wallet
- Blue Wallet
- Ashigaru Wallet
- Samourai Wallet

### Mining Pools
- Lincoin (for payouts)

## Additional Resources

### BIP47 Specification
- [BIP47 - Bitcoin Wiki](https://en.bitcoin.it/wiki/BIP_0047)

### Technical Deep Dives
- [BIP47, The Ugly Duckling](https://21ideas.org/en/bip47-the-ugly-duckling/)
- [How BIP47 Works - Medium](https://medium.com/@ottosch/how-bip47-works-ee641cc14bf3)
- [How BIP47 Enriches Bitcoin UX - Medium](https://medium.com/billion-crypto-stories/how-bip47-reusable-payment-codes-enrich-bitcoin-and-overall-cryptocurrency-user-experience-6f929c87a61b)
- [BIP47, The Ugly Duckling](https://21ideas.org/en/bip47-the-ugly-duckling/)

### PayNym Guides
- [PayNym Directory](https://paynym.is)
- [Bitcoin PayNyms Explained - Bitcoin Manual](https://thebitcoinmanual.com/articles/bitcoin-paynyms/)
- [PayNym Guide - Bitcoiner.guide](https://bitcoiner.guide/paynym/)
- [Guide to PayNyms with BIP47 - D-Central](https://d-central.tech/guide-to-paynyms-enhancing-bitcoin-privacy-with-bip-47/)

### Auth47 (PayNym Authentication)
- [Auth47 PayNym Accounts - Bitcoin Manual](https://thebitcoinmanual.com/articles/auth47-paynym-accounts/)
- [Auth47 PayNyms - RoninDojo Blog](https://blog.ronindojo.io/auth47-paynyms/)

### Video Tutorials
- [What are PayNyms - Andreas Antonopoulos](https://www.youtube.com/watch?v=Qmc1ubPVhnQ)
- [PayNyms: Enhanced Bitcoin Privacy With Public IDs](https://www.youtube.com/watch?v=w6o_3sUcHHY)
- [PayNyms in Sparrow Wallet - Privacy Preserving Public Bitcoin IDs](https://www.youtube.com/watch?v=o-iDeLZ4BiE)
- [Enhancing Privacy and Security: Reusable Payment Codes for Bitcoin Transactions](https://www.youtube.com/watch?v=PTGp4HCrFfc)