### PR TITLE
2025 12 11 Fix various chain test bugs

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/ChainCallbacksTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/ChainCallbacksTest.scala
@@ -36,7 +36,7 @@ class ChainCallbacksTest extends ChainDbUnitTest {
       chainHandler.chainConfig.addCallbacks(callbacks)
 
       val newValidHeader =
-        BlockHeaderHelper.buildNextHeader(ChainTestUtil.genesisHeaderDb)
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
 
       for {
         _ <- chainHandler.processHeader(newValidHeader.blockHeader)
@@ -61,13 +61,14 @@ class ChainCallbacksTest extends ChainDbUnitTest {
       chainHandler.chainConfig.addCallbacks(callbacks)
 
       val newValidHeader =
-        BlockHeaderHelper.buildNextHeader(ChainTestUtil.genesisHeaderDb)
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
       val nextCompactFilterHeaderDb =
         CompactFilterHeaderDb(
           hashBE = DoubleSha256DigestBE.fromHex(
             "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f"
           ),
-          previousFilterHeaderBE = ChainTestUtil.genesisFilterHeaderDb.hashBE,
+          previousFilterHeaderBE =
+            ChainTestUtil.regTestGenesisHeaderCompactFilterHeaderDb.hashBE,
           height = 1,
           filterHashBE = DoubleSha256DigestBE.fromHex(
             "555152535455565758595a5b5c5d5e5f555152535455565758595a5b5c5d5e5f"
@@ -102,7 +103,7 @@ class ChainCallbacksTest extends ChainDbUnitTest {
       chainHandler.chainConfig.addCallbacks(callbacks)
 
       val newValidHeader =
-        BlockHeaderHelper.buildNextHeader(ChainTestUtil.genesisHeaderDb)
+        BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
 
       val bytes = ByteVector(scala.util.Random.nextBytes(32))
       val hashBE = CryptoUtil.doubleSHA256(bytes)
@@ -111,7 +112,8 @@ class ChainCallbacksTest extends ChainDbUnitTest {
           hashBE = DoubleSha256DigestBE.fromHex(
             "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f"
           ),
-          previousFilterHeaderBE = ChainTestUtil.genesisFilterHeaderDb.hashBE,
+          previousFilterHeaderBE =
+            ChainTestUtil.regTestGenesisHeaderCompactFilterHeaderDb.hashBE,
           height = 1,
           filterHashBE = hashBE.flip,
           blockHashBE = newValidHeader.hashBE

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -17,7 +17,7 @@ class BlockchainTest extends BitcoinSAsyncTest {
   behavior of "Blockchain"
 
   it must "have the correct toString" in {
-    val genesis = ChainTestUtil.genesisHeaderDb
+    val genesis = ChainTestUtil.regTestGenesisHeaderDb
     val headerDb =
       BlockHeaderHelper.buildNextHeader(genesis)
     val chain = Blockchain(Vector(headerDb, genesis))
@@ -27,11 +27,11 @@ class BlockchainTest extends BitcoinSAsyncTest {
 
   it must "connect a new header to the current tip of a blockchain" in {
     val blockchain = Blockchain.fromHeaders(
-      headers = Vector(ChainTestUtil.genesisHeaderDb)
+      headers = Vector(ChainTestUtil.regTestGenesisHeaderDb)
     )
 
     val newHeader =
-      BlockHeaderHelper.buildNextHeader(ChainTestUtil.genesisHeaderDb)
+      BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
 
     val connectTip =
       Blockchain.connectTip(header = newHeader.blockHeader,
@@ -49,7 +49,7 @@ class BlockchainTest extends BitcoinSAsyncTest {
 
   it must "reconstruct a blockchain given a child header correctly" in {
     val accum = new mutable.ArrayBuffer[BlockHeaderDb](5)
-    accum.+=(ChainTestUtil.genesisHeaderDb)
+    accum.+=(ChainTestUtil.regTestGenesisHeaderDb)
     // generate 4 headers
     0.until(4).foreach { _ =>
       val newHeader = BlockHeaderHelper.buildNextHeader(accum.last)
@@ -70,20 +70,20 @@ class BlockchainTest extends BitcoinSAsyncTest {
     val chain = reconstructed.head
     assert(chain.toVector.length == 5)
     assert(chain.tip == accum.last)
-    assert(chain.last == ChainTestUtil.genesisHeaderDb)
+    assert(chain.last == ChainTestUtil.regTestGenesisHeaderDb)
     assert(chain.toVector == accum.reverse.toVector)
   }
 
   it must "fail to reconstruct a blockchain if we do not have validly connected headers" in {
     val missingHeader =
-      BlockHeaderHelper.buildNextHeader(ChainTestUtil.genesisHeaderDb)
+      BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
 
     val thirdHeader = BlockHeaderHelper.buildNextHeader(missingHeader)
 
     val reconstructed =
       Blockchain.reconstructFromHeaders(
         thirdHeader,
-        Vector(ChainTestUtil.genesisHeaderDb),
+        Vector(ChainTestUtil.regTestGenesisHeaderDb),
         chainParams = RegTestNetChainParams
       )
 
@@ -91,7 +91,7 @@ class BlockchainTest extends BitcoinSAsyncTest {
   }
 
   it must "fail to create a BlockchainUpdate.Failed with incompatible successful headers" in {
-    val genesis = ChainTestUtil.genesisHeaderDb
+    val genesis = ChainTestUtil.regTestGenesisHeaderDb
     val second = BlockHeaderHelper.buildNextHeader(genesis)
     val chain = Blockchain(Vector(second, genesis))
 
@@ -106,7 +106,7 @@ class BlockchainTest extends BitcoinSAsyncTest {
   }
 
   it must "correctly calculate a BlockchainUpdate.Success's height" in {
-    val genesis = ChainTestUtil.genesisHeaderDb
+    val genesis = ChainTestUtil.regTestGenesisHeaderDb
     val second = BlockHeaderHelper.buildNextHeader(genesis)
     val chain = Blockchain(Vector(second, genesis))
 
@@ -116,7 +116,7 @@ class BlockchainTest extends BitcoinSAsyncTest {
   }
 
   it must "correctly identify a bad tip" in {
-    val genesis = ChainTestUtil.genesisHeaderDb
+    val genesis = ChainTestUtil.regTestGenesisHeaderDb
     val chain = Blockchain(Vector(genesis))
 
     val goodHeader = BlockHeaderHelper.buildNextHeader(genesis).blockHeader

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerCachedTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerCachedTest.scala
@@ -38,7 +38,8 @@ class ChainHandlerCachedTest extends ChainDbUnitTest {
         filterHeaderOpt <- noChainsChainHandler.getBestFilterHeader()
       } yield {
         assert(filterHeaderOpt.isDefined)
-        assert(filterHeaderOpt.get == ChainTestUtil.genesisFilterHeaderDb)
+        assert(
+          filterHeaderOpt.get == ChainTestUtil.regTestGenesisHeaderCompactFilterHeaderDb)
       }
   }
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/MainnetChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/MainnetChainHandlerTest.scala
@@ -28,7 +28,7 @@ class MainnetChainHandlerTest extends ChainDbUnitTest {
   val headersResult: Vector[BlockHeader] =
     Json.parse(arrStr).validate[Vector[BlockHeader]].get
 
-  val genesis: BlockHeaderDb = ChainTestUtil.genesisHeaderDb
+  val genesis: BlockHeaderDb = ChainTestUtil.mainnetGenesisHeaderDb
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withChainHandlerCached(test)
@@ -45,29 +45,29 @@ class MainnetChainHandlerTest extends ChainDbUnitTest {
       val firstBlockHeaderDb =
         BlockHeaderDbHelper.fromBlockHeader(
           ChainUnitTest.FIRST_POW_CHANGE - 2,
-          Pow.getBlockProof(ChainTestUtil.blockHeader562462),
-          ChainTestUtil.blockHeader562462
+          Pow.getBlockProof(ChainTestUtil.mainnetBlockHeader87),
+          ChainTestUtil.mainnetBlockHeader87
         )
 
       val secondBlockHeaderDb = {
         val chainWork = firstBlockHeaderDb.chainWork + Pow.getBlockProof(
-          ChainTestUtil.blockHeader562463
+          ChainTestUtil.mainnetBlockHeader88
         )
         BlockHeaderDbHelper.fromBlockHeader(
           ChainUnitTest.FIRST_POW_CHANGE - 1,
           chainWork,
-          ChainTestUtil.blockHeader562463
+          ChainTestUtil.mainnetBlockHeader88
         )
       }
 
       val thirdBlockHeaderDb = {
         val chainWork = secondBlockHeaderDb.chainWork + Pow.getBlockProof(
-          ChainTestUtil.blockHeader562464
+          ChainTestUtil.mainnetBlockHeader89
         )
         BlockHeaderDbHelper.fromBlockHeader(
           ChainUnitTest.FIRST_POW_CHANGE,
           chainWork,
-          ChainTestUtil.blockHeader562464
+          ChainTestUtil.mainnetBlockHeader89
         )
       }
 
@@ -106,21 +106,21 @@ class MainnetChainHandlerTest extends ChainDbUnitTest {
         BlockHeaderDbHelper.fromBlockHeader(
           height = 1,
           chainWork = BigInt(0),
-          bh = ChainTestUtil.blockHeader562462
+          bh = ChainTestUtil.mainnetBlockHeader87
         )
 
       val highestHeader =
         BlockHeaderDbHelper.fromBlockHeader(
           height = 2,
           chainWork = BigInt(0),
-          bh = ChainTestUtil.blockHeader562463
+          bh = ChainTestUtil.mainnetBlockHeader88
         )
 
       val headerWithMostWork =
         BlockHeaderDbHelper.fromBlockHeader(
           1,
           BigInt(1000),
-          ChainTestUtil.blockHeader562464
+          ChainTestUtil.mainnetBlockHeader89
         )
 
       val tallestBlockchain =
@@ -148,21 +148,21 @@ class MainnetChainHandlerTest extends ChainDbUnitTest {
         BlockHeaderDbHelper.fromBlockHeader(
           ChainUnitTest.FIRST_POW_CHANGE - 2,
           BigInt(0),
-          ChainTestUtil.blockHeader562462
+          ChainTestUtil.mainnetBlockHeader87
         )
 
       val secondBlockHeaderDb =
         BlockHeaderDbHelper.fromBlockHeader(
           ChainUnitTest.FIRST_POW_CHANGE - 1,
           BigInt(0),
-          ChainTestUtil.blockHeader562463
+          ChainTestUtil.mainnetBlockHeader88
         )
 
       val thirdBlockHeaderDb =
         BlockHeaderDbHelper.fromBlockHeader(
           ChainUnitTest.FIRST_POW_CHANGE,
           BigInt(0),
-          ChainTestUtil.blockHeader562464
+          ChainTestUtil.mainnetBlockHeader89
         )
 
       /*
@@ -204,13 +204,13 @@ class MainnetChainHandlerTest extends ChainDbUnitTest {
     (tempHandler: ChainHandlerCached) =>
       val headersWithNoWork = Vector(
         BlockHeaderDbHelper
-          .fromBlockHeader(3, BigInt(0), ChainTestUtil.blockHeader562464),
+          .fromBlockHeader(3, BigInt(0), ChainTestUtil.mainnetBlockHeader89),
         BlockHeaderDbHelper
-          .fromBlockHeader(2, BigInt(0), ChainTestUtil.blockHeader562463),
+          .fromBlockHeader(2, BigInt(0), ChainTestUtil.mainnetBlockHeader88),
         BlockHeaderDbHelper.fromBlockHeader(
           1,
           BigInt(0),
-          ChainTestUtil.blockHeader562462
+          ChainTestUtil.mainnetBlockHeader87
         )
       )
 
@@ -239,7 +239,7 @@ class MainnetChainHandlerTest extends ChainDbUnitTest {
             .forall(_._2.size == 1)
         )
         assert(headerDb.hashBE == headersWithNoWork.head.hashBE)
-        assert(headerDb.chainWork == BigInt(12885098501L))
+        assert(headerDb.chainWork == BigInt(17180131332L))
       }
   }
 

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
@@ -24,7 +24,7 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
 
   behavior of "BlockHeaderDAO"
 
-  private val genesisHeaderDb = ChainTestUtil.genesisHeaderDb
+  private val genesisHeaderDb = ChainTestUtil.regTestGenesisHeaderDb
   it should "insert and read the genesis block header back" in {
     (blockHeaderDAO: BlockHeaderDAO) =>
       val readF = blockHeaderDAO.read(genesisHeaderDb.hashBE)
@@ -325,10 +325,11 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
         foundGenesis <- foundGenesisF
       } yield {
         assert(noGenesisAncestors.length == 1)
-        assert(noGenesisAncestors == Vector(ChainTestUtil.genesisHeaderDb))
+        assert(
+          noGenesisAncestors == Vector(ChainTestUtil.regTestGenesisHeaderDb))
 
         assert(foundGenesis.length == 1)
-        assert(foundGenesis == Vector(ChainTestUtil.genesisHeaderDb))
+        assert(foundGenesis == Vector(ChainTestUtil.regTestGenesisHeaderDb))
       }
 
       val oneChildF = for {
@@ -361,14 +362,14 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
       BlockHeaderDbHelper.fromBlockHeader(
         1,
         BigInt(1, hex"fffef2bf0566ab".toArray),
-        ChainTestUtil.blockHeader562462
+        ChainTestUtil.mainnetBlockHeader87
       )
 
     val db2 =
       BlockHeaderDbHelper.fromBlockHeader(
         2,
         BigInt(1, hex"01253721228459eac00c".toArray),
-        ChainTestUtil.blockHeader562463
+        ChainTestUtil.mainnetBlockHeader88
       )
 
     for {
@@ -386,7 +387,7 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
         BlockHeaderDbHelper.fromBlockHeader(
           1,
           chainWork,
-          ChainTestUtil.blockHeader562462
+          ChainTestUtil.mainnetBlockHeader87
         )
 
       for {
@@ -411,19 +412,19 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
     (blockerHeaderDAO: BlockHeaderDAO) =>
       val duplicate3 = BlockHeader(
         version = Int32.one,
-        previousBlockHash = ChainTestUtil.blockHeader562463.hash,
+        previousBlockHash = ChainTestUtil.mainnetBlockHeader88.hash,
         merkleRootHash = DoubleSha256Digest.empty,
         time = UInt32.zero,
-        nBits = ChainTestUtil.blockHeader562464.nBits,
+        nBits = ChainTestUtil.mainnetBlockHeader89.nBits,
         nonce = UInt32.zero
       )
 
       val duplicate2 = BlockHeader(
         version = Int32.one,
-        previousBlockHash = ChainTestUtil.blockHeader562462.hash,
+        previousBlockHash = ChainTestUtil.mainnetBlockHeader87.hash,
         merkleRootHash = DoubleSha256Digest.empty,
         time = UInt32.zero,
-        nBits = ChainTestUtil.blockHeader562463.nBits,
+        nBits = ChainTestUtil.mainnetBlockHeader88.nBits,
         nonce = UInt32.zero
       )
 
@@ -432,19 +433,19 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
         previousBlockHash = genesisHeaderDb.hashBE.flip,
         merkleRootHash = DoubleSha256Digest.empty,
         time = UInt32.zero,
-        nBits = ChainTestUtil.blockHeader562462.nBits,
+        nBits = ChainTestUtil.mainnetBlockHeader87.nBits,
         nonce = UInt32.zero
       )
 
       val chain1 = Vector(
         BlockHeaderDbHelper
-          .fromBlockHeader(3, BigInt(2), ChainTestUtil.blockHeader562464),
+          .fromBlockHeader(3, BigInt(2), ChainTestUtil.mainnetBlockHeader89),
         BlockHeaderDbHelper
-          .fromBlockHeader(2, BigInt(1), ChainTestUtil.blockHeader562463),
+          .fromBlockHeader(2, BigInt(1), ChainTestUtil.mainnetBlockHeader88),
         BlockHeaderDbHelper.fromBlockHeader(
           1,
           BigInt(0),
-          ChainTestUtil.blockHeader562462
+          ChainTestUtil.mainnetBlockHeader87
         )
       )
 
@@ -453,18 +454,18 @@ class BlockHeaderDAOTest extends ChainDbUnitTest {
         BlockHeaderDbHelper.fromBlockHeader(
           1,
           BigInt(0),
-          ChainTestUtil.blockHeader562462
+          ChainTestUtil.mainnetBlockHeader87
         )
       )
 
       val chain3 = Vector(
         BlockHeaderDbHelper.fromBlockHeader(3, BigInt(2), duplicate3),
         BlockHeaderDbHelper
-          .fromBlockHeader(2, BigInt(1), ChainTestUtil.blockHeader562463),
+          .fromBlockHeader(2, BigInt(1), ChainTestUtil.mainnetBlockHeader88),
         BlockHeaderDbHelper.fromBlockHeader(
           1,
           BigInt(0),
-          ChainTestUtil.blockHeader562462
+          ChainTestUtil.mainnetBlockHeader87
         )
       )
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -1190,7 +1190,8 @@ class ChainHandler(
         if (startHeight == 0) {
           val genesisHeaderF = blockHeaderDAO.getAtHeight(0)
           genesisHeaderF.flatMap { h =>
-            require(h.length == 1, s"Should only have one genesis header!")
+            require(h.length == 1,
+                    s"Should have exactly 1 genesis header!, got=${h.length}")
             calculateChainWorkGenesisBlock(h.head)
               .map(Vector(_))
           }

--- a/core-test/src/test/scala/org/bitcoins/core/util/NetworkUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NetworkUtilTest.scala
@@ -29,7 +29,7 @@ class NetworkUtilTest extends BitcoinSUtilTest {
   }
 
   it must "determine if a block header is stale" in {
-    val staleHeader = ChainTestUtil.genesisHeaderDb
+    val staleHeader = ChainTestUtil.regTestGenesisHeaderDb
     assert(
       NetworkUtil.isBlockHeaderStale(
         staleHeader.blockHeader,
@@ -38,12 +38,12 @@ class NetworkUtilTest extends BitcoinSUtilTest {
     )
 
     val nonStale = BlockHeader(
-      ChainTestUtil.genesisHeaderDb.version,
-      ChainTestUtil.genesisHeaderDb.previousBlockHashBE.flip,
-      ChainTestUtil.genesisHeaderDb.merkleRootHashBE.flip,
+      staleHeader.version,
+      staleHeader.previousBlockHashBE.flip,
+      staleHeader.merkleRootHashBE.flip,
       time = UInt32(Instant.now.getEpochSecond),
-      nBits = ChainTestUtil.genesisHeaderDb.nBits,
-      nonce = ChainTestUtil.genesisHeaderDb.nonce
+      nBits = staleHeader.nBits,
+      nonce = staleHeader.nonce
     )
 
     assert(!NetworkUtil.isBlockHeaderStale(nonStale, MainNetChainParams))
@@ -51,12 +51,12 @@ class NetworkUtilTest extends BitcoinSUtilTest {
     val barleyStaleHeader = {
       val timestamp = Instant.now.minus(31, ChronoUnit.MINUTES).getEpochSecond
       BlockHeader(
-        ChainTestUtil.genesisHeaderDb.version,
-        ChainTestUtil.genesisHeaderDb.previousBlockHashBE.flip,
-        ChainTestUtil.genesisHeaderDb.merkleRootHashBE.flip,
+        staleHeader.version,
+        staleHeader.previousBlockHashBE.flip,
+        staleHeader.merkleRootHashBE.flip,
         time = UInt32(timestamp),
-        nBits = ChainTestUtil.genesisHeaderDb.nBits,
-        nonce = ChainTestUtil.genesisHeaderDb.nonce
+        nBits = staleHeader.nBits,
+        nonce = staleHeader.nonce
       )
     }
 
@@ -67,12 +67,12 @@ class NetworkUtilTest extends BitcoinSUtilTest {
     val barleyNotStaleHeader = {
       val timestamp = Instant.now.minus(29, ChronoUnit.MINUTES).getEpochSecond
       BlockHeader(
-        ChainTestUtil.genesisHeaderDb.version,
-        ChainTestUtil.genesisHeaderDb.previousBlockHashBE.flip,
-        ChainTestUtil.genesisHeaderDb.merkleRootHashBE.flip,
+        staleHeader.version,
+        staleHeader.previousBlockHashBE.flip,
+        staleHeader.merkleRootHashBE.flip,
         time = UInt32(timestamp),
-        nBits = ChainTestUtil.genesisHeaderDb.nBits,
-        nonce = ChainTestUtil.genesisHeaderDb.nonce
+        nBits = staleHeader.nBits,
+        nonce = staleHeader.nonce
       )
     }
 

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/chain/ChainTestUtil.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/chain/ChainTestUtil.scala
@@ -1,12 +1,15 @@
 package org.bitcoins.testkitcore.chain
 
-import org.bitcoins.core.api.chain.db._
+import org.bitcoins.core.api.chain.db.*
 import org.bitcoins.core.gcs.{BlockFilter, FilterHeader, GolombFilter}
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.{
   BlockHeader,
   MainNetChainParams,
-  RegTestNetChainParams
+  RegTestNetChainParams,
+  SigNetChainParams,
+  TestNet4ChainParams,
+  TestNetChainParams
 }
 import org.bitcoins.crypto.DoubleSha256Digest
 
@@ -48,37 +51,43 @@ sealed abstract class ChainTestUtil {
       0
     )
 
-  val genesisHeaderDb: BlockHeaderDb = regTestGenesisHeaderDb
-
-  val genesisFilterDb: CompactFilterDb =
-    regTestGenesisHeaderCompactFilterDb
-
-  val genesisFilterHeaderDb: CompactFilterHeaderDb =
-    regTestGenesisHeaderCompactFilterHeaderDb
-
-  val genesisFilterMessage: CompactFilterMessage = {
+  val regtestGenesisFilterMessage: CompactFilterMessage = {
     CompactFilterMessage(
-      filterType = genesisFilterDb.filterType,
-      blockHash = genesisFilterDb.blockHashBE.flip,
-      filterBytes = genesisFilterDb.golombFilter.bytes
+      filterType = regTestGenesisHeaderCompactFilterDb.filterType,
+      blockHash = regTestGenesisHeaderCompactFilterDb.blockHashBE.flip,
+      filterBytes = regTestGenesisHeaderCompactFilterDb.golombFilter.bytes
     )
   }
 
-  lazy val mainnetChainParam: MainNetChainParams.type = MainNetChainParams
+  val mainnetGenesisHeaderDb: BlockHeaderDb = {
+    val bh = MainNetChainParams.genesisBlock.blockHeader
+    BlockHeaderDbHelper.fromBlockHeader(0, BlockHeader.getBlockProof(bh), bh)
+  }
 
-  lazy val blockHeader562375 = BlockHeader.fromHex(
-    "0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c"
-  )
+  val testnet3GenesisHeaderDb: BlockHeaderDb = {
+    val bh = TestNetChainParams.genesisBlock.blockHeader
+    BlockHeaderDbHelper.fromBlockHeader(0, BlockHeader.getBlockProof(bh), bh)
+  }
 
-  lazy val blockHeader562462 = BlockHeader.fromHex(
+  val testnet4GenesisHeaderDb: BlockHeaderDb = {
+    val bh = TestNet4ChainParams.genesisBlock.blockHeader
+    BlockHeaderDbHelper.fromBlockHeader(0, BlockHeader.getBlockProof(bh), bh)
+  }
+
+  val signetGenesisHeaderDb: BlockHeaderDb = {
+    val bh = SigNetChainParams().genesisBlock.blockHeader
+    BlockHeaderDbHelper.fromBlockHeader(0, BlockHeader.getBlockProof(bh), bh)
+  }
+
+  lazy val mainnetBlockHeader87: BlockHeader = BlockHeader.fromHex(
     "0100000053fb045b4d3ca149faca8e7ea53cdb3168bc58b875e47196b3a6b3f100000000406468307c915485a9c9eabe31cc853e68311176e07e71475c3e26888fb7b7ed30846949ffff001d2b740f74"
   )
 
-  lazy val blockHeader562463 = BlockHeader.fromHex(
+  lazy val mainnetBlockHeader88: BlockHeader = BlockHeader.fromHex(
     "010000003ce6c27ae14022e4b6ea0a5c3633d156e3e3a47509c1adf085371ba300000000f01258747019514aa5c475cddd59a309347280ead98d19d8df8f9f99eb56757938866949ffff001d18bcb4f8"
   )
 
-  lazy val blockHeader562464 = BlockHeader.fromHex(
+  lazy val mainnetBlockHeader89: BlockHeader = BlockHeader.fromHex(
     "010000004bd0b78e90c6b0f361f395535ac170980de0c8214380daefce31fd1100000000282c9db8313817b4835efab229872eae2b8b5011c2e90ed14e57192984da062359896949ffff001d15c6aed8"
   )
 
@@ -87,33 +96,33 @@ sealed abstract class ChainTestUtil {
 
     // this is the first block in the 2016 block proof of work difficulty change interval
     // https://blockstream.info/block/0000000000000000002567dc317da20ddb0d7ef922fe1f9c2375671654f9006c
-    lazy val blockHeader564480 = BlockHeader.fromHex(
+    lazy val blockHeader564480: BlockHeader = BlockHeader.fromHex(
       "000000200cd536b3eb1cd9c028e081f1455006276b293467c3e5170000000000000000007bc1b27489db01c85d38a4bc6d2280611e9804f506d83ad00d2a33ebd663992f76c7725c505b2e174fb90f55"
     )
 
-    lazy val blockHeaderDb564480 =
+    lazy val blockHeaderDb564480: BlockHeaderDb =
       BlockHeaderDbHelper.fromBlockHeader(
         564480,
         BlockHeader.getBlockProof(blockHeader564480),
         blockHeader564480
       )
 
-    lazy val blockHeader566494 = BlockHeader.fromHex(
+    lazy val blockHeader566494: BlockHeader = BlockHeader.fromHex(
       "00000020ea2cb07d670ddb7a158e72ddfcfd9e1b9bf4459278bb240000000000000000004fb33054d79de69bb84b4d5c7dd87d80473c416320427a882c72108f7e43fd0c3d3e855c505b2e178f328fe2"
     )
 
-    lazy val blockHeaderDb566494 =
+    lazy val blockHeaderDb566494: BlockHeaderDb =
       BlockHeaderDbHelper.fromBlockHeader(
         566594,
         BlockHeader.getBlockProof(blockHeader566494),
         blockHeader566494
       )
 
-    lazy val blockHeader566495 = BlockHeader.fromHex(
+    lazy val blockHeader566495: BlockHeader = BlockHeader.fromHex(
       "000000202164d8c4e5246ab003fdebe36c697b9418aa454ec4190d00000000000000000059134ad5aaad38a0e75946c7d4cb09b3ad45b459070195dd564cde193cf0ef29c33e855c505b2e17f61af734"
     )
 
-    lazy val blockHeaderDb566495 = {
+    lazy val blockHeaderDb566495: BlockHeaderDb = {
       val chainWork =
         blockHeaderDb566494.chainWork + BlockHeader.getBlockProof(
           blockHeader566495
@@ -122,11 +131,11 @@ sealed abstract class ChainTestUtil {
     }
 
     // https://blockstream.info/block/00000000000000000015fea169c62eb0a1161aba36932ca32bc3785cbb3480bf
-    lazy val blockHeader566496 = BlockHeader.fromHex(
+    lazy val blockHeader566496: BlockHeader = BlockHeader.fromHex(
       "000000201b61e8961710991a47ff8187d946d93e4fb33569c09622000000000000000000d0098658f53531e6e67fc9448986b5a8f994da42d746079eabe10f55e561e243103f855c17612e1735c4afdb"
     )
 
-    lazy val blockHeaderDb566496 = {
+    lazy val blockHeaderDb566496: BlockHeaderDb = {
       val chainWork =
         blockHeaderDb566495.chainWork + BlockHeader.getBlockProof(
           blockHeader566496

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -13,6 +13,7 @@ import org.bitcoins.chain.models.*
 import org.bitcoins.chain.pow.Pow
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.chain.db.*
+import org.bitcoins.core.config.{MainNet, RegTest, SigNet, TestNet3, TestNet4}
 import org.bitcoins.core.protocol.blockchain.{Block, BlockHeader}
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
@@ -198,11 +199,12 @@ trait ChainUnitTest extends BitcoinSFixture {
     for {
       chainHandler <- createChainHandler()
       filterHeaderChainApi <- chainHandler.processFilterHeader(
-        ChainTestUtil.genesisFilterHeaderDb.filterHeader,
-        ChainTestUtil.genesisHeaderDb.hashBE
+        ChainTestUtil.regTestGenesisHeaderCompactFilterHeaderDb.filterHeader,
+        ChainTestUtil.regTestGenesisHeaderDb.hashBE
       )
       filterChainApi <-
-        filterHeaderChainApi.processFilter(ChainTestUtil.genesisFilterMessage)
+        filterHeaderChainApi.processFilter(
+          ChainTestUtil.regtestGenesisFilterMessage)
     } yield filterChainApi.asInstanceOf[ChainHandler]
   }
 
@@ -211,11 +213,12 @@ trait ChainUnitTest extends BitcoinSFixture {
     for {
       chainHandler <- createChainHandlerCached()
       filterHeaderChainApi <- chainHandler.processFilterHeader(
-        ChainTestUtil.genesisFilterHeaderDb.filterHeader,
-        ChainTestUtil.genesisHeaderDb.hashBE
+        ChainTestUtil.regTestGenesisHeaderCompactFilterHeaderDb.filterHeader,
+        ChainTestUtil.regTestGenesisHeaderDb.hashBE
       )
       filterChainApi <-
-        filterHeaderChainApi.processFilter(ChainTestUtil.genesisFilterMessage)
+        filterHeaderChainApi.processFilter(
+          ChainTestUtil.regtestGenesisFilterMessage)
     } yield filterChainApi.asInstanceOf[ChainHandlerCached]
   }
 
@@ -662,8 +665,15 @@ object ChainUnitTest extends ChainVerificationLogger {
       val chainHandlerF = makeChainHandler()
       for {
         chainHandler <- chainHandlerF
+        header = appConfig.network match {
+          case MainNet  => ChainTestUtil.mainnetGenesisHeaderDb
+          case TestNet3 => ChainTestUtil.testnet3GenesisHeaderDb
+          case TestNet4 => ChainTestUtil.testnet4GenesisHeaderDb
+          case RegTest  => ChainTestUtil.regTestGenesisHeaderDb
+          case SigNet   => ChainTestUtil.signetGenesisHeaderDb
+        }
         genHeader <- chainHandler.blockHeaderDAO.upsert(
-          ChainTestUtil.genesisHeaderDb
+          header
         )
       } yield genHeader
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -98,7 +98,7 @@ trait BaseNodeTest extends BitcoinSFixture with EmbeddedPg {
     override def getBlockCount(): Future[Int] = Future.successful(0)
 
     override def getBestBlockHeader(): Future[BlockHeaderDb] =
-      Future.successful(ChainTestUtil.genesisHeaderDb)
+      Future.successful(ChainTestUtil.regTestGenesisHeaderDb)
 
     override def processFilterHeaders(
         filterHeaders: Vector[FilterHeader],


### PR DESCRIPTION
This PR

- Fixes bug where chain test fixtures would always insert the `regtest` genesis block header even if we were attempting to test a different network such as `mainnet`
- Makes `ChainTestUtil` hard coded block headers reference the network they correspond to
- Fixes incorrect `ChainTestUtil` block header value names that previously referenced an incorrect block height