### PR TITLE
Rework chain test fixtures to call `ChainAppConfig.start()` in the test fixture setup

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/CompactFilterDAOTest.scala
@@ -24,16 +24,12 @@ class CompactFilterDAOTest extends ChainDbUnitTest {
   }
 
   it must "create and read a filter from the database" in { compactFilterDAO =>
-    val blockHeaderDAO =
-      BlockHeaderDAO()(executionContext, compactFilterDAO.appConfig)
     val filterHeaderDAO =
       CompactFilterHeaderDAO()(executionContext, compactFilterDAO.appConfig)
-    val blockHeaderDb = ChainTestUtil.regTestGenesisHeaderDb
     val filterHeaderDb = ChainTestUtil.regTestGenesisHeaderCompactFilterHeaderDb
     val original = ChainTestUtil.regTestGenesisHeaderCompactFilterDb
 
     for {
-      _ <- blockHeaderDAO.create(blockHeaderDb)
       _ <- filterHeaderDAO.create(filterHeaderDb)
       _ <- compactFilterDAO.create(original)
       fromDbOpt <- compactFilterDAO.read(original.blockHashBE)

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -17,7 +17,7 @@ class TipValidationTest extends ChainDbUnitTest {
   override type FixtureParam = BlockHeaderDAO
 
   // we're working with mainnet data
-  implicit override lazy val chainAppConfig: ChainAppConfig = mainnetAppConfig
+  override def chainAppConfig: ChainAppConfig = mainnetAppConfig
 
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBlockHeaderDAO(test)

--- a/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/config/ChainAppConfig.scala
@@ -62,7 +62,6 @@ case class ChainAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
         chainWork = Pow.getBlockProof(chain.genesisBlock.blockHeader),
         bh = chain.genesisBlock.blockHeader
       )
-
     val blockHeaderDAO = BlockHeaderDAO()(ec, appConfig)
     val bhCreatedF = blockHeaderDAO.create(genesisHeader)
     bhCreatedF.flatMap { _ =>

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainDbUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainDbUnitTest.scala
@@ -7,7 +7,7 @@ import org.bitcoins.testkit.{BitcoinSTestAppConfig, EmbeddedPg}
 
 trait ChainDbUnitTest extends ChainUnitTest with EmbeddedPg {
 
-  override lazy val mainnetAppConfig: ChainAppConfig = {
+  override def mainnetAppConfig: ChainAppConfig = {
     val memoryDb =
       BitcoinSTestAppConfig.configWithEmbeddedDb(
         Some(ProjectType.Chain),


### PR DESCRIPTION
Related to #6157 and #6158

The main change in this PR is to call `ChainAppConfig.start()` in the test fixture setup process for various data structures used in chain test cases.