### PR TITLE
core: Make `NotFoundMessage` not inherit from `InventoryMessage`, handle `NotFoundMessage` differently than `InventoryMessage` in node

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/p2p/NotFoundMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/NotFoundMessageTest.scala
@@ -10,4 +10,12 @@ class NotFoundMessageTest extends BitcoinSUnitTest {
       assert(NotFoundMessage.fromBytes(notFound.bytes) == notFound)
     }
   }
+
+  it must "parse a static test vector" in {
+    val hex =
+      "010200000054a02827d7a8b75601275a160279a3c5768de4c1c4a70200000000000000000000"
+    val nfm = NotFoundMessage.fromHex(hex)
+    assert(nfm.commandName == "notfound")
+    assert(nfm.inventories.length == 1)
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -451,9 +451,28 @@ object MerkleBlockMessage extends Factory[MerkleBlockMessage] {
   * @see
   *   [[https://bitcoin.org/en/developer-reference#notfound]]
   */
-sealed trait NotFoundMessage extends DataPayload with InventoryMessage {
+sealed trait NotFoundMessage extends DataPayload {
   override def commandName: String = NetworkPayload.notFoundCommandName
   override def bytes: ByteVector = RawNotFoundMessageSerializer.write(this)
+
+  /** The number of inventory enteries
+    */
+  def inventoryCount: CompactSizeUInt
+
+  /** One or more inventory entries up to a maximum of 50,000 entries.
+    */
+  def inventories: Vector[Inventory]
+
+  override def toString: String = {
+    if (inventories.length > 5) {
+      s"NotFoundMessage(inventoryCount=${inventoryCount.toInt}, inventories=[${inventories
+          .take(5)
+          .mkString(", ")}, ...])"
+    } else {
+      s"NotFoundMessage(inventoryCount=${inventoryCount.toInt}, inventories=${inventories
+          .mkString(", ")})"
+    }
+  }
 }
 
 /** The companion object factory used to create NotFoundMessages on the p2p

--- a/core/src/main/scala/org/bitcoins/core/p2p/ServiceIdentifier.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/ServiceIdentifier.scala
@@ -210,7 +210,7 @@ object ServiceIdentifier
         NODE_COMPACT_FILTERS
       case _: GetHeadersMessage | _: HeadersMessage | SendHeadersMessage =>
         NODE_NETWORK
-      case _: InventoryMessage => NODE_NETWORK
+      case _: InventoryMessage | _: NotFoundMessage => NODE_NETWORK
       case _: MerkleBlockMessage | _: FilterAddMessage | FilterClearMessage |
           _: FilterLoadMessage =>
         NODE_BLOOM

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala
@@ -255,6 +255,11 @@ case class DataMessageHandler(
             s"Received ${notHandling.commandName} message, skipping "
           )
           Future.successful(this)
+
+        case notFoundMessage: NotFoundMessage =>
+          logger.debug(
+            s"Received notfound message: $notFoundMessage from $peer")
+          Future.successful(this)
         case getData: GetDataMessage =>
           logger.info(
             s"Received a getdata message for inventories=${getData.inventories}"


### PR DESCRIPTION
fixes #6173 

Previously we made `NotFoundMessage` a subtype of `InventoryMessage`. This makes sense on the surface as both are a collection of inventories. 

The problem with this is we do not handle them differently in `DataMessageHandler`. Previously we would treat a `NotFoundMessage` as an `InventoryMessage`. This resulted in us [requesting the inventory _again_](https://github.com/bitcoin-s/bitcoin-s/blob/f5cf7a4e8a94a70979408736359ded0c2888e214/node/src/main/scala/org/bitcoins/node/networking/peer/DataMessageHandler.scala#L579) from our peer - as if the `NotFoundMessage` was a regular old `InventoryMessage`. This lead to an infinite loop of us constantly requesting inventories our peer was not aware of.

The fix for this is to handle `NotFoundMessage` and `InventoryMessage` differently. For now, we don't do anything with a `NotFoundMessage` if we receive one. This may change in the future.