### PR TITLE
node: Add `receivedAt` field to `DataMessageWrapper`

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
+++ b/node/src/main/scala/org/bitcoins/node/NodeStreamMessage.scala
@@ -1,19 +1,18 @@
 package org.bitcoins.node
 
 import org.bitcoins.core.api.node.Peer
-import org.bitcoins.core.p2p.{
-  ControlPayload,
-  DataPayload,
-  ExpectsResponse,
-  NetworkMessage,
-  NetworkPayload
-}
+import org.bitcoins.core.p2p.*
+
+import java.time.Instant
 
 sealed abstract class NodeStreamMessage
 
 object NodeStreamMessage {
 
-  case class DataMessageWrapper(payload: DataPayload, peer: Peer)
+  case class DataMessageWrapper(
+      payload: DataPayload,
+      peer: Peer,
+      receivedAt: Instant = Instant.now())
       extends NodeStreamMessage
 
   case class ControlMessageWrapper(payload: ControlPayload, peer: Peer)


### PR DESCRIPTION
add more logs around the amount of time to process a `DataMessage`. This will help debug things like #6192 

Now logs will look like this to give us an idea of when we received a message, and when we actually process it in the stream

```
2026-02-06 19:40:35,713UTC DEBUG [PeerManager] Got tx from peer=Peer(127.0.0.1:8333) in stream receivedAt=2026-02-06T19:40:31.676464275Z
2026-02-06 19:40:35,868UTC DEBUG [PeerManager] Done processing tx in peer=Peer(127.0.0.1:8333) state=DoneSyncing(peers=Set(Peer(127.0.0.1:8333)),waitingForDisconnection=Set()), total=4192ms, stream=155ms
```