### PR TITLE
wallet: Change `processTransaction()` return type from `Unit` -> `ProcessTxResult`

### DIFF
--- a/core/src/main/scala/org/bitcoins/core/api/wallet/ProcessTxResult.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/ProcessTxResult.scala
@@ -4,4 +4,7 @@ import org.bitcoins.core.api.wallet.db.SpendingInfoDb
 
 case class ProcessTxResult(
     updatedIncoming: Vector[SpendingInfoDb],
-    updatedOutgoing: Vector[SpendingInfoDb])
+    updatedOutgoing: Vector[SpendingInfoDb]) {
+  def isEmpty: Boolean = updatedIncoming.isEmpty && updatedOutgoing.isEmpty
+  def nonEmpty: Boolean = !isEmpty
+}

--- a/core/src/main/scala/org/bitcoins/core/api/wallet/TransactionProcessingApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/wallet/TransactionProcessingApi.scala
@@ -28,7 +28,7 @@ trait TransactionProcessingApi {
   def processTransaction(
       transaction: Transaction,
       blockHashWithConfsOpt: Option[BlockHashWithConfs]
-  ): Future[Unit]
+  ): Future[ProcessTxResult]
 
   /** Processes TXs originating from our wallet. This is called right after
     * we've signed a TX, updating our UTXO state.

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -527,9 +527,7 @@ case class DLCTransactionProcessing(
       processTxResult <- txProcessing.processTransaction(transaction,
                                                          blockHashWithConfsOpt)
       _ <- {
-        val isRelevant =
-          processTxResult.updatedIncoming.nonEmpty ||
-            processTxResult.updatedOutgoing.nonEmpty
+        val isRelevant = processTxResult.nonEmpty
 
         if (isRelevant) {
           for {

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/internal/DLCTransactionProcessing.scala
@@ -527,17 +527,15 @@ case class DLCTransactionProcessing(
       processTxResult <- txProcessing.processTransaction(transaction,
                                                          blockHashWithConfsOpt)
       _ <- {
-        val isRelevant = processTxResult.nonEmpty
-
-        if (isRelevant) {
+        if (processTxResult.nonEmpty) {
           for {
             _ <- processFundingTx(transaction,
                                   blockHashWithConfsOpt.map(_.blockHash))
-            _ <- processSettledDLCs(transaction,
-                                    blockHashWithConfsOpt.map(_.blockHash))
           } yield ()
         } else FutureUtil.unit
       }
+      _ <- processSettledDLCs(transaction,
+                              blockHashWithConfsOpt.map(_.blockHash))
     } yield processTxResult
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/ProcessTransactionTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.wallet
 
-import org.bitcoins.core.api.wallet.WalletApi
-import org.bitcoins.core.currency._
+import org.bitcoins.core.api.wallet.{ProcessTxResult, WalletApi}
+import org.bitcoins.core.currency.*
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.transaction.{
   Transaction,
@@ -11,7 +11,7 @@ import org.bitcoins.core.protocol.transaction.{
 import org.bitcoins.core.wallet.fee.SatoshisPerByte
 import org.bitcoins.testkit.chain.MockChainQueryApi
 import org.bitcoins.testkit.wallet.{BitcoinSWalletTest, WalletTestUtil}
-import org.bitcoins.testkitcore.Implicits._
+import org.bitcoins.testkitcore.Implicits.*
 import org.bitcoins.testkitcore.gen.TransactionGenerators
 import org.bitcoins.testkitcore.util.TransactionTestUtil
 import org.scalatest.FutureOutcome
@@ -171,7 +171,7 @@ class ProcessTransactionTest extends BitcoinSWalletTest {
         )
       } yield fundingTx
 
-      val processedFundingTxF: Future[Unit] = for {
+      val processedFundingTxF: Future[ProcessTxResult] = for {
         (fundingTx, _) <- fundingTxF
         // make sure wallet is empty
         balance <- wallet.getBalance()

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -4,12 +4,12 @@ import org.apache.pekko.actor.{ActorRef, Status}
 import org.apache.pekko.stream.OverflowStrategy
 import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import org.bitcoins.core.api.chain.ChainQueryApi
+import org.bitcoins.core.api.wallet.db.*
 import org.bitcoins.core.api.wallet.{
   ProcessTxResult,
   TransactionProcessingApi,
   WalletApi
 }
-import org.bitcoins.core.api.wallet.db.*
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.currency.CurrencyUnit
 import org.bitcoins.core.number.UInt32
@@ -30,17 +30,7 @@ import org.bitcoins.db.SafeDatabase
 import org.bitcoins.wallet.*
 import org.bitcoins.wallet.callback.WalletCallbacks
 import org.bitcoins.wallet.config.WalletAppConfig
-import org.bitcoins.wallet.models.{
-  AddressDAO,
-  AddressTagDAO,
-  IncomingTransactionDAO,
-  OutgoingTransactionDAO,
-  ScriptPubKeyDAO,
-  SpendingInfoDAO,
-  TransactionDAO,
-  WalletDAOs,
-  WalletStateDescriptorDAO
-}
+import org.bitcoins.wallet.models.*
 import org.bitcoins.wallet.util.WalletUtil
 import slick.dbio.{DBIOAction, Effect, NoStream}
 
@@ -86,7 +76,7 @@ case class TransactionProcessing(
   override def processTransaction(
       transaction: Transaction,
       blockHashWithConfsOpt: Option[BlockHashWithConfs]
-  ): Future[Unit] = {
+  ): Future[ProcessTxResult] = {
     for {
       relevantReceivedOutputs <- getRelevantOutputs(transaction)
       action = processTransactionImpl(
@@ -109,7 +99,7 @@ case class TransactionProcessing(
           walletCallbacks.executeOnTransactionProcessed(transaction)
         } else Future.unit
     } yield {
-      ()
+      processTx
     }
   }
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/internal/TransactionProcessing.scala
@@ -90,9 +90,7 @@ case class TransactionProcessing(
       processTx <- safeDatabase.run(action)
       // only notify about our transactions
       _ <-
-        if (
-          processTx.updatedIncoming.nonEmpty || processTx.updatedOutgoing.nonEmpty
-        ) {
+        if (processTx.nonEmpty) {
           logger.info(
             s"Finished processing of transaction=${transaction.txIdBE.hex}. Relevant incomingTXOs=${processTx.updatedIncoming.length}, outgoingTXOs=${processTx.updatedOutgoing.length}"
           )


### PR DESCRIPTION
Allows for small optimization downstream depending on if any processed transactions are relevant to the wallet - such as avoiding method calls inside of DLCWallet when they aren't necessary. Hopefully speeds up processing of transactions gossiped over the network to alleviate #6192 