### PR TITLE
tests: Make sure we have at least 5 blocks for medaiantimepast unit test

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
@@ -57,7 +57,7 @@ class BitcoindChainHandlerViaZmqTest extends ChainDbUnitTest {
       for {
         blockCount <- bitcoind.getBlockCount()
         _ <- ChainUnitTest.isSynced(chainHandler, bitcoind)
-        numBlocks = Random.nextInt(100)
+        numBlocks = Random.between(5, 100)
         _ <- genNBlocksCheckMTP(bitcoind, chainHandler, numBlocks)
         newBlockCount <- chainHandler.getBlockCount()
       } yield {


### PR DESCRIPTION
fixes #6207 