### PR TITLE
2026 02 07 `contextualcheckblockheader` checks

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/ChainHandlerTest.scala
@@ -617,7 +617,7 @@ class ChainHandlerTest extends ChainDbUnitTest {
         assert(newHeaderC.hashBE == marker.stopBlockHash.flip)
       }
 
-      val headerDF = newHeaderCF.map(BlockHeaderHelper.buildNextHeader)
+      val headerDF = newHeaderCF.map(BlockHeaderHelper.buildNextHeader(_, None))
       // now let's build a new block header ontop of C and process it
       // when we call chainHandler.nextBlockHeaderBatchRange it
       // should be C's hash instead of D's hash due to batchSize

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationMainNetTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationMainNetTest.scala
@@ -3,10 +3,7 @@ package org.bitcoins.chain.validation
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.chain.pow.Pow
 import org.bitcoins.core.api.chain.db.BlockHeaderDbHelper
-import org.bitcoins.core.protocol.blockchain.{
-  BlockHeader,
-  RegTestNetChainParams
-}
+import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainDbUnitTest}
 import org.scalatest.{Assertion, FutureOutcome}
 
@@ -70,7 +67,8 @@ class TipValidationMainNetTest extends ChainDbUnitTest {
   ): Assertion = {
     val result = TipValidation.checkNewTip(newPotentialTip = header,
                                            blockchain = blockchain,
-                                           chainParams = RegTestNetChainParams)
+                                           chainParams =
+                                             networkParam.chainParams)
     assert(result == expected)
   }
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationMainNetTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationMainNetTest.scala
@@ -1,0 +1,76 @@
+package org.bitcoins.chain.validation
+
+import org.bitcoins.chain.models.BlockHeaderDAO
+import org.bitcoins.chain.pow.Pow
+import org.bitcoins.core.api.chain.db.BlockHeaderDbHelper
+import org.bitcoins.core.protocol.blockchain.{
+  BlockHeader,
+  RegTestNetChainParams
+}
+import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainDbUnitTest}
+import org.scalatest.{Assertion, FutureOutcome}
+
+class TipValidationMainNetTest extends ChainDbUnitTest {
+  import org.bitcoins.chain.blockchain.Blockchain
+  import org.bitcoins.chain.config.ChainAppConfig
+
+  override type FixtureParam = BlockHeaderDAO
+
+  // we're working with mainnet data
+  override def chainAppConfig: ChainAppConfig = mainnetAppConfig
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome =
+    withBlockHeaderDAO(test)
+
+  behavior of "TipValidationMainNet"
+
+  // blocks 566,092 and 566,093
+  val newValidTip = BlockHeaderHelper.header1
+  val currentTipDb = BlockHeaderHelper.header2Db
+  val blockchain = Blockchain.fromHeaders(Vector(currentTipDb))
+
+  it must "connect two blocks with that are valid" in { _ =>
+    val newValidTipDb =
+      BlockHeaderDbHelper.fromBlockHeader(
+        566093,
+        currentTipDb.chainWork + Pow.getBlockProof(newValidTip),
+        newValidTip
+      )
+    val expected = TipUpdateResult.Success(newValidTipDb)
+
+    runTest(newValidTip, expected, blockchain)
+  }
+
+  it must "fail to connect two blocks that do not reference prev block hash correctly" in {
+    _ =>
+      val badPrevHash = BlockHeaderHelper.badPrevHash
+
+      val expected = TipUpdateResult.BadPreviousBlockHash(badPrevHash)
+
+      runTest(badPrevHash, expected, blockchain)
+  }
+
+  it must "fail to connect two blocks with two different POW requirements at the wrong interval" in {
+    _ =>
+      val badPOW = BlockHeaderHelper.badNBits
+      val expected = TipUpdateResult.BadPOW(badPOW)
+      runTest(badPOW, expected, blockchain)
+  }
+
+  it must "fail to connect two blocks with a bad nonce" in { _ =>
+    val badNonce = BlockHeaderHelper.badNonce
+    val expected = TipUpdateResult.BadNonce(badNonce)
+    runTest(badNonce, expected, blockchain)
+  }
+
+  private def runTest(
+      header: BlockHeader,
+      expected: TipUpdateResult,
+      blockchain: Blockchain
+  ): Assertion = {
+    val result = TipValidation.checkNewTip(newPotentialTip = header,
+                                           blockchain = blockchain,
+                                           chainParams = RegTestNetChainParams)
+    assert(result == expected)
+  }
+}

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -106,7 +106,7 @@ class TipValidationTest extends ChainDbUnitTest {
       )
     } yield {
       assert(
-        tipValidationResultTooNew == TipUpdateResult.TimeToNew(newHeaderTooNew)
+        tipValidationResultTooNew == TipUpdateResult.TimeTooNew(newHeaderTooNew)
       )
       assert(
         tipValidationResultValid == TipUpdateResult.Success(

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -1,76 +1,82 @@
 package org.bitcoins.chain.validation
 
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.bitcoins.chain.blockchain.Blockchain
 import org.bitcoins.chain.models.BlockHeaderDAO
-import org.bitcoins.chain.pow.Pow
-import org.bitcoins.core.api.chain.db.BlockHeaderDbHelper
-import org.bitcoins.core.protocol.blockchain.{
-  BlockHeader,
-  RegTestNetChainParams
-}
+import org.bitcoins.core.api.chain.db.{BlockHeaderDb, BlockHeaderDbHelper}
+import org.bitcoins.core.config.RegTest
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainDbUnitTest}
-import org.scalatest.{Assertion, FutureOutcome}
+import org.scalatest.FutureOutcome
+
+import scala.concurrent.Future
 
 class TipValidationTest extends ChainDbUnitTest {
-  import org.bitcoins.chain.blockchain.Blockchain
-  import org.bitcoins.chain.config.ChainAppConfig
 
+  behavior of "TipValidation"
   override type FixtureParam = BlockHeaderDAO
-
-  // we're working with mainnet data
-  override def chainAppConfig: ChainAppConfig = mainnetAppConfig
-
   override def withFixture(test: OneArgAsyncTest): FutureOutcome =
     withBlockHeaderDAO(test)
 
-  behavior of "TipValidation"
+  it must "reject a new tip whose time is <= the median of the last 11 headers" in {
+    blockHeaderDAO =>
+      require(blockHeaderDAO.appConfig.network == RegTest)
+      val firstHeaderF = blockHeaderDAO.getBestChainTips.map(_.head)
+      val headersDbF: Future[Seq[BlockHeaderDb]] = firstHeaderF.flatMap { f =>
+        Source(f.height.until(f.height + 11))
+          .fold(Vector(f)) { (prevHeaders, _) =>
+            val nextHeader = BlockHeaderHelper.buildNextHeader(prevHeaders.last)
+            prevHeaders.appended(nextHeader)
+          }
+          .toMat(Sink.last)(Keep.right)
+          .run()
+      }
+      val blockchainF = headersDbF.map(_.reverse).map(Blockchain.fromHeaders)
+      for {
+        blockchain <- blockchainF
+        medianTimePast = blockchain.getMedianTimePast
+        newHeaderBadMTP = BlockHeaderHelper
+          .buildNextHeader(blockchain.tip,
+                           timeOpt = Some(UInt32(medianTimePast - 1)))
+          .blockHeader
+        newHeaderStaleMTP = BlockHeaderHelper
+          .buildNextHeader(blockchain.tip,
+                           timeOpt = Some(UInt32(medianTimePast)))
+          .blockHeader
+        newHeaderGoodMTP = BlockHeaderHelper
+          .buildNextHeader(blockchain.tip,
+                           timeOpt = Some(UInt32(medianTimePast + 1)))
+          .blockHeader
+        tipValidationResultBadMTP = TipValidation.checkNewTip(
+          newHeaderBadMTP,
+          blockchain,
+          chainParams
+        )
+        tipValidationResultStaleMTP = TipValidation.checkNewTip(
+          newHeaderStaleMTP,
+          blockchain,
+          chainParams
+        )
+        tipValidationResultGoodMTP = TipValidation.checkNewTip(
+          newHeaderGoodMTP,
+          blockchain,
+          chainParams
+        )
+      } yield {
+        assert(
+          tipValidationResultBadMTP == TipUpdateResult.BadMTP(newHeaderBadMTP)
+        )
+        assert(
+          tipValidationResultStaleMTP == TipUpdateResult.BadMTP(
+            newHeaderStaleMTP))
+        val goodDb = BlockHeaderDbHelper.fromBlockHeader(
+          blockchain.tip.height + 1,
+          blockchain.tip.chainWork + org.bitcoins.chain.pow.Pow
+            .getBlockProof(newHeaderGoodMTP),
+          newHeaderGoodMTP
+        )
+        assert(tipValidationResultGoodMTP == TipUpdateResult.Success(goodDb))
+      }
 
-  // blocks 566,092 and 566,093
-  val newValidTip = BlockHeaderHelper.header1
-  val currentTipDb = BlockHeaderHelper.header2Db
-  val blockchain = Blockchain.fromHeaders(Vector(currentTipDb))
-
-  it must "connect two blocks with that are valid" in { _ =>
-    val newValidTipDb =
-      BlockHeaderDbHelper.fromBlockHeader(
-        566093,
-        currentTipDb.chainWork + Pow.getBlockProof(newValidTip),
-        newValidTip
-      )
-    val expected = TipUpdateResult.Success(newValidTipDb)
-
-    runTest(newValidTip, expected, blockchain)
-  }
-
-  it must "fail to connect two blocks that do not reference prev block hash correctly" in {
-    _ =>
-      val badPrevHash = BlockHeaderHelper.badPrevHash
-
-      val expected = TipUpdateResult.BadPreviousBlockHash(badPrevHash)
-
-      runTest(badPrevHash, expected, blockchain)
-  }
-
-  it must "fail to connect two blocks with two different POW requirements at the wrong interval" in {
-    _ =>
-      val badPOW = BlockHeaderHelper.badNBits
-      val expected = TipUpdateResult.BadPOW(badPOW)
-      runTest(badPOW, expected, blockchain)
-  }
-
-  it must "fail to connect two blocks with a bad nonce" in { _ =>
-    val badNonce = BlockHeaderHelper.badNonce
-    val expected = TipUpdateResult.BadNonce(badNonce)
-    runTest(badNonce, expected, blockchain)
-  }
-
-  private def runTest(
-      header: BlockHeader,
-      expected: TipUpdateResult,
-      blockchain: Blockchain
-  ): Assertion = {
-    val result = TipValidation.checkNewTip(newPotentialTip = header,
-                                           blockchain = blockchain,
-                                           chainParams = RegTestNetChainParams)
-    assert(result == expected)
   }
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -76,7 +76,7 @@ class TipValidationTest extends ChainDbUnitTest {
       }
   }
 
-  it must "reject blocks headers that are too new" in { blockHeaderDAO =>
+  it must "reject block headers that are too new" in { blockHeaderDAO =>
     val firstHeaderF: Future[BlockHeaderDb] =
       blockHeaderDAO.getBestChainTips.map(_.head)
     val blockchainF = firstHeaderF.map(b => Blockchain.fromHeaders(Vector(b)))

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
@@ -42,4 +42,6 @@ object TipUpdateResult {
   case class BadNonce(override val header: BlockHeader) extends Failure
 
   case class BadMTP(override val header: BlockHeader) extends Failure
+
+  case class TimeToNew(override val header: BlockHeader) extends Failure
 }

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
@@ -43,5 +43,5 @@ object TipUpdateResult {
 
   case class BadMTP(override val header: BlockHeader) extends Failure
 
-  case class TimeToNew(override val header: BlockHeader) extends Failure
+  case class TimeTooNew(override val header: BlockHeader) extends Failure
 }

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipUpdateResult.scala
@@ -40,4 +40,6 @@ object TipUpdateResult {
     * invalid
     */
   case class BadNonce(override val header: BlockHeader) extends Failure
+
+  case class BadMTP(override val header: BlockHeader) extends Failure
 }

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -121,7 +121,7 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
       newPotentialTip: BlockHeader,
       blockchain: Blockchain
   ): Boolean = {
-    if (blockchain.length < 11) {
+    if (blockchain.length <= 4) {
       false
     } else {
       val medianTimePast = blockchain.getMedianTimePast

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -51,6 +51,8 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
         TipUpdateResult.BadNonce(newPotentialTip)
       } else if (isBadMTP(newPotentialTip, blockchain)) {
         TipUpdateResult.BadMTP(newPotentialTip)
+      } else if (isTimeToNew(newPotentialTip)) {
+        TipUpdateResult.TimeToNew(newPotentialTip)
       } else {
         val headerDb = BlockHeaderDbHelper.fromBlockHeader(
           height = currentTip.height + 1,
@@ -125,6 +127,11 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
       val medianTimePast = blockchain.getMedianTimePast
       newPotentialTip.time.toLong <= medianTimePast
     }
+  }
+
+  private def isTimeToNew(header: BlockHeader): Boolean = {
+    val currentTime = System.currentTimeMillis() / 1000
+    header.time.toLong > currentTime + 2 * 60 * 60
   }
 }
 

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -49,6 +49,8 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
         TipUpdateResult.BadPOW(newPotentialTip)
       } else if (isBadNonce(newPotentialTip)) {
         TipUpdateResult.BadNonce(newPotentialTip)
+      } else if (isBadMTP(newPotentialTip, blockchain)) {
+        TipUpdateResult.BadMTP(newPotentialTip)
       } else {
         val headerDb = BlockHeaderDbHelper.fromBlockHeader(
           height = currentTip.height + 1,
@@ -111,7 +113,18 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
       blockchain = blockchain,
       chainParams = chainParams
     )
+  }
 
+  private def isBadMTP(
+      newPotentialTip: BlockHeader,
+      blockchain: Blockchain
+  ): Boolean = {
+    if (blockchain.length < 11) {
+      false
+    } else {
+      val medianTimePast = blockchain.getMedianTimePast
+      newPotentialTip.time.toLong <= medianTimePast
+    }
   }
 }
 

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -51,8 +51,8 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
         TipUpdateResult.BadNonce(newPotentialTip)
       } else if (isBadMTP(newPotentialTip, blockchain)) {
         TipUpdateResult.BadMTP(newPotentialTip)
-      } else if (isTimeToNew(newPotentialTip)) {
-        TipUpdateResult.TimeToNew(newPotentialTip)
+      } else if (isTimeTooNew(newPotentialTip)) {
+        TipUpdateResult.TimeTooNew(newPotentialTip)
       } else {
         val headerDb = BlockHeaderDbHelper.fromBlockHeader(
           height = currentTip.height + 1,
@@ -129,7 +129,7 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
     }
   }
 
-  private def isTimeToNew(header: BlockHeader): Boolean = {
+  private def isTimeTooNew(header: BlockHeader): Boolean = {
     val currentTime = System.currentTimeMillis() / 1000
     header.time.toLong > currentTime + 2 * 60 * 60
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -167,6 +167,21 @@ object BlockHeader extends Factory[BlockHeader] {
                     nonce)
   }
 
+  def apply(
+      version: Int32,
+      previousBlockHashBE: DoubleSha256DigestBE,
+      merkleRootHashBE: DoubleSha256DigestBE,
+      time: UInt32,
+      nBits: UInt32,
+      nonce: UInt32): BlockHeader = {
+    BlockHeaderImpl(version,
+                    previousBlockHashBE.flip,
+                    merkleRootHashBE.flip,
+                    time,
+                    nBits,
+                    nonce)
+  }
+
   def fromBytes(bytes: ByteVector): BlockHeader =
     RawBlockHeaderSerializer.read(bytes)
 

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -27,7 +27,7 @@
 
     <logger name="org.bitcoins.node" level="WARN"/>
 
-    <logger name="org.bitcoins.chain" level="INFO"/>
+    <logger name="org.bitcoins.chain" level="WARN"/>
 
     <logger name="org.bitcoins.wallet" level="WARN"/>
 

--- a/testkit-core/.jvm/src/main/resources/logback-test.xml
+++ b/testkit-core/.jvm/src/main/resources/logback-test.xml
@@ -20,14 +20,14 @@
         </encoder>
     </appender>
 
-    <root level="OFF">
+    <root level="INFO">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>
 
     <logger name="org.bitcoins.node" level="WARN"/>
 
-    <logger name="org.bitcoins.chain" level="WARN"/>
+    <logger name="org.bitcoins.chain" level="INFO"/>
 
     <logger name="org.bitcoins.wallet" level="WARN"/>
 

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/BaseAsyncTest.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/BaseAsyncTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.testkitcore.util
 
 import org.bitcoins.asyncutil.AsyncUtil
-import org.bitcoins.core.config.{NetworkParameters, RegTest}
+import org.bitcoins.core.config.{BitcoinNetwork, RegTest}
 import org.bitcoins.core.protocol.blockchain.BitcoinChainParams
 import org.bitcoins.core.util.FutureUtil
 import org.scalacheck.{Gen, Shrink}
@@ -27,10 +27,10 @@ trait BaseAsyncTest
     with ScalaCheckPropertyChecks
     with AsyncTimeLimitedTests { this: AsyncTestSuite =>
 
-  implicit def np: NetworkParameters = RegTest
+  implicit def np: BitcoinNetwork = RegTest
 
   implicit def chainParams: BitcoinChainParams =
-    np.chainParams.asInstanceOf[BitcoinChainParams]
+    np.chainParams
 
   implicit val duration: FiniteDuration = 10.seconds
   override lazy val timeLimit: Span = 5.minutes

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/BaseAsyncTest.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/util/BaseAsyncTest.scala
@@ -2,11 +2,11 @@ package org.bitcoins.testkitcore.util
 
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.config.{NetworkParameters, RegTest}
-import org.bitcoins.core.protocol.blockchain.ChainParams
+import org.bitcoins.core.protocol.blockchain.BitcoinChainParams
 import org.bitcoins.core.util.FutureUtil
 import org.scalacheck.{Gen, Shrink}
 import org.scalactic.anyvals.PosInt
-import org.scalatest._
+import org.scalatest.*
 import org.scalatest.concurrent.AsyncTimeLimitedTests
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.must.Matchers
@@ -15,7 +15,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.annotation.nowarn
 import scala.collection.JavaConverters.iterableAsScalaIterableConverter
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
 
 /** This is a base trait in bitcoin-s for async tests
@@ -29,7 +29,8 @@ trait BaseAsyncTest
 
   implicit def np: NetworkParameters = RegTest
 
-  implicit def chainParams: ChainParams = np.chainParams
+  implicit def chainParams: BitcoinChainParams =
+    np.chainParams.asInstanceOf[BitcoinChainParams]
 
   implicit val duration: FiniteDuration = 10.seconds
   override lazy val timeLimit: Span = 5.minutes

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/BaseNodeTest.scala
@@ -8,7 +8,7 @@ import org.bitcoins.core.api.chain.db.{
   CompactFilterHeaderDb
 }
 import org.bitcoins.core.api.chain.{ChainApi, ChainQueryApi, FilterSyncMarker}
-import org.bitcoins.core.config.{NetworkParameters, RegTest}
+import org.bitcoins.core.config.{BitcoinNetwork, RegTest}
 import org.bitcoins.core.gcs.FilterHeader
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.blockchain.BlockHeader
@@ -30,7 +30,7 @@ trait BaseNodeTest extends BitcoinSFixture with PostgresTestDatabase {
   /** Wallet config with data directory set to user temp directory */
   protected def getFreshConfig: BitcoinSAppConfig
 
-  implicit override lazy val np: NetworkParameters = RegTest
+  implicit override lazy val np: BitcoinNetwork = RegTest
 
   override def beforeAll(): Unit = {
     AppConfig.throwIfDefaultDatadir(getFreshConfig.nodeConf)

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/BitcoinSAsyncTest.scala
@@ -1,13 +1,13 @@
 package org.bitcoins.testkit.util
 
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.util.Timeout
 import org.apache.pekko.testkit.TestKit
+import org.apache.pekko.util.Timeout
 import org.bitcoins.commons.util.BitcoinSLogger
-import org.bitcoins.core.config.NetworkParameters
+import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.testkit.rpc.BitcoindRpcTestUtil
 import org.bitcoins.testkitcore.util.BaseAsyncTest
-import org.scalatest._
+import org.scalatest.*
 import org.scalatest.flatspec.{AsyncFlatSpec, FixtureAsyncFlatSpec}
 
 import scala.concurrent.ExecutionContext
@@ -22,7 +22,7 @@ trait BitcoinSPekkoAsyncTest extends BaseAsyncTest with BitcoinSLogger {
   implicit val system: ActorSystem = {
     ActorSystem(s"${getClass.getSimpleName}-${System.currentTimeMillis()}")
   }
-  implicit val networkParam: NetworkParameters = BitcoindRpcTestUtil.network
+  implicit val networkParam: BitcoinNetwork = BitcoindRpcTestUtil.network
 
   /** Needed because the default execution context will become overloaded if we
     * do not specify a unique execution context for each suite


### PR DESCRIPTION
fixes parts of #6172 

- Implements the [check](https://github.com/bitcoin/bitcoin/blob/8f0e1f6540be5cc4f91f2409f0326a95d498087d/src/validation.cpp#L4141) that ensures our block header's time is increasing according to [mediantimepast rules](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki) on the network
- Implements the [check](https://github.com/bitcoin/bitcoin/blob/8f0e1f6540be5cc4f91f2409f0326a95d498087d/src/validation.cpp#L4157) that our block header's time is not more than 2 hours in the future according to our local machines time.