### PR TITLE
node: Optimize receiving packets in the `PeerConnection` stream

### DIFF
--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -171,7 +171,7 @@ case class PeerConnection(
                       Future.successful(ByteString.empty)
                   }
               }
-              .groupedWithin(64, 10.millis)
+              .groupedWithin(16, 100.millis)
               .map(seq => seq.fold(ByteString.empty)(_ ++ _))
               .viaMat(PeerConnection.parseToNetworkMsgFlow)(Keep.left)
               .toMat(handleNetworkMsgSink)(Keep.right)

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -171,6 +171,8 @@ case class PeerConnection(
                       Future.successful(ByteString.empty)
                   }
               }
+              .groupedWithin(64, 10.millis)
+              .map(seq => seq.fold(ByteString.empty)(_ ++ _))
               .viaMat(PeerConnection.parseToNetworkMsgFlow)(Keep.left)
               .toMat(handleNetworkMsgSink)(Keep.right)
 
@@ -402,7 +404,6 @@ object PeerConnection extends BitcoinSLogger {
       byteVec: ByteString
   ): (ByteString, Vector[NetworkMessage]) = {
     val bytes: ByteVector = ByteVector(unalignedBytes ++ byteVec)
-    logger.trace(s"Bytes for message parsing: ${bytes.toHex}")
     val (messages, newUnalignedBytes) =
       NetworkUtil.parseIndividualMessages(bytes)
 

--- a/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
+++ b/node/src/main/scala/org/bitcoins/node/networking/peer/PeerConnection.scala
@@ -171,8 +171,6 @@ case class PeerConnection(
                       Future.successful(ByteString.empty)
                   }
               }
-              .groupedWithin(16, 100.millis)
-              .map(seq => seq.fold(ByteString.empty)(_ ++ _))
               .viaMat(PeerConnection.parseToNetworkMsgFlow)(Keep.left)
               .toMat(handleNetworkMsgSink)(Keep.right)
 
@@ -412,7 +410,12 @@ object PeerConnection extends BitcoinSLogger {
 
   val parseToNetworkMsgFlow
       : Flow[ByteString, Vector[NetworkMessage], NotUsed] = {
+    // Batch small/fragmented ByteString chunks before parsing. This reduces
+    // allocations and improves throughput when upstream emits many small
+    // ByteStrings. Both socks5 and non-socks5 branches use this flow.
     Flow[ByteString]
+      .groupedWithin(16, 100.millis)
+      .map(seq => seq.fold(ByteString.empty)(_ ++ _))
       .statefulMap(() => ByteString.empty)(
         parseHelper,
         { (_: ByteString) => None }


### PR DESCRIPTION
Part of #6192 

Optimize parsing of messages by batching bytes into bigger chunks to avoid overhead of parsing when we likely wouldn't have all the packets as part of a `NetworkMessage`. 

We now emit `ByteStrings` downstream when either

- 10 milliseconds have passed
- We have accumulated 64 `ByteString`'s