### PR TITLE
chain: Make `CompactFilterDAO` queries lazily created to avoid hotspots in `PeerManager`

### DIFF
--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -242,7 +242,7 @@ case class BlockHeaderDAO()(implicit
     }
   }
 
-  private val lowestNoWorkQuery
+  private lazy val lowestNoWorkQuery
       : profile.ProfileAction[Int, NoStream, Effect.Read] = {
     val noWork =
       table.filter(h => h.chainWork === BigInt(0) || h.chainWork == null)
@@ -260,7 +260,7 @@ case class BlockHeaderDAO()(implicit
     safeDatabase.run(query)
   }
 
-  private val maxHeightQuery
+  private lazy val maxHeightQuery
       : profile.ProfileAction[Int, NoStream, Effect.Read] = {
     val query = table.map(_.height).max.getOrElse(0).result
     query
@@ -274,7 +274,7 @@ case class BlockHeaderDAO()(implicit
     }
   }
 
-  private val maxWorkQuery
+  private lazy val maxWorkQuery
       : profile.ProfileAction[BigInt, NoStream, Effect.Read] = {
     val query = table.map(_.chainWork).max.getOrElse(BigInt(0)).result
     query

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterDAO.scala
@@ -21,7 +21,7 @@ case class CompactFilterDAO()(implicit
     doubleSha256DigestBEMapper,
     filterTypeMapper
   }
-  import profile.api._
+  import profile.api.*
 
   implicit private val bigIntMapper: BaseColumnType[BigInt] =
     appConfig.driver match {
@@ -117,7 +117,7 @@ case class CompactFilterDAO()(implicit
     result
   }
 
-  private val maxHeightQuery
+  private lazy val maxHeightQuery
       : profile.ProfileAction[Int, NoStream, Effect.Read] = {
     val query = table.map(_.height).max.getOrElse(0).result
     query
@@ -143,7 +143,7 @@ case class CompactFilterDAO()(implicit
       .result
   }
 
-  private val bestFilterQuery = {
+  private lazy val bestFilterQuery = {
     val join = table
       .join(blockHeaderTable)
       .on(_.blockHash === _.hash)
@@ -166,7 +166,7 @@ case class CompactFilterDAO()(implicit
     safeDatabase.run(bestFilterQuery).map(_.headOption)
   }
 
-  private val bestFilterHeightQuery
+  private lazy val bestFilterHeightQuery
       : DBIOAction[Option[Int], NoStream, Effect.Read] = {
     table.map(_.height).max.result
   }

--- a/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/CompactFilterHeaderDAO.scala
@@ -13,7 +13,7 @@ case class CompactFilterHeaderDAO()(implicit
     override val appConfig: ChainAppConfig
 ) extends CRUD[CompactFilterHeaderDb, DoubleSha256DigestBE]
     with SlickUtil[CompactFilterHeaderDb, DoubleSha256DigestBE] {
-  import profile.api._
+  import profile.api.*
   val mappers = new org.bitcoins.db.DbCommonsColumnMappers(profile)
   import mappers.doubleSha256DigestBEMapper
 
@@ -127,13 +127,13 @@ case class CompactFilterHeaderDAO()(implicit
     result
   }
 
-  private val maxHeightQuery
+  private lazy val maxHeightQuery
       : profile.ProfileAction[Int, NoStream, Effect.Read] = {
     val query = table.map(_.height).max.getOrElse(0).result
     query
   }
 
-  private val bestFilterHeaderQuery = {
+  private lazy val bestFilterHeaderQuery = {
     val join = table
       .join(blockHeaderTable)
       .on(_.blockHash === _.hash)
@@ -161,7 +161,7 @@ case class CompactFilterHeaderDAO()(implicit
     safeDatabase.run(bestFilterHeaderQuery).map(_.headOption)
   }
 
-  private val bestFilterHeaderHeightQuery: Rep[Option[Int]] = {
+  private lazy val bestFilterHeaderHeightQuery: Rep[Option[Int]] = {
     table.map(_.height).max
   }
 


### PR DESCRIPTION
Observed while working on #6192 - it appears that literally the class instantiation is a hotspot when processing p2p messages in `PeerManager`.

<img width="1624" height="632" alt="image" src="https://github.com/user-attachments/assets/52c6f8c8-284a-4907-bf27-178324c6fc81" />
