### PR TITLE
tests: Fix bug where we wouldn't generate enough property based tests in `cryptoTest`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,7 +332,6 @@ lazy val cryptoTest = crossProject(JVMPlatform, JSPlatform)
   .dependsOn(crypto, testkitCore)
 
 lazy val cryptoTestJVM = cryptoTest.jvm
-  .dependsOn(appCommons)
 
 lazy val cryptoTestJS = cryptoTest.js
   .enablePlugins(ScalaJSBundlerPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -329,9 +329,10 @@ lazy val cryptoTest = crossProject(JVMPlatform, JSPlatform)
     name := "bitcoin-s-crypto-test",
     libraryDependencies ++= Deps.cryptoTest.value
   )
-  .dependsOn(crypto)
+  .dependsOn(crypto, testkitCore)
 
 lazy val cryptoTestJVM = cryptoTest.jvm
+  .dependsOn(appCommons)
 
 lazy val cryptoTestJS = cryptoTest.js
   .enablePlugins(ScalaJSBundlerPlugin)

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/BitcoinSCryptoTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/BitcoinSCryptoTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.crypto
 
+import org.bitcoins.testkitcore.Implicits.GeneratorOps
 import org.scalacheck.Gen
 import org.scalactic.anyvals.PosInt
 import org.scalatest.flatspec.{AnyFlatSpec, AsyncFlatSpec}

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/BitcoinSCryptoTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/BitcoinSCryptoTest.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.crypto
 
-import org.bitcoins.testkitcore.Implicits.GeneratorOps
 import org.scalacheck.Gen
 import org.scalactic.anyvals.PosInt
 import org.scalatest.flatspec.{AnyFlatSpec, AsyncFlatSpec}
@@ -65,7 +64,7 @@ trait BitcoinSCryptoAsyncTest
   )(func: A => Future[Assertion]): Future[Assertion] = {
 
     val samples = 1
-      .to(generatorDrivenConfig.minSize)
+      .to(generatorDrivenConfig.minSuccessful)
       .map(_ => gen.sampleSome)
       .toVector
 
@@ -78,7 +77,7 @@ trait BitcoinSCryptoAsyncTest
       func: (A, B) => Future[Assertion]
   ): Future[Assertion] = {
     val samples = 1
-      .to(generatorDrivenConfig.minSize)
+      .to(generatorDrivenConfig.minSuccessful)
       .map(_ => (genA.sampleSome, genB.sampleSome))
       .toVector
 
@@ -95,7 +94,7 @@ trait BitcoinSCryptoAsyncTest
       val failed = testRuns.filterNot(_ == Succeeded)
       if (succeeded.size < generatorDrivenConfig.minSuccessful) {
         failed.headOption.getOrElse(fail(
-          s"succeded.size=${succeeded.size} failed.size=${failed.size} minSuccessful=${generatorDrivenConfig.minSuccessful}"))
+          s"succeeded.size=${succeeded.size} failed.size=${failed.size} minSuccessful=${generatorDrivenConfig.minSuccessful}"))
       } else {
         succeed
       }


### PR DESCRIPTION
Occurs when generators fail to generate a valid input enough times to not satisfy `minSuccessful` threshold.

This PR introduces `testkitcore` to `cryptoTest` as a dependency and uses `GeneratorOps.sampleSome` to try have more changes to generate enough inputs for property based tests.

This PR also adds a more useful error message if we fail to generate enough sample inputs.