### PR TITLE
core: Cache the byteVector representation of our Script in `ScriptProgram`

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,3 +1,3 @@
--XX:InitialHeapSize=512M
--XX:MaxHeapSize=4G
+-Xms512M
+-Xmx4G
 -Xss2M

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,3 +1,3 @@
--Xms512M
--Xmx4G
+-XX:InitialHeapSize=512M
+-XX:MaxHeapSize=4G
 -Xss2M

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptProgram.scala
@@ -7,8 +7,9 @@ import org.bitcoins.core.script.constant.*
 import org.bitcoins.core.script.control.{OP_ELSE, OP_ENDIF, OP_IF, OP_NOTIF}
 import org.bitcoins.core.script.flag.ScriptFlag
 import org.bitcoins.core.script.result.*
-import org.bitcoins.core.util.BitcoinScriptUtil
+import org.bitcoins.core.util.{BitcoinScriptUtil, BytesUtil}
 import org.bitcoins.crypto.Sha256Digest
+import scodec.bits.ByteVector
 
 /** Created by chris on 2/3/16.
   */
@@ -27,6 +28,8 @@ sealed trait ScriptProgram {
 
   /** The script operations that need to still be executed. */
   def script: List[ScriptToken]
+
+  lazy val scriptByteVector: ByteVector = BytesUtil.toByteVector(script)
 
   /** The original script that was given. */
   def originalScript: List[ScriptToken]

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -768,12 +768,11 @@ sealed abstract class ScriptInterpreter {
   /** Executes a PreExecutionScriptProgram */
   private def executeProgram(
       program: PreExecutionScriptProgram): ExecutedScriptProgram = {
-    val scriptByteVector = BytesUtil.toByteVector(program.script)
     val sigVersion = program.txSignatureComponent.sigVersion
     val isTaprootSigVersion =
       sigVersion == SigVersionTapscript || sigVersion == SigVersionTaprootKeySpend
 
-    if (scriptByteVector.length > 10000 && !isTaprootSigVersion) {
+    if (!isTaprootSigVersion && program.scriptByteVector.length > 10000) {
       program.failExecution(ScriptErrorScriptSize)
     } else {
       loop(program.toExecutionInProgress, 0)
@@ -825,13 +824,14 @@ sealed abstract class ScriptInterpreter {
   private def loop(
       program: ExecutionInProgressScriptProgram,
       opCount: Int): ExecutedScriptProgram = {
-    val scriptByteVector = BytesUtil.toByteVector(program.script)
     val sigVersion = program.txSignatureComponent.sigVersion
     val isTaprootSigVersion =
       sigVersion == SigVersionTapscript || sigVersion == SigVersionTaprootKeySpend
     if (opCount > MAX_SCRIPT_OPS && !isTaprootSigVersion) {
       completeProgramExecution(program.failExecution(ScriptErrorOpCount))
-    } else if (scriptByteVector.length > 10000 && !isTaprootSigVersion) {
+    } else if (
+      !isTaprootSigVersion && program.scriptByteVector.length > 10000
+    ) {
       completeProgramExecution(program.failExecution(ScriptErrorScriptSize))
     } else {
       val (nextProgram, nextOpCount) = program.script match {


### PR DESCRIPTION
This PR does 2 things

1. Caches the `ByteVector` representation of the `Script` we are executing to avoid re-computing it in `loop()` and `executeProgram()`.
2. Inverts the check `scriptByteVector.length > 10000 && !isTaprootSigVersion` -> `!isTaprootSigVersion && program.scriptByteVector.length > 10000` so now if the sigversion is taproot, the script length check won't get run.

This reduces the runtime of `TaprootTxTests` by 50% (24 seconds -> 10 seconds) on my m3 laptop.