### PR TITLE
deps: Update bcrypto to latest release `5.5.2`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val crypto = crossProject(JVMPlatform, JSPlatform)
   )
   .jsSettings(
     Compile / npmDependencies ++= Seq(
-      "bcrypto" -> "5.4.0"
+      "bcrypto" -> "5.5.2"
     )
   )
   .jvmSettings(CommonSettings.jvmSettings: _*)


### PR DESCRIPTION
https://github.com/bcoin-org/bcrypto/releases/tag/v5.5.2