### PR TITLE
testkit: Set eclair.router.channel-spent-splice-delay to 6 so we remo…

### DIFF
--- a/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/eclair/rpc/EclairRpcTestUtil.scala
@@ -120,6 +120,7 @@ trait EclairRpcTestUtil extends BitcoinSLogger {
         "eclair.channel.min-depth-blocks" -> 6,
         "eclair.channel.max-htlc-value-in-flight-msat" -> 100000000000L,
         "eclair.router.broadcast-interval" -> "2 second",
+        "eclair.router.channel-spent-splice-delay" -> 6,
         "eclair.auto-reconnect" -> false,
         "eclair.channel.to-remote-delay-blocks" -> 144,
         "eclair.db.regtest.url" -> "jdbc:sqlite:regtest/",


### PR DESCRIPTION
[`eclair.router.channel-spent-splice-delay`](https://github.com/ACINQ/eclair/blob/656e5039017828da20063e18fcec07ad234cd296/eclair-core/src/main/resources/reference.conf#L431) forces us to remove the channel from the routing graph and no longer try to route payments through it after 6 confirmations

It appears in our spurious test case failures on CI we try to route payments in test cases through channels that have been closed, but do not have 72 confirmations (the default in eclair). Thus we try to route payments through it

```
2026-02-28 14:56:15,925 INFO  f.a.e.c.p.TxPublisher n:02c5b330e947e1f703204b6111a73e17c401e31dc4da98d7b05e4af8131bd0316f c:fcc1a10c1b2ed7238975e83d348b8cd2a2d5f7d93c8203b9953ca637816f986e - publishing closing-tx txid=fa086b68bc11e08acd98b82be2904e32f56d0d3083a543607860d0640577ccc4 spending 6e986f8137a63c95b903823cd9f7d5a2d28c8b343de8758923d72e1b0ca1c1fc:0 with id=9ce00147-8168-4172-9c2f-1151cba4b1ee (0 other attempts)
...
2026-02-28 14:56:19,198 INFO  f.a.e.c.fsm.Channel n:02c5b330e947e1f703204b6111a73e17c401e31dc4da98d7b05e4af8131bd0316f c:fcc1a10c1b2ed7238975e83d348b8cd2a2d5f7d93c8203b9953ca637816f986e - channel closed (type=mutual)
...
2026-02-28 14:56:31,953 WARN  f.a.e.c.fsm.Channel n:02c5b330e947e1f703204b6111a73e17c401e31dc4da98d7b05e4af8131bd0316f c:fcc1a10c1b2ed7238975e83d348b8cd2a2d5f7d93c8203b9953ca637816f986e - channel is unavailable (offline or closing) while processing cmd=CMD_ADD_HTLC in state=CLOSED
```